### PR TITLE
Skip reading unknown IDs

### DIFF
--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -47,6 +47,7 @@ export function readResource(res: Resource, id: Input<ID>, t: string, name: stri
         log.debug(`ReadResource RPC prepared: id=${resolvedID}, t=${t}, name=${name}` +
             (excessiveDebugOutput ? `, obj=${JSON.stringify(resop.serializedProps)}` : ``));
 
+        // Create a resource request and do the RPC.
         const req = new resproto.ReadResourceRequest();
         req.setType(t);
         req.setName(name);
@@ -71,7 +72,7 @@ export function readResource(res: Resource, id: Input<ID>, t: string, name: stri
 
             // Now resolve everything: the URN, the ID (supplied as input), and the output properties.
             resop.resolveURN(resp.getUrn());
-            resop.resolveID!(resolvedID, true);
+            resop.resolveID!(id, id !== undefined);
             await resolveOutputs(res, t, name, props, resp.getProperties(), resop.resolvers);
         });
     }));


### PR DESCRIPTION
This change skips unknown IDs during read operations.  This can happen
when a read is performed using the output property of another resource
during planning.  This is intentionally supported via ID being an
Input<ID> and all we need to do for this to work correctly is skip the
actual provider RPC and the runtime will propagate unknown outputs as
usual.