### PR TITLE
Add a very barebones `pulumi logs` command

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "0.10.0"
 
 [[projects]]
+  name = "github.com/aws/aws-sdk-go"
+  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/xml/xmlutil","service/cloudwatch","service/cloudwatchlogs","service/sts"]
+  revision = "e6c5e190452424b404ecdb81d6e3991d46b18e9d"
+  version = "v1.12.26"
+
+[[projects]]
   name = "github.com/bgentry/speakeasy"
   packages = ["."]
   revision = "4aabc24848ce5fd31929f7d1e4ea74d3709c14cd"
@@ -24,6 +30,12 @@
   packages = ["spew"]
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/go-ini/ini"
+  packages = ["."]
+  revision = "a343d9870e3952dd8a0b894f9e221e210189fefe"
+  version = "v1.31.0"
 
 [[projects]]
   branch = "master"
@@ -60,6 +72,11 @@
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  revision = "0b12d6b5"
 
 [[projects]]
   branch = "master"
@@ -196,6 +213,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7ce4108eb2b933e825a741d32a5b7e744d4b4ad297f89a8224b03c1d6ae0e591"
+  inputs-digest = "88f8f1aaa79c621a82ea2832471395e5bfd12cbdd0ab1473bdf9cf3d7958d15c"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/backend.go
+++ b/cmd/backend.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/component"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
@@ -29,4 +30,6 @@ type pulumiBackend interface {
 	Preview(stackName tokens.QName, debug bool, opts engine.PreviewOptions) error
 	Update(stackName tokens.QName, debug bool, opts engine.DeployOptions) error
 	Destroy(stackName tokens.QName, debug bool, opts engine.DestroyOptions) error
+
+	GetLogs(stackName tokens.QName, query component.LogQuery) ([]component.LogEntry, error)
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -1,0 +1,65 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/component"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+)
+
+func newLogsCmd() *cobra.Command {
+	var stack string
+	var follow bool
+
+	logsCmd := &cobra.Command{
+		Use: "logs",
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			stackName, err := explicitOrCurrent(stack, backend)
+			if err != nil {
+				return err
+			}
+
+			sinceTime := time.Unix(0, 0)
+			highestTimeSeen := time.Unix(0, 0)
+
+			for {
+				logs, err := backend.GetLogs(stackName, component.LogQuery{})
+				if err != nil {
+					return err
+				}
+
+				for _, logEntry := range logs {
+					eventTime := time.Unix(0, logEntry.Timestamp*1000000)
+					if eventTime.After(sinceTime) {
+						fmt.Printf("[%v] %v\n", eventTime, logEntry.Message)
+					}
+
+					if eventTime.After(highestTimeSeen) {
+						highestTimeSeen = eventTime
+					}
+				}
+
+				if !follow {
+					return nil
+				}
+
+				sinceTime = highestTimeSeen
+				time.Sleep(time.Second)
+			}
+		}),
+	}
+
+	logsCmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"List configuration for a different stack than the currently selected stack")
+	logsCmd.PersistentFlags().BoolVarP(
+		&follow, "follow", "f", false,
+		"Follow the log stream in real time (like tail -f)")
+
+	return logsCmd
+}

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -68,6 +68,7 @@ func NewPulumiCmd(version string) *cobra.Command {
 	cmd.AddCommand(newUpdateCmd())
 	cmd.AddCommand(newVersionCmd(version))
 	cmd.AddCommand(newInitCmd())
+	cmd.AddCommand(newLogsCmd())
 
 	// Commands specific to the Pulumi Cloud Management Console.
 	cmd.AddCommand(newLoginCmd())

--- a/pkg/apitype/types.go
+++ b/pkg/apitype/types.go
@@ -100,3 +100,15 @@ type UpdateResults struct {
 	Status string        `json:"status"`
 	Events []UpdateEvent `json:"events"`
 }
+
+// LogsResult is the JSON shape of responses to a Logs operation.
+type LogsResult struct {
+	Logs []LogEntry `json:"logs"`
+}
+
+// LogEntry is the individual entries in a JSON response to a Logs operation.
+type LogEntry struct {
+	ID        string `json:"id"`
+	Timestamp int64  `json:"timestamp"`
+	Message   string `json:"message"`
+}

--- a/pkg/component/component.go
+++ b/pkg/component/component.go
@@ -1,0 +1,82 @@
+package component
+
+import (
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/tokens"
+)
+
+// Components is a map of URN to component
+type Components map[resource.URN]*Component
+
+// Component is a serializable virtual node in a resource graph
+type Component struct {
+	Type       tokens.Type                `json:"type"`                // this components's full type token.
+	Properties resource.PropertyMap       `json:"props,omitempty"`     // the properties of this component.
+	Resources  map[string]*resource.State `json:"resources,omitempty"` // the resources owned by this component.
+}
+
+// LogEntry is a row in the logs for a running compute service
+type LogEntry struct {
+	ID        string
+	Timestamp int64
+	Message   string
+}
+
+// LogQuery represents the parameters to a log query operation.
+// All fields are optional, leaving them off returns all logs.
+type LogQuery struct {
+	StartTime *time.Time
+	EndTime   *time.Time
+	Query     *string
+}
+
+// MetricName is a handle to a metric supported by a Pulumi Framework resources
+type MetricName string
+
+type MetricRequest struct {
+	Name string
+}
+
+type MetricDataPoint struct {
+	Timestamp   time.Time
+	Unit        string
+	Sum         float64
+	SampleCount float64
+	Average     float64
+	Maximum     float64
+	Minimum     float64
+}
+
+// OperationsProvider is the interface for making operational requests about the
+// state of a Component (or Components)
+type OperationsProvider interface {
+	// GetLogs returns logs matching a query
+	GetLogs(query LogQuery) ([]LogEntry, error)
+	// ListMetrics returns the list of supported metrics for the requested component type
+	ListMetrics() []MetricName
+	// GetMetricStatistics provides metrics data for a given metric request
+	GetMetricStatistics(metric MetricRequest) ([]MetricDataPoint, error)
+}
+
+// FilterByType returns only components matching the requested type
+func (c Components) FilterByType(t tokens.Type) Components {
+	ret := make(Components)
+	for k, v := range c {
+		if v.Type == t {
+			ret[k] = v
+		}
+	}
+	return ret
+}
+
+// GetByTypeAndName returns the component with the requested type and name
+func (c Components) GetByTypeAndName(t tokens.Type, name tokens.QName) *Component {
+	for k, v := range c {
+		if k.Type() == t && k.Name() == name {
+			return v
+		}
+	}
+	return nil
+}

--- a/pkg/pulumiframework/awsConnection.go
+++ b/pkg/pulumiframework/awsConnection.go
@@ -1,0 +1,98 @@
+package pulumiframework
+
+import (
+	"regexp"
+
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/golang/glog"
+	"github.com/pulumi/pulumi/pkg/component"
+)
+
+type awsConnection struct {
+	sess      *session.Session
+	logSvc    *cloudwatchlogs.CloudWatchLogs
+	metricSvc *cloudwatch.CloudWatch
+}
+
+func newAWSConnection(sess *session.Session) *awsConnection {
+	return &awsConnection{
+		sess:      sess,
+		logSvc:    cloudwatchlogs.New(sess),
+		metricSvc: cloudwatch.New(sess),
+	}
+}
+
+var logRegexp = regexp.MustCompile(".*Z\t[a-g0-9\\-]*\t(.*)")
+
+func (p *awsConnection) getLogsForFunctionsConcurrently(functions []string) []component.LogEntry {
+	var logs []component.LogEntry
+	ch := make(chan []component.LogEntry)
+	for _, functionName := range functions {
+		go func(functionName string) {
+			ch <- p.getLogsForFunction(functionName)
+		}(functionName)
+	}
+	for i := 0; i < len(functions); i++ {
+		logs = append(logs, <-ch...)
+	}
+	return logs
+}
+
+func (p *awsConnection) getLogsForFunction(functionName string) []component.LogEntry {
+	logGroupName := "/aws/lambda/" + functionName
+	resp, err := p.logSvc.DescribeLogStreams(&cloudwatchlogs.DescribeLogStreamsInput{
+		LogGroupName: aws.String(logGroupName),
+	})
+	if err != nil {
+		glog.V(5).Infof("[getLogs] Error getting logs: %v %v\n", logGroupName, err)
+		return nil
+	}
+	glog.V(5).Infof("[getLogs] Log streams: %v\n", resp)
+	logResult := p.getLogsForFunctionNameStreamsConcurrently(functionName, resp.LogStreams)
+	return logResult
+}
+
+func (p *awsConnection) getLogsForFunctionNameStreamsConcurrently(functionName string,
+	logStreams []*cloudwatchlogs.LogStream) []component.LogEntry {
+	var logs []component.LogEntry
+	ch := make(chan []component.LogEntry)
+	for _, logStream := range logStreams {
+		go func(logStreamName *string) {
+			ch <- p.getLogsForFunctionNameStream(functionName, logStreamName)
+		}(logStream.LogStreamName)
+	}
+	for i := 0; i < len(logStreams); i++ {
+		logs = append(logs, <-ch...)
+	}
+	return logs
+}
+
+func (p *awsConnection) getLogsForFunctionNameStream(functionName string, logStreamName *string) []component.LogEntry {
+	var logResult []component.LogEntry
+	logGroupName := "/aws/lambda/" + functionName
+	logsResp, err := p.logSvc.GetLogEvents(&cloudwatchlogs.GetLogEventsInput{
+		LogGroupName:  aws.String(logGroupName),
+		LogStreamName: logStreamName,
+		StartFromHead: aws.Bool(true),
+	})
+	if err != nil {
+		glog.V(5).Infof("[getLogs] Error getting logs: %v %v\n", logStreamName, err)
+	}
+	glog.V(5).Infof("[getLogs] Log events: %v\n", logsResp)
+	for _, event := range logsResp.Events {
+		innerMatches := logRegexp.FindAllStringSubmatch(aws.StringValue(event.Message), -1)
+		glog.V(5).Infof("[getLogs] Inner matches: %v\n", innerMatches)
+		if len(innerMatches) > 0 {
+			logResult = append(logResult, component.LogEntry{
+				ID:        functionName,
+				Message:   innerMatches[0][1],
+				Timestamp: aws.Int64Value(event.Timestamp),
+			})
+		}
+	}
+	return logResult
+}

--- a/pkg/pulumiframework/resources.go
+++ b/pkg/pulumiframework/resources.go
@@ -1,0 +1,344 @@
+package pulumiframework
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/pkg/errors"
+
+	"github.com/pulumi/pulumi/pkg/component"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+)
+
+// This file contains the implementation of the component.Components interface for the
+// AWS implementation of the Pulumi Framework defined in this repo.
+
+// GetComponents extracts the Pulumi Framework components from a checkpoint
+// file, based on the raw resources created by the implementation of the Pulumi Framework
+// in this repo.
+func GetComponents(source []*resource.State) component.Components {
+	sourceMap := makeIDLookup(source)
+	components := make(component.Components)
+	for _, res := range source {
+		name := string(res.URN.Name())
+		if res.Type == stageType {
+			stage := res
+			deployment := lookup(sourceMap, deploymentType, stage.Inputs["deployment"].StringValue())
+			restAPI := lookup(sourceMap, restAPIType, stage.Inputs["restApi"].StringValue())
+			baseURL := deployment.Outputs["invokeUrl"].StringValue() + stage.Inputs["stageName"].StringValue() + "/"
+			restAPIName := restAPI.URN.Name()
+			urn := newPulumiFrameworkURN(res.URN, pulumiEndpointType, restAPIName)
+			components[urn] = &component.Component{
+				Type: pulumiEndpointType,
+				Properties: resource.NewPropertyMapFromMap(map[string]interface{}{
+					"url": baseURL,
+				}),
+				Resources: map[string]*resource.State{
+					"restapi":    restAPI,
+					"deployment": deployment,
+					"stage":      stage,
+				},
+			}
+		} else if res.Type == eventRuleType {
+			urn := newPulumiFrameworkURN(res.URN, pulumiTimerType, tokens.QName(name))
+			components[urn] = &component.Component{
+				Type: pulumiTimerType,
+				Properties: resource.NewPropertyMapFromMap(map[string]interface{}{
+					"schedule": res.Inputs["scheduleExpression"].StringValue(),
+				}),
+				Resources: map[string]*resource.State{
+					"rule":       res,
+					"target":     nil,
+					"permission": nil,
+				},
+			}
+		} else if res.Type == tableType {
+			urn := newPulumiFrameworkURN(res.URN, pulumiTableType, tokens.QName(name))
+			components[urn] = &component.Component{
+				Type: pulumiTableType,
+				Properties: resource.NewPropertyMapFromMap(map[string]interface{}{
+					"primaryKey": res.Inputs["hashKey"].StringValue(),
+				}),
+				Resources: map[string]*resource.State{
+					"table": res,
+				},
+			}
+		} else if res.Type == topicType {
+			if !strings.HasSuffix(name, "unhandled-error-topic") {
+				urn := newPulumiFrameworkURN(res.URN, pulumiTopicType, tokens.QName(name))
+				components[urn] = &component.Component{
+					Type:       pulumiTopicType,
+					Properties: resource.NewPropertyMapFromMap(map[string]interface{}{}),
+					Resources: map[string]*resource.State{
+						"topic": res,
+					},
+				}
+			}
+		} else if res.Type == functionType {
+			if !strings.HasSuffix(name, "-log-collector") {
+				urn := newPulumiFrameworkURN(res.URN, pulumiFunctionType, tokens.QName(name))
+				components[urn] = &component.Component{
+					Type:       pulumiFunctionType,
+					Properties: resource.NewPropertyMapFromMap(map[string]interface{}{}),
+					Resources: map[string]*resource.State{
+						"function":              res,
+						"role":                  nil,
+						"roleAttachment":        nil,
+						"logGroup":              nil,
+						"logSubscriptionFilter": nil,
+						"permission":            nil,
+					},
+				}
+			}
+		}
+	}
+	return components
+}
+
+// This function grovels through the given configuration bag, extracts the bits necessary to create an AWS session
+// (currently just the AWS region to target), and creates and returns the session. If the bag does not contain the
+// necessary properties or if session creation fails, this function returns `nil, error`.
+func createSessionFromConfig(config map[tokens.ModuleMember]string) (*session.Session, error) {
+	awsRegion, ok := config[regionKey]
+	if !ok {
+		return nil, errors.New("no AWS region found")
+	}
+
+	awsConfig := aws.NewConfig()
+	awsConfig.Region = aws.String(awsRegion)
+	return session.NewSession(awsConfig)
+}
+
+// OperationsProviderForComponent creates an OperationsProvider capable of answering
+// operational queries based on the underlying resources of the AWS  Pulumi Framework implementation.
+func OperationsProviderForComponent(
+	config map[tokens.ModuleMember]string,
+	component *component.Component) (component.OperationsProvider, error) {
+
+	sess, err := createSessionFromConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create AWS session")
+	}
+
+	prov := &componentOpsProvider{
+		awsConnection: newAWSConnection(sess),
+		component:     component,
+	}
+	return prov, nil
+}
+
+type componentOpsProvider struct {
+	awsConnection *awsConnection
+	component     *component.Component
+}
+
+var _ component.OperationsProvider = (*componentOpsProvider)(nil)
+
+const (
+	// AWS config keys
+	regionKey = "aws:config:region"
+
+	// AWS Resource Types
+	stageType      = "aws:apigateway/stage:Stage"
+	deploymentType = "aws:apigateway/deployment:Deployment"
+	restAPIType    = "aws:apigateway/restApi:RestApi"
+	eventRuleType  = "aws:cloudwatch/eventRule:EventRule"
+	tableType      = "aws:dynamodb/table:Table"
+	topicType      = "aws:sns/topic:Topic"
+	functionType   = "aws:lambda/function:Function"
+
+	// Pulumi Framework "virtual" types
+	pulumiEndpointType = tokens.Type("pulumi:framework:Endpoint")
+	pulumiTopicType    = tokens.Type("pulumi:framework:Topic")
+	pulumiTimerType    = tokens.Type("pulumi:framework:Timer")
+	pulumiTableType    = tokens.Type("pulumi:framework:Table")
+	pulumiFunctionType = tokens.Type("pulumi:framework:Function")
+
+	// Operational metric names for Pulumi Framework components
+	functionInvocations        component.MetricName = "Invocation"
+	functionDuration           component.MetricName = "Duration"
+	functionErrors             component.MetricName = "Errors"
+	functionThrottles          component.MetricName = "Throttles"
+	endpoint4xxError           component.MetricName = "4xxerror"
+	endpoint5xxError           component.MetricName = "5xxerror"
+	endpointCount              component.MetricName = "count"
+	endpointLatency            component.MetricName = "latency"
+	topicPulished              component.MetricName = "published"
+	topicPublishSize           component.MetricName = "publishsize"
+	topicDelivered             component.MetricName = "delivered"
+	topicFailed                component.MetricName = "failed"
+	timerInvocations           component.MetricName = "invocations"
+	timerFailedInvocations     component.MetricName = "failedinvocations"
+	tableConsumedReadCapacity  component.MetricName = "consumedreadcapacity"
+	tableConsumedWriteCapacity component.MetricName = "consumerwritecapacity"
+	tableThrottles             component.MetricName = "throttles"
+)
+
+func (ops *componentOpsProvider) GetLogs(query component.LogQuery) ([]component.LogEntry, error) {
+	if query.StartTime != nil || query.EndTime != nil || query.Query != nil {
+		contract.Failf("not yet implemented - StartTime, Endtime, Query")
+	}
+	switch ops.component.Type {
+	case pulumiFunctionType:
+		functionName := ops.component.Resources["function"].Outputs["name"].StringValue()
+		logResult := ops.awsConnection.getLogsForFunction(functionName)
+		sort.SliceStable(logResult, func(i, j int) bool { return logResult[i].Timestamp < logResult[j].Timestamp })
+		return logResult, nil
+	default:
+		return nil, fmt.Errorf("Logs not supported for component type: %s", ops.component.Type)
+	}
+}
+
+func (ops *componentOpsProvider) ListMetrics() []component.MetricName {
+	switch ops.component.Type {
+	case pulumiFunctionType:
+		// Don't include these which are internal implementation metrics: DLQ delivery errors
+		return []component.MetricName{functionInvocations, functionDuration, functionErrors, functionThrottles}
+	case pulumiEndpointType:
+		return []component.MetricName{endpoint4xxError, endpoint5xxError, endpointCount, endpointLatency}
+	case pulumiTopicType:
+		return []component.MetricName{topicPulished, topicPublishSize, topicDelivered, topicFailed}
+	case pulumiTimerType:
+		return []component.MetricName{timerInvocations, timerFailedInvocations}
+	case pulumiTableType:
+		// Internal only: "provisionedreadcapacity", "provisionedwritecapacity", "usererrors", "timetolivedeleted",
+		// "systemerrors", "succesfulrequestlatency", "returnedrecordscount", "returenditemcount", "returnedbytes",
+		// "onlineindex*", "conditionalcheckfailed"
+		return []component.MetricName{tableConsumedReadCapacity, tableConsumedWriteCapacity, tableThrottles}
+	default:
+		contract.Failf("invalid component type")
+		return nil
+	}
+}
+
+func (ops *componentOpsProvider) GetMetricStatistics(metric component.MetricRequest) ([]component.MetricDataPoint, error) {
+
+	var dimensions []*cloudwatch.Dimension
+	var namespace string
+
+	switch ops.component.Type {
+	case pulumiFunctionType:
+		dimensions = append(dimensions, &cloudwatch.Dimension{
+			Name:  aws.String("FunctionName"),
+			Value: aws.String(string(ops.component.Resources["function"].ID)),
+		})
+		namespace = "AWS/Lambda"
+	case pulumiEndpointType:
+		contract.Failf("not yet implemented")
+	case pulumiTopicType:
+		contract.Failf("not yet implemented")
+	case pulumiTimerType:
+		contract.Failf("not yet implemented")
+	case pulumiTableType:
+		contract.Failf("not yet implemented")
+	default:
+		contract.Failf("invalid component type")
+	}
+
+	resp, err := ops.awsConnection.metricSvc.GetMetricStatistics(&cloudwatch.GetMetricStatisticsInput{
+		Namespace:  aws.String(namespace),
+		MetricName: aws.String(metric.Name),
+		Dimensions: dimensions,
+		Statistics: []*string{
+			aws.String("Sum"), aws.String("SampleCount"), aws.String("Average"),
+			aws.String("Maximum"), aws.String("Minimum"),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var metrics []component.MetricDataPoint
+	for _, datapoint := range resp.Datapoints {
+		metrics = append(metrics, component.MetricDataPoint{
+			Timestamp:   aws.TimeValue(datapoint.Timestamp),
+			Unit:        aws.StringValue(datapoint.Unit),
+			Sum:         aws.Float64Value(datapoint.Sum),
+			SampleCount: aws.Float64Value(datapoint.SampleCount),
+			Average:     aws.Float64Value(datapoint.Average),
+			Maximum:     aws.Float64Value(datapoint.Maximum),
+			Minimum:     aws.Float64Value(datapoint.Minimum),
+		})
+	}
+	return metrics, nil
+}
+
+// OperationsProviderForComponents creates an OperationsProvider capable of answering
+// operational queries about a collection of Pulumi Framework Components based on the
+// underlying resources of the AWS  Pulumi Framework implementation.
+func OperationsProviderForComponents(
+	config map[tokens.ModuleMember]string,
+	components component.Components) (component.OperationsProvider, error) {
+
+	sess, err := createSessionFromConfig(config)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create AWS session")
+	}
+
+	prov := &componentsOpsProvider{
+		awsConnection: newAWSConnection(sess),
+		components:    components,
+	}
+	return prov, nil
+}
+
+type componentsOpsProvider struct {
+	awsConnection *awsConnection
+	components    component.Components
+}
+
+var _ component.OperationsProvider = (*componentsOpsProvider)(nil)
+
+// GetLogs for a collection of Components returns combined logs from all Pulumi Function
+// components in the collection.
+func (ops *componentsOpsProvider) GetLogs(query component.LogQuery) ([]component.LogEntry, error) {
+	if query.StartTime != nil || query.EndTime != nil || query.Query != nil {
+		contract.Failf("not yet implemented - StartTime, Endtime, Query")
+	}
+	var functionNames []string
+	functionComponents := ops.components.FilterByType(pulumiFunctionType)
+	for _, v := range functionComponents {
+		functionName := v.Resources["function"].Outputs["name"].StringValue()
+		functionNames = append(functionNames, functionName)
+	}
+	logResults := ops.awsConnection.getLogsForFunctionsConcurrently(functionNames)
+	sort.SliceStable(logResults, func(i, j int) bool { return logResults[i].Timestamp < logResults[j].Timestamp })
+	return logResults, nil
+}
+
+func (ops *componentsOpsProvider) ListMetrics() []component.MetricName {
+	return []component.MetricName{}
+}
+
+func (ops *componentsOpsProvider) GetMetricStatistics(metric component.MetricRequest) ([]component.MetricDataPoint, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}
+
+type typeid struct {
+	Type tokens.Type
+	ID   resource.ID
+}
+
+func makeIDLookup(source []*resource.State) map[typeid]*resource.State {
+	ret := make(map[typeid]*resource.State)
+	for _, state := range source {
+		tid := typeid{Type: state.Type, ID: state.ID}
+		ret[tid] = state
+	}
+	return ret
+}
+
+func lookup(m map[typeid]*resource.State, t string, id string) *resource.State {
+	return m[typeid{Type: tokens.Type(t), ID: resource.ID(id)}]
+}
+
+func newPulumiFrameworkURN(resourceURN resource.URN, t tokens.Type, name tokens.QName) resource.URN {
+	namespace := resourceURN.Namespace()
+	return resource.NewURN(namespace, resourceURN.Alloc(), t, name)
+}

--- a/pkg/pulumiframework/resources_test.go
+++ b/pkg/pulumiframework/resources_test.go
@@ -1,0 +1,96 @@
+package pulumiframework
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/component"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/stack"
+	"github.com/pulumi/pulumi/pkg/tokens"
+)
+
+var sess *session.Session
+
+func init() {
+	var err error
+	config := aws.NewConfig()
+	config.Region = aws.String("eu-west-1")
+	sess, err = session.NewSession(config)
+	if err != nil {
+		panic("Could not create AWS session")
+	}
+}
+
+func getPulumiResources(t *testing.T, path string) (component.Components, tokens.QName) {
+	var checkpoint stack.Checkpoint
+	byts, err := ioutil.ReadFile(path)
+	assert.NoError(t, err)
+	err = json.Unmarshal(byts, &checkpoint)
+	assert.NoError(t, err)
+	name, _, snapshot, err := stack.DeserializeCheckpoint(&checkpoint)
+	assert.NoError(t, err)
+	resources := GetComponents(snapshot.Resources)
+	spew.Dump(resources)
+	return resources, name
+}
+
+func TestTodo(t *testing.T) {
+	components, targetName := getPulumiResources(t, "testdata/todo.json")
+	assert.Equal(t, 5, len(components))
+
+	rawURN := resource.NewURN(targetName, "todo", "aws:dynamodb/table:Table:", "todo")
+
+	tableArn := newPulumiFrameworkURN(rawURN, tokens.Type(pulumiTableType), tokens.QName("todo"))
+	table, ok := components[tableArn]
+	if !assert.True(t, ok) {
+		return
+	}
+	assert.Equal(t, 1, len(table.Properties))
+	assert.Equal(t, "id", table.Properties[resource.PropertyKey("primaryKey")].StringValue())
+	assert.Equal(t, 1, len(table.Resources))
+	assert.Equal(t, pulumiTableType, table.Type)
+
+	endpointArn := newPulumiFrameworkURN(rawURN, tokens.Type(pulumiEndpointType), tokens.QName("todo"))
+	endpoint, ok := components[endpointArn]
+	if !assert.True(t, ok) {
+		return
+	}
+	assert.Equal(t, 1, len(endpoint.Properties))
+	assert.Equal(t, "https://eupwl7wu4i.execute-api.us-east-2.amazonaws.com/stage/",
+		endpoint.Properties[resource.PropertyKey("url")].StringValue())
+	assert.Equal(t, 3, len(endpoint.Resources))
+	assert.Equal(t, pulumiEndpointType, endpoint.Type)
+}
+
+func TestCrawler(t *testing.T) {
+	components, targetName := getPulumiResources(t, "testdata/crawler.json")
+	assert.Equal(t, 4, len(components))
+
+	rawURN := resource.NewURN(targetName, "countdown", "aws:sns/topic:Topic", "countDown")
+
+	countDownArn := newPulumiFrameworkURN(rawURN, tokens.Type(pulumiTopicType), tokens.QName("countDown"))
+	countDown, ok := components[countDownArn]
+	if !assert.True(t, ok) {
+		return
+	}
+	assert.Equal(t, 0, len(countDown.Properties))
+	assert.Equal(t, 1, len(countDown.Resources))
+	assert.Equal(t, pulumiTopicType, countDown.Type)
+
+	heartbeatArn := newPulumiFrameworkURN(rawURN, tokens.Type(pulumiTimerType), tokens.QName("heartbeat"))
+	heartbeat, ok := components[heartbeatArn]
+	if !assert.True(t, ok) {
+		return
+	}
+	assert.Equal(t, 1, len(heartbeat.Properties))
+	assert.Equal(t, "rate(5 minutes)", heartbeat.Properties[resource.PropertyKey("schedule")].StringValue())
+	assert.Equal(t, 3, len(heartbeat.Resources))
+	assert.Equal(t, pulumiTimerType, heartbeat.Type)
+}

--- a/pkg/pulumiframework/testdata/crawler.json
+++ b/pkg/pulumiframework/testdata/crawler.json
@@ -1,0 +1,728 @@
+{
+    "target": "foo",
+    "latest": {
+        "time": "2017-11-08T11:52:26.954469-08:00",
+        "resources": [
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown",
+                "custom": true,
+                "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                "type": "aws:sns/topic:Topic",
+                "defaults": {
+                    "name": "countDown-9d430501c4510322"
+                },
+                "outputs": {
+                    "arn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                    "displayName": "",
+                    "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                    "name": "countDown-9d430501c4510322",
+                    "policy": "{\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"153052954103\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Resource\":\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\",\"Sid\":\"__default_statement_ID\"}],\"Version\":\"2008-10-17\"}"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::cloud:topic:Topic::countDown",
+                "custom": false,
+                "type": "cloud:topic:Topic",
+                "children": [
+                    "urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:sns/topic:Topic::unhandled-error-topic",
+                "custom": true,
+                "id": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                "type": "aws:sns/topic:Topic",
+                "defaults": {
+                    "name": "unhandled-error-topic-ddd8c2cd9a876715"
+                },
+                "outputs": {
+                    "arn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                    "displayName": "",
+                    "id": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715",
+                    "name": "unhandled-error-topic-ddd8c2cd9a876715",
+                    "policy": "{\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"153052954103\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Resource\":\"arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715\",\"Sid\":\"__default_statement_ID\"}],\"Version\":\"2008-10-17\"}"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::countDown_watcher-iamrole",
+                "custom": true,
+                "id": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                "type": "aws:iam/role:Role",
+                "inputs": {
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                },
+                "defaults": {
+                    "forceDetachPolicies": false,
+                    "name": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                    "path": "/"
+                },
+                "outputs": {
+                    "arn": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                    "createDate": "2017-11-08T19:51:32Z",
+                    "forceDetachPolicies": false,
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                    "name": "countDown_watcher-iamrole-bf695eb09a5c3e28",
+                    "path": "/",
+                    "uniqueId": "AROAJBQANPFEXFW2SEVJM"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::countDown_watcher-iampolicy-0",
+                "custom": true,
+                "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195133331200000001",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                },
+                "outputs": {
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195133331200000001",
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::countDown_watcher-iampolicy-1",
+                "custom": true,
+                "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195134625700000002",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                },
+                "outputs": {
+                    "id": "countDown_watcher-iamrole-bf695eb09a5c3e28-20171108195134625700000002",
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "countDown_watcher-iamrole-bf695eb09a5c3e28"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::countDown_watcher",
+                "custom": true,
+                "id": "countDown_watcher-560cf0c8d799e9cd",
+                "type": "aws:lambda/function:Function",
+                "inputs": {
+                    "code": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "assets": {
+                            ".": {
+                                "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                "path": "."
+                            },
+                            "__index.js": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "hash": "2379662c18737708ce800361028a4bb5cc1d3ea619d90ec50811e299e465307a",
+                                "text": "exports.handler = __c9e856d50f915ecde20c43f505596928ee91643e;\n\nfunction __c9e856d50f915ecde20c43f505596928ee91643e() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, handler: __db4cc5ebcb1698516c862c46e2aeec3a258aa47f }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n        Promise.all(ev.Records.map((record) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield handler(record.Sns);\n        })))\n            .then(() =\u003e { cb(null, null); })\n            .catch((err) =\u003e { cb(err, null); });\n    })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __db4cc5ebcb1698516c862c46e2aeec3a258aa47f() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, handler: __820d19c6daf60cebb8ca144dd373a37806be5880 }) {\n    return (function() {\n\nreturn ((snsItem) =\u003e __awaiter(this, void 0, void 0, function* () {\n            const item = JSON.parse(snsItem.Message);\n            yield handler(item);\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __820d19c6daf60cebb8ca144dd373a37806be5880() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, countDown: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((num) =\u003e __awaiter(this, void 0, void 0, function* () {\n    console.log(num);\n    if (num \u003e 0) {\n        yield countDown.publish(num - 1);\n    }\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a() {\n  var _this;\n  with({ _this: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((item) =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            const snsconn = new awssdk.SNS();\n            return snsconn.publish({\n                Message: JSON.stringify(item),\n                TopicArn: this.topic.id,\n            }).promise();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                            }
+                        },
+                        "hash": "b9d3b221cf1e03db6f40d62bddaa4087764f26f0b68c0e3aaf02a1d7921ea9a5"
+                    },
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                        }
+                    ],
+                    "handler": "__index.handler",
+                    "memorySize": 128,
+                    "role": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                    "runtime": "nodejs6.10",
+                    "timeout": 180
+                },
+                "defaults": {
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive025626512",
+                    "memorySize": "128",
+                    "name": "countDown_watcher-560cf0c8d799e9cd",
+                    "publish": false,
+                    "timeout": "180"
+                },
+                "outputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive203107759",
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                        }
+                    ],
+                    "description": "",
+                    "environment": [],
+                    "handler": "__index.handler",
+                    "id": "countDown_watcher-560cf0c8d799e9cd",
+                    "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd/invocations",
+                    "kmsKeyArn": "",
+                    "lastModified": "2017-11-08T19:51:46.320+0000",
+                    "memorySize": "128",
+                    "name": "countDown_watcher-560cf0c8d799e9cd",
+                    "publish": false,
+                    "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd:$LATEST",
+                    "role": "arn:aws:iam::153052954103:role/countDown_watcher-iamrole-bf695eb09a5c3e28",
+                    "runtime": "nodejs6.10",
+                    "sourceCodeHash": "4t/d32Qvj5j7gHSYFhXKoroGD1NDBKC7wsr1mmPB3AM=",
+                    "tags": {},
+                    "timeout": "180",
+                    "tracingConfig": [
+                        {
+                            "mode": "PassThrough"
+                        }
+                    ],
+                    "version": "$LATEST",
+                    "vpcConfig": []
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher",
+                "custom": false,
+                "type": "aws:serverless:Function",
+                "inputs": {
+                    "options": {
+                        "deadLetterConfig": {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                        },
+                        "memorySize": 128,
+                        "policies": [
+                            "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                            "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                        ]
+                    }
+                },
+                "children": [
+                    "urn:pulumi:foo::countdown::aws:iam/role:Role::countDown_watcher-iamrole",
+                    "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::countDown_watcher-iampolicy-0",
+                    "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::countDown_watcher-iampolicy-1",
+                    "urn:pulumi:foo::countdown::aws:lambda/function:Function::countDown_watcher"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logGroup:LogGroup::countDown_watcher-func-logs",
+                "custom": true,
+                "id": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                "type": "aws:cloudwatch/logGroup:LogGroup",
+                "inputs": {
+                    "name": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                    "retentionInDays": 1
+                },
+                "defaults": {
+                    "retentionInDays": "1"
+                },
+                "outputs": {
+                    "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/countDown_watcher-560cf0c8d799e9cd:*",
+                    "id": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                    "name": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                    "retentionInDays": "1",
+                    "tags": {}
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::pulumi-foo-log-collector-iamrole",
+                "custom": true,
+                "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                "type": "aws:iam/role:Role",
+                "inputs": {
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                },
+                "defaults": {
+                    "forceDetachPolicies": false,
+                    "name": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                    "path": "/"
+                },
+                "outputs": {
+                    "arn": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                    "createDate": "2017-11-08T19:51:49Z",
+                    "forceDetachPolicies": false,
+                    "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                    "name": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                    "path": "/",
+                    "uniqueId": "AROAIQAQPEUAL7EJ3HOZM"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-foo-log-collector-iampolicy-0",
+                "custom": true,
+                "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07-20171108195150465100000003",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07"
+                },
+                "outputs": {
+                    "id": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07-20171108195150465100000003",
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "pulumi-foo-log-collector-iamrole-be795575fd1fcf07"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::pulumi-foo-log-collector",
+                "custom": true,
+                "id": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                "type": "aws:lambda/function:Function",
+                "inputs": {
+                    "code": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "assets": {
+                            ".": {
+                                "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                "path": "."
+                            },
+                            "__index.js": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "hash": "371d4d8ead106550e5d7e2d0c02dd2e479dba060c765e09f98840fdfe73ea824",
+                                "text": "exports.handler = __88442d0b4365f25c858d35485cca4f999253cc40;\n\nfunction __88442d0b4365f25c858d35485cca4f999253cc40() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n            const zlib = require(\"zlib\");\n            const payload = new Buffer(ev.awslogs.data, \"base64\");\n            zlib.gunzip(payload, (err, result) =\u003e {\n                if (err !== undefined \u0026\u0026 err !== null) {\n                    cb(err, null);\n                }\n                else {\n                    console.log(result.toString(\"utf8\"));\n                    cb(null, {});\n                }\n            });\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                            }
+                        },
+                        "hash": "8a00ca481f85fe64b20537ac86fcb551b471dcfbff8c4623927d4654cd8a4ed2"
+                    },
+                    "handler": "__index.handler",
+                    "role": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                    "runtime": "nodejs6.10",
+                    "timeout": 180
+                },
+                "defaults": {
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive440249666",
+                    "memorySize": "128",
+                    "name": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "publish": false,
+                    "timeout": "180"
+                },
+                "outputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive938160569",
+                    "deadLetterConfig": [],
+                    "description": "",
+                    "environment": [],
+                    "handler": "__index.handler",
+                    "id": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8/invocations",
+                    "kmsKeyArn": "",
+                    "lastModified": "2017-11-08T19:52:01.821+0000",
+                    "memorySize": "128",
+                    "name": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "publish": false,
+                    "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8:$LATEST",
+                    "role": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-be795575fd1fcf07",
+                    "runtime": "nodejs6.10",
+                    "sourceCodeHash": "ZFzSi0OvUjtU4arIaBHfsxusBAoknUjiAxUTAB6U9oA=",
+                    "tags": {},
+                    "timeout": "180",
+                    "tracingConfig": [
+                        {
+                            "mode": "PassThrough"
+                        }
+                    ],
+                    "version": "$LATEST",
+                    "vpcConfig": []
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::pulumi-foo-log-collector",
+                "custom": false,
+                "type": "aws:serverless:Function",
+                "inputs": {
+                    "options": {
+                        "policies": [
+                            "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+                        ]
+                    }
+                },
+                "children": [
+                    "urn:pulumi:foo::countdown::aws:iam/role:Role::pulumi-foo-log-collector-iamrole",
+                    "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-foo-log-collector-iampolicy-0",
+                    "urn:pulumi:foo::countdown::aws:lambda/function:Function::pulumi-foo-log-collector"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::pulumi-foo-log-collector",
+                "custom": true,
+                "id": "pulumi-foo-log-collector-ba2b0a268e749fe6",
+                "type": "aws:lambda/permission:Permission",
+                "inputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "principal": "logs.us-east-2.amazonaws.com"
+                },
+                "defaults": {
+                    "statementId": "pulumi-foo-log-collector-ba2b0a268e749fe6"
+                },
+                "outputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "id": "pulumi-foo-log-collector-ba2b0a268e749fe6",
+                    "principal": "logs.us-east-2.amazonaws.com",
+                    "qualifier": "",
+                    "statementId": "pulumi-foo-log-collector-ba2b0a268e749fe6"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::countDown_watcher",
+                "custom": true,
+                "id": "cwlsf-2481582075",
+                "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                "inputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "filterPattern": "",
+                    "logGroup": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd"
+                },
+                "defaults": {
+                    "name": "countDown_watcher-57808b716bf46c1d"
+                },
+                "outputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "filterPattern": "",
+                    "id": "cwlsf-2481582075",
+                    "logGroup": "/aws/lambda/countDown_watcher-560cf0c8d799e9cd",
+                    "name": "countDown_watcher-57808b716bf46c1d"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::cloud:function:Function::countDown_watcher",
+                "custom": false,
+                "type": "cloud:function:Function",
+                "inputs": {
+                    "handler": {}
+                },
+                "children": [
+                    "urn:pulumi:foo::countdown::aws:cloudwatch/logGroup:LogGroup::countDown_watcher-func-logs",
+                    "urn:pulumi:foo::countdown::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::countDown_watcher",
+                    "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::pulumi-foo-log-collector",
+                    "urn:pulumi:foo::countdown::aws:serverless:Function::countDown_watcher"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::countDown_watcher",
+                "custom": true,
+                "id": "countDown_watcher-aa73943ce15ac420",
+                "type": "aws:lambda/permission:Permission",
+                "inputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "countDown_watcher-560cf0c8d799e9cd",
+                    "principal": "sns.amazonaws.com",
+                    "sourceArn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322"
+                },
+                "defaults": {
+                    "statementId": "countDown_watcher-aa73943ce15ac420"
+                },
+                "outputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "countDown_watcher-560cf0c8d799e9cd",
+                    "id": "countDown_watcher-aa73943ce15ac420",
+                    "principal": "sns.amazonaws.com",
+                    "qualifier": "",
+                    "sourceArn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322",
+                    "statementId": "countDown_watcher-aa73943ce15ac420"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:sns/topicSubscription:TopicSubscription::countDown_watcher",
+                "custom": true,
+                "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                "type": "aws:sns/topicSubscription:TopicSubscription",
+                "inputs": {
+                    "endpoint": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                    "protocol": "lambda",
+                    "topic": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322"
+                },
+                "defaults": {
+                    "confirmationTimeoutInMinutes": "1",
+                    "endpointAutoConfirms": false,
+                    "rawMessageDelivery": false
+                },
+                "outputs": {
+                    "arn": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                    "confirmationTimeoutInMinutes": "1",
+                    "endpoint": "arn:aws:lambda:us-east-2:153052954103:function:countDown_watcher-560cf0c8d799e9cd",
+                    "endpointAutoConfirms": false,
+                    "id": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322:c4790d7c-8106-438a-b368-cc7ade3eefc8",
+                    "protocol": "lambda",
+                    "rawMessageDelivery": false,
+                    "topic": "arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:iam/role:Role::heartbeat-iamrole",
+                "custom": true,
+                "id": "heartbeat-iamrole-ea19407f5d1f9983",
+                "type": "aws:iam/role:Role",
+                "inputs": {
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                },
+                "defaults": {
+                    "forceDetachPolicies": false,
+                    "name": "heartbeat-iamrole-ea19407f5d1f9983",
+                    "path": "/"
+                },
+                "outputs": {
+                    "arn": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                    "createDate": "2017-11-08T19:52:06Z",
+                    "forceDetachPolicies": false,
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983",
+                    "name": "heartbeat-iamrole-ea19407f5d1f9983",
+                    "path": "/",
+                    "uniqueId": "AROAJTGNWRNQ7OCLFKY7U"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::heartbeat-iampolicy-0",
+                "custom": true,
+                "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195207299700000004",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                },
+                "outputs": {
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195207299700000004",
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::heartbeat-iampolicy-1",
+                "custom": true,
+                "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195208724900000005",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                },
+                "outputs": {
+                    "id": "heartbeat-iamrole-ea19407f5d1f9983-20171108195208724900000005",
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "heartbeat-iamrole-ea19407f5d1f9983"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:lambda/function:Function::heartbeat",
+                "custom": true,
+                "id": "heartbeat-5614fce52cdefed1",
+                "type": "aws:lambda/function:Function",
+                "inputs": {
+                    "code": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "assets": {
+                            ".": {
+                                "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                "hash": "f82fadd12aa67ab9211a7ce021206fc288f10df32d3009291171be2a836cf47b",
+                                "path": "."
+                            },
+                            "__index.js": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "hash": "a468f1c8c9ab41698856ed3792332e6b5777feaed065a53649bdb060cf7f3230",
+                                "text": "exports.handler = __a455c2c731f5040281af02a4818453f11f0b328b;\n\nfunction __a455c2c731f5040281af02a4818453f11f0b328b() {\n  var _this;\n  with({ handler: __cc09ee843518b38f3cd7adfbed024016fa68320d }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n                handler().then(() =\u003e {\n                    cb(null, null);\n                }).catch((err) =\u003e {\n                    cb(err, null);\n                });\n            })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __cc09ee843518b38f3cd7adfbed024016fa68320d() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, countDown: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn (() =\u003e __awaiter(this, void 0, void 0, function* () {\n    yield countDown.publish(25);\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a() {\n  var _this;\n  with({ _this: { children: [ { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" } ], urn: \"urn:pulumi:foo::countdown::cloud:topic:Topic::countDown\", name: \"countDown\", topic: { children: [  ], urn: \"urn:pulumi:foo::countdown::aws:sns/topic:Topic::countDown\", id: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\", displayName: \"\", name: \"countDown-9d430501c4510322\", policy: \"{\\\"Id\\\":\\\"__default_policy_ID\\\",\\\"Statement\\\":[{\\\"Action\\\":[\\\"SNS:GetTopicAttributes\\\",\\\"SNS:SetTopicAttributes\\\",\\\"SNS:AddPermission\\\",\\\"SNS:RemovePermission\\\",\\\"SNS:DeleteTopic\\\",\\\"SNS:Subscribe\\\",\\\"SNS:ListSubscriptionsByTopic\\\",\\\"SNS:Publish\\\",\\\"SNS:Receive\\\"],\\\"Condition\\\":{\\\"StringEquals\\\":{\\\"AWS:SourceOwner\\\":\\\"153052954103\\\"}},\\\"Effect\\\":\\\"Allow\\\",\\\"Principal\\\":{\\\"AWS\\\":\\\"*\\\"},\\\"Resource\\\":\\\"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\\\",\\\"Sid\\\":\\\"__default_statement_ID\\\"}],\\\"Version\\\":\\\"2008-10-17\\\"}\", arn: \"arn:aws:sns:us-east-2:153052954103:countDown-9d430501c4510322\" }, publish: __b95cc3f572fd6cfdf970cdf7bf3f1b0f8d88700a } }) {\n    return (function() {\n\nreturn ((item) =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            const snsconn = new awssdk.SNS();\n            return snsconn.publish({\n                Message: JSON.stringify(item),\n                TopicArn: this.topic.id,\n            }).promise();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                            }
+                        },
+                        "hash": "28d308ff48619077125cb154436fed798c678ede238fc09aad199252747bb9af"
+                    },
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                        }
+                    ],
+                    "handler": "__index.handler",
+                    "memorySize": 128,
+                    "role": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                    "runtime": "nodejs6.10",
+                    "timeout": 180
+                },
+                "defaults": {
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive964270020",
+                    "memorySize": "128",
+                    "name": "heartbeat-5614fce52cdefed1",
+                    "publish": false,
+                    "timeout": "180"
+                },
+                "outputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive024127571",
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                        }
+                    ],
+                    "description": "",
+                    "environment": [],
+                    "handler": "__index.handler",
+                    "id": "heartbeat-5614fce52cdefed1",
+                    "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1/invocations",
+                    "kmsKeyArn": "",
+                    "lastModified": "2017-11-08T19:52:20.380+0000",
+                    "memorySize": "128",
+                    "name": "heartbeat-5614fce52cdefed1",
+                    "publish": false,
+                    "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1:$LATEST",
+                    "role": "arn:aws:iam::153052954103:role/heartbeat-iamrole-ea19407f5d1f9983",
+                    "runtime": "nodejs6.10",
+                    "sourceCodeHash": "H7sZcBf1/eLXcG/KVqmj6frm09XMQkpiLPaf2WEpLUs=",
+                    "tags": {},
+                    "timeout": "180",
+                    "tracingConfig": [
+                        {
+                            "mode": "PassThrough"
+                        }
+                    ],
+                    "version": "$LATEST",
+                    "vpcConfig": []
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat",
+                "custom": false,
+                "type": "aws:serverless:Function",
+                "inputs": {
+                    "options": {
+                        "deadLetterConfig": {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-ddd8c2cd9a876715"
+                        },
+                        "memorySize": 128,
+                        "policies": [
+                            "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                            "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                        ]
+                    }
+                },
+                "children": [
+                    "urn:pulumi:foo::countdown::aws:iam/role:Role::heartbeat-iamrole",
+                    "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::heartbeat-iampolicy-0",
+                    "urn:pulumi:foo::countdown::aws:iam/rolePolicyAttachment:RolePolicyAttachment::heartbeat-iampolicy-1",
+                    "urn:pulumi:foo::countdown::aws:lambda/function:Function::heartbeat"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logGroup:LogGroup::heartbeat-func-logs",
+                "custom": true,
+                "id": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                "type": "aws:cloudwatch/logGroup:LogGroup",
+                "inputs": {
+                    "name": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                    "retentionInDays": 1
+                },
+                "defaults": {
+                    "retentionInDays": "1"
+                },
+                "outputs": {
+                    "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/heartbeat-5614fce52cdefed1:*",
+                    "id": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                    "name": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                    "retentionInDays": "1",
+                    "tags": {}
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::heartbeat",
+                "custom": true,
+                "id": "cwlsf-2719389737",
+                "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                "inputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "filterPattern": "",
+                    "logGroup": "/aws/lambda/heartbeat-5614fce52cdefed1"
+                },
+                "defaults": {
+                    "name": "heartbeat-26ff913c249c7734"
+                },
+                "outputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-2c23bf214eaacce8",
+                    "filterPattern": "",
+                    "id": "cwlsf-2719389737",
+                    "logGroup": "/aws/lambda/heartbeat-5614fce52cdefed1",
+                    "name": "heartbeat-26ff913c249c7734"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat",
+                "custom": false,
+                "type": "cloud:function:Function",
+                "inputs": {
+                    "handler": {}
+                },
+                "children": [
+                    "urn:pulumi:foo::countdown::aws:cloudwatch/logGroup:LogGroup::heartbeat-func-logs",
+                    "urn:pulumi:foo::countdown::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::heartbeat",
+                    "urn:pulumi:foo::countdown::aws:serverless:Function::heartbeat"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/eventRule:EventRule::heartbeat",
+                "custom": true,
+                "id": "heartbeat-c7779a3d5f53ed1e",
+                "type": "aws:cloudwatch/eventRule:EventRule",
+                "inputs": {
+                    "scheduleExpression": "rate(5 minutes)"
+                },
+                "defaults": {
+                    "isEnabled": true,
+                    "name": "heartbeat-c7779a3d5f53ed1e"
+                },
+                "outputs": {
+                    "arn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e",
+                    "description": "",
+                    "id": "heartbeat-c7779a3d5f53ed1e",
+                    "isEnabled": true,
+                    "name": "heartbeat-c7779a3d5f53ed1e",
+                    "roleArn": "",
+                    "scheduleExpression": "rate(5 minutes)"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:cloudwatch/eventTarget:EventTarget::heartbeat",
+                "custom": true,
+                "id": "heartbeat-c7779a3d5f53ed1e-heartbeat",
+                "type": "aws:cloudwatch/eventTarget:EventTarget",
+                "inputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                    "rule": "heartbeat-c7779a3d5f53ed1e",
+                    "targetId": "heartbeat"
+                },
+                "outputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:heartbeat-5614fce52cdefed1",
+                    "id": "heartbeat-c7779a3d5f53ed1e-heartbeat",
+                    "input": "",
+                    "inputPath": "",
+                    "roleArn": "",
+                    "rule": "heartbeat-c7779a3d5f53ed1e",
+                    "targetId": "heartbeat"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::heartbeat",
+                "custom": true,
+                "id": "heartbeat-15d43252e0160c80",
+                "type": "aws:lambda/permission:Permission",
+                "inputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "heartbeat-5614fce52cdefed1",
+                    "principal": "events.amazonaws.com",
+                    "sourceArn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e"
+                },
+                "defaults": {
+                    "statementId": "heartbeat-15d43252e0160c80"
+                },
+                "outputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "heartbeat-5614fce52cdefed1",
+                    "id": "heartbeat-15d43252e0160c80",
+                    "principal": "events.amazonaws.com",
+                    "qualifier": "",
+                    "sourceArn": "arn:aws:events:us-east-2:153052954103:rule/heartbeat-c7779a3d5f53ed1e",
+                    "statementId": "heartbeat-15d43252e0160c80"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::countdown::cloud:timer:Timer::heartbeat",
+                "custom": false,
+                "type": "cloud:timer:Timer",
+                "inputs": {
+                    "scheduleExpression": "rate(5 minutes)"
+                },
+                "children": [
+                    "urn:pulumi:foo::countdown::aws:cloudwatch/eventRule:EventRule::heartbeat",
+                    "urn:pulumi:foo::countdown::aws:cloudwatch/eventTarget:EventTarget::heartbeat",
+                    "urn:pulumi:foo::countdown::aws:lambda/permission:Permission::heartbeat",
+                    "urn:pulumi:foo::countdown::cloud:function:Function::heartbeat"
+                ]
+            }
+        ]
+    }
+}

--- a/pkg/pulumiframework/testdata/todo.json
+++ b/pkg/pulumiframework/testdata/todo.json
@@ -1,0 +1,1168 @@
+{
+    "target": "foo",
+    "latest": {
+        "time": "2017-11-08T11:59:08.512209-08:00",
+        "resources": [
+            {
+                "urn": "urn:pulumi:foo::todo::aws:dynamodb/table:Table::todo",
+                "custom": true,
+                "id": "todo-a1916a6b16ec016b",
+                "type": "aws:dynamodb/table:Table",
+                "inputs": {
+                    "attribute": [
+                        {
+                            "name": "id",
+                            "type": "S"
+                        }
+                    ],
+                    "hashKey": "id",
+                    "readCapacity": 5,
+                    "writeCapacity": 5
+                },
+                "defaults": {
+                    "name": "todo-a1916a6b16ec016b",
+                    "readCapacity": "5",
+                    "writeCapacity": "5"
+                },
+                "outputs": {
+                    "arn": "arn:aws:dynamodb:us-east-2:153052954103:table/todo-a1916a6b16ec016b",
+                    "attribute": [
+                        {
+                            "name": "id",
+                            "type": "S"
+                        }
+                    ],
+                    "globalSecondaryIndex": [],
+                    "hashKey": "id",
+                    "id": "todo-a1916a6b16ec016b",
+                    "localSecondaryIndex": [],
+                    "name": "todo-a1916a6b16ec016b",
+                    "readCapacity": "5",
+                    "writeCapacity": "5"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::cloud:table:Table::todo",
+                "custom": false,
+                "type": "cloud:table:Table",
+                "inputs": {
+                    "primaryKey": "id",
+                    "primaryKeyType": "string"
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:dynamodb/table:Table::todo"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:s3/bucket:Bucket::todo",
+                "custom": true,
+                "id": "todo-8c10043f3d2b0e28",
+                "type": "aws:s3/bucket:Bucket",
+                "defaults": {
+                    "acl": "private",
+                    "bucket": "todo-8c10043f3d2b0e28",
+                    "forceDestroy": false
+                },
+                "outputs": {
+                    "accelerationStatus": "",
+                    "acl": "private",
+                    "arn": "arn:aws:s3:::todo-8c10043f3d2b0e28",
+                    "bucket": "todo-8c10043f3d2b0e28",
+                    "bucketDomainName": "todo-8c10043f3d2b0e28.s3.amazonaws.com",
+                    "forceDestroy": false,
+                    "hostedZoneId": "Z2O1EMRO9K5GLX",
+                    "id": "todo-8c10043f3d2b0e28",
+                    "logging": [],
+                    "region": "us-east-2",
+                    "requestPayer": "BucketOwner",
+                    "tags": {},
+                    "versioning": [
+                        {
+                            "enabled": false,
+                            "mfaDelete": false
+                        }
+                    ],
+                    "website": []
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/role:Role::todo4c238266",
+                "custom": true,
+                "id": "todo4c238266-c22303f113387c32",
+                "type": "aws:iam/role:Role",
+                "inputs": {
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"apigateway.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
+                },
+                "defaults": {
+                    "forceDetachPolicies": false,
+                    "name": "todo4c238266-c22303f113387c32",
+                    "path": "/"
+                },
+                "outputs": {
+                    "arn": "arn:aws:iam::153052954103:role/todo4c238266-c22303f113387c32",
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"apigateway.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                    "createDate": "2017-11-08T19:57:49Z",
+                    "forceDetachPolicies": false,
+                    "id": "todo4c238266-c22303f113387c32",
+                    "name": "todo4c238266-c22303f113387c32",
+                    "path": "/",
+                    "uniqueId": "AROAIZQT7GOCLELAEWHT2"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo4c238266",
+                "custom": true,
+                "id": "todo4c238266-c22303f113387c32-20171108195750237000000001",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+                    "role": "todo4c238266-c22303f113387c32"
+                },
+                "outputs": {
+                    "id": "todo4c238266-c22303f113387c32-20171108195750237000000001",
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonS3FullAccess",
+                    "role": "todo4c238266-c22303f113387c32"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:s3/bucketObject:BucketObject::todo4c238266/favicon.ico",
+                "custom": true,
+                "id": "todo4c238266/favicon.ico",
+                "type": "aws:s3/bucketObject:BucketObject",
+                "inputs": {
+                    "bucket": "todo-8c10043f3d2b0e28",
+                    "contentType": "image/x-icon",
+                    "key": "todo4c238266/favicon.ico",
+                    "source": {
+                        "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                        "hash": "3e928d52d10b060711c530e190e862cb8c1e32ae582da57a633d197c09475081",
+                        "path": "/Users/luke/go/src/github.com/pulumi/pulumi-cloud/examples/todo/www/favicon.ico"
+                    }
+                },
+                "defaults": {
+                    "acl": "private",
+                    "source": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-asset750331830"
+                },
+                "outputs": {
+                    "acl": "private",
+                    "bucket": "todo-8c10043f3d2b0e28",
+                    "cacheControl": "",
+                    "contentDisposition": "",
+                    "contentEncoding": "",
+                    "contentLanguage": "",
+                    "contentType": "image/x-icon",
+                    "etag": "8b29bc54ef1e39d577bd5a5157c7d285",
+                    "id": "todo4c238266/favicon.ico",
+                    "key": "todo4c238266/favicon.ico",
+                    "serverSideEncryption": "",
+                    "source": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-asset678329245",
+                    "storageClass": "STANDARD",
+                    "tags": {},
+                    "versionId": "",
+                    "websiteRedirect": ""
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:s3/bucketObject:BucketObject::todo4c238266/index.html",
+                "custom": true,
+                "id": "todo4c238266/index.html",
+                "type": "aws:s3/bucketObject:BucketObject",
+                "inputs": {
+                    "bucket": "todo-8c10043f3d2b0e28",
+                    "contentType": "text/html",
+                    "key": "todo4c238266/index.html",
+                    "source": {
+                        "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                        "hash": "064df7eb98909d2a5f50e74dfb94899d57d0aaba1ffc580541ca79afebf87bb7",
+                        "path": "/Users/luke/go/src/github.com/pulumi/pulumi-cloud/examples/todo/www/index.html"
+                    }
+                },
+                "defaults": {
+                    "acl": "private",
+                    "source": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-asset637927000"
+                },
+                "outputs": {
+                    "acl": "private",
+                    "bucket": "todo-8c10043f3d2b0e28",
+                    "cacheControl": "",
+                    "contentDisposition": "",
+                    "contentEncoding": "",
+                    "contentLanguage": "",
+                    "contentType": "text/html",
+                    "etag": "b996a167b3143d3a2fc3255ec69dbad4",
+                    "id": "todo4c238266/index.html",
+                    "key": "todo4c238266/index.html",
+                    "serverSideEncryption": "",
+                    "source": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-asset523489751",
+                    "storageClass": "STANDARD",
+                    "tags": {},
+                    "versionId": "",
+                    "websiteRedirect": ""
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:sns/topic:Topic::unhandled-error-topic",
+                "custom": true,
+                "id": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53",
+                "type": "aws:sns/topic:Topic",
+                "defaults": {
+                    "name": "unhandled-error-topic-7c13e147ce8d9e53"
+                },
+                "outputs": {
+                    "arn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53",
+                    "displayName": "",
+                    "id": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53",
+                    "name": "unhandled-error-topic-7c13e147ce8d9e53",
+                    "policy": "{\"Id\":\"__default_policy_ID\",\"Statement\":[{\"Action\":[\"SNS:GetTopicAttributes\",\"SNS:SetTopicAttributes\",\"SNS:AddPermission\",\"SNS:RemovePermission\",\"SNS:DeleteTopic\",\"SNS:Subscribe\",\"SNS:ListSubscriptionsByTopic\",\"SNS:Publish\",\"SNS:Receive\"],\"Condition\":{\"StringEquals\":{\"AWS:SourceOwner\":\"153052954103\"}},\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"*\"},\"Resource\":\"arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53\",\"Sid\":\"__default_statement_ID\"}],\"Version\":\"2008-10-17\"}"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/role:Role::todo035b5d8f-iamrole",
+                "custom": true,
+                "id": "todo035b5d8f-iamrole-4c6d0a50781a686f",
+                "type": "aws:iam/role:Role",
+                "inputs": {
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                },
+                "defaults": {
+                    "forceDetachPolicies": false,
+                    "name": "todo035b5d8f-iamrole-4c6d0a50781a686f",
+                    "path": "/"
+                },
+                "outputs": {
+                    "arn": "arn:aws:iam::153052954103:role/todo035b5d8f-iamrole-4c6d0a50781a686f",
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                    "createDate": "2017-11-08T19:57:56Z",
+                    "forceDetachPolicies": false,
+                    "id": "todo035b5d8f-iamrole-4c6d0a50781a686f",
+                    "name": "todo035b5d8f-iamrole-4c6d0a50781a686f",
+                    "path": "/",
+                    "uniqueId": "AROAJPLTIAHPA4S2PXQPY"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo035b5d8f-iampolicy-0",
+                "custom": true,
+                "id": "todo035b5d8f-iamrole-4c6d0a50781a686f-20171108195757731500000002",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "todo035b5d8f-iamrole-4c6d0a50781a686f"
+                },
+                "outputs": {
+                    "id": "todo035b5d8f-iamrole-4c6d0a50781a686f-20171108195757731500000002",
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "todo035b5d8f-iamrole-4c6d0a50781a686f"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo035b5d8f-iampolicy-1",
+                "custom": true,
+                "id": "todo035b5d8f-iamrole-4c6d0a50781a686f-20171108195759109500000003",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "todo035b5d8f-iamrole-4c6d0a50781a686f"
+                },
+                "outputs": {
+                    "id": "todo035b5d8f-iamrole-4c6d0a50781a686f-20171108195759109500000003",
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "todo035b5d8f-iamrole-4c6d0a50781a686f"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:lambda/function:Function::todo035b5d8f",
+                "custom": true,
+                "id": "todo035b5d8f-7748c68eadc313c0",
+                "type": "aws:lambda/function:Function",
+                "inputs": {
+                    "code": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "assets": {
+                            ".": {
+                                "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                "hash": "817deda9f0a4e4358a82e30faeaaab3bb456d0aa62faeb69aa744b3abf180995",
+                                "path": "."
+                            },
+                            "__index.js": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "hash": "dc21f0f3deefc1f33f9aee13b2861a2e6d24810f0f68fbfd2cc9669438cb0f76",
+                                "text": "exports.handler = __1d93ab845c76406f165a33c3b1aa7b72c82a0245;\n\nfunction __1d93ab845c76406f165a33c3b1aa7b72c82a0245() {\n  var _this;\n  with({ apiGatewayToRequestResponse: __fbf646106cb48cc5348746d6ce09d72037a0bb76, route: { method: \"GET\", path: \"/todo/{id}\", handlers: [ __d2f8baf55a86f7483292ccab09007d22aa150368, __5941ad084d3fce898f986ab0decb5538a0df0be7 ] } }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n                let body;\n                if (ev.body !== null) {\n                    if (ev.isBase64Encoded) {\n                        body = Buffer.from(ev.body, \"base64\");\n                    }\n                    else {\n                        body = Buffer.from(ev.body, \"utf8\");\n                    }\n                }\n                ctx.callbackWaitsForEmptyEventLoop = false;\n                const reqres = apiGatewayToRequestResponse(ev, body, cb);\n                let i = 0;\n                const next = () =\u003e {\n                    const nextHandler = route.handlers[i++];\n                    if (nextHandler !== undefined) {\n                        nextHandler(reqres.req, reqres.res, next);\n                    }\n                };\n                next();\n            })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __fbf646106cb48cc5348746d6ce09d72037a0bb76() {\n  var _this;\n  with({ stageName: \"stage\" }) {\n    return (function() {\n\nreturn (function apiGatewayToRequestResponse(ev, body, cb) {\n    const response = {\n        statusCode: 200,\n        headers: {},\n        body: Buffer.from([]),\n    };\n    const req = {\n        headers: ev.headers,\n        body: body,\n        method: ev.httpMethod,\n        params: ev.pathParameters,\n        query: ev.queryStringParameters,\n        path: ev.path,\n        baseUrl: \"/\" + stageName,\n        hostname: ev.headers[\"Host\"],\n        protocol: ev.headers[\"X-Forwarded-Proto\"],\n    };\n    const res = {\n        status: (code) =\u003e {\n            response.statusCode = code;\n            return res;\n        },\n        setHeader: (name, value) =\u003e {\n            response.headers[name] = value;\n            return res;\n        },\n        write: (data, encoding) =\u003e {\n            if (encoding === undefined) {\n                encoding = \"utf8\";\n            }\n            if (typeof data === \"string\") {\n                data = Buffer.from(data, encoding);\n            }\n            response.body = Buffer.concat([response.body, data]);\n            return res;\n        },\n        end: (data, encoding) =\u003e {\n            if (data !== undefined) {\n                res.write(data, encoding);\n            }\n            cb(null, {\n                statusCode: response.statusCode,\n                headers: response.headers,\n                isBase64Encoded: true,\n                body: response.body.toString(\"base64\"),\n            });\n        },\n        json: (obj) =\u003e {\n            res.setHeader(\"content-type\", \"application/json\");\n            res.end(JSON.stringify(obj));\n        },\n    };\n    return { req, res };\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __d2f8baf55a86f7483292ccab09007d22aa150368() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn ((req, res, next) =\u003e {\n    let auth = req.headers[\"Authorization\"];\n    if (auth !== \"Bearer SECRETPASSWORD\") {\n        res.status(401).end(\"Authorization header required\");\n        return;\n    }\n    next();\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __5941ad084d3fce898f986ab0decb5538a0df0be7() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, todos: { children: [ { children: [  ], urn: \"urn:pulumi:foo::todo::aws:dynamodb/table:Table::todo\", id: \"todo-a1916a6b16ec016b\", attribute: [ { name: \"id\", type: \"S\" } ], globalSecondaryIndex: [  ], hashKey: \"id\", localSecondaryIndex: [  ], name: \"todo-a1916a6b16ec016b\", readCapacity: \"5\", writeCapacity: \"5\", arn: \"arn:aws:dynamodb:us-east-2:153052954103:table/todo-a1916a6b16ec016b\" } ], urn: \"urn:pulumi:foo::todo::cloud:table:Table::todo\", primaryKey: \"id\", primaryKeyType: \"string\", get: __269a86aab19c88ab77347278ae480b2b3f3dd556, insert: __20c08953d1f10c1ddcff1e9ab6a0759b7516e3e3, scan: __42f6b3f709e32e9aee752e63d003b89c2bc2cad7, update: __124ff881420e47686a76c6dcae1754be8fb33422, delete: __3cfb20cfe7124ca024dfadf60ae1edecc10cf690 } }) {\n    return (function() {\n\nreturn ((req, res) =\u003e __awaiter(this, void 0, void 0, function* () {\n    console.log(\"GET /todo/\" + req.params[\"id\"]);\n    try {\n        let item = yield todos.get({ id: req.params[\"id\"] });\n        res.status(200).json(item.value);\n    }\n    catch (err) {\n        res.status(500).json(err);\n    }\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __269a86aab19c88ab77347278ae480b2b3f3dd556() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query) =\u003e __awaiter(this, void 0, void 0, function* () {\n            const result = yield db().get({\n                TableName: getTableName(),\n                Key: query,\n                ConsistentRead: true,\n            }).promise();\n            return result.Item;\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __32fa8104bfb1107c90c2d18cfcadb353e7323c4c() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (() =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            return new awssdk.DynamoDB.DocumentClient();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __2db1ada17876ecdd7d369ad50a160a38c23d44c4() {\n  var _this;\n  with({ tableName: \"todo-a1916a6b16ec016b\" }) {\n    return (function() {\n\nreturn (function getTableName() {\n            // Hack: Because of our outside/inside system for pulumi, tableName is seen as a\n            // Computed\u003cstring\u003e on the outside, but a string on the inside. Of course, there's no\n            // way to make TypeScript aware of that.  So we just fool the typesystem with these\n            // explicit casts.\n            //\n            // see: https://github.com/pulumi/pulumi/issues/331#issuecomment-333280955\n            return tableName;\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __20c08953d1f10c1ddcff1e9ab6a0759b7516e3e3() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((item) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield db().put({\n                TableName: getTableName(),\n                Item: item,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __42f6b3f709e32e9aee752e63d003b89c2bc2cad7() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn (() =\u003e __awaiter(this, void 0, void 0, function* () {\n            const result = yield db().scan({\n                TableName: getTableName(),\n                ConsistentRead: true,\n            }).promise();\n            return result.Items;\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __124ff881420e47686a76c6dcae1754be8fb33422() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query, updates) =\u003e __awaiter(this, void 0, void 0, function* () {\n            let updateExpression = \"\";\n            const attributeValues = {};\n            for (const key of Object.keys(updates)) {\n                const val = updates[key];\n                if (updateExpression === \"\") {\n                    updateExpression += \"SET \";\n                }\n                else {\n                    updateExpression += \", \";\n                }\n                updateExpression += `${key} = :${key}`;\n                attributeValues[`:${key}`] = val;\n            }\n            yield db().update({\n                TableName: getTableName(),\n                Key: query,\n                UpdateExpression: updateExpression,\n                ExpressionAttributeValues: attributeValues,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __3cfb20cfe7124ca024dfadf60ae1edecc10cf690() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield db().delete({\n                TableName: getTableName(),\n                Key: query,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                            }
+                        },
+                        "hash": "bd8cb8017488e278e396f1e3b7eea27bc4b376d0adc075593aea9e32da043a38"
+                    },
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        }
+                    ],
+                    "handler": "__index.handler",
+                    "memorySize": 128,
+                    "role": "arn:aws:iam::153052954103:role/todo035b5d8f-iamrole-4c6d0a50781a686f",
+                    "runtime": "nodejs6.10",
+                    "timeout": 180
+                },
+                "defaults": {
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive035209546",
+                    "memorySize": "128",
+                    "name": "todo035b5d8f-7748c68eadc313c0",
+                    "publish": false,
+                    "timeout": "180"
+                },
+                "outputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:todo035b5d8f-7748c68eadc313c0",
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive894239265",
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        }
+                    ],
+                    "description": "",
+                    "environment": [],
+                    "handler": "__index.handler",
+                    "id": "todo035b5d8f-7748c68eadc313c0",
+                    "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todo035b5d8f-7748c68eadc313c0/invocations",
+                    "kmsKeyArn": "",
+                    "lastModified": "2017-11-08T19:58:07.802+0000",
+                    "memorySize": "128",
+                    "name": "todo035b5d8f-7748c68eadc313c0",
+                    "publish": false,
+                    "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:todo035b5d8f-7748c68eadc313c0:$LATEST",
+                    "role": "arn:aws:iam::153052954103:role/todo035b5d8f-iamrole-4c6d0a50781a686f",
+                    "runtime": "nodejs6.10",
+                    "sourceCodeHash": "Pj7qx3M0/X9sY4nBiLeDFAklTGhYmjG527OkA6cDFgM=",
+                    "tags": {},
+                    "timeout": "180",
+                    "tracingConfig": [
+                        {
+                            "mode": "PassThrough"
+                        }
+                    ],
+                    "version": "$LATEST",
+                    "vpcConfig": []
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:serverless:Function::todo035b5d8f",
+                "custom": false,
+                "type": "aws:serverless:Function",
+                "inputs": {
+                    "options": {
+                        "deadLetterConfig": {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        },
+                        "memorySize": 128,
+                        "policies": [
+                            "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                            "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                        ]
+                    }
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:iam/role:Role::todo035b5d8f-iamrole",
+                    "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo035b5d8f-iampolicy-0",
+                    "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo035b5d8f-iampolicy-1",
+                    "urn:pulumi:foo::todo::aws:lambda/function:Function::todo035b5d8f"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:cloudwatch/logGroup:LogGroup::todo035b5d8f-func-logs",
+                "custom": true,
+                "id": "/aws/lambda/todo035b5d8f-7748c68eadc313c0",
+                "type": "aws:cloudwatch/logGroup:LogGroup",
+                "inputs": {
+                    "name": "/aws/lambda/todo035b5d8f-7748c68eadc313c0",
+                    "retentionInDays": 1
+                },
+                "defaults": {
+                    "retentionInDays": "1"
+                },
+                "outputs": {
+                    "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/todo035b5d8f-7748c68eadc313c0:*",
+                    "id": "/aws/lambda/todo035b5d8f-7748c68eadc313c0",
+                    "name": "/aws/lambda/todo035b5d8f-7748c68eadc313c0",
+                    "retentionInDays": "1",
+                    "tags": {}
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/role:Role::pulumi-foo-log-collector-iamrole",
+                "custom": true,
+                "id": "pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7",
+                "type": "aws:iam/role:Role",
+                "inputs": {
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                },
+                "defaults": {
+                    "forceDetachPolicies": false,
+                    "name": "pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7",
+                    "path": "/"
+                },
+                "outputs": {
+                    "arn": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7",
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                    "createDate": "2017-11-08T19:58:11Z",
+                    "forceDetachPolicies": false,
+                    "id": "pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7",
+                    "name": "pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7",
+                    "path": "/",
+                    "uniqueId": "AROAJ4VEH3V4TL27YZSSM"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-foo-log-collector-iampolicy-0",
+                "custom": true,
+                "id": "pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7-20171108195812293000000004",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7"
+                },
+                "outputs": {
+                    "id": "pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7-20171108195812293000000004",
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:lambda/function:Function::pulumi-foo-log-collector",
+                "custom": true,
+                "id": "pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                "type": "aws:lambda/function:Function",
+                "inputs": {
+                    "code": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "assets": {
+                            ".": {
+                                "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                "hash": "817deda9f0a4e4358a82e30faeaaab3bb456d0aa62faeb69aa744b3abf180995",
+                                "path": "."
+                            },
+                            "__index.js": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "hash": "371d4d8ead106550e5d7e2d0c02dd2e479dba060c765e09f98840fdfe73ea824",
+                                "text": "exports.handler = __88442d0b4365f25c858d35485cca4f999253cc40;\n\nfunction __88442d0b4365f25c858d35485cca4f999253cc40() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n            const zlib = require(\"zlib\");\n            const payload = new Buffer(ev.awslogs.data, \"base64\");\n            zlib.gunzip(payload, (err, result) =\u003e {\n                if (err !== undefined \u0026\u0026 err !== null) {\n                    cb(err, null);\n                }\n                else {\n                    console.log(result.toString(\"utf8\"));\n                    cb(null, {});\n                }\n            });\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                            }
+                        },
+                        "hash": "a9d89fe37b8226be55d17695285012d451d2e749947db7a336962eeb65fc1345"
+                    },
+                    "handler": "__index.handler",
+                    "role": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7",
+                    "runtime": "nodejs6.10",
+                    "timeout": 180
+                },
+                "defaults": {
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive580507404",
+                    "memorySize": "128",
+                    "name": "pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "publish": false,
+                    "timeout": "180"
+                },
+                "outputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive451729659",
+                    "deadLetterConfig": [],
+                    "description": "",
+                    "environment": [],
+                    "handler": "__index.handler",
+                    "id": "pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff/invocations",
+                    "kmsKeyArn": "",
+                    "lastModified": "2017-11-08T19:58:25.717+0000",
+                    "memorySize": "128",
+                    "name": "pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "publish": false,
+                    "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff:$LATEST",
+                    "role": "arn:aws:iam::153052954103:role/pulumi-foo-log-collector-iamrole-2af8f6868f85d7d7",
+                    "runtime": "nodejs6.10",
+                    "sourceCodeHash": "rC8lRsDSOm3VcDZrv8qkZ4LsGBpYHlkcWHRE5qHBWLM=",
+                    "tags": {},
+                    "timeout": "180",
+                    "tracingConfig": [
+                        {
+                            "mode": "PassThrough"
+                        }
+                    ],
+                    "version": "$LATEST",
+                    "vpcConfig": []
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:serverless:Function::pulumi-foo-log-collector",
+                "custom": false,
+                "type": "aws:serverless:Function",
+                "inputs": {
+                    "options": {
+                        "policies": [
+                            "arn:aws:iam::aws:policy/AWSLambdaFullAccess"
+                        ]
+                    }
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:iam/role:Role::pulumi-foo-log-collector-iamrole",
+                    "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::pulumi-foo-log-collector-iampolicy-0",
+                    "urn:pulumi:foo::todo::aws:lambda/function:Function::pulumi-foo-log-collector"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:lambda/permission:Permission::pulumi-foo-log-collector",
+                "custom": true,
+                "id": "pulumi-foo-log-collector-715ade4f6f854187",
+                "type": "aws:lambda/permission:Permission",
+                "inputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "principal": "logs.us-east-2.amazonaws.com"
+                },
+                "defaults": {
+                    "statementId": "pulumi-foo-log-collector-715ade4f6f854187"
+                },
+                "outputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "id": "pulumi-foo-log-collector-715ade4f6f854187",
+                    "principal": "logs.us-east-2.amazonaws.com",
+                    "qualifier": "",
+                    "statementId": "pulumi-foo-log-collector-715ade4f6f854187"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::todo035b5d8f",
+                "custom": true,
+                "id": "cwlsf-2917862896",
+                "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                "inputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "filterPattern": "",
+                    "logGroup": "/aws/lambda/todo035b5d8f-7748c68eadc313c0"
+                },
+                "defaults": {
+                    "name": "todo035b5d8f-c9b30759625946a3"
+                },
+                "outputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "filterPattern": "",
+                    "id": "cwlsf-2917862896",
+                    "logGroup": "/aws/lambda/todo035b5d8f-7748c68eadc313c0",
+                    "name": "todo035b5d8f-c9b30759625946a3"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::cloud:function:Function::todo035b5d8f",
+                "custom": false,
+                "type": "cloud:function:Function",
+                "inputs": {
+                    "handler": {}
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:cloudwatch/logGroup:LogGroup::todo035b5d8f-func-logs",
+                    "urn:pulumi:foo::todo::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::todo035b5d8f",
+                    "urn:pulumi:foo::todo::aws:lambda/permission:Permission::pulumi-foo-log-collector",
+                    "urn:pulumi:foo::todo::aws:serverless:Function::todo035b5d8f"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/role:Role::todo67876f56-iamrole",
+                "custom": true,
+                "id": "todo67876f56-iamrole-ce66deec75ae88fd",
+                "type": "aws:iam/role:Role",
+                "inputs": {
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                },
+                "defaults": {
+                    "forceDetachPolicies": false,
+                    "name": "todo67876f56-iamrole-ce66deec75ae88fd",
+                    "path": "/"
+                },
+                "outputs": {
+                    "arn": "arn:aws:iam::153052954103:role/todo67876f56-iamrole-ce66deec75ae88fd",
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                    "createDate": "2017-11-08T19:58:28Z",
+                    "forceDetachPolicies": false,
+                    "id": "todo67876f56-iamrole-ce66deec75ae88fd",
+                    "name": "todo67876f56-iamrole-ce66deec75ae88fd",
+                    "path": "/",
+                    "uniqueId": "AROAJ4OUDFQWKLTUWKJO6"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo67876f56-iampolicy-0",
+                "custom": true,
+                "id": "todo67876f56-iamrole-ce66deec75ae88fd-20171108195829869300000005",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "todo67876f56-iamrole-ce66deec75ae88fd"
+                },
+                "outputs": {
+                    "id": "todo67876f56-iamrole-ce66deec75ae88fd-20171108195829869300000005",
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "todo67876f56-iamrole-ce66deec75ae88fd"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo67876f56-iampolicy-1",
+                "custom": true,
+                "id": "todo67876f56-iamrole-ce66deec75ae88fd-20171108195831240000000006",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "todo67876f56-iamrole-ce66deec75ae88fd"
+                },
+                "outputs": {
+                    "id": "todo67876f56-iamrole-ce66deec75ae88fd-20171108195831240000000006",
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "todo67876f56-iamrole-ce66deec75ae88fd"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:lambda/function:Function::todo67876f56",
+                "custom": true,
+                "id": "todo67876f56-7069ef1500d0e44e",
+                "type": "aws:lambda/function:Function",
+                "inputs": {
+                    "code": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "assets": {
+                            ".": {
+                                "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                "hash": "817deda9f0a4e4358a82e30faeaaab3bb456d0aa62faeb69aa744b3abf180995",
+                                "path": "."
+                            },
+                            "__index.js": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "hash": "ece4682cb493cbebe3c503bee17d4566db2fe361528d5b1e86acb48fa2aa7362",
+                                "text": "exports.handler = __a950d2f3106e78658d58f1ab976fb89886d8a56a;\n\nfunction __a950d2f3106e78658d58f1ab976fb89886d8a56a() {\n  var _this;\n  with({ apiGatewayToRequestResponse: __fbf646106cb48cc5348746d6ce09d72037a0bb76, route: { method: \"POST\", path: \"/todo/{id}\", handlers: [ __83c5bf0f4cf2fd2730ceee79a34c9fb7ee3f9ded ] } }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n                let body;\n                if (ev.body !== null) {\n                    if (ev.isBase64Encoded) {\n                        body = Buffer.from(ev.body, \"base64\");\n                    }\n                    else {\n                        body = Buffer.from(ev.body, \"utf8\");\n                    }\n                }\n                ctx.callbackWaitsForEmptyEventLoop = false;\n                const reqres = apiGatewayToRequestResponse(ev, body, cb);\n                let i = 0;\n                const next = () =\u003e {\n                    const nextHandler = route.handlers[i++];\n                    if (nextHandler !== undefined) {\n                        nextHandler(reqres.req, reqres.res, next);\n                    }\n                };\n                next();\n            })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __fbf646106cb48cc5348746d6ce09d72037a0bb76() {\n  var _this;\n  with({ stageName: \"stage\" }) {\n    return (function() {\n\nreturn (function apiGatewayToRequestResponse(ev, body, cb) {\n    const response = {\n        statusCode: 200,\n        headers: {},\n        body: Buffer.from([]),\n    };\n    const req = {\n        headers: ev.headers,\n        body: body,\n        method: ev.httpMethod,\n        params: ev.pathParameters,\n        query: ev.queryStringParameters,\n        path: ev.path,\n        baseUrl: \"/\" + stageName,\n        hostname: ev.headers[\"Host\"],\n        protocol: ev.headers[\"X-Forwarded-Proto\"],\n    };\n    const res = {\n        status: (code) =\u003e {\n            response.statusCode = code;\n            return res;\n        },\n        setHeader: (name, value) =\u003e {\n            response.headers[name] = value;\n            return res;\n        },\n        write: (data, encoding) =\u003e {\n            if (encoding === undefined) {\n                encoding = \"utf8\";\n            }\n            if (typeof data === \"string\") {\n                data = Buffer.from(data, encoding);\n            }\n            response.body = Buffer.concat([response.body, data]);\n            return res;\n        },\n        end: (data, encoding) =\u003e {\n            if (data !== undefined) {\n                res.write(data, encoding);\n            }\n            cb(null, {\n                statusCode: response.statusCode,\n                headers: response.headers,\n                isBase64Encoded: true,\n                body: response.body.toString(\"base64\"),\n            });\n        },\n        json: (obj) =\u003e {\n            res.setHeader(\"content-type\", \"application/json\");\n            res.end(JSON.stringify(obj));\n        },\n    };\n    return { req, res };\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __83c5bf0f4cf2fd2730ceee79a34c9fb7ee3f9ded() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, todos: { children: [ { children: [  ], urn: \"urn:pulumi:foo::todo::aws:dynamodb/table:Table::todo\", id: \"todo-a1916a6b16ec016b\", attribute: [ { name: \"id\", type: \"S\" } ], globalSecondaryIndex: [  ], hashKey: \"id\", localSecondaryIndex: [  ], name: \"todo-a1916a6b16ec016b\", readCapacity: \"5\", writeCapacity: \"5\", arn: \"arn:aws:dynamodb:us-east-2:153052954103:table/todo-a1916a6b16ec016b\" } ], urn: \"urn:pulumi:foo::todo::cloud:table:Table::todo\", primaryKey: \"id\", primaryKeyType: \"string\", get: __269a86aab19c88ab77347278ae480b2b3f3dd556, insert: __20c08953d1f10c1ddcff1e9ab6a0759b7516e3e3, scan: __42f6b3f709e32e9aee752e63d003b89c2bc2cad7, update: __124ff881420e47686a76c6dcae1754be8fb33422, delete: __3cfb20cfe7124ca024dfadf60ae1edecc10cf690 } }) {\n    return (function() {\n\nreturn ((req, res) =\u003e __awaiter(this, void 0, void 0, function* () {\n    console.log(\"POST /todo/\" + req.params[\"id\"]);\n    try {\n        yield todos.insert({ id: req.params[\"id\"], value: req.body.toString() });\n        res.status(201).json({});\n    }\n    catch (err) {\n        res.status(500).json(err);\n    }\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __269a86aab19c88ab77347278ae480b2b3f3dd556() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query) =\u003e __awaiter(this, void 0, void 0, function* () {\n            const result = yield db().get({\n                TableName: getTableName(),\n                Key: query,\n                ConsistentRead: true,\n            }).promise();\n            return result.Item;\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __32fa8104bfb1107c90c2d18cfcadb353e7323c4c() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (() =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            return new awssdk.DynamoDB.DocumentClient();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __2db1ada17876ecdd7d369ad50a160a38c23d44c4() {\n  var _this;\n  with({ tableName: \"todo-a1916a6b16ec016b\" }) {\n    return (function() {\n\nreturn (function getTableName() {\n            // Hack: Because of our outside/inside system for pulumi, tableName is seen as a\n            // Computed\u003cstring\u003e on the outside, but a string on the inside. Of course, there's no\n            // way to make TypeScript aware of that.  So we just fool the typesystem with these\n            // explicit casts.\n            //\n            // see: https://github.com/pulumi/pulumi/issues/331#issuecomment-333280955\n            return tableName;\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __20c08953d1f10c1ddcff1e9ab6a0759b7516e3e3() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((item) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield db().put({\n                TableName: getTableName(),\n                Item: item,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __42f6b3f709e32e9aee752e63d003b89c2bc2cad7() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn (() =\u003e __awaiter(this, void 0, void 0, function* () {\n            const result = yield db().scan({\n                TableName: getTableName(),\n                ConsistentRead: true,\n            }).promise();\n            return result.Items;\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __124ff881420e47686a76c6dcae1754be8fb33422() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query, updates) =\u003e __awaiter(this, void 0, void 0, function* () {\n            let updateExpression = \"\";\n            const attributeValues = {};\n            for (const key of Object.keys(updates)) {\n                const val = updates[key];\n                if (updateExpression === \"\") {\n                    updateExpression += \"SET \";\n                }\n                else {\n                    updateExpression += \", \";\n                }\n                updateExpression += `${key} = :${key}`;\n                attributeValues[`:${key}`] = val;\n            }\n            yield db().update({\n                TableName: getTableName(),\n                Key: query,\n                UpdateExpression: updateExpression,\n                ExpressionAttributeValues: attributeValues,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __3cfb20cfe7124ca024dfadf60ae1edecc10cf690() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield db().delete({\n                TableName: getTableName(),\n                Key: query,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                            }
+                        },
+                        "hash": "95023a27d5a4393ec1440ff2d704997748f68087320f130218deb540c457f14a"
+                    },
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        }
+                    ],
+                    "handler": "__index.handler",
+                    "memorySize": 128,
+                    "role": "arn:aws:iam::153052954103:role/todo67876f56-iamrole-ce66deec75ae88fd",
+                    "runtime": "nodejs6.10",
+                    "timeout": 180
+                },
+                "defaults": {
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive069041694",
+                    "memorySize": "128",
+                    "name": "todo67876f56-7069ef1500d0e44e",
+                    "publish": false,
+                    "timeout": "180"
+                },
+                "outputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:todo67876f56-7069ef1500d0e44e",
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive199670501",
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        }
+                    ],
+                    "description": "",
+                    "environment": [],
+                    "handler": "__index.handler",
+                    "id": "todo67876f56-7069ef1500d0e44e",
+                    "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todo67876f56-7069ef1500d0e44e/invocations",
+                    "kmsKeyArn": "",
+                    "lastModified": "2017-11-08T19:58:39.700+0000",
+                    "memorySize": "128",
+                    "name": "todo67876f56-7069ef1500d0e44e",
+                    "publish": false,
+                    "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:todo67876f56-7069ef1500d0e44e:$LATEST",
+                    "role": "arn:aws:iam::153052954103:role/todo67876f56-iamrole-ce66deec75ae88fd",
+                    "runtime": "nodejs6.10",
+                    "sourceCodeHash": "8MW5kWvG/GsKUoKzl6eeave6PJsTtx943FRFO/hizFM=",
+                    "tags": {},
+                    "timeout": "180",
+                    "tracingConfig": [
+                        {
+                            "mode": "PassThrough"
+                        }
+                    ],
+                    "version": "$LATEST",
+                    "vpcConfig": []
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:serverless:Function::todo67876f56",
+                "custom": false,
+                "type": "aws:serverless:Function",
+                "inputs": {
+                    "options": {
+                        "deadLetterConfig": {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        },
+                        "memorySize": 128,
+                        "policies": [
+                            "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                            "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                        ]
+                    }
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:iam/role:Role::todo67876f56-iamrole",
+                    "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo67876f56-iampolicy-0",
+                    "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo67876f56-iampolicy-1",
+                    "urn:pulumi:foo::todo::aws:lambda/function:Function::todo67876f56"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:cloudwatch/logGroup:LogGroup::todo67876f56-func-logs",
+                "custom": true,
+                "id": "/aws/lambda/todo67876f56-7069ef1500d0e44e",
+                "type": "aws:cloudwatch/logGroup:LogGroup",
+                "inputs": {
+                    "name": "/aws/lambda/todo67876f56-7069ef1500d0e44e",
+                    "retentionInDays": 1
+                },
+                "defaults": {
+                    "retentionInDays": "1"
+                },
+                "outputs": {
+                    "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/todo67876f56-7069ef1500d0e44e:*",
+                    "id": "/aws/lambda/todo67876f56-7069ef1500d0e44e",
+                    "name": "/aws/lambda/todo67876f56-7069ef1500d0e44e",
+                    "retentionInDays": "1",
+                    "tags": {}
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::todo67876f56",
+                "custom": true,
+                "id": "cwlsf-1714177476",
+                "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                "inputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "filterPattern": "",
+                    "logGroup": "/aws/lambda/todo67876f56-7069ef1500d0e44e"
+                },
+                "defaults": {
+                    "name": "todo67876f56-b74b44a8d71cb4d7"
+                },
+                "outputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "filterPattern": "",
+                    "id": "cwlsf-1714177476",
+                    "logGroup": "/aws/lambda/todo67876f56-7069ef1500d0e44e",
+                    "name": "todo67876f56-b74b44a8d71cb4d7"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::cloud:function:Function::todo67876f56",
+                "custom": false,
+                "type": "cloud:function:Function",
+                "inputs": {
+                    "handler": {}
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:cloudwatch/logGroup:LogGroup::todo67876f56-func-logs",
+                    "urn:pulumi:foo::todo::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::todo67876f56",
+                    "urn:pulumi:foo::todo::aws:serverless:Function::todo67876f56"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/role:Role::todoc57917fa-iamrole",
+                "custom": true,
+                "id": "todoc57917fa-iamrole-694bcb6442f1858b",
+                "type": "aws:iam/role:Role",
+                "inputs": {
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}"
+                },
+                "defaults": {
+                    "forceDetachPolicies": false,
+                    "name": "todoc57917fa-iamrole-694bcb6442f1858b",
+                    "path": "/"
+                },
+                "outputs": {
+                    "arn": "arn:aws:iam::153052954103:role/todoc57917fa-iamrole-694bcb6442f1858b",
+                    "assumeRolePolicy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}",
+                    "createDate": "2017-11-08T19:58:44Z",
+                    "forceDetachPolicies": false,
+                    "id": "todoc57917fa-iamrole-694bcb6442f1858b",
+                    "name": "todoc57917fa-iamrole-694bcb6442f1858b",
+                    "path": "/",
+                    "uniqueId": "AROAIGQTRMZ65JGHRMYGI"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todoc57917fa-iampolicy-0",
+                "custom": true,
+                "id": "todoc57917fa-iamrole-694bcb6442f1858b-20171108195845358400000007",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "todoc57917fa-iamrole-694bcb6442f1858b"
+                },
+                "outputs": {
+                    "id": "todoc57917fa-iamrole-694bcb6442f1858b-20171108195845358400000007",
+                    "policyArn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                    "role": "todoc57917fa-iamrole-694bcb6442f1858b"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todoc57917fa-iampolicy-1",
+                "custom": true,
+                "id": "todoc57917fa-iamrole-694bcb6442f1858b-20171108195846675000000008",
+                "type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+                "inputs": {
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "todoc57917fa-iamrole-694bcb6442f1858b"
+                },
+                "outputs": {
+                    "id": "todoc57917fa-iamrole-694bcb6442f1858b-20171108195846675000000008",
+                    "policyArn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess",
+                    "role": "todoc57917fa-iamrole-694bcb6442f1858b"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:lambda/function:Function::todoc57917fa",
+                "custom": true,
+                "id": "todoc57917fa-2fb58339c66e2b46",
+                "type": "aws:lambda/function:Function",
+                "inputs": {
+                    "code": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "assets": {
+                            ".": {
+                                "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                "hash": "817deda9f0a4e4358a82e30faeaaab3bb456d0aa62faeb69aa744b3abf180995",
+                                "path": "."
+                            },
+                            "__index.js": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "hash": "c580d01e8cd138bafec86d9637e36c91f0b02f76a93f905107a706023cc38ffa",
+                                "text": "exports.handler = __e1c9effdafcb58b254eea61ac68abf8a58b1f75f;\n\nfunction __e1c9effdafcb58b254eea61ac68abf8a58b1f75f() {\n  var _this;\n  with({ apiGatewayToRequestResponse: __fbf646106cb48cc5348746d6ce09d72037a0bb76, route: { method: \"GET\", path: \"/todo\", handlers: [ __cfa3f168a2b5a7b0e8c87c7c05d9f158fc764d0d ] } }) {\n    return (function() {\n\nreturn ((ev, ctx, cb) =\u003e {\n                let body;\n                if (ev.body !== null) {\n                    if (ev.isBase64Encoded) {\n                        body = Buffer.from(ev.body, \"base64\");\n                    }\n                    else {\n                        body = Buffer.from(ev.body, \"utf8\");\n                    }\n                }\n                ctx.callbackWaitsForEmptyEventLoop = false;\n                const reqres = apiGatewayToRequestResponse(ev, body, cb);\n                let i = 0;\n                const next = () =\u003e {\n                    const nextHandler = route.handlers[i++];\n                    if (nextHandler !== undefined) {\n                        nextHandler(reqres.req, reqres.res, next);\n                    }\n                };\n                next();\n            })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __fbf646106cb48cc5348746d6ce09d72037a0bb76() {\n  var _this;\n  with({ stageName: \"stage\" }) {\n    return (function() {\n\nreturn (function apiGatewayToRequestResponse(ev, body, cb) {\n    const response = {\n        statusCode: 200,\n        headers: {},\n        body: Buffer.from([]),\n    };\n    const req = {\n        headers: ev.headers,\n        body: body,\n        method: ev.httpMethod,\n        params: ev.pathParameters,\n        query: ev.queryStringParameters,\n        path: ev.path,\n        baseUrl: \"/\" + stageName,\n        hostname: ev.headers[\"Host\"],\n        protocol: ev.headers[\"X-Forwarded-Proto\"],\n    };\n    const res = {\n        status: (code) =\u003e {\n            response.statusCode = code;\n            return res;\n        },\n        setHeader: (name, value) =\u003e {\n            response.headers[name] = value;\n            return res;\n        },\n        write: (data, encoding) =\u003e {\n            if (encoding === undefined) {\n                encoding = \"utf8\";\n            }\n            if (typeof data === \"string\") {\n                data = Buffer.from(data, encoding);\n            }\n            response.body = Buffer.concat([response.body, data]);\n            return res;\n        },\n        end: (data, encoding) =\u003e {\n            if (data !== undefined) {\n                res.write(data, encoding);\n            }\n            cb(null, {\n                statusCode: response.statusCode,\n                headers: response.headers,\n                isBase64Encoded: true,\n                body: response.body.toString(\"base64\"),\n            });\n        },\n        json: (obj) =\u003e {\n            res.setHeader(\"content-type\", \"application/json\");\n            res.end(JSON.stringify(obj));\n        },\n    };\n    return { req, res };\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __cfa3f168a2b5a7b0e8c87c7c05d9f158fc764d0d() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, todos: { children: [ { children: [  ], urn: \"urn:pulumi:foo::todo::aws:dynamodb/table:Table::todo\", id: \"todo-a1916a6b16ec016b\", attribute: [ { name: \"id\", type: \"S\" } ], globalSecondaryIndex: [  ], hashKey: \"id\", localSecondaryIndex: [  ], name: \"todo-a1916a6b16ec016b\", readCapacity: \"5\", writeCapacity: \"5\", arn: \"arn:aws:dynamodb:us-east-2:153052954103:table/todo-a1916a6b16ec016b\" } ], urn: \"urn:pulumi:foo::todo::cloud:table:Table::todo\", primaryKey: \"id\", primaryKeyType: \"string\", get: __269a86aab19c88ab77347278ae480b2b3f3dd556, insert: __20c08953d1f10c1ddcff1e9ab6a0759b7516e3e3, scan: __42f6b3f709e32e9aee752e63d003b89c2bc2cad7, update: __124ff881420e47686a76c6dcae1754be8fb33422, delete: __3cfb20cfe7124ca024dfadf60ae1edecc10cf690 } }) {\n    return (function() {\n\nreturn ((req, res) =\u003e __awaiter(this, void 0, void 0, function* () {\n    console.log(\"GET /todo\");\n    try {\n        let items = yield todos.scan();\n        res.status(200).json(items);\n    }\n    catch (err) {\n        res.status(500).json(err);\n    }\n}))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __492fe142c8be132f2ccfdc443ed720d77b1ef3a6() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (function (thisArg, _arguments, P, generator) {\n    return new (P || (P = Promise))(function (resolve, reject) {\n        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }\n        function rejected(value) { try { step(generator[\"throw\"](value)); } catch (e) { reject(e); } }\n        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }\n        step((generator = generator.apply(thisArg, _arguments || [])).next());\n    });\n})\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __269a86aab19c88ab77347278ae480b2b3f3dd556() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query) =\u003e __awaiter(this, void 0, void 0, function* () {\n            const result = yield db().get({\n                TableName: getTableName(),\n                Key: query,\n                ConsistentRead: true,\n            }).promise();\n            return result.Item;\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __32fa8104bfb1107c90c2d18cfcadb353e7323c4c() {\n  var _this;\n  with({  }) {\n    return (function() {\n\nreturn (() =\u003e {\n            const awssdk = require(\"aws-sdk\");\n            return new awssdk.DynamoDB.DocumentClient();\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __2db1ada17876ecdd7d369ad50a160a38c23d44c4() {\n  var _this;\n  with({ tableName: \"todo-a1916a6b16ec016b\" }) {\n    return (function() {\n\nreturn (function getTableName() {\n            // Hack: Because of our outside/inside system for pulumi, tableName is seen as a\n            // Computed\u003cstring\u003e on the outside, but a string on the inside. Of course, there's no\n            // way to make TypeScript aware of that.  So we just fool the typesystem with these\n            // explicit casts.\n            //\n            // see: https://github.com/pulumi/pulumi/issues/331#issuecomment-333280955\n            return tableName;\n        })\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __20c08953d1f10c1ddcff1e9ab6a0759b7516e3e3() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((item) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield db().put({\n                TableName: getTableName(),\n                Item: item,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __42f6b3f709e32e9aee752e63d003b89c2bc2cad7() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn (() =\u003e __awaiter(this, void 0, void 0, function* () {\n            const result = yield db().scan({\n                TableName: getTableName(),\n                ConsistentRead: true,\n            }).promise();\n            return result.Items;\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __124ff881420e47686a76c6dcae1754be8fb33422() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query, updates) =\u003e __awaiter(this, void 0, void 0, function* () {\n            let updateExpression = \"\";\n            const attributeValues = {};\n            for (const key of Object.keys(updates)) {\n                const val = updates[key];\n                if (updateExpression === \"\") {\n                    updateExpression += \"SET \";\n                }\n                else {\n                    updateExpression += \", \";\n                }\n                updateExpression += `${key} = :${key}`;\n                attributeValues[`:${key}`] = val;\n            }\n            yield db().update({\n                TableName: getTableName(),\n                Key: query,\n                UpdateExpression: updateExpression,\n                ExpressionAttributeValues: attributeValues,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\nfunction __3cfb20cfe7124ca024dfadf60ae1edecc10cf690() {\n  var _this;\n  with({ __awaiter: __492fe142c8be132f2ccfdc443ed720d77b1ef3a6, db: __32fa8104bfb1107c90c2d18cfcadb353e7323c4c, getTableName: __2db1ada17876ecdd7d369ad50a160a38c23d44c4 }) {\n    return (function() {\n\nreturn ((query) =\u003e __awaiter(this, void 0, void 0, function* () {\n            yield db().delete({\n                TableName: getTableName(),\n                Key: query,\n            }).promise();\n        }))\n\n    }).apply(_this).apply(this, arguments);\n  }\n}\n\n"
+                            }
+                        },
+                        "hash": "0e2624d7e58513ff02277d9d7ce4f9b6bc32a4cd09002ac82c3b3a31a1257205"
+                    },
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        }
+                    ],
+                    "handler": "__index.handler",
+                    "memorySize": 128,
+                    "role": "arn:aws:iam::153052954103:role/todoc57917fa-iamrole-694bcb6442f1858b",
+                    "runtime": "nodejs6.10",
+                    "timeout": 180
+                },
+                "defaults": {
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive769316096",
+                    "memorySize": "128",
+                    "name": "todoc57917fa-2fb58339c66e2b46",
+                    "publish": false,
+                    "timeout": "180"
+                },
+                "outputs": {
+                    "arn": "arn:aws:lambda:us-east-2:153052954103:function:todoc57917fa-2fb58339c66e2b46",
+                    "code": "/var/folders/h7/n3r2j28517g5bbvlkn1l_h_80000gn/T/pulumi-archive597830751",
+                    "deadLetterConfig": [
+                        {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        }
+                    ],
+                    "description": "",
+                    "environment": [],
+                    "handler": "__index.handler",
+                    "id": "todoc57917fa-2fb58339c66e2b46",
+                    "invokeArn": "arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todoc57917fa-2fb58339c66e2b46/invocations",
+                    "kmsKeyArn": "",
+                    "lastModified": "2017-11-08T19:58:55.468+0000",
+                    "memorySize": "128",
+                    "name": "todoc57917fa-2fb58339c66e2b46",
+                    "publish": false,
+                    "qualifiedArn": "arn:aws:lambda:us-east-2:153052954103:function:todoc57917fa-2fb58339c66e2b46:$LATEST",
+                    "role": "arn:aws:iam::153052954103:role/todoc57917fa-iamrole-694bcb6442f1858b",
+                    "runtime": "nodejs6.10",
+                    "sourceCodeHash": "JOLZIbcsEiyD/ve/26I7FakO5pE4IcDcHw+So/Mxdlo=",
+                    "tags": {},
+                    "timeout": "180",
+                    "tracingConfig": [
+                        {
+                            "mode": "PassThrough"
+                        }
+                    ],
+                    "version": "$LATEST",
+                    "vpcConfig": []
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:serverless:Function::todoc57917fa",
+                "custom": false,
+                "type": "aws:serverless:Function",
+                "inputs": {
+                    "options": {
+                        "deadLetterConfig": {
+                            "targetArn": "arn:aws:sns:us-east-2:153052954103:unhandled-error-topic-7c13e147ce8d9e53"
+                        },
+                        "memorySize": 128,
+                        "policies": [
+                            "arn:aws:iam::aws:policy/AWSLambdaFullAccess",
+                            "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess"
+                        ]
+                    }
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:iam/role:Role::todoc57917fa-iamrole",
+                    "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todoc57917fa-iampolicy-0",
+                    "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todoc57917fa-iampolicy-1",
+                    "urn:pulumi:foo::todo::aws:lambda/function:Function::todoc57917fa"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:cloudwatch/logGroup:LogGroup::todoc57917fa-func-logs",
+                "custom": true,
+                "id": "/aws/lambda/todoc57917fa-2fb58339c66e2b46",
+                "type": "aws:cloudwatch/logGroup:LogGroup",
+                "inputs": {
+                    "name": "/aws/lambda/todoc57917fa-2fb58339c66e2b46",
+                    "retentionInDays": 1
+                },
+                "defaults": {
+                    "retentionInDays": "1"
+                },
+                "outputs": {
+                    "arn": "arn:aws:logs:us-east-2:153052954103:log-group:/aws/lambda/todoc57917fa-2fb58339c66e2b46:*",
+                    "id": "/aws/lambda/todoc57917fa-2fb58339c66e2b46",
+                    "name": "/aws/lambda/todoc57917fa-2fb58339c66e2b46",
+                    "retentionInDays": "1",
+                    "tags": {}
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::todoc57917fa",
+                "custom": true,
+                "id": "cwlsf-166366141",
+                "type": "aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter",
+                "inputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "filterPattern": "",
+                    "logGroup": "/aws/lambda/todoc57917fa-2fb58339c66e2b46"
+                },
+                "defaults": {
+                    "name": "todoc57917fa-80b54f1d26aaf9da"
+                },
+                "outputs": {
+                    "destinationArn": "arn:aws:lambda:us-east-2:153052954103:function:pulumi-foo-log-collector-e9cd6ec58f2116ff",
+                    "filterPattern": "",
+                    "id": "cwlsf-166366141",
+                    "logGroup": "/aws/lambda/todoc57917fa-2fb58339c66e2b46",
+                    "name": "todoc57917fa-80b54f1d26aaf9da"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::cloud:function:Function::todoc57917fa",
+                "custom": false,
+                "type": "cloud:function:Function",
+                "inputs": {
+                    "handler": {}
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:cloudwatch/logGroup:LogGroup::todoc57917fa-func-logs",
+                    "urn:pulumi:foo::todo::aws:cloudwatch/logSubscriptionFilter:LogSubscriptionFilter::todoc57917fa",
+                    "urn:pulumi:foo::todo::aws:serverless:Function::todoc57917fa"
+                ]
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:apigateway/restApi:RestApi::todo",
+                "custom": true,
+                "id": "eupwl7wu4i",
+                "type": "aws:apigateway/restApi:RestApi",
+                "inputs": {
+                    "body": "{\"swagger\":\"2.0\",\"info\":{\"title\":\"todo\",\"version\":\"1.0\"},\"paths\":{\"/\":{\"get\":{\"responses\":{\"200\":{\"description\":\"200 response\",\"schema\":{\"type\":\"object\"},\"headers\":{\"Content-Type\":{\"type\":\"string\"},\"content-type\":{\"type\":\"string\"}}},\"400\":{\"description\":\"400 response\"},\"500\":{\"description\":\"500 response\"}},\"x-amazon-apigateway-integration\":{\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"GET\",\"type\":\"aws\",\"responses\":{\"4\\\\d{2}\":{\"statusCode\":\"400\"},\"default\":{\"statusCode\":\"200\",\"responseParameters\":{\"method.response.header.Content-Type\":\"integration.response.header.Content-Type\",\"method.response.header.content-type\":\"integration.response.header.content-type\"}},\"5\\\\d{2}\":{\"statusCode\":\"500\"}},\"uri\":\"arn:aws:apigateway:us-east-2:s3:path/todo-8c10043f3d2b0e28/todo4c238266/index.html\",\"credentials\":\"arn:aws:iam::153052954103:role/todo4c238266-c22303f113387c32\"}}},\"/{proxy+}\":{\"x-amazon-apigateway-any-method\":{\"parameters\":[{\"name\":\"proxy\",\"in\":\"path\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"200 response\",\"schema\":{\"type\":\"object\"},\"headers\":{\"Content-Type\":{\"type\":\"string\"},\"content-type\":{\"type\":\"string\"}}},\"400\":{\"description\":\"400 response\"},\"500\":{\"description\":\"500 response\"}},\"x-amazon-apigateway-integration\":{\"requestParameters\":{\"integration.request.path.proxy\":\"method.request.path.proxy\"},\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"GET\",\"type\":\"aws\",\"responses\":{\"4\\\\d{2}\":{\"statusCode\":\"400\"},\"default\":{\"statusCode\":\"200\",\"responseParameters\":{\"method.response.header.Content-Type\":\"integration.response.header.Content-Type\",\"method.response.header.content-type\":\"integration.response.header.content-type\"}},\"5\\\\d{2}\":{\"statusCode\":\"500\"}},\"uri\":\"arn:aws:apigateway:us-east-2:s3:path/todo-8c10043f3d2b0e28/todo4c238266/{proxy}\",\"credentials\":\"arn:aws:iam::153052954103:role/todo4c238266-c22303f113387c32\"}}},\"/todo/{id}\":{\"get\":{\"x-amazon-apigateway-integration\":{\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"POST\",\"type\":\"aws_proxy\",\"uri\":\"arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todo035b5d8f-7748c68eadc313c0/invocations\"}},\"post\":{\"x-amazon-apigateway-integration\":{\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"POST\",\"type\":\"aws_proxy\",\"uri\":\"arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todo67876f56-7069ef1500d0e44e/invocations\"}}},\"/todo\":{\"get\":{\"x-amazon-apigateway-integration\":{\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"POST\",\"type\":\"aws_proxy\",\"uri\":\"arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todoc57917fa-2fb58339c66e2b46/invocations\"}}}},\"x-amazon-apigateway-binary-media-types\":[\"*/*\"]}"
+                },
+                "defaults": {
+                    "name": "todo-ad0751ace493404e"
+                },
+                "outputs": {
+                    "body": "{\"swagger\":\"2.0\",\"info\":{\"title\":\"todo\",\"version\":\"1.0\"},\"paths\":{\"/\":{\"get\":{\"responses\":{\"200\":{\"description\":\"200 response\",\"schema\":{\"type\":\"object\"},\"headers\":{\"Content-Type\":{\"type\":\"string\"},\"content-type\":{\"type\":\"string\"}}},\"400\":{\"description\":\"400 response\"},\"500\":{\"description\":\"500 response\"}},\"x-amazon-apigateway-integration\":{\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"GET\",\"type\":\"aws\",\"responses\":{\"4\\\\d{2}\":{\"statusCode\":\"400\"},\"default\":{\"statusCode\":\"200\",\"responseParameters\":{\"method.response.header.Content-Type\":\"integration.response.header.Content-Type\",\"method.response.header.content-type\":\"integration.response.header.content-type\"}},\"5\\\\d{2}\":{\"statusCode\":\"500\"}},\"uri\":\"arn:aws:apigateway:us-east-2:s3:path/todo-8c10043f3d2b0e28/todo4c238266/index.html\",\"credentials\":\"arn:aws:iam::153052954103:role/todo4c238266-c22303f113387c32\"}}},\"/{proxy+}\":{\"x-amazon-apigateway-any-method\":{\"parameters\":[{\"name\":\"proxy\",\"in\":\"path\",\"required\":true,\"type\":\"string\"}],\"responses\":{\"200\":{\"description\":\"200 response\",\"schema\":{\"type\":\"object\"},\"headers\":{\"Content-Type\":{\"type\":\"string\"},\"content-type\":{\"type\":\"string\"}}},\"400\":{\"description\":\"400 response\"},\"500\":{\"description\":\"500 response\"}},\"x-amazon-apigateway-integration\":{\"requestParameters\":{\"integration.request.path.proxy\":\"method.request.path.proxy\"},\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"GET\",\"type\":\"aws\",\"responses\":{\"4\\\\d{2}\":{\"statusCode\":\"400\"},\"default\":{\"statusCode\":\"200\",\"responseParameters\":{\"method.response.header.Content-Type\":\"integration.response.header.Content-Type\",\"method.response.header.content-type\":\"integration.response.header.content-type\"}},\"5\\\\d{2}\":{\"statusCode\":\"500\"}},\"uri\":\"arn:aws:apigateway:us-east-2:s3:path/todo-8c10043f3d2b0e28/todo4c238266/{proxy}\",\"credentials\":\"arn:aws:iam::153052954103:role/todo4c238266-c22303f113387c32\"}}},\"/todo/{id}\":{\"get\":{\"x-amazon-apigateway-integration\":{\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"POST\",\"type\":\"aws_proxy\",\"uri\":\"arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todo035b5d8f-7748c68eadc313c0/invocations\"}},\"post\":{\"x-amazon-apigateway-integration\":{\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"POST\",\"type\":\"aws_proxy\",\"uri\":\"arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todo67876f56-7069ef1500d0e44e/invocations\"}}},\"/todo\":{\"get\":{\"x-amazon-apigateway-integration\":{\"passthroughBehavior\":\"when_no_match\",\"httpMethod\":\"POST\",\"type\":\"aws_proxy\",\"uri\":\"arn:aws:apigateway:us-east-2:lambda:path/2015-03-31/functions/arn:aws:lambda:us-east-2:153052954103:function:todoc57917fa-2fb58339c66e2b46/invocations\"}}}},\"x-amazon-apigateway-binary-media-types\":[\"*/*\"]}",
+                    "createdDate": "2017-11-08T19:58:59Z",
+                    "description": "",
+                    "id": "eupwl7wu4i",
+                    "name": "todo",
+                    "rootResourceId": "jxbhzjh5dd"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:apigateway/deployment:Deployment::todo_f569e86a",
+                "custom": true,
+                "id": "4ws2ht",
+                "type": "aws:apigateway/deployment:Deployment",
+                "inputs": {
+                    "description": "Deployment of version todo_f569e86a",
+                    "restApi": "eupwl7wu4i",
+                    "stageName": ""
+                },
+                "outputs": {
+                    "createdDate": "2017-11-08T19:59:03Z",
+                    "description": "Deployment of version todo_f569e86a",
+                    "executionArn": "arn:aws:execute-api:us-east-2:153052954103:eupwl7wu4i/",
+                    "id": "4ws2ht",
+                    "invokeUrl": "https://eupwl7wu4i.execute-api.us-east-2.amazonaws.com/",
+                    "restApi": "eupwl7wu4i",
+                    "stageName": ""
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:apigateway/stage:Stage::todo",
+                "custom": true,
+                "id": "ags-eupwl7wu4i-stage",
+                "type": "aws:apigateway/stage:Stage",
+                "inputs": {
+                    "deployment": "4ws2ht",
+                    "description": "The current deployment of the API.",
+                    "restApi": "eupwl7wu4i",
+                    "stageName": "stage"
+                },
+                "outputs": {
+                    "cacheClusterEnabled": false,
+                    "cacheClusterSize": "",
+                    "clientCertificateId": "",
+                    "deployment": "4ws2ht",
+                    "description": "The current deployment of the API.",
+                    "documentationVersion": "",
+                    "id": "ags-eupwl7wu4i-stage",
+                    "restApi": "eupwl7wu4i",
+                    "stageName": "stage",
+                    "variables": {}
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:lambda/permission:Permission::todo_invoke_f0c1d77e",
+                "custom": true,
+                "id": "todo_invoke_f0c1d77e-0225bcbbfa5e7941",
+                "type": "aws:lambda/permission:Permission",
+                "inputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "todo035b5d8f-7748c68eadc313c0",
+                    "principal": "apigateway.amazonaws.com",
+                    "sourceArn": "arn:aws:execute-api:us-east-2:153052954103:eupwl7wu4i/stage/GET/todo/{id}"
+                },
+                "defaults": {
+                    "statementId": "todo_invoke_f0c1d77e-0225bcbbfa5e7941"
+                },
+                "outputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "todo035b5d8f-7748c68eadc313c0",
+                    "id": "todo_invoke_f0c1d77e-0225bcbbfa5e7941",
+                    "principal": "apigateway.amazonaws.com",
+                    "qualifier": "",
+                    "sourceArn": "arn:aws:execute-api:us-east-2:153052954103:eupwl7wu4i/stage/GET/todo/{id}",
+                    "statementId": "todo_invoke_f0c1d77e-0225bcbbfa5e7941"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:lambda/permission:Permission::todo_invoke_44308e8f",
+                "custom": true,
+                "id": "todo_invoke_44308e8f-08a405381ef4ecdb",
+                "type": "aws:lambda/permission:Permission",
+                "inputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "todo67876f56-7069ef1500d0e44e",
+                    "principal": "apigateway.amazonaws.com",
+                    "sourceArn": "arn:aws:execute-api:us-east-2:153052954103:eupwl7wu4i/stage/POST/todo/{id}"
+                },
+                "defaults": {
+                    "statementId": "todo_invoke_44308e8f-08a405381ef4ecdb"
+                },
+                "outputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "todo67876f56-7069ef1500d0e44e",
+                    "id": "todo_invoke_44308e8f-08a405381ef4ecdb",
+                    "principal": "apigateway.amazonaws.com",
+                    "qualifier": "",
+                    "sourceArn": "arn:aws:execute-api:us-east-2:153052954103:eupwl7wu4i/stage/POST/todo/{id}",
+                    "statementId": "todo_invoke_44308e8f-08a405381ef4ecdb"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:lambda/permission:Permission::todo_invoke_a55f2cbc",
+                "custom": true,
+                "id": "todo_invoke_a55f2cbc-b70db0537c54d3d2",
+                "type": "aws:lambda/permission:Permission",
+                "inputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "todoc57917fa-2fb58339c66e2b46",
+                    "principal": "apigateway.amazonaws.com",
+                    "sourceArn": "arn:aws:execute-api:us-east-2:153052954103:eupwl7wu4i/stage/GET/todo"
+                },
+                "defaults": {
+                    "statementId": "todo_invoke_a55f2cbc-b70db0537c54d3d2"
+                },
+                "outputs": {
+                    "action": "lambda:invokeFunction",
+                    "function": "todoc57917fa-2fb58339c66e2b46",
+                    "id": "todo_invoke_a55f2cbc-b70db0537c54d3d2",
+                    "principal": "apigateway.amazonaws.com",
+                    "qualifier": "",
+                    "sourceArn": "arn:aws:execute-api:us-east-2:153052954103:eupwl7wu4i/stage/GET/todo",
+                    "statementId": "todo_invoke_a55f2cbc-b70db0537c54d3d2"
+                }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::cloud:http:HttpEndpoint::todo",
+                "custom": false,
+                "type": "cloud:http:HttpEndpoint",
+                "inputs": {
+                    "customDomainNames": [],
+                    "customDomains": [],
+                    "routes": [
+                        {
+                            "handlers": [
+                                {},
+                                {}
+                            ],
+                            "method": "GET",
+                            "path": "/todo/{id}"
+                        },
+                        {
+                            "handlers": [
+                                {}
+                            ],
+                            "method": "POST",
+                            "path": "/todo/{id}"
+                        },
+                        {
+                            "handlers": [
+                                {}
+                            ],
+                            "method": "GET",
+                            "path": "/todo"
+                        }
+                    ],
+                    "staticRoutes": [
+                        {
+                            "localPath": "www",
+                            "options": {},
+                            "path": "/"
+                        }
+                    ],
+                    "url": "https://eupwl7wu4i.execute-api.us-east-2.amazonaws.com/"
+                },
+                "children": [
+                    "urn:pulumi:foo::todo::aws:apigateway/deployment:Deployment::todo_f569e86a",
+                    "urn:pulumi:foo::todo::aws:apigateway/restApi:RestApi::todo",
+                    "urn:pulumi:foo::todo::aws:apigateway/stage:Stage::todo",
+                    "urn:pulumi:foo::todo::aws:iam/role:Role::todo4c238266",
+                    "urn:pulumi:foo::todo::aws:iam/rolePolicyAttachment:RolePolicyAttachment::todo4c238266",
+                    "urn:pulumi:foo::todo::aws:lambda/permission:Permission::todo_invoke_44308e8f",
+                    "urn:pulumi:foo::todo::aws:lambda/permission:Permission::todo_invoke_a55f2cbc",
+                    "urn:pulumi:foo::todo::aws:lambda/permission:Permission::todo_invoke_f0c1d77e",
+                    "urn:pulumi:foo::todo::aws:s3/bucket:Bucket::todo",
+                    "urn:pulumi:foo::todo::aws:s3/bucketObject:BucketObject::todo4c238266/favicon.ico",
+                    "urn:pulumi:foo::todo::aws:s3/bucketObject:BucketObject::todo4c238266/index.html",
+                    "urn:pulumi:foo::todo::cloud:function:Function::todo035b5d8f",
+                    "urn:pulumi:foo::todo::cloud:function:Function::todo67876f56",
+                    "urn:pulumi:foo::todo::cloud:function:Function::todoc57917fa"
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
This is the smallest possible thing that could work for both the local
development case and the case where we are targeting the Pulumi
Service.

Pulling down the pulumiframework and component packages here is a bit
of a feel bad, but we plan to rework the model soon enough to a
provider model which will remove the need for us to hold on to this
code (and will bring back the factoring where the CLI does not have
baked in knowledge of the Pulumi Cloud Framework).

Fixes #527