### PR TITLE
Appease linters.

### DIFF
--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -959,8 +959,9 @@ func addNextFileToZIP(r ArchiveReader, zw *zip.Writer) error {
 		Method: zip.Deflate,
 	}
 
-	// Set a nonzero -- but constant -- modification time.
-	// Otherwise, some agents (e.g. Azure websites) can't extract the resulting archive.
+	// Set a nonzero -- but constant -- modification time. Otherwise, some agents (e.g. Azure websites) can't extract the
+	// resulting archive. We use `SetModTime` for go1.9 compatibility.
+	// nolint: megacheck
 	fh.SetModTime(time.Unix(0, 0))
 
 	fw, err := zw.CreateHeader(fh)

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -202,13 +202,13 @@ func (ctx *Context) ReadResource(
 		}
 
 		// No matter the outcome, make sure all promises are resolved.
-		var urn, id string
+		var urn, resID string
 		var props *structpb.Struct
 		if resp != nil {
-			urn, id = resp.Urn, string(id)
+			urn, resID = resp.Urn, string(id)
 			props = resp.Properties
 		}
-		op.complete(err, urn, id, props)
+		op.complete(err, urn, resID, props)
 
 		// Signal the completion of this RPC and notify any potential awaiters.
 		ctx.endRPC()
@@ -267,13 +267,13 @@ func (ctx *Context) RegisterResource(
 		}
 
 		// No matter the outcome, make sure all promises are resolved.
-		var urn, id string
+		var urn, resID string
 		var props *structpb.Struct
 		if resp != nil {
-			urn, id = resp.Urn, string(id)
+			urn, resID = resp.Urn, resp.Id
 			props = resp.Object
 		}
-		op.complete(err, urn, id, props)
+		op.complete(err, urn, resID, props)
 
 		// Signal the completion of this RPC and notify any potential awaiters.
 		ctx.endRPC()


### PR DESCRIPTION
- Fix a couple self-assignment issues in the Go language support
- Disable `megacheck` for `fh.SetModTime`, which we use for go1.9
  compat.