### PR TITLE
Update ssh-agent dependency for compat with go 1.11

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -21,7 +21,9 @@ install:
 - cmd: >-
     set GOPATH=%USERPROFILE%\go
 
-    set PATH=%PATH%;%GOPATH%\bin
+    set GOROOT=C:\go19
+
+    set PATH=C:\go19\bin;%PATH%;%GOPATH%\bin
 
     set PulumiRoot=C:\Pulumi
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -385,10 +385,10 @@
   version = "v1.1.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/xanzy/ssh-agent"
   packages = ["."]
-  revision = "ba9c9e33906f58169366275e3450db66139a31a9"
+  revision = "640f0ab560aeb89d523bb6ac322b1244d5c3796c"
+  version = "v0.2.0"
 
 [[projects]]
   branch = "master"


### PR DESCRIPTION
Pick up a newer version of ssh-agent which has
https://github.com/xanzy/ssh-agent/pull/3 to fix go 1.11 build issues.

Also, lock AppVeyor back to go 1.9, like we use on Travis.