### PR TITLE
Do not escape json strings when printing out the plan.

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -4,6 +4,7 @@ package engine
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -551,7 +552,7 @@ func printPropertyValue(
 	} else if v.IsNumber() {
 		write(b, op, "%v", v.NumberValue())
 	} else if v.IsString() {
-		write(b, op, "%q", v.StringValue())
+		writePossibleJSONString(b, op, v.StringValue())
 	} else if v.IsArray() {
 		arr := v.ArrayValue()
 		if len(arr) == 0 {
@@ -616,6 +617,19 @@ func printPropertyValue(
 		}
 	}
 	writeVerbatim(b, op, "\n")
+}
+
+func writePossibleJSONString(b *bytes.Buffer, op deploy.StepOp, val string) {
+	var bytes = []byte(val)
+	var js json.RawMessage
+
+	if json.Unmarshal(bytes, &js) == nil {
+		b.WriteString(colors.Reset)
+		b.WriteString(op.Color())
+		json.Compact(b, bytes)
+	} else {
+		write(b, op, "%q", val)
+	}
 }
 
 func printAssetOrArchive(


### PR DESCRIPTION
Printing out as a 'go' string means that things like quotes are escaped, leading to goop like: 

```
"{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"apigateway.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
```

better to just emit this untouched to the console like:

```
{"Version":"2012-10-17","Statement":[{"Sid":"","Effect":"Allow","Principal":{"Service":"apigateway.amazonaws.com"},"Action":"sts:AssumeRole"}]}
```

It makes things a lot nicer to work with (esp. when copying/pasting from the console).


it's even worse with things like:
```
{"application/json":"{\"message\": \"404 Not found\" }"}
```

which become:

```
{\"application/json\":\"{\\\\"message\\\\": \\\\"404 Not found\\\\" }\"}
```