### PR TITLE
Use Pipenv to manage Python environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 **/.vscode/
 coverage.cov
 *.coverprofile
+Pipfile.lock
+**/dist
 
 # Go tests run "in tree" and this folder will linger if they fail (the integration test framework cleans
 # it up when they pass.)

--- a/build/common.mk
+++ b/build/common.mk
@@ -109,42 +109,6 @@ PULUMI_NODE_MODULES := $(PULUMI_ROOT)/node_modules
 # ensure that `default` is the target that is run when no arguments are passed to make
 default::
 
-# Ensure the requisite tools are on the PATH.
-#     - Prefer Python2 over Python.
-PYTHON := $(shell command -v python2 2>/dev/null)
-ifeq ($(PYTHON),)
-	PYTHON = $(shell command -v python 2>/dev/null)
-endif
-ifeq ($(PYTHON),)
-ensure::
-	$(error "missing python 2.7 (`python2` or `python`) from your $$PATH; \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-else
-PYTHON_VERSION := $(shell command $(PYTHON) --version 2>&1)
-ifeq (,$(findstring 2.7,$(PYTHON_VERSION)))
-ensure::
-	$(error "$(PYTHON) did not report a 2.7 version number ($(PYTHON_VERSION)); \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-endif
-endif
-#     - Prefer Pip2 over Pip.
-PIP := $(shell command -v pip2 2>/dev/null)
-ifeq ($(PIP),)
-	PIP = $(shell command -v pip 2>/dev/null)
-endif
-ifeq ($(PIP),)
-ensure::
-	$(error "missing pip 2.7 (`pip2` or `pip`) from your $$PATH; \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-else
-PIP_VERSION := $(shell command $(PIP) --version 2>&1)
-ifeq (,$(findstring python 2.7,$(PIP_VERSION)))
-ensure::
-	$(error "$(PIP) did not report a 2.7 version number ($(PIP_VERSION)); \
-		please see https://github.com/pulumi/home/wiki/Package-Management-Prerequisites")
-endif
-endif
-
 # If there are sub projects, our default, all, and ensure targets will
 # recurse into them.
 ifneq ($(SUB_PROJECTS),)

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -2,7 +2,21 @@ PROJECT_NAME     := Pulumi Python SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python
 VERSION          := $(shell ../../scripts/get-py-version)
 
-PYENV := env
+ifeq ($(PYTHON),)
+	PYTHON := python
+endif
+
+ifeq ($(PIP),)
+	PIP := pip
+endif
+
+ifneq ($(PYTHON_3),)
+	PIPENV_ARGS := --three
+else
+	PIPENV_ARGS := --two
+endif
+
+PYENV := ./env
 PYENVBIN := $(PYENV)/bin
 PYENVSRC := $(PYENV)/src
 PYENVLIB := $(PYENV)/lib
@@ -13,30 +27,18 @@ GOMETALINTER    := ${GOMETALINTERBIN} --config=../../Gometalinter.json
 include ../../build/common.mk
 
 ensure::
-	$(PIP) install --user 'virtualenv>=15.2.0'
-	rm -rf $(PYENV) && virtualenv --python=$(PYTHON) $(PYENV)/
-	echo "export PYTHONPATH=$${PYTHONPATH}:$(shell pwd)/$(PYENVLIB)/python2.7/site-packages" >> $(PYENVBIN)/activate
-	( \
-		source $(PYENVBIN)/activate ; \
-		pip install --upgrade 'pip>=10.0.0' ; \
-		pip install -r requirements.txt ; \
-	)
+	$(PIP) install pipenv --user
+	pipenv $(PIPENV_ARGS) install --dev
 	mkdir -p $(PYENVSRC)
-
+	
 build::
 	rm -rf $(PYENVSRC) && cp -R ./lib/. $(PYENVSRC)/
 	sed -i.bak "s/\$${VERSION}/$(VERSION)/g" $(PYENVSRC)/setup.py && rm $(PYENVSRC)/setup.py.bak
-	( \
-		source $(PYENVBIN)/activate ; \
-		cd $(PYENVSRC) && python setup.py build bdist_wheel --universal ; \
-	)
+	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 lint::
-	( \
-		source $(PYENVBIN)/activate ; \
-		cd $(PYENVSRC) && pylint -E ./pulumi --ignore-patterns '.*_pb2_.*.py' ; \
-	)
+	pipenv run pylint -E ./lib/pulumi --ignore-patterns '.*_pb2_.*.py'
 	$(GOMETALINTER) ./cmd/pulumi-language-python/... | sort ; exit $${PIPESTATUS[0]}
 	$(GOMETALINTER) ./pkg/... | sort ; exit $${PIPESTATUS[0]}
 
@@ -47,4 +49,5 @@ install::
 		  -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 test_fast::
-	$(PYTHON) -m unittest discover -s lib/test
+	pipenv run pip install ./env/src
+	pipenv run python -m unittest discover -s lib/test

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -11,15 +11,13 @@ ifeq ($(PIP),)
 endif
 
 ifneq ($(PYTHON_3),)
-	PIPENV_ARGS := --three
+	PIPENV_PYTHON_VERSION := --three
 else
-	PIPENV_ARGS := --two
+	PIPENV_PYTHON_VERSION := --two
 endif
 
 PYENV := ./env
-PYENVBIN := $(PYENV)/bin
 PYENVSRC := $(PYENV)/src
-PYENVLIB := $(PYENV)/lib
 
 GOMETALINTERBIN := gometalinter
 GOMETALINTER    := ${GOMETALINTERBIN} --config=../../Gometalinter.json
@@ -28,7 +26,7 @@ include ../../build/common.mk
 
 ensure::
 	$(PIP) install pipenv --user
-	pipenv $(PIPENV_ARGS) install --dev
+	pipenv $(PIPENV_PYTHON_VERSION) install --dev
 	mkdir -p $(PYENVSRC)
 	
 build::

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+protobuf = ">=3.6.0"
+grpcio = ">=1.9.1"
+six = ">=1.11.0"
+
+[dev-packages]
+pylint = ">=1.8.2"

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -23,8 +23,8 @@ setup(name='pulumi',
       license='Apache 2.0',
       packages=find_packages(),
       install_requires=[
-          'google==2.0.1',
-          'grpcio==1.9.1',
-          'six==1.11.0'
+          'protobuf>=3.6.0',
+          'grpcio>=1.9.1',
+          'six>=1.11.0'
       ],
       zip_safe=False)

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -1,5 +1,0 @@
-google==2.0.1
-grpcio==1.9.1
-pylint==1.8.2
-six==1.11.0
-wheel==0.30.0


### PR DESCRIPTION
This PR uses Pipenv (https://github.com/pypa/pipenv) to manage virtual environments. Pipenv has a couple of nice advantages:

1. Pipenv manages virtual environments for you, so we don't have to `source` them ourselves
2. Pipenv provides `pipenv run`, which lets our build scripts run commands in the context of a virtual environment
3. Pipenv allows you to easily select the version of Python to use in your created environment

Perhaps best of all, the only things that are required to be installed on the host machine are `python` (any verison), `pip`, and `pipenv` - hopefully that should ease the difficulty of configuring a dev environment.

The motivation for this change is that it is now possible to build and run tests against Python 3, by setting the `PYTHON_3` environment variable.