### PR TITLE
Publish SDK per build

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,6 +46,8 @@ install:
     go get -u github.com/golang/dep/cmd/dep
 
     git clone git@github.com:pulumi/home.git "%USERPROFILE%\go\src\github.com\pulumi\home"
+
+    git clone git@github.com:pulumi/sdk.git "%USERPROFILE%\go\src\github.com\pulumi\sdk"
 build_script:
 - cmd: >-
     if defined APPVEYOR_PULL_REQUEST_NUMBER ( msbuild /t:AppVeyorPullRequest /v:Detailed build.proj ) else ( msbuild /t:AppVeyorPush /v:Detailed build.proj )

--- a/build/travis/prepare-environment.sh
+++ b/build/travis/prepare-environment.sh
@@ -4,6 +4,7 @@
 # we can in a subshell.
 
 export PULUMI_HOME="$(go env GOPATH)/src/github.com/pulumi/home"
+export PULUMI_SDK="$(go env GOPATH)/src/github.com/pulumi/home"
 
 (
     set -o nounset -o errexit -o pipefail
@@ -15,6 +16,9 @@ export PULUMI_HOME="$(go env GOPATH)/src/github.com/pulumi/home"
 
     # We have some shared scripts in pulumi/home, and we use them in other steps
     git clone git@github.com:pulumi/home "${PULUMI_HOME}"
+
+    # We have some shared scripts in pulumi/sdk, and we use them in other steps
+    git clone git@github.com:pulumi/sdk "${PULUMI_SDK}"
 
     # If we have an NPM token, put it in the .npmrc file, so we can use it:
     if [ ! -z "${NPM_TOKEN:-}" ]; then

--- a/scripts/get-version.ps1
+++ b/scripts/get-version.ps1
@@ -10,10 +10,11 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 try { 
-  git describe --tags --exact-match 2>$null
+  git describe --tags --exact-match >$null 2>$null
   # If we get here the above did not throw, so we can use the exact tag
-  Write-Host "$(git describe --tags --exact-match)$dirtyTag"
+  Write-Output "$(git describe --tags --exact-match)$dirtyTag"
 } catch {
   # Otherwise, append the timestamp of the commit and the hash
-  Write-Host "$(git describe --tags --abbrev=0)-$(git show -s --format='%ct-g%h')$dirtyTag"
+  Write-Output "$(git describe --tags --abbrev=0)-$(git show -s --format='%ct-g%h')$dirtyTag"
 }
+

--- a/scripts/publish.ps1
+++ b/scripts/publish.ps1
@@ -3,6 +3,8 @@ Set-StrictMode -Version 2.0
 $ErrorActionPreference="Stop"
 
 $PublishScript="$(go env GOPATH)\src\github.com\pulumi\home\scripts\publish.ps1"
+$BuildSdkScript="$(go env GOPATH)\src\github.com\pulumi\sdk\scripts\build-sdk.ps1"
+
 
 if (!(Test-Path $PublishScript)) {
     Write-Error "Missing publish script at $PublishScript"
@@ -14,3 +16,6 @@ $PublishTargets=${ReleaseInfo}.Targets
 & $PublishScript $ReleaseInfo.ArchivePath "pulumi/windows/amd64" @PublishTargets
 
 Remove-Item -Force $ReleaseInfo.ArchivePath
+
+$Version=& $PSScriptRoot\get-version.ps1
+& $BuildSdkScript $Version $(get rev-parse HEAD)

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -25,3 +25,5 @@ if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
         -u pulumi -p pulumi \
         ${ROOT}/sdk/python/env/src/dist/*.whl
 fi
+
+${PULUMI_SDK}/scripts/build-sdk.sh $(${ROOT}/scripts/get-version) $(git rev-parse HEAD)


### PR DESCRIPTION
After the move to stop including packages in the SDK, we no longer
published an SDK per build. This corrects this. Since the only things
in the SDK today are the language plugins and the CLI itself, we can
publish an SDK per build from pulumi/pulumi.

This change re-uses the existing infrastructure we have in
pulumi/sdk.

Fixes #1076