### PR TITLE
Add deployment to UpdateInfo

### DIFF
--- a/pkg/apitype/history.go
+++ b/pkg/apitype/history.go
@@ -63,7 +63,6 @@ const (
 // flexibility in case there is a breaking change in the backend-type.
 type UpdateInfo struct {
 	// Information known before an update is started.
-
 	Kind        UpdateKind             `json:"kind"`
 	StartTime   int64                  `json:"startTime"`
 	Message     string                 `json:"message"`
@@ -71,10 +70,10 @@ type UpdateInfo struct {
 	Config      map[string]ConfigValue `json:"config"`
 
 	// Information obtained from an update completing.
-
 	Result          UpdateResult   `json:"result"`
 	EndTime         int64          `json:"endTime"`
-	ResourceChanges map[OpType]int `json:"resourceChanges"`
+	Deployment      *Deployment    `json:"deployment,omitempty"`
+	ResourceChanges map[OpType]int `json:"resourceChanges,omitempty"`
 }
 
 // GetHistoryResponse is the response from the Pulumi Service when requesting

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -409,23 +409,18 @@ func (b *cloudBackend) GetHistory(stackName tokens.QName) ([]backend.UpdateInfo,
 		if err != nil {
 			return nil, errors.Wrap(err, "converting configuration")
 		}
-		changes := convertResourceChanges(update.ResourceChanges)
 
-		beUpdate := backend.UpdateInfo{
-			Kind:      backend.UpdateKind(update.Kind),
-			StartTime: update.StartTime,
-
-			Message:     update.Message,
-			Environment: update.Environment,
-
-			Config: cfg,
-
-			Result:  backend.UpdateResult(update.Result),
-			EndTime: update.EndTime,
-
-			ResourceChanges: changes,
-		}
-		beUpdates = append(beUpdates, beUpdate)
+		beUpdates = append(beUpdates, backend.UpdateInfo{
+			Kind:            backend.UpdateKind(update.Kind),
+			Message:         update.Message,
+			Environment:     update.Environment,
+			Config:          cfg,
+			Result:          backend.UpdateResult(update.Result),
+			StartTime:       update.StartTime,
+			EndTime:         update.EndTime,
+			Deployment:      update.Deployment,
+			ResourceChanges: convertResourceChanges(update.ResourceChanges),
+		})
 	}
 
 	return beUpdates, nil

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -3,6 +3,7 @@
 package backend
 
 import (
+	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 )
@@ -56,11 +57,12 @@ const (
 // UpdateInfo describes a previous update.
 type UpdateInfo struct {
 	// Information known before an update is started.
-
 	Kind      UpdateKind `json:"kind"`
 	StartTime int64      `json:"startTime"`
+
 	// Message is an optional message associated with the update.
 	Message string `json:"message"`
+
 	// Environment contains optional data from the deploying environment. e.g. the current
 	// source code control commit information.
 	Environment map[string]string `json:"environment"`
@@ -69,9 +71,8 @@ type UpdateInfo struct {
 	Config config.Map `json:"config"`
 
 	// Information obtained from an update completing.
-
-	Result  UpdateResult `json:"result"`
-	EndTime int64        `json:"endTime"`
-
-	ResourceChanges engine.ResourceChanges `json:"resourceChanges"`
+	Result          UpdateResult           `json:"result"`
+	EndTime         int64                  `json:"endTime"`
+	Deployment      *apitype.Deployment    `json:"deployment,omitempty"`
+	ResourceChanges engine.ResourceChanges `json:"resourceChanges,omitempty"`
 }


### PR DESCRIPTION
This change prepares to add optional full deployment checkpoints to
the UpdateInfo payloads returned by the service.  This new field is
optional -- and the old one it replaces never actually got populated
with anything -- so this shouldn't introduce any compat problems.