### PR TITLE
Add a logout --all command

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -27,22 +27,3 @@ func newLoginCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&cloudURL, "cloud-url", "c", "", "A cloud URL to log into")
 	return cmd
 }
-
-func newLogoutCmd() *cobra.Command {
-	var cloudURL string
-	cmd := &cobra.Command{
-		Use:   "logout",
-		Short: "Log out of the Pulumi Cloud",
-		Long:  "Log out of the Pulumi Cloud.  Deletes stored credentials on the local machine.",
-		Args:  cmdutil.NoArgs,
-		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			if cloudURL == "" {
-				// If no URL was specified, assume it's the default URL.
-				cloudURL = cloud.DefaultURL()
-			}
-			return cloud.Logout(cloudURL)
-		}),
-	}
-	cmd.PersistentFlags().StringVarP(&cloudURL, "cloud-url", "c", "", "A cloud URL to log out of")
-	return cmd
-}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package cmd
+
+import (
+	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/backend/cloud"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+)
+
+func newLogoutCmd() *cobra.Command {
+	var all bool
+	var cloudURL string
+	cmd := &cobra.Command{
+		Use:   "logout",
+		Short: "Log out of the Pulumi Cloud",
+		Long:  "Log out of the Pulumi Cloud.  Deletes stored credentials on the local machine.",
+		Args:  cmdutil.NoArgs,
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			// If --all is passed, log out of all clouds.
+			if all {
+				bes, err := cloud.CurrentBackends()
+				if err != nil {
+					return errors.Wrap(err, "could not read list of current clouds")
+				}
+				var result error
+				for _, be := range bes {
+					if err = cloud.Logout(be.CloudURL()); err != nil {
+						result = multierror.Append(result, err)
+					}
+				}
+				return result
+			}
+
+			// Otherwise, just log out of a single cloud (either the one specified, or the default).
+			return cloud.Logout(cloud.ValueOrDefaultURL(cloudURL))
+		}),
+	}
+	cmd.PersistentFlags().BoolVarP(&all, "all", "a", false, "Log out of all clouds")
+	cmd.PersistentFlags().StringVarP(&cloudURL, "cloud-url", "c", "", "A cloud URL to log out of")
+	return cmd
+}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -32,7 +32,9 @@ func allBackends() ([]backend.Backend, bool) {
 		_, fmterr := fmt.Fprintf(os.Stderr, "error: could not obtain current cloud backends: %v", err)
 		contract.IgnoreError(fmterr)
 	} else {
-		backends = append(backends, cloudBackends...)
+		for _, be := range cloudBackends {
+			backends = append(backends, be)
+		}
 	}
 	return backends, len(cloudBackends) > 0
 }

--- a/pkg/backend/cloud/api.go
+++ b/pkg/backend/cloud/api.go
@@ -33,6 +33,11 @@ const (
 // variable.  If no override is found, the default is the pulumi.com cloud.
 func DefaultURL() string {
 	cloudURL := os.Getenv(defaultURLEnvVar)
+	return ValueOrDefaultURL(cloudURL)
+}
+
+// ValueOrDefaultURL returns the value if specified, or the default cloud URL otherwise.
+func ValueOrDefaultURL(cloudURL string) string {
 	if cloudURL == "" {
 		cloudURL = defaultURL
 	}

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -504,13 +504,13 @@ func Logout(cloudURL string) error {
 }
 
 // CurrentBackends returns a list of the cloud backends the user is currently logged into.
-func CurrentBackends() ([]backend.Backend, error) {
+func CurrentBackends() ([]Backend, error) {
 	creds, err := workspace.GetStoredCredentials()
 	if err != nil {
 		return nil, err
 	}
 
-	var backends []backend.Backend
+	var backends []Backend
 	if creds.AccessTokens != nil {
 		// Sort the URLs so that we return them in a deterministic order.
 		var cloudURLs []string


### PR DESCRIPTION
If a cloud you've previously authenticated with goes away -- as ours
sort of did, because the cloud endpoing in the CLI changed (to actually
be correct) -- then you can't logout without manually editing the
credentials file in your workspace.  This is a little annoying.  So,
rather than that, let's have a `pulumi logout --all` command that just
logs out of all clouds you are presently authenticated with.