### PR TITLE
Fix a "hang" when `tsconfig.json` is not present in the CWD

### DIFF
--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -130,9 +130,17 @@ export function run(argv: minimist.ParsedArgs): void {
     // If this is a typescript project, we'll want to load node-ts.
     const typeScript: boolean = process.env["PULUMI_NODEJS_TYPESCRIPT"] === "true";
 
+    // We provide reasonable defaults for many ts options, meaning you don't need to have a tsconfig.json present
+    // if you want to use TypeScript with Pulumi. However, ts-node's default behavior is to walk up from the cwd to
+    // find a tsconfig.json. For us, it's reasonable to say that the "root" of the project is the cwd,
+    // if there's a tsconfig.json file here. Otherwise, just tell ts-node to not load project options at all.
+    // This helps with cases like pulumi/pulumi#1772.
+    const skipProject = !fs.existsSync("tsconfig.json");
+
     if (typeScript) {
         tsnode.register({
             typeCheck: true,
+            skipProject: skipProject,
             compilerOptions: {
                 target: "es6",
                 module: "commonjs",


### PR DESCRIPTION
If a `tsconfig.json` file is not present at the root of the Pulumi
project, ts-node will look up the directory tree to see if there is
one. If there is, it will treat that as the root of the project. While
reasonable for some cases, this isn't the behavior we want for our use
of ts-node. We actually set compiler options such that in the common
case you don't even need a `tsconfig.json` and for pure JavaScript
projects, there wouldn't be a `tsconfig.json` file.

In both of these cases, there's a big foot-gun waiting. For example in
pulumi/pulumi#1772 we ran into a case where there was a tsconfig.json
file in $HOME, causing the entirety of $HOME to be analyzed by
TypeScript which made it look like Pulumi hung.

To address this, tell ts-node to not use a project in cases where
there is not a `tsconfig.json` at the root of the project.

Fixes #1772