### PR TITLE
Fail refreshes with init errors.

### DIFF
--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -93,7 +93,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 
 	// Set up a step generator and executor for this plan.
 	pe.stepGen = newStepGenerator(pe.plan, opts)
-	pe.stepExec = newStepExecutor(ctx, cancel, pe.plan, opts, preview)
+	pe.stepExec = newStepExecutor(ctx, cancel, pe.plan, opts, preview, false)
 
 	// We iterate the source in its own goroutine because iteration is blocking and we want the main loop to be able to
 	// respond to cancellation requests promptly.
@@ -224,7 +224,7 @@ func (pe *planExecutor) refresh(callerCtx context.Context, opts Options, preview
 
 	// Fire up a worker pool and issue each refresh in turn.
 	ctx, cancel := context.WithCancel(callerCtx)
-	stepExec := newStepExecutor(ctx, cancel, pe.plan, opts, preview)
+	stepExec := newStepExecutor(ctx, cancel, pe.plan, opts, preview, true)
 	for i := range steps {
 		if ctx.Err() != nil {
 			break

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -607,8 +607,6 @@ func (s *RefreshStep) Apply(preview bool) (resource.Status, StepCompleteFunc, er
 			return rst, nil, err
 		}
 		if initErr, isInitErr := err.(*plugin.InitError); isInitErr {
-			// We clear error in this case because we do not want the refresh to fail in the face of initialization
-			// errors.
 			initErrors = initErr.Reasons
 		}
 	}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -609,7 +609,7 @@ func (s *RefreshStep) Apply(preview bool) (resource.Status, StepCompleteFunc, er
 		if initErr, isInitErr := err.(*plugin.InitError); isInitErr {
 			// We clear error in this case because we do not want the refresh to fail in the face of initialization
 			// errors.
-			initErrors, err = initErr.Reasons, nil
+			initErrors = initErr.Reasons
 		}
 	}
 


### PR DESCRIPTION
And ensure that refreshes continue on errors.

Fixes #1881.