### PR TITLE
Elide the root stack in parent URNs

### DIFF
--- a/pkg/resource/deploy/plan_apply.go
+++ b/pkg/resource/deploy/plan_apply.go
@@ -259,7 +259,8 @@ func (iter *PlanIterator) makeRegisterResouceSteps(e RegisterResourceEvent) ([]S
 	// Use the resource goal state name to produce a globally unique URN.
 	res := e.Goal()
 	parentType := tokens.Type("")
-	if res.Parent != "" {
+	if res.Parent != "" && res.Parent.Type() != resource.RootStackType {
+		// Skip empty parents and don't use the root stack type; otherwise, use the full qualified type.
 		parentType = res.Parent.QualifiedType()
 	}
 

--- a/pkg/resource/stack.go
+++ b/pkg/resource/stack.go
@@ -1,0 +1,10 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package resource
+
+import (
+	"github.com/pulumi/pulumi/pkg/tokens"
+)
+
+// RootStackType is the type name that will be used for the root component in the Pulumi resource tree.
+const RootStackType tokens.Type = "pulumi:pulumi:Stack"


### PR DESCRIPTION
Every single resource has a type prefix of

    pulumi:pulumi:Stack$

which makes URNs quite lengthy without adding any value.  Since
they all have this prefix, adding it doesn't help to disambiguate.

This change skips adding the parent URN part when it is the built-in
automatic stack type name.