### PR TITLE
Support empty text assets

### DIFF
--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -81,7 +81,7 @@ func NewURIAsset(uri string) (*Asset, error) {
 	return a, err
 }
 
-func (a *Asset) IsText() bool { return a.Text != "" }
+func (a *Asset) IsText() bool { return !a.IsPath() && !a.IsURI() }
 func (a *Asset) IsPath() bool { return a.Path != "" }
 func (a *Asset) IsURI() bool  { return a.URI != "" }
 
@@ -283,7 +283,6 @@ func (a *Asset) Bytes() ([]byte, error) {
 
 // Read begins reading an asset.
 func (a *Asset) Read() (*Blob, error) {
-	contract.Assertf(a.HasContents(), "cannot read an asset that has no contents")
 	if a.IsText() {
 		return a.readText()
 	} else if a.IsPath() {

--- a/pkg/resource/asset_test.go
+++ b/pkg/resource/asset_test.go
@@ -62,6 +62,20 @@ func TestAssetSerialize(t *testing.T) {
 		assert.Equal(t, text3, asset3.Text)
 		assert.Equal(t, "9a6ed070e1ff834427105844ffd8a399a634753ce7a60ec5aae541524bbe7036", asset3.Hash)
 
+		// check that an empty asset also works correctly.
+		empty, err := NewTextAsset("")
+		assert.Nil(t, err)
+		assert.Equal(t, "", empty.Text)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", empty.Hash)
+		emptySer := empty.Serialize()
+		emptyDes, isasset, err := DeserializeAsset(emptySer)
+		assert.Nil(t, err)
+		assert.True(t, isasset)
+		assert.True(t, emptyDes.IsText())
+		assert.Equal(t, "", emptyDes.Text)
+		assert.Equal(t, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", emptyDes.Hash)
+
+		// now a map of nested assets and/or archives.
 		arch, err := NewAssetArchive(map[string]interface{}{"foo": asset})
 		assert.Nil(t, err)
 		assert.Equal(t, "d8ce0142b3b10300c7c76487fad770f794c1e84e1b0c73a4b2e1503d4fbac093", arch.Hash)


### PR DESCRIPTION
Per #1481, we unintentionally disallowed empty text assets, simply
because of the way we did discriminated union testing.  It's easy
enough to just treat the empty asset like an empty string asset.