### PR TITLE
Don't call process.exit in exit callback

### DIFF
--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -185,7 +185,7 @@ export function run(argv: minimist.ParsedArgs): void {
 
         // If we don't already have an exit code, and we had an unhandled error, exit with a non-success.
         if (code === 0 && uncaught) {
-            process.exit(1);
+            process.exitCode = 1;
         }
     });
 

--- a/sdk/nodejs/runtime/debuggable.ts
+++ b/sdk/nodejs/runtime/debuggable.ts
@@ -46,7 +46,10 @@ export function debuggablePromise<T>(p: Promise<T>, ctx?: any): Promise<T> {
         process.on("exit", (code: number) => {
             // Only print leaks if we're exiting normally.  Otherwise, it could be a crash, which of
             // course yields things that look like "leaks".
-            if (code === 0 && !log.hasErrors()) {
+            //
+            // process.exitCode is undefined unless set, in which case it's the exit code that was
+            // passed to process.exit.
+            if ((process.exitCode === undefined || process.exitCode === 0) && !log.hasErrors()) {
                 const leakedCount = leakCandidates.size;
                 if (leakedCount === 0) {
                     // No leaks - proceed with the exit.


### PR DESCRIPTION
Node calls 'exit' event callbacks when a process is preparing to exit,
via process.exit or otherwise, but it does not execute the next callback
in the chain if a callback calls process.exit.

I'm not 100% sure what the root cause of https://github.com/pulumi/pulumi/issues/1862 or https://github.com/pulumi/pulumi/issues/1835, but there is some nondeterminism around exiting with non-zero exit codes. Calling `process.exit` from within an `exit` callback seems generally dubious, though.