### PR TITLE
Add console link to OperationsProvider/ResourceData

### DIFF
--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -40,4 +40,5 @@ type Provider interface {
 	// GetLogs returns logs matching a query
 	GetLogs(query LogQuery) (*[]LogEntry, error)
 	// TODO[pulumi/pulumi#609] Add support for metrics
+	GetResourceData() (map[string]string, error)
 }

--- a/pkg/operations/operations_cloud_aws.go
+++ b/pkg/operations/operations_cloud_aws.go
@@ -194,3 +194,8 @@ func extractLambdaLogMessage(message string, id string) *LogEntry {
 	glog.V(9).Infof("Could not match Lambda log message: %s", message)
 	return nil
 }
+
+func (ops *cloudOpsProvider) GetResourceData() (map[string]string, error) {
+	// Cloud package components do not have source console links.
+	return nil, nil
+}


### PR DESCRIPTION
I implemented the type->URL mapping for all types in todo.json and crawler.json

WIP:

* There's a couple types where I'm not sure what URL to use
* The result is not exposed anywhere in the UI