### PR TITLE
Fix an erroneous error condition

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -51,7 +51,6 @@ func newConfigLsCmd() *cobra.Command {
 				if err != nil {
 					return errors.Wrap(err, "invalid configuration key")
 				}
-
 				return getConfig(stackName, key)
 			}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -49,7 +49,7 @@ func explicitOrCurrent(name string, backend pulumiBackend) (tokens.QName, error)
 	if stackName == "" {
 		curStack, err := getCurrentStack()
 		if err != nil {
-			return "", nil
+			return "", err
 		}
 
 		stackName = curStack


### PR DESCRIPTION
This code was swallowing an error incorrectly, rather than returning
it.  As a result, certain commands would fail with assertions rather
than the intended error message (like trying to config without a stack).