### PR TITLE
Suport workspace local configuration and use it by default

### DIFF
--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -18,6 +18,7 @@ const BookkeepingDir = ".pulumi"       // the name of our bookeeping folder, we 
 const StackDir = "stacks"              // the name of the directory that holds stack information for projects.
 const WorkspaceDir = "workspaces"      // the name of the directory that holds workspace information for projects.
 const RepoFile = "settings.json"       // the name of the file that holds information specific to the entire repository.
+const ConfigDir = "config"             // the name of the folder that holds local configuration information.
 const WorkspaceFile = "workspace.json" // the name of the file that holds workspace information.
 
 // DetectPackage locates the closest package from the given path, searching "upwards" in the directory hierarchy.  If no

--- a/pkg/workspace/settings.go
+++ b/pkg/workspace/settings.go
@@ -3,11 +3,14 @@
 package workspace
 
 import (
+	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
 
 // Settings defines workspace settings shared amongst many related projects.
+// nolint: lll
 type Settings struct {
-	Namespace string       `json:"namespace,omitempty" yaml:"namespace,omitempty"` // an optional namespace.
-	Stack     tokens.QName `json:"env,omitempty" yaml:"env,omitempty"`             // an optional default stack to use.
+	Namespace string                                                `json:"namespace,omitempty" yaml:"namespace,omitempty"` // an optional namespace.
+	Stack     tokens.QName                                          `json:"env,omitempty" yaml:"env,omitempty"`             // an optional default stack to use.
+	Config    map[tokens.QName]map[tokens.ModuleMember]config.Value `json:"config,omitempty" yaml:"config,omitempty"`       // optional workspace local configuration (overrides values in a project)
 }

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/pack"
+	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
 
@@ -60,6 +61,10 @@ func NewProjectWorkspace(dir string) (W, error) {
 		return nil, err
 	}
 
+	if w.settings.Config == nil {
+		w.settings.Config = make(map[tokens.QName]map[tokens.ModuleMember]config.Value)
+	}
+
 	return &w, nil
 }
 
@@ -76,6 +81,13 @@ func (pw *projectWorkspace) DetectPackage() (string, error) {
 }
 
 func (pw *projectWorkspace) Save() error {
+	// let's remove all the empty entries from the config array
+	for k, v := range pw.settings.Config {
+		if len(v) == 0 {
+			delete(pw.settings.Config, k)
+		}
+	}
+
 	settingsFile := pw.settingsPath()
 
 	// ensure the path exists


### PR DESCRIPTION
Previously, we stored configuration information in the Pulumi.yaml
file. This was a change from the old model where configuration was
stored in a special section of the checkpoint file.

While doing things this way has some upsides with being able to flow
configuration changes with your source code (e.g. fixed values for a
production stack that version with the code) it caused some friction
for the local development scinerio. In this case, setting
configuration values would pend changes to Pulumi.yaml and if you
didn't want to publish these changes, you'd have to remember to remove
them before commiting. It also was problematic for our examples, where
it was not clear if we wanted to actually include values like
`aws:config:region` in our samples.  Finally, we found that for our
own pulumi service, we'd have values that would differ across each
individual dev stack, and publishing these values to a global
Pulumi.yaml file would just be adding noise to things.

We now adopt a hybrid model, where by default configuration is stored
locally, in the workspace's settings per project. A new flag `--save`
tests commands to actual operate on the configuration information
stored in Pulumi.yaml.

With the following change, we have have four "slots" configuration
values can end up in:

1. In the Pulumi.yaml file, applies to all stacks
2. In the Pulumi.yaml file, applied to a specific stack
3. In the local workspace.json file, applied to all stacks
4. In the local workspace.json file, applied to a specific stack

When computing the configuration information for a stack, we apply
configuration in the above order, overriding values as we go
along.

We also invert the default behavior of the `pulumi config` commands so
they operate on a specific stack (i.e. how they did before
e3610989). If you want to apply configuration to all stacks, `--all`
can be passed to any configuration command.