### PR TITLE
Humanize some outputs a little

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,6 +38,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/dustin/go-humanize"
+  packages = ["."]
+  revision = "bb3d318650d48840a39aa21a027c6630e198e626"
+
+[[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
   revision = "a343d9870e3952dd8a0b894f9e221e210189fefe"
@@ -237,6 +243,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5095fcf9fa5079a48c877763175760bc6fe934b5145884e261d8c5e5d41c50e7"
+  inputs-digest = "3c44a01fbe883636d762b57c08a9ef16b797d4fa2503097625340015849d2dbe"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,3 +6,7 @@
 [[constraint]]
   name = "google.golang.org/grpc"
   version = "v1.7.2"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/dustin/go-humanize"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -285,7 +286,15 @@ func listConfig(stack backend.Stack, showSecrets bool) error {
 	}
 
 	if cfg != nil {
-		fmt.Printf("%-32s %-32s\n", "KEY", "VALUE")
+		// Devote 48 characters to the config key, unless there's a key longer, in which case use that.
+		maxkey := 48
+		for key := range cfg {
+			if len(key) > maxkey {
+				maxkey = len(key)
+			}
+		}
+
+		fmt.Printf("%-"+strconv.Itoa(maxkey)+"s %-48s\n", "KEY", "VALUE")
 		var keys []string
 		for key := range cfg {
 			// Note that we use the fully qualified module member here instead of a `prettyKey`, this lets us ensure
@@ -299,7 +308,7 @@ func listConfig(stack backend.Stack, showSecrets bool) error {
 				return errors.Wrap(err, "could not decrypt configuration value")
 			}
 
-			fmt.Printf("%-32s %-32s\n", prettyKey(key), decrypted)
+			fmt.Printf("%-"+strconv.Itoa(maxkey)+"s %-48s\n", prettyKey(key), decrypted)
 		}
 	}
 

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -5,7 +5,9 @@ package cmd
 import (
 	"fmt"
 	"sort"
+	"strconv"
 
+	"github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/backend/cloud"
@@ -51,7 +53,7 @@ func newStackCmd() *cobra.Command {
 				if t := snap.Manifest.Time; t.IsZero() {
 					fmt.Printf("    Last update time unknown\n")
 				} else {
-					fmt.Printf("    Last updated at %v\n", snap.Manifest.Time)
+					fmt.Printf("    Last updated %s (%v)\n", humanize.Time(t), t)
 				}
 				var cliver string
 				if snap.Manifest.Version == "" {
@@ -135,14 +137,18 @@ func printStackOutputs(outputs map[string]interface{}) {
 	if len(outputs) == 0 {
 		fmt.Printf("    No output values currently in this stack\n")
 	} else {
+		maxkey := 48
 		var outkeys []string
 		for outkey := range outputs {
+			if len(outkey) > maxkey {
+				maxkey = len(outkey)
+			}
 			outkeys = append(outkeys, outkey)
 		}
 		sort.Strings(outkeys)
-		fmt.Printf("    %-48s %s\n", "OUTPUT", "VALUE")
+		fmt.Printf("    %-"+strconv.Itoa(maxkey)+"s %s\n", "OUTPUT", "VALUE")
 		for _, key := range outkeys {
-			fmt.Printf("    %-48s %v\n", key, outputs[key])
+			fmt.Printf("    %-"+strconv.Itoa(maxkey)+"s %v\n", key, outputs[key])
 		}
 	}
 }


### PR DESCRIPTION
This does three things:

* Use nice humanized times for update times, to avoid ridiculously
  long timestamps consuming lots of horizontal space.  Instead of

       LAST UPDATE
       2017-12-12 12:22:59.994163319 -0800 PST

  we now see

       LAST UPDATE
       1 day ago

* Use the longest config key for the horizontal spacing when the key
  exceeds the default alignment size.  This avoids individual lines
  wrapping in awkward ways.

* Do the same for stack names.