### PR TITLE
[WIP] Download Node v6.10.2 on install of pulumi/pulumi

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -18,6 +18,7 @@ export NODE_PATH:=$(NODE_PATH):./runtime/native/build/Release
 
 ensure::
 	cd runtime/native && ./ensure_node_v8.sh
+	node install.js
 
 lint::
 	$(GOMETALINTER) cmd/pulumi-language-nodejs/main.go | sort ; exit "$${PIPESTATUS[0]}"
@@ -32,6 +33,8 @@ build::
 	node ../../scripts/reversion.js bin/package.json ${VERSION}
 	node ../../scripts/reversion.js bin/version.js ${VERSION}
 	cp -R proto/. bin/proto/
+	cp runtime/native/build/Release/nativeruntime-v0.11.0.node bin/
+	cp install.js bin/
 	mkdir -p bin/tests/runtime/langhost/cases/
 	find tests/runtime/langhost/cases/* -type d -exec cp -R {} bin/tests/runtime/langhost/cases/ \;
 

--- a/sdk/nodejs/dist/pulumi-language-nodejs-exec
+++ b/sdk/nodejs/dist/pulumi-language-nodejs-exec
@@ -2,5 +2,22 @@
 # we exploit the fact that the cwd when `pulumi-language-nodejs-exec` is
 # run is the root of the node program we want to run and use a relative
 # path here.
-export NODE_PATH="$NODE_PATH:`dirname $0`/`node --version`"
-node ./node_modules/@pulumi/pulumi/cmd/run $@
+PULUMI_NODE_MODULE=./node_modules/@pulumi/pulumi
+if [ ! -e ${PULUMI_NODE_MODULE}/third_party/node ]; then
+    # This is an old version of the Pulumi Node SDK, so we don't have a custom Node
+    # to use here. Use the system one.
+    #
+    # The native Node module also ships alongside the SDK, which we know to
+    # be where this file is located (hence the dirname).
+    export NODE_PATH="$NODE_PATH:`dirname $0`/`node --version`"
+    node ${PULUMI_NODE_MODULE}/cmd/run $@
+    exit
+fi
+
+# Newer versions of the Pulumi Node SDK contain their own version of Node
+# that we should use to execute Pulumi programs. They also contain the
+# native module for that node in the package, so we don't have to look in
+# the CLI install directory.
+export NODE_PATH="$NODE_PATH:$PULUMI_NODE_MODULE"
+PULUMI_NODE=$(find ${PULUMI_NODE_MODULE} -name "node" -type f -follow)
+${PULUMI_NODE} ${PULUMI_NODE_MODULE}/cmd/run $@

--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
@@ -1,3 +1,20 @@
 #!/bin/sh
-export NODE_PATH="$NODE_PATH:`dirname $0`/`node --version`"
-node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider $@
+PULUMI_NODE_MODULE=./node_modules/@pulumi/pulumi
+if [ ! -e ${PULUMI_NODE_MODULE}/third_party/node ]; then
+    # This is an old version of the Pulumi Node SDK, so we don't have a custom Node
+    # to use here. Use the system one.
+    #
+    # The native Node module also ships alongside the SDK, which we know to
+    # be where this file is located (hence the dirname).
+    export NODE_PATH="$NODE_PATH:`dirname $0`/`node --version`"
+    node ${PULUMI_NODE_MODULE}/cmd/dynamic-provider $@
+    exit
+fi
+
+# Newer versions of the Pulumi Node SDK contain their own version of Node
+# that we should use to execute Pulumi programs. They also contain the
+# native module for that node in the package, so we don't have to look in
+# the CLI install directory.
+export NODE_PATH="$NODE_PATH:$PULUMI_NODE_MODULE"
+PULUMI_NODE=$(find ${PULUMI_NODE_MODULE} -name "node" -type f -follow)
+${PULUMI_NODE} ${PULUMI_NODE_MODULE}/cmd/dynamic-provider $@

--- a/sdk/nodejs/install.js
+++ b/sdk/nodejs/install.js
@@ -1,0 +1,146 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+const https = require("https");
+const fs = require("fs");
+const constants = require("constants");
+const path = require("path");
+const child_process = require("child_process");
+
+const nodeVersion = require("./package.json").pulumi.nodeVersion;
+if (!nodeVersion) {
+    console.error("failed to ascertain desired node version - is pulumi.nodeVersion set in package.json?");
+    process.exit(1);
+}
+
+const downloadUrl = constructDownloadUrl(nodeVersion);
+const installDir = makeInstallDirectory(nodeVersion);
+doDownload(downloadUrl, installDir)
+    .then(decompressDownload)
+    .then(validateInstall)
+    .catch(err => {
+        console.error("download failed: ", err);
+        process.exit(1);
+    })
+
+/**
+ * Constructs a URL from which to download a Node binary that we can use to execute Pulumi programs.
+ * If we are running on Windows, we must download a patched version of Node that we have built ourselves
+ * in order to expose some V8 internals that we link against. On non-Windows, we can use stock Node
+ * without any problems and we can download an official Node release.
+ * 
+ * @param {string} nodeVersion The version of Node we intend to install.
+ */
+function constructDownloadUrl(nodeVersion) {
+    let rootUrl = "https://nodejs.org/download/release/";
+    if (process.platform === "win32") {
+        console.error("running on Windows, downloading Pulumi Node");
+        // TODO(swgillespie) Windows
+        process.exit(1);
+    }
+
+    console.log("downloading NodeJS:", nodeVersion);
+    rootUrl += nodeVersion + '/';
+
+    file = "node-" + nodeVersion + "-" + process.platform + "-" + process.arch + ".tar.gz";
+    rootUrl += file;
+    return rootUrl;
+}
+
+/**
+ * Constructs the directory that we will download our Node to.
+ * 
+ * @param {string} nodeVersion 
+ */
+function makeInstallDirectory(nodeVersion) {
+    function tryMkdir(dir) {
+        try {
+            fs.mkdirSync(dir);
+        } catch(e) {
+            if (e.code != "EEXIST") {
+                throw e;
+            }
+        }
+    }
+
+    tryMkdir("third_party");
+    tryMkdir(path.join("third_party", "node"));
+    return path.join("third_party", "node");
+}
+
+/**
+ * Performs the actual download of a released Node, saving it to a file "node.tar.gz" in the
+ * installation directory.
+ * 
+ * @param {string} downloadUrl The URL from which to download
+ * @param {string} installDir The directory to place the downloaded Node tar
+ */
+function doDownload(downloadUrl, installDir) {
+    return new Promise((resolve, reject) => {
+        const file = path.join(installDir, "node.tar.gz");
+        const stream = fs.createWriteStream(file);
+        https.get(downloadUrl, response => {
+            response.pipe(stream);
+            stream.on('finish', () => {
+                stream.close(() => {
+                    resolve(file);
+                });
+            });
+        }).on('error', err => {
+            fs.unlink(file);
+            reject(err);
+        });
+    });
+}
+
+/**
+ * Decompresses the Node tar that we jsut downloaded.
+ * 
+ * @param {string} file The name of the tar we just downloaded.
+ */
+function decompressDownload(file) {
+    return new Promise((resolve, reject) => {
+        child_process.exec("tar -C ./third_party/node -xf " + file, (err, stdout, stderr) => {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            fs.unlink(file, err => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+
+                resolve();
+            });
+        })
+    })
+}
+
+/**
+ * Does a small smoke test of the node that we just downloaded to ensure that 
+ * 1) it's not busted and 2) it's the version we expect.
+ */
+function validateInstall() {
+    const nodeBin = path.join("third_party", "node",
+        "node-" + nodeVersion + "-" + process.platform + "-" + process.arch,
+        "bin",
+        "node");
+
+    return new Promise((resolve, reject) => {
+        child_process.execFile(nodeBin, ["-p", "process.version"], (error, stdout, stderr) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+
+            if (stdout.trim() !== nodeVersion) {
+                reject(new Error("downloaded node is not the expected version, expected " + 
+                    nodeVersion + ", got " + stdout.trim()));
+                return;
+            }
+
+            resolve();
+        })
+    })
+}

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -3,6 +3,9 @@
     "version": "${VERSION}",
     "description": "Pulumi's Node.js SDK",
     "repository": "https://github.com/pulumi/pulumi/sdk/nodejs",
+    "scripts": {
+        "install": "node install.js"
+    },
     "devDependencies": {
         "@types/minimist": "^1.2.0",
         "@types/mocha": "^2.2.42",
@@ -19,5 +22,8 @@
         "require-from-string": "^2.0.1",
         "source-map-support": "^0.4.16",
         "typescript": "^2.5.2"
+    },
+    "pulumi": {
+        "nodeVersion": "v6.10.2"
     }
 }


### PR DESCRIPTION
This helps alleviate some of the pain of our system requiring that you
have a specific version of Node installed. With this change, we will
download the exact version of Node when the pulumi/pulumi npm package is
installed.

This change also places the native Node module inside of the package,
which allows us to version it in lockstep with the package and not as
part of the CLI.

This is as far as I got today - currently it only works for non-Windows platforms. For Windows, all we need to do is download our patched Node and not an official release.

This change is backwards-compatible - the bash scripting should detect whether or not there is a `node` available for us to use and, if there is not, it'll fall back to use the system node and fail in the usual way if the system node isn't `v6.10.2`. With this PR, users can now have arbitrary Nodes installed on their system and still be able to use `pulumi`:

```
$ node --version
v8.10.0
[0 Seans-MacBook-Pro ~/go/src/github.com/pulumi/scratch/stack]
$ pulumi update
Performing changes:
+ pulumi:pulumi:Stack: (create)
    [urn=urn:pulumi:test::stack::pulumi:pulumi:Stack::stack-test]
info: 1 change performed:
    + 1 resource created
Update duration: 727.12357ms
````

Marking this as WIP for now since it can probably be cleaned up a lot and it doesn't work on Windows yet.
