### PR TITLE
Have ListStacksResponse include data required for 'stacks ls'

### DIFF
--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -18,8 +18,10 @@ import "encoding/json"
 
 // StackSummary describes the state of a stack, without including its specific resources, etc.
 type StackSummary struct {
-	// QualifiedName is the name of the stack, prefixed with the organization. e.g. "pulumi/pulumi.io-production".
-	QualifiedName string `json:"qualifiedName"`
+	// OrgName is the organization name the stack is found in.
+	OrgName string `json:"orgName"`
+	// StackName is the name of the stack.
+	StackName string `json:"stackName"`
 
 	// LastUpdate is a Unix timestamp of the stack's last update, as applicable.
 	LastUpdate *int64 `json:"lastUpdate,omitempty"`

--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -16,22 +16,19 @@ package apitype
 
 import "encoding/json"
 
-// StackSummary presents an overview of a particular stack without enumerating its current resource set.
+// StackSummary describes the state of a stack, without including its specific resources, etc.
 type StackSummary struct {
-	// ID is the unique identifier for a stack in the context of its PPC.
-	ID string `json:"id"`
+	Name string `json:"name"`
 
-	// ActiveUpdate is the unique identifier for the stack's active update. This may be empty if no update has
-	// been applied.
-	ActiveUpdate string `json:"activeUpdate"`
+	// LastUpdate is a Unix timestamp of the stack's last update, as applicable.
+	LastUpdate *int64 `json:"lastUpdate,omitempty"`
 
-	// ResourceCount is the number of resources associated with this stack. Note that this is currently unimplemented.
-	ResourceCount int `json:"resourceCount"`
+	// ResourceCount is the number of resources associated with this stack, as applicable.
+	ResourceCount *int `json:"resourceCount,omitempty"`
 }
 
-// ListStacksResponse describes the data returned by the `GET /stacks` endpoint of the PPC API.
+// ListStacksResponse returns a set of stack summaries. This call is designed to be inexpensive.
 type ListStacksResponse struct {
-	// Stacks contains a list of summaries for each stack that currently exists in the PPC.
 	Stacks []StackSummary `json:"stacks"`
 }
 

--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -18,7 +18,8 @@ import "encoding/json"
 
 // StackSummary describes the state of a stack, without including its specific resources, etc.
 type StackSummary struct {
-	Name string `json:"name"`
+	// QualifiedName is the name of the stack, prefixed with the organization. e.g. "pulumi/pulumi.io-production".
+	QualifiedName string `json:"qualifiedName"`
 
 	// LastUpdate is a Unix timestamp of the stack's last update, as applicable.
 	LastUpdate *int64 `json:"lastUpdate,omitempty"`


### PR DESCRIPTION
`pulumi stacks ls` is far, far slower than it needs to be. The root cause is a major disconnect between the data the CLI requests and is returned from the service, and the data the CLI needs to actually power the `stacks ls` command.

This PR introduces new API types (1) `ListStacksResponse` and `StackSummary` that are designed to return just the data necessary for implementing `backend.ListStacks`(2).

(1) These API types already exist, but are unused. These were the types used by the PPC API, but have since been unreferenced. So while this would be a breaking API change several months ago, we are free to change the type shape without any problems.

(2) The `backend.ListStacks` interface method still returns type `[]Stack` (where `Stack` contains the ability to get the last `deploy.Snapshot`, which is part of the problem we are fixing).

Once the service implements an API endpoint that returns this data, we will need to refactor `backend.ListStacks` to return a different type and use that, instead of `backend.Stack`.

The `backend.ListStacks` method is only called in two places. In `stacks_ls.go`, where it gets each stack's `Snapshot` to determine last update and resource count. And in `util.go`, in `chooseStack` which is the implementation behind `pulumi stack select`.

So if we add `backend.StackSummary` with the following definition, we would be able to preserve exiting behavior, while increasing the performance of `pulumi stack ls` by maybe an order of magnitude.

```
# New type I think we should add to backend.go, which will be the new return type from
# backend.ListStacks.

// StackSummary provides a basic description of a stack, without the ability to inspect its resources or make changes.
type StackSummary interface {
	Name() StackReference

	// LastUpdate returns when the stack was last updated, as applicable.
	LastUpdate() *time.Time
	// ResourceCount returns the stack's resource count, as applicable.
	ResourceCount() *int
}
```
