### PR TITLE
Check plugin cache first in some cases

### DIFF
--- a/pkg/resource/plugin/host.go
+++ b/pkg/resource/plugin/host.go
@@ -149,15 +149,16 @@ func (host *defaultHost) Provider(pkg tokens.Package, version *semver.Version) (
 			return nil, infoerr
 		}
 
-		// Ensure that the version reported by the plugin matches what we expected.
+		// Warn if the plugin version was not what we expected
 		if version != nil {
 			if info.Version == nil || !version.EQ(*info.Version) {
 				var v string
 				if info.Version != nil {
 					v = info.Version.String()
 				}
-				return nil,
-					errors.Errorf("resource plugin version %s mis-reported its own version: %s", version.String(), v)
+				host.ctx.Diag.Warningf(
+					diag.Message("resource plugin %s mis-reported its own version, expected %s got %s"),
+					info.Name, version.String(), v)
 			}
 		}
 


### PR DESCRIPTION
Previously, we would prefer a plugin on the $PATH which is more or
less always the case for people hacking on `pulumi`. Later, when we
went to check the loaded plugin version matched the one we requested,
we fail.

Now, if we have a version, we'll first consult the local plugin
cache. If that fails, we'll fall back to the $PATH as we used to.

When we are loading a plugin without a version, we continue to use the
one on the $PATH (without testing the cache) on the assumption it is
newer.

Fixes #977