### PR TITLE
Clarify control flow in step generator

### DIFF
--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -155,8 +155,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 				}
 
 				if res := pe.handleSingleEvent(event.Event); res != nil {
-					resErr := res.Error()
-					if resErr != nil {
+					if resErr := res.Error(); resErr != nil {
 						log.Infof("planExecutor.Execute(...): error handling event: %v", resErr)
 						pe.reportError(pe.plan.generateEventURN(event.Event), resErr)
 					}
@@ -188,11 +187,11 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 
 // handleSingleEvent handles a single source event. For all incoming events, it produces a chain that needs
 // to be executed and schedules the chain for execution.
-func (pe *planExecutor) handleSingleEvent(event SourceEvent) result.Result {
+func (pe *planExecutor) handleSingleEvent(event SourceEvent) *result.Result {
 	contract.Require(event != nil, "event != nil")
 
 	var steps []Step
-	var res result.Result
+	var res *result.Result
 	switch e := event.(type) {
 	case RegisterResourceEvent:
 		log.Infof("planExecutor.handleSingleEvent(...): received RegisterResourceEvent")

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -43,7 +43,7 @@ type stepGenerator struct {
 
 // GenerateReadSteps is responsible for producing one or more steps required to service
 // a ReadResourceEvent coming from the language host.
-func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, result.Result) {
+func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, *result.Result) {
 	urn := sg.plan.generateURN(event.Parent(), event.Type(), event.Name())
 	newState := resource.NewState(event.Type(),
 		urn,
@@ -99,7 +99,7 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, res
 // If the given resource is a custom resource, the step generator will invoke Diff
 // and Check on the provider associated with that resource. If those fail, an error
 // is returned.
-func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, result.Result) {
+func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, *result.Result) {
 	var invalid bool // will be set to true if this object fails validation.
 
 	goal := event.Goal()

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -15,14 +15,13 @@
 package deploy
 
 import (
-	"github.com/pkg/errors"
-
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/logging"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // stepGenerator is responsible for turning resource events into steps that
@@ -44,7 +43,7 @@ type stepGenerator struct {
 
 // GenerateReadSteps is responsible for producing one or more steps required to service
 // a ReadResourceEvent coming from the language host.
-func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, error) {
+func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, result.Result) {
 	urn := sg.plan.generateURN(event.Parent(), event.Type(), event.Name())
 	newState := resource.NewState(event.Type(),
 		urn,
@@ -100,7 +99,7 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, err
 // If the given resource is a custom resource, the step generator will invoke Diff
 // and Check on the provider associated with that resource. If those fail, an error
 // is returned.
-func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, error) {
+func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, result.Result) {
 	var invalid bool // will be set to true if this object fails validation.
 
 	goal := event.Goal()
@@ -140,12 +139,12 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 			contract.Assert(goal.Provider != "")
 			ref, refErr := providers.ParseReference(goal.Provider)
 			if refErr != nil {
-				return nil, errors.Errorf(
+				return nil, result.Errorf(
 					"bad provider reference '%v' for resource '%v': %v", goal.Provider, urn, refErr)
 			}
 			p, ok := sg.plan.GetProvider(ref)
 			if !ok {
-				return nil, errors.Errorf("unknown provider '%v' for resource '%v'", ref, urn)
+				return nil, result.Errorf("unknown provider '%v' for resource '%v'", ref, urn)
 			}
 			prov = p
 		}
@@ -174,7 +173,7 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 		}
 
 		if err != nil {
-			return nil, err
+			return nil, result.FromError(err)
 		} else if sg.issueCheckErrors(new, urn, failures) {
 			invalid = true
 		}
@@ -186,14 +185,14 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 		var analyzer plugin.Analyzer
 		analyzer, err = sg.plan.ctx.Host.Analyzer(a)
 		if err != nil {
-			return nil, err
+			return nil, result.FromError(err)
 		} else if analyzer == nil {
-			return nil, errors.Errorf("analyzer '%v' could not be loaded from your $PATH", a)
+			return nil, result.Errorf("analyzer '%v' could not be loaded from your $PATH", a)
 		}
 		var failures []plugin.AnalyzeFailure
 		failures, err = analyzer.Analyze(new.Type, inputs)
 		if err != nil {
-			return nil, err
+			return nil, result.FromError(err)
 		}
 		for _, failure := range failures {
 			invalid = true
@@ -204,7 +203,7 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 
 	// If the resource isn't valid, don't proceed any further.
 	if invalid {
-		return nil, errors.New("One or more resource validation errors occurred; refusing to proceed")
+		return nil, result.Bail()
 	}
 
 	// There are four cases we need to consider when figuring out what to do with this resource.
@@ -246,7 +245,7 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 		logging.V(7).Infof("Planner recognized '%s' as old external resource, creating instead", urn)
 		sg.creates[urn] = true
 		if err != nil {
-			return nil, err
+			return nil, result.FromError(err)
 		}
 
 		return []Step{
@@ -274,14 +273,14 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 			// Determine whether the change resulted in a diff.
 			d, diffErr := sg.diff(urn, old.ID, oldInputs, oldOutputs, inputs, prov, allowUnknowns)
 			if diffErr != nil {
-				return nil, diffErr
+				return nil, result.FromError(diffErr)
 			}
 			diff = d
 		}
 
 		// Ensure that we received a sensible response.
 		if diff.Changes != plugin.DiffNone && diff.Changes != plugin.DiffSome {
-			return nil, errors.Errorf(
+			return nil, result.Errorf(
 				"unrecognized diff state for %s: %d", urn, diff.Changes)
 		}
 
@@ -296,9 +295,9 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, err
 					var failures []plugin.CheckFailure
 					inputs, failures, err = prov.Check(urn, nil, goal.Properties, allowUnknowns)
 					if err != nil {
-						return nil, err
+						return nil, result.FromError(err)
 					} else if sg.issueCheckErrors(new, urn, failures) {
-						return nil, errors.New("One or more resource validation errors occurred; refusing to proceed")
+						return nil, result.Bail()
 					}
 					new.Inputs = inputs
 				}

--- a/pkg/util/result/result.go
+++ b/pkg/util/result/result.go
@@ -40,41 +40,35 @@ import "github.com/pkg/errors"
 // At the highest level, when a function wishes to return only an `error`, the
 // `Error` member function can be used to turn a nullable `Result` into an
 // `error`.
-type Result interface {
-	// Error produces an `error` from this Result. Returns nil unless the provided
-	// Result represents an internal-to-Pulumi error.
-	Error() error
-}
-
-type resultImpl struct {
+type Result struct {
 	err error
 }
 
-func (r resultImpl) Error() error { return r.err }
+func (r *Result) Error() error { return r.err }
 
 // Bail produces a Result that represents a computation that failed to complete
 // successfully but is not a bug in Pulumi.
-func Bail() Result {
-	return resultImpl{err: nil}
+func Bail() *Result {
+	return &Result{err: nil}
 }
 
 // Errorf produces a Result that represents an internal Pulumi error,
 // constructed from the given format string and arguments.
-func Errorf(msg string, args ...interface{}) Result {
+func Errorf(msg string, args ...interface{}) *Result {
 	err := errors.Errorf(msg, args...)
 	return FromError(err)
 }
 
 // Error produces a Result that represents an internal Pulumi error,
 // constructed from the given message.
-func Error(msg string) Result {
+func Error(msg string) *Result {
 	err := errors.New(msg)
 	return FromError(err)
 }
 
 // FromError produces a Result that wraps an internal Pulumi error.
-func FromError(err error) Result {
-	return resultImpl{err: err}
+func FromError(err error) *Result {
+	return &Result{err: err}
 }
 
 // TODO returns an error that can be used in places that have not yet been

--- a/pkg/util/result/result.go
+++ b/pkg/util/result/result.go
@@ -1,0 +1,85 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package result
+
+import "github.com/pkg/errors"
+
+// Result represents the result of a computation that can fail. The Result type
+// revolves around two notions of failure:
+//
+// 1. Computations can fail, but they can fail gracefully. Computations that
+// fail gracefully do so by logging a diagnostic and returning a non-nil "bail"
+// result.
+//
+// 2. Computations can fail due to bugs in Pulumi. Computations that fail in
+// this manner do so by constructing a Result using the `Error`, `Errorf`, or
+// `FromError` constructor functions.
+//
+// Result is best used as a pointer type so that it can be nullable. A function
+// returning a pointer Result has the following semantics:
+//
+//  * If the result is `nil`, the caller should proceed. The callee believes
+//  that the overarching plan can still continue, even if it logged
+//  diagnostics.
+//
+//  * If the result is non-nil, the caller should not proceed.  Most often, the
+//  caller should return this Result to its caller.
+//
+// At the highest level, when a function wishes to return only an `error`, the
+// `Error` member function can be used to turn a nullable `Result` into an
+// `error`.
+type Result interface {
+	// Error produces an `error` from this Result. Returns nil unless the provided
+	// Result represents an internal-to-Pulumi error.
+	Error() error
+}
+
+type resultImpl struct {
+	err error
+}
+
+func (r resultImpl) Error() error { return r.err }
+
+// Bail produces a Result that represents a computation that failed to complete
+// successfully but is not a bug in Pulumi.
+func Bail() Result {
+	return resultImpl{err: nil}
+}
+
+// Errorf produces a Result that represents an internal Pulumi error,
+// constructed from the given format string and arguments.
+func Errorf(msg string, args ...interface{}) Result {
+	err := errors.Errorf(msg, args...)
+	return FromError(err)
+}
+
+// Error produces a Result that represents an internal Pulumi error,
+// constructed from the given message.
+func Error(msg string) Result {
+	err := errors.New(msg)
+	return FromError(err)
+}
+
+// FromError produces a Result that wraps an internal Pulumi error.
+func FromError(err error) Result {
+	return resultImpl{err: err}
+}
+
+// TODO returns an error that can be used in places that have not yet been
+// adapted to use Results.  Their use is intended to be temporary until Results
+// are plumbed throughout the Pulumi codebase.
+func TODO() error {
+	return errors.New("bailng due to error")
+}


### PR DESCRIPTION
This commit introduces a new type, 'controlFlow', which indicates to
callers whether or not it should continue the operation that it was
doing before it called a particular function. The variants of
'controlFlow', 'Bail' and 'Continue', indicate to the caller what it
should do. Components can signal 'Bail' when a diagnostic is logged and
the plan should no longer continue.