### PR TITLE
Support project config keys in templates and `-c`

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -346,7 +346,7 @@ var (
 // in the Pulumi Console).
 func isPreconfiguredEmptyStack(
 	url string,
-	templateConfig map[config.Key]workspace.ProjectTemplateConfigValue,
+	templateConfig map[string]workspace.ProjectTemplateConfigValue,
 	stackConfig config.Map,
 	snap *deploy.Snapshot) bool {
 
@@ -378,7 +378,13 @@ func isPreconfiguredEmptyStack(
 
 	// Can stackConfig satisfy the config requirements of templateConfig?
 	for templateKey, templateVal := range templateConfig {
-		stackVal, ok := stackConfig[templateKey]
+		parsedTemplateKey, parseErr := parseConfigKey(templateKey)
+		if parseErr != nil {
+			contract.IgnoreError(parseErr)
+			return false
+		}
+
+		stackVal, ok := stackConfig[parsedTemplateKey]
 		if !ok {
 			return false
 		}

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -35,9 +35,9 @@ type Analyzers []tokens.QName
 // ProjectTemplate is a Pulumi project template manifest.
 // nolint: lll
 type ProjectTemplate struct {
-	Description string                                    `json:"description,omitempty" yaml:"description,omitempty"` // an optional description of the template.
-	Quickstart  string                                    `json:"quickstart,omitempty" yaml:"quickstart,omitempty"`   // optional text to be displayed after template creation.
-	Config      map[config.Key]ProjectTemplateConfigValue `json:"config,omitempty" yaml:"config,omitempty"`           // optional template config.
+	Description string                                `json:"description,omitempty" yaml:"description,omitempty"` // an optional description of the template.
+	Quickstart  string                                `json:"quickstart,omitempty" yaml:"quickstart,omitempty"`   // optional text to be displayed after template creation.
+	Config      map[string]ProjectTemplateConfigValue `json:"config,omitempty" yaml:"config,omitempty"`           // optional template config.
 }
 
 // ProjectTemplateConfigValue is a config value included in the project template manifest.

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -27,7 +27,6 @@ import (
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/gitutil"
@@ -114,11 +113,11 @@ func (repo TemplateRepository) Templates() ([]Template, error) {
 
 // Template represents a project template.
 type Template struct {
-	Dir         string                                    // The directory containing Pulumi.yaml.
-	Name        string                                    // The name of the template.
-	Description string                                    // Description of the template.
-	Quickstart  string                                    // Optional text to be displayed after template creation.
-	Config      map[config.Key]ProjectTemplateConfigValue // Optional template config.
+	Dir         string                                // The directory containing Pulumi.yaml.
+	Name        string                                // The name of the template.
+	Description string                                // Description of the template.
+	Quickstart  string                                // Optional text to be displayed after template creation.
+	Config      map[string]ProjectTemplateConfigValue // Optional template config.
 
 	ProjectName        string // Name of the project.
 	ProjectDescription string // Optional description of the project.


### PR DESCRIPTION
Previously, we only supported config keys that included a ':' delimiter in config keys specified in the template manifest and in `-c` flags to `new` and `up`. This prevented the use of project keys in the template manifest and made it more difficult to pass such keys with `-c`, effectively preventing the use of `new pulumi.Config()` in project code.

This change fixes this by allowing config keys that don't have a delimiter in the template manifest and `-c` flags. In such cases, the project name is automatically prepended behind the scenes, the same as what `pulumi config set` does.

For example, you can now specify the following config values in `Pulumi.yaml`:

```yaml
name: aws-js-sqs-slack
description: Post to Slack for each SQS message!
runtime: nodejs
template:
  config:
    slackChannel:
      description: The Slack channel
      default: "#general"
    slackToken:
      description: The Slack access token
      secret: true
```

When prompting for these values, `new` / `up` will output:

```
slackChannel: The Slack channel: (#general) 
slackToken: The Slack access token: 
```

...and these will be saved as `<project-name>:slackChannel` and `<project-name>:slackToken`.

Similarly, `slackChannel` can be specified via a command line flag, e.g. `-c slackChannel=#whatever` and it will be saved as `<project-name>:slackChannel`.

Fixes #1768.