### PR TITLE
Remove test token

### DIFF
--- a/pkg/testing/integration/pulumi.go
+++ b/pkg/testing/integration/pulumi.go
@@ -83,9 +83,3 @@ func GetStacks(e *testing.Environment) ([]string, *string) {
 
 	return stackNames, currentStack
 }
-
-// TestAccountAccessToken is a Pulumi access token of a well-known test account. Most importantly, we can
-// rely on this test account existing in all Pulumi environments. GitHub user "lumi-test-1". See
-// pulumi-service/cmd/service/model/test.go for more information.
-// nolint: gas, intentionally using a test token
-const TestAccountAccessToken = "gGo1WLk2Jh_NZlqo2FFvjPtBvo73IW3xsJvBRmDOPW4="


### PR DESCRIPTION
We now handle test credentials via Travis, so we don't need this
anymore.