### PR TITLE
Resolve to dynamic instead of error type on TypeNotfound

### DIFF
--- a/pkg/compiler/binder/binder_test.go
+++ b/pkg/compiler/binder/binder_test.go
@@ -85,7 +85,8 @@ func TestBadTypeNotFound(t *testing.T) {
 	sink := testBind("testdata", "bad__type_not_found")
 
 	// Check that the compiler complained about the type missisng.
-	assert.Equal(t, 2, sink.Errors(), "expected a single error")
+	assert.Equal(t, 1, sink.Errors(), "expected a single error")
+	assert.Equal(t, 1, sink.Warnings(), "expected a single warning")
 	d1 := errors.ErrorSymbolNotFound
 	assert.Equal(t,
 		fmt.Sprintf("%v %v%v: %v\n",
@@ -95,9 +96,9 @@ func TestBadTypeNotFound(t *testing.T) {
 	d2 := errors.ErrorTypeNotFound
 	assert.Equal(t,
 		fmt.Sprintf("%v %v%v: %v\n",
-			diag.Error, diag.DefaultSinkIDPrefix, d2.ID,
+			diag.Warning, diag.DefaultSinkIDPrefix, d2.ID,
 			fmt.Sprintf(d2.Message, "missing/package:bad/module/Clazz", "type symbol not found")),
-		sink.ErrorMsgs()[1])
+		sink.WarningMsgs()[0])
 }
 
 func TestGoodPrimitiveTypes(t *testing.T) {

--- a/pkg/compiler/binder/context.go
+++ b/pkg/compiler/binder/context.go
@@ -265,13 +265,13 @@ func (ctx *Context) LookupTypeToken(node diag.Diagable, tok tokens.Type, require
 		}
 	}
 
-	// The type was not found; issue an error, and return an error type so we can proceed with typechecking.
+	// The type was not found; issue an warning, and return the dynamic type so we can proceed with typechecking.
 	if ty == nil {
 		if require {
 			contract.Assert(reason != "")
-			ctx.Diag.Errorf(errors.ErrorTypeNotFound.At(node), tok, reason)
+			ctx.Diag.Warningf(errors.ErrorTypeNotFound.At(node), tok, reason)
 		}
-		ty = types.Error
+		ty = types.Dynamic
 	}
 	return ty
 }
@@ -287,7 +287,7 @@ func (ctx *Context) LookupFunctionType(node ast.Function) *symbols.FunctionType 
 
 			// If either the parameter's type was unknown, or the lookup failed, sub in an error type.
 			if ptysym == nil {
-				ptysym = types.Error
+				ptysym = types.Dynamic
 			}
 
 			params = append(params, ptysym)
@@ -351,9 +351,9 @@ func (ctx *Context) lookupBasicType(node diag.Diagable, tok tokens.Type, require
 	glog.V(5).Infof("Failed to bind primitive type '%v'", tok)
 
 	if require {
-		ctx.Diag.Errorf(errors.ErrorTypeNotFound.At(node), tok, "unrecognized primitive type name")
+		ctx.Diag.Warningf(errors.ErrorTypeNotFound.At(node), tok, "unrecognized primitive type name")
 	}
-	return types.Error
+	return types.Dynamic
 }
 
 func (ctx *Context) checkClassVisibility(node diag.Diagable, class symbols.Type, member symbols.ClassMember) {


### PR DESCRIPTION
This unblocks some cases with generics without having to
implement full generics support in the type LumiRT type system
(which we directionally will be removing anyway).