### PR TITLE
Add a `Version` field to `UntypedDeployment`.

### DIFF
--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -55,7 +55,10 @@ func newStackImportCmd() *cobra.Command {
 			// We do, however, now want to unmarshal the json.RawMessage into a real, typed deployment.  We do this so
 			// we can check that the deployment doesn't contain resources from a stack other than the selected one. This
 			// catches errors wherein someone imports the wrong stack's deployment (which can seriously hork things).
-			var typed apitype.Deployment
+			if deployment.Version > 1 {
+				return errors.New("unsupported deployment version")
+			}
+			var typed apitype.DeploymentV1
 			if err = json.Unmarshal(deployment.Deployment, &typed); err != nil {
 				return err
 			}

--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -60,6 +60,8 @@ type DeploymentV1 struct {
 
 // UntypedDeployment contains an inner, untyped deployment structure.
 type UntypedDeployment struct {
+	// Version indicates the schema of the encoded deployment.
+	Version int `json:"version,omitempty"`
 	// The opaque Pulumi deployment. This is conceptually of type `Deployment`, but we use `json.Message` to
 	// permit round-tripping of stack contents when an older client is talking to a newer server.  If we unmarshaled
 	// the contents, and then remarshaled them, we could end up losing important information.

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -881,7 +881,7 @@ func (b *cloudBackend) ExportDeployment(stackName tokens.QName) (*apitype.Untype
 		return nil, err
 	}
 
-	return &apitype.UntypedDeployment{Deployment: deployment}, nil
+	return &deployment, nil
 }
 
 func (b *cloudBackend) ImportDeployment(stackName tokens.QName, deployment *apitype.UntypedDeployment) error {

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -238,13 +238,13 @@ func (pc *Client) GetStackUpdates(stack StackIdentifier) ([]apitype.UpdateInfo, 
 }
 
 // ExportStackDeployment exports the indicated stack's deployment as a raw JSON message.
-func (pc *Client) ExportStackDeployment(stack StackIdentifier) (json.RawMessage, error) {
+func (pc *Client) ExportStackDeployment(stack StackIdentifier) (apitype.UntypedDeployment, error) {
 	var resp apitype.ExportStackResponse
 	if err := pc.restCall("GET", getStackPath(stack, "export"), nil, nil, &resp); err != nil {
-		return nil, err
+		return apitype.UntypedDeployment{}, err
 	}
 
-	return resp.Deployment, nil
+	return apitype.UntypedDeployment(resp), nil
 }
 
 // ImportStackDeployment imports a new deployment into the indicated stack.

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -285,7 +285,10 @@ func (b *localBackend) ExportDeployment(stackName tokens.QName) (*apitype.Untype
 		return nil, err
 	}
 
-	return &apitype.UntypedDeployment{Deployment: json.RawMessage(data)}, nil
+	return &apitype.UntypedDeployment{
+		Version:    1,
+		Deployment: json.RawMessage(data),
+	}, nil
 }
 
 func (b *localBackend) ImportDeployment(stackName tokens.QName, deployment *apitype.UntypedDeployment) error {


### PR DESCRIPTION
This field indicates the schema of the serialized deployment. This field
behaves identically to the `Version` field of
`PatchUpdateCheckpointRequest`.

This is part of pulumi/pulumi-service#1046