### PR TITLE
Missed a pulumi-langhost-nodejs batch wrapper

### DIFF
--- a/dist/sdk/nodejs/pulumi-langhost-nodejs-exec.cmd
+++ b/dist/sdk/nodejs/pulumi-langhost-nodejs-exec.cmd
@@ -1,0 +1,1 @@
+@"%~dp0\node\node.exe" -e "require(\"pulumi/cmd/run\")" dummy_argument %*

--- a/dist/sdk/nodejs/pulumi-langhost-nodejs.cmd
+++ b/dist/sdk/nodejs/pulumi-langhost-nodejs.cmd
@@ -1,1 +1,0 @@
-@"%~dp0\node\node.exe" -e "require(\"pulumi/cmd/langhost\")" dummy_argument %*


### PR DESCRIPTION
Fixes the broken Windows build. Haven't tested this on a Windows machine yet, I'll hold off merging until I can. (It's the build publish step that's broken, which isn't exercised on Appveyor PR builds.)