### PR TITLE
Improve the promise leak experience

### DIFF
--- a/sdk/nodejs/tests/runtime/langhost/cases/016.promise_leak/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/016.promise_leak/index.js
@@ -1,0 +1,3 @@
+const debuggable = require("../../../../../runtime/debuggable");
+
+const leakedPromise = debuggable.debuggablePromise(new Promise((resolve, reject) => {}));

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -361,6 +361,11 @@ describe("rpc", () => {
                 return { urn: makeUrn(t, name), id: name, props: undefined };
             },
         },
+        // Test that leaked debuggable promises fail the deployment.
+        "promise_leak": {
+            program: path.join(base, "016.promise_leak"),
+            expectError: "Program exited with non-zero exit code: 1",
+        },
     };
 
     for (const casename of Object.keys(cases)) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1362
Fixes https://github.com/pulumi/pulumi/issues/1276

There are two parts to this PR:

* The first commit fixes a promise leak in the promise leak implementation (😭). When running with promise leak debugging on, we chained a new promise on the promise that we've adorned with our debuggable metadata without storing it anywhere. This leaked promise's catch handler did not rethrow the exception it received, so any debuggable promises that returned errors would get lost in a quasi-resolved state that we'd later interpret as "leaked" when the process exits. This was the immediate cause of the error spew that Donna observed in her example. In that particular case, closure serialization failed due to a missing identifier in the environment but the exception was swallowed by the leaked promise we created in `debuggablePromise`. The fix here was to not leak the promise but instead return it, this time with `.then` and `.catch` implementations that return and throw their arguments, respectively.

* The second commit makes the verbose promise leak error message opt-in. Setting the `PULUMI_DEBUG_PROMISE_LEAKS` environment variable opts-in to the same error message that you get today. When `PULUMI_DEBUG_PROMISE_LEAKS` is not set, a more friendly error message is displayed.

I also removed the promise timeout debug hook, since it's off by default and I wasn't even aware it existed. If anyone wants it back, I'm happy to throw it back in.

I spent a little bit of time today seeing if we could adapt `async_hooks` to help out here (per https://github.com/pulumi/pulumi-cloud/issues/466#issuecomment-384715390) but I didn't get anywhere interesting in my time box. I do think it's theoretically possible that we could establish an interesting promise graph that we could traverse if needed to produce diagnostics.