### PR TITLE
Ship `nativeruntime.node` as part of the SDK

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -38,6 +38,22 @@
           DestinationFolder="$(NodeJSSdkDirectory)\proto" />
   </Target>
 
+  <Target Name="ConfigureNativeRuntimeModule"
+          DependsOnTargets="EnsureNodeDependencies">
+    <Exec Command="&quot;$(NativeRuntimeModuleDirectory)\ensure_node_v8.cmd&quot;"
+          WorkingDirectory="$(NativeRuntimeModuleDirectory)" />
+    <Exec Command="&quot;$(NodeJSSdkDirectory)\node_modules\.bin\node-gyp.cmd&quot; configure --msvs_version $(MSVSVersion) --devdir &quot;$(NativeRuntimeModuleDirectory)\node_dev&quot;"
+          WorkingDirectory="$(NativeRuntimeModuleDirectory)" />
+    <Copy SourceFiles="$(NodeJSSdkDirectory)\custom_node\node\node.lib"
+          DestinationFiles="$(NativeRuntimeModuleDirectory)\node_dev\$(NodeVersion)\$(NodeArch)\node.lib" />
+  </Target>
+
+  <Target Name="BuildNativeRuntimeModule"
+          DependsOnTargets="ConfigureNativeRuntimeModule">
+    <Exec Command="&quot;$(NodeJSSdkDirectory)\node_modules\.bin\node-gyp.cmd&quot; build --msvs_version $(MSVSVersion) --devdir &quot;$(NativeRuntimeModuleDirectory)\node_dev&quot;"
+          WorkingDirectory="$(NativeRuntimeModuleDirectory)" />
+</Target>
+
   <Target Name="TypeScriptCompileNodeSdk">
     <Exec Command="yarn run tsc"
           WorkingDirectory="$(NodeJSSdkDirectory)" />
@@ -65,6 +81,17 @@
           DestinationFolder="$(NodeJSSdkDirectory)\bin\proto" />
   </Target>
 
+  <Target Name="BinPlaceNodeSdkNativeRuntimeModule"
+          DependsOnTargets="BuildNativeRuntimeModule">
+    <ItemGroup>
+      <NodeSdkNativeRuntimeModuleFiles Include="$(NativeRuntimeModuleDirectory)\build\Release\nativeruntime.node" />
+      <NodeSdkNativeRuntimeModuleFiles Include="$(NativeRuntimeModuleDirectory)\build\Release\nativeruntime.pdb" />
+    </ItemGroup>
+
+    <Copy SourceFiles="@(NodeSdkNativeRuntimeModuleFiles)"
+          DestinationFolder="$(NodeJSSdkDirectory)\bin\runtime\native\build\Release" />
+  </Target>
+
   <Target Name="BinPlaceNodeSdkTestData">
     <ItemGroup>
       <NodeSdkTestDataFiles Include="$(NodeJSSdkDirectory)\tests\runtime\langhost\cases\**\*" />
@@ -82,14 +109,16 @@
   </Target>
 
   <Target Name="BinPlaceNodeSdk"
-          DependsOnTargets="BinPlaceNodeSdkProtos;BinPlaceNodeSdkTestData;YarnLinkSdk">
-    <Copy SourceFiles="$(NodeJSSdkDirectory)\custom_node\node\node.exe" DestinationFiles="$(PulumiBin)\pulumi-langhost-nodejs-node.exe" />
-    <Copy SourceFiles="$(NodeJSSdkDirectory)\pulumi-langhost-nodejs-exec.cmd" DestinationFolder="$(PulumiBin)" />
-    <Copy SourceFiles="$(NodeJSSdkDirectory)\pulumi-provider-pulumi-nodejs.cmd" DestinationFolder="$(PulumiBin)" />
+          DependsOnTargets="BinPlaceNodeSdkProtos;BinPlaceNodeSdkNativeRuntimeModule;BinPlaceNodeSdkTestData;YarnLinkSdk">
+     <Copy SourceFiles="$(NodeJSSdkDirectory)\custom_node\node\node.exe" DestinationFiles="$(PulumiBin)\pulumi-langhost-nodejs-node.exe" />
+     <Copy SourceFiles="$(NodeJSSdkDirectory)\pulumi-langhost-nodejs-exec.cmd" DestinationFolder="$(PulumiBin)" />
+     <Copy SourceFiles="$(NodeJSSdkDirectory)\pulumi-provider-pulumi-nodejs.cmd" DestinationFolder="$(PulumiBin)" />
+     <Copy SourceFiles="$(NodeJSSdkDirectory)\bin\runtime\native\build\Release\nativeruntime.node" DestinationFolder="$(PulumiBin)\v$(NodeVersion)" />
+     <Copy SourceFiles="$(NodeJSSdkDirectory)\bin\runtime\native\build\Release\nativeruntime.pdb" DestinationFolder="$(PulumiBin)\v$(NodeVersion)" />
   </Target>
 
   <Target Name="BuildNodeSdk"
-          DependsOnTargets="CopyNodeSdkProtos;TypeScriptCompileNodeSdk;GoCompileNodeSdk;BinPlaceNodeSdk">
+          DependsOnTargets="CopyNodeSdkProtos;BuildNativeRuntimeModule;TypeScriptCompileNodeSdk;GoCompileNodeSdk;BinPlaceNodeSdk">
   </Target>
 
   <Target Name="BuildGoCmds">

--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -2,6 +2,7 @@
 Set-StrictMode -Version 2.0
 $ErrorActionPreference="Stop"
 
+$NodeVersion = "v6.10.2"
 $Root=Join-Path $PSScriptRoot ".."
 $PublishDir=New-Item -ItemType Directory -Path "$env:TEMP\$([System.IO.Path]::GetRandomFileName())"
 $GitHash=$(git rev-parse HEAD)
@@ -34,6 +35,11 @@ CopyPackage "$Root\sdk\nodejs\bin" "pulumi"
 Copy-Item "$Root\sdk\nodejs\pulumi-langhost-nodejs-exec.cmd" "$PublishDir\bin"
 Copy-Item "$Root\sdk\nodejs\pulumi-provider-pulumi-nodejs.cmd" "$PublishDir\bin"
 Copy-Item "$Root\sdk\nodejs\custom_node\node\node.exe" "$PublishDir\bin\pulumi-langhost-nodejs-node.exe"
+
+$NodeFolder = "$PublishDir\bin\$NodeVersion"
+New-Item -ItemType Directory -Force -Path $NodeFolder
+Copy-Item "$Root\sdk\nodejs\runtime\native\build\Release\nativeruntime.node" $NodeFolder
+Copy-Item "$Root\sdk\nodejs\runtime\native\build\Release\nativeruntime.pdb" $NodeFolder
 
 # By default, if the archive already exists, 7zip will just add files to it, so blow away the existing
 # archive if it exists.

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -51,8 +51,9 @@ run_go_build "${ROOT}/sdk/nodejs/cmd/pulumi-langhost-nodejs"
 cp ${ROOT}/sdk/nodejs/pulumi-langhost-nodejs-exec ${PUBDIR}/bin/
 cp ${ROOT}/sdk/nodejs/pulumi-provider-pulumi-nodejs ${PUBDIR}/bin/
 
-# Copy over our custom Node build
-cp ${ROOT}/sdk/nodejs/custom_node/node/node ${PUBDIR}/bin/pulumi-langhost-nodejs-node
+# Copy over our custom Node plugin
+mkdir -p ${PUBDIR}/bin/$(node --version)
+cp ${ROOT}/sdk/nodejs/runtime/native/build/Release/nativeruntime.node ${PUBDIR}/bin/$(node --version)/nativeruntime.node
 
 # Copy packages
 copy_package "${ROOT}/sdk/nodejs/bin/." "@pulumi/pulumi"

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -14,10 +14,10 @@ TEST_FAST_TIMEOUT := 2m
 include ../../build/common.mk
 
 export PATH:=$(shell yarn bin 2>/dev/null):$(PATH)
-export PATH:=custom_node/node:$(PATH)
+export NODE_PATH:=$(NODE_PATH):./runtime/native/build/Release
 
 ensure::
-	./scripts/download_node.sh
+	cd runtime/native && ./ensure_node_v8.sh
 
 lint::
 	$(GOMETALINTER) cmd/pulumi-langhost-nodejs/main.go | sort ; exit "$${PIPESTATUS[0]}"
@@ -25,7 +25,9 @@ lint::
 
 build::
 	go install -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" ${LANGUAGE_HOST}
+	cd runtime/native && node-gyp configure
 	cp -R ../proto/nodejs/. proto/
+	cd runtime/native && node-gyp build
 	tsc
 	cp README.md ../../LICENSE package.json bin/
 	sed -i.bak "s/\$${VERSION}/$(VERSION)/g" bin/version.js bin/package.json && \
@@ -38,7 +40,8 @@ install::
 	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" ${LANGUAGE_HOST}
 	cp pulumi-langhost-nodejs-exec "$(PULUMI_BIN)"
 	cp pulumi-provider-pulumi-nodejs "$(PULUMI_BIN)"
-	cp custom_node/node/node "$(PULUMI_BIN)/pulumi-langhost-nodejs-node"
+	mkdir -p "$(PULUMI_BIN)/$(shell node --version)"
+	cp runtime/native/build/Release/nativeruntime.node "$(PULUMI_BIN)/$(shell node --version)/nativeruntime.node"
 	rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)/tests"
 
 test_fast::

--- a/sdk/nodejs/pulumi-langhost-nodejs-exec
+++ b/sdk/nodejs/pulumi-langhost-nodejs-exec
@@ -2,5 +2,6 @@
 # we exploit the fact that the cwd when `pulumi-langhost-nodejs-exec` is
 # run is the root of the node program we want to run and use a relative
 # path here.
-pulumi-langhost-nodejs-node ./node_modules/@pulumi/pulumi/cmd/run $@
+export NODE_PATH="$NODE_PATH:`dirname $0`/`node --version`"
+node ./node_modules/@pulumi/pulumi/cmd/run $@
 

--- a/sdk/nodejs/pulumi-langhost-nodejs-exec.cmd
+++ b/sdk/nodejs/pulumi-langhost-nodejs-exec.cmd
@@ -1,1 +1,2 @@
+@set NODE_PATH=%NODE_PATH%;%~dp0.\v6.10.2
 @pulumi-langhost-nodejs-node.exe ./node_modules/@pulumi/pulumi/cmd/run %*

--- a/sdk/nodejs/pulumi-provider-pulumi-nodejs
+++ b/sdk/nodejs/pulumi-provider-pulumi-nodejs
@@ -1,2 +1,3 @@
 #!/bin/sh
-pulumi-langhost-nodejs-node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider $@
+export NODE_PATH="$NODE_PATH:`dirname $0`/`node --version`"
+node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider $@

--- a/sdk/nodejs/pulumi-provider-pulumi-nodejs.cmd
+++ b/sdk/nodejs/pulumi-provider-pulumi-nodejs.cmd
@@ -1,1 +1,2 @@
+@set NODE_PATH=%NODE_PATH%;%~dp0\v6.10.2
 @pulumi-langhost-nodejs-node.exe ./node_modules/@pulumi/pulumi/cmd/dynamic-provider %*

--- a/sdk/nodejs/runtime/closure.ts
+++ b/sdk/nodejs/runtime/closure.ts
@@ -11,18 +11,32 @@ import { debuggablePromise } from "./debuggable";
 // Our closure serialization code links against v8 internals. On Windows,
 // we can't dynamically link against v8 internals because their symbols are
 // unexported. In order to address this problem, Pulumi programs run on a
-// custom build of Node that has our closure serialization code as a built-in
-// module called "pulumi_closure".
+// custom build of Node.
 //
-// `process.binding` invokes the Node bootstrap module loader in order to
-// get to our builtin module.
+// On Linux and OSX, we can dynamically link against v8 internals, so we can run
+// on stock Node. However, we only build nativeruntime.node against specific versions
+// of Node, users running Pulumi programs must explicitly use a supported version
+// of Node.
+const supportedNodeVersions = ["v6.10.2"];
 let nativeruntime: any;
 try {
-    nativeruntime = (<any>process).binding("pulumi_closure");
+    nativeruntime = require("nativeruntime.node");
 }
 catch (err) {
+    // There are two reasons why this can happen:
+    //   1. We messed up when packaging Pulumi and failed to include nativeruntime.node,
+    //   2. A user is running their Pulumi program with a version of Node that we do not explicitly support.
+    const thisNodeVersion = process.version;
+    if (supportedNodeVersions.indexOf(thisNodeVersion) > -1) {
+        // This node version is explicitly supported, but the load still failed.
+        // This means that Pulumi messed up when installing itself.
+        throw new RunError(`Failed to locate custom Pulumi SDK Node.js extension. This is a bug! (${err.message})`);
+    }
+
     throw new RunError(
-        `Failed to load custom Pulumi SDK Node.js extension; are you running using the Pulumi CLI? (${err.message})`);
+        `Failed to load custom Pulumi SDK Node.js extension; The version of Node.js that you are
+         using (${thisNodeVersion}) is not explicitly supported, you must use one of these
+         supported versions of Node.js: ${supportedNodeVersions}`);
 }
 
 /**

--- a/sdk/nodejs/scripts/download_node.ps1
+++ b/sdk/nodejs/scripts/download_node.ps1
@@ -1,19 +1,16 @@
 Set-StrictMode -Version 2.0
 $ErrorActionPreference="Stop"
 
-$NodeVersion="v6.10.2"
+$NodeArch="x64"
+$NodeVersion="6.10.2"
 $NodeBase="custom_node\node"
 $NodeExe="custom_node\node\node.exe"
+$NodeZipName="$NodeBase\node-$NodeVersion-win-$NodeArch.zip"
 if (Test-Path $NodeExe) {
     Write-Output "skipping node.js executable download, as it already exists"
 } else {
     echo "node.js binary does not exist, downloading..."
-    aws s3 cp --only-show-errors "s3://eng.pulumi.com/releases/pulumi-node/windows/$NodeVersion.zip" "$NodeBase\$NodeVersion.zip"
-
-    $NodeZipPath = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
-    7z x -o"$NodeZipPath" "$NodeBase\$NodeVersion.zip"
-    Copy-Item $NodeZipPath\Release\node.exe $NodeExe
-
-    Remove-Item -Force -Recurse $NodeZipPath
-    Remove-Item -Force "$NodeBase\$NodeVersion.zip"
+    aws s3 cp --only-show-errors "s3://eng.pulumi.com/node/node-$NodeVersion-win-$NodeArch.zip" $NodeZipName
+    7z x -o"$NodeBase" $NodeZipName
+    Remove-Item -Force $NodeZipName
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/356.

The M10 strategy of shipping a node binary with a statically-linked `pulumi_closure` module works great, but it's hostile to active development: https://github.com/pulumi/pulumi/issues/356#issuecomment-365800394. This PR attempts to fix that problem by changing up a few things, now that we are past the bootstrap phase of the NPM effort:

1. For OSX/Linux, our closure serialization module has always worked with stock Node. Therefore, it is sufficient to publish our `nativemodule.node` binary with the SDK and, if it runs against the same node that it is compiled against (which we still recommend in the README), everything will work out fine. This PR ensures that we publish our native node module in `$(PULUMI_ROOT)/bin/$(node --version)` as part of the SDK.

2. For Windows, our closure serialization module needs a custom build of Node that exports some private symbols that we link against. This remains unchanged; we still download a custom node as part of build and use it to run Pulumi programs. However, in this PR, we also ship `nativemodule.node` as part of the SDK, in `$(PULUMI_ROOT)/bin/$(node --version)`.

3. `pulumi-langhost-nodejs-exec` is responsible for launching the node that Pulumi programs will run on. In this PR, this involves setting `NODE_PATH` to point to `$(PULUMI_ROOT)/bin/$(node --version)`, where that version's `nativemodule.node` is located. This is especially interesting for us as it gives us a point in which we can make a decision about *which* `nativemodule.node` to load, given that we are about to execute a Pulumi program and we know which version of Node we are using to do so. Today, since we only support `v6.10.2`, `v6.10.2` is the only subdirectory in `$(PULUMI_ROOT)/bin`, but as part of testing this PR I successfully built and ran Pulumi programs against node versions `v6.10.3`, and `v6.13.0` and packaged each `nativemodule.node` for each version alongside one another.

Going forward, `pulumi-langhost-nodejs-exec` has the opportunity to "fault in" versions of `nativemodule.node` that match the version of Node you're using to run your program. Until we can do this, this PR also improves the error message that you get when you run Pulumi programs with a Node we don't support:

```
$ pulumi update
Performing changes:
info: /usr/local/pulumi/node_modules/@pulumi/pulumi/runtime/closure.js:42
info:     throw new errors_1.RunError(`Failed to load custom Pulumi SDK Node.js extension; The version of Node.js that you are using (${thisNodeVersion}) is
info:     ^
info:
info: Error: Failed to load custom Pulumi SDK Node.js extension; The version of Node.js that you are using (v6.13.0) is
info:          not explicitly supported, you must use one of these supported versions of Node.js: v6.10.2
info:     at RunError (/usr/local/pulumi/node_modules/@pulumi/pulumi/errors.js:10:9)
info:     at Object.<anonymous> (/usr/local/pulumi/node_modules/@pulumi/pulumi/runtime/closure.js:42:11)
info:     at Module._compile (module.js:577:32)
info:     at Object.Module._extensions..js (module.js:586:10)
info:     at Module.load (module.js:494:32)
info:     at tryModuleLoad (module.js:453:12)
info:     at Function.Module._load (module.js:445:3)
info:     at Module.require (module.js:504:17)
info:     at require (internal/module.js:20:19)
info:     at Object.<anonymous> (/usr/local/pulumi/node_modules/@pulumi/pulumi/runtime/index.js:7:10)
error: an unhandled error occurred: Program exited with non-zero exit code: 1
```