### PR TITLE
Only build master for AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,6 +3,9 @@ image: Visual Studio 2017
 configuration: Release
 platform: x64
 clone_folder: '%USERPROFILE%\go\src\github.com\pulumi\pulumi'
+branches:
+    only:
+        - master
 init:
 - ps: Install-Product node 6.10.2 x64
 environment:


### PR DESCRIPTION
We only have one AppVeyor worker and building topic branches causes us
to build large backups in our queues. This is made worse when folks
are iterating on a PR because each push queues not only a PR
build (which we want) but also the topic branch build (which we don't
care about so much).