### PR TITLE
Add Tags field to apitype.Stack

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -112,6 +112,21 @@ type ConfigValue struct {
 	Secret bool `json:"secret"`
 }
 
+// StackTagName is the key for the tags bag in stack. This is just a string, but we use a type alias to provide a richer
+// description of how the string is used in our apitype definitions.
+type StackTagName = string
+
+const (
+	// ProjectNameTag is a tag that represents the name of a project (coresponds to the `name` property of Pulumi.yaml).
+	ProjectNameTag StackTagName = "pulumi:project"
+	// GitHubOwnerNameTag is a tag that represents the name of the owner on GitHub that this stack
+	// may be associated with (inferred by the CLI based on git remote info).
+	GitHubOwnerNameTag StackTagName = "gitHub:owner"
+	// GitHubRepositoryNameTag is a tag that represents the name of a repository on GitHub that this stack
+	// may be associated with (inferred by the CLI based on git remote info).
+	GitHubRepositoryNameTag StackTagName = "gitHub:repo"
+)
+
 // Stack describes a Stack running on a Pulumi Cloud.
 type Stack struct {
 	CloudName string `json:"cloudName"`
@@ -121,8 +136,9 @@ type Stack struct {
 	ProjectName string       `json:"projName"`
 	StackName   tokens.QName `json:"stackName"`
 
-	ActiveUpdate string     `json:"activeUpdate"`
-	Resources    []Resource `json:"resources,omitempty"`
+	ActiveUpdate string                  `json:"activeUpdate"`
+	Resources    []Resource              `json:"resources,omitempty"`
+	Tags         map[StackTagName]string `json:"tags,omitempty"`
 
 	Version int `json:"version"`
 }

--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -33,6 +33,8 @@ type CreateStackRequest struct {
 	CloudName string `json:"cloudName"`
 	// The rest of the StackIdentifier (repo, project) is in the URL.
 	StackName string `json:"stackName"`
+	// An optional set of tags to apply to the stack.
+	Tags map[StackTagName]string `json:"tags,omitEmpty"`
 }
 
 // CreateStackResponseByName is the response from a create Stack request.

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -148,6 +148,11 @@ func (pc *Client) CreateStack(project ProjectIdentifier, cloudName string, stack
 		OrgName:     project.Owner,
 		RepoName:    project.Repository,
 		ProjectName: project.Project,
+		Tags: map[apitype.StackTagName]string{
+			apitype.GitHubOwnerNameTag:      project.Owner,
+			apitype.GitHubRepositoryNameTag: project.Repository,
+			apitype.ProjectNameTag:          project.Project,
+		},
 	}
 	createStackReq := apitype.CreateStackRequest{
 		CloudName: cloudName,


### PR DESCRIPTION
As part of the new identity model, we're going to use tagging on
stacks to record metadata, let's create a bag for that, as well as a
few well known tag names that map to metadata we know we'll want to set.