### PR TITLE
Make test package versions valid semvers

### DIFF
--- a/tests/integration/config_basic/nodejs/package.json
+++ b/tests/integration/config_basic/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "config_basic_js",
-    "version": "0.9",
+    "version": "0.0.9",
     "license": "Apache-2.0",
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/tests/integration/config_capture_e2e/nodejs/package.json
+++ b/tests/integration/config_capture_e2e/nodejs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "config_basic_js",
-    "version": "0.9",
+    "version": "0.0.9",
     "license": "Apache-2.0",
     "devDependencies": {
         "typescript": "^2.5.3"

--- a/tests/integration/empty/nodejs/package.json
+++ b/tests/integration/empty/nodejs/package.json
@@ -1,7 +1,7 @@
 {
     "name": "emptyjs",
     "license": "Apache-2.0",
-    "version": "0.9",
+    "version": "0.0.9",
     "devDependencies": {
         "typescript": "^2.5.3"
     },


### PR DESCRIPTION
NPM and some other packages (including read-package-json that
@pulumi/pulumi) uses require the version field to be a valid
semver. So ensure ours are.