### PR TITLE
Copy missing pulumi-resource-pulumi-nodejs binary in node dist target

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -44,3 +44,4 @@ test_fast::
 
 dist::
 	go install -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" ${LANGUAGE_HOST}
+	cp dist/pulumi-resource-pulumi-nodejs "$$(go env GOPATH)"/bin/


### PR DESCRIPTION
Homebrew Pulumi is currently missing the `pulumi-resource-pulumi-nodejs` binary and consequently fails to deploy any Pulumi program relying on dynamic providers (like `@pulumi/eks`).

Edit :

We need to trigger a rebuild of the bottle on Homebrew side. I don't really know if there is any way to trigger this rebuild without a version bump on Pulumi side. So maybe a minor version bump will be needed after this change is merged.