### PR TITLE
Guard BirthTime checks with HasBirthTimes

### DIFF
--- a/cmd/plugin_ls.go
+++ b/cmd/plugin_ls.go
@@ -67,13 +67,13 @@ func newPluginLsCmd() *cobra.Command {
 				}
 				var bytes string
 				if plugin.Size == 0 {
-					bytes = "n/a"
+					bytes = naString
 				} else {
 					bytes = humanize.Bytes(uint64(plugin.Size))
 				}
 				var installTime string
 				if plugin.InstallTime.IsZero() {
-					installTime = humanNeverTime
+					installTime = naString
 				} else {
 					installTime = humanize.Time(plugin.InstallTime)
 				}
@@ -103,3 +103,4 @@ func newPluginLsCmd() *cobra.Command {
 }
 
 const humanNeverTime = "never"
+const naString = "n/a"

--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -113,7 +113,11 @@ func (info *PluginInfo) SetFileMetadata(dir, path string) error {
 
 	// Next get the access times from the plugin binary itself.
 	tinfo := times.Get(file)
-	info.InstallTime = tinfo.BirthTime()
+
+	if tinfo.HasBirthTime() {
+		info.InstallTime = tinfo.BirthTime()
+	}
+
 	info.LastUsedTime = tinfo.AccessTime()
 	return nil
 }


### PR DESCRIPTION
Some file systems do not record BithTimes and BirthTime panics in
these cases. We use HasBirthTimes to guard against this and print n/a
when we do not have a BirthTime.