### PR TITLE
Add option to specify command line flags to `pulumi update` in tests

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -97,6 +97,8 @@ type ProgramTestOptions struct {
 	RelativeWorkDir string
 	// Quick can be set to true to run a "quick" test that skips any non-essential steps (e.g., empty updates).
 	Quick bool
+	// UpdateCommandlineFlags specifies flags to add to the `pulumi update` command line (e.g. "--color=raw")
+	UpdateCommandlineFlags []string
 
 	// StackName allows the stack name to be explicitly provided instead of computed from the
 	// environment during tests.
@@ -350,10 +352,13 @@ func testPreviewUpdateAndEdits(t *testing.T, opts *ProgramTestOptions, dir strin
 
 func previewAndUpdate(t *testing.T, opts *ProgramTestOptions, dir string, name string) error {
 	preview := opts.PulumiCmd([]string{"preview"})
-	update := opts.PulumiCmd([]string{"update", "--color=raw"})
+	update := opts.PulumiCmd([]string{"update"})
 	if opts.GetDebugUpdates() {
 		preview = append(preview, "-d")
 		update = append(update, "-d")
+	}
+	if opts.UpdateCommandlineFlags != nil {
+		update = append(update, opts.UpdateCommandlineFlags...)
 	}
 
 	if !opts.Quick {

--- a/tests/integration/diff/diff_test.go
+++ b/tests/integration/diff/diff_test.go
@@ -21,10 +21,11 @@ func TestDiffs(t *testing.T) {
 	var buf bytes.Buffer
 
 	opts := integration.ProgramTestOptions{
-		Dir:          "step1",
-		Dependencies: []string{"pulumi"},
-		Quick:        true,
-		StackName:    "diffstack",
+		Dir:                    "step1",
+		Dependencies:           []string{"pulumi"},
+		Quick:                  true,
+		StackName:              "diffstack",
+		UpdateCommandlineFlags: []string{"--color=raw"},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 			checkpoint := stack.Checkpoint
 			assert.NotNil(t, checkpoint.Latest)


### PR DESCRIPTION
And use this in the diff test which needs to apply `--colors=raw`.

Fixes #748.