### PR TITLE
Fix up some pulumi init error cases

### DIFF
--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -33,7 +33,13 @@ func isGitFolder(path string) bool {
 
 func isRepositoryFolder(path string) bool {
 	info, err := os.Stat(path)
-	return err == nil && info.IsDir() && info.Name() == BookkeepingDir
+	if err == nil && info.IsDir() && info.Name() == BookkeepingDir {
+		// make sure it has a settings.json file in it
+		info, err := os.Stat(filepath.Join(path, RepoFile))
+		return err == nil && !info.IsDir()
+	}
+
+	return false
 }
 
 // isProject returns true if the path references what appears to be a valid project.  If problems are detected -- like

--- a/pkg/workspace/repository.go
+++ b/pkg/workspace/repository.go
@@ -36,7 +36,7 @@ func NewRepository(root string) *Repository {
 	return &Repository{Root: getDotPulumiDirectoryPath(root)}
 }
 
-var ErrNoRepository = errors.New("no repository")
+var ErrNoRepository = errors.New("no repository detected; did you forget to run 'pulumi init'?")
 
 func GetRepository(root string) (*Repository, error) {
 	dotPulumiPath := getDotPulumiDirectoryPath(root)


### PR DESCRIPTION
- When looking for a `.pulumi` folder to reuse, only consider ones
  that have a `settings.json` in them.
- Make the error message when there is no repository a little more
  informative by telling someone to run `pulumi init`