### PR TITLE
Remove stack configuration when deleting a stack

### DIFF
--- a/cmd/stack_rm.go
+++ b/cmd/stack_rm.go
@@ -51,6 +51,11 @@ func newStackRmCmd() *cobra.Command {
 					return err
 				}
 
+				err = deleteAllStackConfiguration(s.Name())
+				if err != nil {
+					return err
+				}
+
 				msg := fmt.Sprintf("%sStack '%s' has been removed!%s", colors.SpecAttention, s.Name(), colors.Reset)
 				fmt.Println(colors.ColorizeText(msg))
 

--- a/pkg/pack/package.go
+++ b/pkg/pack/package.go
@@ -52,6 +52,11 @@ type StackInfo struct {
 	Config map[tokens.ModuleMember]config.Value `json:"config,omitempty" yaml:"config,omitempty"` // optional config.
 }
 
+// IsEmpty returns True if this object contains no information (i.e. all members have their zero values)
+func (s *StackInfo) IsEmpty() bool {
+	return len(s.Config) == 0
+}
+
 var _ diag.Diagable = (*Package)(nil)
 
 func (pkg *Package) Where() (*diag.Document, *diag.Location) {
@@ -112,6 +117,12 @@ func Save(path string, pkg *Package) error {
 	contract.Require(path != "", "pkg")
 	contract.Require(pkg != nil, "pkg")
 	contract.Requiref(pkg.Validate() == nil, "pkg", "Validate()")
+
+	for name, info := range pkg.Stacks {
+		if info.IsEmpty() {
+			delete(pkg.Stacks, name)
+		}
+	}
 
 	m, err := marshallerForPath(path)
 	if err != nil {

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -18,8 +18,9 @@ import (
 // W offers functionality for interacting with Pulumi workspaces.
 type W interface {
 	Settings() *Settings                 // returns a mutable pointer to the optional workspace settings info.
-	Repository() *Repository             // the repository this project belongs to
-	StackPath(stack tokens.QName) string // returns the path to store stack information
+	Repository() *Repository             // returns the repository this project belongs to.
+	StackPath(stack tokens.QName) string // returns the path to store stack information.
+	GetPackage() (*pack.Package, error)  // returns a copy of the package associated with this workspace.
 	Save() error                         // saves any modifications to the workspace.
 }
 
@@ -84,8 +85,8 @@ func (pw *projectWorkspace) Repository() *Repository {
 	return pw.repo
 }
 
-func (pw *projectWorkspace) DetectPackage() (string, error) {
-	return pw.project, nil
+func (pw *projectWorkspace) GetPackage() (*pack.Package, error) {
+	return pack.Load(pw.project)
 }
 
 func (pw *projectWorkspace) Save() error {


### PR DESCRIPTION
When a stack is removed, we should delete any configuration it had
saved in either the Pulumi.yaml file or the workspace.

Fixes #772