### PR TITLE
Rename package to project

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/backend/state"
 	"github.com/pulumi/pulumi/pkg/diag"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
@@ -246,29 +245,29 @@ func parseConfigKey(key string) (tokens.ModuleMember, error) {
 	// As a convience, we'll treat any key with no delimiter as if:
 	// <program-name>:config:<key> had been written instead
 	if !strings.Contains(key, tokens.TokenDelimiter) {
-		pkg, err := workspace.GetPackage()
+		proj, err := workspace.DetectProject()
 		if err != nil {
 			return "", err
 		}
 
-		return tokens.ParseModuleMember(fmt.Sprintf("%s:config:%s", pkg.Name, key))
+		return tokens.ParseModuleMember(fmt.Sprintf("%s:config:%s", proj.Name, key))
 	}
 
 	return tokens.ParseModuleMember(key)
 }
 
 func prettyKey(key string) string {
-	pkg, err := workspace.GetPackage()
+	proj, err := workspace.DetectProject()
 	if err != nil {
 		return key
 	}
 
-	return prettyKeyForPackage(key, pkg)
+	return prettyKeyForProject(key, proj)
 }
 
-func prettyKeyForPackage(key string, pkg *pack.Package) string {
+func prettyKeyForProject(key string, proj *workspace.Project) string {
 	s := key
-	defaultPrefix := fmt.Sprintf("%s:config:", pkg.Name)
+	defaultPrefix := fmt.Sprintf("%s:config:", proj.Name)
 
 	if strings.HasPrefix(s, defaultPrefix) {
 		return s[len(defaultPrefix):]
@@ -370,7 +369,7 @@ func deleteAllStackConfiguration(stackName tokens.QName) error {
 		return err
 	}
 
-	pkg, err := w.GetPackage()
+	proj, err := w.Project()
 	if err != nil {
 		return err
 	}
@@ -382,32 +381,32 @@ func deleteAllStackConfiguration(stackName tokens.QName) error {
 		return err
 	}
 
-	if info, has := pkg.Stacks[stackName]; has {
+	if info, has := proj.Stacks[stackName]; has {
 		info.Config = nil
 		info.EncryptionSalt = ""
-		pkg.Stacks[stackName] = info
+		proj.Stacks[stackName] = info
 	}
 
-	return workspace.SavePackage(pkg)
+	return workspace.SaveProject(proj)
 }
 
 func deleteProjectConfiguration(stackName tokens.QName, key tokens.ModuleMember) error {
-	pkg, err := workspace.GetPackage()
+	proj, err := workspace.DetectProject()
 	if err != nil {
 		return err
 	}
 
 	if stackName == "" {
-		if pkg.Config != nil {
-			delete(pkg.Config, key)
+		if proj.Config != nil {
+			delete(proj.Config, key)
 		}
 	} else {
-		if pkg.Stacks[stackName].Config != nil {
-			delete(pkg.Stacks[stackName].Config, key)
+		if proj.Stacks[stackName].Config != nil {
+			delete(proj.Stacks[stackName].Config, key)
 		}
 	}
 
-	return workspace.SavePackage(pkg)
+	return workspace.SaveProject(proj)
 }
 
 func deleteWorkspaceConfiguration(stackName tokens.QName, key tokens.ModuleMember) error {
@@ -424,32 +423,32 @@ func deleteWorkspaceConfiguration(stackName tokens.QName, key tokens.ModuleMembe
 }
 
 func setProjectConfiguration(stackName tokens.QName, key tokens.ModuleMember, value config.Value) error {
-	pkg, err := workspace.GetPackage()
+	proj, err := workspace.DetectProject()
 	if err != nil {
 		return err
 	}
 
 	if stackName == "" {
-		if pkg.Config == nil {
-			pkg.Config = make(map[tokens.ModuleMember]config.Value)
+		if proj.Config == nil {
+			proj.Config = make(map[tokens.ModuleMember]config.Value)
 		}
 
-		pkg.Config[key] = value
+		proj.Config[key] = value
 	} else {
-		if pkg.Stacks == nil {
-			pkg.Stacks = make(map[tokens.QName]pack.StackInfo)
+		if proj.Stacks == nil {
+			proj.Stacks = make(map[tokens.QName]workspace.ProjectStack)
 		}
 
-		if pkg.Stacks[stackName].Config == nil {
-			si := pkg.Stacks[stackName]
+		if proj.Stacks[stackName].Config == nil {
+			si := proj.Stacks[stackName]
 			si.Config = make(map[tokens.ModuleMember]config.Value)
-			pkg.Stacks[stackName] = si
+			proj.Stacks[stackName] = si
 		}
 
-		pkg.Stacks[stackName].Config[key] = value
+		proj.Stacks[stackName].Config[key] = value
 	}
 
-	return workspace.SavePackage(pkg)
+	return workspace.SaveProject(proj)
 }
 
 func setWorkspaceConfiguration(stackName tokens.QName, key tokens.ModuleMember, value config.Value) error {

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -5,15 +5,14 @@ package cmd
 import (
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/pack"
-	"github.com/pulumi/pulumi/pkg/tokens"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
-func TestPrettyKeyForPackage(t *testing.T) {
-	pkg := &pack.Package{Name: tokens.PackageName("test-package"), Runtime: "nodejs"}
-
-	assert.Equal(t, "foo", prettyKeyForPackage("test-package:config:foo", pkg))
-	assert.Equal(t, "other-package:config:bar", prettyKeyForPackage("other-package:config:bar", pkg))
+func TestPrettyKeyForProject(t *testing.T) {
+	proj := &workspace.Project{Name: tokens.PackageName("test-package"), Runtime: "nodejs"}
+	assert.Equal(t, "foo", prettyKeyForProject("test-package:config:foo", proj))
+	assert.Equal(t, "other-package:config:bar", prettyKeyForProject("other-package:config:bar", proj))
 }

--- a/cmd/debug_cmds.go
+++ b/cmd/debug_cmds.go
@@ -29,12 +29,12 @@ func newArchiveCommand() *cobra.Command {
 				return errors.New("can't specify --no-default-ignores and --default-ignores at the same time")
 			}
 
-			pkg, programPath, err := workspace.GetPackagePath()
+			proj, path, err := workspace.DetectProjectAndPath()
 			if err != nil {
 				return err
 			}
 
-			useDeafultIgnores := pkg.UseDefaultIgnores()
+			useDeafultIgnores := proj.UseDefaultIgnores()
 
 			if forceDefaultIgnores {
 				useDeafultIgnores = true
@@ -42,9 +42,9 @@ func newArchiveCommand() *cobra.Command {
 				useDeafultIgnores = false
 			}
 
-			// programPath is the path to the Pulumi.yaml file. Need its parent folder.
-			programFolder := filepath.Dir(programPath)
-			archiveContents, err := archive.Process(programFolder, useDeafultIgnores)
+			// path is the path to the Pulumi.yaml file.  Need its parent directory.
+			dir := filepath.Dir(path)
+			archiveContents, err := archive.Process(dir, useDeafultIgnores)
 			if err != nil {
 				return errors.Wrap(err, "creating archive")
 			}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -47,7 +47,7 @@ func newDestroyCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			pkg, root, err := readPackage()
+			proj, root, err := readProject()
 			if err != nil {
 				return err
 			}
@@ -59,7 +59,7 @@ func newDestroyCmd() *cobra.Command {
 
 			if preview || yes ||
 				confirmPrompt("This will permanently destroy all resources in the '%v' stack!", string(s.Name())) {
-				return s.Destroy(pkg, root, debug, m, engine.UpdateOptions{
+				return s.Destroy(proj, root, debug, m, engine.UpdateOptions{
 					Analyzers:            analyzers,
 					DryRun:               preview,
 					Parallel:             parallel,

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -32,26 +32,26 @@ func newPreviewCmd() *cobra.Command {
 		Long: "Show a preview of updates an stack's resources\n" +
 			"\n" +
 			"This command displays a preview of the updates to an existing stack whose state is\n" +
-			"represented by an existing snapshot file. The new desired state is computed by compiling\n" +
-			"and evaluating an executable package, and extracting all resource allocations from its\n" +
-			"resulting object graph. These allocations are then compared against the existing state to\n" +
-			"determine what operations must take place to achieve the desired state. No changes to the\n" +
-			"stack will actually take place.\n" +
+			"represented by an existing snapshot file. The new desired state is computed by running\n" +
+			"a Pulumi program, and extracting all resource allocations from its resulting object graph.\n" +
+			"These allocations are then compared against the existing state to determine what\n" +
+			"operations must take place to achieve the desired state. No changes to the stack will\n" +
+			"actually take place.\n" +
 			"\n" +
-			"The package to execute is loaded from the current directory. Use the `-C` or `--cwd` flag to\n" +
-			"use a different directory.",
+			"The program to run is loaded from the project in the current directory. Use the `-C` or\n" +
+			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			s, err := requireStack(tokens.QName(stack))
 			if err != nil {
 				return err
 			}
-			pkg, root, err := readPackage()
+			proj, root, err := readProject()
 			if err != nil {
 				return err
 			}
 
-			return s.Preview(pkg, root, debug, engine.UpdateOptions{
+			return s.Preview(proj, root, debug, engine.UpdateOptions{
 				Analyzers:            analyzers,
 				DryRun:               true,
 				Parallel:             parallel,

--- a/cmd/stack_ls.go
+++ b/cmd/stack_ls.go
@@ -28,7 +28,7 @@ func newStackLsCmd() *cobra.Command {
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Ensure we are in a project; if not, we will fail.
-			proj, err := workspace.DetectPackage()
+			proj, err := workspace.DetectProjectPath()
 			if err != nil {
 				return errors.Wrapf(err, "could not detect current project")
 			} else if proj == "" {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -35,22 +35,22 @@ func newUpdateCmd() *cobra.Command {
 		Short:      "Update the resources in an stack",
 		Long: "Update the resources in an stack\n" +
 			"\n" +
-			"This command updates an existing stack whose state is represented by the\n" +
-			"existing snapshot file. The new desired state is computed by compiling and evaluating an\n" +
-			"executable package, and extracting all resource allocations from its resulting object graph.\n" +
-			"These allocations are then compared against the existing state to determine what operations\n" +
-			"must take place to achieve the desired state. This command results in a full snapshot of the\n" +
-			"stack's new resource state, so that it may be updated incrementally again later.\n" +
+			"This command updates an existing stack whose state is represented by the existing checkpoint\n" +
+			"file. The new desired state is computed by running a Pulumi program, and extracting all resource\n" +
+			"allocations from its resulting object graph. These allocations are then compared against the\n" +
+			"existing state to determine what operations must take place to achieve the desired state. This\n" +
+			"command results in a checkpoint containing a full snapshot of the stack's new resource state, so\n" +
+			"that it may be updated incrementally again later.\n" +
 			"\n" +
-			"The package to execute is loaded from the current directory. Use the `-C` or `--cwd` flag to\n" +
-			"use a different directory.",
+			"The program to run is loaded from the project in the current directory. Use the `-C` or\n" +
+			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			s, err := requireStack(tokens.QName(stack))
 			if err != nil {
 				return err
 			}
-			pkg, root, err := readPackage()
+			proj, root, err := readProject()
 			if err != nil {
 				return err
 			}
@@ -60,7 +60,7 @@ func newUpdateCmd() *cobra.Command {
 				return errors.Wrap(err, "gathering environment metadata")
 			}
 
-			return s.Update(pkg, root, debug, m, engine.UpdateOptions{
+			return s.Update(proj, root, debug, m, engine.UpdateOptions{
 				Analyzers:            analyzers,
 				DryRun:               preview,
 				Parallel:             parallel,

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // Backend is an interface that represents actions the engine will interact with to manage stacks of cloud resources.
@@ -34,13 +34,13 @@ type Backend interface {
 	GetStackCrypter(stack tokens.QName) (config.Crypter, error)
 
 	// Preview initiates a preview of the current workspace's contents.
-	Preview(stackName tokens.QName, pkg *pack.Package, root string,
+	Preview(stackName tokens.QName, proj *workspace.Project, root string,
 		debug bool, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 	// Update updates the target stack with the current workspace's contents (config and code).
-	Update(stackName tokens.QName, pkg *pack.Package, root string,
+	Update(stackName tokens.QName, proj *workspace.Project, root string,
 		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 	// Destroy destroys all of this stack's resources.
-	Destroy(stackName tokens.QName, pkg *pack.Package, root string,
+	Destroy(stackName tokens.QName, proj *workspace.Project, root string,
 		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 
 	// GetHistory returns all updates for the stack. The returned UpdateInfo slice will be in

--- a/pkg/backend/cloud/context.go
+++ b/pkg/backend/cloud/context.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/util/fsutil"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // getContextAndMain computes the root path of the archive as well as the relative path (from the archive root)
@@ -20,19 +20,19 @@ import (
 // 2. We need to change "main" which was relative to the project root to be relative to the archive root.
 //
 // Note that the relative paths in Pulumi.yaml for Context and Main are always unix style paths, but the returned
-// context is an absolute path, using file system specific seperators. We continue to use a unix style partial path
-// for Main,
-func getContextAndMain(pkg *pack.Package, projectRoot string) (string, string, error) {
+// context is an absolute path, using file system specific seperators.  We continue use a unix style partial path for
+// Main.
+func getContextAndMain(proj *workspace.Project, projectRoot string) (string, string, error) {
 	context, err := filepath.Abs(projectRoot)
 	if err != nil {
 		return "", "", err
 	}
 
-	main := pkg.Main
+	main := proj.Main
 
-	if pkg.Context != "" {
+	if proj.Context != "" {
 		context, err = filepath.Abs(filepath.Join(context,
-			strings.Replace(pkg.Context, "/", string(filepath.Separator), -1)))
+			strings.Replace(proj.Context, "/", string(filepath.Separator), -1)))
 		if err != nil {
 			return "", "", err
 		}

--- a/pkg/backend/cloud/context_test.go
+++ b/pkg/backend/cloud/context_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -19,7 +19,7 @@ func TestNoRootNoMain(t *testing.T) {
 		contract.IgnoreError(os.RemoveAll(dir))
 	}()
 
-	context, main, err := getContextAndMain(&pack.Package{}, dir)
+	context, main, err := getContextAndMain(&workspace.Project{}, dir)
 	assert.NoError(t, err)
 	assert.Equal(t, dir, context)
 	assert.Equal(t, "", main)
@@ -31,12 +31,12 @@ func TestNoRootMain(t *testing.T) {
 		contract.IgnoreError(os.RemoveAll(dir))
 	}()
 
-	testPkg := pack.Package{Main: "foo/bar/baz/"}
+	testProj := workspace.Project{Main: "foo/bar/baz/"}
 
-	context, main, err := getContextAndMain(&testPkg, dir)
+	context, main, err := getContextAndMain(&testProj, dir)
 	assert.NoError(t, err)
 	assert.Equal(t, dir, context)
-	assert.Equal(t, testPkg.Main, main)
+	assert.Equal(t, testProj.Main, main)
 }
 
 func TestRootNoMain(t *testing.T) {
@@ -49,11 +49,11 @@ func TestRootNoMain(t *testing.T) {
 	err := os.MkdirAll(sub, 0700)
 	assert.NoError(t, err, "error creating test directory")
 
-	testPkg := pack.Package{
+	testProj := workspace.Project{
 		Context: "../../../",
 	}
 
-	context, main, err := getContextAndMain(&testPkg, sub)
+	context, main, err := getContextAndMain(&testProj, sub)
 	assert.NoError(t, err)
 	assert.Equal(t, dir, context)
 	assert.Equal(t, "sub1/sub2/sub3/", main)
@@ -69,12 +69,12 @@ func TestRootMain(t *testing.T) {
 	err := os.MkdirAll(sub, 0700)
 	assert.NoError(t, err, "error creating test directory")
 
-	testPkg := pack.Package{
+	testProj := workspace.Project{
 		Context: "../../../",
 		Main:    "sub4/",
 	}
 
-	context, main, err := getContextAndMain(&testPkg, filepath.Dir(sub))
+	context, main, err := getContextAndMain(&testProj, filepath.Dir(sub))
 	assert.NoError(t, err)
 	assert.Equal(t, dir, context)
 	assert.Equal(t, "sub1/sub2/sub3/sub4/", main)
@@ -88,11 +88,11 @@ func TestBadContext(t *testing.T) {
 		contract.IgnoreError(os.RemoveAll(bad))
 	}()
 
-	testPkg := pack.Package{
+	testProj := workspace.Project{
 		Context: bad,
 	}
 
-	_, _, err := getContextAndMain(&testPkg, dir)
+	_, _, err := getContextAndMain(&testProj, dir)
 
 	assert.Error(t, err)
 }

--- a/pkg/backend/cloud/stack.go
+++ b/pkg/backend/cloud/stack.go
@@ -9,11 +9,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // Stack is a cloud stack.  This simply adds some cloud-specific properties atop the standard backend stack interface.
@@ -79,19 +79,19 @@ func (s *cloudStack) Remove(force bool) (bool, error) {
 	return backend.RemoveStack(s, force)
 }
 
-func (s *cloudStack) Preview(pkg *pack.Package, root string,
+func (s *cloudStack) Preview(proj *workspace.Project, root string,
 	debug bool, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
-	return backend.PreviewStack(s, pkg, root, debug, opts, displayOpts)
+	return backend.PreviewStack(s, proj, root, debug, opts, displayOpts)
 }
 
-func (s *cloudStack) Update(pkg *pack.Package, root string,
+func (s *cloudStack) Update(proj *workspace.Project, root string,
 	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
-	return backend.UpdateStack(s, pkg, root, debug, m, opts, displayOpts)
+	return backend.UpdateStack(s, proj, root, debug, m, opts, displayOpts)
 }
 
-func (s *cloudStack) Destroy(pkg *pack.Package, root string,
+func (s *cloudStack) Destroy(proj *workspace.Project, root string,
 	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
-	return backend.DestroyStack(s, pkg, root, debug, m, opts, displayOpts)
+	return backend.DestroyStack(s, proj, root, debug, m, opts, displayOpts)
 }
 
 func (s *cloudStack) GetLogs(query operations.LogQuery) ([]operations.LogEntry, error) {

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/encoding"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -104,10 +103,10 @@ func (b *localBackend) GetStackCrypter(stackName tokens.QName) (config.Crypter, 
 	return symmetricCrypter(stackName)
 }
 
-func (b *localBackend) Preview(stackName tokens.QName, pkg *pack.Package, root string, debug bool,
+func (b *localBackend) Preview(stackName tokens.QName, proj *workspace.Project, root string, debug bool,
 	opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
-	update, err := b.newUpdate(stackName, pkg, root)
+	update, err := b.newUpdate(stackName, proj, root)
 	if err != nil {
 		return err
 	}
@@ -127,10 +126,10 @@ func (b *localBackend) Preview(stackName tokens.QName, pkg *pack.Package, root s
 	return nil
 }
 
-func (b *localBackend) Update(stackName tokens.QName, pkg *pack.Package, root string,
+func (b *localBackend) Update(stackName tokens.QName, proj *workspace.Project, root string,
 	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
-	update, err := b.newUpdate(stackName, pkg, root)
+	update, err := b.newUpdate(stackName, proj, root)
 	if err != nil {
 		return err
 	}
@@ -176,10 +175,10 @@ func (b *localBackend) Update(stackName tokens.QName, pkg *pack.Package, root st
 	return errors.Wrap(saveErr, "saving update info")
 }
 
-func (b *localBackend) Destroy(stackName tokens.QName, pkg *pack.Package, root string,
+func (b *localBackend) Destroy(stackName tokens.QName, proj *workspace.Project, root string,
 	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
-	update, err := b.newUpdate(stackName, pkg, root)
+	update, err := b.newUpdate(stackName, proj, root)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/local/stack.go
+++ b/pkg/backend/local/stack.go
@@ -8,10 +8,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // Stack is a local stack.  This simply adds some local-specific properties atop the standard backend stack interface.
@@ -50,19 +50,19 @@ func (s *localStack) Remove(force bool) (bool, error) {
 	return backend.RemoveStack(s, force)
 }
 
-func (s *localStack) Preview(pkg *pack.Package, root string,
+func (s *localStack) Preview(proj *workspace.Project, root string,
 	debug bool, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
-	return backend.PreviewStack(s, pkg, root, debug, opts, displayOpts)
+	return backend.PreviewStack(s, proj, root, debug, opts, displayOpts)
 }
 
-func (s *localStack) Update(pkg *pack.Package, root string,
+func (s *localStack) Update(proj *workspace.Project, root string,
 	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
-	return backend.UpdateStack(s, pkg, root, debug, m, opts, displayOpts)
+	return backend.UpdateStack(s, proj, root, debug, m, opts, displayOpts)
 }
 
-func (s *localStack) Destroy(pkg *pack.Package, root string,
+func (s *localStack) Destroy(proj *workspace.Project, root string,
 	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
-	return backend.DestroyStack(s, pkg, root, debug, m, opts, displayOpts)
+	return backend.DestroyStack(s, proj, root, debug, m, opts, displayOpts)
 }
 
 func (s *localStack) GetLogs(query operations.LogQuery) ([]operations.LogEntry, error) {

--- a/pkg/backend/local/state.go
+++ b/pkg/backend/local/state.go
@@ -19,7 +19,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/state"
 	"github.com/pulumi/pulumi/pkg/encoding"
 	"github.com/pulumi/pulumi/pkg/engine"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
@@ -37,7 +36,7 @@ var DisableIntegrityChecking bool
 // update is an implementation of engine.Update backed by local state.
 type update struct {
 	root   string
-	pkg    *pack.Package
+	proj   *workspace.Project
 	target *deploy.Target
 }
 
@@ -45,8 +44,8 @@ func (u *update) GetRoot() string {
 	return u.root
 }
 
-func (u *update) GetPackage() *pack.Package {
-	return u.pkg
+func (u *update) GetProject() *workspace.Project {
+	return u.proj
 }
 
 func (u *update) GetTarget() *deploy.Target {
@@ -73,7 +72,7 @@ func (m *localStackMutation) End(snapshot *deploy.Snapshot) error {
 	return saveStack(stack, config, snapshot)
 }
 
-func (b *localBackend) newUpdate(stackName tokens.QName, pkg *pack.Package, root string) (*update, error) {
+func (b *localBackend) newUpdate(stackName tokens.QName, proj *workspace.Project, root string) (*update, error) {
 	contract.Require(stackName != "", "stackName")
 
 	// Construct the deployment target.
@@ -85,7 +84,7 @@ func (b *localBackend) newUpdate(stackName tokens.QName, pkg *pack.Package, root
 	// Construct and return a new update.
 	return &update{
 		root:   root,
-		pkg:    pkg,
+		proj:   proj,
 		target: target,
 	}, nil
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -7,10 +7,10 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // Stack is a stack associated with a particular backend implementation.
@@ -21,13 +21,13 @@ type Stack interface {
 	Backend() Backend           // the backend this stack belongs to.
 
 	// Preview changes to this stack.
-	Preview(pkg *pack.Package, root string,
+	Preview(proj *workspace.Project, root string,
 		debug bool, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 	// Update this stack.
-	Update(pkg *pack.Package, root string,
+	Update(proj *workspace.Project, root string,
 		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 	// Destroy this stack's resources.
-	Destroy(pkg *pack.Package, root string,
+	Destroy(proj *workspace.Project, root string,
 		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 
 	Remove(force bool) (bool, error)                                  // remove this stack.
@@ -42,21 +42,21 @@ func RemoveStack(s Stack, force bool) (bool, error) {
 }
 
 // PreviewStack initiates a preview of the current workspace's contents.
-func PreviewStack(s Stack, pkg *pack.Package, root string,
+func PreviewStack(s Stack, proj *workspace.Project, root string,
 	debug bool, opts engine.UpdateOptions, displayOpts DisplayOptions) error {
-	return s.Backend().Preview(s.Name(), pkg, root, debug, opts, displayOpts)
+	return s.Backend().Preview(s.Name(), proj, root, debug, opts, displayOpts)
 }
 
 // UpdateStack updates the target stack with the current workspace's contents (config and code).
-func UpdateStack(s Stack, pkg *pack.Package, root string,
+func UpdateStack(s Stack, proj *workspace.Project, root string,
 	debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error {
-	return s.Backend().Update(s.Name(), pkg, root, debug, m, opts, displayOpts)
+	return s.Backend().Update(s.Name(), proj, root, debug, m, opts, displayOpts)
 }
 
 // DestroyStack destroys all of this stack's resources.
-func DestroyStack(s Stack, pkg *pack.Package, root string,
+func DestroyStack(s Stack, proj *workspace.Project, root string,
 	debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error {
-	return s.Backend().Destroy(s.Name(), pkg, root, debug, m, opts, displayOpts)
+	return s.Backend().Destroy(s.Name(), proj, root, debug, m, opts, displayOpts)
 }
 
 // GetStackCrypter fetches the encrypter/decrypter for a stack.

--- a/pkg/backend/state/config.go
+++ b/pkg/backend/state/config.go
@@ -23,7 +23,7 @@ func Configuration(d diag.Sink, stackName tokens.QName) (config.Map, error) {
 	if err != nil {
 		return nil, err
 	}
-	pkg, err := workspace.GetPackage()
+	proj, err := workspace.DetectProject()
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func Configuration(d diag.Sink, stackName tokens.QName) (config.Map, error) {
 	var workspaceConfigKeys []string
 
 	// First, apply project-local stack-specific configuration.
-	if stack, has := pkg.Stacks[stackName]; has {
+	if stack, has := proj.Stacks[stackName]; has {
 		for key, value := range stack.Config {
 			result[key] = value
 		}
@@ -52,7 +52,7 @@ func Configuration(d diag.Sink, stackName tokens.QName) (config.Map, error) {
 	}
 
 	// Next, take anything from the global settings in our project file.
-	for key, value := range pkg.Config {
+	for key, value := range proj.Config {
 		if _, has := result[key]; !has {
 			result[key] = value
 		}

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -3,8 +3,8 @@
 package engine
 
 import (
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // Update abstracts away information about an apply, preview, or destroy.
@@ -12,9 +12,9 @@ type Update interface {
 	// GetRoot returns the root directory for this update. This defines the scope for any filesystem resources
 	// accessed by this update.
 	GetRoot() string
-	// GetPackage returns information about the package associated with this update. This includes information such as
+	// GetProject returns information about the project associated with this update. This includes information such as
 	// the runtime that will be used to execute the Pulumi program and the program's relative working directory.
-	GetPackage() *pack.Package
+	GetProject() *workspace.Project
 	// GetTarget returns information about the target of this update. This includes the name of the stack being
 	// updated, the configuration values associated with the target and the target's latest snapshot.
 	GetTarget() *deploy.Target

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -30,13 +30,13 @@ func plan(info *planContext, opts deployOptions) (*planResult, error) {
 
 	// First, load the package metadata and the deployment target in preparation for executing the package's program
 	// and creating resources.
-	pkg, target := info.Update.GetPackage(), info.Update.GetTarget()
-	contract.Assert(pkg != nil)
+	proj, target := info.Update.GetProject(), info.Update.GetTarget()
+	contract.Assert(proj != nil)
 	contract.Assert(target != nil)
 
 	// If the package contains an override for the main entrypoint, use it.
-	pkginfo := &Pkginfo{Pkg: pkg, Root: info.Update.GetRoot()}
-	pwd, main, err := pkginfo.GetPwdMain()
+	projinfo := &Projinfo{Proj: proj, Root: info.Update.GetRoot()}
+	pwd, main, err := projinfo.GetPwdMain()
 	if err != nil {
 		return nil, err
 	}
@@ -50,7 +50,7 @@ func plan(info *planContext, opts deployOptions) (*planResult, error) {
 	// If that succeeded, create a new source that will perform interpretation of the compiled program.
 	// TODO[pulumi/pulumi#88]: we are passing `nil` as the arguments map; we need to allow a way to pass these.
 	source := deploy.NewEvalSource(ctx, &deploy.EvalRunInfo{
-		Pkg:     pkginfo.Pkg,
+		Proj:    projinfo.Proj,
 		Pwd:     pwd,
 		Program: main,
 		Target:  target,
@@ -58,7 +58,7 @@ func plan(info *planContext, opts deployOptions) (*planResult, error) {
 
 	// If there are any analyzers in the project file, add them.
 	var analyzers []tokens.QName
-	if as := pkginfo.Pkg.Analyzers; as != nil {
+	if as := projinfo.Proj.Analyzers; as != nil {
 		for _, a := range *as {
 			analyzers = append(analyzers, a)
 		}

--- a/pkg/engine/project.go
+++ b/pkg/engine/project.go
@@ -10,18 +10,18 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/pulumi/pulumi/pkg/pack"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
-type Pkginfo struct {
-	Pkg  *pack.Package
+type Projinfo struct {
+	Proj *workspace.Project
 	Root string
 }
 
 // GetPwdMain returns the working directory and main entrypoint to use for this package.
-func (pkginfo *Pkginfo) GetPwdMain() (string, string, error) {
-	pwd := pkginfo.Root
-	main := pkginfo.Pkg.Main
+func (projinfo *Projinfo) GetPwdMain() (string, string, error) {
+	pwd := projinfo.Root
+	main := projinfo.Proj.Main
 	if main != "" {
 		// The path must be relative from the package root.
 		if filepath.IsAbs(main) {

--- a/pkg/resource/deploy/plan_apply.go
+++ b/pkg/resource/deploy/plan_apply.go
@@ -266,7 +266,7 @@ func (iter *PlanIterator) makeRegisterResouceSteps(e RegisterResourceEvent) ([]S
 		parentType = res.Parent.QualifiedType()
 	}
 
-	urn := resource.NewURN(iter.p.Target().Name, iter.p.source.Pkg(), parentType, res.Type, res.Name)
+	urn := resource.NewURN(iter.p.Target().Name, iter.p.source.Project(), parentType, res.Type, res.Name)
 	if iter.urns[urn] {
 		invalid = true
 		// TODO[pulumi/pulumi-framework#19]: improve this error message!

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -83,7 +83,7 @@ func (src *errorSource) Close() error {
 	return nil // nothing to do.
 }
 
-func (src *errorSource) Pkg() tokens.PackageName {
+func (src *errorSource) Project() tokens.PackageName {
 	return ""
 }
 

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -12,8 +12,8 @@ import (
 // A Source can generate a new set of resources that the planner will process accordingly.
 type Source interface {
 	io.Closer
-	// Pkg returns the package name of the Pulumi program we are obtaining resources from.
-	Pkg() tokens.PackageName
+	// Project returns the package name of the Pulumi project we are obtaining resources from.
+	Project() tokens.PackageName
 	// Info returns a serializable payload that can be used to stamp snapshots for future reconciliation.
 	Info() interface{}
 	// Iterate begins iterating the source.  Error is non-nil upon failure; otherwise, a valid iterator is returned.

--- a/pkg/resource/deploy/source_fixed.go
+++ b/pkg/resource/deploy/source_fixed.go
@@ -21,7 +21,7 @@ func (src *fixedSource) Close() error {
 	return nil // nothing to do.
 }
 
-func (src *fixedSource) Pkg() tokens.PackageName {
+func (src *fixedSource) Project() tokens.PackageName {
 	return src.ctx
 }
 

--- a/pkg/resource/deploy/source_null.go
+++ b/pkg/resource/deploy/source_null.go
@@ -18,7 +18,7 @@ func (src *nullSource) Close() error {
 	return nil // nothing to do.
 }
 
-func (src *nullSource) Pkg() tokens.PackageName {
+func (src *nullSource) Project() tokens.PackageName {
 	return ""
 }
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/engine"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
@@ -803,12 +802,12 @@ func (pt *programTester) prepareProject(projectDir string) error {
 
 	// Load up the package so we can run Yarn in the correct location.
 	projfile := filepath.Join(projectDir, workspace.ProjectFile+".yaml")
-	pkg, err := pack.Load(projfile)
+	proj, err := workspace.LoadProject(projfile)
 	if err != nil {
 		return err
 	}
-	pkginfo := &engine.Pkginfo{Pkg: pkg, Root: projectDir}
-	cwd, _, err := pkginfo.GetPwdMain()
+	projinfo := &engine.Projinfo{Proj: proj, Root: projectDir}
+	cwd, _, err := projinfo.GetPwdMain()
 	if err != nil {
 		return err
 	}

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/encoding"
-	"github.com/pulumi/pulumi/pkg/pack"
 	"github.com/pulumi/pulumi/pkg/util/fsutil"
 )
 
@@ -25,57 +24,58 @@ const ConfigDir = "config"             // the name of the folder that holds loca
 const WorkspaceFile = "workspace.json" // the name of the file that holds workspace information.
 const IgnoreFile = ".pulumiignore"     // the name of the file that we use to control what to upload to the service.
 
-// DetectPackage locates the closest package from the current working directory, or an error if not found.
-func DetectPackage() (string, error) {
+// DetectProjectPath locates the closest project from the current working directory, or an error if not found.
+func DetectProjectPath() (string, error) {
 	dir, err := os.Getwd()
 	if err != nil {
 		return "", err
 	}
 
-	pkgPath, err := DetectPackageFrom(dir)
+	path, err := DetectProjectPathFrom(dir)
 	if err != nil {
 		return "", err
 	}
 
-	return pkgPath, nil
+	return path, nil
 }
 
-// DetectPackageFrom locates the closest package from the given path, searching "upwards" in the directory hierarchy.
-// If no Project is found, an empty path is returned.  If problems are detected, they are logged to the diag.Sink.
-func DetectPackageFrom(path string) (string, error) {
+// DetectProjectPathFrom locates the closest project from the given path, searching "upwards" in the directory
+// hierarchy.  If no project is found, an empty path is returned.  If problems are detected, they are logged to
+// the diag.Sink.
+func DetectProjectPathFrom(path string) (string, error) {
 	return fsutil.WalkUp(path, isProject, func(s string) bool {
 		return !isRepositoryFolder(filepath.Join(s, BookkeepingDir))
 	})
 }
 
-// GetPackage loads the closest package from the current working directory, or an error if not found.
-func GetPackage() (*pack.Package, error) {
-	pkg, _, err := GetPackagePath()
-	return pkg, err
+// DetectProject loads the closest project from the current working directory, or an error if not found.
+func DetectProject() (*Project, error) {
+	proj, _, err := DetectProjectAndPath()
+	return proj, err
 }
 
-// GetPackagePath loads the closest package from the current working directory, or an error if not found.  It
+// DetectProjectAndPath loads the closest package from the current working directory, or an error if not found.  It
 // also returns the path where the package was found.
-func GetPackagePath() (*pack.Package, string, error) {
-	pkgPath, err := DetectPackage()
+func DetectProjectAndPath() (*Project, string, error) {
+	path, err := DetectProjectPath()
 	if err != nil {
 		return nil, "", err
-	} else if pkgPath == "" {
+	} else if path == "" {
 		return nil, "", errors.Errorf("no Pulumi project found in the current working directory")
 	}
 
-	pkg, err := pack.Load(pkgPath)
-	return pkg, pkgPath, err
+	proj, err := LoadProject(path)
+	return proj, path, err
 }
 
-// SavePackage saves the package file on top of the existing one.
-func SavePackage(pkg *pack.Package) error {
-	pkgPath, err := DetectPackage()
+// SaveProject saves the project file on top of the existing one, using the standard location.
+func SaveProject(proj *Project) error {
+	path, err := DetectProjectPath()
 	if err != nil {
 		return err
 	}
 
-	return pack.Save(pkgPath, pkg)
+	return proj.Save(path)
 }
 
 func isGitFolder(path string) bool {

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -1,7 +1,6 @@
 // Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
 
-// Package pack contains the core LumiPack metadata types.
-package pack
+package workspace
 
 import (
 	"io/ioutil"
@@ -16,7 +15,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 )
 
-// Package is a top-level package definition.
+// Analyzers is a list of analyzers to run on this project.
+type Analyzers []tokens.QName
+
+// Project is a Pulumi project manifest..
 //
 // We explicitly add yaml tags (instead of using the default behavior from https://github.com/ghodss/yaml which works
 // in terms of the JSON tags) so we can directly marshall and unmarshall this struct using go-yaml an have the fields
@@ -24,7 +26,7 @@ import (
 //
 // TODO[pulumi/pulumi#423]: use DOM based marshalling so we can roundtrip the seralized structure perfectly.
 // nolint: lll
-type Package struct {
+type Project struct {
 	Name    tokens.PackageName `json:"name" yaml:"name"`                     // a required fully qualified name.
 	Runtime string             `json:"runtime" yaml:"runtime"`               // a required runtime that executes code.
 	Main    string             `json:"main,omitempty" yaml:"main,omitempty"` // an optional override for the main program location.
@@ -32,7 +34,7 @@ type Package struct {
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"` // an optional informational description.
 	Author      *string `json:"author,omitempty" yaml:"author,omitempty"`           // an optional author.
 	Website     *string `json:"website,omitempty" yaml:"website,omitempty"`         // an optional website for additional info.
-	License     *string `json:"license,omitempty" yaml:"license,omitempty"`         // an optional license governing this package's usage.
+	License     *string `json:"license,omitempty" yaml:"license,omitempty"`         // an optional license governing this project's usage.
 
 	Analyzers *Analyzers `json:"analyzers,omitempty" yaml:"analyzers,omitempty"` // any analyzers enabled for this project.
 
@@ -42,45 +44,67 @@ type Package struct {
 
 	Config map[tokens.ModuleMember]config.Value `json:"config,omitempty" yaml:"config,omitempty"` // optional config (applies to all stacks).
 
-	Stacks map[tokens.QName]StackInfo `json:"stacks,omitempty" yaml:"stacks,omitempty"` // optional stack specific information.
+	Stacks map[tokens.QName]ProjectStack `json:"stacks,omitempty" yaml:"stacks,omitempty"` // optional stack specific information.
 }
 
-// StackInfo holds stack specific information about a package
+func (proj *Project) Validate() error {
+	if proj.Name == "" {
+		return errors.New("project is missing a 'name' attribute")
+	}
+	if proj.Runtime == "" {
+		return errors.New("project is missing a 'runtime' attribute")
+	}
+	return nil
+}
+
+func (proj *Project) UseDefaultIgnores() bool {
+	if proj.NoDefaultIgnores == nil {
+		return true
+	}
+
+	return !(*proj.NoDefaultIgnores)
+}
+
+// Save writes a project defitiniton to a file.
+func (proj *Project) Save(path string) error {
+	contract.Require(path != "", "path")
+	contract.Require(proj != nil, "proj")
+	contract.Requiref(proj.Validate() == nil, "proj", "Validate()")
+
+	for name, info := range proj.Stacks {
+		if info.IsEmpty() {
+			delete(proj.Stacks, name)
+		}
+	}
+
+	m, err := marshallerForPath(path)
+	if err != nil {
+		return err
+	}
+
+	b, err := m.Marshal(proj)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, b, 0644)
+}
+
+// ProjectStack holds stack specific information about a project.
 // nolint: lll
-type StackInfo struct {
+type ProjectStack struct {
 	EncryptionSalt string     `json:"encryptionsalt,omitempty" yaml:"encryptionsalt,omitempty"` // base64 encoded encryption salt.
 	Config         config.Map `json:"config,omitempty" yaml:"config,omitempty"`                 // optional config.
 }
 
 // IsEmpty returns True if this object contains no information (i.e. all members have their zero values)
-func (s *StackInfo) IsEmpty() bool {
+func (s *ProjectStack) IsEmpty() bool {
 	return len(s.Config) == 0 && s.EncryptionSalt == ""
 }
 
-func (pkg *Package) Validate() error {
-	if pkg.Name == "" {
-		return errors.New("package is missing a 'name' attribute")
-	}
-	if pkg.Runtime == "" {
-		return errors.New("package is missing a 'runtime' attribute")
-	}
-	return nil
-}
-
-func (pkg *Package) UseDefaultIgnores() bool {
-	if pkg.NoDefaultIgnores == nil {
-		return true
-	}
-
-	return !(*pkg.NoDefaultIgnores)
-}
-
-// Analyzers is a list of analyzers to run on this project.
-type Analyzers []tokens.QName
-
-// Load reads a package definition from a file
-func Load(path string) (*Package, error) {
-	contract.Require(path != "", "pkg")
+// LoadProject reads a project definition from a file.
+func LoadProject(path string) (*Project, error) {
+	contract.Require(path != "", "proj")
 
 	m, err := marshallerForPath(path)
 	if err != nil {
@@ -92,43 +116,18 @@ func Load(path string) (*Package, error) {
 		return nil, err
 	}
 
-	var pkg Package
-	err = m.Unmarshal(b, &pkg)
+	var proj Project
+	err = m.Unmarshal(b, &proj)
 	if err != nil {
 		return nil, err
 	}
 
-	err = pkg.Validate()
+	err = proj.Validate()
 	if err != nil {
 		return nil, err
 	}
 
-	return &pkg, err
-}
-
-// Save writes a package defitiniton to a file
-func Save(path string, pkg *Package) error {
-	contract.Require(path != "", "pkg")
-	contract.Require(pkg != nil, "pkg")
-	contract.Requiref(pkg.Validate() == nil, "pkg", "Validate()")
-
-	for name, info := range pkg.Stacks {
-		if info.IsEmpty() {
-			delete(pkg.Stacks, name)
-		}
-	}
-
-	m, err := marshallerForPath(path)
-	if err != nil {
-		return err
-	}
-
-	b, err := m.Marshal(pkg)
-	if err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(path, b, 0644)
+	return &proj, err
 }
 
 func marshallerForPath(path string) (encoding.Marshaler, error) {


### PR DESCRIPTION
This addresses pulumi/pulumi#446: what we used to call "package" is
now called "project".  This has gotten more confusing over time, now
that we're doing real package management.

Also fixes pulumi/pulumi#426, while in here.