### PR TITLE
Differentiate between warnings and errors when sending an event

### DIFF
--- a/pkg/backend/cloud/state.go
+++ b/pkg/backend/cloud/state.go
@@ -149,9 +149,9 @@ func (u *cloudUpdate) recordEvent(
 	kind := string(apitype.StdoutEvent)
 	if event.Type == engine.DiagEvent {
 		payload := event.Payload.(engine.DiagEventPayload)
+		fields["severity"] = string(payload.Severity)
 		if payload.Severity == diag.Error || payload.Severity == diag.Warning {
 			kind = string(apitype.StderrEvent)
-			fields["severity"] = string(payload.Severity)
 		}
 	}
 


### PR DESCRIPTION
`UpdateLogEntry` doesn't have enough information to determine whether an incoming event is a warning or an error (or something else entirely), since they both have the `stderr` event kind. Recording the diagnostic severity in the property bag sent to the service gives us enough information to make this determination.