### PR TITLE
Publish tgz's in the middle of the build, packages at the end

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,15 @@ test_fast::
 test_all::
 	PATH=$(PULUMI_ROOT)/bin:$(PATH) go test -cover -parallel ${TESTPARALLELISM} ${EXTRA_TEST_PKGS}
 
-.PHONY: publish
-publish:
+.PHONY: publish_tgz
+publish_tgz:
 	$(call STEP_MESSAGE)
-	./scripts/publish.sh
+	./scripts/publish_tgz.sh
+
+.PHONY: publish_packages
+publish_packages:
+	$(call STEP_MESSAGE)
+	./scripts/publish_packages.sh
 
 .PHONY: coverage
 coverage:
@@ -50,6 +55,6 @@ coverage:
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
 travis_cron: all coverage
-travis_push: only_build publish only_test
+travis_push: only_build publish_tgz only_test publish_packages
 travis_pull_request: all
 travis_api: all

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# publish_packages.sh uploads our packages to package repositories like npm
+set -o nounset -o errexit -o pipefail
+
+if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
+    echo "Publishing NPM package to NPMjs.com:"
+    pushd ${ROOT}/sdk/nodejs/bin && \
+        npm publish && \
+        npm info 2>/dev/null || true && \
+        popd
+
+    echo "Publishing Pip package to pulumi.com:"
+    twine upload \
+        --repository-url https://pypi-dot-testing.moolumi.io?token=${PULUMI_API_TOKEN} \
+        -u pulumi -p pulumi \
+        ${ROOT}/sdk/python/bin/dist/*.whl
+fi

--- a/scripts/publish_tgz.sh
+++ b/scripts/publish_tgz.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# publish.sh builds and publishes a release.
+# publish.sh builds and publishes the tarballs that our other repositories consume.
 set -o nounset -o errexit -o pipefail
 
 ROOT=$(dirname $0)/..
@@ -22,17 +22,3 @@ do
     RELEASE_INFO=($($(dirname $0)/make_release.sh))
     ${PUBLISH} ${RELEASE_INFO[0]} "${PUBLISH_PROJECT}/${OS}/${ARCH}" ${RELEASE_INFO[@]:1}
 done
-
-if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
-    echo "Publishing NPM package to NPMjs.com:"
-    pushd ${ROOT}/sdk/nodejs/bin && \
-        npm publish && \
-        npm info 2>/dev/null || true && \
-        popd
-
-    echo "Publishing Pip package to pulumi.com:"
-    twine upload \
-        --repository-url https://pypi-dot-testing.moolumi.io?token=${PULUMI_API_TOKEN} \
-        -u pulumi -p pulumi \
-        ${ROOT}/sdk/python/bin/dist/*.whl
-fi


### PR DESCRIPTION
While it's safe to publish the tgz that we use internally for other
repositories that are on "the link plan" after the build completes, we
shouldn't publish packages to NPM and PyPi at that point. There are
two reasons for doing this:

1. Publishing packages before they are tested, which means we could
end up publishing packages that don't work.

2. NPM prevents publishing the same package more than once, so if we
had to re-run the job (due to tests failing for transient issues), the
publish step will start failing, preventing us from running the tests
at all.