### PR TITLE
Go back to capturing *non-user* modules by 'require' reference.

### DIFF
--- a/sdk/nodejs/config.ts
+++ b/sdk/nodejs/config.ts
@@ -34,11 +34,8 @@ export class Config {
         // To ease migration of code that already does new Config("<package>:config"), treat this as if
         // just new Config("<package>") was called.
         if (name.endsWith(":config")) {
-            const newName = name.replace(/:config$/, "");
-            log.warn(util.format("`:config` is no longer required at the end of configuration " +
-                "bag names and support will be removed in a future version, please " +
-                "use new Config(\"%s\") instead.", newName));
-            name = newName;
+            name = name.replace(/:config$/, "");
+            warnAtDeploymentTime(name);
         }
 
         this.name = name;
@@ -172,6 +169,15 @@ export class Config {
         return `${this.name}:${key}`;
     }
 }
+
+function warnAtDeploymentTime(newName: string) {
+    log.warn(util.format("`:config` is no longer required at the end of configuration " +
+        "bag names and support will be removed in a future version, please " +
+        "use new Config(\"%s\") instead.", newName));
+}
+
+// warnAtDeploymentTime sends RPC messages and this is only available at deployment time.
+(<any>warnAtDeploymentTime).doNotCapture = true;
 
 /**
  * ConfigTypeError is used when a configuration value is of the wrong type.

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -14,7 +14,6 @@
 
 // The log module logs messages in a way that tightly integrates with the resource engine's interface.
 
-import * as util from "util";
 import * as resourceTypes from "../resource";
 import { getEngine, rpcKeepAlive } from "../runtime/settings";
 const engproto = require("../proto/engine_pb.js");
@@ -121,3 +120,6 @@ function log(
     return lastLog;
 }
 
+// 'log' module is not usable on the inside of a pulumi cloud function.  It expects to be able to
+// make RPC calls to the engine, which is only supported at deployment time.
+export const doNotCapture = true;

--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -228,6 +228,9 @@ function serializeJavaScriptText(
         else if (envEntry.function !== undefined) {
             return emitFunctionAndGetName(envEntry.function);
         }
+        else if (envEntry.module !== undefined) {
+            return `require("${envEntry.module}")`;
+        }
         else if (envEntry.output !== undefined) {
             return envEntryToString(envEntry.output, varName);
         }

--- a/sdk/nodejs/runtime/config.ts
+++ b/sdk/nodejs/runtime/config.ts
@@ -19,6 +19,11 @@ const configEnvKey = "PULUMI_CONFIG";
 
 const config: {[key: string]: string} = {};
 
+// We want this module to actually be captured as a value in a pulumi program.
+// That way, any actual values set at deployment time will also be available at
+// cloud-runtime.
+export const captureAsValue = true;
+
 /**
  * allConfig returns a copy of the full config map.
  */

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -4810,7 +4810,7 @@ return function () { console.log(o1); console.log(o2.b.d); console.log(o3.b.d); 
 var __testConfig_proto = {};
 __f1.prototype = __testConfig_proto;
 Object.defineProperty(__testConfig_proto, "constructor", { configurable: true, writable: true, value: __f1 });
-var __config = {["test:TestingKey1"]: "TestingValue1", ["test:TestingKey2"]: "TestingValue2"};
+var __config = {["test:TestingKey1"]: "TestingValue1", ["test:TestingKey2"]: "TestingValue2"(...)};
 var __runtime = {getConfig: __getConfig};
 Object.defineProperty(__testConfig_proto, "get", { configurable: true, writable: true, value: __f3 });
 __f6.isInstance = __f7;
@@ -4876,7 +4876,7 @@ return function () { const v = testConfig.get("TestingKey1"); console.log(v); };
 
 var __f1_prototype = {};
 Object.defineProperty(__f1_prototype, "constructor", { configurable: true, writable: true, value: __f1 });
-var __0_config = {["test:TestingKey1"]: "TestingValue1", ["test:TestingKey2"]: "TestingValue2"};
+var __0_config = {["test:TestingKey1"]: "TestingValue1", ["test:TestingKey2"]: "TestingValue2"(...)};
 var __runtime = {getConfig: __getConfig};
 Object.defineProperty(__f1_prototype, "get", { configurable: true, writable: true, value: __f3 });
 __f6.isInstance = __f7;


### PR DESCRIPTION
This PR brings module serialization closer to what it used to be.  Specifically, if we see a module captured in a serialized function we will serialize it out into the function as ```require(<module_name>)```.  This means that it is now possible once more to just ```import * as fs from "fs"``` at the top level of a pulumi program and use it within a serialized callback function.

However, there are some slight tweaks to the previous approach that we've taken here that address several of the shortcoming of the previous approach.

1.  Modules can optionally opt-into stating that they do not want to be captured in this manner, and that they should instead be captured by the current 'by value' serialization semantics we have elsewhere.  An example of a module that does this is our 'Config' module.  By capturing as a value (and not as a `require`), the Config object will hydrate on the cloud-callback side with all the configuration values specified at deployment time.
2. We capture the *local* module (i.e. the user's code) by value.  This prevents references to local code from breaking like it used to.  This is necessary so that user code does not try to actually "require" other user code (which would not work, as none of the user code files are actually there at runtime).  Instead, because the local module is entirely captured by value, all references to other user code naturally gets slurped into the closure serialization and is directly available in the cloud lambda.

With this code can revert to the normal idiomatic TS/JS form with all 'imports' at the top level.