### PR TITLE
Add a missing error propagation

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -424,6 +424,7 @@ func (b *cloudBackend) waitForUpdate(path string) (apitype.UpdateStatus, error) 
 				time.Sleep(1 * time.Second)
 				continue
 			}
+			return apitype.StatusFailed, err
 		}
 
 		for _, event := range updateResults.Events {


### PR DESCRIPTION
If the service returns a 504, we happily keep looping around and
retrying until we get a valid update.  Unfortunately, we missed the
else condition, which is what happens when this isn't a 504, leading
us to swallow real errors (500 and the like).  Trivial fix.

Fixes pulumi/pulumi#712.