### PR TITLE
Use per stack key for local stacks instead of per project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+## v0.10.0
+
+### Added
+
+### Changed
+
+ - For local stacks, Pulumi now uses a seperate encryption key for each stack instead of one shared for all stacks, to
+   encrypt secrets. You are now able to use a different passphrase between two stacks. In addition, the top level
+   `encryptionsalt` member of the `Pulumi.yaml` is removed and salts are stored per stack in `Pulumi.yaml`.  Pulumi will
+   automatically re-use the existing key for any local stacks in the Pulumi.yaml file which have encrypted, but future
+   stacks will have new keys generated. There is no impact to stacks deployed using the Pulumi Cloud.
+

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -372,6 +372,7 @@ func deleteAllStackConfiguration(stackName tokens.QName) error {
 
 	if info, has := pkg.Stacks[stackName]; has {
 		info.Config = nil
+		info.EncryptionSalt = ""
 		pkg.Stacks[stackName] = info
 	}
 

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -100,7 +100,7 @@ func (b *localBackend) RemoveStack(stackName tokens.QName, force bool) (bool, er
 }
 
 func (b *localBackend) GetStackCrypter(stackName tokens.QName) (config.Crypter, error) {
-	return symmetricCrypter()
+	return symmetricCrypter(stackName)
 }
 
 func (b *localBackend) Preview(stackName tokens.QName, pkg *pack.Package, root string, debug bool,

--- a/pkg/backend/local/state.go
+++ b/pkg/backend/local/state.go
@@ -91,7 +91,7 @@ func (b *localBackend) getTarget(stackName tokens.QName) (*deploy.Target, error)
 	if err != nil {
 		return nil, err
 	}
-	decrypter, err := defaultCrypter(cfg)
+	decrypter, err := defaultCrypter(stackName, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pack/package.go
+++ b/pkg/pack/package.go
@@ -48,13 +48,15 @@ type Package struct {
 }
 
 // StackInfo holds stack specific information about a package
+// nolint: lll
 type StackInfo struct {
-	Config map[tokens.ModuleMember]config.Value `json:"config,omitempty" yaml:"config,omitempty"` // optional config.
+	EncryptionSalt string     `json:"encryptionsalt,omitempty" yaml:"encryptionsalt,omitempty"` // base64 encoded encryption salt.
+	Config         config.Map `json:"config,omitempty" yaml:"config,omitempty"`                 // optional config.
 }
 
 // IsEmpty returns True if this object contains no information (i.e. all members have their zero values)
 func (s *StackInfo) IsEmpty() bool {
-	return len(s.Config) == 0
+	return len(s.Config) == 0 && s.EncryptionSalt == ""
 }
 
 var _ diag.Diagable = (*Package)(nil)


### PR DESCRIPTION
In the Pulumi Cloud, there is no guarantee that two stacks will share
the same encryption key. This means that encrypted config can not be
shared across stacks (in the Pulumi.yaml) file. To mimic this behavior
in the local experience, we now use a unique key per stack.

When upgrading an existing project, for any stack with existing
secrets, we copy the existing key into this stack. Future stacks will
get thier own encryption key. This strikes a balance between
expediency of implementation, the end user UX and not having to make a
breaking change.

Fixes #769