### PR TITLE
Don't use :config: token when sending values to the service

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -305,14 +305,14 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 
 func parseConfigKey(key string) (config.Key, error) {
 	// As a convience, we'll treat any key with no delimiter as if:
-	// <program-name>:config:<key> had been written instead
+	// <program-name>:<key> had been written instead
 	if !strings.Contains(key, tokens.TokenDelimiter) {
 		proj, err := workspace.DetectProject()
 		if err != nil {
 			return config.Key{}, err
 		}
 
-		return config.ParseKey(fmt.Sprintf("%s:config:%s", proj.Name, key))
+		return config.ParseKey(fmt.Sprintf("%s:%s", proj.Name, key))
 	}
 
 	return config.ParseKey(key)

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -341,7 +341,7 @@ func (pc *Client) CreateUpdate(
 		v, err := cv.Value(config.NopDecrypter)
 		contract.AssertNoError(err)
 
-		wireConfig[k.Namespace()+":config:"+k.Name()] = apitype.ConfigValue{
+		wireConfig[k.String()] = apitype.ConfigValue{
 			String: v,
 			Secret: cv.Secure(),
 		}


### PR DESCRIPTION
The fact that we include the `:config:` portion of a configuration
name when sending to the service is an artifact of history. It was
needed back when we needed to support deploying using a new CLI
against a PPC that had older packages embeded in it.

We don't have that sort of problem anymore, so we can stop sending
this data.