### PR TITLE
Merge updates to install-common-toolchain.sh

### DIFF
--- a/build/travis/install-common-toolchain.sh
+++ b/build/travis/install-common-toolchain.sh
@@ -24,10 +24,13 @@ nvm install ${NODE_VERSION-v8.11.1}
         *) echo "error: unknown host os $(uname)" ; exit 1;;
     esac
 
-    # On Travis, pip is called pip2.7, so alias it, also install jq
+    # Tool installs and workarounds specific to macOS.
     if [ "${TRAVIS_OS_NAME:-}" = "osx" ]; then
-        sudo ln -s $(which pip2.7) /usr/local/bin/pip
         brew install jq
+        # On Travis, pip is called pip2.7, so alias it.
+        if [ ! -f /usr/local/bin/pip ]; then
+            sudo ln -s $(which pip2.7) /usr/local/bin/pip
+        fi
     fi
 
     echo "installing yarn ${YARN_VERSION}"
@@ -70,6 +73,7 @@ nvm install ${NODE_VERSION-v8.11.1}
 
     echo "installing pandoc, so we can generate README.rst for Python packages"
     if [ "${TRAVIS_OS_NAME:-}" = "linux" ]; then
+        sudo apt-get update
         sudo apt-get install pandoc
     else
         brew install pandoc


### PR DESCRIPTION
We started seeing some failures on macOS related to what appears to be a Travis environment change. (They now have `/usr/local/bin/pip` whereas previously the file didn't exist.)

I had already submitted the fix in https://github.com/pulumi/scripts/pull/6, but didn't notice that this repo has a copy of this file. This PR copies the `install-common-toolchain.sh` file to bring it up to commit `4a12895`.

The good part about the file being forked into this repo, is that we can see if this change actually works as part of our Travis CI runs.