### PR TITLE
Fix up scripts when running on macOS

### DIFF
--- a/scripts/build-sdk.sh
+++ b/scripts/build-sdk.sh
@@ -59,7 +59,7 @@ readonly SDK_FILENAME=pulumi-${1:-$(date +"%Y%m%d_%H%M%S")}-${OS}-x64.tar.gz
 readonly PULUMI_REF=${2:-master}
 
 # setup temporary folder to process the package
-readonly PULUMI_FOLDER=$(mktemp --directory)/pulumi
+readonly PULUMI_FOLDER=$(mktemp -d)/pulumi
 mkdir -p "${PULUMI_FOLDER}"
 
 cd "${PULUMI_FOLDER}"

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -5,7 +5,7 @@ set -o errexit
 set -o pipefail
 
 readonly ROOT=$(dirname "${0}")/..
-readonly PUBDIR=$(mktemp --dry-run --directory)
+readonly PUBDIR=$(mktemp -d)
 readonly GITHASH=$(git rev-parse HEAD)
 readonly PUBFILE=$(dirname "${PUBDIR})/${GITHASH}.tgz")
 readonly VERSION=$("${ROOT}/scripts/get-version")
@@ -23,7 +23,7 @@ run_go_build() {
         bin_suffix=".exe"
     fi
 
-    mkdir --parents "${PUBDIR}/bin"
+    mkdir -p "${PUBDIR}/bin"
     go build \
        -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" \
        -o "${PUBDIR}/bin/${output_name}${bin_suffix}" \


### PR DESCRIPTION
macOS doesn't use GNU tools and so some options are missing.