### PR TITLE
Fix an issue where we fail to catch duplicate URNs in the same plan

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -58,6 +58,7 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 		// TODO[pulumi/pulumi-framework#19]: improve this error message!
 		sg.plan.Diag().Errorf(diag.GetDuplicateResourceURNError(urn), urn)
 	}
+	sg.urns[urn] = true
 
 	// Check for an old resource so that we can figure out if this is a create, delete, etc., and/or to diff.
 	old, hasOld := sg.plan.Olds()[urn]

--- a/tests/integration/duplicate_urns/duplicate_urns_test.go
+++ b/tests/integration/duplicate_urns/duplicate_urns_test.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ints
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+)
+
+// Test that the engine does not tolerate duplicate URNs in the same plan.
+func TestDuplicateURNs(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:           "step1",
+		Dependencies:  []string{"@pulumi/pulumi"},
+		Quick:         true,
+		ExpectFailure: true,
+		EditDirs: []integration.EditDir{
+			{
+				Dir:      "step2",
+				Additive: true,
+			},
+			{
+				Dir:           "step3",
+				Additive:      true,
+				ExpectFailure: true,
+			},
+			/* TODO(pulumi/pulumi#1645) - This example runs into trouble with pending deletes.
+			   We currently have a bug where we can't delete a pending-delete resource in the same
+			   plan where we deleted the resource because it no longer exists.
+			{
+				Dir:           "step4",
+				Additive:      true,
+				ExpectFailure: true,
+			},
+			*/
+		},
+	})
+}

--- a/tests/integration/duplicate_urns/step1/Pulumi.yaml
+++ b/tests/integration/duplicate_urns/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: duplicate_urns
+description: A program that tests the engine's ability to handle duplicate URNs
+runtime: nodejs

--- a/tests/integration/duplicate_urns/step1/index.ts
+++ b/tests/integration/duplicate_urns/step1/index.ts
@@ -1,0 +1,21 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Resource } from "./resource";
+
+// Try to create two resources with the same URN.
+const a = new Resource("a", { state: 4 });
+const b = new Resource("a", { state: 4 });
+
+// This should fail, but gracefully.

--- a/tests/integration/duplicate_urns/step1/package.json
+++ b/tests/integration/duplicate_urns/step1/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "duplicate_urns",
+    "license": "Apache-2.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "scripts": {
+        "build": "tsc"
+    },
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/duplicate_urns/step1/resource.ts
+++ b/tests/integration/duplicate_urns/step1/resource.ts
@@ -1,0 +1,62 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
+
+export class Provider implements dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    private id: number = 0;
+
+    public async check(olds: any, news: any): Promise<dynamic.CheckResult> {
+        return {
+            inputs: news,
+        };
+    }
+
+    public async diff(id: pulumi.ID, olds: any, news: any): Promise<dynamic.DiffResult> {
+        if (olds.state !== news.state) {
+            return {
+                changes: true,
+                replaces: ["state"],
+            };
+        }
+
+        return {
+            changes: false,
+        };
+    }
+
+    public async create(inputs: any): Promise<dynamic.CreateResult> {
+        return {
+            id: (this.id++).toString(),
+            outs: inputs,
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    public uniqueKey?: pulumi.Output<number>;
+    public state: pulumi.Output<number>;
+
+    constructor(name: string, props: ResourceProps, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+    }
+}
+
+export interface ResourceProps {
+    readonly uniqueKey?: pulumi.Input<number>;
+    readonly state: pulumi.Input<number>;
+}

--- a/tests/integration/duplicate_urns/step1/tsconfig.json
+++ b/tests/integration/duplicate_urns/step1/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+

--- a/tests/integration/duplicate_urns/step2/index.ts
+++ b/tests/integration/duplicate_urns/step2/index.ts
@@ -1,0 +1,19 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Resource } from "./resource";
+
+// Setup for the next test.
+const a = new Resource("a", { state: 4 });
+

--- a/tests/integration/duplicate_urns/step3/index.ts
+++ b/tests/integration/duplicate_urns/step3/index.ts
@@ -1,0 +1,23 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Resource } from "./resource";
+
+// "a" is already in the snapshot and will be "same"d.
+const a = new Resource("a", { state: 4 });
+
+// "b" is not, but they have the same URN.
+const b = new Resource("a", { state: 5 });
+
+// This should fail, but gracefully.

--- a/tests/integration/duplicate_urns/step4/index.ts
+++ b/tests/integration/duplicate_urns/step4/index.ts
@@ -1,0 +1,26 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Resource } from "./resource";
+
+// "a" is already in the snapshot and will be replaced.
+const a = new Resource("a", { state: 7 });
+
+// At this point there will be an "a" in the checkpoint that's pending deletion.
+
+// "b" is not in the snapshot. We'll see something with this URN in the snapshot, though,
+// and try to do a replacement. This is bad because the thing we're replacing is pending deletion.
+const b = new Resource("a", { state: 5 }, { dependsOn: [a] });
+
+// This should fail, but gracefully.


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1682. One of the tests I wrote is commented out because it runs into (yet another bug) with pending deletion, which I am tracking with https://github.com/pulumi/pulumi/issues/1645.