### PR TITLE
Allow promise exports

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -276,7 +276,7 @@ export class ComponentResource extends Resource {
 
     // registerOutputs registers synthetic outputs that a component has initialized, usually by allocating
     // other child sub-resources and propagating their resulting property values.
-    protected registerOutputs(outputs: Inputs | undefined): void {
+    protected registerOutputs(outputs: Inputs | Promise<Inputs> | Output<Inputs> | undefined): void {
         if (outputs) {
             registerResourceOutputs(this, outputs);
         }

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -282,19 +282,18 @@ async function resolveOutputs(res: Resource, t: string, name: string,
 /**
  * registerResourceOutputs completes the resource registration, attaching an optional set of computed outputs.
  */
-export function registerResourceOutputs(res: Resource, outputs: Inputs) {
+export function registerResourceOutputs(res: Resource, outputs: Input<Inputs>) {
     // Now run the operation. Note that we explicitly do not serialize output registration with
     // respect to other resource operations, as outputs may depend on properties of other resources
     // that will not resolve until later turns. This would create a circular promise chain that can
     // never resolve.
     const opLabel = `monitor.registerResourceOutputs(...)`;
     runAsyncResourceOp(opLabel, async () => {
-        // The registration could very well still be taking place, so we will need to wait for its
-        // URN.  Additionally, the output properties might have come from other resources, so we
-        // must await those too.
+        // The registration could very well still be taking place, so we will need to wait for its URN.
+        // Additionally, the output properties might have come from other resources, so we must await those too.
         const urn = await res.urn.promise();
-        const outputsObj = gstruct.Struct.fromJavaScript(
-            await serializeProperties(`completeResource`, outputs));
+        const resolved = await serializeResourceProperties(opLabel, { outputs });
+        const outputsObj = gstruct.Struct.fromJavaScript(resolved.outputs);
         log.debug(`RegisterResourceOutputs RPC prepared: urn=${urn}` +
             (excessiveDebugOutput ? `, outputs=${JSON.stringify(outputsObj)}` : ``));
 

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -292,7 +292,7 @@ export function registerResourceOutputs(res: Resource, outputs: Inputs | Promise
         // The registration could very well still be taking place, so we will need to wait for its URN.
         // Additionally, the output properties might have come from other resources, so we must await those too.
         const urn = await res.urn.promise();
-        const resolved = await serializeResourceProperties(opLabel, { outputs });
+        const resolved = await serializeProperties(opLabel, { outputs });
         const outputsObj = gstruct.Struct.fromJavaScript(resolved.outputs);
         log.debug(`RegisterResourceOutputs RPC prepared: urn=${urn}` +
             (excessiveDebugOutput ? `, outputs=${JSON.stringify(outputsObj)}` : ``));

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -282,7 +282,7 @@ async function resolveOutputs(res: Resource, t: string, name: string,
 /**
  * registerResourceOutputs completes the resource registration, attaching an optional set of computed outputs.
  */
-export function registerResourceOutputs(res: Resource, outputs: Input<Inputs>) {
+export function registerResourceOutputs(res: Resource, outputs: Inputs | Promise<Inputs> | Output<Inputs>) {
     // Now run the operation. Note that we explicitly do not serialize output registration with
     // respect to other resource operations, as outputs may depend on properties of other resources
     // that will not resolve until later turns. This would create a circular promise chain that can

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -70,7 +70,7 @@ export function transferProperties(onto: Resource, label: string, props: Inputs)
 }
 
 /**
- * serializeFilteredProperties walks the props object passed in, awaiting all interior promises for propertoes with
+ * serializeFilteredProperties walks the props object passed in, awaiting all interior promises for properties with
  * keys that match the provided filter, creating a reasonable POJO object that can be remoted over to
  * registerResource.
  */

--- a/sdk/nodejs/tests/runtime/langhost/cases/019.stack_exports/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/019.stack_exports/index.js
@@ -1,20 +1,14 @@
 function main() {
-    return new Promise((resolve) => {
-        resolve({
-            a: new Promise((resolve2) => {
-                resolve2({
-                    x: new Promise((resolve3) => {
-                        resolve3(99);
-                    }),
-                    y: "z",
-                });
-            }),
-            b: 42,
-            c: {
-                d: "a",
-                e: false,
-            },
-        });
+    return Promise.resolve({
+        a: Promise.resolve({
+            x: Promise.resolve(99),
+            y: "z",
+        }),
+        b: 42,
+        c: {
+            d: "a",
+            e: false,
+        },
     });
 }
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/019.stack_exports/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/019.stack_exports/index.js
@@ -1,0 +1,21 @@
+function main() {
+    return new Promise((resolve) => {
+        resolve({
+            a: new Promise((resolve2) => {
+                resolve2({
+                    x: new Promise((resolve3) => {
+                        resolve3(99);
+                    }),
+                    y: "z",
+                });
+            }),
+            b: 42,
+            c: {
+                d: "a",
+                e: false,
+            },
+        });
+    });
+}
+
+module.exports = main();

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -490,6 +490,26 @@ describe("rpc", () => {
                 }
             },
         },
+        // Test stack outputs via exports.
+        "stack_exports": {
+            program: path.join(base, "019.stack_exports"),
+            expectResourceCount: 0,
+            registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
+                                      t: string, name: string, res: any, outputs: any | undefined) => {
+                assert.strictEqual(t, "pulumi:pulumi:Stack");
+                assert.strictEqual(outputs, {
+                    a: {
+                        x: 99,
+                        y: "z",
+                    },
+                    b: 42,
+                    c: {
+                        d: "a",
+                        e: false,
+                    },
+                });
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {


### PR DESCRIPTION
This change partly addresses pulumi/pulumi#1611, by permitting you
to export a promise at the top-level, and have it be recognized as
a stack output. In other words, you can now say things like

    async function main() {
        ...
        return {
            a: "x",
            ...,
            z: 42,
        };
    }

    module.exports = main();

and your Pulumi program will record distinct outputs as you'd hope:

    ---outputs:---
    a: "x"
    ...
    z: 42

This is arguably just a bug in the way we implemented stack outputs.
The remainder of the requests in #1611 will remain open for future
design and discussion, as they have more subtle ramifications.