### PR TITLE
Add tests for AWS DynamoDB Table provider

### DIFF
--- a/lib/aws/provider/dynamodb/table.go
+++ b/lib/aws/provider/dynamodb/table.go
@@ -374,7 +374,7 @@ func (p *tableProvider) Update(ctx context.Context, id resource.ID,
 func (p *tableProvider) Delete(ctx context.Context, id resource.ID) error {
 	// First, perform the deletion.
 	fmt.Printf("Deleting DynamoDB Table '%v'\n", id)
-	succ, err := awsctx.RetryUntil(
+	succ, err := awsctx.RetryUntilLong(
 		p.ctx,
 		func() (bool, error) {
 			_, err := p.ctx.DynamoDB().DeleteTable(&awsdynamodb.DeleteTableInput{

--- a/lib/aws/provider/dynamodb/table_test.go
+++ b/lib/aws/provider/dynamodb/table_test.go
@@ -1,0 +1,181 @@
+package dynamodb
+
+import (
+	"fmt"
+	"testing"
+
+	"encoding/json"
+
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsdynamodb "github.com/aws/aws-sdk-go/service/dynamodb"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/pulumi/lumi/lib/aws/provider/awsctx"
+	"github.com/pulumi/lumi/lib/aws/rpc/dynamodb"
+	"github.com/pulumi/lumi/pkg/resource"
+	"github.com/pulumi/lumi/sdk/go/pkg/lumirpc"
+	"github.com/stretchr/testify/assert"
+)
+
+const TABLENAMEPREFIX = "lumitest"
+
+func marshal(table dynamodb.Table) (*structpb.Struct, error) {
+	byts, err := json.Marshal(table)
+	if err != nil {
+		return nil, err
+	}
+	var obj map[string]interface{}
+	err = json.Unmarshal(byts, &obj)
+	if err != nil {
+		return nil, err
+	}
+	props := resource.NewPropertyMapFromMap(obj)
+	return resource.MarshalProperties(nil, props, resource.MarshalOptions{}), nil
+}
+
+func cleanup(ctx *awsctx.Context) {
+	fmt.Printf("Cleaning up tables with prefix: %v\n", TABLENAMEPREFIX)
+	list, err := ctx.DynamoDB().ListTables(&awsdynamodb.ListTablesInput{})
+	if err != nil {
+		return
+	}
+	cleaned := 0
+	for _, table := range list.TableNames {
+		if strings.HasPrefix(aws.StringValue(table), TABLENAMEPREFIX) {
+			ctx.DynamoDB().DeleteTable(&awsdynamodb.DeleteTableInput{
+				TableName: table,
+			})
+			cleaned++
+		}
+	}
+	fmt.Printf("Cleaned up %v tables\n", cleaned)
+}
+
+func Test(t *testing.T) {
+	// Create a TableProvider
+	ctx, err := awsctx.New()
+	assert.Nil(t, err, "expected no error getting AWS context")
+	tableProvider := NewTableProvider(ctx)
+
+	defer cleanup(ctx)
+
+	// Table to create
+	table := dynamodb.Table{
+		Name: TABLENAMEPREFIX,
+		Attributes: []dynamodb.Attribute{
+			{Name: "Album", Type: "S"},
+			{Name: "Artist", Type: "S"},
+			{Name: "Sales", Type: "N"},
+		},
+		HashKey:       "Album",
+		RangeKey:      aws.String("Artist"),
+		ReadCapacity:  2,
+		WriteCapacity: 2,
+		GlobalSecondaryIndexes: &[]dynamodb.GlobalSecondaryIndex{
+			{
+				IndexName:        "myGSI",
+				HashKey:          "Sales",
+				RangeKey:         aws.String("Artist"),
+				ReadCapacity:     1,
+				WriteCapacity:    1,
+				NonKeyAttributes: []string{"Album"},
+				ProjectionType:   "INCLUDE",
+			},
+		},
+	}
+	props, err := marshal(table)
+	if !assert.NoError(t, err, "expected no error marshaling object to protobuf") {
+		return
+	}
+	checkResp, err := tableProvider.Check(nil, &lumirpc.CheckRequest{
+		Type:       string(TableToken),
+		Properties: props,
+	})
+	if !assert.NoError(t, err, "expected no error checking table") {
+		return
+	}
+	assert.Equal(t, 0, len(checkResp.Failures), "expected no check failures")
+
+	// Invoke Create request
+	resp, err := tableProvider.Create(nil, &lumirpc.CreateRequest{
+		Type:       string(TableToken),
+		Properties: props,
+	})
+	if !assert.NoError(t, err, "expected no error creating resource") {
+		return
+	}
+	if !assert.NotNil(t, resp, "expected a non-nil response") {
+		return
+	}
+
+	id := resp.Id
+	assert.Contains(t, id, "lumitest", "expected resource ID to contain `lumitest`")
+
+	// Table for update
+	table2 := dynamodb.Table{
+		Name: "lumitest",
+		Attributes: []dynamodb.Attribute{
+			{Name: "Album", Type: "S"},
+			{Name: "Artist", Type: "S"},
+			{Name: "NumberOfSongs", Type: "N"},
+			{Name: "Sales", Type: "N"},
+		},
+		HashKey:       "Album",
+		RangeKey:      aws.String("Artist"),
+		ReadCapacity:  1,
+		WriteCapacity: 1,
+		GlobalSecondaryIndexes: &[]dynamodb.GlobalSecondaryIndex{
+			{
+				IndexName:        "myGSI",
+				HashKey:          "Sales",
+				RangeKey:         aws.String("Artist"),
+				ReadCapacity:     1,
+				WriteCapacity:    1,
+				NonKeyAttributes: []string{"Album"},
+				ProjectionType:   "INCLUDE",
+			},
+			{
+				IndexName:        "myGSI2",
+				HashKey:          "NumberOfSongs",
+				RangeKey:         aws.String("Sales"),
+				NonKeyAttributes: []string{"Album", "Artist"},
+				ProjectionType:   "INCLUDE",
+				ReadCapacity:     1,
+				WriteCapacity:    1,
+			},
+		},
+	}
+	props2, err := marshal(table2)
+	if !assert.NoError(t, err, "expected no error marshaling object to protobuf") {
+		return
+	}
+	checkResp, err = tableProvider.Check(nil, &lumirpc.CheckRequest{
+		Type:       string(TableToken),
+		Properties: props2,
+	})
+	if !assert.NoError(t, err, "expected no error checking table") {
+		return
+	}
+	assert.Equal(t, 0, len(checkResp.Failures), "expected no check failures")
+
+	// Invoke Update request
+	_, err = tableProvider.Update(nil, &lumirpc.ChangeRequest{
+		Type: string(TableToken),
+		Id:   id,
+		Olds: props,
+		News: props2,
+	})
+	if !assert.NoError(t, err, "expected no error creating resource") {
+		return
+	}
+
+	// Invoke the Delete request
+	_, err = tableProvider.Delete(nil, &lumirpc.DeleteRequest{
+		Type: string(TableToken),
+		Id:   id,
+	})
+	if !assert.NoError(t, err, "expected no error deleting resource") {
+		return
+	}
+}

--- a/pkg/resource/properties.go
+++ b/pkg/resource/properties.go
@@ -36,6 +36,10 @@ type PropertyMap map[PropertyKey]PropertyValue
 // NewPropertyMap turns a struct into a property map, using any JSON tags inside to determine naming.
 func NewPropertyMap(s interface{}) PropertyMap {
 	m := structs.Map(s)
+	return NewPropertyMapFromMap(m)
+}
+
+func NewPropertyMapFromMap(m map[string]interface{}) PropertyMap {
 	result := make(PropertyMap)
 	for k, v := range m {
 		result[PropertyKey(k)] = NewPropertyValue(v)
@@ -381,6 +385,13 @@ func NewPropertyValue(v interface{}) PropertyValue {
 		return NewPropertyValue(rv.Elem().Interface())
 	case reflect.Struct:
 		obj := NewPropertyMap(rv.Interface())
+		return NewPropertyObject(obj)
+	case reflect.Map:
+		m := map[string]interface{}{}
+		for _, kv := range rv.MapKeys() {
+			m[kv.String()] = rv.MapIndex(kv).Interface()
+		}
+		obj := NewPropertyMapFromMap(m)
 		return NewPropertyObject(obj)
 	default:
 		contract.Failf("Unrecognized value type: %v", rk)


### PR DESCRIPTION
This is a first test case for our AWS providers.  The test does create/update/delete operations against real AWS resources, as discussed in #181.  

```
Creating DynamoDB Table 'lumitest' with name 'lumitest-ec217d3c409'
DynamoDB Table created: lumitest-ec217d3c409; waiting for it to become active
Updating provisioned capacity for DynamoDB Table lumitest-ec217d3c409
Adding new global secondary index myGSI2 for DynamoDB Table lumitest-ec217d3c409
Deleting DynamoDB Table 'lumitest-ec217d3c409'
DynamoDB Table delete request submitted; waiting for it to delete
Cleaning up tables with prefix: lumitest
Cleaned up 0 tables
PASS
coverage: 67.5% of statements
ok  	github.com/pulumi/lumi/lib/aws/provider/dynamodb	324.621s
Success: Tests passed.
```