### PR TITLE
Add per-resource states

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -153,6 +153,7 @@ func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*plan
 	if err != nil {
 		return nil, err
 	}
+
 	return &planResult{
 		Ctx:     info,
 		Plugctx: plugctx,

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -15,6 +15,10 @@
 package deploy
 
 import (
+	"bufio"
+	"bytes"
+	"fmt"
+
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -58,6 +62,36 @@ type PlanSummary interface {
 	Replaces() map[resource.URN]bool
 	Deletes() map[resource.URN]bool
 	Sames() map[resource.URN]bool
+}
+
+// InvalidResourceError is returned by deploy.NewPlan when the engine observes
+// that one or more resources are in an invalid state. The engine populates `InvalidResources`
+// with the URNs of every resource that was invalid.
+type InvalidResourceError struct {
+	InvalidResources []*resource.State
+}
+
+func (ire InvalidResourceError) Error() string {
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+	fmt.Fprintf(writer,
+		"error: the current deployment has %d resource(s) whose statuses are unknown:\n", len(ire.InvalidResources))
+
+	for _, res := range ire.InvalidResources {
+		fmt.Fprintf(writer, "  * %s, interrupted while %s\n", res.URN, res.Status)
+	}
+
+	fmt.Fprintf(writer, "\n")
+	fmt.Fprintf(writer, "These resources have unknown statuses because the Pulumi CLI was interrupted before it\n")
+	fmt.Fprintf(writer, "had the opportunity to see if an operation that it initiated was successful. You should\n")
+	fmt.Fprintf(writer, "confirm whether or not the above operations completed successfully with your cloud provider.\n")
+	fmt.Fprintf(writer, "\n")
+	fmt.Fprintf(writer, "Once you have confirmed the status of the interrupted operations, you can repair your stack\n")
+	fmt.Fprintf(writer, "using `pulumi stack export` to export your stack to a file. For each operation that succeeded,\n")
+	fmt.Fprintf(writer, "remove the `status` field. Once this is complete, use `pulumi stack export` to import the\n")
+	fmt.Fprintf(writer, "repaired stack.")
+	contract.IgnoreError(writer.Flush())
+	return buf.String()
 }
 
 // Plan is the output of analyzing resource graphs and contains the steps necessary to perform an infrastructure
@@ -172,7 +206,7 @@ func NewPlan(ctx *plugin.Context, target *Target, prev *Snapshot, source Source,
 
 	var depGraph *graph.DependencyGraph
 	var oldResources []*resource.State
-
+	var invalidResources []*resource.State
 	// Produce a map of all old resources for fast resources.
 	olds := make(map[resource.URN]*resource.State)
 	if prev != nil {
@@ -181,6 +215,11 @@ func NewPlan(ctx *plugin.Context, target *Target, prev *Snapshot, source Source,
 		for _, oldres := range oldResources {
 			// Ignore resources that are pending deletion; these should not be recorded in the LUT.
 			if oldres.Delete {
+				continue
+			}
+
+			if oldres.Status != resource.OperationStatusEmpty {
+				invalidResources = append(invalidResources, oldres)
 				continue
 			}
 
@@ -198,6 +237,10 @@ func NewPlan(ctx *plugin.Context, target *Target, prev *Snapshot, source Source,
 	reg, err := providers.NewRegistry(ctx.Host, oldResources, preview)
 	if err != nil {
 		return nil, err
+	}
+
+	if invalidResources != nil {
+		return nil, InvalidResourceError{invalidResources}
 	}
 
 	return &Plan{

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -88,7 +88,7 @@ func (ire InvalidResourceError) Error() string {
 	fmt.Fprintf(writer, "\n")
 	fmt.Fprintf(writer, "Once you have confirmed the status of the interrupted operations, you can repair your stack\n")
 	fmt.Fprintf(writer, "using `pulumi stack export` to export your stack to a file. For each operation that succeeded,\n")
-	fmt.Fprintf(writer, "remove the `status` field. Once this is complete, use `pulumi stack export` to import the\n")
+	fmt.Fprintf(writer, "remove the `status` field. Once this is complete, use `pulumi stack import` to import the\n")
 	fmt.Fprintf(writer, "repaired stack.")
 	contract.IgnoreError(writer.Flush())
 	return buf.String()

--- a/pkg/resource/deploy/plan_test.go
+++ b/pkg/resource/deploy/plan_test.go
@@ -1,0 +1,56 @@
+package deploy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/plugin"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/version"
+)
+
+func newResource(name string) *resource.State {
+	ty := tokens.Type("test")
+	return &resource.State{
+		Type:    ty,
+		URN:     resource.NewURN(tokens.QName("teststack"), tokens.PackageName("pkg"), ty, ty, tokens.QName(name)),
+		Inputs:  make(resource.PropertyMap),
+		Outputs: make(resource.PropertyMap),
+	}
+}
+
+func newSnapshot(resources []*resource.State) *Snapshot {
+	return NewSnapshot(Manifest{
+		Time:    time.Now(),
+		Version: version.Version,
+		Plugins: nil,
+	}, resources)
+}
+
+// Tests that plan creation fails if there are any resources in an invalid state currently in the snapshot.
+func TestInvalidResources(t *testing.T) {
+	resourceA := newResource("a")
+	resourceB := newResource("b")
+	resourceB.Status = resource.OperationStatusCreating
+	snap := newSnapshot([]*resource.State{
+		resourceA,
+		resourceB,
+	})
+
+	_, err := NewPlan(&plugin.Context{}, &Target{}, snap, &fixedSource{}, nil, false)
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+
+	invalidErr, ok := err.(InvalidResourceError)
+	if !assert.True(t, ok) {
+		t.FailNow()
+	}
+
+	assert.Len(t, invalidErr.InvalidResources, 1)
+	assert.Equal(t, resourceB.URN, invalidErr.InvalidResources[0].URN)
+	assert.Equal(t, resource.OperationStatusCreating, invalidErr.InvalidResources[0].Status)
+}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -127,12 +127,15 @@ func (snap *Snapshot) VerifyIntegrity() error {
 				}
 			}
 
-			if _, has := urns[urn]; has && !state.Delete {
-				// The only time we should have duplicate URNs is when all but one of them are marked for deletion.
-				return errors.Errorf("duplicate resource %s (not marked for deletion)", urn)
+			if _, has := urns[urn]; has && !state.Delete && state.Status == "" {
+				// The only time we should have duplicate URNs is when all but one of them are marked for deletion
+				// or have an operation pending on them.
+				return errors.Errorf("duplicate resource %s (not marked for deletion or pending operation)", urn)
 			}
 
-			urns[urn] = state
+			if state.Status == "" {
+				urns[urn] = state
+			}
 		}
 	}
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -61,7 +61,7 @@ func fixedProgram(steps []RegisterResourceEvent) deploytest.ProgramFunc {
 			}
 			s.Done(&RegisterResult{
 				State: resource.NewState(g.Type, urn, g.Custom, false, id, g.Properties, outs, g.Parent, g.Protect,
-					false, g.Dependencies, nil, g.Provider),
+					false, resource.OperationStatusEmpty, g.Dependencies, nil, g.Provider),
 			})
 		}
 		return nil
@@ -196,7 +196,7 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 		}
 		reg.Done(&RegisterResult{
 			State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
-				goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider),
+				goal.Parent, goal.Protect, false, resource.OperationStatusEmpty, goal.Dependencies, nil, goal.Provider),
 		})
 
 		processed++
@@ -283,7 +283,7 @@ func TestRegisterDefaultProviders(t *testing.T) {
 
 		reg.Done(&RegisterResult{
 			State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
-				goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider),
+				goal.Parent, goal.Protect, false, resource.OperationStatusEmpty, goal.Dependencies, nil, goal.Provider),
 		})
 
 		processed++
@@ -372,7 +372,8 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 		urn := newURN(read.Type(), string(read.Name()), read.Parent())
 		read.Done(&ReadResult{
 			State: resource.NewState(read.Type(), urn, true, false, read.ID(), read.Properties(),
-				resource.PropertyMap{}, read.Parent(), false, false, read.Dependencies(), nil, read.Provider()),
+				resource.PropertyMap{}, read.Parent(), false, false, resource.OperationStatusEmpty,
+				read.Dependencies(), nil, read.Provider()),
 		})
 		reads++
 	}
@@ -456,7 +457,7 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 
 			e.Done(&RegisterResult{
 				State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
-					goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider),
+					goal.Parent, goal.Protect, false, resource.OperationStatusEmpty, goal.Dependencies, nil, goal.Provider),
 			})
 			registers++
 
@@ -464,7 +465,8 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 			urn := newURN(e.Type(), string(e.Name()), e.Parent())
 			e.Done(&ReadResult{
 				State: resource.NewState(e.Type(), urn, true, false, e.ID(), e.Properties(),
-					resource.PropertyMap{}, e.Parent(), false, false, e.Dependencies(), nil, e.Provider()),
+					resource.PropertyMap{}, e.Parent(), false, false, resource.OperationStatusEmpty,
+					e.Dependencies(), nil, e.Provider()),
 			})
 			reads++
 		}

--- a/pkg/resource/deploy/source_refresh.go
+++ b/pkg/resource/deploy/source_refresh.go
@@ -142,7 +142,7 @@ func (iter *refreshSourceIterator) newRefreshGoal(s *resource.State) (*resource.
 		}
 		s = resource.NewState(
 			s.Type, s.URN, s.Custom, s.Delete, s.ID, s.Inputs, refreshed,
-			s.Parent, s.Protect, s.External, s.Dependencies, s.InitErrors, s.Provider)
+			s.Parent, s.Protect, s.External, s.Status, s.Dependencies, s.InitErrors, s.Provider)
 	}
 
 	// Now just return the actual state as the goal state.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -56,7 +56,7 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, err
 		event.Parent(),
 		false, /*protect*/
 		true,  /*external*/
-		"",    /* status */
+		resource.OperationStatusEmpty, /* status */
 		event.Dependencies(),
 		nil, /* initErrors */
 		event.Provider())
@@ -503,7 +503,8 @@ func (sg *stepGenerator) getResourcePropertyStates(urn resource.URN, goal *resou
 	}
 	return props, inputs, outputs,
 		resource.NewState(goal.Type, urn, goal.Custom, false, "",
-			inputs, outputs, goal.Parent, goal.Protect, false, "", goal.Dependencies, nil, goal.Provider)
+			inputs, outputs, goal.Parent, goal.Protect, false, resource.OperationStatusEmpty, goal.Dependencies,
+			nil, goal.Provider)
 }
 
 // issueCheckErrors prints any check errors to the diagnostics sink.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -56,6 +56,7 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, err
 		event.Parent(),
 		false, /*protect*/
 		true,  /*external*/
+		"",    /* status */
 		event.Dependencies(),
 		nil, /* initErrors */
 		event.Provider())
@@ -502,7 +503,7 @@ func (sg *stepGenerator) getResourcePropertyStates(urn resource.URN, goal *resou
 	}
 	return props, inputs, outputs,
 		resource.NewState(goal.Type, urn, goal.Custom, false, "",
-			inputs, outputs, goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider)
+			inputs, outputs, goal.Parent, goal.Protect, false, "", goal.Dependencies, nil, goal.Provider)
 }
 
 // issueCheckErrors prints any check errors to the diagnostics sink.

--- a/pkg/resource/resource_state.go
+++ b/pkg/resource/resource_state.go
@@ -19,29 +19,41 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
+type OperationStatus string
+
+const (
+	OperationStatusEmpty    OperationStatus = ""
+	OperationStatusCreating OperationStatus = "creating"
+	OperationStatusUpdating OperationStatus = "updating"
+	OperationStatusDeleting OperationStatus = "deleting"
+	OperationStatusReading  OperationStatus = "reading"
+)
+
 // State is a structure containing state associated with a resource.  This resource may have been serialized and
 // deserialized, or snapshotted from a live graph of resource objects.  The value's state is not, however, associated
 // with any runtime objects in memory that may be actively involved in ongoing computations.
 type State struct {
-	Type         tokens.Type // the resource's type.
-	URN          URN         // the resource's object urn, a human-friendly, unique name for the resource.
-	Custom       bool        // true if the resource is custom, managed by a plugin.
-	Delete       bool        // true if this resource is pending deletion due to a replacement.
-	ID           ID          // the resource's unique ID, assigned by the resource provider (or blank if none/uncreated).
-	Inputs       PropertyMap // the resource's input properties (as specified by the program).
-	Outputs      PropertyMap // the resource's complete output state (as returned by the resource provider).
-	Parent       URN         // an optional parent URN that this resource belongs to.
-	Protect      bool        // true to "protect" this resource (protected resources cannot be deleted).
-	External     bool        // true if this resource is "external" to Pulumi and we don't control the lifecycle
-	Dependencies []URN       // the resource's dependencies
-	InitErrors   []string    // the set of errors encountered in the process of initializing resource.
-	Provider     string      // the provider to use for this resource.
+	Type   tokens.Type // the resource's type.
+	URN    URN         // the resource's object urn, a human-friendly, unique name for the resource.
+	Custom bool        // true if the resource is custom, managed by a plugin.
+	Delete bool        // true if this resource is pending deletion due to a replacement.
+	ID     ID          // the resource's unique ID, assigned by the resource provider, (or blank if none/uncreated).
+
+	Inputs       PropertyMap     // the resource's input properties (as specified by the program).
+	Outputs      PropertyMap     // the resource's complete output state (as returned by the resource provider).
+	Parent       URN             // an optional parent URN that this resource belongs to.
+	Protect      bool            // true to "protect" this resource (protected resources cannot be deleted).
+	External     bool            // true if this resource is "external" to Pulumi and we don't control the lifecycle
+	Status       OperationStatus // the operation status of this resource.
+	Dependencies []URN           // the resource's dependencies
+	InitErrors   []string        // the set of errors encountered in the process of initializing resource.
+	Provider     string          // the provider to use for this resource.
 }
 
 // NewState creates a new resource value from existing resource state information.
 func NewState(t tokens.Type, urn URN, custom bool, del bool, id ID,
 	inputs PropertyMap, outputs PropertyMap, parent URN, protect bool,
-	external bool, dependencies []URN, initErrors []string, provider string) *State {
+	external bool, status OperationStatus, dependencies []URN, initErrors []string, provider string) *State {
 	contract.Assertf(t != "", "type was empty")
 	contract.Assertf(custom || id == "", "is custom or had empty ID")
 	contract.Assertf(inputs != nil, "inputs was non-nil")
@@ -56,6 +68,7 @@ func NewState(t tokens.Type, urn URN, custom bool, del bool, id ID,
 		Parent:       parent,
 		Protect:      protect,
 		External:     external,
+		Status:       status,
 		Dependencies: dependencies,
 		InitErrors:   initErrors,
 		Provider:     provider,

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -176,6 +176,7 @@ func SerializeResource(res *resource.State) apitype.ResourceV2 {
 		Outputs:      outputs,
 		Protect:      res.Protect,
 		External:     res.External,
+		Status:       string(res.Status),
 		Dependencies: res.Dependencies,
 		InitErrors:   res.InitErrors,
 		Provider:     res.Provider,
@@ -241,7 +242,8 @@ func DeserializeResource(res apitype.ResourceV2) (*resource.State, error) {
 
 	return resource.NewState(
 		res.Type, res.URN, res.Custom, res.Delete, res.ID,
-		inputs, outputs, res.Parent, res.Protect, res.External, res.Dependencies, res.InitErrors, res.Provider), nil
+		inputs, outputs, res.Parent, res.Protect, res.External,
+		resource.OperationStatus(res.Status), res.Dependencies, res.InitErrors, res.Provider), nil
 }
 
 // DeserializeProperties deserializes an entire map of deploy properties into a resource property map.

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -70,6 +70,7 @@ func TestDeploymentSerialization(t *testing.T) {
 		"",
 		false,
 		false,
+		resource.OperationStatusEmpty,
 		[]resource.URN{
 			resource.URN("foo:bar:baz"),
 			resource.URN("foo:bar:boo"),

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/backend/local"
+	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/testing/integration"
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -191,6 +192,73 @@ func TestStackCommands(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("FixingInvalidResources", func(t *testing.T) {
+		e := ptesting.NewEnvironment(t)
+		defer func() {
+			if !t.Failed() {
+				e.DeleteEnvironment()
+			}
+		}()
+
+		stackName := addRandomSuffix("invalid-resources")
+		integration.CreateBasicPulumiRepo(e)
+		e.ImportDirectory("integration/stack_dependencies")
+
+		e.RunCommand("pulumi", "login")
+		e.RunCommand("pulumi", "stack", "init", stackName)
+		e.RunCommand("yarn", "install")
+		e.RunCommand("yarn", "link", "@pulumi/pulumi")
+		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview", "--yes")
+
+		// We're going to futz with the stack a little so that one of the resources we just created
+		// becomes invalid.
+		stackFile := path.Join(e.RootPath, "stack.json")
+		e.RunCommand("pulumi", "stack", "export", "--file", "stack.json")
+		stackJSON, err := ioutil.ReadFile(stackFile)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		var deployment apitype.UntypedDeployment
+		err = json.Unmarshal(stackJSON, &deployment)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		snap, err := stack.DeserializeUntypedDeployment(&deployment)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Let's say that the the CLI crashed during the creation of the last resource and we've now got
+		// invalid resources in the snapshot.
+		urn := snap.Resources[len(snap.Resources)-1].URN
+		snap.Resources[len(snap.Resources)-1].Status = resource.OperationStatusCreating
+		v2deployment := stack.SerializeDeployment(snap)
+		data, err := json.Marshal(&v2deployment)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		deployment.Deployment = data
+		bytes, err := json.Marshal(&deployment)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		err = ioutil.WriteFile(stackFile, bytes, os.FileMode(os.O_CREATE))
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		_, stderr := e.RunCommand("pulumi", "stack", "import", "--file", "stack.json")
+		assert.Contains(t, stderr, fmt.Sprintf("repairing URN %s in invalid 'creating' state", urn))
+
+		// The engine should be happy now that there are no invalid resources.
+		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview", "--yes")
+		e.RunCommand("pulumi", "stack", "rm", "--yes", "--force")
+	})
 }
 
 func TestStackBackups(t *testing.T) {
@@ -288,7 +356,7 @@ func getStackProjectBackupDir(e *ptesting.Environment, stackName string) (string
 	), nil
 }
 
-func addRandomSufix(s string) string {
+func addRandomSuffix(s string) string {
 	b := make([]byte, 4)
 	_, err := cryptorand.Read(b)
 	contract.AssertNoError(err)


### PR DESCRIPTION
Fixes pulumi/pulumi#1626. This commit obviates the need to invalidate
and re-validate snapshots as they are mutated, which in turn allows for
correctness when there are multiple snapshot mutations active at a time.

The crux of this commit is that the SnapshotManager will, at the start
of a mutating operation, write the resource into the snapshot before the
operation has begun, but with a non-empty "status". At the end of the
operation, the SnapshotManager will (depending on the outcome of the
step) remove the "status" field. The general idea here is that a
resource will have a non-empty "status" field if there is a resource
operation currently in-flight.

The precise semantics here are different for each kind of step:

* `CreateStep` - SnapshotManager inserts a new node into the snapshot
containing the inputs of the resource being created. This node has
status "creating". If the step succeeds, the "status" field is cleared.
If the step fails, the entire resource is removed from the snapshot.

* `UpdateStep` - SnapshotManager inserts a new node into the snapshot
containing the inputs of the resource being updated. This node has
status "updating". If the step succeeds, the "status" field is cleared
on the new resource and the old resource is removed from the snapshot.
If the tep fails, the entire new resource is removed from the snapshot.

* `ReadStep` - SnapshotManager inserts a new node into the snapshot
containing the search inputs to `read`. This node has status "reading".
If the step succeeds, the existing resource being read over is removed
(if one exists) and the new resource's "status" field is cleared. If the
step fails, the entire new resource is removed from the snapshot.

* `DeleteStep` - SnapshotManager sets the "status" field of the resource
being deleted to "deleting". If the step suceeds, the resource is
removed from the snapshot. If the step fails, the resource's "status"
field is cleared.

As part of this commit, the engine will reject any snapshot that has a
resource within it with the "status" field set. Running "pulumi stack
import" on a stack with invalid resources in it will remove those
resources from the snapshot.