### PR TITLE
Ensure published binaries have the correct version

### DIFF
--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -6,14 +6,14 @@ $Root=Join-Path $PSScriptRoot ".."
 $PublishDir=New-Item -ItemType Directory -Path "$env:TEMP\$([System.IO.Path]::GetRandomFileName())"
 $GitHash=$(git rev-parse HEAD)
 $PublishFile="$(Split-Path -Parent -Path $PublishDir)\$GitHash.zip"
-$Version = $(git describe --tags 2>$null)
+$Version = $(git describe --tags --dirty 2>$null)
 $Branch = $(if (Test-Path env:APPVEYOR_REPO_BRANCH) { $env:APPVEYOR_REPO_BRANCH } else { $(git rev-parse --abbrev-ref HEAD) })
 $PublishTargets = @($GitHash, $Version, $Branch)
 
 function RunGoBuild($goPackage) {
     $binRoot = New-Item -ItemType Directory -Force -Path "$PublishDir\bin"
     $outputName = Split-Path -Leaf $(go list -f "{{.Target}}" $goPackage)
-    go build -ldflags "-X main.version=$Version" -o "$binRoot\$outputName" $goPackage
+    go build -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=$Version" -o "$binRoot\$outputName" $goPackage
 }
 
 function CopyPackage($pathToModule, $moduleName) {

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -6,7 +6,7 @@ ROOT=$(dirname $0)/..
 PUBDIR=$(mktemp -du)
 GITHASH=$(git rev-parse HEAD)
 PUBFILE=$(dirname ${PUBDIR})/${GITHASH}.tgz
-VERSION=$(git describe --tags 2>/dev/null)
+VERSION=$(git describe --tags --dirty 2>/dev/null)
 
 # Figure out which branch we're on. Prefer $TRAVIS_BRANCH, if set, since
 # Travis leaves us at detached HEAD and `git rev-parse` just returns "HEAD".
@@ -22,7 +22,10 @@ function run_go_build() {
     fi
 
     mkdir -p "${PUBDIR}/bin"
-    go build -ldflags "-X main.version=${VERSION}" -o "${PUBDIR}/bin/${output_name}${bin_suffix}" "$1"
+    go build \
+       -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" \
+       -o "${PUBDIR}/bin/${output_name}${bin_suffix}" \
+       "$1"
 }
 
 # usage: copy_package <path-to-module> <module-name>


### PR DESCRIPTION
Ideally we would just use `make build` and `make install` in favor of
having yet another way to build the product, but before we can do that
in general we need to come up with a better story for cross
building. For now, just ensure we pass the correct version string to
go build when building.