### PR TITLE
Add more context information to assert

### DIFF
--- a/pkg/resource/properties.go
+++ b/pkg/resource/properties.go
@@ -450,7 +450,7 @@ func (v PropertyValue) MapRepl(replk func(string) (string, bool),
 	} else if v.IsOutput() {
 		return v.OutputValue()
 	}
-	contract.Assert(v.IsObject())
+	contract.Assertf(v.IsObject(), "v is not Object '%v' instead", v.TypeString())
 	return v.ObjectValue().MapRepl(replk, replv)
 }
 


### PR DESCRIPTION
@pgavlin @joeduffy I'm trying to track down some crashes in the PPC that are tripping over this assert. Is it possible to have the PPC repo pick up my local version of the `pulumi/pulumi` package with this change? i.e. how can I rebuild the PPC to pick up this update?

A few random, related questions if you don't mind:

- Am I correct in believing that `dep` only pulls sources from GitHub, and won't pick up changes to cross-repo projects? e.g. I need to submit this code to GitHub, then `dep ensure` to pick up the update? (If desperate enough I could probably poke at whatever is in the /vendor/ folder...)
- When the PPC does its deployment, it communicates with the deployment engine via gRPC. Right? So I assume it is ran as a separate process? And as such, may-or-may-not be built along and packaged with `pulumi-ppc/cmd/ppcd`? (Or are both the gRPC client and server running in the same binary? Since otherwise there would be another build target.)
