### PR TITLE
Use full state during updates

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -284,7 +284,9 @@ func (s *UpdateStep) Apply() (resource.Status, error) {
 		if err != nil {
 			return resource.StatusOK, err
 		}
-		outs, rst, upderr := prov.Update(s.URN(), s.old.ID, s.old.AllInputs(), s.new.AllInputs())
+		// Update to the combination of the old "all" state (including outputs), but overwritten with new inputs.
+		news := s.old.All().Merge(s.new.Inputs)
+		outs, rst, upderr := prov.Update(s.URN(), s.old.ID, s.old.All(), news)
 		if upderr != nil {
 			return rst, upderr
 		}


### PR DESCRIPTION
In our existing code, we only use the input state for old and new
properties.  This is incorrect and I'm astonished we've been flying
blind for so long here.  Some resources require the output properties
from the prior operation in order to perform updates.  Interestingly,
we did correclty use the full synthesized state during deletes.

I ran into this with the AWS Cloudfront Distribution resource,
which requires the etag from the prior operation in order to
successfully apply any subsequent operations.