### PR TITLE
Bump windows test timeout

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -108,7 +108,7 @@
 
     <!-- Ignore the exit code (but retain it) so we can kill all the lingering node processes even when go test
          fails. Otherwise, the AppVeyor job would hang until it reached the timeout -->
-    <Exec Command="go test -timeout 2m -cover -parallel $(TestParallelism) .\examples"
+    <Exec Command="go test -timeout 10m -cover -parallel $(TestParallelism) .\examples"
           IgnoreExitCode="true"
           WorkingDirectory="$(RepoRootDirectory)">
       <Output TaskParameter="ExitCode" PropertyName="GoTestExitCode" />


### PR DESCRIPTION
Some of the AppVeyor integration tests are timing out (from time to
time) and I think the deadline of 2 mins is a tad too short. We've
actually done similar bumps for macOS in Travis which was also a
little slow.