### PR TITLE
Add newline after update completes.

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -192,6 +192,8 @@ func newCloudUpdateCmd() *cobra.Command {
 
 			// Wait for the update to complete.
 			status, err := waitForUpdate(path)
+			fmt.Println() // The PPC's final message we print to STDOUT doesn't include a newline.
+
 			if err != nil {
 				return fmt.Errorf("waiting for update: %v", err)
 			}


### PR DESCRIPTION
The last status message from the PPC doesn't include a newline. So the `pulumi` CLI renders any error messages on the same line as the last diagnostic message. Not ideal.