### PR TITLE
Include a query parameter on generated console URLs

### DIFF
--- a/pkg/backend/cloud/console.go
+++ b/pkg/backend/cloud/console.go
@@ -36,5 +36,8 @@ func cloudConsoleURL(cloudURL string, paths ...string) string {
 	}
 
 	u.Path = path.Join(paths...)
+	q := u.Query()
+	q.Set("s", "cli")
+	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/pkg/backend/cloud/console_test.go
+++ b/pkg/backend/cloud/console_test.go
@@ -21,15 +21,15 @@ import (
 
 func TestConsoleURL(t *testing.T) {
 	assert.Equal(t,
-		"https://app.pulumi.com/pulumi-bot/my-stack",
+		"https://app.pulumi.com/pulumi-bot/my-stack?s=cli",
 		cloudConsoleURL("https://api.pulumi.com", "pulumi-bot", "my-stack"))
 
 	assert.Equal(t,
-		"http://app.pulumi.example.com/pulumi-bot/my-stack",
+		"http://app.pulumi.example.com/pulumi-bot/my-stack?s=cli",
 		cloudConsoleURL("http://api.pulumi.example.com", "pulumi-bot", "my-stack"))
 
 	assert.Equal(t,
-		"http://localhost:3000/pulumi-bot/my-stack",
+		"http://localhost:3000/pulumi-bot/my-stack?s=cli",
 		cloudConsoleURL("http://localhost:8080", "pulumi-bot", "my-stack"))
 
 	assert.Equal(t, "", cloudConsoleURL("https://example.com", "pulumi-bot", "my-stack"))


### PR DESCRIPTION
This will help us understand how folks use the CLI to Pulumi Console
linking.

Fix #1451

The resulting output for a `pulumi stack ls`:

Before:
```
[ellismg@localhost aws-serverless-js-httpendpoint]$ pulumi stack ls
NAME                                             LAST UPDATE              RESOURCE COUNT     URL
test-one                                         n/a                      0                  https://pulumi.com/ellismg/test-one
test-three*                                      n/a                      0                  https://pulumi.com/ellismg/test-three
test-two                                         n/a                      0                  https://pulumi.com/ellismg/test-two
```

After
```
[ellismg@localhost aws-serverless-js-httpendpoint]$ ~/go/bin/pulumi stack ls
NAME                                             LAST UPDATE              RESOURCE COUNT     URL
test-one                                         n/a                      0                  https://app.pulumi.com/ellismg/test-one?s=cli
test-three*                                      n/a                      0                  https://app.pulumi.com/ellismg/test-three?s=cli
test-two                                         n/a                      0                  https://app.pulumi.com/ellismg/test-two?s=cli
```

The resulting links (including the query string) still appear clickable in my terminal, and doing so does correctly flow the query parameter to the browser when it opens.
