### PR TITLE
Make tokenSource.Close() synchronous.

### DIFF
--- a/pkg/backend/cloud/state.go
+++ b/pkg/backend/cloud/state.go
@@ -31,7 +31,7 @@ type tokenResponse struct {
 // tokenSource is a helper type that manages the renewal of the lease token for a managed update.
 type tokenSource struct {
 	requests chan tokenRequest
-	done chan bool
+	done     chan bool
 }
 
 func newTokenSource(ctx context.Context, token string, backend *cloudBackend, update client.UpdateIdentifier,


### PR DESCRIPTION
Without these changes, it is possible for a token renewal to race with
CLI shutdown, which appears to be the cause of #1344.

Fixes #1344.