### PR TITLE
Introduce ResourceV2, DeploymentV2, and CheckpointV2

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -134,13 +134,13 @@ type ResourceV1 struct {
 
 // ResourceV2 is the second version of the Resource API type. It absorbs two breaking changes:
 //   1. The deprecated `Defaults` field is removed because it is not used anywhere,
-//   2. It adds an additional bool field, "Read", which reflects whether or not this resource
+//   2. It adds an additional bool field, "External", which reflects whether or not this resource
 //      exists because of a call to `ReadResource`. This is motivated by a need to store
 //      resources that Pulumi does not own in the deployment.
 //
 // Migrating from ResourceV1 to ResourceV2 involves:
 //  1. Dropping the `Defaults` field (it should be empty anyway)
-//  2. Setting the `Read` field to "false", since a ResourceV1 existing for a resource
+//  2. Setting the `External` field to "false", since a ResourceV1 existing for a resource
 //     implies that it is owned by Pulumi. Note that since this is the default value for
 //     booleans in Go, no explicit assignment needs to be made.
 type ResourceV2 struct {
@@ -162,8 +162,8 @@ type ResourceV2 struct {
 	Parent resource.URN `json:"parent,omitempty" yaml:"parent,omitempty"`
 	// Protect is set to true when this resource is "protected" and may not be deleted.
 	Protect bool `json:"protect,omitempty" yaml:"protect,omitempty"`
-	// Read is set to true when this resource was "read" and is not explicitly owned by Pulumi.
-	Read bool `json:"read,omitempty" yaml:"read,omitempty"`
+	// External is set to true when the lifecycle of this resource is not managed by Pulumi.
+	External bool `json:"external,omitempty" yaml:"external,omitempty"`
 	// Dependencies contains the dependency edges to other resources that this depends on.
 	Dependencies []resource.URN `json:"dependencies" yaml:"dependencies,omitempty"`
 }

--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -67,6 +67,17 @@ type CheckpointV1 struct {
 	Latest *DeploymentV1 `json:"latest,omitempty" yaml:"latest,omitempty"`
 }
 
+// CheckpointV2 is the second version of the Checkpoint. It contains a newer version of
+// the latest deployment.
+type CheckpointV2 struct {
+	// Stack is the stack to update.
+	Stack tokens.QName `json:"stack" yaml:"stack"`
+	// Config contains a bag of optional configuration keys/values.
+	Config config.Map `json:"config,omitempty" yaml:"config,omitempty"`
+	// Latest is the latest/current deployment (if an update has occurred).
+	Latest *DeploymentV2 `json:"latest,omitempty" yaml:"latest,omitempty"`
+}
+
 // DeploymentV1 represents a deployment that has actually occurred. It is similar to the engine's snapshot structure,
 // except that it flattens and rearranges a few data structures for serializability.
 type DeploymentV1 struct {
@@ -74,6 +85,15 @@ type DeploymentV1 struct {
 	Manifest ManifestV1 `json:"manifest" yaml:"manifest"`
 	// Resources contains all resources that are currently part of this stack after this deployment has finished.
 	Resources []ResourceV1 `json:"resources,omitempty" yaml:"resources,omitempty"`
+}
+
+// DeploymentV2 is the second version of the Deployment. It contains never versions of the
+// Resource API type.
+type DeploymentV2 struct {
+	// Manifest contains metadata about this deployment.
+	Manifest ManifestV1 `json:"manifest" yaml:"manifest"`
+	// Resources contains all resources that are currently part of this stack after this deployment has finished.
+	Resources []ResourceV2 `json:"resources,omitempty" yaml:"resources,omitempty"`
 }
 
 // UntypedDeployment contains an inner, untyped deployment structure.
@@ -108,6 +128,42 @@ type ResourceV1 struct {
 	Parent resource.URN `json:"parent,omitempty" yaml:"parent,omitempty"`
 	// Protect is set to true when this resource is "protected" and may not be deleted.
 	Protect bool `json:"protect,omitempty" yaml:"protect,omitempty"`
+	// Dependencies contains the dependency edges to other resources that this depends on.
+	Dependencies []resource.URN `json:"dependencies" yaml:"dependencies,omitempty"`
+}
+
+// ResourceV2 is the second version of the Resource API type. It absorbs two breaking changes:
+//   1. The deprecated `Defaults` field is removed because it is not used anywhere,
+//   2. It adds an additional bool field, "Read", which reflects whether or not this resource
+//      exists because of a call to `ReadResource`. This is motivated by a need to store
+//      resources that Pulumi does not own in the deployment.
+//
+// Migrating from ResourceV1 to ResourceV2 involves:
+//  1. Dropping the `Defaults` field (it should be empty anyway)
+//  2. Setting the `Read` field to "false", since a ResourceV1 existing for a resource
+//     implies that it is owned by Pulumi. Note that since this is the default value for
+//     booleans in Go, no explicit assignment needs to be made.
+type ResourceV2 struct {
+	// URN uniquely identifying this resource.
+	URN resource.URN `json:"urn" yaml:"urn"`
+	// Custom is true when it is managed by a plugin.
+	Custom bool `json:"custom" yaml:"custom"`
+	// Delete is true when the resource should be deleted during the next update.
+	Delete bool `json:"delete,omitempty" yaml:"delete,omitempty"`
+	// ID is the provider-assigned resource, if any, for custom resources.
+	ID resource.ID `json:"id,omitempty" yaml:"id,omitempty"`
+	// Type is the resource's full type token.
+	Type tokens.Type `json:"type" yaml:"type"`
+	// Inputs are the input properties supplied to the provider.
+	Inputs map[string]interface{} `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	// Outputs are the output properties returned by the provider after provisioning.
+	Outputs map[string]interface{} `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	// Parent is an optional parent URN if this resource is a child of it.
+	Parent resource.URN `json:"parent,omitempty" yaml:"parent,omitempty"`
+	// Protect is set to true when this resource is "protected" and may not be deleted.
+	Protect bool `json:"protect,omitempty" yaml:"protect,omitempty"`
+	// Read is set to true when this resource was "read" and is not explicitly owned by Pulumi.
+	Read bool `json:"read,omitempty" yaml:"read,omitempty"`
 	// Dependencies contains the dependency edges to other resources that this depends on.
 	Dependencies []resource.URN `json:"dependencies" yaml:"dependencies,omitempty"`
 }


### PR DESCRIPTION
First step towards fixing https://github.com/pulumi/pulumi/issues/1521.

Per the design meeting last week, we decided that we want to move towards storing resources that Pulumi does not explicitly own in the deployment. To summarize (my understanding of) the design meeting:

### Summary
<details>
Pulumi today deals exclusively in resources that it "owns". To "own" a resource is to be responsible for that resource's lifecycle, as Pulumi does; it and it alone is responsible for CRUD operations on that resource. Today, Pulumi owns all resources that pass through `RegisterResource`, which is to say pretty much everything.

Pulumi also exposes a way to get non-owning references to existing infrastructure, using the `.get` API on resources. `.get` produces a real Resource object in the host language, but its lifecycle is not owned by Pulumi at all. The implication is that this resource was created outside of Pulumi and the current program only wishes to observe the resource.

Storing non-owned resources in the deployment is desirable for several reasons. The obvious motivator here is that the above bug makes `.get` not useful because it is currently illegal in our system for an owned resource to have a dependency on a non-owned resource. Looking forward, though, it's also desirable to store non-owned resource in the deployment so that the deployment can contain a more complete view of the state of the world, for UI and query purposes.

To accomplish this, we can add an additional per-resource bit that indicates whether or not the resource is owned by Pulumi. This bit (called `Read` in this PR), when set, indicates that this resource was created via `.get` (a.k.a `ReadResource`) and is not owned by Pulumi.

The engine semantics of this are that if a `Read` resource is ever the target of a `Delete` step, that resource is simply removed from the snapshot. The provider is not asked to delete the resource.

A few other invariants are that:
1. A `Read` resource must be `Custom` (`Read` is a provider operation and does not make sense for component resources)
2.  A `Read` resource can't be the target of any step other than `Delete`

Mentioned in the meeting was the desire to have a `Read` step, but that's getting into implementation details and has implications for UI display.
</details>

### Procedure
Since this PR is a breaking change, this is the procedure I am following:

1. Land this PR with `DeploymentV2`, `CheckpointV2`, and `ResourceV2`.
2. Enlighten the Pulumi service about these new API types. At this point the service should be able to deal in both V1 and V2 API types based on what the caller requested.
3. Land the engine implementation of `Read` resources, which uses the new `Read` bit in `ResourceV2`. Bump the engine's maximum deployment to 2 so that it will accept deployments with a version number of 2 from the service.

As an added bonus, since we are already making a breaking change to `Resource`, I fixed https://github.com/pulumi/pulumi/issues/637 while I was at it. This field is not used anywhere and has been ignored for the past six months. I don't anticipate any trouble removing this field.