### PR TITLE
Pass target Cloud and PPC to integation test Reporter

### DIFF
--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -71,6 +71,8 @@ func RunCommand(t *testing.T, name string, args []string, wd string, opts *Progr
 			TestID:         wd,
 			TestName:       filepath.Base(opts.Dir),
 			IsError:        runerr != nil,
+			CloudURL:       opts.CloudURL,
+			CloudPPC:       opts.PPCName,
 		})
 	}
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -76,6 +76,10 @@ type TestCommandStats struct {
 	TestName string `json:"testName"`
 	// IsError is true if the command failed
 	IsError bool `json:"isError"`
+	// The Cloud that the test was run against, or empty for local deployments
+	CloudURL string `json:"cloudURL"`
+	// The PPC that the test was run against, or empty for local deployments or for the default PPC
+	CloudPPC string `json:"cloudPPC"`
 }
 
 // TestStatsReporter reports results and metadata from a test run.


### PR DESCRIPTION
Ensure that we capture this information in our test reporting so that we can filter on it in queries and reports.