### PR TITLE
Change configuration verbs for getting and setting values

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -3,10 +3,8 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -47,13 +45,11 @@ func loginCmd() error {
 	if accessToken != "" {
 		fmt.Printf("Using access token from %s.\n", PulumiAccessTokenEnvVar)
 	} else {
-		fmt.Print("Enter Pulumi access token: ")
-		reader := bufio.NewReader(os.Stdin)
-		raw, err := reader.ReadString('\n')
+		token, err := readConsole("Enter Pulumi access token")
 		if err != nil {
-			return fmt.Errorf("reading STDIN: %v", err)
+			return err
 		}
-		accessToken = strings.TrimSpace(raw)
+		accessToken = token
 	}
 
 	// Try and use the credentials to see if they are valid.

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -17,7 +17,8 @@ func newLogsCmd() *cobra.Command {
 	var follow bool
 
 	logsCmd := &cobra.Command{
-		Use: "logs",
+		Use:   "logs",
+		Short: "Show aggregated logs for a project",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			stackName, err := explicitOrCurrent(stack, backend)
 			if err != nil {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"bufio"
 	cryptorand "crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
@@ -177,6 +178,20 @@ func readConsoleNoEchoWithPrompt(prompt string) (string, error) {
 	}
 
 	return readConsoleNoEcho()
+}
+
+func readConsole(prompt string) (string, error) {
+	if prompt != "" {
+		fmt.Printf("%s: ", prompt)
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	raw, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(raw), nil
 }
 
 func readPassphrase(prompt string) (string, error) {

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -167,8 +167,8 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 //   yarn run build
 //   pulumi init
 //   pulumi stack init integrationtesting
-//   pulumi config text <each opts.Config>
-//   pulumi config secret <each opts.Secrets>
+//   pulumi config set <each opts.Config>
+//   pulumi config set --secret <each opts.Secrets>
 //   pulumi preview
 //   pulumi update
 //   pulumi preview (expected to be empty)
@@ -204,14 +204,14 @@ func ProgramTest(t *testing.T, opts ProgramTestOptions) {
 	}
 	for key, value := range opts.Config {
 		if err = RunCommand(t, "pulumi-config",
-			[]string{opts.Bin, "config", "text", key, value}, dir, opts); err != nil {
+			[]string{opts.Bin, "config", "set", key, value}, dir, opts); err != nil {
 			return
 		}
 	}
 
 	for key, value := range opts.Secrets {
 		if err = RunCommand(t, "pulumi-config",
-			[]string{opts.Bin, "config", "secret", key, value}, dir, opts); err != nil {
+			[]string{opts.Bin, "config", "set", "--secret", key, value}, dir, opts); err != nil {
 			return
 		}
 	}


### PR DESCRIPTION
Move from two top level commands `text` and `secret` to a single `set`
command to set a value. To store a value encrypted, use `--secret` as
an argument to `set`.

Renames `ls` to `get`. The command is otherwise unchanged, so `get`
with no additional arguments will print all the configuration values
for a stack (in a table format), while `get <key-name>` will print the
value for that key by itself (useful for scripting).

Fixes #552