### PR TITLE
Refactor plan execution in preparation for refresh.

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -195,23 +195,16 @@ func (res *planResult) Chdir() (func(), error) {
 // failed, if the error is non-nil; and finally the state of the resource modified in the failing step.
 func (res *planResult) Walk(cancelCtx *Context, events deploy.Events, preview bool) (deploy.PlanSummary, error) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
-	opts := deploy.Options{
-		Events:   events,
-		Parallel: res.Options.Parallel,
-	}
-
-	src, err := res.Plan.Source().Iterate(ctx, opts, res.Plan)
-	if err != nil {
-		cancelFunc()
-		return nil, err
-	}
 
 	done := make(chan bool)
 	var summary deploy.PlanSummary
+	var err error
 	go func() {
-		planExec := deploy.NewPlanExecutor(ctx, res.Plan, opts, preview, src)
-		err = planExec.Execute()
-		summary = planExec.Summary()
+		opts := deploy.Options{
+			Events:   events,
+			Parallel: res.Options.Parallel,
+		}
+		summary, err = res.Plan.Execute(ctx, opts, preview)
 		close(done)
 	}()
 
@@ -219,7 +212,7 @@ func (res *planResult) Walk(cancelCtx *Context, events deploy.Events, preview bo
 	go func() {
 		select {
 		case <-cancelCtx.Cancel.Canceled():
-			// Cancel the plan executor's context, so it begins to shut down.
+			// Cancel the plan's execution context, so it begins to shut down.
 			cancelFunc()
 			cancelErr := res.Plan.SignalCancellation()
 			if cancelErr != nil {

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/golang/glog"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
@@ -214,11 +213,6 @@ func (res *planResult) Walk(cancelCtx *Context, events deploy.Events, preview bo
 		case <-cancelCtx.Cancel.Canceled():
 			// Cancel the plan's execution context, so it begins to shut down.
 			cancelFunc()
-			cancelErr := res.Plan.SignalCancellation()
-			if cancelErr != nil {
-				glog.V(3).Infof("Attempted to signal cancellation to resource providers, but failed: %s",
-					cancelErr.Error())
-			}
 		case <-done:
 			return
 		}

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -260,3 +260,20 @@ func (p *Plan) generateURN(parent resource.URN, ty tokens.Type, name tokens.QNam
 func defaultProviderURN(target *Target, source Source, pkg tokens.Package) resource.URN {
 	return resource.NewURN(target.Name, source.Project(), "", providers.MakeProviderType(pkg), "default")
 }
+
+// generateEventURN generates a URN for the resource associated with the given event.
+func (p *Plan) generateEventURN(event SourceEvent) resource.URN {
+	contract.Require(event != nil, "event != nil")
+
+	switch e := event.(type) {
+	case RegisterResourceEvent:
+		goal := e.Goal()
+		return p.generateURN(goal.Parent, goal.Type, goal.Name)
+	case ReadResourceEvent:
+		return p.generateURN(e.Parent(), e.Type(), e.Name())
+	case RegisterResourceOutputsEvent:
+		return e.URN()
+	default:
+		return ""
+	}
+}

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -288,7 +288,6 @@ func (p *Plan) Execute(ctx context.Context, opts Options, preview bool) (PlanSum
 		return nil, err
 	}
 
-	planExec := NewPlanExecutor(ctx, p, opts, preview, src)
-	err = planExec.Execute()
-	return planExec.Summary(), err
+	planExec := newPlanExecutor(ctx, p, opts, preview, src)
+	return planExec.Execute()
 }

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -15,6 +15,8 @@
 package deploy
 
 import (
+	"context"
+
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -276,4 +278,17 @@ func (p *Plan) generateEventURN(event SourceEvent) resource.URN {
 	default:
 		return ""
 	}
+}
+
+// Execute executes a plan to completion, using the given cancellation context and running a preview
+// or update.
+func (p *Plan) Execute(ctx context.Context, opts Options, preview bool) (PlanSummary, error) {
+	src, err := p.source.Iterate(ctx, opts, p)
+	if err != nil {
+		return nil, err
+	}
+
+	planExec := NewPlanExecutor(ctx, p, opts, preview, src)
+	err = planExec.Execute()
+	return planExec.Summary(), err
 }

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -237,10 +237,6 @@ func (p *Plan) Olds() map[resource.URN]*resource.State { return p.olds }
 func (p *Plan) Source() Source                         { return p.source }
 func (p *Plan) IsRefresh() bool                        { return p.source.IsRefresh() }
 
-func (p *Plan) SignalCancellation() error {
-	return p.ctx.Host.SignalCancellation()
-}
-
 func (p *Plan) GetProvider(ref providers.Reference) (plugin.Provider, bool) {
 	return p.providers.GetProvider(ref)
 }
@@ -283,11 +279,6 @@ func (p *Plan) generateEventURN(event SourceEvent) resource.URN {
 // Execute executes a plan to completion, using the given cancellation context and running a preview
 // or update.
 func (p *Plan) Execute(ctx context.Context, opts Options, preview bool) (PlanSummary, error) {
-	src, err := p.source.Iterate(ctx, opts, p)
-	if err != nil {
-		return nil, err
-	}
-
-	planExec := newPlanExecutor(ctx, p, opts, preview, src)
-	return planExec.Execute()
+	planExec := &planExecutor{plan: p}
+	return planExec.Execute(ctx, opts, preview)
 }

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -16,10 +16,9 @@ package deploy
 
 import (
 	"context"
-	"sync/atomic"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/logging"
 )
 
@@ -28,25 +27,13 @@ const (
 	planExecutorLogLevel = 4
 )
 
-var (
-	// ErrPreviewFailed is returned whenever a preview fails.
-	ErrPreviewFailed = errors.New("preview failed")
-
-	// ErrUpdateFailed is returned whenever an update fails.
-	ErrUpdateFailed = errors.New("update failed")
-
-	// ErrCanceled is returned whenever a plan is canceled.
-	ErrCanceled = errors.New("plan canceled")
-)
-
 // PlanExecutor is responsible for taking a plan and driving it to completion.
 // Its primary responsibility is to own a `stepGenerator` and `stepExecutor`, serving
 // as the glue that links the two subsystems together.
 type PlanExecutor struct {
-	plan    *Plan          // The plan that we are executing
-	opts    Options        // Options for the plan execution
-	src     SourceIterator // The iterator that generates SourceEvents
-	preview bool           // are we running a preview?
+	plan *Plan          // The plan that we are executing
+	opts Options        // Options for the plan execution
+	src  SourceIterator // The iterator that generates SourceEvents
 
 	stepGen  *stepGenerator // step generator owned by this plan
 	stepExec *stepExecutor  // step executor owned by this plan
@@ -54,48 +41,26 @@ type PlanExecutor struct {
 	parentCtx context.Context    // cancellation context for the current CLI session.
 	ctx       context.Context    // cancellation context for the current plan. Child of parentCtx.
 	cancel    context.CancelFunc // CancelFunc that cancels the above context.
-
-	sawError  atomic.Value // have we seen an error?
-	sawCancel atomic.Value // have we seen a cancel?
 }
 
 // Execute executes a plan to completion, using the given cancellation context and running a preview
 // or update.
 func (pe *PlanExecutor) Execute() error {
-	// Before heading into the main event loop, we launch two goroutines. The first one links
-	// the parent cancellation context (which signals cancellation from the CLI level, i.e. Ctrl+C)
-	// to the cancellation context that the plan executor shares with its step executor. This ensures
-	// that top-level cancellations result in quick teardown of all worker threads and the plan executor
-	// itself.
-	go func() {
-		// Note that there's a bug here in that it's a little nondeterministic what happens here when
-		// the cancel signal is sent. Which arm of this select that is selected depends on the Go runtime
-		// and so it's possible that we'll issue a bad error message.
-		//
-		// TODO[pulumi/pulumi#1712] - The plan executor doesn't really need to know about ctrl-c cancellation
-		// at all so it would be nice to lift this into Plan.Walk or something higher up the stack.
-		select {
-		case <-pe.parentCtx.Done():
-			logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): received cancel signal")
-			pe.sawCancel.Store(true)
-		case <-pe.ctx.Done():
-			logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): cancel goroutine exiting")
-		}
-	}()
-
-	// The second one polls for incoming source events and writes them to the `incomingEvents` channel,
-	// so the man loop can `select` on it.
+	// We iterate the source in its own goroutine because iteration is blocking and we want the main loop to be able to
+	// respond to cancellation requests promptly.
 	type nextEvent struct {
 		Event SourceEvent
 		Error error
 	}
-
 	incomingEvents := make(chan nextEvent)
 	go func() {
 		for {
 			event, sourceErr := pe.src.Next()
 			select {
 			case incomingEvents <- nextEvent{event, sourceErr}:
+				if event == nil {
+					return
+				}
 			case <-pe.ctx.Done():
 				logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): incoming events goroutine exiting")
 				return
@@ -111,65 +76,50 @@ func (pe *PlanExecutor) Execute() error {
 	//     should bail.
 	//  3. The stepExecCancel cancel context gets canceled. This means some error occurred in the step executor
 	//     and we need to bail. This can also happen if the user hits Ctrl-C.
-outer:
-	for {
-		logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): waiting for incoming events")
-		select {
-		case event := <-incomingEvents:
-			logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): incoming event")
-			if event.Error != nil {
-				logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): saw incoming error: %v", event.Error)
-				pe.cancelDueToError()
-				pe.plan.Diag().Errorf(diag.RawMessage("" /*urn*/, event.Error.Error()))
-				break outer
+	err := func() error {
+		for {
+			logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): waiting for incoming events")
+			select {
+			case event := <-incomingEvents:
+				logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): incoming event (nil? %v, %v)",
+					event.Event == nil, event.Error)
+
+				if event.Error != nil {
+					logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): saw incoming error: %v", event.Error)
+					pe.cancel()
+					pe.plan.Diag().Errorf(diag.RawMessage("" /*urn*/, event.Error.Error()))
+					return event.Error
+				}
+				if event.Event == nil {
+					// TODO[pulumi/pulumi#1625] Today we lack the ability to parallelize deletions. We have all the
+					// information we need to do so (namely, a dependency graph). `GenerateDeletes` returns a single
+					// chain of every delete that needs to be executed.
+					deletes := pe.stepGen.GenerateDeletes()
+					pe.stepExec.Execute(deletes)
+
+					// Signal completion to the step executor. It'll exit once it's done retiring all of the steps in
+					// the chain that we just gave it.
+					pe.stepExec.SignalCompletion()
+					logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): issued deletes, exiting loop")
+
+					return nil
+				}
+				pe.handleSingleEvent(event.Event)
+			case <-pe.ctx.Done():
+				logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): context finished: %v", pe.ctx.Err())
+				return pe.ctx.Err()
 			}
-
-			if event.Event == nil {
-				logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): saw nil event, beginning termination")
-
-				// TODO[pulumi/pulumi#1625] Today we lack the ability to parallelize deletions. We have all the
-				// information we need to do so (namely, a dependency graph). `GenerateDeletes` returns a single
-				// chain of every delete that needs to be executed.
-				deletes := pe.stepGen.GenerateDeletes()
-				pe.stepExec.Execute(deletes)
-
-				// Signal completion to the step executor. It'll exit once it's done retiring all of the steps in
-				// the chain that we just gave it.
-				pe.stepExec.SignalCompletion()
-				logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): completed deletes, exiting loop")
-				break outer
-			}
-
-			pe.handleSingleEvent(event.Event)
-		case <-pe.ctx.Done():
-			logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): context canceled")
-			pe.cancelDueToError()
-			break outer
 		}
-	}
+	}()
 
-	logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): exited event loop, waiting for completion")
 	pe.stepExec.WaitForCompletion()
 	logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): step executor has completed")
 
-	// To provide the best error message we can, we've kept track of whether or not we were successful and, if we
-	// were not, if we failed because of a cancel or because the step executor died.
-	if pe.canceled() {
-		logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): observed that the plan was canceled")
-		return ErrCanceled
+	if err == nil && pe.stepExec.Errored() {
+		err = errStepApplyFailed
 	}
 
-	if pe.errored() {
-		logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): observed that the plan errored")
-		if pe.preview {
-			return ErrPreviewFailed
-		}
-
-		return ErrUpdateFailed
-	}
-
-	logging.V(planExecutorLogLevel).Infof("PlanExecutor.Execute(...): observed that the plan was successful")
-	return nil
+	return err
 }
 
 // Summary returns a PlanSummary of the plan that was executed.
@@ -177,31 +127,10 @@ func (pe *PlanExecutor) Summary() PlanSummary {
 	return pe.stepGen
 }
 
-// errored returns whether or not this plan failed due to an error in step application.
-func (pe *PlanExecutor) errored() bool {
-	return pe.sawError.Load().(bool) || pe.stepExec.Errored()
-}
-
-// canceled returns whether or not this plan failed because it was canceled through Ctrl-C.
-func (pe *PlanExecutor) canceled() bool {
-	return pe.sawCancel.Load().(bool)
-}
-
-// cancelDueToError cancels the step executor and signals shutdown because the plan executor witnessed
-// an error that the step executor would not have witnessed. The main reason this happens is because of errors
-// occurring in the source program that can't be translated into chains for the step executor to execute.
-func (pe *PlanExecutor) cancelDueToError() {
-	pe.sawError.Store(true)
-	pe.cancel()
-}
-
 // handleSingleEvent handles a single source event. For all incoming events, it produces a chain that needs
 // to be executed and schedules the chain for execution.
 func (pe *PlanExecutor) handleSingleEvent(event SourceEvent) {
-	if event == nil {
-		logging.V(planExecutorLogLevel).Infof("PlanExecutor.handleSingleEvent(...): received nil event")
-		return
-	}
+	contract.Require(event != nil, "event != nil")
 
 	logging.V(planExecutorLogLevel).Infof("PlanExecutor.handleSingleEvent(...): received event")
 	switch e := event.(type) {
@@ -246,15 +175,11 @@ func NewPlanExecutor(parentCtx context.Context, plan *Plan, opts Options,
 		plan:      plan,
 		opts:      opts,
 		src:       src,
-		preview:   preview,
 		stepGen:   newStepGenerator(plan, opts),
 		stepExec:  newStepExecutor(ctx, cancel, plan, opts, preview),
 		parentCtx: parentCtx,
 		ctx:       ctx,
 		cancel:    cancel,
 	}
-
-	pe.sawError.Store(false)
-	pe.sawCancel.Store(false)
 	return pe
 }

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -96,7 +96,7 @@ func (pe *planExecutor) Execute(parentCtx context.Context, opts Options, preview
 				if event == nil {
 					return
 				}
-			case <-ctx.Done():
+			case <-done:
 				log.Infof("planExecutor.Execute(...): incoming events goroutine exiting")
 				return
 			}

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -139,7 +139,7 @@ func (pe *planExecutor) Execute(parentCtx context.Context, opts Options, preview
 				}
 			case <-ctx.Done():
 				logging.V(planExecutorLogLevel).Infof("planExecutor.Execute(...): context finished: %v", ctx.Err())
-				return ctx.Err()
+				return nil
 			}
 		}
 	}()


### PR DESCRIPTION
These changes simplify a couple aspects of plan execution in the hopes of
clarifying some responsibilities and preparing the code for changes to the
implementation of refresh.

1. All aspects of plan execution are now managed by the plan executor,
   which is no longer exported. Instead, it is abstracted behind
   `Plan.Execute`.
2. The plan executor's error-handling and reporting have been unified
   and simplified somewhat.