### PR TITLE
Don't include pending-delete resources in tree representation

### DIFF
--- a/pkg/operations/resources.go
+++ b/pkg/operations/resources.go
@@ -44,12 +44,15 @@ func makeResourceTreeMap(source []*resource.State) (*Resource, map[resource.URN]
 	for _, state := range source {
 		ns = state.URN.Namespace()
 		alloc = state.URN.Alloc()
-		contract.Assertf(resources[state.URN] == nil, "Unexpected duplicate resource %s", state.URN)
-		resources[state.URN] = &Resource{
-			NS:       ns,
-			Alloc:    alloc,
-			State:    state,
-			Children: make(map[resource.URN]*Resource),
+		if !state.Delete {
+			// Only include resources which are not marked as pending-deletion.
+			contract.Assertf(resources[state.URN] == nil, "Unexpected duplicate resource %s", state.URN)
+			resources[state.URN] = &Resource{
+				NS:       ns,
+				Alloc:    alloc,
+				State:    state,
+				Children: make(map[resource.URN]*Resource),
+			}
 		}
 	}
 

--- a/pkg/operations/testdata/todo.json
+++ b/pkg/operations/testdata/todo.json
@@ -1144,6 +1144,28 @@
                     ],
                     "url": "https://eupwl7wu4i.execute-api.us-east-2.amazonaws.com/"
                 }
+            },
+            {
+                "urn": "urn:pulumi:foo::todo::aws:apigateway/deployment:Deployment::todo_f569e86a",
+                "delete": true,
+                "custom": true,
+                "id": "abc123",
+                "type": "aws:apigateway/deployment:Deployment",
+                "parent": "urn:pulumi:foo::todo::cloud:http:HttpEndpoint::todo",
+                "inputs": {
+                    "description": "Deployment of version todo_f569e86a",
+                    "restApi": "eupwl7wu4i",
+                    "stageName": ""
+                },
+                "outputs": {
+                    "createdDate": "2017-11-08T19:59:03Z",
+                    "description": "Deployment of version todo_f569e86a",
+                    "executionArn": "arn:aws:execute-api:us-east-2:153052954103:eupwl7wu4i/",
+                    "id": "abc123",
+                    "invokeUrl": "https://eupwl7wu4i.execute-api.us-east-2.amazonaws.com/",
+                    "restApi": "eupwl7wu4i",
+                    "stageName": ""
+                }
             }
         ]
     }


### PR DESCRIPTION
Resources in the checkpoint file which are pending-delete represent old versions of resources which are no longer part of the active deployment.  For purposes of constructing the active resource tree, we should skip these resources.

Note - it's not immediately clear what the right thing is to do here.  Because of pending-deletes, we do not actually have any way of building a canonical map from URN to resources.  But for some purposes, visualizations of the state of a stack may want to treat pending-delete-but-still-around resources as part of the stack.

Fixes #897.