### PR TITLE
Fix replacement ops regression

### DIFF
--- a/pkg/engine/preview.go
+++ b/pkg/engine/preview.go
@@ -97,7 +97,7 @@ func (acts *previewActions) OnResourceStepPre(step deploy.Step) (interface{}, er
 }
 
 func (acts *previewActions) OnResourceStepPost(ctx interface{},
-	step deploy.Step, status resource.Status, state *resource.State, err error) error {
+	step deploy.Step, status resource.Status, err error) error {
 	// We let `printPlan` handle error reporting for now.
 	if err == nil {
 		// Track the operation if shown and/or if it is a logically meaningful operation.
@@ -106,12 +106,12 @@ func (acts *previewActions) OnResourceStepPost(ctx interface{},
 		}
 
 		// Also show outputs here, since there might be some from the initial registration.
-		_ = acts.OnResourceOutputs(step, state)
+		_ = acts.OnResourceOutputs(step)
 	}
 	return nil
 }
 
-func (acts *previewActions) OnResourceOutputs(step deploy.Step, state *resource.State) error {
+func (acts *previewActions) OnResourceOutputs(step deploy.Step) error {
 	// Print this step's output properties.
 	if shouldShow(acts.Seen, step, acts.Opts) && !acts.Opts.Summary {
 		printResourceOutputProperties(&acts.Summary, step, acts.Seen, acts.Shown, 0 /*indent*/)

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -231,6 +231,7 @@ func TestBasicCRUDPlan(t *testing.T) {
 			break
 		}
 
+		var state *resource.State
 		var urn resource.URN
 		var realID bool
 		var expectOuts resource.PropertyMap
@@ -243,6 +244,7 @@ func TestBasicCRUDPlan(t *testing.T) {
 			assert.Equal(t, urnA, new.URN)
 			assert.Equal(t, newResA.Properties, new.Inputs)
 			assert.Equal(t, newResA.Properties, new.AllInputs())
+			state = new
 			urn, realID = urnA, false
 		case *UpdateStep: // B is updated
 			old := s.Old()
@@ -254,6 +256,7 @@ func TestBasicCRUDPlan(t *testing.T) {
 			assert.Equal(t, urnB, new.URN)
 			assert.Equal(t, newResB.Properties, new.Inputs)
 			assert.Equal(t, newResB.Properties, new.AllInputs())
+			state = new
 			urn, realID = urnB, true
 		case *SameStep: // C is the same
 			old := s.Old()
@@ -265,6 +268,7 @@ func TestBasicCRUDPlan(t *testing.T) {
 			assert.Equal(t, urnC, new.URN)
 			assert.Equal(t, newResC.Properties, new.Inputs)
 			assert.Equal(t, newResC.Properties, new.AllInputs())
+			state = new
 			urn, realID, expectOuts = urnC, true, oldResC.Outputs
 		case *DeleteStep: // D is deleted
 			old := s.Old()
@@ -277,15 +281,11 @@ func TestBasicCRUDPlan(t *testing.T) {
 			t.FailNow() // unexpected step kind.
 		}
 
-		var state *resource.State
-		_, state, err = step.Apply(true)
+		_, err = step.Apply(true)
 		assert.Nil(t, err)
 
 		op := step.Op()
 		if state != nil {
-			// The state should be non-nil by now and it should have a URN.
-			assert.NotNil(t, state)
-
 			// Ensure the URN, ID, and properties are populated correctly.
 			assert.Equal(t, urn, state.URN,
 				"Expected op %v to populate a URN equal to %v", op, urn)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -12,7 +12,7 @@ import (
 
 // Step is a specification for a deployment operation.
 type Step interface {
-	Apply(preview bool) (resource.Status, *resource.State, error) // applies or previews this step.
+	Apply(preview bool) (resource.Status, error) // applies or previews this step.
 
 	Op() StepOp           // the operation performed by this step.
 	URN() resource.URN    // the resource URN (for before and after).
@@ -60,13 +60,17 @@ func (s *SameStep) Type() tokens.Type       { return s.old.Type }
 func (s *SameStep) URN() resource.URN       { return s.old.URN }
 func (s *SameStep) Old() *resource.State    { return s.old }
 func (s *SameStep) New() *resource.State    { return s.new }
-func (s *SameStep) Res() *resource.State    { return s.new }
+func (s *SameStep) Res() *resource.State    { return s.old }
 func (s *SameStep) Logical() bool           { return true }
 
-func (s *SameStep) Apply(preview bool) (resource.Status, *resource.State, error) {
-	result := &RegisterResult{State: s.old, Stable: true}
-	s.reg.Done(result)
-	return resource.StatusOK, result.State, nil
+func (s *SameStep) Apply(preview bool) (resource.Status, error) {
+	*s.new = *s.old
+	if !preview {
+		s.iter.MarkStateSnapshot(s.old)
+		s.iter.AppendStateSnapshot(s.old)
+	}
+	s.reg.Done(&RegisterResult{State: s.old, Stable: true})
+	return resource.StatusOK, nil
 }
 
 // CreateStep is a mutating step that creates an entirely new resource.
@@ -132,22 +136,26 @@ func (s *CreateStep) Res() *resource.State         { return s.new }
 func (s *CreateStep) Keys() []resource.PropertyKey { return s.keys }
 func (s *CreateStep) Logical() bool                { return !s.replacing }
 
-func (s *CreateStep) Apply(preview bool) (resource.Status, *resource.State, error) {
-	if !preview && s.new.Custom {
-		// Invoke the Create RPC function for this provider:
-		prov, err := getProvider(s)
-		if err != nil {
-			return resource.StatusOK, nil, err
-		}
-		id, outs, rst, err := prov.Create(s.URN(), s.new.AllInputs())
-		if err != nil {
-			return rst, nil, err
-		}
-		contract.Assert(id != "")
+func (s *CreateStep) Apply(preview bool) (resource.Status, error) {
+	if !preview {
+		if s.new.Custom {
+			// Invoke the Create RPC function for this provider:
+			prov, err := getProvider(s)
+			if err != nil {
+				return resource.StatusOK, err
+			}
+			id, outs, rst, err := prov.Create(s.URN(), s.new.AllInputs())
+			if err != nil {
+				return rst, err
+			}
+			contract.Assert(id != "")
 
-		// Copy any of the default and output properties on the live object state.
-		s.new.ID = id
-		s.new.Outputs = outs
+			// Copy any of the default and output properties on the live object state.
+			s.new.ID = id
+			s.new.Outputs = outs
+		}
+
+		s.iter.AppendStateSnapshot(s.new)
 	}
 
 	// Mark the old resource as pending deletion if necessary.
@@ -155,9 +163,8 @@ func (s *CreateStep) Apply(preview bool) (resource.Status, *resource.State, erro
 		s.old.Delete = true
 	}
 
-	result := &RegisterResult{State: s.new}
-	s.reg.Done(result)
-	return resource.StatusOK, result.State, nil
+	s.reg.Done(&RegisterResult{State: s.new})
+	return resource.StatusOK, nil
 }
 
 // DeleteStep is a mutating step that deletes an existing resource.
@@ -196,18 +203,23 @@ func (s *DeleteStep) New() *resource.State    { return nil }
 func (s *DeleteStep) Res() *resource.State    { return s.old }
 func (s *DeleteStep) Logical() bool           { return !s.replacing }
 
-func (s *DeleteStep) Apply(preview bool) (resource.Status, *resource.State, error) {
-	if !preview && s.old.Custom {
-		// Invoke the Delete RPC function for this provider:
-		prov, err := getProvider(s)
-		if err != nil {
-			return resource.StatusOK, nil, err
+func (s *DeleteStep) Apply(preview bool) (resource.Status, error) {
+	if !preview {
+		if s.old.Custom {
+			// Invoke the Delete RPC function for this provider:
+			prov, err := getProvider(s)
+			if err != nil {
+				return resource.StatusOK, err
+			}
+			if rst, err := prov.Delete(s.URN(), s.old.ID, s.old.All()); err != nil {
+				return rst, err
+			}
 		}
-		if rst, err := prov.Delete(s.URN(), s.old.ID, s.old.All()); err != nil {
-			return rst, nil, err
-		}
+
+		s.iter.MarkStateSnapshot(s.old)
 	}
-	return resource.StatusOK, nil, nil
+
+	return resource.StatusOK, nil
 }
 
 // UpdateStep is a mutating step that updates an existing resource's state.
@@ -251,32 +263,36 @@ func (s *UpdateStep) New() *resource.State    { return s.new }
 func (s *UpdateStep) Res() *resource.State    { return s.new }
 func (s *UpdateStep) Logical() bool           { return true }
 
-func (s *UpdateStep) Apply(preview bool) (resource.Status, *resource.State, error) {
+func (s *UpdateStep) Apply(preview bool) (resource.Status, error) {
 	if preview {
 		// In the case of an update, the URN, defaults, and ID are the same, however, the outputs remain unknown.
+		s.new.URN = s.old.URN
 		s.new.ID = s.old.ID
 	} else if s.new.Custom {
 		// Invoke the Update RPC function for this provider:
 		prov, err := getProvider(s)
 		if err != nil {
-			return resource.StatusOK, nil, err
+			return resource.StatusOK, err
 		}
 		// Update to the combination of the old "all" state (including outputs), but overwritten with new inputs.
 		news := s.old.All().Merge(s.new.Inputs)
 		outs, rst, upderr := prov.Update(s.URN(), s.old.ID, s.old.All(), news)
 		if upderr != nil {
-			return rst, nil, upderr
+			return rst, upderr
 		}
 
 		// Now copy any output state back in case the update triggered cascading updates to other properties.
 		s.new.ID = s.old.ID
 		s.new.Outputs = outs
+
+		// Mark the old state as having been processed, and add the new state.
+		s.iter.MarkStateSnapshot(s.old)
+		s.iter.AppendStateSnapshot(s.new)
 	}
 
 	// Finally, mark this operation as complete.
-	result := &RegisterResult{State: s.new, Stables: s.stables}
-	s.reg.Done(result)
-	return resource.StatusOK, result.State, nil
+	s.reg.Done(&RegisterResult{State: s.new, Stables: s.stables})
+	return resource.StatusOK, nil
 }
 
 // ReplaceStep is a logical step indicating a resource will be replaced.  This is comprised of three physical steps:
@@ -319,17 +335,16 @@ func (s *ReplaceStep) Res() *resource.State         { return s.new }
 func (s *ReplaceStep) Keys() []resource.PropertyKey { return s.keys }
 func (s *ReplaceStep) Logical() bool                { return true }
 
-func (s *ReplaceStep) Apply(preview bool) (resource.Status, *resource.State, error) {
+func (s *ReplaceStep) Apply(preview bool) (resource.Status, error) {
 	// We should have marked the old resource for deletion in the CreateReplacement step.
 	contract.Assert(s.old.Delete)
-	return resource.StatusOK, nil, nil
+	return resource.StatusOK, nil
 }
 
 // StepOp represents the kind of operation performed by a step.  It evaluates to its string label.
 type StepOp string
 
 const (
-	OpNone              StepOp = "none"               // no semantically meaningful value.
 	OpSame              StepOp = "same"               // nothing to do.
 	OpCreate            StepOp = "create"             // creating a new resource.
 	OpUpdate            StepOp = "update"             // updating an existing resource.
@@ -341,7 +356,6 @@ const (
 
 // StepOps contains the full set of step operation types.
 var StepOps = []StepOp{
-	OpNone,
 	OpSame,
 	OpCreate,
 	OpUpdate,
@@ -354,8 +368,6 @@ var StepOps = []StepOp{
 // Color returns a suggested color for lines of this op type.
 func (op StepOp) Color() string {
 	switch op {
-	case OpNone:
-		return ""
 	case OpSame:
 		return colors.SpecUnimportant
 	case OpCreate:
@@ -384,8 +396,6 @@ func (op StepOp) Prefix() string {
 // RawPrefix returns the uncolorized prefix text.
 func (op StepOp) RawPrefix() string {
 	switch op {
-	case OpNone:
-		return "  "
 	case OpSame:
 		return "* "
 	case OpCreate:


### PR DESCRIPTION
The prior change was incorrectly handling snapshotting of replacement
operations.  Further, in hindsight, the older model of having steps
manage their interaction with the snapshot marking was clearer, so
I've essentially brought that back, merging it with the other changes.