### PR TITLE
Make config a little less error prone

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -22,7 +22,7 @@ func newLogoutCmd() *cobra.Command {
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// If --all is passed, log out of all clouds.
 			if all {
-				bes, err := cloud.CurrentBackends()
+				bes, err := cloud.CurrentBackends(cmdutil.Diag())
 				if err != nil {
 					return errors.Wrap(err, "could not read list of current clouds")
 				}

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -50,7 +50,7 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		defaultHelp(cmd, args)
 
-		loggedInto, logErr := cloud.CurrentBackends()
+		loggedInto, logErr := cloud.CurrentBackends(cmdutil.Diag())
 		contract.IgnoreError(logErr) // we want to make progress anyway.
 		if len(loggedInto) > 0 {
 			fmt.Printf("\n")

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -33,13 +33,13 @@ func newStackInitCmd() *cobra.Command {
 				if ppc != "" {
 					return errors.New("cannot pass both --local and --ppc; PPCs only available in cloud mode")
 				}
-				b = local.New()
+				b = local.New(cmdutil.Diag())
 			} else {
 				// If no cloud URL override was given, fall back to the default.
 				if cloudURL == "" {
 					cloudURL = cloud.DefaultURL()
 				}
-				b = cloud.New(cloudURL)
+				b = cloud.New(cmdutil.Diag(), cloudURL)
 				opts = cloud.CreateStackOptions{CloudName: ppc}
 			}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/local"
 	"github.com/pulumi/pulumi/pkg/backend/state"
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/fsutil"
 )
@@ -25,8 +26,9 @@ import (
 func allBackends() ([]backend.Backend, bool) {
 	// Add all the known backends to the list and query them all.  We always use the local backend,
 	// in addition to all of those cloud backends we are currently logged into.
-	backends := []backend.Backend{local.New()}
-	cloudBackends, err := cloud.CurrentBackends()
+	d := cmdutil.Diag()
+	backends := []backend.Backend{local.New(d)}
+	cloudBackends, err := cloud.CurrentBackends(d)
 	if err != nil {
 		// Print the error, but keep going so that the local operations still occur.
 		_, fmterr := fmt.Fprintf(os.Stderr, "error: could not obtain current cloud backends: %v", err)

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/backend/cloud/apitype"
 	"github.com/pulumi/pulumi/pkg/backend/state"
+	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
@@ -38,12 +39,13 @@ type Backend interface {
 }
 
 type cloudBackend struct {
+	d        diag.Sink
 	cloudURL string
 }
 
 // New creates a new Pulumi backend for the given cloud API URL.
-func New(cloudURL string) Backend {
-	return &cloudBackend{cloudURL: cloudURL}
+func New(d diag.Sink, cloudURL string) Backend {
+	return &cloudBackend{d: d, cloudURL: cloudURL}
 }
 
 func (b *cloudBackend) Name() string     { return b.cloudURL }
@@ -178,7 +180,7 @@ func (b *cloudBackend) updateStack(action updateKind, stackName tokens.QName, de
 	if err != nil {
 		return err
 	}
-	updateRequest, err := makeProgramUpdateRequest(stackName)
+	updateRequest, err := b.makeProgramUpdateRequest(stackName)
 	if err != nil {
 		return err
 	}
@@ -322,8 +324,8 @@ func (b *cloudBackend) listCloudStacks() ([]apitype.Stack, error) {
 }
 
 // getDecryptedConfig returns the stack's configuration with any secrets in plain-text.
-func getDecryptedConfig(stackName tokens.QName) (map[tokens.ModuleMember]string, error) {
-	cfg, err := state.Configuration(stackName)
+func (b *cloudBackend) getDecryptedConfig(stackName tokens.QName) (map[tokens.ModuleMember]string, error) {
+	cfg, err := state.Configuration(b.d, stackName)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting configuration")
 	}
@@ -371,7 +373,7 @@ func getCloudProjectIdentifier() (*cloudProjectIdentifier, error) {
 }
 
 // makeProgramUpdateRequest constructs the apitype.UpdateProgramRequest based on the local machine state.
-func makeProgramUpdateRequest(stackName tokens.QName) (apitype.UpdateProgramRequest, error) {
+func (b *cloudBackend) makeProgramUpdateRequest(stackName tokens.QName) (apitype.UpdateProgramRequest, error) {
 	// Zip up the Pulumi program's directory, which may be a parent of CWD.
 	programPath, err := workspace.DetectPackage()
 	if err != nil {
@@ -395,7 +397,7 @@ func makeProgramUpdateRequest(stackName tokens.QName) (apitype.UpdateProgramRequ
 
 	// Gather up configuration.
 	// TODO(pulumi-service/issues/221): Have pulumi.com handle the encryption/decryption.
-	textConfig, err := getDecryptedConfig(stackName)
+	textConfig, err := b.getDecryptedConfig(stackName)
 	if err != nil {
 		return apitype.UpdateProgramRequest{}, errors.Wrap(err, "getting decrypted configuration")
 	}
@@ -505,7 +507,7 @@ func Logout(cloudURL string) error {
 }
 
 // CurrentBackends returns a list of the cloud backends the user is currently logged into.
-func CurrentBackends() ([]Backend, error) {
+func CurrentBackends(d diag.Sink) ([]Backend, error) {
 	creds, err := workspace.GetStoredCredentials()
 	if err != nil {
 		return nil, err
@@ -521,7 +523,7 @@ func CurrentBackends() ([]Backend, error) {
 		sort.Strings(cloudURLs)
 
 		for _, url := range cloudURLs {
-			backends = append(backends, New(url))
+			backends = append(backends, New(d, url))
 		}
 	}
 

--- a/pkg/backend/state/config.go
+++ b/pkg/backend/state/config.go
@@ -3,6 +3,9 @@
 package state
 
 import (
+	"sort"
+
+	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -10,45 +13,69 @@ import (
 )
 
 // Configuration reads the configuration for a given stack from the current workspace.  It applies a hierarchy of
-// configuration settings based on stack overrides and workspace-wide global settings.
-func Configuration(stackName tokens.QName) (config.Map, error) {
+// configuration settings based on stack overrides and workspace-wide global settings.  If any of the workspace
+// settings had an impact on the values returned, the second return value will be true.
+func Configuration(d diag.Sink, stackName tokens.QName) (config.Map, error) {
 	contract.Require(stackName != "", "stackName")
 
-	config := make(config.Map)
-
-	// First apply global configs from the package.
-	pkg, err := workspace.GetPackage()
-	if err != nil {
-		return nil, err
-	}
-	for key, value := range pkg.Config {
-		config[key] = value
-	}
-
-	// Next, apply configs from this particular stack, if any.
-	if stackInfo, has := pkg.Stacks[stackName]; has {
-		for key, value := range stackInfo.Config {
-			config[key] = value
-		}
-	}
-
-	// Now, if there are global settings in the workspace, apply those.
+	// Get the workspace and package and get ready to merge their views of the configuration.
 	ws, err := workspace.New()
 	if err != nil {
 		return nil, err
 	}
-	if localAllStackConfig, has := ws.Settings().Config[""]; has {
-		for key, value := range localAllStackConfig {
-			config[key] = value
+	pkg, err := workspace.GetPackage()
+	if err != nil {
+		return nil, err
+	}
+
+	// We need to apply workspace and project configuration values in the right order.  Basically, we want to
+	// end up taking the most specific settings, where per-stack configuration is more specific than global, and
+	// project configuration is more specific than workspace.
+	result := make(config.Map)
+	var workspaceConfigKeys []string
+
+	// First, apply project-local stack-specific configuration.
+	if stack, has := pkg.Stacks[stackName]; has {
+		for key, value := range stack.Config {
+			result[key] = value
 		}
 	}
 
-	// And finally, if there are global workspace settings for this stack, apply those.
-	if localStackConfig, has := ws.Settings().Config[stackName]; has {
-		for key, value := range localStackConfig {
-			config[key] = value
+	// Now, apply workspace stack-specific configuration.
+	if wsStackConfig, has := ws.Settings().Config[stackName]; has {
+		for key, value := range wsStackConfig {
+			if _, has := result[key]; !has {
+				result[key] = value
+				workspaceConfigKeys = append(workspaceConfigKeys, string(key))
+			}
 		}
 	}
 
-	return config, nil
+	// Next, take anything from the global settings in our project file.
+	for key, value := range pkg.Config {
+		if _, has := result[key]; !has {
+			result[key] = value
+		}
+	}
+
+	// Finally, take anything left in the workspace's global configuration.
+	if wsGlobalConfig, has := ws.Settings().Config[""]; has {
+		for key, value := range wsGlobalConfig {
+			if _, has := result[key]; !has {
+				result[key] = value
+				workspaceConfigKeys = append(workspaceConfigKeys, string(key))
+			}
+		}
+	}
+
+	// If there are any configuration settings from the workspace being used, issue a warning.  This can be a subtle
+	// source of discrepancy when deploying stacks to the cloud, and can be tough to track down.
+	if len(workspaceConfigKeys) > 0 {
+		sort.Strings(workspaceConfigKeys)
+		d.Warningf(
+			diag.Message("configuration variables were taken from your local workspace; proceed with caution: %v"),
+			workspaceConfigKeys)
+	}
+
+	return result, nil
 }

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -175,27 +175,25 @@ func TestConfigSave(t *testing.T) {
 
 	// Now configure and save a few different things:
 	//     1) do not save.
-	e.RunCommand("pulumi", "config", "set", "configA", "value1")
+	e.RunCommand("pulumi", "config", "set", "configA", "value1", "--save=false")
 	//     2) save to the project file, under the current stack.
-	e.RunCommand("pulumi", "config", "set", "configB", "value2", "--save")
+	e.RunCommand("pulumi", "config", "set", "configB", "value2")
 	//     3) save to the project file, underneath an entirely different stack.
-	e.RunCommand("pulumi", "config", "set", "configC", "value3", "--save", "--stack", "testing-2")
+	e.RunCommand("pulumi", "config", "set", "configC", "value3", "--stack", "testing-2")
 	//     4) save to the project file, across all stacks.
-	e.RunCommand("pulumi", "config", "set", "configD", "value4", "--save", "--all")
+	e.RunCommand("pulumi", "config", "set", "configD", "value4", "--all")
 	//     5) save the same config key with a different value in the stack versus all stacks.
-	e.RunCommand("pulumi", "config", "set", "configE", "value55", "--save")
-	e.RunCommand("pulumi", "config", "set", "configE", "value66", "--save", "--all")
+	e.RunCommand("pulumi", "config", "set", "configE", "value55")
+	e.RunCommand("pulumi", "config", "set", "configE", "value66", "--all")
 
 	// Now read back the config using the CLI:
 	{
-		stdout, stderr := e.RunCommand("pulumi", "config", "get", "configA")
+		stdout, _ := e.RunCommand("pulumi", "config", "get", "configA")
 		assert.Equal(t, "value1\n", stdout)
-		assert.Equal(t, "", stderr)
 	}
 	{
-		stdout, stderr := e.RunCommand("pulumi", "config", "get", "configB")
+		stdout, _ := e.RunCommand("pulumi", "config", "get", "configB")
 		assert.Equal(t, "value2\n", stdout)
-		assert.Equal(t, "", stderr)
 	}
 	{
 		// config is in a different stack, should yield a stderr:
@@ -204,19 +202,16 @@ func TestConfigSave(t *testing.T) {
 		assert.NotEqual(t, "", stderr)
 	}
 	{
-		stdout, stderr := e.RunCommand("pulumi", "config", "get", "configC", "--stack", "testing-2")
+		stdout, _ := e.RunCommand("pulumi", "config", "get", "configC", "--stack", "testing-2")
 		assert.Equal(t, "value3\n", stdout)
-		assert.Equal(t, "", stderr)
 	}
 	{
-		stdout, stderr := e.RunCommand("pulumi", "config", "get", "configD")
+		stdout, _ := e.RunCommand("pulumi", "config", "get", "configD")
 		assert.Equal(t, "value4\n", stdout)
-		assert.Equal(t, "", stderr)
 	}
 	{
-		stdout, stderr := e.RunCommand("pulumi", "config", "get", "configE")
+		stdout, _ := e.RunCommand("pulumi", "config", "get", "configE")
 		assert.Equal(t, "value55\n", stdout)
-		assert.Equal(t, "", stderr)
 	}
 
 	// Finally, check that the project file contains what we expected.


### PR DESCRIPTION
As articulated in #714, the way config defaults to workspace-local
configuration is a bit error prone, especially now with the cloud
workflow being the default.  This change implements several improvements:

* First, --save defaults to true, so that configuration changes will
  persist into your project file.  If you want the old local workspace
  behavior, you can specify --save=false.

* Second, the order in which we applied configuration was a little
  strange, because workspace settings overwrote project settings.
  The order is changed now so that we take most specific over least
  specific configuration.  Per-stack is considered more specific
  than global and project settings are considered more specific
  than workspace.

* We now warn anytime workspace local configuration is used.  This
  is a developer scenario and can have subtle effects.  It is simply
  not safe to use in a team environment.  In fact, I lost an arm
  this morning due to workspace config... and that's why you always
  issue warnings for unsafe things.