### PR TITLE
Reintroduce untyped deployments

### DIFF
--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -35,16 +35,22 @@ func newStackImportCmd() *cobra.Command {
 				return err
 			}
 
-			// Read the checkpoint from stdin.
-			var deployment apitype.Deployment
+			// Read the checkpoint from stdin.  We decode this into a json.RawMessage so as not to lose any fields
+			// sent by the server that the client CLI does not recognize (enabling round-tripping).
+			var deployment json.RawMessage
 			if err = json.NewDecoder(os.Stdin).Decode(&deployment); err != nil {
 				return err
 			}
 
-			// Check to see if the checkpoint contains resources with names other than the selected stack.  This can
-			// catch errors wherein someone imports the wrong stack's checkpoint (which can seriously hork things).
+			// We do, however, now want to unmarshal the json.RawMessage into a real, typed deployment.  We do this so
+			// we can check that the checkpoint doesn't contain resources from a stack other than the selected one. This
+			// catches errors wherein someone imports the wrong stack's checkpoint (which can seriously hork things).
+			var typed apitype.Deployment
+			if err = json.Unmarshal(deployment, &typed); err != nil {
+				return err
+			}
 			var result error
-			for _, res := range deployment.Resources {
+			for _, res := range typed.Resources {
 				if res.URN.Stack() != s.Name() {
 					msg := fmt.Sprintf("resource '%s' is from a different stack (%s != %s)",
 						res.URN, res.URN.Stack(), s.Name())
@@ -63,7 +69,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 
 			// Now perform the deployment.
-			if err = s.ImportDeployment(&deployment); err != nil {
+			if err = s.ImportDeployment(&apitype.UntypedDeployment{Deployment: deployment}); err != nil {
 				return errors.Wrap(err, "could not import deployment")
 			}
 			fmt.Printf("Import successful.\n")

--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -15,6 +15,7 @@
 package apitype
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/pulumi/pulumi/pkg/resource"
@@ -40,6 +41,14 @@ type Deployment struct {
 	Manifest Manifest `json:"manifest" yaml:"manifest"`
 	// Resources contains all resources that are currently part of this stack after this deployment has finished.
 	Resources []Resource `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+// UntypedDeployment contains an inner, untyped deployment structure.
+type UntypedDeployment struct {
+	// The opaque Pulumi deployment.  This is conceptually of type `Deployment`, but we use `json.Message` to
+	// permit round-tripping of stack contents when an older client is talking to a newer server.  If we unmarshaled
+	// the contents, and then remarshaled them, we could end up losing important information.
+	Deployment json.RawMessage `json:"deployment,omitempty"`
 }
 
 // Resource describes a Cloud resource constructed by Pulumi.

--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -91,17 +91,11 @@ type DecryptValueResponse struct {
 	Plaintext []byte `json:"plaintext"`
 }
 
-// StackExport describes an exported stack.
-type StackExport struct {
-	// The opaque Pulumi deployment.
-	Deployment *Deployment `json:"deployment,omitempty"`
-}
-
 // ExportStackResponse defines the response body for exporting a Stack.
-type ExportStackResponse StackExport
+type ExportStackResponse UntypedDeployment
 
 // ImportStackRequest defines the request body for importing a Stack.
-type ImportStackRequest StackExport
+type ImportStackRequest UntypedDeployment
 
 // ImportStackResponse defines the response body for importing a Stack.
 type ImportStackResponse struct {

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -49,7 +49,7 @@ type Backend interface {
 	GetLogs(stackName tokens.QName, query operations.LogQuery) ([]operations.LogEntry, error)
 
 	// ExportDeployment exports the deployment for the given stack as an opaque JSON message.
-	ExportDeployment(stackName tokens.QName) (*apitype.Deployment, error)
+	ExportDeployment(stackName tokens.QName) (*apitype.UntypedDeployment, error)
 	// ImportDeployment imports the given deployment into the indicated stack.
-	ImportDeployment(stackName tokens.QName, deployment *apitype.Deployment) error
+	ImportDeployment(stackName tokens.QName, deployment *apitype.UntypedDeployment) error
 }

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -480,7 +480,7 @@ func (b *cloudBackend) GetLogs(stackName tokens.QName,
 	return logs, nil
 }
 
-func (b *cloudBackend) ExportDeployment(stackName tokens.QName) (*apitype.Deployment, error) {
+func (b *cloudBackend) ExportDeployment(stackName tokens.QName) (*apitype.UntypedDeployment, error) {
 	projID, err := getCloudProjectIdentifier()
 	if err != nil {
 		return nil, err
@@ -493,10 +493,10 @@ func (b *cloudBackend) ExportDeployment(stackName tokens.QName) (*apitype.Deploy
 		return nil, err
 	}
 
-	return response.Deployment, nil
+	return &apitype.UntypedDeployment{Deployment: response.Deployment}, nil
 }
 
-func (b *cloudBackend) ImportDeployment(stackName tokens.QName, deployment *apitype.Deployment) error {
+func (b *cloudBackend) ImportDeployment(stackName tokens.QName, deployment *apitype.UntypedDeployment) error {
 	projID, err := getCloudProjectIdentifier()
 	if err != nil {
 		return err
@@ -505,7 +505,7 @@ func (b *cloudBackend) ImportDeployment(stackName tokens.QName, deployment *apit
 	stackPath := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks/%s",
 		projID.Owner, projID.Repository, projID.Project, string(stackName))
 
-	request := apitype.ImportStackRequest{Deployment: deployment}
+	request := apitype.ImportStackRequest{Deployment: deployment.Deployment}
 	var response apitype.ImportStackResponse
 	if err = pulumiRESTCall(b.cloudURL, "POST", stackPath+"/import", nil, &request, &response); err != nil {
 		return err

--- a/pkg/backend/cloud/stack.go
+++ b/pkg/backend/cloud/stack.go
@@ -99,10 +99,10 @@ func (s *cloudStack) GetLogs(query operations.LogQuery) ([]operations.LogEntry, 
 	return backend.GetStackLogs(s, query)
 }
 
-func (s *cloudStack) ExportDeployment() (*apitype.Deployment, error) {
+func (s *cloudStack) ExportDeployment() (*apitype.UntypedDeployment, error) {
 	return backend.ExportStackDeployment(s)
 }
 
-func (s *cloudStack) ImportDeployment(deployment *apitype.Deployment) error {
+func (s *cloudStack) ImportDeployment(deployment *apitype.UntypedDeployment) error {
 	return backend.ImportStackDeployment(s, deployment)
 }

--- a/pkg/backend/local/stack.go
+++ b/pkg/backend/local/stack.go
@@ -68,10 +68,10 @@ func (s *localStack) GetLogs(query operations.LogQuery) ([]operations.LogEntry, 
 	return backend.GetStackLogs(s, query)
 }
 
-func (s *localStack) ExportDeployment() (*apitype.Deployment, error) {
+func (s *localStack) ExportDeployment() (*apitype.UntypedDeployment, error) {
 	return backend.ExportStackDeployment(s)
 }
 
-func (s *localStack) ImportDeployment(deployment *apitype.Deployment) error {
+func (s *localStack) ImportDeployment(deployment *apitype.UntypedDeployment) error {
 	return backend.ImportStackDeployment(s, deployment)
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -31,8 +31,8 @@ type Stack interface {
 
 	Remove(force bool) (bool, error)                                  // remove this stack.
 	GetLogs(query operations.LogQuery) ([]operations.LogEntry, error) // list log entries for this stack.
-	ExportDeployment() (*apitype.Deployment, error)                   // export this stack's deployment.
-	ImportDeployment(deployment *apitype.Deployment) error            // import the given deployment into this stack.
+	ExportDeployment() (*apitype.UntypedDeployment, error)            // export this stack's deployment.
+	ImportDeployment(deployment *apitype.UntypedDeployment) error     // import the given deployment into this stack.
 }
 
 // RemoveStack returns the stack, or returns an error if it cannot.
@@ -69,11 +69,11 @@ func GetStackLogs(s Stack, query operations.LogQuery) ([]operations.LogEntry, er
 }
 
 // ExportStackDeployment exports the given stack's deployment as an opaque JSON message.
-func ExportStackDeployment(s Stack) (*apitype.Deployment, error) {
+func ExportStackDeployment(s Stack) (*apitype.UntypedDeployment, error) {
 	return s.Backend().ExportDeployment(s.Name())
 }
 
 // ImportStackDeployment imports the given deployment into the indicated stack.
-func ImportStackDeployment(s Stack, deployment *apitype.Deployment) error {
+func ImportStackDeployment(s Stack, deployment *apitype.UntypedDeployment) error {
 	return s.Backend().ImportDeployment(s.Name(), deployment)
 }


### PR DESCRIPTION
By using untyped deployment structures via `json.RawMessage`, we can
support round-tripping between old CLI clients and newer servers, without
dropping possibly-important information on the floor.  I hadn't realized
this design goal with the original system, and after talking to @pgavlin,
I better realized the intent and that we want to preserve this.