### PR TITLE
Only build `master`, `release/*` and tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-if: (branch = master) OR (branch =~ release/.*) OR (tag IS present)
+# It may be tempting to add parens around each individual clause in this expression, but Travis then builds pushes anyway
+if: branch = master OR branch =~ ^release/ OR tag IS present
 jobs:
   include:
     - os: linux


### PR DESCRIPTION
Our use of parens around the individual clauses of our if condition
seemed to cause Travis to ignore the condition and build
regardless. I've asked Travis about this, but for now, drop them (with
a comment) so we stop building pushes for topic branchs.