### PR TITLE
Remove unused stack name from deploy.Snapshot

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -836,7 +836,7 @@ func (b *cloudBackend) runEngineAction(
 	}
 
 	persister := b.newSnapshotPersister(ctx, u.update, u.tokenSource)
-	manager := backend.NewSnapshotManager(stackRef.StackName(), persister, u.GetTarget().Snapshot)
+	manager := backend.NewSnapshotManager(persister, u.GetTarget().Snapshot)
 	displayEvents := make(chan engine.Event)
 	displayDone := make(chan bool)
 

--- a/pkg/backend/cloud/stack.go
+++ b/pkg/backend/cloud/stack.go
@@ -83,7 +83,7 @@ func newStack(apistack apitype.Stack, b *cloudBackend) Stack {
 			[]resource.URN{},
 		))
 	}
-	snapshot := deploy.NewSnapshot(stackName, deploy.Manifest{}, resources)
+	snapshot := deploy.NewSnapshot(deploy.Manifest{}, resources)
 
 	// Now assemble all the pieces into a stack structure.
 	return &cloudStack{

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -262,7 +262,7 @@ func (b *localBackend) performEngineOp(op string, kind backend.UpdateKind,
 
 	// Create the management machinery.
 	persister := b.newSnapshotPersister(stackName)
-	manager := backend.NewSnapshotManager(stackName, persister, update.GetTarget().Snapshot)
+	manager := backend.NewSnapshotManager(persister, update.GetTarget().Snapshot)
 	engineCtx := &engine.Context{Cancel: cancelScope.Context(), Events: events, SnapshotManager: manager}
 
 	// Perform the update

--- a/pkg/backend/local/snapshot.go
+++ b/pkg/backend/local/snapshot.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/tokens"
-	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
 // localSnapshotManager is a simple SnapshotManager implementation that persists snapshots
@@ -22,15 +21,12 @@ func (sm *localSnapshotPersister) Invalidate() error {
 }
 
 func (sm *localSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
-	stack := snapshot.Stack
-	contract.Assert(sm.name == stack)
-
-	config, _, _, err := sm.backend.getStack(stack)
+	config, _, _, err := sm.backend.getStack(sm.name)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	_, err = sm.backend.saveStack(stack, config, snapshot)
+	_, err = sm.backend.saveStack(sm.name, config, snapshot)
 	return err
 
 }

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -26,7 +26,7 @@ func TestNullPlan(t *testing.T) {
 	ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil, nil, "", nil)
 	assert.Nil(t, err)
 	targ := &Target{Name: tokens.QName("null")}
-	prev := NewSnapshot(targ.Name, Manifest{}, nil)
+	prev := NewSnapshot(Manifest{}, nil)
 	plan := NewPlan(ctx, targ, prev, NullSource, nil, false)
 	iter, err := plan.Start(Options{})
 	assert.Nil(t, err)
@@ -47,7 +47,7 @@ func TestErrorPlan(t *testing.T) {
 		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil, nil, "", nil)
 		assert.Nil(t, err)
 		targ := &Target{Name: tokens.QName("errs")}
-		prev := NewSnapshot(targ.Name, Manifest{}, nil)
+		prev := NewSnapshot(Manifest{}, nil)
 		plan := NewPlan(ctx, targ, prev, &errorSource{err: errors.New("ITERATE"), duringIterate: true}, nil, false)
 		iter, err := plan.Start(Options{})
 		assert.Nil(t, iter)
@@ -62,7 +62,7 @@ func TestErrorPlan(t *testing.T) {
 		ctx, err := plugin.NewContext(cmdutil.Diag(), nil, nil, nil, "", nil)
 		assert.Nil(t, err)
 		targ := &Target{Name: tokens.QName("errs")}
-		prev := NewSnapshot(targ.Name, Manifest{}, nil)
+		prev := NewSnapshot(Manifest{}, nil)
 		plan := NewPlan(ctx, targ, prev, &errorSource{err: errors.New("NEXT"), duringIterate: false}, nil, false)
 		iter, err := plan.Start(Options{})
 		assert.Nil(t, err)
@@ -187,7 +187,7 @@ func TestBasicCRUDPlan(t *testing.T) {
 		false,
 		nil,
 	)
-	oldsnap := NewSnapshot(ns, Manifest{}, []*resource.State{oldResB, oldResC, oldResD})
+	oldsnap := NewSnapshot(Manifest{}, []*resource.State{oldResB, oldResC, oldResD})
 
 	// Create the new resource objects a priori.
 	//     - A is created:

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/resource"
-	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -18,7 +17,6 @@ import (
 // IDs, names, and properties; their dependencies; and more.  A snapshot is a diffable entity and can be used to create
 // or apply an infrastructure deployment plan in order to make reality match the snapshot state.
 type Snapshot struct {
-	Stack     tokens.QName      // the stack being deployed into.
 	Manifest  Manifest          // a deployment manifest of versions, checksums, and so on.
 	Resources []*resource.State // fetches all resources and their associated states.
 }
@@ -42,9 +40,8 @@ func (m Manifest) NewMagic() string {
 
 // NewSnapshot creates a snapshot from the given arguments.  The resources must be in topologically sorted order.
 // This property is not checked; for verification, please refer to the VerifyIntegrity function below.
-func NewSnapshot(stack tokens.QName, manifest Manifest, resources []*resource.State) *Snapshot {
+func NewSnapshot(manifest Manifest, resources []*resource.State) *Snapshot {
 	return &Snapshot{
-		Stack:     stack,
 		Manifest:  manifest,
 		Resources: resources,
 	}

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -73,7 +73,6 @@ func DeserializeCheckpoint(chkpoint *apitype.CheckpointV1) (*deploy.Snapshot, er
 	contract.Require(chkpoint != nil, "chkpoint")
 
 	var snap *deploy.Snapshot
-	stack := chkpoint.Stack
 	if latest := chkpoint.Latest; latest != nil {
 		// Unpack the versions.
 		manifest := deploy.Manifest{
@@ -107,7 +106,7 @@ func DeserializeCheckpoint(chkpoint *apitype.CheckpointV1) (*deploy.Snapshot, er
 			resources = append(resources, desres)
 		}
 
-		snap = deploy.NewSnapshot(stack, manifest, resources)
+		snap = deploy.NewSnapshot(manifest, resources)
 	}
 
 	return snap, nil


### PR DESCRIPTION
I'm cleaning up debt in the engine this week and I noticed that the `Stack` property on `deploy.Snapshot` is not useful or used anywhere, so I deleted it. This field is not read anywhere in this repo or the PPC.