### PR TITLE
Show all templates when running `pulumi new`

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -412,8 +412,9 @@ func chooseTemplate(backend cloud.Backend, offline bool, opts backend.DisplayOpt
 
 	var option string
 	if err := survey.AskOne(&survey.Select{
-		Message: message,
-		Options: options,
+		Message:  message,
+		Options:  options,
+		PageSize: len(options),
 	}, &option, nil); err != nil {
 		return "", errors.New(chooseTemplateErr)
 	}


### PR DESCRIPTION
Previously, it would only show the first 7 templates (we currently have 9 total)...

```bash
$ pulumi new
Please choose a template:
> aws-go
  aws-javascript
  aws-python
  aws-typescript
  go
  hello-aws-javascript
  javascript
```

...and you'd have to move the cursor down to the bottom to show the last 2:

```bash
$ pulumi new
Please choose a template:
  aws-python
  aws-typescript
  go
  hello-aws-javascript
  javascript
  python
> typescript
```

After this change, it will show all the templates:

```bash
$ pulumi new
Please choose a template:
> aws-go
  aws-javascript
  aws-python
  aws-typescript
  go
  hello-aws-javascript
  javascript
  python
  typescript
```

Showing all seems reasonable for now given the number of templates we currently have (even if we add a few more in the future). We can always reevaluate if/when the number of templates makes showing all too unwieldy.