### PR TITLE
Make some stack-related CLI improvements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -9,7 +9,36 @@
 
 [[projects]]
   name = "github.com/aws/aws-sdk-go"
-  packages = ["aws","aws/awserr","aws/awsutil","aws/client","aws/client/metadata","aws/corehandlers","aws/credentials","aws/credentials/ec2rolecreds","aws/credentials/endpointcreds","aws/credentials/stscreds","aws/defaults","aws/ec2metadata","aws/endpoints","aws/request","aws/session","aws/signer/v4","internal/shareddefaults","private/protocol","private/protocol/json/jsonutil","private/protocol/jsonrpc","private/protocol/query","private/protocol/query/queryutil","private/protocol/rest","private/protocol/restxml","private/protocol/xml/xmlutil","service/cloudwatchlogs","service/s3","service/sts"]
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/restxml",
+    "private/protocol/xml/xmlutil",
+    "service/cloudwatchlogs",
+    "service/s3",
+    "service/sts"
+  ]
   revision = "e6c5e190452424b404ecdb81d6e3991d46b18e9d"
   version = "v1.12.26"
 
@@ -58,7 +87,16 @@
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","protoc-gen-go/descriptor","ptypes","ptypes/any","ptypes/duration","ptypes/empty","ptypes/struct","ptypes/timestamp"]
+  packages = [
+    "proto",
+    "protoc-gen-go/descriptor",
+    "ptypes",
+    "ptypes/any",
+    "ptypes/duration",
+    "ptypes/empty",
+    "ptypes/struct",
+    "ptypes/timestamp"
+  ]
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 
 [[projects]]
@@ -109,10 +147,28 @@
   version = "0.2"
 
 [[projects]]
+  name = "github.com/mattn/go-colorable"
+  packages = ["."]
+  revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
+  version = "v0.0.9"
+
+[[projects]]
+  name = "github.com/mattn/go-isatty"
+  packages = ["."]
+  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
+  version = "v0.0.3"
+
+[[projects]]
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
   revision = "9e777a8366cce605130a531d2cd6363d07ad7317"
   version = "v0.0.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/mgutz/ansi"
+  packages = ["."]
+  revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
   branch = "master"
@@ -134,7 +190,11 @@
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
-  packages = [".","ext","log"]
+  packages = [
+    ".",
+    "ext",
+    "log"
+  ]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
 
@@ -188,7 +248,12 @@
 
 [[projects]]
   name = "github.com/src-d/gcfg"
-  packages = [".","scanner","token","types"]
+  packages = [
+    ".",
+    "scanner",
+    "token",
+    "types"
+  ]
   revision = "f187355171c936ac84a82793659ebb4936bc1c23"
   version = "v1.3.0"
 
@@ -200,7 +265,17 @@
 
 [[projects]]
   name = "github.com/uber/jaeger-client-go"
-  packages = [".","internal/spanlog","log","thrift-gen/agent","thrift-gen/jaeger","thrift-gen/sampling","thrift-gen/zipkincore","transport/zipkin","utils"]
+  packages = [
+    ".",
+    "internal/spanlog",
+    "log",
+    "thrift-gen/agent",
+    "thrift-gen/jaeger",
+    "thrift-gen/sampling",
+    "thrift-gen/zipkincore",
+    "transport/zipkin",
+    "utils"
+  ]
   revision = "3e3870040def0ebdaf65a003863fa64f5cb26139"
   version = "v2.9.0"
 
@@ -219,25 +294,67 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["cast5","curve25519","ed25519","ed25519/internal/edwards25519","openpgp","openpgp/armor","openpgp/elgamal","openpgp/errors","openpgp/packet","openpgp/s2k","pbkdf2","ssh","ssh/agent","ssh/knownhosts","ssh/terminal"]
+  packages = [
+    "cast5",
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "openpgp",
+    "openpgp/armor",
+    "openpgp/elgamal",
+    "openpgp/errors",
+    "openpgp/packet",
+    "openpgp/s2k",
+    "pbkdf2",
+    "ssh",
+    "ssh/agent",
+    "ssh/knownhosts",
+    "ssh/terminal"
+  ]
   revision = "6a293f2d4b14b8e6d3f0539e383f6d0d30fce3fd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","http2","http2/hpack","idna","internal/timeseries","lex/httplex","trace"]
+  packages = [
+    "context",
+    "http2",
+    "http2/hpack",
+    "idna",
+    "internal/timeseries",
+    "lex/httplex",
+    "trace"
+  ]
   revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "4b45465282a4624cf39876842a017334f13b8aff"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
@@ -248,19 +365,96 @@
 
 [[projects]]
   name = "google.golang.org/grpc"
-  packages = [".","balancer","codes","connectivity","credentials","grpclb/grpc_lb_v1/messages","grpclog","internal","keepalive","metadata","naming","peer","reflection","reflection/grpc_reflection_v1alpha","resolver","stats","status","tap","transport"]
+  packages = [
+    ".",
+    "balancer",
+    "codes",
+    "connectivity",
+    "credentials",
+    "grpclb/grpc_lb_v1/messages",
+    "grpclog",
+    "internal",
+    "keepalive",
+    "metadata",
+    "naming",
+    "peer",
+    "reflection",
+    "reflection/grpc_reflection_v1alpha",
+    "resolver",
+    "stats",
+    "status",
+    "tap",
+    "transport"
+  ]
   revision = "5ffe3083946d5603a0578721101dc8165b1d5b5f"
   version = "v1.7.2"
 
 [[projects]]
+  name = "gopkg.in/AlecAivazis/survey.v1"
+  packages = [
+    ".",
+    "core",
+    "terminal"
+  ]
+  revision = "0aa8b6a162b391fe2d95648b7677d1d6ac2090a6"
+  version = "v1.4.1"
+
+[[projects]]
   name = "gopkg.in/src-d/go-billy.v4"
-  packages = [".","helper/chroot","helper/polyfill","osfs","util"]
+  packages = [
+    ".",
+    "helper/chroot",
+    "helper/polyfill",
+    "osfs",
+    "util"
+  ]
   revision = "e940f8b62a8e61adc71f69802c1cc8305b64ec96"
   version = "v4.0.2"
 
 [[projects]]
   name = "gopkg.in/src-d/go-git.v4"
-  packages = [".","config","internal/revision","plumbing","plumbing/cache","plumbing/filemode","plumbing/format/config","plumbing/format/diff","plumbing/format/gitignore","plumbing/format/idxfile","plumbing/format/index","plumbing/format/objfile","plumbing/format/packfile","plumbing/format/pktline","plumbing/object","plumbing/protocol/packp","plumbing/protocol/packp/capability","plumbing/protocol/packp/sideband","plumbing/revlist","plumbing/storer","plumbing/transport","plumbing/transport/client","plumbing/transport/file","plumbing/transport/git","plumbing/transport/http","plumbing/transport/internal/common","plumbing/transport/server","plumbing/transport/ssh","storage","storage/filesystem","storage/filesystem/internal/dotgit","storage/memory","utils/binary","utils/diff","utils/ioutil","utils/merkletrie","utils/merkletrie/filesystem","utils/merkletrie/index","utils/merkletrie/internal/frame","utils/merkletrie/noder"]
+  packages = [
+    ".",
+    "config",
+    "internal/revision",
+    "plumbing",
+    "plumbing/cache",
+    "plumbing/filemode",
+    "plumbing/format/config",
+    "plumbing/format/diff",
+    "plumbing/format/gitignore",
+    "plumbing/format/idxfile",
+    "plumbing/format/index",
+    "plumbing/format/objfile",
+    "plumbing/format/packfile",
+    "plumbing/format/pktline",
+    "plumbing/object",
+    "plumbing/protocol/packp",
+    "plumbing/protocol/packp/capability",
+    "plumbing/protocol/packp/sideband",
+    "plumbing/revlist",
+    "plumbing/storer",
+    "plumbing/transport",
+    "plumbing/transport/client",
+    "plumbing/transport/file",
+    "plumbing/transport/git",
+    "plumbing/transport/http",
+    "plumbing/transport/internal/common",
+    "plumbing/transport/server",
+    "plumbing/transport/ssh",
+    "storage",
+    "storage/filesystem",
+    "storage/filesystem/internal/dotgit",
+    "storage/memory",
+    "utils/binary",
+    "utils/diff",
+    "utils/ioutil",
+    "utils/merkletrie",
+    "utils/merkletrie/filesystem",
+    "utils/merkletrie/index",
+    "utils/merkletrie/internal/frame",
+    "utils/merkletrie/noder"
+  ]
   revision = "e9247ce9c5ce12126f646ca3ddf0066e4829bd14"
   version = "v4.1.0"
 
@@ -279,6 +473,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "406689f2111986438fab15c1c0e770b08c857bdbe8b16e72f89502b32c77cffe"
+  inputs-digest = "5c20f99999e8bede3229f96972decac288fd412bcf7d18ef42f5588117dad2a6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,5 +8,5 @@
   version = "=v1.7.2"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/dustin/go-humanize"
+  branch = "master"

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -36,7 +36,7 @@ func newConfigCmd() *cobra.Command {
 			"for a specific configuration key, use 'pulumi config get <key-name>'.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			stack, err := requireStack(tokens.QName(stack))
+			stack, err := requireStack(tokens.QName(stack), true)
 			if err != nil {
 				return err
 			}
@@ -65,7 +65,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 		Short: "Get a single configuration value",
 		Args:  cmdutil.SpecificArgs([]string{"key"}),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			s, err := requireStack(tokens.QName(*stack))
+			s, err := requireStack(tokens.QName(*stack), true)
 			if err != nil {
 				return err
 			}
@@ -97,7 +97,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(stackName)
+			s, err := requireStack(stackName, true)
 			if err != nil {
 				return err
 			}
@@ -154,7 +154,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(stackName)
+			s, err := requireStack(stackName, true)
 			if err != nil {
 				return err
 			}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -43,7 +43,7 @@ func newDestroyCmd() *cobra.Command {
 			"is generally irreversable and should be used with great care.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			s, err := requireStack(tokens.QName(stack))
+			s, err := requireStack(tokens.QName(stack), false)
 			if err != nil {
 				return err
 			}

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -29,7 +29,7 @@ func newHistoryCmd() *cobra.Command {
 			"This command lists data about previous updates for a stack.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			s, err := requireStack(tokens.QName(stack))
+			s, err := requireStack(tokens.QName(stack), false)
 			if err != nil {
 				return err
 			}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -33,7 +33,7 @@ func newLogsCmd() *cobra.Command {
 		Short: "Show aggregated logs for a project",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			s, err := requireStack(tokens.QName(stack))
+			s, err := requireStack(tokens.QName(stack), false)
 			if err != nil {
 				return err
 			}

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -42,11 +42,12 @@ func newPreviewCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			s, err := requireStack(tokens.QName(stack))
+			proj, root, err := readProject()
 			if err != nil {
 				return err
 			}
-			proj, root, err := readProject()
+
+			s, err := requireStack(tokens.QName(stack), true)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -28,7 +28,7 @@ func newStackCmd() *cobra.Command {
 			"the workspace, in addition to a full checkpoint of the last known good update.\n",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			s, err := requireCurrentStack()
+			s, err := requireCurrentStack(true)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_export.go
+++ b/cmd/stack_export.go
@@ -25,7 +25,7 @@ func newStackExportCmd() *cobra.Command {
 			"resources, etc.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Fetch the current stack and export its deployment
-			s, err := requireCurrentStack()
+			s, err := requireCurrentStack(false)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -26,7 +26,7 @@ func newStackImportCmd() *cobra.Command {
 			"The updated deployment will be read from standard in.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Fetch the current stack and import a deployment.
-			s, err := requireCurrentStack()
+			s, err := requireCurrentStack(false)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -23,7 +23,7 @@ func newStackOutputCmd() *cobra.Command {
 			"If a specific property-name is supplied, just that property's value is shown.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Fetch the current stack and its output properties.
-			s, err := requireCurrentStack()
+			s, err := requireCurrentStack(false)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_rm.go
+++ b/cmd/stack_rm.go
@@ -33,7 +33,7 @@ func newStackRmCmd() *cobra.Command {
 			if len(args) > 0 {
 				stack = tokens.QName(args[0])
 			}
-			s, err := requireStack(stack)
+			s, err := requireStack(stack, false)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_select.go
+++ b/cmd/stack_select.go
@@ -18,49 +18,50 @@ import (
 func newStackSelectCmd() *cobra.Command {
 	var cloud string
 	cmd := &cobra.Command{
-		Use:   "select [<stack-name>]",
+		Use:   "select [<stack>]",
 		Short: "Switch the current workspace to the given stack",
-		Long: "Switch the current workspace to the given stack.  This allows you to use\n" +
-			"other commands like `config`, `preview`, and `update` without needing to specify the\n" +
-			"stack name each and every time.\n" +
+		Long: "Switch the current workspace to the given stack.\n" +
 			"\n" +
-			"If no <stack> argument is supplied, the current stack is printed.",
+			"Selecting a stack allows you to use commands like `config`, `preview`, and `update`\n" +
+			"without needing to type the stack name each time.\n" +
+			"\n" +
+			"If no <stack> argument is supplied, you will be prompted to select one interactively.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			// Display the name of the current stack if a new one isn't specified.
-			if len(args) == 0 {
-				name, err := requireCurrentStack()
-				if err != nil {
-					return err
-				}
-
-				fmt.Printf("%v\n", name)
-				return nil
-			}
-
-			// Ask all known backends about this stack.
-			var result error
 			bes, hasClouds := allBackends()
-			toSelect := tokens.QName(args[0])
-			for _, b := range bes {
-				stack, err := b.GetStack(toSelect)
-				if err != nil {
-					// If there is an error, file it away, but keep going in case it's a transient cloud error.
-					result = multierror.Append(result, errors.Wrapf(err,
-						"could not query '%s' backend for stack selection", b.Name()))
-					continue
-				} else if stack != nil {
-					return state.SetCurrentStack(toSelect)
+			if len(args) > 0 {
+				// A stack was given, ask all known backends about it
+				stackName := tokens.QName(args[0])
+
+				var result error
+				for _, b := range bes {
+					stack, err := b.GetStack(stackName)
+					if err != nil {
+						// If there is an error, file it away, but keep going in case it's a transient cloud error.
+						result = multierror.Append(result, errors.Wrapf(err,
+							"could not query '%s' backend for stack selection", b.Name()))
+						continue
+					} else if stack != nil {
+						return state.SetCurrentStack(stackName)
+					}
 				}
+
+				// If we fell through, the stack was not found.  Issue an error.  Also customize the error
+				// message if no clouds are logged into, since that is presumably a common mistake.
+				msg := fmt.Sprintf("no stack named '%s' found", stackName)
+				if !hasClouds {
+					msg += "; you aren't logged into the Pulumi Cloud -- did you forget to 'pulumi login'?"
+				}
+				return multierror.Append(result, errors.New(msg))
 			}
 
-			// If we fell through, the stack was not found.  Issue an error.  Also customize the error
-			// message if no clouds are logged into, since that is presumably a common mistake.
-			msg := fmt.Sprintf("no stack named '%s' found", toSelect)
-			if !hasClouds {
-				msg += "; you aren't logged into the Pulumi Cloud -- did you forget to 'pulumi login'?"
+			// If no stack was given, prompt the user to select a name from the available ones.
+			stack, err := chooseStack(bes, true)
+			if err != nil {
+				return err
 			}
-			return multierror.Append(result, errors.New(msg))
+			return state.SetCurrentStack(stack.Name())
+
 		}),
 	}
 	cmd.PersistentFlags().StringVarP(

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -46,7 +46,7 @@ func newUpdateCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			s, err := requireStack(tokens.QName(stack))
+			s, err := requireStack(tokens.QName(stack), true)
 			if err != nil {
 				return err
 			}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -8,9 +8,12 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
+	"gopkg.in/AlecAivazis/survey.v1"
+	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 	git "gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
@@ -45,29 +48,157 @@ func allBackends() ([]backend.Backend, bool) {
 	return backends, len(cloudBackends) > 0
 }
 
-func requireStack(stackName tokens.QName) (backend.Stack, error) {
-	if stackName == "" {
-		return requireCurrentStack()
+// createStack creates a stack with the given name, and selects it as the current.
+func createStack(b backend.Backend, stackName tokens.QName, opts interface{}) (backend.Stack, error) {
+	stack, err := b.CreateStack(stackName, opts)
+	if err != nil {
+		return nil, errors.Wrapf(err, "could not create stack")
 	}
+
+	if err = state.SetCurrentStack(stackName); err != nil {
+		return nil, err
+	}
+
+	return stack, nil
+}
+
+// requireStack will require that a stack exists.  If stackName is blank, the currently selected stack from
+// the workspace is returned.  If no stack with either the given name, or a currently selected stack, exists,
+// and we are in an interactive terminal, the user will be prompted to create a new stack.
+func requireStack(stackName tokens.QName, offerNew bool) (backend.Stack, error) {
+	if stackName == "" {
+		return requireCurrentStack(offerNew)
+	}
+
+	// Search all known backends for this stack.
 	bes, _ := allBackends()
 	stack, err := state.Stack(stackName, bes)
 	if err != nil {
 		return nil, err
-	} else if stack == nil {
-		return nil, errors.Errorf("no stack named '%s' found; double check that you're logged in", stackName)
 	}
-	return stack, nil
+	if stack != nil {
+		return stack, err
+	}
+
+	// No stack was found.  If we're in a terminal, prompt to create one.
+	if cmdutil.Interactive() {
+		fmt.Printf("The stack '%s' does not exist.\n", stackName)
+		fmt.Printf("\n")
+		fmt.Printf("It is possible that you aren't logged into the correct cloud where this stack\n")
+		fmt.Printf("has been provisioned.  If that is the case, please press ^C and run `pulumi login`\n")
+		fmt.Printf("to log into the cloud, and then try this operation again.\n")
+		fmt.Printf("\n")
+		_, err = cmdutil.ReadConsole("If instead, you would like to create this stack now, please press <ENTER>")
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO[pulumi/pulumi#816]: right now, we assume that we're creating a local stack.  This is a little
+		//     inconsistent compared to where we are now, but it's closer to where we think we're going.  As
+		//     part of 816, we should tidy this up.
+		b := local.New(cmdutil.Diag())
+		return createStack(b, stackName, nil)
+	}
+
+	return nil, errors.Errorf("no stack named '%s' found; double check that you're logged in", stackName)
 }
 
-func requireCurrentStack() (backend.Stack, error) {
+func requireCurrentStack(offerNew bool) (backend.Stack, error) {
+	// Search for the current stack.
 	bes, _ := allBackends()
 	stack, err := state.CurrentStack(bes)
 	if err != nil {
 		return nil, err
-	} else if stack == nil {
-		return nil, errors.New("no current stack detected; please use `pulumi stack` to `init` or `select` one")
+	} else if stack != nil {
+		return stack, nil
 	}
-	return stack, nil
+
+	// If no current stack exists, and we are interactive, prompt to select or create one.
+	return chooseStack(bes, offerNew)
+}
+
+// chooseStack will prompt the user to choose amongst the full set of stacks in the given backends.  If offerNew is
+// true, then the option to create an entirely new stack is provided and will create one as desired.
+func chooseStack(bes []backend.Backend, offerNew bool) (backend.Stack, error) {
+	// Prepare our error in case we need to issue it.  Bail early if we're not interactive.
+	var chooseStackErr string
+	if offerNew {
+		chooseStackErr = "no stack selected; please use `pulumi stack select` or `pulumi stack init` to choose one"
+	} else {
+		chooseStackErr = "no stack selected; please use `pulumi stack select` to choose one"
+	}
+	if !cmdutil.Interactive() {
+		return nil, errors.New(chooseStackErr)
+	}
+
+	// First create a list and map of stack names.
+	var options []string
+	stacks := make(map[string]backend.Stack)
+	for _, be := range bes {
+		allStacks, err := be.ListStacks()
+		if err != nil {
+			return nil, errors.Wrapf(err, "could not query backend for stacks")
+		}
+		for _, stack := range allStacks {
+			name := string(stack.Name())
+			options = append(options, name)
+			stacks[name] = stack
+		}
+	}
+	sort.Strings(options)
+
+	// If we are offering to create a new stack, add that to the end of the list.
+	newOption := "<create a new stack>"
+	if offerNew {
+		options = append(options, newOption)
+	} else if len(options) == 0 {
+		// If no options are available, we can't offer a choice!
+		return nil, errors.New("this command requires a stack, but there are none; are you logged in?")
+	}
+
+	// If a stack is already selected, make that the default.
+	var current string
+	currStack, currErr := state.CurrentStack(bes)
+	contract.IgnoreError(currErr)
+	if currStack != nil {
+		current = string(currStack.Name())
+	}
+
+	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).
+	surveycore.DisableColor = true
+	surveycore.QuestionIcon = ""
+	surveycore.SelectFocusIcon = colors.ColorizeText(colors.BrightGreen + ">" + colors.Reset)
+	message := "\rPlease choose a stack"
+	if offerNew {
+		message += ", or create a new one:"
+	} else {
+		message += ":"
+	}
+	message = colors.ColorizeText(colors.BrightWhite + message + colors.Reset)
+
+	var option string
+	if err := survey.AskOne(&survey.Select{
+		Message: message,
+		Options: options,
+		Default: current,
+	}, &option, nil); err != nil {
+		return nil, errors.New(chooseStackErr)
+	}
+
+	if option == newOption {
+		stackName, err := cmdutil.ReadConsole("Please enter your desired stack name")
+		if err != nil {
+			return nil, err
+		}
+
+		// TODO[pulumi/pulumi#816]: right now, we assume that we're creating a local stack.  This is a little
+		//     inconsistent compared to where we are now, but it's closer to where we think we're going.  As
+		//     part of 816, we should tidy this up.
+		b := local.New(cmdutil.Diag())
+		return createStack(b, tokens.QName(stackName), nil)
+	}
+
+	return stacks[option], nil
 }
 
 func detectOwnerAndName(dir string) (string, string, error) {

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -22,7 +22,7 @@ type Backend interface {
 	// GetStack returns a stack object tied to this backend with the given name, or nil if it cannot be found.
 	GetStack(name tokens.QName) (Stack, error)
 	// CreateStack creates a new stack with the given name and options that are specific to the backend provider.
-	CreateStack(name tokens.QName, opts interface{}) error
+	CreateStack(name tokens.QName, opts interface{}) (Stack, error)
 	// RemoveStack removes a stack with the given name.  If force is true, the stack will be removed even if it
 	// still contains resources.  Otherwise, if the stack contains resources, a non-nil error is returned, and the
 	// first boolean return value will be set to true.

--- a/pkg/util/cmdutil/console.go
+++ b/pkg/util/cmdutil/console.go
@@ -8,12 +8,23 @@ import (
 	"os"
 	"runtime"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/pulumi/pulumi/pkg/diag/colors"
 )
+
+// Interactive returns true if we're in an interactive terminal session.
+func Interactive() bool {
+	return terminal.IsTerminal(int(os.Stdin.Fd()))
+}
 
 // ReadConsole reads the console with the given prompt text.
 func ReadConsole(prompt string) (string, error) {
 	if prompt != "" {
-		fmt.Printf("%s: ", prompt)
+		prompt = colors.ColorizeText(
+			fmt.Sprintf("%s%s:%s ", colors.BrightCyan, prompt, colors.Reset))
+		fmt.Print(prompt)
 	}
 
 	reader := bufio.NewReader(os.Stdin)

--- a/pkg/util/cmdutil/console_password.go
+++ b/pkg/util/cmdutil/console_password.go
@@ -8,12 +8,16 @@ import (
 	"syscall"
 
 	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/pulumi/pulumi/pkg/diag/colors"
 )
 
 // ReadConsoleNoEcho reads from the console without echoing.  This is useful for reading passwords.
 func ReadConsoleNoEcho(prompt string) (string, error) {
 	if prompt != "" {
-		fmt.Printf("%s: ", prompt)
+		prompt = colors.ColorizeText(
+			fmt.Sprintf("%s%s:%s ", colors.BrightCyan, prompt, colors.Reset))
+		fmt.Print(prompt)
 	}
 
 	b, err := terminal.ReadPassword(syscall.Stdin)

--- a/pkg/util/cmdutil/console_password_windows.go
+++ b/pkg/util/cmdutil/console_password_windows.go
@@ -7,12 +7,16 @@ import (
 	"fmt"
 
 	"github.com/bgentry/speakeasy"
+
+	"github.com/pulumi/pulumi/pkg/diag/colors"
 )
 
 // ReadConsoleNoEcho reads from the console without echoing.  This is useful for reading passwords.
 func ReadConsoleNoEcho(prompt string) (string, error) {
 	if prompt != "" {
-		fmt.Printf("%s: ", prompt)
+		prompt = colors.ColorizeText(
+			fmt.Sprintf("%s%s:%s ", colors.BrightCyan, prompt, colors.Reset))
+		fmt.Print(prompt)
 	}
 
 	s, err := speakeasy.Ask("")

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -63,7 +63,7 @@ func TestHistoryCommand(t *testing.T) {
 
 		out, err := e.RunCommandExpectError("pulumi", "history")
 		assert.Equal(t, "", out)
-		assert.Contains(t, err, "error: no current stack detected")
+		assert.NotEqual(t, err, "")
 	})
 
 	// We don't display any history for a stack that has never been updated.


### PR DESCRIPTION
This change includes a handful of stack-related CLI formatting
improvements that I've been noodling on in the background for a while,
based on things that tend to trip up demos and the inner loop workflow.

This includes:

* If `pulumi stack select` is run by itself, use an interactive
  CLI menu to let the user select an existing stack, or choose to
  create a new one.  This looks as follows

      $ pulumi stack select
      Please choose a stack, or create a new one:
        abcdef
        babblabblabble
      > currentlyselected
        defcon
        <create a new stack>

  and is navigated in the usual way (key up, down, enter).

* If a stack name is passed that does not exist, prompt the user
  to ask whether s/he wants to create one on-demand.  This hooks
  interesting moments in time, like `pulumi stack select foo`,
  and cuts down on the need to run additional commands.

* If a current stack is required, but none is currently selected,
  then pop the same interactive menu shown above to select one.
  Depending on the command being run, we may or may not show the
  option to create a new stack (e.g., that doesn't make much sense
  when you're running `pulumi destroy`, but might when you're
  running `pulumi stack`).  This again lets you do with a single
  command what would have otherwise entailed an error with multiple
  commands to recover from it.

* If you run `pulumi stack init` without any additional arguments,
  we interactively prompt for the stack name.  Before, we would
  error and you'd then need to run `pulumi stack init <name>`.

* Colorize some things nicely; for example, now all prompts will
  by default become bright white.