### PR TITLE
Implement partial read

### DIFF
--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -45,7 +45,8 @@ type Provider struct {
 		olds, news resource.PropertyMap) (resource.PropertyMap, resource.Status, error)
 	DeleteF func(urn resource.URN, id resource.ID, olds resource.PropertyMap) (resource.Status, error)
 
-	ReadF   func(urn resource.URN, id resource.ID, props resource.PropertyMap) (resource.PropertyMap, error)
+	ReadF func(urn resource.URN, id resource.ID,
+		props resource.PropertyMap) (resource.PropertyMap, resource.Status, error)
 	InvokeF func(tok tokens.ModuleMember,
 		inputs resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
 }
@@ -129,9 +130,9 @@ func (prov *Provider) Delete(urn resource.URN,
 }
 
 func (prov *Provider) Read(urn resource.URN, id resource.ID,
-	props resource.PropertyMap) (resource.PropertyMap, error) {
+	props resource.PropertyMap) (resource.PropertyMap, resource.Status, error) {
 	if prov.ReadF == nil {
-		return resource.PropertyMap{}, nil
+		return resource.PropertyMap{}, resource.StatusUnknown, nil
 	}
 	return prov.ReadF(urn, id, props)
 }

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -339,8 +339,8 @@ func (r *Registry) Delete(urn resource.URN, id resource.ID, props resource.Prope
 }
 
 func (r *Registry) Read(urn resource.URN, id resource.ID,
-	props resource.PropertyMap) (resource.PropertyMap, error) {
-	return nil, errors.New("provider resources may not be read")
+	props resource.PropertyMap) (resource.PropertyMap, resource.Status, error) {
+	return nil, resource.StatusUnknown, errors.New("provider resources may not be read")
 }
 
 func (r *Registry) Invoke(tok tokens.ModuleMember,

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -111,8 +111,8 @@ func (prov *testProvider) Create(urn resource.URN, props resource.PropertyMap) (
 	return "", nil, resource.StatusOK, errors.New("unsupported")
 }
 func (prov *testProvider) Read(urn resource.URN, id resource.ID,
-	props resource.PropertyMap) (resource.PropertyMap, error) {
-	return nil, errors.New("unsupported")
+	props resource.PropertyMap) (resource.PropertyMap, resource.Status, error) {
+	return nil, resource.StatusUnknown, errors.New("unsupported")
 }
 func (prov *testProvider) Diff(urn resource.URN, id resource.ID,
 	olds resource.PropertyMap, news resource.PropertyMap, _ bool) (plugin.DiffResult, error) {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -257,7 +257,7 @@ func (d *defaultProviders) newRegisterDefaultProviderEvent(
 	// Create the result channel and the event.
 	done := make(chan *RegisterResult)
 	event := &registerResourceEvent{
-		goal: resource.NewGoal(providers.MakeProviderType(pkg), "default", true, inputs, "", false, nil, ""),
+		goal: resource.NewGoal(providers.MakeProviderType(pkg), "default", true, inputs, "", false, nil, "", nil),
 		done: done,
 	}
 	return event, done, nil
@@ -601,7 +601,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 
 	// Send the goal state to the engine.
 	step := &registerResourceEvent{
-		goal: resource.NewGoal(t, name, custom, props, parent, protect, dependencies, provider),
+		goal: resource.NewGoal(t, name, custom, props, parent, protect, dependencies, provider, nil),
 		done: make(chan *RegisterResult),
 	}
 

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -142,16 +142,16 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 		// Register a component resource.
 		&testRegEvent{
 			goal: resource.NewGoal(componentURN.Type(), componentURN.Name(), false, resource.PropertyMap{}, "", false,
-				nil, ""),
+				nil, "", []string{}),
 		},
 		// Register a couple resources using provider A.
 		&testRegEvent{
 			goal: resource.NewGoal("pkgA:index:typA", "res1", true, resource.PropertyMap{}, componentURN, false, nil,
-				providerARef.String()),
+				providerARef.String(), []string{}),
 		},
 		&testRegEvent{
 			goal: resource.NewGoal("pkgA:index:typA", "res2", true, resource.PropertyMap{}, componentURN, false, nil,
-				providerARef.String()),
+				providerARef.String(), []string{}),
 		},
 		// Register two more providers.
 		newProviderEvent("pkgA", "providerB", nil, ""),
@@ -159,11 +159,11 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 		// Register a few resources that use the new providers.
 		&testRegEvent{
 			goal: resource.NewGoal("pkgB:index:typB", "res3", true, resource.PropertyMap{}, "", false, nil,
-				providerBRef.String()),
+				providerBRef.String(), []string{}),
 		},
 		&testRegEvent{
 			goal: resource.NewGoal("pkgB:index:typC", "res4", true, resource.PropertyMap{}, "", false, nil,
-				providerCRef.String()),
+				providerCRef.String(), []string{}),
 		},
 	}
 
@@ -225,21 +225,25 @@ func TestRegisterDefaultProviders(t *testing.T) {
 		// Register a component resource.
 		&testRegEvent{
 			goal: resource.NewGoal(componentURN.Type(), componentURN.Name(), false, resource.PropertyMap{}, "", false,
-				nil, ""),
+				nil, "", []string{}),
 		},
 		// Register a couple resources from package A.
 		&testRegEvent{
-			goal: resource.NewGoal("pkgA:m:typA", "res1", true, resource.PropertyMap{}, componentURN, false, nil, ""),
+			goal: resource.NewGoal("pkgA:m:typA", "res1", true, resource.PropertyMap{},
+				componentURN, false, nil, "", []string{}),
 		},
 		&testRegEvent{
-			goal: resource.NewGoal("pkgA:m:typA", "res2", true, resource.PropertyMap{}, componentURN, false, nil, ""),
+			goal: resource.NewGoal("pkgA:m:typA", "res2", true, resource.PropertyMap{},
+				componentURN, false, nil, "", []string{}),
 		},
 		// Register a few resources from other packages.
 		&testRegEvent{
-			goal: resource.NewGoal("pkgB:m:typB", "res3", true, resource.PropertyMap{}, "", false, nil, ""),
+			goal: resource.NewGoal("pkgB:m:typB", "res3", true, resource.PropertyMap{}, "", false,
+				nil, "", []string{}),
 		},
 		&testRegEvent{
-			goal: resource.NewGoal("pkgB:m:typC", "res4", true, resource.PropertyMap{}, "", false, nil, ""),
+			goal: resource.NewGoal("pkgB:m:typC", "res4", true, resource.PropertyMap{}, "", false,
+				nil, "", []string{}),
 		},
 	}
 

--- a/pkg/resource/deploy/source_refresh_test.go
+++ b/pkg/resource/deploy/source_refresh_test.go
@@ -81,9 +81,9 @@ func TestRefresh(t *testing.T) {
 
 	reads := int32(0)
 	noopProvider := &deploytest.Provider{
-		ReadF: func(resource.URN, resource.ID, resource.PropertyMap) (resource.PropertyMap, error) {
+		ReadF: func(resource.URN, resource.ID, resource.PropertyMap) (resource.PropertyMap, resource.Status, error) {
 			atomic.AddInt32(&reads, 1)
-			return resource.PropertyMap{}, nil
+			return resource.PropertyMap{}, resource.StatusUnknown, nil
 		},
 	}
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -502,7 +502,7 @@ func (sg *stepGenerator) getResourcePropertyStates(urn resource.URN, goal *resou
 	}
 	return props, inputs, outputs,
 		resource.NewState(goal.Type, urn, goal.Custom, false, "",
-			inputs, outputs, goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider)
+			inputs, outputs, goal.Parent, goal.Protect, false, goal.Dependencies, goal.InitErrors, goal.Provider)
 }
 
 // issueCheckErrors prints any check errors to the diagnostics sink.

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -57,7 +57,8 @@ type Provider interface {
 	// Read the current live state associated with a resource.  Enough state must be include in the inputs to uniquely
 	// identify the resource; this is typically just the resource ID, but may also include some properties.  If the
 	// resource is missing (for instance, because it has been deleted), the resulting property map will be nil.
-	Read(urn resource.URN, id resource.ID, props resource.PropertyMap) (resource.PropertyMap, error)
+	Read(urn resource.URN, id resource.ID,
+		props resource.PropertyMap) (resource.PropertyMap, resource.Status, error)
 	// Update updates an existing resource with new values.
 	Update(urn resource.URN, id resource.ID,
 		olds resource.PropertyMap, news resource.PropertyMap) (resource.PropertyMap, resource.Status, error)

--- a/pkg/resource/resource_goal.go
+++ b/pkg/resource/resource_goal.go
@@ -29,11 +29,12 @@ type Goal struct {
 	Protect      bool         // true to protect this resource from deletion.
 	Dependencies []URN        // dependencies of this resource object.
 	Provider     string       // the provider to use for this resource.
+	InitErrors   []string     // errors encountered as we attempted to initialize the resource.
 }
 
 // NewGoal allocates a new resource goal state.
 func NewGoal(t tokens.Type, name tokens.QName, custom bool, props PropertyMap,
-	parent URN, protect bool, dependencies []URN, provider string) *Goal {
+	parent URN, protect bool, dependencies []URN, provider string, initErrors []string) *Goal {
 	return &Goal{
 		Type:         t,
 		Name:         name,
@@ -43,5 +44,6 @@ func NewGoal(t tokens.Type, name tokens.QName, custom bool, props PropertyMap,
 		Protect:      protect,
 		Dependencies: dependencies,
 		Provider:     provider,
+		InitErrors:   initErrors,
 	}
 }


### PR DESCRIPTION
Some time ago, we introduced the concept of the initialization error to
Pulumi (i.e., an error where the resource was successfully created but
failed to fully initialize). This was originally implemented in `Create`
and `Update`  methods of the resource provider interface; when we
detected an initialization failure, we'd pack the live version of the
object into the error, and return that to the engine.

Omitted from this initial implementation was a similar semantics for
`Read`. There are many implications of this, but one of them is that a
`pulumi refresh` will erase any initialization errors that had
previously been observed, even if the initialization errors still exist
in the resource.

This commit will introduce the initialization error semantics to `Read`,
fixing this issue.