### PR TITLE
Fix panic when using commands w/o Pulumi.yaml

### DIFF
--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -42,7 +42,7 @@ func NewProjectWorkspace(dir string) (W, error) {
 		return nil, err
 	}
 	if project == "" {
-		return nil, errors.New("no Pulumi program found (or in any of the parent directories)")
+		return nil, errors.New("no Pulumi project file found, are you missing a Pulumi.yaml file?")
 	}
 
 	pkg, err := pack.Load(project)


### PR DESCRIPTION
Calls to `NewProjectWorkspace` will panic if there is no Pulumi.yaml found in the folder hierarchy. Simple repo:

```
git init
pulumi init
pulumi stack init x
```

`DetectPackage` will search until it gets to the `.pulumi` directory or finds a `Pulumi.yaml` file. In the case of the former, we pass "" to `LoadPackage` which then asserts because the file doesn't exist.

We now detect this condition and surface an error to the user. The error text is patterned after running a git command when there is no .git folder found:

fatal: Not a git repository (or any of the parent directories): .git