### PR TITLE
Don't close eventChannel when panicking

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -77,7 +77,7 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	// we can build up the diff display in case the user asks to see the details of the diff
 
 	// Note that eventsChannel is not closed in a `defer`. It is generally unsafe to do so, since defers run during
-	// panics and we can't know whether or not we were in the middle of writing to this channel when the panic occured.
+	// panics and we can't know whether or not we were in the middle of writing to this channel when the panic occurred.
 	//
 	// Instead of using a `defer`, we manually close `eventsChannel` on every exit of this function.
 	eventsChannel := make(chan engine.Event)

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -75,7 +75,13 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	op UpdateOperation, apply Applier) (engine.ResourceChanges, error) {
 	// create a channel to hear about the update events from the engine. this will be used so that
 	// we can build up the diff display in case the user asks to see the details of the diff
+
+	// Note that eventsChannel is not closed in a `defer`. It is generally unsafe to do so, since defers run during
+	// panics and we can't know whether or not we were in the middle of writing to this channel when the panic occured.
+	//
+	// Instead of using a `defer`, we manually close `eventsChannel` on every exit of this function.
 	eventsChannel := make(chan engine.Event)
+
 	var events []engine.Event
 	go func() {
 		// pull the events from the channel and store them locally


### PR DESCRIPTION
The state of the system is completely unknown when panicking and in
general it's not safe to infer whether or not it is safe to close a
channel when in this state.

Fixes https://github.com/pulumi/pulumi/issues/1879, but we only get into this state when panicking so there's probably another issue lurking.