### PR TITLE
Fix `up` to save -c config values for non-url case

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -64,6 +64,18 @@ func newUpCmd() *cobra.Command {
 			return err
 		}
 
+		// Save any config values passed via flags.
+		if len(configArray) > 0 {
+			commandLineConfig, err := parseConfig(configArray)
+			if err != nil {
+				return err
+			}
+
+			if err = saveConfig(s.Name().StackName(), commandLineConfig); err != nil {
+				return errors.Wrap(err, "saving config")
+			}
+		}
+
 		proj, root, err := readProject()
 		if err != nil {
 			return err


### PR DESCRIPTION
Previously, we were only saving config values specified on the command line (via --config/-c) for the URL case. This change fixes things to save these config values for the non-URL path.

Fixes #1795