### PR TITLE
Allow tests to be run by users outside of the Pulumi organization

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -141,9 +141,6 @@ type ProgramTestOptions struct {
 	// CloudURL is an optional URL to override the default Pulumi Service API (https://api.pulumi-staging.io). The
 	// PULUMI_ACCESS_TOKEN environment variable must also be set to a valid access token for the target cloud.
 	CloudURL string
-	// Owner is an optional value to specify during calls to `pulumi stack init`. Otherwise the --owner flag will
-	// not be set
-	Owner string
 	// PPCName is the name of the PPC to use when running a test against the hosted service. If
 	// not set, the --ppc flag will not be set on `pulumi stack init`.
 	PPCName string
@@ -264,9 +261,6 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 	}
 	if overrides.CloudURL != "" {
 		opts.CloudURL = overrides.CloudURL
-	}
-	if overrides.Owner != "" {
-		opts.Owner = overrides.Owner
 	}
 	if overrides.PPCName != "" {
 		opts.PPCName = overrides.PPCName
@@ -517,17 +511,6 @@ func (pt *programTester) testLifeCycleInitialize(dir string) error {
 		}
 	}
 
-	// Set the owner organization from an environment variable if not overridden in options.
-	if pt.opts.Owner == "" {
-		pulumiAPIOwnerOrganization := os.Getenv("PULUMI_API_OWNER_ORGANIZATION")
-		if pulumiAPIOwnerOrganization != "" {
-			pt.opts.Owner = pulumiAPIOwnerOrganization
-		} else {
-			// Default to the `pulumi` organization.
-			pt.opts.Owner = "pulumi"
-		}
-	}
-
 	// Set the target PPC from an environment variable if not overridden in options.
 	if pt.opts.PPCName == "" {
 		ppcName := os.Getenv("PULUMI_API_PPC_NAME")
@@ -555,8 +538,15 @@ func (pt *programTester) testLifeCycleInitialize(dir string) error {
 		}
 	}
 
+	// If an optional test owner is provided in the environment, create the stack under that owner. We use this in
+	// CI to ensure stacks are owned by an organization that all Pulumi developers have access to.
+	qualifiedStackName := string(stackName)
+	if owner := os.Getenv("PULUMI_TEST_OWNER"); owner != "" {
+		qualifiedStackName = owner + "/" + qualifiedStackName
+	}
+
 	// Stack init
-	stackInitArgs := []string{"stack", "init", fmt.Sprintf("%s/%s", pt.opts.Owner, string(stackName))}
+	stackInitArgs := []string{"stack", "init", qualifiedStackName}
 	stackInitArgs = addFlagIfNonNil(stackInitArgs, "--ppc", pt.opts.PPCName)
 
 	if err := pt.runPulumiCommand("pulumi-stack-init", stackInitArgs, dir); err != nil {


### PR DESCRIPTION
Today we defaulted our tests to create stacks in the `pulumi`
organization. We did this because our tests run with `pulumi-bot` and
we'd rather create the stacks in our shared organization, so any
Pulumi developer can see them.

Of course, as we prepare to have folks outside of the Pulumi
organization write and run tests, this has now become a bad default.

Remove the ability to explicitly set an owner in
ProgramTestOptions (since that would more or less only lead to pain
going forward) and default to just creating the stacks in whatever
account is currently logged in. In CI, we'll set a new environment
variable "PULUMI_TEST_OWNER" which controls the owner of the stacks,
which we'll set to `pulumi`.

Impact to day to day developers is during test runs locally you'll see
stacks in your list of stacks. If any of the tests fail to clean up,
you'll see these lingering stacks (but you can go clean them up).