### PR TITLE
Ensure we can capture non-built-in modules with 'require'.

### DIFF
--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -29,4 +29,5 @@ import * as runtime from "./runtime";
 export { asset, dynamic, log, runtime };
 
 // @pulumi is a deployment-only module.  If someone tries to capture it, we want to hard fail.
+/* @internal */
 export const deploymentOnlyModule = true;

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -27,3 +27,6 @@ import * as dynamic from "./dynamic";
 import * as log from "./log";
 import * as runtime from "./runtime";
 export { asset, dynamic, log, runtime };
+
+// @pulumi is a deployment-only module.  If someone tries to capture it, we want to hard fail.
+export const deploymentOnlyModule = true;

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -28,6 +28,9 @@ import * as log from "./log";
 import * as runtime from "./runtime";
 export { asset, dynamic, log, runtime };
 
-// @pulumi is a deployment-only module.  If someone tries to capture it, we want to hard fail.
+// @pulumi is a deployment-only module.  If someone tries to capture it, and we fail for some reason
+// we want to give a good message about what the problem likely is.  Note that capturing a
+// deployment time module can be ok in some cases.  For example, using "new pulumi.Config" is fine.
+// However, in general, the majority of this API is not safe to use at 'run time' and will fail.
 /* @internal */
 export const deploymentOnlyModule = true;

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1077,8 +1077,13 @@ function getOrCreateEntry(
         const isLocalModule = moduleName.startsWith(".") && !moduleName.startsWith("./node_modules/");
 
         if (obj.deploymentOnlyModule || isLocalModule) {
+            // Try to serialize deployment-time and local-modules by-value.
+            //
             // A deployment-only modules can't ever be successfully 'required' on the 'inside'. But
-            // parts of it may be serializable on the inside (i.e. pulumi.Config).
+            // parts of it may be serializable on the inside (i.e. pulumi.Config).  So just try to
+            // capture this as a value.  If it fails, we will give the user a good message.
+            // Otherwise, it may succeed if the user is only using a small part of the API that is
+            // serializable (like pulumi.Config)
             //
             // Or this is a reference to a local module (i.e. starts with '.', but isn't in
             // ./node_modules). Always capture the local module as a value.  We do this because

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -613,7 +613,7 @@ function throwSerializationError(
             message += `'${frame.capturedFunctionName}', a function defined at\n`;
         }
         else if (frame.capturedModuleName) {
-            if (i == n - 1) {
+            if (i === n - 1) {
                 message += `module '${frame.capturedModuleName}'\n`;
             }
             else {

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1140,8 +1140,11 @@ for (const name of builtInModuleNames) {
     builtInModules.set(require(name), name);
 }
 
-// findRequirableModuleName attempts to find a global name bound to the object, which can
-// be used as a stable reference across serialization.
+// findRequirableModuleName attempts to find a global name bound to the object, which can be used as
+// a stable reference across serialization.  For built-in modules (i.e. "os", "fs", etc.) this will
+// return that exact name of the module.  Otherwise, this will return the relative path to the
+// module from the current working directory of the process.  This will normally be something of the
+// form ./node_modules/<package_name>...
 function findModuleName(obj: any): string | undefined {
     // First, check the built-in modules
     const key = builtInModules.get(obj);

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1058,7 +1058,7 @@ function getOrCreateEntry(
     }
 
     function captureModule(moduleName: string) {
-        if (moduleName[0] === ".") {
+        if (moduleName.startsWith(".") && !moduleName.startsWith("./node_modules/")) {
             // This is a reference to a local module (i.e. starts with '.'). Always capture the
             // local module as a value.  We do this because capturing as a reference (i.e.
             // 'require(...)') has the following problems:

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -20,6 +20,7 @@ import { runtime } from "../../index";
 import { output } from "../../resource";
 import { assertAsyncThrows, asyncTest } from "../util";
 import * as config from "../../config";
+import * as typescript from "typescript";
 
 interface ClosureCase {
     pre?: () => void;               // an optional function to run before this case.
@@ -4762,6 +4763,25 @@ function __f0() {
     with({ o1: __o1, o2: __o2, o3: __o3 }) {
 
 return function () { console.log(o1); console.log(o2.b.d); console.log(o3.b.d); };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+
+    {
+        cases.push({
+            title: "Capture non-built-in module",
+            func: function () { typescript.parseCommandLine([""]); },
+            expectText: `exports.handler = __f0;
+
+function __f0() {
+  return (function() {
+    with({ typescript: require("./node_modules/typescript/lib/typescript.js") }) {
+
+return function () { typescript.parseCommandLine([""]); };
 
     }
   }).apply(undefined, undefined).apply(this, arguments);

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -17,6 +17,7 @@
 import * as assert from "assert";
 import { EOL } from "os";
 import { runtime } from "../../index";
+import * as pulumi from "../../index";
 import { output } from "../../resource";
 import { assertAsyncThrows, asyncTest } from "../util";
 import * as config from "../../config";
@@ -4787,6 +4788,22 @@ return function () { typescript.parseCommandLine([""]); };
   }).apply(undefined, undefined).apply(this, arguments);
 }
 `,
+        });
+    }
+
+    {
+        cases.push({
+            title: "Fail to capture non-deployment module",
+            func: function () { pulumi.output(1); },
+            error: `Error serializing function 'func': closure.spec.js(0,0)
+
+function 'func': closure.spec.js(0,0): captured
+  module './bin/index.js'
+    module './bin/index.js' can only be used at 'deployment time' and should not used inside a function intended for 'run time'.
+
+Function code:
+  function () { pulumi.output(1); }
+`
         });
     }
 

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -4802,18 +4802,9 @@ function 'func': closure.spec.js(0,0): captured
       module './bin/runtime/settings.js' which indirectly referenced
         function 'getEngine': settings.js(0,0): which captured
           module './bin/proto/engine_grpc_pb.js' which indirectly referenced
-            function 'ServiceClient': client.js(0,0): which referenced
-              function 'Client': client.js(0,0): which referenced
-                function '<anonymous>': client.js(0,0): which referenced
-                  function 'ClientWritableStream': client.js(0,0): which referenced
-                    function 'Writable': _stream_writable.js(0,0): which captured
-                      'realHasInstance', a function defined at
-                        function '[Symbol.hasInstance]': which could not be serialized because
-                          it was a native code function.
-
+(...)
 Function code:
-  function [Symbol.hasInstance]() { [native code] }
-
+(...)
 Module './bin/index.js' is a 'deployment only' module. In general these cannot be captured inside a 'run time' function.`
         });
     }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1676

Previous work only ensured that built-in modules captured properly.  This expands this out to any module we find in the node_modules path.