### PR TITLE
Use better resolution in start and end times in local backend

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -34,14 +34,11 @@ func newHistoryCmd() *cobra.Command {
 				return err
 			}
 
-			b := s.Backend()
-			updates, err := b.GetHistory(s.Name())
+			// GetHistory returns an array with the newest update first
+			updates, err := s.Backend().GetHistory(s.Name())
 			if err != nil {
 				return errors.Wrap(err, "getting history")
 			}
-
-			// Sort the updates to ensure the most recent updates come first.
-			backend.Sort(updates)
 
 			if outputJSON {
 				b, err := json.MarshalIndent(updates, "", "    ")

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -44,7 +44,7 @@ type Backend interface {
 		debug bool, m UpdateMetadata, opts engine.UpdateOptions, displayOpts DisplayOptions) error
 
 	// GetHistory returns all updates for the stack. The returned UpdateInfo slice will be in
-	// descending order by Version.
+	// descending order (newest first).
 	GetHistory(stackName tokens.QName) ([]UpdateInfo, error)
 	// GetLogs fetches a list of log entries for the given stack, with optional filtering/querying.
 	GetLogs(stackName tokens.QName, query operations.LogQuery) ([]operations.LogEntry, error)

--- a/pkg/backend/local/state.go
+++ b/pkg/backend/local/state.go
@@ -306,7 +306,11 @@ func getHistory(name tokens.QName) ([]backend.UpdateInfo, error) {
 	}
 
 	var updates []backend.UpdateInfo
-	for _, file := range allFiles {
+
+	// os.ReadDir returns the array sorted by file name, but because of how we name files, older updates come before
+	// newer ones. Loop backwards so we added the newest updates to the array we will return first.
+	for i := len(allFiles) - 1; i >= 0; i-- {
+		file := allFiles[i]
 		filepath := path.Join(dir, file.Name())
 
 		// Open all of the history files, ignoring the checkpoints.
@@ -345,7 +349,7 @@ func addToHistory(name tokens.QName, update backend.UpdateInfo) error {
 	}
 
 	// Prefix for the update and checkpoint files.
-	pathPrefix := path.Join(dir, fmt.Sprintf("%s-%d", name, update.StartTime))
+	pathPrefix := path.Join(dir, fmt.Sprintf("%s-%d", name, time.Now().UnixNano()))
 
 	// Save the history file.
 	b, err := json.MarshalIndent(&update, "", "    ")

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -3,8 +3,6 @@
 package backend
 
 import (
-	"sort"
-
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 )
@@ -76,28 +74,4 @@ type UpdateInfo struct {
 	EndTime int64        `json:"endTime"`
 
 	ResourceChanges engine.ResourceChanges `json:"resourceChanges"`
-}
-
-// updateSorter implements the sort.Interface interface.
-// Sorts by StartTime in *descending* order (more recent first).
-type updateSorter struct {
-	u []UpdateInfo
-}
-
-func (us *updateSorter) Len() int {
-	return len(us.u)
-}
-
-func (us *updateSorter) Swap(i, j int) {
-	us.u[i], us.u[j] = us.u[j], us.u[i]
-}
-
-func (us *updateSorter) Less(i, j int) bool {
-	return us.u[i].StartTime > us.u[j].StartTime
-}
-
-// Sort orders the UpdateInfo slice by StartTime descending.
-func Sort(updates []UpdateInfo) {
-	us := updateSorter{u: updates}
-	sort.Sort(&us)
 }


### PR DESCRIPTION
These times flow into the file-names we use to retain history and at
second resolution it makes the local history test flaky if you have a
fast machine as multiple `pulumi update` invocations can happen in a
second and they stomp over the history for one another.