### PR TITLE
Pad provider arguments on Windows.

### DIFF
--- a/sdk/nodejs/bin/pulumi-langhost-nodejs.cmd
+++ b/sdk/nodejs/bin/pulumi-langhost-nodejs.cmd
@@ -4,4 +4,8 @@ cd "%~dp0"
 REM We depend on a custom node build that has exposed some internal state
 REM This node is downloaded and extracted via the EnsureCustomNode target
 REM in the root build.proj
-"%~dp0\..\custom_node\node.exe" -e "require('./cmd/langhost');" %*
+REM
+REM NOTE: we pass a dummy argument before the actual args because the
+REM langhost module expects to be invoked as `node path/to/langhost args`,
+REM but we are invoking it with `-e`.
+"%~dp0\..\custom_node\node.exe" -e "require('./cmd/langhost');" dummy_argument %*

--- a/sdk/nodejs/bin/pulumi-provider-pulumi-nodejs.cmd
+++ b/sdk/nodejs/bin/pulumi-provider-pulumi-nodejs.cmd
@@ -4,4 +4,8 @@ cd "%~dp0"
 REM We depend on a custom node build that has exposed some internal state
 REM This node is downloaded and extracted via the EnsureCustomNode target
 REM in the root build.proj
-"%~dp0\..\custom_node\node.exe" -e "require('./cmd/dynamic-provider');" %*
+REM
+REM NOTE: we pass a dummy argument before the actual args because the
+REM provider module expects to be invoked as `node path/to/provider args`,
+REM but we are invoking it with `-e`.
+"%~dp0\..\custom_node\node.exe" -e "require('./cmd/dynamic-provider');" dummy_argument %*


### PR DESCRIPTION
All of our providers expect to be invoked as `node path/to/provider
...provider_args`, but on Windows, we are invoking them as `node -e
require(path/to/provider) ...provider_args`. This throws off the
provider's argument processing and causes connections to the resource
monitor to fail.

Fixes #477, though I think that there is going to be another issue with
dynamic resources.