### PR TITLE
Improve two minor UX things in the CLI

### DIFF
--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -856,7 +856,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	if display.isPreview {
 		// During a preview, when we transition to done, we still just print the same thing we
 		// did while running the step.
-		return step.Op.Prefix() + getPreviewText(step.Op) + colors.Reset
+		return step.Op.Color() + getPreviewText(step.Op) + colors.Reset
 	}
 
 	// most of the time a stack is unchanged.  in that case we just show it as "running->done"
@@ -907,7 +907,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 		return makeError(getDescription())
 	}
 
-	return op.Prefix() + getDescription() + colors.Reset
+	return op.Color() + getDescription() + colors.Reset
 }
 
 func getPreviewText(op deploy.StepOp) string {
@@ -930,6 +930,10 @@ func getPreviewText(op deploy.StepOp) string {
 
 	contract.Failf("Unrecognized resource step op: %v", op)
 	return ""
+}
+
+func (display *ProgressDisplay) getStepOpLabel(step engine.StepEventMetadata) string {
+	return step.Op.Prefix() + colors.Reset
 }
 
 func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEventMetadata) string {
@@ -966,7 +970,7 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 		contract.Failf("Unrecognized resource step op: %v", op)
 		return ""
 	}
-	return op.Prefix() + getDescription() + colors.Reset
+	return op.Color() + getDescription() + colors.Reset
 }
 
 func writePropertyKeys(b *bytes.Buffer, propMap resource.PropertyMap, op deploy.StepOp) {

--- a/pkg/backend/local/rows.go
+++ b/pkg/backend/local/rows.go
@@ -64,7 +64,7 @@ func (data *headerRowData) SetDisplayOrderIndex(time int) {
 func (data *headerRowData) ColorizedColumns() []string {
 	if len(data.columns) == 0 {
 		blue := func(msg string) string {
-			return colors.Blue + msg + colors.Reset
+			return colors.BrightBlue + msg + colors.Reset
 		}
 
 		header := func(msg string) string {
@@ -77,7 +77,7 @@ func (data *headerRowData) ColorizedColumns() []string {
 		} else {
 			statusColumn = header("Status")
 		}
-		data.columns = []string{header("Resource Type"), header("Name"), statusColumn, header("Extra Info")}
+		data.columns = []string{"", header("Type"), header("Name"), statusColumn, header("Info")}
 	}
 
 	return data.columns
@@ -189,10 +189,11 @@ func (data *resourceRowData) RecordDiagEvent(event engine.Event) {
 type column int
 
 const (
-	typeColumn   column = 0
-	nameColumn   column = 1
-	statusColumn column = 2
-	infoColumn   column = 3
+	opColumn     column = 0
+	typeColumn   column = 1
+	nameColumn   column = 2
+	statusColumn column = 3
+	infoColumn   column = 4
 )
 
 func (data *resourceRowData) ColorizedSuffix() string {
@@ -221,7 +222,8 @@ func (data *resourceRowData) ColorizedColumns() []string {
 		typ = simplifyTypeName(data.step.URN.Type())
 	}
 
-	columns := make([]string, 4)
+	columns := make([]string, 5)
+	columns[opColumn] = data.display.getStepOpLabel(step)
 	columns[typeColumn] = typ
 	columns[nameColumn] = name
 


### PR DESCRIPTION
This changes three minor UX things in the CLI's update flow:

1. Use bright blue for column headers, since the dark blue is nearly
   invisible on a black background.

2. Move the operation symbol to the far left, as a sort of "bullet
   point" for each line of output.  This was how they initial symbols
   were designed and this helps to glance at the summary to see what's
   going on.

3. Shorten some of the column headers that didn't add extra clarity.