### PR TITLE
Don't require PULUMI_DEBUG_COMMANDS to be set to use local backend

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -36,7 +36,7 @@ func newLoginCmd() *cobra.Command {
 			var b backend.Backend
 			var err error
 
-			if hasDebugCommands() && local.IsLocalBackendURL(cloudURL) {
+			if local.IsLocalBackendURL(cloudURL) {
 				b, err = local.Login(cmdutil.Diag(), cloudURL)
 			} else {
 				b, err = cloud.Login(commandContext(), cmdutil.Diag(), cloudURL)


### PR DESCRIPTION
This was an artifact of history. Since we'll be supporting the local
backend, we don't need yet another flag guarding it (you already have
to opt in with -c local:// which is enough of a hoop).