### PR TITLE
Capture plugin names in the manifest

### DIFF
--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -110,7 +110,8 @@ func (a *analyzer) GetPluginInfo() (workspace.PluginInfo, error) {
 	}
 
 	return workspace.PluginInfo{
-		Name:    a.plug.Bin,
+		Name:    string(a.name),
+		Path:    a.plug.Bin,
 		Kind:    workspace.AnalyzerPlugin,
 		Version: version,
 	}, nil

--- a/pkg/resource/plugin/langruntime_plugin.go
+++ b/pkg/resource/plugin/langruntime_plugin.go
@@ -149,7 +149,8 @@ func (h *langhost) GetPluginInfo() (workspace.PluginInfo, error) {
 	}
 
 	return workspace.PluginInfo{
-		Name:    h.plug.Bin,
+		Name:    h.runtime,
+		Path:    h.plug.Bin,
 		Kind:    workspace.LanguagePlugin,
 		Version: version,
 	}, nil

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -344,7 +344,8 @@ func (p *provider) GetPluginInfo() (workspace.PluginInfo, error) {
 	}
 
 	return workspace.PluginInfo{
-		Name:    p.plug.Bin,
+		Name:    string(p.pkg),
+		Path:    p.plug.Bin,
 		Kind:    workspace.ResourcePlugin,
 		Version: version,
 	}, nil

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -32,6 +32,7 @@ type Manifest struct {
 // PluginInfo captures the version and information about a plugin.
 type PluginInfo struct {
 	Name    string               `json:"name" yaml:"name"`
+	Path    string               `json:"path" yaml:"path"`
 	Type    workspace.PluginKind `json:"type" yaml:"type"`
 	Version string               `json:"version" yaml:"version"`
 }
@@ -66,6 +67,7 @@ func SerializeDeployment(snap *deploy.Snapshot) *Deployment {
 		}
 		manifest.Plugins = append(manifest.Plugins, PluginInfo{
 			Name:    plug.Name,
+			Path:    plug.Path,
 			Type:    plug.Kind,
 			Version: version,
 		})

--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -29,6 +29,7 @@ import (
 // however the primary loadable executable must be named `pulumi-<kind>-<name>`.
 type PluginInfo struct {
 	Name         string          // the simple name of the plugin.
+	Path         string          // the path that a plugin was loaded from.
 	Kind         PluginKind      // the kind of the plugin (language, resource, etc).
 	Version      *semver.Version // the plugin's semantic version, if present.
 	Size         int64           // the size of the plugin, in bytes.


### PR DESCRIPTION
Previously, the checkpoint manifest contained the full path to a plugin
binary, in places of its friendly name.  Now that we must move to a model
where we install plugins in the PPC based on the manifest contents, we
actually need to store the name, in addition to the version (which is
already there).  We still also capture the path for debugging purposes.