### PR TITLE
Write a .yarnrc file when running tests to enable mutex

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -245,6 +245,14 @@ func prepareProject(t *testing.T, srcDir string, lumiSrc string, opts LumiProgra
 		}
 	}
 
+	// Write a .yarnrc file to pass --mutex network to all yarn invocations, since tests
+	// may run concurrently and yarn may fail if invoked concurrently
+	// https://github.com/yarnpkg/yarn/issues/683
+	yarnrcerr := ioutil.WriteFile(filepath.Join(dir, ".yarnrc"), []byte("--mutex network\n"), 0644)
+	if yarnrcerr != nil {
+		return "", yarnrcerr
+	}
+
 	// Now ensure dependencies are present.
 	RunCommand(t, withOptionalYarnFlags([]string{opts.YarnBin, "install", "--verbose"}), dir, opts)
 	for _, dependency := range opts.Dependencies {


### PR DESCRIPTION
In #411 we started to run tests in parallel again. To support that, we
added a .yarnrc file in the root of our repository to pass --mutex
network to all yarn invocations, because tests may run yarn commands
concurrently with one another and yarn is not safe to run
concurrently.

However, when we run the integration tests, we actually copy them into
a folder under `/tmp` and so yarn's logic to walk up the directory to
tree to find a `.yarnrc` will not see this `.yarnrc` and we're back
where we started.

Have the testing package explicitly write this file, which should
prevent this issue from happening in the future.