### PR TITLE
Produce a single message for the text we receive when running, not a message per line of output.

### DIFF
--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -120,12 +120,12 @@ func getDiagnosticInformation(status Status) (
 		case diag.Error:
 			errors++
 			lastError = &ev
-		case diag.Infoerr:
-			errors++
-			lastInfoError = &ev
 		case diag.Warning:
 			warnings++
 			lastWarning = &ev
+		case diag.Infoerr:
+			infos++
+			lastInfoError = &ev
 		case diag.Info:
 			infos++
 			lastInfo = &ev
@@ -137,10 +137,10 @@ func getDiagnosticInformation(status Status) (
 
 	if lastError != nil {
 		worstDiag = lastError
-	} else if lastInfoError != nil {
-		worstDiag = lastInfoError
 	} else if lastWarning != nil {
 		worstDiag = lastWarning
+	} else if lastInfoError != nil {
+		worstDiag = lastInfoError
 	} else if lastInfo != nil {
 		worstDiag = lastInfo
 	} else {

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -4,11 +4,13 @@ package plugin
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -90,18 +92,20 @@ func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin,
 	// For now, we will spawn goroutines that will spew STDOUT/STDERR to the relevant diag streams.
 	runtrace := func(t io.Reader, stderr bool, done chan<- bool) {
 		reader := bufio.NewReader(t)
-		for {
-			line, readerr := reader.ReadString('\n')
-			if readerr != nil {
-				break
-			}
-			msg := line[:len(line)-1]
+
+		buf := &bytes.Buffer{}
+		_, err1 := buf.ReadFrom(reader)
+		contract.IgnoreError(err1)
+
+		msg := buf.String()
+		if strings.TrimSpace(msg) != "" {
 			if stderr {
 				ctx.Diag.Infoerrf(diag.RawMessage("" /*urn*/, msg))
 			} else {
 				ctx.Diag.Infof(diag.RawMessage("" /*urn*/, msg))
 			}
 		}
+
 		close(done)
 	}
 


### PR DESCRIPTION
Also, group infoerr messages along with info messages in the progress display.  They are displayed as "info:" so it does not make sense that we would increment our error count when we get them.

Fixes https://github.com/pulumi/pulumi-cloud/issues/460