### PR TITLE
Log errors coming from the language host

### DIFF
--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -1328,9 +1328,10 @@ func TestLanguageHostDiagnostics(t *testing.T) {
 		}),
 	}
 
+	errorText := "oh no"
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, _ *deploytest.ResourceMonitor) error {
 		// Exiting immediately with an error simulates a language exiting immediately with a non-zero exit code.
-		return errors.New("oh no")
+		return errors.New(errorText)
 	})
 
 	host := deploytest.NewPluginHost(nil, program, loaders...)
@@ -1347,7 +1348,7 @@ func TestLanguageHostDiagnostics(t *testing.T) {
 					if evt.Type == DiagEvent {
 						e := evt.Payload.(DiagEventPayload)
 						msg := colors.Never.Colorize(e.Message)
-						sawExitCode = strings.Contains(msg, "oh no") && e.Severity == diag.Error
+						sawExitCode = strings.Contains(msg, errorText) && e.Severity == diag.Error
 						if sawExitCode {
 							break
 						}

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -120,6 +120,7 @@ outer:
 			if event.Error != nil {
 				logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): saw incoming error: %v", event.Error)
 				pe.cancelDueToError()
+				pe.plan.Diag().Errorf(diag.RawMessage("" /*urn*/, event.Error.Error()))
 				break outer
 			}
 


### PR DESCRIPTION
Similar to pulumi/pulumi#1762, fixes pulumi/pulumi#1775. The language
host can fail without issuing any diagnostics and it is very unclear
what happens if the engine does not log the error.