### PR TITLE
Fix missing emojis on Windows

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -7,6 +7,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/golang/glog"
@@ -54,7 +55,7 @@ func NewPulumiCmd() *cobra.Command {
 		contract.IgnoreError(logErr) // we want to make progress anyway.
 		if len(loggedInto) > 0 {
 			fmt.Printf("\n")
-			fmt.Printf("Currently logged into the Pulumi Cloud ☁️\n")
+			fmt.Printf("Currently logged into the Pulumi Cloud%s\n", cmdutil.EmojiOr(" ☁️", ""))
 			for _, be := range loggedInto {
 				var marker string
 				if be.Name() == current {
@@ -66,6 +67,8 @@ func NewPulumiCmd() *cobra.Command {
 	})
 
 	cmd.PersistentFlags().StringVarP(&cwd, "cwd", "C", "", "Run pulumi as if it had been started in another directory")
+	cmd.PersistentFlags().BoolVarP(&cmdutil.Emoji, "emoji", "e",
+		runtime.GOOS == "darwin", "Enable emojis in the output")
 	cmd.PersistentFlags().BoolVar(&local.DisableIntegrityChecking, "disable-integrity-checking", false,
 		"Disable integrity checking of checkpoint files")
 	cmd.PersistentFlags().BoolVar(&logFlow, "logflow", false, "Flow log settings to child processes (like plugins)")

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -287,7 +287,7 @@ func (b *cloudBackend) updateStack(action updateKind, stackName tokens.QName, pk
 	contract.Assertf(ok, "unsupported update kind: %v", action)
 	fmt.Printf(
 		colors.ColorizeText(
-			colors.BrightMagenta+"%s stack '%s' in the Pulumi Cloud"+colors.Reset+" ☁️\n"),
+			colors.BrightMagenta+"%s stack '%s' in the Pulumi Cloud"+colors.Reset+cmdutil.EmojiOr(" ☁️", "")+"\n"),
 		actionLabel, stackName)
 
 	// First create the update object.
@@ -664,7 +664,7 @@ func (b *cloudBackend) waitForUpdate(action string,
 }
 
 func displayEvents(action string, events <-chan displayEvent, done chan<- bool, opts backend.DisplayOptions) {
-	prefix := fmt.Sprintf("✨ %s...", action)
+	prefix := fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), action)
 	spinner, ticker := cmdutil.NewSpinnerAndTicker(prefix, nil)
 
 	defer func() {

--- a/pkg/backend/local/display.go
+++ b/pkg/backend/local/display.go
@@ -19,7 +19,7 @@ import (
 // await all the events being written.
 func displayEvents(action string,
 	events <-chan engine.Event, done chan<- bool, debug bool, opts backend.DisplayOptions) {
-	prefix := fmt.Sprintf("✨ %s...", action)
+	prefix := fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), action)
 	spinner, ticker := cmdutil.NewSpinnerAndTicker(prefix, nil)
 
 	defer func() {

--- a/pkg/util/cmdutil/console.go
+++ b/pkg/util/cmdutil/console.go
@@ -14,6 +14,17 @@ import (
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 )
 
+// Emoji controls whether emojis will by default be printed in the output.
+var Emoji = (runtime.GOOS == "darwin")
+
+// EmojiOr returns the emoji string e if emojis are enabled, or the string or if emojis are disabled.
+func EmojiOr(e, or string) string {
+	if Emoji {
+		return e
+	}
+	return or
+}
+
 // Interactive returns true if we're in an interactive terminal session.
 func Interactive() bool {
 	return terminal.IsTerminal(int(os.Stdin.Fd()))

--- a/pkg/util/cmdutil/spinner.go
+++ b/pkg/util/cmdutil/spinner.go
@@ -16,7 +16,12 @@ import (
 // dot on each tick and updates slowly.
 func NewSpinnerAndTicker(prefix string, ttyFrames []string) (Spinner, *time.Ticker) {
 	if ttyFrames == nil {
-		ttyFrames = DefaultSpinFrames
+		// If explicit tick frames weren't specified, default to unicode for Mac and ASCII for Windows/Linux.
+		if Emoji {
+			ttyFrames = DefaultEmojiSpinFrames
+		} else {
+			ttyFrames = DefaultASCIISpinFrames
+		}
 	}
 
 	if terminal.IsTerminal(int(os.Stdout.Fd())) {
@@ -42,8 +47,14 @@ type Spinner interface {
 }
 
 var (
-	// DefaultSpinFrames is the default set of symbols to show while spinning in a TTY setting.
-	DefaultSpinFrames = []string{"⠋", "⠙", "⠚", "⠒", "⠂", "⠂", "⠒", "⠲", "⠴", "⠦", "⠖", "⠒", "⠐", "⠐", "⠒", "⠓", "⠋"}
+	// DefaultASCIISpinFrames is the default set of symbols to show while spinning in an ASCII TTY setting.
+	DefaultASCIISpinFrames = []string{
+		"|", "/", "-", "\\",
+	}
+	// DefaultEmojiSpinFrames is the default set of symbols to show while spinning in a Unicode-enabled TTY setting.
+	DefaultEmojiSpinFrames = []string{
+		"⠋", "⠙", "⠚", "⠒", "⠂", "⠂", "⠒", "⠲", "⠴", "⠦", "⠖", "⠒", "⠐", "⠐", "⠒", "⠓", "⠋",
+	}
 )
 
 // ttySpinner is the spinner that can be used when standard out is a tty. When we are connected to a TTY we can erase


### PR DESCRIPTION
I was reminded of this yesterday with unprintable characters as I
debugged some things on Windows.  Inspired by Yarn, this change adds
a new flag --emoji (-e for short) that can be used to control whether
we show ASCII-only characters or not in the console.  On Mac, it
defaults to true, and on Windows and Linux, it defaults to false.

This also brings back the retro ASCII-friendly progress spinner
when --emoji is disabled.