### PR TITLE
Add Apache 2.0 License metadata to Python package

### DIFF
--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -20,6 +20,7 @@ setup(name='pulumi',
       version='${VERSION}',
       description='Pulumi\'s Python SDK',
       url='https://github.com/pulumi/pulumi',
+      license='Apache 2.0',
       packages=find_packages(),
       install_requires=[
           'google==2.0.1',


### PR DESCRIPTION
This ensures we have a License listed when the package is published to PyPI.

Before: https://test.pypi.org/project/pulumi/0.12.4.dev1528774573/
After: https://test.pypi.org/project/pulumi/0.14.1.dev1529086603/

Note the additional Meta section that lists "Apache 2.0" as the license.