### PR TITLE
Consider the key name as part of secret detection

### DIFF
--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -33,3 +33,11 @@ func TestPrettyKeyForProject(t *testing.T) {
 	assert.Equal(t, "foo", prettyKeyForProject(config.MustMakeKey("test-package", "foo"), proj))
 	assert.Equal(t, "other-package:bar", prettyKeyForProject(config.MustMakeKey("other-package", "bar"), proj))
 }
+
+func TestSecretDetection(t *testing.T) {
+	assert.True(t, looksLikeSecret(config.MustMakeKey("test", "token"), "1415fc1f4eaeb5e096ee58c1480016638fff29bf"))
+	assert.True(t, looksLikeSecret(config.MustMakeKey("test", "apiToken"), "1415fc1f4eaeb5e096ee58c1480016638fff29bf"))
+
+	// The key name does not match the, so even though this "looks like" a secret, we say it is not.
+	assert.False(t, looksLikeSecret(config.MustMakeKey("test", "okay"), "1415fc1f4eaeb5e096ee58c1480016638fff29bf"))
+}


### PR DESCRIPTION
Many non-secrets are actually pretty high entropy, at least according
to `zxcvbn`. For example: "Hello, Pulumi Timers!" would actually cause
us to say: "this looks like a secret", much in the same way that
"correct horse battery staple" is high entropy according to that
package.

In addition to considering the entropy of the value, gosec (the linter
we copied this logic from) also considers the name of the value that
is being assigned to.

In that spirit, let's only do this check when the config key name
actually looks like it is something we'd want to warn the user about.

We use the same regular expression as `gosec`.

Fixes #1732