### PR TITLE
Work around a potentially bad assert in the engine

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -323,6 +323,10 @@ func (sg *stepGenerator) GenerateDeletes() []Step {
 				// Regardless, it is better to admit strange behavior in corner cases than it is to crash the CLI
 				// whenever we see multiple deletes for the same URN.
 				// contract.Assert(!sg.deletes[res.URN])
+				if sg.deletes[res.URN] {
+					logging.V(7).Infof(
+						"Planner is deleting pending-delete urn '%v' that has already been deleted", res.URN)
+				}
 				sg.deletes[res.URN] = true
 				dels = append(dels, NewDeleteReplacementStep(sg.plan, res, true))
 			} else if !sg.sames[res.URN] && !sg.updates[res.URN] && !sg.replaces[res.URN] && !sg.deletes[res.URN] {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -307,10 +307,32 @@ func (sg *stepGenerator) GenerateDeletes() []Step {
 			res := prev.Resources[i]
 			if res.Delete {
 				logging.V(7).Infof("Planner decided to delete '%v' due to replacement", res.URN)
-				contract.Assert(!sg.deletes[res.URN])
+				// The below assert is commented-out because it's believed to be wrong.
+				//
+				// The original justification for this assert is that the author (swgillespie) believed that
+				// it was impossible for a single URN to be deleted multiple times in the same program.
+				// This has empirically been proven to be false - it is possible using today engine to construct
+				// a series of actions that puts arbitrarily many pending delete resources with the same URN in
+				// the snapshot.
+				//
+				// It is not clear whether or not this is OK. I (swgillespie), the author of this comment, have
+				// seen no evidence that it is *not* OK. However, concerns were raised about what this means for
+				// structural resources, and so until that question is answered, I am leaving this comment and
+				// assert in the code.
+				//
+				// Regardless, it is better to admit strange behavior in corner cases than it is to crash the CLI
+				// whenever we see multiple deletes for the same URN.
+				// contract.Assert(!sg.deletes[res.URN])
 				sg.deletes[res.URN] = true
 				dels = append(dels, NewDeleteReplacementStep(sg.plan, res, true))
 			} else if !sg.sames[res.URN] && !sg.updates[res.URN] && !sg.replaces[res.URN] && !sg.deletes[res.URN] {
+				// In addition to the above comment, I am fairly certain there is a bug here. If a resource
+				// is not registered in a plan, but there exists a pending delete copy of that resource in the
+				// snapshot, we will choose not to delete the live resource and instead be content with deleting
+				// the pending delete resource.
+				//
+				// This is fairly benign, since in the worst case we'll delete the resource on the next plan, but
+				// it points to a need for a more principled handling of pending deletions.
 				logging.V(7).Infof("Planner decided to delete '%v'", res.URN)
 				sg.deletes[res.URN] = true
 				dels = append(dels, NewDeleteStep(sg.plan, res))

--- a/tests/integration/double_pending_delete/double_pending_delete_test.go
+++ b/tests/integration/double_pending_delete/double_pending_delete_test.go
@@ -1,0 +1,94 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package ints
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that the engine tolerates two deletions of the same URN in the same plan.
+func TestDoublePendingDelete(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "step1",
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        true,
+		EditDirs: []integration.EditDir{
+			{
+				Dir:           "step2",
+				Additive:      true,
+				ExpectFailure: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					assert.NotNil(t, stackInfo.Deployment)
+
+					// Four resources in this deployment: the root resource, A, B, and A (pending delete)
+					assert.Equal(t, 4, len(stackInfo.Deployment.Resources))
+					stackRes := stackInfo.Deployment.Resources[0]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+					a := stackInfo.Deployment.Resources[1]
+					assert.Equal(t, "a", string(a.URN.Name()))
+					assert.False(t, a.Delete)
+
+					aCondemned := stackInfo.Deployment.Resources[2]
+					assert.Equal(t, "a", string(aCondemned.URN.Name()))
+					assert.True(t, aCondemned.Delete)
+
+					b := stackInfo.Deployment.Resources[3]
+					assert.Equal(t, "b", string(b.URN.Name()))
+					assert.False(t, b.Delete)
+
+				},
+			},
+			{
+				Dir:           "step3",
+				Additive:      true,
+				ExpectFailure: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					// Now there are two pending deletes in the deployment.
+					assert.NotNil(t, stackInfo.Deployment)
+
+					assert.Equal(t, 5, len(stackInfo.Deployment.Resources))
+					stackRes := stackInfo.Deployment.Resources[0]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+					a := stackInfo.Deployment.Resources[1]
+					assert.Equal(t, "a", string(a.URN.Name()))
+					assert.False(t, a.Delete)
+
+					aCondemned := stackInfo.Deployment.Resources[2]
+					assert.Equal(t, "a", string(aCondemned.URN.Name()))
+					assert.True(t, aCondemned.Delete)
+
+					aSecondCondemned := stackInfo.Deployment.Resources[3]
+					assert.Equal(t, "a", string(aSecondCondemned.URN.Name()))
+					assert.True(t, aSecondCondemned.Delete)
+
+					b := stackInfo.Deployment.Resources[4]
+					assert.Equal(t, "b", string(b.URN.Name()))
+					assert.False(t, b.Delete)
+				},
+			},
+			{
+				Dir:      "step4",
+				Additive: true,
+				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+					// We should have cleared out all of the pending deletes now.
+					assert.NotNil(t, stackInfo.Deployment)
+
+					assert.Equal(t, 3, len(stackInfo.Deployment.Resources))
+					stackRes := stackInfo.Deployment.Resources[0]
+					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
+					a := stackInfo.Deployment.Resources[1]
+					assert.Equal(t, "a", string(a.URN.Name()))
+					assert.False(t, a.Delete)
+
+					b := stackInfo.Deployment.Resources[2]
+					assert.Equal(t, "b", string(b.URN.Name()))
+					assert.False(t, b.Delete)
+				},
+			},
+		},
+	})
+}

--- a/tests/integration/double_pending_delete/step1/Pulumi.yaml
+++ b/tests/integration/double_pending_delete/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: double_pending_delete
+description: A program that produces multiple pending deletes for the same URN
+runtime: nodejs

--- a/tests/integration/double_pending_delete/step1/index.ts
+++ b/tests/integration/double_pending_delete/step1/index.ts
@@ -1,0 +1,23 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Resource } from "./resource";
+
+// Setup: Resources A and B are created successfully.
+const a = new Resource("a", { fail: 0 });
+const b = new Resource("b", { fail: 0 });
+// The snapshot now contains:
+//  A: Created
+//  B: Created
+

--- a/tests/integration/double_pending_delete/step1/package.json
+++ b/tests/integration/double_pending_delete/step1/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "double_pending_delete",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "typescript": "^2.9.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/double_pending_delete/step1/resource.ts
+++ b/tests/integration/double_pending_delete/step1/resource.ts
@@ -1,0 +1,62 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
+
+export class Provider implements dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    private id: number = 0;
+
+    public async check(olds: any, news: any): Promise<dynamic.CheckResult> {
+        return {
+            inputs: news,
+        }
+    }
+
+    public async diff(id: pulumi.ID, olds: any, news: any): Promise<dynamic.DiffResult> {
+        if (news.fail != olds.fail) {
+            return {
+                changes: true,
+                replaces: ["fail"]
+            }
+        }
+
+        return {
+            changes: false,
+        }
+    }
+
+    public async create(inputs: any): Promise<dynamic.CreateResult> {
+        if (inputs.fail == 1) {
+            throw new Error("failed to create this resource");
+        }
+
+        return {
+            id: (this.id++).toString(),
+            outs: inputs,
+        }
+    }
+
+    public async update(id: string, olds: any, news: any): Promise<dynamic.UpdateResult> {
+        throw Error("this resource is replace-only and can't be updated");
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    constructor(name: string, props: any, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+    }
+}

--- a/tests/integration/double_pending_delete/step1/tsconfig.json
+++ b/tests/integration/double_pending_delete/step1/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/integration/double_pending_delete/step2/index.ts
+++ b/tests/integration/double_pending_delete/step2/index.ts
@@ -1,0 +1,29 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Resource } from "./resource";
+
+// The changes in this plan trigger replacement of both A and B.
+// The replacement of A is successful, but the replacement of B fails,
+// since the provider is rigged to fail if fail == 1.
+//
+// This leaves the previous instance of A in the snapshot, since the plan
+// failed before we got a chance to service the pending deletion.
+const a = new Resource("a", { fail: 2 });
+const b = new Resource("b", { fail: 1 });
+// The snapshot now contains:
+//  A: Created
+//  A: Pending Delete
+//  B: Created
+

--- a/tests/integration/double_pending_delete/step3/index.ts
+++ b/tests/integration/double_pending_delete/step3/index.ts
@@ -1,0 +1,36 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Resource } from "./resource";
+
+// The previous plan failed, but we're going to initiate *another* plan that
+// introduces new changes, while still keeping around the failed state
+// from the previous plan.
+//
+// To do this, we're going to trigger another replacement of A:
+const a = new Resource("a", { fail: 3 });
+
+// We will still fail to replace B, since fail == 1.
+const b = new Resource("b", { fail: 1 });
+// The snapshot now contains:
+//  A: Created
+//  A: Pending Delete
+//  A: Pending Delete
+//  B: Created
+
+// This plan is interesting because it shows that it is legal to delete the same URN multiple
+// times in the same plan. This previously triggered an assert in the engine that asserted
+// that this is impossible (https://github.com/pulumi/pulumi/issues/1503)
+
+

--- a/tests/integration/double_pending_delete/step4/index.ts
+++ b/tests/integration/double_pending_delete/step4/index.ts
@@ -1,0 +1,34 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Resource } from "./resource";
+
+// We'll complete our disaster recovery by triggering replacements of A and B again,
+// but this time the replacement of B will succeed.
+// The engine should generate:
+//
+// Create A (mark old A as pending delete)
+const a = new Resource("a", { fail: 4 });
+
+// Create B
+const b = new Resource("b", { fail: 2 });
+
+// Delete A
+// Delete B
+// Delete A
+// Delete A
+
+// Like the last step, this is interesting because we delete A's URN three times in the same plan.
+// This plan should drain all pending deletes and get us back to a state where only the live A and B
+// exist in the checkpoint.


### PR DESCRIPTION
The engine asserts if presented with a plan that deletes the same URN
more than once. This has been empirically proven to be possible, so I am
removing the assert.

This fixes the immediate badness of https://github.com/pulumi/pulumi/issues/1503, but I'm going to leave the issue open until we understand all of the implications of deleting the same URN multiple times. I am certain that there are bugs lurking here and we may have to re-think how we do pending deletes in order to iron them all out.

This PR makes the CLI not crash when it sees a plan that deletes the same URN multiple times, which I think is a big enough improvement to justify the risk. It is really, *really* annoying to fix a stack that has wandered into this state as it is today.