### PR TITLE
Bring back stack outputs

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -115,9 +116,14 @@ func newStackCmd() *cobra.Command {
 					if len(outputs) == 0 {
 						fmt.Printf("    No output values currently in this stack\n")
 					} else {
+						var outkeys []string
+						for outkey := range outputs {
+							outkeys = append(outkeys, outkey)
+						}
+						sort.Strings(outkeys)
 						fmt.Printf("    %-48s %s\n", "OUTPUT", "VALUE")
-						for key, val := range outputs {
-							fmt.Printf("    %-48s %s\n", key, val)
+						for _, key := range outkeys {
+							fmt.Printf("    %-48s %v\n", key, outputs[key])
 						}
 					}
 				}

--- a/pkg/resource/deploy/plan_apply.go
+++ b/pkg/resource/deploy/plan_apply.go
@@ -430,10 +430,11 @@ func (iter *PlanIterator) registerResourceOutputs(e RegisterResourceOutputsEvent
 	contract.Assertf(reg != nil, "expected a non-nil resource step ('%v')", urn)
 	delete(iter.regs, urn)
 
-	// If there are any extra properties to add to the outputs, append them now.
-	if outs := e.Outputs(); outs != nil {
-		reg.New().AddOutputs(outs)
-	}
+	// Unconditionally set the resource's outputs to what was provided.  This intentionally overwrites whatever
+	// might already be there, since otherwise "deleting" outputs would have no affect.
+	outs := e.Outputs()
+	glog.V(7).Infof("Registered resource outputs %s: old=#%d, new=#%d", urn, len(reg.New().Outputs), len(outs))
+	reg.New().Outputs = e.Outputs()
 
 	// If there is an event subscription for finishing the resource, execute them.
 	if e := iter.opts.Events; e != nil {

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -60,16 +60,16 @@ func (s *SameStep) Type() tokens.Type       { return s.old.Type }
 func (s *SameStep) URN() resource.URN       { return s.old.URN }
 func (s *SameStep) Old() *resource.State    { return s.old }
 func (s *SameStep) New() *resource.State    { return s.new }
-func (s *SameStep) Res() *resource.State    { return s.old }
+func (s *SameStep) Res() *resource.State    { return s.new }
 func (s *SameStep) Logical() bool           { return true }
 
 func (s *SameStep) Apply(preview bool) (resource.Status, error) {
 	*s.new = *s.old
 	if !preview {
 		s.iter.MarkStateSnapshot(s.old)
-		s.iter.AppendStateSnapshot(s.old)
+		s.iter.AppendStateSnapshot(s.new)
 	}
-	s.reg.Done(&RegisterResult{State: s.old, Stable: true})
+	s.reg.Done(&RegisterResult{State: s.new, Stable: true})
 	return resource.StatusOK, nil
 }
 

--- a/pkg/resource/resource_state.go
+++ b/pkg/resource/resource_state.go
@@ -43,8 +43,3 @@ func NewState(t tokens.Type, urn URN, custom bool, del bool, id ID,
 func (s *State) All() PropertyMap {
 	return s.Inputs.Merge(s.Outputs)
 }
-
-// AddOutputs adds an optional set of extra output properties to the current map.
-func (s *State) AddOutputs(outs PropertyMap) {
-	s.Outputs = s.Outputs.Merge(outs)
-}

--- a/tests/ints/stack_outputs/.gitignore
+++ b/tests/ints/stack_outputs/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/node_modules/
+yarn.lock

--- a/tests/ints/stack_outputs/Pulumi.yaml
+++ b/tests/ints/stack_outputs/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: stack_outputs
+description: A program that exports some outputs.
+runtime: nodejs

--- a/tests/ints/stack_outputs/index.ts
+++ b/tests/ints/stack_outputs/index.ts
@@ -1,0 +1,4 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+export let xyz = "ABC";
+export let foo = 42;

--- a/tests/ints/stack_outputs/package.json
+++ b/tests/ints/stack_outputs/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "stack_project_name",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    }
+}

--- a/tests/ints/stack_outputs/tsconfig.json
+++ b/tests/ints/stack_outputs/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+


### PR DESCRIPTION
At some point, we fixed a bug in the way state is managed for "same"
steps, which meant that we wouldn't see newly added output properties.
This had the effect that, if you had a stack already stood up, and
updated it to have output properties, we would miss them.  (Stacks
stood up from scratch would still have them.)  This fixes that problem,
in addition to two other things: 1) we need to sort output property
names to ensure a deterministic ordering, and 2) we need to also
unconditionally apply the outputs RPC coming in, to ensure that the
resulting resource always has the correct outputs (so that for example
deleting prior output properties actually deletes them).

Also add some testing for this area to make sure we don't break again.

Fixes pulumi/pulumi#631.