### PR TITLE
Support module capture without serialization

### DIFF
--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -177,6 +177,38 @@ describe("closure", () => {
             runtime: "nodejs",
         },
     });
+    {
+        let os = require("os");
+        cases.push({
+            title: "Capture built-in modules as stable references, not serialized values",
+            func: () => os,
+            expect: {
+                code: `(() => os)`,
+                environment: {
+                    os: {
+                        module: "os",
+                    },
+                },
+                runtime: "nodejs",
+            },
+        });
+    }
+    {
+        let util = require("../util");
+        cases.push({
+            title: "Capture user-defined modules as stable references, not serialized values",
+            func: () => util,
+            expect: {
+                code: `(() => util)`,
+                environment: {
+                    util: {
+                        module: "./bin/tests/util.js",
+                    },
+                },
+                runtime: "nodejs",
+            },
+        });
+    }
     cases.push({
         title: "Don't capture catch variables",
         // tslint:disable-next-line
@@ -276,7 +308,7 @@ describe("closure", () => {
             },
         };
         cases.push({
-            title: "Serializes `this` capturing closures",
+            title: "Serializes `this` capturing arrow functions",
             func: cap.f,
             expect: {
                 code: "(() => { console.log(this.x); })",
@@ -285,6 +317,15 @@ describe("closure", () => {
             },
         });
     }
+    cases.push({
+        title: "Don't serialize `this` in function expressions",
+        func: function() { return this; },
+        expect: {
+            code: `(function () { return this; })`,
+            environment: {},
+            runtime: "nodejs",
+        },
+    });
 
     // Now go ahead and run the test cases, each as its own case.
     for (let test of cases) {


### PR DESCRIPTION
This change adds first class support for capturing objects which are references to loaded Node modules.

If an object to be serialized is found as a loaded module which can be referenced as `require(<name>)`, then is is not serialized and is passed as a new kind of environment entry - `module` which will be de-serialized as a `require` statement.

Supports three cases:
1. built-in modules such as `http` and `path`
2. dependencies in the `node_modules` folder
3. other user-defined modules in the source folder

This allows natural use of `import`s with "inside" code.  For example - note the use of `$` in the outside scope only on the "inside".

```typescript
import * as cloud from "@pulumi/cloud";
import * as $ from "cheerio";
let queue = new pulumi.Topic<string>("sites_to_process");
queue.subscribe("foreachurl", async (url) => {
    let x = $("a", "<a href='foo'>hello</a>");
});
```

Also fixes free variable capture of `this` in arrow functions.

Fixes #342.