### PR TITLE
Fix deletes with duplicate URNs.

### DIFF
--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -781,3 +781,149 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 	p.Steps = steps[2:]
 	p.Run(t, snap)
 }
+
+func TestDestroyWithPendingDelete(t *testing.T) {
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{host: host},
+	}
+
+	resURN := p.NewURN("pkgA:m:typA", "resA", "")
+
+	// Create an old snapshot with two copies of a resource that share a URN: one that is pending deletion and one
+	// that is not.
+	old := &deploy.Snapshot{
+		Resources: []*resource.State{
+			{
+				Type:    resURN.Type(),
+				URN:     resURN,
+				Custom:  true,
+				ID:      "1",
+				Inputs:  resource.PropertyMap{},
+				Outputs: resource.PropertyMap{},
+			},
+			{
+				Type:    resURN.Type(),
+				URN:     resURN,
+				Custom:  true,
+				ID:      "0",
+				Inputs:  resource.PropertyMap{},
+				Outputs: resource.PropertyMap{},
+				Delete:  true,
+			},
+		},
+	}
+
+	p.Steps = []TestStep{{
+		Op: Update,
+		Validate: func(_ workspace.Project, _ deploy.Target, j *Journal, err error) error {
+			// Verify that we see a DeleteReplacement for the resource with ID 0 and a Delete for the resouce with
+			// ID 1.
+			deletedID0, deletedID1 := false, false
+			for _, entry := range j.Entries {
+				// Ignore non-terminal steps and steps that affect the injected default provider.
+				if entry.Kind != JournalEntrySuccess || entry.Step.URN() != resURN ||
+					(entry.Step.Op() != deploy.OpDelete && entry.Step.Op() != deploy.OpDeleteReplaced) {
+					continue
+				}
+
+				switch id := entry.Step.Old().ID; id {
+				case "0":
+					assert.False(t, deletedID0)
+					deletedID0 = true
+				case "1":
+					assert.False(t, deletedID1)
+					deletedID1 = true
+				default:
+					assert.Fail(t, "unexpected resource ID %v", string(id))
+				}
+			}
+			assert.True(t, deletedID0)
+			assert.True(t, deletedID1)
+
+			return err
+		},
+	}}
+	p.Run(t, old)
+}
+
+func TestUpdateWithPendingDelete(t *testing.T) {
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	host := deploytest.NewPluginHost(nil, nil, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{host: host},
+	}
+
+	resURN := p.NewURN("pkgA:m:typA", "resA", "")
+
+	// Create an old snapshot with two copies of a resource that share a URN: one that is pending deletion and one
+	// that is not.
+	old := &deploy.Snapshot{
+		Resources: []*resource.State{
+			{
+				Type:    resURN.Type(),
+				URN:     resURN,
+				Custom:  true,
+				ID:      "1",
+				Inputs:  resource.PropertyMap{},
+				Outputs: resource.PropertyMap{},
+			},
+			{
+				Type:    resURN.Type(),
+				URN:     resURN,
+				Custom:  true,
+				ID:      "0",
+				Inputs:  resource.PropertyMap{},
+				Outputs: resource.PropertyMap{},
+				Delete:  true,
+			},
+		},
+	}
+
+	p.Steps = []TestStep{{
+		Op: Destroy,
+		Validate: func(_ workspace.Project, _ deploy.Target, j *Journal, err error) error {
+			// Verify that we see a DeleteReplacement for the resource with ID 0 and a Delete for the resouce with
+			// ID 1.
+			deletedID0, deletedID1 := false, false
+			for _, entry := range j.Entries {
+				// Ignore non-terminal steps and steps that affect the injected default provider.
+				if entry.Kind != JournalEntrySuccess || entry.Step.URN() != resURN ||
+					(entry.Step.Op() != deploy.OpDelete && entry.Step.Op() != deploy.OpDeleteReplaced) {
+					continue
+				}
+
+				switch id := entry.Step.Old().ID; id {
+				case "0":
+					assert.False(t, deletedID0)
+					deletedID0 = true
+				case "1":
+					assert.False(t, deletedID1)
+					deletedID1 = true
+				default:
+					assert.Fail(t, "unexpected resource ID %v", string(id))
+				}
+			}
+			assert.True(t, deletedID0)
+			assert.True(t, deletedID1)
+
+			return err
+		},
+	}}
+	p.Run(t, old)
+}

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -207,11 +207,11 @@ func (r *Registry) Check(urn resource.URN, olds, news resource.PropertyMap,
 		return nil, []plugin.CheckFailure{{Property: "version", Reason: err.Error()}}, nil
 	}
 	provider, err := r.host.Provider(getProviderPackage(urn.Type()), version)
-	if provider == nil {
-		return nil, nil, errors.New("could not find plugin")
-	}
 	if err != nil {
 		return nil, nil, err
+	}
+	if provider == nil {
+		return nil, nil, errors.New("could not find plugin")
 	}
 
 	// Check the provider's config. If the check fails, unload the provider.

--- a/tests/integration/duplicate_urns/duplicate_urns_test.go
+++ b/tests/integration/duplicate_urns/duplicate_urns_test.go
@@ -37,15 +37,11 @@ func TestDuplicateURNs(t *testing.T) {
 				Additive:      true,
 				ExpectFailure: true,
 			},
-			/* TODO(pulumi/pulumi#1645) - This example runs into trouble with pending deletes.
-			   We currently have a bug where we can't delete a pending-delete resource in the same
-			   plan where we deleted the resource because it no longer exists.
 			{
 				Dir:           "step4",
 				Additive:      true,
 				ExpectFailure: true,
 			},
-			*/
 		},
 	})
 }


### PR DESCRIPTION
When calculating deletes, we will only issue a single delete step for a
particular URN. This is incorrect in the presence of pending deletes
that share URNs with a live resource if the pending deletes follow the
live resource in the checkpoint: instead of issuing a delete for
every resource with a particular URN, we will only issue deletes for
the pending deletes.

Before first-class providers, this was mostly benigin: any remaining
resources could be deleted by re-running the destroy. With the
first-class provider changes, however, the provider for the undeleted
resources will be deleted, leaving the checkpoint in an invalid state.

These changes fix this issue by allowing the step generator to issue
mutiple deletes for a single URN and add a test for this scenario.