### PR TITLE
Exclude resources originating from `ReadResource` from dependency list

### DIFF
--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -50,7 +50,7 @@ func TestMarshalRoundtrip(t *testing.T) {
 	}
 
 	// Marshal those inputs.
-	_, m, deps, err := marshalInputs(input)
+	_, m, deps, err := marshalInputs(nil, input)
 	if !assert.Nil(t, err) {
 		assert.Equal(t, 0, len(deps))
 

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -34,6 +34,14 @@ export abstract class Resource {
      // tslint:disable-next-line:variable-name
      /* @internal */ private readonly __pulumiResource: boolean = true;
 
+
+    /**
+     * An internal field that indicates whether or not this resource originated from
+     * a `readResource` call, rather than `registerResource`. Originating from `readResource`
+     * means that Pulumi does not manage this resource.
+     */
+    /* @internal */ public wasRead: boolean = false;
+
     /**
      * urn is the stable logical URN used to distinctly address a resource, both before and after
      * deployments.
@@ -79,6 +87,7 @@ export abstract class Resource {
                 throw new RunError("Cannot read an existing resource unless it has a custom provider");
             }
             readResource(this, t, name, props, opts);
+            this.wasRead = true;
         } else {
             // Kick off the resource registration.  If we are actually performing a deployment, this
             // resource's properties will be resolved asynchronously after the operation completes, so

--- a/sdk/nodejs/tests/runtime/langhost/cases/017.read_dependency/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/017.read_dependency/index.js
@@ -1,0 +1,28 @@
+// Test the ability to invoke provider functions via RPC.
+
+const assert = require("assert");
+const pulumi = require("../../../../../");
+
+const inputs = {
+    field: "state"
+};
+
+const res = new pulumi.CustomResource("custom:read:Read", "test", inputs, {
+    id: "foobar"
+});
+
+const notRead = new pulumi.CustomResource("custom:read:Read", "not-read", {
+    field: "testing",
+});
+
+const other = new pulumi.CustomResource("custom:read:Read", "dependent", {
+    field: pulumi.all([res.field, notRead.field]).apply(([a, b]) => a + " " + b),
+});
+
+// Same thing as above, but using `dependsOn` instead of output dependencies
+const dependsOnDep = new pulumi.CustomResource("custom:read:Read", "dependson", {
+    field: "unrelated",
+}, { dependsOn: [res, notRead]});
+
+other.field.apply(v => assert.strictEqual(v, "foobar testing"));
+dependsOnDep.field.apply(v => assert.strictEqual(v, "unrelated"));

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -378,6 +378,38 @@ describe("rpc", () => {
             program: path.join(base, "016.promise_leak"),
             expectError: "Program exited with non-zero exit code: 1",
         },
+        "read_dependency": {
+            program: path.join(base, "017.read_dependency"),
+            expectResourceCount: 3,
+            readResource: (ctx: any, t: string, name: string, id: string, par: string, state: any) => {
+                assert.strictEqual(t, "custom:read:Read");
+                assert.strictEqual(name, "test");
+                assert.strictEqual(id, "foobar");
+                return {
+                    urn: makeUrn(t, name),
+                    props: {
+                        field: "foobar",
+                    },
+                };
+            },
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string,
+                               res: any, dependencies: string[]) => {
+                assert.strictEqual(t, "custom:read:Read");
+                if (name === "dependent" || name === "dependson") {
+                    assert.deepEqual(dependencies, [
+                        makeUrn(t, "not-read"),
+                    ]);
+                }
+
+                return {
+                    id: name,
+                    urn: makeUrn(t, name),
+                    props: {
+                        field: res.field,
+                    },
+                };
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1521.

When computing the list of dependencies of a resource to send to the engine, both the Go and NodeJS language hosts enumerated all implicit and explicit dependencies and passed that list verbatim to the engine. However, these implicit and explicit dependencies can refer to resources that we do not manage, but were instead created through calls to `ReadResource` (exposed as `get` in Node). The engine is not aware of these resources at all and is very confused when a resource shows up that depends on a resource that does not exist.

To fix this problem, this PR only informs the engine of a dependency if that resource did not come from a Read. This PR provides Go and Node fixes for the bug in separate commits. The Node commit adds a test. The Go commit does not, mostly because `ReadResource` doesn't work for Go so this fix can't be tested anyway (https://github.com/pulumi/pulumi/issues/1530).