### PR TITLE
Pull default options from a resource's parent. 

### DIFF
--- a/sdk/nodejs/invoke.ts
+++ b/sdk/nodejs/invoke.ts
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { ProviderResource } from "./resource";
+import { ComponentResource, ProviderResource } from "./resource";
 
 /*
  * InvokeOptions is a bag of options that control the behavior of a call to runtime.invoke.

--- a/sdk/nodejs/invoke.ts
+++ b/sdk/nodejs/invoke.ts
@@ -19,6 +19,11 @@ import { ProviderResource } from "./resource";
  */
 export interface InvokeOptions {
     /**
+     * An optional parent to use for default options for this invoke (e.g. the default provider to use).
+     */
+    parent?: ComponentResource;
+
+    /**
      * An optional provider to use for this invocation. If no provider is supplied, the default provider for the
      * invoked function's package will be used.
      */

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -69,8 +69,8 @@ export abstract class Resource {
             opts.parent = getRootResource();
         }
 
-        if (opts.parent && !Resource.isInstance(opts.parent)) {
-            throw new RunError(`Resource parent is not a valid Resource: ${opts.parent}`);
+        if (opts.parent && (!Resource.isInstance(opts.parent) || CustomResource.isInstance(opts.parent)) {
+            throw new RunError(`Resource parent is not a valid ComponentResource: ${opts.parent}`);
         }
 
         if (opts.id) {
@@ -102,7 +102,7 @@ export interface ResourceOptions {
     /**
      * An optional parent resource to which this resource belongs.
      */
-    parent?: Resource;
+    parent?: ComponentResource;
     /**
      * An optional additional explicit dependencies on other resources.
      */

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { RunError } from "../errors";
-import { Resource } from "../resource";
+import { ComponentResource } from "../resource";
 import { debuggablePromise } from "./debuggable";
 
 const grpc = require("grpc");
@@ -209,20 +209,20 @@ export function rpcKeepAlive(): () => void {
     return done!;
 }
 
-let rootResource: Resource | undefined;
+let rootResource: ComponentResource | undefined;
 
 /**
  * getRootResource returns a root resource that will automatically become the default parent of all resources.  This
  * can be used to ensure that all resources without explicit parents are parented to a common parent resource.
  */
-export function getRootResource(): Resource | undefined {
+export function getRootResource(): ComponentResource | undefined {
     return rootResource;
 }
 
 /**
  * setRootResource registers a resource that will become the default parent for all resources without explicit parents.
  */
-export function setRootResource(res: Resource | undefined): void {
+export function setRootResource(res: ComponentResource | undefined): void {
     if (rootResource && res) {
         throw new Error("Cannot set multiple root resources");
     }

--- a/sdk/nodejs/tests/runtime/langhost/cases/017.parent_defaults/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/017.parent_defaults/index.js
@@ -1,0 +1,65 @@
+// This tests the creation of ten resources that contains "simple" input and output propeprties.
+// In particular, there aren't any fancy dataflow linked properties.
+
+let assert = require("assert");
+
+let pulumi = require("../../../../../");
+
+class Provider extends pulumi.ProviderResource {
+	constructor(name, opts) {
+		super("test", name, {}, opts);
+	}
+}
+
+class Resource extends pulumi.CustomResource {
+	constructor(name, props, opts) {
+		super("test:index:Resource", name, props, opts)
+	}
+}
+
+class Component extends pulumi.ComponentResource {
+	constructor(name, createChildren, opts) {
+		super("test:index:Component", name, {}, opts);
+
+		createChildren(name, this);
+	}
+}
+
+function createResources(name, parent) {
+	// Use all parent defaults
+	new Resource(`${name}/r0`, {}, { parent: parent });
+
+	// Override protect
+	new Resource(`${name}/r1`, {}, { parent: parent, protect: false });
+	new Resource(`${name}/r2`, {}, { parent: parent, protect: true });
+
+	// Override provider
+	new Resource(`${name}/r3`, {}, { parent: parent, provider: new Provider(`${name}-p`, { parent: parent }) });
+}
+
+function createComponents(name, createChildren, parent) {
+	// Use all parent defaults
+	new Component(`${name}/c0`, createChildren, { parent: parent });
+
+	// Override protect.
+	new Component(`${name}/c1`, createChildren, { parent: parent, protect: false });
+	new Component(`${name}/c2`, createChildren, { parent: parent, protect: true });
+
+	// Override providers.
+	new Component(`${name}/c3`, createChildren, { parent: parent, providers: {} });
+	new Component(`${name}/c4`, createChildren, {
+		parent: parent,
+		providers: { "test": new Provider(`${name}-p`, { parent: parent }) },
+	});
+}
+
+// Create default (unparented) resources
+createResources("unparented");
+
+// Create singly-nested resources
+createComponents("single-nest", createResources);
+
+// Create doubly-nested resources
+createComponents("double-nest", (name, parent) => {
+	createComponents(name, createResources, parent);
+});

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -39,7 +39,8 @@ interface RunCase {
     invoke?: (ctx: any, tok: string, args: any) => { failures: any, ret: any };
     readResource?: (ctx: any, t: string, name: string, id: string, par: string, state: any) => {
         urn: URN | undefined, props: any | undefined };
-    registerResource?: (ctx: any, dryrun: boolean, t: string, name: string, res: any, dependencies?: string[]) => {
+    registerResource?: (ctx: any, dryrun: boolean, t: string, name: string, res: any, dependencies?: string[],
+                        custom?: boolean, protect?: boolean, parent?: string, provider?: string) => {
         urn: URN | undefined, id: ID | undefined, props: any | undefined };
     registerResourceOutputs?: (ctx: any, dryrun: boolean, urn: URN,
                                t: string, name: string, res: any, outputs: any | undefined) => void;
@@ -378,6 +379,57 @@ describe("rpc", () => {
             program: path.join(base, "016.promise_leak"),
             expectError: "Program exited with non-zero exit code: 1",
         },
+        // A test of parent default behaviors.
+        "parent_defaults": {
+            program: path.join(base, "017.parent_defaults"),
+            expectResourceCount: 197,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, dependencies?: string[],
+                               custom?: boolean, protect?: boolean, parent?: string, provider?: string) => {
+
+                if (custom && !t.startsWith("pulumi:providers:")) {
+                    let expectProtect = false;
+                    let expectProviderName = "";
+
+                    const rpath = name.split("/");
+                    for (let i = 1; i < rpath.length; i++) {
+                        switch (rpath[i]) {
+                        case "c0":
+                        case "r0":
+                            // Pass through parent values
+                            break;
+                        case "c1":
+                        case "r1":
+                            // Force protect to false
+                            expectProtect = false;
+                            break;
+                        case "c2":
+                        case "r2":
+                            // Force protect to true
+                            expectProtect = true;
+                            break;
+                        case "c3":
+                            // Force provider to empty
+                            expectProviderName = "";
+                            break;
+                        case "c4":
+                        case "r3":
+                            // Force provider
+                            expectProviderName = `${rpath.slice(0, i).join("/")}-p`;
+                            break;
+                        default:
+                            assert.fail(`unexpected path element in name: ${rpath[i]}`);
+                        }
+                    }
+
+                    const providerName = provider!.split("::").reduce((_, v) => v);
+
+                    assert.strictEqual(protect!, expectProtect);
+                    assert.strictEqual(providerName, expectProviderName);
+                }
+
+                return { urn: makeUrn(t, name), id: name, props: {} };
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {
@@ -432,7 +484,12 @@ describe("rpc", () => {
                                 const name = req.getName();
                                 const res: any = req.getObject().toJavaScript();
                                 const deps: string[] = req.getDependenciesList();
-                                const { urn, id, props } = opts.registerResource(ctx, dryrun, t, name, res, deps);
+                                const custom: boolean = req.getCustom();
+                                const protect: boolean = req.getProtect();
+                                const parent: string = req.getParent();
+                                const provider: string = req.getProvider();
+                                const { urn, id, props } = opts.registerResource(ctx, dryrun, t, name, res, deps,
+                                    custom, protect, parent, provider);
                                 resp.setUrn(urn);
                                 resp.setId(id);
                                 resp.setObject(gstruct.Struct.fromJavaScript(props));


### PR DESCRIPTION
If a resource's options bag does not specify `protect` or `provider`,
pull a default value from the resource's parent.

In order to allow a parent resource to specify providers for multiple
resource types, component resources now accept an optional map from
package name to provider instance. When a custom resource needs a
default provider from its parent, it checks its parent provider bag for
an entry under its package. If a component resource does not have a
provider bag, its pulls a default from its parent.

These changes also add a `parent` field to `InvokeOptions` s.t. calls to
invoke can use the same behavior as resource creation w.r.t. providers.

Fixes #1735, #1736.