### PR TITLE
Clean up colorization logic

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
@@ -61,12 +62,13 @@ func newDestroyCmd() *cobra.Command {
 				return s.Destroy(pkg, root, debug, m, engine.UpdateOptions{
 					Analyzers:            analyzers,
 					DryRun:               preview,
-					Color:                color.Colorization(),
 					Parallel:             parallel,
 					ShowConfig:           showConfig,
 					ShowReplacementSteps: showReplacementSteps,
 					ShowSames:            showSames,
 					Summary:              summary,
+				}, backend.DisplayOptions{
+					Color: color.Colorization(),
 				})
 			}
 

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
@@ -53,12 +54,13 @@ func newPreviewCmd() *cobra.Command {
 			return s.Preview(pkg, root, debug, engine.UpdateOptions{
 				Analyzers:            analyzers,
 				DryRun:               true,
-				Color:                color.Colorization(),
 				Parallel:             parallel,
 				ShowConfig:           showConfig,
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSames:            showSames,
 				Summary:              summary,
+			}, backend.DisplayOptions{
+				Color: color.Colorization(),
 			})
 		}),
 	}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -6,6 +6,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
@@ -62,12 +63,13 @@ func newUpdateCmd() *cobra.Command {
 			return s.Update(pkg, root, debug, m, engine.UpdateOptions{
 				Analyzers:            analyzers,
 				DryRun:               preview,
-				Color:                color.Colorization(),
 				Parallel:             parallel,
 				ShowConfig:           showConfig,
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSames:            showSames,
 				Summary:              summary,
+			}, backend.DisplayOptions{
+				Color: color.Colorization(),
 			})
 		}),
 	}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -34,13 +34,14 @@ type Backend interface {
 	GetStackCrypter(stack tokens.QName) (config.Crypter, error)
 
 	// Preview initiates a preview of the current workspace's contents.
-	Preview(stackName tokens.QName, pkg *pack.Package, root string, debug bool, opts engine.UpdateOptions) error
+	Preview(stackName tokens.QName, pkg *pack.Package, root string,
+		debug bool, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 	// Update updates the target stack with the current workspace's contents (config and code).
 	Update(stackName tokens.QName, pkg *pack.Package, root string,
-		debug bool, m UpdateMetadata, opts engine.UpdateOptions) error
+		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 	// Destroy destroys all of this stack's resources.
 	Destroy(stackName tokens.QName, pkg *pack.Package, root string,
-		debug bool, m UpdateMetadata, opts engine.UpdateOptions) error
+		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 
 	// GetHistory returns all updates for the stack. The returned UpdateInfo slice will be in
 	// descending order by Version.

--- a/pkg/backend/cloud/stack.go
+++ b/pkg/backend/cloud/stack.go
@@ -79,18 +79,19 @@ func (s *cloudStack) Remove(force bool) (bool, error) {
 	return backend.RemoveStack(s, force)
 }
 
-func (s *cloudStack) Preview(pkg *pack.Package, root string, debug bool, opts engine.UpdateOptions) error {
-	return backend.PreviewStack(s, pkg, root, debug, opts)
+func (s *cloudStack) Preview(pkg *pack.Package, root string,
+	debug bool, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
+	return backend.PreviewStack(s, pkg, root, debug, opts, displayOpts)
 }
 
 func (s *cloudStack) Update(pkg *pack.Package, root string,
-	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions) error {
-	return backend.UpdateStack(s, pkg, root, debug, m, opts)
+	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
+	return backend.UpdateStack(s, pkg, root, debug, m, opts, displayOpts)
 }
 
 func (s *cloudStack) Destroy(pkg *pack.Package, root string,
-	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions) error {
-	return backend.DestroyStack(s, pkg, root, debug, m, opts)
+	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
+	return backend.DestroyStack(s, pkg, root, debug, m, opts, displayOpts)
 }
 
 func (s *cloudStack) GetLogs(query operations.LogQuery) ([]operations.LogEntry, error) {

--- a/pkg/backend/display.go
+++ b/pkg/backend/display.go
@@ -1,0 +1,10 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package backend
+
+import "github.com/pulumi/pulumi/pkg/diag/colors"
+
+// DisplayOptions controls how the output of events are rendered
+type DisplayOptions struct {
+	Color colors.Colorization // colorization to apply to events
+}

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -105,7 +105,7 @@ func (b *localBackend) GetStackCrypter(stackName tokens.QName) (config.Crypter, 
 }
 
 func (b *localBackend) Preview(stackName tokens.QName, pkg *pack.Package, root string, debug bool,
-	opts engine.UpdateOptions) error {
+	opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
 	update, err := b.newUpdate(stackName, pkg, root)
 	if err != nil {
@@ -115,7 +115,7 @@ func (b *localBackend) Preview(stackName tokens.QName, pkg *pack.Package, root s
 	events := make(chan engine.Event)
 	done := make(chan bool)
 
-	go displayEvents(events, done, debug)
+	go displayEvents(events, done, debug, displayOpts)
 
 	if err = engine.Preview(update, events, opts); err != nil {
 		return err
@@ -128,7 +128,7 @@ func (b *localBackend) Preview(stackName tokens.QName, pkg *pack.Package, root s
 }
 
 func (b *localBackend) Update(stackName tokens.QName, pkg *pack.Package, root string,
-	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions) error {
+	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
 	update, err := b.newUpdate(stackName, pkg, root)
 	if err != nil {
@@ -138,7 +138,7 @@ func (b *localBackend) Update(stackName tokens.QName, pkg *pack.Package, root st
 	events := make(chan engine.Event)
 	done := make(chan bool)
 
-	go displayEvents(events, done, debug)
+	go displayEvents(events, done, debug, displayOpts)
 
 	// Perform the update
 	start := time.Now().Unix()
@@ -177,7 +177,7 @@ func (b *localBackend) Update(stackName tokens.QName, pkg *pack.Package, root st
 }
 
 func (b *localBackend) Destroy(stackName tokens.QName, pkg *pack.Package, root string,
-	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions) error {
+	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
 	update, err := b.newUpdate(stackName, pkg, root)
 	if err != nil {
@@ -187,7 +187,7 @@ func (b *localBackend) Destroy(stackName tokens.QName, pkg *pack.Package, root s
 	events := make(chan engine.Event)
 	done := make(chan bool)
 
-	go displayEvents(events, done, debug)
+	go displayEvents(events, done, debug, displayOpts)
 
 	// Perform the destroy
 	start := time.Now().Unix()

--- a/pkg/backend/local/display.go
+++ b/pkg/backend/local/display.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
@@ -17,7 +18,7 @@ import (
 // displayEvents reads events from the `events` channel until it is closed, displaying each event as it comes in.
 // Once all events have been read from the channel and displayed, it closes the `done` channel so the caller can
 // await all the events being written.
-func displayEvents(events <-chan engine.Event, done chan<- bool, debug bool) {
+func displayEvents(events <-chan engine.Event, done chan<- bool, debug bool, opts backend.DisplayOptions) {
 	spinner, ticker := cmdutil.NewSpinnerAndTicker()
 
 	defer func() {
@@ -36,7 +37,7 @@ func displayEvents(events <-chan engine.Event, done chan<- bool, debug bool) {
 				return
 			case engine.StdoutColorEvent:
 				payload := event.Payload.(engine.StdoutEventPayload)
-				fmt.Print(payload.Color.Colorize(payload.Message))
+				fmt.Print(opts.Color.Colorize(payload.Message))
 			case engine.DiagEvent:
 				payload := event.Payload.(engine.DiagEventPayload)
 				var out io.Writer
@@ -49,7 +50,7 @@ func displayEvents(events <-chan engine.Event, done chan<- bool, debug bool) {
 					out = ioutil.Discard
 				}
 				msg := payload.Message
-				msg = payload.Color.Colorize(msg)
+				msg = opts.Color.Colorize(msg)
 				_, fmterr := fmt.Fprint(out, msg)
 				contract.IgnoreError(fmterr)
 			default:

--- a/pkg/backend/local/stack.go
+++ b/pkg/backend/local/stack.go
@@ -50,18 +50,19 @@ func (s *localStack) Remove(force bool) (bool, error) {
 	return backend.RemoveStack(s, force)
 }
 
-func (s *localStack) Preview(pkg *pack.Package, root string, debug bool, opts engine.UpdateOptions) error {
-	return backend.PreviewStack(s, pkg, root, debug, opts)
+func (s *localStack) Preview(pkg *pack.Package, root string,
+	debug bool, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
+	return backend.PreviewStack(s, pkg, root, debug, opts, displayOpts)
 }
 
 func (s *localStack) Update(pkg *pack.Package, root string,
-	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions) error {
-	return backend.UpdateStack(s, pkg, root, debug, m, opts)
+	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
+	return backend.UpdateStack(s, pkg, root, debug, m, opts, displayOpts)
 }
 
 func (s *localStack) Destroy(pkg *pack.Package, root string,
-	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions) error {
-	return backend.DestroyStack(s, pkg, root, debug, m, opts)
+	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
+	return backend.DestroyStack(s, pkg, root, debug, m, opts, displayOpts)
 }
 
 func (s *localStack) GetLogs(query operations.LogQuery) ([]operations.LogEntry, error) {

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -21,11 +21,14 @@ type Stack interface {
 	Backend() Backend           // the backend this stack belongs to.
 
 	// Preview changes to this stack.
-	Preview(pkg *pack.Package, root string, debug bool, opts engine.UpdateOptions) error
+	Preview(pkg *pack.Package, root string,
+		debug bool, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 	// Update this stack.
-	Update(pkg *pack.Package, root string, debug bool, m UpdateMetadata, opts engine.UpdateOptions) error
+	Update(pkg *pack.Package, root string,
+		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 	// Destroy this stack's resources.
-	Destroy(pkg *pack.Package, root string, debug bool, m UpdateMetadata, opts engine.UpdateOptions) error
+	Destroy(pkg *pack.Package, root string,
+		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 
 	Remove(force bool) (bool, error)                                  // remove this stack.
 	GetLogs(query operations.LogQuery) ([]operations.LogEntry, error) // list log entries for this stack.
@@ -39,20 +42,21 @@ func RemoveStack(s Stack, force bool) (bool, error) {
 }
 
 // PreviewStack initiates a preview of the current workspace's contents.
-func PreviewStack(s Stack, pkg *pack.Package, root string, debug bool, opts engine.UpdateOptions) error {
-	return s.Backend().Preview(s.Name(), pkg, root, debug, opts)
+func PreviewStack(s Stack, pkg *pack.Package, root string,
+	debug bool, opts engine.UpdateOptions, displayOpts DisplayOptions) error {
+	return s.Backend().Preview(s.Name(), pkg, root, debug, opts, displayOpts)
 }
 
 // UpdateStack updates the target stack with the current workspace's contents (config and code).
 func UpdateStack(s Stack, pkg *pack.Package, root string,
-	debug bool, m UpdateMetadata, opts engine.UpdateOptions) error {
-	return s.Backend().Update(s.Name(), pkg, root, debug, m, opts)
+	debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error {
+	return s.Backend().Update(s.Name(), pkg, root, debug, m, opts, displayOpts)
 }
 
 // DestroyStack destroys all of this stack's resources.
 func DestroyStack(s Stack, pkg *pack.Package, root string,
-	debug bool, m UpdateMetadata, opts engine.UpdateOptions) error {
-	return s.Backend().Destroy(s.Name(), pkg, root, debug, m, opts)
+	debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error {
+	return s.Backend().Destroy(s.Name(), pkg, root, debug, m, opts, displayOpts)
 }
 
 // GetStackCrypter fetches the encrypter/decrypter for a stack.

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -3,7 +3,6 @@
 package engine
 
 import (
-	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
@@ -24,8 +23,6 @@ func Destroy(update Update, events chan<- Event, opts UpdateOptions) (ResourceCh
 		Destroy: true,
 
 		Events: events,
-		Diag: newEventSink(events, diag.FormatOptions{
-			Color: opts.Color,
-		}),
+		Diag:   newEventSink(events),
 	})
 }

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -41,66 +41,66 @@ type StdoutEventPayload struct {
 	Color   colors.Colorization
 }
 
-func stdOutEventWithColor(s fmt.Stringer, color colors.Colorization) Event {
+func stdOutEventWithColor(s fmt.Stringer) Event {
 	return Event{
 		Type: StdoutColorEvent,
 		Payload: StdoutEventPayload{
 			Message: s.String(),
-			Color:   color,
+			Color:   colors.Raw,
 		},
 	}
 }
 
-func diagDebugEvent(msg string, color colors.Colorization) Event {
+func diagDebugEvent(msg string) Event {
 	return Event{
 		Type: DiagEvent,
 		Payload: DiagEventPayload{
 			Message:  msg,
-			Color:    color,
+			Color:    colors.Raw,
 			Severity: diag.Debug,
 		},
 	}
 }
 
-func diagInfoEvent(msg string, color colors.Colorization) Event {
+func diagInfoEvent(msg string) Event {
 	return Event{
 		Type: DiagEvent,
 		Payload: DiagEventPayload{
 			Message:  msg,
-			Color:    color,
+			Color:    colors.Raw,
 			Severity: diag.Info,
 		},
 	}
 }
 
-func diagInfoerrEvent(msg string, color colors.Colorization) Event {
+func diagInfoerrEvent(msg string) Event {
 	return Event{
 		Type: DiagEvent,
 		Payload: DiagEventPayload{
 			Message:  msg,
-			Color:    color,
+			Color:    colors.Raw,
 			Severity: diag.Infoerr,
 		},
 	}
 }
 
-func diagErrorEvent(msg string, color colors.Colorization) Event {
+func diagErrorEvent(msg string) Event {
 	return Event{
 		Type: DiagEvent,
 		Payload: DiagEventPayload{
 			Message:  msg,
-			Color:    color,
+			Color:    colors.Raw,
 			Severity: diag.Error,
 		},
 	}
 }
 
-func diagWarningEvent(msg string, color colors.Colorization) Event {
+func diagWarningEvent(msg string) Event {
 	return Event{
 		Type: DiagEvent,
 		Payload: DiagEventPayload{
 			Message:  msg,
-			Color:    color,
+			Color:    colors.Raw,
 			Severity: diag.Warning,
 		},
 	}

--- a/pkg/engine/eventsink.go
+++ b/pkg/engine/eventsink.go
@@ -13,12 +13,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
-func newEventSink(events chan<- Event, opts diag.FormatOptions) diag.Sink {
+func newEventSink(events chan<- Event) diag.Sink {
 	contract.Require(events != nil, "events")
 
 	return &eventSink{
 		events: events,
-		opts:   opts,
 		counts: make(map[diag.Severity]int),
 	}
 }
@@ -28,7 +27,6 @@ const eventSinkIDPrefix = "PU"
 // eventSink is a sink which writes all events to a channel
 type eventSink struct {
 	events chan<- Event          // the channel to emit events into.
-	opts   diag.FormatOptions    // a set of options that control output style and content.
 	counts map[diag.Severity]int // the number of messages that have been issued per severity.
 	mutex  sync.RWMutex          // a mutex for guarding updates to the counts map
 }
@@ -65,7 +63,7 @@ func (s *eventSink) Debugf(d *diag.Diag, args ...interface{}) {
 	if glog.V(9) {
 		glog.V(9).Infof("eventSink::Debug(%v)", msg[:len(msg)-1])
 	}
-	s.events <- diagDebugEvent(msg, s.opts.Color)
+	s.events <- diagDebugEvent(msg)
 	s.incrementCount(diag.Debug)
 }
 
@@ -74,7 +72,7 @@ func (s *eventSink) Infof(d *diag.Diag, args ...interface{}) {
 	if glog.V(5) {
 		glog.V(5).Infof("eventSink::Info(%v)", msg[:len(msg)-1])
 	}
-	s.events <- diagInfoEvent(msg, s.opts.Color)
+	s.events <- diagInfoEvent(msg)
 	s.incrementCount(diag.Info)
 }
 
@@ -83,7 +81,7 @@ func (s *eventSink) Infoerrf(d *diag.Diag, args ...interface{}) {
 	if glog.V(5) {
 		glog.V(5).Infof("eventSink::Infoerr(%v)", msg[:len(msg)-1])
 	}
-	s.events <- diagInfoerrEvent(msg, s.opts.Color)
+	s.events <- diagInfoerrEvent(msg)
 	s.incrementCount(diag.Infoerr)
 }
 
@@ -92,7 +90,7 @@ func (s *eventSink) Errorf(d *diag.Diag, args ...interface{}) {
 	if glog.V(5) {
 		glog.V(5).Infof("eventSink::Error(%v)", msg[:len(msg)-1])
 	}
-	s.events <- diagErrorEvent(msg, s.opts.Color)
+	s.events <- diagErrorEvent(msg)
 	s.incrementCount(diag.Error)
 }
 
@@ -101,7 +99,7 @@ func (s *eventSink) Warningf(d *diag.Diag, args ...interface{}) {
 	if glog.V(5) {
 		glog.V(5).Infof("eventSink::Warning(%v)", msg[:len(msg)-1])
 	}
-	s.events <- diagWarningEvent(msg, s.opts.Color)
+	s.events <- diagWarningEvent(msg)
 	s.incrementCount(diag.Warning)
 }
 
@@ -160,5 +158,5 @@ func (s *eventSink) Stringify(sev diag.Severity, d *diag.Diag, args ...interface
 	// TODO[pulumi/pulumi#15]: support Clang-style expressive diagnostics.  This would entail, for example, using
 	//     the buffer within the target document, to demonstrate the offending line/column range of code.
 
-	return s.opts.Color.Colorize(buffer.String())
+	return buffer.String()
 }

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -165,7 +165,7 @@ func printPlan(result *planResult) (ResourceChanges, error) {
 
 	// Now walk the plan's steps and and pretty-print them out.
 	prelude.WriteString(fmt.Sprintf("%vPreviewing changes:%v\n", colors.SpecUnimportant, colors.Reset))
-	result.Options.Events <- stdOutEventWithColor(&prelude, result.Options.Color)
+	result.Options.Events <- stdOutEventWithColor(&prelude)
 
 	actions := newPreviewActions(result.Options)
 	_, _, _, err := result.Walk(actions, true)
@@ -183,7 +183,7 @@ func printPlan(result *planResult) (ResourceChanges, error) {
 	var summary bytes.Buffer
 	changes := ResourceChanges(actions.Ops)
 	printChangeSummary(&summary, changes, true)
-	result.Options.Events <- stdOutEventWithColor(&summary, result.Options.Color)
+	result.Options.Events <- stdOutEventWithColor(&summary)
 	return changes, nil
 }
 

--- a/pkg/engine/preview.go
+++ b/pkg/engine/preview.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -34,9 +33,7 @@ func Preview(update Update, events chan<- Event, opts UpdateOptions) error {
 		Destroy: false,
 
 		Events: events,
-		Diag: newEventSink(events, diag.FormatOptions{
-			Color: opts.Color,
-		}),
+		Diag:   newEventSink(events),
 	})
 }
 
@@ -89,7 +86,7 @@ func (acts *previewActions) OnResourceStepPre(step deploy.Step) (interface{}, er
 		var b bytes.Buffer
 		printStep(&b, step,
 			acts.Seen, acts.Shown, acts.Opts.Summary, acts.Opts.Detailed, true, 0 /*indent*/)
-		acts.Opts.Events <- stdOutEventWithColor(&b, acts.Opts.Color)
+		acts.Opts.Events <- stdOutEventWithColor(&b)
 	}
 	return nil, nil
 }
@@ -116,7 +113,7 @@ func (acts *previewActions) OnResourceOutputs(step deploy.Step) error {
 	if (shouldShow(acts.Seen, step, acts.Opts) || isRootStack(step)) && !acts.Opts.Summary {
 		var b bytes.Buffer
 		printResourceOutputProperties(&b, step, acts.Seen, acts.Shown, true, 0 /*indent*/)
-		acts.Opts.Events <- stdOutEventWithColor(&b, acts.Opts.Color)
+		acts.Opts.Events <- stdOutEventWithColor(&b)
 	}
 	return nil
 }


### PR DESCRIPTION
The existing logic would flow colorization information into the
engine, so depending on the settings in the CLI, the engine may or may
not have emitted colorized events. This coupling is not great and we
want to start moving to a world where the presentation happens
exclusively at the CLI level.

With this change, the engine will always produce strings that have the
colorization formatting directives (i.e. the directives that
reconquest/loreley understands) and the CLI will apply
colorization (which could mean either running loreley to turn the
directives into ANSI escape codes, or drop them or retain them, for
debuging purposes).

Fixes #742