### PR TITLE
Allow overriding config location

### DIFF
--- a/examples/dynamic-provider/simple/Pulumi.yaml
+++ b/examples/dynamic-provider/simple/Pulumi.yaml
@@ -1,4 +1,4 @@
 name: four-function
 description: A silly four-function calculator.
 runtime: nodejs
-
+config: ./.config/

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -50,12 +50,12 @@ func DetectProjectPath() (string, error) {
 // DetectProjectStackPath returns the name of the file to store stack specific project settings in. We place stack
 // specific settings next to the Pulumi.yaml file, named like: Pulumi.<stack-name>.yaml
 func DetectProjectStackPath(stackName tokens.QName) (string, error) {
-	projPath, err := DetectProjectPath()
+	proj, projPath, err := DetectProjectAndPath()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(filepath.Dir(projPath), fmt.Sprintf("%s.%s%s", ProjectFile, qnameFileName(stackName),
+	return filepath.Join(filepath.Dir(projPath), proj.Config, fmt.Sprintf("%s.%s%s", ProjectFile, qnameFileName(stackName),
 		filepath.Ext(projPath))), nil
 }
 

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -39,13 +39,10 @@ type Project struct {
 
 	Analyzers *Analyzers `json:"analyzers,omitempty" yaml:"analyzers,omitempty"` // any analyzers enabled for this project.
 
-	EncryptionSaltDeprecated string `json:"encryptionsalt,omitempty" yaml:"encryptionsalt,omitempty"`     // base64 encoded encryption salt.
-	Context                  string `json:"context,omitempty" yaml:"context,omitempty"`                   // an optional path (combined with the on disk location of Pulumi.yaml) to control the data uploaded to the service.
-	NoDefaultIgnores         *bool  `json:"nodefaultignores,omitempty" yaml:"nodefaultignores,omitempty"` // true if we should only respect .pulumiignore when archiving
+	Context          string `json:"context,omitempty" yaml:"context,omitempty"`                   // an optional path (combined with the on disk location of Pulumi.yaml) to control the data uploaded to the service.
+	NoDefaultIgnores *bool  `json:"nodefaultignores,omitempty" yaml:"nodefaultignores,omitempty"` // true if we should only respect .pulumiignore when archiving
 
-	ConfigDeprecated map[config.Key]config.Value `json:"config,omitempty" yaml:"config,omitempty"` // optional config (applies to all stacks).
-
-	StacksDeprecated map[tokens.QName]ProjectStack `json:"stacks,omitempty" yaml:"stacks,omitempty"` // optional stack specific information.
+	Config string `json:"config,omitempty" yaml:"config,omitempty"` // where to store Pulumi.<stack-name>.yaml files, this is combined with the folder Pulumi.yaml is in.
 }
 
 func (proj *Project) Validate() error {
@@ -72,12 +69,6 @@ func (proj *Project) Save(path string) error {
 	contract.Require(proj != nil, "proj")
 	contract.Requiref(proj.Validate() == nil, "proj", "Validate()")
 
-	for name, info := range proj.StacksDeprecated {
-		if info.isEmpty() {
-			delete(proj.StacksDeprecated, name)
-		}
-	}
-
 	m, err := marshallerForPath(path)
 	if err != nil {
 		return err
@@ -98,11 +89,6 @@ type ProjectStack struct {
 	Config         config.Map `json:"config,omitempty" yaml:"config,omitempty"`                 // optional config.
 }
 
-// isEmpty returns True if this object contains no information (i.e. all members have their zero values)
-func (ps *ProjectStack) isEmpty() bool {
-	return len(ps.Config) == 0 && ps.EncryptionSalt == ""
-}
-
 // Save writes a project definition to a file.
 func (ps *ProjectStack) Save(path string) error {
 	contract.Require(path != "", "path")
@@ -115,6 +101,11 @@ func (ps *ProjectStack) Save(path string) error {
 
 	b, err := m.Marshal(ps)
 	if err != nil {
+		return err
+	}
+
+	// nolint: gas, gas prefers 0700 for a directory, but 0755 (so group and world can read it) is what we prefer
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/workspace/settings.go
+++ b/pkg/workspace/settings.go
@@ -2,20 +2,14 @@
 
 package workspace
 
-import (
-	"github.com/pulumi/pulumi/pkg/resource/config"
-	"github.com/pulumi/pulumi/pkg/tokens"
-)
-
 // Settings defines workspace settings shared amongst many related projects.
 // nolint: lll
 type Settings struct {
-	Stack            string                      `json:"stack,omitempty" yaml:"env,omitempty"`     // an optional default stack to use.
-	ConfigDeprecated map[tokens.QName]config.Map `json:"config,omitempty" yaml:"config,omitempty"` // optional workspace local configuration (overrides values in a project)
+	Stack string `json:"stack,omitempty" yaml:"env,omitempty"` // an optional default stack to use.
 }
 
 // IsEmpty returns true when the settings object is logically empty (no selected stack and nothing in the deprecated
 // configuration bag).
 func (s *Settings) IsEmpty() bool {
-	return s.Stack == "" && len(s.ConfigDeprecated) == 0
+	return s.Stack == ""
 }

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -14,7 +14,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
@@ -105,10 +104,6 @@ func NewFrom(dir string) (W, error) {
 		return nil, err
 	}
 
-	if w.settings.ConfigDeprecated == nil {
-		w.settings.ConfigDeprecated = make(map[tokens.QName]config.Map)
-	}
-
 	upsertIntoCache(dir, w)
 	return w, nil
 }
@@ -122,13 +117,6 @@ func (pw *projectWorkspace) Repository() *Repository {
 }
 
 func (pw *projectWorkspace) Save() error {
-	// let's remove all the empty entries from the config array
-	for k, v := range pw.settings.ConfigDeprecated {
-		if len(v) == 0 {
-			delete(pw.settings.ConfigDeprecated, k)
-		}
-	}
-
 	settingsFile := pw.settingsPath()
 
 	// If the settings file is empty, don't write an new one, and delete the old one if present. Since we put workspaces


### PR DESCRIPTION
Now that the "config" member of Pulumi.yaml has been deprecated for a
while, we'll change it's meaning. When set, the value is treated as a
path and joined with the path to Pulumi.yaml, and per stack
configuration is stored in that folder

Fixes #1031