### PR TITLE
Permit setting multi line config from stdin

### DIFF
--- a/pkg/util/cmdutil/console.go
+++ b/pkg/util/cmdutil/console.go
@@ -6,6 +6,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 )
 
@@ -21,10 +22,22 @@ func ReadConsole(prompt string) (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSpace(raw), nil
+	return RemoveTralingNewline(raw), nil
 }
 
 // IsTruthy returns true if the given string represents a CLI input interpreted as "true".
 func IsTruthy(s string) bool {
 	return s == "1" || strings.EqualFold(s, "true")
+}
+
+// RemoveTralingNewline removes a trailing newline from a string. On windows, we'll remove either \r\n or \n, on other
+// platforms, we just remove \n.
+func RemoveTralingNewline(s string) string {
+	s = strings.TrimSuffix(s, "\n")
+
+	if runtime.GOOS == "windows" {
+		s = strings.TrimSuffix(s, "\r")
+	}
+
+	return s
 }


### PR DESCRIPTION
When reading a configuration value from standard in and standard in is
not connected to a terminal, read until EOF and then trim a trailing
newline (if present) to get the value

Fixes #822