### PR TITLE
Fix an issue where errors outside of resource creation got dropped

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -236,8 +236,14 @@ func printPlan(ctx *Context, result *planResult, dryRun bool) (ResourceChanges, 
 
 	// Walk the plan's steps and and pretty-print them out.
 	actions := newPreviewActions(result.Options)
-	_, _, _, err := result.Walk(ctx, actions, true)
+	_, step, _, err := result.Walk(ctx, actions, true)
 	if err != nil {
+		var failedUrn resource.URN
+		if step != nil {
+			failedUrn = step.URN()
+		}
+
+		result.Options.Diag.Errorf(diag.Message(failedUrn, err.Error()))
 		return nil, errors.New("an error occurred while advancing the preview")
 	}
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1125. The issue here is that the error returned from `result.Walk` is completely dropped and never printed anywhere.

Clearly, getting this right is super hard. I'm envisioning a simplification of our error model in the future so that we aren't squashing bugs like this until the end of time. I think it may be worth a design document and it's probably a prerequisite for parallelism. In the interest of time and keeping things moving, though, I figured I'd submit the fix for this and move on, since parallelism isn't in scope until after the initial release.