### PR TITLE
Cleanup provider launch scripts and fix some windows build oddities

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,7 +30,9 @@ install:
 
     set PATH=%PATH%;%GOPATH%\bin
 
-    set PATH=%USERPROFILE%\go\src\github.com\pulumi\pulumi\sdk\nodejs\bin;%PATH%
+    set PulumiRoot=C:\Pulumi
+
+    set PATH=%PulumiRoot%\bin;%PATH%
 
     go version
 

--- a/build.proj
+++ b/build.proj
@@ -9,6 +9,8 @@
     <NodeArch>x64</NodeArch>
     <TestParallelism>10</TestParallelism>
     <MSVSVersion>2017</MSVSVersion>
+    <PulumiRoot Condition="'$(PulumiRoot)' == ''">C:\Pulumi\</PulumiRoot>
+    <PulumiBin>$(PulumiRoot)\bin</PulumiBin>
   </PropertyGroup>
  
   <Target Name="EnsureGoDependencies">
@@ -50,7 +52,8 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="Version" />
     </Exec>
 
-    <Exec Command="go install -ldflags &quot;-X main.version=$(Version)&quot; %(GoPackagesToBuild.Identity)" />
+    <Exec Command="go install -ldflags &quot;-X github.com/pulumi/pulumi/pkg/version.Version=$(Version)&quot; %(GoPackagesToBuild.Identity)"
+          EnvironmentVariables="GOBIN=$(PulumiBin)"/>
   </Target>
 
   <Target Name="BinplaceNodeSdkProtos">
@@ -80,9 +83,12 @@
 
   <Target Name="BinPlaceNodeSdk"
           DependsOnTargets="BinPlaceNodeSdkProtos;BinPlaceNodeSdkTestData;YarnLinkSdk">
+    <Copy SourceFiles="$(NodeJSSdkDirectory)\custom_node\node\node.exe" DestinationFiles="$(PulumiBin)\pulumi-langhost-nodejs-node.exe" />
+    <Copy SourceFiles="$(NodeJSSdkDirectory)\pulumi-langhost-nodejs-exec.cmd" DestinationFolder="$(PulumiBin)" />
+    <Copy SourceFiles="$(NodeJSSdkDirectory)\pulumi-provider-pulumi-nodejs.cmd" DestinationFolder="$(PulumiBin)" />
   </Target>
 
-    <Target Name="BuildNodeSdk"
+  <Target Name="BuildNodeSdk"
           DependsOnTargets="CopyNodeSdkProtos;TypeScriptCompileNodeSdk;GoCompileNodeSdk;BinPlaceNodeSdk">
   </Target>
 
@@ -95,7 +101,8 @@
       <Output TaskParameter="ConsoleOutput" PropertyName="Version" />
     </Exec>
 
-    <Exec Command="go install -ldflags &quot;-X main.version=$(Version)&quot; %(GoCmdsToBuild.Identity)" />
+    <Exec Command="go install -ldflags &quot;-X github.com/pulumi/pulumi/pkg/version.Version=$(Version)&quot; %(GoCmdsToBuild.Identity)"
+          EnvironmentVariables="GOBIN=$(PulumiBin)"/>
   </Target>
 
   <Target Name="Build"
@@ -113,7 +120,7 @@
       <Output TaskParameter="ExitCode" PropertyName="WhereLangHostExitCode" />
     </Exec>
 
-    <Error Text="Please add &quot;$(NodeJSSdkDirectory)\bin&quot; to your path before running integration tests."
+    <Error Text="Please add &quot;$(PulumiRoot)\bin&quot; to your path before running integration tests."
            Condition="$(WhereLangHostExitCode) != 0 Or $(WhereLangHostExecExitCode) != 0"/>
 
     <!-- Ignore the exit code (but retain it) so we can kill all the lingering node processes even when go test

--- a/dist/sdk/nodejs/.gitattributes
+++ b/dist/sdk/nodejs/.gitattributes
@@ -1,1 +1,0 @@
-*.cmd text eol=crlf

--- a/dist/sdk/nodejs/pulumi-langhost-nodejs-exec.cmd
+++ b/dist/sdk/nodejs/pulumi-langhost-nodejs-exec.cmd
@@ -1,1 +1,0 @@
-@"%~dp0\node\node.exe" -e "require(\"pulumi/cmd/run\")" dummy_argument %*

--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -31,11 +31,9 @@ RunGoBuild "github.com/pulumi/pulumi"
 RunGoBuild "github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-langhost-nodejs"
 CopyPackage "$Root\sdk\nodejs\bin" "pulumi"
 
-Copy-Item "$Root\dist\sdk\nodejs\pulumi-langhost-nodejs-exec.cmd" "$PublishDir\bin"
+Copy-Item "$Root\sdk\nodejs\pulumi-langhost-nodejs-exec.cmd" "$PublishDir\bin"
+Copy-Item "$Root\sdk\nodejs\pulumi-provider-pulumi-nodejs.cmd" "$PublishDir\bin"
 Copy-Item "$Root\sdk\nodejs\custom_node\node\node.exe" "$PublishDir\bin\pulumi-langhost-nodejs-node.exe"
-
-Remove-Item "$PublishDir\node_modules\pulumi\pulumi-langhost-nodejs-exec.cmd"
-Remove-Item "$PublishDir\node_modules\pulumi\pulumi-provider-pulumi-nodejs.cmd"
 
 # By default, if the archive already exists, 7zip will just add files to it, so blow away the existing
 # archive if it exists.

--- a/sdk/nodejs/bin/pulumi-langhost-nodejs-exec.cmd
+++ b/sdk/nodejs/bin/pulumi-langhost-nodejs-exec.cmd
@@ -1,5 +1,0 @@
-@echo off
-REM We depend on a custom node build that has exposed some internal state
-REM This node is downloaded and extracted via the EnsureCustomNode target
-REM in the root build.proj
-"%~dp0..\custom_node\node\node.exe" "./node_modules/@pulumi/pulumi/cmd/run" %*

--- a/sdk/nodejs/bin/pulumi-provider-pulumi-nodejs.cmd
+++ b/sdk/nodejs/bin/pulumi-provider-pulumi-nodejs.cmd
@@ -1,7 +1,0 @@
-@echo off
-SET REQUIRE_ROOT=%~dp0
-SET REQUIRE_ROOT=%REQUIRE_ROOT:\=/%
-REM We depend on a custom node build that has exposed some internal state
-REM This node is downloaded and extracted via the EnsureCustomNode target
-REM in the root build.proj
-"%~dp0..\custom_node\node\node.exe" "%REQUIRE_ROOT%./cmd/dynamic-provider" %*

--- a/sdk/nodejs/pulumi-langhost-nodejs-exec.cmd
+++ b/sdk/nodejs/pulumi-langhost-nodejs-exec.cmd
@@ -1,0 +1,1 @@
+@pulumi-langhost-nodejs-node.exe ./node_modules/@pulumi/pulumi/cmd/run %*

--- a/sdk/nodejs/pulumi-provider-pulumi-nodejs
+++ b/sdk/nodejs/pulumi-provider-pulumi-nodejs
@@ -1,3 +1,2 @@
 #!/bin/sh
-SDK_DIR=`dirname $0`/../node_modules
-pulumi-langhost-nodejs-node "$SDK_DIR/@pulumi/pulumi/cmd/dynamic-provider" $@
+pulumi-langhost-nodejs-node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider $@

--- a/sdk/nodejs/pulumi-provider-pulumi-nodejs.cmd
+++ b/sdk/nodejs/pulumi-provider-pulumi-nodejs.cmd
@@ -1,0 +1,1 @@
+@pulumi-langhost-nodejs-node.exe ./node_modules/@pulumi/pulumi/cmd/dynamic-provider %*


### PR DESCRIPTION
The windows build was still on the old plan from way back when where
we had binaries littered in the build tree and you had to add parts of
your build-tree to the `%PATH%` for the integration tests to work.

This cleans that up and moves all of our scripts that invoke
javascript to be on the same plan. They invoke our specially named
node with a relative path to the JS code we want to run.