### PR TITLE
Serialize SourceEvents coming from the refresh source

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -195,12 +195,11 @@ func (res *planResult) Chdir() (func(), error) {
 func (res *planResult) Walk(cancelCtx *Context, events deploy.Events, preview bool) (deploy.PlanSummary, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	opts := deploy.Options{
-		Context:  ctx,
 		Events:   events,
 		Parallel: res.Options.Parallel,
 	}
 
-	src, err := res.Plan.Source().Iterate(opts, res.Plan)
+	src, err := res.Plan.Source().Iterate(ctx, opts, res.Plan)
 	if err != nil {
 		cancelFunc()
 		return nil, err

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -15,6 +15,8 @@
 package deploy
 
 import (
+	"context"
+
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -30,8 +32,9 @@ import (
 
 // Options controls the planning and deployment process.
 type Options struct {
-	Events   Events // an optional events callback interface.
-	Parallel int    // the degree of parallelism for resource operations (<=1 for serial).
+	Context  context.Context // context for this plan/deployment.
+	Events   Events          // an optional events callback interface.
+	Parallel int             // the degree of parallelism for resource operations (<=1 for serial).
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -15,8 +15,6 @@
 package deploy
 
 import (
-	"context"
-
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -32,9 +30,8 @@ import (
 
 // Options controls the planning and deployment process.
 type Options struct {
-	Context  context.Context // context for this plan/deployment.
-	Events   Events          // an optional events callback interface.
-	Parallel int             // the degree of parallelism for resource operations (<=1 for serial).
+	Events   Events // an optional events callback interface.
+	Parallel int    // the degree of parallelism for resource operations (<=1 for serial).
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -15,6 +15,7 @@
 package deploy
 
 import (
+	"context"
 	"io"
 
 	"github.com/pulumi/pulumi/pkg/resource"
@@ -42,7 +43,7 @@ type Source interface {
 	IsRefresh() bool
 
 	// Iterate begins iterating the source. Error is non-nil upon failure; otherwise, a valid iterator is returned.
-	Iterate(opts Options, providers ProviderSource) (SourceIterator, error)
+	Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error)
 }
 
 // A SourceIterator enumerates the list of resources that a source has to offer and tracks associated state.

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -84,7 +84,9 @@ func (src *evalSource) Info() interface{} { return src.runinfo }
 func (src *evalSource) IsRefresh() bool   { return false }
 
 // Iterate will spawn an evaluator coroutine and prepare to interact with it on subsequent calls to Next.
-func (src *evalSource) Iterate(opts Options, providers ProviderSource) (SourceIterator, error) {
+func (src *evalSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error) {
+	contract.Ignore(ctx) // TODO[pulumi/pulumi#1714]
+
 	// First, fire up a resource monitor that will watch for and record resource creation.
 	regChan := make(chan *registerResourceEvent)
 	regOutChan := make(chan *registerResourceOutputsEvent)

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -15,6 +15,7 @@
 package deploy
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -170,7 +171,7 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(fixedProgram(steps))
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(Options{}, &testProviderSource{})
+	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
 	assert.NoError(t, err)
 
 	processed := 0
@@ -246,7 +247,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(fixedProgram(steps))
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(Options{}, &testProviderSource{})
+	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
 	assert.NoError(t, err)
 
 	processed, defaults := 0, make(map[string]struct{})
@@ -356,7 +357,7 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(program)
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(Options{}, providerSource)
+	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
 	assert.NoError(t, err)
 
 	reads := 0
@@ -428,7 +429,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 
 	providerSource := &testProviderSource{providers: make(map[providers.Reference]plugin.Provider)}
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(Options{}, providerSource)
+	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
 	assert.NoError(t, err)
 
 	reads, registers := 0, 0

--- a/pkg/resource/deploy/source_fixed.go
+++ b/pkg/resource/deploy/source_fixed.go
@@ -15,7 +15,10 @@
 package deploy
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
 // NewFixedSource returns a valid planning source that is comprised of a list of pre-computed steps.
@@ -34,7 +37,8 @@ func (src *fixedSource) Project() tokens.PackageName { return src.ctx }
 func (src *fixedSource) Info() interface{}           { return nil }
 func (src *fixedSource) IsRefresh() bool             { return false }
 
-func (src *fixedSource) Iterate(opts Options, providers ProviderSource) (SourceIterator, error) {
+func (src *fixedSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error) {
+	contract.Ignore(ctx) // TODO[pulumi/pulumi#1714]
 	return &fixedSourceIterator{
 		src:     src,
 		current: -1,

--- a/pkg/resource/deploy/source_null.go
+++ b/pkg/resource/deploy/source_null.go
@@ -15,7 +15,10 @@
 package deploy
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
 // NullSource is a singleton source that never returns any resources.  This may be used in scenarios where the "new"
@@ -31,7 +34,8 @@ func (src *nullSource) Project() tokens.PackageName { return "" }
 func (src *nullSource) Info() interface{}           { return nil }
 func (src *nullSource) IsRefresh() bool             { return false }
 
-func (src *nullSource) Iterate(opts Options, providers ProviderSource) (SourceIterator, error) {
+func (src *nullSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error) {
+	contract.Ignore(ctx)
 	return &nullSourceIterator{}, nil
 }
 

--- a/pkg/resource/deploy/source_refresh.go
+++ b/pkg/resource/deploy/source_refresh.go
@@ -52,15 +52,15 @@ func (src *refreshSource) Project() tokens.PackageName { return src.proj.Name }
 func (src *refreshSource) Info() interface{}           { return nil }
 func (src *refreshSource) IsRefresh() bool             { return true }
 
-func (src *refreshSource) Iterate(opts Options, provs ProviderSource) (SourceIterator, error) {
-	contract.Require(opts.Context != nil, "opts.Context != nil")
+func (src *refreshSource) Iterate(ctx context.Context, opts Options, provs ProviderSource) (SourceIterator, error) {
+	contract.Require(ctx != nil, "opts.Context != nil")
 	var states []*resource.State
 	if snap := src.target.Snapshot; snap != nil {
 		states = snap.Resources
 	}
 
 	return &refreshSourceIterator{
-		ctx:       opts.Context,
+		ctx:       ctx,
 		plugctx:   src.plugctx,
 		target:    src.target,
 		providers: provs,

--- a/pkg/resource/deploy/source_refresh_test.go
+++ b/pkg/resource/deploy/source_refresh_test.go
@@ -114,10 +114,7 @@ func TestRefresh(t *testing.T) {
 	target.Snapshot = &Snapshot{Resources: olds}
 
 	// Create and iterate a source.
-	iter, err := NewRefreshSource(nil, proj, target, false).Iterate(Options{
-		// Context used for cancellation.
-		Context: context.Background(),
-	}, providerSource)
+	iter, err := NewRefreshSource(nil, proj, target, false).Iterate(context.Background(), Options{}, providerSource)
 	assert.NoError(t, err)
 
 	processed := 0

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -35,7 +35,7 @@ type Step interface {
 	// a function to call to signal that this step has fully completed, and an error, if one occurred while applying
 	// the step.
 	//
-	// The returned StepCompleteFunc, if not null, must be called after committing the results of this step into
+	// The returned StepCompleteFunc, if not nil, must be called after committing the results of this step into
 	// the state of the deployment.
 	Apply(preview bool) (resource.Status, StepCompleteFunc, error) // applies or previews this step.
 


### PR DESCRIPTION
The engine requires that a source event coming from a source be "ready
to execute" at the moment that it is sent to the engine. Since the
refresh source sent all goal states eagerly through its source iterator,
the engine assumed that it was legal to execute them all in parallel and
did so. This is a problem for the snapshot, since the snapshot expects
to be in an order that is a legal topological ordering of the dependency
DAG.

This PR fixes the issue by sending refresh source events one-at-a-time
through the refresh source iterator, only unblocking to send the next
step as soon as the previous step completes.