### PR TITLE
Crossbuild and publish to new layout format

### DIFF
--- a/dist/sdk/nodejs/.gitattributes
+++ b/dist/sdk/nodejs/.gitattributes
@@ -1,0 +1,1 @@
+*.cmd text eol=crlf

--- a/dist/sdk/nodejs/pulumi-langhost-nodejs
+++ b/dist/sdk/nodejs/pulumi-langhost-nodejs
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+require("@pulumi/pulumi-fabric/cmd/langhost");
+

--- a/dist/sdk/nodejs/pulumi-langhost-nodejs.cmd
+++ b/dist/sdk/nodejs/pulumi-langhost-nodejs.cmd
@@ -1,0 +1,1 @@
+@%~dp0\node.exe -e "require(\"@pulumi/pulumi-fabric/cmd/langhost\")" %*

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 # install.sh installs an existing release.
 set -e
 
-INSTALL=$GOPATH/src/github.com/pulumi/home/scripts/install.sh
+INSTALL=$GOPATH/src/github.com/pulumi/home/scripts/install2.sh
 if [ ! -f $PUBLISH ]; then
     >&2 echo "error: Missing publish script at $INSTALL"
     exit 1

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # make_release.sh will create a build package ready for publishing.
-set -e
+set -o nounset -o errexit -o pipefail
 
 ROOT=$(dirname $0)/..
 PUBDIR=$(mktemp -du)
@@ -10,16 +10,43 @@ PUBFILE=$(dirname ${PUBDIR})/${GITVER}.tgz
 # Figure out which branch we're on. Prefer $TRAVIS_BRANCH, if set, since
 # Travis leaves us at detached HEAD and `git rev-parse` just returns "HEAD".
 BRANCH=${TRAVIS_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
-declare -a PUBTARGETS=(${GITVER} $(git describe --tags) ${BRANCH})
+declare -a PUBTARGETS=(${GITVER} $(git describe --tags 2>/dev/null) ${BRANCH})
 
-# Copy the binaries, scripts, and packs.
-mkdir -p ${PUBDIR}/bin/
-cp ${GOPATH}/bin/pulumi ${PUBDIR}/bin/
-mkdir -p ${PUBDIR}/sdk/
-cp -R ${GOPATH}/src/github.com/pulumi/home/scripts/. ${PUBDIR}/scripts/
-cp -R ${ROOT}/sdk/nodejs/bin/. ${PUBDIR}/sdk/nodejs/
-cp -R ${ROOT}/sdk/nodejs/node_modules/. ${PUBDIR}/sdk/nodejs/node_modules/
-echo sdk/nodejs/ >> ${PUBDIR}/packs.txt
+# usage: run_go_build <path-to-package-to-build>
+function run_go_build() {
+    local BINSUFFIX=""
+    if [ "$(go env GOOS)" = "windows" ]; then
+        BINSUFFIX=".exe"
+    fi
+
+    mkdir -p "${PUBDIR}/bin"
+    go build -o "${PUBDIR}/bin/$(basename "${1}")${BINSUFFIX}" "${1}"
+}
+
+# usage: copy_package <path-to-module> <module-name>
+copy_package() {
+    local MODULE_ROOT=${PUBDIR}/node_modules/${2}
+
+    mkdir -p "${MODULE_ROOT}"   
+    cp -R "${1}" "${MODULE_ROOT}/"
+    if [ -e "${MODULE_ROOT}/node_modules" ]; then
+        rm -rf "${MODULE_ROOT}/node_modules"
+    fi
+}
+
+
+# Build binaries
+run_go_build "${ROOT}/cmd/lumi"
+
+# Copy over the langhost
+if [ "$(go env GOOS)" != "windows" ]; then
+    cp ${ROOT}/dist/sdk/nodejs/pulumi-langhost-nodejs ${PUBDIR}/bin/
+else
+    cp ${ROOT}/dist/sdk/nodejs/pulumi-langhost-nodejs.cmd ${PUBDIR}/bin/
+fi
+
+# Copy packages
+copy_package "${ROOT}/sdk/nodejs/bin/." "@pulumi/pulumi"
 
 # Tar up the file and then print it out for use by the caller or script.
 tar -czf ${PUBFILE} -C ${PUBDIR} .

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,13 +1,26 @@
 #!/bin/bash
 # publish.sh builds and publishes a release.
-set -e
+set -o nounset -o errexit -o pipefail
 
 PUBLISH=$GOPATH/src/github.com/pulumi/home/scripts/publish.sh
+PUBLISH_GOOS=("linux" "windows" "darwin")
+PUBLISH_GOARCH=("amd64")
+PUBLISH_PROJECT="pulumi"
+
 if [ ! -f $PUBLISH ]; then
     >&2 echo "error: Missing publish script at $PUBLISH"
     exit 1
 fi
 
-RELEASE_INFO=($($(dirname $0)/make_release.sh))
-${PUBLISH} ${RELEASE_INFO[0]} pulumi ${RELEASE_INFO[@]:1}
+for OS in "${PUBLISH_GOOS[@]}"
+do
+    for ARCH in "${PUBLISH_GOARCH[@]}"
+    do
+        export GOOS=${OS}
+        export GOARCH=${ARCH}
+
+        RELEASE_INFO=($($(dirname $0)/make_release.sh))
+        ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
+    done
+done
 


### PR DESCRIPTION
This change does two things:

1. During publishing, crossbuilds the golang code (publishing a different tgz for each arch)
2. Changes the layout to just have `bin` and `node_modules` folders.