### PR TITLE
Add a PULUMI_DEV flag, and suppress warnings

### DIFF
--- a/pkg/resource/plugin/host.go
+++ b/pkg/resource/plugin/host.go
@@ -3,6 +3,8 @@
 package plugin
 
 import (
+	"os"
+
 	"github.com/blang/semver"
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-multierror"
@@ -12,6 +14,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
@@ -206,7 +209,7 @@ func (host *defaultHost) Provider(pkg tokens.Package, version *semver.Version) (
 			}
 
 			// Warn if the plugin version was not what we expected
-			if version != nil {
+			if version != nil && !cmdutil.IsTruthy(os.Getenv("PULUMI_DEV")) {
 				if info.Version == nil || !info.Version.GTE(*version) {
 					var v string
 					if info.Version != nil {


### PR DESCRIPTION
This change suppresses the warning

    warning: resource plugin aws is expected to have version >=0.11.3,
        but has 0.11.1-dev-1523506162-g06ec765; the wrong version may
        be on your path, or this may be a bug in the plugin

when the `PULUMI_DEV` envvar is set to a truthy value.

This warning keeps popping up in demos since I'm always using dev builds
and I'd like a way to shut it off, even though this can legitimately
point out a problem.  Eventually I'll switch to official builds but,
until then, it seems worth having a simple way to suppress.