### PR TITLE
Ensure resources are always parented to a stack

### DIFF
--- a/examples/dynamic-provider/multiple-turns/index.ts
+++ b/examples/dynamic-provider/multiple-turns/index.ts
@@ -25,6 +25,8 @@ class NullResource extends dynamic.Resource {
         const a = new NullResource("a");
         await sleep(1000);
         const b = new NullResource("b");
+        await sleep(1000);
+        const c = new NullResource("c");
         const urn = await b.urn;
         assert.notStrictEqual(urn, undefined, "expected a defined urn");
         assert.notStrictEqual(urn, "", "expected a valid urn");

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -52,6 +52,14 @@ func TestExamples(t *testing.T) {
 		{
 			Dir:          path.Join(cwd, "dynamic-provider/multiple-turns"),
 			Dependencies: []string{"pulumi"},
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				for _, res := range stackInfo.Snapshot.Resources {
+					if res.Parent == "" {
+						assert.Equal(t, stackInfo.RootResource.URN, res.URN,
+							"every resource but the root resource should have a parent, but %v didn't", res.URN)
+					}
+				}
+			},
 		},
 		{
 			Dir:          path.Join(cwd, "formattable"),

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -34,7 +34,7 @@ class Stack extends ComponentResource {
         }
         finally {
             super.registerOutputs(outputs); // save the outputs for this component to whatever the init returned.
-            setRootResource(undefined);     // restore the original root resource.
+            // intentionally not removing the root resource because we want subsequent async turns to parent to it.
         }
     }
 }


### PR DESCRIPTION
It was possiblef for the finally for a stack to complete before all
other resources had been created. In this case, we would put these new
resources at top level, instead of having them as children of the
stack resource.

Since we do not use the langhost across stacks, we can simply set the
stack resource at top level and never remove it.

Fixes #818