### PR TITLE
Close assets while creating ZIP archives.

### DIFF
--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -860,6 +860,7 @@ func addNextFileToZIP(r ArchiveReader, zw *zip.Writer) error {
 	if err != nil {
 		return err
 	}
+	defer contract.IgnoreClose(data)
 
 	fw, err := zw.Create(file)
 	if err != nil {


### PR DESCRIPTION
This was an unintentional omission from my earlier change that
refactored the archive code.

Fixes pulumi/pulumi-ppc#133.