### PR TITLE
Retain historical checkpoints

### DIFF
--- a/cmd/provider_local.go
+++ b/cmd/provider_local.go
@@ -3,9 +3,12 @@
 package cmd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/encoding"
@@ -132,7 +135,18 @@ func saveStack(target *deploy.Target, snap *deploy.Snapshot) error {
 		return errors.Wrap(err, "An IO error occurred during the current operation")
 	}
 
+	// And if we are retaining historical checkpoint information, write it out again
+	if isTruthy(os.Getenv("PULUMI_RETAIN_CHECKPOINTS")) {
+		if err = ioutil.WriteFile(fmt.Sprintf("%v.%v", file, time.Now().UnixNano()), b, 0600); err != nil {
+			return errors.Wrap(err, "An IO error occurred during the current operation")
+		}
+	}
+
 	return nil
+}
+
+func isTruthy(s string) bool {
+	return s == "1" || strings.EqualFold(s, "true")
 }
 
 func removeStack(stack *deploy.Target) error {

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -225,11 +225,14 @@ func RunCommand(t *testing.T, args []string, wd string, opts ProgramTestOptions)
 		}
 	}()
 
+	env := append(os.Environ(), "PULUMI_RETAIN_CHECKPOINTS=true")
+
 	// Now run the command and wait for it to be finished.
 	cmd := exec.Cmd{
 		Path:   path,
 		Dir:    wd,
 		Args:   args,
+		Env:    env,
 		Stdout: opts.Stdout,
 		Stderr: opts.Stderr,
 	}


### PR DESCRIPTION
When `PULUMI_RETAIN_CHECKPOINTS` is set in the environment, also write
the checkpoint file to <stack-name>.<ext>.<timestamp>.

This ensures we have historical information about every snapshot, which
would aid in debugging issues like #451. We set this to true for our
integration tests.

Fixes #453