### PR TITLE
Skip loading language plugins when not needed

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -58,7 +58,7 @@ func getProjectPlugins() ([]workspace.PluginInfo, error) {
 		Proj:    proj,
 		Pwd:     pwd,
 		Program: main,
-	})
+	}, plugin.AllPlugins)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -36,7 +36,9 @@ func newDestroySource(
 
 	// For destroy, we consult the manifest for the plugin versions/ required to destroy it.
 	if target != nil && target.Snapshot != nil {
-		if err := plugctx.Host.EnsurePlugins(target.Snapshot.Manifest.Plugins); err != nil {
+		// We don't need the language plugin, since destroy doesn't run code, so we will leave that out.
+		kinds := plugin.AllPlugins & ^plugin.LanguagePlugins
+		if err := plugctx.Host.EnsurePlugins(target.Snapshot.Manifest.Plugins, kinds); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -37,7 +37,9 @@ func newRefreshSource(opts planOptions, proj *workspace.Project, pwd, main strin
 
 	// First, consult the manifest for the plugins we will need to ask to refresh the state.
 	if target != nil && target.Snapshot != nil {
-		if err := plugctx.Host.EnsurePlugins(target.Snapshot.Manifest.Plugins); err != nil {
+		// We don't need the language plugin, since refresh doesn't run code, so we will leave that out.
+		kinds := plugin.AllPlugins & ^plugin.LanguagePlugins
+		if err := plugctx.Host.EnsurePlugins(target.Snapshot.Manifest.Plugins, kinds); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -70,13 +70,13 @@ func newUpdateSource(
 		Proj:    proj,
 		Pwd:     pwd,
 		Program: main,
-	})
+	}, plugin.AllPlugins)
 	if err != nil {
 		return nil, err
 	}
 
 	// Now ensure that we have loaded up any plugins that the program will need in advance.
-	if err = plugctx.Host.EnsurePlugins(plugins); err != nil {
+	if err = plugctx.Host.EnsurePlugins(plugins, plugin.AllPlugins); err != nil {
 		return nil, err
 	}
 

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -373,10 +373,11 @@ func (host *testProviderHost) LanguageRuntime(runtime string) (plugin.LanguageRu
 func (host *testProviderHost) ListPlugins() []workspace.PluginInfo {
 	return nil
 }
-func (host *testProviderHost) EnsurePlugins(plugins []workspace.PluginInfo) error {
+func (host *testProviderHost) EnsurePlugins(plugins []workspace.PluginInfo, kinds plugin.Flags) error {
 	return nil
 }
-func (host *testProviderHost) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.PluginInfo, error) {
+func (host *testProviderHost) GetRequiredPlugins(info plugin.ProgInfo,
+	kinds plugin.Flags) ([]workspace.PluginInfo, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
In pulumi/pulumi#1356, we observed that we can fail during a destroy
because we attempt to load the language plugin, which now eagerly looks
for the @pulumi/pulumi package.

This is also blocking ingestion of the latest engine bits into the PPC.

It turns out that for destroy (and refresh), we have no need for the
language plugin.  So, let's skip loading it when appropriate.