### PR TITLE
Clarify condition for displaying outputs

### DIFF
--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -239,8 +239,9 @@ func GetResourceOutputsPropertiesString(
 	// Technically, 2 and 3 are the same, since they're both bottoming out at a provider's implementation of Read, but
 	// the upshot is that either way we're ending up with outputs that are exactly accurate. If we are not sure that we
 	// are in one of the above states, we shouldn't try to print outputs.
-	if planning && !refresh {
-		if step.Op != deploy.OpRead && step.Op != deploy.OpReadReplacement {
+	if planning {
+		printOutputDuringPlanning := refresh || step.Op == deploy.OpRead || step.Op == deploy.OpReadReplacement
+		if !printOutputDuringPlanning {
 			return ""
 		}
 	}


### PR DESCRIPTION
[Cyrus pointed out](https://github.com/pulumi/pulumi/pull/1919#discussion_r216877046) that this condition is error prone (clearly, since I erred when writing it). This commit cleans it up a bit to be extremely clear about what the short-circuit condition is, as described in English:

"We will return the empty string if we are planning and we are not doing a refresh and the step being performed is not some kind of read."