### PR TITLE
Create update objects for previews

### DIFF
--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -371,12 +371,7 @@ func (pc *Client) CreateUpdate(
 	var endpoint string
 	switch kind {
 	case UpdateKindUpdate:
-		if dryRun {
-			endpoint = "preview"
-			kind = UpdateKindPreview
-		} else {
-			endpoint = "update"
-		}
+		endpoint = "update"
 	case UpdateKindPreview:
 		endpoint = "preview"
 	case UpdateKindRefresh:


### PR DESCRIPTION
Create update objects for previews requested by the CLI. Previously, updates were only persisted on pulumi.com for updates with kind update, refresh, import, or destroy. Updates with kind preview were omitted from this process by some if-statements looking at the `dryRun` flag.

This PR adds a separate `persist` flag, indicating whether or not the update should be persisted on pulumi.com. This flag allows us to separate the notion of "stored on pulumi.com" from being coupled with `dryRun` or even the specific kind of update.

I do feel awful adding the 11th parameter to a method. Though refactoring this code will probably need to wait until we finish passing full engine update events, and landing the "parallel checkpoint updates" work.

I've put the value of the `persist` flag in the preview case behind the `PULUMI_PERSIST_PREVIEWS` environment variable. If not set, previews will not be persisted and the existing behavior will be preserved. I'll report back when I have timing and performance data.

This is the second, and arguably cleaner, attempt at adding this to the CLI. The first being https://github.com/pulumi/pulumi/pull/1636.