### PR TITLE
Early-out integration tests if PATH is incorrect. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ banner_all:
 configure:
 	dep ensure -v
 	cd sdk/nodejs/ && make configure
+	@if [ -z "`which pulumi-langhost-nodejs`" ]; then $(ECHO) NOTE: please add "`pwd`/sdk/nodejs/bin" to your path before running lumi or the nodejs language plugin will not load.; fi
 
 .PHONY: install
 install:
@@ -77,6 +78,7 @@ test:
 .PHONY: integrationtest
 integrationtest:
 	@$(ECHO) "\033[0;32mINTEGRATION TEST:\033[0m"
+	@if [ -z "`which pulumi-langhost-nodejs`" ]; then $(ECHO) Please add "`pwd`/sdk/nodejs/bin" to your path before running integration tests. && exit 1; fi
 	go test -cover -parallel ${TESTPARALLELISM} ./examples
 
 sdk/nodejs:


### PR DESCRIPTION
This provides a friendlier experience if the nodejs language service is
not on the path. Also, print a helpful message at the end of
`make configure` if PATH has not yet been setup.