### PR TITLE
Get Cloud args from repository, package; Bug fixes

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -11,7 +11,10 @@ import (
 	"os"
 
 	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/pack"
+	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // pulumiCloudEndpoint returns the endpoint for the Pulumi Cloud Management Console API.
@@ -28,6 +31,39 @@ func pulumiConsoleAPI() (string, error) {
 func usePulumiCloudCommands() bool {
 	_, err := pulumiConsoleAPI()
 	return err == nil
+}
+
+// cloudProjectIdentifier is the set of data needed to identify a Pulumi Cloud project. This the
+// logical "home" of a stack on the Pulumi Cloud.
+type cloudProjectIdentifier struct {
+	Owner      string
+	Repository string
+	Project    tokens.PackageName
+}
+
+// getCloudProjectIdentifiers returns the owner, repo name, and project name of the current package and workspace.
+func getCloudProjectIdentifier(w workspace.W) (*cloudProjectIdentifier, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	path, err := workspace.DetectPackage(cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	pkg, err := pack.Load(path)
+	if err != nil {
+		return nil, err
+	}
+
+	repo := w.Repository()
+	return &cloudProjectIdentifier{
+		Owner:      repo.Owner,
+		Repository: repo.Name,
+		Project:    pkg.Name,
+	}, nil
 }
 
 // pulumiAPICall makes an HTTP request to the Pulumi API.

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -11,7 +11,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
-	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
 func newStackInitCmd() *cobra.Command {
@@ -43,16 +42,13 @@ func newFAFStackInitCmd() *cobra.Command {
 				return err
 			}
 
-			return setCurrentStack(stackName, false)
+			return setCurrentStack(stackName)
 		}),
 	}
 }
 
 func newCloudStackInitCmd() *cobra.Command {
-	var org string
 	var cloud string
-	var repo string
-	var project string
 
 	cmd := &cobra.Command{
 		Use:   "init <stack>",
@@ -63,6 +59,16 @@ func newCloudStackInitCmd() *cobra.Command {
 			"This command creates an empty stack with the given name.  It has no resources,\n" +
 			"but afterwards it can become the target of a deployment using the `update` command.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			// Look up the owner, repository, and project from the workspace and nearest package.
+			w, err := newWorkspace()
+			if err != nil {
+				return err
+			}
+			projID, err := getCloudProjectIdentifier(w)
+			if err != nil {
+				return err
+			}
+
 			stackName := args[0]
 			createStackReq := apitype.CreateStackRequest{
 				CloudName: cloud,
@@ -70,37 +76,21 @@ func newCloudStackInitCmd() *cobra.Command {
 			}
 
 			var createStackResp apitype.CreateStackResponse
-			path := fmt.Sprintf("/orgs/%s/programs/%s/%s/stacks", org, repo, project)
+			path := fmt.Sprintf("/orgs/%s/programs/%s/%s/stacks", projID.Owner, projID.Repository, projID.Project)
 			if err := pulumiRESTCall("POST", path, &createStackReq, &createStackResp); err != nil {
 				return err
 			}
 			fmt.Printf("Created Stack '%s' hosted in Cloud '%s'\n", stackName, createStackResp.CloudName)
 
 			stackQName := tokens.QName(stackName)
-			return setCurrentStack(stackQName, false)
+			return setCurrentStack(stackQName)
 		}),
 	}
 
-	// "cloud" is not a persistent flag. If not set will use the "default" cloud for the organization.
+	// If not set will use the "default" cloud for the organization.
 	cmd.PersistentFlags().StringVarP(
 		&cloud, "cloud", "c", "",
 		"Target cloud")
-
-	cmd.PersistentFlags().StringVarP(
-		&org, "organization", "o", "",
-		"Target organization")
-	cmd.PersistentFlags().StringVarP(
-		&repo, "repo", "r", "",
-		"Target Pulumi repo")
-	cmd.PersistentFlags().StringVarP(
-		&project, "project", "p", "",
-		"Target Pulumi project")
-
-	// We need all of these flags to be set. In the future we'll get some of these from the .pulumi folder, and have
-	// a meaningful default for others. So in practice users won't need to specify all of these. (Ideally none.)
-	contract.AssertNoError(cmd.MarkPersistentFlagRequired("organization"))
-	contract.AssertNoError(cmd.MarkPersistentFlagRequired("repo"))
-	contract.AssertNoError(cmd.MarkPersistentFlagRequired("project"))
 
 	return cmd
 }

--- a/cmd/stack_select.go
+++ b/cmd/stack_select.go
@@ -29,9 +29,23 @@ func newStackSelectCmd() *cobra.Command {
 				}
 
 				fmt.Printf("%v\n", name)
+				return nil
 			}
 
-			return setCurrentStack(tokens.QName(args[0]), true)
+			allStacks, err := getStacks()
+			if err != nil {
+				return err
+			}
+
+			// Confirm the stack name is valid.
+			selectedStack := tokens.QName(args[0])
+			for _, stack := range allStacks {
+				if stack == selectedStack {
+					return setCurrentStack(selectedStack)
+				}
+			}
+
+			return fmt.Errorf("no stack with name '%v' found", selectedStack)
 		}),
 	}
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/archive"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
-	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -133,9 +132,6 @@ func newFAFUpdateCmd() *cobra.Command {
 }
 
 func newCloudUpdateCmd() *cobra.Command {
-	var org string
-	var repo string
-	var project string
 	var stack string
 
 	var cmd = &cobra.Command{
@@ -147,9 +143,23 @@ func newCloudUpdateCmd() *cobra.Command {
 			"\n" +
 			"This command creates or updates a Stack hosted in a Pulumi Cloud.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			stackName, err := explicitOrCurrent(stack)
+			// Look up the owner, repository, and project from the workspace and nearest package.
+			w, err := newWorkspace()
 			if err != nil {
 				return err
+			}
+			projID, err := getCloudProjectIdentifier(w)
+			if err != nil {
+				return err
+			}
+
+			// Default to the workspace settings if stack isn't provided.
+			stackName := tokens.QName(stack)
+			if stackName == "" {
+				stackName = w.Settings().Stack
+			}
+			if stackName == "" {
+				return errors.New("stack argument not set and workspace does not have selected stack")
 			}
 
 			// Zip up the Pulumi program's directory, which may be a parent of CWD.
@@ -184,7 +194,8 @@ func newCloudUpdateCmd() *cobra.Command {
 				Config:         textConfig,
 			}
 			var updateResponse apitype.UpdateProgramResponse
-			path := fmt.Sprintf("/orgs/%s/programs/%s/%s/stacks/%s/update", org, repo, project, string(stackName))
+			path := fmt.Sprintf("/orgs/%s/programs/%s/%s/stacks/%s/update",
+				projID.Owner, projID.Repository, projID.Project, string(stackName))
 			if err = pulumiRESTCall("POST", path, &updateRequest, &updateResponse); err != nil {
 				return err
 			}
@@ -208,21 +219,6 @@ func newCloudUpdateCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"Choose an stack other than the currently selected one")
-	cmd.PersistentFlags().StringVarP(
-		&org, "organization", "o", "",
-		"Target organization")
-	cmd.PersistentFlags().StringVarP(
-		&repo, "repo", "r", "",
-		"Target Pulumi repo")
-	cmd.PersistentFlags().StringVarP(
-		&project, "project", "p", "",
-		"Target Pulumi project")
-
-	// We need all of these flags to be set. In the future we'll get some of these from the .pulumi folder, and have
-	// a meaningful default for others. So in practice users won't need to specify all of these. (Ideally none.)
-	contract.AssertNoError(cmd.MarkPersistentFlagRequired("organization"))
-	contract.AssertNoError(cmd.MarkPersistentFlagRequired("repo"))
-	contract.AssertNoError(cmd.MarkPersistentFlagRequired("project"))
 
 	return cmd
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -66,14 +66,8 @@ func getCurrentStack() (tokens.QName, error) {
 	return stack, nil
 }
 
-// setCurrentStack changes the current stack to the given stack name, issuing an error if it doesn't exist.
-func setCurrentStack(name tokens.QName, verify bool) error {
-	if verify {
-		if _, _, _, err := getStack(name); err != nil {
-			return err
-		}
-	}
-
+// setCurrentStack changes the current stack to the given stack name.
+func setCurrentStack(name tokens.QName) error {
 	// Switch the current workspace to that stack.
 	w, err := newWorkspace()
 	if err != nil {


### PR DESCRIPTION
This PR removes three command line parameters from Cloud-enabled Pulumi commands (`update` and `stack init`). Previously we required users to pass in `--organization`, `--repository`, and `--project`. But with the recent "Pulumi repository" changes, we can now get that from the Pulumi workspace. And the project name from the `Pulumi.yaml`.

This PR also fixes a bugs that block the Cloud-enabled CLI path: `update` was getting the stack name via `explicitOrCurrent`, but that fails if the current stack (e.g. the one just initialized in the cloud) doesn't exist on the local disk.

As for better handling of "current stack" and and Cloud-enabled commands, https://github.com/pulumi/pulumi/pull/493 and the PR to enable `stack select`, `stack rm`, and `stack ls` do a better job of handling situations like this.
