### PR TITLE
Initial support for passing URLs to `new` and `up`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -577,6 +577,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a3253944db378ee26f07b4bcdcc8685be1c49dba2998473b8b2da74b10be6afc"
+  inputs-digest = "54dbb01365a37a74aba07358a4e069c1ae7e9efd3a893e8c2ca6b6d3aea3bfb2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/cancel.go
+++ b/cmd/cancel.go
@@ -51,7 +51,7 @@ func newCancelCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts)
+			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -50,7 +50,7 @@ func newConfigCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			stack, err := requireStack(stack, true, opts)
+			stack, err := requireStack(stack, true, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -84,7 +84,7 @@ func newConfigGetCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(*stack, true, opts)
+			s, err := requireStack(*stack, true, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -111,7 +111,7 @@ func newConfigRmCmd(stack *string) *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(*stack, true, opts)
+			s, err := requireStack(*stack, true, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -149,7 +149,7 @@ func newConfigRefreshCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(*stack, false, opts)
+			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}
@@ -225,7 +225,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(*stack, true, opts)
+			s, err := requireStack(*stack, true, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -76,7 +76,7 @@ func newDestroyCmd() *cobra.Command {
 				Debug:                debug,
 			}
 
-			s, err := requireStack(stack, false, opts.Display)
+			s, err := requireStack(stack, false, opts.Display, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -49,7 +49,7 @@ func newLogsCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts)
+			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -40,6 +40,7 @@ import (
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 )
 
+// nolint: vetshadow, intentionally disabling here for cleaner err declaration/assignment.
 func newNewCmd() *cobra.Command {
 	var configArray []string
 	var name string
@@ -56,8 +57,6 @@ func newNewCmd() *cobra.Command {
 		Short:      "Create a new Pulumi project",
 		Args:       cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			var err error
-
 			// Validate name (if specified) before further prompts/operations.
 			if name != "" && !workspace.IsValidProjectName(name) {
 				return errors.Errorf("'%s' is not a valid project name", name)
@@ -68,8 +67,8 @@ func newNewCmd() *cobra.Command {
 			}
 
 			// Get the current working directory.
-			var cwd string
-			if cwd, err = os.Getwd(); err != nil {
+			cwd, err := os.Getwd()
+			if err != nil {
 				return errors.Wrap(err, "getting the working directory")
 			}
 			originalCwd := cwd
@@ -97,8 +96,7 @@ func newNewCmd() *cobra.Command {
 			// will kick off the login flow (if not already logged-in).
 			var b backend.Backend
 			if !generateOnly {
-				b, err = currentBackend(displayOpts)
-				if err != nil {
+				if b, err = currentBackend(displayOpts); err != nil {
 					return err
 				}
 			}
@@ -109,8 +107,7 @@ func newNewCmd() *cobra.Command {
 			}
 
 			// Retrieve the template repo.
-			var repo workspace.TemplateRepository
-			repo, err = workspace.RetrieveTemplates(templateNameOrURL, offline)
+			repo, err := workspace.RetrieveTemplates(templateNameOrURL, offline)
 			if err != nil {
 				return err
 			}
@@ -119,8 +116,7 @@ func newNewCmd() *cobra.Command {
 			}()
 
 			// List the templates from the repo.
-			var templates []workspace.Template
-			templates, err = repo.Templates()
+			templates, err := repo.Templates()
 			if err != nil {
 				return err
 			}
@@ -189,8 +185,7 @@ func newNewCmd() *cobra.Command {
 				defaultValue := getDevStackName(name)
 
 				for {
-					var stackName string
-					stackName, err = promptForValue(yes, "stack name", defaultValue, false, nil, displayOpts)
+					stackName, err := promptForValue(yes, "stack name", defaultValue, false, nil, displayOpts)
 					if err != nil {
 						return err
 					}
@@ -212,15 +207,13 @@ func newNewCmd() *cobra.Command {
 			// Prompt for config values and save.
 			if !generateOnly {
 				// Get config values passed on the command line.
-				var commandLineConfig config.Map
-				commandLineConfig, err = parseConfig(configArray)
+				commandLineConfig, err := parseConfig(configArray)
 				if err != nil {
 					return err
 				}
 
 				// Prompt for config as needed.
-				var c config.Map
-				c, err = promptForConfig(template.Config, commandLineConfig, nil, yes, displayOpts)
+				c, err := promptForConfig(template.Config, commandLineConfig, nil, yes, displayOpts)
 				if err != nil {
 					return err
 				}
@@ -404,7 +397,6 @@ func installDependencies() error {
 		return errors.Wrapf(err, "installing dependencies; rerun '%s' manually to try again", command)
 	}
 
-	fmt.Println("Finished installing dependencies.")
 	return nil
 }
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -351,7 +351,7 @@ func stackInit(b backend.Backend, stackName string) (backend.Stack, error) {
 	if err != nil {
 		return nil, err
 	}
-	return createStack(b, stackRef, nil)
+	return createStack(b, stackRef, nil, true /*setCurrent*/)
 }
 
 // saveConfig saves the config for the stack.

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -390,7 +390,7 @@ func chooseTemplate(templates []workspace.Template, opts backend.DisplayOptions)
 	message := "\rPlease choose a template:"
 	message = opts.Color.Colorize(colors.BrightWhite + message + colors.Reset)
 
-	options, optionToTemplateMap := templateArrayToStringArrayAndMap(templates)
+	options, optionToTemplateMap := templatesToOptionArrayAndMap(templates)
 
 	var option string
 	if err := survey.AskOne(&survey.Select{
@@ -550,14 +550,27 @@ func promptForValue(
 	}
 }
 
-// templateArrayToStringArrayAndMap returns an array of template names and map of names to templates
-// from an array of templates.
-func templateArrayToStringArrayAndMap(templates []workspace.Template) ([]string, map[string]workspace.Template) {
+// templatesToOptionArrayAndMap returns an array of option strings and a map of option strings to templates.
+// Each option string is made up of the template name and description with some padding in between.
+func templatesToOptionArrayAndMap(templates []workspace.Template) ([]string, map[string]workspace.Template) {
+	// Find the longest name length. Used to add padding between the name and description.
+	maxNameLength := 0
+	for _, template := range templates {
+		if len(template.Name) > maxNameLength {
+			maxNameLength = len(template.Name)
+		}
+	}
+
+	// Build the array and map.
 	var options []string
 	nameToTemplateMap := make(map[string]workspace.Template)
 	for _, template := range templates {
-		options = append(options, template.Name)
-		nameToTemplateMap[template.Name] = template
+		// Create the option string that combines the name, padding, and description.
+		option := fmt.Sprintf(fmt.Sprintf("%%%ds    %%s", -maxNameLength), template.Name, template.Description)
+
+		// Add it to the array and map.
+		options = append(options, option)
+		nameToTemplateMap[option] = template
 	}
 	sort.Strings(options)
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -15,9 +15,7 @@
 package cmd
 
 import (
-	"bufio"
 	"fmt"
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,7 +24,6 @@ import (
 	"unicode"
 
 	"github.com/pulumi/pulumi/pkg/backend"
-	"github.com/pulumi/pulumi/pkg/backend/cloud"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/workspace"
@@ -35,16 +32,15 @@ import (
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/spf13/cobra"
 
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 )
 
-const defaultURLEnvVar = "PULUMI_TEMPLATE_API"
-
 func newNewCmd() *cobra.Command {
-	var cloudURL string
+	var configArray []string
 	var name string
 	var description string
 	var force bool
@@ -96,11 +92,6 @@ func newNewCmd() *cobra.Command {
 				}
 			}
 
-			releases, err := cloud.New(cmdutil.Diag(), getCloudURL(cloudURL))
-			if err != nil {
-				return errors.Wrap(err, "creating API client")
-			}
-
 			// If we're going to be creating a stack, get the current backend, which
 			// will kick off the login flow (if not already logged-in).
 			var b backend.Backend
@@ -111,51 +102,46 @@ func newNewCmd() *cobra.Command {
 				}
 			}
 
-			// Get the selected template.
-			var templateName string
+			templateNameOrURL := ""
 			if len(args) > 0 {
-				templateName = strings.ToLower(args[0])
-			} else {
-				if templateName, err = chooseTemplate(releases, offline, displayOpts); err != nil {
-					return err
-				}
+				templateNameOrURL = args[0]
 			}
 
-			// Download and install the template to the local template cache.
-			if !offline {
-				var tarball io.ReadCloser
-				source := releases.CloudURL()
+			// Retrieve the template repo.
+			var repo workspace.TemplateRepository
+			repo, err = workspace.RetrieveTemplates(templateNameOrURL, offline)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				contract.IgnoreError(repo.Delete())
+			}()
 
-				if tarball, err = releases.DownloadTemplate(commandContext(), templateName, false, displayOpts); err != nil {
-					message := ""
-					// If the local template is available locally, provide a nicer error message.
-					if localTemplates, localErr := workspace.ListLocalTemplates(); localErr == nil && len(localTemplates) > 0 {
-						_, m := templateArrayToStringArrayAndMap(localTemplates)
-						if _, ok := m[templateName]; ok {
-							message = fmt.Sprintf(
-								"; rerun the command and pass --offline to use locally cached template '%s'",
-								templateName)
-						}
-					}
-
-					return errors.Wrapf(err, "downloading template '%s' from %s%s", templateName, source, message)
-				}
-				if err = workspace.InstallTemplate(templateName, tarball); err != nil {
-					return errors.Wrapf(err, "installing template '%s' from %s", templateName, source)
-				}
+			// List the templates from the repo.
+			var templates []workspace.Template
+			templates, err = repo.Templates()
+			if err != nil {
+				return err
 			}
 
-			// Load the local template.
 			var template workspace.Template
-			if template, err = workspace.LoadLocalTemplate(templateName); err != nil {
-				return errors.Wrapf(err, "template '%s' not found", templateName)
+			if len(templates) == 0 {
+				return errors.New("no templates")
+			} else if len(templates) == 1 {
+				template = templates[0]
+			} else {
+				if !cmdutil.Interactive() {
+					return errors.New("no template specified; please use `pulumi new` to choose one")
+				}
+
+				template = chooseTemplate(templates, displayOpts)
 			}
 
 			// Do a dry run, if we're not forcing files to be overwritten.
 			if !force {
 				if err = template.CopyTemplateFilesDryRun(cwd); err != nil {
 					if os.IsNotExist(err) {
-						return errors.Wrapf(err, "template '%s' not found", templateName)
+						return errors.Wrapf(err, "template '%s' not found", templateNameOrURL)
 					}
 					return err
 				}
@@ -173,19 +159,25 @@ func newNewCmd() *cobra.Command {
 			// Prompt for the project name, if it wasn't already specified.
 			if name == "" {
 				defaultValue := workspace.ValueOrSanitizedDefaultProjectName(name, filepath.Base(cwd))
-				name = promptForValue(yes, "project name", defaultValue, workspace.IsValidProjectName, displayOpts)
+				name, err = promptForValue(yes, "project name", defaultValue, false, workspace.IsValidProjectName, displayOpts)
+				if err != nil {
+					return err
+				}
 			}
 
 			// Prompt for the project description, if it wasn't already specified.
 			if description == "" {
 				defaultValue := workspace.ValueOrDefaultProjectDescription(description, template.Description)
-				description = promptForValue(yes, "project description", defaultValue, nil, displayOpts)
+				description, err = promptForValue(yes, "project description", defaultValue, false, nil, displayOpts)
+				if err != nil {
+					return err
+				}
 			}
 
 			// Actually copy the files.
 			if err = template.CopyTemplateFiles(cwd, force, name, description); err != nil {
 				if os.IsNotExist(err) {
-					return errors.Wrapf(err, "template '%s' not found", templateName)
+					return errors.Wrapf(err, "template '%s' not found", templateNameOrURL)
 				}
 				return err
 			}
@@ -198,7 +190,11 @@ func newNewCmd() *cobra.Command {
 				defaultValue := getDevStackName(name)
 
 				for {
-					stackName := promptForValue(yes, "stack name", defaultValue, nil, displayOpts)
+					var stackName string
+					stackName, err = promptForValue(yes, "stack name", defaultValue, false, nil, displayOpts)
+					if err != nil {
+						return err
+					}
 					stack, err = stackInit(b, stackName)
 					if err != nil {
 						if !yes {
@@ -216,19 +212,22 @@ func newNewCmd() *cobra.Command {
 
 			// Prompt for config values and save.
 			if !generateOnly {
-				var keys config.KeyArray
-				for k := range template.Config {
-					keys = append(keys, k)
+				// Get config values passed on the command line.
+				var commandLineConfig config.Map
+				commandLineConfig, err = parseConfig(configArray)
+				if err != nil {
+					return err
 				}
-				if len(keys) > 0 {
-					sort.Sort(keys)
 
-					c := make(config.Map)
-					for _, k := range keys {
-						value := promptForValue(yes, k.String(), template.Config[k], nil, displayOpts)
-						c[k] = config.NewValue(value)
-					}
+				// Prompt for config as needed.
+				var c config.Map
+				c, err = promptForConfig(template.Config, commandLineConfig, nil, yes, displayOpts)
+				if err != nil {
+					return err
+				}
 
+				// Save the config.
+				if c != nil {
 					if err = saveConfig(stack.Name().StackName(), c); err != nil {
 						return errors.Wrap(err, "saving config")
 					}
@@ -238,13 +237,11 @@ func newNewCmd() *cobra.Command {
 			}
 
 			// Install dependencies.
-			if !generateOnly && template.InstallDependencies {
-				fmt.Println("Installing dependencies...")
+			if !generateOnly {
 				err = installDependencies()
 				if err != nil {
 					return err
 				}
-				fmt.Println("Finished installing dependencies.")
 
 				// Write a summary with next steps.
 				fmt.Println(
@@ -281,12 +278,17 @@ func newNewCmd() *cobra.Command {
 				fmt.Println(displayOpts.Color.Colorize(deployMsg))
 			}
 
+			if template.Quickstart != "" {
+				fmt.Println(template.Quickstart)
+			}
+
 			return nil
 		}),
 	}
 
-	cmd.PersistentFlags().StringVarP(&cloudURL,
-		"cloud-url", "c", "", "A cloud URL to download templates from")
+	cmd.PersistentFlags().StringArrayVarP(
+		&configArray, "config", "c", []string{},
+		"Config to save")
 	cmd.PersistentFlags().StringVarP(
 		&name, "name", "n", "",
 		"The project name; if not specified, a prompt will request it")
@@ -305,7 +307,8 @@ func newNewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&generateOnly, "generate-only", false,
 		"Generate the project only; do not create a stack, save config, or install dependencies")
-	cmd.PersistentFlags().StringVar(&dir, "dir", "",
+	cmd.PersistentFlags().StringVar(
+		&dir, "dir", "",
 		"The location to place the generated project; if not specified, the current directory is used")
 
 	return cmd
@@ -363,60 +366,20 @@ func installDependencies() error {
 		return nil
 	}
 
+	fmt.Println("Installing dependencies...")
+
 	// Run the command.
 	if out, err := c.CombinedOutput(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s", out)
 		return errors.Wrapf(err, "installing dependencies; rerun '%s' manually to try again", command)
 	}
 
+	fmt.Println("Finished installing dependencies.")
 	return nil
 }
 
-// getCloudURL returns the URL used to download the template.
-func getCloudURL(cloudURL string) string {
-	// If we have a cloud URL, just return it.
-	if cloudURL != "" {
-		return cloudURL
-	}
-
-	// Otherwise, respect the PULUMI_TEMPLATE_API override.
-	if fromEnv := os.Getenv(defaultURLEnvVar); fromEnv != "" {
-		return fromEnv
-	}
-
-	// Otherwise, use the default.
-	return cloud.DefaultURL()
-}
-
 // chooseTemplate will prompt the user to choose amongst the available templates.
-func chooseTemplate(backend cloud.Backend, offline bool, opts backend.DisplayOptions) (string, error) {
-	const chooseTemplateErr = "no template selected; please use `pulumi new` to choose one"
-	if !cmdutil.Interactive() {
-		return "", errors.New(chooseTemplateErr)
-	}
-
-	var templates []workspace.Template
-	var err error
-
-	if !offline {
-		if templates, err = backend.ListTemplates(commandContext()); err != nil {
-			message := "could not fetch list of remote templates"
-
-			// If we couldn't fetch the list, see if there are any local templates
-			if localTemplates, localErr := workspace.ListLocalTemplates(); localErr == nil && len(localTemplates) > 0 {
-				options, _ := templateArrayToStringArrayAndMap(localTemplates)
-				message = message + "\nrerun the command and pass --offline to use locally cached templates: " +
-					strings.Join(options, ", ")
-			}
-
-			return "", errors.Wrap(err, message)
-		}
-	} else {
-		if templates, err = workspace.ListLocalTemplates(); err != nil || len(templates) == 0 {
-			return "", errors.Wrap(err, chooseTemplateErr)
-		}
-	}
-
+func chooseTemplate(templates []workspace.Template, opts backend.DisplayOptions) workspace.Template {
 	// Customize the prompt a little bit (and disable color since it doesn't match our scheme).
 	surveycore.DisableColor = true
 	surveycore.QuestionIcon = ""
@@ -424,18 +387,112 @@ func chooseTemplate(backend cloud.Backend, offline bool, opts backend.DisplayOpt
 	message := "\rPlease choose a template:"
 	message = opts.Color.Colorize(colors.BrightWhite + message + colors.Reset)
 
-	options, _ := templateArrayToStringArrayAndMap(templates)
+	options, optionToTemplateMap := templateArrayToStringArrayAndMap(templates)
 
 	var option string
-	if err := survey.AskOne(&survey.Select{
+	err := survey.AskOne(&survey.Select{
 		Message:  message,
 		Options:  options,
 		PageSize: len(options),
-	}, &option, nil); err != nil {
-		return "", errors.New(chooseTemplateErr)
+	}, &option, nil)
+	contract.IgnoreError(err)
+
+	return optionToTemplateMap[option]
+}
+
+// parseConfig parses the config values passed via command line flags.
+// These are passed as `-c aws:region=us-east-1 -c foo:bar=blah` and end up
+// in configArray as ["aws:region=us-east-1", "foo:bar=blah"].
+// This function converts the array into a config.Map.
+func parseConfig(configArray []string) (config.Map, error) {
+	configMap := make(config.Map)
+	for _, c := range configArray {
+		kvp := strings.SplitN(c, "=", 2)
+
+		key, err := config.ParseKey(kvp[0])
+		if err != nil {
+			return nil, err
+		}
+
+		value := config.NewValue("")
+		if len(kvp) == 2 {
+			value = config.NewValue(kvp[1])
+		}
+
+		configMap[key] = value
+	}
+	return configMap, nil
+}
+
+// promptForConfig will go through each config key needed by the template and prompt for a value.
+// If a config value exists in commandLineConfig, it will be used without prompting.
+// If stackConfig is non-nil and a config value exists in stackConfig, it will be used as the default
+// value when prompting instead of the default value specified in templateConfig.
+func promptForConfig(
+	templateConfig map[config.Key]workspace.ProjectTemplateConfigValue,
+	commandLineConfig config.Map,
+	stackConfig config.Map,
+	yes bool,
+	opts backend.DisplayOptions) (config.Map, error) {
+
+	c := make(config.Map)
+
+	var keys config.KeyArray
+	for k := range templateConfig {
+		keys = append(keys, k)
 	}
 
-	return option, nil
+	if len(keys) > 0 {
+		sort.Sort(keys)
+
+		for _, k := range keys {
+			// If it was passed as a command line flag, use it without prompting.
+			if val, ok := commandLineConfig[k]; ok {
+				c[k] = val
+				continue
+			}
+
+			templateConfigValue := templateConfig[k]
+
+			// Prepare a default value.
+			defaultValue := ""
+			if stackConfig != nil {
+				// Use the stack's existing value as the default.
+				if val, ok := stackConfig[k]; ok && !val.Secure() {
+					value, err := val.Value(nil)
+					contract.AssertNoError(err)
+					defaultValue = value
+				}
+			}
+			if defaultValue == "" {
+				defaultValue = templateConfigValue.Default
+			}
+
+			// Prepare the prompt.
+			prompt := k.String()
+			if templateConfigValue.Description != "" {
+				prompt = prompt + ": " + templateConfigValue.Description
+			}
+
+			// Actually prompt.
+			value, err := promptForValue(yes, prompt, defaultValue, templateConfigValue.Secret, nil, opts)
+			if err != nil {
+				return nil, err
+			}
+
+			// Save the value.
+			c[k] = config.NewValue(value)
+		}
+	}
+
+	// Add any other config values from the command line.
+	for k, v := range commandLineConfig {
+		if _, ok := c[k]; !ok {
+			c[k] = v
+		}
+	}
+
+	return c, nil
 }
 
 // promptForValue prompts the user for a value with a defaultValue preselected. Hitting enter accepts the
@@ -443,11 +500,11 @@ func chooseTemplate(backend cloud.Backend, offline bool, opts backend.DisplayOpt
 // when specified, it will be run to validate that value entered. An invalid value will result in an error
 // message followed by another prompt for the value.
 func promptForValue(
-	yes bool, prompt string, defaultValue string,
-	isValidFn func(value string) bool, opts backend.DisplayOptions) string {
+	yes bool, prompt string, defaultValue string, secret bool,
+	isValidFn func(value string) bool, opts backend.DisplayOptions) (string, error) {
 
 	if yes {
-		return defaultValue
+		return defaultValue, nil
 	}
 
 	for {
@@ -460,20 +517,32 @@ func promptForValue(
 		}
 		fmt.Print(prompt)
 
-		reader := bufio.NewReader(os.Stdin)
-		line, _ := reader.ReadString('\n')
-		value := strings.TrimSpace(line)
+		// Read the value.
+		var err error
+		var value string
+		if secret {
+			value, err = cmdutil.ReadConsoleNoEcho("")
+			if err != nil {
+				return "", err
+			}
+		} else {
+			value, err = cmdutil.ReadConsole("")
+			if err != nil {
+				return "", err
+			}
+		}
+		value = strings.TrimSpace(value)
 
 		if value != "" {
 			if isValidFn == nil || isValidFn(value) {
-				return value
+				return value, nil
 			}
 
 			// The value is invalid, let the user know and try again
 			fmt.Printf("Sorry, '%s' is not a valid %s.\n", value, prompt)
 			continue
 		}
-		return defaultValue
+		return defaultValue, nil
 	}
 }
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -230,7 +230,7 @@ func newNewCmd() *cobra.Command {
 
 			// Install dependencies.
 			if !generateOnly {
-				err = installDependencies()
+				err = installDependencies("Installing dependencies...")
 				if err != nil {
 					return err
 				}
@@ -370,7 +370,7 @@ func saveConfig(stackName tokens.QName, c config.Map) error {
 
 // installDependencies will install dependencies for the project, e.g. by running
 // `npm install` for nodejs projects or `pip install` for python projects.
-func installDependencies() error {
+func installDependencies(message string) error {
 	proj, _, err := readProject()
 	if err != nil {
 		return err
@@ -389,7 +389,9 @@ func installDependencies() error {
 		return nil
 	}
 
-	fmt.Println("Installing dependencies...")
+	if message != "" {
+		fmt.Println(message)
+	}
 
 	// Run the command.
 	if out, err := c.CombinedOutput(); err != nil {

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -73,7 +73,7 @@ func newPreviewCmd() *cobra.Command {
 				},
 			}
 
-			s, err := requireStack(stack, true, opts.Display)
+			s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -75,7 +75,7 @@ func newRefreshCmd() *cobra.Command {
 				Debug:                debug,
 			}
 
-			s, err := requireStack(stack, true, opts.Display)
+			s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -47,7 +47,7 @@ func newStackCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireCurrentStack(true, opts)
+			s, err := requireCurrentStack(true, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_export.go
+++ b/cmd/stack_export.go
@@ -45,7 +45,7 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and export its deployment
-			s, err := requireStack(stackName, false, opts)
+			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_graph.go
+++ b/cmd/stack_graph.go
@@ -55,7 +55,7 @@ func newStackGraphCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stackName, false, opts)
+			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -50,7 +50,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and import a deployment.
-			s, err := requireStack(stackName, false, opts)
+			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -70,7 +70,7 @@ func newStackInitCmd() *cobra.Command {
 				return err
 			}
 
-			_, err = createStack(b, stackRef, createOpts)
+			_, err = createStack(b, stackRef, createOpts, true /*setCurrent*/)
 			return err
 		}),
 	}

--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -41,7 +41,7 @@ func newStackOutputCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and its output properties.
-			s, err := requireStack(stackName, false, opts)
+			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_rm.go
+++ b/cmd/stack_rm.go
@@ -52,7 +52,7 @@ func newStackRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts)
+			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/stack_select.go
+++ b/cmd/stack_select.go
@@ -64,7 +64,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			// If no stack was given, prompt the user to select a name from the available ones.
-			stack, err := chooseStack(b, true, opts)
+			stack, err := chooseStack(b, true, opts, true /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -174,7 +174,7 @@ func newUpCmd() *cobra.Command {
 				}
 
 				// Install dependencies.
-				if err = installDependencies(); err != nil {
+				if err = installDependencies(""); err != nil {
 					return err
 				}
 			}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -180,16 +180,8 @@ func newUpCmd() *cobra.Command {
 				return err
 			}
 
-			// Get the crypter if needed.
-			var crypter config.Crypter
-			if stackConfig != nil && stackConfig.HasSecureValue() {
-				if crypter, err = backend.GetStackCrypter(s); err != nil {
-					return err
-				}
-			}
-
 			// Prompt for config as needed.
-			c, err = promptForConfig(template.Config, commandLineConfig, stackConfig, crypter, yes, opts.Display)
+			c, err = promptForConfig(s, template.Config, commandLineConfig, stackConfig, yes, opts.Display)
 			if err != nil {
 				return err
 			}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -27,6 +27,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
@@ -49,6 +51,195 @@ func newUpCmd() *cobra.Command {
 	var showSames bool
 	var skipPreview bool
 	var yes bool
+
+	// up implementation used when the source of the Pulumi program is in the current working directory.
+	upWorkingDirectory := func(opts backend.UpdateOptions) error {
+		s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
+		if err != nil {
+			return err
+		}
+
+		proj, root, err := readProject()
+		if err != nil {
+			return err
+		}
+
+		m, err := getUpdateMetadata(message, root)
+		if err != nil {
+			return errors.Wrap(err, "gathering environment metadata")
+		}
+
+		opts.Engine = engine.UpdateOptions{
+			Analyzers: analyzers,
+			Parallel:  parallel,
+			Debug:     debug,
+		}
+
+		changes, err := s.Update(commandContext(), proj, root, m, opts, cancellationScopes)
+		switch {
+		case err == context.Canceled:
+			return errors.New("update cancelled")
+		case err != nil:
+			return err
+		case expectNop && changes != nil && changes.HasChanges():
+			return errors.New("error: no changes were expected but changes occurred")
+		default:
+			return nil
+		}
+	}
+
+	// up implementation used when the source of the Pulumi program is a URL.
+	upURL := func(url string, opts backend.UpdateOptions) error {
+		if !workspace.IsTemplateURL(url) {
+			return errors.Errorf("%s is not a valid URL", url)
+		}
+
+		// Retrieve the template repo.
+		repo, err := workspace.RetrieveTemplates(url, false)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			contract.IgnoreError(repo.Delete())
+		}()
+
+		// List the templates from the repo.
+		templates, err := repo.Templates()
+		if err != nil {
+			return err
+		}
+
+		// Make sure only a single template is found.
+		// Alternatively, we could consider prompting to choose one instead of failing.
+		if len(templates) != 1 {
+			return errors.Errorf("more than one application found at %s", url)
+		}
+		template := templates[0]
+
+		// Create temp directory for the "virtual workspace".
+		temp, err := ioutil.TempDir("", "pulumi-up-")
+		if err != nil {
+			return err
+		}
+		defer func() {
+			contract.IgnoreError(os.RemoveAll(temp))
+		}()
+
+		// Cleanup the project name/description if needed.
+		projectName := template.ProjectName
+		if projectName == "${PROJECT}" {
+			projectName = workspace.ValueOrSanitizedDefaultProjectName(projectName, template.Name)
+		}
+		projectDescription := template.ProjectDescription
+		if projectDescription == "${DESCRIPTION}" {
+			projectDescription = ""
+		}
+
+		// Copy the template files from the repo to the temporary "virtual workspace" directory.
+		if err = template.CopyTemplateFiles(temp, true, projectName, projectDescription); err != nil {
+			return err
+		}
+
+		// Change the working directory to the "virtual workspace" directory.
+		if err = os.Chdir(temp); err != nil {
+			return errors.Wrap(err, "changing the working directory")
+		}
+
+		// Get a stack, but don't set it to current.
+		s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
+		if err != nil {
+			return err
+		}
+
+		// Get the existing config. stackConfig will be nil if there wasn't a previous deployment.
+		stackConfig, err := backend.GetLatestConfiguration(commandContext(), s)
+		if err != nil && err != backend.ErrNoPreviousDeployment {
+			return err
+		}
+
+		// Get the existing snapshot.
+		snap, err := s.Snapshot(commandContext())
+		if err != nil {
+			return err
+		}
+
+		// Handle config.
+		// If this is an initial preconfigured empty stack (i.e. configured in the Pulumi Console),
+		// use its config without prompting.
+		// Otherwise, use the values specified on the command line and prompt for new values.
+		// If the stack already existed and had previous config, those values will be used as the defaults.
+		var c config.Map
+		templateURL := getPreconfiguredEmptyStackTemplateURL(stackConfig, snap)
+		if templateURL != "" {
+			c = stackConfig
+			// TODO consider warning if the specific URL is different from templateURL.
+		} else {
+			// Get config values passed on the command line.
+			commandLineConfig, err := parseConfig(configArray)
+			if err != nil {
+				return err
+			}
+
+			// Get the crypter if needed.
+			var crypter config.Crypter
+			if stackConfig != nil && stackConfig.HasSecureValue() {
+				if crypter, err = backend.GetStackCrypter(s); err != nil {
+					return err
+				}
+			}
+
+			// Prompt for config as needed.
+			c, err = promptForConfig(template.Config, commandLineConfig, stackConfig, crypter, yes, opts.Display)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Save the config locally.
+		if c != nil {
+			if err = saveConfig(s.Name().StackName(), c); err != nil {
+				return errors.Wrap(err, "saving config")
+			}
+		}
+
+		// Install dependencies.
+		if err = installDependencies("Installing dependencies..."); err != nil {
+			return err
+		}
+
+		proj, root, err := readProject()
+		if err != nil {
+			return err
+		}
+
+		m, err := getUpdateMetadata(message, root)
+		if err != nil {
+			return errors.Wrap(err, "gathering environment metadata")
+		}
+
+		opts.Engine = engine.UpdateOptions{
+			Analyzers: analyzers,
+			Parallel:  parallel,
+			Debug:     debug,
+		}
+
+		// TODO for the URL case:
+		// - suppress preview display/prompt unless error.
+		// - attempt `destroy` on any update errors.
+		// - show template.Quickstart?
+
+		changes, err := s.Update(commandContext(), proj, root, m, opts, cancellationScopes)
+		switch {
+		case err == context.Canceled:
+			return errors.New("update cancelled")
+		case err != nil:
+			return err
+		case expectNop && changes != nil && changes.HasChanges():
+			return errors.New("error: no changes were expected but changes occurred")
+		default:
+			return nil
+		}
+	}
 
 	var cmd = &cobra.Command{
 		Use:        "up [url]",
@@ -88,157 +279,11 @@ func newUpCmd() *cobra.Command {
 				Debug:                debug,
 			}
 
-			var c config.Map
-			var s backend.Stack
-			hasStack := false
-
 			if len(args) > 0 {
-				url := args[0]
-
-				if !workspace.IsTemplateURL(url) {
-					return errors.Errorf("%s is not a valid URL", url)
-				}
-
-				// Retrieve the template repo.
-				repo, err := workspace.RetrieveTemplates(url, false)
-				if err != nil {
-					return err
-				}
-				defer func() {
-					contract.IgnoreError(repo.Delete())
-				}()
-
-				// List the templates from the repo.
-				templates, err := repo.Templates()
-				if err != nil {
-					return err
-				}
-
-				// Make sure only a single template is found.
-				// Alternatively, we could consider prompting to choose one instead of failing.
-				if len(templates) != 1 {
-					return errors.Errorf("more than one application found at %s", url)
-				}
-				template := templates[0]
-
-				// Create temp directory for the "virtual workspace".
-				temp, err := ioutil.TempDir("", "pulumi-up-")
-				if err != nil {
-					return err
-				}
-				defer func() {
-					contract.IgnoreError(os.RemoveAll(temp))
-				}()
-
-				// Cleanup the project name/description if needed.
-				projectName := template.ProjectName
-				if projectName == "${PROJECT}" {
-					projectName = workspace.ValueOrSanitizedDefaultProjectName(projectName, template.Name)
-				}
-				projectDescription := template.ProjectDescription
-				if projectDescription == "${DESCRIPTION}" {
-					projectDescription = ""
-				}
-
-				// Copy the template files.
-				if err = template.CopyTemplateFiles(temp, true, projectName, projectDescription); err != nil {
-					return err
-				}
-
-				// Change the working directory to the "virtual workspace".
-				if err = os.Chdir(temp); err != nil {
-					return errors.Wrap(err, "changing the working directory")
-				}
-
-				// If it's an existing stack, use it to fetch the latest config.
-				var stackConfig config.Map
-				if stack != "" {
-					s, err = getStack(stack)
-					// TODO: if not found, offer to create it.
-					if err != nil {
-						return err
-					}
-					hasStack = true
-
-					if stackConfig, err = backend.GetLatestConfiguration(commandContext(), s); err != nil {
-						return err
-					}
-
-					// TODO: if the stack exists, pull down the latest snapshot and see if it was
-					// the initial deployment used to save the config from the service and use
-					// that config as-is without prompting.
-				}
-
-				// Get config values passed on the command line.
-				commandLineConfig, err := parseConfig(configArray)
-				if err != nil {
-					return err
-				}
-
-				// Get the crypter if needed.
-				var crypter config.Crypter
-				if stackConfig != nil && stackConfig.HasSecureValue() {
-					if crypter, err = backend.GetStackCrypter(s); err != nil {
-						return err
-					}
-				}
-
-				// Prompt for config as needed.
-				c, err = promptForConfig(template.Config, commandLineConfig, stackConfig, crypter, yes, opts.Display)
-				if err != nil {
-					return err
-				}
-
-				// Install dependencies.
-				if err = installDependencies(""); err != nil {
-					return err
-				}
+				return upURL(args[0], opts)
 			}
 
-			if !hasStack {
-				if s, err = requireStack(stack, true, opts.Display); err != nil {
-					return err
-				}
-			}
-
-			if c != nil {
-				if err = saveConfig(s.Name().StackName(), c); err != nil {
-					return errors.Wrap(err, "saving config")
-				}
-			}
-
-			proj, root, err := readProject()
-			if err != nil {
-				return err
-			}
-
-			m, err := getUpdateMetadata(message, root)
-			if err != nil {
-				return errors.Wrap(err, "gathering environment metadata")
-			}
-
-			opts.Engine = engine.UpdateOptions{
-				Analyzers: analyzers,
-				Parallel:  parallel,
-				Debug:     debug,
-			}
-
-			// TODO for the URL case:
-			// - suppress preview display/prompt unless error.
-			// - attempt `destroy` on any update errors.
-			// - show template.Quickstart?
-
-			changes, err := s.Update(commandContext(), proj, root, m, opts, cancellationScopes)
-			switch {
-			case err == context.Canceled:
-				return errors.New("update cancelled")
-			case err != nil:
-				return err
-			case expectNop && changes != nil && changes.HasChanges():
-				return errors.New("error: no changes were expected but changes occurred")
-			default:
-				return nil
-			}
+			return upWorkingDirectory(opts)
 		}),
 	}
 
@@ -290,29 +335,20 @@ func newUpCmd() *cobra.Command {
 	return cmd
 }
 
-// getStack gets the stack from the current backend.
-func getStack(stackName string) (backend.Stack, error) {
-	opts := backend.DisplayOptions{
-		Color: cmdutil.GetGlobalColorization(),
+var (
+	templateKey = config.MustMakeKey("pulumi", "template")
+)
+
+// getPreconfiguredEmptyStackTemplateURL returns the template URL of the preconfigured empty stack, otherwise "".
+func getPreconfiguredEmptyStackTemplateURL(c config.Map, snap *deploy.Snapshot) string {
+	templateURL, hasTemplateKey := c[templateKey]
+	stackResource, _ := stack.GetRootStackResource(snap)
+
+	if hasTemplateKey && len(snap.Resources) == 1 && stackResource != nil {
+		if val, err := templateURL.Value(nil); err == nil {
+			return val
+		}
 	}
 
-	b, err := currentBackend(opts)
-	if err != nil {
-		return nil, err
-	}
-
-	stackRef, err := b.ParseStackReference(stackName)
-	if err != nil {
-		return nil, err
-	}
-
-	stack, err := b.GetStack(commandContext(), stackRef)
-	if err != nil {
-		return nil, err
-	}
-	if stack != nil {
-		return stack, err
-	}
-
-	return nil, errors.Errorf("no stack named '%s' found", stackName)
+	return ""
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -145,7 +145,7 @@ func newUpCmd() *cobra.Command {
 			return errors.Wrap(err, "changing the working directory")
 		}
 
-		// Get a stack, but don't set it to current.
+		// Get a stack, but don't set it as the current stack, to avoid writing to ~/.pulumi/workspaces.
 		s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
 		if err != nil {
 			return err

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -167,8 +167,16 @@ func newUpCmd() *cobra.Command {
 					return err
 				}
 
+				// Get the crypter if needed.
+				var crypter config.Crypter
+				if stackConfig != nil && stackConfig.HasSecureValue() {
+					if crypter, err = backend.GetStackCrypter(s); err != nil {
+						return err
+					}
+				}
+
 				// Prompt for config as needed.
-				c, err = promptForConfig(template.Config, commandLineConfig, stackConfig, yes, opts.Display)
+				c, err = promptForConfig(template.Config, commandLineConfig, stackConfig, crypter, yes, opts.Display)
 				if err != nil {
 					return err
 				}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"
@@ -26,6 +27,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cancel"
 	"github.com/pulumi/pulumi/pkg/workspace"
+)
+
+var (
+	// ErrNoPreviousDeployment is returned when there isn't a previous deployment.
+	ErrNoPreviousDeployment = errors.New("no previous deployment")
 )
 
 // StackAlreadyExistsError is returned from CreateStack when the stack already exists in the backend.

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -139,9 +139,6 @@ type Backend interface {
 		ctx context.Context, info workspace.PluginInfo,
 		progress bool, opts backend.DisplayOptions) (io.ReadCloser, error)
 
-	DownloadTemplate(ctx context.Context, name string, progress bool, opts backend.DisplayOptions) (io.ReadCloser, error)
-	ListTemplates(ctx context.Context) ([]workspace.Template, error)
-
 	CancelCurrentUpdate(ctx context.Context, stackRef backend.StackReference) error
 	StackConsoleURL(stackRef backend.StackReference) (string, error)
 }
@@ -433,33 +430,6 @@ func (b *cloudBackend) DownloadPlugin(ctx context.Context, info workspace.Plugin
 		bar := pb.New(int(size))
 		result = newBarProxyReadCloser(bar, result)
 		bar.Prefix(opts.Color.Colorize(colors.SpecUnimportant + "Downloading plugin: "))
-		bar.Postfix(opts.Color.Colorize(colors.Reset))
-		bar.SetMaxWidth(80)
-		bar.SetUnits(pb.U_BYTES)
-		bar.Start()
-	}
-
-	return result, nil
-}
-
-func (b *cloudBackend) ListTemplates(ctx context.Context) ([]workspace.Template, error) {
-	return b.client.ListTemplates(ctx)
-}
-
-func (b *cloudBackend) DownloadTemplate(
-	ctx context.Context, name string,
-	progress bool, opts backend.DisplayOptions) (io.ReadCloser, error) {
-
-	result, size, err := b.client.DownloadTemplate(ctx, name)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to download template")
-	}
-
-	// If progress is requested, and we know the length, show a little animated ASCII progress bar.
-	if progress && size != -1 {
-		bar := pb.New(int(size))
-		result = newBarProxyReadCloser(bar, result)
-		bar.Prefix(opts.Color.Colorize(colors.SpecUnimportant + "Downloading template: "))
 		bar.Postfix(opts.Color.Colorize(colors.Reset))
 		bar.SetMaxWidth(80)
 		bar.SetUnits(pb.U_BYTES)

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -125,27 +125,6 @@ func (pc *Client) DownloadPlugin(ctx context.Context, info workspace.PluginInfo,
 	return resp.Body, resp.ContentLength, nil
 }
 
-// ListTemplates lists all templates of which the Pulumi API knows.
-func (pc *Client) ListTemplates(ctx context.Context) ([]workspace.Template, error) {
-	// Query all templates.
-	var templates []workspace.Template
-	if err := pc.restCall(ctx, "GET", "/releases/templates", nil, nil, &templates); err != nil {
-		return nil, err
-	}
-	return templates, nil
-}
-
-// DownloadTemplate downloads the indicated template from the Pulumi API.
-func (pc *Client) DownloadTemplate(ctx context.Context, name string) (io.ReadCloser, int64, error) {
-	// Make the GET request to download the template.
-	endpoint := fmt.Sprintf("/releases/templates/%s.tar.gz", name)
-	_, resp, err := pc.apiCall(ctx, "GET", endpoint, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	return resp.Body, resp.ContentLength, nil
-}
-
 // ListStacks lists all stacks for the indicated project.
 func (pc *Client) ListStacks(ctx context.Context, projectFilter *tokens.PackageName) ([]apitype.Stack, error) {
 

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -153,7 +153,7 @@ func (pc *Client) GetLatestConfiguration(ctx context.Context, stackID StackIdent
 	if err := pc.restCall(ctx, "GET", getStackPath(stackID, "updates", "latest"), nil, nil, &latest); err != nil {
 		if restErr, ok := err.(*apitype.ErrorResponse); ok {
 			if restErr.Code == http.StatusNotFound {
-				return nil, errors.New("no previous deployment")
+				return nil, backend.ErrNoPreviousDeployment
 			}
 		}
 

--- a/pkg/backend/local/backend.go
+++ b/pkg/backend/local/backend.go
@@ -197,7 +197,7 @@ func (b *localBackend) GetLatestConfiguration(ctx context.Context,
 		return nil, err
 	}
 	if len(hist) == 0 {
-		return nil, errors.New("no previous deployment")
+		return nil, backend.ErrNoPreviousDeployment
 	}
 
 	return hist[0].Config, nil

--- a/pkg/testing/environment.go
+++ b/pkg/testing/environment.go
@@ -26,8 +26,12 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/util/fsutil"
-	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	bookkeepingDir              = ".pulumi"
+	pulumiCredentialsPathEnvVar = "PULUMI_CREDENTIALS_PATH"
 )
 
 // Environment is an extension of the testing.T type that provides support for a test environment
@@ -105,7 +109,7 @@ func (e *Environment) RunCommandExpectError(cmd string, args ...string) (string,
 // LocalURL returns a URL that uses the "fire and forget", storing its data inside the test folder (so multiple tests)
 // may reuse stack names.
 func (e *Environment) LocalURL() string {
-	return "local://" + filepath.Join(e.RootPath, workspace.BookkeepingDir)
+	return "local://" + filepath.Join(e.RootPath, bookkeepingDir)
 }
 
 // GetCommandResults runs the given command and args in the Environments CWD, returning
@@ -123,7 +127,7 @@ func (e *Environment) GetCommandResults(t *testing.T, command string, args ...st
 	cmd.Dir = e.CWD
 	cmd.Stdout = &outBuffer
 	cmd.Stderr = &errBuffer
-	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", workspace.PulumiCredentialsPathEnvVar, e.RootPath))
+	cmd.Env = append(os.Environ(), fmt.Sprintf("%s=%s", pulumiCredentialsPathEnvVar, e.RootPath))
 	cmd.Env = append(cmd.Env, "PULUMI_DEBUG_COMMANDS=true")
 
 	runErr := cmd.Run()

--- a/pkg/util/gitutil/git.go
+++ b/pkg/util/gitutil/git.go
@@ -120,13 +120,19 @@ func GitCloneAndCheckoutCommit(url string, commit plumbing.Hash, path string) er
 }
 
 // GitCloneOrPull clones or updates the specified referenceName (branch or tag) of a Git repository.
-func GitCloneOrPull(url string, referenceName plumbing.ReferenceName, path string) error {
+func GitCloneOrPull(url string, referenceName plumbing.ReferenceName, path string, shallow bool) error {
+	// For shallow clones, use a depth of 1.
+	depth := 0
+	if shallow {
+		depth = 1
+	}
+
 	// Attempt to clone the repo.
 	_, cloneErr := git.PlainClone(path, false, &git.CloneOptions{
 		URL:           url,
 		ReferenceName: referenceName,
 		SingleBranch:  true,
-		Depth:         1,
+		Depth:         depth,
 		Tags:          git.NoTags,
 	})
 	if cloneErr != nil {
@@ -145,7 +151,6 @@ func GitCloneOrPull(url string, referenceName plumbing.ReferenceName, path strin
 			if err = w.Pull(&git.PullOptions{
 				ReferenceName: referenceName,
 				SingleBranch:  true,
-				Depth:         1,
 				Force:         true,
 			}); err != nil && err != git.NoErrAlreadyUpToDate {
 				return err

--- a/pkg/util/gitutil/git.go
+++ b/pkg/util/gitutil/git.go
@@ -1,16 +1,34 @@
-// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package gitutil
 
 import (
 	"fmt"
+	"net/url"
 	"path"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/util/fsutil"
 	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/config"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/storage/memory"
 )
 
 // GetGitRepository returns the git repository by walking up from the provided directory.
@@ -81,6 +99,237 @@ func GetGitHubProjectForOriginByRepo(repo *git.Repository) (string, string, erro
 	return split[0], split[1], nil
 }
 
+// GitCloneAndCheckoutCommit clones the Git repository and checkouts the specified commit.
+func GitCloneAndCheckoutCommit(url string, commit plumbing.Hash, path string) error {
+	repo, err := git.PlainClone(path, false, &git.CloneOptions{
+		URL: url,
+	})
+	if err != nil {
+		return err
+	}
+
+	w, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+
+	return w.Checkout(&git.CheckoutOptions{
+		Hash:  commit,
+		Force: true,
+	})
+}
+
+// GitCloneOrPull clones or updates the specified referenceName (branch or tag) of a Git repository.
+func GitCloneOrPull(url string, referenceName plumbing.ReferenceName, path string) error {
+	// Attempt to clone the repo.
+	_, cloneErr := git.PlainClone(path, false, &git.CloneOptions{
+		URL:           url,
+		ReferenceName: referenceName,
+		SingleBranch:  true,
+		Depth:         1,
+		Tags:          git.NoTags,
+	})
+	if cloneErr != nil {
+		// If the repo already exists, open it and pull.
+		if cloneErr == git.ErrRepositoryAlreadyExists {
+			repo, err := git.PlainOpen(path)
+			if err != nil {
+				return err
+			}
+
+			w, err := repo.Worktree()
+			if err != nil {
+				return err
+			}
+
+			if err = w.Pull(&git.PullOptions{
+				ReferenceName: referenceName,
+				SingleBranch:  true,
+				Depth:         1,
+				Force:         true,
+			}); err != nil && err != git.NoErrAlreadyUpToDate {
+				return err
+			}
+		} else {
+			return cloneErr
+		}
+	}
+
+	return nil
+}
+
+// ParseGitRepoURL returns the URL to the Git repository and path from a raw URL.
+// For example, an input of "https://github.com/pulumi/templates/templates/javascript" returns
+// "https://github.com/pulumi/templates.git" and "templates/javascript".
+func ParseGitRepoURL(rawurl string) (string, string, error) {
+	u, err := url.Parse(rawurl)
+	if err != nil {
+		return "", "", err
+	}
+
+	if u.Scheme != "https" {
+		return "", "", errors.New("invalid URL scheme")
+	}
+
+	path := strings.TrimPrefix(u.Path, "/")
+
+	// Special case Gists.
+	if u.Hostname() == "gist.github.com" {
+		// We currently accept Gist URLs in the form: https://gist.github.com/owner/id.
+		// We may want to consider supporting https://gist.github.com/id at some point,
+		// as well as arbitrary revisions, e.g. https://gist.github.com/owner/id/commit.
+		path = strings.TrimSuffix(path, "/")
+		paths := strings.Split(path, "/")
+		if len(paths) != 2 {
+			return "", "", errors.New("invalid Gist URL")
+		}
+
+		owner := paths[0]
+		if owner == "" {
+			return "", "", errors.New("invalid Gist URL; no owner")
+		}
+
+		id := paths[1]
+		if id == "" {
+			return "", "", errors.New("invalid Gist URL; no id")
+		}
+
+		if !strings.HasSuffix(id, ".git") {
+			id = id + ".git"
+		}
+
+		resultURL := u.Scheme + "://" + u.Host + "/" + id
+		return resultURL, "", nil
+	}
+
+	paths := strings.Split(path, "/")
+	if len(paths) < 2 {
+		return "", "", errors.New("invalid Git URL")
+	}
+
+	owner := paths[0]
+	if owner == "" {
+		return "", "", errors.New("invalid Git URL; no owner")
+	}
+
+	repo := paths[1]
+	if repo == "" {
+		return "", "", errors.New("invalid Git URL; no repository")
+	}
+
+	if !strings.HasSuffix(repo, ".git") {
+		repo = repo + ".git"
+	}
+
+	resultURL := u.Scheme + "://" + u.Host + "/" + owner + "/" + repo
+	resultPath := strings.TrimSuffix(strings.Join(paths[2:], "/"), "/")
+	return resultURL, resultPath, nil
+}
+
+var gitSHARegex = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)
+
+// GetGitReferenceNameOrHashAndSubDirectory returns the reference name or hash, and sub directory path.
+// The sub directory path always uses "/" as the separator.
+func GetGitReferenceNameOrHashAndSubDirectory(url string, urlPath string) (
+	plumbing.ReferenceName, plumbing.Hash, string, error) {
+
+	// If path is empty, use HEAD.
+	if urlPath == "" {
+		return plumbing.HEAD, plumbing.ZeroHash, "", nil
+	}
+
+	// Trim leading/trailing separator(s).
+	urlPath = strings.TrimPrefix(urlPath, "/")
+	urlPath = strings.TrimSuffix(urlPath, "/")
+
+	paths := strings.Split(urlPath, "/")
+
+	// Ensure the path components are not "." or "..".
+	for _, path := range paths {
+		if path == "." || path == ".." {
+			return "", plumbing.ZeroHash, "", errors.New("invalid Git URL")
+		}
+	}
+
+	if paths[0] == "tree" {
+		if len(paths) >= 2 {
+			// If it looks like a SHA, use that.
+			if gitSHARegex.MatchString(paths[1]) {
+				return "", plumbing.NewHash(paths[1]), strings.Join(paths[2:], "/"), nil
+			}
+
+			// Otherwise, try matching based on the repo's refs.
+
+			// Get the list of refs sorted by length.
+			refs, err := GitListBranchesAndTags(url)
+			if err != nil {
+				return "", plumbing.ZeroHash, "", err
+			}
+
+			// Try to find the matching ref, checking the longest names first, so
+			// if there are multiple refs that would match, we pick the longest.
+			path := strings.Join(paths[1:], "/") + "/"
+			for _, ref := range refs {
+				shortName := ref.Short()
+				prefix := shortName + "/"
+				if strings.HasPrefix(path, prefix) {
+					subDir := strings.TrimPrefix(path, prefix)
+					return ref, plumbing.ZeroHash, strings.TrimSuffix(subDir, "/"), nil
+				}
+			}
+		}
+
+		// If there aren't any path components after "tree", it's an error.
+		return "", plumbing.ZeroHash, "", errors.New("invalid Git URL")
+	}
+
+	// If there wasn't "tree" in the path, just use HEAD.
+	return plumbing.HEAD, plumbing.ZeroHash, strings.Join(paths, "/"), nil
+}
+
+// GitListBranchesAndTags fetches a remote Git repository's branch and tag references
+// (including HEAD), sorted by the length of the short name descending.
+func GitListBranchesAndTags(url string) ([]plumbing.ReferenceName, error) {
+	// We're only listing the references, so just use in-memory storage.
+	repo, err := git.Init(memory.NewStorage(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	remote, err := repo.CreateRemote(&config.RemoteConfig{
+		Name: "origin",
+		URLs: []string{url},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	refs, err := remote.List(&git.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var results []plumbing.ReferenceName
+	for _, ref := range refs {
+		name := ref.Name()
+		if name == plumbing.HEAD || name.IsBranch() || name.IsTag() {
+			results = append(results, name)
+		}
+	}
+
+	sort.Sort(byShortNameLengthDesc(results))
+
+	return results, nil
+}
+
 func trimGitRemoteURL(url string, prefix string, suffix string) string {
 	return strings.TrimSuffix(strings.TrimPrefix(url, prefix), suffix)
+}
+
+type byShortNameLengthDesc []plumbing.ReferenceName
+
+func (r byShortNameLengthDesc) Len() int      { return len(r) }
+func (r byShortNameLengthDesc) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r byShortNameLengthDesc) Less(i, j int) bool {
+	return len(r[j].Short()) < len(r[i].Short())
 }

--- a/pkg/util/gitutil/git_test.go
+++ b/pkg/util/gitutil/git_test.go
@@ -1,0 +1,226 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitutil
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	ptesting "github.com/pulumi/pulumi/pkg/testing"
+)
+
+func TestParseGitRepoURL(t *testing.T) {
+	test := func(expectedURL string, expectedURLPath string, rawurl string) {
+		actualURL, actualURLPath, err := ParseGitRepoURL(rawurl)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedURL, actualURL)
+		assert.Equal(t, expectedURLPath, actualURLPath)
+	}
+
+	// GitHub.
+	pre := "https://github.com/pulumi/templates"
+	exp := pre + ".git"
+	test(exp, "", pre+".git")
+	test(exp, "", pre+"")
+	test(exp, "", pre+"/")
+	test(exp, "templates", pre+"/templates")
+	test(exp, "templates", pre+"/templates/")
+	test(exp, "templates/javascript", pre+"/templates/javascript")
+	test(exp, "templates/javascript", pre+"/templates/javascript/")
+	test(exp, "tree/master/templates", pre+"/tree/master/templates")
+	test(exp, "tree/master/templates/python", pre+"/tree/master/templates/python")
+	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates",
+		pre+"/tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates")
+	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates/python",
+		pre+"/tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates/python")
+
+	// Gists.
+	pre = "https://gist.github.com/user/1c8c6e43daf20924287c0d476e17de9a"
+	exp = "https://gist.github.com/1c8c6e43daf20924287c0d476e17de9a.git"
+	test(exp, "", pre+"")
+	test(exp, "", pre+"/")
+
+	testError := func(rawurl string) {
+		_, _, err := ParseGitRepoURL(rawurl)
+		assert.Error(t, err)
+	}
+
+	// No owner.
+	testError("https://github.com")
+	testError("https://github.com/")
+
+	// No repo.
+	testError("https://github.com/pulumi")
+	testError("https://github.com/pulumi/")
+
+	// Not HTTPS.
+	testError("http://github.com/pulumi/templates.git")
+	testError("http://github.com/pulumi/templates")
+}
+
+func TestGetGitReferenceNameOrHashAndSubDirectory(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	defer deleteIfNotFailed(e)
+
+	// Create local test repository.
+	repoPath := filepath.Join(e.RootPath, "repo")
+	err := os.MkdirAll(repoPath, os.ModePerm)
+	assert.NoError(e, err, "making repo dir %s", repoPath)
+	e.CWD = repoPath
+	createTestRepo(e)
+
+	// Create temp directory to clone to.
+	cloneDir := filepath.Join(e.RootPath, "temp")
+	err = os.MkdirAll(cloneDir, os.ModePerm)
+	assert.NoError(e, err, "making clone dir %s", cloneDir)
+
+	test := func(expectedHashOrBranch string, expectedSubDirectory string, urlPath string) {
+		ref, hash, subDirectory, err := GetGitReferenceNameOrHashAndSubDirectory(repoPath, urlPath)
+		assert.NoError(t, err)
+
+		if ref != "" {
+			assert.True(t, hash.IsZero())
+			shortNameWithoutOrigin := strings.TrimPrefix(ref.Short(), "origin/")
+			assert.Equal(t, expectedHashOrBranch, shortNameWithoutOrigin)
+		} else {
+			assert.False(t, hash.IsZero())
+			assert.Equal(t, expectedHashOrBranch, hash.String())
+		}
+
+		assert.Equal(t, expectedSubDirectory, subDirectory)
+	}
+
+	// No ref or path.
+	test("HEAD", "", "")
+	test("HEAD", "", "/")
+
+	// No "tree" path component.
+	test("HEAD", "foo", "foo")
+	test("HEAD", "foo", "foo/")
+	test("HEAD", "content/foo", "content/foo")
+	test("HEAD", "content/foo", "content/foo/")
+
+	// master.
+	test("master", "", "tree/master")
+	test("master", "", "tree/master/")
+	test("master", "foo", "tree/master/foo")
+	test("master", "foo", "tree/master/foo/")
+	test("master", "content/foo", "tree/master/content/foo")
+	test("master", "content/foo", "tree/master/content/foo/")
+
+	// HEAD.
+	test("HEAD", "", "tree/HEAD")
+	test("HEAD", "", "tree/HEAD/")
+	test("HEAD", "foo", "tree/HEAD/foo")
+	test("HEAD", "foo", "tree/HEAD/foo/")
+	test("HEAD", "content/foo", "tree/HEAD/content/foo")
+	test("HEAD", "content/foo", "tree/HEAD/content/foo/")
+
+	// Tag.
+	test("my", "", "tree/my")
+	test("my", "", "tree/my/")
+	test("my", "foo", "tree/my/foo")
+	test("my", "foo", "tree/my/foo/")
+
+	// Commit SHA.
+	test("2ba6921f3163493809bcbb0ec7283a0446048076", "",
+		"tree/2ba6921f3163493809bcbb0ec7283a0446048076")
+	test("2ba6921f3163493809bcbb0ec7283a0446048076", "",
+		"tree/2ba6921f3163493809bcbb0ec7283a0446048076/")
+	test("2ba6921f3163493809bcbb0ec7283a0446048076", "foo",
+		"tree/2ba6921f3163493809bcbb0ec7283a0446048076/foo")
+	test("2ba6921f3163493809bcbb0ec7283a0446048076", "foo",
+		"tree/2ba6921f3163493809bcbb0ec7283a0446048076/foo/")
+	test("2ba6921f3163493809bcbb0ec7283a0446048076", "content/foo",
+		"tree/2ba6921f3163493809bcbb0ec7283a0446048076/content/foo")
+	test("2ba6921f3163493809bcbb0ec7283a0446048076", "content/foo",
+		"tree/2ba6921f3163493809bcbb0ec7283a0446048076/content/foo/")
+
+	// The longest ref is matched, so we should get "my/content" as the expected ref
+	// and "foo" as the path (instead of "my" and "content/foo").
+	test("my/content", "foo", "tree/my/content/foo")
+	test("my/content", "foo", "tree/my/content/foo/")
+
+	testError := func(urlPath string) {
+		_, _, _, err := GetGitReferenceNameOrHashAndSubDirectory(repoPath, urlPath)
+		assert.Error(t, err)
+	}
+
+	// No ref specified.
+	testError("tree")
+	testError("tree/")
+
+	// Invalid casing.
+	testError("tree/Master")
+	testError("tree/head")
+	testError("tree/My")
+
+	// Path components cannot contain "." or "..".
+	testError(".")
+	testError("./")
+	testError("..")
+	testError("../")
+	testError("foo/.")
+	testError("foo/./")
+	testError("foo/..")
+	testError("foo/../")
+	testError("content/./foo")
+	testError("content/./foo/")
+	testError("content/../foo")
+	testError("content/../foo/")
+}
+
+func createTestRepo(e *ptesting.Environment) {
+	e.RunCommand("git", "init")
+
+	writeTestFile(e, "README.md", "test repo")
+	e.RunCommand("git", "add", "*")
+	e.RunCommand("git", "commit", "-m", "'Initial commit'")
+
+	writeTestFile(e, "foo/bar.md", "foo-bar.md")
+	e.RunCommand("git", "add", "*")
+	e.RunCommand("git", "commit", "-m", "'foo dir'")
+
+	writeTestFile(e, "content/foo/bar.md", "content-foo-bar.md")
+	e.RunCommand("git", "add", "*")
+	e.RunCommand("git", "commit", "-m", "'content-foo dir'")
+
+	e.RunCommand("git", "branch", "my/content")
+	e.RunCommand("git", "tag", "my")
+}
+
+func writeTestFile(e *ptesting.Environment, filename string, contents string) {
+	filename = filepath.Join(e.CWD, filename)
+
+	dir := filepath.Dir(filename)
+	err := os.MkdirAll(dir, os.ModePerm)
+	assert.NoError(e, err, "making all directories %s", dir)
+
+	err = ioutil.WriteFile(filename, []byte(contents), os.ModePerm)
+	assert.NoError(e, err, "writing %s file", filename)
+}
+
+// deleteIfNotFailed deletes the files in the testing environment if the testcase has
+// not failed. (Otherwise they are left to aid debugging.)
+func deleteIfNotFailed(e *ptesting.Environment) {
+	if !e.T.Failed() {
+		e.DeleteEnvironment()
+	}
+}

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -32,6 +32,22 @@ import (
 // Analyzers is a list of analyzers to run on this project.
 type Analyzers []tokens.QName
 
+// ProjectTemplate is a Pulumi project template manifest.
+// nolint: lll
+type ProjectTemplate struct {
+	Description string                                    `json:"description,omitempty" yaml:"description,omitempty"` // an optional description of the template.
+	Quickstart  string                                    `json:"quickstart,omitempty" yaml:"quickstart,omitempty"`   // optional text to be displayed after template creation.
+	Config      map[config.Key]ProjectTemplateConfigValue `json:"config,omitempty" yaml:"config,omitempty"`           // optional template config.
+}
+
+// ProjectTemplateConfigValue is a config value included in the project template manifest.
+// nolint: lll
+type ProjectTemplateConfigValue struct {
+	Description string `json:"description,omitempty" yaml:"description,omitempty"` // an optional description for the config value.
+	Default     string `json:"default,omitempty" yaml:"default,omitempty"`         // an optional default value for the config value.
+	Secret      bool   `json:"secret,omitempty" yaml:"secret,omitempty"`           // an optional value indicating whether the config value should be encrypted.
+}
+
 // Project is a Pulumi project manifest..
 //
 // We explicitly add yaml tags (instead of using the default behavior from https://github.com/ghodss/yaml which works
@@ -56,6 +72,8 @@ type Project struct {
 	NoDefaultIgnores *bool  `json:"nodefaultignores,omitempty" yaml:"nodefaultignores,omitempty"` // true if we should only respect .pulumiignore when archiving
 
 	Config string `json:"config,omitempty" yaml:"config,omitempty"` // where to store Pulumi.<stack-name>.yaml files, this is combined with the folder Pulumi.yaml is in.
+
+	Template *ProjectTemplate `json:"template,omitempty" yaml:"template,omitempty"` // optional template manifest.
 }
 
 func (proj *Project) Validate() error {

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -205,12 +205,13 @@ func retrievePulumiTemplates(templateName string, offline bool) (TemplateReposit
 
 	if !offline {
 		// Clone or update the pulumi/templates repo.
-		if err := gitutil.GitCloneOrPull(pulumiTemplateGitRepository, plumbing.HEAD, templateDir); err != nil {
+		err := gitutil.GitCloneOrPull(pulumiTemplateGitRepository, plumbing.HEAD, templateDir, false /*shallow*/)
+		if err != nil {
 			return TemplateRepository{}, err
 		}
 	}
 
-	subDir := filepath.Join(templateDir, "templates")
+	subDir := templateDir
 	if templateName != "" {
 		subDir = filepath.Join(subDir, templateName)
 	}
@@ -235,7 +236,7 @@ func RetrieveTemplate(rawurl string, path string) (string, error) {
 	}
 
 	if ref != "" {
-		if cloneErr := gitutil.GitCloneOrPull(url, ref, path); cloneErr != nil {
+		if cloneErr := gitutil.GitCloneOrPull(url, ref, path, true /*shallow*/); cloneErr != nil {
 			return "", cloneErr
 		}
 	} else {

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -15,10 +15,7 @@
 package workspace
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/user"
@@ -26,143 +23,279 @@ import (
 	"runtime"
 	"strings"
 
-	"gopkg.in/yaml.v2"
+	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/gitutil"
 )
 
 const (
 	defaultProjectName = "project"
 
+	pulumiTemplateGitRepository = "https://github.com/pulumi/templates.git"
+
 	// This file will be ignored when copying from the template cache to
 	// a project directory.
-	pulumiTemplateManifestFile = ".pulumi.template.yaml"
+	legacyPulumiTemplateManifestFile = ".pulumi.template.yaml"
 
 	// pulumiLocalTemplatePathEnvVar is a path to the folder where templates are stored.
 	// It is used in sandboxed environments where the classic template folder may not be writable.
 	pulumiLocalTemplatePathEnvVar = "PULUMI_TEMPLATE_PATH"
 )
 
-// Template represents a project template.
-type Template struct {
-	// The name of the template.
-	Name string `json:"name" yaml:"name"`
-	// Optional description of the template, also used as a default project description.
-	Description string `json:"description" yaml:"description"`
-	// Optional bool which determines whether dependencies should be installed after project creation.
-	InstallDependencies bool `json:"installdependencies" yaml:"installdependencies"`
-	// Optional default config values.
-	Config map[config.Key]string `json:"config" yaml:"config"`
+// TemplateRepository represents a repository of templates.
+type TemplateRepository struct {
+	Root         string // The full path to the root directory of the repository.
+	SubDirectory string // The full path to the sub directory within the repository.
+	ShouldDelete bool   // Whether the root directory should be deleted.
 }
 
-// LoadLocalTemplate returns a local template.
-func LoadLocalTemplate(name string) (Template, error) {
-	templateDir, err := GetTemplateDir(name)
+// Delete deletes the template repository.
+func (repo TemplateRepository) Delete() error {
+	if repo.ShouldDelete {
+		return os.RemoveAll(repo.Root)
+	}
+	return nil
+}
+
+// Templates lists the templates in the repository.
+func (repo TemplateRepository) Templates() ([]Template, error) {
+	path := repo.SubDirectory
+
+	info, err := os.Stat(path)
 	if err != nil {
-		return Template{}, err
+		return nil, err
 	}
 
-	info, err := os.Stat(templateDir)
-	if err != nil {
-		return Template{}, err
-	}
+	// If it's a file, look in its directory.
 	if !info.IsDir() {
-		return Template{}, errors.Errorf("template '%s' in %s is not a directory", name, templateDir)
+		path = filepath.Dir(path)
 	}
 
-	// Read the description from the manifest (if it exists).
-	template, err := readTemplateManifest(filepath.Join(templateDir, pulumiTemplateManifestFile))
+	// See if there's a Pulumi.yaml in the directory.
+	template, err := LoadTemplate(path)
 	if err != nil && !os.IsNotExist(err) {
-		return Template{}, err
+		return nil, err
+	} else if err == nil {
+		return []Template{template}, nil
 	}
 
-	template.Name = name
-	return template, nil
-}
-
-// ListLocalTemplates returns a list of local templates.
-func ListLocalTemplates() ([]Template, error) {
-	templateDir, err := GetTemplateDir("")
+	// Otherwise, read all subdirectories to find the ones
+	// that contain a Pulumi.yaml.
+	infos, err := ioutil.ReadDir(path)
 	if err != nil {
 		return nil, err
 	}
 
-	infos, err := ioutil.ReadDir(templateDir)
-	if err != nil {
-		return nil, err
-	}
-
-	var templates []Template
+	var result []Template
 	for _, info := range infos {
 		if info.IsDir() {
-			template, err := LoadLocalTemplate(info.Name())
-			if err != nil {
-				return nil, err
+			name := info.Name()
+
+			// Ignore the .git directory.
+			if name == GitDir {
+				continue
 			}
-			templates = append(templates, template)
+
+			template, err := LoadTemplate(filepath.Join(path, name))
+			if err != nil && !os.IsNotExist(err) {
+				return nil, err
+			} else if err == nil {
+				result = append(result, template)
+			}
 		}
 	}
-	return templates, nil
+	return result, nil
 }
 
-// InstallTemplate installs a template tarball into the local cache.
-func InstallTemplate(name string, tarball io.ReadCloser) error {
-	contract.Require(name != "", "name")
-	contract.Require(tarball != nil, "tarball")
+// Template represents a project template.
+type Template struct {
+	Dir         string                                    // The directory containing Pulumi.yaml.
+	Name        string                                    // The name of the template.
+	Description string                                    // Description of the template.
+	Quickstart  string                                    // Optional text to be displayed after template creation.
+	Config      map[config.Key]ProjectTemplateConfigValue // Optional template config.
+}
 
-	var templateDir string
-	var err error
-
-	// Get the template directory.
-	if templateDir, err = GetTemplateDir(name); err != nil {
+// cleanupLegacyTemplateDir deletes an existing ~/.pulumi/templates directory if it isn't a git repository.
+func cleanupLegacyTemplateDir() error {
+	templateDir, err := GetTemplateDir()
+	if err != nil {
 		return err
 	}
 
-	// Delete the directory if it exists.
-	if err = os.RemoveAll(templateDir); err != nil {
-		return errors.Wrapf(err, "removing existing template directory %s", templateDir)
-	}
-
-	// Ensure it exists since we may have just deleted it.
-	if err = os.MkdirAll(templateDir, 0700); err != nil {
-		return errors.Wrapf(err, "creating template directory %s", templateDir)
-	}
-
-	// Extract the tarball to its directory.
-	if err = extractTarball(tarball, templateDir); err != nil {
-		return errors.Wrapf(err, "extracting template to %s", templateDir)
-	}
-
-	// On Windows, we need to replace \n with \r\n. We'll just do this as a separate step.
-	if runtime.GOOS == "windows" {
-		if err = fixWindowsLineEndings(templateDir); err != nil {
-			return errors.Wrapf(err, "fixing line endings in %s", templateDir)
+	// See if the template directory is a Git repository.
+	if _, err = git.PlainOpen(templateDir); err != nil {
+		// If the repository doesn't exist, it's a legacy directory.
+		// Delete the entire template directory and all children.
+		if err == git.ErrRepositoryNotExists {
+			return os.RemoveAll(templateDir)
 		}
+
+		return err
 	}
 
 	return nil
 }
 
+// IsTemplateURL returns true if templateNameOrURL starts with "https://".
+func IsTemplateURL(templateNameOrURL string) bool {
+	return strings.HasPrefix(templateNameOrURL, "https://")
+}
+
+// RetrieveTemplates retrieves a "template repository" based on the specified name or URL.
+func RetrieveTemplates(templateNameOrURL string, offline bool) (TemplateRepository, error) {
+	if IsTemplateURL(templateNameOrURL) {
+		return retrieveURLTemplates(templateNameOrURL, offline)
+	}
+	return retrievePulumiTemplates(templateNameOrURL, offline)
+}
+
+// retrieveURLTemplates retrieves the "template repository" at the specified URL.
+func retrieveURLTemplates(rawurl string, offline bool) (TemplateRepository, error) {
+	if offline {
+		return TemplateRepository{}, errors.Errorf("cannot use %s offline", rawurl)
+	}
+
+	var err error
+
+	// Create a temp dir.
+	var temp string
+	if temp, err = ioutil.TempDir("", "pulumi-template-"); err != nil {
+		return TemplateRepository{}, err
+	}
+
+	var fullPath string
+	if fullPath, err = RetrieveTemplate(rawurl, temp); err != nil {
+		return TemplateRepository{}, err
+	}
+
+	return TemplateRepository{
+		Root:         temp,
+		SubDirectory: fullPath,
+		ShouldDelete: true,
+	}, nil
+}
+
+// retrievePulumiTemplates retrieves the "template repository" for Pulumi templates.
+// Instead of retrieving to a temporary directory, the Pulumi templates are managed from
+// ~/.pulumi/templates.
+func retrievePulumiTemplates(templateName string, offline bool) (TemplateRepository, error) {
+	templateName = strings.ToLower(templateName)
+
+	// Cleanup the template directory.
+	if err := cleanupLegacyTemplateDir(); err != nil {
+		return TemplateRepository{}, err
+	}
+
+	// Get the template directory.
+	templateDir, err := GetTemplateDir()
+	if err != nil {
+		return TemplateRepository{}, err
+	}
+
+	// Ensure the template directory exists.
+	if err := os.MkdirAll(templateDir, 0700); err != nil {
+		return TemplateRepository{}, err
+	}
+
+	if !offline {
+		// Clone or update the pulumi/templates repo.
+		if err := gitutil.GitCloneOrPull(pulumiTemplateGitRepository, plumbing.HEAD, templateDir); err != nil {
+			return TemplateRepository{}, err
+		}
+	}
+
+	subDir := filepath.Join(templateDir, "templates")
+	if templateName != "" {
+		subDir = filepath.Join(subDir, templateName)
+	}
+
+	return TemplateRepository{
+		Root:         templateDir,
+		SubDirectory: subDir,
+		ShouldDelete: false,
+	}, nil
+}
+
+// RetrieveTemplate downloads the repo to path and returns the full path on disk.
+func RetrieveTemplate(rawurl string, path string) (string, error) {
+	url, urlPath, err := gitutil.ParseGitRepoURL(rawurl)
+	if err != nil {
+		return "", err
+	}
+
+	ref, commit, subDirectory, err := gitutil.GetGitReferenceNameOrHashAndSubDirectory(url, urlPath)
+	if err != nil {
+		return "", err
+	}
+
+	if ref != "" {
+		if cloneErr := gitutil.GitCloneOrPull(url, ref, path); cloneErr != nil {
+			return "", cloneErr
+		}
+	} else {
+		if cloneErr := gitutil.GitCloneAndCheckoutCommit(url, commit, path); cloneErr != nil {
+			return "", cloneErr
+		}
+	}
+
+	// Verify the sub directory exists.
+	fullPath := filepath.Join(path, filepath.FromSlash(subDirectory))
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", errors.Errorf("%s is not a directory", fullPath)
+	}
+
+	return fullPath, nil
+}
+
+// LoadTemplate returns a template from a path.
+func LoadTemplate(path string) (Template, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Template{}, err
+	}
+	if !info.IsDir() {
+		return Template{}, errors.Errorf("%s is not a directory", path)
+	}
+
+	// TODO handle other extensions like Pulumi.yml and Pulumi.json?
+	proj, err := LoadProject(filepath.Join(path, "Pulumi.yaml"))
+	if err != nil {
+		return Template{}, err
+	}
+
+	template := Template{
+		Dir:  path,
+		Name: filepath.Base(path),
+	}
+	if proj.Template != nil {
+		template.Description = proj.Template.Description
+		template.Quickstart = proj.Template.Quickstart
+		template.Config = proj.Template.Config
+	}
+
+	return template, nil
+}
+
 // CopyTemplateFilesDryRun does a dry run of copying a template to a destination directory,
 // to ensure it won't overwrite any files.
 func (template Template) CopyTemplateFilesDryRun(destDir string) error {
-	var err error
-	var sourceDir string
-	if sourceDir, err = GetTemplateDir(template.Name); err != nil {
-		return err
-	}
-
 	var existing []string
-	err = walkFiles(sourceDir, destDir, func(info os.FileInfo, source string, dest string) error {
+	if err := walkFiles(template.Dir, destDir, func(info os.FileInfo, source string, dest string) error {
 		if destInfo, statErr := os.Stat(dest); statErr == nil && !destInfo.IsDir() {
 			existing = append(existing, filepath.Base(dest))
 		}
 		return nil
-	})
-	if err != nil {
+	}); err != nil {
 		return err
 	}
 
@@ -176,12 +309,7 @@ func (template Template) CopyTemplateFilesDryRun(destDir string) error {
 func (template Template) CopyTemplateFiles(
 	destDir string, force bool, projectName string, projectDescription string) error {
 
-	sourceDir, err := GetTemplateDir(template.Name)
-	if err != nil {
-		return err
-	}
-
-	return walkFiles(sourceDir, destDir, func(info os.FileInfo, source string, dest string) error {
+	return walkFiles(template.Dir, destDir, func(info os.FileInfo, source string, dest string) error {
 		if info.IsDir() {
 			// Create the destination directory.
 			return os.Mkdir(dest, 0700)
@@ -213,7 +341,7 @@ func (template Template) CopyTemplateFiles(
 }
 
 // GetTemplateDir returns the directory in which templates on the current machine are stored.
-func GetTemplateDir(name string) (string, error) {
+func GetTemplateDir() (string, error) {
 	// Allow the folder we use to store templates to be overridden.
 	dir := os.Getenv(pulumiLocalTemplatePathEnvVar)
 
@@ -224,10 +352,6 @@ func GetTemplateDir(name string) (string, error) {
 			return "", errors.Wrap(err, "getting user home directory")
 		}
 		dir = filepath.Join(u.HomeDir, BookkeepingDir, TemplateDir)
-	}
-
-	if name != "" {
-		dir = filepath.Join(dir, name)
 	}
 
 	return dir, nil
@@ -282,50 +406,6 @@ func getValidProjectName(name string) string {
 	return result
 }
 
-// extractTarball extracts the tarball to the specified destination directory.
-func extractTarball(tarball io.ReadCloser, destDir string) error {
-	// Unzip and untar the file as we go.
-	defer contract.IgnoreClose(tarball)
-	gzr, err := gzip.NewReader(tarball)
-	if err != nil {
-		return errors.Wrapf(err, "unzipping")
-	}
-	r := tar.NewReader(gzr)
-	for {
-		header, err := r.Next()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return errors.Wrapf(err, "untarring")
-		}
-
-		path := filepath.Join(destDir, header.Name)
-
-		switch header.Typeflag {
-		case tar.TypeDir:
-			// Create any directories as needed.
-			if _, err := os.Stat(path); err != nil {
-				if err = os.MkdirAll(path, 0700); err != nil {
-					return errors.Wrapf(err, "untarring dir %s", path)
-				}
-			}
-		case tar.TypeReg:
-			// Expand files into the target directory.
-			dst, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-			if err != nil {
-				return errors.Wrapf(err, "opening file %s for untar", path)
-			}
-			defer contract.IgnoreClose(dst)
-			if _, err = io.Copy(dst, r); err != nil {
-				return errors.Wrapf(err, "untarring file %s", path)
-			}
-		default:
-			return errors.Errorf("unexpected plugin file type %s (%v)", header.Name, header.Typeflag)
-		}
-	}
-	return nil
-}
-
 // walkFiles is a helper that walks the directories/files in a source directory
 // and performs an action for each item.
 func walkFiles(sourceDir string, destDir string,
@@ -345,6 +425,11 @@ func walkFiles(sourceDir string, destDir string,
 		dest := filepath.Join(destDir, name)
 
 		if info.IsDir() {
+			// Ignore the .git directory.
+			if name == GitDir {
+				continue
+			}
+
 			if err := actionFn(info, source, dest); err != nil {
 				return err
 			}
@@ -353,8 +438,8 @@ func walkFiles(sourceDir string, destDir string,
 				return err
 			}
 		} else {
-			// Ignore template manifest file.
-			if name == pulumiTemplateManifestFile {
+			// Ignore the legacy template manifest.
+			if name == legacyPulumiTemplateManifestFile {
 				continue
 			}
 
@@ -365,22 +450,6 @@ func walkFiles(sourceDir string, destDir string,
 	}
 
 	return nil
-}
-
-// readTemplateManifest reads a template manifest file.
-func readTemplateManifest(filename string) (Template, error) {
-	b, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return Template{}, err
-	}
-
-	var manifest Template
-	err = yaml.Unmarshal(b, &manifest)
-	if err != nil {
-		return Template{}, err
-	}
-
-	return manifest, nil
 }
 
 // newExistingFilesError returns a new error from a list of existing file names
@@ -398,6 +467,10 @@ func newExistingFilesError(existing []string) error {
 // transform returns a new string with ${PROJECT} and ${DESCRIPTION} replaced by
 // the value of projectName and projectDescription.
 func transform(content string, projectName string, projectDescription string) string {
+	// On Windows, we need to replace \n with \r\n because go-git does not currently handle it.
+	if runtime.GOOS == "windows" {
+		content = strings.Replace(content, "\n", "\r\n", -1)
+	}
 	content = strings.Replace(content, "${PROJECT}", projectName, -1)
 	content = strings.Replace(content, "${DESCRIPTION}", projectDescription, -1)
 	return content
@@ -440,40 +513,4 @@ func isBinary(bytes []byte) bool {
 	}
 
 	return false
-}
-
-// fixWindowsLineEndings will go through the sourceDir, read each file, replace \n with \r\n,
-// and save the changes.
-// It'd be more efficient to do this during tarball extraction, but this is sufficient for now.
-func fixWindowsLineEndings(sourceDir string) error {
-	return walkFiles(sourceDir, sourceDir, func(info os.FileInfo, source string, dest string) error {
-		// Skip directories.
-		if info.IsDir() {
-			return nil
-		}
-
-		// Read the source file.
-		b, err := ioutil.ReadFile(source)
-		if err != nil {
-			return err
-		}
-
-		// Transform only if it isn't a binary file.
-		result := b
-		if !isBinary(b) {
-			content := string(b)
-			content = strings.Replace(content, "\n", "\r\n", -1)
-			result = []byte(content)
-		}
-
-		// Write to the destination file.
-		err = writeAllBytes(dest, result, true /*overwrite*/)
-		if err != nil {
-			// An existing file has shown up in between the dry run and the actual copy operation.
-			if os.IsExist(err) {
-				return newExistingFilesError([]string{filepath.Base(dest)})
-			}
-		}
-		return err
-	})
 }

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -119,6 +119,9 @@ type Template struct {
 	Description string                                    // Description of the template.
 	Quickstart  string                                    // Optional text to be displayed after template creation.
 	Config      map[config.Key]ProjectTemplateConfigValue // Optional template config.
+
+	ProjectName        string // Name of the project.
+	ProjectDescription string // Optional description of the project.
 }
 
 // cleanupLegacyTemplateDir deletes an existing ~/.pulumi/templates directory if it isn't a git repository.
@@ -277,11 +280,16 @@ func LoadTemplate(path string) (Template, error) {
 	template := Template{
 		Dir:  path,
 		Name: filepath.Base(path),
+
+		ProjectName: proj.Name.String(),
 	}
 	if proj.Template != nil {
 		template.Description = proj.Template.Description
 		template.Quickstart = proj.Template.Quickstart
 		template.Config = proj.Template.Config
+	}
+	if proj.Description != nil {
+		template.ProjectDescription = *proj.Description
 	}
 
 	return template, nil

--- a/tests/new_test.go
+++ b/tests/new_test.go
@@ -1,19 +1,23 @@
-// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 package tests
 
 import (
-	"fmt"
-	"io/ioutil"
-	"os"
-	"os/user"
-	"path"
-	"path/filepath"
 	"testing"
-	"time"
 
 	ptesting "github.com/pulumi/pulumi/pkg/testing"
-	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -26,95 +30,6 @@ func deleteIfNotFailed(e *ptesting.Environment) {
 }
 
 func TestPulumiNew(t *testing.T) {
-	t.Run("SanityTest", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Create a subdirectory and CD into it.
-		subdir := filepath.Join(e.RootPath, "foo")
-		err := os.MkdirAll(subdir, os.ModePerm)
-		assert.NoError(t, err, "error creating subdirectory")
-		e.CWD = subdir
-
-		// Run pulumi new.
-		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes")
-
-		assertSuccess(t, subdir, "foo", "")
-	})
-
-	t.Run("SanityTestWithDir", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Run pulumi new.
-		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes", "--dir", "foo")
-
-		assertSuccess(t, filepath.Join(e.RootPath, "foo"), "foo", "")
-	})
-
-	t.Run("SanityTestWithDirMultiplePaths", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Run pulumi new.
-		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes", "--dir", filepath.Join("bar", "foo"))
-
-		assertSuccess(t, filepath.Join(e.RootPath, "bar", "foo"), "foo", "")
-	})
-
-	t.Run("SanityTestWithCAndDir", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Create a sub directory.
-		subdir := filepath.Join(e.RootPath, "bar")
-		err := os.MkdirAll(subdir, os.ModePerm)
-		assert.NoError(t, err, "error creating subdirectory")
-
-		// Run pulumi new.
-		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes", "-C", "bar", "--dir", "foo")
-
-		assertSuccess(t, filepath.Join(subdir, "foo"), "foo", "")
-	})
-
-	t.Run("SanityTestWithManifest", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		const description = "My project description."
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, description)
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Create a subdirectory and CD into it.
-		subdir := filepath.Join(e.RootPath, "foo")
-		err := os.MkdirAll(subdir, os.ModePerm)
-		assert.NoError(t, err, "error creating subdirectory")
-		e.CWD = subdir
-
-		// Run pulumi new.
-		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes")
-
-		assertSuccess(t, subdir, "foo", description)
-	})
-
 	t.Run("NoTemplateSpecified", func(t *testing.T) {
 		e := ptesting.NewEnvironment(t)
 		defer deleteIfNotFailed(e)
@@ -147,10 +62,6 @@ func TestPulumiNew(t *testing.T) {
 		// Confirm this fails.
 		_, stderr := e.RunCommandExpectError("pulumi", "new", template, "--offline", "--generate-only", "--yes")
 		assert.NotEmpty(t, stderr)
-
-		// Ensure the unknown template dir doesn't remain in the home directory.
-		_, err := os.Stat(getTemplateDir(t, template))
-		assert.Error(t, err, "dir shouldn't exist")
 	})
 
 	t.Run("RemoteTemplateNotFound", func(t *testing.T) {
@@ -163,230 +74,5 @@ func TestPulumiNew(t *testing.T) {
 		// Confirm this fails.
 		_, stderr := e.RunCommandExpectError("pulumi", "new", template)
 		assert.NotEmpty(t, stderr)
-
-		// Ensure the unknown template dir doesn't remain in the home directory.
-		_, err := os.Stat(getTemplateDir(t, template))
-		assert.Error(t, err, "dir shouldn't exist")
 	})
-
-	t.Run("NameDescriptionPassedExplicitly", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Run pulumi new.
-		e.RunCommand("pulumi", "new", template, "--name", "bar", "--description", "A project.", "--offline", "--generate-only")
-
-		assertSuccess(t, e.CWD, "bar", "A project.")
-	})
-
-	t.Run("WorkingDirNameIsntAValidProjectName", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Create a subdirectory that contains an invalid char
-		// for project names and CD into it.
-		subdir := path.Join(e.RootPath, "@foo")
-		err := os.MkdirAll(subdir, os.ModePerm)
-		assert.NoError(t, err, "error creating subdirectory")
-		e.CWD = subdir
-
-		// Run pulumi new.
-		e.RunCommand("pulumi", "new", template, "--offline", "--generate-only", "--yes")
-
-		// Assert the default name used is "foo" not "@foo".
-		assertSuccess(t, subdir, "foo", "")
-	})
-
-	t.Run("ExistingFileNotOverwritten", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Create a subdirectory and CD into it.
-		subdir := filepath.Join(e.RootPath, "foo")
-		err := os.MkdirAll(subdir, os.ModePerm)
-		assert.NoError(t, err, "error creating subdirectory")
-		e.CWD = subdir
-
-		// Create an existing Pulumi.yaml.
-		err = ioutil.WriteFile(filepath.Join(subdir, "Pulumi.yaml"), []byte("name: blah"), 0600)
-		assert.NoError(t, err, "creating Pulumi.yaml")
-
-		// Confirm failure due to existing file.
-		_, stderr := e.RunCommandExpectError("pulumi", "new", template, "--offline", "--generate-only", "--yes")
-		assert.Contains(t, stderr, "Pulumi.yaml")
-
-		// Confirm the contents of the file wasn't changed.
-		content := readFile(t, filepath.Join(subdir, "Pulumi.yaml"))
-		assert.Equal(t, "name: blah", content)
-
-		// Confirm no other files were copied over.
-		infos, err := ioutil.ReadDir(subdir)
-		assert.NoError(t, err, "reading the dir")
-		assert.Equal(t, 1, len(infos))
-		assert.Equal(t, "Pulumi.yaml", infos[0].Name())
-		assert.False(t, infos[0].IsDir())
-	})
-
-	t.Run("MultipleExistingFilesNotOverwritten", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Create a subdirectory and CD into it.
-		subdir := filepath.Join(e.RootPath, "foo")
-		err := os.MkdirAll(subdir, os.ModePerm)
-		assert.NoError(t, err, "error creating subdirectory")
-		e.CWD = subdir
-
-		// Create an existing Pulumi.yaml.
-		err = ioutil.WriteFile(filepath.Join(subdir, "Pulumi.yaml"), []byte("name: blah"), 0600)
-		assert.NoError(t, err, "creating Pulumi.yaml")
-
-		// Create an existing test2.txt.
-		err = ioutil.WriteFile(filepath.Join(subdir, "test2.txt"), []byte("foo"), 0600)
-		assert.NoError(t, err, "creating test2.txt")
-
-		// Confirm failure due to existing files.
-		_, stderr := e.RunCommandExpectError("pulumi", "new", template, "--offline", "--generate-only", "--yes")
-		assert.Contains(t, stderr, "Pulumi.yaml")
-		assert.Contains(t, stderr, "test2.txt")
-
-		// Confirm the contents of Pulumi.yaml wasn't changed.
-		content := readFile(t, filepath.Join(subdir, "Pulumi.yaml"))
-		assert.Equal(t, "name: blah", content)
-
-		// Confirm the contents of test2.txt wasn't changed.
-		content = readFile(t, filepath.Join(subdir, "test2.txt"))
-		assert.Equal(t, "foo", content)
-
-		// Confirm no other files were copied over.
-		infos, err := ioutil.ReadDir(subdir)
-		assert.NoError(t, err, "reading the dir")
-		assert.Equal(t, 2, len(infos))
-		for _, info := range infos {
-			assert.True(t, info.Name() == "Pulumi.yaml" || info.Name() == "test2.txt")
-			assert.False(t, info.IsDir())
-		}
-	})
-
-	t.Run("MultipleExistingFilesForce", func(t *testing.T) {
-		e := ptesting.NewEnvironment(t)
-		defer deleteIfNotFailed(e)
-
-		// Create a temporary local template.
-		template := createTemporaryLocalTemplate(t, "")
-		defer deleteTemporaryLocalTemplate(t, template)
-
-		// Create a subdirectory and CD into it.
-		subdir := filepath.Join(e.RootPath, "foo")
-		err := os.MkdirAll(subdir, os.ModePerm)
-		assert.NoError(t, err, "error creating subdirectory")
-		e.CWD = subdir
-
-		// Create an existing Pulumi.yaml.
-		err = ioutil.WriteFile(filepath.Join(subdir, "Pulumi.yaml"), []byte("name: blah"), 0600)
-		assert.NoError(t, err, "creating Pulumi.yaml")
-
-		// Create an existing test2.txt.
-		err = ioutil.WriteFile(filepath.Join(subdir, "test2.txt"), []byte("foo"), 0600)
-		assert.NoError(t, err, "creating test2.txt")
-
-		// Run pulumi new with --force.
-		e.RunCommand("pulumi", "new", template, "--force", "--offline", "--generate-only", "--yes")
-
-		assertSuccess(t, subdir, "foo", "")
-	})
-}
-
-func assertSuccess(t *testing.T, dir string, expectedProjectName string, expectedProjectDescription string) {
-	// Confirm the template file was copied/transformed.
-	content := readFile(t, filepath.Join(dir, "Pulumi.yaml"))
-	assert.Contains(t, content, fmt.Sprintf("name: %s", expectedProjectName))
-	assert.Contains(t, content, fmt.Sprintf("description: %s", expectedProjectDescription))
-
-	// Confirm the test1.txt file was copied.
-	content = readFile(t, filepath.Join(dir, "test1.txt"))
-	assert.Equal(t, "test1", content)
-
-	// Confirm the test2.txt file was copied.
-	content = readFile(t, filepath.Join(dir, "test2.txt"))
-	assert.Equal(t, "test2", content)
-
-	// Confirm the sub/blah.json file was copied.
-	content = readFile(t, filepath.Join(dir, "sub", "blah.json"))
-	assert.Equal(t, "{}", content)
-
-	// Confirm the .pulumi.template.yaml file was skipped.
-	_, err := os.Stat(filepath.Join(dir, ".pulumi.template.yaml"))
-	assert.Error(t, err)
-
-	infos, err := ioutil.ReadDir(dir)
-	assert.NoError(t, err, "reading dir")
-	assert.Equal(t, 4, len(infos))
-}
-
-func readFile(t *testing.T, filename string) string {
-	b, err := ioutil.ReadFile(filename)
-	assert.NoError(t, err, "reading file")
-	return string(b)
-}
-
-func createTemporaryLocalTemplate(t *testing.T, description string) string {
-	name := fmt.Sprintf("%v", time.Now().UnixNano())
-	dir := getTemplateDir(t, name)
-	err := os.MkdirAll(dir, 0700)
-	assert.NoError(t, err, "creating temporary template dir")
-
-	text := "name: ${PROJECT}\n" +
-		"description: ${DESCRIPTION}\n" +
-		"runtime: nodejs\n"
-	err = ioutil.WriteFile(filepath.Join(dir, "Pulumi.yaml"), []byte(text), 0600)
-	assert.NoError(t, err, "creating Pulumi.yaml")
-
-	err = ioutil.WriteFile(filepath.Join(dir, "test1.txt"), []byte("test1"), 0600)
-	assert.NoError(t, err, "creating test1.txt")
-
-	err = ioutil.WriteFile(filepath.Join(dir, "test2.txt"), []byte("test2"), 0600)
-	assert.NoError(t, err, "creating test2.txt")
-
-	err = os.MkdirAll(filepath.Join(dir, "sub"), os.ModePerm)
-	assert.NoError(t, err, "creating sub")
-
-	err = ioutil.WriteFile(filepath.Join(dir, "sub", "blah.json"), []byte("{}"), 0600)
-	assert.NoError(t, err, "creating sub/blah.json")
-
-	// If description is not empty, write it out in a manifest file.
-	if description != "" {
-		descriptionBytes := []byte(fmt.Sprintf("description: %s", description))
-		err = ioutil.WriteFile(filepath.Join(dir, ".pulumi.template.yaml"), descriptionBytes, 0600)
-		assert.NoError(t, err, "creating .pulumi.template.yaml")
-	}
-
-	return name
-}
-
-func deleteTemporaryLocalTemplate(t *testing.T, name string) {
-	err := os.RemoveAll(getTemplateDir(t, name))
-	assert.NoError(t, err, "deleting temporary template dir")
-}
-
-func getTemplateDir(t *testing.T, name string) string {
-	user, err := user.Current()
-	assert.NoError(t, err, "getting home directory")
-	return filepath.Join(user.HomeDir, workspace.BookkeepingDir, workspace.TemplateDir, name)
 }


### PR DESCRIPTION
This PR adds initial support for `pulumi new` using Git under the covers
to manage Pulumi templates, providing the same experience as before.

You can now also optionally pass a URL to a Git repository, e.g.
`pulumi new [<url>]`, including subdirectories within the repository,
and arbitrary branches, tags, or commits.

The following commands result in the same behavior from the user's
perspective:
 - `pulumi new javascript`
 - `pulumi new https://github.com/pulumi/templates/templates/javascript`
 - `pulumi new https://github.com/pulumi/templates/tree/master/templates/javascript`
 - `pulumi new https://github.com/pulumi/templates/tree/HEAD/templates/javascript`

To specify an arbitrary branch, tag, or commit:
 - `pulumi new https://github.com/pulumi/templates/tree/<branch>/templates/javascript`
 - `pulumi new https://github.com/pulumi/templates/tree/<tag>/templates/javascript`
 - `pulumi new https://github.com/pulumi/templates/tree/<commit>/templates/javascript`

Branches and tags can include '/' separators, and `pulumi` will still
find the right subdirectory.

URLs to Gists are also supported, e.g.:
`pulumi new https://gist.github.com/justinvp/6673959ceb9d2ac5a14c6d536cb871a6`

If the specified subdirectory in the repository does not contain a
`Pulumi.yaml`, it will look for subdirectories inside containing
`Pulumi.yaml` files, and prompt the user to choose a template, along the
lines of how `pulumi new` behaves when no template is specified.

The following commands result in the CLI prompting to choose a template:
 - `pulumi new`
 - `pulumi new https://github.com/pulumi/templates/templates`
 - `pulumi new https://github.com/pulumi/templates/tree/master/templates`
 - `pulumi new https://github.com/pulumi/templates/tree/HEAD/templates`

Of course, arbitrary branches, tags, or commits can be specified as well:
 - `pulumi new https://github.com/pulumi/templates/tree/<branch>/templates`
 - `pulumi new https://github.com/pulumi/templates/tree/<tag>/templates`
 - `pulumi new https://github.com/pulumi/templates/tree/<commit>/templates`

This PR also includes initial support for passing URLs to `pulumi up`,
providing a streamlined way to deploy installable cloud applications
with Pulumi, without having to manage source code locally before doing
a deployment.

For example, `pulumi up https://github.com/justinvp/aws` can be used to
deploy a sample AWS app. The stack can be updated with different
versions, e.g.
`pulumi up https://github.com/justinvp/aws/tree/v2 -s <stack>`. Or going back to a previous tagged version, e.g. `pulumi up https://github.com/justinvp/aws/tree/v1 -s <stack>`

Config values can optionally be passed via command line flags, e.g.
`pulumi up https://github.com/justinvp/aws -c aws:region=us-west-2 -c foo:bar=blah`

Gists can also be used, e.g.
`pulumi up https://gist.github.com/justinvp/62fde0463f243fcb49f5a7222e51bc76`

Fixes #1544
Fixes #1657
Fixes #1527
Fixes #1674
Fixes #1156 

There are some remaining work items that I will address in separate PRs:
 - new: Order of pulumi new args could be improved - #1677
 - new: Improve the error message for `pulumi new` when the template doesn’t exist - #1525
 - new: Add back tests and round out with new Git-based tests
 - up: Suppress preview output by default when URL is passed (unless error)
 - up: Prompt on update failure and prompt to attempt destroy to rollback
 - up: More E2E validation