### PR TITLE
Several fixes relating to Pulumi clouds and auth

### DIFF
--- a/pkg/backend/cloud/api.go
+++ b/pkg/backend/cloud/api.go
@@ -34,17 +34,9 @@ const (
 func DefaultURL() string {
 	cloudURL := os.Getenv(defaultURLEnvVar)
 	if cloudURL == "" {
-		cloudURL = canonicalizeURL(defaultURL)
+		cloudURL = defaultURL
 	}
 	return cloudURL
-}
-
-// canonicalizeURL unifies cosmetic differences in a URL endpoint. We don't intend this to be 100% correct
-// for arbitrary URLS. (e.g. handling "/a/b/../../c") Instead this is to safeguard against common mistakes
-// in user configuration.
-func canonicalizeURL(url string) string {
-	url = strings.TrimSuffix(url, "/")
-	return url
 }
 
 // cloudProjectIdentifier is the set of data needed to identify a Pulumi Cloud project. This the

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -455,9 +455,8 @@ func printEvent(event apitype.UpdateEvent) {
 	fmt.Fprint(stream, text)
 }
 
-// Login logs into the target cloud URL. If "" is used,
+// Login logs into the target cloud URL.
 func Login(cloudURL string) error {
-	cloudURL = canonicalizeURL(cloudURL)
 	fmt.Printf("Logging into Pulumi Cloud: %s\n", cloudURL)
 
 	// We intentionally don't accept command-line args for the user's access token. Having it in


### PR DESCRIPTION
- Fix #644 "Re-enable use of local dev stacks". Rather than trying to be smart about using "pulumi.com" and inferring "api.pulumi.com", we just use whatever cloud URL the user provides. (e.g. "http://localhost:8080") We can improve the user experience later by providing friendly names for these things upon login. So we can show "Pulumi" or "Contoso" instead of the URL -- but let's cross that bridge later.

- Fix #640, "Better error on `pulumi login`". We only provide the more friendly error about needing to login IFF you are trying to use an authenticated Pulumi API without having creds.

- Fix #649, "Able to have duplicate stacks with the same cloud/stack name?" This was totally user-error. But `pulumi` doesn't canonicalize "api.pulumi.com" with/without a trailing slash, which isn't great. Add a `canonicalizeUrl` method to prevent this pilot error in the future. 