### PR TITLE
Continue to add native modules to NODE_PATH

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -20,6 +20,13 @@
           WorkingDirectory="$(NodeJSSdkDirectory)" />
   </Target>
 
+  <Target Name="EnsurePrebuilt">
+    <MakeDir Directories="$(NodeJSSdkDirectory)\prebuilt" />
+    <Exec Command="aws s3 cp s3://eng.pulumi.com/nativeruntime/windows/nativeruntime.node $(NodeJSSdkDirectory)\prebuilt\nativeruntime.node" />
+    <Exec Command="aws s3 cp s3://eng.pulumi.com/nativeruntime/windows/nativeruntime-v0.11.0.node $(NodeJSSdkDirectory)\prebuilt\nativeruntime-v0.11.0.node" />
+    <Exec Command="aws s3 cp s3://eng.pulumi.com/nativeruntime/windows/pulumi-language-nodejs-node.exe $(NodeJSSdkDirectory)\prebuilt\pulumi-language-nodejs-node.exe" />
+  </Target>
+
   <Target Name="TypeScriptCompileNodeSdk">
     <Exec Command="&quot;$(MSBuildThisFileDirectory)\scripts\get-version.cmd&quot;" ConsoleToMSBuild="true" Condition="'$(Version)' == ''">
       <Output TaskParameter="ConsoleOutput" PropertyName="Version" />
@@ -70,6 +77,11 @@
           DependsOnTargets="BinPlaceNodeSdkProtos;BinPlaceNodeSdkTestData;YarnLinkSdk">
      <Copy SourceFiles="$(NodeJSSdkDirectory)\dist\pulumi-language-nodejs-exec.cmd" DestinationFolder="$(PulumiBin)" />
      <Copy SourceFiles="$(NodeJSSdkDirectory)\dist\pulumi-resource-pulumi-nodejs.cmd" DestinationFolder="$(PulumiBin)" />
+     <MakeDir Directories="$(PulumiBin)\v6.10.2" />
+     <MakeDir Directories="$(PulumiBin)\custom_node" />
+     <Copy SourceFiles="$(NodeJSSdkDirectory)\prebuilt\nativeruntime.node" DestinationFolder="$(PulumiBin)\v6.10.2" />
+     <Copy SourceFiles="$(NodeJSSdkDirectory)\prebuilt\nativeruntime-v0.11.0.node" DestinationFolder="$(PulumiBin)\v6.10.2" />
+     <Copy SourceFiles="$(NodeJSSdkDirectory)\prebuilt\pulumi-language-nodejs-node.exe" DestinationFiles="$(PulumiBin)\custom_node\node.exe" />
   </Target>
 
   <Target Name="BuildNodeSdk"
@@ -90,7 +102,7 @@
   </Target>
 
   <Target Name="Build"
-          DependsOnTargets="EnsureGoDependencies;EnsureNodeDependencies;BuildNodeSdk;BuildGoCmds">
+          DependsOnTargets="EnsureGoDependencies;EnsureNodeDependencies;EnsurePrebuilt;BuildNodeSdk;BuildGoCmds">
   </Target>
 
   <Target Name="IntegrationTest">

--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -35,6 +35,12 @@ CopyPackage "$Root\sdk\nodejs\bin" "pulumi"
 Copy-Item "$Root\sdk\nodejs\dist\pulumi-language-nodejs-exec.cmd" "$PublishDir\bin"
 Copy-Item "$Root\sdk\nodejs\dist\pulumi-resource-pulumi-nodejs.cmd" "$PublishDir\bin"
 
+New-Item -ItemType Directory -Path "$PublishDir\bin\v6.10.2"
+New-Item -ItemType Directory -Path "$PublishDir\bin\custom_node"
+Copy-Item "$Root\sdk\nodejs\prebuilt\nativeruntime.node" "$PublishDir\bin\v6.10.2"
+Copy-Item "$Root\sdk\nodejs\prebuilt\nativeruntime-v0.11.0.node" "$PublishDir\bin\v6.10.2"
+Copy-Item "$Root\sdk\nodejs\prebuilt\pulumi-language-nodejs-node.exe" "$PublishDir\bin\custom_node\node.exe"
+
 # By default, if the archive already exists, 7zip will just add files to it, so blow away the existing
 # archive if it exists.
 if (Test-Path $PublishFile) {

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -56,6 +56,10 @@ cp ${ROOT}/sdk/python/cmd/pulumi-language-python-exec ${PUBDIR}/bin/
 # Copy packages
 copy_package "${ROOT}/sdk/nodejs/bin/." "@pulumi/pulumi"
 
+# Copy prebuilt native modules
+mkdir ${PUBDIR}/bin/v6.10.2/
+cp ${ROOT}/sdk/nodejs/prebuilt/*.node ${PUBDIR}/bin/v6.10.2/
+
 # Tar up the file and then print it out for use by the caller or script.
 tar -czf ${PUBFILE} -C ${PUBDIR} .
 echo ${PUBFILE} ${PUBTARGETS[@]}

--- a/sdk/nodejs/.gitignore
+++ b/sdk/nodejs/.gitignore
@@ -1,5 +1,6 @@
 /bin/
 /coverage/
+/prebuilt/
 /node_modules/
 /custom_node/
 /runtime/native/node_dev/

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -15,6 +15,11 @@ include ../../build/common.mk
 
 export PATH:=$(shell yarn bin 2>/dev/null):$(PATH)
 
+ensure::
+	[ -d "./prebuilt/" ] || mkdir "./prebuilt"
+	[ -e "./prebuilt/nativeruntime.node" ] || aws s3 cp "s3://eng.pulumi.com/nativeruntime/$$(go env GOOS)/nativeruntime.node" "./prebuilt/"
+	[ -e "./prebuilt/nativeruntime-v0.11.0.node" ] || aws s3 cp "s3://eng.pulumi.com/nativeruntime/$$(go env GOOS)/nativeruntime-v0.11.0.node" "./prebuilt/"
+
 lint::
 	$(GOMETALINTER) cmd/pulumi-language-nodejs/main.go | sort ; exit "$${PIPESTATUS[0]}"
 	tslint -c tslint.json -p tsconfig.json
@@ -33,6 +38,8 @@ install::
 	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" ${LANGUAGE_HOST}
 	cp dist/pulumi-language-nodejs-exec "$(PULUMI_BIN)"
 	cp dist/pulumi-resource-pulumi-nodejs "$(PULUMI_BIN)"
+	mkdir -p "$(PULUMI_BIN)/v6.10.2"
+	cp ./prebuilt/*.node "$(PULUMI_BIN)/v6.10.2/"
 	rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)/tests"
 
 test_fast::

--- a/sdk/nodejs/dist/pulumi-language-nodejs-exec
+++ b/sdk/nodejs/dist/pulumi-language-nodejs-exec
@@ -2,4 +2,5 @@
 # we exploit the fact that the cwd when `pulumi-language-nodejs-exec` is
 # run is the root of the node program we want to run and use a relative
 # path here.
+export NODE_PATH="$NODE_PATH:`dirname $0`/v6.10.2"
 node ./node_modules/@pulumi/pulumi/cmd/run $@

--- a/sdk/nodejs/dist/pulumi-language-nodejs-exec.cmd
+++ b/sdk/nodejs/dist/pulumi-language-nodejs-exec.cmd
@@ -1,1 +1,2 @@
+@set NODE_PATH=%NODE_PATH%;%~dp0\v6.10.2
 @node ./node_modules/@pulumi/pulumi/cmd/run %*

--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
@@ -1,2 +1,3 @@
 #!/bin/sh
+export NODE_PATH="$NODE_PATH:`dirname $0`/v6.10.2"
 node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider $@

--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
@@ -1,1 +1,2 @@
+@set NODE_PATH=%NODE_PATH%;%~dp0\v6.10.2
 @node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider %*


### PR DESCRIPTION
While we no longer use the native runtime module, older versions of
@pulumi/pulumi still require it. Let's continue to have the launcher
put the native module location on the `$PATH`. And we'll include them
in the SDK for a while longer.

Fixes #1177