### PR TITLE
Only publish packages on the linux v8.11 node leg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - os: linux
       env: NODE_VERSION=v6.10.3
     - os: linux
-      env: NODE_VERSION=v8.11.1
+      env: NODE_VERSION=v8.11.1 TRAVIS_PUBLISH_PACKAGES=true
     - os: osx
       env: NODE_VERSION=v9.11.1
 language: go

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -3,7 +3,7 @@
 set -o nounset -o errexit -o pipefail
 ROOT=$(dirname $0)/..
 
-if [[ "${TRAVIS_OS_NAME:-}" == "linux" ]]; then
+if [[ "${TRAVIS_PUBLISH_PACKAGES:-}" == "true" ]]; then
     echo "Publishing NPM package to NPMjs.com:"
     NPM_TAG="dev"
 


### PR DESCRIPTION
Running multiple jobs on linux causes `scripts/publish_packages.sh` to attempt to publish NPM and PyPI packages twice. This PR explicitly authorizes one leg (the v8.11.1 leg, targeting the current node LTS) to publish packages.