### PR TITLE
Only pass old inputs to `Check`.

### DIFF
--- a/pkg/resource/deploy/plan_apply.go
+++ b/pkg/resource/deploy/plan_apply.go
@@ -281,10 +281,10 @@ func (iter *PlanIterator) makeRegisterResouceSteps(e RegisterResourceEvent) ([]S
 	// Check for an old resource before going any further.
 	old, hasold := iter.p.Olds()[urn]
 	var olds resource.PropertyMap
-	var oldouts resource.PropertyMap
+	var oldState resource.PropertyMap
 	if hasold {
 		olds = old.Inputs
-		oldouts = old.All()
+		oldState = old.All()
 	}
 
 	// Fetch the provider for this resource type, assuming it isn't just a logical one.
@@ -300,7 +300,7 @@ func (iter *PlanIterator) makeRegisterResouceSteps(e RegisterResourceEvent) ([]S
 	news, inputs := new.Inputs, new.Inputs
 	if prov != nil {
 		var failures []plugin.CheckFailure
-		inputs, failures, err = prov.Check(urn, oldouts, news)
+		inputs, failures, err = prov.Check(urn, olds, news)
 		if err != nil {
 			return nil, err
 		} else if iter.issueCheckErrors(new, urn, failures) {
@@ -354,7 +354,7 @@ func (iter *PlanIterator) makeRegisterResouceSteps(e RegisterResourceEvent) ([]S
 			// The properties changed; we need to figure out whether to do an update or replacement.
 			var diff plugin.DiffResult
 			if prov != nil {
-				if diff, err = prov.Diff(urn, old.ID, oldouts, inputs); err != nil {
+				if diff, err = prov.Diff(urn, old.ID, oldState, inputs); err != nil {
 					return nil, err
 				}
 			}


### PR DESCRIPTION
We do not need all of the information in the old state for this call, as
outputs will not be read by the provider during validation or defaults
computation.