### PR TITLE
Fix wierd interactions due to Cobra and glog

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -128,10 +128,11 @@
   version = "v1.31.0"
 
 [[projects]]
-  branch = "master"
+  branch = "pulumi-master"
   name = "github.com/golang/glog"
   packages = ["."]
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
+  revision = "7eaa6ffb71e4c94df8bd5d7f4c0404eefc01bd2b"
+  source = "github.com/pulumi/glog"
 
 [[projects]]
   name = "github.com/golang/protobuf"
@@ -577,6 +578,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "54dbb01365a37a74aba07358a4e069c1ae7e9efd3a893e8c2ca6b6d3aea3bfb2"
+  inputs-digest = "71208477393825ddcf9e60bd0a6855758c05f49ec560fd9e5ba6336592a18da0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -6,3 +6,8 @@
 [[constraint]]
   name = "github.com/golang/protobuf"
   version = "v1.1.0"
+
+[[override]]
+  name = "github.com/golang/glog"
+  source = "github.com/pulumi/glog"
+  branch = "pulumi-master"

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"bufio"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -165,12 +164,6 @@ func NewPulumiCmd() *cobra.Command {
 		cmd.PersistentFlags().StringVar(&tracingHeaderFlag, "tracing-header", "",
 			"Include the tracing header with the given contents.")
 	}
-
-	// Tell flag about -C, so someone can do pulumi -C <working-directory> stack and the call to cmdutil.InitLogging
-	// which calls flag.Parse under the hood doesn't yell at you.
-	//
-	// TODO[pulumi/pulumi#301]: when we move away from using glog, it should be safe to remove this.
-	flag.StringVar(&cwd, "C", "", "Run pulumi as if it had been started in another directory")
 
 	return cmd
 }

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -229,7 +229,7 @@ func execPlugin(bin string, pluginArgs []string, pwd string) (*plugin, error) {
 	// Flow the logging information if set.
 	if logging.LogFlow {
 		if logging.LogToStderr {
-			args = append(args, "--logtostderr")
+			args = append(args, "-logtostderr")
 		}
 		if logging.Verbose > 0 {
 			args = append(args, "-v="+strconv.Itoa(logging.Verbose))

--- a/pkg/util/logging/log.go
+++ b/pkg/util/logging/log.go
@@ -71,9 +71,8 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	Verbose = verbose
 	LogFlow = logFlow
 
-	// Ensure the logging library has been initialized, including calling flag.Parse beforehand.  Unfortunately,
-	// this is the only way to control the way logging runs.  That includes poking around at flags below.
-	flag.Parse()
+	// glog uses golang's built in flags package to set configuration values, which is incompatible with how
+	// we use cobra. So we explicitly set the flags we care about here, and don't call flag.Parse()
 	if logToStderr {
 		err := flag.Lookup("logtostderr").Value.Set("true")
 		assertNoError(err)


### PR DESCRIPTION
The glog package force the use of golang's underyling flag package,
which Cobra does not use. To work around this, we had a complicated
dance around defining flags in multiple places, calling flag.Parse
explicitly and then stomping values in the flag package with values we
got from Cobra.

Because we ended up parsing parts of the command line twice, each with
a different set of semantics, we ended up with bad UX in some
cases. For example:

`$ pulumi -v=10 --logflow update`

Would fail with an error message that looked nothing like normal CLI
errors, where as:

`$ pulumi -v=10 update --logflow`

Would behave as you expect. To address this, we now do two things:

- We never call flag.Parse() anymore. Wacking the flags with values we
  got from Cobra is sufficent for what we care about.

- We use a forked copy of glog which does not complain when
  flag.Parse() is not called before logging.

Fixes #301
Fixes #710
Fixes #968