### PR TITLE
Reformat call to action when we fail to launch browser for login

### DIFF
--- a/pkg/backend/cloud/backend.go
+++ b/pkg/backend/cloud/backend.go
@@ -222,8 +222,8 @@ func loginWithBrowser(ctx context.Context, d diag.Sink, cloudURL string) (Backen
 
 	// Launch the web browser and navigate to the login URL.
 	if openErr := open.Run(u.String()); openErr != nil {
-		fmt.Printf("We couldn't launch your browser for some reason.\n\nPlease visit %s "+
-			"to finish the login process.\n", u)
+		fmt.Printf("We couldn't launch your web browser for some reason. Please visit:\n\n%s\n\n"+
+			"to finish the login process.", u)
 	} else {
 		fmt.Println("We've launched your web browser to complete the login process.")
 	}


### PR DESCRIPTION
The existing message put the URL to visit and some explanation text on
the same line, which makes it a little harder to copy only the URL
into a browser. If this extra text ends up being copied as well as the
URL it can lead to failures later, when we try to decode the query
string as part of the OAuth flow.

It's easy enough to fix by just putting the URL on its own line, split
off from the text itself.

Fixes #1832