### PR TITLE
Eliminate use of nonstandard tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,5 @@
 language: go
 go: 1.8.2
-addons:
-    apt:
-        packages:
-            - realpath
 before_install:
     # GoDep for Go dependency management.
     - go get -v github.com/tools/godep

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 PROJECT=github.com/pulumi/lumi
 PROJECT_PKGS=$(shell go list ./cmd/... ./pkg/... | grep -v /vendor/)
-PROCCNT=$(shell nproc --all)
 
 .PHONY: default
 default: banner lint_quiet vet test install
@@ -58,7 +57,7 @@ vet:
 .PHONY: test
 test:
 	@echo "\033[0;32mTEST:\033[0m"
-	@go test -parallel ${PROCCNT} -cover ${PROJECT_PKGS}
+	@go test -cover ${PROJECT_PKGS}
 
 .PHONY: lumijs
 lumijs:

--- a/cmd/lumijs/Makefile
+++ b/cmd/lumijs/Makefile
@@ -1,4 +1,3 @@
-BASE=$(realpath ./)
 INSTALL=/usr/local/bin
 
 .PHONY: default
@@ -23,7 +22,7 @@ build:
 .PHONY: install
 install:
 	@echo "\033[0;32mINSTALL:\033[0m"
-	@ln -sf ${BASE}/lumijs ${INSTALL}/lumijs
+	@ln -sf ${shell pwd}/lumijs ${INSTALL}/lumijs
 
 .PHONY: test
 test:

--- a/cmd/lumijs/lumijs
+++ b/cmd/lumijs/lumijs
@@ -1,4 +1,3 @@
-#!/bin/bash
-DIR="$(dirname "$(realpath "$0")" )"
-node ${DIR}/bin/cmd "$@"
+#!/usr/bin/env node
+require("./bin/cmd");
 

--- a/lib/aws/Makefile
+++ b/lib/aws/Makefile
@@ -1,5 +1,4 @@
 GOPKGS    = $(shell go list ./provider/... | grep -v /vendor/)
-PROCCNT   = $(shell nproc --all)
 LUMIROOT ?= /usr/local/lumi
 LUMILIB   = ${LUMIROOT}/packs
 THISLIB   = ${LUMILIB}/aws
@@ -64,7 +63,7 @@ vet:
 .PHONY: test
 test:
 	@echo "\033[0;32mTEST:\033[0m"
-	@go test -parallel ${PROCCNT} -cover ${GOPKGS}
+	@go test -cover ${GOPKGS}
 
 .PHONY: verify
 verify: gen


### PR DESCRIPTION
This change eliminates the use of nonstandard tools in our build:

* `go test` automatically uses `GOMAXPROCS` for its parallelism
  setting.  In modern Go, this is now set to the number of processors.
  So, there is no need to set it explicitly using `nproc`.

* We can avoid `realpath` in the `lumijs` executable by making it
  a Node.js file and using a relative require import of main.

* We can avoid `realpath` in our Makefiles by just using `pwd`.