### PR TITLE
Many asset improvements

### DIFF
--- a/cmd/provider_local.go
+++ b/cmd/provider_local.go
@@ -82,7 +82,10 @@ func getStack(name tokens.QName) (*deploy.Target, *deploy.Snapshot, error) {
 		return nil, nil, err
 	}
 
-	target, snapshot := stack.DeserializeCheckpoint(&checkpoint)
+	target, snapshot, err := stack.DeserializeCheckpoint(&checkpoint)
+	if err != nil {
+		return nil, nil, err
+	}
 	contract.Assert(target != nil)
 	return target, snapshot, nil
 }

--- a/pkg/resource/asset_test.go
+++ b/pkg/resource/asset_test.go
@@ -3,83 +3,158 @@
 package resource
 
 import (
+	"archive/tar"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
 func TestAssetSerialize(t *testing.T) {
 	// Ensure that asset and archive serialization round trips.
 	{
 		text := "a test asset"
-		asset := NewTextAsset(text)
+		asset, err := NewTextAsset(text)
+		assert.Nil(t, err)
+		assert.Equal(t, text, asset.Text)
+		assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", asset.Hash)
 		assetSer := asset.Serialize()
-		assetDes, isasset := DeserializeAsset(assetSer)
+		assetDes, isasset, err := DeserializeAsset(assetSer, true)
+		assert.Nil(t, err)
 		assert.True(t, isasset)
 		assert.True(t, assetDes.IsText())
 		assert.Equal(t, text, assetDes.Text)
+		assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", assetDes.Hash)
 
-		arch := NewAssetArchive(map[string]Asset{"foo": asset})
+		// another text asset with the same contents, should hash the same way.
+		text2 := "a test asset"
+		asset2, err := NewTextAsset(text2)
+		assert.Nil(t, err)
+		assert.Equal(t, text2, asset2.Text)
+		assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", asset2.Hash)
+
+		// another text asset, but with different contents, should be a different hash.
+		text3 := "a very different and special test asset"
+		asset3, err := NewTextAsset(text3)
+		assert.Nil(t, err)
+		assert.Equal(t, text3, asset3.Text)
+		assert.Equal(t, "9a6ed070e1ff834427105844ffd8a399a634753ce7a60ec5aae541524bbe7036", asset3.Hash)
+
+		arch, err := NewAssetArchive(map[string]interface{}{"foo": asset})
+		assert.Nil(t, err)
+		assert.Equal(t, "d8ce0142b3b10300c7c76487fad770f794c1e84e1b0c73a4b2e1503d4fbac093", arch.Hash)
 		archSer := arch.Serialize()
-		archDes, isarch := DeserializeArchive(archSer)
+		archDes, isarch, err := DeserializeArchive(archSer, true)
+		assert.Nil(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsAssets())
 		assert.Equal(t, 1, len(archDes.Assets))
-		assert.True(t, archDes.Assets["foo"].IsText())
-		assert.Equal(t, text, archDes.Assets["foo"].Text)
+		assert.True(t, archDes.Assets["foo"].(*Asset).IsText())
+		assert.Equal(t, text, archDes.Assets["foo"].(*Asset).Text)
+		assert.Equal(t, "d8ce0142b3b10300c7c76487fad770f794c1e84e1b0c73a4b2e1503d4fbac093", archDes.Hash)
 	}
 	{
 		file := "/dev/null"
-		asset := NewPathAsset(file)
+		asset, err := NewPathAsset(file)
+		assert.Nil(t, err)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", asset.Hash)
 		assetSer := asset.Serialize()
-		assetDes, isasset := DeserializeAsset(assetSer)
+		assetDes, isasset, err := DeserializeAsset(assetSer, true)
+		assert.Nil(t, err)
 		assert.True(t, isasset)
 		assert.True(t, assetDes.IsPath())
 		assert.Equal(t, file, assetDes.Path)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", assetDes.Hash)
 
-		arch := NewAssetArchive(map[string]Asset{"foo": asset})
+		arch, err := NewAssetArchive(map[string]interface{}{"foo": asset})
+		assert.Nil(t, err)
+		assert.Equal(t, "23f6c195eb154be262216cd97209f2dcc8a40038ac8ec18ca6218d3e3dfacd4e", arch.Hash)
 		archSer := arch.Serialize()
-		archDes, isarch := DeserializeArchive(archSer)
+		archDes, isarch, err := DeserializeArchive(archSer, true)
+		assert.Nil(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsAssets())
 		assert.Equal(t, 1, len(archDes.Assets))
-		assert.True(t, archDes.Assets["foo"].IsPath())
-		assert.Equal(t, file, archDes.Assets["foo"].Path)
+		assert.True(t, archDes.Assets["foo"].(*Asset).IsPath())
+		assert.Equal(t, file, archDes.Assets["foo"].(*Asset).Path)
+		assert.Equal(t, "23f6c195eb154be262216cd97209f2dcc8a40038ac8ec18ca6218d3e3dfacd4e", archDes.Hash)
 	}
 	{
-		url := "https://pulumi.com/robots.txt"
-		asset := NewURIAsset(url)
+		url := "file:///dev/null"
+		asset, err := NewURIAsset(url)
+		assert.Nil(t, err)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", asset.Hash)
 		assetSer := asset.Serialize()
-		assetDes, isasset := DeserializeAsset(assetSer)
+		assetDes, isasset, err := DeserializeAsset(assetSer, true)
+		assert.Nil(t, err)
 		assert.True(t, isasset)
 		assert.True(t, assetDes.IsURI())
 		assert.Equal(t, url, assetDes.URI)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", assetDes.Hash)
 
-		arch := NewAssetArchive(map[string]Asset{"foo": asset})
+		arch, err := NewAssetArchive(map[string]interface{}{"foo": asset})
+		assert.Nil(t, err)
+		assert.Equal(t, "23f6c195eb154be262216cd97209f2dcc8a40038ac8ec18ca6218d3e3dfacd4e", arch.Hash)
 		archSer := arch.Serialize()
-		archDes, isarch := DeserializeArchive(archSer)
+		archDes, isarch, err := DeserializeArchive(archSer, true)
+		assert.Nil(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsAssets())
 		assert.Equal(t, 1, len(archDes.Assets))
-		assert.True(t, archDes.Assets["foo"].IsURI())
-		assert.Equal(t, url, archDes.Assets["foo"].URI)
+		assert.True(t, archDes.Assets["foo"].(*Asset).IsURI())
+		assert.Equal(t, url, archDes.Assets["foo"].(*Asset).URI)
+		assert.Equal(t, "23f6c195eb154be262216cd97209f2dcc8a40038ac8ec18ca6218d3e3dfacd4e", archDes.Hash)
 	}
 	{
-		file := "/dev/null"
-		arch := NewPathArchive(file)
+		file, err := tempArchive("test")
+		assert.Nil(t, err)
+		defer func() { contract.IgnoreError(os.Remove(file)) }()
+		arch, err := NewPathArchive(file)
+		assert.Nil(t, err)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", arch.Hash)
 		archSer := arch.Serialize()
-		archDes, isarch := DeserializeArchive(archSer)
+		archDes, isarch, err := DeserializeArchive(archSer, true)
+		assert.Nil(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsPath())
 		assert.Equal(t, file, archDes.Path)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", archDes.Hash)
 	}
 	{
-		url := "https://pulumi.com/robots.tgz"
-		arch := NewURIArchive(url)
+		file, err := tempArchive("test")
+		assert.Nil(t, err)
+		defer func() { contract.IgnoreError(os.Remove(file)) }()
+		url := "file:///" + file
+		arch, err := NewURIArchive(url)
+		assert.Nil(t, err)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", arch.Hash)
 		archSer := arch.Serialize()
-		archDes, isarch := DeserializeArchive(archSer)
+		archDes, isarch, err := DeserializeArchive(archSer, true)
+		assert.Nil(t, err)
 		assert.True(t, isarch)
 		assert.True(t, archDes.IsURI())
 		assert.Equal(t, url, archDes.URI)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", archDes.Hash)
+	}
+}
+
+func tempArchive(prefix string) (string, error) {
+	for {
+		path := filepath.Join(os.TempDir(), fmt.Sprintf("%s-%x.tar", prefix, rand.Uint32()))
+		f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0600)
+		if !os.IsExist(err) {
+			if err != nil {
+				defer contract.IgnoreClose(f)
+				// write out an empty tar file.
+				w := tar.NewWriter(f)
+				contract.IgnoreClose(w)
+			}
+			return path, err
+		}
 	}
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -265,7 +265,7 @@ func (rm *resmon) NewResource(ctx context.Context,
 
 	// Communicate the type, name, and object information to the iterator that is awaiting us.
 	props, err := plugin.UnmarshalProperties(
-		req.GetObject(), plugin.MarshalOptions{AllowUnknowns: true})
+		req.GetObject(), plugin.MarshalOptions{AllowUnknowns: true, ComputeAssetHashes: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/plugin/rpc_test.go
+++ b/pkg/resource/plugin/rpc_test.go
@@ -3,6 +3,7 @@
 package plugin
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,17 +14,24 @@ import (
 func TestAssetSerialize(t *testing.T) {
 	// Ensure that asset and archive serialization round trips.
 	text := "a test asset"
-	asset := resource.NewTextAsset(text)
+	asset, err := resource.NewTextAsset(text)
+	assert.Nil(t, err)
+	assert.Equal(t, text, asset.Text)
+	assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", asset.Hash)
 	assetProps, err := MarshalPropertyValue(resource.NewAssetProperty(asset), MarshalOptions{})
 	assert.Nil(t, err)
+	fmt.Printf("%v\n", assetProps)
 	assetValue, err := UnmarshalPropertyValue(assetProps, MarshalOptions{})
 	assert.Nil(t, err)
 	assert.True(t, assetValue.IsAsset())
 	assetDes := assetValue.AssetValue()
 	assert.True(t, assetDes.IsText())
 	assert.Equal(t, text, assetDes.Text)
+	assert.Equal(t, "e34c74529110661faae4e121e57165ff4cb4dbdde1ef9770098aa3695e6b6704", assetDes.Hash)
 
-	arch := resource.NewAssetArchive(map[string]resource.Asset{"foo": asset})
+	arch, err := resource.NewAssetArchive(map[string]interface{}{"foo": asset})
+	assert.Nil(t, err)
+	assert.Equal(t, "d8ce0142b3b10300c7c76487fad770f794c1e84e1b0c73a4b2e1503d4fbac093", arch.Hash)
 	archProps, err := MarshalPropertyValue(resource.NewArchiveProperty(arch), MarshalOptions{})
 	assert.Nil(t, err)
 	archValue, err := UnmarshalPropertyValue(archProps, MarshalOptions{})
@@ -32,8 +40,9 @@ func TestAssetSerialize(t *testing.T) {
 	archDes := archValue.ArchiveValue()
 	assert.True(t, archDes.IsAssets())
 	assert.Equal(t, 1, len(archDes.Assets))
-	assert.True(t, archDes.Assets["foo"].IsText())
-	assert.Equal(t, text, archDes.Assets["foo"].Text)
+	assert.True(t, archDes.Assets["foo"].(*resource.Asset).IsText())
+	assert.Equal(t, text, archDes.Assets["foo"].(*resource.Asset).Text)
+	assert.Equal(t, "d8ce0142b3b10300c7c76487fad770f794c1e84e1b0c73a4b2e1503d4fbac093", archDes.Hash)
 }
 
 func TestComputedSerialize(t *testing.T) {

--- a/pkg/resource/properties.go
+++ b/pkg/resource/properties.go
@@ -162,8 +162,8 @@ func NewBoolProperty(v bool) PropertyValue             { return PropertyValue{v}
 func NewNumberProperty(v float64) PropertyValue        { return PropertyValue{v} }
 func NewStringProperty(v string) PropertyValue         { return PropertyValue{v} }
 func NewArrayProperty(v []PropertyValue) PropertyValue { return PropertyValue{v} }
-func NewAssetProperty(v Asset) PropertyValue           { return PropertyValue{v} }
-func NewArchiveProperty(v Archive) PropertyValue       { return PropertyValue{v} }
+func NewAssetProperty(v *Asset) PropertyValue          { return PropertyValue{v} }
+func NewArchiveProperty(v *Archive) PropertyValue      { return PropertyValue{v} }
 func NewObjectProperty(v PropertyMap) PropertyValue    { return PropertyValue{v} }
 func NewComputedProperty(v Computed) PropertyValue     { return PropertyValue{v} }
 func NewOutputProperty(v Output) PropertyValue         { return PropertyValue{v} }
@@ -219,9 +219,9 @@ func NewPropertyValueRepl(v interface{},
 		return NewNumberProperty(t)
 	case string:
 		return NewStringProperty(t)
-	case Asset:
+	case *Asset:
 		return NewAssetProperty(t)
-	case Archive:
+	case *Archive:
 		return NewArchiveProperty(t)
 	case Computed:
 		return NewComputedProperty(t)
@@ -313,10 +313,10 @@ func (v PropertyValue) StringValue() string { return v.V.(string) }
 func (v PropertyValue) ArrayValue() []PropertyValue { return v.V.([]PropertyValue) }
 
 // AssetValue fetches the underlying asset value (panicking if it isn't an asset).
-func (v PropertyValue) AssetValue() Asset { return v.V.(Asset) }
+func (v PropertyValue) AssetValue() *Asset { return v.V.(*Asset) }
 
 // ArchiveValue fetches the underlying archive value (panicking if it isn't an archive).
-func (v PropertyValue) ArchiveValue() Archive { return v.V.(Archive) }
+func (v PropertyValue) ArchiveValue() *Archive { return v.V.(*Archive) }
 
 // ObjectValue fetches the underlying object value (panicking if it isn't a object).
 func (v PropertyValue) ObjectValue() PropertyMap { return v.V.(PropertyMap) }
@@ -358,13 +358,13 @@ func (v PropertyValue) IsArray() bool {
 
 // IsAsset returns true if the underlying value is an object.
 func (v PropertyValue) IsAsset() bool {
-	_, is := v.V.(Asset)
+	_, is := v.V.(*Asset)
 	return is
 }
 
 // IsArchive returns true if the underlying value is an object.
 func (v PropertyValue) IsArchive() bool {
-	_, is := v.V.(Archive)
+	_, is := v.V.(*Archive)
 	return is
 }
 

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -36,7 +36,7 @@ func SerializeCheckpoint(targ *deploy.Target, snap *deploy.Snapshot) *Checkpoint
 }
 
 // DeserializeCheckpoint takes a serialized deployment record and returns its associated snapshot.
-func DeserializeCheckpoint(chkpoint *Checkpoint) (*deploy.Target, *deploy.Snapshot) {
+func DeserializeCheckpoint(chkpoint *Checkpoint) (*deploy.Target, *deploy.Snapshot, error) {
 	contract.Require(chkpoint != nil, "chkpoint")
 
 	var snap *deploy.Snapshot
@@ -45,7 +45,11 @@ func DeserializeCheckpoint(chkpoint *Checkpoint) (*deploy.Target, *deploy.Snapsh
 		// For every serialized resource vertex, create a ResourceDeployment out of it.
 		var resources []*resource.State
 		for _, res := range latest.Resources {
-			resources = append(resources, DeserializeResource(res))
+			desres, err := DeserializeResource(res)
+			if err != nil {
+				return nil, nil, err
+			}
+			resources = append(resources, desres)
 		}
 
 		snap = deploy.NewSnapshot(name, chkpoint.Latest.Time, resources, latest.Info)
@@ -55,5 +59,5 @@ func DeserializeCheckpoint(chkpoint *Checkpoint) (*deploy.Target, *deploy.Snapsh
 	return &deploy.Target{
 		Name:   name,
 		Config: chkpoint.Config,
-	}, snap
+	}, snap, nil
 }

--- a/sdk/nodejs/asset/archive.ts
+++ b/sdk/nodejs/asset/archive.ts
@@ -12,10 +12,10 @@ export abstract class Archive {
 /**
  * AssetMap is a map of assets.
  */
-export type AssetMap = {[name: string]: Asset};
+export type AssetMap = {[name: string]: Asset | Archive};
 
 /**
- * An AssetArchive is an archive created with a collection of named assets.
+ * An AssetArchive is an archive created from an in-memory collection of named assets or other archives.
  */
 export class AssetArchive extends Archive {
     public readonly assets: Computed<AssetMap>; // a map of name to asset.
@@ -27,7 +27,8 @@ export class AssetArchive extends Archive {
 }
 
 /**
- * A FileArchive is an archive in a file-based archive in one of the supported formats (.tar, .tar.gz, or .zip).
+ * A FileArchive is a file-based archive, or a collection of file-based assets.  This can be a raw directory or a
+ * single archive file in one of the supported formats (.tar, .tar.gz, or .zip).
  */
 export class FileArchive extends Archive {
     public readonly path: Computed<string>; // the path to the asset file.
@@ -39,7 +40,7 @@ export class FileArchive extends Archive {
 }
 
 /**
- * A RemoteArchive is an archive in a file-based archive fetched from a remote location.  The URI's scheme dictates the
+ * A RemoteArchive is a file-based archive fetched from a remote location.  The URI's scheme dictates the
  * protocol for fetching the archive's contents: `file://` is a local file (just like a FileArchive), `http://` and
  * `https://` specify HTTP and HTTPS, respectively, and specific providers may recognize custom schemes.
  */

--- a/sdk/nodejs/asset/asset.ts
+++ b/sdk/nodejs/asset/asset.ts
@@ -3,7 +3,7 @@
 import { Computed, ComputedValue } from "../resource";
 
 /**
- * Asset represents a blob of text or data that is managed as a first class entity.
+ * Asset represents a single blob of text or data that is managed as a first class entity.
  */
 export abstract class Asset {
 }


### PR DESCRIPTION
This improves a few things about assets:

* Compute and store hashes as input properties, so that changes on
  disk are recognized and trigger updates (pulumi/pulumi#153).

* Issue explicit and prompt diagnostics when an asset is missing or
  of an unexpected kind, rather than failing late (pulumi/pulumi#156).

* Permit raw directories to be passed as archives, in addition to
  archive formats like tar, zip, etc. (pulumi/pulumi#240).

* Permit not only assets as elements of an archive's member list, but
  also other archives themselves (pulumi/pulumi#280).