### PR TITLE
Use crypto/rand when generating a stack suffix

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -16,7 +16,7 @@ package integration
 
 import (
 	"context"
-	"crypto/rand"
+	cryptorand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -233,7 +233,7 @@ func (opts *ProgramTestOptions) GetStackName() tokens.QName {
 		}
 
 		b := make([]byte, 4)
-		_, err = rand.Read(b)
+		_, err = cryptorand.Read(b)
 		contract.AssertNoError(err)
 
 		opts.StackName = strings.ToLower("p-it-" + host + "-" + test + "-" + hex.EncodeToString(b))

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -3,10 +3,11 @@
 package tests
 
 import (
+	cryptorand "crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path"
 	"path/filepath"
@@ -19,6 +20,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/local"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/stretchr/testify/assert"
 
@@ -198,8 +200,8 @@ func TestStackCommands(t *testing.T) {
 			e.DeleteEnvironment()
 		}()
 
-		// Semi-random stack name to avoid collisions in the service.
-		stackName := fmt.Sprintf("roundtrip-%d", rand.Int63())
+		// Random stack name to avoid collisions in the service.
+		stackName := addRandomSufix("roundtrip")
 		integration.CreateBasicPulumiRepo(e)
 		e.ImportDirectory("integration/empty/nodejs")
 
@@ -317,4 +319,11 @@ func getStackProjectBackupDir(e *ptesting.Environment, stackName string) (string
 		workspace.BackupDir,
 		stackName,
 	), nil
+}
+
+func addRandomSufix(s string) string {
+	b := make([]byte, 4)
+	_, err := cryptorand.Read(b)
+	contract.AssertNoError(err)
+	return s + "-" + hex.EncodeToString(b)
 }


### PR DESCRIPTION
math/rand uses a fixed seed, meaning that across runs the Kth call to
`rand.Int63()` will always return the same value.

Given that we want to provide a unique suffix across multiple
concurrent runs, this isn't the behavior we want.

I saw an instance fail in CI where all three legs ran the test
concurrently and they raced on creating the test stack, since they all
generated the same name.