### PR TITLE
Properly display multi-step replaces in the progress UI.

### DIFF
--- a/pkg/backend/local/display.go
+++ b/pkg/backend/local/display.go
@@ -44,9 +44,6 @@ func DisplayEvents(
 	if opts.DiffDisplay {
 		DisplayDiffEvents(action, events, done, opts)
 	} else {
-		// in progress display, we can't show separate create/delete for a single resource.
-		// we have to always show them as a single 'replace'.
-		opts.ShowReplacementSteps = false
 		DisplayProgressEvents(action, events, done, opts)
 	}
 }
@@ -314,11 +311,8 @@ func shouldShow(step engine.StepEventMetadata, opts backend.DisplayOptions) bool
 			return true
 		}
 		return opts.ShowSameResources
-	} else if step.Op == deploy.OpCreateReplacement || step.Op == deploy.OpDeleteReplaced {
-		return opts.ShowReplacementSteps
-	} else if step.Op == deploy.OpReplace {
-		return !opts.ShowReplacementSteps
 	}
+
 	return true
 }
 

--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -628,11 +628,11 @@ func (display *ProgressDisplay) refreshAllRowsIfInTerminal() {
 // print out all final diagnostics. and finally will print out the summary.
 func (display *ProgressDisplay) processEndSteps() {
 	// Figure out the rows that are currently in progress.
-	nonDoneRows := []ResourceRow{}
+	inProgressRows := []ResourceRow{}
 
 	for _, v := range display.eventUrnToResourceRow {
 		if !v.IsDone() {
-			nonDoneRows = append(nonDoneRows, v)
+			inProgressRows = append(inProgressRows, v)
 		}
 	}
 
@@ -643,7 +643,7 @@ func (display *ProgressDisplay) processEndSteps() {
 	// Now print out all those rows that were in progress.  They will now be 'done'
 	// since the display was marked 'done'.
 	if !display.isTerminal {
-		for _, v := range nonDoneRows {
+		for _, v := range inProgressRows {
 			display.refreshSingleRow("", v, nil)
 		}
 	}

--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -1005,11 +1005,11 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 			switch op {
 			case deploy.OpSame:
 				return "failed"
-			case deploy.OpCreate:
+			case deploy.OpCreate, deploy.OpCreateReplacement:
 				return "creating failed"
 			case deploy.OpUpdate:
 				return "updating failed"
-			case deploy.OpDelete:
+			case deploy.OpDelete, deploy.OpDeleteReplaced:
 				return "deleting failed"
 			case deploy.OpReplace:
 				return "replacing failed"
@@ -1026,6 +1026,10 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return "deleted"
 			case deploy.OpReplace:
 				return "replaced"
+			case deploy.OpCreateReplacement:
+				return "created for replacement"
+			case deploy.OpDeleteReplaced:
+				return "deleted for replacement"
 			}
 		}
 
@@ -1041,14 +1045,6 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 }
 
 func (display *ProgressDisplay) getPreviewText(op deploy.StepOp) string {
-
-	// In the progress-display, show all the steps for a replace as 'OpReplace'
-	if display.isTerminal {
-		if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced {
-			op = deploy.OpReplace
-		}
-	}
-
 	switch op {
 	case deploy.OpSame:
 		return "no change"
@@ -1060,6 +1056,10 @@ func (display *ProgressDisplay) getPreviewText(op deploy.StepOp) string {
 		return "delete"
 	case deploy.OpReplace:
 		return "replace"
+	case deploy.OpCreateReplacement:
+		return "create for replacement"
+	case deploy.OpDeleteReplaced:
+		return "delete for replacement"
 	}
 
 	contract.Failf("Unrecognized resource step op: %v", op)
@@ -1108,6 +1108,10 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 			return "deleting"
 		case deploy.OpReplace:
 			return "replacing"
+		case deploy.OpCreateReplacement:
+			return "creating for replacement"
+		case deploy.OpDeleteReplaced:
+			return "deleting for replacement"
 		}
 
 		contract.Failf("Unrecognized resource step op: %v", op)

--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -990,7 +990,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	if display.isPreview {
 		// During a preview, when we transition to done, we still just print the same thing we
 		// did while running the step.
-		return step.Op.Color() + getPreviewText(step.Op) + colors.Reset
+		return step.Op.Color() + display.getPreviewText(step.Op) + colors.Reset
 	}
 
 	// most of the time a stack is unchanged.  in that case we just show it as "running->done"
@@ -999,8 +999,12 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	}
 
 	op := step.Op
-	if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced {
-		op = deploy.OpReplace
+
+	// In the progress-display, show all the steps for a replace as 'OpReplace'
+	if display.isTerminal {
+		if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced {
+			op = deploy.OpReplace
+		}
 	}
 
 	getDescription := func() string {
@@ -1043,9 +1047,13 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	return op.Color() + getDescription() + colors.Reset
 }
 
-func getPreviewText(op deploy.StepOp) string {
-	if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced {
-		op = deploy.OpReplace
+func (display *ProgressDisplay) getPreviewText(op deploy.StepOp) string {
+
+	// In the progress-display, show all the steps for a replace as 'OpReplace'
+	if display.isTerminal {
+		if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced {
+			op = deploy.OpReplace
+		}
 	}
 
 	switch op {
@@ -1078,13 +1086,16 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 		return "running"
 	}
 
-	if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced {
-		op = deploy.OpReplace
+	// In the progress-display, show all the steps for a replace as 'OpReplace'
+	if display.isTerminal {
+		if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced {
+			op = deploy.OpReplace
+		}
 	}
 
 	getDescription := func() string {
 		if display.isPreview {
-			return getPreviewText(op)
+			return display.getPreviewText(op)
 		}
 
 		switch op {

--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -992,7 +992,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	if display.isPreview {
 		// During a preview, when we transition to done, we still just print the same thing we
 		// did while running the step.
-		return op.Color() + display.getPreviewText(op) + colors.Reset
+		return op.Color() + getPreviewText(op) + colors.Reset
 	}
 
 	// most of the time a stack is unchanged.  in that case we just show it as "running->done"
@@ -1044,7 +1044,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	return op.Color() + getDescription() + colors.Reset
 }
 
-func (display *ProgressDisplay) getPreviewText(op deploy.StepOp) string {
+func getPreviewText(op deploy.StepOp) string {
 	switch op {
 	case deploy.OpSame:
 		return "no change"
@@ -1094,7 +1094,7 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 
 	getDescription := func() string {
 		if display.isPreview {
-			return display.getPreviewText(op)
+			return getPreviewText(op)
 		}
 
 		switch op {

--- a/pkg/backend/local/rows.go
+++ b/pkg/backend/local/rows.go
@@ -328,6 +328,17 @@ func (data *resourceRowData) ColorizedColumns() []string {
 
 func (data *resourceRowData) getInfoColumn() string {
 	step := data.step
+
+	if step.Op == deploy.OpCreateReplacement || step.Op == deploy.OpDeleteReplaced {
+		// if we're doing a replacement, see if we can find a replace step that contains useful
+		// information to display.
+		for _, outputStep := range data.outputSteps {
+			if outputStep.Op == deploy.OpReplace {
+				step = outputStep
+			}
+		}
+	}
+
 	changesBuf := &bytes.Buffer{}
 
 	if step.Old != nil && step.New != nil && step.Old.Inputs != nil && step.New.Inputs != nil {

--- a/pkg/backend/local/rows.go
+++ b/pkg/backend/local/rows.go
@@ -294,12 +294,12 @@ func (data *resourceRowData) ColorizedColumns() []string {
 
 	var name string
 	var typ string
-	if step.URN == "" {
+	if data.step.URN == "" {
 		name = "global"
 		typ = "global"
 	} else {
-		name = string(step.URN.Name())
-		typ = simplifyTypeName(step.URN.Type())
+		name = string(data.step.URN.Name())
+		typ = simplifyTypeName(data.step.URN.Type())
 	}
 
 	columns := make([]string, 5)

--- a/pkg/backend/local/rows.go
+++ b/pkg/backend/local/rows.go
@@ -277,11 +277,12 @@ func (data *resourceRowData) ContainsOutputsStep(op deploy.StepOp) bool {
 
 func (data *resourceRowData) ColorizedSuffix() string {
 	if !data.IsDone() {
-		if data.step.Op != deploy.OpSame || isRootURN(data.step.URN) {
+		op := data.display.getStepOp(data.step)
+		if op != deploy.OpSame || isRootURN(data.step.URN) {
 			suffixes := data.display.suffixesArray
 			ellipses := suffixes[(data.tick+data.display.currentTick)%len(suffixes)]
 
-			return data.step.Op.Color() + ellipses + colors.Reset
+			return op.Color() + ellipses + colors.Reset
 		}
 	}
 

--- a/pkg/backend/local/rows.go
+++ b/pkg/backend/local/rows.go
@@ -240,31 +240,9 @@ func (data *resourceRowData) IsDone() bool {
 		return true
 	}
 
-	if data.display.Done {
+	if data.display.done {
 		// if the display is done, then we're definitely done.
 		return true
-	}
-
-	// When we are in interactive mode, we collapse all replacements steps into one
-	// conceptual replacement going from "create-replacement/replace/delete-replaced" or
-	// "delete-replaced/replace/create-replacement".  So we only consider ourselves done
-	// if we've seen the output step for both the create-replacement *and* delete-replaced.
-	if data.display.isTerminal {
-		if data.ContainsOutputsStep(deploy.OpCreateReplacement) &&
-			!data.ContainsOutputsStep(deploy.OpDeleteReplaced) {
-
-			// we've heard about the create-replacement but not the delete-replacement yet.
-			// this resource is not done yet.
-			return false
-		}
-
-		if data.ContainsOutputsStep(deploy.OpDeleteReplaced) &&
-			!data.ContainsOutputsStep(deploy.OpCreateReplacement) {
-
-			// we've heard about the delete-replacement but not the create-replacement yet.
-			// this resource is not done yet.
-			return false
-		}
 	}
 
 	// We're done if we have the output-step for whatever step operation we're performing
@@ -282,7 +260,7 @@ func (data *resourceRowData) ContainsOutputsStep(op deploy.StepOp) bool {
 }
 
 func (data *resourceRowData) ColorizedSuffix() string {
-	if !data.IsDone() {
+	if !data.IsDone() && data.display.isTerminal {
 		op := data.display.getStepOp(data.step)
 		if op != deploy.OpSame || isRootURN(data.step.URN) {
 			suffixes := data.display.suffixesArray
@@ -401,7 +379,7 @@ func (data *resourceRowData) getInfoColumn() string {
 		appendDiagMessage(fmt.Sprintf("%v debug messages", diagInfo.DebugCount))
 	}
 
-	if !data.display.Done {
+	if !data.display.done {
 		// If we're not totally done, and we're in the tree-view also print out the worst diagnostic
 		// next to the status message. This is helpful for long running tasks to know what's going
 		// on. However, once done, we print the diagnostics at the bottom, so we don't need to show

--- a/pkg/backend/local/rows.go
+++ b/pkg/backend/local/rows.go
@@ -49,7 +49,6 @@ type ResourceRow interface {
 	Tick() int
 
 	IsDone() bool
-	// SetDone()
 
 	SetFailed()
 
@@ -154,14 +153,6 @@ func (data *resourceRowData) Step() engine.StepEventMetadata {
 }
 
 func (data *resourceRowData) SetStep(step engine.StepEventMetadata) {
-	// never update a 'replace' step with an CreateReplacement DeleteReplacement step.
-	// in the progress view we never want to show those individually, we always want
-	// them combined since we only show a single line per resource.
-	if data.step.Op == deploy.OpReplace &&
-		(step.Op == deploy.OpCreateReplacement || step.Op == deploy.OpDeleteReplaced) {
-		return
-	}
-
 	data.step = step
 }
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/1595

Previous code used to strip out OpCreateReplacement and OpDeleteReplaced events from the UI event stream.  This led to large sequences of time when the UI was displaying nothing, leading to a confusing expeirence.

We now buffer and keep track of the steps taken for a resource, and we can properly keep track of a replacement of a resource from start till end.

Another core part of this change is that we no longer think of a resource as being explicitly marked as 'done'.  We used to do this when we heard about the 'outputs' step for it. But clearly that doesn't necessarily apply given that we may hear about many output steps for a single resource.  Now 'done'-ness is something computed about a resource and is determined based on many factors (for example, if we've heard about the entire chain of replacement steps).