### PR TITLE
Fix an issue where we fail to rethrow exceptions arising from failed …

### DIFF
--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -111,6 +111,11 @@ def register_resource(typ, name, custom, props, opts):
         if exn.code() == grpc.StatusCode.UNAVAILABLE:
             wait_for_death()
 
+        # If the RPC otherwise failed, re-throw an exception with the message details - the contents
+        # are suitable for user presentation.
+        raise Exception(exn.details())
+
+
     # Return the URN, ID, and output properties.
     urn = resp.urn
     if custom:
@@ -151,6 +156,11 @@ def register_resource_outputs(res, outputs):
         # pylint: disable=no-member
         if exn.code() == grpc.StatusCode.UNAVAILABLE:
             wait_for_death()
+            
+        # If the RPC otherwise failed, re-throw an exception with the message details - the contents
+        # are suitable for user presentation.
+        raise Exception(exn.details())
+
 
 
 # wait_for_death loops forever. This is a hack.

--- a/sdk/python/lib/test/langhost/README.md
+++ b/sdk/python/lib/test/langhost/README.md
@@ -57,6 +57,7 @@ keyword arguments:
 * `config` - A dict of configuration keys and values to pass to the program.
 * `expected_resource_count` - The number of resources this test is expected to register.
 * `expected_error` - If non-None, the *exact* error text that is expected to be received.
+* `expected_stderr_contains` - If non-None, asserts that the given substring exists in stderr
 
 If `expected_error` is None, the expected error is asserted to be the empty string.
 

--- a/sdk/python/lib/test/langhost/resource_op_fail/__init__.py
+++ b/sdk/python/lib/test/langhost/resource_op_fail/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/resource_op_fail/__main__.py
+++ b/sdk/python/lib/test/langhost/resource_op_fail/__main__.py
@@ -1,0 +1,22 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import CustomResource
+
+
+class MyResource(CustomResource):
+    def __init__(self, name):
+        CustomResource.__init__(self, "test:index:MyResource", name)
+
+
+MyResource("testResource1")

--- a/sdk/python/lib/test/langhost/resource_op_fail/test_resource_op_fail.py
+++ b/sdk/python/lib/test/langhost/resource_op_fail/test_resource_op_fail.py
@@ -1,0 +1,27 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class UnhandledExceptionTest(LanghostTest):
+    def test_unhandled_exception(self):
+        self.run_test(
+            program=path.join(self.base_path(), "resource_op_fail"),
+            expected_stderr_contains="oh no",
+            expected_error="Program exited with non-zero exit code: 1")
+
+    def register_resource(self, _ctx, _dry_run, _ty, _name, _resource,
+                          _dependencies):
+        raise Exception("oh no")


### PR DESCRIPTION
…resource operations.

This is a papercut issue that I often ran into when working with Python. The problem is that we were failing to re-throw exceptions that occurred due to a failed engine RPC. We were crashing immediately afterwards, but the error message was really bad.

This commit fixes the issue around `register_resource` and `register_resource_outputs` and adds a test for it.