### PR TITLE
Follow up to PR feedback for #475.

### DIFF
--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -140,7 +140,7 @@ export function main(args: string[]): void {
     process.on("exit", () => { runtime.disconnectSync(); });
 
     // Now go ahead and execute the code. The process will remain alive until the message loop empties.
-    console.log(`Running program '${program}' in pwd '${process.cwd()}' w/ args: ${programArgs}`);
+    log.debug(`Running program '${program}' in pwd '${process.cwd()}' w/ args: ${programArgs}`);
     require(program);
 }
 

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -103,9 +103,11 @@ export function disconnectSync(): void {
     // Otherwise, actually perform the close activities.
     if (options.monitor) {
         (<any>options.monitor).close();
+        (<any>options).monitor = null;
     }
     if (options.engine) {
         (<any>options.engine).close();
+        (<any>options).engine = null;
     }
 }
 


### PR DESCRIPTION
- Change a `console.log` to `log.debug`
- Null out gRPC clients after disconnecting.