### PR TITLE
Keep test files on assertion failure

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -399,7 +399,9 @@ func (pt *programTester) testLifeCycleInitAndDestroy() error {
 		return errors.Wrap(err, "running test preview, update, and edits")
 	}
 
-	keepTestDir = false
+	// Ran to completion. Delete the test directory if the test passed.
+	keepTestDir = pt.t.Failed()
+
 	return nil
 }
 


### PR DESCRIPTION
We were pretty careful to keep the test directory around if the test ever
exited early due to a panic or error return. But if the test ran to
completion and failed -- for example, if ExtraRuntimeValidation caused the
test to fail -- we would end up deleting the test directory.

Fixes #868