### PR TITLE
Adjust stack output formating in the CLI

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strconv"
@@ -150,7 +151,23 @@ func printStackOutputs(outputs map[string]interface{}) {
 		sort.Strings(outkeys)
 		fmt.Printf("    %-"+strconv.Itoa(maxkey)+"s %s\n", "OUTPUT", "VALUE")
 		for _, key := range outkeys {
-			fmt.Printf("    %-"+strconv.Itoa(maxkey)+"s %v\n", key, outputs[key])
+			fmt.Printf("    %-"+strconv.Itoa(maxkey)+"s %s\n", key, stringifyOutput(outputs[key]))
 		}
 	}
+}
+
+// stringifyOutput formats an output value for presentation to a user. We use JSON formatting, except in the case
+// of top level strings, where we just return the raw value.
+func stringifyOutput(v interface{}) string {
+	s, ok := v.(string)
+	if ok {
+		return s
+	}
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		return "error: could not format value"
+	}
+
+	return string(b)
 }

--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -37,7 +37,7 @@ func newStackOutputCmd() *cobra.Command {
 				name := args[0]
 				v, has := outputs[name]
 				if has {
-					fmt.Printf("%v\n", v)
+					fmt.Printf("%v\n", stringifyOutput(v))
 				} else {
 					return errors.Errorf("current stack does not have output property '%v'", name)
 				}

--- a/cmd/stack_output_test.go
+++ b/cmd/stack_output_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStringifyOutput(t *testing.T) {
+	num := 42
+	str := "ABC"
+	arr := []string{"hello", "goodbye"}
+	obj := map[string]interface{}{
+		"foo": 42,
+		"bar": map[string]interface{}{
+			"baz": true,
+		},
+	}
+
+	assert.Equal(t, "42", stringifyOutput(num))
+	assert.Equal(t, "ABC", stringifyOutput(str))
+	assert.Equal(t, "[\"hello\",\"goodbye\"]", stringifyOutput(arr))
+	assert.Equal(t, "{\"bar\":{\"baz\":true},\"foo\":42}", stringifyOutput(obj))
+}


### PR DESCRIPTION
Previously, we would just use normal go formatting when displaying
output values. This was fine for simple values like strings and ints,
but for arrays or objects, you'd end up with values that looked a
little stange.

We now run the objects through json.Marshal first, to get nicer string
values for more complex objects. However, when the top level value is
a single string, we elide the quotes. This is not true JSON, but it
displays much nicer.

When we add something like `--format=json` (see pulumi#496) it will
provide a way to treat output unfiormly as JSON.

Fixes #736