### PR TITLE
Optionally enable debug output in integration tests.

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -413,7 +413,7 @@ func printResourceProperties(
 		children = old.Children
 	}
 	for _, child := range children {
-		writeWithIndent(b, indent, simplePropOp, "=> %s\n", indent, child)
+		writeWithIndent(b, indent, simplePropOp, "=> %s\n", child)
 	}
 
 	if !summary {


### PR DESCRIPTION
By default, debugging events are not displayed by `pulumi`; the `-d`
flag must be provided to enable their display. This is necessary e.g.
to view debugging output from Terraform when TF logging is enabled.
These changes add the option to display debug output from `pulumi` to
the integration test framework.

These changes also contain a small fix for the display of component
children.