### PR TITLE
Indent stack outputs by 1.

### DIFF
--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -702,19 +702,17 @@ func (display *ProgressDisplay) processEndSteps() {
 		}
 	}
 
-	// If we're not previewing, and we get stack outputs, then display them at the end.
-	if !display.isPreview {
-		if display.stackUrn != "" {
-			stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
-			props := engine.GetResourceOutputsPropertiesString(stackStep, 0, false, display.opts.Debug)
-			if props != "" {
-				if !wroteDiagnosticHeader {
-					display.writeBlankLine()
-				}
-
-				wroteDiagnosticHeader = true
-				display.writeSimpleMessage(props)
+	// If we get stack outputs, display them at the end.
+	if display.stackUrn != "" {
+		stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
+		props := engine.GetResourceOutputsPropertiesString(stackStep, 1, display.isPreview, display.opts.Debug)
+		if props != "" {
+			if !wroteDiagnosticHeader {
+				display.writeBlankLine()
 			}
+
+			wroteDiagnosticHeader = true
+			display.writeSimpleMessage(props)
 		}
 	}
 

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -252,10 +252,16 @@ func GetResourceOutputsPropertiesString(
 		outputDiff = step.Old.Outputs.Diff(outs)
 	}
 
+	var keys []resource.PropertyKey
+	if outputDiff == nil {
+		keys = outs.StableKeys()
+	} else {
+		keys = outputDiff.Keys()
+	}
+	maxkey := maxKey(keys)
+
 	// Now sort the keys and enumerate each output property in a deterministic order.
 	firstout := true
-	keys := outs.StableKeys()
-	maxkey := maxKey(keys)
 	for _, k := range keys {
 		out := outs[k]
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -187,8 +187,8 @@ func TestStackOutputsDisplayed(t *testing.T) {
 			output := stdout.String()
 
 			// ensure we get the --outputs:-- info both for the normal update, and for the no-change update.
-			assert.Contains(t, output, "---outputs:---\nfoo: 42\nxyz: \"ABC\"\n\ninfo: 1 change performed")
-			assert.Contains(t, output, "---outputs:---\nfoo: 42\nxyz: \"ABC\"\n\ninfo: no changes required")
+			assert.Contains(t, output, "---outputs:---\n    foo: 42\n    xyz: \"ABC\"\n\ninfo: 1 change performed")
+			assert.Contains(t, output, "---outputs:---\n    foo: 42\n    xyz: \"ABC\"\n\ninfo: no changes required")
 		},
 	})
 }


### PR DESCRIPTION
Also:
- Show stack output diffs during preview
- Fix a bug where deletes in stack outputs were not displayed

Fixes #1821.