### PR TITLE
Consolidate some `new` and `up` functionality

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -25,8 +25,10 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/backend/display"
+	"github.com/pulumi/pulumi/pkg/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -49,6 +51,7 @@ func newNewCmd() *cobra.Command {
 	var configArray []string
 	var name string
 	var description string
+	var stack string
 	var force bool
 	var yes bool
 	var offline bool
@@ -120,9 +123,8 @@ func newNewCmd() *cobra.Command {
 
 			// If we're going to be creating a stack, get the current backend, which
 			// will kick off the login flow (if not already logged-in).
-			var b backend.Backend
 			if !generateOnly {
-				if b, err = currentBackend(opts.Display); err != nil {
+				if _, err = currentBackend(opts.Display); err != nil {
 					return err
 				}
 			}
@@ -168,8 +170,16 @@ func newNewCmd() *cobra.Command {
 				}
 			}
 
+			// If a stack was specified via --stack, see if it already exists.
+			var s backend.Stack
+			if stack != "" {
+				if s, err = getStack(stack, &name, &description, opts.Display); err != nil {
+					return err
+				}
+			}
+
 			// Show instructions, if we're going to show at least one prompt.
-			hasAtLeastOnePrompt := (name == "") || (description == "") || !generateOnly
+			hasAtLeastOnePrompt := (name == "") || (description == "") || (stack == "")
 			if !yes && hasAtLeastOnePrompt {
 				fmt.Println("This command will walk you through creating a new Pulumi project.")
 				fmt.Println()
@@ -217,50 +227,18 @@ func newNewCmd() *cobra.Command {
 				return errors.Wrap(err, "saving project")
 			}
 
-			// Prompt for the stack name and create the stack.
-			var stack backend.Stack
-			if !generateOnly {
-				defaultValue := getDevStackName(name)
-
-				for {
-					stackName, err := promptForValue(yes, "stack name", defaultValue, false, nil, opts.Display)
-					if err != nil {
-						return err
-					}
-					stack, err = stackInit(b, stackName)
-					if err != nil {
-						if !yes {
-							// Let the user know about the error and loop around to try again.
-							fmt.Printf("Sorry, could not create stack '%s': %v.\n", stackName, err)
-							continue
-						}
-						return err
-					}
-					break
+			// Create the stack, if needed.
+			if !generateOnly && s == nil {
+				if s, err = promptAndCreateStack(stack, name, true /*setCurrent*/, yes, opts.Display); err != nil {
+					return err
 				}
-
 				// The backend will print "Created stack '<stack>'." on success.
 			}
 
-			// Prompt for config values and save.
+			// Prompt for config values (if needed) and save.
 			if !generateOnly {
-				// Get config values passed on the command line.
-				commandLineConfig, err := parseConfig(configArray)
-				if err != nil {
+				if err = handleConfig(s, templateNameOrURL, template, configArray, yes, opts.Display); err != nil {
 					return err
-				}
-
-				// Prompt for config as needed.
-				c, err := promptForConfig(stack, template.Config, commandLineConfig, nil, yes, opts.Display)
-				if err != nil {
-					return err
-				}
-
-				// Save the config.
-				if c != nil {
-					if err = saveConfig(stack.Ref().Name(), c); err != nil {
-						return errors.Wrap(err, "saving config")
-					}
 				}
 			}
 
@@ -278,7 +256,7 @@ func newNewCmd() *cobra.Command {
 
 			// Run `up` automatically, or print out next steps to run `up` manually.
 			if !generateOnly {
-				if err = runUpOrPrintNextSteps(stack, originalCwd, cwd, opts, yes); err != nil {
+				if err = runUpOrPrintNextSteps(s, originalCwd, cwd, opts, yes); err != nil {
 					return err
 				}
 			}
@@ -331,6 +309,9 @@ func newNewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&description, "description", "d", "",
 		"The project description; if not specified, a prompt will request it")
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The stack name; either an existing stack or stack to create; if not specified, a prompt will request it")
 	cmd.PersistentFlags().BoolVarP(
 		&force, "force", "f", false,
 		"Forces content to be generated even if it would change existing files")
@@ -367,6 +348,76 @@ func errorIfNotEmptyDirectory(path string) error {
 	return nil
 }
 
+// getStack gets a stack or returns nil if the stack doesn't exist.
+// name and description are set if not empty and those values are available from the existing stack.
+func getStack(stack string, name *string, description *string, opts display.Options) (backend.Stack, error) {
+	b, err := currentBackend(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	stackRef, err := b.ParseStackReference(stack)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := b.GetStack(commandContext(), stackRef)
+	if err != nil {
+		return nil, err
+	}
+
+	// We have an existing stack, use its project name/description.
+	if s != nil {
+		if cs, ok := s.(httpstate.Stack); ok {
+			tags := cs.Tags()
+			if *name == "" {
+				*name = tags[apitype.ProjectNameTag]
+			}
+			if *description == "" {
+				*description = tags[apitype.ProjectDescriptionTag]
+			}
+		}
+	}
+
+	return s, nil
+}
+
+// promptAndCreateStack creates and returns a new stack (prompting for the name as needed).
+func promptAndCreateStack(
+	stack string, projectName string, setCurrent bool, yes bool, opts display.Options) (backend.Stack, error) {
+	b, err := currentBackend(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	if stack != "" {
+		s, err := stackInit(b, stack, setCurrent)
+		if err != nil {
+			return nil, err
+		}
+		return s, nil
+	}
+
+	defaultValue := getDevStackName(projectName)
+
+	for {
+		stackName, err := promptForValue(yes, "stack name", defaultValue, false, nil, opts)
+		if err != nil {
+			return nil, err
+		}
+		s, err := stackInit(b, stackName, setCurrent)
+		if err != nil {
+			if !yes {
+				// Let the user know about the error and loop around to try again.
+				fmt.Printf("Sorry, could not create stack '%s': %v.\n", stackName, err)
+				continue
+			}
+			return nil, err
+		}
+		return s, nil
+	}
+}
+
 // getDevStackName returns the stack name suffixed with -dev.
 func getDevStackName(name string) string {
 	const suffix = "-dev"
@@ -376,12 +427,12 @@ func getDevStackName(name string) string {
 }
 
 // stackInit creates the stack.
-func stackInit(b backend.Backend, stackName string) (backend.Stack, error) {
+func stackInit(b backend.Backend, stackName string, setCurrent bool) (backend.Stack, error) {
 	stackRef, err := b.ParseStackReference(stackName)
 	if err != nil {
 		return nil, err
 	}
-	return createStack(b, stackRef, nil, true /*setCurrent*/)
+	return createStack(b, stackRef, nil, setCurrent)
 }
 
 // saveConfig saves the config for the stack.

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -151,87 +151,71 @@ func newUpCmd() *cobra.Command {
 			contract.IgnoreError(os.RemoveAll(temp))
 		}()
 
-		// Get the project name/description.
-		projectName := workspace.ValueOrSanitizedDefaultProjectName("", template.ProjectName, template.Name)
-		projectDescription := workspace.ValueOrDefaultProjectDescription(
-			"", template.ProjectDescription, template.Description)
-
-		// Copy the template files from the repo to the temporary "virtual workspace" directory.
-		if err = template.CopyTemplateFiles(temp, true, projectName, projectDescription); err != nil {
-			return err
-		}
-
 		// Change the working directory to the "virtual workspace" directory.
 		if err = os.Chdir(temp); err != nil {
 			return errors.Wrap(err, "changing the working directory")
 		}
 
+		// If a stack was specified via --stack, see if it already exists.
+		var name string
+		var description string
+		var s backend.Stack
+		if stack != "" {
+			if s, err = getStack(stack, &name, &description, opts.Display); err != nil {
+				return err
+			}
+		}
+
+		// Prompt for the project name, if we don't already have one from an existing stack.
+		if name == "" {
+			defaultValue := workspace.ValueOrSanitizedDefaultProjectName(name, template.ProjectName, template.Name)
+			name, err = promptForValue(yes, "project name", defaultValue, false, workspace.IsValidProjectName, opts.Display)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Prompt for the project description, if we don't already have one from an existing stack.
+		if description == "" {
+			defaultValue := workspace.ValueOrDefaultProjectDescription(
+				description, template.ProjectDescription, template.Description)
+			description, err = promptForValue(yes, "project description", defaultValue, false, nil, opts.Display)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Copy the template files from the repo to the temporary "virtual workspace" directory.
+		if err = template.CopyTemplateFiles(temp, true, name, description); err != nil {
+			return err
+		}
+
 		// Load the project, update the name & description, and save it.
-		proj, _, err := readProject()
+		proj, root, err := readProject()
 		if err != nil {
 			return err
 		}
-		proj.Name = tokens.PackageName(projectName)
-		proj.Description = &projectDescription
+		proj.Name = tokens.PackageName(name)
+		proj.Description = &description
 		if err = workspace.SaveProject(proj); err != nil {
 			return errors.Wrap(err, "saving project")
 		}
 
-		// Get a stack, but don't set it as the current stack, to avoid writing to ~/.pulumi/workspaces.
-		s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
-		if err != nil {
-			return err
-		}
-
-		// Get the existing config. stackConfig will be nil if there wasn't a previous deployment.
-		stackConfig, err := backend.GetLatestConfiguration(commandContext(), s)
-		if err != nil && err != backend.ErrNoPreviousDeployment {
-			return err
-		}
-
-		// Get the existing snapshot.
-		snap, err := s.Snapshot(commandContext())
-		if err != nil {
-			return err
-		}
-
-		// Handle config.
-		// If this is an initial preconfigured empty stack (i.e. configured in the Pulumi Console),
-		// use its config without prompting.
-		// Otherwise, use the values specified on the command line and prompt for new values.
-		// If the stack already existed and had previous config, those values will be used as the defaults.
-		var c config.Map
-		if isPreconfiguredEmptyStack(url, template.Config, stackConfig, snap) {
-			c = stackConfig
-			// TODO consider warning if the specific URL is different from templateURL.
-		} else {
-			// Get config values passed on the command line.
-			commandLineConfig, err := parseConfig(configArray)
-			if err != nil {
+		// Create the stack, if needed.
+		if s == nil {
+			if s, err = promptAndCreateStack(stack, name, false /*setCurrent*/, yes, opts.Display); err != nil {
 				return err
 			}
-
-			// Prompt for config as needed.
-			c, err = promptForConfig(s, template.Config, commandLineConfig, stackConfig, yes, opts.Display)
-			if err != nil {
-				return err
-			}
+			// The backend will print "Created stack '<stack>'." on success.
 		}
 
-		// Save the config locally.
-		if c != nil {
-			if err = saveConfig(s.Ref().Name(), c); err != nil {
-				return errors.Wrap(err, "saving config")
-			}
+		// Prompt for config values (if needed) and save.
+		if err = handleConfig(s, url, template, configArray, yes, opts.Display); err != nil {
+			return err
 		}
 
 		// Install dependencies.
 		if err = installDependencies("Installing dependencies..."); err != nil {
-			return err
-		}
-
-		proj, root, err := readProject()
-		if err != nil {
 			return err
 		}
 
@@ -366,6 +350,60 @@ func newUpCmd() *cobra.Command {
 		"Automatically approve and perform the update after previewing it")
 
 	return cmd
+}
+
+// handleConfig handles prompting for config values (as needed) and saving config.
+func handleConfig(
+	s backend.Stack,
+	templateNameOrURL string,
+	template workspace.Template,
+	configArray []string,
+	yes bool,
+	opts display.Options) error {
+
+	// Get the existing config. stackConfig will be nil if there wasn't a previous deployment.
+	stackConfig, err := backend.GetLatestConfiguration(commandContext(), s)
+	if err != nil && err != backend.ErrNoPreviousDeployment {
+		return err
+	}
+
+	// Get the existing snapshot.
+	snap, err := s.Snapshot(commandContext())
+	if err != nil {
+		return err
+	}
+
+	// Handle config.
+	// If this is an initial preconfigured empty stack (i.e. configured in the Pulumi Console),
+	// use its config without prompting.
+	// Otherwise, use the values specified on the command line and prompt for new values.
+	// If the stack already existed and had previous config, those values will be used as the defaults.
+	var c config.Map
+	if isPreconfiguredEmptyStack(templateNameOrURL, template.Config, stackConfig, snap) {
+		c = stackConfig
+		// TODO consider warning if the specific URL is different from templateURL.
+	} else {
+		// Get config values passed on the command line.
+		commandLineConfig, parseErr := parseConfig(configArray)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		// Prompt for config as needed.
+		c, err = promptForConfig(s, template.Config, commandLineConfig, stackConfig, yes, opts)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Save the config.
+	if c != nil {
+		if err = saveConfig(s.Ref().Name(), c); err != nil {
+			return errors.Wrap(err, "saving config")
+		}
+	}
+
+	return nil
 }
 
 var (

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -161,7 +161,7 @@ func newUpCmd() *cobra.Command {
 		var description string
 		var s backend.Stack
 		if stack != "" {
-			if s, err = getStack(stack, &name, &description, opts.Display); err != nil {
+			if s, name, description, err = getStack(stack, opts.Display); err != nil {
 				return err
 			}
 		}
@@ -381,7 +381,8 @@ func handleConfig(
 	var c config.Map
 	if isPreconfiguredEmptyStack(templateNameOrURL, template.Config, stackConfig, snap) {
 		c = stackConfig
-		// TODO consider warning if the specific URL is different from templateURL.
+		// TODO[pulumi/pulumi#1894] consider warning if templateNameOrURL is different from
+		// the stack's `pulumi:template` config value.
 	} else {
 		// Get config values passed on the command line.
 		commandLineConfig, parseErr := parseConfig(configArray)


### PR DESCRIPTION
Previously `new` was operating under the assumption that it was always going to be creating a new project/stack, and would always prompt for these values. However, we want to be able to use `new` to pull down the source for an existing stack. This change adds a `--stack` flag to `new` that can be used to specify an existing stack.
 - If the specified stack already exists, we won't prompt for the project name/description, and instead just use the existing stack's values.
 - If `--stack` is specified, but doesn't already exist, `new` will use that as the stack name (instead of prompting) when creating the stack.

`new` also now handles configuration like `up <url>`: if the stack is a preconfigured empty stack (i.e. it was created/configured in the Pulumi Console via Pulumi Button or New Project), we will use the existing stack's config without prompting. Otherwise we will prompt for config, and just like `up <url>`, we'll use the existing stack's config values as defaults when prompting, or if the stack didn't exist, use the defaults from the template.

Previously `up <url>`'s handling of the project name/description wasn't correct: it would always automatically use the values from the template without prompting. Now, just like `new`:

 - When updating an existing stack, it will not prompt for the project name/description, and just use the existing stack's values.
 - When creating a new stack, it will prompt for the project name/description, using the defaults from the template.

This PR consolidates some of the `new`/`up` implementation into some shared functions. There's definitely opportunities for a lot more code reuse, but that cleanup can happen down the line if/when we have the cycles.

Fixes #1871 
Fixes #1872