### PR TITLE
Avoid resource leaks by recovering from panics in integration tests

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -269,6 +269,15 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 func ProgramTest(t *testing.T, opts *ProgramTestOptions) {
 	t.Parallel()
 
+	// If the test panics, recover and log instead of letting the panic escape the test. Even though *this* test will
+	// have run deferred functions and cleaned up, if the panic reaches toplevel it will kill the process and prevent
+	// other tests running in parallel from cleaning up.
+	defer func() {
+		if failure := recover(); failure != nil {
+			t.Errorf("panic testing %v: %v", opts.Dir, failure)
+		}
+	}()
+
 	pt := newProgramTester(t, opts)
 	err := pt.testLifeCycleInitAndDestroy()
 	assert.NoError(t, err)


### PR DESCRIPTION
Avoids resource leaks in cases like https://github.com/pulumi/pulumi-cloud/issues/342.

This seems like a much simpler approach than overbuilding our test/validation code to fail gracefully on all error paths.