### PR TITLE
Do a better job of uploading failed test artifacts to S3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ script:
     - make travis_${TRAVIS_EVENT_TYPE} TEST_FAST_TIMEOUT=10m
 after_failure:
     # Copy any data from failed tests to S3.
-    - aws --region us-west-2 s3 cp --recursive "${PULUMI_FAILED_TESTS_DIR}" "s3://eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/failures"
-    - echo "one or more tests failed, to view detailed failure information, visit https://s3.console.aws.amazon.com/s3/buckets/eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/failures/"
+    - tar czf - -C "${PULUMI_FAILED_TESTS_DIR}" . | aws --region us-west-2 s3 cp - "s3://eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/failed-tests.tar.gz" --acl bucket-owner-full-control
+    - echo "one or more tests failed, to view detailed failure information, visit https://s3.console.aws.amazon.com/s3/buckets/eng.pulumi.com/travis-logs/${TRAVIS_REPO_SLUG}/${TRAVIS_JOB_NUMBER}/"
 notifications:
     webhooks: https://ufci1w66n3.execute-api.us-west-2.amazonaws.com/stage/travis


### PR DESCRIPTION
Uploading a bunch of tiny files is inefficient. Worse, it results in a ton of
paths printed to `stdout` -- enough that we could hit Travis' 4MB limit and
kill the job before we'd finished uploading.

Now we create a `.tar.gz` and upload that one, compressed file.

We also noticed that copied files might not be accessible from the `dev`
account, even though that account owns the `eng.pulumi.com` bucket. When
files are uploaded by one AWS account to a bucket owned by another, the
objects are, by default, only readable by the first account (the writer).
Change the ACL so the account that owns the bucket also has full access.

Part of the fix across repos for https://github.com/pulumi/home/issues/155.