### PR TITLE
Don't set NODE_PATH in dynamic provider

### DIFF
--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
@@ -1,3 +1,2 @@
 #!/bin/sh
-export NODE_PATH="$NODE_PATH:`dirname $0`/v6.10.2"
 node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider $@

--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
@@ -1,2 +1,1 @@
-@set NODE_PATH=%NODE_PATH%;%~dp0\v6.10.2
 @node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider %*


### PR DESCRIPTION
This is a holdover from our old strategy for closure serialization. We
no longer use this module, so we don't need to tell Node where it is
anymore.