### PR TITLE
Fix Python versions (again)

### DIFF
--- a/scripts/get-py-version
+++ b/scripts/get-py-version
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -o nounset -o errexit -o pipefail
+
+SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# To generate a Python version, we will need to mangle it
+# slightly.  Namely, we must perform the following translations:
+#
+#     1) Skip the leading "v" (i.e., "1.3.11", not "v1.3.11").
+#     2) Change "-dev-<xyz>" into an alpha release "a<xyz>".
+#     3) Change "-rc-<xyz>" into a release candidate "rc<xyz>".
+#     4) Change "-<commitish><dirty>" into a local version label;
+#        e.g. "+37bc2f9-dirty" rather than "-37bc2f9-dirty".
+#
+# This ensures conformance with PEP440:
+# https://www.python.org/dev/peps/pep-0440/#version-scheme.
+echo $($SCRIPT_ROOT/get-version "$@") | \
+    sed 's/v//'      | \
+    sed 's/-dev-/a/' | \
+    sed 's/-rc-/rc/' | \
+    sed 's/-/+/'

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME     := Pulumi Python SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python
-VERSION          := $(shell ../../scripts/get-version | sed "s/v//" | sed "s/-dev-/a/" | sed "s/-rc/rc/")
+VERSION          := $(shell ../../scripts/get-py-version)
 
 PYENV := env
 PYENVBIN := $(PYENV)/bin


### PR DESCRIPTION
This change actually makes our Python version numbers conformant
to PEP440.  Previously we were including the Git commit hash in the
alpha "version number" part, which is incorrect.  This simply led to
warnings upon publication and installation, but that warning very
clearly states that support for invalid versions will stop at some
point.  This change puts any "informative" parts, like the Git hash,
inside of a local version tag, where such things are permitted.

Also move away from the inline sed silliness so that we can more
easily share this logic across all of our repos.