### PR TITLE
Speed up `make install` for javascript projects

### DIFF
--- a/build/common.mk
+++ b/build/common.mk
@@ -156,9 +156,10 @@ install::
 	mkdir -p "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
 	cp -r bin/. "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
 	cp package.json "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
+	cp yarn.lock "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)"
 	rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)/node_modules"
 	cd "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)" && \
-	yarn install --production && \
+	yarn install --offline --production && \
 	(yarn unlink > /dev/null 2>&1 || true) && \
 	yarn link
 endif


### PR DESCRIPTION
To install a package, we copied the pacakge to the destination root,
deleted the node_modules folder and then restored just the production
dependencies. Because of how we were using yarn, this meant hitting
the network, which sucks.

Make two changes:

1. Copy over the yarn.lock file we created when we did our initial
restore (e.g from `make ensure`) so yarn can reuse it.
2. Pass --offline to yarn when we do yarn install. Since we already
installed the packages previously (as part of `make ensure`) they will
be present in the cache and hence we do not need network access.

This cuts the time spent in the make install step by half or more.