### PR TITLE
 Elide our serialized function preamble and postamble when printing user code

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -1016,8 +1016,10 @@ var (
 	shaRegexp         = regexp.MustCompile("__[a-zA-Z0-9]{40}")
 	withRegexp        = regexp.MustCompile(`    with\({ .* }\) {`)
 	environmentRegexp = regexp.MustCompile(`  }\).apply\(.*\).apply\(this, arguments\);`)
-	preambleRegexp    = regexp.MustCompile(`function __shaHash\(\) {\n  return \(function\(\) {\n    with \(__closure\) {\n\nreturn \(`)
-	postambleRegexp   = regexp.MustCompile(`\)\n\n    }\n  }\).apply\(__environment\).apply\(this, arguments\);\n}`)
+	preambleRegexp    = regexp.MustCompile(
+		`function __shaHash\(\) {\n  return \(function\(\) {\n    with \(__closure\) {\n\nreturn \(`)
+	postambleRegexp = regexp.MustCompile(
+		`\)\n\n    }\n  }\).apply\(__environment\).apply\(this, arguments\);\n}`)
 )
 
 // massageText takes the text for a function and cleans it up a bit to make the user visible diffs


### PR DESCRIPTION
Now looks like:

![image](https://user-images.githubusercontent.com/4564579/34018793-7c0150aa-e0e0-11e7-84b2-217b59878b6a.png)
