### PR TITLE
Bump the test timeout in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
     - git clone git@github.com:pulumi/home ${GOPATH}/src/github.com/pulumi/home
     - make ensure
 script:
-    - make travis_${TRAVIS_EVENT_TYPE}
+    - make travis_${TRAVIS_EVENT_TYPE} TEST_FAST_TIMEOUT=10m
 notifications:
     webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis
 

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GOMETALINTERBIN := gometalinter
 GOMETALINTER    := ${GOMETALINTERBIN} --config=Gometalinter.json
 
 TESTPARALLELISM := 10
+TEST_FAST_TIMEOUT := 2m
 
 build::
 	go install -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" ${PROJECT}
@@ -26,7 +27,7 @@ lint::
 	$(GOMETALINTER) ./cmd/... | grep -vE ${LINT_SUPPRESS} | sort ; exit $$(($${PIPESTATUS[1]}-1))
 
 test_fast::
-	go test -timeout 5m -cover -parallel ${TESTPARALLELISM} ${PROJECT_PKGS}
+	go test -timeout $(TEST_FAST_TIMEOUT) -cover -parallel ${TESTPARALLELISM} ${PROJECT_PKGS}
 
 test_all::
 	PATH=$(PULUMI_ROOT)/bin:$(PATH) go test -cover -parallel ${TESTPARALLELISM} ${EXTRA_TEST_PKGS}


### PR DESCRIPTION
Parameterize the timeout for the fast tests with a default of 2 minutes
that is bumped to 10 minutes in CI due to slow I/O during macOS builds.