### PR TITLE
Don't attempt to preview a destroy operation for a PPC hosted stack

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -640,6 +640,12 @@ func (b *cloudBackend) PreviewThenPromptThenExecute(
 		return err
 	}
 
+	if !stack.(Stack).RunLocally() && updateKind == client.UpdateKindDestroy {
+		// The service does not support preview of a destroy for a stack managed by a PPC.  So behave as if (--force)
+		// had been passed (so we don't run the preview step)
+		opts.Force = true
+	}
+
 	if !opts.Force {
 		// If we're not forcing, then preview the operation to the user and ask them if
 		// they want to proceed.


### PR DESCRIPTION
The service has no good way to preview a destroy operation for a stack
managed by a PPC. Until it does, just behave as if --force was passed
to the CLI in this case (i.e. skip the preview).

Fixes #1301