### PR TITLE
Build tags that look like versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+if: branch = master OR tag IS present
 jobs:
   include:
     - os: linux
@@ -7,9 +8,6 @@ go: 1.9
 sudo: true # give us 7.5GB and >2 bursted cores.
 git:
   depth: false
-branches:
-  only:
-    - master
 cache:
     yarn: true
 before_install:


### PR DESCRIPTION
Safelisting (which we use to ensure we only build specific branches
instead of all pushes to topic branchs) means that tag pushes are no
longer built.

Our versioning workflow requires that we rebuild on tag pushes,
because the tag plays into the version number we embed in our programs
and packages.

This change causes us to build any thing that looks like what we would
tag a release with.

Part of pulumi/sdk#11