### PR TITLE
Improve the error message when data source invocations fail

### DIFF
--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -441,8 +441,9 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 
 	resp, err := client.Invoke(p.ctx.Request(), &pulumirpc.InvokeRequest{Tok: string(tok), Args: margs})
 	if err != nil {
-		logging.V(7).Infof("%s failed: %v", label, err)
-		return nil, nil, err
+		rpcError := rpcerror.Convert(err)
+		logging.V(7).Infof("%s failed: %v", label, rpcError.Message())
+		return nil, nil, rpcError
 	}
 
 	// Unmarshal any return values.

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -53,6 +53,10 @@ def invoke(tok, args):
         if exn.code() == grpc.StatusCode.UNAVAILABLE:
             wait_for_death()
 
+        # If the RPC otherwise failed, re-throw an exception with the message details - the contents
+        # are suitable for user presentation.
+        raise Exception(exn.details())
+
 
     # If the invoke failed, raise an error.
     if resp.failures:


### PR DESCRIPTION
I ran into this when investigating https://github.com/pulumi/pulumi-terraform/issues/160.

The `Invoke` RPC endpoint of the `ResourceMonitor` service (hosted by the engine, and interacted with by the language host) can fail, and the error message we were giving in this case was really bad.

JS:
```
$ pulumi preview
Previewing update of stack 'datasource-js'
Previewing changes:

     Type    Name    Plan          Info
 *   global  global  no change     3 errors

Diagnostics:
  global: global
    error: Running program '/Users/swgillespie/go/src/github.com/pulumi/scratch/python/datasource-js' failed with an unhandled exception:

    error: { Error: 2 UNKNOWN: invocation of aws:ec2/getSubnet:getSubnet returned an error: rpc error: code = Unknown desc = invoking aws:ec2/getSubnet:getSubnet: multiple subnets matched; use additional constraints to reduce matches to a single subnet
        at Object.exports.createStatusError (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/common.js:87:15)
        at Object.onReceiveStatus (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/client_interceptors.js:1214:28)
        at InterceptingListener._callNext (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/client_interceptors.js:590:42)
        at InterceptingListener.onReceiveStatus (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/client_interceptors.js:640:8)
        at callback (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/client_interceptors.js:867:24)
      code: 2,
      metadata: Metadata { _internal_repr: {} },
      details: 'invocation of aws:ec2/getSubnet:getSubnet returned an error: rpc error: code = Unknown desc = invoking aws:ec2/getSubnet:getSubnet: multiple subnets matched; use additional constraints to reduce matches to a single subnet' }

    error: an unhandled error occurred: Program exited with non-zero exit code: 1

error: an error occurred while advancing the preview
```

Python:
```
$ pulumi preview
Previewing update of stack 'datasource-py'
Previewing changes:

     Type    Name    Plan          Info
 *   global  global  no change     1 error, 1 info message

Diagnostics:
  global: global
    info: Traceback (most recent call last):
      File "/usr/local/pulumi/bin/pulumi-language-python-exec", line 55, in <module>
        pulumi.runtime.run_in_stack(lambda: runpy.run_path(args.PROGRAM, run_name='__main__'))
      File "/Users/swgillespie/go/src/github.com/pulumi/pulumi/sdk/python/env/src/pulumi/runtime/stack.py", line 28, in run_in_stack
        Stack(func)
      File "/Users/swgillespie/go/src/github.com/pulumi/pulumi/sdk/python/env/src/pulumi/runtime/stack.py", line 47, in __init__
        func()
      File "/usr/local/pulumi/bin/pulumi-language-python-exec", line 55, in <lambda>
        pulumi.runtime.run_in_stack(lambda: runpy.run_path(args.PROGRAM, run_name='__main__'))
      File "/usr/local/Cellar/python@2/2.7.15/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 276, in run_path
        run_name, fname, loader, pkg_name).copy()
      File "/usr/local/Cellar/python@2/2.7.15/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
        exec code in run_globals
      File "/Users/swgillespie/go/src/github.com/pulumi/scratch/python/datasource/__main__.py", line 5, in <module>
        subnets = pulumi_aws.ec2.get_subnet()
      File "/Users/swgillespie/go/src/github.com/pulumi/pulumi-aws/pack/python/bin/pulumi_aws/ec2/get_subnet.py", line 88, in get_subnet
        __ret__ = pulumi.runtime.invoke('aws:ec2/getSubnet:getSubnet', __args__)
      File "/Users/swgillespie/go/src/github.com/pulumi/pulumi/sdk/python/env/src/pulumi/runtime/resource.py", line 58, in invoke
        if resp.failures:
    UnboundLocalError: local variable 'resp' referenced before assignment

  global: global
    error: an unhandled error occurred: Program exited with non-zero exit code: 1

error: an error occurred while advancing the preview
```

The JS error message has lots of RPC gunk in it and the Python error message is just wrong. This PR brings us to these error messages:

JS:
```
$ pulumi preview
Previewing update of stack 'datasource-js'
Previewing changes:

     Type    Name    Plan          Info
 *   global  global  no change     3 errors

Diagnostics:
  global: global
    error: Running program '/Users/swgillespie/go/src/github.com/pulumi/scratch/python/datasource-js' failed with an unhandled exception:

    error: Error: invocation of aws:ec2/getSubnet:getSubnet returned an error: invoking aws:ec2/getSubnet:getSubnet: multiple subnets matched; use additional constraints to reduce matches to a single subnet
        at monitor.invoke (/usr/local/pulumi/node_modules/@pulumi/pulumi/runtime/invoke.js:61:33)
        at Object.onReceiveStatus (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/client_interceptors.js:1215:9)
        at InterceptingListener._callNext (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/client_interceptors.js:590:42)
        at InterceptingListener.onReceiveStatus (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/client_interceptors.js:640:8)
        at callback (/usr/local/pulumi/node_modules/@pulumi/pulumi/node_modules/grpc/src/client_interceptors.js:867:24)

    error: an unhandled error occurred: Program exited with non-zero exit code: 1

error: an error occurred while advancing the preview
```

Python:
```
Previewing update of stack 'datasource-py'
Previewing changes:

     Type    Name    Plan          Info
 *   global  global  no change     1 error, 1 info message

Diagnostics:
  global: global
    info: Traceback (most recent call last):
      File "/usr/local/pulumi/bin/pulumi-language-python-exec", line 55, in <module>
        pulumi.runtime.run_in_stack(lambda: runpy.run_path(args.PROGRAM, run_name='__main__'))
      File "/Users/swgillespie/go/src/github.com/pulumi/pulumi/sdk/python/env/src/pulumi/runtime/stack.py", line 28, in run_in_stack
        Stack(func)
      File "/Users/swgillespie/go/src/github.com/pulumi/pulumi/sdk/python/env/src/pulumi/runtime/stack.py", line 47, in __init__
        func()
      File "/usr/local/pulumi/bin/pulumi-language-python-exec", line 55, in <lambda>
        pulumi.runtime.run_in_stack(lambda: runpy.run_path(args.PROGRAM, run_name='__main__'))
      File "/usr/local/Cellar/python@2/2.7.15/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 276, in run_path
        run_name, fname, loader, pkg_name).copy()
      File "/usr/local/Cellar/python@2/2.7.15/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
        exec code in run_globals
      File "/Users/swgillespie/go/src/github.com/pulumi/scratch/python/datasource/__main__.py", line 5, in <module>
        subnets = pulumi_aws.ec2.get_subnet()
      File "/Users/swgillespie/go/src/github.com/pulumi/pulumi-aws/pack/python/bin/pulumi_aws/ec2/get_subnet.py", line 88, in get_subnet
        __ret__ = pulumi.runtime.invoke('aws:ec2/getSubnet:getSubnet', __args__)
      File "/Users/swgillespie/go/src/github.com/pulumi/pulumi/sdk/python/env/src/pulumi/runtime/resource.py", line 58, in invoke
        raise Exception(exn.details())
    Exception: invocation of aws:ec2/getSubnet:getSubnet returned an error: invoking aws:ec2/getSubnet:getSubnet: multiple subnets matched; use additional constraints to reduce matches to a single subnet

  global: global
    error: an unhandled error occurred: Program exited with non-zero exit code: 1

error: an error occurred while advancing the preview
```