### PR TITLE
Construct version based on git information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ TESTPARALLELISM=10
 ECHO=echo -e
 GOMETALINTERBIN=gometalinter
 GOMETALINTER=${GOMETALINTERBIN} --config=Gometalinter.json
+VERSION=$(shell git describe --tags 2>/dev/null)
 
 .PHONY: all
 all: banner_all core sdk/nodejs integrationtest
@@ -35,8 +36,8 @@ banner_all:
 .PHONY: install
 install:
 	@$(ECHO) "\033[0;32mINSTALL:\033[0m"
-	go install ${PROJECT}
-	go install ${PROJECT}/cmd/lumidl
+	go install -ldflags "-X main.version=${VERSION}" ${PROJECT}
+	go install -ldflags "-X main.version=${VERSION}" ${PROJECT}/cmd/lumidl
 
 .PHONY: lint
 lint:

--- a/build.proj
+++ b/build.proj
@@ -107,11 +107,11 @@
       <GoCmdsToBuild Include="github.com/pulumi/pulumi/cmd/lumidl" />
     </ItemGroup>
 
-    <Exec Command="go install %(GoCmdsToBuild.Identity)" />
+    <Exec Command="git describe --tags 2>nul" ConsoleToMSBuild="true" Condition="'$(Version)' == ''">
+      <Output TaskParameter="ConsoleOutput" PropertyName="Version" />
+    </Exec>
 
-    <ItemGroup>
-      <GoCmdsToBuild />
-    </ItemGroup>
+    <Exec Command="go install -ldflags &quot;-X main.version=$(Version)&quot; %(GoCmdsToBuild.Identity)" />
   </Target>
 
   <Target Name="Build"

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -29,7 +29,7 @@ func init() {
 }
 
 // NewPulumiCmd creates a new Pulumi Cmd instance.
-func NewPulumiCmd() *cobra.Command {
+func NewPulumiCmd(version string) *cobra.Command {
 	var logFlow bool
 	var logToStderr bool
 	var verbose int
@@ -62,7 +62,7 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.AddCommand(newEnvCmd())
 	cmd.AddCommand(newPreviewCmd())
 	cmd.AddCommand(newUpdateCmd())
-	cmd.AddCommand(newVersionCmd())
+	cmd.AddCommand(newVersionCmd(version))
 
 	// Tell flag about -C, so someone can do pulumi -C <working-directory> env and the call to cmdutil.InitLogging
 	// which calls flag.Parse under the hood doesn't yell at you.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,14 +9,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.6.1" // TODO[pulumi/pulumi#13]: a real auto-incrementing version number.
-
-func newVersionCmd() *cobra.Command {
+func newVersionCmd(version string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print Pulumi's version number",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			fmt.Printf("Pulumi version %v\n", version)
+			fmt.Printf("%v\n", version)
 			return nil
 		}),
 	}

--- a/main.go
+++ b/main.go
@@ -10,8 +10,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
+var version = "<unknown>" // Our Makefiles override this by pasing -X main.version to the linker
+
 func main() {
-	if err := cmd.NewPulumiCmd().Execute(); err != nil {
+	if err := cmd.NewPulumiCmd(version).Execute(); err != nil {
 		_, err = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		contract.IgnoreError(err)
 		os.Exit(-1)


### PR DESCRIPTION
We use `git describe --tags` to construct a version number based on
the current version tag.

The properties VERSION (when using make) and Version (when using
MSBuild) can be explicitly set to use a fixed value instead.

Fixes #13