### PR TITLE
Fix two DST bugs in logs test

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -38,7 +38,7 @@ func newLogsCmd() *cobra.Command {
 				return err
 			}
 
-			startTime, err := parseSince(since)
+			startTime, err := parseSince(since, time.Now())
 			if err != nil {
 				return errors.Wrapf(err, "failed to parse argument to '--since' as duration or timestamp")
 			}
@@ -103,8 +103,8 @@ func newLogsCmd() *cobra.Command {
 	return logsCmd
 }
 
-func parseSince(since string) (*time.Time, error) {
-	startTimestamp, err := mobytime.GetTimestamp(since, time.Now())
+func parseSince(since string, reference time.Time) (*time.Time, error) {
+	startTimestamp, err := mobytime.GetTimestamp(since, reference)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/logs_test.go
+++ b/cmd/logs_test.go
@@ -11,17 +11,26 @@ import (
 )
 
 func TestParseSince(t *testing.T) {
-	a, _ := parseSince("")
+	a, _ := parseSince("", time.Now())
 	assert.Nil(t, a)
 
-	now := time.Now()
-	b, _ := parseSince("1m30s")
+	now := time.Now().UTC()
+	b, _ := parseSince("1m30s", now)
 	assert.True(t, b.UnixNano() < now.UnixNano())
 	fmt.Printf("Res: %v\n", b)
 
-	c, _ := parseSince("2006-01-02T15:04:05")
-	assert.Equal(t, "Mon Jan  2 15:04:05 2006", c.Format(time.ANSIC))
+	c, _ := parseSince("2006-01-02T15:04:05", time.Now().UTC())
+	assert.Equal(t, "2006-01-02T15:04:05Z", c.UTC().Format(time.RFC3339))
 
-	d, _ := parseSince("2006-01-02")
-	assert.Equal(t, "Mon Jan  2 00:00:00 2006", d.Format(time.ANSIC))
+	d, _ := parseSince("2006-01-02", time.Now().UTC())
+	assert.Equal(t, "2006-01-02T00:00:00Z", d.UTC().Format(time.RFC3339))
+
+	pst, err := time.LoadLocation("America/Los_Angeles")
+	assert.Nil(t, err)
+
+	e, _ := parseSince("2006-01-02T15:04:05-08:00", time.Now().In(pst))
+	assert.Equal(t, "2006-01-02T15:04:05-08:00", e.In(pst).Format(time.RFC3339))
+
+	f, _ := parseSince("2006-01-02-08:00", time.Now().In(pst))
+	assert.Equal(t, "2006-01-02T00:00:00-08:00", f.In(pst).Format(time.RFC3339))
 }


### PR DESCRIPTION
This fixes two different DST bugs in the logs test, one of which
led to the failure in pulumi/pulumi#1041:

1) The assertion was using ANSIC formatting, which does not contain
   a time-zone, and because we are now in DST, the resulting time
   didn't parse and format in a round-trippable way.  Instead, let's
   use RFC3339, and let's be explicit about the timezone.

2) The parseSince("1m30s") would in theory fail if the DST changed
   at just the right moment, since the reference time could end up
   different from the reference time that the test is using.  Let's
   expose the reference time to the caller, so that they may decide
   how to deal with these situations, and let's use UTC here.