### PR TITLE
Simplify resource lookup

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -32,10 +32,8 @@ export abstract class Resource {
      * @param custom True to indicate that this is a custom resource, managed by a plugin.
      * @param props The arguments to use to populate the new resource.
      * @param opts A bag of options that control this resource's behavior.
-     * @param existing If non-empty, state will be read from an existing custom resource with the given ID.
      */
-    constructor(t: string, name: string, custom: boolean,
-                props: Inputs = {}, opts: ResourceOptions = {}, existing?: Input<ID>) {
+    constructor(t: string, name: string, custom: boolean, props: Inputs = {}, opts: ResourceOptions = {}) {
         if (!t) {
             throw new Error("Missing resource type argument");
         }
@@ -48,12 +46,12 @@ export abstract class Resource {
             opts.parent = getRootResource();
         }
 
-        if (existing) {
+        if (opts.id) {
             // If this resource already exists, read its state rather than registering it anew.
             if (!custom) {
                 throw new Error("Cannot read an existing resource unless it has a custom provider");
             }
-            readResource(this, existing, t, name, props, opts);
+            readResource(this, t, name, props, opts);
         } else {
             // Kick off the resource registration.  If we are actually performing a deployment, this
             // resource's properties will be resolved asynchronously after the operation completes, so
@@ -70,6 +68,10 @@ export abstract class Resource {
  * ResourceOptions is a bag of optional settings that control a resource's behavior.
  */
 export interface ResourceOptions {
+    /**
+     * An optional existing ID to load, rather than create.
+     */
+    id?: Input<ID>;
     /**
      * An optional parent resource to which this resource belongs.
      */
@@ -109,10 +111,9 @@ export abstract class CustomResource extends Resource {
      * @param name The _unique_ name of the resource.
      * @param props The arguments to use to populate the new resource.
      * @param opts A bag of options that control this resource's behavior.
-     * @param existing An optional existing resource ID to read state from rather than register anew.
      */
-    constructor(t: string, name: string, props?: Inputs, opts?: ResourceOptions, existing?: Input<ID>) {
-        super(t, name, true, props, opts, existing);
+    constructor(t: string, name: string, props?: Inputs, opts?: ResourceOptions) {
+        super(t, name, true, props, opts);
     }
 }
 

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -20,7 +20,7 @@ interface ResourceResolverOperation {
     // A resolver for a resource's URN.
     resolveURN: (urn: URN) => void;
     // A resolver for a resource's ID (for custom resources only).
-    resolveID: ((v: any, performApply: boolean) => void) | undefined;
+    resolveID: ((v: ID, performApply: boolean) => void) | undefined;
     // A collection of resolvers for a resource's properties.
     resolvers: OutputResolvers;
     // A parent URN, fully resolved, if any.
@@ -35,8 +35,12 @@ interface ResourceResolverOperation {
  * Reads an existing custom resource's state from the resource monitor.  Note that resources read in this way
  * will not be part of the resulting stack's state, as they are presumed to belong to another.
  */
-export function readResource(res: Resource, id: Input<ID>, t: string, name: string,
-                             props: Inputs, opts: ResourceOptions): void {
+export function readResource(res: Resource, t: string, name: string, props: Inputs, opts: ResourceOptions): void {
+    const id: Input<ID> | undefined = opts.id;
+    if (!id) {
+        throw new Error("Cannot read resource whose options are lacking an ID value");
+    }
+
     const label = `resource:${name}[${t}]#...`;
     log.debug(`Reading resource: id=${id}, t=${t}, name=${name}`);
 
@@ -72,7 +76,7 @@ export function readResource(res: Resource, id: Input<ID>, t: string, name: stri
 
             // Now resolve everything: the URN, the ID (supplied as input), and the output properties.
             resop.resolveURN(resp.getUrn());
-            resop.resolveID!(id, id !== undefined);
+            resop.resolveID!(resolvedID, resolvedID !== undefined);
             await resolveOutputs(res, t, name, props, resp.getProperties(), resop.resolvers);
         });
     }));

--- a/sdk/nodejs/tests/runtime/langhost/cases/014.read_resource/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/014.read_resource/index.js
@@ -10,7 +10,7 @@ let inputs = {
     d: undefined,
 };
 
-let res = new pulumi.CustomResource("test:read:resource", "foo", inputs, undefined, "abc123");
+let res = new pulumi.CustomResource("test:read:resource", "foo", inputs, { id: "abc123" });
 res.id.apply(id => assert.strictEqual(id, "abc123"));
 res.urn.apply(urn => assert.strictEqual(urn, "test:read:resource::foo"));
 res.a.apply(a => assert.strictEqual(a, inputs.a)); // same as input


### PR DESCRIPTION
As I began to write code using the ability to perform resource
lookups, especially in the code-generators, I realized the way it
was surfaced as an argument to the Resource base constructor would
lead to overload explosion.  Instead of doing that, let's pass it
in the ResourceOptions bag.