### PR TITLE
Use an even more reasonable modtime in ZIP entries

### DIFF
--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -959,10 +959,12 @@ func addNextFileToZIP(r ArchiveReader, zw *zip.Writer) error {
 		Method: zip.Deflate,
 	}
 
-	// Set a nonzero -- but constant -- modification time. Otherwise, some agents (e.g. Azure websites) can't extract the
-	// resulting archive. We use `SetModTime` for go1.9 compatibility.
+	// Set a nonzero -- but constant -- modification time. Otherwise, some agents (e.g. Azure
+	// websites) can't extract the resulting archive. The date is comfortably after 1980 because
+	// the ZIP format includes a date representation that starts at 1980. Use `SetModTime` to
+	// remain compatible with Go 1.9.
 	// nolint: megacheck
-	fh.SetModTime(time.Unix(0, 0))
+	fh.SetModTime(time.Date(1990, time.January, 1, 0, 0, 0, 0, time.UTC))
 
 	fw, err := zw.CreateHeader(fh)
 	if err != nil {


### PR DESCRIPTION
The ZIP format started with MS-DOS dates, which start in 1980. Other dates
have been layered on, but the ZIP file handler used by Azure websites still
relies on the MS-DOS dates.

Using the Unix epoch here (1970) results in ZIP entries that (e.g.)
OSX `unzip` sees as 12-31-1969 (timezones) but Azure websites sees as
01/01/2098.