### PR TITLE
Add Go code coverage reports to nightly tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 /mu
 /vendor/
 /.vscode/
+coverage.cov
+*.coverprofile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
     # Gometalinter for good Go linting/hygiene.
     - go get -v github.com/alecthomas/gometalinter
     - gometalinter --install
+    # gocovmerge for Go code coverage.
+    - go get -v github.com/wadey/gocovmerge
     # Node.js 7.x for LumiJS and associated JS code.
     - nvm install v7
     # Install Yarn as per https://yarnpkg.com/lang/en/docs/install-ci/#travis-tab.

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ default: banner vet test install lint_quiet
 all: banner_all vet test install lint_quiet lumijs lumirtpkg lumijspkg lumipkg awspkg
 
 .PHONY: nightly
-nightly: banner_all vet test install lint_quiet lumijs lumirtpkg lumijspkg lumipkg awspkg examples
+nightly: banner_all vet test install lint_quiet lumijs lumirtpkg lumijspkg lumipkg awspkg examples gocover
 
 .PHONY: banner
 banner:
@@ -99,4 +99,9 @@ verify:
 examples:
 	@$(ECHO) "\033[0;32mTEST EXAMPLES:\033[0m"
 	go test -v -cover -timeout 1h -parallel ${TESTPARALLELISM} ./examples
+
+.PHONY: gocover
+gocover:
+	@$(ECHO) "\033[0;32mGO CODE COVERAGE:\033[0m"
+	./gocover.sh
 

--- a/gocover.sh
+++ b/gocover.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+export PKGS='./pkg/... ./cmd/... ./lib/aws/provider/...'
+export PKGS_COMMA='./pkg/...,./cmd/...,./lib/aws/provider/...'
+go test -i $PKGS
+go list -f '{{if gt (len .TestGoFiles) 0}}"go test -covermode count -coverprofile {{.Name}}.coverprofile -coverpkg $PKGS_COMMA {{.ImportPath}}"{{end}}' $PKGS | xargs -P100 -I {} bash -c {} 2>&1 | grep -v '^warning: no packages being tested depend on '
+gocovmerge `ls *.coverprofile` > coverage.cov
+go tool cover -func=coverage.cov
+rm *.coverprofile
+


### PR DESCRIPTION
Adds a make task to generate code coverage for all Go sources.

That make task re-runs the tests, and can be fairly expensive,
so it is enabled only in the nightly tests for now.

Part of #206.