### PR TITLE
Add `pulumi config refresh` to fetch most recent configuration

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -80,6 +80,8 @@ type Backend interface {
 	GetHistory(ctx context.Context, stackRef StackReference) ([]UpdateInfo, error)
 	// GetLogs fetches a list of log entries for the given stack, with optional filtering/querying.
 	GetLogs(ctx context.Context, stackRef StackReference, query operations.LogQuery) ([]operations.LogEntry, error)
+	// Get the configuration from the most recent deployment of the stack.
+	GetLatestConfiguration(ctx context.Context, stackRef StackReference) (config.Map, error)
 
 	// ExportDeployment exports the deployment for the given stack as an opaque JSON message.
 	ExportDeployment(ctx context.Context, stackRef StackReference) (*apitype.UntypedDeployment, error)

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -934,15 +933,6 @@ func (b *cloudBackend) GetHistory(ctx context.Context, stackRef backend.StackRef
 	// Convert apitype.UpdateInfo objects to the backend type.
 	var beUpdates []backend.UpdateInfo
 	for _, update := range updates {
-		// Decode the deployment.
-		if update.Version > 1 {
-			return nil, errors.Errorf("unsupported checkpoint version %v", update.Version)
-		}
-		var deployment apitype.DeploymentV1
-		if err := json.Unmarshal([]byte(update.Deployment), &deployment); err != nil {
-			return nil, err
-		}
-
 		// Convert types from the apitype package into their internal counterparts.
 		cfg, err := convertConfig(update.Config)
 		if err != nil {
@@ -957,12 +947,22 @@ func (b *cloudBackend) GetHistory(ctx context.Context, stackRef backend.StackRef
 			Result:          backend.UpdateResult(update.Result),
 			StartTime:       update.StartTime,
 			EndTime:         update.EndTime,
-			Deployment:      &deployment,
 			ResourceChanges: convertResourceChanges(update.ResourceChanges),
 		})
 	}
 
 	return beUpdates, nil
+}
+
+func (b *cloudBackend) GetLatestConfiguration(ctx context.Context,
+	stackRef backend.StackReference) (config.Map, error) {
+
+	stackID, err := b.getCloudStackIdentifier(stackRef)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.client.GetLatestConfiguration(ctx, stackID)
 }
 
 // convertResourceChanges converts the apitype version of engine.ResourceChanges into the internal version.

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -177,6 +177,20 @@ func (b *localBackend) GetStackCrypter(stackRef backend.StackReference) (config.
 	return symmetricCrypter(stackRef.StackName())
 }
 
+func (b *localBackend) GetLatestConfiguration(ctx context.Context,
+	stackRef backend.StackReference) (config.Map, error) {
+
+	hist, err := b.GetHistory(ctx, stackRef)
+	if err != nil {
+		return nil, err
+	}
+	if len(hist) == 0 {
+		return nil, errors.New("no previous deployment")
+	}
+
+	return hist[0].Config, nil
+}
+
 func (b *localBackend) Preview(
 	_ context.Context, stackRef backend.StackReference, proj *workspace.Project, root string,
 	m backend.UpdateMetadata, opts backend.UpdateOptions, scopes backend.CancellationScopeSource) error {

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -79,6 +79,11 @@ func GetStackCrypter(s Stack) (config.Crypter, error) {
 	return s.Backend().GetStackCrypter(s.Name())
 }
 
+// GetLatestConfiguration returns the configuration for the most recent deployment of the stack.
+func GetLatestConfiguration(ctx context.Context, s Stack) (config.Map, error) {
+	return s.Backend().GetLatestConfiguration(ctx, s.Name())
+}
+
 // GetStackLogs fetches a list of log entries for the current stack in the current backend.
 func GetStackLogs(ctx context.Context, s Stack, query operations.LogQuery) ([]operations.LogEntry, error) {
 	return s.Backend().GetLogs(ctx, s.Name(), query)

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -3,7 +3,6 @@
 package backend
 
 import (
-	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 )
@@ -84,6 +83,5 @@ type UpdateInfo struct {
 	// Information obtained from an update completing.
 	Result          UpdateResult           `json:"result"`
 	EndTime         int64                  `json:"endTime"`
-	Deployment      *apitype.DeploymentV1  `json:"deployment,omitempty"`
 	ResourceChanges engine.ResourceChanges `json:"resourceChanges,omitempty"`
 }


### PR DESCRIPTION
The newly added `pulumi config refresh` updates your local copy of the
`Pulumi.<stack-name>.yaml` file to have the same configuration as the
most recent deployment in the cloud.

This can be used in a varirty of ways. One place we plan to use it is
in automation to clean up "leaked" stacks we have in CI. With the
changes you'll now be able to do the following:

```
$ cd $(mktemp -d)
$ yarn add @pulumi/pulumi
$ echo -e "name: who-cares\nruntime: nodejs" > Pulumi.yaml
$ pulumi stack select <leaked-stack-name>
$ pulumi config refresh -f
$ pulumi destroy --force
```

Having a simpler gesture for the above is something we'll want to do
long term (we should be able to support `pulumi destory <stack-name>`
from a completely empty folder, today you need a Pulumi.yaml file
present, even if the contents don't matter).

But this gets us a little closer to where we want to be and introduces
a helpful primitive in the system.

Contributes to #814 