### PR TITLE
Workaround for issue with python setup.py

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -23,7 +23,7 @@ build::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 install::
-	cd ./bin/ && python setup.py install --user --force
+	cd ./bin/ && python setup.py install --user --force --prefix=
 	cp ./cmd/pulumi-language-python-exec "$(PULUMI_BIN)"
 	GOBIN=$(PULUMI_BIN) go install \
 		  -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}


### PR DESCRIPTION
Pass `--prefix=` to avoid hitting: 

```
error: can't combine user with with prefix/exec_prefix/home or install_(plat)base
```

Per recommendation at: https://stackoverflow.com/questions/4495120/combine-user-with-prefix-error-with-setup-py-install.

Not clear why this is needed, or why others aren't hitting it - but this appears to be required for me to build locally.