### PR TITLE
Add a few more CI env vars

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -435,7 +435,13 @@ func addCIMetadataToEnvironment(env map[string]string) {
 	if os.Getenv("TRAVIS") == "true" {
 		env[backend.CISystem] = "travis-ci"
 
-		// Pass pull request-specific vales as needed.
+		// Pass build-related information.
+		env[backend.CIBuildID] = os.Getenv("TRAVIS_JOB_ID")
+		env[backend.CIBuildType] = os.Getenv("TRAVIS_EVENT_TYPE")
+		// Travis doesn't set a build URL in its environment, see:
+		// https://github.com/travis-ci/travis-ci/issues/8935
+
+		// Pass pull request-specific vales as appropriate.
 		if sha := os.Getenv("TRAVIS_PULL_REQUEST_SHA"); sha != "" {
 			env[backend.CIPRHeadSHA] = sha
 		}

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -77,6 +77,12 @@ const (
 
 	// CISystem is the name of the CI system running the pulumi operation.
 	CISystem = "ci.system"
+	// CIBuildID is an opaque ID of the build in the CI system.
+	CIBuildID = "ci.build.id"
+	// CIBuildType is the type of build of the CI system, e.g. "push", "pull_request", "test_only".
+	CIBuildType = "ci.build.type"
+	// CIBuildURL is a URL to get more information about the particular CI build.
+	CIBuildURL = "ci.build.url"
 
 	// CIPRHeadSHA is the SHA of the HEAD commit of a pull request running on CI. This is needed since the CI
 	// server will run at a different, merge commit. (headSHA merged into the target branch.)


### PR DESCRIPTION
Adds a few more possible update environment values, specifically `ci.build.id`, `ci.build.type`, and `ci.build.url`. We also provide `ci.build.id` and `ci.build.type` for Travis CI-based builds.

Without these values we cannot link to the CI build as part of our workflow system. e.g. we'll be able to add a message like "Update performed on Travis Build #xxx".

The only design wart here is that we emit the `TRAVIS_JOB_ID` value, not `TRAVIS_JOB_NUMBER`. The difference between the two is that job ID is internal to Travis, and job number is the user-facing name. It seemed odd to include both a "job id" and "job friendly name". So I just added the job ID.