### PR TITLE
Support for destructing patterns in free variable computation

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -1,7 +1,7 @@
 PROCCNT=$(shell nproc --all)
 
 .PHONY: default
-default: banner build install
+default: banner build test install
 
 .PHONY: banner
 banner:
@@ -28,6 +28,11 @@ clean:
 build:
 	@echo "\033[0;32mBUILD:\033[0m"
 	yarn run build
+
+.PHONY: test
+test:
+	@echo "\033[0;32mTEST:\033[0m"
+	yarn run test
 
 .PHONY: install
 install:

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -118,7 +118,8 @@ describe("closure", () => {
         });
     }
     {
-        let nocap1 = 1, nocap2 = 2, nocap3 = 3, nocap4 = 4, nocap5 = 5, nocap6 = 6, nocap7 = 7;
+        let nocap1 = 1, nocap2 = 2, nocap3 = 3, nocap4 = 4, nocap5 = 5, nocap6 = 6, nocap7 = 7,
+            nocap8 = 8, nocap9 = 9, nocap10 = 10;
         let cap1 = 100, cap2 = 200, cap3 = 300, cap4 = 400;
         let functext = `((nocap1, nocap2) => {
     let zz = nocap1 + nocap2; // not a capture: args
@@ -147,6 +148,8 @@ describe("closure", () => {
         function nocap7() {
         }
     }
+    let [{t: [nocap8]},,nocap9 = "hello",...nocap10] = [{t: [true]},null,undefined,1,2];
+    let vvv = [nocap8, nocap9, nocap10]; // not a capture; declarations from destructuring
 })`;
         cases.push({
             title: "Doesn't serialize non-free variables (but retains frees)",

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -425,7 +425,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@7.1.1, glob@^7.0.3, glob@^7.0.5:
+glob@7.1.1, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.1.tgz#805211df04faaf1c63a3600306cdf5ade50b2ec8"
   dependencies:
@@ -446,7 +446,7 @@ glob@^5.0.15:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.1, glob@~7.1.2:
+glob@~7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:


### PR DESCRIPTION
Adds a new recursive AST visitor for processing variable declaration bindings to handle nested array/object/assignment/rest patterns as well as plain identifiers inside variable bindings.

Also runs sdk/nodejs tests by default during build.