### PR TITLE
Fix an issue where the Version field of an UntypedDeployment was lost

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -1037,7 +1037,7 @@ func (b *cloudBackend) ImportDeployment(ctx context.Context, stackRef backend.St
 		return err
 	}
 
-	update, err := b.client.ImportStackDeployment(ctx, stack, deployment.Deployment)
+	update, err := b.client.ImportStackDeployment(ctx, stack, deployment)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -310,11 +310,10 @@ func (pc *Client) ExportStackDeployment(ctx context.Context,
 
 // ImportStackDeployment imports a new deployment into the indicated stack.
 func (pc *Client) ImportStackDeployment(ctx context.Context, stack StackIdentifier,
-	deployment json.RawMessage) (UpdateIdentifier, error) {
+	deployment *apitype.UntypedDeployment) (UpdateIdentifier, error) {
 
-	req := apitype.ImportStackRequest{Deployment: deployment}
 	var resp apitype.ImportStackResponse
-	if err := pc.restCall(ctx, "POST", getStackPath(stack, "import"), nil, &req, &resp); err != nil {
+	if err := pc.restCall(ctx, "POST", getStackPath(stack, "import"), nil, deployment, &resp); err != nil {
 		return UpdateIdentifier{}, err
 	}
 


### PR DESCRIPTION
The Version field was inadvertently dropped when sending an import
request to the service. Now that we are requiring that the Version field
be set in deployments, this was causing errors.