### PR TITLE
Decrypt configuration nearer to its use.

### DIFF
--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -177,8 +177,13 @@ func (b *localBackend) GetLogs(stackName tokens.QName, query operations.LogQuery
 	contract.Assert(snap != nil)
 	contract.Assert(target != nil)
 
+	config, err := target.Config.Decrypt(target.Decrypter)
+	if err != nil {
+		return nil, err
+	}
+
 	components := operations.NewResourceTree(snap.Resources)
-	ops := components.OperationsProvider(target.Config)
+	ops := components.OperationsProvider(config)
 	logs, err := ops.GetLogs(query)
 	if logs == nil {
 		return nil, err

--- a/pkg/backend/local/state.go
+++ b/pkg/backend/local/state.go
@@ -39,17 +39,7 @@ func (p localStackProvider) GetTarget(name tokens.QName) (*deploy.Target, error)
 		return nil, err
 	}
 
-	decryptedConfig := make(map[tokens.ModuleMember]string)
-
-	for k, v := range config {
-		decrypted, err := v.Value(p.decrypter)
-		if err != nil {
-			return nil, errors.Wrap(err, "could not decrypt configuration value")
-		}
-		decryptedConfig[k] = decrypted
-	}
-
-	return &deploy.Target{Name: name, Config: decryptedConfig}, nil
+	return &deploy.Target{Name: name, Config: config, Decrypter: p.decrypter}, nil
 }
 
 func (p localStackProvider) GetSnapshot(name tokens.QName) (*deploy.Snapshot, error) {

--- a/pkg/resource/config/crypt.go
+++ b/pkg/resource/config/crypt.go
@@ -36,7 +36,7 @@ type Crypter interface {
 // be used when you want to display configuration information to a user but don't want to prompt for a password
 // so secrets will not be decrypted.
 func NewBlindingDecrypter() Decrypter {
-	return &blindingDecrypter{}
+	return blindingDecrypter{}
 }
 
 type blindingDecrypter struct{}

--- a/pkg/resource/config/value.go
+++ b/pkg/resource/config/value.go
@@ -12,6 +12,19 @@ import (
 // Map is a bag of config stored in the settings file.
 type Map map[tokens.ModuleMember]Value
 
+// Decrypt returns the configuration as a map from module member to decrypted value.
+func (m Map) Decrypt(decrypter Decrypter) (map[tokens.ModuleMember]string, error) {
+	r := map[tokens.ModuleMember]string{}
+	for k, c := range m {
+		v, err := c.Value(decrypter)
+		if err != nil {
+			return nil, err
+		}
+		r[k] = v
+	}
+	return r, nil
+}
+
 // HasSecureValue returns true if the config map contains a secure (encrypted) value.
 func (m Map) HasSecureValue() bool {
 	for _, v := range m {

--- a/pkg/resource/deploy/plan_apply.go
+++ b/pkg/resource/deploy/plan_apply.go
@@ -63,13 +63,17 @@ func (p *Plan) Start(opts Options) (*PlanIterator, error) {
 func (p *Plan) configure() error {
 	var pkgs []string
 	pkgconfigs := make(map[tokens.Package]map[tokens.ModuleMember]string)
-	for k, v := range p.target.Config {
+	for k, c := range p.target.Config {
 		pkg := k.Package()
 		pkgs = append(pkgs, string(pkg))
 		pkgconfig, has := pkgconfigs[pkg]
 		if !has {
 			pkgconfig = make(map[tokens.ModuleMember]string)
 			pkgconfigs[pkg] = pkgconfig
+		}
+		v, err := c.Value(p.target.Decrypter)
+		if err != nil {
+			return err
 		}
 		pkgconfig[k] = v
 	}

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -3,11 +3,13 @@
 package deploy
 
 import (
+	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
 
 // Target represents information about a deployment target.
 type Target struct {
-	Name   tokens.QName                   // the target stack name.
-	Config map[tokens.ModuleMember]string // optional configuration key/values.
+	Name      tokens.QName     // the target stack name.
+	Config    config.Map       // optional configuration key/value pairs.
+	Decrypter config.Decrypter // decrypter for secret configuration values.
 }


### PR DESCRIPTION
These changes push the `config.{Map,Value}` interfaces further down into
the deployment engine so that configuration can be decrypted nearer to
its use.

This is the first part of the fix for pulumi/pulumi-ppc#112.