### PR TITLE
Fix some potential bugs in the refresher.

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -607,7 +607,9 @@ func (s *RefreshStep) Apply(preview bool) (resource.Status, StepCompleteFunc, er
 			return rst, nil, err
 		}
 		if initErr, isInitErr := err.(*plugin.InitError); isInitErr {
-			initErrors = initErr.Reasons
+			// We clear error in this case because we do not want the refresh to fail in the face of initialization
+			// errors.
+			initErrors, err = initErr.Reasons, nil
 		}
 	}
 


### PR DESCRIPTION
- Create all refresh steps before issuing any. This is important as the
  state update loop expects all steps to exist.
- Check for cancellation later in the refresher.

This also fixes races in the SnapshotManager and the test journal that
could cause panics during cancellation.