### PR TITLE
Allow overriding a Pulumi.yaml's entrypoint

### DIFF
--- a/pkg/pack/package.go
+++ b/pkg/pack/package.go
@@ -18,14 +18,16 @@ import (
 )
 
 // Package is a top-level package definition.
-// We explicitly add yaml tags (instead of using the default behavior from https://github.com/ghodss/yaml which works in terms of the
-// JSON tags) so we can directly marshall and unmarshall this struct using https://github.com/go-yaml/yaml an have the fields in the
-// serialized object match the order they are defined in this struct
 //
-// TODO[pulumi/pulumi#423]: use DOM based marshalling so we can make minimal changes to the seralized structure when roundtripping
+// We explicitly add yaml tags (instead of using the default behavior from https://github.com/ghodss/yaml which works
+// in terms of the JSON tags) so we can directly marshall and unmarshall this struct using go-yaml an have the fields
+// in the serialized object match the order they are defined in this struct.
+//
+// TODO[pulumi/pulumi#423]: use DOM based marshalling so we can roundtrip the seralized structure perfectly.
 type Package struct {
 	Name    tokens.PackageName `json:"name" yaml:"name"`       // a required fully qualified name.
 	Runtime string             `json:"runtime" yaml:"runtime"` // a required runtime that executes code.
+	Main    string             `json:"main" yaml:"main"`       // an optional override for the main program location.
 
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"` // an optional informational description.
 	Author      *string `json:"author,omitempty" yaml:"author,omitempty"`           // an optional author.

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -227,15 +227,15 @@ func (p *plugin) Close() error {
 	// we need to kill all the children of the PID we have recorded, as well. Otherwise we will block waiting for the child
 	// processes to close.
 	if runtime.GOOS == "windows" {
-		err := cmdutil.KillChildren(p.Proc.Pid)
-		if err != nil {
+		if err := cmdutil.KillChildren(p.Proc.Pid); err != nil {
 			result = multierror.Append(result, err)
 		}
 	}
 
 	// IDEA: consider a more graceful termination than just SIGKILL.
-	err := p.Proc.Kill()
-	result = multierror.Append(result, err)
+	if err := p.Proc.Kill(); err != nil {
+		result = multierror.Append(result, err)
+	}
 
 	// Wait for stdout and stderr to drain
 	<-p.stdoutDone

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -109,16 +109,9 @@ export function main(args: string[]): void {
         process.exit(-1);
     }
     let program: string = argv._[0];
-    if (program.indexOf(".") === 0) {
-        // If there was a pwd change, make this relative to it.
-        if (pwd) {
-            program = path.join(pwd, program);
-        }
-    } else if (program.indexOf("/") !== 0) {
-        // Neither absolute nor relative module, we refuse to execute it.
-        console.error(`fatal: Program path '${program}' must be an absolute or relative path to the program`);
-        usage();
-        process.exit(-1);
+    if (program.indexOf("/") !== 0) {
+        // If this isn't an absolute path, make it relative to the working directory.
+        program = path.join(process.cwd(), program);
     }
 
     // Now fake out the process-wide argv, to make the program think it was run normally.

--- a/tests/ints/ints_test.go
+++ b/tests/ints/ints_test.go
@@ -1,0 +1,25 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package ints
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/resource/stack"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+)
+
+func TestProjectMain(t *testing.T) {
+	var test integration.ProgramTestOptions
+	test = integration.ProgramTestOptions{
+		Dir:          "project_main",
+		Dependencies: []string{"pulumi"},
+		ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
+			// Simple runtime validation that just ensures the checkpoint was written and read.
+			assert.Equal(t, test.StackName(), checkpoint.Target)
+		},
+	}
+	integration.ProgramTest(t, test)
+}

--- a/tests/ints/project_main/Pulumi.yaml
+++ b/tests/ints/project_main/Pulumi.yaml
@@ -1,0 +1,5 @@
+name: project_main
+description: A program with a different main specification.
+runtime: nodejs
+main: a/path/to/main/
+

--- a/tests/ints/project_main/a/path/to/main/.gitignore
+++ b/tests/ints/project_main/a/path/to/main/.gitignore
@@ -1,0 +1,4 @@
+/bin/
+/node_modules/
+yarn.lock
+

--- a/tests/ints/project_main/a/path/to/main/index.ts
+++ b/tests/ints/project_main/a/path/to/main/index.ts
@@ -1,0 +1,3 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+console.log("So much main");

--- a/tests/ints/project_main/a/path/to/main/package.json
+++ b/tests/ints/project_main/a/path/to/main/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "project_main",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    }
+}

--- a/tests/ints/project_main/a/path/to/main/tsconfig.json
+++ b/tests/ints/project_main/a/path/to/main/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+


### PR DESCRIPTION
Because the Pulumi.yaml file demarcates the boundary used when
uploading a program to the Pulumi.com service at the moment, we
have trouble when a Pulumi program uses "up and over" references.
For instance, our customer wants to build a Dockerfile located
in some relative path, such as `../../elsewhere/`.

To support this, we will allow the Pulumi.yaml file to live
somewhere other than the main Pulumi entrypoint.  For example,
it can live at the root of the repo, while the Pulumi program
lives in, say, `infra/`:

    Pulumi.yaml:
    name: as-before
    main: infra/

This fixes pulumi/pulumi#575.  Further work can be done here to
provide even more flexibility; see pulumi/pulumi#574.