### PR TITLE
Add optional `--dir` flag to `pulumi new`

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -50,6 +50,7 @@ func newNewCmd() *cobra.Command {
 	var yes bool
 	var offline bool
 	var generateOnly bool
+	var dir string
 
 	cmd := &cobra.Command{
 		Use:   "new [template]",
@@ -61,6 +62,20 @@ func newNewCmd() *cobra.Command {
 			// Validate name (if specified) before further prompts/operations.
 			if name != "" && !workspace.IsValidProjectName(name) {
 				return errors.Errorf("'%s' is not a valid project name", name)
+			}
+
+			// If dir was specified, ensure it exists and use it as the
+			// current working directory.
+			if dir != "" {
+				// Ensure the directory exists.
+				if err = os.MkdirAll(dir, os.ModePerm); err != nil {
+					return errors.Wrap(err, "creating the directory")
+				}
+
+				// Change the working directory to the specified directory.
+				if err = os.Chdir(dir); err != nil {
+					return errors.Wrap(err, "changing the working directory")
+				}
 			}
 
 			// Get the current working directory.
@@ -246,6 +261,8 @@ func newNewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&generateOnly, "generate-only", false,
 		"Generate the project only; do not create a stack, save config, or install dependencies")
+	cmd.PersistentFlags().StringVar(&dir, "dir", "",
+		"The location to place the generated project; if not specified, the current directory is used")
 
 	return cmd
 }

--- a/tests/new_test.go
+++ b/tests/new_test.go
@@ -35,7 +35,7 @@ func TestPulumiNew(t *testing.T) {
 		defer deleteTemporaryLocalTemplate(t, template)
 
 		// Create a subdirectory and CD into it.
-		subdir := path.Join(e.RootPath, "foo")
+		subdir := filepath.Join(e.RootPath, "foo")
 		err := os.MkdirAll(subdir, os.ModePerm)
 		assert.NoError(t, err, "error creating subdirectory")
 		e.CWD = subdir
@@ -44,6 +44,53 @@ func TestPulumiNew(t *testing.T) {
 		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes")
 
 		assertSuccess(t, subdir, "foo", "")
+	})
+
+	t.Run("SanityTestWithDir", func(t *testing.T) {
+		e := ptesting.NewEnvironment(t)
+		defer deleteIfNotFailed(e)
+
+		// Create a temporary local template.
+		template := createTemporaryLocalTemplate(t, "")
+		defer deleteTemporaryLocalTemplate(t, template)
+
+		// Run pulumi new.
+		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes", "--dir", "foo")
+
+		assertSuccess(t, filepath.Join(e.RootPath, "foo"), "foo", "")
+	})
+
+	t.Run("SanityTestWithDirMultiplePaths", func(t *testing.T) {
+		e := ptesting.NewEnvironment(t)
+		defer deleteIfNotFailed(e)
+
+		// Create a temporary local template.
+		template := createTemporaryLocalTemplate(t, "")
+		defer deleteTemporaryLocalTemplate(t, template)
+
+		// Run pulumi new.
+		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes", "--dir", filepath.Join("bar", "foo"))
+
+		assertSuccess(t, filepath.Join(e.RootPath, "bar", "foo"), "foo", "")
+	})
+
+	t.Run("SanityTestWithCAndDir", func(t *testing.T) {
+		e := ptesting.NewEnvironment(t)
+		defer deleteIfNotFailed(e)
+
+		// Create a temporary local template.
+		template := createTemporaryLocalTemplate(t, "")
+		defer deleteTemporaryLocalTemplate(t, template)
+
+		// Create a sub directory.
+		subdir := filepath.Join(e.RootPath, "bar")
+		err := os.MkdirAll(subdir, os.ModePerm)
+		assert.NoError(t, err, "error creating subdirectory")
+
+		// Run pulumi new.
+		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes", "-C", "bar", "--dir", "foo")
+
+		assertSuccess(t, filepath.Join(subdir, "foo"), "foo", "")
 	})
 
 	t.Run("SanityTestWithManifest", func(t *testing.T) {
@@ -57,7 +104,7 @@ func TestPulumiNew(t *testing.T) {
 		defer deleteTemporaryLocalTemplate(t, template)
 
 		// Create a subdirectory and CD into it.
-		subdir := path.Join(e.RootPath, "foo")
+		subdir := filepath.Join(e.RootPath, "foo")
 		err := os.MkdirAll(subdir, os.ModePerm)
 		assert.NoError(t, err, "error creating subdirectory")
 		e.CWD = subdir
@@ -167,7 +214,7 @@ func TestPulumiNew(t *testing.T) {
 		defer deleteTemporaryLocalTemplate(t, template)
 
 		// Create a subdirectory and CD into it.
-		subdir := path.Join(e.RootPath, "foo")
+		subdir := filepath.Join(e.RootPath, "foo")
 		err := os.MkdirAll(subdir, os.ModePerm)
 		assert.NoError(t, err, "error creating subdirectory")
 		e.CWD = subdir
@@ -201,7 +248,7 @@ func TestPulumiNew(t *testing.T) {
 		defer deleteTemporaryLocalTemplate(t, template)
 
 		// Create a subdirectory and CD into it.
-		subdir := path.Join(e.RootPath, "foo")
+		subdir := filepath.Join(e.RootPath, "foo")
 		err := os.MkdirAll(subdir, os.ModePerm)
 		assert.NoError(t, err, "error creating subdirectory")
 		e.CWD = subdir
@@ -246,7 +293,7 @@ func TestPulumiNew(t *testing.T) {
 		defer deleteTemporaryLocalTemplate(t, template)
 
 		// Create a subdirectory and CD into it.
-		subdir := path.Join(e.RootPath, "foo")
+		subdir := filepath.Join(e.RootPath, "foo")
 		err := os.MkdirAll(subdir, os.ModePerm)
 		assert.NoError(t, err, "error creating subdirectory")
 		e.CWD = subdir


### PR DESCRIPTION
Usage:

```
pulumi new <template> --dir folderName
```

Used to specify the directory where to place the generated project.
If the directory does not exist, it will be created.

Fixes #1407