### PR TITLE
s/docs.pulumi.com/pulumi.io/g

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -80,7 +80,7 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.SetHelpFunc(func(cmd *cobra.Command, args []string) {
 		defaultHelp(cmd, args)
 		fmt.Println("")
-		fmt.Println("Additional documentation available at https://docs.pulumi.com")
+		fmt.Println("Additional documentation available at https://pulumi.io")
 	})
 
 	cmd.PersistentFlags().StringVarP(&cwd, "cwd", "C", "",

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -19,7 +19,7 @@ Using yarn:
 $ yarn add @pulumi/pulumi
 ```
 
-This SDK is meant for use with the Pulumi CLI.  Please visit [docs.pulumi.com](https://docs.pulumi.com) for
+This SDK is meant for use with the Pulumi CLI.  Please visit [pulumi.io](https://pulumi.io) for
 installation instructions.
 
 ## Building and Testing


### PR DESCRIPTION
The docs website is moving to https://pulumi.io from
https://docs.pulumi.com