### PR TITLE
Only run quick tests for `make`; add a `make full` target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
     - go get -v github.com/golang/lint/golint
 install:
     - godep restore -v
+script: make full
 notifications:
   slack:
     secure: tPhYdqclnOhFTiKhLn0EqY4/UhJ30c3SFRKHTMPYFfYflCQOyrIARYrzlm+oEOBISw/oNP0wR1LxawhLC2KfDb0ST9Zph8wKyQ8dujk9jXGACuuRic1n/IU9yiu2grZQqcwlieLN6IvGvK+736D2ZxhcjUF5ZwORkpe9jl+nr65NzWH5H+pr4jVWXvYddB2gJ/49i+COydfbaRJ+6O3JORqmSP2VA4CtrArl0L/uDT0osvBwJkeoTSzKjkPWZUwI3ZlGOCSGe+6i5hto6WOzUnU74UgNVZ6dCUOKJrmu146DDzTYB7g4xTkiBi8W5jEo7E6PRqAA6/zGGzUp0J8AMmKcrYnmBf3ALaAIzwiQAFwn9m4V3cKEnnfwzN+SrrmrA3KpwWuj2PNS0UEaxFr35Lb7NNORibmBJi5gj9q138C+b9uD5MQ3poq0PpXG+ZPYTQU1QZODsxcHpR3OyyI89OXBugrP9CTcYpknUgPmiAJgOQn+7H+Xcmme3CB9G5292hC5McZZtyxUAoNwAtg316bXSWWH9MkFRmjTWt7lRGZZ99T1TO/iG0DntyCWxy8lHIbYvCdbY5oTN3WMN93NFrmFMiZJcmmV79meMe/6LNLWVIWVaTXZSpS8IflRmVFp1twveSh4i1+mogh8CsMs2Lqp2Ca7HdakLtRBxHzcH/4=

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,15 @@ PROJECT_PKGS=$(shell go list ./... | grep -v /vendor/)
 CORE_PROJECT_PKGS=$(shell go list ./cmd/... ./pkg/...)
 PROCCNT=$(shell nproc --all)
 
-default: banner test lint_quiet vet install
+default: banner test_core lint_quiet vet install
+full: banner_full test lint_quiet vet install
 
 banner:
+	@echo "\033[0;33mRunning quick build; to run full tests, run 'make full'\033[0m"
+	@echo "\033[0;33mRemember to do this before checkin, otherwise your CI will fail\033[0m"
+	@go version
+
+banner_full:
 	@go version
 
 build:


### PR DESCRIPTION
The AWS tests take a while to run and it's easy to forget.  Further,
they are going to start taking quite a bit longer very soon.

So, this change introduces a `make full` target, which is what our
CI tests run.  But the ordinary `make` skips the long tests for faster
inner loop verification.  Over time, I'm sure we'll get far more
sophisticated with the split between inner vs. outer loop testing,
especially for performance, stress, and so on.