### PR TITLE
computeCodePath won't find modules in an organization on Windows

### DIFF
--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -222,7 +222,7 @@ function findDependency(root: readPackageTree.Node | undefined | null, name: str
             const childFolderName = filepath.basename(child.path);
             const parentFolderName = filepath.basename(filepath.dirname(child.path));
             if (parentFolderName[0] === "@") {
-                childName = filepath.join(parentFolderName, childFolderName);
+                childName = `${parentFolderName}/${childFolderName}`;
             }
 
             if (childName === name) {


### PR DESCRIPTION
The most straightforward fix for https://github.com/pulumi/pulumi/issues/1888
Be sure to check I don't break other scenarios. At least you know the place where my problem occurs ;)