### PR TITLE
Move node_module inclusion logic down to pulumi/pulumi so we can use it from both aws and azure.

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -11,7 +11,8 @@
         "protobufjs": "^6.8.6",
         "require-from-string": "^2.0.1",
         "source-map-support": "^0.4.16",
-        "typescript": "^3.0.0"
+        "typescript": "^3.0.0",
+        "read-package-tree": "^5.2.1"
     },
     "devDependencies": {
         "@types/minimist": "^1.2.0",

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -28,6 +28,11 @@ import { RunError } from "../../errors";
 //
 // [extraIncludePaths], [extraExcludePackages] and [extraExcludePackages] can all be used to adjust
 // the final set of paths included in the resultant asset/archive map.
+//
+// Note: this functionality is specifically intended for use by downstream library code that is
+// determining what is needed for a cloud-lambda.  i.e. the aws.serverless.Function or
+// azure.serverless.FunctionApp libraries.  In general, other clients should not need to use this
+// helper.
 export async function computeCodePaths(
     extraIncludePaths?: string[],
     extraIncludePackages?: string[],

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -39,25 +39,15 @@ export async function computeCodePaths(
     extraExcludePackages?: string[]): Promise<Map<string, asset.Asset | asset.Archive>> {
 
     // Construct the set of paths to include in the archive for upload.
-    extraIncludePaths = extraIncludePaths || [];
-    extraIncludePackages = extraIncludePackages || [];
-    extraExcludePackages = extraExcludePackages || [];
 
-    const includedPackages = new Set<string>();
-    const excludedPackages = new Set<string>();
-
-    for (const p of extraExcludePackages) {
-        excludedPackages.add(p);
-    }
-
-    for (const p of extraIncludePackages) {
-        includedPackages.add(p);
-    }
+    const includedPackages = new Set<string>(extraIncludePackages || []);
+    const excludedPackages = new Set<string>(extraExcludePackages || []);
 
     // Find folders for all packages requested by the user
     const pathSet = await allFoldersForPackages(includedPackages, excludedPackages);
 
     // Add all paths explicitly requested by the user
+    extraIncludePaths = extraIncludePaths || [];
     for (const path of extraIncludePaths) {
         pathSet.add(path);
     }

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -1,0 +1,186 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as fs from "fs";
+import * as filepath from "path";
+import * as readPackageTree from "read-package-tree";
+import * as asset from "../../asset";
+import { RunError } from "../../errors";
+
+// computeCodePaths computes the local node_module paths to include in an uploaded Lambda.
+export async function computeCodePaths(
+    extraIncludePaths?: string[],
+    extraIncludePackages?: string[],
+    extraExcludePackages?: string[]): Promise<Map<string, asset.Asset | asset.Archive>> {
+
+    // Construct the set of paths to include in the archive for upload.
+    extraIncludePaths = extraIncludePaths || [];
+    extraIncludePackages = extraIncludePackages || [];
+    extraExcludePackages = extraExcludePackages || [];
+
+    const includedPackages = new Set<string>();
+    const excludedPackages = new Set<string>();
+
+    for (const p of extraExcludePackages) {
+        excludedPackages.add(p);
+    }
+
+    for (const p of extraIncludePackages) {
+        includedPackages.add(p);
+    }
+
+    // Find folders for all packages requested by the user
+    const pathSet = await allFoldersForPackages(includedPackages, excludedPackages);
+
+    // Add all paths explicitly requested by the user
+    for (const path of extraIncludePaths) {
+        pathSet.add(path);
+    }
+
+    const codePaths: Map<string, asset.Asset | asset.Archive> = new Map();
+
+    // For each of the required paths, add the corresponding FileArchive or FileAsset to the AssetMap.
+    for (const path of pathSet.values()) {
+        // The Asset model does not support a consistent way to embed a file-or-directory into an `AssetArchive`, so
+        // we stat the path to figure out which it is and use the appropriate Asset constructor.
+        const stats = fs.lstatSync(path);
+        if (stats.isDirectory()) {
+            codePaths.set(path, new asset.FileArchive(path));
+        }
+        else {
+            codePaths.set(path, new asset.FileAsset(path));
+        }
+    }
+
+    return codePaths;
+}
+
+const lambdaRolePolicy = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Principal": {
+                "Service": "lambda.amazonaws.com",
+            },
+            "Effect": "Allow",
+            "Sid": "",
+        },
+    ],
+};
+
+// Package is a node in the package tree returned by readPackageTree.
+interface Package {
+    name: string;
+    path: string;
+    package: {
+        dependencies?: { [key: string]: string; };
+    };
+    parent?: Package;
+    children: Package[];
+    error: any;
+}
+
+// allFolders computes the set of package folders that are transitively required by the root
+// 'dependencies' node in the client's project.json file.
+function allFoldersForPackages(includedPackages: Set<string>, excludedPackages: Set<string>): Promise<Set<string>> {
+    return new Promise((resolve, reject) => {
+        readPackageTree(".", undefined, (err: any, root: Package) => {
+            if (err) {
+                return reject(err);
+            }
+
+            // read-package-tree defers to read-package-json to parse the project.json file. If that
+            // fails, root.error is set to the underlying error.  In that case, we want to fail as
+            // well.  Otherwise, we will silently proceed as if package.json was empty, which would
+            // result in us uploading no node_modules.
+            if (root.error) {
+                return reject(new RunError(
+                    "Failed to parse package.json. Underlying issue:\n  " + root.error.toString()));
+            }
+
+            // This is the core starting point of the algorithm.  We use readPackageTree to get the
+            // package.json information for this project, and then we start by walking the
+            // .dependencies node in that package.  Importantly, we do not look at things like
+            // .devDependencies or or .peerDependencies.  These are not what are considered part of
+            // the final runtime configuration of the app and should not be uploaded.
+            const referencedPackages = new Set<string>(includedPackages);
+            if (root.package && root.package.dependencies) {
+                for (const depName of Object.keys(root.package.dependencies)) {
+                    referencedPackages.add(depName);
+                }
+            }
+
+            const packagePaths = new Set<string>();
+            for (const pkg of referencedPackages) {
+                addPackageAndDependenciesToSet(root, pkg, packagePaths, excludedPackages);
+            }
+
+            resolve(packagePaths);
+        });
+    });
+}
+
+// addPackageAndDependenciesToSet adds all required dependencies for the requested pkg name from the given root package
+// into the set.  It will recurse into all dependencies of the package.
+function addPackageAndDependenciesToSet(
+    root: Package, pkg: string, packagePaths: Set<string>, excludedPackages: Set<string>) {
+    // Don't process this packages if it was in the set the user wants to exclude.
+
+    // Also, exclude it if it's an @pulumi package.  These packages are intended for deployment
+    // time only and will only bloat up the serialized lambda package.
+    if (excludedPackages.has(pkg) ||
+        pkg.startsWith("@pulumi")) {
+
+        return;
+    }
+
+    const child = findDependency(root, pkg);
+    if (!child) {
+        console.warn(`Could not include required dependency '${pkg}' in '${filepath.resolve(root.path)}'.`)
+        return;
+    }
+
+    packagePaths.add(child.path);
+    if (child.package.dependencies) {
+        for (const dep of Object.keys(child.package.dependencies)) {
+            addPackageAndDependenciesToSet(child, dep, packagePaths, excludedPackages);
+        }
+    }
+}
+
+// findDependency searches the package tree starting at a root node (possibly a child) for a match
+// for the given name. It is assumed that the tree was correctly constructed such that dependencies
+// are resolved to compatible versions in the closest available match starting at the provided root
+// and walking up to the head of the tree.
+function findDependency(root: Package, name: string) {
+    for (; root; root = root.parent) {
+        for (const child of root.children) {
+            let childName = child.name;
+            // Note: `read-package-tree` returns incorrect `.name` properties for packages in an orgnaization - like
+            // `@types/express` or `@protobufjs/path`.  Compute the correct name from the `path` property instead. Match
+            // any name that ends with something that looks like `@foo/bar`, such as `node_modules/@foo/bar` or
+            // `node_modules/baz/node_modules/@foo/bar.
+            const childFolderName = filepath.basename(child.path);
+            const parentFolderName = filepath.basename(filepath.dirname(child.path));
+            if (parentFolderName[0] === "@") {
+                childName = filepath.join(parentFolderName, childFolderName);
+            }
+
+            if (childName === name) {
+                return child;
+            }
+        }
+    }
+}

--- a/sdk/nodejs/yarn.lock
+++ b/sdk/nodejs/yarn.lock
@@ -129,6 +129,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+asap@^2.0.0:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+
 ascli@~1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ascli/-/ascli-1.0.1.tgz#bcfa5974a62f18e81cabaeb49732ab4a88f906bc"
@@ -207,7 +211,7 @@ browser-stdout@1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.0.tgz#f351d32969d32fa5d7a5567154263d928ae3bd1f"
 
-builtin-modules@^1.1.1:
+builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
@@ -348,6 +352,10 @@ debug@^2.1.2:
   dependencies:
     ms "2.0.0"
 
+debuglog@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -371,6 +379,13 @@ delegates@^1.0.0:
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
+
+dezalgo@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dezalgo/-/dezalgo-1.0.3.tgz#7f742de066fc748bc8db820569dddce49bf0d456"
+  dependencies:
+    asap "^2.0.0"
+    wrappy "1"
 
 diff@3.2.0:
   version "3.2.0"
@@ -604,6 +619,10 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
+hosted-git-info@^2.1.4:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.7.1.tgz#97f236977bd6e125408930ff6de3eec6281ec047"
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
@@ -646,6 +665,12 @@ invert-kv@^1.0.0:
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
+
+is-builtin-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-builtin-module/-/is-builtin-module-1.0.0.tgz#540572d34f7ac3119f8f76c30cbc1b1e037affbe"
+  dependencies:
+    builtin-modules "^1.0.0"
 
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
@@ -702,6 +727,10 @@ js-yaml@3.x, js-yaml@^3.7.0:
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+json-parse-better-errors@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz#bb867cfb3450e69107c131d1c514bab3dc8bcaa9"
 
 json-schema-traverse@^0.3.0:
   version "0.3.1"
@@ -940,6 +969,15 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+normalize-package-data@^2.0.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  dependencies:
+    hosted-git-info "^2.1.4"
+    is-builtin-module "^1.0.0"
+    semver "2 || 3 || 4 || 5"
+    validate-npm-package-license "^3.0.1"
+
 npm-bundled@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.3.tgz#7e71703d973af3370a9591bafe3a63aca0be2308"
@@ -1085,6 +1123,27 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+read-package-json@^2.0.0:
+  version "2.0.13"
+  resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-2.0.13.tgz#2e82ebd9f613baa6d2ebe3aa72cefe3f68e41f4a"
+  dependencies:
+    glob "^7.1.1"
+    json-parse-better-errors "^1.0.1"
+    normalize-package-data "^2.0.0"
+    slash "^1.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.2"
+
+read-package-tree@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/read-package-tree/-/read-package-tree-5.2.1.tgz#6218b187d6fac82289ce4387bbbaf8eef536ad63"
+  dependencies:
+    debuglog "^1.0.1"
+    dezalgo "^1.0.0"
+    once "^1.3.0"
+    read-package-json "^2.0.0"
+    readdir-scoped-modules "^1.0.0"
+
 readable-stream@^2.0.6:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
@@ -1096,6 +1155,15 @@ readable-stream@^2.0.6:
     safe-buffer "~5.1.1"
     string_decoder "~1.0.3"
     util-deprecate "~1.0.1"
+
+readdir-scoped-modules@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz#9fafa37d286be5d92cbaebdee030dc9b5f406747"
+  dependencies:
+    debuglog "^1.0.1"
+    dezalgo "^1.0.0"
+    graceful-fs "^4.1.2"
+    once "^1.3.0"
 
 repeat-string@^1.5.2:
   version "1.6.1"
@@ -1170,7 +1238,7 @@ sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
-semver@^5.3.0:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -1185,6 +1253,10 @@ set-blocking@~2.0.0:
 signal-exit@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
 sntp@2.x.x:
   version "2.1.0"
@@ -1213,6 +1285,28 @@ source-map@~0.2.0:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.2.0.tgz#dab73fbcfc2ba819b4de03bd6f6eaa48164b3f9d"
   dependencies:
     amdefine ">=0.0.4"
+
+spdx-correct@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.0.0.tgz#05a5b4d7153a195bc92c3c425b69f3b2a9524c82"
+  dependencies:
+    spdx-expression-parse "^3.0.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-exceptions@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz#2c7ae61056c714a5b9b9b2b2af7d311ef5c78fe9"
+
+spdx-expression-parse@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
+  dependencies:
+    spdx-exceptions "^2.1.0"
+    spdx-license-ids "^3.0.0"
+
+spdx-license-ids@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz#7a7cd28470cc6d3a1cfe6d66886f6bc430d3ac87"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1375,6 +1469,13 @@ util-deprecate@~1.0.1:
 uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
+
+validate-npm-package-license@^3.0.1:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
+  dependencies:
+    spdx-correct "^3.0.0"
+    spdx-expression-parse "^3.0.0"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
You can see the original code here: https://github.com/pulumi/pulumi-aws/blob/3883f732f543444ce6be3c724765872de1521473/overlays/nodejs/serverless/function.ts#L187

And: https://github.com/pulumi/pulumi-azure-serverless/blob/64b0a879a5a38ea566579d20fcbbfd009c1b798c/nodejs/azure-serverless/subscription.ts#L148

These will go away by calling into this core helper.

These