### PR TITLE
Fix the make_release.ps1 script

### DIFF
--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -37,7 +37,7 @@ Copy-Item "$Root\sdk\nodejs\pulumi-provider-pulumi-nodejs.cmd" "$PublishDir\bin"
 Copy-Item "$Root\sdk\nodejs\custom_node\node\node.exe" "$PublishDir\bin\pulumi-langhost-nodejs-node.exe"
 
 $NodeFolder = "$PublishDir\bin\$NodeVersion"
-New-Item -ItemType Directory -Force -Path $NodeFolder
+New-Item -ItemType Directory -Force -Path $NodeFolder | Out-Null
 Copy-Item "$Root\sdk\nodejs\runtime\native\build\Release\nativeruntime.node" $NodeFolder
 Copy-Item "$Root\sdk\nodejs\runtime\native\build\Release\nativeruntime.pdb" $NodeFolder
 


### PR DESCRIPTION
Fixes the Windows publish build break.

New-Item produces a new object on success, which ultimately gets output by the make_release.ps1 cmdlet and consumed by the release.ps1 script. This messes up the release script that is expecting exactly one object to come out of the pipeline from make_release.ps1.

Powershell, oh Powershell... at least this explains why running `scripts/make_release.ps1` by itself worked fine when I tested my last PR...