### PR TITLE
Simple EC2 instance example

### DIFF
--- a/examples/ec2instance/.gitignore
+++ b/examples/ec2instance/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/examples/ec2instance/Mu.yaml
+++ b/examples/ec2instance/Mu.yaml
@@ -1,0 +1,2 @@
+name: ec2instance
+description: Simple example of using AWS resources.

--- a/examples/ec2instance/index.ts
+++ b/examples/ec2instance/index.ts
@@ -1,0 +1,264 @@
+import * as mu from 'mu';
+import { InternetGateway, Instance, SecurityGroup } from '@mu/aws/ec2';
+
+let keyName = "lukehoban-us-east-1";
+let instanceType = "t2.micro";
+let sshLocation = "0.0.0.0";
+let region = "us-east-1";
+
+let awsRegionArch2AMI: { [name: string]: { [key: string]: string; } }= {
+    "us-east-1": {
+        "PV64": "ami-2a69aa47",
+        "HVM64": "ami-6869aa05",
+        "HVMG2": "ami-648d9973"
+    },
+    "us-west-2": {
+        "PV64": "ami-7f77b31f",
+        "HVM64": "ami-7172b611",
+        "HVMG2": "ami-09cd7a69"
+    },
+    "us-west-1": {
+        "PV64": "ami-a2490dc2",
+        "HVM64": "ami-31490d51",
+        "HVMG2": "ami-1e5f0e7e"
+    },
+    "eu-west-1": {
+        "PV64": "ami-4cdd453f",
+        "HVM64": "ami-f9dd458a",
+        "HVMG2": "ami-b4694ac7"
+    },
+    "eu-west-2": {
+        "PV64": "NOT_SUPPORTED",
+        "HVM64": "ami-886369ec",
+        "HVMG2": "NOT_SUPPORTED"
+    },
+    "eu-central-1": {
+        "PV64": "ami-6527cf0a",
+        "HVM64": "ami-ea26ce85",
+        "HVMG2": "ami-de5191b1"
+    },
+    "ap-northeast-1": {
+        "PV64": "ami-3e42b65f",
+        "HVM64": "ami-374db956",
+        "HVMG2": "ami-df9ff4b8"
+    },
+    "ap-northeast-2": {
+        "PV64": "NOT_SUPPORTED",
+        "HVM64": "ami-2b408b45",
+        "HVMG2": "NOT_SUPPORTED"
+    },
+    "ap-southeast-1": {
+        "PV64": "ami-df9e4cbc",
+        "HVM64": "ami-a59b49c6",
+        "HVMG2": "ami-8d8d23ee"
+    },
+    "ap-southeast-2": {
+        "PV64": "ami-63351d00",
+        "HVM64": "ami-dc361ebf",
+        "HVMG2": "ami-cbaf94a8"
+    },
+    "ap-south-1": {
+        "PV64": "NOT_SUPPORTED",
+        "HVM64": "ami-ffbdd790",
+        "HVMG2": "ami-decdbab1"
+    },
+    "us-east-2": {
+        "PV64": "NOT_SUPPORTED",
+        "HVM64": "ami-f6035893",
+        "HVMG2": "NOT_SUPPORTED"
+    },
+    "ca-central-1": {
+        "PV64": "NOT_SUPPORTED",
+        "HVM64": "ami-730ebd17",
+        "HVMG2": "NOT_SUPPORTED"
+    },
+    "sa-east-1": {
+        "PV64": "ami-1ad34676",
+        "HVM64": "ami-6dd04501",
+        "HVMG2": "NOT_SUPPORTED"
+    },
+    "cn-north-1": {
+        "PV64": "ami-77559f1a",
+        "HVM64": "ami-8e6aa0e3",
+        "HVMG2": "NOT_SUPPORTED"
+    }
+};
+
+let awsInstanceType2Arch: { [name: string]: { Arch: string; } } = {
+    "t1.micro": {
+        "Arch": "PV64"
+    },
+    "t2.nano": {
+        "Arch": "HVM64"
+    },
+    "t2.micro": {
+        "Arch": "HVM64"
+    },
+    "t2.small": {
+        "Arch": "HVM64"
+    },
+    "t2.medium": {
+        "Arch": "HVM64"
+    },
+    "t2.large": {
+        "Arch": "HVM64"
+    },
+    "m1.small": {
+        "Arch": "PV64"
+    },
+    "m1.medium": {
+        "Arch": "PV64"
+    },
+    "m1.large": {
+        "Arch": "PV64"
+    },
+    "m1.xlarge": {
+        "Arch": "PV64"
+    },
+    "m2.xlarge": {
+        "Arch": "PV64"
+    },
+    "m2.2xlarge": {
+        "Arch": "PV64"
+    },
+    "m2.4xlarge": {
+        "Arch": "PV64"
+    },
+    "m3.medium": {
+        "Arch": "HVM64"
+    },
+    "m3.large": {
+        "Arch": "HVM64"
+    },
+    "m3.xlarge": {
+        "Arch": "HVM64"
+    },
+    "m3.2xlarge": {
+        "Arch": "HVM64"
+    },
+    "m4.large": {
+        "Arch": "HVM64"
+    },
+    "m4.xlarge": {
+        "Arch": "HVM64"
+    },
+    "m4.2xlarge": {
+        "Arch": "HVM64"
+    },
+    "m4.4xlarge": {
+        "Arch": "HVM64"
+    },
+    "m4.10xlarge": {
+        "Arch": "HVM64"
+    },
+    "c1.medium": {
+        "Arch": "PV64"
+    },
+    "c1.xlarge": {
+        "Arch": "PV64"
+    },
+    "c3.large": {
+        "Arch": "HVM64"
+    },
+    "c3.xlarge": {
+        "Arch": "HVM64"
+    },
+    "c3.2xlarge": {
+        "Arch": "HVM64"
+    },
+    "c3.4xlarge": {
+        "Arch": "HVM64"
+    },
+    "c3.8xlarge": {
+        "Arch": "HVM64"
+    },
+    "c4.large": {
+        "Arch": "HVM64"
+    },
+    "c4.xlarge": {
+        "Arch": "HVM64"
+    },
+    "c4.2xlarge": {
+        "Arch": "HVM64"
+    },
+    "c4.4xlarge": {
+        "Arch": "HVM64"
+    },
+    "c4.8xlarge": {
+        "Arch": "HVM64"
+    },
+    "g2.2xlarge": {
+        "Arch": "HVMG2"
+    },
+    "g2.8xlarge": {
+        "Arch": "HVMG2"
+    },
+    "r3.large": {
+        "Arch": "HVM64"
+    },
+    "r3.xlarge": {
+        "Arch": "HVM64"
+    },
+    "r3.2xlarge": {
+        "Arch": "HVM64"
+    },
+    "r3.4xlarge": {
+        "Arch": "HVM64"
+    },
+    "r3.8xlarge": {
+        "Arch": "HVM64"
+    },
+    "i2.xlarge": {
+        "Arch": "HVM64"
+    },
+    "i2.2xlarge": {
+        "Arch": "HVM64"
+    },
+    "i2.4xlarge": {
+        "Arch": "HVM64"
+    },
+    "i2.8xlarge": {
+        "Arch": "HVM64"
+    },
+    "d2.xlarge": {
+        "Arch": "HVM64"
+    },
+    "d2.2xlarge": {
+        "Arch": "HVM64"
+    },
+    "d2.4xlarge": {
+        "Arch": "HVM64"
+    },
+    "d2.8xlarge": {
+        "Arch": "HVM64"
+    },
+    "hi1.4xlarge": {
+        "Arch": "HVM64"
+    },
+    "hs1.8xlarge": {
+        "Arch": "HVM64"
+    },
+    "cr1.8xlarge": {
+        "Arch": "HVM64"
+    },
+    "cc2.8xlarge": {
+        "Arch": "HVM64"
+    }
+};
+
+let securityGroup = new SecurityGroup({
+    groupDescription: "Enable SSH access",
+    securityGroupIngress: [{
+        ipProtocol: "tcp",
+        fromPort: 22,
+        toPort: 22,
+        cidrIp: sshLocation
+    }]
+});
+
+let instance = new Instance({
+    instanceType: instanceType,
+    securityGroups: [securityGroup],
+    keyName: keyName,
+    imageId: awsRegionArch2AMI[region][awsInstanceType2Arch[instanceType].Arch]
+});

--- a/examples/ec2instance/tsconfig.json
+++ b/examples/ec2instance/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/lib/aws/ec2/index.ts
+++ b/lib/aws/ec2/index.ts
@@ -1,5 +1,6 @@
 // Copyright 2016 Marapongo, Inc. All rights reserved.
 
+export * from './instance';
 export * from './internetGateway';
 export * from './route';
 export * from './routeTable';

--- a/lib/aws/ec2/instance.ts
+++ b/lib/aws/ec2/instance.ts
@@ -1,0 +1,29 @@
+// Copyright 2016 Marapongo, Inc. All rights reserved.
+
+import * as mu from 'mu';
+import {SecurityGroup} from './securityGroup';
+import * as cloudformation from '../cloudformation';
+
+// An Amazon EC2 security group.
+// @name: aws/ec2/securityGroup
+// @website: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-ec2-security-group.html
+export class Instance extends cloudformation.Resource  {
+    constructor(args: InstanceArgs) {
+        cloudformation.expandTags(args);
+        super({
+            resource: "AWS::EC2::Instance",
+            properties: args,
+        });
+    }
+}
+
+export interface InstanceArgs extends cloudformation.TagArgs {
+    // The instance type, such as t2.micro. The default type is "m3.medium".
+    instanceType: string;
+    // A list that contains the Amazon EC2 security groups to assign to the Amazon EC2 instance.
+    securityGroups: SecurityGroup[];
+    // Provides the name of the Amazon EC2 key pair.
+    keyName: string;
+    // Provides the unique ID of the Amazon Machine Image (AMI) that was assigned during registration.
+    imageId: string;
+}

--- a/lib/aws/ec2/securityGroup.ts
+++ b/lib/aws/ec2/securityGroup.ts
@@ -22,7 +22,7 @@ export interface SecurityGroupArgs extends cloudformation.TagArgs {
     // Description of the security group.
     readonly groupDescription: string;
     // The VPC in which this security group resides.
-    readonly vpc: VPC;
+    readonly vpc?: VPC;
     // A list of Amazon EC2 security group egress rules.
     securityGroupEgress?: SecurityGroupEgressRule[];
     // A list of Amazon EC2 security group ingress rules.
@@ -54,11 +54,11 @@ export interface SecurityGroupEgressRule extends SecurityGroupRule {
 // An EC2 Security Group Ingress Rule is an embedded property of the SecurityGroup (different from the resource).
 export interface SecurityGroupIngressRule extends SecurityGroupRule {
     // For VPC security groups only. Specifies the ID of the Amazon EC2 Security Group to allow access.
-    sourceSecurityGroup: SecurityGroup;
+    sourceSecurityGroup?: SecurityGroup;
     // For non-VPC security groups only. Specifies the name of the Amazon EC2 Security Group to use for access.
-    sourceSecurityGroupName: string;
+    sourceSecurityGroupName?: string;
     // Specifies the AWS Account ID of the owner of the Amazon EC2 Security Group that is specified in the
     // SourceSecurityGroupName property.
-    sourceSecurityGroupOwnerId: string;
+    sourceSecurityGroupOwnerId?: string;
 }
 

--- a/tools/mujs/lib/compiler/transform.ts
+++ b/tools/mujs/lib/compiler/transform.ts
@@ -2264,8 +2264,10 @@ export class Transformer {
         switch (node.kind) {
             case ts.SyntaxKind.Identifier:
                 return this.transformIdentifier(<ts.Identifier>node);
+            case ts.SyntaxKind.StringLiteral:
+                return this.withLocation(node, ident((<ts.StringLiteral>node).text));
             default:
-                return contract.fail("Property names other than identifiers not yet supported");
+                return contract.fail("Property names other than identifiers and string literals not yet supported");
         }
     }
 }


### PR DESCRIPTION
Adds a simple example using AWS resources based on: https://s3-us-west-2.amazonaws.com/cloudformation-templates-us-west-2/EC2InstanceWithSecurityGroupSample.template

Adds support for string literal property keys in MuJS.

Adds the `Instance` resource type for AWS EC2.

