### PR TITLE
Make `opts.providers` robust to SxS scenarios.

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -103,16 +103,18 @@ export abstract class Resource {
             }
 
             this.__providers = opts.parent.__providers;
+
             if (custom) {
                 const provider = (<CustomResourceOptions>opts).provider;
                 if (provider === undefined) {
                     (<CustomResourceOptions>opts).provider = opts.parent.getProvider(t);
                 }
-            } else {
-                const providers = (<ComponentResourceOptions>opts).providers;
-                if (providers) {
-                    this.__providers = { ...this.__providers, ...providers };
-                }
+            }
+        }
+        if (!custom) {
+            const providers = (<ComponentResourceOptions>opts).providers;
+            if (providers) {
+                this.__providers = { ...this.__providers, ...providers };
             }
         }
         this.__protect = !!opts.protect;


### PR DESCRIPTION
`opts.providers` is currently only read by the `Resource` constructor if
either `opts.parent` or `getRootResource` is not `undefined`. In
scnearios where exactly one copy of `@pulumi/pulumi` is loaded, one of
these conditions will always be true. In SxS scenarios, however, it is
possible for neither of these conditions to be true, and the created
resource will end up without a `providers` map. These changes fix that
by always copying the contents of `opts.providers` if it is defined.