### PR TITLE
Remove UpdateProgramRequestUntyped, now extinct

### DIFF
--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -56,21 +56,6 @@ type UpdateMetadata struct {
 	Environment map[string]string `json:"environment"`
 }
 
-// UpdateProgramRequestUntyped is a legacy type: see comment in pulumi-service stacks_update.go
-// unmarshalConfig()
-// TODO(#478): remove support for string-only config.
-type UpdateProgramRequestUntyped struct {
-	// Properties from the Project file.
-	Name        string `json:"name"`
-	Runtime     string `json:"runtime"`
-	Main        string `json:"main"`
-	Description string `json:"description"`
-
-	// Configuration values. Note that although the element type of this map is an `interface{}`, the value
-	// must be either a string or a ConfigValue.
-	Config map[string]interface{} `json:"config"`
-}
-
 // UpdateProgramResponse is the result of an update program request.
 type UpdateProgramResponse struct {
 	// UpdateID is the opaque identifier of the requested update. This value is needed to begin an update, as


### PR DESCRIPTION
We needed to have two types of `UpdateProgramRequest` to serve both newer shapes of Pulumi configuration values as well as the older, untyped version. (The original change was supporting the `ConfigValue` type, which had a flag to indiciate if the configuration value was encrypted or not.)

Now that LM has been migrated to the M10 bits https://github.com/pulumi/home/issues/168 , we can remove this type. (The PR to remove existing references in the `pulumi-service` repo is https://github.com/pulumi/pulumi-service/pull/957.)