### PR TITLE
Fix two issues that can cause hangs during refresh

### DIFF
--- a/pkg/resource/deploy/source_refresh.go
+++ b/pkg/resource/deploy/source_refresh.go
@@ -135,7 +135,9 @@ func (iter *refreshSourceIterator) Next() (SourceEvent, error) {
 			iter.lastEventDone = event.done
 			return event, nil
 		}
-		// If the goal was nil, it means the resource was deleted, and we should keep going.
+		// If the goal was nil, it means the resource was deleted, and we should keep going
+		// without waiting.
+		iter.lastEventDone = nil
 	}
 }
 

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -439,7 +439,7 @@ func (p *provider) Read(
 		}
 		// Else it's a `StatusPartialFailure`.
 	} else {
-		id = resource.ID(resp.GetId())
+		readID = resource.ID(resp.GetId())
 		liveObject = resp.GetProperties()
 	}
 


### PR DESCRIPTION
1. 'readID' was never assigned to and was always the default value,
leading the refresh source to believe a resource was deleted
2. The refresh source could hang when a resource is deleted.