### PR TITLE
Cache workspaces based on full path.

### DIFF
--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -33,7 +33,7 @@ type projectWorkspace struct {
 	repo     *Repository        // the repo this workspace is associated with.
 }
 
-var cache map[string]W = make(map[string]W)
+var cache = make(map[string]W)
 var cacheMutex sync.RWMutex
 
 func loadFromCache(key string) (W, bool) {


### PR DESCRIPTION
As it stands, we recompute the workspace for the current directory
potentially many times during some CLI operations, most notably
`stack ls`. These changes add a simple cache based on the complete path
passed to `NewFrom`, and eliminate some lagginess in `stack ls` when
there are multiple stacks.

Another option is to calculate the current workspace once in the CLI and
then fetch it as necessary.