### PR TITLE
Report initialization errors as warnings during previews as well as updates

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -15,7 +15,9 @@
 package engine
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"sync"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
+	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
@@ -277,6 +280,22 @@ func (acts *planActions) OnResourceStepPre(step deploy.Step) (interface{}, error
 	acts.Seen[step.URN()] = step
 	acts.MapLock.Unlock()
 	acts.Opts.Events.resourcePreEvent(step, true /*planning*/, acts.Opts.Debug)
+
+	// Warn the user if they're not updating a resource whose initialization failed.
+	if step.Op() == deploy.OpSame && len(step.Old().InitErrors) > 0 {
+		indent := "         "
+
+		// TODO: Move indentation to the display logic, instead of doing it ourselves.
+		var warning bytes.Buffer
+		warning.WriteString("This resource failed to initialize in a previous deployment. It is recommended\n")
+		warning.WriteString(indent + "to update it to fix these issues:\n")
+		for i, err := range step.Old().InitErrors {
+			warning.WriteString(colors.SpecImportant + indent + fmt.Sprintf("  - Problem #%d", i+1) +
+				colors.Reset + " " + err + "\n")
+		}
+		acts.Opts.Diag.Warningf(diag.RawMessage(step.URN(), warning.String()))
+	}
+
 	return nil, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1719. We have two different implementations of `deploy.Events`: `updateActions`, used for updates, and `planActions`, used for previews. We need to issue `initErrors` warnings in both cases.