### PR TITLE
Emit export at the end-of-file for factory functions.

### DIFF
--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -145,15 +145,14 @@ function serializeJavaScriptText(
     // the module function we created by serializing it.  For a factory function this will export
     // the function produced by invoking the factory function once.
     let text: string;
+    const exportText = `exports.${exportName} = ${outerFunctionName}${isFactoryFunction ? "()" : ""};`;
     if (isFactoryFunction) {
         // for a factory function, we need to call the function at the end.  That way all the logic
         // to set up the environment has run.
-        text = environmentText + functionText + "\n" +
-            `exports.${exportName} = ${outerFunctionName}${isFactoryFunction ? "()" : ""};`;
+        text = environmentText + functionText + "\n" + exportText;
     }
     else {
-        text = `exports.${exportName} = ${outerFunctionName}${isFactoryFunction ? "()" : ""};\n`
-            + environmentText + functionText;
+        text = exportText + "\n" + environmentText + functionText;
     }
 
     return {

--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -144,8 +144,17 @@ function serializeJavaScriptText(
     // Export the appropriate value.  For a normal function, this will just be exporting the name of
     // the module function we created by serializing it.  For a factory function this will export
     // the function produced by invoking the factory function once.
-    const text = `exports.${exportName} = ${outerFunctionName}${isFactoryFunction ? "()" : ""};\n`
-        + environmentText + functionText;
+    let text: string;
+    if (isFactoryFunction) {
+        // for a factory function, we need to call the function at the end.  That way all the logic
+        // to set up the environment has run.
+        text = environmentText + functionText + "\n" +
+            `exports.${exportName} = ${outerFunctionName}${isFactoryFunction ? "()" : ""};`;
+    }
+    else {
+        text = `exports.${exportName} = ${outerFunctionName}${isFactoryFunction ? "()" : ""};\n`
+            + environmentText + functionText;
+    }
 
     return {
         text: text,

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -5058,8 +5058,7 @@ return function () { const v = new pulumi.Config("test").get("TestingKey2"); con
                     serverlessExpress.proxy(server, event, context);
                 };
             },
-            expectText: `exports.handler = __f0();
-
+            expectText: `
 function __f0() {
   return (function() {
     with({  }) {
@@ -5080,7 +5079,80 @@ return () => {
     }
   }).apply(undefined, undefined).apply(this, arguments);
 }
-`,
+
+exports.handler = __f0();`,
+        });
+    }
+
+    {
+        const outerVal = [{}];
+        (<any>outerVal[0]).inner = outerVal;
+
+        function foo() {
+            outerVal.pop();
+        }
+
+        function bar() {
+            outerVal.join();
+        }
+
+        cases.push({
+            title: "Capture factory func #2",
+            factoryFunc: () => {
+                outerVal.push({});
+                foo();
+
+                return (event: any, context: any) => {
+                    bar();
+                };
+            },
+            expectText: `
+var __outerVal = [];
+var __outerVal_0 = {};
+__outerVal_0.inner = __outerVal;
+__outerVal[0] = __outerVal_0;
+
+function __foo() {
+  return (function() {
+    with({ outerVal: __outerVal, foo: __foo }) {
+
+return function /*foo*/() {
+            outerVal.pop();
+        };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __bar() {
+  return (function() {
+    with({ outerVal: __outerVal, bar: __bar }) {
+
+return function /*bar*/() {
+            outerVal.join();
+        };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f0() {
+  return (function() {
+    with({ outerVal: __outerVal, foo: __foo, bar: __bar }) {
+
+return () => {
+                outerVal.push({});
+                foo();
+                return (event, context) => {
+                    bar();
+                };
+            };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+exports.handler = __f0();`,
         });
     }
 


### PR DESCRIPTION
This is necessary for correct semantics.  We should only execute the factory function once we've initialized the memory graph.