### PR TITLE
Fix provider cancellation.

### DIFF
--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -1894,7 +1894,6 @@ func TestBadResourceType(t *testing.T) {
 
 // Tests that provider cancellation occurs as expected.
 func TestProviderCancellation(t *testing.T) {
-	const resType = "pkgA:m:typA"
 	const resourceCount = 4
 
 	// Set up a cancelable context for the refresh operation.

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/blang/semver"
@@ -236,7 +237,17 @@ func (op TestOp) RunWithContext(callerCtx context.Context, project workspace.Pro
 	// Create an appropriate update info and context.
 	info := &updateInfo{project: project, target: target}
 
-	cancelCtx, _ := cancel.NewContext(callerCtx)
+	cancelCtx, cancelSrc := cancel.NewContext(context.Background())
+	done := make(chan bool)
+	defer close(done)
+	go func() {
+		select {
+		case <-callerCtx.Done():
+			cancelSrc.Cancel()
+		case <-done:
+		}
+	}()
+
 	events := make(chan Event)
 	journal := newJournal()
 
@@ -1879,4 +1890,77 @@ func TestBadResourceType(t *testing.T) {
 	}
 
 	p.Run(t, nil)
+}
+
+// Tests that provider cancellation occurs as expected.
+func TestProviderCancellation(t *testing.T) {
+	const resType = "pkgA:m:typA"
+	const resourceCount = 4
+
+	// Set up a cancelable context for the refresh operation.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Wait for our resource ops, then cancel.
+	var ops sync.WaitGroup
+	ops.Add(resourceCount)
+	go func() {
+		ops.Wait()
+		cancel()
+	}()
+
+	// Set up an independent cancelable context for the provider's operations.
+	provCtx, provCancel := context.WithCancel(context.Background())
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(urn resource.URN,
+					inputs resource.PropertyMap) (resource.ID, resource.PropertyMap, resource.Status, error) {
+
+					// Inform the waiter that we've entered a provider op and wait for cancellation.
+					ops.Done()
+					<-provCtx.Done()
+
+					return resource.ID(urn.Name()), resource.PropertyMap{}, resource.StatusOK, nil
+				},
+				CancelF: func() error {
+					provCancel()
+					return nil
+				},
+			}, nil
+		}),
+	}
+
+	done := make(chan bool)
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		errors := make([]error, resourceCount)
+		var resources sync.WaitGroup
+		resources.Add(resourceCount)
+		for i := 0; i < resourceCount; i++ {
+			go func(idx int) {
+				_, _, _, errors[idx] = monitor.RegisterResource("pkgA:m:typA", fmt.Sprintf("res%d", idx), true, "",
+					false, nil, "", resource.PropertyMap{})
+				resources.Done()
+			}(i)
+		}
+		resources.Wait()
+		for _, err := range errors {
+			assert.NoError(t, err)
+		}
+		close(done)
+		return nil
+	})
+
+	p := &TestPlan{}
+	op := TestOp(Update)
+	options := UpdateOptions{
+		Parallel: resourceCount,
+		host:     deploytest.NewPluginHost(nil, nil, program, loaders...),
+	}
+	project, target := p.GetProject(), p.GetTarget(nil)
+
+	_, err := op.RunWithContext(ctx, project, target, options, false, nil)
+	assert.Error(t, err)
+
+	// Wait for the program to finish.
+	<-done
 }

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -49,10 +49,15 @@ type Provider struct {
 		props resource.PropertyMap) (resource.PropertyMap, resource.Status, error)
 	InvokeF func(tok tokens.ModuleMember,
 		inputs resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
+
+	CancelF func() error
 }
 
 func (prov *Provider) SignalCancellation() error {
-	return nil
+	if prov.CancelF == nil {
+		return nil
+	}
+	return prov.CancelF()
 }
 
 func (prov *Provider) Close() error {

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -37,9 +37,6 @@ type planExecutor struct {
 	stepExec *stepExecutor  // step executor owned by this plan
 }
 
-// Utility for convenient logging.
-var log = logging.V(4)
-
 // execError creates an error appropriate for returning from planExecutor.Execute.
 func execError(message string, preview bool) error {
 	kind := "update"

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -61,14 +61,17 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	// not hang this off of the context we create below because we do not want the failure of a single step to cause
 	// other steps to fail.
 	done := make(chan bool)
+	defer close(done)
 	go func() {
 		select {
 		case <-callerCtx.Done():
+			logging.V(4).Infof("planExecutor.Execute(...): signalling cancellation to providers...")
 			cancelErr := pe.plan.ctx.Host.SignalCancellation()
 			if cancelErr != nil {
-				log.Infof("planExecutor.Execute(...): failed to signal cancellation to providers: %v", cancelErr)
+				logging.V(4).Infof("planExecutor.Execute(...): failed to signal cancellation to providers: %v", cancelErr)
 			}
 		case <-done:
+			logging.V(4).Infof("planExecutor.Execute(...): exiting provider canceller")
 		}
 	}()
 
@@ -112,7 +115,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 					return
 				}
 			case <-done:
-				log.Infof("planExecutor.Execute(...): incoming events goroutine exiting")
+				logging.V(4).Infof("planExecutor.Execute(...): incoming events goroutine exiting")
 				return
 			}
 		}
@@ -127,11 +130,11 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	//  3. The stepExecCancel cancel context gets canceled. This means some error occurred in the step executor
 	//     and we need to bail. This can also happen if the user hits Ctrl-C.
 	canceled, err := func() (bool, error) {
-		log.Infof("planExecutor.Execute(...): waiting for incoming events")
+		logging.V(4).Infof("planExecutor.Execute(...): waiting for incoming events")
 		for {
 			select {
 			case event := <-incomingEvents:
-				log.Infof("planExecutor.Execute(...): incoming event (nil? %v, %v)", event.Event == nil, event.Error)
+				logging.V(4).Infof("planExecutor.Execute(...): incoming event (nil? %v, %v)", event.Event == nil, event.Error)
 
 				if event.Error != nil {
 					pe.reportError("", event.Error)
@@ -149,21 +152,21 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 					// Signal completion to the step executor. It'll exit once it's done retiring all of the steps in
 					// the chain that we just gave it.
 					pe.stepExec.SignalCompletion()
-					log.Infof("planExecutor.Execute(...): issued deletes")
+					logging.V(4).Infof("planExecutor.Execute(...): issued deletes")
 
 					return false, nil
 				}
 
 				if res := pe.handleSingleEvent(event.Event); res != nil {
 					if resErr := res.Error(); resErr != nil {
-						log.Infof("planExecutor.Execute(...): error handling event: %v", resErr)
+						logging.V(4).Infof("planExecutor.Execute(...): error handling event: %v", resErr)
 						pe.reportError(pe.plan.generateEventURN(event.Event), resErr)
 					}
 					cancel()
 					return false, result.TODO()
 				}
 			case <-ctx.Done():
-				log.Infof("planExecutor.Execute(...): context finished: %v", ctx.Err())
+				logging.V(4).Infof("planExecutor.Execute(...): context finished: %v", ctx.Err())
 
 				// NOTE: we use the presence of an error in the caller context in order to distinguish caller-initiated
 				// cancellation from internally-initiated cancellation.
@@ -171,10 +174,9 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 			}
 		}
 	}()
-	close(done)
 
 	pe.stepExec.WaitForCompletion()
-	log.Infof("planExecutor.Execute(...): step executor has completed")
+	logging.V(4).Infof("planExecutor.Execute(...): step executor has completed")
 
 	// Figure out if execution failed and why. Step generation and execution errors trump cancellation.
 	if err != nil || pe.stepExec.Errored() {
@@ -194,13 +196,13 @@ func (pe *planExecutor) handleSingleEvent(event SourceEvent) *result.Result {
 	var res *result.Result
 	switch e := event.(type) {
 	case RegisterResourceEvent:
-		log.Infof("planExecutor.handleSingleEvent(...): received RegisterResourceEvent")
+		logging.V(4).Infof("planExecutor.handleSingleEvent(...): received RegisterResourceEvent")
 		steps, res = pe.stepGen.GenerateSteps(e)
 	case ReadResourceEvent:
-		log.Infof("planExecutor.handleSingleEvent(...): received ReadResourceEvent")
+		logging.V(4).Infof("planExecutor.handleSingleEvent(...): received ReadResourceEvent")
 		steps, res = pe.stepGen.GenerateReadSteps(e)
 	case RegisterResourceOutputsEvent:
-		log.Infof("planExecutor.handleSingleEvent(...): received register resource outputs")
+		logging.V(4).Infof("planExecutor.handleSingleEvent(...): received register resource outputs")
 		pe.stepExec.ExecuteRegisterResourceOutputs(e)
 		return nil
 	}


### PR DESCRIPTION
We signal provider cancellation by hangning a goroutine off of the plan
executor's parent context. To ensure clean shutdown, this goroutine also
listens on a channel that closes once the plan has finished executing.
Unfortunately, we were closing this channel too early, and the close was
racing with the cancellation signal. These changes ensure that the
channel closes after the plan has fully completed.

Fixes #1906.
Fixes https://github.com/pulumi/pulumi-kubernetes/issues/185.