### PR TITLE
Small Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ all: banner_all core sdk/nodejs integrationtest
 nightly: all gocover
 
 .PHONY: core
-core: vet test install lint
+core: test install lint
 
 .PHONY: banner
 banner:
@@ -61,11 +61,6 @@ lint:
 	$(GOMETALINTER) ./pkg/... | grep -vE ${LINT_SUPPRESS} | sort ; exit $$(($${PIPESTATUS[1]}-1))
 	$(GOMETALINTER) ./cmd/... | grep -vE ${LINT_SUPPRESS} | sort ; exit $$(($${PIPESTATUS[1]}-1))
 	@$(ECHO) "\033[0;33mlint was run quietly; to run with noisy errors, run 'make lint_full'\033[0m"
-
-.PHONY: vet
-vet:
-	@$(ECHO) "\033[0;32mVET:\033[0m"
-	go tool vet -printf=false cmd/ pkg/
 
 .PHONY: test
 test:


### PR DESCRIPTION
Before I jump into larger scale changes in 0.8.1, pick off some low-hanging fruit.  This makes `make lint` do the unsurprising thing (i.e. run the lint target you have to pass to check in), drops the `vet` target as `go vet` is already run as part of the meta-linting process and cleans up an invocation of `go test`