### PR TITLE
Do not buffer output during planning

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -179,8 +179,9 @@ func (eng *Engine) printPlan(result *planResult) error {
 	}
 
 	// Print a summary of operation counts.
-	printChangeSummary(&actions.Summary, actions.Ops, true)
-	result.Options.Events <- stdOutEventWithColor(&actions.Summary)
+	var summary bytes.Buffer
+	printChangeSummary(&summary, actions.Ops, true)
+	result.Options.Events <- stdOutEventWithColor(&summary)
 	return nil
 }
 

--- a/pkg/engine/preview.go
+++ b/pkg/engine/preview.go
@@ -79,11 +79,10 @@ func (eng *Engine) previewLatest(info *planContext, opts deployOptions) error {
 }
 
 type previewActions struct {
-	Summary bytes.Buffer
-	Ops     map[deploy.StepOp]int
-	Opts    deployOptions
-	Seen    map[resource.URN]deploy.Step
-	Shown   map[resource.URN]bool
+	Ops   map[deploy.StepOp]int
+	Opts  deployOptions
+	Seen  map[resource.URN]deploy.Step
+	Shown map[resource.URN]bool
 }
 
 func newPreviewActions(opts deployOptions) *previewActions {
@@ -98,8 +97,10 @@ func newPreviewActions(opts deployOptions) *previewActions {
 func (acts *previewActions) OnResourceStepPre(step deploy.Step) (interface{}, error) {
 	// Print this step information (resource and all its properties).
 	if shouldShow(acts.Seen, step, acts.Opts) || isRootStack(step) {
-		printStep(&acts.Summary, step,
+		var b bytes.Buffer
+		printStep(&b, step,
 			acts.Seen, acts.Shown, acts.Opts.Summary, acts.Opts.Detailed, true, 0 /*indent*/)
+		acts.Opts.Events <- stdOutEventWithColor(&b)
 	}
 	return nil, nil
 }
@@ -124,7 +125,9 @@ func (acts *previewActions) OnResourceStepPost(ctx interface{},
 func (acts *previewActions) OnResourceOutputs(step deploy.Step) error {
 	// Print this step's output properties.
 	if (shouldShow(acts.Seen, step, acts.Opts) || isRootStack(step)) && !acts.Opts.Summary {
-		printResourceOutputProperties(&acts.Summary, step, acts.Seen, acts.Shown, 0 /*indent*/)
+		var b bytes.Buffer
+		printResourceOutputProperties(&b, step, acts.Seen, acts.Shown, 0 /*indent*/)
+		acts.Opts.Events <- stdOutEventWithColor(&b)
 	}
 	return nil
 }


### PR DESCRIPTION
Previously, we would compute all the output from plan and then display
it as a single event. Instead, we should do this how we handle things
during deploy. Each logical print operaton gets a single event and we
stream them back over a channel during planning.

Fixes #660