### PR TITLE
Show a better error message when decrypting fails

### DIFF
--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -60,11 +60,10 @@ use 'pulumi stack import' to import the repaired stack.`)
 func printDecryptError(e engine.DecryptError) {
 	var buf bytes.Buffer
 	writer := bufio.NewWriter(&buf)
-	fprintf(writer, "failed to decrypt encrypted configuration key '%s': %s", e.Key, e.Err.Error())
+	fprintf(writer, "failed to decrypt encrypted configuration value '%s': %s", e.Key, e.Err.Error())
 	fprintf(writer, `
-This most commonly occurs when using a secret encrypted by a stack and then using the encrypted
-configuration in another stack. Configuration encryption is done per-stack and it is not possible
-for another stack to decrypt a stack's encrypted configuration.
+This can occur when a secret is copied from one stack to another. Encryption of secrets is done per-stack and
+it is not possible to share an encrypted configuration value across stacks.
 
 You can re-encrypt your configuration buy running 'pulumi config set %s [value] --secret' with your
 new stack selected.`, e.Key)

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/pulumi/pulumi/pkg/diag"
+	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -22,6 +23,9 @@ func PrintEngineError(err error) error {
 	switch e := err.(type) {
 	case deploy.PlanPendingOperationsError:
 		printPendingOperationsError(e)
+		return fmt.Errorf("refusing to proceed")
+	case engine.DecryptError:
+		printDecryptError(e)
 		return fmt.Errorf("refusing to proceed")
 	default:
 		return err
@@ -50,6 +54,21 @@ remove that operation from the "pending_operations" section of the file. Once th
 use 'pulumi stack import' to import the repaired stack.`)
 	contract.IgnoreError(writer.Flush())
 
+	cmdutil.Diag().Errorf(diag.RawMessage("" /*urn*/, buf.String()))
+}
+
+func printDecryptError(e engine.DecryptError) {
+	var buf bytes.Buffer
+	writer := bufio.NewWriter(&buf)
+	fprintf(writer, "failed to decrypt encrypted configuration key '%s': %s", e.Key, e.Err.Error())
+	fprintf(writer, `
+This most commonly occurs when using a secret encrypted by a stack and then using the encrypted
+configuration in another stack. Configuration encryption is done per-stack and it is not possible
+for another stack to decrypt a stack's encrypted configuration.
+
+You can re-encrypt your configuration buy running 'pulumi config set %s [value] --secret' with your
+new stack selected.`, e.Key)
+	contract.IgnoreError(writer.Flush())
 	cmdutil.Diag().Errorf(diag.RawMessage("" /*urn*/, buf.String()))
 }
 

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -33,7 +33,10 @@ func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 	}
 	defer info.Close()
 
-	emitter := makeEventEmitter(ctx.Events, u)
+	emitter, err := makeEventEmitter(ctx.Events, u)
+	if err != nil {
+		return nil, err
+	}
 	return update(ctx, info, planOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newDestroySource,

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -1,0 +1,40 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/resource/config"
+)
+
+//
+// This file contains type definitions for errors that can arise in the engine that the CLI layer would
+// like to provide high-quality diagnostics for. cmd/errors.go is aware of these events and will use them
+// and the data within them to provide long-form diagnostics that are inappropriate to be done in the Error()
+// implementation of these types.
+//
+
+// DecryptError is the type of errors that arise when the engine can't decrypt a configuration key.
+// The most common reason why this happens is that this key is being decrypted in a stack that's not the same
+// one that encrypted it.
+type DecryptError struct {
+	Key config.Key // The configuration key whose value couldn't be decrypted
+	Err error      // The error that occured while decrypting
+}
+
+func (d DecryptError) Error() string {
+	return fmt.Sprintf("failed to decrypt configuration key '%s': %s", d.Key, d.Err.Error())
+}

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -32,7 +32,7 @@ import (
 // one that encrypted it.
 type DecryptError struct {
 	Key config.Key // The configuration key whose value couldn't be decrypted
-	Err error      // The error that occured while decrypting
+	Err error      // The error that occurred while decrypting
 }
 
 func (d DecryptError) Error() string {

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -33,7 +33,10 @@ func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 	}
 	defer info.Close()
 
-	emitter := makeEventEmitter(ctx.Events, u)
+	emitter, err := makeEventEmitter(ctx.Events, u)
+	if err != nil {
+		return nil, err
+	}
 	return update(ctx, info, planOptions{
 		UpdateOptions: opts,
 		SkipOutputs:   true, // refresh is exclusively about outputs

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -77,7 +77,10 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resour
 	}
 	defer info.Close()
 
-	emitter := makeEventEmitter(ctx.Events, u)
+	emitter, err := makeEventEmitter(ctx.Events, u)
+	if err != nil {
+		return nil, err
+	}
 	return update(ctx, info, planOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newUpdateSource,


### PR DESCRIPTION
It is most often the case that failing to decrypt a secret implies that
the secret was transferred from one stack to another via copying the
configuration. This commit introduces a better error message for this
case and instructs users to explicitly re-encrypt their encrypted keys
in the context of the new stack.

Fixes https://github.com/pulumi/pulumi/issues/1763.
![screen shot 2018-08-22 at 11 39 22 am](https://user-images.githubusercontent.com/1871912/44483461-093cf200-a600-11e8-958e-5b134f143765.png)
