### PR TITLE
Add an experimental run command

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -123,6 +123,7 @@ func NewPulumiCmd() *cobra.Command {
 	// set to true.
 	if hasDebugCommands() {
 		cmd.AddCommand(newArchiveCommand())
+		cmd.AddCommand(newRunCmd())
 
 		cmd.PersistentFlags().StringVar(&tracingHeaderFlag, "tracing-header", "",
 			"Include the tracing header with the given contents.")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,0 +1,212 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/backend"
+	"github.com/pulumi/pulumi/pkg/diag"
+	"github.com/pulumi/pulumi/pkg/engine"
+	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/workspace"
+)
+
+func newRunCmd() *cobra.Command {
+	var analyzers []string
+	var color colorFlag
+	var configVars []string
+	var debug bool
+	var diffDisplay bool
+	var message string
+	var nonInteractive bool
+	var parallel int
+	var secretVars []string
+	var stack string
+
+	var cmd = &cobra.Command{
+		Use:   "run",
+		Short: "Run a Pulumi program anonymously",
+		Long: "Run a Pulumi program anonymously.\n" +
+			"\n" +
+			"This command will stand up a new stack, deploy resources into it, and block the CLI while\n" +
+			"the resulting program executes.  Any logs emitted while be printed to the console.  When you\n" +
+			"are done, hit ^C, and the program will halt and the stack will be torn down and deleted.",
+		Args: cmdutil.NoArgs,
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			// Grab the options we'll use for the update, mainly just whether to do interactive displays.
+			interactive := isInteractive(nonInteractive)
+			opts, err := updateFlagsToOptions(interactive, true, true)
+			if err != nil {
+				return err
+			}
+			opts.Engine = engine.UpdateOptions{
+				Analyzers: analyzers,
+				Parallel:  parallel,
+				Debug:     debug,
+			}
+			opts.Display = backend.DisplayOptions{
+				Color:         color.Colorization(),
+				IsInteractive: interactive,
+				DiffDisplay:   diffDisplay,
+				Debug:         debug,
+			}
+
+			// Ensure there's a project for us to deploy.
+			proj, root, err := readProject()
+			if err != nil {
+				return err
+			}
+
+			// Create a new stack.  If the stack name wasn't given, we will pick a random one.
+			b, s, err := createTempStack(proj, stack)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if _, err := removeStack(s, true); err != nil {
+					cmdutil.Diag().Warningf(
+						diag.Message("", "failed to remove stack; exiting anyway: %v"), err)
+				}
+			}()
+
+			// Parse and set configuration variables.
+			ps, err := workspace.DetectProjectStack(s.Name().StackName())
+			for i, vars := range [][]string{configVars, secretVars} {
+				for _, kv := range vars {
+					ix := strings.IndexRune(kv, '=')
+					if ix == -1 {
+						return errors.Errorf("invalid configuration flag; expected '<key>=<value>': %s\n", kv)
+					}
+
+					key, err := parseConfigKey(kv[:ix])
+					if err != nil {
+						return errors.Wrap(err, "invalid configuration key")
+					}
+
+					val := kv[ix+1:]
+					if secret := i == 1; secret {
+						crypter, err := b.GetStackCrypter(s.Name())
+						if err != nil {
+							return err
+						}
+						enc, err := crypter.EncryptValue(val)
+						if err != nil {
+							return err
+						}
+						ps.Config[key] = config.NewSecureValue(enc)
+					} else {
+						ps.Config[key] = config.NewValue(val)
+					}
+				}
+			}
+			if err = workspace.SaveProjectStack(s.Name().StackName(), ps); err != nil {
+				return err
+			}
+
+			// Grab some update metadata to use for updates and destroys.
+			m, err := getUpdateMetadata(message, root)
+			if err != nil {
+				return errors.Wrap(err, "gathering environment metadata")
+			}
+
+			// Ensure we destroy the stack before exiting.
+			defer func() {
+				if _, err := s.Destroy(commandContext(), proj, root, m, opts, cancellationScopes); err != nil {
+					cmdutil.Diag().Warningf(
+						diag.Message("", "failed to destroy stack; removal may fail: %v"), err)
+				}
+			}()
+
+			// Perform an update to stand up the initial stack.
+			if _, err := s.Update(commandContext(), proj, root, m, opts, cancellationScopes); err != nil {
+				return err
+			}
+
+			// Now, tail the logs.  Keep doing this until ^C is pressed, and then tear down the stack.
+			now := time.Now()
+			return showLogs(s, &now, nil, true)
+		}),
+	}
+
+	cmd.PersistentFlags().BoolVarP(
+		&debug, "debug", "d", false,
+		"Print detailed debugging output during resource operations")
+	cmd.PersistentFlags().StringVarP(
+		&message, "message", "m", "",
+		"Optional message to associate with the update operation")
+
+	// Flags for engine.UpdateOptions.
+	cmd.PersistentFlags().StringSliceVar(
+		&analyzers, "analyzer", []string{},
+		"Run one or more analyzers as part of this update")
+	cmd.PersistentFlags().VarP(
+		&color, "color", "c", "Colorize output. Choices are: always, never, raw, auto")
+	cmd.PersistentFlags().StringArrayVar(
+		&configVars, "config", nil, "Set configuration variables of the form '<key>=<value>'")
+	cmd.PersistentFlags().BoolVar(
+		&diffDisplay, "diff", false,
+		"Display operation as a rich diff showing the overall change")
+	cmd.PersistentFlags().BoolVar(
+		&nonInteractive, "non-interactive", false, "Disable interactive mode")
+	cmd.PersistentFlags().IntVarP(
+		&parallel, "parallel", "p", 0,
+		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")
+	cmd.PersistentFlags().StringArrayVar(
+		&secretVars, "secret", nil, "Set secret encrypted configuration variables of the form '<key>=<value>'")
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "", "Use a specific stack name, rather than auto-generating one")
+
+	return cmd
+}
+
+func createTempStack(proj *workspace.Project, stack string) (backend.Backend, backend.Stack, error) {
+	b, err := currentBackend()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if stack == "" {
+		rs, err := randomStackName(proj)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "generating random stack name")
+		}
+		stack = rs
+	}
+
+	stackRef, err := b.ParseStackReference(stack)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	s, err := createStack(b, stackRef, nil)
+	return b, s, err
+}
+
+func randomStackName(proj *workspace.Project) (string, error) {
+	hash := make([]byte, 8)
+	if _, err := rand.Read(hash); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("run-%s-%s", proj.Name, hex.EncodeToString(hash)), nil
+}

--- a/cmd/stack_rm.go
+++ b/cmd/stack_rm.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -24,7 +23,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/state"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
-	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 func newStackRmCmd() *cobra.Command {
@@ -57,22 +55,12 @@ func newStackRmCmd() *cobra.Command {
 				return errors.New("confirmation declined")
 			}
 
-			hasResources, err := s.Remove(commandContext(), force)
+			hasResources, err := removeStack(s, force)
 			if err != nil {
 				if hasResources {
 					return errors.Errorf(
 						"'%s' still has resources; removal rejected; pass --force to override", s.Name())
 				}
-				return err
-			}
-
-			// Blow away stack specific settings if they exist
-			path, err := workspace.DetectProjectStackPath(s.Name().StackName())
-			if err != nil {
-				return err
-			}
-
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 				return err
 			}
 

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -400,11 +400,11 @@ func (b *cloudBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 	}
 
 	stack := newStack(apistack, b)
-	fmt.Printf("Created stack '%s'", stack.Name())
+	fmt.Printf(colors.ColorizeText(colors.BrightMagenta+"Created stack '%s'"), stack.Name())
 	if !stack.RunLocally() {
 		fmt.Printf(" in PPC %s", stack.CloudName())
 	}
-	fmt.Println(".")
+	fmt.Printf(colors.ColorizeText(colors.Reset) + "\n")
 
 	return stack, nil
 }

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/diag"
+	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/encoding"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
@@ -134,7 +135,7 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 	}
 
 	stack := newStack(stackRef, file, nil, nil, b)
-	fmt.Printf("Created stack '%s'.\n", stack.Name())
+	fmt.Printf(colors.ColorizeText(colors.BrightMagenta+"Created stack '%s'\n"+colors.Reset), stack.Name())
 
 	return stack, nil
 }


### PR DESCRIPTION
This adds an experimental run command, tucked beneath the debug-only
CLI envvar.  The idea here is to experiment with the notion that a
Pulumi program can operate just like a normal program you'd execute on
your machine, except that it executes in the cloud.  To do this, we
simply new up an anonymous stack, configure it, deploy the program, tail
the logs, and then, upon ^C, tear it all down again afterwards.  This
works remarkably well for "simple" stacks -- especially serverless ones
-- but obviously not so muchf or stacks that take eons to stand up.