### PR TITLE
Fix an issue where the plugin context was not correctly persisted to the...

### DIFF
--- a/pkg/engine/preview.go
+++ b/pkg/engine/preview.go
@@ -29,7 +29,7 @@ func Preview(u UpdateInfo, manager SnapshotManager, events chan<- Event, opts Up
 	emitter := makeEventEmitter(events, u)
 	return preview(ctx, planOptions{
 		UpdateOptions: opts,
-		SourceFunc:    newUpdateSource,
+		SourceFunc:    newUpdateSource(manager),
 		Events:        emitter,
 		Diag:          newEventSink(emitter),
 	})

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -42,37 +42,45 @@ func Update(u UpdateInfo, manager SnapshotManager,
 	emitter := makeEventEmitter(events, u)
 	return update(ctx, planOptions{
 		UpdateOptions: opts,
-		SourceFunc:    newUpdateSource,
+		SourceFunc:    newUpdateSource(manager),
 		Events:        emitter,
 		Diag:          newEventSink(emitter),
 	})
 }
 
-func newUpdateSource(opts planOptions, proj *workspace.Project, pwd, main string,
-	target *deploy.Target, plugctx *plugin.Context) (deploy.Source, error) {
-	// Figure out which plugins to load by inspecting the program contents.
-	plugins, err := plugctx.Host.GetRequiredPlugins(plugin.ProgInfo{
-		Proj:    proj,
-		Pwd:     pwd,
-		Program: main,
-	})
-	if err != nil {
-		return nil, err
-	}
+func newUpdateSource(manager SnapshotManager) planSourceFunc {
+	return func(opts planOptions, proj *workspace.Project, pwd, main string,
+		target *deploy.Target, plugctx *plugin.Context) (deploy.Source, error) {
+		// Figure out which plugins to load by inspecting the program contents.
+		plugins, err := plugctx.Host.GetRequiredPlugins(plugin.ProgInfo{
+			Proj:    proj,
+			Pwd:     pwd,
+			Program: main,
+		})
+		if err != nil {
+			return nil, err
+		}
 
-	// Now ensure that we have loaded up any plugins that the program will need in advance.
-	if err = plugctx.Host.EnsurePlugins(plugins); err != nil {
-		return nil, err
-	}
+		// Save the required plugins into the manifest so they can be loaded
+		// during potential destroy operations.
+		if err = manager.RecordPlugins(plugins); err != nil {
+			return nil, err
+		}
 
-	// If that succeeded, create a new source that will perform interpretation of the compiled program.
-	// TODO[pulumi/pulumi#88]: we are passing `nil` as the arguments map; we need to allow a way to pass these.
-	return deploy.NewEvalSource(plugctx, &deploy.EvalRunInfo{
-		Proj:    proj,
-		Pwd:     pwd,
-		Program: main,
-		Target:  target,
-	}, opts.DryRun), nil
+		// Now ensure that we have loaded up any plugins that the program will need in advance.
+		if err = plugctx.Host.EnsurePlugins(plugins); err != nil {
+			return nil, err
+		}
+
+		// If that succeeded, create a new source that will perform interpretation of the compiled program.
+		// TODO[pulumi/pulumi#88]: we are passing `nil` as the arguments map; we need to allow a way to pass these.
+		return deploy.NewEvalSource(plugctx, &deploy.EvalRunInfo{
+			Proj:    proj,
+			Pwd:     pwd,
+			Program: main,
+			Target:  target,
+		}, opts.DryRun), nil
+	}
 }
 
 func update(info *planContext, opts planOptions) (ResourceChanges, error) {


### PR DESCRIPTION
manifest

This fixes a crash on shutdown that can occur if a resource provider is
used to create a resource but is not saved in the manifest.

This is unfortunately the opposite of some code review feedback I gave @joeduffy last week. 😆 This fix correctly persists plugin info in the manifest using `SnapshotManager.RecordPlugins`.

