### PR TITLE
Put StartUpdateRequest in POST body

### DIFF
--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -419,7 +419,7 @@ func (pc *Client) StartUpdate(update UpdateIdentifier, tags map[apitype.StackTag
 	}
 
 	var resp apitype.StartUpdateResponse
-	if err := pc.restCall("POST", getUpdatePath(update), req, nil, &resp); err != nil {
+	if err := pc.restCall("POST", getUpdatePath(update), nil, req, &resp); err != nil {
 		return 0, "", err
 	}
 


### PR DESCRIPTION
We upload the stack's tags with every update. This way we can keep the project name, description, and other tags up-to-date as the `Pulumi.yaml` file changes.

When this feature was initially added ([here](https://github.com/pulumi/pulumi/commit/7490c25d8eecb344ad3c1cd9d9c9dbb555bc7dfa#diff-497f00c04213b29e9c00dc1041354fa7R341)) the author put the request object into the wrong parameter of `restCall`. Instead of the object being serialized as the request body, it was instead put into the URL query parameters.

```
// restCall makes a REST-style request to the Pulumi API using the given method, path, query object, and request
// object. If a response object is provided, the server's response is deserialized into that object.
func (pc *Client) restCall(method, path string, queryObj, reqObj, respObj interface{}) error {
	return pulumiRESTCall(pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken, httpCallOptions{})
}
```

We haven't noticed before because the service-side of this hasn't been hooked up yet. (As not every stack is on the simplified identity model plan yet.)