### PR TITLE
Move serialization of Closures to JavaScript text to pulumi SDK

### DIFF
--- a/sdk/nodejs/runtime/closure.ts
+++ b/sdk/nodejs/runtime/closure.ts
@@ -1,6 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
 import * as acorn from "acorn";
+import * as crypto from "crypto";
 import * as estree from "estree";
 import { relative as pathRelative } from "path";
 import { debuggablePromise } from "./debuggable";
@@ -508,3 +509,154 @@ class FreeVariableComputer {
     }
 }
 
+/**
+ * serializeJavaScript Text converts a Closure object into a string
+ * representation of a Node.js module body which exposes a single function
+ * `exports.handler` representing the serialized function.
+ * @param c The Closure to be serialized into a module string.
+ */
+export function serializeJavaScriptText(c: Closure): string {
+    // Ensure the closure is targeting a supported runtime.
+    if (c.runtime !== "nodejs") {
+        throw new Error(`Runtime '${c.runtime}' not yet supported (currently only 'nodejs')`);
+    }
+
+    // Now produce a textual representation of the closure and its serialized captured environment.
+    let funcsForClosure = new FuncsForClosure(c);
+    let funcs = funcsForClosure.funcs;
+    let text = "exports.handler = " + funcsForClosure.root + ";\n\n";
+    for (let name of Object.keys(funcs)) {
+        text +=
+            "function " + name + "() {\n" +
+            "  var _this;\n" +
+            "  with(" + envObjToString(funcs[name].env) + ") {\n" +
+            "    return (function() {\n\n" +
+            "return " + funcs[name].code + "\n\n" +
+            "    }).apply(_this).apply(this, arguments);\n" +
+            "  }\n" +
+            "}\n" +
+            "\n";
+    }
+    return text;
+}
+
+interface FuncEnv {
+    code: string;
+    env: { [key: string]: string; };
+}
+
+/**
+ * FuncsForClosure collects all the function defintions needed to support serialization of a given Closure object.
+ * Context is the shape of the context object passed to a Function callback.
+ * Note that a Closure object can reference other Closure objects and can also have cycles, so we recursively walk the
+ * graph and cache serialized nodes along the way to avoid cycles.
+ */
+class FuncsForClosure {
+    public funcs: { [hash: string]: FuncEnv }; // a cache of functions.
+    public root: string;                       // the root closure hash.
+
+    constructor(closure: Closure) {
+        this.funcs = {};
+        this.root = this.createFuncForClosure(closure);
+    }
+
+    private createFuncForClosure(closure: Closure): string {
+        // Produce a hash to identify the function.
+        let shasum: crypto.Hash = crypto.createHash("sha1");
+        shasum.update(closure.code);
+        let hash: string = "__" + shasum.digest("hex");
+
+        // Now only store if this function hasn't already been hashed.
+        if (this.funcs[hash] === undefined) {
+            this.funcs[hash] = {
+                code: closure.code,
+                env: {}, // initialize as empty - update after recursive call
+            };
+            this.funcs[hash].env = this.envFromEnvObj(closure.environment);
+        }
+
+        return hash;
+    }
+
+    private envFromEnvObj(env: Environment): {[key: string]: string} {
+        let envObj: {[key: string]: string} = {};
+        for (let key of Object.keys(env)) {
+            let val = this.envEntryToString(env[key]);
+            if (val !== undefined) {
+                envObj[key] = val;
+            }
+        }
+        return envObj;
+    }
+
+    private envFromEnvArr(arr: EnvironmentEntry[]): (string | undefined)[] {
+        let envArr: (string | undefined)[] = [];
+        for (let i = 0; i < arr.length; i++) {
+            envArr[i] = this.envEntryToString(arr[i]);
+        }
+        return envArr;
+    }
+
+    private envEntryToString(envEntry: EnvironmentEntry): string | undefined {
+        if (envEntry.json !== undefined) {
+            return JSON.stringify(envEntry.json);
+        }
+        else if (envEntry.closure !== undefined) {
+            let innerHash = this.createFuncForClosure(envEntry.closure);
+            return innerHash;
+        }
+        else if (envEntry.obj !== undefined) {
+            return envObjToString(this.envFromEnvObj(envEntry.obj));
+        }
+        else if (envEntry.arr !== undefined) {
+            return envArrToString(this.envFromEnvArr(envEntry.arr));
+        }
+        else if (envEntry.module !== undefined) {
+            return `require("${envEntry.module}")`;
+        }
+        else {
+            return undefined;
+        }
+    }
+}
+
+/**
+ * Converts an environment object into a string which can be embedded into a serialized function body.  Note that this
+ * is not JSON serialization, as we may have proeprty values which are variable references to other global functions.
+ * In other words, there can be free variables in the resulting object literal.
+ *
+ * @param envObj The environment object to convert to a string.
+ */
+function envObjToString(envObj: { [key: string]: string; }): string {
+    let result = "";
+    let first = true;
+    for (let key of Object.keys(envObj)) {
+        let val = envObj[key];
+
+        // Rewrite references to `this` to the special name `_this`.  This will get rewritten to use `.apply` later.
+        if (key === "this") {
+            key = "_this";
+        }
+
+        if (!first) {
+            result += ", ";
+        }
+
+        result += key + ": " + val;
+        first = false;
+    }
+    return "{ " + result + " }";
+}
+
+function envArrToString(envArr: (string | undefined)[]): string {
+    let result = "";
+    let first = true;
+    for (let i = 0; i < envArr.length; i++) {
+        if (!first) {
+            result += ", ";
+        }
+        result += envArr[i];
+        first = false;
+    }
+    return "[ " + result + " ]";
+}

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -8,6 +8,7 @@ interface ClosureCase {
     title: string;            // a title banner for the test case.
     func: Function;           // the function whose body and closure to serialize.
     expect?: runtime.Closure; // if undefined, error expected; otherwise, the serialized shape.
+    expectText?: string;      // optionally also validate the serialization to JavaScript text.
 }
 
 // This group of tests ensure that we serialize closures properly.
@@ -24,6 +25,20 @@ describe("closure", () => {
             environment: {},
             runtime: "nodejs",
         },
+        expectText: `exports.handler = __b2fc45402c8ebf8ff0305045b5863b179df417e2;
+
+function __b2fc45402c8ebf8ff0305045b5863b179df417e2() {
+  var _this;
+  with({  }) {
+    return (function() {
+
+return (function () { })
+
+    }).apply(_this).apply(this, arguments);
+  }
+}
+
+`,
     });
     cases.push({
         title: "Empty arrow closure",
@@ -333,6 +348,10 @@ describe("closure", () => {
             if (test.expect) {
                 let closure: runtime.Closure = await runtime.serializeClosure(test.func);
                 assert.deepEqual(closure, test.expect);
+                if (test.expectText) {
+                    let text = runtime.serializeJavaScriptText(closure);
+                    assert.equal(text, test.expectText);
+                }
             } else {
                 await assertAsyncThrows(async () => {
                     await runtime.serializeClosure(test.func);


### PR DESCRIPTION
This logic was previously in the `@pulumi/aws` pacakge.  Moving it into the `pulumi` SDK as part of the overall closure serialization logic to make it more broadly accessible, and to centralize this functionality.

Now that it's all in one place, we may decide to remove the publically exposed `Closure` abstraction completely, which may also enable significant simplicifcation to the logic in closure serialization.

Also add one initial test case for this code.

Fixes pulumi/pulumi-aws#14.