### PR TITLE
Include README in pypi package

### DIFF
--- a/build/travis/install-common-toolchain.sh
+++ b/build/travis/install-common-toolchain.sh
@@ -67,6 +67,13 @@ nvm install ${NODE_VERSION-v8.11.1}
 
     echo "installing Wheel and Twine, so we can publish Python packages"
     pip install --user "wheel==${WHEEL_VERSION}" "twine==${TWINE_VERSION}"
+
+    echo "installing pandoc, so we can generate README.rst for Python packages"
+    if [ "${TRAVIS_OS_NAME:-}" = "linux" ]; then
+        sudo apt-get install pandoc
+    else
+        brew install pandoc
+    fi
 )
 
 # If the sub shell failed, bail out now.
@@ -76,7 +83,7 @@ nvm install ${NODE_VERSION-v8.11.1}
 
 # On OSX, the user folder that `pip` installs tools to is not on the
 # $PATH by default.
-if [[ "${TRAVIS_OS_NAME:-}" == "osx" ]]; then
+if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
     export PATH=$PATH:$HOME/Library/Python/2.7/bin
     export PYTHONPATH=$PYTHONPATH:/usr/local/lib/python2.7/site-packages
 fi

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -29,10 +29,16 @@ ensure::
 	$(PIP) install pipenv==$(PIPENV_VERSION) --user
 	pipenv $(PIPENV_PYTHON_VERSION) install --dev
 	mkdir -p $(PYENVSRC)
-	
+
 build::
 	rm -rf $(PYENVSRC) && cp -R ./lib/. $(PYENVSRC)/
 	sed -i.bak "s/\$${VERSION}/$(VERSION)/g" $(PYENVSRC)/setup.py && rm $(PYENVSRC)/setup.py.bak
+	if [ ! -z "$$(command -v pandoc)" ]; then \
+		pandoc --from=markdown --to=rst --output="$(PYENVSRC)/README.rst" ../../README.md; \
+	else \
+		echo "warning: pandoc not found, generating empty README.rst"; \
+		echo "" > "$(PYENVSRC)/README.rst"; \
+	fi
 	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}
 

--- a/sdk/python/lib/MANIFEST.in
+++ b/sdk/python/lib/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -16,9 +16,14 @@
 
 from setuptools import setup, find_packages
 
+def readme():
+    with open('README.rst') as f:
+        return f.read()
+
 setup(name='pulumi',
       version='${VERSION}',
       description='Pulumi\'s Python SDK',
+      long_description=readme(),
       url='https://github.com/pulumi/pulumi',
       license='Apache 2.0',
       packages=find_packages(),


### PR DESCRIPTION
Use `pandoc` to convert our README.md to a README.rst and then include
that as the long_description in our pypi package.