### PR TITLE
Assume --remote when --cloud-url is set

### DIFF
--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -86,7 +86,13 @@ func TestStackCommands(t *testing.T) {
 		// Confirm passing both --local and --remote fails.
 		out, err = e.RunCommandExpectError("pulumi", "stack", "init", "foo", "--local", "--remote")
 		assert.Empty(t, out, "expected no stdout")
-		assert.Contains(t, err, "cannot pass both --local and --remote")
+		assert.Contains(t, err, "cannot pass both --local with either --remote or --cloud-url")
+
+		// Confirm passing both --local and --cloud-url similarly fails.
+		out, err = e.RunCommandExpectError("pulumi", "stack", "init", "foo",
+			"--local", "--cloud-url", "https://api.pulumi.com/api")
+		assert.Empty(t, out, "expected no stdout")
+		assert.Contains(t, err, "cannot pass both --local with either --remote or --cloud-url")
 
 		// Confirm passing --remote while logged out fails.
 		e.RunCommand("pulumi", "logout")


### PR DESCRIPTION
If you use --cloud-url, as in

    $ pulumi stack init foo --cloud-url https://x.io

we would silently fall back to logic that creates local stacks.

I realize all of this will get better with the new stack identity
model, however in the meantime, let's infer that the user wanted
--remote when --cloud-url is non-"".