### PR TITLE
Improve UX for partial failures

### DIFF
--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -231,6 +231,11 @@ func printObject(
 // there is an old snapshot of the resource, differ from the prior old snapshot's output properties.
 func GetResourceOutputsPropertiesString(
 	step StepEventMetadata, indent int, planning bool, debug bool) string {
+	// Resources that have initialization errors did not successfully complete, and therefore do not
+	// have outputs to render diffs for. So, simply return.
+	if step.Old != nil && len(step.Old.InitErrors) > 0 {
+		return ""
+	}
 
 	b := &bytes.Buffer{}
 

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -137,6 +137,9 @@ type StepEventStateMetadata struct {
 	Outputs resource.PropertyMap
 	// the resource's provider reference
 	Provider string
+	// InitErrors is the set of errors encountered in the process of initializing resource (i.e.,
+	// during create or update).
+	InitErrors []string
 }
 
 func makeEventEmitter(events chan<- Event, update UpdateInfo) (eventEmitter, error) {
@@ -199,16 +202,17 @@ func makeStepEventStateMetadata(state *resource.State, debug bool) *StepEventSta
 	}
 
 	return &StepEventStateMetadata{
-		Type:     state.Type,
-		URN:      state.URN,
-		Custom:   state.Custom,
-		Delete:   state.Delete,
-		ID:       state.ID,
-		Parent:   state.Parent,
-		Protect:  state.Protect,
-		Inputs:   filterPropertyMap(state.Inputs, debug),
-		Outputs:  filterPropertyMap(state.Outputs, debug),
-		Provider: state.Provider,
+		Type:       state.Type,
+		URN:        state.URN,
+		Custom:     state.Custom,
+		Delete:     state.Delete,
+		ID:         state.ID,
+		Parent:     state.Parent,
+		Protect:    state.Protect,
+		Inputs:     filterPropertyMap(state.Inputs, debug),
+		Outputs:    filterPropertyMap(state.Outputs, debug),
+		Provider:   state.Provider,
+		InitErrors: state.InitErrors,
 	}
 }
 

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -15,16 +15,13 @@
 package engine
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"sync"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
-	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
@@ -276,21 +273,6 @@ func (acts *planActions) OnResourceStepPre(step deploy.Step) (interface{}, error
 	}
 
 	acts.Opts.Events.resourcePreEvent(step, true /*planning*/, acts.Opts.Debug)
-
-	// Warn the user if they're not updating a resource whose initialization failed.
-	if step.Op() == deploy.OpSame && len(step.Old().InitErrors) > 0 {
-		indent := "         "
-
-		// TODO: Move indentation to the display logic, instead of doing it ourselves.
-		var warning bytes.Buffer
-		warning.WriteString("This resource failed to initialize in a previous deployment. It is recommended\n")
-		warning.WriteString(indent + "to update it to fix these issues:\n")
-		for i, err := range step.Old().InitErrors {
-			warning.WriteString(colors.SpecImportant + indent + fmt.Sprintf("  - Problem #%d", i+1) +
-				colors.Reset + " " + err + "\n")
-		}
-		acts.Opts.Diag.Warningf(diag.RawMessage(step.URN(), warning.String()))
-	}
 
 	return nil, nil
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -15,15 +15,12 @@
 package engine
 
 import (
-	"bytes"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/blang/semver"
 
 	"github.com/pulumi/pulumi/pkg/diag"
-	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
@@ -212,21 +209,6 @@ func (acts *updateActions) OnResourceStepPre(step deploy.Step) (interface{}, err
 	// Check for a default provider step and skip reporting if necessary.
 	if acts.Opts.reportDefaultProviderSteps || !isDefaultProviderStep(step) {
 		acts.Opts.Events.resourcePreEvent(step, false /*planning*/, acts.Opts.Debug)
-
-		// Warn the user if they're not updating a resource whose initialization failed.
-		if step.Op() == deploy.OpSame && len(step.Old().InitErrors) > 0 {
-			indent := "         "
-
-			// TODO: Move indentation to the display logic, instead of doing it ourselves.
-			var warning bytes.Buffer
-			warning.WriteString("This resource failed to initialize in a previous deployment. It is recommended\n")
-			warning.WriteString(indent + "to update it to fix these issues:\n")
-			for i, err := range step.Old().InitErrors {
-				warning.WriteString(colors.SpecImportant + indent + fmt.Sprintf("  - Problem #%d", i+1) +
-					colors.Reset + " " + err + "\n")
-			}
-			acts.Opts.Diag.Warningf(diag.RawMessage(step.URN(), warning.String()))
-		}
 	}
 
 	// Inform the snapshot service that we are about to perform a step.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -376,6 +376,13 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 			return []Step{NewUpdateStep(sg.plan, event, old, new, diff.StableKeys)}, nil
 		}
 
+		// If resource was unchanged, but there were initialization errors, generate an empty update
+		// step to attempt to "continue" awaiting initialization.
+		if len(old.InitErrors) > 0 {
+			sg.updates[urn] = true
+			return []Step{NewUpdateStep(sg.plan, event, old, new, diff.StableKeys)}, nil
+		}
+
 		// No need to update anything, the properties didn't change.
 		sg.sames[urn] = true
 		if logging.V(7) {


### PR DESCRIPTION
Quoting from the first commit message:

### Generate empty update steps for partial failures

This commit will greatly improve the experience of dealing with partial
failures by simply re-trying to initialize the relevant resources on
every subsequent `pulumi up`, instead of printing a list of reasons the
resource had previously failed to initialize.

As motivation, consider our behavior in the following common, painful
scenario:

  * The user creates a `Service` and a `Deployment`.
  * The `Pod`s in the `Deployment` fail to become live. This causes the
    `Service` to fail, since it does not target any live `Pod`s.
  * The user fixes the `Deployment`. A run of `pulumi up` sees the
    `Pod`s successfully initialize.
  * Users will expect that the `Service` is now in a state of success,
    as the `Pod`s it targets are alive. But, because we don't update the
    `Service` by default, it perpetually exists in a state of error.
  * The user is now required to change some trivial feature of the
    `Service` just to trigger an update, so that we can see it succeed.

There are many situations like this. Another very common one is waiting
for test `Pod`s that are meant to successfully complete when some object
becomes live.

By triggering an empty update step for all resources that have any
initialization errors, we avoid all problems like this.

This commit will implement this empty-update semantics for partial
failures, as well as fix the display UX to correctly render the diff in
these cases.

<hr>

The flow looks basically like this. In the part where I drill into details, this actually outputs an empty diff for the deployment update -- sorry, it got cut off, I did not have the foresight to make the screen taller.

[![asciicast](https://asciinema.org/a/198652.png)](https://asciinema.org/a/198652?speed=3)