### PR TITLE
[WIP] Simple error and panic telemetry

### DIFF
--- a/cmd/update.go
+++ b/cmd/update.go
@@ -64,6 +64,7 @@ func newUpdateCmd() *cobra.Command {
 				return err
 			}
 
+			defer s.Backend().EnableCrashReporting()
 			proj, root, err := readProject()
 			if err != nil {
 				return err

--- a/pkg/apitype/telemetry.go
+++ b/pkg/apitype/telemetry.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package apitype
+
+const (
+	// TelemetryErrorSeverityWarning represents a warning reported to the service.
+	TelemetryErrorSeverityWarning = "warning"
+
+	// TelemetryErrorSeverityError represents an error reported to the service.
+	TelemetryErrorSeverityError = "error"
+
+	// TelemetryErrorSeverityPanic represents a panic reported to the service.
+	TelemetryErrorSeverityPanic = "panic"
+)
+
+// TelemetryEnvironmentInfo is some basic information about the environment that
+// caused a warning, error, or panic.
+type TelemetryEnvironmentInfo struct {
+	PulumiVersion string `json:"pulumiVersion"` // The version of this CLI
+	GoVersion     string `json:"goVersion"`     // The version of Go that compiled the CLI
+	OS            string `json:"os"`            // The current operating system
+	Arch          string `json:"arch"`          // The current arch
+}
+
+// TelemetryError represents an error, warning, or panic seen by the CLI.
+type TelemetryError struct {
+	Environment TelemetryEnvironmentInfo `json:"environment"` // Machine environment information
+	Severity    string                   `json:"severity"`    // The severity of the error
+	Message     string                   `json:"message"`     // The message of the error
+	DryRun      bool                     `json:"dryRun"`      // If the error occurred during plan execution,
+	// whether we were doing a preview or an update
+}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -89,6 +89,10 @@ type Backend interface {
 	ImportDeployment(ctx context.Context, stackRef StackReference, deployment *apitype.UntypedDeployment) error
 	// Logout logs you out of the backend and removes any stored credentials.
 	Logout() error
+
+	// EnableCrashReporting enables crash reporting for this process.
+	// Must be called using `defer`.
+	EnableCrashReporting()
 }
 
 // UpdateOptions is the full set of update options, including backend and engine options.

--- a/pkg/backend/cloud/client/api_endpoints.go
+++ b/pkg/backend/cloud/client/api_endpoints.go
@@ -137,4 +137,5 @@ func init() {
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/update/{updateID}/complete", "completeUpdate")
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/update/{updateID}/log", "appendUpdateLogEntry")
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/update/{updateID}/renew_lease", "renewUpdateLease")
+	addEndpoint("POST", "/api/telemetry/errors", "telemetryLogError")
 }

--- a/pkg/backend/cloud/state.go
+++ b/pkg/backend/cloud/state.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -127,6 +128,21 @@ func (u *cloudUpdate) Complete(status apitype.UpdateStatus) error {
 func (u *cloudUpdate) recordEvent(
 	event engine.Event, seen map[resource.URN]engine.StepEventMetadata,
 	opts backend.DisplayOptions) error {
+
+	// Before anything else, throw this diagnostic at our telemetry endpoint.
+	// Even if we're not rendering anything for this update/preview, we'd still
+	// like to know about errors that arise.
+	if event.Type == engine.DiagEvent {
+		payload := event.Payload.(engine.DiagEventPayload)
+		if payload.Severity == diag.Error || payload.Severity == diag.Warning {
+			messageNoColor := colors.Never.Colorize(payload.Message)
+			err := u.backend.client.TelemetryLogError(
+				u.context, string(payload.Severity), messageNoColor, u.tokenSource == nil)
+
+			// Best effort. Don't fail the update if we can't talk to the telemetry endpoint.
+			contract.IgnoreError(err)
+		}
+	}
 
 	// If we don't have a token source, we can't perform any mutations.
 	if u.tokenSource == nil {

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -394,6 +394,10 @@ func (b *localBackend) Logout() error {
 	return workspace.DeleteAccessToken(b.url)
 }
 
+func (b *localBackend) EnableCrashReporting() {
+	// Crash reporting does not make sense for the local case.
+}
+
 func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
 	var stacks []tokens.QName
 


### PR DESCRIPTION
This commit records warnings, errors, and panics by sending them to the service in a really simple way.

The basic idea here is to send all warnings, errors, and panics to a Service API endpoint. I'm sending this out early in the hopes of getting some feedback about the general approach and to get people's thoughts on telemetry in general. This WIP PR collects some basic metadata about the environment (version of Pulumi, version of Go, operating system, and architecture), the severity of the error (warning, error, panic), the full text of the warning/error/panic (including stack trace), and whether or not we were doing a dry run at the time of the error.

The things that we are sending in this PR that we are not already sending to the service are
1. Full text of panics
2. User's operating system
3. User's arch
4. Pulumi + Go versions