### PR TITLE
Fix preview against a PPC

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -582,7 +582,9 @@ func (b *cloudBackend) PreviewThenPrompt(
 		if err != nil {
 			return false, err
 		}
-		hasChanges = changes.HasChanges()
+
+		// TODO(ellismg)[pulumi/pulumi#1347]: Work around 1347 by forcing a choice when running a preview against a PPC
+		hasChanges = changes.HasChanges() || !stack.(Stack).RunLocally()
 	}
 
 	// If there are no changes, or we're auto-approving or just previewing, we can skip the confirmation prompt.

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -370,6 +370,8 @@ func (pc *Client) CreateUpdate(
 		} else {
 			endpoint = "update"
 		}
+	case UpdateKindPreview:
+		endpoint = "preview"
 	case UpdateKindRefresh:
 		return UpdateIdentifier{},
 			errors.New("'refresh' not yet supported for managed stacks [pulumi/pulumi#1081]")


### PR DESCRIPTION
This will unblock `pulumi preview` against a PPC, which regressed
recently (c5b702e0ff79adced1cbba5f7e9cbc610941e0fe was the likely
cause).