### PR TITLE
Enable distributed tracing.

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -50,8 +50,11 @@ func currentBackend() (backend.Backend, error) {
 
 func commandContext() context.Context {
 	ctx := context.Background()
-	if cmdutil.TracingRootSpan != nil {
-		ctx = opentracing.ContextWithSpan(ctx, cmdutil.TracingRootSpan)
+	if cmdutil.IsTracingEnabled() {
+		if cmdutil.TracingRootSpan != nil {
+			ctx = opentracing.ContextWithSpan(ctx, cmdutil.TracingRootSpan)
+		}
+		ctx = backend.ContextWithTracingOptions(ctx, backend.TracingOptions{PropagateSpans: true})
 	}
 	return ctx
 }

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -115,3 +115,25 @@ type CancellationScopeSource interface {
 	// NewScope creates a new cancellation scope.
 	NewScope(events chan<- engine.Event, isPreview bool) CancellationScope
 }
+
+// tracingOptionsKey is the value used as the context key for TracingOptions.
+var tracingOptionsKey struct{}
+
+// TracingOptions describes the set of options available for configuring tracing on a per-request basis.
+type TracingOptions struct {
+	// PropagateSpans indicates that spans should be propagated from the client to the Pulumi service when making API
+	// calls.
+	PropagateSpans bool
+}
+
+// ContextWithTracingOptions returns a new context.Context with the indicated tracing options.
+func ContextWithTracingOptions(ctx context.Context, opts TracingOptions) context.Context {
+	return context.WithValue(ctx, tracingOptionsKey, opts)
+}
+
+// TracingOptionsFromContext retrieves any tracing options present in the given context. If no options are present,
+// this function returns the zero value.
+func TracingOptionsFromContext(ctx context.Context) TracingOptions {
+	opts, _ := ctx.Value(tracingOptionsKey).(TracingOptions)
+	return opts
+}

--- a/pkg/util/cmdutil/trace.go
+++ b/pkg/util/cmdutil/trace.go
@@ -16,6 +16,10 @@ var TracingRootSpan opentracing.Span
 
 var traceCloser io.Closer
 
+func IsTracingEnabled() bool {
+	return TracingEndpoint != ""
+}
+
 // InitTracing initializes tracing
 func InitTracing(name, rootSpanName, tracingEndpoint string) {
 	// If no tracing endpoint was provided, just return. The default global tracer is already a no-op tracer.
@@ -57,7 +61,7 @@ func InitTracing(name, rootSpanName, tracingEndpoint string) {
 
 // CloseTracing ensures that all pending spans have been flushed.  It should be called before process exit.
 func CloseTracing() {
-	if TracingEndpoint == "" {
+	if !IsTracingEnabled() {
 		return
 	}
 


### PR DESCRIPTION
These changes add support for injecting client tracing spans into HTTP
requests to the Pulumi API. The server can then rematerialize these span
references and attach its own spans for distributed tracing.