### PR TITLE
Add required fields to Cloud update requests

### DIFF
--- a/pkg/apitype/types.go
+++ b/pkg/apitype/types.go
@@ -45,6 +45,10 @@ type CreateStackResponse struct {
 
 // UpdateProgramRequest is the request type for updating (aka deploying) a Pulumi program.
 type UpdateProgramRequest struct {
+	// Properties from the Project file.
+	Name    tokens.PackageName `json:"name"`
+	Runtime string             `json:"runtime"`
+
 	// Base-64 encoded Zip archive of the program's root directory.
 	ProgramArchive string `json:"programArchive"`
 


### PR DESCRIPTION
Add `Name` (Pulumi project name) and `Runtime` (Pulumi runtime, e.g. "nodejs") properties to `UpdateProgramRequest`; as they are now required.

The long story is that as part of the PPC enabling destroy operations, data that was previously obtained from `Pulumi.yaml` is now required as part of the update request. This PR simply provides that data from the CLI.

This is the final step of a line of breaking changes.
pulumi-ppc https://github.com/pulumi/pulumi-ppc/commit/8ddce15b29be9e90a2701521de1cd38d332eb081
pulumi-service https://github.com/pulumi/pulumi-service/commit/8941431d57ce2fe0b6bac0578562260ff20cc9fc#diff-05a07bc54b30a35b10afe9674747fe53