### PR TITLE
Fix logging error in GetPluginPath

### DIFF
--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -312,7 +312,7 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version) (strin
 			if m != nil {
 				match = m
 				glog.V(6).Infof("GetPluginPath(%s, %s, %s): found candidate (#%s)",
-					kind, name, *version, match.Version)
+					kind, name, version, match.Version)
 			}
 		}
 	}


### PR DESCRIPTION
If version was nil, we would assert when trying to log a message. We
were hitting this on windows when trying to destroy a stack.

Fixes #1168