### PR TITLE
Fix pulumi-aws integration tests

### DIFF
--- a/tests/integration/diff/diff_test.go
+++ b/tests/integration/diff/diff_test.go
@@ -43,9 +43,10 @@ func TestDiffs(t *testing.T) {
 		},
 		EditDirs: []integration.EditDir{
 			{
-				Dir:     "step2",
-				Stdout:  &buf,
-				Verbose: true,
+				Dir:      "step2",
+				Additive: true,
+				Stdout:   &buf,
+				Verbose:  true,
 				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 					checkpoint := stack.Checkpoint
 					assert.NotNil(t, checkpoint.Latest)
@@ -83,9 +84,10 @@ func TestDiffs(t *testing.T) {
 				},
 			},
 			{
-				Dir:     "step3",
-				Stdout:  &buf,
-				Verbose: true,
+				Dir:      "step3",
+				Additive: true,
+				Stdout:   &buf,
+				Verbose:  true,
 				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 					checkpoint := stack.Checkpoint
 					assert.NotNil(t, checkpoint.Latest)
@@ -117,9 +119,10 @@ func TestDiffs(t *testing.T) {
 				},
 			},
 			{
-				Dir:     "step4",
-				Stdout:  &buf,
-				Verbose: true,
+				Dir:      "step4",
+				Additive: true,
+				Stdout:   &buf,
+				Verbose:  true,
 				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 					checkpoint := stack.Checkpoint
 					assert.NotNil(t, checkpoint.Latest)
@@ -148,9 +151,10 @@ func TestDiffs(t *testing.T) {
 				},
 			},
 			{
-				Dir:     "step5",
-				Stdout:  &buf,
-				Verbose: true,
+				Dir:      "step5",
+				Additive: true,
+				Stdout:   &buf,
+				Verbose:  true,
 				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
 					checkpoint := stack.Checkpoint
 					assert.NotNil(t, checkpoint.Latest)

--- a/tests/integration/protect_resources/protect_test.go
+++ b/tests/integration/protect_resources/protect_test.go
@@ -29,7 +29,8 @@ func TestSteps(t *testing.T) {
 		},
 		EditDirs: []integration.EditDir{
 			{
-				Dir: "step2",
+				Dir:      "step2",
+				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// An update to "eternal"; should still be there.
 					assert.NotNil(t, stackInfo.Checkpoint.Latest)
@@ -42,12 +43,14 @@ func TestSteps(t *testing.T) {
 				},
 			},
 			{
-				Dir: "step3",
+				Dir:      "step3",
+				Additive: true,
 				// This step will fail because the resource is protected.
 				ExpectFailure: true,
 			},
 			{
-				Dir: "step4",
+				Dir:      "step4",
+				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// "eternal" should now be unprotected.
 					assert.NotNil(t, stackInfo.Checkpoint.Latest)
@@ -60,7 +63,8 @@ func TestSteps(t *testing.T) {
 				},
 			},
 			{
-				Dir: "step5",
+				Dir:      "step5",
+				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					// Finally, "eternal" should be deleted.
 					assert.NotNil(t, stackInfo.Checkpoint.Latest)

--- a/tests/integration/steps/steps_test.go
+++ b/tests/integration/steps/steps_test.go
@@ -33,7 +33,8 @@ func TestSteps(t *testing.T) {
 		},
 		EditDirs: []integration.EditDir{
 			{
-				Dir: "step2",
+				Dir:      "step2",
+				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.NotNil(t, stackInfo.Checkpoint.Latest)
 					assert.Equal(t, 5, len(stackInfo.Checkpoint.Latest.Resources))
@@ -50,7 +51,8 @@ func TestSteps(t *testing.T) {
 				},
 			},
 			{
-				Dir: "step3",
+				Dir:      "step3",
+				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.NotNil(t, stackInfo.Checkpoint.Latest)
 					assert.Equal(t, 4, len(stackInfo.Checkpoint.Latest.Resources))
@@ -65,7 +67,8 @@ func TestSteps(t *testing.T) {
 				},
 			},
 			{
-				Dir: "step4",
+				Dir:      "step4",
+				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.NotNil(t, stackInfo.Checkpoint.Latest)
 					assert.Equal(t, 4, len(stackInfo.Checkpoint.Latest.Resources))
@@ -80,7 +83,8 @@ func TestSteps(t *testing.T) {
 				},
 			},
 			{
-				Dir: "step5",
+				Dir:      "step5",
+				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.NotNil(t, stackInfo.Checkpoint.Latest)
 					// assert.Equal(t, 5, len(checkpoint.Latest.Resources))
@@ -99,7 +103,8 @@ func TestSteps(t *testing.T) {
 				},
 			},
 			{
-				Dir: "step6",
+				Dir:      "step6",
+				Additive: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 					assert.NotNil(t, stackInfo.Checkpoint.Latest)
 					assert.Equal(t, 1, len(stackInfo.Checkpoint.Latest.Resources))


### PR DESCRIPTION
The `pulumi-aws` integration tests relied on support for non-Additive tests that I removed in https://github.com/pulumi/pulumi/pull/783.

This fixes two other problems @lukehoban noticed:
- Program output was only written to files, not echoed to `stderr`.
- Prefix was always the start of the file path rather than the end