### PR TITLE
Run Travis on both macOS and Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+jobs:
+    include:
+        -
+            os: linux
+        -
+            if: type IN (push, api, cron)
+            os: osx
 language: go
 go: 1.9
 sudo: true # give us 7.5GB and >2 bursted cores.
@@ -16,6 +23,7 @@ before_install:
     - export PATH=$HOME/.yarn/bin:$PATH
     # Install the AWS CLI so that we can publish the resulting release (if applicable) at the end.
     - pip install --upgrade --user awscli
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$PATH:$HOME/Library/Python/2.7/bin; fi
 cache:
     yarn: true
 install:

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,7 +3,6 @@
 set -o nounset -o errexit -o pipefail
 
 PUBLISH=$GOPATH/src/github.com/pulumi/home/scripts/publish.sh
-PUBLISH_GOOS=("linux" "darwin")
 PUBLISH_GOARCH=("amd64")
 PUBLISH_PROJECT="pulumi"
 
@@ -12,15 +11,14 @@ if [ ! -f $PUBLISH ]; then
     exit 1
 fi
 
-for OS in "${PUBLISH_GOOS[@]}"
-do
-    for ARCH in "${PUBLISH_GOARCH[@]}"
-    do
-        export GOOS=${OS}
-        export GOARCH=${ARCH}
+OS=$(go env GOOS)
 
-        RELEASE_INFO=($($(dirname $0)/make_release.sh))
-        ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
-    done
+for ARCH in "${PUBLISH_GOARCH[@]}"
+do
+    export GOARCH=${ARCH}
+
+    RELEASE_INFO=($($(dirname $0)/make_release.sh))
+    ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
 done
+
 


### PR DESCRIPTION
Unlike go binaries (where we can cross compile) the node module that
we publish needs to be built on the platform we publish for. Update
our `.travis.yml` file to also build on macOS and fix the publishing
script so we don't don't cross publish Darwin from Linux. Once we have
CI working for Windows, we'll remove the loop over PUBLISH_GOOS and
each build will publish just the artifacts for the host OS.