### PR TITLE
Emit diagnostics for errors coming from step generation

### DIFF
--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/util/logging"
 )
 
@@ -208,6 +209,9 @@ func (pe *PlanExecutor) handleSingleEvent(event SourceEvent) {
 		if steperr != nil {
 			logging.V(planExecutorLogLevel).Infof(
 				"PlanExecutor.handleSingleEvent(...): received step event error: %v", steperr.Error())
+			goal := e.Goal()
+			urn := pe.plan.generateURN(goal.Parent, goal.Type, goal.Name)
+			pe.plan.Diag().Errorf(diag.RawMessage(urn, steperr.Error()))
 			pe.cancel()
 			return
 		}
@@ -219,6 +223,8 @@ func (pe *PlanExecutor) handleSingleEvent(event SourceEvent) {
 		if steperr != nil {
 			logging.V(planExecutorLogLevel).Infof(
 				"PlanExecutor.handleSingleEvent(...): received step event error: %v", steperr.Error())
+			urn := pe.plan.generateURN(e.Parent(), e.Type(), e.Name())
+			pe.plan.Diag().Errorf(diag.RawMessage(urn, steperr.Error()))
 			pe.cancel()
 			return
 		}


### PR DESCRIPTION
The plan executor assumed that the step generator was responsible for
logging its own diagnostics, which it sort-of is but also doesn't log a
majority of the diagnositcs that come out of it. This commit logs all
errors coming out of step generation so that we don't unintentionally
drop errors.

Fixes https://github.com/pulumi/pulumi/issues/1762.