### PR TITLE
Fix bug(?) in where we put the Pulumi Workspace

### DIFF
--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -26,9 +26,10 @@ func DetectPackage(path string) (string, error) {
 	return fsutil.WalkUp(path, isProject, func(s string) bool { return !isRepositoryFolder(filepath.Join(s, BookkeepingDir)) })
 }
 
-func isGitFolder(path string) bool {
+// isGitOrRepositoryFolder returns whether or not the provided path is a .git or .pulumi directory.
+func isGitOrRepositoryFolder(path string) bool {
 	info, err := os.Stat(path)
-	return err == nil && info.IsDir() && info.Name() == ".git"
+	return err == nil && info.IsDir() && (info.Name() == ".git" || info.Name() == BookkeepingDir)
 }
 
 func isRepositoryFolder(path string) bool {

--- a/pkg/workspace/repository.go
+++ b/pkg/workspace/repository.go
@@ -74,17 +74,13 @@ func GetRepository(root string) (*Repository, error) {
 	return &repo, nil
 }
 
+// getDotPulumiDirectoryPath returns the path of the .pulumi Workspace directory starting at the
+// given location. Will stop its search at the first directory with a .git or .pulumi folder, and
+// if none are found, simply returns the provided directory + "/.pulumi".
 func getDotPulumiDirectoryPath(dir string) string {
-	// First, let's look to see if there's an existing .pulumi folder
-	dotpulumipath, _ := fsutil.WalkUp(dir, isRepositoryFolder, nil)
-	if dotpulumipath != "" {
-		return dotpulumipath
-	}
-
-	// If there's a .git folder, put .pulumi there
-	dotgitpath, _ := fsutil.WalkUp(dir, isGitFolder, nil)
-	if dotgitpath != "" {
-		return filepath.Join(filepath.Dir(dotgitpath), ".pulumi")
+	folder, _ := fsutil.WalkUp(dir, isGitOrRepositoryFolder, nil)
+	if folder != "" {
+		return filepath.Join(filepath.Dir(folder), ".pulumi")
 	}
 
 	return filepath.Join(dir, ".pulumi")


### PR DESCRIPTION
I believe there is a logic bug in the code for where `pulumi init` places the `.pulumi` folder. We didn't catch this earlier because it only manifests when you are using the cloud-enabled variants of commands. (If you haven't ran `pulumi login` before, the command works like I expect.)

Repro:

```
$ cd ~/wasteland/pulumi-cli-testing
$ git init
Initialized empty Git repository in /Users/chris/wasteland/pulumi-cli-testing/.git/
$ pulumi init --owner moolumi --name chris-cli-testing
Initialized Pulumi repository in /Users/chris/.pulumi
```

I'm in a directory called `pulumi-cli-testing` with a `.git` folder. However, `pulumi init` initializes the repository all the way in `$HOME` and not the current directory. The expected behavior was that `pulumi init` would have put it in the working directory, because that is the closest `.git` folder. Right?

The issue is in the code we first look for a `.pulumi` folder up the tree, and if one isn't found, we _then_ look for the `.git` folder. The problem is that when you are using the cloud versions of the commands, we store the user's credentials in a  `$HOME/.pulumi/credentials.json` file. So the first search for a `.pulumi` folder terminates with `$HOME`.

We could change where we store the credentials, but it seems like we should instead do the "walk up the directory structure" looking for either a `.git` OR `.pulumi` folder. And stopping as soon as we find either. That guarantees we'll (1) find the closest `.pulumi` folder, (2) the closest `.git` folder, (3) default to putting it in the current directory if neither is found.

Anyways, take a close look since I could be missing some subtle aspect of how we intended this to work.