### PR TITLE
Export RunError from top level of Node.js SDK

### DIFF
--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -5,6 +5,7 @@ import "source-map-support/register";
 
 // Export top-level elements.
 export * from "./config";
+export * from "./errors";
 export * from "./metadata";
 export * from "./resource";
 


### PR DESCRIPTION
This special error kind should be used by all Pulumi components as the error type for user input validation errors.  Although it can already be referenced via `@pulumi/pulumi/errors`, also explicitly export it directly on `@pulumi/pulumi`.

See https://github.com/pulumi/pulumi-cloud/pull/420 where we had to use a more awkward import to be able to use this error.

Note that we may also want to come up with a better name.  `UserError`, `ValidationError`, just `pulumi.Error`?