### PR TITLE
Make the default `pulumi new` project description empty

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -368,8 +368,13 @@ func promptForValue(yes bool, prompt string, defaultValue string, isValidFn func
 	}
 
 	for {
-		prompt = colors.ColorizeText(
-			fmt.Sprintf("%s%s: (%s)%s ", colors.BrightCyan, prompt, defaultValue, colors.Reset))
+		if defaultValue == "" {
+			prompt = colors.ColorizeText(
+				fmt.Sprintf("%s%s:%s ", colors.BrightCyan, prompt, colors.Reset))
+		} else {
+			prompt = colors.ColorizeText(
+				fmt.Sprintf("%s%s: (%s)%s ", colors.BrightCyan, prompt, defaultValue, colors.Reset))
+		}
 		fmt.Print(prompt)
 
 		reader := bufio.NewReader(os.Stdin)

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	defaultProjectName        = "project"
-	defaultProjectDescription = "A Pulumi project."
+	defaultProjectName = "project"
 
 	// This file will be ignored when copying from the template cache to
 	// a project directory.
@@ -232,7 +231,7 @@ func ValueOrDefaultProjectDescription(description string, defaultDescription str
 	if defaultDescription != "" {
 		return defaultDescription
 	}
-	return defaultProjectDescription
+	return ""
 }
 
 // getValidProjectName returns a valid project name based on the passed-in name.

--- a/tests/new_test.go
+++ b/tests/new_test.go
@@ -43,7 +43,7 @@ func TestPulumiNew(t *testing.T) {
 		// Run pulumi new.
 		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes")
 
-		assertSuccess(t, subdir, "foo", "A Pulumi project.")
+		assertSuccess(t, subdir, "foo", "")
 	})
 
 	t.Run("SanityTestWithManifest", func(t *testing.T) {
@@ -155,7 +155,7 @@ func TestPulumiNew(t *testing.T) {
 		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes")
 
 		// Assert the default name used is "foo" not "@foo".
-		assertSuccess(t, subdir, "foo", "A Pulumi project.")
+		assertSuccess(t, subdir, "foo", "")
 	})
 
 	t.Run("ExistingFileNotOverwritten", func(t *testing.T) {
@@ -262,7 +262,7 @@ func TestPulumiNew(t *testing.T) {
 		// Run pulumi new with --force.
 		e.RunCommand("pulumi", "new", template, "--force", "--offline", "--generate-only", "--yes")
 
-		assertSuccess(t, subdir, "foo", "A Pulumi project.")
+		assertSuccess(t, subdir, "foo", "")
 	})
 }
 


### PR DESCRIPTION
Previously, we'd default to `"A Pulumi project."`, which isn't a helpful description for any real project.

Fixes #1337