### PR TITLE
Use explicit targets in Makefile for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ install:
 before_script:
     - export PATH=$TRAVIS_BUILD_DIR/sdk/nodejs/bin:$PATH
 script:
-    - if [ $TRAVIS_EVENT_TYPE = "cron" ]; then make nightly; else make; fi
-after_success:
-    - if [ $TRAVIS_EVENT_TYPE = "push" ]; then make publish; fi
+    - make travis_${TRAVIS_EVENT_TYPE}
 notifications:
   slack:
     secure: tPhYdqclnOhFTiKhLn0EqY4/UhJ30c3SFRKHTMPYFfYflCQOyrIARYrzlm+oEOBISw/oNP0wR1LxawhLC2KfDb0ST9Zph8wKyQ8dujk9jXGACuuRic1n/IU9yiu2grZQqcwlieLN6IvGvK+736D2ZxhcjUF5ZwORkpe9jl+nr65NzWH5H+pr4jVWXvYddB2gJ/49i+COydfbaRJ+6O3JORqmSP2VA4CtrArl0L/uDT0osvBwJkeoTSzKjkPWZUwI3ZlGOCSGe+6i5hto6WOzUnU74UgNVZ6dCUOKJrmu146DDzTYB7g4xTkiBi8W5jEo7E6PRqAA6/zGGzUp0J8AMmKcrYnmBf3ALaAIzwiQAFwn9m4V3cKEnnfwzN+SrrmrA3KpwWuj2PNS0UEaxFr35Lb7NNORibmBJi5gj9q138C+b9uD5MQ3poq0PpXG+ZPYTQU1QZODsxcHpR3OyyI89OXBugrP9CTcYpknUgPmiAJgOQn+7H+Xcmme3CB9G5292hC5McZZtyxUAoNwAtg316bXSWWH9MkFRmjTWt7lRGZZ99T1TO/iG0DntyCWxy8lHIbYvCdbY5oTN3WMN93NFrmFMiZJcmmV79meMe/6LNLWVIWVaTXZSpS8IflRmVFp1twveSh4i1+mogh8CsMs2Lqp2Ca7HdakLtRBxHzcH/4=

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ ECHO=echo -e
 GOMETALINTERBIN=gometalinter
 GOMETALINTER=${GOMETALINTERBIN} --config=Gometalinter.json
 
-.PHONY: default
+.PHONY: all
 all: banner_all core sdk/nodejs integrationtest
 
 .PHONY: nightly
-nightly: default gocover
+nightly: all gocover
 
 .PHONY: core
 core: vet test install lint_quiet
@@ -95,3 +95,15 @@ gocover:
 	@$(ECHO) "\033[0;32mGO CODE COVERAGE:\033[0m"
 	./scripts/gocover.sh
 
+# The travis_* targets are entrypoints for CI.
+.PHONY: travis_cron
+travis_cron: nightly
+
+.PHONY: travis_push
+travis_push: all publish
+
+.PHONY: travis_pull_request
+travis_pull_request: all
+
+.PHONY: travis_api
+travis_api: all


### PR DESCRIPTION
Defer build and publish logic into the makefiles instead of trying to
use Travis to do so. This let's us sidestep Travis's not great error
handling (see pulumi/home#21 for more details)