### PR TITLE
Don't show stack outputs when update fails

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -716,7 +716,9 @@ func (display *ProgressDisplay) processEndSteps() {
 		}
 	}
 
-	// If we get stack outputs and there weren't any errors, display them at the end.
+	// If we get stack outputs and there weren't any errors, display them at the end. Stack outputs are meaningless if
+	// there were errors; it is possible that the update encountered an error and exited before the entire Pulumi
+	// program ran to populate the stack outputs.
 	if display.stackUrn != "" && !sawError {
 		stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
 		props := engine.GetResourceOutputsPropertiesString(stackStep, 1, display.isPreview, display.opts.Debug)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -633,7 +633,14 @@ func (display *ProgressDisplay) processEndSteps() {
 	// Figure out the rows that are currently in progress.
 	inProgressRows := []ResourceRow{}
 
+	// Remember if any rows have errors. Stack outputs are not meaningful to display if there were errors.
+	sawError := false
+
 	for _, v := range display.eventUrnToResourceRow {
+		if v.DiagInfo().LastError != nil {
+			sawError = true
+		}
+
 		if !v.IsDone() {
 			inProgressRows = append(inProgressRows, v)
 		}
@@ -709,8 +716,8 @@ func (display *ProgressDisplay) processEndSteps() {
 		}
 	}
 
-	// If we get stack outputs, display them at the end.
-	if display.stackUrn != "" {
+	// If we get stack outputs and there weren't any errors, display them at the end.
+	if display.stackUrn != "" && !sawError {
 		stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
 		props := engine.GetResourceOutputsPropertiesString(stackStep, 1, display.isPreview, display.opts.Debug)
 		if props != "" {


### PR DESCRIPTION
It is basically guaranteed that stack outputs are going to be
meaningless if a plan fails, so this commmit doesn't display them if an
error has occured.

Fixes pulumi/pulumi#1913, in that it won't show outputs in Luke's example.