### PR TITLE
Retire pending deletions at start of plan

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -233,6 +233,12 @@
   revision = "9520e82c474b0a04dd04f8a40959027271bab992"
 
 [[projects]]
+  name = "github.com/mitchellh/copystructure"
+  packages = ["."]
+  revision = "9a1b6f44e8da0e0e374624fb0a825a231b00c537"
+  version = "v1.0.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
@@ -243,6 +249,12 @@
   name = "github.com/mitchellh/go-ps"
   packages = ["."]
   revision = "4fdf99ab29366514c69ccccddab5dc58b8d84062"
+
+[[projects]]
+  name = "github.com/mitchellh/reflectwalk"
+  packages = ["."]
+  revision = "eecee6c969c02c8cc2ae48e1e269843ae8590796"
+  version = "v1.0.0"
 
 [[projects]]
   name = "github.com/nbutton23/zxcvbn-go"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -596,6 +596,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d6db93501077426a275193a3d77e69cc4fe68fd80603907438fcb0503d7817a0"
+  inputs-digest = "4bf258f7745882980a44a294945cfdf156062ef42c03ddffa81156b5b31d210d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1069,7 +1069,7 @@ func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) st
 		return "update"
 	case deploy.OpDelete:
 		if step.Old.Delete {
-			return "delete from previous plan"
+			return "delete from previous replacement"
 		}
 		return "delete"
 	case deploy.OpReplace:
@@ -1142,7 +1142,7 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 			return "updating"
 		case deploy.OpDelete:
 			if step.Old.Delete {
-				return "deleting from previous plan"
+				return "deleting from previous replacement"
 			}
 			return "deleting"
 		case deploy.OpReplace:

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1068,9 +1068,6 @@ func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) st
 	case deploy.OpUpdate:
 		return "update"
 	case deploy.OpDelete:
-		if step.Old.Delete {
-			return "delete from previous replacement"
-		}
 		return "delete"
 	case deploy.OpReplace:
 		return "replace"
@@ -1141,9 +1138,6 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 		case deploy.OpUpdate:
 			return "updating"
 		case deploy.OpDelete:
-			if step.Old.Delete {
-				return "deleting from previous replacement"
-			}
 			return "deleting"
 		case deploy.OpReplace:
 			return "replacing"

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -996,7 +996,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	if display.isPreview {
 		// During a preview, when we transition to done, we still just print the same thing we
 		// did while running the step.
-		return op.Color() + display.getPreviewText(op) + colors.Reset
+		return op.Color() + display.getPreviewText(step) + colors.Reset
 	}
 
 	// most of the time a stack is unchanged.  in that case we just show it as "running->done"
@@ -1059,8 +1059,8 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 	return op.Color() + getDescription() + colors.Reset
 }
 
-func (display *ProgressDisplay) getPreviewText(op deploy.StepOp) string {
-	switch op {
+func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) string {
+	switch step.Op {
 	case deploy.OpSame:
 		return "no change"
 	case deploy.OpCreate:
@@ -1068,6 +1068,9 @@ func (display *ProgressDisplay) getPreviewText(op deploy.StepOp) string {
 	case deploy.OpUpdate:
 		return "update"
 	case deploy.OpDelete:
+		if step.Old.Delete {
+			return "delete from previous plan"
+		}
 		return "delete"
 	case deploy.OpReplace:
 		return "replace"
@@ -1083,7 +1086,7 @@ func (display *ProgressDisplay) getPreviewText(op deploy.StepOp) string {
 		return "refreshing"
 	}
 
-	contract.Failf("Unrecognized resource step op: %v", op)
+	contract.Failf("Unrecognized resource step op: %v", step.Op)
 	return ""
 }
 
@@ -1127,7 +1130,7 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 
 	getDescription := func() string {
 		if display.isPreview {
-			return display.getPreviewText(op)
+			return display.getPreviewText(step)
 		}
 
 		switch op {
@@ -1138,6 +1141,9 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 		case deploy.OpUpdate:
 			return "updating"
 		case deploy.OpDelete:
+			if step.Old.Delete {
+				return "deleting from previous plan"
+			}
 			return "deleting"
 		case deploy.OpReplace:
 			return "replacing"

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -241,6 +241,12 @@ func (pe *planExecutor) retirePendingDeletes(callerCtx context.Context, opts Opt
 	// Submit the deletes for execution and wait for them all to retire.
 	stepExec.Execute(steps)
 	stepExec.SignalCompletion()
+
+	// Log an ephemeral diagnostic for each resource we're deleting so it's clear why we are deleting it.
+	for _, step := range steps {
+		pe.plan.Ctx().StatusDiag.Infof(diag.RawMessage(step.URN(), "completing deletion from previous update"))
+	}
+
 	stepExec.WaitForCompletion()
 
 	// Like Refresh, we use the presence of an error in the caller's context to detect whether or not we have been

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -88,12 +88,19 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 		return err
 	}
 
+	// Set up a step generator for this plan.
+	pe.stepGen = newStepGenerator(pe.plan, opts)
+
+	// Retire any pending deletes that are currently present in this plan.
+	if err = pe.retirePendingDeletes(callerCtx, opts, preview); err != nil {
+		return err
+	}
+
 	// Derive a cancellable context for this plan. We will only cancel this context if some piece of the plan's
 	// execution fails.
 	ctx, cancel := context.WithCancel(callerCtx)
 
 	// Set up a step generator and executor for this plan.
-	pe.stepGen = newStepGenerator(pe.plan, opts)
 	pe.stepExec = newStepExecutor(ctx, cancel, pe.plan, opts, preview, false)
 
 	// We iterate the source in its own goroutine because iteration is blocking and we want the main loop to be able to
@@ -210,6 +217,46 @@ func (pe *planExecutor) handleSingleEvent(event SourceEvent) *result.Result {
 	}
 
 	pe.stepExec.Execute(steps)
+	return nil
+}
+
+// retirePendingDeletes deletes all resources that are pending deletion. Run before the start of a plan, this pass
+// ensures that the engine never sees any resources that are pending deletion from a previous plan.
+//
+// retirePendingDeletes re-uses the plan executor's step generator but uses its own step executor.
+func (pe *planExecutor) retirePendingDeletes(callerCtx context.Context, opts Options, preview bool) error {
+	prev := pe.plan.prev
+	if prev == nil || len(prev.Resources) == 0 {
+		logging.V(4).Infoln("planExecutor.retirePendingDeletes(...): no resources")
+		return nil
+	}
+
+	contract.Require(pe.stepGen != nil, "pe.stepGen != nil")
+	steps := pe.stepGen.GeneratePendingDeletes()
+	if len(steps) == 0 {
+		logging.V(4).Infoln("planExecutor.retirePendingDeletes(...): no pending deletions")
+		return nil
+	}
+	logging.V(4).Infof("planExecutor.retirePendingDeletes(...): executing %d steps", len(steps))
+	ctx, cancel := context.WithCancel(callerCtx)
+
+	options := opts
+	options.Parallel = 1 // deletes can't be executed in parallel yet (pulumi/pulumi#1625)
+	stepExec := newStepExecutor(ctx, cancel, pe.plan, options, preview)
+
+	// Submit the deletes for execution and wait for them all to retire.
+	stepExec.Execute(steps)
+	stepExec.SignalCompletion()
+	stepExec.WaitForCompletion()
+
+	// Like Refresh, we use the presence of an error in the caller's context to detect whether or not we have been
+	// cancelled.
+	canceled := callerCtx.Err() != nil
+	if stepExec.Errored() {
+		return execError("failed", preview)
+	} else if canceled {
+		return execError("canceled", preview)
+	}
 	return nil
 }
 

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -242,7 +242,7 @@ func (pe *planExecutor) retirePendingDeletes(callerCtx context.Context, opts Opt
 
 	options := opts
 	options.Parallel = 1 // deletes can't be executed in parallel yet (pulumi/pulumi#1625)
-	stepExec := newStepExecutor(ctx, cancel, pe.plan, options, preview)
+	stepExec := newStepExecutor(ctx, cancel, pe.plan, options, preview, false)
 
 	// Submit the deletes for execution and wait for them all to retire.
 	stepExec.Execute(steps)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -225,7 +225,6 @@ func NewDeleteStep(plan *Plan, old *resource.State) Step {
 	contract.Assert(old.URN != "")
 	contract.Assert(old.ID != "" || !old.Custom)
 	contract.Assert(!old.Custom || old.Provider != "" || providers.IsProviderType(old.Type))
-	contract.Assert(!old.Delete)
 	return &DeleteStep{
 		plan: plan,
 		old:  old,

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -427,7 +427,7 @@ func (sg *stepGenerator) GenerateDeletes() []Step {
 				// contract.Assert(!sg.deletes[res.URN])
 				if sg.pendingDeletes[res] {
 					logging.V(7).Infof(
-						"Planner ignoring pending-delete urn '%v' that was already deleted", res.URN)
+						"Planner ignoring pending-delete resource (%v, %v) that was already deleted", res.URN, res.ID)
 					continue
 				}
 
@@ -460,7 +460,8 @@ func (sg *stepGenerator) GeneratePendingDeletes() []Step {
 		for i := len(prev.Resources) - 1; i >= 0; i-- {
 			res := prev.Resources[i]
 			if res.Delete {
-				logging.V(7).Infof("stepGenerator.GeneratePendingDeletes(): resource %s is pending deletion", res.URN)
+				logging.V(7).Infof(
+					"stepGenerator.GeneratePendingDeletes(): resource (%v, %v) is pending deletion", res.URN, res.ID)
 				sg.pendingDeletes[res] = true
 				dels = append(dels, NewDeleteStep(sg.plan, res))
 			}

--- a/tests/integration/double_pending_delete/double_pending_delete_test.go
+++ b/tests/integration/double_pending_delete/double_pending_delete_test.go
@@ -51,10 +51,10 @@ func TestDoublePendingDelete(t *testing.T) {
 				Additive:      true,
 				ExpectFailure: true,
 				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-					// Now there are two pending deletes in the deployment.
+					// There is still only one pending delete resource in this snapshot.
 					assert.NotNil(t, stackInfo.Deployment)
 
-					assert.Equal(t, 6, len(stackInfo.Deployment.Resources))
+					assert.Equal(t, 5, len(stackInfo.Deployment.Resources))
 					stackRes := stackInfo.Deployment.Resources[0]
 					assert.Equal(t, resource.RootStackType, stackRes.URN.Type())
 					providerRes := stackInfo.Deployment.Resources[1]
@@ -68,11 +68,7 @@ func TestDoublePendingDelete(t *testing.T) {
 					assert.Equal(t, "a", string(aCondemned.URN.Name()))
 					assert.True(t, aCondemned.Delete)
 
-					aSecondCondemned := stackInfo.Deployment.Resources[4]
-					assert.Equal(t, "a", string(aSecondCondemned.URN.Name()))
-					assert.True(t, aSecondCondemned.Delete)
-
-					b := stackInfo.Deployment.Resources[5]
+					b := stackInfo.Deployment.Resources[4]
 					assert.Equal(t, "b", string(b.URN.Name()))
 					assert.False(t, b.Delete)
 				},

--- a/tests/integration/double_pending_delete/step3/index.ts
+++ b/tests/integration/double_pending_delete/step3/index.ts
@@ -16,7 +16,8 @@ import { Resource } from "./resource";
 
 // The previous plan failed, but we're going to initiate *another* plan that
 // introduces new changes, while still keeping around the failed state
-// from the previous plan.
+// from the previous plan. The engine should delete all pending deletes before
+// attempting to start the next plan.
 //
 // To do this, we're going to trigger another replacement of A:
 const a = new Resource("a", { fail: 3 });
@@ -26,8 +27,9 @@ const b = new Resource("b", { fail: 1 }, { dependsOn: a });
 // The snapshot now contains:
 //  A: Created
 //  A: Pending Delete
-//  A: Pending Delete
 //  B: Created
+
+// The A from the previous snapshot should have been deleted.
 
 // This plan is interesting because it shows that it is legal to delete the same URN multiple
 // times in the same plan. This previously triggered an assert in the engine that asserted

--- a/tests/integration/double_pending_delete/step4/index.ts
+++ b/tests/integration/double_pending_delete/step4/index.ts
@@ -18,6 +18,7 @@ import { Resource } from "./resource";
 // but this time the replacement of B will succeed.
 // The engine should generate:
 //
+// Delete A
 // Create A (mark old A as pending delete)
 const a = new Resource("a", { fail: 4 });
 
@@ -26,8 +27,6 @@ const b = new Resource("b", { fail: 2 }, { dependsOn: a });
 
 // Delete A
 // Delete B
-// Delete A
-// Delete A
 
 // Like the last step, this is interesting because we delete A's URN three times in the same plan.
 // This plan should drain all pending deletes and get us back to a state where only the live A and B


### PR DESCRIPTION
Instead of letting pending deletions pile up to be retired at the end of
a plan, this commit eagerly disposes of any pending deletions that were
pending at the end of the previous plan. This is a nice usability win
and also reclaims an invariant that at most one resource with a given
URN is live and at most one is pending deletion at any point in time.

Here's a video of the UX of this change in action. The setup here is that I have created an update that causes a bunch of resources to be replaced, but the update fails halfway through and leaves a number of objects in the snapshot in the pending delete state. The next update deletes them first before performing the rest of the update. https://asciinema.org/a/psJd5Te8GTtzRFiHctP3L1iz3.