### PR TITLE
Fix a confusing error message arising from multiple API calls failing…

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -886,7 +886,7 @@ func (b *cloudBackend) runEngineAction(
 
 		completeErr := u.Complete(status)
 		if completeErr != nil {
-			err = multierror.Append(err, completeErr)
+			err = multierror.Append(err, errors.Wrap(completeErr, "failed to complete update"))
 		}
 	}
 

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -98,6 +98,10 @@ func (sm *SnapshotManager) mutate(mutator func()) error {
 			}
 		}
 
+		if err != nil {
+			err = errors.Wrap(err, "failed to save snapshot")
+		}
+
 		responseChan <- err
 	}
 


### PR DESCRIPTION
… in the same way.

Fixes https://github.com/pulumi/pulumi/issues/1389. The use of multierror here is especially confusing because multiple API calls failing in the same way appears as if it's the same error message being presented multiple times.