### PR TITLE
Check GitHubLogin instead of Name for check

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -874,7 +874,7 @@ func isValidAccessToken(cloud, accessToken string) (bool, error) {
 	// Make a request to get the authenticated user. If it returns a successful response,
 	// we know the access token is legit. We also parse the response as JSON and confirm
 	// it has a githubLogin field that is non-empty (like the Pulumi Service would return).
-	_, githubLogin, _, err := client.NewClient(cloud, accessToken).DescribeUser()
+	githubLogin, err := client.NewClient(cloud, accessToken).DescribeUser()
 	if err != nil {
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == 401 {
 			return false, nil

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -79,16 +79,14 @@ func getUpdatePath(update UpdateIdentifier, components ...string) string {
 }
 
 // DescribeUser describes the user implied by the API token associated with this client.
-func (pc *Client) DescribeUser() (string, string, string, error) {
+func (pc *Client) DescribeUser() (string, error) {
 	resp := struct {
-		Name        string `json:"name"`
 		GitHubLogin string `json:"githubLogin"`
-		AvatarURL   string `json:"avatarUrl"`
 	}{}
 	if err := pc.restCall("GET", "/api/user", nil, nil, &resp); err != nil {
-		return "", "", "", err
+		return "", err
 	}
-	return resp.Name, resp.GitHubLogin, resp.AvatarURL, nil
+	return resp.GitHubLogin, nil
 }
 
 // DownloadPlugin downloads the indicated plugin from the Pulumi API.


### PR DESCRIPTION
We confirm that a Pulumi access token is valid by making a request to the `/user` endpoint and confirming that some reasonable data was returned, e.g. the `Name` field is set.

However, if you create a brand, spankin' new GitHub account. That name field will be legitimately empty. (Since you haven't configured the GitHub profile yet.)

So we instead now check for `GitHubLogin` which will always have a non-empty value.

Fixes https://github.com/pulumi/pulumi/issues/1101.