### PR TITLE
Restructure test framework to ease multiple languages

### DIFF
--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -1,0 +1,118 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	pioutil "github.com/pulumi/pulumi/pkg/util/ioutil"
+)
+
+// RunCommand executes the specified command and additional arguments, wrapping any output in the
+// specialized test output streams that list the location the test is running in.
+func RunCommand(t *testing.T, name string, args []string, wd string, opts *ProgramTestOptions) error {
+	path := args[0]
+	command := strings.Join(args, " ")
+	pioutil.MustFprintf(opts.Stdout, "**** Invoke '%v' in '%v'\n", command, wd)
+
+	// Spawn a goroutine to print out "still running..." messages.
+	finished := false
+	go func() {
+		for !finished {
+			time.Sleep(30 * time.Second)
+			if !finished {
+				pioutil.MustFprintf(opts.Stderr, "Still running command '%s' (%s)...\n", command, wd)
+			}
+		}
+	}()
+
+	var env []string
+	env = append(env, os.Environ()...)
+	env = append(env, "PULUMI_RETAIN_CHECKPOINTS=true")
+	env = append(env, "PULUMI_CONFIG_PASSPHRASE=correct horse battery staple")
+
+	cmd := exec.Cmd{
+		Path: path,
+		Dir:  wd,
+		Args: args,
+		Env:  env,
+	}
+
+	startTime := time.Now()
+
+	var runout []byte
+	var runerr error
+	if opts.Verbose || os.Getenv("PULUMI_VERBOSE_TEST") != "" {
+		cmd.Stdout = opts.Stdout
+		cmd.Stderr = opts.Stderr
+		runerr = cmd.Run()
+	} else {
+		runout, runerr = cmd.CombinedOutput()
+	}
+
+	endTime := time.Now()
+
+	if opts.ReportStats != nil {
+		// Note: This data is archived and used by external analytics tools.  Take care if changing the schema or format
+		// of this data.
+		opts.ReportStats.ReportCommand(TestCommandStats{
+			StartTime:      startTime.Format("2006/01/02 15:04:05"),
+			EndTime:        endTime.Format("2006/01/02 15:04:05"),
+			ElapsedSeconds: float64((endTime.Sub(startTime)).Nanoseconds()) / 1000000000,
+			StepName:       name,
+			CommandLine:    command,
+			StackName:      string(opts.GetStackName()),
+			TestID:         wd,
+			TestName:       filepath.Base(opts.Dir),
+			IsError:        runerr != nil,
+		})
+	}
+
+	finished = true
+	if runerr != nil {
+		pioutil.MustFprintf(opts.Stderr, "Invoke '%v' failed: %s\n", command, cmdutil.DetailedError(runerr))
+
+		if !opts.Verbose {
+			// We've seen long fprintf's fail on Travis, so avoid panicing.
+			if _, err := fmt.Fprintf(opts.Stderr, "%s\n", string(runout)); err != nil {
+				pioutil.MustFprintf(opts.Stderr, "\n\nOutput truncated: %v\n", err)
+			}
+		}
+	}
+
+	// If we collected any program output, write it to a log file -- success or failure.
+	if len(runout) > 0 {
+		if logFile, err := writeCommandOutput(name, wd, runout); err != nil {
+			pioutil.MustFprintf(opts.Stderr, "Failed to write output: %v\n", err)
+		} else {
+			pioutil.MustFprintf(opts.Stderr, "Wrote output to %s\n", logFile)
+		}
+	}
+
+	return runerr
+}
+
+func withOptionalYarnFlags(args []string) []string {
+	flags := os.Getenv("YARNFLAGS")
+
+	if flags != "" {
+		return append(args, flags)
+	}
+
+	return args
+}
+
+// addFlagIfNonNil will take a set of command-line flags, and add a new one if the provided flag value is not empty.
+func addFlagIfNonNil(args []string, flag, flagValue string) []string {
+	if flagValue != "" {
+		args = append(args, flag, flagValue)
+	}
+	return args
+}

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -1,0 +1,89 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package integration
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/pkg/errors"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+)
+
+// getCmdBin returns the binary named bin in location loc or, if it hasn't yet been initialized, will lazily
+// populate it by either using the default def or, if empty, looking on the current $PATH.
+func getCmdBin(loc *string, bin, def string) (string, error) {
+	if *loc == "" {
+		*loc = def
+		if *loc == "" {
+			var err error
+			*loc, err = exec.LookPath(bin)
+			if err != nil {
+				return "", errors.Wrapf(err, "Expected to find `%s` binary on $PATH", bin)
+			}
+		}
+	}
+	return *loc, nil
+}
+
+func uniqueSuffix() string {
+	// .<timestamp>.<five random hex characters>
+	timestamp := time.Now().Format("20060102-150405")
+	suffix, err := resource.NewUniqueHex("."+timestamp+".", 5, -1)
+	contract.AssertNoError(err)
+	return suffix
+}
+
+func writeCommandOutput(commandName, runDir string, output []byte) (string, error) {
+	logFileDir := filepath.Join(runDir, "command-output")
+	if err := os.MkdirAll(logFileDir, 0700); err != nil {
+		return "", errors.Wrapf(err, "Failed to create '%s'", logFileDir)
+	}
+
+	logFile := filepath.Join(logFileDir, commandName+uniqueSuffix()+".log")
+
+	if err := ioutil.WriteFile(logFile, output, 0644); err != nil {
+		return "", errors.Wrapf(err, "Failed to write '%s'", logFile)
+	}
+
+	return logFile, nil
+}
+
+type prefixer struct {
+	writer    io.Writer
+	prefix    []byte
+	anyOutput bool
+}
+
+// newPrefixer wraps an io.Writer, prepending a fixed prefix after each \n emitting on the wrapped writer
+func newPrefixer(writer io.Writer, prefix string) *prefixer {
+	return &prefixer{writer, []byte(prefix), false}
+}
+
+var _ io.Writer = (*prefixer)(nil)
+
+func (prefixer *prefixer) Write(p []byte) (int, error) {
+	n := 0
+	lines := bytes.SplitAfter(p, []byte{'\n'})
+	for _, line := range lines {
+		if len(line) > 0 {
+			_, err := prefixer.writer.Write(prefixer.prefix)
+			if err != nil {
+				return n, err
+			}
+		}
+		m, err := prefixer.writer.Write(line)
+		n += m
+		if err != nil {
+			return n, err
+		}
+	}
+	return n, nil
+}


### PR DESCRIPTION
This change restructures the test framework code a bit, to make it
easier to introduce additional languages.  Our knowledge of Yarn and
Node.js project structure, for instance, was previously baked in to
the test logic, in a way that was hard to make, for instance, Yarn
optional.  (In Python, of course, it will not be used.)  To better
support this, I've moved some state onto a new programTester struct
that we can use to lazily find binaries required during the testing
(such as Yarn, Pip, and so on).  I'm committing this separately so
that I can minimize merge conflicts in the Python work.