### PR TITLE
Issue a better error message if you capture a V8 intrinsic

### DIFF
--- a/sdk/nodejs/tests/runtime/jsClosureCases.js
+++ b/sdk/nodejs/tests/runtime/jsClosureCases.js
@@ -74,6 +74,18 @@ return async (a) => { await a; };
 `,
 });
 
+cases.push({
+    title: "Function captures V8 intrinsic (js)",
+    func: () => { %AbortJS(0) },
+    error: `Error serializing function 'func': jsClosureCases.js(0,0)
+
+function 'func': jsClosureCases.js(0,0): which could not be serialized because
+  the function could not be parsed: (...)
+
+Function code:
+  () => { %AbortJS(0) }`
+});
+
 
 module.exports.cases = cases;
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1400.

The TypeScript compiler (correctly) rejects V8 intrinsics as being invalid identifiers, which caused us to throw an exception when trying to closure serialize a function that uses one. Instead of throwing an exception, this PR issues an error message through the usual closure serialization scheme so that users can see the full stack of functions that ultimately closed over an intrinsic.