### PR TITLE
Early out in project file upgrade code

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -405,8 +405,20 @@ func getUpdateMetadata(msg, root string) (backend.UpdateMetadata, error) {
 // workspace settings and Pulumi.yaml, to the new system where configuration data is stored in Pulumi.<stack-name>.yaml
 func upgradeConfigurationFiles() error {
 	// If there's no workspace, don't even try to upgrade.
-	_, err := workspace.New()
+	w, err := workspace.New()
 	if err != nil {
+		return nil
+	}
+
+	// If we can't detect a project, also don't try to upgrade.
+	proj, err := workspace.DetectProject()
+	if err != nil {
+		return nil
+	}
+
+	// If the project does not have any workspace or project level configuration (this will be true for new projects
+	// and for any projects that have been upgraded), we can bail out early, as there is nothing to do.
+	if len(w.Settings().ConfigDeprecated) == 0 && len(proj.ConfigDeprecated) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION
We have some code that deals with upgrading legacy projects (which had
workspace level configuration) to the new format where configuration
information was stored SxS with the application.

This code requires us to get a list of stacks from the backend (which
for hosted stacks means hitting api.pulumi.com) as part of the upgrade
process, so we knew all the stacks the user's project has. This is a
somewhat slow operation (which we will make faster regardless) but we
can structure things such that we don't need to do this often.

In the common case, we don't need to actually do upgrading at
all (new projects won't need it and once a project is upgraded that
project won't need it either) so update the code first to check if we
would need to do any work and if so, do the expensive operation of
getting stacks from a backend.

This should help with the slight pauses we've seen on the command line
since the work to default to folks logging in has landed.