### PR TITLE
Fix NPM tagging

### DIFF
--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -5,8 +5,17 @@ ROOT=$(dirname $0)/..
 
 if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
     echo "Publishing NPM package to NPMjs.com:"
+    NPM_TAG="dev"
+
+    # If the package doesn't have a pre-release tag, use the tag of latest instead of
+    # dev. NPM uses this tag as the default version to add, so we want it to mean
+    # the newest released version.
+    if [[ ! $(jq -r .version < "${ROOT}/sdk/nodejs/bin/package.json") != *-* ]]; then
+        NPM_TAG="latest"
+    fi
+
     pushd ${ROOT}/sdk/nodejs/bin && \
-        npm publish && \
+        npm publish --tag "${NPM_TAG}" && \
         npm info 2>/dev/null || true && \
         popd
 


### PR DESCRIPTION
`npm publish`'s default was to tag the package we published with
`latest` tag. The NPM ecosystem has expected semantics around this
tag (it uses it by default if you don't pass a version).

From the NPM Docs:

> Typically, projects only use the latest tag for stable release
> versions, and use other tags for unstable versions such as
> prereleases.

We were not doing this, but now we will.  We'll have a new tag `dev`
which is the latest build out of CI, and we'll tag builds without a
pre-release tag with `latest`.