### PR TITLE
Use fixed versions of the tools we install in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,45 +10,14 @@ sudo: true # give us 7.5GB and >2 bursted cores.
 git:
   depth: false
 before_install:
-    - export PULUMI_ROOT=/opt/pulumi
-    # on OSX, /opt/ is not writeable by normal users, so we create /opt/pulumi as root and take ownership of it
-    - if [ "$TRAVIS_OS_NAME" == "osx" ]; then sudo mkdir /opt/pulumi && sudo chown $USER /opt/pulumi; fi
-    # Dep for Go dependency management.
-    - go get -v github.com/golang/dep/cmd/dep
-    # Gometalinter for good Go linting/hygiene.
-    - go get -v github.com/alecthomas/gometalinter
-    - gometalinter --install
-    # gocovmerge for Go code coverage.
-    - go get -v github.com/wadey/gocovmerge
-    # Node.js 6.10.2 for all JavaScript code (to match AWS Lambda).
-    - nvm install v6.10.2
-    # Install Yarn as per https://yarnpkg.com/lang/en/docs/install-ci/#travis-tab.
-    - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
-    - export PATH=$HOME/.yarn/bin:$PATH
-    # Ensure that we can access Pulumi's private NPM org.
-    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
-    # On OSX, the place pip installs user commands to is not on the $PATH and also pip is called pip2.7
-    - export PIP=pip
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$PATH:$HOME/Library/Python/2.7/bin; export PIP=pip2.7; fi
-    # Install the AWS CLI so that we can publish the resulting release (if applicable) at the end.
-    - $PIP install --upgrade --user awscli
-    - export PULUMI_FAILED_TESTS_DIR=$(mktemp -d); echo "${PULUMI_FAILED_TESTS_DIR}"
+    - source ./build/travis/prepare-environment.sh
 install:
-    # Clone the Pulumi-wide repo so we can use its scripts.
-    - git clone git@github.com:pulumi/home ${GOPATH}/src/github.com/pulumi/home
-    - make ensure
+    - source ./build/travis/install-common-toolchain.sh
 before_script:
-    # Ensure the working tree is clean (make ensure may have updated lock files)
-    - ${GOPATH}/src/github.com/pulumi/home/scripts/check-worktree-is-clean.sh
-    # Set stdout back to blocking to avoid problems writing large outputs.
-    # The call to `nvm` above may have changed it.
-    # https://github.com/pulumi/pulumi-ppc/issues/176
-    - python -c 'import fcntl, os, sys; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); print("stdout was " + ("nonblocking" if flags & os.O_NONBLOCK else "blocking")); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)'
+    - ./build/travis/ensure-dependencies
 script:
-    - make travis_${TRAVIS_EVENT_TYPE} TEST_FAST_TIMEOUT=10m
+    - make travis_${TRAVIS_EVENT_TYPE}
 after_failure:
-    # Copy any data from failed tests to S3.
-    - tar czf - -C "${PULUMI_FAILED_TESTS_DIR}" . | aws --region us-west-2 s3 cp - "s3://eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/failed-tests.tar.gz" --acl bucket-owner-full-control
-    - echo "one or more tests failed, to view detailed failure information, visit https://s3.console.aws.amazon.com/s3/buckets/eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/"
+    - ./build/travis/upload-failure-logs
 notifications:
     webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,13 @@ GOMETALINTERBIN := gometalinter
 GOMETALINTER    := ${GOMETALINTERBIN} --config=Gometalinter.json
 
 TESTPARALLELISM := 10
+
+# Our travis workers are a little show and sometime the fast tests take a little longer
+ifeq ($(TRAVIS),true)
+TEST_FAST_TIMEOUT := 10m
+else
 TEST_FAST_TIMEOUT := 2m
+endif
 
 build::
 	go install -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" ${PROJECT}

--- a/build/travis/ensure-dependencies
+++ b/build/travis/ensure-dependencies
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+# Run our target to dep ensure and yarn install everything
+make ensure
+
+# Ensure the working tree is clean (make ensure may have updated lock files)
+$(go env GOPATH)/src/github.com/pulumi/home/scripts/check-worktree-is-clean.sh
+
+# Set stdout back to blocking to avoid problems writing large outputs.
+# https://github.com/pulumi/pulumi-ppc/issues/176
+python -c 'import fcntl, os, sys; flags = fcntl.fcntl(sys.stdout, fcntl.F_GETFL); print("stdout was " + ("nonblocking" if flags & os.O_NONBLOCK else "blocking")); fcntl.fcntl(sys.stdout, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)'

--- a/build/travis/install-common-toolchain.sh
+++ b/build/travis/install-common-toolchain.sh
@@ -1,0 +1,71 @@
+nvm install v6.10.2
+
+# Travis sources this script, so we can export variables into the
+# outer shell, so we don't want to set options like nounset because
+# they would be set in the outer shell as well, so do as much logic as
+# we can in a subshell.
+(
+    set -o nounset -o errexit -o pipefail
+    [ -e "$(go env GOPATH)/bin" ] || mkdir -p "$(go env GOPATH)/bin"
+
+    YARN_VERSION="1.3.2"
+    DEP_VERSION="0.4.1"
+    GOMETALINTER_VERSION="2.0.3"
+    AWSCLI_VERSION="1.14.30"
+
+    OS=""
+    case $(uname) in
+        "Linux") OS="linux";;
+        "Darwin") OS="darwin";;
+        *) echo "error: unknown host os $(uname)" ; exit 1;;
+    esac
+
+    PIP_CMD=pip
+
+    # On Travis, pip is called pip2.7
+    if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
+        PIP_CMD=pip2.7
+    fi
+
+    echo "installing yarn ${YARN_VERSION}"
+    curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version ${YARN_VERSION}
+
+    echo "installing dep ${DEP_VERSION}"
+    curl -L -o "$(go env GOPATH)/bin/dep" https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-${OS}-amd64
+    chmod +x "$(go env GOPATH)/bin/dep"
+
+
+    echo "installing Gometalinter ${GOMETALINTER_VERSION}"
+    curl -L "https://github.com/alecthomas/gometalinter/releases/download/v${GOMETALINTER_VERSION}/gometalinter-v${GOMETALINTER_VERSION}-${OS}-amd64.tar.bz2" | tar -jxv --strip-components=1 -C "$(go env GOPATH)/bin"
+
+    chmod +x "$(go env GOPATH)/bin/gometalinter"
+    chmod +x "$(go env GOPATH)/bin/linters/"*
+
+    # Gometalinter looks for linters on the $PATH, so let's move them out
+    # of the linters folder and into GOBIN (which we know is on the $PATH)
+    mv "$(go env GOPATH)/bin/linters/"* "$(go env GOPATH)/bin/."
+    rm -rf "$(go env GOPATH)/bin/linters/"
+
+    echo "installing gocovmerge"
+
+    # gocovmerge does not publish versioned releases, but it also hasn't been updated in two years, so
+    # getting HEAD is pretty safe.
+    go get -v github.com/wadey/gocovmerge
+
+    echo "installing AWS cli ${AWSCLI_VERSION}"
+    ${PIP_CMD} install --user "awscli==${AWSCLI_VERSION}"
+)
+
+# If the sub shell failed, bail out now.
+[ "$?" -eq 0 ] || exit 1
+
+# By default some tools are not on the PATH, let's fix that
+
+# On OSX, the user folder that `pip` installs tools to is not on the
+# $PATH by default.
+if [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then
+    export PATH=$PATH:$HOME/Library/Python/2.7/bin
+fi
+
+# Add yarn to the $PATH
+export PATH=$HOME/.yarn/bin:$PATH

--- a/build/travis/prepare-environment.sh
+++ b/build/travis/prepare-environment.sh
@@ -1,0 +1,27 @@
+# Travis sources this script, so we can export variables into the
+# outer shell, so we don't want to set options like nounset because
+# they would be set in the outer shell as well, so do as much logic as
+# we can in a subshell.
+(
+    set -o nounset -o errexit -o pipefail
+
+    if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
+        sudo mkdir /opt/pulumi
+        sudo chown "${USER}" /opt/pulumi
+    fi
+
+    # We have some shared scripts in pulumi/home, and we use them in other steps
+    git clone git@github.com:pulumi/home "$(go env GOPATH)/src/github.com/pulumi/home"
+
+    # If we have an NPM token, put it in the .npmrc file, so we can use it:
+    if [ ! -z "${NPM_TOKEN:-}" ]; then
+        echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
+    fi
+)
+
+# If the sub shell failed, bail out now.
+[ "$?" -eq 0 ] || exit 1
+
+export PULUMI_ROOT=/opt/pulumi
+export PULUMI_FAILED_TESTS_DIR=$(mktemp -d)
+echo "PULUMI_FAILED_TESTS_DIR=${PULUMI_FAILED_TESTS_DIR}"

--- a/build/travis/upload-failure-logs
+++ b/build/travis/upload-failure-logs
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+tar czf - -C "${PULUMI_FAILED_TESTS_DIR}" . | aws --region us-west-2 s3 cp - "s3://eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/failed-tests.tar.gz" --acl bucket-owner-full-control
+echo "one or more tests failed, to view detailed failure information, visit https://s3.console.aws.amazon.com/s3/buckets/eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/"


### PR DESCRIPTION
We now lock to explicit versions of the tools we have installed in
.travis.yml. To make it easy for developers to install the same
copies (and to prevent adding a bunch of gunk to .travis.yml) we now
have a script per tool. It is expected these scripts could be run
locally.