### PR TITLE
Fix Preview against a PPC

### DIFF
--- a/pkg/backend/cloud/client/api.go
+++ b/pkg/backend/cloud/client/api.go
@@ -26,6 +26,7 @@ type UpdateKind string
 
 const (
 	UpdateKindUpdate  UpdateKind = "update"
+	UpdateKindPreview UpdateKind = "preview"
 	UpdateKindRefresh UpdateKind = "refresh"
 	UpdateKindDestroy UpdateKind = "destroy"
 	UpdateKindImport  UpdateKind = "import"

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -355,6 +355,7 @@ func (pc *Client) CreateUpdate(
 	case UpdateKindUpdate:
 		if dryRun {
 			endpoint = "preview"
+			kind = UpdateKindPreview
 		} else {
 			endpoint = "update"
 		}


### PR DESCRIPTION
Refactoring to support "preview" and "update" as part of the same
operation interacted poorly with deploying into a PPC via the service.

Per Pat, this is the quickest fix that gets us off the floor.

Part of #1301