### PR TITLE
Add necessary refresh apitypes

### DIFF
--- a/pkg/apitype/history.go
+++ b/pkg/apitype/history.go
@@ -15,6 +15,8 @@ const (
 	DeployUpdate UpdateKind = "update"
 	// PreviewUpdate is a preview of an update, without impacting resources.
 	PreviewUpdate UpdateKind = "preview"
+	// RefreshUpdate is an update that came from a refresh operation.
+	RefreshUpdate UpdateKind = "refresh"
 	// DestroyUpdate is an update which removes all resources.
 	DestroyUpdate UpdateKind = "destroy"
 )

--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -151,9 +151,11 @@ type UpdateProgram struct {
 	// Analyzers is the set of analyzers to run when this program is executed.
 	Analyzers []string `json:"analyzers"`
 
-	// Destroy indicates whether or not this program is the nil program (i.e. the program that generates no
-	// resources).
+	// Destroy indicates whether or not this program is the nil program (i.e. the program that generates no resources).
 	Destroy bool `json:"destroy"`
+
+	// Refresh is true if this is a refresh-style update, which simply takes state from the current cloud resources.
+	Refresh bool `json:"refresh"`
 }
 
 // CreateUpdateRequest describe the data provided as the body of a request to the `POST /updates` endpoint of


### PR DESCRIPTION
This change adds the apitypes required to make refresh-style updates
work in the PPC and in the service.