### PR TITLE
Fix a condition in archive deserialization.

### DIFF
--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -289,8 +289,9 @@ function deserializeProperty(prop: any): any {
                         const assets: {[name: string]: asset.Asset} = {};
                         for (const name of Object.keys(prop["assets"])) {
                             const a = deserializeProperty(prop["assets"][name]);
-                            if (!(a instanceof asset.Asset)) {
-                                throw new Error("Expected an AssetArchive's assets to be unmarshaled Asset objects");
+                            if (!(a instanceof asset.Asset) && !(a instanceof asset.Archive)) {
+                                throw new Error(
+                                    "Expected an AssetArchive's assets to be unmarshaled Asset or Archive objects");
                             }
                             assets[name] = a;
                         }

--- a/sdk/proto/provider.proto
+++ b/sdk/proto/provider.proto
@@ -16,7 +16,10 @@ service ResourceProvider {
     // Invoke dynamically executes a built-in function in the provider.
     rpc Invoke(InvokeRequest) returns (InvokeResponse) {}
     // Check validates that the given property bag is valid for a resource of the given type and returns the inputs
-    // that should be passed to successive calls to Diff, Create, or Update for this resource.
+    // that should be passed to successive calls to Diff, Create, or Update for this resource. As a rule, the provider
+    // inputs returned by a call to Check should preserve the original representation of the properties as present in
+    // the program inputs. Though this rule is not required for correctness, violations thereof can negatively impact
+    // the end-user experience, as the provider inputs are using for detecting and rendering diffs.
     rpc Check(CheckRequest) returns (CheckResponse) {}
     // Diff checks what impacts a hypothetical update will have on the resource's properties.
     rpc Diff(DiffRequest) returns (DiffResponse) {}


### PR DESCRIPTION
Asset archives may contain both assets and archives.