### PR TITLE
Improve failure messages

### DIFF
--- a/sdk/nodejs/config.ts
+++ b/sdk/nodejs/config.ts
@@ -169,4 +169,3 @@ class ConfigMissingError extends RunError {
         );
     }
 }
-

--- a/sdk/nodejs/runtime/closure.ts
+++ b/sdk/nodejs/runtime/closure.ts
@@ -3,6 +3,7 @@
 import * as crypto from "crypto";
 import { relative as pathRelative } from "path";
 import * as ts from "typescript";
+import { RunError } from "../errors";
 import * as log from "../log";
 import * as resource from "../resource";
 import { debuggablePromise } from "./debuggable";
@@ -15,7 +16,14 @@ import { debuggablePromise } from "./debuggable";
 //
 // `process.binding` invokes the Node bootstrap module loader in order to
 // get to our builtin module.
-const nativeruntime = (<any>process).binding("pulumi_closure");
+let nativeruntime: any;
+try {
+    nativeruntime = (<any>process).binding("pulumi_closure");
+}
+catch (err) {
+    throw new RunError(
+        `Failed to load custom Pulumi SDK Node.js extension; are you running using the Pulumi CLI? (${err.message})`);
+}
 
 /**
  * Closure represents the serialized form of a JavaScript serverless function.

--- a/sdk/nodejs/runtime/config.ts
+++ b/sdk/nodejs/runtime/config.ts
@@ -69,4 +69,3 @@ export function getConfigEnv(): {[key: string]: string} {
     }
     return {};
 }
-

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -1,5 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
+import { RunError } from "../errors";
 import { Resource } from "../resource";
 import { debuggablePromise } from "./debuggable";
 
@@ -30,11 +31,6 @@ export let options: Options = <any>{
 };
 
 /**
- * configured is set to true once configuration has been set.
- */
-let configured: boolean;
-
-/**
  * hasMonitor returns true if we are currently connected to a resource monitoring service.
  */
 export function hasMonitor(): boolean {
@@ -45,9 +41,10 @@ export function hasMonitor(): boolean {
  * getMonitor returns the current resource monitoring service client for RPC communications.
  */
 export function getMonitor(): Object {
-    if (!configured) {
-        configured = true;
-        console.warn("warning: Pulumi Fabric monitor is missing; no resources will be created");
+    if (!options.monitor) {
+        throw new RunError(
+            "Pulumi program not connected to the engine -- are you running with the `pulumi` CLI?\n" +
+            "This can also happen if you've loaded the Pulumi SDK module multiple times into the same proces");
     }
     return options.monitor;
 }
@@ -65,6 +62,11 @@ export function getEngine(): Object | undefined {
 export function serialize(): boolean {
     return !options.parallel || options.parallel <= 1;
 }
+
+/**
+ * configured is set to true once configuration has been set.
+ */
+let configured: boolean;
 
 /**
  * configure initializes the current resource monitor and engine RPC connections, and whether we are performing a "dry


### PR DESCRIPTION
This improves the failure messages in two circumstances:

1) If the resource monitor RPC connection is missing.  This can happen
   two ways: either you run a Pulumi program using vanilla Node.js, instead
   of the CLI, or you've accidentally loaded the Pulumi SDK more than once.

2) Failure to load the custom Pulumi SDK Node.js extension.  This is a new
   addition and would happen if you tried running a Pulumi program using a
   vanilla Node.js, rather than using the Pulumi CLI.