### PR TITLE
Add automatic integrity checking

### DIFF
--- a/cmd/provider_local.go
+++ b/cmd/provider_local.go
@@ -70,7 +70,8 @@ func (m localStackMutation) End(snapshot *deploy.Snapshot) error {
 	return saveStack(name, config, snapshot)
 }
 
-func getStack(name tokens.QName) (tokens.QName, map[tokens.ModuleMember]config.Value, *deploy.Snapshot, string, error) {
+func getStack(name tokens.QName) (tokens.QName,
+	map[tokens.ModuleMember]config.Value, *deploy.Snapshot, string, error) {
 	workspace, err := newWorkspace()
 	if err != nil {
 		return "", nil, nil, "", err
@@ -105,15 +106,21 @@ func getStack(name tokens.QName) (tokens.QName, map[tokens.ModuleMember]config.V
 		return "", nil, nil, file, err
 	}
 
+	// Ensure the snapshot passes verification before returning it, to catch bugs early.
+	if verifyerr := snapshot.VerifyIntegrity(); verifyerr != nil {
+		return "", nil, nil, file,
+			errors.Wrapf(verifyerr, "snapshot integrity failure; refusing to use it")
+	}
+
 	return name, config, snapshot, file, nil
 }
 
-func saveStack(name tokens.QName, config map[tokens.ModuleMember]config.Value, snap *deploy.Snapshot) error {
+func saveStack(name tokens.QName,
+	config map[tokens.ModuleMember]config.Value, snap *deploy.Snapshot) error {
 	workspace, err := newWorkspace()
 	if err != nil {
 		return err
 	}
-
 	file := workspace.StackPath(name)
 
 	// Make a serializable stack and then use the encoder to encode it.
@@ -131,7 +138,7 @@ func saveStack(name tokens.QName, config map[tokens.ModuleMember]config.Value, s
 	}
 
 	// Back up the existing file if it already exists.
-	backupTarget(file)
+	bck := backupTarget(file)
 
 	// Ensure the directory exists.
 	if err = os.MkdirAll(filepath.Dir(file), 0700); err != nil {
@@ -148,6 +155,15 @@ func saveStack(name tokens.QName, config map[tokens.ModuleMember]config.Value, s
 		if err = ioutil.WriteFile(fmt.Sprintf("%v.%v", file, time.Now().UnixNano()), b, 0600); err != nil {
 			return errors.Wrap(err, "An IO error occurred during the current operation")
 		}
+	}
+
+	// Finally, *after* writing the checkpoint, check the integrity.  This is done afterwards so that we write
+	// out the checkpoint file since it may contain resource state updates.  But we will warn the user that the
+	// file is already written and might be bad.
+	if verifyerr := snap.VerifyIntegrity(); verifyerr != nil {
+		return errors.Wrapf(verifyerr,
+			"snapshot integrity failure; it was already written to %s, but is invalid (a backup is available at %s)",
+			file, bck)
 	}
 
 	return nil
@@ -173,9 +189,11 @@ func removeStack(name tokens.QName) error {
 
 // backupTarget makes a backup of an existing file, in preparation for writing a new one.  Instead of a copy, it
 // simply renames the file, which is simpler, more efficient, etc.
-func backupTarget(file string) {
+func backupTarget(file string) string {
 	contract.Require(file != "", "file")
-	err := os.Rename(file, file+".bak")
+	bck := file + ".bak"
+	err := os.Rename(file, bck)
 	contract.IgnoreError(err) // ignore errors.
 	// IDEA: consider multiple backups (.bak.bak.bak...etc).
+	return bck
 }

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -5,6 +5,8 @@ package deploy
 import (
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
@@ -19,10 +21,45 @@ type Snapshot struct {
 }
 
 // NewSnapshot creates a snapshot from the given arguments.  The resources must be in topologically sorted order.
+// This property is not checked; for verification, please refer to the VerifyIntegrity function below.
 func NewSnapshot(ns tokens.QName, time time.Time, resources []*resource.State) *Snapshot {
 	return &Snapshot{
 		Namespace: ns,
 		Time:      time,
 		Resources: resources,
 	}
+}
+
+// VerifyIntegrity checks a snapshot to ensure it is well-formed.  Because of the cost of this operation,
+// integrity verification is only performed on demand, and not automatically during snapshot construction.
+func (snap *Snapshot) VerifyIntegrity() error {
+	if snap != nil {
+		// For now, we just verify that parents come before children.  Eventually, we will capture the full resource
+		// DAG (see https://github.com/pulumi/pulumi/issues/624), on which we can then do additional verification.
+		urns := make(map[resource.URN]*resource.State)
+		for i, state := range snap.Resources {
+			urn := state.URN
+			if par := state.Parent; par != "" {
+				if _, has := urns[par]; !has {
+					// The parent isn't there; to give a good error message, see whether it's missing entirely, or
+					// whether it comes later in the snapshot (neither of which should ever happen).
+					for _, other := range snap.Resources[i+1:] {
+						if other.URN == par {
+							return errors.Errorf("child resource %s's parent %s comes after it", urn, par)
+						}
+					}
+					return errors.Errorf("child resource %s refers to missing parent %s", urn, par)
+				}
+			}
+
+			if _, has := urns[urn]; has && !state.Delete {
+				// The only time we should have duplicate URNs is when all but one of them are marked for deletion.
+				return errors.Errorf("duplicate resource %s (not marked for deletion)", urn)
+			}
+
+			urns[urn] = state
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This change introduces automatic integrity checking for snapshots.
Hopefully this will help us track down what's going on in
pulumi/pulumi#613.  Eventually we probably want to make this opt-in,
or disable it entirely other than for internal Pulumi debugging, but
until we add more complete DAG verification, it's relatively cheap
and is worthwhile to leave on for now.