### PR TITLE
Set pwd for plugins

### DIFF
--- a/pkg/engine/deploy.go
+++ b/pkg/engine/deploy.go
@@ -80,6 +80,14 @@ func (eng *Engine) deployLatest(info *planContext, opts deployOptions) error {
 	}
 	if result != nil {
 		defer contract.IgnoreClose(result)
+
+		// Make the current working directory the same as the program's, and restore it upon exit.
+		done, err := result.Chdir()
+		if err != nil {
+			return err
+		}
+		defer done()
+
 		if opts.DryRun {
 			// If a dry run, just print the plan, don't actually carry out the deployment.
 			if err := eng.printPlan(result); err != nil {

--- a/pkg/engine/preview.go
+++ b/pkg/engine/preview.go
@@ -58,6 +58,14 @@ func (eng *Engine) previewLatest(info *planContext, opts deployOptions) error {
 	}
 	if result != nil {
 		defer contract.IgnoreClose(result)
+
+		// Make the current working directory the same as the program's, and restore it upon exit.
+		done, err := result.Chdir()
+		if err != nil {
+			return err
+		}
+		defer done()
+
 		if err := eng.printPlan(result); err != nil {
 			return err
 		}

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -20,7 +20,7 @@ import (
 func TestNullPlan(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil)
+	ctx, err := plugin.NewContext(cmdutil.Diag(), nil, "", nil)
 	assert.Nil(t, err)
 	targ := &Target{Name: tokens.QName("null")}
 	prev := NewSnapshot(targ.Name, Manifest{}, nil)
@@ -41,7 +41,7 @@ func TestErrorPlan(t *testing.T) {
 
 	// First trigger an error from Iterate:
 	{
-		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil)
+		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, "", nil)
 		assert.Nil(t, err)
 		targ := &Target{Name: tokens.QName("errs")}
 		prev := NewSnapshot(targ.Name, Manifest{}, nil)
@@ -56,7 +56,7 @@ func TestErrorPlan(t *testing.T) {
 
 	// Next trigger an error from Next:
 	{
-		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil)
+		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, "", nil)
 		assert.Nil(t, err)
 		targ := &Target{Name: tokens.QName("errs")}
 		prev := NewSnapshot(targ.Name, Manifest{}, nil)
@@ -133,7 +133,7 @@ func TestBasicCRUDPlan(t *testing.T) {
 				// we don't actually execute the plan, so there's no need to implement the other functions.
 			}, nil
 		},
-	}, nil)
+	}, "", nil)
 	assert.Nil(t, err)
 
 	// Setup a fake namespace/target combination.

--- a/pkg/resource/plugin/context.go
+++ b/pkg/resource/plugin/context.go
@@ -16,16 +16,18 @@ import (
 type Context struct {
 	Diag diag.Sink // the diagnostics sink to use for messages.
 	Host Host      // the host that can be used to fetch providers.
+	Pwd  string    // the working directory to spawn all plugins in.
 
 	tracingSpan opentracing.Span // the OpenTracing span to parent requests within.
 }
 
 // NewContext allocates a new context with a given sink and host.  Note that the host is "owned" by this context from
 // here forwards, such that when the context's resources are reclaimed, so too are the host's.
-func NewContext(d diag.Sink, host Host, parentSpan opentracing.Span) (*Context, error) {
+func NewContext(d diag.Sink, host Host, pwd string, parentSpan opentracing.Span) (*Context, error) {
 	ctx := &Context{
 		Diag:        d,
 		Host:        host,
+		Pwd:         pwd,
 		tracingSpan: parentSpan,
 	}
 	if host == nil {

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -55,7 +55,7 @@ func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin,
 	}
 
 	// Try to execute the binary.
-	plug, err := execPlugin(bin, args)
+	plug, err := execPlugin(bin, args, ctx.Pwd)
 	if err != nil {
 		// If we failed simply because we couldn't load the binary, return nil rather than an error.
 		if execerr, isexecerr := err.(*exec.Error); isexecerr && execerr.Err == exec.ErrNotFound {
@@ -184,7 +184,7 @@ func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin,
 	return plug, nil
 }
 
-func execPlugin(bin string, pluginArgs []string) (*plugin, error) {
+func execPlugin(bin string, pluginArgs []string, pwd string) (*plugin, error) {
 	var args []string
 	// Flow the logging information if set.
 	if cmdutil.LogFlow {
@@ -203,6 +203,7 @@ func execPlugin(bin string, pluginArgs []string) (*plugin, error) {
 
 	// nolint: gas
 	cmd := exec.Command(bin, args...)
+	cmd.Dir = pwd
 	in, _ := cmd.StdinPipe()
 	out, _ := cmd.StdoutPipe()
 	err, _ := cmd.StderrPipe()


### PR DESCRIPTION
This change just flows the project's "main" directory all the way
through to the plugins, fixing #667.  In that work item, we discussed
alternative approaches, such as rewriting the asset paths, but this
is tricky because it's very tough to do without those absolute paths
somehow ending up in the checkpoint files.  Just launching the
processes with the right pwd is far easier and safer, and it turns
out that, conveniently, we set up the plugin context in exactly the
same place that we read the project information.