### PR TITLE
Remove unused apitype

### DIFF
--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -208,25 +208,6 @@ type UpdateApplyRequest struct {
 	Summary bool `json:"summary,omitempty"`
 }
 
-// GetUpdateResponse describes the data retuerned by a request to the `GET /updates/{updateID}` endpoint of the
-// PPC API.
-type GetUpdateResponse struct {
-	CreateUpdateResponse
-
-	// State indicates which state the update is in.
-	State string `json:"state"`
-
-	// StackAlias is the friendly name for the update's stack that will be exposed to the update's Pulumi
-	// program.
-	StackAlias string `json:"stackAlias,omitempty"`
-
-	// Config records the configuration values for an update.
-	Config map[string]string `json:"config"`
-
-	// Program records the program metadata for an update.
-	Program UpdateProgram `json:"program"`
-}
-
 // GetApplyUpdateResultsResponse describes the data returned by the `GET /updates/{updateID}/apply` endpoint of
 // the PPC API.
 type GetApplyUpdateResultsResponse UpdateResults


### PR DESCRIPTION
This type is exposed on the PPC API and not used directly from the pulumi CLI. As a result, it should be exposed from the `pulumi-ppc` repo.

There are other types that can be removed for the same reason, but to avoid yak shaving I'll "trueup" these types incrementally along with the PPC changes.