### PR TITLE
Add optional CI properties to environment metadata

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -358,9 +358,7 @@ func getUpdateMetadata(msg, root string) (backend.UpdateMetadata, error) {
 	if err := addGitMetadataToEnvironment(root, m.Environment); err != nil {
 		cmdutil.Diag().Warningf(diag.Message("", "adding git env data: %v"), err)
 	}
-	if err := addCIMetadataToEnvironment(m.Environment); err != nil {
-		cmdutil.Diag().Warningf(diag.Message("", "adding CI env data: %v"), err)
-	}
+	addCIMetadataToEnvironment(m.Environment)
 
 	return m, nil
 }
@@ -411,19 +409,17 @@ func addGitMetadataToEnvironment(repoRoot string, env map[string]string) error {
 }
 
 // addCIMetadataToEnvironment populate's the environment metadata bag with CI/CD-related values.
-func addCIMetadataToEnvironment(env map[string]string) error {
+func addCIMetadataToEnvironment(env map[string]string) {
 	// Check if running on Travis CI. See:
 	// https://docs.travis-ci.com/user/environment-variables/
-	if os.Getenv("CI") == "true" && os.Getenv("TRAVIS") == "true" {
+	if os.Getenv("TRAVIS") == "true" {
 		env[backend.CISystem] = "travis-ci"
 
 		// Pass pull request-specific vales as needed.
 		if sha := os.Getenv("TRAVIS_PULL_REQUEST_SHA"); sha != "" {
-			env[backend.CIPRSourceSHA] = sha
+			env[backend.CIPRHeadSHA] = sha
 		}
 	}
-
-	return nil
 }
 
 type cancellationScope struct {

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -74,6 +74,13 @@ const (
 	GitHubLogin = "github.login"
 	// GitHubRepo is the name of the GitHub repo, if the local git repo's remote origin is hosted on GitHub.com.
 	GitHubRepo = "github.repo"
+
+	// CISystem is the name of the CI system running the pulumi operation.
+	CISystem = "ci.system"
+
+	// CIPRSourceSHA is the SHA of the HEAD commit of a pull request running on CI. This is needed since the CI
+	// server will run at a different, merge commit.
+	CIPRSourceSHA = "ci.pr.sourceSHA"
 )
 
 // UpdateInfo describes a previous update.

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -78,9 +78,9 @@ const (
 	// CISystem is the name of the CI system running the pulumi operation.
 	CISystem = "ci.system"
 
-	// CIPRSourceSHA is the SHA of the HEAD commit of a pull request running on CI. This is needed since the CI
-	// server will run at a different, merge commit.
-	CIPRSourceSHA = "ci.pr.sourceSHA"
+	// CIPRHeadSHA is the SHA of the HEAD commit of a pull request running on CI. This is needed since the CI
+	// server will run at a different, merge commit. (headSHA merged into the target branch.)
+	CIPRHeadSHA = "ci.pr.headSHA"
 )
 
 // UpdateInfo describes a previous update.


### PR DESCRIPTION
Adds CI-related properties to the environment metadata that is set for each update. We need this to associate `pulumi` operations running under CI with their source pull request.