### PR TITLE
Properly capture modules that are in a non-local node_modules path.

### DIFF
--- a/tests/integration/config_capture_e2e/nodejs/index.ts
+++ b/tests/integration/config_capture_e2e/nodejs/index.ts
@@ -31,9 +31,12 @@ function tempDirName(prefix: string) {
     const outsideDir = path.join(os.tmpdir(), tempDirName("outside"));
     const insideDir = path.join(os.tmpdir(), tempDirName("inside"));
 
-
     fs.mkdirSync(outsideDir);
     fs.mkdirSync(insideDir);
+
+    const nodeModulesPath = path.join(process.cwd(), "node_modules");
+    fs.symlinkSync(nodeModulesPath, outsideDir + "/node_modules");
+    fs.symlinkSync(nodeModulesPath, insideDir + "/node_modules");
 
     fs.writeFileSync(path.join(outsideDir, "index.js"), outsideCapture.text);
     fs.writeFileSync(path.join(insideDir, "index.js"), insideCapture.text);

--- a/tests/integration/config_capture_e2e/nodejs/package.json
+++ b/tests/integration/config_capture_e2e/nodejs/package.json
@@ -2,6 +2,10 @@
     "name": "config_basic_js",
     "version": "0.0.9",
     "license": "Apache-2.0",
+    "main": "bin/index.js",
+    "scripts": {
+        "build": "tsc"
+    },
     "devDependencies": {
         "typescript": "^2.5.3"
     },

--- a/tests/integration/config_capture_e2e/nodejs/tsconfig.json
+++ b/tests/integration/config_capture_e2e/nodejs/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}
+


### PR DESCRIPTION
This occurs locally when we yarn link packages.  Because of the linking, node may often say that some referenced module is in a path like `./../../../opt/pulumi/node_modules/@pulumi/etc.`  In this case, we do not want to capture this module 'by value'.  we want to capture it as `require("@pulumi/etc")`.