### PR TITLE
Add a `stack output` command

### DIFF
--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -1,0 +1,49 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+)
+
+func newStackOutputCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "output [property-name]",
+		Args:  cmdutil.MaximumNArgs(1),
+		Short: "Show a stack's output properties",
+		Long: "Show a stack's output properties.\n" +
+			"\n" +
+			"By default, this command lists all output properties exported from a stack.\n" +
+			"If a specific property-name is supplied, just that property's value is shown.",
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			// Fetch the current stack and its output properties.
+			s, err := requireCurrentStack()
+			if err != nil {
+				return err
+			}
+			res, outputs := getRootStackResource(s.Snapshot())
+			if res == nil || outputs == nil {
+				return errors.New("current stack has no output properties")
+			}
+
+			// If there is an argument, just print that property.  Else, print them all (similar to `pulumi stack`).
+			if len(args) > 0 {
+				name := args[0]
+				v, has := outputs[name]
+				if has {
+					fmt.Printf("%v\n", v)
+				} else {
+					return errors.Errorf("current stack does not have output property '%v'", name)
+				}
+			} else {
+				printStackOutputs(outputs)
+			}
+			return nil
+		}),
+	}
+}

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -50,9 +50,6 @@ type Resource struct {
 	Parent   resource.URN           `json:"parent,omitempty" yaml:"parent,omitempty"`     // an optional parent URN if this is a child resource.
 }
 
-// RootPulumiStackTypeName is the type name that will be used for the root component in the Pulumi resource tree.
-const RootPulumiStackTypeName tokens.Type = "pulumi:pulumi:Stack"
-
 // SerializeDeployment serializes an entire snapshot as a deploy record.
 func SerializeDeployment(snap *deploy.Snapshot) *Deployment {
 	// Capture the version information into a manifest.

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
 	ptesting "github.com/pulumi/pulumi/pkg/testing"
 	"github.com/pulumi/pulumi/pkg/testing/integration"
@@ -81,7 +82,7 @@ func TestStackOutputs(t *testing.T) {
 			if assert.Equal(t, 1, len(checkpoint.Latest.Resources)) {
 				stackRes := checkpoint.Latest.Resources[0]
 				assert.NotNil(t, stackRes)
-				assert.Equal(t, stack.RootPulumiStackTypeName, stackRes.URN.Type())
+				assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
 				assert.Equal(t, 0, len(stackRes.Inputs))
 				assert.Equal(t, 2, len(stackRes.Outputs))
 				assert.Equal(t, "ABC", stackRes.Outputs["xyz"])
@@ -112,7 +113,7 @@ func TestStackParenting(t *testing.T) {
 			if assert.Equal(t, 8, len(checkpoint.Latest.Resources)) {
 				stackRes := checkpoint.Latest.Resources[0]
 				assert.NotNil(t, stackRes)
-				assert.Equal(t, stack.RootPulumiStackTypeName, stackRes.Type)
+				assert.Equal(t, resource.RootStackType, stackRes.Type)
 				assert.Equal(t, "", string(stackRes.Parent))
 				a := checkpoint.Latest.Resources[1]
 				assert.NotNil(t, a)


### PR DESCRIPTION
This change adds a `pulumi stack output` command.  When passed no
arguments, it prints all stack output properties, in exactly the
same format as `pulumi stack` does (just without all the other stuff).
More importantly, if you pass a specific output property, a la
`pulumi stack output clusterARN`, just that property will be printed,
in a scriptable-friendly manner.  This will help us automate wiring
multiple layers of stacks together during deployments.

This fixes pulumi/pulumi#659.