### PR TITLE
Rename envCmdInfo to planContext

### DIFF
--- a/pkg/engine/config_delete.go
+++ b/pkg/engine/config_delete.go
@@ -11,7 +11,7 @@ import (
 func (eng *Engine) DeleteConfig(envName tokens.QName, key tokens.ModuleMember) error {
 	contract.Require(envName != tokens.QName(""), "envName")
 
-	info, err := eng.initEnvCmdName(envName, "")
+	info, err := eng.planContextFromEnvironment(envName, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/config_list.go
+++ b/pkg/engine/config_list.go
@@ -10,7 +10,7 @@ import (
 func (eng *Engine) GetConfiguration(environment tokens.QName) (map[tokens.ModuleMember]string, error) {
 	contract.Require(environment != tokens.QName(""), "environment")
 
-	info, err := eng.initEnvCmdName(environment, "")
+	info, err := eng.planContextFromEnvironment(environment, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/config_set.go
+++ b/pkg/engine/config_set.go
@@ -11,7 +11,7 @@ import (
 func (eng *Engine) SetConfig(envName tokens.QName, key tokens.ModuleMember, value string) error {
 	contract.Require(envName != tokens.QName(""), "envName")
 
-	info, err := eng.initEnvCmdName(envName, "")
+	info, err := eng.planContextFromEnvironment(envName, "")
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func (eng *Engine) SetConfig(envName tokens.QName, key tokens.ModuleMember, valu
 // the environment. Note that config values that were present in the old environment but are
 // not present in `newConfig` will be removed from the environment
 func (eng *Engine) ReplaceConfig(envName tokens.QName, newConfig map[tokens.ModuleMember]string) error {
-	info, err := eng.initEnvCmdName(envName, "")
+	info, err := eng.planContextFromEnvironment(envName, "")
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/deploy.go
+++ b/pkg/engine/deploy.go
@@ -39,7 +39,7 @@ func (eng *Engine) Deploy(environment tokens.QName, opts DeployOptions) error {
 		Debug:  opts.Debug,
 	})
 
-	info, err := eng.initEnvCmdName(environment, opts.Package)
+	info, err := eng.planContextFromEnvironment(environment, opts.Package)
 	if err != nil {
 		return err
 	}
@@ -70,7 +70,7 @@ type deployOptions struct {
 	DOT                  bool     // true if we should print the DOT file for this plan.
 }
 
-func (eng *Engine) deployLatest(info *envCmdInfo, opts deployOptions) error {
+func (eng *Engine) deployLatest(info *planContext, opts deployOptions) error {
 	result, err := eng.plan(info, opts)
 	if err != nil {
 		return err

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -18,7 +18,7 @@ type DestroyOptions struct {
 func (eng *Engine) Destroy(environment tokens.QName, opts DestroyOptions) error {
 	contract.Require(environment != tokens.QName(""), "environment")
 
-	info, err := eng.initEnvCmdName(environment, opts.Package)
+	info, err := eng.planContextFromEnvironment(environment, opts.Package)
 	if err != nil {
 		return err
 	}

--- a/pkg/engine/env.go
+++ b/pkg/engine/env.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
-func (eng *Engine) initEnvCmdName(name tokens.QName, pkgarg string) (*envCmdInfo, error) {
+func (eng *Engine) planContextFromEnvironment(name tokens.QName, pkgarg string) (*planContext, error) {
 	contract.Require(name != tokens.QName(""), "name")
 
 	// Read in the deployment information, bailing if an IO error occurs.
@@ -25,7 +25,7 @@ func (eng *Engine) initEnvCmdName(name tokens.QName, pkgarg string) (*envCmdInfo
 
 	contract.Assert(target != nil)
 	contract.Assert(checkpoint != nil)
-	return &envCmdInfo{
+	return &planContext{
 		Target:     target,
 		Checkpoint: checkpoint,
 		Snapshot:   snapshot,
@@ -33,7 +33,7 @@ func (eng *Engine) initEnvCmdName(name tokens.QName, pkgarg string) (*envCmdInfo
 	}, nil
 }
 
-type envCmdInfo struct {
+type planContext struct {
 	Target     *deploy.Target          // the target environment.
 	Checkpoint *environment.Checkpoint // the full serialized checkpoint from which this came.
 	Snapshot   *deploy.Snapshot        // the environment's latest deployment snapshot

--- a/pkg/engine/env_remove.go
+++ b/pkg/engine/env_remove.go
@@ -11,7 +11,7 @@ import (
 func (eng *Engine) RemoveEnv(envName tokens.QName, force bool) error {
 	contract.Assert(envName != "")
 
-	info, err := eng.initEnvCmdName(envName, "")
+	info, err := eng.planContextFromEnvironment(envName, "")
 
 	if err != nil {
 		return err

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -19,7 +19,7 @@ import (
 )
 
 // plan just uses the standard logic to parse arguments, options, and to create a snapshot and plan.
-func (eng *Engine) plan(info *envCmdInfo, opts deployOptions) (*planResult, error) {
+func (eng *Engine) plan(info *planContext, opts deployOptions) (*planResult, error) {
 	contract.Assert(info != nil)
 	contract.Assert(info.Target != nil)
 
@@ -68,7 +68,7 @@ func (eng *Engine) plan(info *envCmdInfo, opts deployOptions) (*planResult, erro
 
 type planResult struct {
 	Ctx     *plugin.Context // the context containing plugins and their state.
-	Info    *envCmdInfo     // plan command information.
+	Info    *planContext    // plan command information.
 	Plan    *deploy.Plan    // the plan created by this command.
 	Options deployOptions   // the deployment options.
 }

--- a/pkg/engine/preview.go
+++ b/pkg/engine/preview.go
@@ -29,7 +29,7 @@ func (eng *Engine) Preview(environment tokens.QName, opts PreviewOptions) error 
 		Debug:  opts.Debug,
 	})
 
-	info, err := eng.initEnvCmdName(environment, opts.Package)
+	info, err := eng.planContextFromEnvironment(environment, opts.Package)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This name is still not great, but the old name was really, really bad.