### PR TITLE
Updating getCredsFilePath to store credentials under %localappdata%\pulumi for windows

### DIFF
--- a/cmd/creds.go
+++ b/cmd/creds.go
@@ -40,6 +40,8 @@ func getCredsFileName() string {
 	return pulumiCredentialsFileName
 }
 
+// getCredsFilePath returns the path to the Pulumi credentials file on disk, if it
+// exists. Otherwise nil and the related OS error.
 func getCredsFilePath() (string, error) {
 	var pulumiFolder string
 


### PR DESCRIPTION
fixing issue #49 
Use runtime.GOOS to identify OS and store credentials file based on OS.
for Windows -> %localappdata%\PULUMI\.PULUMI
for non-windows -> $HOME/.pulumi
