### PR TITLE
Support secrets for cloud stacks.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -173,7 +173,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			// Encrypt the config value if needed.
 			var v config.Value
 			if secret {
-				c, cerr := state.SymmetricCrypter()
+				c, cerr := backend.GetStackCrypter(s)
 				if cerr != nil {
 					return cerr
 				}
@@ -277,7 +277,7 @@ func listConfig(stack backend.Stack, showSecrets bool) error {
 	// By default, we will use a blinding decrypter to show '******'.  If requested, display secrets in plaintext.
 	var decrypter config.Decrypter
 	if cfg.HasSecureValue() && showSecrets {
-		decrypter, err = state.SymmetricCrypter()
+		decrypter, err = backend.GetStackCrypter(stack)
 		if err != nil {
 			return err
 		}
@@ -326,7 +326,7 @@ func getConfig(stack backend.Stack, key tokens.ModuleMember) error {
 			var d config.Decrypter
 			if v.Secure() {
 				var err error
-				if d, err = state.DefaultCrypter(cfg); err != nil {
+				if d, err = backend.GetStackCrypter(stack); err != nil {
 					return errors.Wrap(err, "could not create a decrypter")
 				}
 			} else {

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -6,6 +6,7 @@ package backend
 import (
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
+	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
 
@@ -25,6 +26,9 @@ type Backend interface {
 	RemoveStack(name tokens.QName, force bool) (bool, error)
 	// ListStacks returns a list of stack summaries for all known stacks in the target backend.
 	ListStacks() ([]Stack, error)
+
+	// GetStackCrypter returns an encrypter/decrypter for the given stack's secret config values.
+	GetStackCrypter(stack tokens.QName) (config.Crypter, error)
 
 	// Preview initiates a preview of the current workspace's contents.
 	Preview(stackName tokens.QName, debug bool, opts engine.PreviewOptions) error

--- a/pkg/backend/cloud/apitype/stacks.go
+++ b/pkg/backend/cloud/apitype/stacks.go
@@ -43,3 +43,27 @@ type CreateStackResponse struct {
 	// The name of the cloud used if the default was sent.
 	CloudName string `json:"cloudName"`
 }
+
+// EncryptValueRequest defines the request body for encrypting a value.
+type EncryptValueRequest struct {
+	// The value to encrypt.
+	Plaintext []byte `json:"plaintext"`
+}
+
+// EncryptValueResponse defines the response body for an encrypted value.
+type EncryptValueResponse struct {
+	// The encrypted value.
+	Ciphertext []byte `json:"ciphertext"`
+}
+
+// DecryptValueRequest defines the request body for decrypting a value.
+type DecryptValueRequest struct {
+	// The value to decrypt.
+	Ciphertext []byte `json:"ciphertext"`
+}
+
+// DecryptValueResponse defines the response body for a decrypted value.
+type DecryptValueResponse struct {
+	// The decrypted value.
+	Plaintext []byte `json:"plaintext"`
+}

--- a/pkg/backend/cloud/apitype/updates.go
+++ b/pkg/backend/cloud/apitype/updates.go
@@ -2,6 +2,14 @@ package apitype
 
 import "github.com/pulumi/pulumi/pkg/tokens"
 
+// ConfigValue describes a single (possibly secret) configuration value.
+type ConfigValue struct {
+	// String is either the plaintext value (for non-secrets) or the base64-encoded ciphertext (for secrets).
+	String string `json:"string"`
+	// Secret is true if this value is a secret and false otherwise.
+	Secret bool `json:"secret"`
+}
+
 // UpdateProgramRequest is the request type for updating (aka deploying) a Pulumi program.
 type UpdateProgramRequest struct {
 	// Properties from the Project file. Subset of pack.Package.
@@ -11,7 +19,7 @@ type UpdateProgramRequest struct {
 	Description string             `json:"description"`
 
 	// Configuration values.
-	Config map[tokens.ModuleMember]string `json:"config"`
+	Config map[tokens.ModuleMember]ConfigValue `json:"config"`
 }
 
 // UpdateProgramResponse is the result of an update program request.

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/encoding"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
+	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/workspace"
@@ -95,6 +96,10 @@ func (b *localBackend) RemoveStack(stackName tokens.QName, force bool) (bool, er
 	}
 
 	return false, removeStack(stackName)
+}
+
+func (b *localBackend) GetStackCrypter(stackName tokens.QName) (config.Crypter, error) {
+	return symmetricCrypter()
 }
 
 func (b *localBackend) Preview(stackName tokens.QName, debug bool, opts engine.PreviewOptions) error {
@@ -208,7 +213,7 @@ func (b *localBackend) getEngine(stackName tokens.QName) (engine.Engine, error) 
 		return engine.Engine{}, err
 	}
 
-	decrypter, err := state.DefaultCrypter(cfg)
+	decrypter, err := defaultCrypter(cfg)
 	if err != nil {
 		return engine.Engine{}, err
 	}

--- a/pkg/backend/local/crypto.go
+++ b/pkg/backend/local/crypto.go
@@ -1,6 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-package state
+package local
 
 import (
 	cryptorand "crypto/rand"
@@ -24,19 +24,19 @@ func readPassphrase(prompt string) (string, error) {
 	return cmdutil.ReadConsoleNoEcho(prompt)
 }
 
-// DefaultCrypter gets the right value encrypter/decrypter given the project configuration.
-func DefaultCrypter(cfg config.Map) (config.Crypter, error) {
+// defaultCrypter gets the right value encrypter/decrypter given the project configuration.
+func defaultCrypter(cfg config.Map) (config.Crypter, error) {
 	// If there is no config, we can use a standard panic crypter.
 	if !cfg.HasSecureValue() {
 		return config.NewPanicCrypter(), nil
 	}
 
 	// Otherwise, we will use an encrypted one.
-	return SymmetricCrypter()
+	return symmetricCrypter()
 }
 
 // SymmetricCrypter gets the right value encrypter/decrypter for this project.
-func SymmetricCrypter() (config.Crypter, error) {
+func symmetricCrypter() (config.Crypter, error) {
 	// First, read the package to see if we've got a key.
 	pkg, err := workspace.GetPackage()
 	if err != nil {

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -44,6 +44,11 @@ func DestroyStack(s Stack, debug bool, opts engine.DestroyOptions) error {
 	return s.Backend().Destroy(s.Name(), debug, opts)
 }
 
+// GetStackCrypter fetches the encrypter/decrypter for a stack.
+func GetStackCrypter(s Stack) (config.Crypter, error) {
+	return s.Backend().GetStackCrypter(s.Name())
+}
+
 // GetStackLogs fetches a list of log entries for the current stack in the current backend.
 func GetStackLogs(s Stack, query operations.LogQuery) ([]operations.LogEntry, error) {
 	return s.Backend().GetLogs(s.Name(), query)

--- a/pkg/resource/config/crypt.go
+++ b/pkg/resource/config/crypt.go
@@ -21,15 +21,24 @@ type Encrypter interface {
 	EncryptValue(plaintext string) (string, error)
 }
 
-// Decrypter decrypts encrypted cyphertext to its plaintext representation.
+// Decrypter decrypts encrypted ciphertext to its plaintext representation.
 type Decrypter interface {
-	DecryptValue(cypertext string) (string, error)
+	DecryptValue(ciphertext string) (string, error)
 }
 
 // Crypter can both encrypt and decrypt values.
 type Crypter interface {
 	Encrypter
 	Decrypter
+}
+
+// A nopDecrypter simply returns the ciphertext as-is.
+type nopDecrypter int
+
+var NopDecrypter Decrypter = nopDecrypter(0)
+
+func (nopDecrypter) DecryptValue(ciphertext string) (string, error) {
+	return ciphertext, nil
 }
 
 // NewBlindingDecrypter returns a Decrypter that instead of decrypting data, just returns "********", it can


### PR DESCRIPTION
Use the new {en,de}crypt endpoints in the Pulumi.com API to secure
secret config values. The ciphertext for a secret config value is bound
to the stack to which it applies and cannot be shared with other stacks
(e.g. by copy/pasting it around in Pulumi.yaml). All secrets will need
to be encrypted once per target stack.