### PR TITLE
Detect secret-like config

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -244,6 +244,22 @@
   revision = "4fdf99ab29366514c69ccccddab5dc58b8d84062"
 
 [[projects]]
+  name = "github.com/nbutton23/zxcvbn-go"
+  packages = [
+    ".",
+    "adjacency",
+    "data",
+    "entropy",
+    "frequency",
+    "match",
+    "matching",
+    "scoring",
+    "utils/math"
+  ]
+  revision = "eafdab6b0663b4b528c35975c8b0e78be6e25261"
+  version = "v0.1"
+
+[[projects]]
   name = "github.com/opentracing/opentracing-go"
   packages = [
     ".",
@@ -555,6 +571,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "09466a544e10908eeb96ddc4a6cf596a72aec1c36bab6a1f02cf5ac0dfa0986c"
+  inputs-digest = "c841a519c28c6cb917a7d17871050063dc84af04c600b6d5b203e2d5dd0b3e84"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Previously, we would unconditionally warn anytime you added a non-secret
config:

    $ pulumi config set aws:region us-west-2
    warning: saved config key '%s' value '%s' as plaintext;
        re-run with --secret to encrypt the value instead.
        Use --plaintext to avoid this warning

This was particularly annoying, since it is very common to store
non-secret config. For instance, the AWS region. And it was easy to tune
out because it wasn't actually warning about anything interesting.

This change, which resolves pulumi/pulumi#570, uses an approach similar
to Go's gas linter, to detect high entropy values, and issue an error.
This ensures that we only make noise on things we suspect are actually
secrets being stored in plaintext, and forces the user to pass
--plaintext. For instance, the common case issues no errors:

    $ pulumi config set aws:region us-west-2

And in the event that you store something that is secret-like:

    $ pulumi config set aws:region nq8r4B4xslzrtj0a3
    error: config value 'nq8r4B4xslzrtj0a3' looks like a secret;
        rerun with --secret to encrypt it, or --plaintext if you meant
        to store in plaintext

To suppress this, simply pass --secret (to encrypt) or --plaintext (to
override the warning).