### PR TITLE
Also copy python helper script during `make dist`

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -59,3 +59,4 @@ test_fast::
 
 dist::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}
+	cp ./cmd/pulumi-language-python-exec "$(go env GOPATH)"/bin/


### PR DESCRIPTION
During Code Review, I forgot that for the python language host we need
both the go binary and the -exec script.