### PR TITLE
Allow duplicate error IDs.

### DIFF
--- a/pkg/diag/errors.go
+++ b/pkg/diag/errors.go
@@ -16,7 +16,6 @@ package diag
 
 import (
 	"github.com/pulumi/pulumi/pkg/resource"
-	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
 // newError registers a new error message underneath the given id.


### PR DESCRIPTION
There is no longer a reason to ensure that these IDs are distinct.

Fixes #1464.