### PR TITLE
Secrets in Pulumi.yaml

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,12 @@
 
 
 [[projects]]
+  name = "github.com/bgentry/speakeasy"
+  packages = ["."]
+  revision = "4aabc24848ce5fd31929f7d1e4ea74d3709c14cd"
+  version = "v0.1.0"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
@@ -70,7 +76,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = ["pbkdf2","ssh/terminal"]
   revision = "74b34b9dd60829a9fcaf56a59e81c3877a8ecd2c"
 
 [[projects]]
@@ -118,6 +124,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "550845a56ab0a1d7523ebe43fe3885254e4e6740a615714022bfef8a7a8796d9"
+  inputs-digest = "687b22c2bbc91854f6457658d31cfe26d030ba8d3af1ac3d72161a554c366d4b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/crypt.go
+++ b/cmd/crypt.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	cryptorand "crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+
+	"github.com/pkg/errors"
+)
+
+const aes256GCMKeyBytes = 32
+
+// This implements to config.EncrypterDecrypter interface but panics if any methods are called.
+type panicCrypter struct{}
+
+func (p panicCrypter) EncryptValue(plaintext string) (string, error) {
+	panic("attempt to encrypt value")
+}
+
+func (p panicCrypter) DecryptValue(ciphertext string) (string, error) {
+	panic("attempt to decrypt value")
+}
+
+// symmetricCrypter encrypts and decrypts values using AES-256-GCM. The nonce is stored with the value itself as a pair of base64 values
+// separated by a colon and a version tag `v1` is prepended.
+type symmetricCrypter struct {
+	key []byte
+}
+
+func (s symmetricCrypter) EncryptValue(value string) (string, error) {
+	secret, nonce := encryptAES256GCGM(value, s.key)
+
+	return fmt.Sprintf("v1:%s:%s", base64.StdEncoding.EncodeToString(nonce), base64.StdEncoding.EncodeToString(secret)), nil
+}
+
+func (s symmetricCrypter) DecryptValue(value string) (string, error) {
+	vals := strings.Split(value, ":")
+
+	if len(vals) != 3 {
+		return "", errors.New("bad value")
+	}
+
+	if vals[0] != "v1" {
+		return "", errors.New("unknown value version")
+	}
+
+	nonce, err := base64.StdEncoding.DecodeString(vals[1])
+	if err != nil {
+		return "", errors.Wrap(err, "bad value")
+	}
+
+	enc, err := base64.StdEncoding.DecodeString(vals[2])
+	if err != nil {
+		return "", errors.Wrap(err, "bad value")
+	}
+
+	return decryptAES256GCM(enc, s.key, nonce)
+}
+
+// given a passphrase and an encryption state, construct a config.ValueEncrypterDecrypter from it. Our encryption
+// state value is a version tag followed by version specific state information. Presently, we only have one version
+// we support (`v1`) which is AES-256-GCM using a key derived from a passphrase using 1,000,000 iterations of PDKDF2
+// using SHA256.
+func symmetricCrypterFromPhraseAndState(phrase string, state string) (config.ValueEncrypterDecrypter, error) {
+	splits := strings.SplitN(state, ":", 3)
+	if len(splits) != 3 {
+		return nil, errors.New("malformed state value")
+	}
+
+	if splits[0] != "v1" {
+		return nil, errors.New("unknown state version")
+	}
+
+	salt, err := base64.StdEncoding.DecodeString(splits[1])
+	if err != nil {
+		return nil, err
+	}
+
+	key := keyFromPassPhrase(phrase, salt, aes256GCMKeyBytes)
+
+	decrypter := symmetricCrypter{key: key}
+
+	decrypted, err := decrypter.DecryptValue(state[indexN(state, ":", 2)+1:])
+
+	if err != nil || decrypted != "pulumi" {
+		return nil, errors.New("incorrect passphrase")
+	}
+
+	return symmetricCrypter{key: key}, nil
+}
+
+func indexN(s string, substr string, n int) int {
+	contract.Require(n > 0, "n")
+	scratch := s
+
+	for i := n; i > 0; i-- {
+		idx := strings.Index(scratch, substr)
+		if i == -1 {
+			return -1
+		}
+
+		scratch = scratch[idx+1:]
+	}
+
+	return len(s) - (len(scratch) + len(substr))
+}
+
+// encryptAES256GCGM returns the ciphertext and the generated nonce
+func encryptAES256GCGM(plaintext string, key []byte) ([]byte, []byte) {
+	contract.Requiref(len(key) == aes256GCMKeyBytes, "key", "AES-256-GCM needs a 32 byte key")
+
+	nonce := make([]byte, 12)
+
+	_, err := cryptorand.Read(nonce)
+	contract.Assertf(err == nil, "could not read from system random source")
+
+	block, err := aes.NewCipher(key)
+	contract.Assert(err == nil)
+
+	aesgcm, err := cipher.NewGCM(block)
+	contract.Assert(err == nil)
+
+	msg := aesgcm.Seal(nil, nonce, []byte(plaintext), nil)
+
+	return msg, nonce
+}
+
+func decryptAES256GCM(ciphertext []byte, key []byte, nonce []byte) (string, error) {
+	contract.Requiref(len(key) == aes256GCMKeyBytes, "key", "AES-256-GCM needs a 32 byte key")
+
+	block, err := aes.NewCipher(key)
+	contract.Assert(err == nil)
+
+	aesgcm, err := cipher.NewGCM(block)
+	contract.Assert(err == nil)
+
+	msg, err := aesgcm.Open(nil, nonce, ciphertext, nil)
+
+	return string(msg), err
+}

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/engine"
+	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 )
 
@@ -39,12 +40,29 @@ func newPreviewCmd() *cobra.Command {
 				return err
 			}
 
+			cfg, err := getConfiguration(stackName)
+			if err != nil {
+				return err
+			}
+
+			var decrypter config.ValueDecrypter = panicCrypter{}
+
+			if hasSecureValue(cfg) {
+				decrypter, err = getSymmetricCrypter()
+				if err != nil {
+					return err
+				}
+			}
+
+			localProvider := localStackProvider{decrypter: decrypter}
+			pulumiEngine := engine.Engine{Targets: localProvider, Snapshots: localProvider}
+
 			events := make(chan engine.Event)
 			done := make(chan bool)
 
 			go displayEvents(events, done, debug)
 
-			if err = lumiEngine.Preview(stackName, events, engine.PreviewOptions{
+			if err = pulumiEngine.Preview(stackName, events, engine.PreviewOptions{
 				Analyzers:            analyzers,
 				Parallel:             parallel,
 				ShowConfig:           showConfig,

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -12,21 +12,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/diag/colors"
-	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 )
-
-var (
-	// The lumi engine provides an API for common lumi tasks.  It's shared across the
-	// `pulumi` command and the deployment engine in the pulumi-service. For `pulumi` we set
-	// the engine to write output and errors to os.Stdout and os.Stderr.
-	lumiEngine    engine.Engine
-	localProvider localStackProvider
-)
-
-func init() {
-	lumiEngine = engine.Engine{Targets: localProvider, Snapshots: localProvider}
-}
 
 // NewPulumiCmd creates a new Pulumi Cmd instance.
 func NewPulumiCmd(version string) *cobra.Command {

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -28,12 +27,10 @@ func newStackCmd() *cobra.Command {
 				return err
 			}
 
-			target, snapshot, err := getStack(stackName)
+			_, config, snapshot, err := getStack(stackName)
 			if err != nil {
 				return err
 			}
-
-			config := target.Config
 
 			fmt.Printf("Current stack is %v\n", stackName)
 			fmt.Printf("    (use `pulumi stack select` to change stack; `pulumi stack ls` lists known ones)\n")
@@ -43,13 +40,6 @@ func newStackCmd() *cobra.Command {
 			}
 			if snapshot != nil {
 				fmt.Printf("Last update at %v\n", snapshot.Time)
-				if snapshot.Info != nil {
-					info, err := json.MarshalIndent(snapshot.Info, "    ", "    ")
-					if err != nil {
-						return err
-					}
-					fmt.Printf("Additional update info:\n    %s\n", string(info))
-				}
 			}
 			if len(config) > 0 {
 				fmt.Printf("%v configuration variables set (see `pulumi config` for details)\n", len(config))

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -5,8 +5,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/pulumi/pulumi/pkg/resource/deploy"
-
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -32,14 +30,12 @@ func newStackInitCmd() *cobra.Command {
 
 			stackName := tokens.QName(args[0])
 
-			if _, _, err := getStack(stackName); err == nil {
+			if _, _, _, err := getStack(stackName); err == nil {
 				return fmt.Errorf("stack '%v' already exists", stackName)
 
 			}
 
-			target := deploy.Target{Name: stackName}
-
-			err := saveStack(&target, nil)
+			err := saveStack(stackName, nil, nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_ls.go
+++ b/cmd/stack_ls.go
@@ -39,7 +39,7 @@ func newStackLsCmd() *cobra.Command {
 
 			fmt.Printf("%-20s %-48s %-12s\n", "NAME", "LAST UPDATE", "RESOURCE COUNT")
 			for _, stack := range stacks {
-				_, snapshot, err := getStack(stack)
+				_, _, snapshot, err := getStack(stack)
 				if err != nil {
 					continue
 				}
@@ -88,7 +88,7 @@ func getStacks() ([]tokens.QName, error) {
 
 		// Read in this stack's information.
 		name := tokens.QName(stackfn[:len(stackfn)-len(ext)])
-		_, _, err := getStack(name)
+		_, _, _, err := getStack(name)
 		if err != nil {
 			continue // failure reading the stack information.
 		}

--- a/cmd/stack_rm.go
+++ b/cmd/stack_rm.go
@@ -37,7 +37,7 @@ func newStackRmCmd() *cobra.Command {
 			if yes ||
 				confirmPrompt("This will permanently remove the '%v' stack!", stackName.String()) {
 
-				target, snapshot, err := getStack(stackName)
+				name, _, snapshot, err := getStack(stackName)
 				if err != nil {
 					return err
 				}
@@ -48,7 +48,7 @@ func newStackRmCmd() *cobra.Command {
 						"'%v' still has resources; removal rejected; pass --force to override", stackName)
 				}
 
-				err = removeStack(target)
+				err = removeStack(name)
 				if err != nil {
 					return err
 				}

--- a/cmd/util_password.go
+++ b/cmd/util_password.go
@@ -1,0 +1,19 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+// +build !windows
+
+package cmd
+
+import (
+	"fmt"
+	"syscall"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+func readConsoleNoEcho() (string, error) {
+	b, err := terminal.ReadPassword(syscall.Stdin)
+
+	fmt.Println() // echo a newline, since the user's keypress did not generate one
+
+	return string(b), err
+}

--- a/cmd/util_password_windows.go
+++ b/cmd/util_password_windows.go
@@ -1,0 +1,18 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+// +build windows
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/bgentry/speakeasy"
+)
+
+func readConsoleNoEcho() (string, error) {
+	s, err := speakeasy.Ask("")
+
+	fmt.Println() // echo a newline, since the user's keypress did not generate one
+
+	return s, err
+}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -24,6 +24,9 @@ func TestExamples(t *testing.T) {
 			Config: map[string]string{
 				"name": "Pulumi",
 			},
+			Secrets: map[string]string{
+				"secret": "this is my secret message",
+			},
 		},
 		{
 			Dir:          path.Join(cwd, "dynamic-provider/simple"),

--- a/examples/minimal/index.ts
+++ b/examples/minimal/index.ts
@@ -4,4 +4,5 @@ import { Config } from "pulumi";
 
 let config = new Config("minimal:config");
 console.log(`Hello, ${config.require("name")}!`);
+console.log(`Psst, ${config.require("secret")}`);
 

--- a/pkg/pack/package.go
+++ b/pkg/pack/package.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pkg/errors"
@@ -33,7 +34,9 @@ type Package struct {
 
 	Analyzers *Analyzers `json:"analyzers,omitempty" yaml:"analyzers,omitempty"` // any analyzers enabled for this project.
 
-	Config map[tokens.ModuleMember]string `json:"config,omitempty" yaml:"config,omitempty"` // optional config that applies to all stacks.
+	EncryptionSalt string `json:"encryptionsalt,omitempty" yaml:"encryptionsalt,omitempty"` // base64 encoded encryption salt.
+
+	Config map[tokens.ModuleMember]config.Value `json:"config,omitempty" yaml:"config,omitempty"` // optional config (applies to all stacks).
 
 	Stacks map[tokens.QName]StackInfo `json:"stacks,omitempty" yaml:"stacks,omitempty"` // optional stack specific information.
 
@@ -42,7 +45,7 @@ type Package struct {
 
 // StackInfo holds stack specific information about a package
 type StackInfo struct {
-	Config map[tokens.ModuleMember]string `json:"config,omitempty" yaml:"config,omitempty"` // optional config.
+	Config map[tokens.ModuleMember]config.Value `json:"config,omitempty" yaml:"config,omitempty"` // optional config.
 }
 
 var _ diag.Diagable = (*Package)(nil)

--- a/pkg/resource/config/value.go
+++ b/pkg/resource/config/value.go
@@ -1,0 +1,115 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package config
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
+)
+
+type Value struct {
+	value  string
+	secure bool
+}
+
+func (c Value) Value(decrypter ValueDecrypter) (string, error) {
+	contract.Require(decrypter != nil, "decrypter")
+
+	if !c.secure {
+		return c.value, nil
+	}
+
+	return decrypter.DecryptValue(c.value)
+}
+
+func (c Value) Secure() bool {
+	return c.secure
+}
+
+func (c *Value) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var m map[string]string
+	err := unmarshal(&m)
+	if err == nil {
+		if len(m) != 1 {
+			return errors.New("malformed secure data")
+		}
+
+		val, has := m["secure"]
+		if !has {
+			return errors.New("malformed secure data")
+		}
+
+		c.value = val
+		c.secure = true
+		return nil
+	}
+
+	c.secure = false
+	return unmarshal(&c.value)
+}
+
+func (c Value) MarshalYAML() (interface{}, error) {
+	if !c.secure {
+		return c.value, nil
+	}
+
+	m := make(map[string]string)
+	m["secure"] = c.value
+
+	return m, nil
+}
+
+func (c *Value) UnmarshalJSON(b []byte) error {
+	var m map[string]string
+	err := json.Unmarshal(b, &m)
+	if err == nil {
+		if len(m) != 1 {
+			return errors.New("malformed secure data")
+		}
+
+		val, has := m["secure"]
+		if !has {
+			return errors.New("malformed secure data")
+		}
+
+		c.value = val
+		c.secure = true
+		return nil
+	}
+
+	return json.Unmarshal(b, &c.value)
+}
+
+func (c Value) MarshalJSON() ([]byte, error) {
+	if !c.secure {
+		return json.Marshal(c.value)
+	}
+
+	m := make(map[string]string)
+	m["secure"] = c.value
+
+	return json.Marshal(m)
+}
+
+func NewSecureValue(v string) Value {
+	return Value{value: v, secure: true}
+}
+
+func NewValue(v string) Value {
+	return Value{value: v, secure: false}
+}
+
+type ValueDecrypter interface {
+	DecryptValue(cypertext string) (string, error)
+}
+
+type ValueEncrypter interface {
+	EncryptValue(plaintext string) (string, error)
+}
+
+type ValueEncrypterDecrypter interface {
+	ValueEncrypter
+	ValueDecrypter
+}

--- a/pkg/resource/config/value_test.go
+++ b/pkg/resource/config/value_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package config
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestMarshallNormalValueYAML(t *testing.T) {
+	v := NewValue("value")
+
+	b, err := yaml.Marshal(v)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("value\n"), b)
+
+	newV, err := roundtripYAML(v)
+	assert.NoError(t, err)
+	assert.Equal(t, v, newV)
+}
+
+func TestMarshallSecureValueYAML(t *testing.T) {
+	v := NewSecureValue("value")
+
+	b, err := yaml.Marshal(v)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("secure: value\n"), b)
+
+	newV, err := roundtripYAML(v)
+	assert.NoError(t, err)
+	assert.Equal(t, v, newV)
+}
+
+func TestMarshallNormalValueJSON(t *testing.T) {
+	v := NewValue("value")
+
+	b, err := json.Marshal(v)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("\"value\""), b)
+
+	newV, err := roundtripJSON(v)
+	assert.NoError(t, err)
+	assert.Equal(t, v, newV)
+}
+
+func TestMarshallSecureValueJSON(t *testing.T) {
+	v := NewSecureValue("value")
+
+	b, err := json.Marshal(v)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("{\"secure\":\"value\"}"), b)
+
+	newV, err := roundtripJSON(v)
+	assert.NoError(t, err)
+	assert.Equal(t, v, newV)
+}
+
+func roundtripYAML(v Value) (Value, error) {
+	return roundtrip(v, yaml.Marshal, yaml.Unmarshal)
+}
+
+func roundtripJSON(v Value) (Value, error) {
+	return roundtrip(v, json.Marshal, json.Unmarshal)
+}
+
+func roundtrip(v Value, marshal func(v interface{}) ([]byte, error), unmarshal func([]byte, interface{}) error) (Value, error) {
+	b, err := marshal(v)
+	if err != nil {
+		return Value{}, err
+	}
+
+	var newV Value
+	err = unmarshal(b, &newV)
+	return newV, err
+}

--- a/pkg/resource/deploy/plan_apply.go
+++ b/pkg/resource/deploy/plan_apply.go
@@ -409,7 +409,7 @@ func (iter *PlanIterator) Snap() *Snapshot {
 	// Always add the new resoures afterwards that got produced during the evaluation of the current plan.
 	resources = append(resources, iter.resources...)
 
-	return NewSnapshot(iter.p.Target().Name, time.Now(), resources, iter.p.source.Info())
+	return NewSnapshot(iter.p.Target().Name, time.Now(), resources)
 }
 
 // MarkStateSnapshot marks an old state snapshot as being processed.  This is done to recover from failures partway

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -24,7 +24,7 @@ func TestNullPlan(t *testing.T) {
 	ctx, err := plugin.NewContext(cmdutil.Diag(), nil)
 	assert.Nil(t, err)
 	targ := &Target{Name: tokens.QName("null")}
-	prev := NewSnapshot(targ.Name, time.Now(), nil, nil)
+	prev := NewSnapshot(targ.Name, time.Now(), nil)
 	plan := NewPlan(ctx, targ, prev, NullSource, nil)
 	iter, err := plan.Start(Options{})
 	assert.Nil(t, err)
@@ -45,7 +45,7 @@ func TestErrorPlan(t *testing.T) {
 		ctx, err := plugin.NewContext(cmdutil.Diag(), nil)
 		assert.Nil(t, err)
 		targ := &Target{Name: tokens.QName("errs")}
-		prev := NewSnapshot(targ.Name, time.Now(), nil, nil)
+		prev := NewSnapshot(targ.Name, time.Now(), nil)
 		plan := NewPlan(ctx, targ, prev, &errorSource{err: errors.New("ITERATE"), duringIterate: true}, nil)
 		iter, err := plan.Start(Options{})
 		assert.Nil(t, iter)
@@ -60,7 +60,7 @@ func TestErrorPlan(t *testing.T) {
 		ctx, err := plugin.NewContext(cmdutil.Diag(), nil)
 		assert.Nil(t, err)
 		targ := &Target{Name: tokens.QName("errs")}
-		prev := NewSnapshot(targ.Name, time.Now(), nil, nil)
+		prev := NewSnapshot(targ.Name, time.Now(), nil)
 		plan := NewPlan(ctx, targ, prev, &errorSource{err: errors.New("NEXT"), duringIterate: false}, nil)
 		iter, err := plan.Start(Options{})
 		assert.Nil(t, err)
@@ -188,7 +188,7 @@ func TestBasicCRUDPlan(t *testing.T) {
 		nil,
 		nil,
 	)
-	oldsnap := NewSnapshot(ns, time.Now(), []*resource.State{oldResB, oldResC, oldResD}, nil)
+	oldsnap := NewSnapshot(ns, time.Now(), []*resource.State{oldResB, oldResC, oldResD})
 
 	// Create the new resource objects a priori.
 	//     - A is created:

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -16,15 +16,13 @@ type Snapshot struct {
 	Namespace tokens.QName      // the namespace target being deployed into.
 	Time      time.Time         // the time this snapshot was taken.
 	Resources []*resource.State // fetches all resources and their associated states.
-	Info      interface{}       // optional information about the source.
 }
 
 // NewSnapshot creates a snapshot from the given arguments.  The resources must be in topologically sorted order.
-func NewSnapshot(ns tokens.QName, time time.Time, resources []*resource.State, info interface{}) *Snapshot {
+func NewSnapshot(ns tokens.QName, time time.Time, resources []*resource.State) *Snapshot {
 	return &Snapshot{
 		Namespace: ns,
 		Time:      time,
 		Resources: resources,
-		Info:      info,
 	}
 }

--- a/pkg/resource/resource_id.go
+++ b/pkg/resource/resource_id.go
@@ -3,7 +3,7 @@
 package resource
 
 import (
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"crypto/sha1"
 	"encoding/hex"
 
@@ -54,7 +54,7 @@ func NewUniqueHex(prefix string, maxlen, randlen int) string {
 	}
 
 	bs := make([]byte, randlen)
-	n, err := rand.Read(bs)
+	n, err := cryptorand.Read(bs)
 	contract.Assert(err == nil)
 	contract.Assert(n == len(bs))
 

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -17,9 +17,8 @@ import (
 // to the actual Snapshot structure, except that it flattens and rearranges a few data structures for serializability.
 // Over time, we also expect this to gather more information about deploys themselves.
 type Deployment struct {
-	Time      time.Time   `json:"time" yaml:"time"`                               // the time of the deploy.
-	Info      interface{} `json:"info,omitempty" yaml:"info,omitempty"`           // optional information about the source.
-	Resources []Resource  `json:"resources,omitempty" yaml:"resources,omitempty"` // an array of resources.
+	Time      time.Time  `json:"time" yaml:"time"`                               // the time of the deploy.
+	Resources []Resource `json:"resources,omitempty" yaml:"resources,omitempty"` // an array of resources.
 }
 
 // Resource is a serializable vertex within a LumiGL graph, specifically for resource snapshots.
@@ -45,7 +44,6 @@ func SerializeDeployment(snap *deploy.Snapshot) *Deployment {
 
 	return &Deployment{
 		Time:      snap.Time,
-		Info:      snap.Info,
 		Resources: resources,
 	}
 }


### PR DESCRIPTION
This PR adds support for configuration values to be encrypted within the Pulumi.yaml file.  Presently. we derive a key from a passphrase supplied by the user and use that to encrypt the data.  For CI/CD scenarios, we allow the passphrase to be supplied via an environment variable.

For Pulumi.com, we'll adopt a model where Pulumi.com handles encryption of secrets transparently (i.e. passing --secure to pulumi config will cause it to pass the secret data to Pulumi.com which will then encrypt it and return it back to the CLI to persist) so folks using Pulumi.com will not need to worry about passphrases.

However, this mode will remain in the product for the "fire/forget" open-source type workflows. 