### PR TITLE
Warn when `pulumi` is out of date

### DIFF
--- a/pkg/apitype/cli.go
+++ b/pkg/apitype/cli.go
@@ -1,0 +1,21 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// CLIVersionResponse is the response from the server with information about CLI versions.
+type CLIVersionResponse struct {
+	LatestVersion        string `json:"latestVersion"`
+	OldestWithoutWarning string `json:"oldestWithoutWarning"`
+}

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -17,6 +17,7 @@ package workspace
 import (
 	"fmt"
 	"os"
+	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -27,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/fsutil"
 )
 
+//nolint: lll
 const (
 	BackupDir      = "backups"    // the name of the folder where backup stack information is stored.
 	BookkeepingDir = ".pulumi"    // the name of our bookeeping folder, we store state here (like .git for git).
@@ -38,10 +40,11 @@ const (
 	TemplateDir    = "templates"  // the name of the directory containing templates.
 	WorkspaceDir   = "workspaces" // the name of the directory that holds workspace information for projects.
 
-	IgnoreFile    = ".pulumiignore"  // the name of the file that we use to control what to upload to the service.
-	ProjectFile   = "Pulumi"         // the base name of a project file.
-	RepoFile      = "settings.json"  // the name of the file that holds information specific to the entire repository.
-	WorkspaceFile = "workspace.json" // the name of the file that holds workspace information.
+	IgnoreFile        = ".pulumiignore"      // the name of the file that we use to control what to upload to the service.
+	ProjectFile       = "Pulumi"             // the base name of a project file.
+	RepoFile          = "settings.json"      // the name of the file that holds information specific to the entire repository.
+	WorkspaceFile     = "workspace.json"     // the name of the file that holds workspace information.
+	CachedVersionFile = ".cachedVersionInfo" // the name of the file we use to store when we last checked if the CLI was out of date
 )
 
 // DetectProjectPath locates the closest project from the current working directory, or an error if not found.
@@ -156,4 +159,15 @@ func isMarkupFile(path string, expect string) bool {
 	}
 
 	return false
+}
+
+// GetCachedVersionFilePath returns the location where the CLI caches information from pulumi.com on the newest
+// available version of the CLI
+func GetCachedVersionFilePath() (string, error) {
+	user, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(user.HomeDir, BookkeepingDir, CachedVersionFile), nil
 }


### PR DESCRIPTION
Before running any commands, try to access
https://pulumi.io/latest-version and compare it to the version we have
embedded. If it is newer, issue a warning, but continue to operation.

We do not preform this check for dev builds, under the assumption that
if you are using a dev build you have a good reason for doing so and
you'd track upgrades yourself.

Fixes #1686