### PR TITLE
Don't try to convert a checkpoint's Latest field if nil

### DIFF
--- a/pkg/apitype/migrate/checkpoint.go
+++ b/pkg/apitype/migrate/checkpoint.go
@@ -28,7 +28,11 @@ func UpToCheckpointV2(v1 apitype.CheckpointV1) apitype.CheckpointV2 {
 		v2.Config[key] = value
 	}
 
-	v2deploy := UpToDeploymentV2(*v1.Latest)
-	v2.Latest = &v2deploy
+	var v2deploy *apitype.DeploymentV2
+	if v1.Latest != nil {
+		deploy := UpToDeploymentV2(*v1.Latest)
+		v2deploy = &deploy
+	}
+	v2.Latest = v2deploy
 	return v2
 }

--- a/pkg/apitype/migrate/checkpoint_test.go
+++ b/pkg/apitype/migrate/checkpoint_test.go
@@ -42,3 +42,19 @@ func TestCheckpointV1ToV2(t *testing.T) {
 	}, v2.Config)
 	assert.Len(t, v2.Latest.Resources, 0)
 }
+
+func TestCheckpointV1ToV2NilLatest(t *testing.T) {
+	v1 := apitype.CheckpointV1{
+		Stack: tokens.QName("mystack"),
+		Config: config.Map{
+			config.MustMakeKey("foo", "number"): config.NewValue("42"),
+		},
+	}
+
+	v2 := UpToCheckpointV2(v1)
+	assert.Equal(t, tokens.QName("mystack"), v2.Stack)
+	assert.Equal(t, config.Map{
+		config.MustMakeKey("foo", "number"): config.NewValue("42"),
+	}, v2.Config)
+	assert.Nil(t, v2.Latest)
+}


### PR DESCRIPTION
Not all checkpoints have a Latest field and it is not guaranteed to be
non-nil. Fixes pulumi/pulumi#1788.