### PR TITLE
Resolve missing outputs as `undefined`.

### DIFF
--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -188,17 +188,13 @@ export function resolveProperties(
         }
     }
 
-    // Now latch all properties in case the inputs did not contain any values.  If we're doing a dry-run, we won't
-    // actually propagate the provisional state, because we cannot know for sure that it is final yet.
+    // `allProps` may not have contained a value for every resolver: for example, optional outputs may not be present.
+    // We will resolve all of these values as `undefined`, and will mark the value as known if we are not running a
+    // preview.
     for (const k of Object.keys(resolvers)) {
         if (!allProps.hasOwnProperty(k)) {
-            if (!isDryRun()) {
-                throw new Error(
-                    `Unexpected missing property '${k}' on resource '${name}' [${t}] during final deployment`);
-            }
-
             const resolve = resolvers[k];
-            resolve(undefined, false);
+            resolve(undefined, !isDryRun());
         }
     }
 }

--- a/sdk/nodejs/tests/runtime/langhost/cases/003.one_complex_resource/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/003.one_complex_resource/index.js
@@ -22,9 +22,12 @@ class MyResource extends pulumi.CustomResource {
                 o: { z: "x" },
             },
 
-            // Next some properties that are completely unresolved (outputs).
+            // Next some properties that are completely unresolved (outputs) but will be provided after creation.
             "outprop1": undefined,
             "outprop2": undefined,
+
+            // Finally define an output property that will not be provided after creation.
+            "outprop3": undefined,
         });
     }
 }
@@ -35,21 +38,19 @@ res.urn.apply(urn => {
     assert.equal(urn, "test:index:MyResource::testResource1");
 });
 res.id.apply(id => {
-    if (id) {
-        console.log(`ID: ${id}`);
-        assert.equal(id, "testResource1");
-    }
+    console.log(`ID: ${id}`);
+    assert.equal(id, "testResource1");
 });
 res.outprop1.apply(prop => {
-    if (prop) {
-        console.log(`OutProp1: ${prop}`);
-        assert.equal(prop, "output properties ftw");
-    }
+    console.log(`OutProp1: ${prop}`);
+    assert.equal(prop, "output properties ftw");
 });
 res.outprop2.apply(prop => {
-    if (prop) {
-        console.log(`OutProp2: ${prop}`);
-        assert.equal(prop, 998.6);
-    }
+    console.log(`OutProp2: ${prop}`);
+    assert.equal(prop, 998.6);
+});
+res.outprop3.apply(prop => {
+    console.log(`OutProp3: ${prop}`);
+    assert.equal(prop, undefined);
 });
 


### PR DESCRIPTION
Before the changes in #1414, all output properties were guaranteed to
have values after deserialization. After #1414, any properties with no
value were no longer resolved, which was treated as an error. These
changes resolve all missing proprties to `undefined`. If a property is
missing during an update, its `undefined` value is marked as known.