### PR TITLE
Fix login/logout issue against non api.pulumi.com clouds

### DIFF
--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -3,11 +3,13 @@
 package cmd
 
 import (
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/backend/cloud"
 	"github.com/pulumi/pulumi/pkg/backend/local"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 func newLogoutCmd() *cobra.Command {
@@ -18,6 +20,15 @@ func newLogoutCmd() *cobra.Command {
 		Long:  "Log out of the Pulumi Cloud.  Deletes stored credentials on the local machine.",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			if cloudURL == "" {
+				creds, err := workspace.GetStoredCredentials()
+				if err != nil {
+					return errors.Wrap(err, "could not determine current cloud")
+				}
+
+				cloudURL = creds.Current
+			}
+
 			if local.IsLocalBackendURL(cloudURL) {
 				return local.New(cmdutil.Diag(), cloudURL).Logout()
 			}


### PR DESCRIPTION
Pat ran into a weird error when trying to do some development agains
the testing cloud:

```
$ pulumi logout
$ pulumi login --cloud-url [test-cloud-url]
Logged into [test-cloud-url]
$ pulumi stack ls
Enter your Pulumi access token from https://pulumi.com/account:
```

In his case, we did not have `current` set in our credentials.json
file (likely due to him calling `pulumi logout` at some point) but we
did have stored credentials for that cloud. When he logged in the CLI
noticed we could reuse the stored credentials but did not update the
the current setting to set the current cloud.

While investigating, I also noticed that `logout` did not always do
the right thing when you were logged into a different backend than
pulumi.com