### PR TITLE
Don't mention PPC unless needed in the CLI

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -3,8 +3,11 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 
+	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/backend/cloud"
 	"github.com/pulumi/pulumi/pkg/backend/local"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
@@ -18,13 +21,21 @@ func newLoginCmd() *cobra.Command {
 		Long:  "Log into the Pulumi Cloud.  You can script by using PULUMI_ACCESS_TOKEN environment variable.",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			var b backend.Backend
+			var err error
+
 			if local.IsLocalBackendURL(cloudURL) {
-				_, err := local.Login(cmdutil.Diag(), cloudURL)
+				b, err = local.Login(cmdutil.Diag(), cloudURL)
+			} else {
+				b, err = cloud.Login(cmdutil.Diag(), cloudURL)
+			}
+
+			if err != nil {
 				return err
 			}
 
-			_, err := cloud.Login(cmdutil.Diag(), cloudURL)
-			return err
+			fmt.Printf("Logged into %s\n", b.Name())
+			return nil
 		}),
 	}
 	cmd.PersistentFlags().StringVarP(&cloudURL, "cloud-url", "c", "", "A cloud URL to log into")

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -13,11 +13,9 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
 
-	"github.com/pulumi/pulumi/pkg/backend/cloud"
 	"github.com/pulumi/pulumi/pkg/backend/local"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
-	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // NewPulumiCmd creates a new Pulumi Cmd instance.
@@ -50,17 +48,6 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		defaultHelp(cmd, args)
 		fmt.Println("See documentation at https://docs.pulumi.com")
-
-		url, err := workspace.GetCurrentCloudURL()
-		if err == nil && url != "" && !local.IsLocalBackendURL(url) {
-			fmt.Printf("\n")
-			suffix := ""
-			if url != cloud.PulumiCloudURL {
-				suffix = fmt.Sprintf(" (%s)", url)
-			}
-
-			fmt.Printf("Currently logged into the Pulumi Cloud%s%s\n", cmdutil.EmojiOr(" ☁️", ""), suffix)
-		}
 	})
 
 	cmd.PersistentFlags().StringVarP(&cwd, "cwd", "C", "", "Run pulumi as if it had been started in another directory")

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -39,15 +39,17 @@ func newStackCmd() *cobra.Command {
 			fmt.Printf("Current stack is %s:\n", s.Name())
 
 			be := s.Backend()
-			fmt.Printf("    Managed by %s", be.Name())
-			if _, isCloud := be.(cloud.Backend); isCloud {
-				fmt.Printf(" ☁️\n")
+			cloudBe, isCloud := be.(cloud.Backend)
+			if !isCloud || cloudBe.CloudURL() != cloud.PulumiCloudURL {
+				fmt.Printf("    Managed by %s\n", be.Name())
+			}
+			if isCloud {
 				if cs, ok := s.(cloud.Stack); ok {
-					fmt.Printf("    Organization %s\n", cs.OrgName())
-					fmt.Printf("    PPC %s\n", cs.CloudName())
+					fmt.Printf("    Owner: %s\n", cs.OrgName())
+					if !cs.RunLocally() {
+						fmt.Printf("    PPC: %s\n", cs.CloudName())
+					}
 				}
-			} else {
-				fmt.Printf("\n")
 			}
 
 			snap := s.Snapshot()
@@ -55,7 +57,7 @@ func newStackCmd() *cobra.Command {
 				if t := snap.Manifest.Time; t.IsZero() {
 					fmt.Printf("    Last update time unknown\n")
 				} else {
-					fmt.Printf("    Last updated %s (%v)\n", humanize.Time(t), t)
+					fmt.Printf("    Last updated: %s (%v)\n", humanize.Time(t), t)
 				}
 				var cliver string
 				if snap.Manifest.Version == "" {
@@ -63,7 +65,7 @@ func newStackCmd() *cobra.Command {
 				} else {
 					cliver = snap.Manifest.Version
 				}
-				fmt.Printf("    Pulumi version %s\n", cliver)
+				fmt.Printf("    Pulumi version: %s\n", cliver)
 				for _, plugin := range snap.Manifest.Plugins {
 					var plugver string
 					if plugin.Version == nil {
@@ -71,7 +73,7 @@ func newStackCmd() *cobra.Command {
 					} else {
 						plugver = plugin.Version.String()
 					}
-					fmt.Printf("    Plugin %s [%s] version %s\n", plugin.Name, plugin.Kind, plugver)
+					fmt.Printf("    Plugin %s [%s] version: %s\n", plugin.Name, plugin.Kind, plugver)
 				}
 			} else {
 				fmt.Printf("    No updates yet; run 'pulumi update'\n")
@@ -112,6 +114,15 @@ func newStackCmd() *cobra.Command {
 					printStackOutputs(outputs)
 				}
 			}
+
+			// Add a link to the pulumi.com console page for this stack, if it has one.
+			if cs, ok := s.(cloud.Stack); ok {
+				if consoleURL, err := cs.ConsoleURL(); err == nil {
+					fmt.Printf("\n")
+					fmt.Printf("More information at: %s\n", consoleURL)
+				}
+			}
+
 			fmt.Printf("\n")
 
 			fmt.Printf("Use `pulumi stack select` to change stack; `pulumi stack ls` lists known ones\n")


### PR DESCRIPTION
PPCs are no longer a central concept to our model, but instead a
feature that that pulumi.com provides to some organizations. Let's
remove most mentions of PPCs except for cases where we really need to
talk about them (e.g. when a stack is actually hosted in a PPC instead
of just via the normal pulumi.com service)

Also remove some "in the Pulumi Cloud" messages from the CLI, as using
the Pulumi Cloud is now the only real way to use pulumi.

Fixes pulumi/pulumi-service#1117