### PR TITLE
Add `refresh` support for managed stacks.

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -717,6 +717,11 @@ func (b *cloudBackend) updateStack(
 	displayOpts backend.DisplayOptions, callerEventsOpt chan<- engine.Event, dryRun bool,
 	scopes backend.CancellationScopeSource) error {
 
+	// Check for an attempt to refresh a PPC-managed stack: this is not yet a supported scenario.
+	if action == client.UpdateKindRefresh && !stack.(Stack).RunLocally() {
+		return errors.New("'refresh' not yet supported for PPC stacks [pulumi/pulumi#1081]")
+	}
+
 	// Print a banner so it's clear this is going to the cloud.
 	actionLabel := getActionLabel(string(action), dryRun)
 	fmt.Printf(

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -359,8 +359,9 @@ func (pc *Client) CreateUpdate(
 			endpoint = "update"
 		}
 	case UpdateKindRefresh:
-		return UpdateIdentifier{},
-			errors.New("'refresh' not yet supported for managed stacks [pulumi/pulumi#1081]")
+		// Issue #1081: this will not work for PPC-managed stacks: instead, it will run an update. We rely on the
+		// caller to do the right thing here.
+		endpoint, kind = "update", UpdateKindUpdate
 	case UpdateKindDestroy:
 		endpoint = "destroy"
 	default:


### PR DESCRIPTION
These changes add support for refreshing managed stacks by treating
refreshes as a special-case of updates. These changes explicitly
disallow refreshing PPC-based stacks, as doing so is not yet supported.