### PR TITLE
Publish Pulumi Python SDK package

### DIFF
--- a/build/travis/install-common-toolchain.sh
+++ b/build/travis/install-common-toolchain.sh
@@ -12,6 +12,8 @@ nvm install v6.10.2
     DEP_VERSION="0.4.1"
     GOMETALINTER_VERSION="2.0.3"
     AWSCLI_VERSION="1.14.30"
+    WHEEL_VERSION="0.30.0"
+    TWINE_VERSION="1.9.1"
 
     OS=""
     case $(uname) in
@@ -51,6 +53,9 @@ nvm install v6.10.2
 
     echo "installing AWS cli ${AWSCLI_VERSION}"
     pip install --user "awscli==${AWSCLI_VERSION}"
+
+    echo "installing Wheel and Twine, so we can publish Python packages"
+    pip install --user "wheel==${WHEEL_VERSION}" "twine==${TWINE_VERSION}"
 )
 
 # If the sub shell failed, bail out now.
@@ -62,6 +67,7 @@ nvm install v6.10.2
 # $PATH by default.
 if [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then
     export PATH=$PATH:$HOME/Library/Python/2.7/bin
+    export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages
 fi
 
 # Add yarn to the $PATH

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -28,3 +28,8 @@ pushd ${ROOT}/sdk/nodejs/bin && \
     npm publish && \
     npm info 2>/dev/null || true && \
     popd
+
+echo "Publishing Pip package to pulumi.com:"
+twine upload \
+    --repository-url https://${PULUMI_API_TOKEN}@pypi-dot-testing.moolumi.io \
+    ${ROOT}/sdk/python/bin/dist/*.whl

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -19,7 +19,7 @@ build::
 	cd ./lib/ && python setup.py clean --all 2>/dev/null
 	rm -rf ./bin/ && cp -R ./lib/. ./bin/
 	sed -i.bak "s/\$${VERSION}/$(VERSION)/g" ./bin/setup.py && rm ./bin/setup.py.bak
-	cd ./bin/ && python setup.py build
+	cd ./bin/ && python setup.py build bdist_wheel --universal
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 install::


### PR DESCRIPTION
We now publish the Pulumi Python SDK package to our private PyPI
server at the same time we also publish the NPM package.  For now,
we use the test Pulumi.com service, and will switch to staging as
soon as it becomes available.