### PR TITLE
Only display preview/no-op resource rows once on non-TTYs.

### DIFF
--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -838,6 +838,13 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 
 		step := event.Payload.(engine.ResourceOutputsEventPayload).Metadata
 		row.SetStep(step)
+
+		// If we're not in a terminal, we may not want to display this row again: if we're displaying a preview or if
+		// this step is a no-op for a custom resource, refreshing this row will simply duplicate its earlier output.
+		hasMeaningfulOutput := !display.isPreview && (step.Res == nil || step.Res.Custom && step.Op != deploy.OpSame)
+		if !display.isTerminal && !hasMeaningfulOutput {
+			return
+		}
 	} else if event.Type == engine.ResourceOperationFailed {
 		row.SetDone()
 		row.SetFailed()


### PR DESCRIPTION
Our current strategy for the progress display on non-TTYs causes us to
display multiple identical rows for each resource when the row is a
preview or a no-op. This behavior is not particularly useful, and
generally just makes the display noisier than it needs to be.

These changes avoid displaying resource rows without meaningful output
by supressing the display of resource output events that are delivered
during a preview or that correspond to a no-op update.

Fixes #1384.