### PR TITLE
Provide a rudimentary progress spinner

### DIFF
--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -109,7 +109,7 @@ const (
 	StatusSucceeded UpdateStatus = "succeeded"
 )
 
-// UpdateResults returns a series of events and the current status of an update. The vents can be filtered. See
+// UpdateResults returns a series of events and the current status of an update. The events can be filtered. See
 // API call for more details.
 type UpdateResults struct {
 	Status UpdateStatus  `json:"status"`

--- a/pkg/backend/local/display.go
+++ b/pkg/backend/local/display.go
@@ -10,42 +10,51 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/engine"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
 // displayEvents reads events from the `events` channel until it is closed, displaying each event as it comes in.
 // Once all events have been read from the channel and displayed, it closes the `done` channel so the caller can
 // await all the events being written.
-func displayEvents(events <-chan engine.Event, done chan bool, debug bool) {
+func displayEvents(events <-chan engine.Event, done chan<- bool, debug bool) {
+	spinner, ticker := cmdutil.NewSpinnerAndTicker()
+
 	defer func() {
+		ticker.Stop()
 		done <- true
 	}()
 
-Outer:
-	for event := range events {
-		switch event.Type {
-		case engine.CancelEvent:
-			break Outer
-		case engine.StdoutColorEvent:
-			payload := event.Payload.(engine.StdoutEventPayload)
-			fmt.Print(payload.Color.Colorize(payload.Message))
-		case engine.DiagEvent:
-			payload := event.Payload.(engine.DiagEventPayload)
-			var out io.Writer
-			out = os.Stdout
+	for {
+		select {
+		case <-ticker.C:
+			spinner.Tick()
+		case event := <-events:
+			spinner.Reset()
+			switch event.Type {
+			case engine.CancelEvent:
+				return
+			case engine.StdoutColorEvent:
+				payload := event.Payload.(engine.StdoutEventPayload)
+				fmt.Print(payload.Color.Colorize(payload.Message))
+			case engine.DiagEvent:
+				payload := event.Payload.(engine.DiagEventPayload)
+				var out io.Writer
+				out = os.Stdout
 
-			if payload.Severity == diag.Error || payload.Severity == diag.Warning {
-				out = os.Stderr
+				if payload.Severity == diag.Error || payload.Severity == diag.Warning {
+					out = os.Stderr
+				}
+				if payload.Severity == diag.Debug && !debug {
+					out = ioutil.Discard
+				}
+				msg := payload.Message
+				msg = payload.Color.Colorize(msg)
+				_, fmterr := fmt.Fprint(out, msg)
+				contract.IgnoreError(fmterr)
+			default:
+				contract.Failf("unknown event type '%s'", event.Type)
 			}
-			if payload.Severity == diag.Debug && !debug {
-				out = ioutil.Discard
-			}
-			msg := payload.Message
-			msg = payload.Color.Colorize(msg)
-			_, fmterr := fmt.Fprint(out, msg)
-			contract.IgnoreError(fmterr)
-		default:
-			contract.Failf("unknown event type '%s'", event.Type)
 		}
 	}
 }

--- a/pkg/util/cmdutil/spinner.go
+++ b/pkg/util/cmdutil/spinner.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package cmdutil
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// NewSpinnerAndTicker returns a new Spinner and a ticker that will fire an event when the next call to Spinner.Tick()
+// should be called. NewSpinnerAndTicket takes into account if stdout is connected to a tty or not and returns either a
+// nice animated spinner that updates quickly or a simple spinner that just prints a dot on each tick and updates
+// slowly.
+func NewSpinnerAndTicker() (Spinner, *time.Ticker) {
+	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+		return &ttySpinner{}, time.NewTicker(time.Second / 8)
+	}
+	return &dotSpinner{}, time.NewTicker(time.Second * 20)
+}
+
+// Spinner represents a very simple progress reporter.
+type Spinner interface {
+	// Print the next frame of the spinner. After Tick() has been called, there should be no writes to Stdout before
+	// calling Reset().
+	Tick()
+
+	// Called to release ownership of stdout, so others may write to it.
+	Reset()
+}
+
+var spinFrames = []string{"|", "/", "-", "\\"}
+
+// ttySpinner is the spinner that can be used when standard out is a tty. When we are connected to a TTY we can erase
+// characters we've written and provide a nice quick progress spinner.
+type ttySpinner struct {
+	index int
+}
+
+func (spin *ttySpinner) Tick() {
+	fmt.Printf("\r \r")
+	fmt.Printf(spinFrames[spin.index])
+	spin.index = (spin.index + 1) % len(spinFrames)
+}
+
+func (spin *ttySpinner) Reset() {
+	fmt.Printf("\r \r")
+	spin.index = 0
+}
+
+// dotSpinner is the spinner that can be used when standard out is not a tty. In this case, we just write a single
+// dot on each tick.
+type dotSpinner struct {
+	hasWritten bool
+}
+
+func (spin *dotSpinner) Tick() {
+	if !spin.hasWritten {
+		fmt.Printf("still working")
+	}
+	fmt.Printf(".")
+	spin.hasWritten = true
+}
+
+func (spin *dotSpinner) Reset() {
+	if spin.hasWritten {
+		fmt.Println()
+	}
+	spin.hasWritten = false
+}


### PR DESCRIPTION
Previously, the `pulumi` tool did not show any indication of progress
when doing a deployment. Combined with the fact that we do not create
resources in parallel it meant that sometime `pulumi` would appear to
hang, when really it was just waiting on some resource to be created
in AWS. In addition, some AWS resources take a long time to create and
CI systems like travis will kill the job if there is no output. This
causes us (and our customers) to have to do crazy dances where we
launch shell scripts that write a dot to the console every once in a
while so we don't get killed. While we plan to overhaul the output
logic (see #617), we take a first step towards interactivity by simply
having a nice little spinner (in the interactive case) and when run
non interactive have `pulumi` print a message that it is still
working.

Fixes #794