### PR TITLE
Fix #372.

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -221,19 +221,20 @@ func printChangeSummary(b *bytes.Buffer, counts map[deploy.StepOp]int, preview b
 		colors.SpecInfo, colors.Reset, changesLabel, plural("change", changes), kind))
 
 	var planTo string
-	var pastTense string
 	if preview {
 		planTo = "to "
-	} else {
-		pastTense = "d"
 	}
 
 	// Now summarize all of the changes; we print sames a little differently.
 	for _, op := range deploy.StepOps {
 		if op != deploy.OpSame {
 			if c := counts[op]; c > 0 {
-				b.WriteString(fmt.Sprintf("    %v%v %v %v%v%v%v\n",
-					op.Prefix(), c, plural("resource", c), planTo, op, pastTense, colors.Reset))
+				opDescription := string(op)
+				if !preview {
+					opDescription = op.PastTense()
+				}
+				b.WriteString(fmt.Sprintf("    %v%v %v %v%v%v\n",
+					op.Prefix(), c, plural("resource", c), planTo, opDescription, colors.Reset))
 			}
 		}
 	}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -416,6 +416,18 @@ func (op StepOp) Prefix() string {
 	}
 }
 
+func (op StepOp) PastTense() string {
+	switch op {
+	case OpSame, OpCreate, OpDelete, OpReplace, OpCreateReplacement, OpDeleteReplaced:
+		return string(op) + "d"
+	case OpUpdate:
+		return "modified"
+	default:
+		contract.Failf("Unrecognized resource step op: %v", op)
+		return ""
+	}
+}
+
 // Suffix returns a suggested suffix for lines of this op type.
 func (op StepOp) Suffix() string {
 	if op == OpCreateReplacement || op == OpUpdate || op == OpReplace {


### PR DESCRIPTION
Print "modified" rather than "modifyd". This introduces a new method,
`resource.StepOp.PastTense()`, which returns the past tense description
of the operation.