### PR TITLE
Advise about --plaintext in config warning message

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -208,7 +208,8 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 				cmdutil.Diag().Warningf(
 					diag.Message(
 						"saved config key '%s' value '%s' as plaintext; "+
-							"re-run with --secret to encrypt the value instead"),
+							"re-run with --secret to encrypt the value instead. Use"+
+							"--plaintext to avoid this warning"),
 					key, value)
 			}
 


### PR DESCRIPTION
When run without a `--plaintext` or `--secret` argument, `pulumi
config` warns that the value is stored unecrypted and that you can
pass `--secret` to encrypt it. Now, we also mention that `--plaintext`
can be pased explicity on the command line to avoid the warning.

Fixes #752