### PR TITLE
Fix `stack import`.

### DIFF
--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -37,7 +37,7 @@ func newStackImportCmd() *cobra.Command {
 
 			// Read the checkpoint from stdin.  We decode this into a json.RawMessage so as not to lose any fields
 			// sent by the server that the client CLI does not recognize (enabling round-tripping).
-			var deployment json.RawMessage
+			var deployment apitype.UntypedDeployment
 			if err = json.NewDecoder(os.Stdin).Decode(&deployment); err != nil {
 				return err
 			}
@@ -46,7 +46,7 @@ func newStackImportCmd() *cobra.Command {
 			// we can check that the checkpoint doesn't contain resources from a stack other than the selected one. This
 			// catches errors wherein someone imports the wrong stack's checkpoint (which can seriously hork things).
 			var typed apitype.Deployment
-			if err = json.Unmarshal(deployment, &typed); err != nil {
+			if err = json.Unmarshal(deployment.Deployment, &typed); err != nil {
 				return err
 			}
 			var result error
@@ -69,7 +69,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 
 			// Now perform the deployment.
-			if err = s.ImportDeployment(&apitype.UntypedDeployment{Deployment: deployment}); err != nil {
+			if err = s.ImportDeployment(&deployment); err != nil {
 				return errors.Wrap(err, "could not import deployment")
 			}
 			fmt.Printf("Import successful.\n")


### PR DESCRIPTION
At some point--likely when we were tweaking API types--`stack import`
stopped working correctly. These changes straighten things out again.