### PR TITLE
 Do a better job preventing serialization of unnecessary objects in closure serialization

### DIFF
--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -923,6 +923,10 @@ function getOrCreateEntry(
                 // Determine what chained property names we're accessing off of this sub-property.
                 // if we have no sub property name chain, then indicate that with an empty array
                 // so that we capture the entire object.
+                //
+                // i.e.: if we started with a.b.c.d, and we've finally gotten to the point where
+                // we're serializing out the 'd' property, then we need to serialize it out fully
+                // since there are no more accesses off of it.
                 let nestedPropChains = propChains.map(chain => ({ infos: chain.infos.slice(1) }));
                 if (nestedPropChains.some(chain => chain.infos.length === 0)) {
                     nestedPropChains = [];

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -198,6 +198,10 @@ class SerializedOutput<T> implements resource.Output<T> {
 export async function createFunctionInfoAsync(
     func: Function, serialize: (o: any) => boolean): Promise<FunctionInfo> {
 
+    if ("a".length > 0) {
+        throw new RunError("blah blah");
+    }
+
     const context: Context = {
         cache: new Map(),
         classInstanceMemberToSuperEntry: new Map(),
@@ -602,10 +606,10 @@ function throwSerializationError(func: Function, context: Context, info: string)
             message += `'${frame.capturedFunctionName}', a function defined at\n`;
         }
         else if (frame.capturedModuleName) {
-            message += `module '${frame.capturedModuleName}' which indirectly referenced\n`;
+            message += `module1 '${frame.capturedModuleName}' which indirectly referenced\n`;
         }
         else if (frame.capturedVariableName) {
-            message += `variable '${frame.capturedVariableName}' which indirectly referenced\n`;
+            message += `variable1 '${frame.capturedVariableName}' which indirectly referenced\n`;
         }
     }
 

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -754,10 +754,6 @@ function getOrCreateEntry(
             // caller explicitly does not want us to capture this value.
             entry.json = undefined;
         }
-        else if (obj instanceof Function) {
-            // Serialize functions recursively, and store them in a closure property.
-            entry.function = createFunctionInfo(obj, context, serialize, logInfo);
-        }
         else if (obj && obj.doNotCapture) {
             // object has set itself as something that should not be captured.
             entry.json = undefined;

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -903,7 +903,7 @@ function getOrCreateEntry(
         // validate our invariants.
         for (const chain of localCapturedPropertyChains) {
             if (chain.infos.length === 0) {
-                throw new Error("We should never have gotten an empty chain.");
+                throw new Error("Expected a non-empty chain.");
             }
         }
 

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -314,9 +314,6 @@ function createFunctionInfo(
         serialize: (o: any) => boolean, logInfo?: boolean): FunctionInfo {
 
     // logInfo = logInfo || func.name === "addHandler";
-    if (logInfo) {
-        console.log("Serializing " + func.name);
-    }
 
     const file: string =  v8.getFunctionFile(func);
     const line: number = v8.getFunctionLine(func);
@@ -367,20 +364,6 @@ function createFunctionInfo(
         const [error, parsedFunction] = parseFunction(functionString);
         if (error) {
             throwSerializationError(func, context, error);
-        }
-
-        if (logInfo) {
-            console.log("required variables: " + JSON.stringify(makeObject(parsedFunction.capturedVariables.required)));
-        }
-
-        function makeObject(map: Map<string, any>) {
-            const res: any = {};
-
-            map.forEach((v, k) => {
-                res[k] = v;
-            });
-
-            return res;
         }
 
         const funcExprWithName = parsedFunction.funcExprWithName;
@@ -530,10 +513,6 @@ function createFunctionInfo(
 
             const properties = capturedVariables.get(name);
             const serializedName = getOrCreateEntry(name, undefined, context, serialize, logInfo);
-
-            if (logInfo) {
-                console.log("Serializing " + name + ", " + JSON.stringify(properties));
-            }
 
             // try to only serialize out the properties that were used by the user's code.
             const serializedValue = getOrCreateEntry(value, properties, context, serialize, logInfo);
@@ -825,17 +804,8 @@ function getOrCreateEntry(
     function serializeObject() {
         // Serialize the set of property names asked for.  If we discover that any of them
         // use this/super, then go and reserialize all the properties.
-
-        if (logInfo) {
-            console.log("First trying to serialize some props.");
-        }
-
         const serializeAll = serializeObjectWorker(capturedObjectProperties || []);
         if (serializeAll) {
-            if (logInfo) {
-                console.log("Falling back to trying to serialize all props.");
-            }
-
             serializeObjectWorker([]);
         }
     }
@@ -846,10 +816,6 @@ function getOrCreateEntry(
         const objectInfo: ObjectInfo = entry.object || { env: new Map() };
         entry.object = objectInfo;
         const environment = entry.object.env;
-
-        if (logInfo) {
-            console.log("Serializing object");
-        }
 
         if (localCapturedPropertyChains.length === 0) {
             serializeAllObjectProperties(environment);
@@ -862,10 +828,6 @@ function getOrCreateEntry(
     // Serializes out all the properties of this object.  Used when we can't prove that
     // only a subset of properties are used on this object.
     function serializeAllObjectProperties(environment: PropertyMap) {
-        if (logInfo) {
-            console.log("Serializing all props.");
-        }
-
         // we wanted to capture everything (including the prototype chain)
         const ownPropertyNamesAndSymbols = getOwnPropertyNamesAndSymbols(obj);
 
@@ -907,11 +869,8 @@ function getOrCreateEntry(
     // and have recorded in localCapturedPropertyChains
     function serializeSomeObjectProperties(
             environment: PropertyMap, localCapturedPropertyChains: CapturedPropertyChain[]): boolean {
-        if (logInfo) {
-            console.log("Serializing some props " + JSON.stringify(localCapturedPropertyChains));
-        }
 
-        // validate our invariants.
+                // validate our invariants.
         for (const chain of localCapturedPropertyChains) {
             if (chain.infos.length === 0) {
                 throw new Error("We should never have gotten an empty chain.");

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -60,6 +60,14 @@ export interface CapturedPropertyChain {
     infos: CapturedPropertyInfo[];
 }
 
+// A mapping from the names of variables we captured, to information about how those variables were
+// used.  For example, if we see "a.b.c()" (and 'a' is not declared in the function), we'll record a
+// mapping of { "a": ['b', 'c' (invoked)] }.  i.e. we captured 'a', accessed the properties 'b.c'
+// off of it, and we invoked that property access.  With this information we can decide the totality
+// of what we need to capture for 'a'.
+//
+// Note: if we want to capture everything, we just use an empty array for 'CapturedPropertyChain[]'.
+// Otherwise, we'll use the chains to determine what portions of the object to serialize.
 export type CapturedVariableMap = Map<string, CapturedPropertyChain[]>;
 
 // The set of variables the function attempts to capture.  There is a required set an an optional

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -509,7 +509,8 @@ function computeCapturedVariableNames(file: ts.SourceFile): CapturedVariables {
     function determineCapturedPropertyChain(node: ts.Node): CapturedPropertyChain | undefined {
         let infos: CapturedPropertyInfo[] | undefined;
 
-        // Walk up a sequence of dotted names until we hit something else.
+        // Walk up a sequence of property-access'es, recording the names we hit, until we hit
+        // something that isn't a property-access.
         while (node &&
                node.parent &&
                ts.isPropertyAccessExpression(node.parent) &&
@@ -531,6 +532,7 @@ function computeCapturedVariableNames(file: ts.SourceFile): CapturedVariables {
         }
 
         if (infos) {
+            // Invariant checking.
             if (infos.length === 0) {
                 throw new Error("How did we end up with an empty list?");
             }

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -501,22 +501,8 @@ function computeCapturedVariableNames(file: ts.SourceFile): CapturedVariables {
         // We want to capture a specific set of properties.  Add this set of properties
         // into the existing set.
         const combined = existing || [];
-
-        // See if we've already marked this property as captured.  If so, make sure we still record
-        // if this property was invoked or not.
-        // if (current.infos[current.infos.length - 1].invoked) {
-
-        // }
-
-        // for (const existingProp of combined) {
-        //     if (existingProp.name === current.name) {
-        //         existingProp.invoked = existingProp.invoked || current.invoked;
-        //         return combined;
-        //     }
-        // }
-
-        // Haven't seen this property.  Record that we're capturing it.
         combined.push(current);
+
         return combined;
     }
 

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -137,7 +137,10 @@ function parseFunctionCode(funcString: string): [string, ParsedFunctionCode] {
         return [`the function form was not understood.`, <any>undefined];
     }
 
-    if (funcString.indexOf("[native code]") !== -1) {
+    // Split this constant out so that if this function *itself* is closure serialized,
+    // it will not be thought to be native code itself.
+    const nativeCodeString = "[native " + "code]";
+    if (funcString.indexOf(nativeCodeString) !== -1) {
         return [`it was a native code function.`, <any>undefined];
     }
 

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -53,7 +53,14 @@ export interface CapturedPropertyInfo {
     invoked: boolean;
 }
 
-export type CapturedVariableMap = Map<string, CapturedPropertyInfo[]>;
+// Information about a chain of captured properties.  i.e. if you have "foo.bar.baz.quux()", we'll
+// say that 'foo' was captured, but that "[bar, baz, quux]" was accessed off of it.  We'll also note
+// that 'quux' was invoked.
+export interface CapturedPropertyChain {
+    infos: CapturedPropertyInfo[];
+}
+
+export type CapturedVariableMap = Map<string, CapturedPropertyChain[]>;
 
 // The set of variables the function attempts to capture.  There is a required set an an optional
 // set. The optional set will not block closure-serialization if we cannot find them, while the
@@ -422,14 +429,14 @@ function computeCapturedVariableNames(file: ts.SourceFile): CapturedVariables {
         }
 
         // We reached the top of the scope chain and this wasn't found; it's captured.
-        const capturedProperty = determineCapturedPropertyInfo(node);
+        const capturedPropertyChain = determineCapturedPropertyChain(node);
         if (node.parent!.kind === ts.SyntaxKind.TypeOfExpression) {
             // "typeof undeclared_id" is legal in JS (and is actually used in libraries). So keep
             // track that we would like to capture this variable, but mark that capture as optional
             // so we will not throw if we aren't able to find it in scope.
-            optional.set(name, combineProperties(optional.get(name), capturedProperty));
+            optional.set(name, combineProperties(optional.get(name), capturedPropertyChain));
         } else {
-            required.set(name, combineProperties(required.get(name), capturedProperty));
+            required.set(name, combineProperties(required.get(name), capturedPropertyChain));
         }
     }
 
@@ -474,11 +481,12 @@ function computeCapturedVariableNames(file: ts.SourceFile): CapturedVariables {
     }
 
     function visitThisExpression(node: ts.ThisExpression): void {
-        required.set("this", combineProperties(required.get("this"), determineCapturedPropertyInfo(node)));
+        required.set(
+            "this", combineProperties(required.get("this"), determineCapturedPropertyChain(node)));
     }
 
-    function combineProperties(existing: CapturedPropertyInfo[] | undefined,
-                               current: CapturedPropertyInfo | undefined) {
+    function combineProperties(existing: CapturedPropertyChain[] | undefined,
+                               current: CapturedPropertyChain | undefined) {
         if (existing && existing.length === 0) {
             // We already want to capture everything.  Keep things that way.
             return existing;
@@ -496,29 +504,58 @@ function computeCapturedVariableNames(file: ts.SourceFile): CapturedVariables {
 
         // See if we've already marked this property as captured.  If so, make sure we still record
         // if this property was invoked or not.
-        for (const existingProp of combined) {
-            if (existingProp.name === current.name) {
-                existingProp.invoked = existingProp.invoked || current.invoked;
-                return combined;
-            }
-        }
+        // if (current.infos[current.infos.length - 1].invoked) {
+
+        // }
+
+        // for (const existingProp of combined) {
+        //     if (existingProp.name === current.name) {
+        //         existingProp.invoked = existingProp.invoked || current.invoked;
+        //         return combined;
+        //     }
+        // }
 
         // Haven't seen this property.  Record that we're capturing it.
         combined.push(current);
         return combined;
     }
 
-    function determineCapturedPropertyInfo(node: ts.Node): CapturedPropertyInfo | undefined {
-        if (node.parent &&
-            ts.isPropertyAccessExpression(node.parent) &&
-            node.parent.expression === node) {
+    function determineCapturedPropertyChain(node: ts.Node): CapturedPropertyChain | undefined {
+        let infos: CapturedPropertyInfo[] | undefined;
+
+        // Walk up a sequence of dotted names until we hit something else.
+        while (node &&
+               node.parent &&
+               ts.isPropertyAccessExpression(node.parent) &&
+               node.parent.expression === node) {
 
             const propertyAccess = <ts.PropertyAccessExpression>node.parent;
             const invoked = propertyAccess.parent !== undefined &&
                             ts.isCallExpression(propertyAccess.parent) &&
                             propertyAccess.parent.expression === propertyAccess;
 
-            return { name: node.parent.name.text, invoked };
+            if (!infos) {
+                infos = [];
+            }
+
+            // Keep track if this name was invoked.  If so, we'll have to analyze it later
+            // to see if it captured 'this'
+            infos.push({ name: node.parent.name.text, invoked });
+            node = node.parent;
+        }
+
+        if (infos) {
+            if (infos.length === 0) {
+                throw new Error("How did we end up with an empty list?");
+            }
+
+            for (let i = 0; i < infos.length - 1; i++) {
+                if (infos[i].invoked) {
+                    throw new Error("Only the last item in the dotted chain is allowed to be invoked.");
+                }
+            }
+
+            return { infos };
         }
 
         // For all other cases, capture everything.

--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -438,6 +438,7 @@ function serializeJavaScriptText(
         }
     }
 }
+(<any>serializeJavaScriptText).doNotCapture = true;
 
 const makeLegalRegex = /[^0-9a-zA-Z_]/g;
 function makeLegalJSName(n: string) {

--- a/sdk/nodejs/runtime/closure/v8.ts
+++ b/sdk/nodejs/runtime/closure/v8.ts
@@ -62,8 +62,17 @@ interface V8SourceLocation {
 // index i.
 const getFunctionScopeDetails: (func: Function, index: number) => any[] =
     new Function("func", "index", "return %GetFunctionScopeDetails(func, index);") as any;
+
 const getFunctionScopeCount: (func: Function) => number =
     new Function("func", "return %GetFunctionScopeCount(func);") as any;
+
+// All of these functions contain syntax that is not legal TS/JS (i.e. "%Whatever").  As such,
+// we cannot serialize them.  In case they somehow get captured, just block them from closure
+// serialization entirely.
+(<any>getScript).doNotCapture = true;
+(<any>getSourcePosition).doNotCapture = true;
+(<any>getFunctionScopeDetails).doNotCapture = true;
+(<any>getFunctionScopeCount).doNotCapture = true;
 
 // `GetFunctionScopeDetails` returns a raw JavaScript array. This enum enumerates the objects that
 // are at specific indices of the array. We only care about one of these.

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -3852,6 +3852,46 @@ return function /*f1*/() {
     }
 
     {
+        const o = { a: 1, b: () => console.log("the actual function") };
+        (<any>o.b).doNotCapture = true;
+
+        function f1() {
+            console.log(o);
+        }
+
+        cases.push({
+            title: "Do not capture #2",
+            func: f1,
+            expectText: `exports.handler = __f1;
+
+var __o = {a: 1, b: __f0};
+
+function __f0() {
+  return (function() {
+    with({ message: "Function 'b' cannot be called at runtime. It can only be used at deployment time.\\n\\nFunction code:\\n  () => console.log(\\"the actual function\\")\\n" }) {
+
+return () => { throw new Error(message); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f1() {
+  return (function() {
+    with({ o: __o, f1: __f1 }) {
+
+return function /*f1*/() {
+            console.log(o);
+        };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+});
+    }
+
+    {
         const lambda1 = () => console.log(1);
         const lambda2 = () => console.log(1);
 

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -4433,6 +4433,58 @@ return function () { console.log(o.b()); console.log(o.b.name); };
         });
     }
 
+    {
+        const o1 = { c: 2, d: 3 };
+        const o2 = { a: 1, b: o1 };
+
+        cases.push({
+            title: "Analyze property chain #14",
+            func: function () { console.log(o2.b.d); console.log(o1); },
+            expectText: `exports.handler = __f0;
+
+var __o2 = {};
+var __o2_b = {d: 3, c: 2};
+__o2.b = __o2_b;
+
+function __f0() {
+  return (function() {
+    with({ o2: __o2, o1: __o2_b }) {
+
+return function () { console.log(o2.b.d); console.log(o1); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o1 = { c: 2, d: 3 };
+        const o2 = { a: 1, b: o1 };
+
+        cases.push({
+            title: "Analyze property chain #15",
+            func: function () { console.log(o1); console.log(o2.b.d); },
+            expectText: `exports.handler = __f0;
+
+var __o1 = {c: 2, d: 3};
+var __o2 = {};
+__o2.b = __o1;
+
+function __f0() {
+  return (function() {
+    with({ o1: __o1, o2: __o2 }) {
+
+return function () { console.log(o1); console.log(o2.b.d); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
     // Run a bunch of direct checks on async js functions if we're in node 8 or above.
     // We can't do this inline as node6 doesn't understand 'async functions'.  And we
     // can't do this in TS as TS will convert the async-function to be a normal non-async

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -4007,9 +4007,7 @@ return function () { console.log(exports.exportedValue); };
             expectText: `exports.handler = __f0;
 
 var __module = {};
-var __module_exports = {};
-Object.defineProperty(__module_exports, "__esModule", { value: true });
-__module_exports.exportedValue = 42;
+var __module_exports = {exportedValue: 42};
 __module.exports = __module_exports;
 
 function __f0() {
@@ -4032,7 +4030,7 @@ return function () { console.log(module.exports.exportedValue); };
         }
 
         cases.push({
-            title: "Required pacakges #1",
+            title: "Required packages #1",
             func: function () { require("typescript"); foo(); if (true) { require("os") } },
             expectPackages: new Set(["os", "typescript", "./util"]),
             expectText: `exports.handler = __f0;
@@ -4056,6 +4054,377 @@ function __f0() {
 return function () { require("typescript"); foo(); if (true) {
                 require("os");
             } };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: { c: 2, d: 3 } };
+
+        cases.push({
+            title: "Analyze property chain #1",
+            func: function () { console.log(o.b.c); },
+            expectText: `exports.handler = __f0;
+
+var __o = {};
+var __o_b = {c: 2};
+__o.b = __o_b;
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b.c); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: { c: 2, d: 3 } };
+
+        cases.push({
+            title: "Analyze property chain #2",
+            func: function () { console.log(o.b); console.log(o.b.c); },
+            expectText: `exports.handler = __f0;
+
+var __o = {};
+var __o_b = {c: 2, d: 3};
+__o.b = __o_b;
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b); console.log(o.b.c); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: { c: 2, d: 3 } };
+
+        cases.push({
+            title: "Analyze property chain #3",
+            func: function () { console.log(o.b); },
+            expectText: `exports.handler = __f0;
+
+var __o = {};
+var __o_b = {c: 2, d: 3};
+__o.b = __o_b;
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: { c: 2, d: 3 } };
+
+        cases.push({
+            title: "Analyze property chain #4",
+            func: function () { console.log(o.a); },
+            expectText: `exports.handler = __f0;
+
+var __o = {a: 1};
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.a); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: { c: { d: 1, e: 3 } } };
+
+        cases.push({
+            title: "Analyze property chain #5",
+            func: function () { console.log(o.b.c.d); },
+            expectText: `exports.handler = __f0;
+
+var __o = {};
+var __o_b = {};
+var __o_b_c = {d: 1};
+__o_b.c = __o_b_c;
+__o.b = __o_b;
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b.c.d); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: { c: { d: 1, e: 3 } } };
+
+        cases.push({
+            title: "Analyze property chain #6",
+            func: function () { console.log(o.b.c.d); console.log(o.b); },
+            expectText: `exports.handler = __f0;
+
+var __o = {};
+var __o_b = {};
+var __o_b_c = {d: 1, e: 3};
+__o_b.c = __o_b_c;
+__o.b = __o_b;
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b.c.d); console.log(o.b); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: { c: { d: 1, e: 3 } } };
+
+        cases.push({
+            title: "Analyze property chain #7",
+            func: function () { console.log(o.b.c.d); console.log(o.b.c); },
+            expectText: `exports.handler = __f0;
+
+var __o = {};
+var __o_b = {};
+var __o_b_c = {d: 1, e: 3};
+__o_b.c = __o_b_c;
+__o.b = __o_b;
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b.c.d); console.log(o.b.c); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: { c: { d: 1, e: 3 } } };
+
+        cases.push({
+            title: "Analyze property chain #8",
+            func: function () { console.log(o.b.c.d); console.log(o.b.c); console.log(o.b); },
+            expectText: `exports.handler = __f0;
+
+var __o = {};
+var __o_b = {};
+var __o_b_c = {d: 1, e: 3};
+__o_b.c = __o_b_c;
+__o.b = __o_b;
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b.c.d); console.log(o.b.c); console.log(o.b); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: function () { } };
+
+        cases.push({
+            title: "Analyze property chain #9",
+            func: function () { console.log(o.b.name); },
+            expectText: `exports.handler = __f0;
+
+var __o = {b: __f1};
+
+function __f1() {
+  return (function() {
+    with({  }) {
+
+return function () { };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b.name); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: function () { } };
+
+        cases.push({
+            title: "Analyze property chain #10",
+            func: function () { console.log(o.b.name); console.log(o.b()); },
+            expectText: `exports.handler = __f0;
+
+var __o = {b: __f1};
+
+function __f1() {
+  return (function() {
+    with({  }) {
+
+return function () { };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b.name); console.log(o.b()); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: function () { } };
+
+        cases.push({
+            title: "Analyze property chain #11",
+            func: function () { console.log(o.b()); console.log(o.b.name); },
+            expectText: `exports.handler = __f0;
+
+var __o = {b: __f1};
+
+function __f1() {
+  return (function() {
+    with({  }) {
+
+return function () { };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b()); console.log(o.b.name); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: function () { return this; } };
+
+        cases.push({
+            title: "Analyze property chain #12",
+            func: function () { console.log(o.b.name); console.log(o.b()); },
+            expectText: `exports.handler = __f0;
+
+var __o = {a: 1, b: __f1};
+
+function __f1() {
+  return (function() {
+    with({  }) {
+
+return function () { return this; };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b.name); console.log(o.b()); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o = { a: 1, b: function () { return this; } };
+
+        cases.push({
+            title: "Analyze property chain #13",
+            func: function () { console.log(o.b()); console.log(o.b.name); },
+            expectText: `exports.handler = __f0;
+
+var __o = {a: 1, b: __f1};
+
+function __f1() {
+  return (function() {
+    with({  }) {
+
+return function () { return this; };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f0() {
+  return (function() {
+    with({ o: __o }) {
+
+return function () { console.log(o.b()); console.log(o.b.name); };
 
     }
   }).apply(undefined, undefined).apply(this, arguments);

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -4485,6 +4485,180 @@ return function () { console.log(o1); console.log(o2.b.d); };
         });
     }
 
+    {
+        const o1 = { c: 2, d: 3 };
+        const o2 = { a: 1, b: o1 };
+        const o3 = { a: 1, b: o1 };
+
+        cases.push({
+            title: "Analyze property chain #16",
+            func: function () { console.log(o2.b.c); console.log(o3.b.d); },
+            expectText: `exports.handler = __f0;
+
+var __o2 = {};
+var __o2_b = {c: 2, d: 3};
+__o2.b = __o2_b;
+var __o3 = {};
+__o3.b = __o2_b;
+
+function __f0() {
+  return (function() {
+    with({ o2: __o2, o3: __o3 }) {
+
+return function () { console.log(o2.b.c); console.log(o3.b.d); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o1 = { c: 2, d: 3 };
+        const o2 = { a: 1, b: o1 };
+        const o3 = { a: 1, b: o1 };
+
+        cases.push({
+            title: "Analyze property chain #17",
+            func: function () { console.log(o2.b.d); console.log(o3.b.d); },
+            expectText: `exports.handler = __f0;
+
+var __o2 = {};
+var __o2_b = {d: 3};
+__o2.b = __o2_b;
+var __o3 = {};
+__o3.b = __o2_b;
+
+function __f0() {
+  return (function() {
+    with({ o2: __o2, o3: __o3 }) {
+
+return function () { console.log(o2.b.d); console.log(o3.b.d); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o1 = { c: 2, d: 3 };
+        const o2 = { a: 1, b: o1 };
+        const o3 = { a: 1, b: o1 };
+
+        cases.push({
+            title: "Analyze property chain #18",
+            func: function () { console.log(o2.b); console.log(o2.b.d); console.log(o3.b.d); },
+            expectText: `exports.handler = __f0;
+
+var __o2 = {};
+var __o2_b = {c: 2, d: 3};
+__o2.b = __o2_b;
+var __o3 = {};
+__o3.b = __o2_b;
+
+function __f0() {
+  return (function() {
+    with({ o2: __o2, o3: __o3 }) {
+
+return function () { console.log(o2.b); console.log(o2.b.d); console.log(o3.b.d); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o1 = { c: 2, d: 3 };
+        const o2 = { a: 1, b: o1 };
+        const o3 = { a: 1, b: o1 };
+
+        cases.push({
+            title: "Analyze property chain #19",
+            func: function () { console.log(o2.b.d); console.log(o3.b.d); console.log(o2.b); },
+            expectText: `exports.handler = __f0;
+
+var __o2 = {};
+var __o2_b = {c: 2, d: 3};
+__o2.b = __o2_b;
+var __o3 = {};
+__o3.b = __o2_b;
+
+function __f0() {
+  return (function() {
+    with({ o2: __o2, o3: __o3 }) {
+
+return function () { console.log(o2.b.d); console.log(o3.b.d); console.log(o2.b); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o1 = { c: 2, d: 3 };
+        const o2 = { a: 1, b: o1 };
+        const o3 = { a: 1, b: o1 };
+
+        cases.push({
+            title: "Analyze property chain #20",
+            func: function () { console.log(o2.b.d); console.log(o3.b.d); console.log(o1); },
+            expectText: `exports.handler = __f0;
+
+var __o2 = {};
+var __o2_b = {d: 3, c: 2};
+__o2.b = __o2_b;
+var __o3 = {};
+__o3.b = __o2_b;
+
+function __f0() {
+  return (function() {
+    with({ o2: __o2, o3: __o3, o1: __o2_b }) {
+
+return function () { console.log(o2.b.d); console.log(o3.b.d); console.log(o1); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        const o1 = { c: 2, d: 3 };
+        const o2 = { a: 1, b: o1 };
+        const o3 = { a: 1, b: o1 };
+
+        cases.push({
+            title: "Analyze property chain #21",
+            func: function () { console.log(o1); console.log(o2.b.d); console.log(o3.b.d);  },
+            expectText: `exports.handler = __f0;
+
+var __o1 = {c: 2, d: 3};
+var __o2 = {};
+__o2.b = __o1;
+var __o3 = {};
+__o3.b = __o1;
+
+function __f0() {
+  return (function() {
+    with({ o1: __o1, o2: __o2, o3: __o3 }) {
+
+return function () { console.log(o1); console.log(o2.b.d); console.log(o3.b.d); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
     // Run a bunch of direct checks on async js functions if we're in node 8 or above.
     // We can't do this inline as node6 doesn't understand 'async functions'.  And we
     // can't do this in TS as TS will convert the async-function to be a normal non-async


### PR DESCRIPTION
I recommend reviewing https://github.com/pulumi/pulumi/pull/1543/files?w=1 as this will make the indentation changes tolerable.

I also recommend looking at parseFunction.ts first, then createClosure.ts.