### PR TITLE
Added a way to override the template directory used with pulumi new

### DIFF
--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -41,7 +41,7 @@ const (
 	// a project directory.
 	pulumiTemplateManifestFile = ".pulumi.template.yaml"
 
-	// pulumiLocalTemplatePathEnvVar is a path to the folder where template are stored.
+	// pulumiLocalTemplatePathEnvVar is a path to the folder where templates are stored.
 	// It is used in sandboxed environments where the classic template folder may not be writable.
 	pulumiLocalTemplatePathEnvVar = "PULUMI_TEMPLATE_PATH"
 )
@@ -214,10 +214,10 @@ func (template Template) CopyTemplateFiles(
 
 // GetTemplateDir returns the directory in which templates on the current machine are stored.
 func GetTemplateDir(name string) (string, error) {
-	// Allow the folder we use to store template to be overridden
+	// Allow the folder we use to store templates to be overridden.
 	dir := os.Getenv(pulumiLocalTemplatePathEnvVar)
 
-	// Use the classic template directory if there is no override
+	// Use the classic template directory if there is no override.
 	if dir == "" {
 		u, err := user.Current()
 		if u == nil || err != nil {

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -40,6 +40,10 @@ const (
 	// This file will be ignored when copying from the template cache to
 	// a project directory.
 	pulumiTemplateManifestFile = ".pulumi.template.yaml"
+
+	// pulumiLocalTemplatePathEnvVar is a path to the folder where template are stored.
+	// It is used in sandboxed environments where the classic template folder may not be writable.
+	pulumiLocalTemplatePathEnvVar = "PULUMI_TEMPLATE_PATH"
 )
 
 // Template represents a project template.
@@ -210,14 +214,22 @@ func (template Template) CopyTemplateFiles(
 
 // GetTemplateDir returns the directory in which templates on the current machine are stored.
 func GetTemplateDir(name string) (string, error) {
-	u, err := user.Current()
-	if u == nil || err != nil {
-		return "", errors.Wrap(err, "getting user home directory")
+	// Allow the folder we use to store template to be overridden
+	dir := os.Getenv(pulumiLocalTemplatePathEnvVar)
+
+	// Use the classic template directory if there is no override
+	if dir == "" {
+		u, err := user.Current()
+		if u == nil || err != nil {
+			return "", errors.Wrap(err, "getting user home directory")
+		}
+		dir = filepath.Join(u.HomeDir, BookkeepingDir, TemplateDir)
 	}
-	dir := filepath.Join(u.HomeDir, BookkeepingDir, TemplateDir)
+
 	if name != "" {
 		dir = filepath.Join(dir, name)
 	}
+
 	return dir, nil
 }
 


### PR DESCRIPTION
The general goal of this PR is to provide a way to override the template directory.
I encountered a problem while trying to implement a good test in the pulumi brew formula. Homebrew tests are run in a sandboxed environment with limited permissions and `pulumi new` is performing several write/read in the user home directory that are not allowed.

I've started working on a solution by adding a `--no-cache` flag to `pulumi new`. The result of this work is in the `add-new-no-cache-opt` branch of my fork. This was quite verbose to implement and I was not really satisfied with the result. I'm not even sure that users would use the `--no-cache` flag so there is no need to add that. 

While doing the initial work I was always thinking _If only I could just modify the GetTemplateDir function_. But template path resolving is quite coupled with every function needing it.

The branch (with a bad name 😞) in this PR solves the problem gracefully by just adding a env variable overriding the template path. `GetTemplateDir` is the only modified function. It's inspired by the `creds.go` path override.

As always open to any modification. I can also one unit test if this is needed but I didn't find an easy one.


Edit: Sorry @justinvp I didn't see that you were working on an important update to `pulumi new`. I checked your work and this should be fine with what you are doing.