### PR TITLE
Support offline template descriptions

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -53,11 +53,11 @@ func newNewCmd() *cobra.Command {
 			releases := cloud.New(cmdutil.Diag(), getCloudURL(cloudURL))
 
 			// Get the selected template.
-			var template workspace.Template
+			var templateName string
 			if len(args) > 0 {
-				template = workspace.Template{Name: strings.ToLower(args[0])}
+				templateName = strings.ToLower(args[0])
 			} else {
-				if template, err = chooseTemplate(releases, offline); err != nil {
+				if templateName, err = chooseTemplate(releases, offline); err != nil {
 					return err
 				}
 			}
@@ -66,23 +66,29 @@ func newNewCmd() *cobra.Command {
 			if !offline {
 				var tarball io.ReadCloser
 				source := releases.CloudURL()
-				if tarball, err = releases.DownloadTemplate(template.Name, false); err != nil {
+				if tarball, err = releases.DownloadTemplate(templateName, false); err != nil {
 					message := ""
 					// If the local template is available locally, provide a nicer error message.
 					if localTemplates, localErr := workspace.ListLocalTemplates(); localErr == nil && len(localTemplates) > 0 {
 						_, m := templateArrayToStringArrayAndMap(localTemplates)
-						if _, ok := m[template.Name]; ok {
+						if _, ok := m[templateName]; ok {
 							message = fmt.Sprintf(
 								"; rerun the command and pass --offline to use locally cached template '%s'",
-								template.Name)
+								templateName)
 						}
 					}
 
-					return errors.Wrapf(err, "downloading template '%s' from %s%s", template.Name, source, message)
+					return errors.Wrapf(err, "downloading template '%s' from %s%s", templateName, source, message)
 				}
-				if err = workspace.InstallTemplate(template.Name, tarball); err != nil {
-					return errors.Wrapf(err, "installing template '%s' from %s", template.Name, source)
+				if err = workspace.InstallTemplate(templateName, tarball); err != nil {
+					return errors.Wrapf(err, "installing template '%s' from %s", templateName, source)
 				}
+			}
+
+			// Load the local template.
+			var template workspace.Template
+			if template, err = workspace.LoadLocalTemplate(templateName); err != nil {
+				return errors.Wrapf(err, "template '%s' not found", templateName)
 			}
 
 			// Get the values to fill in.
@@ -91,18 +97,18 @@ func newNewCmd() *cobra.Command {
 
 			// Do a dry run if we're not forcing files to be overwritten.
 			if !force {
-				if err = workspace.CopyTemplateFilesDryRun(template.Name, cwd); err != nil {
+				if err = template.CopyTemplateFilesDryRun(cwd); err != nil {
 					if os.IsNotExist(err) {
-						return errors.Wrapf(err, "template not found")
+						return errors.Wrapf(err, "template '%s' not found", templateName)
 					}
 					return err
 				}
 			}
 
 			// Actually copy the files.
-			if err = workspace.CopyTemplateFiles(template.Name, cwd, force, name, description); err != nil {
+			if err = template.CopyTemplateFiles(cwd, force, name, description); err != nil {
 				if os.IsNotExist(err) {
-					return errors.Wrapf(err, "template not found")
+					return errors.Wrapf(err, "template '%s' not found", templateName)
 				}
 				return err
 			}
@@ -146,10 +152,10 @@ func getCloudURL(cloudURL string) string {
 }
 
 // chooseTemplate will prompt the user to choose amongst the available templates.
-func chooseTemplate(backend cloud.Backend, offline bool) (workspace.Template, error) {
+func chooseTemplate(backend cloud.Backend, offline bool) (string, error) {
 	const chooseTemplateErr = "no template selected; please use `pulumi new` to choose one"
 	if !cmdutil.Interactive() {
-		return workspace.Template{}, errors.New(chooseTemplateErr)
+		return "", errors.New(chooseTemplateErr)
 	}
 
 	var templates []workspace.Template
@@ -166,11 +172,11 @@ func chooseTemplate(backend cloud.Backend, offline bool) (workspace.Template, er
 					strings.Join(options, ", ")
 			}
 
-			return workspace.Template{}, errors.Wrap(err, message)
+			return "", errors.Wrap(err, message)
 		}
 	} else {
 		if templates, err = workspace.ListLocalTemplates(); err != nil || len(templates) == 0 {
-			return workspace.Template{}, errors.Wrap(err, chooseTemplateErr)
+			return "", errors.Wrap(err, chooseTemplateErr)
 		}
 	}
 
@@ -181,17 +187,17 @@ func chooseTemplate(backend cloud.Backend, offline bool) (workspace.Template, er
 	message := "\rPlease choose a template:"
 	message = colors.ColorizeText(colors.BrightWhite + message + colors.Reset)
 
-	options, nameToTemplateMap := templateArrayToStringArrayAndMap(templates)
+	options, _ := templateArrayToStringArrayAndMap(templates)
 
 	var option string
 	if err := survey.AskOne(&survey.Select{
 		Message: message,
 		Options: options,
 	}, &option, nil); err != nil {
-		return workspace.Template{}, errors.New(chooseTemplateErr)
+		return "", errors.New(chooseTemplateErr)
 	}
 
-	return nameToTemplateMap[option], nil
+	return option, nil
 }
 
 // templateArrayToStringArrayAndMap returns an array of template names and map of names to templates


### PR DESCRIPTION
Note: This is a minor issue that I didn't get to for M11 that isn't required for M11 and would be fine merging for post-M11.

When you specify a template name explicitly (e.g. `pulumi new typescript`), we'll try to download the template tarball without first downloading the JSON list of available templates. The JSON includes a description used when replacing the `${DESCRIPTION}` string in template files. Since we didn't download the JSON, we won't have a description, so we fallback to a default value (`"A Pulumi project."`). This also happens when specifying `--offline` to use an existing template under `~/.pulumi/templates`; we won't have a description for the template, so we fallback to a default description. The fallback value happens to be the same as the description for each of our current templates, so noone will currently notice an issue.

For M11, I included initial support for a template manifest file where the description (and any future metadata) could be stored, but didn't go as far as actually reading the file.

This change makes it so the CLI actually reads the description from the manifest file (if it exists), otherwise falling back to the default value as is done currently. Some minor related cleanup is included in this change.