### PR TITLE
Fix the indentation of output property rendering

### DIFF
--- a/pkg/backend/local/display.go
+++ b/pkg/backend/local/display.go
@@ -240,7 +240,7 @@ func RenderResourceOutputsEvent(
 
 	if (shouldShow(payload.Metadata, opts) || isRootStack(payload.Metadata)) && !opts.Summary {
 		indent := engine.GetIndent(payload.Metadata, seen)
-		text := engine.GetResourceOutputsPropertiesString(payload.Metadata, indent, payload.Planning, payload.Debug)
+		text := engine.GetResourceOutputsPropertiesString(payload.Metadata, indent+1, payload.Planning, payload.Debug)
 
 		fprintIgnoreError(out, opts.Color.Colorize(text))
 	}


### PR DESCRIPTION
We indent the input properties 1 further than the base indent, but were not doing the same for output properties.

I know @CyrusNajmabadi is going to replace all of this soon - but in the meantime this makes `pulumi update` output much more readable.

Before:

```
Performing changes:
* pulumi:pulumi:Stack: (same)
    [urn=urn:pulumi:foo::2-vms-loadbalancer-lbrules::pulumi:pulumi:Stack::2-vms-loadbalancer-lbrules-foo]
    + azure:core/resourceGroup:ResourceGroup: (create)
        [urn=urn:pulumi:foo::2-vms-loadbalancer-lbrules::azure:core/resourceGroup:ResourceGroup::resourcegroup]
        location: "West US"
        name    : "resourcegroupea30d22c"
    ---outputs:---
    id      : "/subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/resourcegroupea30d22c"
    location: "westus"
    + azure:storage/account:Account: (create)
        [urn=urn:pulumi:foo::2-vms-loadbalancer-lbrules::azure:storage/account:Account::storageaccount]
        accountEncryptionSource: "Microsoft.Storage"
        accountKind            : "Storage"
        accountReplicationType : "LRS"
        accountTier            : "standard"
        location               : "westus"
        name                   : "storageaccountcf75161f"
        resourceGroupName      : "resourcegroupea30d22c"
    ---outputs:---
    accountTier                : "Standard"
    accountType                : "Standard_LRS"
    enableBlobEncryption       : true
    enableFileEncryption       : true
    enableHttpsTrafficOnly     : false
    id                         : "/subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/resourcegroupea30d22c/providers/Microsoft.Storage/storageAccounts/storageaccountcf75161f"
    primaryAccessKey           : "NX+YXAD1F6xcAHYDpz3SFOka7nN6EPtcwsgd6hTzKTQzrULThw/3GNC/3RQNqHJPco5I2NI78LSR1kCQv5paJA=="
    primaryBlobConnectionString: "DefaultEndpointsProtocol=https;BlobEndpoint=https://storageaccountcf75161f.blob.core.windows.net/;AccountName=storageaccountcf75161f;AccountKey=NX+YXAD1F6xcAHYDpz3SFOka7nN6EPtcwsgd6hTzKTQzrULThw/3GNC/3RQNqHJPco5I2NI78LSR1kCQv5paJA=="
    primaryBlobEndpoint        : "https://storageaccountcf75161f.blob.core.windows.net/"
    primaryConnectionString    : "DefaultEndpointsProtocol=https;AccountName=storageaccountcf75161f;AccountKey=NX+YXAD1F6xcAHYDpz3SFOka7nN6EPtcwsgd6hTzKTQzrULThw/3GNC/3RQNqHJPco5I2NI78LSR1kCQv5paJA==;EndpointSuffix=core.windows.net"
    primaryFileEndpoint        : "https://storageaccountcf75161f.file.core.windows.net/"
    primaryLocation            : "westus"
    primaryQueueEndpoint       : "https://storageaccountcf75161f.queue.core.windows.net/"
    primaryTableEndpoint       : "https://storageaccountcf75161f.table.core.windows.net/"
    secondaryAccessKey         : "CgVEN70hJGo1yudVkeUj6RIf5iYrrtLMbYgqDAmc9ZvU2mO7uHuY94QvM08RhZ55vGIQa84BVNvPMTKtzVH4sw=="
    secondaryConnectionString  : "DefaultEndpointsProtocol=https;AccountName=storageaccountcf75161f;AccountKey=CgVEN70hJGo1yudVkeUj6RIf5iYrrtLMbYgqDAmc9ZvU2mO7uHuY94QvM08RhZ55vGIQa84BVNvPMTKtzVH4sw==;EndpointSuffix=core.windows.net"
```

After:

```
Performing changes:
+ pulumi:pulumi:Stack: (create)
    [urn=urn:pulumi:foo::2-vms-loadbalancer-lbrules::pulumi:pulumi:Stack::2-vms-loadbalancer-lbrules-foo]
    + azure:core/resourceGroup:ResourceGroup: (create)
        [urn=urn:pulumi:foo::2-vms-loadbalancer-lbrules::azure:core/resourceGroup:ResourceGroup::resourcegroup]
        location: "West US"
        name    : "resourcegroupe662e7a3"
        ---outputs:---
        id      : "/subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/resourcegroupe662e7a3"
        location: "westus"
    + azure:storage/account:Account: (create)
        [urn=urn:pulumi:foo::2-vms-loadbalancer-lbrules::azure:storage/account:Account::storageaccount]
        accountEncryptionSource: "Microsoft.Storage"
        accountKind            : "Storage"
        accountReplicationType : "LRS"
        accountTier            : "standard"
        location               : "westus"
        name                   : "storageaccount07900715"
        resourceGroupName      : "resourcegroupe662e7a3"
        ---outputs:---
        accountTier                : "Standard"
        accountType                : "Standard_LRS"
        enableBlobEncryption       : true
        enableFileEncryption       : true
        enableHttpsTrafficOnly     : false
        id                         : "/subscriptions/0282681f-7a9e-424b-80b2-96babd57a8a1/resourceGroups/resourcegroupe662e7a3/providers/Microsoft.Storage/storageAccounts/storageaccount07900715"
        primaryAccessKey           : "B1YOC49Jubyi4cW6rafyPmKyUT0VObRR7OIC7klemM82PrSK9GzlUIssu88nEd4EY/8pY94u3PyGbIfdaysJ6Q=="
        primaryBlobConnectionString: "DefaultEndpointsProtocol=https;BlobEndpoint=https://storageaccount07900715.blob.core.windows.net/;AccountName=storageaccount07900715;AccountKey=B1YOC49Jubyi4cW6rafyPmKyUT0VObRR7OIC7klemM82PrSK9GzlUIssu88nEd4EY/8pY94u3PyGbIfdaysJ6Q=="
        primaryBlobEndpoint        : "https://storageaccount07900715.blob.core.windows.net/"
        primaryConnectionString    : "DefaultEndpointsProtocol=https;AccountName=storageaccount07900715;AccountKey=B1YOC49Jubyi4cW6rafyPmKyUT0VObRR7OIC7klemM82PrSK9GzlUIssu88nEd4EY/8pY94u3PyGbIfdaysJ6Q==;EndpointSuffix=core.windows.net"
        primaryFileEndpoint        : "https://storageaccount07900715.file.core.windows.net/"
        primaryLocation            : "westus"
        primaryQueueEndpoint       : "https://storageaccount07900715.queue.core.windows.net/"
        primaryTableEndpoint       : "https://storageaccount07900715.table.core.windows.net/"
        secondaryAccessKey         : "rBW/KUyMb2DAPvcGz1zJyygHO3AKTAviSlgYrI2/6ZJFxCjH13mirTZOTRWcDBSzmZyknEisOe+sMbnCjo9HWQ=="
        secondaryConnectionString  : "DefaultEndpointsProtocol=https;AccountName=storageaccount07900715;AccountKey=rBW/KUyMb2DAPvcGz1zJyygHO3AKTAviSlgYrI2/6ZJFxCjH13mirTZOTRWcDBSzmZyknEisOe+sMbnCjo9HWQ==;EndpointSuffix=core.windows.net"
```