### PR TITLE
Tighten gRPC constraint

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -243,6 +243,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "79bc7379ccff63e1fa7f1b601455b368368e26e44742350c82f2bf44adbdb733"
+  inputs-digest = "81ff7acf83155ff8f38517e1db5f26cce3492962ce4c292c8909a4a2154bc216"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,7 +5,7 @@
 # TODO[pulumi/pulumi#701]: remove this constraint and let updates pick the latest when this bug is fixed.
 [[constraint]]
   name = "google.golang.org/grpc"
-  version = "v1.7.2"
+  version = "=v1.7.2"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
For us to lock to exactly a version instead, of just constraiting the
major version.