### PR TITLE
Trim whitespace around user input before comparing

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
@@ -83,7 +84,7 @@ func confirmPrompt(msg string, name string) bool {
 		colors.ColorizeText(fmt.Sprintf("%v%v%v\n", colors.SpecAttention, prompt, colors.Reset)))
 	fmt.Printf("Please confirm that this is what you'd like to do by typing (\"%v\"): ", name)
 	reader := bufio.NewReader(os.Stdin)
-	if line, _ := reader.ReadString('\n'); line != name+"\n" {
+	if line, _ := reader.ReadString('\n'); strings.TrimSpace(line) != name {
 		fmt.Fprintf(os.Stderr, "Confirmation declined -- exiting without doing anything\n")
 		return false
 	}


### PR DESCRIPTION
Doing it this way will make things work on both *nix and Windows

Fixes #534