### PR TITLE
Fix some unecessary branches to appease golint

### DIFF
--- a/cmd/upgrade_config.go
+++ b/cmd/upgrade_config.go
@@ -156,11 +156,7 @@ func removeOldConfiguration(stackName tokens.QName) error {
 		return err
 	}
 
-	if err := workspace.SaveProject(proj); err != nil {
-		return err
-	}
-
-	return nil
+	return workspace.SaveProject(proj)
 }
 
 // removeOldProjectConfiguration deletes all project level configuration information from both the workspace and the
@@ -183,9 +179,5 @@ func removeOldProjectConfiguration() error {
 		return err
 	}
 
-	if err := workspace.SaveProject(proj); err != nil {
-		return err
-	}
-
-	return nil
+	return workspace.SaveProject(proj)
 }


### PR DESCRIPTION
My version of `golint` flags this but I guess the one in our CI doesn't. At any rate, this PR makes golint happy by getting rid of the `if` at the end of these two functions.