### PR TITLE
Fix false-positives in login verification

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -613,8 +613,6 @@ func Login(cloudURL string) error {
 // isValidAccessToken tries to use the provided Pulumi access token and returns if it is accepted
 // or not. Returns error on any unexpected error.
 func isValidAccessToken(cloud, accessToken string) (bool, error) {
-	errValidatingToken := errors.New("error validating access token. Is cloud URL correct?")
-
 	// Make a request to get the authenticated user. If it returns a successful response,
 	// we know the access token is legit. We also parse the response as JSON and confirm
 	// it has a name field that is non-empty (like the Pulumi Service would return).
@@ -625,12 +623,11 @@ func isValidAccessToken(cloud, accessToken string) (bool, error) {
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == 401 {
 			return false, nil
 		}
-		glog.V(1).Infof("Error response testing access token: %v", err)
-		return false, errValidatingToken
+		return false, errors.Wrapf(err, "getting user info from %v", cloud)
 	}
 
 	if respObj.Name == "" {
-		return false, errValidatingToken
+		return false, errors.New("unexpected response from cloud API")
 	}
 
 	return true, nil


### PR DESCRIPTION
Surprisingly `pulumi login -c https://google.com` would succeed. This was because we were too lax in our way of validating credentials. We take the provided cloud URL and call the "GetCurrentUserHandler" method. But we were only checking that it returned a successful response, not that it was actually valid JSON.

So in the "https://google.com" case, Google returned HTML describing a 404 error, but since the sever response was 200, the Pulumi CLI assumed things were on the up and up.

We now parse the response as JSON, and confirm the response has a `name` property that is non-nil. This heuristic covers the majority of false-positive cases, but without us needing to move all of the service's API shape for users, which includes organizations, which includes Clouds, etc. into `pulumi`.

Fixes https://github.com/pulumi/pulumi-service/issues/457. As an added bonus, we now return a much more useful error message.