### PR TITLE
1-index error messages printed to the console

### DIFF
--- a/pkg/util/cmdutil/exit.go
+++ b/pkg/util/cmdutil/exit.go
@@ -135,7 +135,7 @@ func errorMessage(err error) string {
 		}
 		msg := fmt.Sprintf("%d errors occurred:", len(wr))
 		for i, werr := range wr {
-			msg += fmt.Sprintf("\n    %d) %s", i, errorMessage(werr))
+			msg += fmt.Sprintf("\n    %d) %s", i+1, errorMessage(werr))
 		}
 		return msg
 	}


### PR DESCRIPTION
The `range` operator  returns array indexes that are 0-indexed. This is helpful when working with the computer code, but since we print the error to humans it looks really strange.

e.g. 
```
error: 7 errors occurred:
    0) resource 'urn:pulumi:timer-ex::timer::pulumi:pulumi:Stack::timer-timer-ex' is from a different stack (timer-ex != timer-import)
    1) resource 'urn:pulumi:timer-ex::timer::cloud:timer:Timer::test-timer' is from a different stack (timer-ex != timer-import)
    ...
```