### PR TITLE
Plumb result.Result through step executor

### DIFF
--- a/pkg/util/result/result_test.go
+++ b/pkg/util/result/result_test.go
@@ -1,0 +1,49 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package result
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Smoke test for wrapping Results.
+func TestWrap(t *testing.T) {
+	firstMsg := "something failed"
+	secondMsg := "while doing the first thing"
+	base := Error(firstMsg)
+	wrapped := Wrap(base, secondMsg)
+	assert.Equal(t, secondMsg, wrapped.Error().Error())
+	if !assert.NotNil(t, wrapped.Cause()) {
+		t.FailNow()
+	}
+
+	assert.Equal(t, base, wrapped.Cause())
+	assert.Equal(t, firstMsg, wrapped.Cause().Error().Error())
+}
+
+// Smoke test for All, composing multiple Results into a single Result.
+func TestAll(t *testing.T) {
+	assert.Nil(t, All([]*Result{nil, nil, nil}))
+
+	bail := All([]*Result{nil, nil, Bail(), nil})
+	assert.NotNil(t, bail)
+	assert.Nil(t, bail.Error())
+
+	errRes := All([]*Result{nil, nil, Error("oh no"), nil})
+	assert.NotNil(t, errRes)
+	assert.NotNil(t, errRes.Error())
+}


### PR DESCRIPTION
This PR continues onward with https://github.com/pulumi/pulumi/issues/1712 by plumbing `*result.Result` through the step executor. The main structural change here is that all worker threads are required to provide a `Result` when terminating. These statuses are aggregated by the step executor and, when `WaitForCompletion` is called, a `Result` aggregated from all worker thread results is returned. This result is suitable for use by the plan executor to determine whether or not the step executor completed successfully, obviating the need for `Errored` to be public. (The presence of a non-nil `Result` implies that a step failed.)

I also added a few new combinators to the `result` package:

1. `Wrap` and `Wrapf`- As `Results` flow up the call stack, it is useful to attach some amount of context to them. This will be especially useful when we begin asking for bug reports when a Pulumi-internal error reaches the top-level of the CLI; it will be possible to describe exactly what the engine was doing at the point that the bug occurred.
2. `All` - All combines multiple Results into a single Result. The single Result contains any errors that were contained in the multiple Results. This can be used to aggregate Results across worker goroutines, which is what this PR uses it for.

As always, I'd love API design/coding convention feedback here - I don't expect `Result` to survive first contact with the enemy. I do think that this PR was not too difficult to write so I am optimistic that `Result` will be reasonably simple to flow throughout the rest of the engine and upward.