### PR TITLE
Pass more stack info to ExtraRuntimeValidation

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -9,8 +9,6 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/backend/cloud"
-	"github.com/pulumi/pulumi/pkg/resource"
-	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 )
@@ -105,7 +103,7 @@ func newStackCmd() *cobra.Command {
 				}
 
 				// Print out the output properties for the stack, if present.
-				if res, outputs := getRootStackResource(snap); res != nil {
+				if res, outputs := stack.GetRootStackResource(snap); res != nil {
 					fmt.Printf("\n")
 					printStackOutputs(outputs)
 				}
@@ -130,20 +128,6 @@ func newStackCmd() *cobra.Command {
 	cmd.AddCommand(newStackSelectCmd())
 
 	return cmd
-}
-
-// getStackResource returns the root stack resource from a given snapshot, or nil if not found.  If the stack exists,
-// its output properties, if any, are also returned in the resulting map.
-func getRootStackResource(snap *deploy.Snapshot) (*resource.State, map[string]interface{}) {
-	if snap != nil {
-		for _, res := range snap.Resources {
-			if res.Type == resource.RootStackType {
-				return res, stack.SerializeResource(res).Outputs
-			}
-		}
-	}
-	return nil, nil
-
 }
 
 func printStackOutputs(outputs map[string]interface{}) {

--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 )
 
@@ -26,7 +27,7 @@ func newStackOutputCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			res, outputs := getRootStackResource(s.Snapshot())
+			res, outputs := stack.GetRootStackResource(s.Snapshot())
 			if res == nil || outputs == nil {
 				return errors.New("current stack has no output properties")
 			}

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/testing/integration"
 )
 
@@ -31,9 +30,9 @@ func TestExamples(t *testing.T) {
 		Secrets: map[string]string{
 			"secret": "this is my secret message",
 		},
-		ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Simple runtime validation that just ensures the checkpoint was written and read.
-			assert.Equal(t, minimal.StackName(), checkpoint.Stack)
+			assert.Equal(t, minimal.StackName(), stackInfo.Checkpoint.Stack)
 		},
 		ReportStats: integration.NewS3Reporter("us-west-2", "eng.pulumi.com", "testreports"),
 	}
@@ -57,7 +56,7 @@ func TestExamples(t *testing.T) {
 		{
 			Dir:          path.Join(cwd, "formattable"),
 			Dependencies: []string{"pulumi"},
-			ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 				// Note that we're abusing this hook to validate stdout. We don't actually care about the checkpoint.
 				stdout := formattableStdout.String()
 				assert.False(t, strings.Contains(stdout, "MISSING"))

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -90,3 +90,16 @@ func DeserializeCheckpoint(chkpoint *Checkpoint) (*deploy.Snapshot, error) {
 
 	return snap, nil
 }
+
+// GetRootStackResource returns the root stack resource from a given snapshot, or nil if not found.  If the stack
+// exists, its output properties, if any, are also returned in the resulting map.
+func GetRootStackResource(snap *deploy.Snapshot) (*resource.State, map[string]interface{}) {
+	if snap != nil {
+		for _, res := range snap.Resources {
+			if res.Type == resource.RootStackType {
+				return res, SerializeResource(res).Outputs
+			}
+		}
+	}
+	return nil, nil
+}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/engine"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
@@ -28,10 +30,18 @@ import (
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
+// RuntimeValidationStackInfo contains details related to the stack that runtime validation logic may want to use.
+type RuntimeValidationStackInfo struct {
+	Checkpoint   stack.Checkpoint
+	Snapshot     deploy.Snapshot
+	RootResource resource.State
+	Outputs      map[string]interface{}
+}
+
 // EditDir is an optional edit to apply to the example, as subsequent deployments.
 type EditDir struct {
 	Dir                    string
-	ExtraRuntimeValidation func(t *testing.T, checkpoint stack.Checkpoint)
+	ExtraRuntimeValidation func(t *testing.T, stack RuntimeValidationStackInfo)
 	Additive               bool // set to true to keep the prior test dir, applying this edit atop.
 }
 
@@ -75,7 +85,7 @@ type ProgramTestOptions struct {
 	// EditDirs is an optional list of edits to apply to the example, as subsequent deployments.
 	EditDirs []EditDir
 	// ExtraRuntimeValidation is an optional callback for additional validation, called before applying edits.
-	ExtraRuntimeValidation func(t *testing.T, checkpoint stack.Checkpoint)
+	ExtraRuntimeValidation func(t *testing.T, stack RuntimeValidationStackInfo)
 	// RelativeWorkDir is an optional path relative to `Dir` which should be used as working directory during tests.
 	RelativeWorkDir string
 	// Quick can be set to true to run a "quick" test that skips any non-essential steps (e.g., empty updates).
@@ -372,7 +382,7 @@ func TestEdit(t *testing.T, opts *ProgramTestOptions, dir string, i int, edit Ed
 
 func performExtraRuntimeValidation(
 	t *testing.T, opts *ProgramTestOptions,
-	extraRuntimeValidation func(t *testing.T, checkpoint stack.Checkpoint), dir string) error {
+	extraRuntimeValidation func(t *testing.T, stack RuntimeValidationStackInfo), dir string) error {
 
 	if extraRuntimeValidation == nil {
 		return nil
@@ -391,7 +401,29 @@ func performExtraRuntimeValidation(
 	} else if !assert.NotNil(t, chk, "expected checkpoint file to be populated from %v: %v", stackName, err) {
 		return errors.New("missing checkpoint")
 	}
-	extraRuntimeValidation(t, *chk)
+
+	// Deserialize snapshot from checkpoint
+	snapshot, err := stack.DeserializeCheckpoint(chk)
+	if !assert.NoError(t, err, "expected checkpoint deserialization to succeed") {
+		return err
+	} else if !assert.NotNil(t, snapshot, "expected snapshot to be populated from checkpoint file %v", stackName) {
+		return errors.New("missing snapshot")
+	}
+
+	// Get root resources from snapshot
+	rootResource, outputs := stack.GetRootStackResource(snapshot)
+	if !assert.NotNil(t, rootResource, "expected root resource to be populated from snapshot file %v", stackName) {
+		return errors.New("missing root resource")
+	}
+
+	// Populate stack info object with all of this data to pass to the validation function
+	stackInfo := RuntimeValidationStackInfo{
+		Checkpoint:   *chk,
+		Snapshot:     *snapshot,
+		RootResource: *rootResource,
+		Outputs:      outputs,
+	}
+	extraRuntimeValidation(t, stackInfo)
 	return nil
 }
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource"
-	"github.com/pulumi/pulumi/pkg/resource/stack"
 	ptesting "github.com/pulumi/pulumi/pkg/testing"
 	"github.com/pulumi/pulumi/pkg/testing/integration"
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -22,9 +21,9 @@ func TestProjectMain(t *testing.T) {
 	test = integration.ProgramTestOptions{
 		Dir:          "project_main",
 		Dependencies: []string{"pulumi"},
-		ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Simple runtime validation that just ensures the checkpoint was written and read.
-			assert.Equal(t, test.StackName(), checkpoint.Stack)
+			assert.Equal(t, test.StackName(), stackInfo.Checkpoint.Stack)
 		},
 	}
 	integration.ProgramTest(t, &test)
@@ -79,11 +78,11 @@ func TestStackOutputs(t *testing.T) {
 		Dir:          "stack_outputs",
 		Dependencies: []string{"pulumi"},
 		Quick:        true,
-		ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Ensure the checkpoint contains a single resource, the Stack, with two outputs.
-			assert.NotNil(t, checkpoint.Latest)
-			if assert.Equal(t, 1, len(checkpoint.Latest.Resources)) {
-				stackRes := checkpoint.Latest.Resources[0]
+			assert.NotNil(t, stackInfo.Checkpoint.Latest)
+			if assert.Equal(t, 1, len(stackInfo.Checkpoint.Latest.Resources)) {
+				stackRes := stackInfo.Checkpoint.Latest.Resources[0]
 				assert.NotNil(t, stackRes)
 				assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
 				assert.Equal(t, 0, len(stackRes.Inputs))
@@ -101,7 +100,7 @@ func TestStackParenting(t *testing.T) {
 		Dir:          "stack_parenting",
 		Dependencies: []string{"pulumi"},
 		Quick:        true,
-		ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Ensure the checkpoint contains resources parented correctly.  This should look like this:
 			//
 			//     A      F
@@ -112,38 +111,38 @@ func TestStackParenting(t *testing.T) {
 			//
 			// with the caveat, of course, that A and F will share a common parent, the implicit stack.
 
-			assert.NotNil(t, checkpoint.Latest)
-			if assert.Equal(t, 8, len(checkpoint.Latest.Resources)) {
-				stackRes := checkpoint.Latest.Resources[0]
+			assert.NotNil(t, stackInfo.Checkpoint.Latest)
+			if assert.Equal(t, 8, len(stackInfo.Checkpoint.Latest.Resources)) {
+				stackRes := stackInfo.Checkpoint.Latest.Resources[0]
 				assert.NotNil(t, stackRes)
 				assert.Equal(t, resource.RootStackType, stackRes.Type)
 				assert.Equal(t, "", string(stackRes.Parent))
-				a := checkpoint.Latest.Resources[1]
+				a := stackInfo.Checkpoint.Latest.Resources[1]
 				assert.NotNil(t, a)
 				assert.Equal(t, "a", string(a.URN.Name()))
 				assert.NotEqual(t, "", a.Parent)
 				assert.Equal(t, stackRes.URN, a.Parent)
-				b := checkpoint.Latest.Resources[2]
+				b := stackInfo.Checkpoint.Latest.Resources[2]
 				assert.NotNil(t, b)
 				assert.Equal(t, "b", string(b.URN.Name()))
 				assert.Equal(t, a.URN, b.Parent)
-				c := checkpoint.Latest.Resources[3]
+				c := stackInfo.Checkpoint.Latest.Resources[3]
 				assert.NotNil(t, c)
 				assert.Equal(t, "c", string(c.URN.Name()))
 				assert.Equal(t, a.URN, c.Parent)
-				d := checkpoint.Latest.Resources[4]
+				d := stackInfo.Checkpoint.Latest.Resources[4]
 				assert.NotNil(t, d)
 				assert.Equal(t, "d", string(d.URN.Name()))
 				assert.Equal(t, c.URN, d.Parent)
-				e := checkpoint.Latest.Resources[5]
+				e := stackInfo.Checkpoint.Latest.Resources[5]
 				assert.NotNil(t, e)
 				assert.Equal(t, "e", string(e.URN.Name()))
 				assert.Equal(t, c.URN, e.Parent)
-				f := checkpoint.Latest.Resources[6]
+				f := stackInfo.Checkpoint.Latest.Resources[6]
 				assert.NotNil(t, f)
 				assert.Equal(t, "f", string(f.URN.Name()))
 				assert.Equal(t, stackRes.URN, f.Parent)
-				g := checkpoint.Latest.Resources[7]
+				g := stackInfo.Checkpoint.Latest.Resources[7]
 				assert.NotNil(t, g)
 				assert.Equal(t, "g", string(g.URN.Name()))
 				assert.Equal(t, f.URN, g.Parent)

--- a/tests/integration/steps/steps_test.go
+++ b/tests/integration/steps/steps_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/resource"
-	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/testing/integration"
 )
 
@@ -18,85 +17,85 @@ func TestSteps(t *testing.T) {
 		Dir:          "step1",
 		Dependencies: []string{"pulumi"},
 		Quick:        true,
-		ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
-			assert.NotNil(t, checkpoint.Latest)
-			assert.Equal(t, 5, len(checkpoint.Latest.Resources))
-			stackRes := checkpoint.Latest.Resources[0]
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			assert.NotNil(t, stackInfo.Checkpoint.Latest)
+			assert.Equal(t, 5, len(stackInfo.Checkpoint.Latest.Resources))
+			stackRes := stackInfo.Checkpoint.Latest.Resources[0]
 			assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
-			a := checkpoint.Latest.Resources[1]
+			a := stackInfo.Checkpoint.Latest.Resources[1]
 			assert.Equal(t, "a", string(a.URN.Name()))
-			b := checkpoint.Latest.Resources[2]
+			b := stackInfo.Checkpoint.Latest.Resources[2]
 			assert.Equal(t, "b", string(b.URN.Name()))
-			c := checkpoint.Latest.Resources[3]
+			c := stackInfo.Checkpoint.Latest.Resources[3]
 			assert.Equal(t, "c", string(c.URN.Name()))
-			d := checkpoint.Latest.Resources[4]
+			d := stackInfo.Checkpoint.Latest.Resources[4]
 			assert.Equal(t, "d", string(d.URN.Name()))
 		},
 		EditDirs: []integration.EditDir{
 			{
 				Dir:      "step2",
 				Additive: true,
-				ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
-					assert.NotNil(t, checkpoint.Latest)
-					assert.Equal(t, 5, len(checkpoint.Latest.Resources))
-					stackRes := checkpoint.Latest.Resources[0]
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Checkpoint.Latest)
+					assert.Equal(t, 5, len(stackInfo.Checkpoint.Latest.Resources))
+					stackRes := stackInfo.Checkpoint.Latest.Resources[0]
 					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
-					a := checkpoint.Latest.Resources[1]
+					a := stackInfo.Checkpoint.Latest.Resources[1]
 					assert.Equal(t, "a", string(a.URN.Name()))
-					b := checkpoint.Latest.Resources[2]
+					b := stackInfo.Checkpoint.Latest.Resources[2]
 					assert.Equal(t, "b", string(b.URN.Name()))
-					c := checkpoint.Latest.Resources[3]
+					c := stackInfo.Checkpoint.Latest.Resources[3]
 					assert.Equal(t, "c", string(c.URN.Name()))
-					e := checkpoint.Latest.Resources[4]
+					e := stackInfo.Checkpoint.Latest.Resources[4]
 					assert.Equal(t, "e", string(e.URN.Name()))
 				},
 			},
 			{
 				Dir:      "step3",
 				Additive: true,
-				ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
-					assert.NotNil(t, checkpoint.Latest)
-					assert.Equal(t, 4, len(checkpoint.Latest.Resources))
-					stackRes := checkpoint.Latest.Resources[0]
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Checkpoint.Latest)
+					assert.Equal(t, 4, len(stackInfo.Checkpoint.Latest.Resources))
+					stackRes := stackInfo.Checkpoint.Latest.Resources[0]
 					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
-					a := checkpoint.Latest.Resources[1]
+					a := stackInfo.Checkpoint.Latest.Resources[1]
 					assert.Equal(t, "a", string(a.URN.Name()))
-					c := checkpoint.Latest.Resources[2]
+					c := stackInfo.Checkpoint.Latest.Resources[2]
 					assert.Equal(t, "c", string(c.URN.Name()))
-					e := checkpoint.Latest.Resources[3]
+					e := stackInfo.Checkpoint.Latest.Resources[3]
 					assert.Equal(t, "e", string(e.URN.Name()))
 				},
 			},
 			{
 				Dir:      "step4",
 				Additive: true,
-				ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
-					assert.NotNil(t, checkpoint.Latest)
-					assert.Equal(t, 4, len(checkpoint.Latest.Resources))
-					stackRes := checkpoint.Latest.Resources[0]
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Checkpoint.Latest)
+					assert.Equal(t, 4, len(stackInfo.Checkpoint.Latest.Resources))
+					stackRes := stackInfo.Checkpoint.Latest.Resources[0]
 					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
-					a := checkpoint.Latest.Resources[1]
+					a := stackInfo.Checkpoint.Latest.Resources[1]
 					assert.Equal(t, "a", string(a.URN.Name()))
-					c := checkpoint.Latest.Resources[2]
+					c := stackInfo.Checkpoint.Latest.Resources[2]
 					assert.Equal(t, "c", string(c.URN.Name()))
-					e := checkpoint.Latest.Resources[3]
+					e := stackInfo.Checkpoint.Latest.Resources[3]
 					assert.Equal(t, "e", string(e.URN.Name()))
 				},
 			},
 			{
 				Dir:      "step5",
 				Additive: true,
-				ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
-					assert.NotNil(t, checkpoint.Latest)
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Checkpoint.Latest)
 					// assert.Equal(t, 5, len(checkpoint.Latest.Resources))
-					assert.Equal(t, 4, len(checkpoint.Latest.Resources))
-					stackRes := checkpoint.Latest.Resources[0]
+					assert.Equal(t, 4, len(stackInfo.Checkpoint.Latest.Resources))
+					stackRes := stackInfo.Checkpoint.Latest.Resources[0]
 					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
-					a := checkpoint.Latest.Resources[1]
+					a := stackInfo.Checkpoint.Latest.Resources[1]
 					assert.Equal(t, "a", string(a.URN.Name()))
-					c := checkpoint.Latest.Resources[2]
+					c := stackInfo.Checkpoint.Latest.Resources[2]
 					assert.Equal(t, "c", string(c.URN.Name()))
-					e := checkpoint.Latest.Resources[3]
+					e := stackInfo.Checkpoint.Latest.Resources[3]
 					assert.Equal(t, "e", string(e.URN.Name()))
 					// aPendingDelete := checkpoint.Latest.Resources[4]
 					// assert.Equal(t, "a", string(aPendingDelete.URN.Name()))
@@ -106,10 +105,10 @@ func TestSteps(t *testing.T) {
 			{
 				Dir:      "step6",
 				Additive: true,
-				ExtraRuntimeValidation: func(t *testing.T, checkpoint stack.Checkpoint) {
-					assert.NotNil(t, checkpoint.Latest)
-					assert.Equal(t, 1, len(checkpoint.Latest.Resources))
-					stackRes := checkpoint.Latest.Resources[0]
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Checkpoint.Latest)
+					assert.Equal(t, 1, len(stackInfo.Checkpoint.Latest.Resources))
+					stackRes := stackInfo.Checkpoint.Latest.Resources[0]
 					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
 				},
 			},


### PR DESCRIPTION
This will allow us to remove a lot of current boilerplate in individual tests, and move it into the test harness.

Note that this will require updating users of the integration test framework.  By moving to a property bag of inputs, we should avoid needing future breaking changes to this API though.