### PR TITLE
Publish built binaries upon successful push CI to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ before_script:
     - export LUMIROOT=~/.lumi
 script:
     - if [ $TRAVIS_EVENT_TYPE = "cron" ]; then make nightly; else make all; fi
+after_script:
+    - if [ $TRAVIS_EVENT_TYPE = "push" ] && [ $TRAVIS_BRANCH = "master" ]; then make publish; fi
 notifications:
   slack:
     secure: tPhYdqclnOhFTiKhLn0EqY4/UhJ30c3SFRKHTMPYFfYflCQOyrIARYrzlm+oEOBISw/oNP0wR1LxawhLC2KfDb0ST9Zph8wKyQ8dujk9jXGACuuRic1n/IU9yiu2grZQqcwlieLN6IvGvK+736D2ZxhcjUF5ZwORkpe9jl+nr65NzWH5H+pr4jVWXvYddB2gJ/49i+COydfbaRJ+6O3JORqmSP2VA4CtrArl0L/uDT0osvBwJkeoTSzKjkPWZUwI3ZlGOCSGe+6i5hto6WOzUnU74UgNVZ6dCUOKJrmu146DDzTYB7g4xTkiBi8W5jEo7E6PRqAA6/zGGzUp0J8AMmKcrYnmBf3ALaAIzwiQAFwn9m4V3cKEnnfwzN+SrrmrA3KpwWuj2PNS0UEaxFr35Lb7NNORibmBJi5gj9q138C+b9uD5MQ3poq0PpXG+ZPYTQU1QZODsxcHpR3OyyI89OXBugrP9CTcYpknUgPmiAJgOQn+7H+Xcmme3CB9G5292hC5McZZtyxUAoNwAtg316bXSWWH9MkFRmjTWt7lRGZZ99T1TO/iG0DntyCWxy8lHIbYvCdbY5oTN3WMN93NFrmFMiZJcmmV79meMe/6LNLWVIWVaTXZSpS8IflRmVFp1twveSh4i1+mogh8CsMs2Lqp2Ca7HdakLtRBxHzcH/4=


### PR DESCRIPTION
This adds a new make target, publish, that will create a release
package and upload it to an S3 bucket.  This package simply contains
the built CLI plus the core library packages, lumi, lumirt, and lumijs.

This target is invoked automatically at the end of a successful
Travis run against a push to master.