### PR TITLE
Add a migrate package for migrating to and from differently-versioned API types

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -39,16 +39,8 @@ import (
 const (
 	// DeploymentSchemaVersionCurrent is the current version of the `Deployment` schema.
 	// Any deployments newer than this version will be rejected.
-	DeploymentSchemaVersionCurrent = 1
+	DeploymentSchemaVersionCurrent = 2
 )
-
-// We alias the latest versions of the various types below to their friendly names here.
-
-type Checkpoint = CheckpointV1
-type Deployment = DeploymentV1
-type Manifest = ManifestV1
-type PluginInfo = PluginInfoV1
-type Resource = ResourceV1
 
 // VersionedCheckpoint is a version number plus a json document. The version number describes what
 // version of the Checkpoint structure the Checkpoint member's json document can decode into.

--- a/pkg/apitype/migrate/checkpoint.go
+++ b/pkg/apitype/migrate/checkpoint.go
@@ -1,0 +1,48 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/resource/config"
+)
+
+// UpToCheckpointV2 migrates a CheckpointV1 to a CheckpointV2.
+func UpToCheckpointV2(v1 apitype.CheckpointV1) apitype.CheckpointV2 {
+	var v2 apitype.CheckpointV2
+	v2.Stack = v1.Stack
+	v2.Config = make(config.Map)
+	for key, value := range v1.Config {
+		v2.Config[key] = value
+	}
+
+	v2deploy := UpToDeploymentV2(*v1.Latest)
+	v2.Latest = &v2deploy
+	return v2
+}
+
+// DownToCheckpointV1 migrates a CheckpointV2 to a CheckpointV1
+func DownToCheckpointV1(v2 apitype.CheckpointV2) apitype.CheckpointV1 {
+	var v1 apitype.CheckpointV1
+	v1.Stack = v2.Stack
+	v1.Config = make(config.Map)
+	for key, value := range v2.Config {
+		v1.Config[key] = value
+	}
+
+	v1deploy := DownToDeploymentV1(*v2.Latest)
+	v1.Latest = &v1deploy
+	return v1
+}

--- a/pkg/apitype/migrate/checkpoint_test.go
+++ b/pkg/apitype/migrate/checkpoint_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckpointV1ToV2(t *testing.T) {
+	v1 := apitype.CheckpointV1{
+		Stack: tokens.QName("mystack"),
+		Config: config.Map{
+			config.MustMakeKey("foo", "number"): config.NewValue("42"),
+		},
+		Latest: &apitype.DeploymentV1{
+			Manifest:  apitype.ManifestV1{},
+			Resources: []apitype.ResourceV1{},
+		},
+	}
+
+	v2 := UpToCheckpointV2(v1)
+	assert.Equal(t, tokens.QName("mystack"), v2.Stack)
+	assert.Equal(t, config.Map{
+		config.MustMakeKey("foo", "number"): config.NewValue("42"),
+	}, v2.Config)
+	assert.Len(t, v2.Latest.Resources, 0)
+}
+
+func TestCheckpointV2ToV1(t *testing.T) {
+	v2 := apitype.CheckpointV2{
+		Stack: tokens.QName("mystack"),
+		Config: config.Map{
+			config.MustMakeKey("foo", "number"): config.NewValue("42"),
+		},
+		Latest: &apitype.DeploymentV2{
+			Manifest:  apitype.ManifestV1{},
+			Resources: []apitype.ResourceV2{},
+		},
+	}
+
+	v1 := DownToCheckpointV1(v2)
+	assert.Equal(t, tokens.QName("mystack"), v1.Stack)
+	assert.Equal(t, config.Map{
+		config.MustMakeKey("foo", "number"): config.NewValue("42"),
+	}, v1.Config)
+	assert.Len(t, v1.Latest.Resources, 0)
+}

--- a/pkg/apitype/migrate/deployment.go
+++ b/pkg/apitype/migrate/deployment.go
@@ -1,0 +1,45 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import "github.com/pulumi/pulumi/pkg/apitype"
+
+// UpToDeploymentV2 migrates a deployment from DeploymentV1 to DeploymentV2.
+func UpToDeploymentV2(v1 apitype.DeploymentV1) apitype.DeploymentV2 {
+	var v2 apitype.DeploymentV2
+	// The manifest format did not change between V1 and V2.
+	v2.Manifest = v1.Manifest
+	for _, res := range v1.Resources {
+		v2.Resources = append(v2.Resources, UpToResourceV2(res))
+	}
+
+	return v2
+}
+
+// DownToDeploymentV1 migrates a deployment from DeploymentV2 to DeploymentV1.
+func DownToDeploymentV1(v2 apitype.DeploymentV2) apitype.DeploymentV1 {
+	var v1 apitype.DeploymentV1
+	v1.Manifest = v2.Manifest
+	for _, res := range v2.Resources {
+		if res.External {
+			// External resources were not stored in the deployment prior to V2.
+			continue
+		}
+
+		v1.Resources = append(v1.Resources, DownToResourceV1(res))
+	}
+
+	return v1
+}

--- a/pkg/apitype/migrate/deployment_test.go
+++ b/pkg/apitype/migrate/deployment_test.go
@@ -1,0 +1,64 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeploymentV1ToV2(t *testing.T) {
+	v1 := apitype.DeploymentV1{
+		Manifest: apitype.ManifestV1{},
+		Resources: []apitype.ResourceV1{
+			apitype.ResourceV1{
+				URN: resource.URN("a"),
+			},
+			apitype.ResourceV1{
+				URN: resource.URN("b"),
+			},
+		},
+	}
+
+	v2 := UpToDeploymentV2(v1)
+	assert.Equal(t, v1.Manifest, v2.Manifest)
+	assert.Len(t, v1.Resources, 2)
+	assert.Equal(t, resource.URN("a"), v1.Resources[0].URN)
+	assert.Equal(t, resource.URN("b"), v1.Resources[1].URN)
+}
+
+func TestDeploymentV2ToV1(t *testing.T) {
+	v2 := apitype.DeploymentV2{
+		Manifest: apitype.ManifestV1{},
+		Resources: []apitype.ResourceV2{
+			apitype.ResourceV2{
+				URN: resource.URN("a"),
+			},
+			apitype.ResourceV2{
+				URN: resource.URN("b"),
+				// this resource gets excluded from the V1 snapshot because it's external
+				External: true,
+			},
+		},
+	}
+
+	v1 := DownToDeploymentV1(v2)
+	assert.Equal(t, v2.Manifest, v1.Manifest)
+	assert.Len(t, v1.Resources, 1)
+	assert.Equal(t, resource.URN("a"), v1.Resources[0].URN)
+}

--- a/pkg/apitype/migrate/deployment_test.go
+++ b/pkg/apitype/migrate/deployment_test.go
@@ -26,10 +26,10 @@ func TestDeploymentV1ToV2(t *testing.T) {
 	v1 := apitype.DeploymentV1{
 		Manifest: apitype.ManifestV1{},
 		Resources: []apitype.ResourceV1{
-			apitype.ResourceV1{
+			{
 				URN: resource.URN("a"),
 			},
-			apitype.ResourceV1{
+			{
 				URN: resource.URN("b"),
 			},
 		},
@@ -46,10 +46,10 @@ func TestDeploymentV2ToV1(t *testing.T) {
 	v2 := apitype.DeploymentV2{
 		Manifest: apitype.ManifestV1{},
 		Resources: []apitype.ResourceV2{
-			apitype.ResourceV2{
+			{
 				URN: resource.URN("a"),
 			},
-			apitype.ResourceV2{
+			{
 				URN: resource.URN("b"),
 				// this resource gets excluded from the V1 snapshot because it's external
 				External: true,

--- a/pkg/apitype/migrate/doc.go
+++ b/pkg/apitype/migrate/doc.go
@@ -1,0 +1,26 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package migrate is responsible for converting to and from the various API
+// type versions that are in use in Pulumi. This package can migrate "up" and
+// "down" versions for every versioned API that needs to be migrated between
+// versions. Today, there are three versionable entities that can be migrated
+// with this package:
+//   * Checkpoint, the on-disk format for Fire-and-Forget stack state,
+//   * Deployment, the wire format for service-managed stacks,
+//   * Resource, the wire format for resources saved in deployments,
+//
+// The migrations in this package are designed to preserve semantics between
+// versions. It is always safe to migrate an entity from one version to another.
+package migrate

--- a/pkg/apitype/migrate/resource.go
+++ b/pkg/apitype/migrate/resource.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+)
+
+// UpToResourceV2 migrates a resource from ResourceV1 to ResourceV2.
+func UpToResourceV2(v1 apitype.ResourceV1) apitype.ResourceV2 {
+	var v2 apitype.ResourceV2
+	v2.URN = v1.URN
+	v2.Custom = v1.Custom
+	v2.Delete = v1.Delete
+	v2.ID = v1.ID
+	v2.Type = v1.Type
+	v2.Inputs = make(map[string]interface{})
+	for key, value := range v1.Inputs {
+		v2.Inputs[key] = value
+	}
+	// v1.Defaults was deprecated in v2.
+	v2.Outputs = make(map[string]interface{})
+	for key, value := range v1.Outputs {
+		v2.Outputs[key] = value
+	}
+	v2.Parent = v1.Parent
+	v2.Protect = v1.Protect
+	// v2.External is a new field that, when true, indicates that this resource's
+	// lifecycle is not owned by Pulumi. Since all V1 resources have their lifecycles
+	// owned by Pulumi, this is `false` for all V1 resources.
+	v2.External = false
+	v2.Dependencies = append(v1.Dependencies, v2.Dependencies...)
+	return v2
+}
+
+// DownToResourceV1 migrates a resource from ResourceV2 to ResourceV1.
+func DownToResourceV1(v2 apitype.ResourceV2) apitype.ResourceV1 {
+	contract.Assertf(!v2.External, "Can't convert a V2 External resource to V1")
+	var v1 apitype.ResourceV1
+	v1.URN = v2.URN
+	v1.Custom = v2.Custom
+	v1.Delete = v2.Delete
+	v1.ID = v2.ID
+	v1.Type = v2.Type
+	v1.Inputs = make(map[string]interface{})
+	for key, value := range v2.Inputs {
+		v1.Inputs[key] = value
+	}
+	// Defaults was deprecated in v2.
+	v1.Defaults = make(map[string]interface{})
+	v1.Outputs = make(map[string]interface{})
+	for key, value := range v2.Outputs {
+		v1.Outputs[key] = value
+	}
+	v1.Parent = v2.Parent
+	v1.Protect = v2.Protect
+	v1.Dependencies = append(v1.Dependencies, v2.Dependencies...)
+	return v1
+}

--- a/pkg/apitype/migrate/resource_test.go
+++ b/pkg/apitype/migrate/resource_test.go
@@ -1,0 +1,139 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestV1ToV2(t *testing.T) {
+	v1 := apitype.ResourceV1{
+		URN:    resource.URN("foo"),
+		Custom: true,
+		Delete: true,
+		ID:     resource.ID("bar"),
+		Type:   tokens.Type("special"),
+		Inputs: map[string]interface{}{
+			"foo_in": "baz",
+		},
+		Defaults: map[string]interface{}{
+			"foo_default": "stuff",
+		},
+		Outputs: map[string]interface{}{
+			"foo_out": "out",
+		},
+		Parent:  resource.URN("parent"),
+		Protect: true,
+		Dependencies: []resource.URN{
+			resource.URN("dep1"),
+			resource.URN("dep2"),
+		},
+	}
+
+	v2 := UpToResourceV2(v1)
+	assert.Equal(t, resource.URN("foo"), v2.URN)
+	assert.True(t, v2.Custom)
+	assert.True(t, v2.Delete)
+	assert.Equal(t, resource.ID("bar"), v2.ID)
+	assert.Equal(t, tokens.Type("special"), v2.Type)
+	assert.Equal(t, map[string]interface{}{
+		"foo_in": "baz",
+	}, v2.Inputs)
+	assert.Equal(t, map[string]interface{}{
+		"foo_out": "out",
+	}, v2.Outputs)
+	assert.Equal(t, resource.URN("parent"), v2.Parent)
+	assert.True(t, v2.Protect)
+	assert.False(t, v2.External)
+	assert.Equal(t, []resource.URN{
+		resource.URN("dep1"),
+		resource.URN("dep2"),
+	}, v2.Dependencies)
+}
+
+func TestV2ToV1(t *testing.T) {
+	v2 := apitype.ResourceV2{
+		URN:    resource.URN("foo"),
+		Custom: true,
+		Delete: true,
+		ID:     resource.ID("bar"),
+		Type:   tokens.Type("special"),
+		Inputs: map[string]interface{}{
+			"foo_in": "baz",
+		},
+		Outputs: map[string]interface{}{
+			"foo_out": "out",
+		},
+		Parent:   resource.URN("parent"),
+		Protect:  true,
+		External: false,
+		Dependencies: []resource.URN{
+			resource.URN("dep1"),
+			resource.URN("dep2"),
+		},
+	}
+
+	v1 := DownToResourceV1(v2)
+	assert.Equal(t, resource.URN("foo"), v1.URN)
+	assert.True(t, v1.Custom)
+	assert.True(t, v1.Delete)
+	assert.Equal(t, resource.ID("bar"), v1.ID)
+	assert.Equal(t, tokens.Type("special"), v1.Type)
+	assert.Equal(t, map[string]interface{}{
+		"foo_in": "baz",
+	}, v1.Inputs)
+	assert.Equal(t, map[string]interface{}{}, v1.Defaults)
+	assert.Equal(t, map[string]interface{}{
+		"foo_out": "out",
+	}, v1.Outputs)
+	assert.Equal(t, resource.URN("parent"), v1.Parent)
+	assert.True(t, v1.Protect)
+	assert.Equal(t, []resource.URN{
+		resource.URN("dep1"),
+		resource.URN("dep2"),
+	}, v2.Dependencies)
+}
+
+func TestInvalidV2ToV1(t *testing.T) {
+	v2 := apitype.ResourceV2{
+		URN:    resource.URN("foo"),
+		Custom: true,
+		Delete: true,
+		ID:     resource.ID("bar"),
+		Type:   tokens.Type("special"),
+		Inputs: map[string]interface{}{
+			"foo_in": "baz",
+		},
+		Outputs: map[string]interface{}{
+			"foo_out": "out",
+		},
+		Parent:   resource.URN("parent"),
+		Protect:  true,
+		External: true,
+		Dependencies: []resource.URN{
+			resource.URN("dep1"),
+			resource.URN("dep2"),
+		},
+	}
+
+	assert.Panics(t, func() {
+		DownToResourceV1(v2)
+	})
+}

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/apitype/migrate"
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/engine"
@@ -34,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/logging"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -497,10 +499,13 @@ func (pc *Client) InvalidateUpdateCheckpoint(ctx context.Context, update UpdateI
 }
 
 // PatchUpdateCheckpoint patches the checkpoint for the indicated update with the given contents.
-func (pc *Client) PatchUpdateCheckpoint(ctx context.Context, update UpdateIdentifier, deployment *apitype.DeploymentV1,
+func (pc *Client) PatchUpdateCheckpoint(ctx context.Context, update UpdateIdentifier, deployment *apitype.DeploymentV2,
 	token string) error {
 
-	rawDeployment, err := json.Marshal(deployment)
+	// TODO(pulumi/pulumi#1521): until the service can understand V2 checkpoints, downgrade to V1 before sending it.
+	logging.V(7).Infof("PatchUpdateCheckpoint: downgrading V2 checkpoint to V1 to speak to service")
+	v1deployment := migrate.DownToDeploymentV1(*deployment)
+	rawDeployment, err := json.Marshal(v1deployment)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -387,17 +387,7 @@ func (b *localBackend) ImportDeployment(ctx context.Context, stackRef backend.St
 		return err
 	}
 
-	var latest apitype.Deployment
-	if err = json.Unmarshal(deployment.Deployment, &latest); err != nil {
-		return err
-	}
-
-	checkpoint := &apitype.CheckpointV1{
-		Stack:  stackName,
-		Config: config,
-		Latest: &latest,
-	}
-	snap, err := stack.DeserializeCheckpoint(checkpoint)
+	snap, err := stack.DeserializeDeployment(deployment)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/local/state.go
+++ b/pkg/backend/local/state.go
@@ -136,7 +136,7 @@ func (b *localBackend) getStack(name tokens.QName) (config.Map, *deploy.Snapshot
 }
 
 // GetCheckpoint loads a checkpoint file for the given stack in this project, from the current project workspace.
-func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.CheckpointV1, error) {
+func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.CheckpointV2, error) {
 	chkpath := b.stackPath(stackName)
 	bytes, err := ioutil.ReadFile(chkpath)
 	if err != nil {

--- a/pkg/operations/resources_test.go
+++ b/pkg/operations/resources_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func getPulumiResources(t *testing.T, path string) *Resource {
-	var checkpoint apitype.CheckpointV1
+	var checkpoint apitype.CheckpointV2
 	byts, err := ioutil.ReadFile(path)
 	assert.NoError(t, err)
 	err = json.Unmarshal(byts, &checkpoint)

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/apitype/migrate"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
@@ -31,7 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
-func UnmarshalVersionedCheckpointToLatestCheckpoint(bytes []byte) (*apitype.CheckpointV1, error) {
+func UnmarshalVersionedCheckpointToLatestCheckpoint(bytes []byte) (*apitype.CheckpointV2, error) {
 	var versionedCheckpoint apitype.VersionedCheckpoint
 	if err := json.Unmarshal(bytes, &versionedCheckpoint); err != nil {
 		return nil, err
@@ -47,12 +48,23 @@ func UnmarshalVersionedCheckpointToLatestCheckpoint(bytes []byte) (*apitype.Chec
 		if err := json.Unmarshal(bytes, &checkpoint); err != nil {
 			return nil, err
 		}
-		return &checkpoint, nil
+
+		v2checkpoint := migrate.UpToCheckpointV2(checkpoint)
+		return &v2checkpoint, nil
 	case 1:
 		var checkpoint apitype.CheckpointV1
 		if err := json.Unmarshal(versionedCheckpoint.Checkpoint, &checkpoint); err != nil {
 			return nil, err
 		}
+
+		v2checkpoint := migrate.UpToCheckpointV2(checkpoint)
+		return &v2checkpoint, nil
+	case 2:
+		var checkpoint apitype.CheckpointV2
+		if err := json.Unmarshal(versionedCheckpoint.Checkpoint, &checkpoint); err != nil {
+			return nil, err
+		}
+
 		return &checkpoint, nil
 	default:
 		return nil, errors.Errorf("unsupported checkpoint version %d", versionedCheckpoint.Version)
@@ -62,12 +74,12 @@ func UnmarshalVersionedCheckpointToLatestCheckpoint(bytes []byte) (*apitype.Chec
 // SerializeCheckpoint turns a snapshot into a data structure suitable for serialization.
 func SerializeCheckpoint(stack tokens.QName, config config.Map, snap *deploy.Snapshot) *apitype.VersionedCheckpoint {
 	// If snap is nil, that's okay, we will just create an empty deployment; otherwise, serialize the whole snapshot.
-	var latest *apitype.Deployment
+	var latest *apitype.DeploymentV2
 	if snap != nil {
 		latest = SerializeDeployment(snap)
 	}
 
-	b, err := json.Marshal(apitype.CheckpointV1{
+	b, err := json.Marshal(apitype.CheckpointV2{
 		Stack:  stack,
 		Config: config,
 		Latest: latest,
@@ -81,7 +93,7 @@ func SerializeCheckpoint(stack tokens.QName, config config.Map, snap *deploy.Sna
 }
 
 // DeserializeCheckpoint takes a serialized deployment record and returns its associated snapshot.
-func DeserializeCheckpoint(chkpoint *apitype.CheckpointV1) (*deploy.Snapshot, error) {
+func DeserializeCheckpoint(chkpoint *apitype.CheckpointV2) (*deploy.Snapshot, error) {
 	contract.Require(chkpoint != nil, "chkpoint")
 
 	var snap *deploy.Snapshot

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -51,8 +51,8 @@ import (
 // RuntimeValidationStackInfo contains details related to the stack that runtime validation logic may want to use.
 type RuntimeValidationStackInfo struct {
 	StackName    tokens.QName
-	Deployment   *apitype.Deployment
-	RootResource apitype.Resource
+	Deployment   *apitype.DeploymentV2
+	RootResource apitype.ResourceV2
 	Outputs      map[string]interface{}
 }
 
@@ -860,13 +860,13 @@ func (pt *programTester) performExtraRuntimeValidation(
 	if err = json.NewDecoder(f).Decode(&untypedDeployment); err != nil {
 		return err
 	}
-	var deployment apitype.Deployment
+	var deployment apitype.DeploymentV2
 	if err = json.Unmarshal(untypedDeployment.Deployment, &deployment); err != nil {
 		return err
 	}
 
 	// Get the root resource and outputs from the deployment
-	var rootResource apitype.Resource
+	var rootResource apitype.ResourceV2
 	var outputs map[string]interface{}
 	for _, res := range deployment.Resources {
 		if res.Type == resource.RootStackType {

--- a/tests/integration/steps/steps_test.go
+++ b/tests/integration/steps/steps_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/testing/integration"
 )
 
-func validateResources(t *testing.T, resources []apitype.Resource, expectedNames ...string) {
+func validateResources(t *testing.T, resources []apitype.ResourceV2, expectedNames ...string) {
 	// Build the lookup table of expected resource names.
 	expectedNamesTable := make(map[string]struct{})
 	for _, n := range expectedNames {


### PR DESCRIPTION
There's a lot of code in this PR but I promise that most of the code are for tests 😄 .

This PR creates a new `migrate` subpackage of `apitypes` that is responsible for migrating API types from one version to another. This package is immediately used in this PR to only use the `V2` deployment, resource, and checkpoint API types in the CLI. Any use of the V1 deployment, resource, and checkpoint APIs are immediately projected into V2 in the process of deserializing the API types into engine data structures.

Because the service is not yet ready to accept V2 deployments yet, and because V2 deployments don't have any additional semantics yet (i.e. the fix for https://github.com/pulumi/pulumi/issues/1521), V2 deployments are coerced again back to V1 so that they can be sent to the service. This is temporary until the service is ready to understand these new versions.

Also of note is that this PR does not project V2 checkpoints back to V1 before saving them on-disk in the fire and forget case. Everything works fine, but any CLI that operates on the on-disk V2 checkpoint must be this commit or newer in order to understand the new format.