### PR TITLE
Add two-phase snapshotting.

### DIFF
--- a/cmd/provider_local.go
+++ b/cmd/provider_local.go
@@ -49,7 +49,7 @@ type localStackMutation struct {
 	name tokens.QName
 }
 
-func (p localStackProvider) BeginMutation(name tokens.QName) (engine.Mutation, error) {
+func (p localStackProvider) BeginMutation(name tokens.QName) (engine.SnapshotMutation, error) {
 	return localStackMutation{name: name}, nil
 }
 

--- a/pkg/engine/deploy.go
+++ b/pkg/engine/deploy.go
@@ -154,7 +154,7 @@ func (acts *deployActions) Run(step deploy.Step) (resource.Status, error) {
 	}
 
 	// Inform the snapshot service that we are about to perform a step.
-	var mutation Mutation
+	var mutation SnapshotMutation
 	if _, ismut := step.(deploy.MutatingStep); ismut {
 		m, err := acts.Engine.Snapshots.BeginMutation(acts.Target.Name)
 		if err != nil {

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -17,13 +17,27 @@ type TargetProvider interface {
 	GetTarget(name tokens.QName) (*deploy.Target, error)
 }
 
-// Mutation abstracts away managing changes to snapshots
-type Mutation interface {
+// SnapshotMutation abstracts away managing changes to snapshots
+type SnapshotMutation interface {
+	// End indicates that the current mutation has completed and that its results (given by snapshot) should be persisted. See the comments
+	// on SnapshotProvider.BeginMutation for more details.
 	End(snapshot *deploy.Snapshot) error
 }
 
 // SnapshotProvider abstracts away retrieving and storing snapshots
 type SnapshotProvider interface {
 	GetSnapshot(name tokens.QName) (*deploy.Snapshot, error)
-	BeginMutation(name tokens.QName) (Mutation, error)
+
+	// BeginMutation and SnapshotMutation.End allow a snapshot provider to be robust in the face of failures that occur between the points
+	// at which they are called. The semantics are as follows:
+	//     1. The engine calls `SnapshotProvider.Begin` to indicate that it is about to mutate the state of the resources tracked by the
+	//        snapshot.
+	//     2. The engine mutates the state of the resoures tracked by the snapshot.
+	//     3. The engine calls `SnapshotMutation.End` with the new snapshot to indicate that the mutation(s) it was performing has/have
+	//        finished.
+	// During (1), the snapshot provider should record the fact that any currently persisted snapshot is being mutated and cannot be
+	// assumed to represent the actual state of the system. This ensures that if the engine crashes during (2), then the current snapshot
+	// is known to be unreliable. During (3), the snapshot provider should persist the provided snapshot and record that it is known to be
+	// reliable.
+	BeginMutation(name tokens.QName) (SnapshotMutation, error)
 }


### PR DESCRIPTION
The existing `SnapshotProvider` interface does not sufficiently lend
itself to reliable persistence of snapshot data. For example, consider
the following:
- The deployment engine creates a resource
- The snapshot provider fails to save the updated snapshot

In this scenario, we have no mechanism by which we can discover that the
existing snapshot (if any) does not reflect the actual state of the
resources managed by the stack, and future updates may operate
incorrectly. To address this, these changes split snapshotting into two
phases: the `Begin` phase and the `End` phase. A provider that needs to
be robust against the scenario described above (or any other scenario
that allows for a mutation to the state of the stack that is not
persisted) can use the `Begin` phase to persist the fact that there are
outstanding mutations to the stack. It would then use the `End` phase to
persist the updated snapshot and indicate that the mutation is no longer
outstanding. These steps are somewhat analogous to the prepare and
commit phases of two-phase commit.