### PR TITLE
Fix an issue where Unknown does not coerce to a bool correctly on Python

### DIFF
--- a/sdk/python/lib/pulumi/runtime/unknown.py
+++ b/sdk/python/lib/pulumi/runtime/unknown.py
@@ -39,6 +39,13 @@ class Unknown(str):
         """
         return True
 
+    def __nonzero__(self):
+        """
+        Python 2/3 compatibility shim for __bool__. Also returns True if this
+        value is not zero, which it is.
+        """
+        return True
+
     def __str__(self):
         """
         Called whenever this value is coerced to a string, via "str".

--- a/sdk/python/lib/test/langhost/preview/__init__.py
+++ b/sdk/python/lib/test/langhost/preview/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/preview/__main__.py
+++ b/sdk/python/lib/test/langhost/preview/__main__.py
@@ -1,0 +1,53 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import six
+from pulumi import CustomResource
+from pulumi.runtime import Unknown
+
+
+class Bucket(CustomResource):
+    def __init__(self, name):
+        CustomResource.__init__(self, "test:index:Bucket", name)
+
+    def set_outputs(self, outputs):
+        self.bucket = Unknown()
+        self.stable = Unknown()
+        if "stable" in outputs:
+            self.bucket = outputs["stable"]
+        if "bucket" in outputs:
+            self.bucket = outputs["bucket"]
+
+
+class BucketObject(CustomResource):
+    def __init__(self, name, bucket=None):
+        if not bucket:
+            raise TypeError("bucket is required")
+
+        if not isinstance(bucket, six.string_types):
+            raise TypeError("bucket must be a string")
+
+        CustomResource.__init__(self, "test:index:BucketObject", name, props={
+            "bucket": bucket
+        })
+
+    def set_outputs(self, outputs):
+        self.stabke = Unknown()
+        self.bucket = Unknown()
+        if "stable" in outputs:
+            self.bucket = outputs["stable"]
+        if "bucket" in outputs:
+            self.bucket = outputs["bucket"]
+
+bucket = Bucket("mybucket")
+obj = BucketObject("mybucketobject", bucket=bucket.id)

--- a/sdk/python/lib/test/langhost/preview/test_preview.py
+++ b/sdk/python/lib/test/langhost/preview/test_preview.py
@@ -1,0 +1,57 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from pulumi.runtime.rpc import Unknown
+from ..util import LanghostTest
+
+
+class PreviewTest(LanghostTest):
+    """
+    This test tries to re-create a common setup for doing previews
+    in Python.
+
+    It is extremely common to use the "id" fields of resources to
+    associate one resource to another. This test does this so that
+    we are absolutely sure that it works for previews, otherwise
+    previews in Python are pretty useless.
+    """
+    def test_preview(self):
+        self.run_test(
+            program=path.join(self.base_path(), "preview"),
+            expected_resource_count=2)
+
+    def register_resource(self, _ctx, dry_run, ty, name, resource,
+                          _dependencies):
+        id_ = None
+        props = resource
+        props["stable"] = "cool stable"
+        if ty == "test:index:Bucket":
+            self.assertEqual(name, "mybucket")
+            if not dry_run:
+                id_ = "mybucketid"
+        elif ty == "test:index:BucketObject":
+            self.assertEqual(name, "mybucketobject")
+            if dry_run:
+                self.assertIsInstance(resource["bucket"], Unknown)
+            else:
+                self.assertEqual(resource["bucket"], "mybucketid")
+
+            if not dry_run:
+                id_ = name
+
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": id_,
+            "object": props
+        }

--- a/sdk/python/lib/test/test_unknown.py
+++ b/sdk/python/lib/test/test_unknown.py
@@ -1,0 +1,55 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from pulumi.runtime import Unknown
+
+
+
+class UnknownTests(unittest.TestCase):
+    """
+    Tests that Unknown works well enough to get us through previews.
+    """
+    def test_nonzero_bool(self):
+        unknown = Unknown()
+        self.assertFalse(not unknown)
+        if not unknown:
+            self.fail("if boolean conversion failed")
+        self.assertTrue(bool(unknown))
+
+    def test_attr(self):
+        class MockPreviewObj(object):
+            def __init__(self):
+                self.id = Unknown()
+                self.output = Unknown()
+
+        preview_obj = MockPreviewObj()
+        self.assertIsInstance(preview_obj.id, Unknown)
+        self.assertIsInstance(preview_obj.output, Unknown)
+
+    def test_str(self):
+        unknown = Unknown()
+        self.assertEqual(str(unknown), "<computed>")
+
+    def test_dict_list(self):
+        unknown = Unknown()
+        self.assertIsInstance(unknown["foo"], Unknown)
+        self.assertIsInstance(unknown[0], Unknown)
+
+    def test_iter_dir(self):
+        unknown = Unknown()
+        for _ in unknown:
+            self.fail("Unknown iterator should be empty")
+
+        for _ in dir(unknown):
+            self.fail("Dir should return empty")


### PR DESCRIPTION
I accidentally regressed this when doing the Python 2/3 migration. This is arguably a bug in `futurize`, the tool that did the automatic 2/3 conversion, but whatever, this is what tests are for 😄 .

Failing to coerce `Unknown` to a boolean caused instances of `Unknown` to return `False` when queried for truthiness, which severely regressed the Python preview experience. This PR fixes the issue by ensuring that we coerce `Unkown` to bool correctly. I also added a few tests to avoid regressing the preview experience in this way going forward.