### PR TITLE
Fix {computed,output}<> display in preview.

### DIFF
--- a/pkg/backend/local/display.go
+++ b/pkg/backend/local/display.go
@@ -257,7 +257,7 @@ func renderResourcePreEvent(
 		indent := engine.GetIndent(payload.Metadata, seen)
 		summary := engine.GetResourcePropertiesSummary(payload.Metadata, indent)
 		details := engine.GetResourcePropertiesDetails(
-			payload.Metadata, indent, opts.SummaryDiff, payload.Planning, payload.Debug)
+			payload.Metadata, indent, payload.Planning, opts.SummaryDiff, payload.Debug)
 
 		fprintIgnoreError(out, opts.Color.Colorize(summary))
 		fprintIgnoreError(out, opts.Color.Colorize(details))


### PR DESCRIPTION
At some point the summary and preview parameters to
`engine.GetResourcePropertiesDetails` were flipped s.t. we stopped
rendering computed<> and output<> values properly during previews.
