### PR TITLE
Log any errors coming from the langhost during tests

### DIFF
--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -603,6 +603,10 @@ describe("rpc", () => {
                     const message = req.getMessage();
                     const urn = req.getUrn();
                     const streamId = req.getStreamid();
+                    if (severity === engineproto.LogSeverity.ERROR) {
+                        console.log("log error: " + message);
+                    }
+
                     if (opts.expectedLogs) {
                         if (!opts.expectedLogs.ignoreDebug || severity !== engineproto.LogSeverity.DEBUG) {
                             logCnt++;


### PR DESCRIPTION
Looks like there's still some residual flakiness coming from the NodeJS langhost tests (https://travis-ci.com/pulumi/pulumi/jobs/144283001). Since it looks like (from the job) that tests are trying to log errors to the engine, let's print them out.