### PR TITLE
Always upload previews

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -33,10 +33,17 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
-// Applier applies the changes specified by this update operation against the target stack. If dryRun is true,
-// a preview is performed, rather than an actual update, and in any case events are written to the events channel.
+// ApplierOptions is a bag of configuration settings for an Applier.
+type ApplierOptions struct {
+	// DryRun indiciates if the update should not change any resource state and instead just preview changes.
+	DryRun bool
+	// ShowLink indiciates if a link to the update persisted result should be displayed.
+	ShowLink bool
+}
+
+// Applier applies the changes specified by this update operation against the target stack.
 type Applier func(ctx context.Context, kind apitype.UpdateKind, stack Stack, op UpdateOperation,
-	dryRun, persist bool, events chan<- engine.Event) (engine.ResourceChanges, error)
+	opts ApplierOptions, events chan<- engine.Event) (engine.ResourceChanges, error)
 
 var (
 	updateTextMap = map[apitype.UpdateKind]struct {
@@ -98,7 +105,15 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	// Perform the update operations, passing true for dryRun, so that we get a preview.
 	changes := engine.ResourceChanges(nil)
 	if !op.Opts.SkipPreview {
-		c, err := apply(ctx, kind, stack, op, true /*dryRun*/, true /*persist*/, eventsChannel)
+		// We perform the preview (DryRun), but don't display the cloud link since the
+		// thing the user cares about would be the link to the actual update if they
+		// confirm the prompt.
+		opts := ApplierOptions{
+			DryRun:   true,
+			ShowLink: false,
+		}
+
+		c, err := apply(ctx, kind, stack, op, opts, eventsChannel)
 		if err != nil {
 			close(eventsChannel)
 			return c, err
@@ -185,8 +200,13 @@ func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, 
 		return changes, err
 	}
 
-	// Now do the real operation. We don't care about the events it issues, so just pass a nil channel along.
-	return apply(ctx, kind, stack, op, false /*dryRun*/, true /*persist*/, nil /*events*/)
+	// Perform the change (!DryRun) and show the cloud link to the result.
+	// We don't care about the events it issues, so just pass a nil channel along.
+	opts := ApplierOptions{
+		DryRun:   false,
+		ShowLink: true,
+	}
+	return apply(ctx, kind, stack, op, opts, nil /*events*/)
 }
 
 func createDiff(updateKind apitype.UpdateKind, events []engine.Event, displayOpts display.Options) string {

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -98,7 +98,7 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	// Perform the update operations, passing true for dryRun, so that we get a preview.
 	changes := engine.ResourceChanges(nil)
 	if !op.Opts.SkipPreview {
-		c, err := apply(ctx, kind, stack, op, true /*dryRun*/, false /*persist*/, eventsChannel)
+		c, err := apply(ctx, kind, stack, op, true /*dryRun*/, true /*persist*/, eventsChannel)
 		if err != nil {
 			close(eventsChannel)
 			return c, err

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -612,9 +612,12 @@ func (b *cloudBackend) Preview(ctx context.Context, stackRef backend.StackRefere
 	}
 
 	// We can skip PreviewtThenPromptThenExecute, and just go straight to Execute.
+	opts := backend.ApplierOptions{
+		DryRun:   true,
+		ShowLink: true,
+	}
 	return b.apply(
-		ctx, apitype.PreviewUpdate, stack, op,
-		true /*dryRun*/, true /* persist */, nil /*events*/)
+		ctx, apitype.PreviewUpdate, stack, op, opts, nil /*events*/)
 }
 
 func (b *cloudBackend) Update(ctx context.Context, stackRef backend.StackReference,
@@ -694,29 +697,23 @@ func (b *cloudBackend) createAndStartUpdate(
 
 // apply actually performs the provided type of update on a stack hosted in the Pulumi Cloud.
 func (b *cloudBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack backend.Stack,
-	op backend.UpdateOperation, dryRun, persist bool, events chan<- engine.Event) (engine.ResourceChanges, error) {
+	op backend.UpdateOperation, opts backend.ApplierOptions, events chan<- engine.Event) (engine.ResourceChanges, error) {
 	// Print a banner so it's clear this is going to the cloud.
-	actionLabel := backend.ActionLabel(kind, dryRun)
+	actionLabel := backend.ActionLabel(kind, opts.DryRun)
 	fmt.Printf(op.Opts.Display.Color.Colorize(
 		colors.BrightMagenta+"%s stack '%s'"+colors.Reset+"\n"), actionLabel, stack.Ref())
 
-	// Create an update object if we will persist the results, e.g. when not doing a local preview.
-	var update client.UpdateIdentifier
-	var version int
-	var token string
-	var err error
-	if persist {
-		update, version, token, err = b.createAndStartUpdate(ctx, kind, stack.Ref(), op, dryRun)
-	}
+	// Create an update object to persist results.
+	update, version, token, err := b.createAndStartUpdate(ctx, kind, stack.Ref(), op, opts.DryRun)
 	if err != nil {
 		return nil, err
 	}
 
-	if persist {
+	if opts.ShowLink {
 		// Print a URL at the end of the update pointing to the Pulumi Service.
 		var link string
 		base := b.cloudConsoleStackPath(update.StackIdentifier)
-		if !dryRun {
+		if !opts.DryRun {
 			link = b.CloudConsoleURL(base, "updates", strconv.Itoa(version))
 		} else {
 			link = b.CloudConsoleURL(base, "previews", update.UpdateID)
@@ -730,7 +727,7 @@ func (b *cloudBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 		}
 	}
 
-	return b.runEngineAction(ctx, kind, stack.Ref(), op, update, token, events, dryRun, persist)
+	return b.runEngineAction(ctx, kind, stack.Ref(), op, update, token, events, opts.DryRun)
 }
 
 // uploadArchive archives the current Pulumi program and uploads it to a signed URL. "current"
@@ -764,8 +761,8 @@ func getUpdateContents(
 func (b *cloudBackend) runEngineAction(
 	ctx context.Context, kind apitype.UpdateKind, stackRef backend.StackReference,
 	op backend.UpdateOperation, update client.UpdateIdentifier, token string,
-	callerEventsOpt chan<- engine.Event, dryRun bool, persist bool) (engine.ResourceChanges, error) {
-	contract.Assertf(!persist || token != "", "persisted actions require a token")
+	callerEventsOpt chan<- engine.Event, dryRun bool) (engine.ResourceChanges, error) {
+	contract.Assertf(token != "", "persisted actions require a token")
 	u, err := b.newUpdate(ctx, stackRef, op.Proj, op.Root, update, token)
 	if err != nil {
 		return nil, err
@@ -828,16 +825,15 @@ func (b *cloudBackend) runEngineAction(
 	// Make sure that the goroutine writing to displayEvents and callerEventsOpt
 	// has exited before proceeding
 	<-eventsDone
-	if persist {
-		status := apitype.UpdateStatusSucceeded
-		if err != nil {
-			status = apitype.UpdateStatusFailed
-		}
 
-		completeErr := u.Complete(status)
-		if completeErr != nil {
-			err = multierror.Append(err, errors.Wrap(completeErr, "failed to complete update"))
-		}
+	status := apitype.UpdateStatusSucceeded
+	if err != nil {
+		status = apitype.UpdateStatusFailed
+	}
+
+	completeErr := u.Complete(status)
+	if completeErr != nil {
+		err = multierror.Append(err, errors.Wrap(completeErr, "failed to complete update"))
 	}
 
 	return changes, err

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -606,18 +606,15 @@ func getStack(ctx context.Context, b *cloudBackend, stackRef backend.StackRefere
 
 func (b *cloudBackend) Preview(ctx context.Context, stackRef backend.StackReference,
 	op backend.UpdateOperation) (engine.ResourceChanges, error) {
-	// Get the stack.
 	stack, err := getStack(ctx, b, stackRef)
 	if err != nil {
 		return nil, err
 	}
 
-	// Persisting update previews is a new feature to pulumi.com, and is enabled via a flag
-	// so performance data can be gathered before enabling it by default.
-	persist := os.Getenv("PULUMI_PERSIST_PREVIEWS") != ""
-
 	// We can skip PreviewtThenPromptThenExecute, and just go straight to Execute.
-	return b.apply(ctx, apitype.PreviewUpdate, stack, op, true /*dryRun*/, persist, nil /*events*/)
+	return b.apply(
+		ctx, apitype.PreviewUpdate, stack, op,
+		true /*dryRun*/, true /* persist */, nil /*events*/)
 }
 
 func (b *cloudBackend) Update(ctx context.Context, stackRef backend.StackReference,


### PR DESCRIPTION
Previously the `httpstate` backend only persisted previews if the `PULUMI_PERSIST_PREVIEWS` flag was set. The `httpstate` backend how will always persist the results of `pulumi preview`.

Fixes #1826 