### PR TITLE
Run refresh in integration test framework

### DIFF
--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -163,16 +163,19 @@ async function readRPC(call: any, callback: any): Promise<void> {
         const req: any = call.request;
         const resp = new provproto.ReadResponse();
 
+        const id = req.getId();
         const props = req.getProperties().toJavaScript();
         const provider = getProvider(props);
         if (provider.read) {
             // If there's a read function, consult the provider.  Ensure to propagate the special __provider
             // value too, so that the provider's CRUD operations continue to function after a refresh.
-            const result: any = await provider.read(req.getId(), props);
+            const result: any = await provider.read(id, props);
+            resp.setId(result.id);
             const resultProps = resultIncludingProvider(result.properties, props);
             resp.setProperties(structproto.Struct.fromJavaScript(resultProps));
         } else {
-            // In the event of a missing read, simply return back the input properties.
+            // In the event of a missing read, simply return back the input state.
+            resp.setId(id);
             resp.setProperties(req.getProperties());
         }
 

--- a/sdk/nodejs/dynamic/index.ts
+++ b/sdk/nodejs/dynamic/index.ts
@@ -88,9 +88,13 @@ export interface CreateResult {
 
 export interface ReadResult {
     /**
+     * The ID of the resource ready back (or blank if missing).
+     */
+    readonly id?: resource.ID;
+    /**
      * The current property state read from the live environment.
      */
-    readonly props?: any;
+    readonly properties?: any;
 }
 
 /**


### PR DESCRIPTION
Now that refresh is alive for managed stacks, we can do a refresh
in the integration test framework.  We also add the --expect-no-changes
flag to refresh and use it to validate that no changes result from the
refresh.  Since it's possible that some resources will always yield
refresh changes (e.g., perhaps a last updated timestamp), we also
support an ExpectRefreshChanges flag for tests to opt into.