### PR TITLE
Add a command-line flag to opt-in to the "parallel" engine

### DIFF
--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -38,6 +38,7 @@ func newPreviewCmd() *cobra.Command {
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
+	var useParallelEngine bool
 
 	var cmd = &cobra.Command{
 		Use:        "preview",
@@ -74,9 +75,10 @@ func newPreviewCmd() *cobra.Command {
 
 			opts := backend.UpdateOptions{
 				Engine: engine.UpdateOptions{
-					Analyzers: analyzers,
-					Parallel:  parallel,
-					Debug:     debug,
+					Analyzers:      analyzers,
+					Parallel:       parallel,
+					Debug:          debug,
+					ParallelEngine: useParallelEngine,
 				},
 				Display: backend.DisplayOptions{
 					Color:                color.Colorization(),
@@ -137,6 +139,9 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&showSames, "show-sames", false,
 		"Show resources that needn't be updated because they haven't changed, alongside those that do")
+	cmd.PersistentFlags().BoolVar(
+		&useParallelEngine, "use-parallel-engine", false,
+		"Use the new experimental parallel engine")
 
 	return cmd
 }

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -41,6 +41,7 @@ func newRefreshCmd() *cobra.Command {
 	var nonInteractive bool
 	var skipPreview bool
 	var yes bool
+	var useParallelEngine bool
 
 	var cmd = &cobra.Command{
 		Use:   "refresh",
@@ -82,9 +83,10 @@ func newRefreshCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				Analyzers: analyzers,
-				Parallel:  parallel,
-				Debug:     debug,
+				Analyzers:      analyzers,
+				Parallel:       parallel,
+				Debug:          debug,
+				ParallelEngine: useParallelEngine,
 			}
 			opts.Display = backend.DisplayOptions{
 				Color:                color.Colorization(),
@@ -141,6 +143,9 @@ func newRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the refresh after previewing it")
+	cmd.PersistentFlags().BoolVar(
+		&useParallelEngine, "use-parallel-engine", false,
+		"Use the new experimental parallel engine")
 
 	return cmd
 }

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -42,6 +42,7 @@ func newUpdateCmd() *cobra.Command {
 	var showSames bool
 	var skipPreview bool
 	var yes bool
+	var useParallelEngine bool
 
 	var cmd = &cobra.Command{
 		Use:        "update",
@@ -87,9 +88,10 @@ func newUpdateCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				Analyzers: analyzers,
-				Parallel:  parallel,
-				Debug:     debug,
+				Analyzers:      analyzers,
+				Parallel:       parallel,
+				Debug:          debug,
+				ParallelEngine: useParallelEngine,
 			}
 			opts.Display = backend.DisplayOptions{
 				Color:                color.Colorization(),
@@ -158,6 +160,9 @@ func newUpdateCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the update after previewing it")
+	cmd.PersistentFlags().BoolVar(
+		&useParallelEngine, "use-parallel-engine", false,
+		"Use the new experimental parallel engine")
 
 	return cmd
 }

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -186,8 +186,9 @@ func (res *planResult) Chdir() (func(), error) {
 func (res *planResult) Walk(ctx *Context, events deploy.Events, preview bool) (deploy.PlanSummary,
 	deploy.Step, resource.Status, error) {
 	opts := deploy.Options{
-		Events:   events,
-		Parallel: res.Options.Parallel,
+		Events:         events,
+		Parallel:       res.Options.Parallel,
+		ParallelEngine: res.Options.ParallelEngine,
 	}
 
 	// Fetch a plan iterator and keep walking it until we are done.

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -35,6 +35,9 @@ type UpdateOptions struct {
 
 	// true if debugging output it enabled
 	Debug bool
+
+	// true if using the new parallel engine, false if using the legacy engine.
+	ParallelEngine bool
 }
 
 // ResourceChanges contains the aggregate resource changes by operation type.

--- a/pkg/resource/deploy/plan_apply.go
+++ b/pkg/resource/deploy/plan_apply.go
@@ -29,8 +29,9 @@ import (
 
 // Options controls the planning and deployment process.
 type Options struct {
-	Events   Events // an optional events callback interface.
-	Parallel int    // the degree of parallelism for resource operations (<=1 for serial).
+	Events         Events // an optional events callback interface.
+	Parallel       int    // the degree of parallelism for resource operations (<=1 for serial).
+	ParallelEngine bool   // if enabled, uses the new parallel engine instead of the legacy engine
 }
 
 // Events is an interface that can be used to hook interesting engine/planning events.


### PR DESCRIPTION
On-deck for this milestone is a bunch of work to enable the engine to perform steps in parallel (https://github.com/pulumi/pulumi/issues/106). To ensure that we don't regress the customer experience while parallelism is still experimental (or, in this case, not yet implemented...), this PR introduces a flag on `preview`, `refresh`, and `update` (`--use-parallel-engine`) which opts-in to the new "parallel" engine.

Note that the flag doesn't do anything, it'll be future PRs that add code behind the `ParallelEngine` feature flag.