### PR TITLE
Pretty-print some JSON files we persist to disk

### DIFF
--- a/pkg/workspace/repository.go
+++ b/pkg/workspace/repository.go
@@ -19,7 +19,7 @@ type Repository struct {
 }
 
 func (r *Repository) Save() error {
-	b, err := json.Marshal(r)
+	b, err := json.MarshalIndent(r, "", "    ")
 	if err != nil {
 		return err
 	}

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -105,7 +105,7 @@ func (pw *projectWorkspace) Save() error {
 		return err
 	}
 
-	b, err := json.Marshal(pw.settings)
+	b, err := json.MarshalIndent(pw.settings, "", "    ")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We did not pretty print either the workspace settings file or the
repository settings file, but pretty print other files like the
credentials file and checkpoints. Now we do.

Fixes #540