### PR TITLE
Add some randomness to stack names in our integration tests

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -4,6 +4,8 @@ package integration
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -202,9 +204,11 @@ func (opts *ProgramTestOptions) GetStackName() tokens.QName {
 			}
 		}
 
-		lowerStackName := strings.ToLower("p-it-" + host + "-" + test)
-		legalStackName := strings.TrimRight(lowerStackName, "-_")
-		opts.StackName = legalStackName
+		b := make([]byte, 4)
+		_, err = rand.Read(b)
+		contract.AssertNoError(err)
+
+		opts.StackName = strings.ToLower("p-it-" + host + "-" + test + "-" + hex.EncodeToString(b))
 	}
 
 	return tokens.QName(opts.StackName)


### PR DESCRIPTION
To prepare for a world where stack names must be unique across an
owner, add some randomness to the names we use for stacks as part of
our integration tests.