### PR TITLE
Enable VM-based builds in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: go
 go: 1.8.2
+sudo: true # give us 7.5GB and >2 bursted cores.
 before_install:
     # GoDep for Go dependency management.
     - go get -v github.com/tools/godep


### PR DESCRIPTION
This change enables VM-based builds in Travis, versus the default of
container-based builds.  This will give us more memory (7.5GB rather
than 4GB max), and more compute (~2, bursted rather than 2).  This
may help to fix some of the build/test speed time issues we are seeing.