### PR TITLE
Retry HTTP operations

### DIFF
--- a/pkg/backend/cloud/client/api.go
+++ b/pkg/backend/cloud/client/api.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/httputil"
 	"github.com/pulumi/pulumi/pkg/version"
 )
 
@@ -121,7 +122,7 @@ func pulumiAPICall(cloudAPI, method, path string, body []byte, tok accessToken) 
 		glog.V(9).Infof("Pulumi API call details (%s): headers=%v; body=%v", url, req.Header, string(body))
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := httputil.DoWithRetry(req)
 	if err != nil {
 		return "", nil, errors.Wrapf(err, "performing HTTP request")
 	}

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/httputil"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -310,7 +311,7 @@ func (pc *Client) CreateUpdate(kind UpdateKind, stack StackIdentifier, pkg *work
 			return UpdateIdentifier{}, err
 		}
 
-		resp, err := http.DefaultClient.Do(&http.Request{
+		resp, err := httputil.DoWithRetry(&http.Request{
 			Method:        "PUT",
 			URL:           uploadURL,
 			ContentLength: size,

--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -24,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/httputil"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -321,7 +321,7 @@ func (a *Asset) readURI() (*Blob, error) {
 	contract.Assertf(isurl, "Expected a URI-based asset")
 	switch s := url.Scheme; s {
 	case "http", "https":
-		resp, err := http.Get(url.String())
+		resp, err := httputil.GetWithRetry(url.String())
 		if err != nil {
 			return nil, err
 		}
@@ -827,7 +827,7 @@ func (a *Archive) readURI() (ArchiveReader, error) {
 func (a *Archive) openURLStream(url *url.URL) (io.ReadCloser, error) {
 	switch s := url.Scheme; s {
 	case "http", "https":
-		resp, err := http.Get(url.String())
+		resp, err := httputil.GetWithRetry(url.String())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -1,0 +1,44 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/util/retry"
+)
+
+// maxRetryCount is the number of times to try an http request before giving up an returning the last error
+const maxRetryCount = 5
+
+// DoWithRetry is like http.DefaultClient.Do expect that if it returns an error, we retry the operation again after a
+// slight delay. Note that in the case where the server returns an error response (e.g. 4xx or 5xx) we do not rety the
+// request. This method only concerns itself with trying to get a response back from the server.
+func DoWithRetry(req *http.Request) (*http.Response, error) {
+	_, res, err := retry.Until(context.Background(), retry.Acceptor{
+		Accept: func(try int, nextRetryTime time.Duration) (bool, interface{}, error) {
+			res, resErr := http.DefaultClient.Do(req)
+			if resErr == nil {
+				return true, res, nil
+			}
+			if try >= (maxRetryCount - 1) {
+				return false, res, resErr
+			}
+			return false, nil, nil
+		},
+	})
+
+	return res.(*http.Response), err
+}
+
+// GetWithRetry is like http.DefaultClient.Get expect that if it returns an error, we retry the operation again after a
+// slight delay. Note that in the case where the server returns an error response (e.g. 4xx or 5xx) we do not rety the
+// request. This method only concerns itself with trying to get a response back from the server.
+func GetWithRetry(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return DoWithRetry(req)
+}


### PR DESCRIPTION
We've seen failures in CI where DNS lookups fail which cause our
operations against the service to fail, as well as other sorts of
timeouts.

Add a set of helper methods in a new httputil package that helps us do
retries on these operations.