### PR TITLE
Avoid prompting for project name or description when not needed

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -143,7 +143,9 @@ func newNewCmd() *cobra.Command {
 			}
 
 			// Show instructions, if we're going to show at least one prompt.
-			hasAtLeastOnePrompt := (name == "") || (description == "") || !generateOnly
+			hasAtLeastOnePrompt := (template.ProjectNameNeedsReplacement() && name == "") ||
+				(template.ProjectDescriptionNeedsReplacement() && description == "") ||
+				!generateOnly
 			if !yes && hasAtLeastOnePrompt {
 				fmt.Println("This command will walk you through creating a new Pulumi project.")
 				fmt.Println()
@@ -151,8 +153,8 @@ func newNewCmd() *cobra.Command {
 				fmt.Println("Press ^C at any time to quit.")
 			}
 
-			// Prompt for the project name, if it wasn't already specified.
-			if name == "" {
+			// Prompt for the project name, if it needs replacement and it wasn't already specified.
+			if template.ProjectNameNeedsReplacement() && name == "" {
 				defaultValue := workspace.ValueOrSanitizedDefaultProjectName(name, filepath.Base(cwd))
 				name, err = promptForValue(yes, "project name", defaultValue, false, workspace.IsValidProjectName, displayOpts)
 				if err != nil {
@@ -160,8 +162,13 @@ func newNewCmd() *cobra.Command {
 				}
 			}
 
-			// Prompt for the project description, if it wasn't already specified.
-			if description == "" {
+			// At this point, if the name is empty, use the existing project name.
+			if name == "" {
+				name = template.ProjectName
+			}
+
+			// Prompt for the project description, if it needs replacement and it wasn't already specified.
+			if template.ProjectDescriptionNeedsReplacement() && description == "" {
 				defaultValue := workspace.ValueOrDefaultProjectDescription(description, template.Description)
 				description, err = promptForValue(yes, "project description", defaultValue, false, nil, displayOpts)
 				if err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -127,11 +127,11 @@ func newUpCmd() *cobra.Command {
 
 		// Cleanup the project name/description if needed.
 		projectName := template.ProjectName
-		if projectName == "${PROJECT}" {
+		if template.ProjectNameNeedsReplacement() {
 			projectName = workspace.ValueOrSanitizedDefaultProjectName(projectName, template.Name)
 		}
 		projectDescription := template.ProjectDescription
-		if projectDescription == "${DESCRIPTION}" {
+		if template.ProjectDescriptionNeedsReplacement() {
 			projectDescription = ""
 		}
 

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -124,6 +124,16 @@ type Template struct {
 	ProjectDescription string // Optional description of the project.
 }
 
+// ProjectNameNeedsReplacement returns true of ProjectName is "${PROJECT}".
+func (template Template) ProjectNameNeedsReplacement() bool {
+	return template.ProjectName == "${PROJECT}"
+}
+
+// ProjectDescriptionNeedsReplacement returns true of ProjectDescription is "${DESCRIPTION}".
+func (template Template) ProjectDescriptionNeedsReplacement() bool {
+	return template.ProjectDescription == "${DESCRIPTION}"
+}
+
 // cleanupLegacyTemplateDir deletes an existing ~/.pulumi/templates directory if it isn't a git repository.
 func cleanupLegacyTemplateDir() error {
 	templateDir, err := GetTemplateDir()


### PR DESCRIPTION
Avoid prompting for the project name/description when using `new` with examples or apps that already have those values specified in Pulumi.yaml.

Fixes #1776