### PR TITLE
Support -C/--cwd instead of path to package

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -36,7 +36,6 @@ func newDestroyCmd() *cobra.Command {
 			if preview || yes ||
 				confirmPrompt("This will permanently destroy all resources in the '%v' environment!", envName.String()) {
 				return lumiEngine.Destroy(envName, engine.DestroyOptions{
-					Package:  pkgargFromArgs(args),
 					DryRun:   preview,
 					Debug:    debug,
 					Parallel: parallel,

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -19,7 +19,7 @@ func newPreviewCmd() *cobra.Command {
 	var showSames bool
 	var summary bool
 	var cmd = &cobra.Command{
-		Use:   "preview [<package>] [-- [<args>]]",
+		Use:   "preview",
 		Short: "Show a preview of updates to an environment's resources",
 		Long: "Show a preview of updates an environment's resources\n" +
 			"\n" +
@@ -30,8 +30,8 @@ func newPreviewCmd() *cobra.Command {
 			"determine what operations must take place to achieve the desired state. No changes to the\n" +
 			"environment will actually take place.\n" +
 			"\n" +
-			"By default, the package to execute is loaded from the current directory. Optionally, an\n" +
-			"explicit path can be provided using the [package] argument.",
+			"The package to execute is loaded from the current directory. Use the `-C` or `--cwd` flag to\n" +
+			"use a different directory.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			envName, err := explicitOrCurrent(env)
 			if err != nil {
@@ -39,7 +39,6 @@ func newPreviewCmd() *cobra.Command {
 			}
 
 			return lumiEngine.Preview(envName, engine.PreviewOptions{
-				Package:              pkgargFromArgs(args),
 				Debug:                debug,
 				Analyzers:            analyzers,
 				Parallel:             parallel,

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -31,9 +31,17 @@ func NewPulumiCmd() *cobra.Command {
 	var logFlow bool
 	var logToStderr bool
 	var verbose int
+	var cwd string
 	cmd := &cobra.Command{
 		Use: "pulumi",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if cwd != "" {
+				err := os.Chdir(cwd)
+				if err != nil {
+					cmdutil.ExitError(err.Error())
+				}
+			}
+
 			cmdutil.InitLogging(logToStderr, verbose, logFlow)
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
@@ -41,6 +49,7 @@ func NewPulumiCmd() *cobra.Command {
 		},
 	}
 
+	cmd.PersistentFlags().StringVarP(&cwd, "cwd", "C", "", "Run pulumi as if it had been started in another directory")
 	cmd.PersistentFlags().BoolVar(&logFlow, "logflow", false, "Flow log settings to child processes (like plugins)")
 	cmd.PersistentFlags().BoolVar(&logToStderr, "logtostderr", false, "Log to stderr instead of to files")
 	cmd.PersistentFlags().IntVarP(
@@ -54,14 +63,6 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.AddCommand(newVersionCmd())
 
 	return cmd
-}
-
-func pkgargFromArgs(args []string) string {
-	if len(args) > 0 {
-		return args[0]
-	}
-
-	return ""
 }
 
 func confirmPrompt(msg string, name string) bool {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -20,7 +20,7 @@ func newUpdateCmd() *cobra.Command {
 	var showSames bool
 	var summary bool
 	var cmd = &cobra.Command{
-		Use:   "update [<package>] [-- [<args>]]",
+		Use:   "update",
 		Short: "Update the resources in an environment",
 		Long: "Update the resources in an environment\n" +
 			"\n" +
@@ -31,8 +31,8 @@ func newUpdateCmd() *cobra.Command {
 			"must take place to achieve the desired state. This command results in a full snapshot of the\n" +
 			"environment's new resource state, so that it may be updated incrementally again later.\n" +
 			"\n" +
-			"By default, the package to execute is loaded from the current directory. Optionally, an\n" +
-			"explicit path can be provided using the [package] argument.",
+			"The package to execute is loaded from the current directory. Use the `-C` or `--cwd` flag to\n" +
+			"use a different directory.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			envName, err := explicitOrCurrent(env)
 			if err != nil {
@@ -40,7 +40,6 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			return lumiEngine.Deploy(envName, engine.DeployOptions{
-				Package:              pkgargFromArgs(args),
 				Debug:                debug,
 				DryRun:               dryRun,
 				Analyzers:            analyzers,


### PR DESCRIPTION
Previously, you could pass an explicit path to a Pulumi program when
running preview or update and the tool would use that program when
planning or deploying, but continue to write state in the cwd. While
being able to operate on a specific package without having to cd'd all
over over the place is nice, this specific implemntation was a little
scary because it made it easier to run two different programs with the
same local state (e.g config and checkpoints) which would lead to
surprising results.

Let's move to a model that some tools have where you can pass a
working directory and the tool chdir's to that directory before
running. This way any local state that is stored will be stored
relative to the package we are operating on instead of whatever the
current working directory is.

Fixes #398