### PR TITLE
Implementation of Assets for Python

### DIFF
--- a/sdk/python/lib/pulumi/asset.py
+++ b/sdk/python/lib/pulumi/asset.py
@@ -55,7 +55,6 @@ class StringAsset(Asset):
             self.text = text
 
 
-
 @known_types.remote_asset
 class RemoteAsset(Asset):
     """
@@ -68,5 +67,55 @@ class RemoteAsset(Asset):
         # type: (str) -> None
         if not isinstance(uri, six.string_types):
             raise TypeError("RemoteAsset URI must be a string")
+
+        self.uri = uri
+
+
+@known_types.archive
+class Archive(object):
+    """
+    Asset represents a collection of named assets.
+    """
+    pass
+
+
+@known_types.asset_archive
+class AssetArchive(Archive):
+    """
+    An AssetArchive is an archive created from an in-memory collection of named assets or other archives.
+    """
+    def __init__(self, assets):
+        if not isinstance(assets, dict):
+            raise TypeError("AssetArchive assets must be a dictionary")
+        for k, v in assets.items():
+            if not isinstance(v, Asset) and not isinstance(v, Archive):
+                raise TypeError("AssetArchive assets must contain only Assets or Archives")
+        self.assets = assets
+
+
+@known_types.file_archive
+class FileArchive(Archive):
+    """
+    A FileArchive is a file-based archive, or collection of file-based assets.  This can be
+    a raw directory or a single archive file in one of the supported formats (.tar, .tar.gz, or .zip).
+    """
+    def __init__(self, path):
+        # type: (str) -> None
+        if not isinstance(path, six.string_types):
+            raise TypeError("FileArchive path must be a string")
+        self.path = path
+
+
+@known_types.remote_archive
+class RemoteArchive(Archive):
+    """
+    A RemoteArchive is a file-based archive fetched from a remote location.  The URI's scheme dictates
+    the protocol for fetching contents: "file://" specifies a local file, "http://" and "https://"
+    specify HTTP and HTTPS, respectively, and specific providers may recognize custom schemes.
+    """
+    def __init__(self, uri):
+        # type: (str) -> None
+        if not isinstance(uri, six.string_types):
+            raise TypeError("RemoteArchive URI must be a string")
 
         self.uri = uri

--- a/sdk/python/lib/pulumi/asset.py
+++ b/sdk/python/lib/pulumi/asset.py
@@ -1,0 +1,72 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Assets are the Pulumi notion of data blobs that can be passed to resources.
+"""
+import six
+from pulumi.runtime import known_types
+
+@known_types.asset
+class Asset(object):
+    """
+    Asset represents a single blob of text or data that is managed as a first
+    class entity.
+    """
+    pass
+
+
+@known_types.file_asset
+class FileAsset(Asset):
+    """
+    A FileAsset is a kind of asset produced from a given path to a file on
+    the local filesysetm.
+    """
+    def __init__(self, path):
+        # type: (str) -> None
+        if not isinstance(path, six.string_types):
+            raise TypeError("FileAsset path must be a string")
+        self.path = path
+
+
+@known_types.string_asset
+class StringAsset(Asset):
+    """
+    A StringAsset is a kind of asset produced from an in-memory UTF-8 encoded string.
+    """
+    def __init__(self, text):
+        # type: (six.string_types) -> None
+        if not isinstance(text, six.string_types):
+            raise TypeError("StringAsset data must be a string")
+
+        if six.PY2 and not isinstance(text, unicode):
+            self.text = unicode(text, "utf-8")
+        else:
+            self.text = text
+
+
+
+@known_types.remote_asset
+class RemoteAsset(Asset):
+    """
+    A RemoteAsset is a kind of asset produced from a given URI string. The URI's scheme
+    dictates the protocol for fetching contents: "file://" specifies a local file, "http://"
+    and "https://" specify HTTP and HTTPS, respectively. Note that specific providers may recognize
+    alternative schemes; this is merely the base-most set that all providers support.
+    """
+    def __init__(self, uri):
+        # type: (str) -> None
+        if not isinstance(uri, six.string_types):
+            raise TypeError("RemoteAsset URI must be a string")
+
+        self.uri = uri

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -16,8 +16,8 @@
 from __future__ import absolute_import
 import six
 
+from .runtime import known_types
 from .runtime.resource import register_resource, register_resource_outputs
-from .runtime.rpc import register_custom_resource_type
 from .runtime.settings import get_root_resource
 from .runtime.unknown import Unknown
 
@@ -87,6 +87,7 @@ class ResourceOptions(object):
         self.depends_on = depends_on
         self.protect = protect
 
+@known_types.custom_resource
 class CustomResource(Resource):
     """
     CustomResource is a resource whose CRUD operations are managed by performing external operations on some
@@ -96,8 +97,6 @@ class CustomResource(Resource):
     def __init__(self, t, name, props=None, opts=None):
         Resource.__init__(self, t, name, True, props, opts)
 
-# Elsewhere in the runtime, we depend on the object identity of the CustomResource class.
-register_custom_resource_type(CustomResource)
 
 class ComponentResource(Resource):
     """

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -47,6 +47,18 @@ _string_asset_resource_type = None
 _remote_asset_resource_type = None
 """The type of RemoteAsset. Filled-in as the Pulumi package is initializing."""
 
+_archive_resource_type = None
+"""The type of Archive. Filled-in as the Pulumi package is initializing."""
+
+_asset_archive_resource_type = None
+"""The type of AssetArchive. Filled-in as the Pulumi package is initializing."""
+
+_file_archive_resource_type = None
+"""The type of FileArchive. Filled-in as the Pulumi package is initializing."""
+
+_remote_archive_resource_type = None
+"""The type of RemoteArchive. Filled-in as the Pulumi package is initializing."""
+
 _custom_resource_type = None
 """The type of CustomResource. Filled-in as the Pulumi package is initializing."""
 
@@ -86,8 +98,48 @@ def remote_asset(class_obj):
     as the RemoteAsset known type.
     """
     assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
-    global _remote_asset_resource_type 
+    global _remote_asset_resource_type
     _remote_asset_resource_type = class_obj
+    return class_obj
+
+def archive(class_obj):
+    """
+    Decorator to annotate the Archive class. Registers the decorated class
+    as the Archive known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _archive_resource_type
+    _archive_resource_type = class_obj
+    return class_obj
+
+def asset_archive(class_obj):
+    """
+    Decorator to annotate the AssetArchive class. Registers the decorated class
+    as the AssetArchive known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _asset_archive_resource_type
+    _asset_archive_resource_type = class_obj
+    return class_obj
+
+def file_archive(class_obj):
+    """
+    Decorator to annotate the FileArchive class. Registers the decorated class
+    as the FileArchive known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _file_archive_resource_type
+    _file_archive_resource_type = class_obj
+    return class_obj
+
+def remote_archive(class_obj):
+    """
+    Decorator to annotate the RemoteArchive class. Registers the decorated class
+    as the RemoteArchive known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _remote_archive_resource_type
+    _remote_archive_resource_type = class_obj
     return class_obj
 
 def custom_resource(class_obj):
@@ -118,12 +170,35 @@ def new_remote_asset(*args):
     """
     return _remote_asset_resource_type(*args)
 
+def new_asset_archive(*args):
+    """
+    Instantiates a new AssetArchive, passing the given arguments to the constructor.
+    """
+    return _asset_archive_resource_type(*args)
+
+def new_file_archive(*args):
+    """
+    Instantiates a new FileArchive, passing the given arguments to the constructor.
+    """
+    return _file_archive_resource_type(*args)
+
+def new_remote_archive(*args):
+    """
+    Instantiates a new StringArchive, passing the given arguments to the constructor.
+    """
+    return _remote_archive_resource_type(*args)
 
 def is_asset(obj):
     """
     Returns true if the given type is an Asset, false otherwise.
     """
     return _asset_resource_type is not None and isinstance(obj, _asset_resource_type)
+
+def is_archive(obj):
+    """
+    Returns true if the given type is an Archive, false otherwise.
+    """
+    return _archive_resource_type is not None and isinstance(obj, _archive_resource_type)
 
 def is_custom_resource(obj):
     """

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -1,0 +1,132 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The known_types module contains state for keeping track of types that
+are known to be special in the Pulumi type system.
+
+Python strictly disallows circular references between imported packages.
+Because the Pulumi top-level module depends on the `pulumi.runtime` submodule,
+it is not allowed for `pulumi.runtime` to reach back to the `pulumi` top-level
+to reference types that are defined there.
+
+In order to break this circular reference, and to be clear about what types
+the runtime knows about and treats specially, this module exports a number of
+"known type" decorators that can be applied to types in `pulumi` to indicate
+that they are specially treated.
+
+The implementation of this mechanism is that, for every known type, that type
+is stashed away in a global variable. Whenever the runtime wants to do a type
+test using that type (or instantiate an instance of this type), it uses the
+functions defined in this module to do so.
+"""
+import six
+
+_custom_resource_type = None
+"""The type of CustomResource. Filled-in as the Pulumi package is initializing."""
+
+_asset_resource_type = None
+"""The type of Asset. Filled-in as the Pulumi package is initializing."""
+
+_file_asset_resource_type = None
+"""The type of FileAsset. Filled-in as the Pulumi package is initializing."""
+
+_string_asset_resource_type = None
+"""The type of StringAsset. Filled-in as the Pulumi package is initializing."""
+
+_remote_asset_resource_type = None
+"""The type of RemoteAsset. Filled-in as the Pulumi package is initializing."""
+
+_custom_resource_type = None
+"""The type of CustomResource. Filled-in as the Pulumi package is initializing."""
+
+def asset(class_obj):
+    """
+    Decorator to annotate the Asset class. Registers the decorated class
+    as the Asset known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _asset_resource_type
+    _asset_resource_type = class_obj
+    return class_obj
+
+def file_asset(class_obj):
+    """
+    Decorator to annotate the FileAsset class. Registers the decorated class
+    as the FileAsset known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _file_asset_resource_type
+    _file_asset_resource_type = class_obj
+    return class_obj
+
+def string_asset(class_obj):
+    """
+    Decorator to annotate the StringAsset class. Registers the decorated class
+    as the StringAsset known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _string_asset_resource_type
+    _string_asset_resource_type = class_obj
+    return class_obj
+
+def remote_asset(class_obj):
+    """
+    Decorator to annotate the RemoteAsset class. Registers the decorated class
+    as the RemoteAsset known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _remote_asset_resource_type 
+    _remote_asset_resource_type = class_obj
+    return class_obj
+
+def custom_resource(class_obj):
+    """
+    Decorator to annotate the CustomResource class. Registers the decorated class
+    as the CustomResource known type.
+    """
+    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
+    global _custom_resource_type
+    _custom_resource_type = class_obj
+    return class_obj
+
+def new_file_asset(*args):
+    """
+    Instantiates a new FileAsset, passing the given arguments to the constructor.
+    """
+    return _file_asset_resource_type(*args)
+
+def new_string_asset(*args):
+    """
+    Instantiates a new StringAsset, passing the given arguments to the constructor.
+    """
+    return _string_asset_resource_type(*args)
+
+def new_remote_asset(*args):
+    """
+    Instantiates a new StringAsset, passing the given arguments to the constructor.
+    """
+    return _remote_asset_resource_type(*args)
+
+
+def is_asset(obj):
+    """
+    Returns true if the given type is an Asset, false otherwise.
+    """
+    return _asset_resource_type is not None and isinstance(obj, _asset_resource_type)
+
+def is_custom_resource(obj):
+    """
+    Returns true if the given type is a CustomResource, false otherwise.
+    """
+    return _custom_resource_type is not None and isinstance(obj, _custom_resource_type)

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -47,7 +47,7 @@ def serialize_resource_value(value):
     Serializes a resource property value so that it's ready for marshaling to the gRPC endpoint.
     """
 
-    assert _custom_resource_type is not None, "failed to set CustomResource type"
+    assert known_types._custom_resource_type is not None, "failed to set CustomResource type"
     if known_types.is_custom_resource(value):
         # Resource objects aren't serializable.  Instead, serialize them as references to their IDs.
         return serialize_resource_value(value.id)

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -22,12 +22,16 @@ from six.moves import map
 
 from google.protobuf import struct_pb2
 from .unknown import Unknown
+from . import known_types
 
 UNKNOWN = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
 """If a value is None, we serialize as UNKNOWN, which tells the engine that it may be computed later."""
 
-_custom_resource_type = None
-"""The type of CustomResource. Filled-in as the Pulumi package is initializing."""
+_special_sig_key = "4dabf18193072939515e22adb298388d"
+"""specialSigKey is sometimes used to encode type identity inside of a map.  See pkg/resource/properties.go."""
+
+_special_asset_sig = "c44067f5952c0a294b673a41bacd8c17"
+"""specialAssetSig is a randomly assigned hash used to identify assets in maps.  See pkg/resource/asset.go."""
 
 def serialize_resource_props(props):
     """
@@ -44,7 +48,7 @@ def serialize_resource_value(value):
     """
 
     assert _custom_resource_type is not None, "failed to set CustomResource type"
-    if isinstance(value, _custom_resource_type):
+    if known_types.is_custom_resource(value):
         # Resource objects aren't serializable.  Instead, serialize them as references to their IDs.
         return serialize_resource_value(value.id)
     elif isinstance(value, dict):
@@ -56,6 +60,23 @@ def serialize_resource_value(value):
     elif isinstance(value, Unknown):
         # Serialize instances of Unknown as the UNKNOWN guid
         return UNKNOWN
+    elif known_types.is_asset(value):
+        # Serializing an asset or archive requires the use of a magical signature key, since otherwise it would look
+        # like any old weakly typed object/map when received by the other side of the RPC boundary.
+        obj = {
+            _special_sig_key: _special_asset_sig
+        }
+
+        if hasattr(value, "path"):
+            obj["path"] = value.path
+        elif hasattr(value, "text"):
+            obj["text"] = value.text
+        elif hasattr(value, "uri"):
+            obj["uri"] = value.uri
+        else:
+            raise AssertionError("unknown asset type: " + str(value))
+
+        return obj
     else:
         # All other values are directly serializable.
         # TODO[pulumi/pulumi#1063]: eventually, we want to think about Output, Properties, and so on.
@@ -72,6 +93,20 @@ def deserialize_resource_props(props_struct):
     # We assume that we are deserializing properties that we got from a Resource RPC endpoint,
     # which has type `Struct` in our gRPC proto definition.
     assert isinstance(props_struct, struct_pb2.Struct)
+
+    if _special_sig_key in props_struct:
+        if props_struct[_special_sig_key] == _special_asset_sig:
+            # This is an asset. Re-hydrate this object into an Asset.
+            if "path" in props_struct:
+                return known_types.new_file_asset(props_struct["path"])
+            if "text" in props_struct:
+                return known_types.new_string_asset(props_struct["text"])
+            if "uri" in props_struct:
+                return known_types.new_remote_asset(props_struct["uri"])
+            raise AssertionError("Invalid asset encountered when unmarshaling resource property")
+
+        raise AssertionError("Unrecognized signature when unmarshaling resource property")
+
 
     # Struct is duck-typed like a dictionary, so we can iterate over it in the normal ways.
     return {k: deserialize_property(v) for (k, v) in list(props_struct.items())}
@@ -95,12 +130,3 @@ def deserialize_property(prop):
 
     # Everything else is identity projected.
     return prop
-
-def register_custom_resource_type(class_obj):
-    """
-    Registers the given class object as the CustomResource type,
-    for use in serialization.
-    """
-    assert isinstance(class_obj, six.class_types), "class_obj is not a Class"
-    global _custom_resource_type
-    _custom_resource_type = class_obj

--- a/sdk/python/lib/test/langhost/asset/__init__.py
+++ b/sdk/python/lib/test/langhost/asset/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/asset/__main__.py
+++ b/sdk/python/lib/test/langhost/asset/__main__.py
@@ -1,0 +1,27 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import CustomResource
+from pulumi.asset import FileAsset, StringAsset, RemoteAsset
+
+
+
+class MyResource(CustomResource):
+    def __init__(self, name, asset):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={
+            "asset": asset
+        })
+
+MyResource("file", FileAsset("./testfile.txt"))
+MyResource("string", StringAsset("its a string"))
+MyResource("remote", RemoteAsset("https://pulumi.io"))

--- a/sdk/python/lib/test/langhost/asset/test_asset.py
+++ b/sdk/python/lib/test/langhost/asset/test_asset.py
@@ -1,0 +1,42 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from pulumi.asset import FileAsset, StringAsset, RemoteAsset
+from ..util import LanghostTest
+
+
+
+class AssetTest(LanghostTest):
+    def test_asset(self):
+        self.run_test(
+            program=path.join(self.base_path(), "asset"),
+            expected_resource_count=3)
+
+    def register_resource(self, _ctx, _dry_run, ty, name, resource,
+                          _dependencies):
+        self.assertEqual(ty, "test:index:MyResource")
+        if name == "file":
+            self.assertIsInstance(resource["asset"], FileAsset)
+            self.assertEqual(resource["asset"].path, "./testfile.txt")
+        elif name == "string":
+            self.assertIsInstance(resource["asset"], StringAsset)
+            self.assertEqual(resource["asset"].text, "its a string")
+        elif name == "remote":
+            self.assertIsInstance(resource["asset"], RemoteAsset)
+            self.assertEqual(resource["asset"].uri, "https://pulumi.io")
+        else:
+            self.fail("unexpected resource name: " + name)
+        return {
+            "urn": self.make_urn(ty, name),
+        }

--- a/sdk/python/lib/test/test_deserialize.py
+++ b/sdk/python/lib/test/test_deserialize.py
@@ -14,6 +14,7 @@
 
 import unittest
 from google.protobuf import struct_pb2
+from pulumi.asset import FileAsset, StringAsset
 from pulumi.runtime import rpc, Unknown
 
 class PropertyDeserializeTests(unittest.TestCase):
@@ -73,5 +74,34 @@ class PropertyDeserializeTests(unittest.TestCase):
         deserialized = rpc.deserialize_resource_props(proto)
         self.assertTrue(isinstance(deserialized["vpc_id"], Unknown))
 
+    def test_file_asset(self):
+        """
+        Tests that we deserialize file assets correctly.
+        """
+        proto = struct_pb2.Struct()
+        
+        # pylint: disable=no-member
+        subproto = proto.get_or_create_struct("asset")
+        subproto[rpc._special_sig_key] = rpc._special_asset_sig
+        subproto["path"] = "foo.txt"
+        deserialized = rpc.deserialize_resource_props(proto)
+        self.assertIsInstance(deserialized["asset"], FileAsset)
+        self.assertEqual("foo.txt", deserialized["asset"].path)
+
+    def test_string_asset(self):
+        """
+        Tests that we deserialize string assets correctly.
+        """
+        proto = struct_pb2.Struct()
+        
+        # pylint: disable=no-member
+        subproto = proto.get_or_create_struct("asset")
+        subproto[rpc._special_sig_key] = rpc._special_asset_sig
+        subproto["text"] = u"this is some text"
+        deserialized = rpc.deserialize_resource_props(proto)
+        self.assertIsInstance(deserialized["asset"], StringAsset)
+        self.assertEqual(u"this is some text", deserialized["asset"].text)
+
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1065.

This PR provides an implementation of assets for Python. Concretely, this incudes `Asset`, `FileAsset`, `StringAsset`, and `RemoteAsset` types that can be used to communicate assets to the engine.

Python does not look kindly on circular import dependencies. Because of this, and because `pulumi.runtime` often needs to know about types in the top-level `pulumi` module (in particular, anything that participates in serialization/deserialization), I added a `known_types` module that provides an easy-to-use mechanism for breaking the dependency cycle between `pulumi` and `pulumi.runtime`.

The `known_types` module exposes a few decorators and functions:

1. `asset`, `file_asset`, `string_asset`, `remote_asset` and `custom_resource` are all decorators that can be applied to classes that represent implementations of these types. Putting this decorator on a type informs the runtime that the decorated type is the concrete instance of a particular known type.
2. `is_asset`, `is_custom_resource` provide type assertions
3. `new_file_asset`, `new_string_asset`, `new_remote_asset` are constructors that produce instances of each respected known type

Basically, `known_types` is a way for `pulumi.runtime` to reach "upwards" towards types defined in `pulumi`, which it it can't do directly without introducing a circular dependency.

The main work of this PR involves serializing and deserializing assets by producing (and interpreting, in the case of deserializing) a map with a special key. The engine is aware of this key and its values (one for `File`, `String`, and `RemoteAsset`). We basically just have to stick this special key in a dictionary, populate the key with the correct magic value, and send the resulting property bag to the engine.

With one hack to work around https://github.com/pulumi/pulumi-terraform/issues/190, with this code I was able to translate our [js s3 website](https://github.com/pulumi/examples/tree/master/aws-js-s3-folder) example to Python and successfully deploy it.