### PR TITLE
Only call `Configure` on a package once

### DIFF
--- a/pkg/resource/deploy/plan_apply.go
+++ b/pkg/resource/deploy/plan_apply.go
@@ -62,7 +62,11 @@ func (p *Plan) configure() error {
 		pkgconfig[k] = v
 	}
 	sort.Strings(pkgs)
+	initialized := make(map[string]bool)
 	for _, pkg := range pkgs {
+		if _, ready := initialized[pkg]; ready {
+			continue
+		}
 		pkgt := tokens.Package(pkg)
 		prov, err := p.Provider(pkgt)
 		if err != nil {
@@ -74,6 +78,7 @@ func (p *Plan) configure() error {
 				return goerr.Wrapf(err, "failed to configure pkg '%v' resource provider", pkg)
 			}
 		}
+		initialized[pkg] = true
 	}
 	return nil
 }


### PR DESCRIPTION
We were previously calling configure on each package once per time it was mentioned in the config.  We only need to call it once ever as we pass the full bag of relevent config through on that one call.