### PR TITLE
Provide copy-pasteable output on CLI panics

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,15 +5,38 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
+	"runtime/debug"
 
 	"github.com/pulumi/pulumi/cmd"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/version"
 )
 
+func panicHandler() {
+	if panicPayload := recover(); panicPayload != nil {
+		stack := string(debug.Stack())
+		fmt.Fprintln(os.Stderr, "================================================================================")
+		fmt.Fprintln(os.Stderr, "The Pulumi CLI encountered a fatal error. This is a bug!")
+		fmt.Fprintln(os.Stderr, "We would appreciate a report: https://github.com/pulumi/pulumi/issues/")
+		fmt.Fprintln(os.Stderr, "Please provide all of the below text in your report.")
+		fmt.Fprintln(os.Stderr, "================================================================================")
+		fmt.Fprintf(os.Stderr, "Pulumi Version:   %s\n", version.Version)
+		fmt.Fprintf(os.Stderr, "Go Version:       %s\n", runtime.Version())
+		fmt.Fprintf(os.Stderr, "Go Compiler:      %s\n", runtime.Compiler)
+		fmt.Fprintf(os.Stderr, "Architecture:     %s\n", runtime.GOARCH)
+		fmt.Fprintf(os.Stderr, "Operating System: %s\n", runtime.GOOS)
+		fmt.Fprintf(os.Stderr, "Panic:            %s\n\n", panicPayload)
+		fmt.Fprintln(os.Stderr, stack)
+		os.Exit(1)
+	}
+}
+
 func main() {
+	defer panicHandler()
 	if err := cmd.NewPulumiCmd().Execute(); err != nil {
 		_, err = fmt.Fprintf(os.Stderr, "An error occurred: %v\n", err)
 		contract.IgnoreError(err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Branched off from https://github.com/pulumi/pulumi/pull/1413. This commit produces copy-pasteable output whenever the CLI crashes hard with a panic. Based on our discussion this week, this PR does not make any attempt to send this crash report to the service but instead points users to our bug tracker and asks to create a bug report.

Here's some example output form a crash I placed in the engine:
```
$ pulumi update
Previewing update of stack 'minimal'
================================================================================
The Pulumi CLI encountered a fatal error. This is a bug!
We would appreciate a report: https://github.com/pulumi/pulumi/issues/
Please provide all of the below text in your report.
================================================================================
Pulumi Version:   v0.12.3-dev-1527188071-g38cf2de3-dirty
Go Version:       go1.10.1
Go Compiler:      gc
Architecture:     amd64
Operating System: darwin
Panic:            fatal: A precondition has failed for update

goroutine 1 [running]:
runtime/debug.Stack(0xc4204e2e00, 0x1886900, 0xc42060a1f0)
        /usr/local/go/src/runtime/debug/stack.go:24 +0xa7
main.panicHandler()
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/main.go:18 +0x71
panic(0x1886900, 0xc42060a1f0)
        /usr/local/go/src/runtime/panic.go:502 +0x229
github.com/pulumi/pulumi/pkg/util/contract.failfast(0xc42054b890, 0x24)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/util/contract/failfast.go:23 +0xe9
github.com/pulumi/pulumi/pkg/util/contract.Require(0xc4204e2f00, 0x1a0fca0, 0x6)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/util/contract/require.go:26 +0xcb
github.com/pulumi/pulumi/pkg/engine.Update(0x1af17a0, 0xc420366200, 0xc4200b7530, 0x1febad0, 0x0, 0x0, 0x0, 0x0, 0x1, 0x0, ...)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/engine/update.go:55 +0x6f
github.com/pulumi/pulumi/pkg/backend/cloud.(*cloudBackend).runEngineAction(0xc420617f80, 0x1af5020, 0xc42003c0c8, 0x1a0fca0, 0x6, 0x1aef1a0, 0xc420178e40, 0xc4202de240, 0xc4206be320, 0x43, ...)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/backend/cloud/backend.go:862 +0x8a7
github.com/pulumi/pulumi/pkg/backend/cloud.(*cloudBackend).updateStack(0xc420617f80, 0x1af5020, 0xc42003c0c8, 0x1a0fca0, 0x6, 0x1afb9a0, 0xc42046a060, 0xc4202de240, 0xc4206be320, 0x43, ...)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/backend/cloud/backend.go:772 +0x795
github.com/pulumi/pulumi/pkg/backend/cloud.(*cloudBackend).PreviewThenPrompt(0xc420617f80, 0x1af5020, 0xc42003c0c8, 0x1a0fca0, 0x6, 0x1afb9a0, 0xc42046a060, 0xc4202de240, 0xc4206be320, 0x43, ...)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/backend/cloud/backend.go:564 +0x3a2
github.com/pulumi/pulumi/pkg/backend/cloud.(*cloudBackend).PreviewThenPromptThenExecute(0xc420617f80, 0x1af5020, 0xc42003c0c8, 0x1a0fca0, 0x6, 0x1aef1a0, 0xc4206b0900, 0xc4202de240, 0xc4206be320, 0x43, ...)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/backend/cloud/backend.go:652 +0x1e7
github.com/pulumi/pulumi/pkg/backend/cloud.(*cloudBackend).Update(0xc420617f80, 0x1af5020, 0xc42003c0c8, 0x1aef1a0, 0xc4206b0900, 0xc4202de240, 0xc4206be320, 0x43, 0x0, 0x0, ...)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/backend/cloud/backend.go:670 +0x124
github.com/pulumi/pulumi/pkg/backend.UpdateStack(0x1af5020, 0xc42003c0c8, 0x1afb9a0, 0xc42046a5a0, 0xc4202de240, 0xc4206be320, 0x43, 0x0, 0x0, 0xc4206b0a20, ...)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/backend/stack.go:77 +0x163
github.com/pulumi/pulumi/pkg/backend/cloud.(*cloudStack).Update(0xc42046a5a0, 0x1af5020, 0xc42003c0c8, 0xc4202de240, 0xc4206be320, 0x43, 0x0, 0x0, 0xc4206b0a20, 0x1febad0, ...)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/backend/cloud/stack.go:130 +0x101
github.com/pulumi/pulumi/cmd.newUpdateCmd.func1(0xc420444240, 0x1febad0, 0x0, 0x0, 0x0, 0x0)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/cmd/update.go:104 +0x4e7
github.com/pulumi/pulumi/pkg/util/cmdutil.RunFunc.func1(0xc420444240, 0x1febad0, 0x0, 0x0)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/pkg/util/cmdutil/exit.go:92 +0x5a
github.com/pulumi/pulumi/vendor/github.com/spf13/cobra.(*Command).execute(0xc420444240, 0x1febad0, 0x0, 0x0, 0xc420444240, 0x1febad0)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/vendor/github.com/spf13/cobra/command.go:702 +0x2c6
github.com/pulumi/pulumi/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc42024c6c0, 0xc42041cbf1, 0xc42041cbf0, 0xc420430240)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/vendor/github.com/spf13/cobra/command.go:783 +0x2e4
github.com/pulumi/pulumi/vendor/github.com/spf13/cobra.(*Command).Execute(0xc42024c6c0, 0x1a4ffe0, 0x100609c)
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/vendor/github.com/spf13/cobra/command.go:736 +0x2b
main.main()
        /Users/swgillespie/go/src/github.com/pulumi/pulumi/main.go:37 +0x4b

```

Also in this PR is a change to make the exit code on errors 1 instead of -1, since negative error codes get translated to 255 on POSIX-y systems which doesn't have any particular meaning.