### PR TITLE
Clarify refresh text

### DIFF
--- a/pkg/apitype/history.go
+++ b/pkg/apitype/history.go
@@ -23,14 +23,16 @@ import "encoding/json"
 type UpdateKind string
 
 const (
-	// DeployUpdate is the prototypical Pulumi program update.
-	DeployUpdate UpdateKind = "update"
+	// UpdateUpdate is the prototypical Pulumi program update.
+	UpdateUpdate UpdateKind = "update"
 	// PreviewUpdate is a preview of an update, without impacting resources.
 	PreviewUpdate UpdateKind = "preview"
 	// RefreshUpdate is an update that came from a refresh operation.
 	RefreshUpdate UpdateKind = "refresh"
 	// DestroyUpdate is an update which removes all resources.
 	DestroyUpdate UpdateKind = "destroy"
+	// ImportUpdate is an update that entails importing a raw checkpoint file.
+	ImportUpdate UpdateKind = "import"
 )
 
 // UpdateResult is an enum for the result of the update.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/operations"

--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -697,7 +697,10 @@ func confirmBeforeUpdating(updateKind apitype.UpdateKind, stack backend.Stack,
 			colors.BrightWhite+fmt.Sprintf("Do you want to perform this %s%s?",
 				updateKind, previewWarning)+colors.Reset)
 		if updateKind == apitype.RefreshUpdate {
-			prompt += "\nNo resources will be modified as part of this refresh; just your stack's state will be."
+			prompt += "\n" +
+				opts.Display.Color.Colorize(colors.BrightYellow+
+					"No resources will be modified as part of this refresh; just your stack's state will be."+
+					colors.Reset)
 		}
 
 		// Now prompt the user for a yes, no, or details, and then proceed accordingly.

--- a/pkg/backend/cloud/client/api.go
+++ b/pkg/backend/cloud/client/api.go
@@ -36,17 +36,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/version"
 )
 
-// UpdateKind is an enum for describing the kinds of updates we support.
-type UpdateKind string
-
-const (
-	UpdateKindUpdate  UpdateKind = "update"
-	UpdateKindPreview UpdateKind = "preview"
-	UpdateKindRefresh UpdateKind = "refresh"
-	UpdateKindDestroy UpdateKind = "destroy"
-	UpdateKindImport  UpdateKind = "import"
-)
-
 // StackIdentifier is the set of data needed to identify a Pulumi Cloud stack.
 type StackIdentifier struct {
 	Owner string
@@ -57,7 +46,7 @@ type StackIdentifier struct {
 type UpdateIdentifier struct {
 	StackIdentifier
 
-	UpdateKind UpdateKind
+	UpdateKind apitype.UpdateKind
 	UpdateID   string
 }
 

--- a/pkg/backend/cloud/client/client.go
+++ b/pkg/backend/cloud/client/client.go
@@ -90,7 +90,7 @@ func getStackPath(stack StackIdentifier, components ...string) string {
 // getUpdatePath returns the API path to for the given stack with the given components joined with path separators
 // and appended to the update root.
 func getUpdatePath(update UpdateIdentifier, components ...string) string {
-	components = append([]string{string(update.UpdateKind), update.UpdateID}, components...)
+	components = append([]string{string(apitype.UpdateUpdate), update.UpdateID}, components...)
 	return getStackPath(update.StackIdentifier, components...)
 }
 
@@ -322,7 +322,7 @@ func (pc *Client) ImportStackDeployment(ctx context.Context, stack StackIdentifi
 
 	return UpdateIdentifier{
 		StackIdentifier: stack,
-		UpdateKind:      UpdateKindUpdate,
+		UpdateKind:      apitype.UpdateUpdate,
 		UpdateID:        resp.UpdateID,
 	}, nil
 }
@@ -331,7 +331,7 @@ func (pc *Client) ImportStackDeployment(ctx context.Context, stack StackIdentifi
 // requires that the Pulumi program is uploaded, the provided getContents callback will be invoked to fetch the
 // contents of the Pulumi program.
 func (pc *Client) CreateUpdate(
-	ctx context.Context, kind UpdateKind, stack StackIdentifier, pkg *workspace.Project, cfg config.Map,
+	ctx context.Context, kind apitype.UpdateKind, stack StackIdentifier, pkg *workspace.Project, cfg config.Map,
 	main string, m apitype.UpdateMetadata, opts engine.UpdateOptions, dryRun bool,
 	getContents func() (io.ReadCloser, int64, error)) (UpdateIdentifier, error) {
 
@@ -373,13 +373,13 @@ func (pc *Client) CreateUpdate(
 	// Create the initial update object.
 	var endpoint string
 	switch kind {
-	case UpdateKindUpdate:
+	case apitype.UpdateUpdate:
 		endpoint = "update"
-	case UpdateKindPreview:
+	case apitype.PreviewUpdate:
 		endpoint = "preview"
-	case UpdateKindRefresh:
+	case apitype.RefreshUpdate:
 		endpoint = "refresh"
-	case UpdateKindDestroy:
+	case apitype.DestroyUpdate:
 		endpoint = "destroy"
 	default:
 		contract.Failf("Unknown kind: %s", kind)
@@ -392,7 +392,7 @@ func (pc *Client) CreateUpdate(
 	}
 
 	// Now upload the program if necessary.
-	if kind != UpdateKindDestroy && updateResponse.UploadURL != "" {
+	if kind != apitype.DestroyUpdate && updateResponse.UploadURL != "" {
 		uploadURL, err := url.Parse(updateResponse.UploadURL)
 		if err != nil {
 			return UpdateIdentifier{}, errors.Wrap(err, "parsing upload URL")

--- a/pkg/backend/local/display.go
+++ b/pkg/backend/local/display.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
@@ -38,13 +39,13 @@ import (
 // it comes in. Once all events have been read from the channel and displayed, it closes the `done`
 // channel so the caller can await all the events being written.
 func DisplayEvents(
-	action string, events <-chan engine.Event,
+	op string, action apitype.UpdateKind, events <-chan engine.Event,
 	done chan<- bool, opts backend.DisplayOptions) {
 
 	if opts.DiffDisplay {
-		DisplayDiffEvents(action, events, done, opts)
+		DisplayDiffEvents(op, action, events, done, opts)
 	} else {
-		DisplayProgressEvents(action, events, done, opts)
+		DisplayProgressEvents(op, action, events, done, opts)
 	}
 }
 
@@ -58,10 +59,10 @@ func (s *nopSpinner) Reset() {
 }
 
 // DisplayDiffEvents displays the engine events with the diff view.
-func DisplayDiffEvents(action string,
+func DisplayDiffEvents(op string, action apitype.UpdateKind,
 	events <-chan engine.Event, done chan<- bool, opts backend.DisplayOptions) {
 
-	prefix := fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), action)
+	prefix := fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op)
 
 	var spinner cmdutil.Spinner
 	var ticker *time.Ticker
@@ -96,7 +97,7 @@ func DisplayDiffEvents(action string,
 				}
 			}
 
-			msg := RenderDiffEvent(event, seen, opts)
+			msg := RenderDiffEvent(action, event, seen, opts)
 			if msg != "" && out != nil {
 				fprintIgnoreError(out, msg)
 			}
@@ -108,8 +109,8 @@ func DisplayDiffEvents(action string,
 	}
 }
 
-func RenderDiffEvent(
-	event engine.Event, seen map[resource.URN]engine.StepEventMetadata, opts backend.DisplayOptions) string {
+func RenderDiffEvent(action apitype.UpdateKind, event engine.Event,
+	seen map[resource.URN]engine.StepEventMetadata, opts backend.DisplayOptions) string {
 
 	switch event.Type {
 	case engine.CancelEvent:
@@ -117,7 +118,7 @@ func RenderDiffEvent(
 	case engine.PreludeEvent:
 		return renderPreludeEvent(event.Payload.(engine.PreludeEventPayload), opts)
 	case engine.SummaryEvent:
-		return renderSummaryEvent(event.Payload.(engine.SummaryEventPayload), opts)
+		return renderSummaryEvent(action, event.Payload.(engine.SummaryEventPayload), opts)
 	case engine.ResourceOperationFailed:
 		return renderResourceOperationFailedEvent(event.Payload.(engine.ResourceOperationFailedPayload), opts)
 	case engine.ResourceOutputsEvent:
@@ -147,7 +148,8 @@ func renderStdoutColorEvent(
 	return opts.Color.Colorize(payload.Message)
 }
 
-func renderSummaryEvent(event engine.SummaryEventPayload, opts backend.DisplayOptions) string {
+func renderSummaryEvent(
+	action apitype.UpdateKind, event engine.SummaryEventPayload, opts backend.DisplayOptions) string {
 	changes := event.ResourceChanges
 
 	changeCount := 0
@@ -159,6 +161,8 @@ func renderSummaryEvent(event engine.SummaryEventPayload, opts backend.DisplayOp
 	var kind string
 	if event.IsPreview {
 		kind = "previewed"
+	} else if action == apitype.RefreshUpdate {
+		kind = "refreshed"
 	} else {
 		kind = "performed"
 	}

--- a/pkg/backend/local/display.go
+++ b/pkg/backend/local/display.go
@@ -158,30 +158,34 @@ func renderSummaryEvent(
 			changeCount += c
 		}
 	}
-	var kind string
-	if event.IsPreview {
-		kind = "previewed"
-	} else if action == apitype.RefreshUpdate {
-		kind = "refreshed"
+
+	var actionVerbLabel string
+	if action == apitype.RefreshUpdate {
+		actionVerbLabel = "found during refresh"
+	} else if event.IsPreview {
+		actionVerbLabel = "previewed"
 	} else {
-		kind = "performed"
+		actionVerbLabel = "performed"
 	}
 
 	var changesLabel string
 	if changeCount == 0 {
-		kind = "required"
 		changesLabel = "no"
+
+		if action != apitype.RefreshUpdate {
+			actionVerbLabel = "required"
+		}
 	} else {
 		changesLabel = strconv.Itoa(changeCount)
 	}
 
 	if changeCount > 0 || changes[deploy.OpSame] > 0 {
-		kind += ":"
+		actionVerbLabel += ":"
 	}
 
 	out := &bytes.Buffer{}
 	fprintIgnoreError(out, opts.Color.Colorize(fmt.Sprintf("%vinfo%v: %v %v %v\n",
-		colors.SpecInfo, colors.Reset, changesLabel, plural("change", changeCount), kind)))
+		colors.SpecInfo, colors.Reset, changesLabel, plural("change", changeCount), actionVerbLabel)))
 
 	var planTo string
 	if event.IsPreview {

--- a/pkg/backend/local/progress.go
+++ b/pkg/backend/local/progress.go
@@ -25,6 +25,10 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/docker/docker/pkg/term"
+	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
@@ -34,9 +38,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
-
-	"github.com/docker/docker/pkg/term"
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // Progress describes a message we want to show in the display.  There are two types of messages,
@@ -85,6 +86,9 @@ type DiagInfo struct {
 type ProgressDisplay struct {
 	opts           backend.DisplayOptions
 	progressOutput chan<- Progress
+
+	// action is the kind of action (preview, update, refresh, etc) being performed.
+	action apitype.UpdateKind
 
 	// Whether or not we're previewing.  We don't know what we are actually doing until
 	// we get the initial 'prelude' event.
@@ -223,14 +227,14 @@ func (display *ProgressDisplay) writeBlankLine() {
 
 // DisplayProgressEvents displays the engine events with docker's progress view.
 func DisplayProgressEvents(
-	action string, events <-chan engine.Event,
+	op string, action apitype.UpdateKind, events <-chan engine.Event,
 	done chan<- bool, opts backend.DisplayOptions) {
 
 	// Create a ticker that will update all our status messages once a second.  Any
 	// in-flight resources will get a varying .  ..  ... ticker appended to them to
 	// let the user know what is still being worked on.
 	spinner, ticker := cmdutil.NewSpinnerAndTicker(
-		fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), action),
+		fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op),
 		nil, 1 /*timesPerSecond*/)
 
 	// The channel we push progress messages into, and which DisplayProgressToStream pulls
@@ -238,6 +242,7 @@ func DisplayProgressEvents(
 	progressOutput := make(chan Progress)
 
 	display := &ProgressDisplay{
+		action:                 action,
 		opts:                   opts,
 		progressOutput:         progressOutput,
 		eventUrnToResourceRow:  make(map[resource.URN]ResourceRow),
@@ -718,7 +723,7 @@ func (display *ProgressDisplay) processEndSteps() {
 
 	// print the summary
 	if display.summaryEventPayload != nil {
-		msg := renderSummaryEvent(*display.summaryEventPayload, display.opts)
+		msg := renderSummaryEvent(display.action, *display.summaryEventPayload, display.opts)
 
 		if !wroteDiagnosticHeader {
 			display.writeBlankLine()

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -15,6 +15,7 @@
 package backend
 
 import (
+	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 )
@@ -27,20 +28,6 @@ type UpdateMetadata struct {
 	// source code control commit information.
 	Environment map[string]string `json:"environment"`
 }
-
-// UpdateKind is an enum for the type of update performed.
-type UpdateKind string
-
-const (
-	// DeployUpdate is the prototypical Pulumi program update.
-	DeployUpdate UpdateKind = "update"
-	// PreviewUpdate is a preview of an update, without impacting resources.
-	PreviewUpdate UpdateKind = "preview"
-	// RefreshUpdate is an update that adopts a cloud's existing resource state.
-	RefreshUpdate UpdateKind = "refresh"
-	// DestroyUpdate is an update which removes all resources.
-	DestroyUpdate UpdateKind = "destroy"
-)
 
 // UpdateResult is an enum for the result of the update.
 type UpdateResult string
@@ -92,8 +79,8 @@ const (
 // UpdateInfo describes a previous update.
 type UpdateInfo struct {
 	// Information known before an update is started.
-	Kind      UpdateKind `json:"kind"`
-	StartTime int64      `json:"startTime"`
+	Kind      apitype.UpdateKind `json:"kind"`
+	StartTime int64              `json:"startTime"`
 
 	// Message is an optional message associated with the update.
 	Message string `json:"message"`


### PR DESCRIPTION
The wording for refresh doesn't accurately convey that the operations
aren't actually mutating your resources, but instead are simply changing
your checkpoint state. This change (hopefully) helps in two ways:

First, put text just before the prompt:

    Do you want to perform this refresh?
    No resources will be modified as part of this refresh; just your stack's state will be.

Second, alter the summary ever-so-slightly, from:

    info: 2 changes performed:
        ~ 2 resources updated
          3 resources unchanged

to:

    info: 2 changes refreshed:
        ~ 2 resources updated
          3 resources unchanged

This reads just slightly better, and removes any sense of panic I might
have otherwise had that my refresh just did something wrong.

As I was in here, since I had to pass UpdateKind information to new
places, I cleaned up the situation where we had three mostly-similar
enums (but which actually diverged) and several areas where we were
using untyped strings for this same information. Now there's just one.

This fixes pulumi/pulumi#1551.