### PR TITLE
Show manifest information for stacks

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -45,6 +45,10 @@ func newStackCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			snap, err := s.Snapshot(commandContext())
+			if err != nil {
+				return err
+			}
 
 			// First print general info about the current stack.
 			fmt.Printf("Current stack is %s:\n", s.Name())
@@ -63,7 +67,6 @@ func newStackCmd() *cobra.Command {
 				}
 			}
 
-			snap := s.Snapshot()
 			if snap != nil {
 				if t := snap.Manifest.Time; t.IsZero() {
 					fmt.Printf("    Last update time unknown\n")

--- a/cmd/stack_graph.go
+++ b/cmd/stack_graph.go
@@ -52,8 +52,12 @@ func newStackGraphCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+			snap, err := s.Snapshot(commandContext())
+			if err != nil {
+				return err
+			}
 
-			dg := makeDependencyGraph(s.Snapshot())
+			dg := makeDependencyGraph(snap)
 			file, err := os.Create(args[0])
 			if err != nil {
 				return err

--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -39,7 +39,12 @@ func newStackOutputCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			res, outputs := stack.GetRootStackResource(s.Snapshot())
+			snap, err := s.Snapshot(commandContext())
+			if err != nil {
+				return err
+			}
+
+			res, outputs := stack.GetRootStackResource(snap)
 			if res == nil || outputs == nil {
 				return errors.New("current stack has no output properties")
 			}

--- a/pkg/backend/cloud/stack.go
+++ b/pkg/backend/cloud/stack.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
-	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -47,7 +46,7 @@ type cloudStack struct {
 	orgName   string                 // the organization that owns this stack.
 	cloudName string                 // the PPC in which this stack is running.
 	config    config.Map             // the stack's config bag.
-	snapshot  *deploy.Snapshot       // a snapshot representing the latest deployment state.
+	snapshot  **deploy.Snapshot      // a snapshot representing the latest deployment state (allocated on first use)
 	b         *cloudBackend          // a pointer to the backend this stack belongs to.
 }
 
@@ -75,39 +74,18 @@ func (c cloudBackendReference) StackName() tokens.QName {
 }
 
 func newStack(apistack apitype.Stack, b *cloudBackend) Stack {
-	// Create a fake snapshot out of this stack.
-	// TODO[pulumi/pulumi-service#249]: add time, version, etc. info to the manifest.
-	stackName := apistack.StackName
-
-	var resources []*resource.State
-	for _, res := range apistack.Resources {
-		resources = append(resources, resource.NewState(
-			res.Type,
-			res.URN,
-			res.Custom,
-			false,
-			res.ID,
-			resource.NewPropertyMapFromMap(res.Inputs),
-			resource.NewPropertyMapFromMap(res.Outputs),
-			res.Parent,
-			res.Protect,
-			res.Dependencies,
-		))
-	}
-	snapshot := deploy.NewSnapshot(deploy.Manifest{}, resources)
-
 	// Now assemble all the pieces into a stack structure.
 	return &cloudStack{
 		name: cloudBackendReference{
 			owner: apistack.OrgName,
-			name:  stackName,
+			name:  apistack.StackName,
 			b:     b,
 		},
 		cloudURL:  b.CloudURL(),
 		orgName:   apistack.OrgName,
 		cloudName: apistack.CloudName,
 		config:    nil, // TODO[pulumi/pulumi-service#249]: add the config variables.
-		snapshot:  snapshot,
+		snapshot:  nil, // We explicitly allocate the snapshot on first use, since it is expensive to compute.
 		b:         b,
 	}
 }
@@ -118,12 +96,25 @@ const managedCloudName = "pulumi"
 
 func (s *cloudStack) Name() backend.StackReference { return s.name }
 func (s *cloudStack) Config() config.Map           { return s.config }
-func (s *cloudStack) Snapshot() *deploy.Snapshot   { return s.snapshot }
 func (s *cloudStack) Backend() backend.Backend     { return s.b }
 func (s *cloudStack) CloudURL() string             { return s.cloudURL }
 func (s *cloudStack) OrgName() string              { return s.orgName }
 func (s *cloudStack) CloudName() string            { return s.cloudName }
 func (s *cloudStack) RunLocally() bool             { return s.cloudName == managedCloudName }
+
+func (s *cloudStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) {
+	if s.snapshot != nil {
+		return *s.snapshot, nil
+	}
+
+	snap, err := s.b.getSnapshot(ctx, s.name)
+	if err != nil {
+		return nil, err
+	}
+
+	s.snapshot = &snap
+	return *s.snapshot, nil
+}
 
 func (s *cloudStack) Remove(ctx context.Context, force bool) (bool, error) {
 	return backend.RemoveStack(ctx, s, force)

--- a/pkg/backend/local/stack.go
+++ b/pkg/backend/local/stack.go
@@ -52,11 +52,11 @@ func newStack(name backend.StackReference, path string, config config.Map,
 	}
 }
 
-func (s *localStack) Name() backend.StackReference { return s.name }
-func (s *localStack) Config() config.Map           { return s.config }
-func (s *localStack) Snapshot() *deploy.Snapshot   { return s.snapshot }
-func (s *localStack) Backend() backend.Backend     { return s.b }
-func (s *localStack) Path() string                 { return s.path }
+func (s *localStack) Name() backend.StackReference                           { return s.name }
+func (s *localStack) Config() config.Map                                     { return s.config }
+func (s *localStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) { return s.snapshot, nil }
+func (s *localStack) Backend() backend.Backend                               { return s.b }
+func (s *localStack) Path() string                                           { return s.path }
 
 func (s *localStack) Remove(ctx context.Context, force bool) (bool, error) {
 	return backend.RemoveStack(ctx, s, force)

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -32,10 +32,10 @@ import (
 
 // Stack is a stack associated with a particular backend implementation.
 type Stack interface {
-	Name() StackReference       // this stack's identity.
-	Config() config.Map         // the current config map.
-	Snapshot() *deploy.Snapshot // the latest deployment snapshot.
-	Backend() Backend           // the backend this stack belongs to.
+	Name() StackReference                                   // this stack's identity.
+	Config() config.Map                                     // the current config map.
+	Snapshot(ctx context.Context) (*deploy.Snapshot, error) // the latest deployment snapshot.
+	Backend() Backend                                       // the backend this stack belongs to.
 
 	// Preview changes to this stack.
 	Preview(ctx context.Context, proj *workspace.Project, root string, m UpdateMetadata, opts UpdateOptions,


### PR DESCRIPTION
This change supports displaying manifest information for a stack and
changes the way we handle Snapshots in our backend.

Previously, every call to GetStack would synthesize a Snapshot by
taking the set of resources returned from the
`/api/stacks/<owner>/<name>` endpoint, combined with an empty
manfiest (since the service was not returning the manifest).

This wasn't great for two reasons:

1. We didn't have manifest information, so we couldn't display any of
   its information (most important the last updated time).

2. This strategy required that the service return all the resources
   for a stack anytime GetStack was called. While the CLI did not
   often need this detailed information the fact that we forced the
   Service to produce it (which in the case of stack managed PPC would
   require the service to talk to yet another service) creates a bunch
   of work that we end up ignoring.

I've refactored the code such that `backend.Stack`'s `Snapshot()` method
now lazily requests the information from the service such that we can
construct a `Snapshot()` on demand and only pay the cost when we
actually need it.

I think making more of this stuff lazy is the long term direction we
want to follow.

Unfortunately, right now, it means in cases where we do need this data
we end up fetching it twice. The service does it once when we call
GetStack and then we do it again when we actually need to get at the
Snapshot.  However, once we land this change, we can update the
service to no longer return resources on the apistack.Stack type. The
CLI no longer needs this property.  We'll likely want to continue in a
direction where `apistack.Stack` can be created quickly by the
service (without expensive database queries or fetching remote
resources) and just add additional endpoints that let us get at the
specific information we want in the specific cases when we want it
instead of forcing us to return a bunch of data that we often ignore.

Fixes pulumi/pulumi-service#371