### PR TITLE
Fix panic when langhost not found

### DIFF
--- a/pkg/resource/plugin/langruntime_plugin.go
+++ b/pkg/resource/plugin/langruntime_plugin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/golang/glog"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
+	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/tokens"
 	pulumirpc "github.com/pulumi/pulumi/sdk/proto/go"
@@ -31,7 +32,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime string, monitorAddr str
 	if err != nil {
 		return nil, err
 	} else if plug == nil {
-		return nil, nil
+		return nil, errors.Errorf("unable to find language runtime %q on PATH", srvexe)
 	}
 
 	return &langhost{


### PR DESCRIPTION
When you try to run a Pulumi program but don't have the appropriate langhost installed, we would panic. We now emit an error message, e.g.:

```
error: An error occurred while advancing the preview: failed to launch language host for 'nodejs': unable to find language runtime "pulumi-langhost-nodejs" on PATH
```

Fixes: https://github.com/pulumi/pulumi/issues/639