### PR TITLE
Remove PPC-specific codepaths

### DIFF
--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -67,9 +67,6 @@ func newStackCmd() *cobra.Command {
 			if isCloud {
 				if cs, ok := s.(cloud.Stack); ok {
 					fmt.Printf("    Owner: %s\n", cs.OrgName())
-					if !cs.RunLocally() {
-						fmt.Printf("    PPC: %s\n", cs.CloudName())
-					}
 				}
 			}
 

--- a/cmd/stack_ls.go
+++ b/cmd/stack_ls.go
@@ -82,7 +82,6 @@ func newStackLsCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			showPPCColumn, maxPPC := hasAnyPPCStacks(bs)
 			_, showURLColumn := b.(cloud.Backend)
 
 			for _, stack := range bs {
@@ -115,10 +114,6 @@ func newStackLsCmd() *cobra.Command {
 			formatDirective := "%-" + strconv.Itoa(maxname) + "s %-24s %-18s"
 			headers := []interface{}{"NAME", "LAST UPDATE", "RESOURCE COUNT"}
 
-			if showPPCColumn {
-				formatDirective += " %-" + strconv.Itoa(maxPPC) + "s"
-				headers = append(headers, "PPC")
-			}
 			if showURLColumn {
 				formatDirective += " %s"
 				headers = append(headers, "URL")
@@ -149,16 +144,6 @@ func newStackLsCmd() *cobra.Command {
 				}
 
 				values := []interface{}{name, lastUpdate, resourceCount}
-				if showPPCColumn {
-					// Print out the PPC name.
-					var cloudInfo string
-					if cs, ok := stack.(cloud.Stack); ok && !cs.RunLocally() {
-						cloudInfo = cs.CloudName()
-					} else {
-						cloudInfo = none
-					}
-					values = append(values, cloudInfo)
-				}
 				if showURLColumn {
 					var url string
 					if cs, ok := stack.(cloud.Stack); ok {
@@ -182,18 +167,4 @@ func newStackLsCmd() *cobra.Command {
 		&allStacks, "all", "a", false, "List all stacks instead of just stacks for the current project")
 
 	return cmd
-}
-
-func hasAnyPPCStacks(stacks []backend.Stack) (bool, int) {
-	res, maxLen := false, 0
-	for _, s := range stacks {
-		if cs, ok := s.(cloud.Stack); ok {
-			if !cs.RunLocally() {
-				res = true
-				maxLen = len(cs.CloudName())
-			}
-		}
-	}
-
-	return res, maxLen
 }

--- a/pkg/backend/cloud/stack.go
+++ b/pkg/backend/cloud/stack.go
@@ -34,20 +34,17 @@ type Stack interface {
 	backend.Stack
 	CloudURL() string            // the URL to the cloud containing this stack.
 	OrgName() string             // the organization that owns this stack.
-	CloudName() string           // the PPC in which this stack is running.
-	RunLocally() bool            // true if previews/updates/destroys targeting this stack run locally.
 	ConsoleURL() (string, error) // the URL to view the stack's information on Pulumi.com
 }
 
 // cloudStack is a cloud stack descriptor.
 type cloudStack struct {
-	name      backend.StackReference // the stack's name.
-	cloudURL  string                 // the URL to the cloud containing this stack.
-	orgName   string                 // the organization that owns this stack.
-	cloudName string                 // the PPC in which this stack is running.
-	config    config.Map             // the stack's config bag.
-	snapshot  **deploy.Snapshot      // a snapshot representing the latest deployment state (allocated on first use)
-	b         *cloudBackend          // a pointer to the backend this stack belongs to.
+	name     backend.StackReference // the stack's name.
+	cloudURL string                 // the URL to the cloud containing this stack.
+	orgName  string                 // the organization that owns this stack.
+	config   config.Map             // the stack's config bag.
+	snapshot **deploy.Snapshot      // a snapshot representing the latest deployment state (allocated on first use)
+	b        *cloudBackend          // a pointer to the backend this stack belongs to.
 }
 
 type cloudBackendReference struct {
@@ -81,26 +78,19 @@ func newStack(apistack apitype.Stack, b *cloudBackend) Stack {
 			name:  apistack.StackName,
 			b:     b,
 		},
-		cloudURL:  b.CloudURL(),
-		orgName:   apistack.OrgName,
-		cloudName: apistack.CloudName,
-		config:    nil, // TODO[pulumi/pulumi-service#249]: add the config variables.
-		snapshot:  nil, // We explicitly allocate the snapshot on first use, since it is expensive to compute.
-		b:         b,
+		cloudURL: b.CloudURL(),
+		orgName:  apistack.OrgName,
+		config:   nil, // TODO[pulumi/pulumi-service#249]: add the config variables.
+		snapshot: nil, // We explicitly allocate the snapshot on first use, since it is expensive to compute.
+		b:        b,
 	}
 }
-
-// managedCloudName is the name used to refer to the cloud in the Pulumi Service that owns all of an organization's
-// managed stacks. All engine operations for a managed stack--previews, updates, destroys, etc.--run locally.
-const managedCloudName = "pulumi"
 
 func (s *cloudStack) Name() backend.StackReference { return s.name }
 func (s *cloudStack) Config() config.Map           { return s.config }
 func (s *cloudStack) Backend() backend.Backend     { return s.b }
 func (s *cloudStack) CloudURL() string             { return s.cloudURL }
 func (s *cloudStack) OrgName() string              { return s.orgName }
-func (s *cloudStack) CloudName() string            { return s.cloudName }
-func (s *cloudStack) RunLocally() bool             { return s.cloudName == managedCloudName }
 
 func (s *cloudStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) {
 	if s.snapshot != nil {


### PR DESCRIPTION
Removes PPC-specific codepaths in the Pulumi CLI. At this point `RunLocally()` will be `true` for all stacks, so we can remove it from if-statements and delete any code that required `RunLocally()` to be `false`.

Are there any other things that may have been missed?