### PR TITLE
Fix several output-related issues

### DIFF
--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -290,12 +290,15 @@ func renderResourceOutputsEvent(
 	if shouldShow(payload.Metadata, opts) || isRootStack(payload.Metadata) {
 		indent := engine.GetIndent(payload.Metadata, seen)
 
+		refresh := false // are these outputs from a refresh?
 		if m, has := seen[payload.Metadata.URN]; has && m.Op == deploy.OpRefresh {
+			refresh = true
 			summary := engine.GetResourcePropertiesSummary(payload.Metadata, indent)
 			fprintIgnoreError(out, opts.Color.Colorize(summary))
 		}
 
-		text := engine.GetResourceOutputsPropertiesString(payload.Metadata, indent+1, payload.Planning, payload.Debug)
+		text := engine.GetResourceOutputsPropertiesString(
+			payload.Metadata, indent+1, payload.Planning, payload.Debug, refresh)
 
 		fprintIgnoreError(out, opts.Color.Colorize(text))
 	}

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -633,14 +633,7 @@ func (display *ProgressDisplay) processEndSteps() {
 	// Figure out the rows that are currently in progress.
 	inProgressRows := []ResourceRow{}
 
-	// Remember if any rows have errors. Stack outputs are not meaningful to display if there were errors.
-	sawError := false
-
 	for _, v := range display.eventUrnToResourceRow {
-		if v.DiagInfo().LastError != nil {
-			sawError = true
-		}
-
 		if !v.IsDone() {
 			inProgressRows = append(inProgressRows, v)
 		}
@@ -716,10 +709,8 @@ func (display *ProgressDisplay) processEndSteps() {
 		}
 	}
 
-	// If we get stack outputs and there weren't any errors, display them at the end. Stack outputs are meaningless if
-	// there were errors; it is possible that the update encountered an error and exited before the entire Pulumi
-	// program ran to populate the stack outputs.
-	if display.stackUrn != "" && !sawError {
+	// If we get stack outputs, display them at the end.
+	if display.stackUrn != "" {
 		stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
 		props := engine.GetResourceOutputsPropertiesString(stackStep, 1, display.isPreview, display.opts.Debug)
 		if props != "" {

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -231,22 +231,18 @@ func printObject(
 // there is an old snapshot of the resource, differ from the prior old snapshot's output properties.
 func GetResourceOutputsPropertiesString(
 	step StepEventMetadata, indent int, planning bool, debug bool, refresh bool) string {
-	// We should only attempt to write out outputs if we are sure that this resource's outputs are complete. We know
-	// this for sure when we are performing updates, since we have just performed some resource operation and received
-	// outputs, but for previews we must be careful to not display a diff against outputs that are not complete.
-	if planning {
-		// If we are doing a preview, the only times that we are confident that our output bag is complete is when we
-		// are doing a refresh. So when we aren't...
-		if !refresh {
-			// ... we can only be sure that our outputs are complete if we have performed a Read or ReadReplacement, in
-			// which case the provider has given us a complete set of outputs for this resource.
-			if step.Op != deploy.OpRead && step.Op != deploy.OpReadReplacement {
-				return ""
-			}
+	// We should only print outputs if the outputs are known to be complete. This will be the case if we are
+	//   1) not doing a preview
+	//   2) doing a refresh
+	//   3) doing a read
+	//
+	// Technically, 2 and 3 are the same, since they're both bottoming out at a provider's implementation of Read, but
+	// the upshot is that either way we're ending up with outputs that are exactly accurate. If we are not sure that we
+	// are in one of the above states, we shouldn't try to print outputs.
+	if planning && !refresh {
+		if step.Op != deploy.OpRead && step.Op != deploy.OpReadReplacement {
+			return ""
 		}
-
-		// If we are doing a refresh, all of our outputs came from a provider's Read and we also can be confident that
-		// the set our outputs we are working with is complete.
 	}
 
 	// Resources that have initialization errors did not successfully complete, and therefore do not

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -230,7 +230,19 @@ func printObject(
 // GetResourceOutputsPropertiesString prints only those properties that either differ from the input properties or, if
 // there is an old snapshot of the resource, differ from the prior old snapshot's output properties.
 func GetResourceOutputsPropertiesString(
-	step StepEventMetadata, indent int, planning bool, debug bool) string {
+	step StepEventMetadata, indent int, planning bool, debug bool, refresh bool) string {
+	// We should only print outputs if the outputs are known to be complete. This will be the case if we are
+	//   1) not doing a preview
+	//   2) doing a refresh
+	//   3) doing a read
+	//
+	// Technically, 2 and 3 are the same, since they're both bottoming out at a provider's implementation of Read, but
+	// the upshot is that either way we're ending up with outputs that are exactly accurate. If we are not sure that we
+	// are in one of the above states, we shouldn't try to print outputs.
+	if planning && (!refresh || step.Op == deploy.OpRead || step.Op == deploy.OpReadReplacement) {
+		return ""
+	}
+
 	// Resources that have initialization errors did not successfully complete, and therefore do not
 	// have outputs to render diffs for. So, simply return.
 	if step.Old != nil && len(step.Old.InitErrors) > 0 {
@@ -436,7 +448,9 @@ func printOldNewDiffs(
 	if diff := olds.Diff(news); diff != nil {
 		printObjectDiff(b, *diff, planning, indent, summary, debug)
 	} else {
-		printObject(b, news, planning, indent, op, true, debug)
+		// If there's no diff, report the op as Same - there's no diff to render
+		// so it should be rendered as if nothing changed.
+		printObject(b, news, planning, indent, deploy.OpSame, true, debug)
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1885, https://github.com/pulumi/pulumi/issues/1913.

This PR reverts https://github.com/pulumi/pulumi/pull/1916 and replaces it with a better and more correct fix.

There are a few components in this PR:

1. To fix https://github.com/pulumi/pulumi/issues/1885, this PR only renders outputs when not doing a preview, or when doing a refresh, read, or read replacement. This ensures that we only ever diff outputs when we know that they are completely accurate because they have come from a provider's `Read`.
2. To fix an issue where empty-diff updates were rendered as a giant update, this PR attaches the `deploy.OpSame` step to resources that we are printing but have no diff associated with them. This ensures that they are printed out like a Same step, i.e. greyed out.
3. To fix https://github.com/pulumi/pulumi/issues/1913, this PR makes a note whenever a resource output event is received for the Stack itself and only prints the outputs if it has seen this event.