### PR TITLE
Use optional parent event stream for cancellation

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -292,8 +292,6 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 	engineEvents := make(chan engine.Event)
 
 	scope := op.Scopes.NewScope(engineEvents, dryRun)
-	defer scope.Close()
-
 	eventsDone := make(chan bool)
 	go func() {
 		// Pull in all events from the engine and send them to the two listeners.
@@ -334,6 +332,7 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 
 	// Wait for the display to finish showing all the events.
 	<-displayDone
+	scope.Close() // Don't take any cancellations anymore, we're shutting down.
 	close(engineEvents)
 	close(displayEvents)
 	close(displayDone)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -768,8 +768,6 @@ func (b *cloudBackend) runEngineAction(
 	engineEvents := make(chan engine.Event)
 
 	scope := op.Scopes.NewScope(engineEvents, dryRun)
-	defer scope.Close()
-
 	eventsDone := make(chan bool)
 	go func() {
 		// Pull in all events from the engine and send to them to the two listeners.
@@ -807,6 +805,7 @@ func (b *cloudBackend) runEngineAction(
 
 	// Wait for the display to finish showing all the events.
 	<-displayDone
+	scope.Close() // Don't take any cancellations anymore, we're shutting down.
 	close(engineEvents)
 	close(displayEvents)
 	close(displayDone)


### PR DESCRIPTION
Engine backends allow a caller to specify an optional event channel for
communicating engine events. The engine does not own this channel and
does not close it. This commit uses this channel to communicate
cancellation instead of the channel the engine creates so that cancels
in specific places do not try to send the cancellation message on an
already-closed channel.

Fixes pulumi/pulumi#1706