### PR TITLE
Add deployment version fields to more types.

### DIFF
--- a/pkg/apitype/history.go
+++ b/pkg/apitype/history.go
@@ -2,6 +2,8 @@
 
 package apitype
 
+import "encoding/json"
+
 // UpdateKind is an enum for the type of update performed.
 //
 // Should generally mirror backend.UpdateKind, but we clone it in this package to add
@@ -70,10 +72,11 @@ type UpdateInfo struct {
 	Config      map[string]ConfigValue `json:"config"`
 
 	// Information obtained from an update completing.
-	Result          UpdateResult   `json:"result"`
-	EndTime         int64          `json:"endTime"`
-	Deployment      *DeploymentV1  `json:"deployment,omitempty"`
-	ResourceChanges map[OpType]int `json:"resourceChanges,omitempty"`
+	Result          UpdateResult    `json:"result"`
+	EndTime         int64           `json:"endTime"`
+	Version         int             `json:"version"`
+	Deployment      json.RawMessage `json:"deployment,omitempty"`
+	ResourceChanges map[OpType]int  `json:"resourceChanges,omitempty"`
 }
 
 // GetHistoryResponse is the response from the Pulumi Service when requesting

--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -2,6 +2,8 @@
 
 package apitype
 
+import "encoding/json"
+
 // StackSummary presents an overview of a particular stack without enumerating its current resource set.
 type StackSummary struct {
 	// ID is the unique identifier for a stack in the context of its PPC.
@@ -59,6 +61,9 @@ type GetStackResponse struct {
 	// TODO: [pulumi/pulumi-ppc#29]: make this state recoverable. This could be as simple as import/export.
 	UnknownState bool `json:"unknownState"`
 
+	// Version indicates the schema of the Resources, Manifest, and Deployment fields below.
+	Version int `json:"version"`
+
 	// Resources provides the list of cloud resources managed by this stack.
 	Resources []ResourceV1 `json:"resources"`
 
@@ -66,7 +71,7 @@ type GetStackResponse struct {
 	Manifest ManifestV1 `json:"manifest"`
 
 	// Deployment provides a view of the stack as an opaque Pulumi deployment.
-	Deployment *DeploymentV1 `json:"deployment,omitempty"`
+	Deployment json.RawMessage `json:"deployment,omitempty"`
 }
 
 // EncryptValueRequest defines the request body for encrypting a value.

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -75,6 +75,6 @@ type UpdateInfo struct {
 	// Information obtained from an update completing.
 	Result          UpdateResult           `json:"result"`
 	EndTime         int64                  `json:"endTime"`
-	Deployment      *apitype.Deployment    `json:"deployment,omitempty"`
+	Deployment      *apitype.DeploymentV1  `json:"deployment,omitempty"`
 	ResourceChanges engine.ResourceChanges `json:"resourceChanges,omitempty"`
 }


### PR DESCRIPTION
This completes the rollout of deployment version fields in the API
types.