### PR TITLE
Add a few `gas` exceptions.

### DIFF
--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -199,6 +199,7 @@ func execPlugin(bin string, pluginArgs []string) (*plugin, error) {
 	}
 	args = append(args, pluginArgs...)
 
+	// nolint: gas
 	cmd := exec.Command(bin, args...)
 	in, _ := cmd.StdinPipe()
 	out, _ := cmd.StdoutPipe()

--- a/pkg/testing/environment.go
+++ b/pkg/testing/environment.go
@@ -74,6 +74,7 @@ func runCommand(t *testing.T, expectSuccess bool, command, cwd string, args ...s
 	var outBuffer bytes.Buffer
 	var errBuffer bytes.Buffer
 
+	// nolint: gas
 	cmd := exec.Command(command, args...)
 	cmd.Dir = cwd
 	cmd.Stdout = &outBuffer

--- a/pkg/testing/integration/pulumi.go
+++ b/pkg/testing/integration/pulumi.go
@@ -97,4 +97,5 @@ func GetStacks(e *testing.Environment) ([]string, *string) {
 // TestAccountAccessToken is a Pulumi access token of a well-known test account. Most importantly, we can
 // rely on this test account existing in all Pulumi environments. GitHub user "lumi-test-1". See
 // pulumi-service/cmd/service/model/test.go for more information.
+// nolint: gas
 const TestAccountAccessToken = "gGo1WLk2Jh_NZlqo2FFvjPtBvo73IW3xsJvBRmDOPW4="

--- a/pkg/workspace/repository.go
+++ b/pkg/workspace/repository.go
@@ -24,6 +24,7 @@ func (r *Repository) Save() error {
 		return err
 	}
 
+	// nolint: gas
 	err = os.MkdirAll(r.Root, 0755)
 	if err != nil {
 		return err


### PR DESCRIPTION
The first exception relates to how we launch plugins. Plugin paths are
calculated using a well-known set of rules; this makes `gas` suspicious
due to the need to use a variable to store the path of the plugin.

The second and third are in test code and aren't terribly concerning.
The latter exception asks `gas` to ignore the access key we hard-code
into the integration tests for our Pulumi test account.

The fourth exception allows use to use more permissive permissions for
the `.pulumi` directory than `gas` would prefer. We use `755`; `gas`
wants `700` or stricter. `755` is the default for `mkdir` and `.git` and
so seems like a reasonable choice for us.