### PR TITLE
Support -s in stack {export, graph, import, output}

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -60,7 +60,7 @@ func newConfigCmd() *cobra.Command {
 		"Show secret values when listing config instead of displaying blinded values")
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"Operate on a different stack than the currently selected stack")
+		"The name of the stack to operate on. Defaults to the current stack")
 
 	cmd.AddCommand(newConfigGetCmd(&stack))
 	cmd.AddCommand(newConfigRmCmd(&stack))

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -109,7 +109,7 @@ func newDestroyCmd() *cobra.Command {
 		"Print detailed debugging output during resource operations")
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"Choose a stack other than the currently selected one")
+		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVarP(
 		&message, "message", "m", "",
 		"Optional message to associate with the destroy operation")

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -100,7 +100,7 @@ func newLogsCmd() *cobra.Command {
 
 	logsCmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"List configuration for a different stack than the currently selected stack")
+		"The name of the stack to operate on. Defaults to the current stack")
 	logsCmd.PersistentFlags().BoolVarP(
 		&follow, "follow", "f", false,
 		"Follow the log stream in real time (like tail -f)")

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -108,7 +108,7 @@ func newPreviewCmd() *cobra.Command {
 		"Return an error if any changes are proposed by this preview")
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"Choose a stack other than the currently selected one")
+		"The name of the stack to operate on. Defaults to the current stack")
 
 	cmd.PersistentFlags().StringVarP(
 		&message, "message", "m", "",

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -109,7 +109,7 @@ func newRefreshCmd() *cobra.Command {
 		"Print detailed debugging output during resource operations")
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"Choose a stack other than the currently selected one")
+		"The name of the stack to operate on. Defaults to the current stack")
 
 	cmd.PersistentFlags().StringVarP(
 		&message, "message", "m", "",

--- a/cmd/stack_export.go
+++ b/cmd/stack_export.go
@@ -26,6 +26,7 @@ import (
 
 func newStackExportCmd() *cobra.Command {
 	var file string
+	var stackName string
 	cmd := &cobra.Command{
 		Use:   "export",
 		Args:  cmdutil.MaximumNArgs(0),
@@ -38,7 +39,7 @@ func newStackExportCmd() *cobra.Command {
 			"resources, etc.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Fetch the current stack and export its deployment
-			s, err := requireCurrentStack(false)
+			s, err := requireStack(stackName, false)
 			if err != nil {
 				return err
 			}
@@ -66,6 +67,8 @@ func newStackExportCmd() *cobra.Command {
 			return nil
 		}),
 	}
+	cmd.PersistentFlags().StringVarP(
+		&stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().StringVarP(
 		&file, "file", "", "", "A filename to write stack output to")
 	return cmd

--- a/cmd/stack_graph.go
+++ b/cmd/stack_graph.go
@@ -38,6 +38,7 @@ var dependencyEdgeColor string
 var parentEdgeColor string
 
 func newStackGraphCmd() *cobra.Command {
+	var stackName string
 	cmd := &cobra.Command{
 		Use:   "graph",
 		Args:  cmdutil.ExactArgs(1),
@@ -48,7 +49,7 @@ func newStackGraphCmd() *cobra.Command {
 			"admitted when it was ran. This graph is output in the DOT format. This command operates\n" +
 			"on your stack's most recent deployment.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			s, err := requireCurrentStack(false)
+			s, err := requireStack(stackName, false)
 			if err != nil {
 				return err
 			}
@@ -73,14 +74,15 @@ func newStackGraphCmd() *cobra.Command {
 			return file.Close()
 		}),
 	}
-
-	cmd.Flags().BoolVar(&ignoreParentEdges, "ignore-parent-edges", false,
+	cmd.PersistentFlags().StringVarP(
+		&stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	cmd.PersistentFlags().BoolVar(&ignoreParentEdges, "ignore-parent-edges", false,
 		"Ignores edges introduced by parent/child resource relationships")
-	cmd.Flags().BoolVar(&ignoreDependencyEdges, "ignore-dependency-edges", false,
+	cmd.PersistentFlags().BoolVar(&ignoreDependencyEdges, "ignore-dependency-edges", false,
 		"Ignores edges introduced by dependency resource relationships")
-	cmd.Flags().StringVar(&dependencyEdgeColor, "dependency-edge-color", "#246C60",
+	cmd.PersistentFlags().StringVar(&dependencyEdgeColor, "dependency-edge-color", "#246C60",
 		"Sets the color of dependency edges in the graph")
-	cmd.Flags().StringVar(&parentEdgeColor, "parent-edge-color", "#AA6639",
+	cmd.PersistentFlags().StringVar(&parentEdgeColor, "parent-edge-color", "#AA6639",
 		"Sets the color of parent edges in the graph")
 	return cmd
 }

--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -32,6 +32,7 @@ import (
 func newStackImportCmd() *cobra.Command {
 	var force bool
 	var file string
+	var stackName string
 	cmd := &cobra.Command{
 		Use:   "import",
 		Args:  cmdutil.MaximumNArgs(0),
@@ -44,7 +45,7 @@ func newStackImportCmd() *cobra.Command {
 			"The updated deployment will be read from standard in.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Fetch the current stack and import a deployment.
-			s, err := requireCurrentStack(false)
+			s, err := requireStack(stackName, false)
 			if err != nil {
 				return err
 			}
@@ -113,6 +114,8 @@ func newStackImportCmd() *cobra.Command {
 		}),
 	}
 
+	cmd.PersistentFlags().StringVarP(
+		&stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
 	cmd.PersistentFlags().BoolVarP(
 		&force, "force", "f", false,
 		"Force the import to occur, even if apparent errors are discovered beforehand (not recommended)")

--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -25,7 +25,8 @@ import (
 )
 
 func newStackOutputCmd() *cobra.Command {
-	return &cobra.Command{
+	var stackName string
+	cmd := &cobra.Command{
 		Use:   "output [property-name]",
 		Args:  cmdutil.MaximumNArgs(1),
 		Short: "Show a stack's output properties",
@@ -35,7 +36,7 @@ func newStackOutputCmd() *cobra.Command {
 			"If a specific property-name is supplied, just that property's value is shown.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// Fetch the current stack and its output properties.
-			s, err := requireCurrentStack(false)
+			s, err := requireStack(stackName, false)
 			if err != nil {
 				return err
 			}
@@ -64,4 +65,7 @@ func newStackOutputCmd() *cobra.Command {
 			return nil
 		}),
 	}
+	cmd.PersistentFlags().StringVarP(
+		&stackName, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+	return cmd
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -123,7 +123,7 @@ func newUpdateCmd() *cobra.Command {
 		"Return an error if any changes occur during this update")
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
-		"Choose a stack other than the currently selected one")
+		"The name of the stack to operate on. Defaults to the current stack")
 
 	cmd.PersistentFlags().StringVarP(
 		&message, "message", "m", "",


### PR DESCRIPTION
Instead of needing you to first select the current stack to use any of
these commands, allow passing `-s <stack-name>` or `--stack
<stack-name>` to say what stack you want to operate on.

These commands still require a `Pulumi.yaml` file to be present, which
is not ideal, but would require a larger refactoring to fix. That
refactoring will happen as part of #1556.

Fixes #1370 

---

For the changelog:

`pulumi stack export`, `pulumi stack graph`, `pulumi stack import` and `pulumi stack output` now support a `-s` or `--stack` flag, which allows them to operate on a different stack that the currently selected one.