### PR TITLE
Add git ref to environment map

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -382,6 +382,8 @@ func getUpdateMetadata(msg, root string) (backend.UpdateMetadata, error) {
 	} else {
 		hash := head.Hash()
 		m.Environment[backend.GitHead] = hash.String()
+		m.Environment[backend.GitRefName] = head.Name().String()
+
 		commit, commitErr := repo.CommitObject(hash)
 		if commitErr != nil {
 			cmdutil.Diag().Warningf(

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -58,6 +58,9 @@ const (
 const (
 	// GitHead is the commit hash of HEAD.
 	GitHead = "git.head"
+	// GitRefName is the name of the current reference at HEAD. Typically a branch, e.g. refs/heads/master.
+	// If in a detached HEAD state, will simply be HEAD.
+	GitRefName = "git.ref"
 	// GitDirty ("true", "false") indiciates if there are any unstaged or modified files in the local repo.
 	GitDirty = "git.dirty"
 


### PR DESCRIPTION
The `getUpdateMetadata` function is called as part of running an update to build a map of local environment information. The data is used in the service to associate the update with its source context, e.g. "stack X was updated in git repo Y at commit Z".

This PR adds another piece of git environment data to the map, the current ref name. I'm not 100% sure of all the corner cases, but my understanding is that it is either "HEAD" (detached head), a "refs/heads/foo" (branch name), or "refs/tags/bar" (tag name).

We need to know the ref name so we can disambiguate the source of a Pulumi update in various workflow type scenarios. e.g. associating the `pulumi preview` with a specific PR, which in some situations could be ambiguous.