### PR TITLE
Use the local backend in another test

### DIFF
--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -203,7 +203,7 @@ func TestStackCommands(t *testing.T) {
 		stackName := addRandomSuffix("invalid-resources")
 		integration.CreateBasicPulumiRepo(e)
 		e.ImportDirectory("integration/stack_dependencies")
-		e.RunCommand("pulumi", "login")
+		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", stackName)
 		e.RunCommand("yarn", "install")
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")


### PR DESCRIPTION
In CI, when runing a test job for a Pull Request from a fork of
pulumi/pulumi we are unable to use the service (since we don't have an
access token, since Travis does not allow secure environment
varables in pull requests job).

Our "Lifecycle" tests already are no-ops in these cases, and some of our
directed tests use the local backend (in favor of just getting
skipped). Move one other directed test over to using the local
backend, as well. This should get PR's from forks green again.