### PR TITLE
Add developer only `pulumi archive` command

### DIFF
--- a/cmd/debug_cmds.go
+++ b/cmd/debug_cmds.go
@@ -1,0 +1,49 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/util/archive"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/workspace"
+	"github.com/spf13/cobra"
+)
+
+// newArchiveCommand creates a command which just builds the archive we would ship to Pulumi.com to
+// do a deployment.
+func newArchiveCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "archive <path-to-archive>",
+		Short: "create an archive suitable for deployment",
+		Args:  cobra.ExactArgs(1),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			cwd, err := os.Getwd()
+			if err != nil {
+				return errors.Wrap(err, "getting working directory")
+			}
+			programPath, err := workspace.DetectPackage(cwd)
+			if err != nil {
+				return errors.Wrap(err, "looking for Pulumi package")
+			}
+			if programPath == "" {
+				return errors.New("no Pulumi package found")
+			}
+
+			// programPath is the path to the Pulumi.yaml file. Need its parent folder.
+			programFolder := filepath.Dir(programPath)
+			archiveContents, err := archive.Process(programFolder)
+			if err != nil {
+				return err
+			}
+
+			return ioutil.WriteFile(args[0], archiveContents.Bytes(), 0644)
+		}),
+	}
+
+	return cmd
+}

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -74,6 +74,12 @@ func NewPulumiCmd(version string) *cobra.Command {
 	cmd.AddCommand(newLoginCmd())
 	cmd.AddCommand(newLogoutCmd())
 
+	// We have a set of commands that are useful for developers of pulumi that we add when PULUMI_DEBUG_COMMANDS is
+	// set to true.
+	if isTruthy(os.Getenv("PULUMI_DEBUG_COMMANDS")) {
+		cmd.AddCommand(newArchiveCommand())
+	}
+
 	// Tell flag about -C, so someone can do pulumi -C <working-directory> stack and the call to cmdutil.InitLogging
 	// which calls flag.Parse under the hood doesn't yell at you.
 	//


### PR DESCRIPTION
When working on the `.pulumiignore` support, I added a small command
that would just dump the file we sent to the service (without actually
talking to the service) so I could do some measurements on archive
sizes.

I mentioned this to Chris who said he had hacked up a similar thing
for something he was working on, so it felt worthwhile to check this
command in (hidden behind a flag) to share the implementation.

This command is hidden behind an environment variable, so customers
will not see it unless they opt in.