### PR TITLE
Add User-Agent header to CLI requests

### DIFF
--- a/pkg/backend/cloud/api.go
+++ b/pkg/backend/cloud/api.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/golang/glog"
@@ -18,6 +19,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/version"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -85,6 +87,11 @@ func pulumiAPICall(apiEndpoint, method, path string, body []byte, accessToken st
 		return "", nil, fmt.Errorf("creating new HTTP request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+
+	// Add a User-Agent header to allow for the backend to make breaking API changes while preserving
+	// backwards compatibility.
+	userAgent := fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)
+	req.Header.Set("User-Agent", userAgent)
 
 	// Apply credentials if provided.
 	if accessToken != "" {


### PR DESCRIPTION
Today we don't send any version information with API requests to the service, so we cannot make breaking changes between versions of the backend API while preserving backwards compatibility.

This PR adds a `User-Agent` header with REST requests that sends a CLI version number of "1". If the service were to make a breaking change, it could use this header to determine which response handler to use. (e.g. return a different response for "" or "1" and another for "2".) Obviously we want to avoid being in this situation, but in the event that we need to make a breaking change, we'll need this value.

We send the Pulumi version as well, though the SDK will probably rev much more quickly than the backend API client version.

Fixes #848 