### PR TITLE
Ensure correct version is in published package

### DIFF
--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -19,8 +19,11 @@ function RunGoBuild($goPackage) {
 function CopyPackage($pathToModule, $moduleName) {
     $moduleRoot = New-Item -ItemType Directory -Force -Path "$PublishDir\node_modules\$moduleName"
     Copy-Item -Recurse $pathToModule\* $moduleRoot
-    if (Test-Path (Join-Path $moduleRoot "node_modules")) { 
+    if (Test-Path "$moduleRoot\node_modules") {
         Remove-Item -Recurse -Force "$moduleRoot\node_modules"
+    }
+    if (Test-Path "$moduleRoot\tests") {
+        Remove-Item -Recurse -Force "$moduleRoot\tests"
     }
 }
 

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -31,7 +31,6 @@ copy_package() {
 
     mkdir -p "${module_root}"
     cp -R "$1" "${module_root}/"
-    cp "$1/../package.json" "${module_root}"
     if [ -e "${module_root}/node_modules" ]; then
         rm -rf "${module_root}/node_modules"
     fi


### PR DESCRIPTION
We need to take the package.json from the folder (which will have been
rewritten by the build to include the version number) instead of the
version we have checked into the tree (which has ${VERSION} as a version)

Windows didn't have this issue, but it did include some stuff we did
not include in the unified release, so I cleaned that up as well.