### PR TITLE
Fold "global" messages under the stack resource.

### DIFF
--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -776,6 +776,7 @@ func (display *ProgressDisplay) getRowForURN(urn resource.URN, metadata *engine.
 		tick:                 display.currentTick,
 		diagInfo:             &DiagInfo{},
 		step:                 step,
+		hideRowIfUnnecessary: true,
 	}
 
 	display.eventUrnToResourceRow[urn] = row


### PR DESCRIPTION
We currently display at most two rows for messages that are not
associated with a URN: one for those that arrive before the stack
resource is first observed and one for those that arrive after the stack
resource is first observed. The former is labeled "global"; the latter
is the row associated with the stack resource. These changes remove the
duplication by reassociating the row used for events with no URN that
arrive before the stack resource with the stack resource once it has
been observed.

Fixes #1385.