### PR TITLE
Skip provider tests when AWS credentials are unavailable

### DIFF
--- a/lib/aws/provider/dynamodb/table_test.go
+++ b/lib/aws/provider/dynamodb/table_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pulumi/lumi/lib/aws/provider/awsctx"
 	"github.com/pulumi/lumi/lib/aws/provider/testutil"
 	"github.com/pulumi/lumi/lib/aws/rpc/dynamodb"
-	"github.com/stretchr/testify/assert"
 )
 
 const RESOURCEPREFIX = "lumitest"
@@ -19,9 +18,7 @@ const RESOURCEPREFIX = "lumitest"
 func Test(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := awsctx.New()
-	assert.Nil(t, err, "expected no error getting AWS context")
-
+	ctx := testutil.CreateContext(t)
 	cleanup(ctx)
 
 	testutil.ProviderTestSimple(t, NewTableProvider(ctx), TableToken, []interface{}{

--- a/lib/aws/provider/ec2/instance_test.go
+++ b/lib/aws/provider/ec2/instance_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pulumi/lumi/lib/aws/provider/awsctx"
 	"github.com/pulumi/lumi/lib/aws/provider/testutil"
 	"github.com/pulumi/lumi/lib/aws/rpc/ec2"
-	"github.com/stretchr/testify/assert"
 )
 
 const RESOURCEPREFIX = "lumitest"
@@ -35,9 +34,7 @@ var amis = map[string]string{
 func Test(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := awsctx.New()
-	assert.Nil(t, err, "expected no error getting AWS context")
-
+	ctx := testutil.CreateContext(t)
 	cleanup(ctx)
 
 	instanceType := ec2.InstanceType("t2.nano")

--- a/lib/aws/provider/lambda/function_test.go
+++ b/lib/aws/provider/lambda/function_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/pulumi/lumi/lib/aws/rpc/iam"
 	"github.com/pulumi/lumi/lib/aws/rpc/lambda"
 	"github.com/pulumi/lumi/pkg/resource"
-	"github.com/stretchr/testify/assert"
 )
 
 const RESOURCEPREFIX = "lumitest"
@@ -23,9 +22,7 @@ const RESOURCEPREFIX = "lumitest"
 func Test(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := awsctx.New()
-	assert.Nil(t, err, "expected no error getting AWS context")
-
+	ctx := testutil.CreateContext(t)
 	cleanupFunctions(ctx)
 	cleanupRoles(ctx)
 

--- a/lib/aws/provider/testutil/provider.go
+++ b/lib/aws/provider/testutil/provider.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/pulumi/lumi/lib/aws/provider/awsctx"
 	"github.com/pulumi/lumi/pkg/resource"
 	"github.com/pulumi/lumi/pkg/resource/plugin"
 	"github.com/pulumi/lumi/pkg/tokens"
@@ -212,4 +213,14 @@ func deleteResource(t *testing.T, id string, provider lumirpc.ResourceProviderSe
 		return false
 	}
 	return true
+}
+
+// CreateContext creates an AWS Context object for executing tests, and skips the test if the context cannot be
+// created succefully, most likely because credentials are unavailable in the execution environment.
+func CreateContext(t *testing.T) *awsctx.Context {
+	ctx, err := awsctx.New()
+	if err != nil {
+		t.Skipf("AWS context could not be acquired: %v", err)
+	}
+	return ctx
 }


### PR DESCRIPTION
Instead of asserting, we will skip these tests if the environment
does not provide access to credentials to create an AWS context.

This fixes #232.