### PR TITLE
Add "Sign in to Pulumi" to the login prompt

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -168,7 +168,7 @@ func Login(d diag.Sink, cloudURL string) (Backend, error) {
 		fmt.Printf("Using access token from %s\n", AccessTokenEnvVar)
 	} else {
 		token, readerr := cmdutil.ReadConsoleNoEcho(
-			fmt.Sprintf("Enter your Pulumi access token from %s", cloudConsoleURL(cloudURL, "account")))
+			fmt.Sprintf("Sign in to Pulumi and enter your access token from %s", cloudConsoleURL(cloudURL, "account")))
 		if readerr != nil {
 			return nil, readerr
 		}


### PR DESCRIPTION
Minor tweak to the login prompt to be more friendly to new users (in the meantime in lieu of the CLI being able to acquire the access token automatically by opening the browser and polling an endpoint).

Before:

```
Enter your Pulumi access token from https://pulumi.com/account: 
```

After:

```
Sign in to Pulumi and enter your access token from https://pulumi.com/account:
```

Part of #1157