### PR TITLE
Support better previews in Python by mocking out Unknown values

### DIFF
--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -17,6 +17,7 @@
 from runtime.resource import register_resource, register_resource_outputs
 from runtime.rpc import register_custom_resource_type
 from runtime.settings import get_root_resource
+from runtime.unknown import Unknown
 
 class Resource(object):
     """
@@ -64,6 +65,9 @@ class Resource(object):
             The provider-assigned unique ID for this managed resource.  It is set during deployments and may
             be missing during planning phases.
             """
+        else:
+            self.id = Unknown()
+
         if result.outputs:
             self.set_outputs(result.outputs)
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -19,6 +19,7 @@ out of RPC calls.
 import six
 from six.moves import map
 from google.protobuf import struct_pb2
+from .unknown import Unknown
 
 UNKNOWN = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
 """If a value is None, we serialize as UNKNOWN, which tells the engine that it may be computed later."""
@@ -50,6 +51,9 @@ def serialize_resource_value(value):
     elif isinstance(value, list):
         # Deeply serialize lists.
         return list(map(serialize_resource_value, value))
+    elif isinstance(value, Unknown):
+        # Serialize instances of Unknown as the UNKNOWN guid
+        return UNKNOWN
     else:
         # All other values are directly serializable.
         # TODO[pulumi/pulumi#1063]: eventually, we want to think about Output, Properties, and so on.
@@ -77,7 +81,7 @@ def deserialize_property(prop):
     """
 
     if prop == UNKNOWN:
-        return None
+        return Unknown()
 
     # ListValues are projected to lists
     if isinstance(prop, struct_pb2.ListValue):

--- a/sdk/python/lib/pulumi/runtime/unknown.py
+++ b/sdk/python/lib/pulumi/runtime/unknown.py
@@ -1,0 +1,72 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class Unknown(unicode):
+    """
+    Unknown is a class representing values that are not known during
+    previews. This class is designed to lie its way through the entire
+    Pulumi runtime.
+
+    We inherit from `unicode` to lie to resources that we are a string.
+    """
+    def __getattribute__(self, attr):
+        """
+        Called whenever a property is read from an Unknown object. A property
+        access like `foo.bar` would call `Unknown.__getattribute__(foo, 'bar')`.
+
+        Unknown claims that all properties are Unknown, which should get us through
+        most previews.
+        """
+        return Unknown()
+
+    def __nonzero__(self):
+        """
+        Called whenever this value is coerced to a boolean, via "bool" or the "not"
+        operator. This value is not zero, so we return True.
+        """
+        return True
+
+    def __str__(self):
+        """
+        Called whenever this value is coerced to a string, via "str".
+        """
+        return "<computed>"
+
+    def __len__(self):
+        """
+        Called whenever somebody calls `len` on us, allowing us to masquerade as a list.
+        """
+        return 0
+
+    def __getitem__(self, name):
+        """
+        Called whenever somebody uses the index operator on us, allowing us to masquerade as
+        lists and dicts.
+        """
+        return Unknown()
+
+    def __iter__(self):
+        """
+        Called whenever somebody calls `iter` on us or uses us in a `for..in` statement.
+        """
+        return iter([])
+
+    def __dir__(self):
+        """
+        Called whenever somebody calls `dir` on us. We're lying about all of our
+        properties so we say that we don't have any.
+        """
+        return []
+
+

--- a/sdk/python/lib/test/test_deserialize.py
+++ b/sdk/python/lib/test/test_deserialize.py
@@ -14,7 +14,7 @@
 
 import unittest
 from google.protobuf import struct_pb2
-from pulumi.runtime import rpc
+from pulumi.runtime import rpc, Unknown
 
 class PropertyDeserializeTests(unittest.TestCase):
     """
@@ -71,9 +71,7 @@ class PropertyDeserializeTests(unittest.TestCase):
         # pylint: disable=unsupported-assignment-operation
         proto["vpc_id"] = rpc.UNKNOWN
         deserialized = rpc.deserialize_resource_props(proto)
-        self.assertDictEqual({
-            "vpc_id": None
-        }, deserialized)
+        self.assertTrue(isinstance(deserialized["vpc_id"], Unknown))
 
 if __name__ == '__main__':
     unittest.main()

--- a/sdk/python/lib/test/test_serialize.py
+++ b/sdk/python/lib/test/test_serialize.py
@@ -15,7 +15,7 @@
 import unittest
 from google.protobuf import struct_pb2
 from pulumi import CustomResource
-from pulumi.runtime import rpc
+from pulumi.runtime import rpc, Unknown
 
 class PropertySerializeTests(unittest.TestCase):
     """
@@ -47,6 +47,19 @@ class PropertySerializeTests(unittest.TestCase):
         self.assertEqual(1, proto_list[0])
         self.assertEqual("2", proto_list[1])
         self.assertEqual(True, proto_list[2])
+
+    def test_unknown(self):
+        """
+        Tests that we serialize instances of the Unknown class to
+        the unknown GUID.
+        """
+        struct = rpc.serialize_resource_props({
+            "unknown_prop": Unknown()
+        })
+
+        # pylint: disable=unsubscriptable-object
+        unknown = struct["unknown_prop"]
+        self.assertEqual(rpc.UNKNOWN, unknown)
 
 class FakeCustomResource(object):
     """


### PR DESCRIPTION
This PR is a little wacky, and I totally understand if we don't want to take it, but it results in a *much* better preview experience for Python.

@pgavlin suggested the other day that the Python Unknown value be just the string `<computed>`. This PR is basically an elaboration on this idea that addresses some of the practical concerns that come out of it.

In JavaScript, we use `Output` to hide the existence of Unknown values. In this way we can prevent the user from ever observing an unknown value, since we don't run `apply` callbacks on previews. Python does not have `Output` (yet) so there's nothing stopping unknown values from leaking into user programs during previews.

It's not an awful thing for users to observe unknown values. An unknown value, though, should

1. Be able to be passed to other resources without modification (e.g. the scenario of creating a resource and then creating another resource that references the first resource's ID)
2. Be able to be printed as if it were a string
3. Pass type checks imposed by `tfgen`-generated code - usually asserting that a value is a string, a list, or a dict
4. Be able to be identified as `Unknown` elsewhere in the runtime, so it can be turned in to the unknown sentinel GUID before being sent to the engine.

This PR accomplishes all but the second two parts of 3 (masquerading as a list or dict) by defining an `Unknown` class that inherits from `unicode` and lies about its internals:

1. Converting an `Unknown` to a string (e.g. by printing it or calling `str` on it) produces the string `"computed"`. This allows users to safely treat `Unknown` as a string for concatenation, printing, or formatting.
2. Converting an `Unknown` to a boolean (e.g. by using `not` with it or using it in a conditional. This passes all required argument presence checks in `tfgen`-generated code.
3. Reading properties off of an `Unknown` produces another `Unknown`, regardless of the property. This allows `Unknown` to masquerade as a resource.
4. Using the index operator on an `Unknown` produces another `Unknown`, which allows `Unknown` to masquerade as lists and dicts.
5. Iterating over an `Unknown` produces an empty iterator.

With this object, we're able to do nontrivial previews on Python programs, as long as the preview does not attempt to use `Unknown` as a list or dict. `Unknown` inherits from `unicode`, the unicode string type, so it passes all `tfgen` checks that a property is a string, but it does not pass `isinstance(..., list)` or `isinstance(..., dict`).