### PR TITLE
Reparameterize NewUniqueHex/ID

### DIFF
--- a/pkg/resource/resource_id.go
+++ b/pkg/resource/resource_id.go
@@ -5,7 +5,8 @@ package resource
 import (
 	cryptorand "crypto/rand"
 	"encoding/hex"
-	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
@@ -46,35 +47,30 @@ func MaybeID(s *string) *ID {
 	return ret
 }
 
-// NewUniqueHex generates a new "random" hex string for use by resource providers. It will take
-// the prefix and add 8 random chars to it.  If this is greater in length than maxlen an error
-// will be returned.
-func NewUniqueHex(prefix string, maxlen int) (string, error) {
-	const randChars = 8
-
-	if maxlen != -1 &&
-		len(prefix)+randChars > maxlen {
-
-		return "", fmt.Errorf("Name '%s' is longer than maximum length %v", prefix, maxlen-randChars)
+// NewUniqueHex generates a new "random" hex string for use by resource providers. It will take the optional prefix
+// and append randlen random characters (defaulting to 8 if not > 0).  The result must not exceed maxlen total
+// characterss (if > 0).  Note that capping to maxlen necessarily increases the risk of collisions.
+func NewUniqueHex(prefix string, randlen, maxlen int) (string, error) {
+	if randlen <= 0 {
+		randlen = 8
+	}
+	if maxlen > 0 && len(prefix)+randlen > maxlen {
+		return "", errors.Errorf(
+			"name '%s' plus %d random chars is longer than maximum length %d", prefix, randlen, maxlen)
 	}
 
-	bs := make([]byte, randChars/2)
+	bs := make([]byte, randlen+1/2)
 	n, err := cryptorand.Read(bs)
 	contract.Assert(err == nil)
 	contract.Assert(n == len(bs))
 
-	str := prefix + hex.EncodeToString(bs)
-	return str, nil
+	return prefix + hex.EncodeToString(bs)[:randlen], nil
 }
 
-// NewUniqueHexID generates a new "random" hex ID for use by resource providers.  It has the given
-// optional prefix and the total length is capped to the maxlen.  Note that capping to maxlen
-// necessarily increases the risk of collisions.
-func NewUniqueHexID(prefix string, maxlen int) (ID, error) {
-	u, err := NewUniqueHex(prefix, maxlen)
-	if err != nil {
-		return "", err
-	}
-
-	return ID(u), nil
+// NewUniqueHexID generates a new "random" hex string for use by resource providers. It will take the optional prefix
+// and append randlen random characters (defaulting to 8 if not > 0).  The result must not exceed maxlen total
+// characterss (if > 0).  Note that capping to maxlen necessarily increases the risk of collisions.
+func NewUniqueHexID(prefix string, randlen, maxlen int) (ID, error) {
+	u, err := NewUniqueHex(prefix, randlen, maxlen)
+	return ID(u), err
 }

--- a/pkg/resource/resource_id_test.go
+++ b/pkg/resource/resource_id_test.go
@@ -11,25 +11,28 @@ import (
 
 func TestNewUniqueHex(t *testing.T) {
 	prefix := "prefix"
+	randlen := 8
 	maxlen := 100
-	id, err := NewUniqueHex(prefix, maxlen)
+	id, err := NewUniqueHex(prefix, randlen, maxlen)
 	assert.Nil(t, err)
-	assert.Equal(t, len(prefix)+8, len(id))
+	assert.Equal(t, len(prefix)+randlen, len(id))
 	assert.Equal(t, true, strings.HasPrefix(id, prefix))
 }
 
 func TestNewUniqueHexMaxLen2(t *testing.T) {
 	prefix := "prefix"
+	randlen := 8
 	maxlen := 13
-	_, err := NewUniqueHex(prefix, maxlen)
+	_, err := NewUniqueHex(prefix, randlen, maxlen)
 	assert.NotNil(t, err)
 }
 
 func TestNewUniqueHexEnsureRandomness2(t *testing.T) {
 	prefix := "prefix"
 	// Just enough space to have 8 chars of randomenss
+	randlen := 8
 	maxlen := 14
-	id, err := NewUniqueHex(prefix, maxlen)
+	id, err := NewUniqueHex(prefix, randlen, maxlen)
 	assert.Nil(t, err)
 	assert.Equal(t, maxlen, len(id))
 	assert.Equal(t, true, strings.HasPrefix(id, prefix))
@@ -37,7 +40,7 @@ func TestNewUniqueHexEnsureRandomness2(t *testing.T) {
 
 func TestNewUniqueDefaults(t *testing.T) {
 	prefix := "prefix"
-	id, err := NewUniqueHex(prefix, -1)
+	id, err := NewUniqueHex(prefix, -1, -1)
 	assert.Nil(t, err)
 	assert.Equal(t, len(prefix)+8, len(id))
 	assert.Equal(t, true, strings.HasPrefix(id, prefix))
@@ -45,8 +48,9 @@ func TestNewUniqueDefaults(t *testing.T) {
 
 func TestNewUniqueHexID(t *testing.T) {
 	prefix := "prefix"
+	randlen := 8
 	maxlen := 100
-	id, err := NewUniqueHexID(prefix, maxlen)
+	id, err := NewUniqueHexID(prefix, randlen, maxlen)
 	assert.Nil(t, err)
 	assert.Equal(t, len(prefix)+8, len(id))
 	assert.Equal(t, true, strings.HasPrefix(string(id), prefix))
@@ -54,8 +58,9 @@ func TestNewUniqueHexID(t *testing.T) {
 
 func TestNewUniqueHexMaxLenID(t *testing.T) {
 	prefix := "prefix"
+	randlen := 8
 	maxlen := 20
-	id, err := NewUniqueHexID(prefix, maxlen)
+	id, err := NewUniqueHexID(prefix, randlen, maxlen)
 	assert.Nil(t, err)
 	assert.Equal(t, len(prefix)+8, len(id))
 	assert.Equal(t, true, strings.HasPrefix(string(id), prefix))
@@ -63,7 +68,7 @@ func TestNewUniqueHexMaxLenID(t *testing.T) {
 
 func TestNewUniqueDefaultsID(t *testing.T) {
 	prefix := "prefix"
-	id, err := NewUniqueHexID(prefix, -1)
+	id, err := NewUniqueHexID(prefix, -1, -1)
 	assert.Nil(t, err)
 	assert.Equal(t, len(prefix)+8, len(id))
 	assert.Equal(t, true, strings.HasPrefix(string(id), prefix))

--- a/pkg/testing/integration/s3reporter.go
+++ b/pkg/testing/integration/s3reporter.go
@@ -48,7 +48,7 @@ func (r *S3Reporter) ReportCommand(stats TestCommandStats) {
 		fmt.Printf("Failed to serialize report for upload to S3: %v: %v\n", stats, err)
 		return
 	}
-	name, _ := resource.NewUniqueHex(fmt.Sprintf("%v-", time.Now().UnixNano()), -1)
+	name, _ := resource.NewUniqueHex(fmt.Sprintf("%v-", time.Now().UnixNano()), -1, -1)
 	_, err = r.s3svc.PutObject(&s3.PutObjectInput{
 		Bucket: aws.String(r.bucket),
 		Key:    aws.String(path.Join(r.keyPrefix, name)),


### PR DESCRIPTION
This change adds a randlen parameter to NewUniqueHex/ID so that the
caller can decide how long of a random string to generate.