### PR TITLE
Add continuation token to UpdateResults API

### DIFF
--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -114,6 +114,16 @@ const (
 type UpdateResults struct {
 	Status UpdateStatus  `json:"status"`
 	Events []UpdateEvent `json:"events"`
+
+	// ContinuationToken is an opaque value used to indiciate the end of the returned update
+	// results. Pass it in the next request to obtain subsequent update events.
+	//
+	// The same continuation token may be returned if no new update events are available, but the
+	// update is still in-progress.
+	//
+	// A value of nil means that no new updates will be available. Everything has been returned to
+	// the client and the update has completed.
+	ContinuationToken *string `json:"continuationToken,omitempty"`
 }
 
 // UpdateProgram describes the metadata associated with an update's Pulumi program. Note that this does not


### PR DESCRIPTION
To properly fix https://github.com/pulumi/pulumi-service/issues/1023, we need a way to support pagination in the APIs for fetching update logs.  I saw the comment here about abusing the `UpdateStatus` field to indiciate more results are available... let's instead just make pagination a first-class concept.

This PR adds a new `ContinuationToken` field in the response type. It will contain what amounts to be the `afterIndex` parameter that we have now. So a non-nil value will allow the server to communicate there are more results to be fetched, even if they aren't immediately available.

Once this PR lands, I'll update the PPC to return the _next_ afterIndex value in the continuation token. This will actually make our polling logic cleaner too.