### PR TITLE
Configure resource providers upon load.

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -46,7 +46,7 @@ func getProjectPlugins() ([]workspace.PluginInfo, error) {
 	}
 
 	projinfo := &engine.Projinfo{Proj: proj, Root: root}
-	pwd, main, ctx, err := engine.ProjectInfoContext(projinfo, cmdutil.Diag(), nil)
+	pwd, main, ctx, err := engine.ProjectInfoContext(projinfo, nil, cmdutil.Diag(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -27,7 +27,7 @@ import (
 )
 
 // ProjectInfoContext returns information about the current project, including its pwd, main, and plugin context.
-func ProjectInfoContext(projinfo *Projinfo, diag diag.Sink,
+func ProjectInfoContext(projinfo *Projinfo, config plugin.ConfigSource, diag diag.Sink,
 	tracingSpan opentracing.Span) (string, string, *plugin.Context, error) {
 	contract.Require(projinfo != nil, "projinfo")
 
@@ -38,7 +38,7 @@ func ProjectInfoContext(projinfo *Projinfo, diag diag.Sink,
 	}
 
 	// Create a context for plugins.
-	ctx, err := plugin.NewContext(diag, nil, pwd, tracingSpan)
+	ctx, err := plugin.NewContext(diag, nil, config, pwd, tracingSpan)
 	if err != nil {
 		return "", "", nil, err
 	}
@@ -57,7 +57,7 @@ func plan(info *planContext, opts deployOptions) (*planResult, error) {
 	contract.Assert(proj != nil)
 	contract.Assert(target != nil)
 	projinfo := &Projinfo{Proj: proj, Root: info.Update.GetRoot()}
-	pwd, main, ctx, err := ProjectInfoContext(projinfo, opts.Diag, info.TracingSpan)
+	pwd, main, ctx, err := ProjectInfoContext(projinfo, target, opts.Diag, info.TracingSpan)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -3,8 +3,6 @@
 package deploy
 
 import (
-	"os"
-
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
@@ -83,25 +81,4 @@ func (p *Plan) Provider(pkg tokens.Package) (plugin.Provider, error) {
 	// TODO: ideally we would flow versions on specific requests along to the underlying host function.  Absent that,
 	//     we will just pass nil, which returns us the most recent version available to us.
 	return p.ctx.Host.Provider(pkg, nil)
-}
-
-// TryProvider attempts to load a provider for the given package.  If it is missing, nil is returned.
-func (p *Plan) TryProvider(pkg tokens.Package) (plugin.Provider, error) {
-	// TODO: ideally we would flow versions on specific requests along to the underlying host function.  Absent that,
-	//     we will just pass nil, which returns us the most recent version available to us.
-	prov, err := p.ctx.Host.Provider(pkg, nil)
-	if err != nil {
-		// If a plugin missing error, just return nil.
-		if _, ok := err.(*plugin.MissingError); ok {
-			return nil, nil
-		}
-		// If an OS file not found error, also just return nil.
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		// Otherwise propagate the error.
-		return nil, err
-	}
-
-	return prov, nil
 }

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -22,7 +22,7 @@ import (
 func TestNullPlan(t *testing.T) {
 	t.Parallel()
 
-	ctx, err := plugin.NewContext(cmdutil.Diag(), nil, "", nil)
+	ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil, "", nil)
 	assert.Nil(t, err)
 	targ := &Target{Name: tokens.QName("null")}
 	prev := NewSnapshot(targ.Name, Manifest{}, nil)
@@ -43,7 +43,7 @@ func TestErrorPlan(t *testing.T) {
 
 	// First trigger an error from Iterate:
 	{
-		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, "", nil)
+		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil, "", nil)
 		assert.Nil(t, err)
 		targ := &Target{Name: tokens.QName("errs")}
 		prev := NewSnapshot(targ.Name, Manifest{}, nil)
@@ -58,7 +58,7 @@ func TestErrorPlan(t *testing.T) {
 
 	// Next trigger an error from Next:
 	{
-		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, "", nil)
+		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil, "", nil)
 		assert.Nil(t, err)
 		targ := &Target{Name: tokens.QName("errs")}
 		prev := NewSnapshot(targ.Name, Manifest{}, nil)
@@ -135,7 +135,7 @@ func TestBasicCRUDPlan(t *testing.T) {
 				// we don't actually execute the plan, so there's no need to implement the other functions.
 			}, nil
 		},
-	}, "", nil)
+	}, nil, "", nil)
 	assert.Nil(t, err)
 
 	// Setup a fake namespace/target combination.

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -14,3 +14,22 @@ type Target struct {
 	Decrypter config.Decrypter // decrypter for secret configuration values.
 	Snapshot  *Snapshot        // the last snapshot deployed to the target.
 }
+
+// GetPackageConfig returns the set of configuration parameters for the indicated package, if any.
+func (t *Target) GetPackageConfig(pkg tokens.Package) (map[tokens.ModuleMember]string, error) {
+	var result map[tokens.ModuleMember]string
+	for k, c := range t.Config {
+		if k.Package() != pkg {
+			continue
+		}
+		v, err := c.Value(t.Decrypter)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			result = make(map[tokens.ModuleMember]string)
+		}
+		result[k] = v
+	}
+	return result, nil
+}

--- a/pkg/resource/plugin/config_source.go
+++ b/pkg/resource/plugin/config_source.go
@@ -1,0 +1,14 @@
+// Copyright 2016-2017, Pulumi Corporation.  All rights reserved.
+
+package plugin
+
+import (
+	"github.com/pulumi/pulumi/pkg/tokens"
+)
+
+// ConfigSource is an interface that allows a plugin context to fetch configuration data for a plugin named by
+// package.
+type ConfigSource interface {
+	// GetPackageConfig returns the set of configuration parameters for the indicated package, if any.
+	GetPackageConfig(pkg tokens.Package) (map[tokens.ModuleMember]string, error)
+}

--- a/pkg/resource/plugin/context.go
+++ b/pkg/resource/plugin/context.go
@@ -23,7 +23,7 @@ type Context struct {
 
 // NewContext allocates a new context with a given sink and host.  Note that the host is "owned" by this context from
 // here forwards, such that when the context's resources are reclaimed, so too are the host's.
-func NewContext(d diag.Sink, host Host, pwd string, parentSpan opentracing.Span) (*Context, error) {
+func NewContext(d diag.Sink, host Host, cfg ConfigSource, pwd string, parentSpan opentracing.Span) (*Context, error) {
 	ctx := &Context{
 		Diag:        d,
 		Host:        host,
@@ -31,7 +31,7 @@ func NewContext(d diag.Sink, host Host, pwd string, parentSpan opentracing.Span)
 		tracingSpan: parentSpan,
 	}
 	if host == nil {
-		h, err := NewDefaultHost(ctx)
+		h, err := NewDefaultHost(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
As it stands, we only configure those providers for which configuration
is present. This can lead to surprising failure modes if those providers
are then used to create resources. These changes ensure that all
resource providers that are not configured during plan initialization
are configured upon first load.

Fixes #758.