### PR TITLE
Move away from ${PROJECT} and ${DESCRIPTION}

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pkg/errors"
@@ -143,15 +144,10 @@ func newUpCmd() *cobra.Command {
 			contract.IgnoreError(os.RemoveAll(temp))
 		}()
 
-		// Cleanup the project name/description if needed.
-		projectName := template.ProjectName
-		if projectName == "${PROJECT}" {
-			projectName = workspace.ValueOrSanitizedDefaultProjectName(projectName, template.Name)
-		}
-		projectDescription := template.ProjectDescription
-		if projectDescription == "${DESCRIPTION}" {
-			projectDescription = ""
-		}
+		// Get the project name/description.
+		projectName := workspace.ValueOrSanitizedDefaultProjectName("", template.ProjectName, template.Name)
+		projectDescription := workspace.ValueOrDefaultProjectDescription(
+			"", template.ProjectDescription, template.Description)
 
 		// Copy the template files from the repo to the temporary "virtual workspace" directory.
 		if err = template.CopyTemplateFiles(temp, true, projectName, projectDescription); err != nil {
@@ -161,6 +157,17 @@ func newUpCmd() *cobra.Command {
 		// Change the working directory to the "virtual workspace" directory.
 		if err = os.Chdir(temp); err != nil {
 			return errors.Wrap(err, "changing the working directory")
+		}
+
+		// Load the project, update the name & description, and save it.
+		proj, _, err := readProject()
+		if err != nil {
+			return err
+		}
+		proj.Name = tokens.PackageName(projectName)
+		proj.Description = &projectDescription
+		if err = workspace.SaveProject(proj); err != nil {
+			return errors.Wrap(err, "saving project")
 		}
 
 		// Get a stack, but don't set it as the current stack, to avoid writing to ~/.pulumi/workspaces.

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -382,22 +382,37 @@ func IsValidProjectName(name string) bool {
 
 // ValueOrSanitizedDefaultProjectName returns the value or a sanitized valid project name
 // based on defaultNameToSanitize.
-func ValueOrSanitizedDefaultProjectName(name string, defaultNameToSanitize string) string {
+func ValueOrSanitizedDefaultProjectName(name string, projectName string, defaultNameToSanitize string) string {
+	// If we have a name, use it.
 	if name != "" {
 		return name
 	}
+
+	// If the project already has a name that isn't a replacement string, use it.
+	if projectName != "${PROJECT}" {
+		return projectName
+	}
+
+	// Otherwise, get a sanitized version of `defaultNameToSanitize`.
 	return getValidProjectName(defaultNameToSanitize)
 }
 
 // ValueOrDefaultProjectDescription returns the value or defaultDescription.
-func ValueOrDefaultProjectDescription(description string, defaultDescription string) string {
+func ValueOrDefaultProjectDescription(
+	description string, projectDescription string, defaultDescription string) string {
+
+	// If we have a description, use it.
 	if description != "" {
 		return description
 	}
-	if defaultDescription != "" {
-		return defaultDescription
+
+	// If the project already has a description that isn't a replacement string, use it.
+	if projectDescription != "${DESCRIPTION}" {
+		return projectDescription
 	}
-	return ""
+
+	// Otherwise, use the default, which may be an empty string.
+	return defaultDescription
 }
 
 // getValidProjectName returns a valid project name based on the passed-in name.


### PR DESCRIPTION
We generally want examples and apps to be authored such that they are
clonable/deployable as-is without using `new`/`up` (and want to
encourage this). That means no longer using the ${PROJECT} and
${DESCRIPTION} replacement strings in Pulumi.yaml and other text files.
Instead, good default project names and descriptions should be specified
in Pulumi.yaml and elsewhere.

We'll use the specified values as defaults when prompting the user, and
then directly serialize/save the values to Pulumi.yaml when configuring
the user's project. This does mean that name in package.json (for nodejs
projects) won't be updated if it isn't using ${PROJECT}, but that's OK.

Our templates in the pulumi/templates repo will still use
${PROJECT}/${DESCRIPTION} for now, to continue to work well with v0.15
of the CLI. After that version is no longer in use, we can update the
templates to no longer use the replacement strings and delete the code
in the CLI that deals with it.

Fixes #1776