### PR TITLE
Fix `httputil.DoWithRetry`.

### DIFF
--- a/pkg/util/httputil/http.go
+++ b/pkg/util/httputil/http.go
@@ -51,7 +51,7 @@ func DoWithRetry(req *http.Request, client *http.Client) (*http.Response, error)
 				return true, res, nil
 			}
 			if try >= (maxRetryCount - 1) {
-				return false, res, resErr
+				return true, res, resErr
 			}
 
 			// Close the response body, if present, since our caller can't.


### PR DESCRIPTION
If we've hit the maximum number of retry attempts, return `true` for
`done`. As it stands, it is possible for us to return a `nil` error
(e.g. if the request sends successfully but returns a `50x` status) and
`false` for `done`, which `retry.Until` will interpret as "keep
retrying".