### PR TITLE
Argument validation for CLI commands

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -29,6 +29,7 @@ func newConfigCmd() *cobra.Command {
 		Long: "Lists all configuration values for a specific stack. To add a new configuration value, run\n" +
 			"'pulumi config set', to remove and existing value run 'pulumi config rm'. To get the value of\n" +
 			"for a specific configuration key, use 'pulumi config get <key-name>'.",
+		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			stackName, err := explicitOrCurrent(stack, backend)
 			if err != nil {
@@ -57,7 +58,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 	getCmd := &cobra.Command{
 		Use:   "get <key>",
 		Short: "Get a single configuration value",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.ExactArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			stackName, err := explicitOrCurrent(*stack, backend)
 			if err != nil {
@@ -82,7 +83,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 	rmCmd := &cobra.Command{
 		Use:   "rm <key>",
 		Short: "Remove configuration value",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.ExactArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			if all && *stack != "" {
 				return errors.New("if --all is specified, an explicit stack can not be provided")
@@ -127,7 +128,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 	setCmd := &cobra.Command{
 		Use:   "set <key> [value]",
 		Short: "Set configuration value",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  cmdutil.RangeArgs(1, 2),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			if all && *stack != "" {
 				return errors.New("if --all is specified, an explicit stack can not be provided")

--- a/cmd/debug_cmds.go
+++ b/cmd/debug_cmds.go
@@ -21,7 +21,7 @@ func newArchiveCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "archive <path-to-archive>",
 		Short: "create an archive suitable for deployment",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.ExactArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			if forceDefaultIgnores && forceNoDefaultIgnores {
 				return errors.New("can't specify --no-default-ignores and --default-ignores at the same time")

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -28,6 +28,7 @@ func newDestroyCmd() *cobra.Command {
 			"\n" +
 			"Warning: although old snapshots can be used to recreate an stack, this command\n" +
 			"is generally irreversable and should be used with great care.",
+		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			stackName, err := explicitOrCurrent(stack, backend)
 			if err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,6 +18,7 @@ func newInitCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Initialize a new Pulumi repository",
+		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			cwd, err := os.Getwd()
 			if err != nil {

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -20,6 +20,7 @@ func newLoginCmd() *cobra.Command {
 		Use:   "login",
 		Short: "Log into the Pulumi Cloud Console",
 		Long:  "Log into the Pulumi Cloud Console. You can script by using PULUMI_ACCESS_TOKEN environment variable.",
+		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			return loginCmd()
 		}),
@@ -31,6 +32,7 @@ func newLogoutCmd() *cobra.Command {
 		Use:   "logout",
 		Short: "Log out of the Pulumi CLI",
 		Long:  "Log out of the Pulumi CLI. Deletes stored credentials on the local machine.",
+		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			return deleteStoredCredentials()
 		}),

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -23,6 +23,7 @@ func newLogsCmd() *cobra.Command {
 	logsCmd := &cobra.Command{
 		Use:   "logs",
 		Short: "Show aggregated logs for a project",
+		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			stackName, err := explicitOrCurrent(stack, backend)
 			if err != nil {

--- a/cmd/lumidl/lumidl.go
+++ b/cmd/lumidl/lumidl.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -36,13 +35,8 @@ func NewIDLCCmd() *cobra.Command {
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			cmdutil.InitLogging(logToStderr, verbose, true)
 		},
+		Args: cmdutil.ExactArgs(2),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			if len(args) == 0 {
-				return cmd.Usage()
-			} else if len(args) == 1 {
-				return errors.New("missing required [idl-path] argument")
-			}
-
 			// Now pass the arguments and compile the package.
 			name := args[0] // the name of the Lumi package.
 			path := args[1] // the path to the IDL directory that is compiled recursively.

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -34,6 +34,7 @@ func newPreviewCmd() *cobra.Command {
 			"\n" +
 			"The package to execute is loaded from the current directory. Use the `-C` or `--cwd` flag to\n" +
 			"use a different directory.",
+		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			stackName, err := explicitOrCurrent(stack, backend)
 			if err != nil {

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -23,6 +23,7 @@ func newStackCmd() *cobra.Command {
 			"An stack is a named update target, and a single project may have many of them.\n" +
 			"Each stack has a configuration and update history associated with it, stored in\n" +
 			"the workspace, in addition to a full checkpoint of the last known good update.\n",
+		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			stackName, err := getCurrentStack()
 			if err != nil {

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -15,7 +15,7 @@ func newStackInitCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "init <stack>",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.ExactArgs(1),
 		Short: "Create an empty stack with the given name, ready for updates",
 		Long: "Create an empty stack with the given name, ready for updates\n" +
 			"\n" +

--- a/cmd/stack_ls.go
+++ b/cmd/stack_ls.go
@@ -16,6 +16,7 @@ func newStackLsCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "ls",
 		Short: "List all known stacks",
+		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			currentStack, err := getCurrentStack()
 			if err != nil {

--- a/cmd/stack_rm.go
+++ b/cmd/stack_rm.go
@@ -18,7 +18,7 @@ func newStackRmCmd() *cobra.Command {
 	var force bool
 	var cmd = &cobra.Command{
 		Use:   "rm <stack>",
-		Args:  cobra.ExactArgs(1),
+		Args:  cmdutil.ExactArgs(1),
 		Short: "Remove an stack and its configuration",
 		Long: "Remove an stack and its configuration\n" +
 			"\n" +

--- a/cmd/stack_select.go
+++ b/cmd/stack_select.go
@@ -22,7 +22,7 @@ func newStackSelectCmd() *cobra.Command {
 			"stack name each and every time.\n" +
 			"\n" +
 			"If no <stack> argument is supplied, the current stack is printed.",
-		Args: cobra.MaximumNArgs(1),
+		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Display the name of the current stack if a new one isn't specified.
 			if len(args) == 0 {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,6 +35,7 @@ func newUpdateCmd() *cobra.Command {
 			"\n" +
 			"The package to execute is loaded from the current directory. Use the `-C` or `--cwd` flag to\n" +
 			"use a different directory.",
+		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			stackName, err := explicitOrCurrent(stack, backend)
 			if err != nil {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -13,6 +13,7 @@ func newVersionCmd(version string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print Pulumi's version number",
+		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			fmt.Printf("%v\n", version)
 			return nil

--- a/pkg/util/cmdutil/args.go
+++ b/pkg/util/cmdutil/args.go
@@ -1,0 +1,41 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package cmdutil
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// ArgsFunc wraps a standard cobra argument validator with standard Pulumi error handling.
+func ArgsFunc(argsValidator cobra.PositionalArgs) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		err := argsValidator(cmd, args)
+		if err != nil {
+			ExitError(err.Error())
+		}
+
+		return nil
+	}
+}
+
+// NoArgs is the same as cobra.NoArgs, except it is wrapped with ArgsFunc to provide standard
+// Pulumi error handling.
+var NoArgs = ArgsFunc(cobra.NoArgs)
+
+// MaximumNArgs is the same as cobra.MaximumNArgs, except it is wrapped with ArgsFunc to provide standard
+// Pulumi error handling.
+func MaximumNArgs(n int) cobra.PositionalArgs {
+	return ArgsFunc(cobra.MaximumNArgs(n))
+}
+
+// ExactArgs is the same as cobra.ExactArgs, except it is wrapped with ArgsFunc to provide standard
+// Pulumi error handling.
+func ExactArgs(n int) cobra.PositionalArgs {
+	return ArgsFunc(cobra.ExactArgs(n))
+}
+
+// RangeArgs is the same as cobra.RangeArgs, except it is wrapped with ArgsFunc to provide standard
+// Pulumi error handling.
+func RangeArgs(min int, max int) cobra.PositionalArgs {
+	return ArgsFunc(cobra.RangeArgs(min, max))
+}

--- a/pkg/util/cmdutil/exit.go
+++ b/pkg/util/cmdutil/exit.go
@@ -45,7 +45,7 @@ func DetailedError(err error) string {
 	return msg
 }
 
-// RunFunc wraps an error-returning run func with standard Pulumi error handling.  All Lumi commands should wrap
+// RunFunc wraps an error-returning run func with standard Pulumi error handling.  All Pulumi commands should wrap
 // themselves in this to ensure consistent and appropriate error behavior.  In particular, we want to avoid any calls to
 // os.Exit in the middle of a callstack which might prohibit reaping of child processes, resources, etc.  And we wish to
 // avoid the default Cobra unhandled error behavior, because it is formatted incorrectly and needlessly prints usage.


### PR DESCRIPTION
Previously, we were inconsistent on how we handled argument validation
in the CLI. Many commands used cobra.Command's Args property to
provide a validator if they took arguments, but commands which did not
rarely used cobra.NoArgs to indicate this.

This change does two things:

1. Introduce `cmdutil.ArgsFunc` which works like `cmdutil.RunFunc`, it
wraps an existing cobra type and lets us control the behavior when an
arguments validator fails.

2. Ensure every command sets the Args property with an instance of
cmdutil.ArgsFunc. The cmdutil package defines wrapers for all the
cobra validators we are using, to prevent us from having to spell out
`cmduitl.ArgsFunc(...)` everywhere.

Fixes #588