### PR TITLE
Extract a Pulumi API client.

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -50,7 +50,10 @@ func newNewCmd() *cobra.Command {
 				return errors.Wrap(err, "getting the working directory")
 			}
 
-			releases := cloud.New(cmdutil.Diag(), getCloudURL(cloudURL))
+			releases, err := cloud.New(cmdutil.Diag(), getCloudURL(cloudURL))
+			if err != nil {
+				return errors.Wrap(err, "creating API client")
+			}
 
 			// Get the selected template.
 			var templateName string

--- a/cmd/plugin_install.go
+++ b/cmd/plugin_install.go
@@ -74,7 +74,11 @@ func newPluginInstallCmd() *cobra.Command {
 			// Target the cloud URL for downloads.
 			var releases cloud.Backend
 			if len(installs) > 0 && file == "" {
-				releases = cloud.New(cmdutil.Diag(), cloud.ValueOrDefaultURL(cloudURL))
+				r, err := cloud.New(cmdutil.Diag(), cloud.ValueOrDefaultURL(cloudURL))
+				if err != nil {
+					return errors.Wrap(err, "creating API client")
+				}
+				releases = r
 			}
 
 			// Now for each kind, name, version pair, download it from the release website, and install it.

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -42,7 +42,11 @@ func newStackInitCmd() *cobra.Command {
 				}
 				b = local.New(cmdutil.Diag())
 			} else if url := cloud.ValueOrDefaultURL(cloudURL); isLoggedIn(url) {
-				b = cloud.New(cmdutil.Diag(), url)
+				c, err := cloud.New(cmdutil.Diag(), url)
+				if err != nil {
+					return errors.Wrap(err, "creating API client")
+				}
+				b = c
 				opts = cloud.CreateStackOptions{CloudName: ppc}
 			} else {
 				// If the user is not logged in and --remote or --cloud-url was passed, fail.

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"net/url"
 	"os"
 	"runtime"
 	"sort"
@@ -22,6 +20,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/backend"
+	"github.com/pulumi/pulumi/pkg/backend/cloud/client"
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/engine"
@@ -36,6 +35,73 @@ import (
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
+const (
+	// defaultURL is the Cloud URL used if no environment or explicit cloud is chosen.
+	defaultURL = "https://api.pulumi.com"
+	// defaultAPIEnvVar can be set to override the default cloud chosen, if `--cloud` is not present.
+	defaultURLEnvVar = "PULUMI_API"
+	// AccessTokenEnvVar is the environment variable used to bypass a prompt on login.
+	AccessTokenEnvVar = "PULUMI_ACCESS_TOKEN"
+)
+
+// DefaultURL returns the default cloud URL.  This may be overridden using the PULUMI_API environment
+// variable.  If no override is found, and we are authenticated with only one cloud, choose that.  Otherwise,
+// we will default to the https://api.pulumi.com/ endpoint.
+func DefaultURL() string {
+	return ValueOrDefaultURL("")
+}
+
+// ValueOrDefaultURL returns the value if specified, or the default cloud URL otherwise.
+func ValueOrDefaultURL(cloudURL string) string {
+	// If we have a cloud URL, just return it.
+	if cloudURL != "" {
+		return cloudURL
+	}
+
+	// Otherwise, respect the PULUMI_API override.
+	if cloudURL := os.Getenv(defaultURLEnvVar); cloudURL != "" {
+		return cloudURL
+	}
+
+	// If that didn't work, see if we're authenticated with any clouds.
+	urls, current, err := CurrentBackendURLs()
+	if err == nil {
+		if current != "" {
+			// If there's a current cloud selected, return that.
+			return current
+		} else if len(urls) == 1 {
+			// Else, if we're authenticated with a single cloud, use that.
+			return urls[0]
+		}
+	}
+
+	// If none of those led to a cloud URL, simply return the default.
+	return defaultURL
+}
+
+// barCloser is an implementation of io.Closer that finishes a progress bar upon Close() as well as closing its
+// underlying readCloser.
+type barCloser struct {
+	bar        *pb.ProgressBar
+	readCloser io.ReadCloser
+}
+
+func (bc *barCloser) Read(dest []byte) (int, error) {
+	return bc.readCloser.Read(dest)
+}
+
+func (bc *barCloser) Close() error {
+	bc.bar.Finish()
+	return bc.readCloser.Close()
+}
+
+func newBarProxyReadCloser(bar *pb.ProgressBar, r io.Reader) io.ReadCloser {
+	return &barCloser{
+		bar:        bar,
+		readCloser: bar.NewProxyReader(r),
+	}
+}
+
 // Backend extends the base backend interface with specific information about cloud backends.
 type Backend interface {
 	backend.Backend
@@ -46,17 +112,27 @@ type Backend interface {
 }
 
 type cloudBackend struct {
-	d        diag.Sink
-	cloudURL string
+	d      diag.Sink
+	name   string
+	client *client.Client
 }
 
-// New creates a new Pulumi backend for the given cloud API URL.
-func New(d diag.Sink, cloudURL string) Backend {
-	return &cloudBackend{d: d, cloudURL: cloudURL}
+// New creates a new Pulumi backend for the given cloud API URL and token.
+func New(d diag.Sink, apiURL string) (Backend, error) {
+	apiToken, err := workspace.GetAccessToken(apiURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting stored credentials")
+	}
+
+	return &cloudBackend{
+		d:      d,
+		name:   apiURL,
+		client: client.NewClient(apiURL, apiToken),
+	}, nil
 }
 
-func (b *cloudBackend) Name() string     { return b.cloudURL }
-func (b *cloudBackend) CloudURL() string { return b.cloudURL }
+func (b *cloudBackend) Name() string     { return b.name }
+func (b *cloudBackend) CloudURL() string { return b.name }
 
 // DownloadPlugin downloads a plugin as a tarball from the release endpoint.  The returned reader is a stream
 // that reads the tar.gz file, which should be expanded and closed after the download completes.  If progress
@@ -78,62 +154,45 @@ func (b *cloudBackend) DownloadPlugin(info workspace.PluginInfo, progress bool) 
 		return nil, errors.Errorf("unsupported plugin architecture: %s", runtime.GOARCH)
 	}
 
-	// Now make the GET request.
-	endpoint := fmt.Sprintf("/releases/plugins/pulumi-%s-%s-v%s-%s-%s.tar.gz",
-		info.Kind, info.Name, info.Version, os, arch)
-	_, resp, err := pulumiAPICall(b.cloudURL, "GET", endpoint, nil)
+	// Now make the client request.
+	result, size, err := b.client.DownloadPlugin(info, os, arch)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to download plugin")
 	}
 
 	// If progress is requested, and we know the length, show a little animated ASCII progress bar.
-	result := resp.Body
-	if progress && resp.ContentLength != -1 {
-		bar := pb.New(int(resp.ContentLength))
-		result = bar.NewProxyReader(result)
+	if progress && size != -1 {
+		bar := pb.New(int(size))
+		result = newBarProxyReadCloser(bar, result)
 		bar.Prefix(colors.ColorizeText(colors.SpecUnimportant + "Downloading plugin: "))
 		bar.Postfix(colors.ColorizeText(colors.Reset))
 		bar.SetMaxWidth(80)
 		bar.SetUnits(pb.U_BYTES)
 		bar.Start()
-		defer func() {
-			bar.Finish()
-		}()
 	}
 
 	return result, nil
 }
 
 func (b *cloudBackend) ListTemplates() ([]workspace.Template, error) {
-	// Query all templates.
-	var templates []workspace.Template
-	if err := pulumiRESTCall(b.cloudURL, "GET", "/releases/templates", nil, nil, &templates); err != nil {
-		return nil, err
-	}
-	return templates, nil
+	return b.client.ListTemplates()
 }
 
 func (b *cloudBackend) DownloadTemplate(name string, progress bool) (io.ReadCloser, error) {
-	// Make the GET request to download the template.
-	endpoint := fmt.Sprintf("/releases/templates/%s.tar.gz", name)
-	_, resp, err := pulumiAPICall(b.cloudURL, "GET", endpoint, nil)
+	result, size, err := b.client.DownloadTemplate(name)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to download template")
 	}
 
 	// If progress is requested, and we know the length, show a little animated ASCII progress bar.
-	result := resp.Body
-	if progress && resp.ContentLength != -1 {
-		bar := pb.New(int(resp.ContentLength))
-		result = bar.NewProxyReader(result)
+	if progress && size != -1 {
+		bar := pb.New(int(size))
+		result = newBarProxyReadCloser(bar, result)
 		bar.Prefix(colors.ColorizeText(colors.SpecUnimportant + "Downloading template: "))
 		bar.Postfix(colors.ColorizeText(colors.Reset))
 		bar.SetMaxWidth(80)
 		bar.SetUnits(pb.U_BYTES)
 		bar.Start()
-		defer func() {
-			bar.Finish()
-		}()
 	}
 
 	return result, nil
@@ -160,7 +219,7 @@ type CreateStackOptions struct {
 }
 
 func (b *cloudBackend) CreateStack(stackName tokens.QName, opts interface{}) (backend.Stack, error) {
-	projID, err := getCloudProjectIdentifier()
+	project, err := getCloudProjectIdentifier()
 	if err != nil {
 		return nil, err
 	}
@@ -174,25 +233,11 @@ func (b *cloudBackend) CreateStack(stackName tokens.QName, opts interface{}) (ba
 		}
 	}
 
-	stack := apitype.Stack{
-		CloudName:   cloudName,
-		StackName:   stackName,
-		OrgName:     projID.Owner,
-		RepoName:    projID.Repository,
-		ProjectName: string(projID.Project),
-	}
-	createStackReq := apitype.CreateStackRequest{
-		CloudName: cloudName,
-		StackName: string(stackName),
-	}
-
-	var createStackResp apitype.CreateStackResponseByName
-	path := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks", stack.OrgName, stack.RepoName, stack.ProjectName)
-	if err := pulumiRESTCall(b.cloudURL, "POST", path, nil, &createStackReq, &createStackResp); err != nil {
+	stack, err := b.client.CreateStack(project, cloudName, string(stackName))
+	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("Created stack '%s' hosted in Pulumi Cloud PPC %s\n",
-		stackName, createStackResp.CloudName)
+	fmt.Printf("Created stack '%s' hosted in Pulumi Cloud PPC %s\n", stackName, stack.CloudName)
 
 	return newStack(stack, b), nil
 }
@@ -213,109 +258,79 @@ func (b *cloudBackend) ListStacks() ([]backend.Stack, error) {
 }
 
 func (b *cloudBackend) RemoveStack(stackName tokens.QName, force bool) (bool, error) {
-	projID, err := getCloudProjectIdentifier()
+	stack, err := getCloudStackIdentifier(stackName)
 	if err != nil {
 		return false, err
 	}
 
-	queryParam := ""
-	if force {
-		queryParam = "?force=true"
-	}
-	path := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks/%s%s",
-		projID.Owner, projID.Repository, projID.Project, string(stackName), queryParam)
-
-	// TODO[pulumi/pulumi-service#196] When the service returns a well known response for "this stack still has
-	//     resources and `force` was not true", we should sniff for that message and return a true for the boolean.
-	return false, pulumiRESTCall(b.cloudURL, "DELETE", path, nil, nil, nil)
+	return b.client.DeleteStack(stack, force)
 }
 
 // cloudCrypter is an encrypter/decrypter that uses the Pulumi cloud to encrypt/decrypt a stack's secrets.
 type cloudCrypter struct {
-	backend   *cloudBackend
-	stackName string
+	backend *cloudBackend
+	stack   client.StackIdentifier
 }
 
 func (c *cloudCrypter) EncryptValue(plaintext string) (string, error) {
-	projID, err := getCloudProjectIdentifier()
+	ciphertext, err := c.backend.client.EncryptValue(c.stack, []byte(plaintext))
 	if err != nil {
 		return "", err
 	}
-
-	path := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks/%s/encrypt",
-		projID.Owner, projID.Repository, projID.Project, c.stackName)
-
-	var resp apitype.EncryptValueResponse
-	req := apitype.EncryptValueRequest{Plaintext: []byte(plaintext)}
-	if err := pulumiRESTCall(c.backend.cloudURL, "POST", path, nil, &req, &resp); err != nil {
-		return "", err
-	}
-	return base64.StdEncoding.EncodeToString(resp.Ciphertext), nil
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
 func (c *cloudCrypter) DecryptValue(cipherstring string) (string, error) {
-	projID, err := getCloudProjectIdentifier()
-	if err != nil {
-		return "", err
-	}
-
 	ciphertext, err := base64.StdEncoding.DecodeString(cipherstring)
 	if err != nil {
 		return "", err
 	}
-
-	path := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks/%s/decrypt",
-		projID.Owner, projID.Repository, projID.Project, c.stackName)
-
-	var resp apitype.DecryptValueResponse
-	req := apitype.DecryptValueRequest{Ciphertext: ciphertext}
-	if err := pulumiRESTCall(c.backend.cloudURL, "POST", path, nil, &req, &resp); err != nil {
+	plaintext, err := c.backend.client.DecryptValue(c.stack, ciphertext)
+	if err != nil {
 		return "", err
 	}
-	return string(resp.Plaintext), nil
+	return string(plaintext), nil
 }
 
 func (b *cloudBackend) GetStackCrypter(stackName tokens.QName) (config.Crypter, error) {
-	return &cloudCrypter{backend: b, stackName: string(stackName)}, nil
+	stack, err := getCloudStackIdentifier(stackName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &cloudCrypter{backend: b, stack: stack}, nil
 }
 
-// updateKind is an enum for describing the kinds of updates we support.
-type updateKind string
-
-const (
-	update  updateKind = "update"
-	preview updateKind = "preview"
-	destroy updateKind = "destroy"
-)
-
 var actionLabels = map[string]string{
-	string(update):  "Updating",
-	string(preview): "Previewing",
-	string(destroy): "Destroying",
-	"import":        "Importing",
+	string(client.UpdateKindUpdate):  "Updating",
+	string(client.UpdateKindPreview): "Previewing",
+	string(client.UpdateKindDestroy): "Destroying",
+	"import": "Importing",
 }
 
 func (b *cloudBackend) Preview(stackName tokens.QName, pkg *workspace.Project, root string,
 	debug bool, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
-	return b.updateStack(preview, stackName, pkg, root, debug, backend.UpdateMetadata{}, opts, displayOpts)
+	return b.updateStack(client.UpdateKindPreview, stackName, pkg, root, debug, backend.UpdateMetadata{}, opts,
+		displayOpts)
 }
 
 func (b *cloudBackend) Update(stackName tokens.QName, pkg *workspace.Project, root string,
 	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
-	return b.updateStack(update, stackName, pkg, root, debug, m, opts, displayOpts)
+	return b.updateStack(client.UpdateKindUpdate, stackName, pkg, root, debug, m, opts, displayOpts)
 }
 
 func (b *cloudBackend) Destroy(stackName tokens.QName, pkg *workspace.Project, root string,
 	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
 
-	return b.updateStack(destroy, stackName, pkg, root, debug, m, opts, displayOpts)
+	return b.updateStack(client.UpdateKindDestroy, stackName, pkg, root, debug, m, opts, displayOpts)
 }
 
 // updateStack performs a the provided type of update on a stack hosted in the Pulumi Cloud.
-func (b *cloudBackend) updateStack(action updateKind, stackName tokens.QName, pkg *workspace.Project, root string,
-	debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions, displayOpts backend.DisplayOptions) error {
+func (b *cloudBackend) updateStack(action client.UpdateKind, stackName tokens.QName, pkg *workspace.Project,
+	root string, debug bool, m backend.UpdateMetadata, opts engine.UpdateOptions,
+	displayOpts backend.DisplayOptions) error {
 
 	// Print a banner so it's clear this is going to the cloud.
 	actionLabel, ok := actionLabels[string(action)]
@@ -326,7 +341,7 @@ func (b *cloudBackend) updateStack(action updateKind, stackName tokens.QName, pk
 		actionLabel, stackName)
 
 	// First create the update object.
-	projID, err := getCloudProjectIdentifier()
+	stack, err := getCloudStackIdentifier(stackName)
 	if err != nil {
 		return err
 	}
@@ -334,44 +349,34 @@ func (b *cloudBackend) updateStack(action updateKind, stackName tokens.QName, pk
 	if err != nil {
 		return err
 	}
-
-	updateRequest, err := b.makeProgramUpdateRequest(stackName, pkg, main, m, opts)
+	workspaceStack, err := workspace.DetectProjectStack(stackName)
+	if err != nil {
+		return errors.Wrap(err, "getting configuration")
+	}
+	metadata := apitype.UpdateMetadata{
+		Message:     m.Message,
+		Environment: m.Environment,
+	}
+	getContents := func() (io.ReadCloser, int64, error) {
+		const showProgress = true
+		return getUpdateContents(context, pkg.UseDefaultIgnores(), showProgress)
+	}
+	update, err := b.client.CreateUpdate(action, stack, pkg, workspaceStack.Config, main, metadata, opts, getContents)
 	if err != nil {
 		return err
 	}
 
-	// Generate the URL we'll use for all the REST calls.
-	restURLRoot := fmt.Sprintf(
-		"/api/orgs/%s/programs/%s/%s/stacks/%s/%s",
-		projID.Owner, projID.Repository, projID.Project, string(stackName), action)
-
-	// Create the initial update object.
-	var updateResponse apitype.UpdateProgramResponse
-	if err = pulumiRESTCall(b.cloudURL, "POST", restURLRoot, nil, &updateRequest, &updateResponse); err != nil {
-		return err
-	}
-
-	// Upload the program's contents to the signed URL if appropriate.
-	if action != destroy {
-		err = uploadArchive(context, updateResponse.UploadURL, pkg.UseDefaultIgnores(), true /* show progress */)
-		if err != nil {
-			return err
-		}
-	}
-
 	// Start the update.
-	restURLWithUpdateID := fmt.Sprintf("%s/%s", restURLRoot, updateResponse.UpdateID)
-	var startUpdateResponse apitype.StartUpdateResponse
-	if err = pulumiRESTCall(b.cloudURL, "POST", restURLWithUpdateID,
-		nil, nil /* no req body */, &startUpdateResponse); err != nil {
+	version, err := b.client.StartUpdate(update)
+	if err != nil {
 		return err
 	}
-	if action == update {
-		glog.V(7).Infof("Stack %s being updated to version %d", stackName, startUpdateResponse.Version)
+	if action == client.UpdateKindUpdate {
+		glog.V(7).Infof("Stack %s being updated to version %d", stackName, version)
 	}
 
 	// Wait for the update to complete, which also polls and renders event output to STDOUT.
-	status, err := b.waitForUpdate(actionLabel, restURLWithUpdateID, displayOpts)
+	status, err := b.waitForUpdate(actionLabel, update, displayOpts)
 	if err != nil {
 		return errors.Wrapf(err, "waiting for %s", action)
 	} else if status != apitype.StatusSucceeded {
@@ -383,64 +388,42 @@ func (b *cloudBackend) updateStack(action updateKind, stackName tokens.QName, pk
 // uploadArchive archives the current Pulumi program and uploads it to a signed URL. "current"
 // meaning whatever Pulumi program is found in the CWD or parent directory.
 // If set, printSize will print the size of the data being uploaded.
-func uploadArchive(context string, uploadURL string, useDefaultIgnores bool, progress bool) error {
-	parsedURL, err := url.Parse(uploadURL)
-	if err != nil {
-		return errors.Wrap(err, "parsing URL")
-	}
-
-	// programPath is the path to the Pulumi.yaml file. Need its parent folder.
+func getUpdateContents(context string, useDefaultIgnores bool, progress bool) (io.ReadCloser, int64, error) {
 	archiveContents, err := archive.Process(context, useDefaultIgnores)
 	if err != nil {
-		return errors.Wrap(err, "creating archive")
+		return nil, 0, errors.Wrap(err, "creating archive")
 	}
-	var archiveReader io.Reader = archiveContents
+
+	archiveReader := ioutil.NopCloser(archiveContents)
 
 	// If progress is requested, show a little animated ASCII progress bar.
 	if progress {
 		bar := pb.New(archiveContents.Len())
-		archiveReader = bar.NewProxyReader(archiveReader)
+		archiveReader = newBarProxyReadCloser(bar, archiveReader)
 		bar.Prefix(colors.ColorizeText(colors.SpecUnimportant + "Uploading program: "))
 		bar.Postfix(colors.ColorizeText(colors.Reset))
 		bar.SetMaxWidth(80)
 		bar.SetUnits(pb.U_BYTES)
 		bar.Start()
-		defer func() {
-			bar.Finish()
-		}()
 	}
 
-	resp, err := http.DefaultClient.Do(&http.Request{
-		Method:        "PUT",
-		URL:           parsedURL,
-		ContentLength: int64(archiveContents.Len()),
-		Body:          ioutil.NopCloser(archiveReader),
-	})
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return errors.Wrap(err, "upload failed")
-	}
-	return nil
+	return archiveReader, int64(archiveContents.Len()), nil
 }
 
 func (b *cloudBackend) GetHistory(stackName tokens.QName) ([]backend.UpdateInfo, error) {
-	projID, err := getCloudProjectIdentifier()
+	stack, err := getCloudStackIdentifier(stackName)
 	if err != nil {
 		return nil, err
 	}
 
-	var response apitype.GetHistoryResponse
-	path := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks/%s/updates",
-		projID.Owner, projID.Repository, projID.Project, string(stackName))
-	if err = pulumiRESTCall(b.cloudURL, "GET", path, nil, nil, &response); err != nil {
+	updates, err := b.client.GetStackUpdates(stack)
+	if err != nil {
 		return nil, err
 	}
 
 	// Convert apitype.UpdateInfo objects to the backend type.
 	var beUpdates []backend.UpdateInfo
-	for _, update := range response.Updates {
+	for _, update := range updates {
 		// Convert types from the apitype package into their internal counterparts.
 		cfg, err := convertConfig(update.Config)
 		if err != nil {
@@ -489,63 +472,42 @@ func convertConfig(apiConfig map[string]apitype.ConfigValue) (config.Map, error)
 	return c, nil
 }
 
-func (b *cloudBackend) GetLogs(stackName tokens.QName,
-	logQuery operations.LogQuery) ([]operations.LogEntry, error) {
-
-	projID, err := getCloudProjectIdentifier()
+func (b *cloudBackend) GetLogs(stackName tokens.QName, logQuery operations.LogQuery) ([]operations.LogEntry, error) {
+	stack, err := getCloudStackIdentifier(stackName)
 	if err != nil {
 		return nil, err
 	}
 
-	var response apitype.LogsResult
-	path := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks/%s/logs",
-		projID.Owner, projID.Repository, projID.Project, string(stackName))
-	if err = pulumiRESTCall(b.cloudURL, "GET", path, logQuery, nil, &response); err != nil {
-		return nil, err
-	}
-
-	logs := make([]operations.LogEntry, 0, len(response.Logs))
-	for _, entry := range response.Logs {
-		logs = append(logs, operations.LogEntry(entry))
-	}
-
-	return logs, nil
+	return b.client.GetStackLogs(stack, logQuery)
 }
 
 func (b *cloudBackend) ExportDeployment(stackName tokens.QName) (*apitype.UntypedDeployment, error) {
-	projID, err := getCloudProjectIdentifier()
+	stack, err := getCloudStackIdentifier(stackName)
 	if err != nil {
 		return nil, err
 	}
 
-	var response apitype.ExportStackResponse
-	path := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks/%s/export",
-		projID.Owner, projID.Repository, projID.Project, string(stackName))
-	if err := pulumiRESTCall(b.cloudURL, "GET", path, nil, nil, &response); err != nil {
+	deployment, err := b.client.ExportStackDeployment(stack)
+	if err != nil {
 		return nil, err
 	}
 
-	return &apitype.UntypedDeployment{Deployment: response.Deployment}, nil
+	return &apitype.UntypedDeployment{Deployment: deployment}, nil
 }
 
 func (b *cloudBackend) ImportDeployment(stackName tokens.QName, deployment *apitype.UntypedDeployment) error {
-	projID, err := getCloudProjectIdentifier()
+	stack, err := getCloudStackIdentifier(stackName)
 	if err != nil {
 		return err
 	}
 
-	stackPath := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks/%s",
-		projID.Owner, projID.Repository, projID.Project, string(stackName))
-
-	request := apitype.ImportStackRequest{Deployment: deployment.Deployment}
-	var response apitype.ImportStackResponse
-	if err = pulumiRESTCall(b.cloudURL, "POST", stackPath+"/import", nil, &request, &response); err != nil {
+	update, err := b.client.ImportStackDeployment(stack, deployment.Deployment)
+	if err != nil {
 		return err
 	}
 
 	// Wait for the import to complete, which also polls and renders event output to STDOUT.
-	importPath := fmt.Sprintf("%s/update/%s", stackPath, response.UpdateID)
-	status, err := b.waitForUpdate(actionLabels["import"], importPath, backend.DisplayOptions{Color: colors.Always})
+	status, err := b.waitForUpdate(actionLabels["import"], update, backend.DisplayOptions{Color: colors.Always})
 	if err != nil {
 		return errors.Wrap(err, "waiting for import")
 	} else if status != apitype.StatusSucceeded {
@@ -556,84 +518,46 @@ func (b *cloudBackend) ImportDeployment(stackName tokens.QName, deployment *apit
 
 // listCloudStacks returns all stacks for the current repository x workspace on the Pulumi Cloud.
 func (b *cloudBackend) listCloudStacks() ([]apitype.Stack, error) {
-	projID, err := getCloudProjectIdentifier()
+	project, err := getCloudProjectIdentifier()
 	if err != nil {
 		return nil, err
 	}
 
-	// Query all stacks for the project on Pulumi.
-	var stacks []apitype.Stack
-	path := fmt.Sprintf("/api/orgs/%s/programs/%s/%s/stacks", projID.Owner, projID.Repository, projID.Project)
-	if err := pulumiRESTCall(b.cloudURL, "GET", path, nil, nil, &stacks); err != nil {
-		return nil, err
-	}
-	return stacks, nil
+	return b.client.ListStacks(project)
 }
 
 // getCloudProjectIdentifier returns information about the current repository and project, based on the current
 // working directory.
-func getCloudProjectIdentifier() (*cloudProjectIdentifier, error) {
+func getCloudProjectIdentifier() (client.ProjectIdentifier, error) {
 	w, err := workspace.New()
 	if err != nil {
-		return nil, err
+		return client.ProjectIdentifier{}, err
 	}
 
 	proj, err := workspace.DetectProject()
 	if err != nil {
-		return nil, err
+		return client.ProjectIdentifier{}, err
 	}
 
 	repo := w.Repository()
-	return &cloudProjectIdentifier{
+	return client.ProjectIdentifier{
 		Owner:      repo.Owner,
 		Repository: repo.Name,
-		Project:    proj.Name,
+		Project:    string(proj.Name),
 	}, nil
 }
 
-// makeProgramUpdateRequest constructs the apitype.UpdateProgramRequest based on the local machine state.
-func (b *cloudBackend) makeProgramUpdateRequest(stackName tokens.QName, proj *workspace.Project, main string,
-	m backend.UpdateMetadata, opts engine.UpdateOptions) (apitype.UpdateProgramRequest, error) {
-
-	// Convert the configuration into its wire form.
-	stk, err := workspace.DetectProjectStack(stackName)
+// getCloudStackIdentifier returns information about the given stack in the current repository and project, based on
+// the current working directory.
+func getCloudStackIdentifier(stackName tokens.QName) (client.StackIdentifier, error) {
+	project, err := getCloudProjectIdentifier()
 	if err != nil {
-		return apitype.UpdateProgramRequest{}, errors.Wrap(err, "getting configuration")
-	}
-	wireConfig := make(map[string]apitype.ConfigValue)
-	for k, cv := range stk.Config {
-		v, err := cv.Value(config.NopDecrypter)
-		contract.AssertNoError(err)
-
-		wireConfig[k.Namespace()+":config:"+k.Name()] = apitype.ConfigValue{
-			String: v,
-			Secret: cv.Secure(),
-		}
+		return client.StackIdentifier{}, errors.Wrap(err, "failed to detect project")
 	}
 
-	description := ""
-	if proj.Description != nil {
-		description = *proj.Description
-	}
-	return apitype.UpdateProgramRequest{
-		Name:        string(proj.Name),
-		Runtime:     proj.Runtime,
-		Main:        main,
-		Description: description,
-		Config:      wireConfig,
-		Options: apitype.UpdateOptions{
-			Analyzers:            opts.Analyzers,
-			Color:                colors.Raw, // force raw colorization, we handle colorization in the CLI
-			DryRun:               opts.DryRun,
-			Parallel:             opts.Parallel,
-			ShowConfig:           false, // This is a legacy option now, the engine will always emit config information
-			ShowReplacementSteps: false, // This is a legacy option now, the engine will always emit this information
-			ShowSames:            false, // This is a legacy option now, the engine will always emit this information
-		},
-		Metadata: apitype.UpdateMetadata{
-			Message:     m.Message,
-			Environment: m.Environment,
-		},
+	return client.StackIdentifier{
+		ProjectIdentifier: project,
+		Stack:             string(stackName),
 	}, nil
 }
 
@@ -651,8 +575,9 @@ type displayEvent struct {
 
 // waitForUpdate waits for the current update of a Pulumi program to reach a terminal state. Returns the
 // final state. "path" is the URL endpoint to poll for updates.
-func (b *cloudBackend) waitForUpdate(action string,
-	path string, displayOpts backend.DisplayOptions) (apitype.UpdateStatus, error) {
+func (b *cloudBackend) waitForUpdate(actionLabel string, update client.UpdateIdentifier,
+	displayOpts backend.DisplayOptions) (apitype.UpdateStatus, error) {
+
 	events, done := make(chan displayEvent), make(chan bool)
 	defer func() {
 		events <- displayEvent{Kind: ShutdownEvent, Payload: nil}
@@ -660,16 +585,15 @@ func (b *cloudBackend) waitForUpdate(action string,
 		close(events)
 		close(done)
 	}()
-	go displayEvents(strings.ToLower(action), events, done, displayOpts)
+	go displayEvents(strings.ToLower(actionLabel), events, done, displayOpts)
 
 	// Events occur in sequence, filter out all the ones we have seen before in each request.
 	eventIndex := "0"
 	for {
 		// Query for the latest update results, including log entries so we can provide active status updates.
-		pathWithIndex := fmt.Sprintf("%s?afterIndex=%s", path, eventIndex)
 		_, results, err := retry.Until(context.Background(), retry.Acceptor{
 			Accept: func(try int, nextRetryTime time.Duration) (bool, interface{}, error) {
-				return b.tryNextUpdate(pathWithIndex, try, nextRetryTime)
+				return b.tryNextUpdate(update, eventIndex, try, nextRetryTime)
 			},
 		})
 		if err != nil {
@@ -738,13 +662,11 @@ func displayEvents(action string, events <-chan displayEvent, done chan<- bool, 
 
 // tryNextUpdate tries to get the next update for a Pulumi program.  This may time or error out, which resutls in a
 // false returned in the first return value.  If a non-nil error is returned, this operation should fail.
-func (b *cloudBackend) tryNextUpdate(pathWithIndex string,
-	try int, nextRetryTime time.Duration) (bool, interface{}, error) {
-	// Perform the REST call.
-	var results apitype.UpdateResults
-	err := pulumiRESTCall(b.cloudURL, "GET", pathWithIndex, nil, nil, &results)
+func (b *cloudBackend) tryNextUpdate(update client.UpdateIdentifier, afterIndex string, try int,
+	nextRetryTime time.Duration) (bool, interface{}, error) {
 
 	// If there is no error, we're done.
+	results, err := b.client.GetUpdateEvents(update, afterIndex)
 	if err == nil {
 		return true, results, nil
 	}
@@ -765,15 +687,15 @@ func (b *cloudBackend) tryNextUpdate(pathWithIndex string,
 				warn = false
 			}
 			glog.V(3).Infof("Expected %s HTTP %d error after %d retries (retrying): %v",
-				b.cloudURL, errResp.Code, try, err)
+				b.CloudURL(), errResp.Code, try, err)
 		} else {
 			// Otherwise, we will issue an error.
 			glog.V(3).Infof("Unexpected %s HTTP %d error after %d retries (erroring): %v",
-				b.cloudURL, errResp.Code, try, err)
+				b.CloudURL(), errResp.Code, try, err)
 			return false, nil, err
 		}
 	} else {
-		glog.V(3).Infof("Unexpected %s error after %d retries (retrying): %v", b.cloudURL, try, err)
+		glog.V(3).Infof("Unexpected %s error after %d retries (retrying): %v", b.CloudURL(), try, err)
 	}
 
 	// Issue a warning if appropriate.
@@ -821,17 +743,15 @@ func isValidAccessToken(cloud, accessToken string) (bool, error) {
 	// Make a request to get the authenticated user. If it returns a successful response,
 	// we know the access token is legit. We also parse the response as JSON and confirm
 	// it has a name field that is non-empty (like the Pulumi Service would return).
-	respObj := struct {
-		Name string `json:"name"`
-	}{}
-	if err := pulumiRESTCallToken(cloud, "GET", "/api/user", nil, nil, &respObj, accessToken); err != nil {
+	name, err := client.NewClient(cloud, accessToken).DescribeUser()
+	if err != nil {
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == 401 {
 			return false, nil
 		}
 		return false, errors.Wrapf(err, "getting user info from %v", cloud)
 	}
 
-	if respObj.Name == "" {
+	if name == "" {
 		return false, errors.New("unexpected response from cloud API")
 	}
 
@@ -852,7 +772,12 @@ func CurrentBackends(d diag.Sink) ([]Backend, string, error) {
 
 	var backends []Backend
 	for _, url := range urls {
-		backends = append(backends, New(d, url))
+		b, err := New(d, url)
+		if err != nil {
+			return nil, "", errors.Wrapf(err, "creating backend for %s", url)
+		}
+
+		backends = append(backends, b)
 	}
 	return backends, current, nil
 }

--- a/pkg/backend/cloud/client/api.go
+++ b/pkg/backend/cloud/client/api.go
@@ -1,6 +1,6 @@
 // Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
 
-package cloud
+package client
 
 import (
 	"bytes"
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"runtime"
 	"strings"
 
@@ -17,76 +16,44 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/apitype"
-	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/version"
-	"github.com/pulumi/pulumi/pkg/workspace"
 )
+
+// UpdateKind is an enum for describing the kinds of updates we support.
+type UpdateKind string
 
 const (
-	// defaultURL is the Cloud URL used if no environment or explicit cloud is chosen.
-	defaultURL = "https://api.pulumi.com"
-	// defaultAPIEnvVar can be set to override the default cloud chosen, if `--cloud` is not present.
-	defaultURLEnvVar = "PULUMI_API"
-	// AccessTokenEnvVar is the environment variable used to bypass a prompt on login.
-	AccessTokenEnvVar = "PULUMI_ACCESS_TOKEN"
+	UpdateKindUpdate  UpdateKind = "update"
+	UpdateKindPreview UpdateKind = "preview"
+	UpdateKindDestroy UpdateKind = "destroy"
 )
 
-// DefaultURL returns the default cloud URL.  This may be overridden using the PULUMI_API environment
-// variable.  If no override is found, and we are authenticated with only one cloud, choose that.  Otherwise,
-// we will default to the https://api.pulumi.com/ endpoint.
-func DefaultURL() string {
-	return ValueOrDefaultURL("")
-}
-
-// ValueOrDefaultURL returns the value if specified, or the default cloud URL otherwise.
-func ValueOrDefaultURL(cloudURL string) string {
-	// If we have a cloud URL, just return it.
-	if cloudURL != "" {
-		return cloudURL
-	}
-
-	// Otherwise, respect the PULUMI_API override.
-	if cloudURL := os.Getenv(defaultURLEnvVar); cloudURL != "" {
-		return cloudURL
-	}
-
-	// If that didn't work, see if we're authenticated with any clouds.
-	urls, current, err := CurrentBackendURLs()
-	if err == nil {
-		if current != "" {
-			// If there's a current cloud selected, return that.
-			return current
-		} else if len(urls) == 1 {
-			// Else, if we're authenticated with a single cloud, use that.
-			return urls[0]
-		}
-	}
-
-	// If none of those led to a cloud URL, simply return the default.
-	return defaultURL
-}
-
-// cloudProjectIdentifier is the set of data needed to identify a Pulumi Cloud project. This the
+// ProjectIdentifier is the set of data needed to identify a Pulumi Cloud project. This the
 // logical "home" of a stack on the Pulumi Cloud.
-type cloudProjectIdentifier struct {
+type ProjectIdentifier struct {
 	Owner      string
 	Repository string
-	Project    tokens.PackageName
+	Project    string
+}
+
+// StackIdentifier is the set of data needed to identify a Pulumi Cloud stack.
+type StackIdentifier struct {
+	ProjectIdentifier
+
+	Stack string
+}
+
+// UpdateIdentifier is the set of data needed to identify an update to a Pulumi Cloud stack.
+type UpdateIdentifier struct {
+	StackIdentifier
+
+	UpdateKind UpdateKind
+	UpdateID   string
 }
 
 // pulumiAPICall makes an HTTP request to the Pulumi API.
-func pulumiAPICall(cloudAPI, method, path string, body []byte) (string, *http.Response, error) {
-	accessToken, err := workspace.GetAccessToken(cloudAPI)
-	if err != nil {
-		return "", nil, errors.Wrapf(err, "getting stored credentials")
-	}
-	return pulumiAPICallToken(cloudAPI, method, path, body, accessToken)
-}
-
-// pulumiAPICallToken makes an HTTP request to the Pulumi API with an explicit access token.
-func pulumiAPICallToken(cloudAPI, method, path string, body []byte,
-	accessToken string) (string, *http.Response, error) {
+func pulumiAPICall(cloudAPI, method, path string, body []byte, accessToken string) (string, *http.Response, error) {
 	// Normalize URL components
 	cloudAPI = strings.TrimSuffix(cloudAPI, "/")
 	path = strings.TrimPrefix(path, "/")
@@ -113,8 +80,7 @@ func pulumiAPICallToken(cloudAPI, method, path string, body []byte,
 		glog.V(9).Infof("Pulumi API call details (%s): headers=%v; body=%v", url, req.Header, string(body))
 	}
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "performing HTTP request")
 	}
@@ -152,19 +118,7 @@ func pulumiAPICallToken(cloudAPI, method, path string, body []byte,
 // the request body (use nil for GETs), and if successful, marshalling the responseObj
 // as JSON and storing it in respObj (use nil for NoContent). The error return type might
 // be an instance of apitype.ErrorResponse, in which case will have the response code.
-func pulumiRESTCall(cloudAPI, method, path string,
-	queryObj interface{}, reqObj interface{}, respObj interface{}) error {
-	accessToken, err := workspace.GetAccessToken(cloudAPI)
-	if err != nil {
-		return errors.Wrapf(err, "getting stored credentials")
-	}
-	return pulumiRESTCallToken(cloudAPI, method, path, queryObj, reqObj, respObj, accessToken)
-}
-
-// pulumiRESTCallToken calls the Pulumi REST API, just like pulumiRESTCall, only with
-// an explicit accessToken rather than reading it from the workspace.
-func pulumiRESTCallToken(cloudAPI, method, path string,
-	queryObj interface{}, reqObj interface{}, respObj interface{}, accessToken string) error {
+func pulumiRESTCall(cloudAPI, method, path string, queryObj, reqObj, respObj interface{}, accessToken string) error {
 	// Compute query string from query object
 	querystring := ""
 	if queryObj != nil {
@@ -189,7 +143,7 @@ func pulumiRESTCallToken(cloudAPI, method, path string,
 	}
 
 	// Make API call
-	url, resp, err := pulumiAPICallToken(cloudAPI, method, path+querystring, reqBody, accessToken)
+	url, resp, err := pulumiAPICall(cloudAPI, method, path+querystring, reqBody, accessToken)
 	if err != nil {
 		return errors.Wrapf(err, "calling API")
 	}

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -1,0 +1,330 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/pkg/errors"
+
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/diag/colors"
+	"github.com/pulumi/pulumi/pkg/engine"
+	"github.com/pulumi/pulumi/pkg/operations"
+	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/workspace"
+)
+
+// Client provides a slim wrapper around the Pulumi HTTP/REST API.
+type Client struct {
+	apiURL   string
+	apiToken string
+}
+
+// NewClient creates a new Pulumi API client with the given URL and API token.
+func NewClient(apiURL, apiToken string) *Client {
+	return &Client{
+		apiURL:   apiURL,
+		apiToken: apiToken,
+	}
+}
+
+// apiCall makes a raw HTTP request to the Pulumi API using the given method, path, and request body.
+func (pc *Client) apiCall(method, path string, body []byte) (string, *http.Response, error) {
+	return pulumiAPICall(pc.apiURL, method, path, body, pc.apiToken)
+}
+
+// restCall makes a REST-style request to the Pulumi API using the given method, path, query object, and request
+// object. If a response object is provided, the server's response is deserialized into that object.
+func (pc *Client) restCall(method, path string, queryObj, reqObj, respObj interface{}) error {
+	return pulumiRESTCall(pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken)
+}
+
+// getProjectPath returns the API path to for the given project with the given components joined with path separators
+// and appended to the project root.
+func getProjectPath(project ProjectIdentifier, components ...string) string {
+	projectRoot := fmt.Sprintf("/api/orgs/%s/programs/%s/%s", project.Owner, project.Repository, project.Project)
+	return path.Join(append([]string{projectRoot}, components...)...)
+}
+
+// getStackPath returns the API path to for the given stack with the given components joined with path separators
+// and appended to the stack root.
+func getStackPath(stack StackIdentifier, components ...string) string {
+	components = append([]string{"stacks", stack.Stack}, components...)
+	return getProjectPath(stack.ProjectIdentifier, components...)
+}
+
+// getUpdatePath returns the API path to for the given stack with the given components joined with path separators
+// and appended to the update root.
+func getUpdatePath(update UpdateIdentifier, components ...string) string {
+	components = append([]string{string(update.UpdateKind), update.UpdateID}, components...)
+	return getStackPath(update.StackIdentifier, components...)
+}
+
+// DescribeUser describes the user implied by the API token associated with this client.
+func (pc *Client) DescribeUser() (string, error) {
+	resp := struct {
+		Name string `json:"name"`
+	}{}
+	if err := pc.restCall("GET", "/api/user", nil, nil, &resp); err != nil {
+		return "", err
+	}
+	return resp.Name, nil
+}
+
+// DownloadPlugin downloads the indicated plugin from the Pulumi API.
+func (pc *Client) DownloadPlugin(info workspace.PluginInfo, os, arch string) (io.ReadCloser, int64, error) {
+	endpoint := fmt.Sprintf("/releases/plugins/pulumi-%s-%s-v%s-%s-%s.tar.gz",
+		info.Kind, info.Name, info.Version, os, arch)
+	_, resp, err := pc.apiCall("GET", endpoint, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	return resp.Body, resp.ContentLength, nil
+}
+
+// ListTemplates lists all templates of which the Pulumi API knows.
+func (pc *Client) ListTemplates() ([]workspace.Template, error) {
+	// Query all templates.
+	var templates []workspace.Template
+	if err := pc.restCall("GET", "/releases/templates", nil, nil, &templates); err != nil {
+		return nil, err
+	}
+	return templates, nil
+}
+
+// DownloadTemplate downloads the indicated template from the Pulumi API.
+func (pc *Client) DownloadTemplate(name string) (io.ReadCloser, int64, error) {
+	// Make the GET request to download the template.
+	endpoint := fmt.Sprintf("/releases/templates/%s.tar.gz", name)
+	_, resp, err := pc.apiCall("GET", endpoint, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	return resp.Body, resp.ContentLength, nil
+}
+
+// ListStacks lists all stacks for the indicated project.
+func (pc *Client) ListStacks(project ProjectIdentifier) ([]apitype.Stack, error) {
+	// Query all stacks for the project on Pulumi.
+	var stacks []apitype.Stack
+	if err := pc.restCall("GET", getProjectPath(project, "stacks"), nil, nil, &stacks); err != nil {
+		return nil, err
+	}
+	return stacks, nil
+}
+
+// CreateStack creates a stack with the given cloud and stack name in the scope of the indicated project.
+func (pc *Client) CreateStack(project ProjectIdentifier, cloudName string, stackName string) (apitype.Stack, error) {
+	stack := apitype.Stack{
+		CloudName:   cloudName,
+		StackName:   tokens.QName(stackName),
+		OrgName:     project.Owner,
+		RepoName:    project.Repository,
+		ProjectName: project.Project,
+	}
+	createStackReq := apitype.CreateStackRequest{
+		CloudName: cloudName,
+		StackName: stackName,
+	}
+
+	var createStackResp apitype.CreateStackResponseByName
+	if err := pc.restCall("POST", getProjectPath(project, "stacks"), nil, &createStackReq, &createStackResp); err != nil {
+		return apitype.Stack{}, err
+	}
+
+	stack.CloudName = createStackResp.CloudName
+	return stack, nil
+}
+
+// DeleteStack deletes the indicated stack. If force is true, the stack is deleted even if it contains resources.
+func (pc *Client) DeleteStack(stack StackIdentifier, force bool) (bool, error) {
+	path := getStackPath(stack)
+	if force {
+		path += "?force=true"
+	}
+
+	// TODO[pulumi/pulumi-service#196] When the service returns a well known response for "this stack still has
+	//     resources and `force` was not true", we should sniff for that message and return a true for the boolean.
+	return false, pc.restCall("DELETE", path, nil, nil, nil)
+}
+
+// EncryptValue encrypts a plaintext value in the context of the indicated stack.
+func (pc *Client) EncryptValue(stack StackIdentifier, plaintext []byte) ([]byte, error) {
+	req := apitype.EncryptValueRequest{Plaintext: plaintext}
+	var resp apitype.EncryptValueResponse
+	if err := pc.restCall("POST", getStackPath(stack, "encrypt"), nil, &req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Ciphertext, nil
+}
+
+// DecryptValue decrypts a ciphertext value in the context of the indicated stack.
+func (pc *Client) DecryptValue(stack StackIdentifier, ciphertext []byte) ([]byte, error) {
+	req := apitype.DecryptValueRequest{Ciphertext: ciphertext}
+	var resp apitype.DecryptValueResponse
+	if err := pc.restCall("POST", getStackPath(stack, "decrypt"), nil, &req, &resp); err != nil {
+		return nil, err
+	}
+	return resp.Plaintext, nil
+}
+
+// GetStackLogs retrieves the log entries for the indicated stack that match the given query.
+func (pc *Client) GetStackLogs(stack StackIdentifier, logQuery operations.LogQuery) ([]operations.LogEntry, error) {
+	var response apitype.LogsResult
+	if err := pc.restCall("GET", getStackPath(stack, "logs"), logQuery, nil, &response); err != nil {
+		return nil, err
+	}
+
+	logs := make([]operations.LogEntry, 0, len(response.Logs))
+	for _, entry := range response.Logs {
+		logs = append(logs, operations.LogEntry(entry))
+	}
+
+	return logs, nil
+}
+
+// GetStackUpdates returns all updates to the indicated stack.
+func (pc *Client) GetStackUpdates(stack StackIdentifier) ([]apitype.UpdateInfo, error) {
+	var response apitype.GetHistoryResponse
+	if err := pc.restCall("GET", getStackPath(stack, "updates"), nil, nil, &response); err != nil {
+		return nil, err
+	}
+
+	return response.Updates, nil
+}
+
+// ExportStackDeployment exports the indicated stack's deployment as a raw JSON message.
+func (pc *Client) ExportStackDeployment(stack StackIdentifier) (json.RawMessage, error) {
+	var resp apitype.ExportStackResponse
+	if err := pc.restCall("GET", getStackPath(stack, "export"), nil, nil, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Deployment, nil
+}
+
+// ImportStackDeployment imports a new deployment into the indicated stack.
+func (pc *Client) ImportStackDeployment(stack StackIdentifier, deployment json.RawMessage) (UpdateIdentifier, error) {
+	req := apitype.ImportStackRequest{Deployment: deployment}
+	var resp apitype.ImportStackResponse
+	if err := pc.restCall("POST", getStackPath(stack, "import"), nil, &req, &resp); err != nil {
+		return UpdateIdentifier{}, err
+	}
+
+	return UpdateIdentifier{
+		StackIdentifier: stack,
+		UpdateKind:      UpdateKindUpdate,
+		UpdateID:        resp.UpdateID,
+	}, nil
+}
+
+// CreateUpdate creates a new update for the indicated stack with the given kind and assorted options. If the update
+// requires that the Pulumi program is uploaded, the provided getContents callback will be invoked to fetch the
+// contents of the Pulumi program.
+func (pc *Client) CreateUpdate(kind UpdateKind, stack StackIdentifier, pkg *workspace.Project, cfg config.Map,
+	main string, m apitype.UpdateMetadata, opts engine.UpdateOptions,
+	getContents func() (io.ReadCloser, int64, error)) (UpdateIdentifier, error) {
+
+	// First create the update program request.
+	wireConfig := make(map[string]apitype.ConfigValue)
+	for k, cv := range cfg {
+		v, err := cv.Value(config.NopDecrypter)
+		contract.AssertNoError(err)
+
+		wireConfig[k.Namespace()+":config:"+k.Name()] = apitype.ConfigValue{
+			String: v,
+			Secret: cv.Secure(),
+		}
+	}
+
+	description := ""
+	if pkg.Description != nil {
+		description = *pkg.Description
+	}
+	updateRequest := apitype.UpdateProgramRequest{
+		Name:        string(pkg.Name),
+		Runtime:     pkg.Runtime,
+		Main:        main,
+		Description: description,
+		Config:      wireConfig,
+		Options: apitype.UpdateOptions{
+			Analyzers:            opts.Analyzers,
+			Color:                colors.Raw, // force raw colorization, we handle colorization in the CLI
+			DryRun:               opts.DryRun,
+			Parallel:             opts.Parallel,
+			ShowConfig:           false, // This is a legacy option now, the engine will always emit config information
+			ShowReplacementSteps: false, // This is a legacy option now, the engine will always emit this information
+			ShowSames:            false, // This is a legacy option now, the engine will always emit this information
+		},
+		Metadata: m,
+	}
+
+	// Create the initial update object.
+	path := getStackPath(stack, string(kind))
+	var updateResponse apitype.UpdateProgramResponse
+	if err := pc.restCall("POST", path, nil, &updateRequest, &updateResponse); err != nil {
+		return UpdateIdentifier{}, err
+	}
+
+	// Now upload the program if necessary.
+	if kind != UpdateKindDestroy {
+		uploadURL, err := url.Parse(updateResponse.UploadURL)
+		if err != nil {
+			return UpdateIdentifier{}, errors.Wrap(err, "parsing upload URL")
+		}
+
+		contents, size, err := getContents()
+		if err != nil {
+			return UpdateIdentifier{}, err
+		}
+
+		resp, err := http.DefaultClient.Do(&http.Request{
+			Method:        "PUT",
+			URL:           uploadURL,
+			ContentLength: size,
+			Body:          contents,
+		})
+		if err != nil {
+			return UpdateIdentifier{}, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			return UpdateIdentifier{}, errors.Errorf("upload failed: %d %s", resp.StatusCode, http.StatusText(resp.StatusCode))
+		}
+	}
+
+	return UpdateIdentifier{
+		StackIdentifier: stack,
+		UpdateKind:      kind,
+		UpdateID:        updateResponse.UpdateID,
+	}, nil
+}
+
+// StartUpdate starts the indicated update. It returns the new version of the update's target stack.
+func (pc *Client) StartUpdate(update UpdateIdentifier) (int, error) {
+	var resp apitype.StartUpdateResponse
+	if err := pc.restCall("POST", getUpdatePath(update), nil, nil, &resp); err != nil {
+		return 0, err
+	}
+
+	return resp.Version, nil
+}
+
+// GetUpdateEvents returns all events for the indicated update after the given index.
+func (pc *Client) GetUpdateEvents(update UpdateIdentifier, afterIndex string) (apitype.UpdateResults, error) {
+	path := fmt.Sprintf("%s?afterIndex=%s", getUpdatePath(update), afterIndex)
+
+	var results apitype.UpdateResults
+	if err := pc.restCall("GET", path, nil, nil, &results); err != nil {
+		return apitype.UpdateResults{}, err
+	}
+
+	return results, nil
+}

--- a/pkg/backend/cloud/stack.go
+++ b/pkg/backend/cloud/stack.go
@@ -59,7 +59,7 @@ func newStack(apistack apitype.Stack, b *cloudBackend) Stack {
 	// Now assemble all the pieces into a stack structure.
 	return &cloudStack{
 		name:      stackName,
-		cloudURL:  b.cloudURL,
+		cloudURL:  b.CloudURL(),
 		orgName:   apistack.OrgName,
 		cloudName: apistack.CloudName,
 		config:    nil, // TODO[pulumi/pulumi-service#249]: add the config variables.


### PR DESCRIPTION
These changes refactor direct interactions with the Pulumi API out of
the cloud backend and into a subpackage, `pkg/backend/cloud/client`.
This package exposes a slightly higher-level API that takes care of
calculating paths, performing HTTP calls, and occasionally wrapping
multiple physical calls into a single logical call (notably the creation
of an update and the upload of its program).

This is primarily intended as preparation for some of the changes
suggested in the feedback for #1067.