### PR TITLE
Publish SDK builds to get.pulumi.com

### DIFF
--- a/scripts/build-sdk.ps1
+++ b/scripts/build-sdk.ps1
@@ -6,7 +6,7 @@
 Set-StrictMode -Version 2.0
 $ErrorActionPreference = "Stop"
 
-$S3ProdBucketRoot="s3://rel.pulumi.com/releases/"
+$S3ProdBucketRoot="s3://get.pulumi.com/releases/"
 $S3EngBucketRoot="s3://eng.pulumi.com/releases/"
 $S3PublishFolderSdk="${S3ProdBucketRoot}sdk/"
 
@@ -38,7 +38,7 @@ function Download-Release ($repoName, $repoCommit, [ValidateSet("zip", "tgz")]$e
 if (!$VersionTag) { $VersionTag=Get-Date -UFormat '%Y%m%d_%H%M%S' }
 if (!$PulumiRef) { $PulumiRef="master" }
 
-$SdkFileName="pulumi-$VersionTag-windows.x64.zip"
+$SdkFileName="pulumi-$VersionTag-windows-x64.zip"
 
 $PulumiFolder=(Join-Path (New-TemporaryDirectory) "Pulumi")
 
@@ -72,7 +72,7 @@ $env:AWS_ACCESS_KEY_ID=$AWSCreds.Credentials.AccessKeyId
 $env:AWS_SECRET_ACCESS_KEY=$AWSCreds.Credentials.SecretAccessKey
 $env:AWS_SECURITY_TOKEN=$AWSCreds.Credentials.SessionToken
 
-aws s3 cp --only-show-errors "$SdkPackagePath" "${S3PublishFolderSdk}${SdkFileName}"
+aws s3 cp --acl public-read --only-show-errors "$SdkPackagePath" "${S3PublishFolderSdk}${SdkFileName}"
 
 Pop-Location | Out-Null
 

--- a/scripts/build-sdk.sh
+++ b/scripts/build-sdk.sh
@@ -6,7 +6,7 @@
 set -o nounset -o errexit -o pipefail
 SCRIPT_DIR="$( cd "$( dirname "$0" )" && pwd )"
 
-S3_PROD_BUCKET_ROOT="s3://rel.pulumi.com/releases/"
+S3_PROD_BUCKET_ROOT="s3://get.pulumi.com/releases/"
 S3_ENG_BUCKET_ROOT="s3://eng.pulumi.com/releases/"
 S3_PUBLISH_FOLDER_SDK="${S3_PROD_BUCKET_ROOT}sdk/"
 
@@ -56,7 +56,7 @@ case $(uname) in
     *) echo "error: unknown host os $(uname)" ; exit 1;;
 esac
 
-SDK_FILENAME=pulumi-${1:-$(date +"%Y%m%d_%H%M%S")}-${OS}.x64.tar.gz
+SDK_FILENAME=pulumi-${1:-$(date +"%Y%m%d_%H%M%S")}-${OS}-x64.tar.gz
 PULUMI_REF=${2:-master}
 
 # setup temporary folder to process the package
@@ -96,7 +96,7 @@ export AWS_ACCESS_KEY_ID=$(echo ${CREDS_JSON}     | jq ".Credentials.AccessKeyId
 export AWS_SECRET_ACCESS_KEY=$(echo ${CREDS_JSON} | jq ".Credentials.SecretAccessKey" --raw-output)
 export AWS_SECURITY_TOKEN=$(echo ${CREDS_JSON}    | jq ".Credentials.SessionToken" --raw-output)
 
-aws s3 cp --only-show-errors "${SDK_PACKAGE_PATH}" "${S3_PUBLISH_FOLDER_SDK}${SDK_FILENAME}"
+aws s3 cp --acl public-read --only-show-errors "${SDK_PACKAGE_PATH}" "${S3_PUBLISH_FOLDER_SDK}${SDK_FILENAME}"
 
 rm "${SDK_PACKAGE_PATH}"
 rm -rf "${PULUMI_FOLDER}/"


### PR DESCRIPTION
Previously, we published builds to rel.pulumi.com and only put actual
released builds (eg. rc's and final builds) on get.pulumi.com. We
should just publish all of the SDK builds to get.pulumi.com.

This also makes a slight tweak to the filename of the package we
upload (we took the switch over to get.pulumi.com to make this change
and now that we are uploading automatically, we need to encode this
change instead of doing it by hand).