### PR TITLE
Issue an error when attempting to read an invalid Asset.

### DIFF
--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -291,7 +291,7 @@ func (a *Asset) Read() (*Blob, error) {
 	} else if a.IsURI() {
 		return a.readURI()
 	}
-	return nil, nil
+	return nil, errors.New("unrecognized asset type")
 }
 
 func (a *Asset) readText() (*Blob, error) {


### PR DESCRIPTION
As an alternative we could consider simply returning an empty `Blob`.
I think it's better to fail loudly, though, as this situation can result
from unexpected/invalid archives (which we need to do a better job of
validating).

Fixes #1493.