### PR TITLE
Reenable integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,10 @@ PROJECT_NAME := Pulumi Fabric
 SUB_PROJECTS := sdk/nodejs
 include build/common.mk
 
-PROJECT      := github.com/pulumi/pulumi
-PROJECT_PKGS := $(shell go list ./cmd/... ./pkg/... | grep -v /vendor/)
-VERSION      := $(shell git describe --tags --dirty 2>/dev/null)
+PROJECT         := github.com/pulumi/pulumi
+PROJECT_PKGS    := $(shell go list ./cmd/... ./pkg/... | grep -v /vendor/)
+EXTRA_TEST_PKGS := $(shell go list ./examples/ ./tests/... | grep -v /vendor/)
+VERSION         := $(shell git describe --tags --dirty 2>/dev/null)
 
 GOMETALINTERBIN := gometalinter
 GOMETALINTER    := ${GOMETALINTERBIN} --config=Gometalinter.json
@@ -28,7 +29,7 @@ test_fast::
 	go test -timeout 2m -cover -parallel ${TESTPARALLELISM} ${PROJECT_PKGS}
 
 test_all::
-	PATH=$(PULUMI_ROOT)/bin:$(PATH) go test -cover -parallel ${TESTPARALLELISM} ./examples ./tests
+	PATH=$(PULUMI_ROOT)/bin:$(PATH) go test -cover -parallel ${TESTPARALLELISM} ${EXTRA_TEST_PKGS}
 
 .PHONY: publish
 publish:

--- a/tests/cloud/login_test.go
+++ b/tests/cloud/login_test.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/pulumi/pulumi/cmd"
+	"github.com/pulumi/pulumi/pkg/backend/cloud"
 	ptesting "github.com/pulumi/pulumi/pkg/testing"
 	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -17,8 +18,8 @@ func TestRequireLogin(t *testing.T) {
 		t.Skip("PULUMI_API environment variable not set. This means the Cloud-variant Pulumi commands won't run.")
 	}
 	// Use the alt path for credentials as to not impact the local deverloper's machine.
-	if err := os.Setenv(cmd.UseAltCredentialsLocationEnvVar, "1"); err != nil {
-		t.Fatalf("error setting env var '%s': %v", cmd.UseAltCredentialsLocationEnvVar, err)
+	if err := os.Setenv(workspace.UseAltCredentialsLocationEnvVar, "1"); err != nil {
+		t.Fatalf("error setting env var '%s': %v", workspace.UseAltCredentialsLocationEnvVar, err)
 	}
 
 	t.Run("SanityTest", func(t *testing.T) {
@@ -35,7 +36,7 @@ func TestRequireLogin(t *testing.T) {
 		assert.Contains(t, err, "error: getting stored credentials: credentials file not found")
 
 		// login and confirm things work.
-		os.Setenv(cmd.PulumiAccessTokenEnvVar, integration.TestAccountAccessToken)
+		os.Setenv(cloud.AccessTokenEnvVar, integration.TestAccountAccessToken)
 		e.RunCommand("pulumi", "login")
 
 		e.RunCommand("pulumi", "stack", "init", "--local", "foo")


### PR DESCRIPTION
Because of the way we passed packages to test commands, we were skipping
the tests/cloud/ and tests/ints/ tests altogether.  This reenables them.