### PR TITLE
Don't link to update if operation failed

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -871,34 +871,34 @@ func (b *cloudBackend) updateStack(
 		opts.Display.Color.Colorize(colors.BrightMagenta+"%s stack '%s'"+colors.Reset+"\n"),
 		actionLabel, stack.Name())
 
-	// Create an update object (except if this won't yield an update; i.e., doing a local preview).
+	// Create an update object if we will persist the results, e.g. when not doing a local preview.
 	var update client.UpdateIdentifier
 	var version int
 	var token string
 	var err error
 	if persist {
 		update, version, token, err = b.createAndStartUpdate(ctx, action, stack.Name(), pkg, root, m, opts, dryRun)
-
-		// Print a URL at the end of the update pointing to the Pulumi Service.
-		if err != nil {
-			var link string
-			base := b.cloudConsoleStackPath(update.StackIdentifier)
-			if !dryRun {
-				link = b.CloudConsoleURL(base, "updates", strconv.Itoa(version))
-			} else {
-				link = b.CloudConsoleURL(base, "previews", update.UpdateID)
-			}
-			if link != "" {
-				defer func() {
-					fmt.Printf(
-						opts.Display.Color.Colorize(
-							colors.BrightMagenta+"Permalink: %s"+colors.Reset+"\n"), link)
-				}()
-			}
-		}
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	if persist {
+		// Print a URL at the end of the update pointing to the Pulumi Service.
+		var link string
+		base := b.cloudConsoleStackPath(update.StackIdentifier)
+		if !dryRun {
+			link = b.CloudConsoleURL(base, "updates", strconv.Itoa(version))
+		} else {
+			link = b.CloudConsoleURL(base, "previews", update.UpdateID)
+		}
+		if link != "" {
+			defer func() {
+				fmt.Printf(
+					opts.Display.Color.Colorize(
+						colors.BrightMagenta+"Permalink: %s"+colors.Reset+"\n"), link)
+			}()
+		}
 	}
 
 	return b.runEngineAction(

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -880,19 +880,21 @@ func (b *cloudBackend) updateStack(
 		update, version, token, err = b.createAndStartUpdate(ctx, action, stack.Name(), pkg, root, m, opts, dryRun)
 
 		// Print a URL at the end of the update pointing to the Pulumi Service.
-		var link string
-		base := b.cloudConsoleStackPath(update.StackIdentifier)
-		if !dryRun {
-			link = b.CloudConsoleURL(base, "updates", strconv.Itoa(version))
-		} else {
-			link = b.CloudConsoleURL(base, "previews", update.UpdateID)
-		}
-		if link != "" {
-			defer func() {
-				fmt.Printf(
-					opts.Display.Color.Colorize(
-						colors.BrightMagenta+"Permalink: %s"+colors.Reset+"\n"), link)
-			}()
+		if err != nil {
+			var link string
+			base := b.cloudConsoleStackPath(update.StackIdentifier)
+			if !dryRun {
+				link = b.CloudConsoleURL(base, "updates", strconv.Itoa(version))
+			} else {
+				link = b.CloudConsoleURL(base, "previews", update.UpdateID)
+			}
+			if link != "" {
+				defer func() {
+					fmt.Printf(
+						opts.Display.Color.Colorize(
+							colors.BrightMagenta+"Permalink: %s"+colors.Reset+"\n"), link)
+				}()
+			}
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
#1667 introduced a subtle regression in the CLI, which this PR fixes.
https://github.com/pulumi/pulumi/pull/1667/files#diff-12c2620128294dece07c84633b233225R894

Originally we only printed links to the Pulumi Service if the `version` local variable was not 0, which would be the case for "non-local stacks". Recently this behavior was changed to always print the service link for non-local stacks. Since we assumed the `version` field would always be non-zero. 

However, in the case where `update, version, token, err = b.createAndStartUpdate(...)` returns an error, the information required to create the link would be uninitialized and we'd wind up with bogus links.

This case was handled in the earlier code, checking if `version` was 0, but the newer code prints the link even even though the required data like stack name and version are not provided.

Fixes #1755