### PR TITLE
Fix the "stack select" test.

### DIFF
--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -95,7 +95,7 @@ func TestStackCommands(t *testing.T) {
 		// Error
 		out, err := e.RunCommandExpectError("pulumi", "stack", "select", "anor-londo")
 		assert.Empty(t, out)
-		assert.Contains(t, err, ".pulumi/stacks/pulumi-test/anor-londo.json: no such file or directory")
+		assert.Contains(t, err, "no stack with name 'anor-londo' found")
 	})
 
 	t.Run("StackRm", func(t *testing.T) {


### PR DESCRIPTION
PR #501 regressed this test due to a change in its error message. We
should consider updating the rest of the `stack` commands to use a
similar message (rather than the "file not found" they currently emit).