### PR TITLE
Remove unnecessary `os.Stat` call

### DIFF
--- a/pkg/workspace/repository.go
+++ b/pkg/workspace/repository.go
@@ -44,15 +44,10 @@ func GetRepository(root string) (*Repository, error) {
 
 	repofilePath := filepath.Join(dotPulumiPath, RepoFile)
 
-	_, err := os.Stat(repofilePath)
+	b, err := ioutil.ReadFile(repofilePath)
 	if os.IsNotExist(err) {
 		return nil, ErrNoRepository
 	} else if err != nil {
-		return nil, err
-	}
-
-	b, err := ioutil.ReadFile(repofilePath)
-	if err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Just a nit: It's possible (though, unlikely) that the repo file is deleted between the call to `os.Stat` and `ioutil.ReadFile`. Instead, just try to read the file -- if the file doesn't exist, `ioutil.ReadFile` will return an error that works the same with `os.IsNotExist(err)` as the error returned from `os.Stat`.