### PR TITLE
Fix "interactive" stack creation

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -350,6 +350,10 @@ func ownerFromRef(stackRef backend.StackReference) string {
 }
 
 func (b *cloudBackend) CreateStack(stackRef backend.StackReference, opts interface{}) (backend.Stack, error) {
+	if opts == nil {
+		opts = CreateStackOptions{}
+	}
+
 	cloudOpts, ok := opts.(CreateStackOptions)
 	if !ok {
 		return nil, errors.New("expected a CloudStackOptions value for opts parameter")


### PR DESCRIPTION
The cloud backend would fail if `nil` was passed in as the options to
use when creating a stack. However, we passed nil in places where we
allow the user to create stacks interacively. I noticed this while
dogfooding.

In the cloud backend, treat a `nil` opts as if the default set of
options was passed.