### PR TITLE
Add Manifest to GetStackResponse

### DIFF
--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -104,7 +104,7 @@ type GetStackResponse struct {
 type Manifest struct {
 	// Time of the update.
 	Time int64 `json:"time"`
-	// Magic number, used to identify itegrity of the checkpoint.
+	// Magic number, used to identify integrity of the checkpoint.
 	Magic string `json:"magic"`
 	// Version of the Pulumi engine used to render the checkpoint.
 	Version string `json:"version"`


### PR DESCRIPTION
In order to surface a stack's manifest, we first need to add it to the REST response type.

`GetStackResponse` is actually referenced by the PPC, and not used anywhere in the `pulumi/pulumi` repo. But rather than send out a PR to delete it (and reintroduce it in `pulumi-ppc`) I'll save that for a separate PR once I have more time to think about how to stage and rollout those type of changes.

Part of https://github.com/pulumi/pulumi-service/issues/371