### PR TITLE
Simplify cmdutil.InitTracing.

### DIFF
--- a/pkg/util/cmdutil/trace.go
+++ b/pkg/util/cmdutil/trace.go
@@ -18,34 +18,30 @@ var traceCloser io.Closer
 
 // InitTracing initializes tracing
 func InitTracing(name, rootSpanName, tracingEndpoint string) {
+	// If no tracing endpoint was provided, just return. The default global tracer is already a no-op tracer.
+	if tracingEndpoint == "" {
+		return
+	}
 
 	// Store the tracing endpoint
 	TracingEndpoint = tracingEndpoint
 
-	// Create a reporter
-	var reporter jaeger.Reporter
-	if tracingEndpoint == "" {
-		reporter = jaeger.NewInMemoryReporter()
-	} else {
-		// Jaeger tracer can be initialized with a transport that will
-		// report tracing Spans to a Zipkin backend
-		transport, err := zipkin.NewHTTPTransport(
-			tracingEndpoint,
-			zipkin.HTTPBatchSize(1),
-			zipkin.HTTPLogger(jaeger.StdLogger),
-		)
-		if err != nil {
-			log.Fatalf("Cannot initialize HTTP transport: %v", err)
-		}
-		reporter = jaeger.NewRemoteReporter(transport)
+	// Jaeger tracer can be initialized with a transport that will
+	// report tracing Spans to a Zipkin backend
+	transport, err := zipkin.NewHTTPTransport(
+		tracingEndpoint,
+		zipkin.HTTPBatchSize(1),
+		zipkin.HTTPLogger(jaeger.StdLogger),
+	)
+	if err != nil {
+		log.Fatalf("Cannot initialize HTTP transport: %v", err)
 	}
 
 	// create Jaeger tracer
 	tracer, closer := jaeger.NewTracer(
 		name,
 		jaeger.NewConstSampler(true), // sample all traces
-		reporter,
-	)
+		jaeger.NewRemoteReporter(transport))
 
 	// Store the closer so that we can flush the Jaeger span cache on process exit
 	traceCloser = closer
@@ -61,6 +57,10 @@ func InitTracing(name, rootSpanName, tracingEndpoint string) {
 
 // CloseTracing ensures that all pending spans have been flushed.  It should be called before process exit.
 func CloseTracing() {
+	if TracingEndpoint == "" {
+		return
+	}
+
 	if TracingRootSpan != nil {
 		TracingRootSpan.Finish()
 	}


### PR DESCRIPTION
If no tracing endpoint was specified, just use the default no-op tracer.