### PR TITLE
Pin to a specific Pipenv version

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -16,6 +16,7 @@ else
 	PIPENV_PYTHON_VERSION := --two
 endif
 
+PIPENV_VERSION := 2018.05.18
 PYENV := ./env
 PYENVSRC := $(PYENV)/src
 
@@ -25,7 +26,7 @@ GOMETALINTER    := ${GOMETALINTERBIN} --config=../../Gometalinter.json
 include ../../build/common.mk
 
 ensure::
-	$(PIP) install pipenv --user
+	$(PIP) install pipenv==$(PIPENV_VERSION) --user
 	pipenv $(PIPENV_PYTHON_VERSION) install --dev
 	mkdir -p $(PYENVSRC)
 	


### PR DESCRIPTION
Running nightlies is fun and all but let's... not do that.

Pipenv released a new nightly this morning and it's broken, so this fixes us to version `2018.05.18`, which is the one that I have on my computer and I believe to not be broken.