### PR TITLE
Make cloud authentication more intuitive

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -22,7 +22,7 @@ func newLogoutCmd() *cobra.Command {
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// If --all is passed, log out of all clouds.
 			if all {
-				bes, err := cloud.CurrentBackends(cmdutil.Diag())
+				bes, _, err := cloud.CurrentBackends(cmdutil.Diag())
 				if err != nil {
 					return errors.Wrap(err, "could not read list of current clouds")
 				}

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -50,13 +50,17 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		defaultHelp(cmd, args)
 
-		loggedInto, logErr := cloud.CurrentBackends(cmdutil.Diag())
+		loggedInto, current, logErr := cloud.CurrentBackends(cmdutil.Diag())
 		contract.IgnoreError(logErr) // we want to make progress anyway.
 		if len(loggedInto) > 0 {
 			fmt.Printf("\n")
 			fmt.Printf("Currently logged into the Pulumi Cloud ☁️\n")
 			for _, be := range loggedInto {
-				fmt.Printf("    %s\n", be.Name())
+				var marker string
+				if be.Name() == current {
+					marker = "*"
+				}
+				fmt.Printf("    %s%s\n", be.Name(), marker)
 			}
 		}
 	})

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -29,7 +29,7 @@ func allBackends() ([]backend.Backend, bool) {
 	// in addition to all of those cloud backends we are currently logged into.
 	d := cmdutil.Diag()
 	backends := []backend.Backend{local.New(d)}
-	cloudBackends, err := cloud.CurrentBackends(d)
+	cloudBackends, _, err := cloud.CurrentBackends(d)
 	if err != nil {
 		// Print the error, but keep going so that the local operations still occur.
 		_, fmterr := fmt.Fprintf(os.Stderr, "error: could not obtain current cloud backends: %v", err)

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -39,11 +39,14 @@ func DeleteAccessToken(key string) error {
 	if creds.AccessTokens != nil {
 		delete(creds.AccessTokens, key)
 	}
+	if creds.Current == key {
+		creds.Current = ""
+	}
 	return StoreCredentials(creds)
 }
 
 // StoreAccessToken saves the given access token underneath the given key.
-func StoreAccessToken(key string, token string) error {
+func StoreAccessToken(key string, token string, current bool) error {
 	creds, err := GetStoredCredentials()
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -52,13 +55,17 @@ func StoreAccessToken(key string, token string) error {
 		creds.AccessTokens = make(map[string]string)
 	}
 	creds.AccessTokens[key] = token
+	if current {
+		creds.Current = key
+	}
 	return StoreCredentials(creds)
 }
 
 // Credentials hold the information necessary for authenticating Pulumi Cloud API requests.  It contains
 // a map from the cloud API URL to the associated access token.
 type Credentials struct {
-	AccessTokens map[string]string `json:"accessTokens"`
+	Current      string            `json:"current,omitempty"`      // the currently selected key.
+	AccessTokens map[string]string `json:"accessTokens,omitempty"` // a map of arbitrary key strings to tokens.
 }
 
 // getCredsFilePath returns the path to the Pulumi credentials file on disk, regardless of


### PR DESCRIPTION
The prior behavior with cloud authentication was a bit confusing
when authenticating against anything but https://pulumi.com/.  This
change fixes a few aspects of this:

* Improve error messages to differentiate between "authentication
  failed" and "you haven't logged into the target cloud URL."

* Default to the cloud you're currently authenticated with, rather
  than unconditionally selecting https://pulumi.com/.  This ensures

      $ pulumi login -c https://api.moolumi.io
      $ pulumi stack ls

  works, versus what was currently required

      $ pulumi login -c https://api.moolumi.io
      $ pulumi stack ls -c https://api.moolumi.io

  with confusing error messages if you forgot the second -c.

* To do this, our default cloud logic changes to

    1) Prefer the explicit -c if supplied;

    2) Otherwise, pick the "currently authenticated" cloud; this is
       the last cloud to have been targeted with pulumi login, or
       otherwise the single cloud in the list if there is only one;

    3) https://pulumi.com/ otherwise.