### PR TITLE
Do not merge old state and inputs for Update.

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -288,8 +288,7 @@ func (s *UpdateStep) Apply(preview bool) (resource.Status, error) {
 				return resource.StatusOK, err
 			}
 			// Update to the combination of the old "all" state (including outputs), but overwritten with new inputs.
-			news := s.old.All().Merge(s.new.Inputs)
-			outs, rst, upderr := prov.Update(s.URN(), s.old.ID, s.old.All(), news)
+			outs, rst, upderr := prov.Update(s.URN(), s.old.ID, s.old.All(), s.new.Inputs)
 			if upderr != nil {
 				return rst, upderr
 			}


### PR DESCRIPTION
This merging causes similar issues to those it did in `Check`, and
differs from the approach we take to `Diff`. This can causes problems
such as an inability to remove properties.