### PR TITLE
Rename pulumi package to @pulumi/pulumi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,10 @@ before_install:
     # Install Yarn as per https://yarnpkg.com/lang/en/docs/install-ci/#travis-tab.
     - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
     - export PATH=$HOME/.yarn/bin:$PATH
-    - export PIP=pip
+    # Ensure that we can access Pulumi's private NPM org.
+    - echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > ~/.npmrc
     # On OSX, the place pip installs user commands to is not on the $PATH and also pip is called pip2.7
+    - export PIP=pip
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH=$PATH:$HOME/Library/Python/2.7/bin; export PIP=pip2.7; fi
     # Install the AWS CLI so that we can publish the resulting release (if applicable) at the end.
     - $PIP install --upgrade --user awscli

--- a/examples/dynamic-provider/derived-inputs/index.ts
+++ b/examples/dynamic-provider/derived-inputs/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
-import * as dynamic from "pulumi/dynamic";
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
 
 const sleep = require("sleep-promise");
 const assert = require("assert");

--- a/examples/dynamic-provider/derived-inputs/package.json
+++ b/examples/dynamic-provider/derived-inputs/package.json
@@ -13,5 +13,8 @@
     "dependencies": {
         "assert": "^1.4.1",
         "sleep-promise": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/examples/dynamic-provider/multiple-turns-2/index.ts
+++ b/examples/dynamic-provider/multiple-turns-2/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
-import * as dynamic from "pulumi/dynamic";
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
 
 const sleep = require("sleep-promise");
 const assert = require("assert");

--- a/examples/dynamic-provider/multiple-turns-2/package.json
+++ b/examples/dynamic-provider/multiple-turns-2/package.json
@@ -13,5 +13,8 @@
     "dependencies": {
         "assert": "^1.4.1",
         "sleep-promise": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/examples/dynamic-provider/multiple-turns/index.ts
+++ b/examples/dynamic-provider/multiple-turns/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
-import * as dynamic from "pulumi/dynamic";
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
 
 const sleep = require("sleep-promise");
 const assert = require("assert");

--- a/examples/dynamic-provider/multiple-turns/package.json
+++ b/examples/dynamic-provider/multiple-turns/package.json
@@ -13,5 +13,8 @@
     "dependencies": {
         "assert": "^1.4.1",
         "sleep-promise": "^2.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/examples/dynamic-provider/simple/index.ts
+++ b/examples/dynamic-provider/simple/index.ts
@@ -1,7 +1,7 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
-import * as dynamic from "pulumi/dynamic";
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
 
 class OperatorProvider implements dynamic.ResourceProvider {
     private op: (l: number, r: number) => any;

--- a/examples/dynamic-provider/simple/package.json
+++ b/examples/dynamic-provider/simple/package.json
@@ -7,5 +7,8 @@
     },
     "devDependencies": {
         "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -23,7 +23,7 @@ func TestExamples(t *testing.T) {
 	var minimal integration.ProgramTestOptions
 	minimal = integration.ProgramTestOptions{
 		Dir:          path.Join(cwd, "minimal"),
-		Dependencies: []string{"pulumi"},
+		Dependencies: []string{"@pulumi/pulumi"},
 		Config: map[string]string{
 			"name": "Pulumi",
 		},
@@ -42,7 +42,7 @@ func TestExamples(t *testing.T) {
 		minimal,
 		{
 			Dir:          path.Join(cwd, "dynamic-provider/simple"),
-			Dependencies: []string{"pulumi"},
+			Dependencies: []string{"@pulumi/pulumi"},
 			Config: map[string]string{
 				"simple:config:w": "1",
 				"simple:config:x": "1",
@@ -51,7 +51,7 @@ func TestExamples(t *testing.T) {
 		},
 		{
 			Dir:          path.Join(cwd, "dynamic-provider/multiple-turns"),
-			Dependencies: []string{"pulumi"},
+			Dependencies: []string{"@pulumi/pulumi"},
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 				for _, res := range stackInfo.Snapshot.Resources {
 					if res.Parent == "" {
@@ -63,11 +63,11 @@ func TestExamples(t *testing.T) {
 		},
 		{
 			Dir:          path.Join(cwd, "dynamic-provider/derived-inputs"),
-			Dependencies: []string{"pulumi"},
+			Dependencies: []string{"@pulumi/pulumi"},
 		},
 		{
 			Dir:          path.Join(cwd, "formattable"),
-			Dependencies: []string{"pulumi"},
+			Dependencies: []string{"@pulumi/pulumi"},
 			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 				// Note that we're abusing this hook to validate stdout. We don't actually care about the checkpoint.
 				stdout := formattableStdout.String()
@@ -78,9 +78,8 @@ func TestExamples(t *testing.T) {
 		},
 		{
 			Dir:          path.Join(cwd, "dynamic-provider/multiple-turns-2"),
-			Dependencies: []string{"pulumi"},
+			Dependencies: []string{"@pulumi/pulumi"},
 		},
-
 	}
 
 	for _, ex := range examples {

--- a/examples/minimal/index.ts
+++ b/examples/minimal/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import { Config } from "pulumi";
+import { Config } from "@pulumi/pulumi";
 
 let config = new Config("minimal:config");
 console.log(`Hello, ${config.require("name")}!`);

--- a/examples/minimal/package.json
+++ b/examples/minimal/package.json
@@ -7,5 +7,8 @@
     },
     "devDependencies": {
         "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,6 +2,7 @@
 # publish.sh builds and publishes a release.
 set -o nounset -o errexit -o pipefail
 
+ROOT=$(dirname $0)/..
 PUBLISH=$GOPATH/src/github.com/pulumi/home/scripts/publish.sh
 PUBLISH_GOARCH=("amd64")
 PUBLISH_PROJECT="pulumi"
@@ -13,6 +14,7 @@ fi
 
 OS=$(go env GOOS)
 
+echo "Publishing SDK build to s3://eng.pulumi.com/:"
 for ARCH in "${PUBLISH_GOARCH[@]}"
 do
     export GOARCH=${ARCH}
@@ -21,4 +23,8 @@ do
     ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
 done
 
-
+echo "Publishing NPM package to NPMjs.com:"
+pushd ${ROOT}/sdk/nodejs/bin && \
+    npm publish && \
+    npm info 2>/dev/null || true && \
+    popd

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "pulumi",
+    "name": "@pulumi/pulumi",
     "version": "${VERSION}",
     "description": "Pulumi's Node.js SDK",
     "repository": "https://github.com/pulumi/pulumi/sdk/nodejs",

--- a/tests/integration/diff/diff_test.go
+++ b/tests/integration/diff/diff_test.go
@@ -22,7 +22,7 @@ func TestDiffs(t *testing.T) {
 
 	opts := integration.ProgramTestOptions{
 		Dir:                    "step1",
-		Dependencies:           []string{"pulumi"},
+		Dependencies:           []string{"@pulumi/pulumi"},
 		Quick:                  true,
 		StackName:              "diffstack",
 		UpdateCommandlineFlags: []string{"--color=raw"},

--- a/tests/integration/diff/step1/package.json
+++ b/tests/integration/diff/step1/package.json
@@ -7,5 +7,8 @@
     },
     "devDependencies": {
         "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/tests/integration/diff/step1/resource.ts
+++ b/tests/integration/diff/step1/resource.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
+import * as pulumi from "@pulumi/pulumi";
 
 let currentID = 0;
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -20,7 +20,7 @@ func TestProjectMain(t *testing.T) {
 	var test integration.ProgramTestOptions
 	test = integration.ProgramTestOptions{
 		Dir:          "project_main",
-		Dependencies: []string{"pulumi"},
+		Dependencies: []string{"@pulumi/pulumi"},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Simple runtime validation that just ensures the checkpoint was written and read.
 			assert.Equal(t, test.GetStackName(), stackInfo.Checkpoint.Stack)
@@ -67,7 +67,7 @@ func TestProjectMain(t *testing.T) {
 func TestStackProjectName(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          "stack_project_name",
-		Dependencies: []string{"pulumi"},
+		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 	})
 }
@@ -76,7 +76,7 @@ func TestStackProjectName(t *testing.T) {
 func TestStackOutputs(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          "stack_outputs",
-		Dependencies: []string{"pulumi"},
+		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Ensure the checkpoint contains a single resource, the Stack, with two outputs.
@@ -98,7 +98,7 @@ func TestStackOutputs(t *testing.T) {
 func TestStackParenting(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          "stack_parenting",
-		Dependencies: []string{"pulumi"},
+		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// Ensure the checkpoint contains resources parented correctly.  This should look like this:

--- a/tests/integration/protect_resources/protect_test.go
+++ b/tests/integration/protect_resources/protect_test.go
@@ -15,7 +15,7 @@ import (
 func TestSteps(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          "step1",
-		Dependencies: []string{"pulumi"},
+		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			// A single synthetic stack and a single "eternal" resource.

--- a/tests/integration/protect_resources/step1/package.json
+++ b/tests/integration/protect_resources/step1/package.json
@@ -7,5 +7,8 @@
     },
     "devDependencies": {
         "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/tests/integration/protect_resources/step1/resource.ts
+++ b/tests/integration/protect_resources/step1/resource.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
+import * as pulumi from "@pulumi/pulumi";
 
 let currentID = 0;
 

--- a/tests/integration/stack_parenting/index.ts
+++ b/tests/integration/stack_parenting/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
+import * as pulumi from "@pulumi/pulumi";
 
 let currentID = 0;
 

--- a/tests/integration/stack_parenting/package.json
+++ b/tests/integration/stack_parenting/package.json
@@ -7,5 +7,8 @@
     },
     "devDependencies": {
         "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/tests/integration/stack_project_name/index.ts
+++ b/tests/integration/stack_project_name/index.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
+import * as pulumi from "@pulumi/pulumi";
 
 const stackName = pulumi.getStack();
 if (!stackName) {

--- a/tests/integration/stack_project_name/package.json
+++ b/tests/integration/stack_project_name/package.json
@@ -7,5 +7,8 @@
     },
     "devDependencies": {
         "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/tests/integration/steps/step1/package.json
+++ b/tests/integration/steps/step1/package.json
@@ -7,5 +7,8 @@
     },
     "devDependencies": {
         "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
     }
 }

--- a/tests/integration/steps/step1/resource.ts
+++ b/tests/integration/steps/step1/resource.ts
@@ -1,6 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-import * as pulumi from "pulumi";
+import * as pulumi from "@pulumi/pulumi";
 
 let currentID = 0;
 

--- a/tests/integration/steps/steps_test.go
+++ b/tests/integration/steps/steps_test.go
@@ -20,7 +20,7 @@ func validateResources(t *testing.T, resources []stack.Resource, expectedNames .
 	}
 
 	// Ensure that the resource count is correct.
-	assert.Equal(t, len(resources), len(expectedNames) + 1)
+	assert.Equal(t, len(resources), len(expectedNames)+1)
 
 	// Pull out the stack resource, which must be the first resource in the checkpoint.
 	stackRes := resources[0]
@@ -39,7 +39,7 @@ func validateResources(t *testing.T, resources []stack.Resource, expectedNames .
 func TestSteps(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          "step1",
-		Dependencies: []string{"pulumi"},
+		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Checkpoint.Latest)


### PR DESCRIPTION
In order to begin publishing our core SDK package to NPM, we will
need it to be underneath the @pulumi scope so that it may remain
private.  Eventually, we can alias pulumi back to it.

This is part of pulumi/pulumi#915.