### PR TITLE
Use glog instead of printf

### DIFF
--- a/pkg/operations/operations_aws.go
+++ b/pkg/operations/operations_aws.go
@@ -3,7 +3,6 @@
 package operations
 
 import (
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -174,7 +173,7 @@ func (p *awsConnection) getLogsForLogGroupsConcurrently(
 			}, func(resp *cloudwatchlogs.FilterLogEventsOutput, lastPage bool) bool {
 				ret = append(ret, resp.Events...)
 				if !lastPage {
-					fmt.Printf("Getting more logs for %v...\n", logGroup)
+					glog.V(5).Infof("[getLogs] Getting more logs for %v...\n", logGroup)
 				}
 				return true
 			})


### PR DESCRIPTION
When running `pulumi logs -f` we'd also see these messages printed to
standard out:

Getting more logs for /aws/lambda/urlshortenereeb67ce9-d8fa6fa...

This could be useful diagnostics information, but we should be
glog'ing it not unconditionally writing it to the terminal.