### PR TITLE
build: Use canonical import path for `mobytime`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 coverage.cov
 *.coverprofile
 
+/.idea/
+*.iml
+
 # Go tests run "in tree" and this folder will linger if they fail (the integration test framework cleans
 # it up when they pass.)
 **/command-output/

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -108,6 +108,7 @@
 [[projects]]
   name = "github.com/docker/docker"
   packages = [
+    "api/types/time",
     "pkg/term",
     "pkg/term/windows"
   ]
@@ -241,12 +242,6 @@
   name = "github.com/mitchellh/go-ps"
   packages = ["."]
   revision = "4fdf99ab29366514c69ccccddab5dc58b8d84062"
-
-[[projects]]
-  name = "github.com/moby/moby"
-  packages = ["api/types/time"]
-  revision = "092cba3727bb9b4a2f0e922cd6c0f93ea270e363"
-  version = "v1.13.1"
 
 [[projects]]
   name = "github.com/opentracing/opentracing-go"
@@ -560,6 +555,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f974a423ae8de19a1ba9f68115b5ab111040baece859d32f89e885094d3ebd86"
+  inputs-digest = "0bff1a5b9459d6e71d8e42332e8c67470efe703c93a73ea3f97c205e1e499973"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"time"
 
-	mobytime "github.com/moby/moby/api/types/time"
+	mobytime "github.com/docker/docker/api/types/time"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 


### PR DESCRIPTION
This change fixes the following warning issued by using `go get` with the Pulumi repository:

```
package github.com/moby/moby/api/types/time: code in directory /Users/James/Code/go/src/github.com/moby/moby/api/types/time
    expects import "github.com/docker/docker/api/types/time"
```

Moby defines [canonical import paths][1] reflecting the lineage back to the `docker/docker` repository.

[1]: https://github.com/moby/moby/blob/master/api/types/time/duration_convert.go#L1