### PR TITLE
Skip unknown properties

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -234,7 +234,7 @@ func (rm *resmon) Invoke(ctx context.Context, req *lumirpc.InvokeRequest) (*lumi
 
 	// Now unpack all of the arguments and prepare to perform the invocation.
 	args, err := plugin.UnmarshalProperties(
-		req.GetArgs(), plugin.MarshalOptions{AllowUnknowns: true})
+		req.GetArgs(), plugin.MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to unmarshal %v args", tok)
 	}
@@ -245,7 +245,7 @@ func (rm *resmon) Invoke(ctx context.Context, req *lumirpc.InvokeRequest) (*lumi
 	if err != nil {
 		return nil, errors.Wrapf(err, "invocation of %v returned an error", tok)
 	}
-	mret, err := plugin.MarshalProperties(ret, plugin.MarshalOptions{AllowUnknowns: true})
+	mret, err := plugin.MarshalProperties(ret, plugin.MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal %v return", tok)
 	}
@@ -265,7 +265,7 @@ func (rm *resmon) NewResource(ctx context.Context,
 
 	// Communicate the type, name, and object information to the iterator that is awaiting us.
 	props, err := plugin.UnmarshalProperties(
-		req.GetObject(), plugin.MarshalOptions{AllowUnknowns: true, ComputeAssetHashes: true})
+		req.GetObject(), plugin.MarshalOptions{KeepUnknowns: true, ComputeAssetHashes: true})
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +305,7 @@ func (rm *resmon) NewResource(ctx context.Context,
 
 	// Finally, unpack the response into properties that we can return to the language runtime.  This mostly includes
 	// an ID, URN, and defaults and output properties that will all be blitted back onto the runtime object.
-	outs, err := plugin.MarshalProperties(outprops, plugin.MarshalOptions{AllowUnknowns: true})
+	outs, err := plugin.MarshalProperties(outprops, plugin.MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -65,7 +65,7 @@ func (p *provider) Configure(vars map[tokens.ModuleMember]string) error {
 // Check validates that the given property bag is valid for a resource of the given type.
 func (p *provider) Check(urn resource.URN, props resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error) {
 	glog.V(7).Infof("resource[%v].Check(urn=%v,#props=%v) executing", p.pkg, urn, len(props))
-	mprops, err := MarshalProperties(props, MarshalOptions{AllowUnknowns: true})
+	mprops, err := MarshalProperties(props, MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -82,7 +82,7 @@ func (p *provider) Check(urn resource.URN, props resource.PropertyMap) (resource
 	// Unmarshal any defaults.
 	var defaults resource.PropertyMap
 	if defs := resp.GetDefaults(); defs != nil {
-		defaults, err = UnmarshalProperties(defs, MarshalOptions{AllowUnknowns: true})
+		defaults, err = UnmarshalProperties(defs, MarshalOptions{KeepUnknowns: true})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -113,7 +113,7 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 	if err != nil {
 		return DiffResult{}, err
 	}
-	mnews, err := MarshalProperties(news, MarshalOptions{AllowUnknowns: true})
+	mnews, err := MarshalProperties(news, MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return DiffResult{}, err
 	}
@@ -253,7 +253,7 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 	[]CheckFailure, error) {
 	contract.Assert(tok != "")
 
-	margs, err := MarshalProperties(args, MarshalOptions{AllowUnknowns: true})
+	margs, err := MarshalProperties(args, MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, nil, err
 	}
@@ -266,7 +266,7 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 	}
 
 	// Unmarshal any return values.
-	ret, err := UnmarshalProperties(resp.GetReturn(), MarshalOptions{AllowUnknowns: true})
+	ret, err := UnmarshalProperties(resp.GetReturn(), MarshalOptions{KeepUnknowns: true})
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/resource/plugin/rpc.go
+++ b/pkg/resource/plugin/rpc.go
@@ -17,7 +17,7 @@ import (
 // MarshalOptions controls the marshaling of RPC structures.
 type MarshalOptions struct {
 	SkipNulls          bool // true to skip nulls altogether in the resulting map.
-	AllowUnknowns      bool // true if we are allowing unknown values (otherwise an error results).
+	KeepUnknowns       bool // true if we are keeping unknown values (otherwise we skip them).
 	ComputeAssetHashes bool // true if we are computing missing asset hashes on the fly.
 }
 
@@ -59,8 +59,9 @@ func MarshalProperties(props resource.PropertyMap, opts MarshalOptions) (*struct
 			m, err := MarshalPropertyValue(v, opts)
 			if err != nil {
 				return nil, err
+			} else if m != nil {
+				fields[string(key)] = m
 			}
-			fields[string(key)] = m
 		}
 	}
 	return &structpb.Struct{
@@ -111,19 +112,17 @@ func MarshalPropertyValue(v resource.PropertyValue, opts MarshalOptions) (*struc
 		}
 		return MarshalStruct(obj, opts), nil
 	} else if v.IsComputed() {
-		elem := v.ComputedValue().Element
-		if opts.AllowUnknowns {
-			return marshalUnknownProperty(elem, opts), nil
+		if opts.KeepUnknowns {
+			return marshalUnknownProperty(v.ComputedValue().Element, opts), nil
 		}
-		return nil, errors.Errorf("unexpected computed property during marshaling: %v", elem)
+		return nil, nil // return nil and the caller will ignore it.
 	} else if v.IsOutput() {
 		// Note that at the moment we don't differentiate between computed and output properties on the wire.  As
 		// a result, they will show up as computed on the other end.  This distinction isn't currently interesting.
-		elem := v.ComputedValue().Element
-		if opts.AllowUnknowns {
+		if opts.KeepUnknowns {
 			return marshalUnknownProperty(v.OutputValue().Element, opts), nil
 		}
-		return nil, errors.Errorf("unexpected output property during marshaling: %v", elem)
+		return nil, nil // return nil and the caller will ignore it.
 	}
 
 	contract.Failf("Unrecognized property value: %v (type=%v)", v.V, reflect.TypeOf(v.V))
@@ -184,12 +183,13 @@ func UnmarshalProperties(props *structpb.Struct, opts MarshalOptions) (resource.
 		v, err := UnmarshalPropertyValue(props.Fields[key], opts)
 		if err != nil {
 			return nil, err
-		}
-		glog.V(9).Infof("Unmarshaling property for RPC: %v=%v", key, v)
-		if opts.SkipNulls && v.IsNull() {
-			glog.V(9).Infof("Skipping unmarshaling of %v (it is null)", key)
-		} else {
-			result[pk] = v
+		} else if v != nil {
+			glog.V(9).Infof("Unmarshaling property for RPC: %v=%v", key, v)
+			if opts.SkipNulls && v.IsNull() {
+				glog.V(9).Infof("Skipping unmarshaling of %v (it is null)", key)
+			} else {
+				result[pk] = *v
+			}
 		}
 	}
 
@@ -197,79 +197,87 @@ func UnmarshalProperties(props *structpb.Struct, opts MarshalOptions) (resource.
 }
 
 // UnmarshalPropertyValue unmarshals a single "JSON-like" value into a new property value.
-func UnmarshalPropertyValue(v *structpb.Value, opts MarshalOptions) (resource.PropertyValue, error) {
+func UnmarshalPropertyValue(v *structpb.Value, opts MarshalOptions) (*resource.PropertyValue, error) {
 	contract.Assert(v != nil)
 
 	switch v.Kind.(type) {
 	case *structpb.Value_NullValue:
-		return resource.NewNullProperty(), nil
+		m := resource.NewNullProperty()
+		return &m, nil
 	case *structpb.Value_BoolValue:
-		return resource.NewBoolProperty(v.GetBoolValue()), nil
+		m := resource.NewBoolProperty(v.GetBoolValue())
+		return &m, nil
 	case *structpb.Value_NumberValue:
-		return resource.NewNumberProperty(v.GetNumberValue()), nil
+		m := resource.NewNumberProperty(v.GetNumberValue())
+		return &m, nil
 	case *structpb.Value_StringValue:
 		// If it's a string, it could be an unknown property, or just a regular string.
 		s := v.GetStringValue()
 		if unk, isunk := unmarshalUnknownPropertyValue(s, opts); isunk {
-			if opts.AllowUnknowns {
-				return unk, nil
+			if opts.KeepUnknowns {
+				return &unk, nil
 			}
-			return resource.PropertyValue{},
-				errors.Errorf("unexpected unknown property during unmarshaling: %v", unk)
+			return nil, nil
 		}
-		return resource.NewStringProperty(s), nil
+		m := resource.NewStringProperty(s)
+		return &m, nil
 	case *structpb.Value_ListValue:
 		// If there's already an array, prefer to swap elements within it.
 		var elems []resource.PropertyValue
 		lst := v.GetListValue()
 		for i, elem := range lst.GetValues() {
-			if i == len(elems) {
-				elems = append(elems, resource.PropertyValue{})
-			}
-			contract.Assert(len(elems) > i)
 			e, err := UnmarshalPropertyValue(elem, opts)
 			if err != nil {
-				return resource.PropertyValue{}, err
+				return nil, err
+			} else if e != nil {
+				if i == len(elems) {
+					elems = append(elems, *e)
+				} else {
+					elems[i] = *e
+				}
 			}
-			elems[i] = e
 		}
-		return resource.NewArrayProperty(elems), nil
+		m := resource.NewArrayProperty(elems)
+		return &m, nil
 	case *structpb.Value_StructValue:
 		// Start by unmarshaling.
 		obj, err := UnmarshalProperties(v.GetStructValue(), opts)
 		if err != nil {
-			return resource.PropertyValue{}, err
+			return nil, err
 		}
 
 		// Before returning it as an object, check to see if it's a known recoverable type.
 		objmap := obj.Mappable()
 		asset, isasset, err := resource.DeserializeAsset(objmap)
 		if err != nil {
-			return resource.PropertyValue{}, err
+			return nil, err
 		} else if isasset {
 			if opts.ComputeAssetHashes {
 				if err = asset.EnsureHash(); err != nil {
-					return resource.PropertyValue{}, errors.Wrapf(err, "failed to compute asset hash")
+					return nil, errors.Wrapf(err, "failed to compute asset hash")
 				}
 			}
-			return resource.NewAssetProperty(asset), nil
+			m := resource.NewAssetProperty(asset)
+			return &m, nil
 		}
 		archive, isarchive, err := resource.DeserializeArchive(objmap)
 		if err != nil {
-			return resource.PropertyValue{}, err
+			return nil, err
 		} else if isarchive {
 			if opts.ComputeAssetHashes {
 				if err = archive.EnsureHash(); err != nil {
-					return resource.PropertyValue{}, errors.Wrapf(err, "failed to compute archive hash")
+					return nil, errors.Wrapf(err, "failed to compute archive hash")
 				}
 			}
-			return resource.NewArchiveProperty(archive), nil
+			m := resource.NewArchiveProperty(archive)
+			return &m, nil
 		}
-		return resource.NewObjectProperty(obj), nil
+		m := resource.NewObjectProperty(obj)
+		return &m, nil
 
 	default:
 		contract.Failf("Unrecognized structpb value kind: %v", reflect.TypeOf(v.Kind))
-		return resource.PropertyValue{}, nil
+		return nil, nil
 	}
 }
 

--- a/pkg/resource/plugin/rpc_test.go
+++ b/pkg/resource/plugin/rpc_test.go
@@ -47,7 +47,7 @@ func TestAssetSerialize(t *testing.T) {
 
 func TestComputedSerialize(t *testing.T) {
 	// Ensure that computed properties survive round trips.
-	opts := MarshalOptions{AllowUnknowns: true}
+	opts := MarshalOptions{KeepUnknowns: true}
 	{
 		cprop, err := MarshalPropertyValue(
 			resource.NewComputedProperty(
@@ -67,5 +67,24 @@ func TestComputedSerialize(t *testing.T) {
 		assert.Nil(t, err)
 		assert.True(t, cpropU.IsComputed())
 		assert.True(t, cpropU.ComputedValue().Element.IsNumber())
+	}
+}
+
+func TestComputedSkip(t *testing.T) {
+	// Ensure that computed properties are skipped when KeepUnknowns == false.
+	opts := MarshalOptions{KeepUnknowns: false}
+	{
+		cprop, err := MarshalPropertyValue(
+			resource.NewComputedProperty(
+				resource.Computed{Element: resource.NewStringProperty("")}), opts)
+		assert.Nil(t, err)
+		assert.Nil(t, cprop)
+	}
+	{
+		cprop, err := MarshalPropertyValue(
+			resource.NewComputedProperty(
+				resource.Computed{Element: resource.NewNumberProperty(0)}), opts)
+		assert.Nil(t, err)
+		assert.Nil(t, cprop)
 	}
 }


### PR DESCRIPTION
It's legal and possible for undefined properties to show up in
objects, since that's an idiomatic JavaScript way of initializing
missing properties.  Instead of failing for these during deployment,
we should simply skip marshaling them to Terraform and let it do
its thing as usual.  This came up during our customer workload.