### PR TITLE
Strip off the node_modules prefix from our require() calls.

### DIFF
--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1075,7 +1075,8 @@ function getOrCreateEntry(
 
     function captureModule(moduleName: string) {
         const nodeModulesPrefix = "./node_modules/";
-        const isLocalModule = moduleName.startsWith(".") && !moduleName.startsWith(nodeModulesPrefix);
+        const isInNodeModules = moduleName.startsWith(nodeModulesPrefix);
+        const isLocalModule = moduleName.startsWith(".") && !isInNodeModules;
 
         if (obj.deploymentOnlyModule || isLocalModule) {
             // Try to serialize deployment-time and local-modules by-value.
@@ -1105,7 +1106,7 @@ function getOrCreateEntry(
             // will help ensure that lookup of those modules will work on the cloud-side even if the
             // module isn't in a relative node_modules directory.  For example, this happens with
             // aws-sdk.  It ends up actually being in /var/runtime/node_modules inside aws lambda.
-            entry.module = moduleName.startsWith(nodeModulesPrefix)
+            entry.module = isInNodeModules
                 ? moduleName.substring(nodeModulesPrefix.length)
                 : moduleName;
         }

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -4779,7 +4779,7 @@ return function () { console.log(o1); console.log(o2.b.d); console.log(o3.b.d); 
 
 function __f0() {
   return (function() {
-    with({ typescript: require("./node_modules/typescript/lib/typescript.js") }) {
+    with({ typescript: require("typescript/lib/typescript.js") }) {
 
 return function () { typescript.parseCommandLine([""]); };
 


### PR DESCRIPTION
This is important for aws-sdk.  We do not upload this ourself (since it's in every aws lambda).  However, it's not under a local ./node_modules/ path.  instead, it's in /var/runtime/node_modules.