### PR TITLE
Pass planning flag to print resource outputs

### DIFF
--- a/pkg/engine/deploy.go
+++ b/pkg/engine/deploy.go
@@ -215,7 +215,7 @@ func (acts *deployActions) OnResourceStepPost(ctx interface{},
 
 		// Also show outputs here, since there might be some from the initial registration.
 		if shouldShow(acts.Seen, step, acts.Opts) && !acts.Opts.Summary {
-			printResourceOutputProperties(&b, step, acts.Seen, acts.Shown, 0 /*indent*/)
+			printResourceOutputProperties(&b, step, acts.Seen, acts.Shown, false, 0 /*indent*/)
 		}
 	}
 
@@ -233,7 +233,7 @@ func (acts *deployActions) OnResourceOutputs(step deploy.Step) error {
 	// Print this step's output properties.
 	if (shouldShow(acts.Seen, step, acts.Opts) || isRootStack(step)) && !acts.Opts.Summary {
 		var b bytes.Buffer
-		printResourceOutputProperties(&b, step, acts.Seen, acts.Shown, 0 /*indent*/)
+		printResourceOutputProperties(&b, step, acts.Seen, acts.Shown, false, 0 /*indent*/)
 		acts.Opts.Events <- stdOutEventWithColor(&b, acts.Opts.Color)
 	}
 

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -460,7 +460,7 @@ func printObject(
 // printResourceOutputProperties prints only those properties that either differ from the input properties or, if
 // there is an old snapshot of the resource, differ from the prior old snapshot's output properties.
 func printResourceOutputProperties(b *bytes.Buffer, step deploy.Step,
-	seen map[resource.URN]deploy.Step, shown map[resource.URN]bool, indent int) {
+	seen map[resource.URN]deploy.Step, shown map[resource.URN]bool, planning bool, indent int) {
 	// Only certain kinds of steps have output properties associated with them.
 	new := step.New()
 	if new == nil || new.Outputs == nil {
@@ -497,7 +497,7 @@ func printResourceOutputProperties(b *bytes.Buffer, step deploy.Step,
 					firstout = false
 				}
 				printPropertyTitle(b, string(k), maxkey, indent, op, false)
-				printPropertyValue(b, out, false, indent, op, false)
+				printPropertyValue(b, out, planning, indent, op, false)
 			}
 		}
 	}

--- a/pkg/engine/preview.go
+++ b/pkg/engine/preview.go
@@ -128,7 +128,7 @@ func (acts *previewActions) OnResourceOutputs(step deploy.Step) error {
 	// Print this step's output properties.
 	if (shouldShow(acts.Seen, step, acts.Opts) || isRootStack(step)) && !acts.Opts.Summary {
 		var b bytes.Buffer
-		printResourceOutputProperties(&b, step, acts.Seen, acts.Shown, 0 /*indent*/)
+		printResourceOutputProperties(&b, step, acts.Seen, acts.Shown, true, 0 /*indent*/)
 		acts.Opts.Events <- stdOutEventWithColor(&b, acts.Opts.Color)
 	}
 	return nil


### PR DESCRIPTION
We hadn't previously passed the planning flag when printing resource
outputs, meaning any computed ones now are being printed as "undefined".
Instead, we prefer to see the "computed<string>" type name.