### PR TITLE
Fix some build and test issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 **/.vscode/
 coverage.cov
 *.coverprofile
-custom_node/
 
-# Too much awesome to store in Git.
-.pulumi
+# Go tests run "in tree" and this folder will linger if they fail (the integration test framework cleans
+# it up when they pass.)
+**/command-output/

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -300,6 +300,8 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 //   pulumi config set --secret <each opts.Secrets>
 //   pulumi preview
 //   pulumi update
+//   pulumi stack export --file stack.json
+//   pulumi stack import --file stack.json
 //   pulumi preview (expected to be empty)
 //   pulumi update (expected to be empty)
 //   pulumi destroy --yes
@@ -620,6 +622,13 @@ func (pt *programTester) testPreviewUpdateAndEdits(dir string) error {
 
 	// Perform an empty preview and update; nothing is expected to happen here.
 	if !pt.opts.Quick {
+
+		fprintf(pt.opts.Stdout, "Roundtripping checkpoint via stack export and stack import\n")
+
+		if err := pt.exportImport(dir); err != nil {
+			return err
+		}
+
 		msg := ""
 		if !pt.opts.AllowEmptyUpdateChanges {
 			msg = "(no changes expected)"
@@ -639,6 +648,21 @@ func (pt *programTester) testPreviewUpdateAndEdits(dir string) error {
 
 	// If there are any edits, apply them and run a preview and update for each one.
 	return pt.testEdits(dir)
+}
+
+func (pt *programTester) exportImport(dir string) error {
+	exportCmd := []string{"stack", "export", "--file", "stack.json"}
+	importCmd := []string{"stack", "import", "--file", "stack.json"}
+
+	defer func() {
+		contract.IgnoreError(os.Remove(filepath.Join(dir, "stack.json")))
+	}()
+
+	if err := pt.runPulumiCommand("pulumi-stack-export", exportCmd, dir); err != nil {
+		return err
+	}
+
+	return pt.runPulumiCommand("pulumi-stack-import", importCmd, dir)
 }
 
 func (pt *programTester) previewAndUpdate(dir string, name string, shouldFail, expectNopPreview,

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -58,7 +58,7 @@ func TestRunCommandLog(t *testing.T) {
 	err = RunCommand(nil, "node", args, tempdir, opts)
 	assert.Nil(t, err)
 
-	matches, err := filepath.Glob(filepath.Join(tempdir, "command-output", "node.*"))
+	matches, err := filepath.Glob(filepath.Join(tempdir, commandOutputFolderName, "node.*"))
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(matches))
 

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -64,8 +64,12 @@ func uniqueSuffix() string {
 	return suffix
 }
 
+const (
+	commandOutputFolderName = "command-output"
+)
+
 func writeCommandOutput(commandName, runDir string, output []byte) (string, error) {
-	logFileDir := filepath.Join(runDir, "command-output")
+	logFileDir := filepath.Join(runDir, commandOutputFolderName)
 	if err := os.MkdirAll(logFileDir, 0700); err != nil {
 		return "", errors.Wrapf(err, "Failed to create '%s'", logFileDir)
 	}


### PR DESCRIPTION
- Don't leave the worktree dirty after running the integration tests for golang
- Do Export/Import as part of the standard lifecycle testing instead of in a one off test.