### PR TITLE
Add URN to dummy row for new events

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -799,7 +799,7 @@ func (display *ProgressDisplay) getRowForURN(urn resource.URN, metadata *engine.
 	}
 
 	// First time we're hearing about this resource. Create an initial nearly-empty status for it.
-	step := engine.StepEventMetadata{Op: deploy.OpSame}
+	step := engine.StepEventMetadata{URN: urn, Op: deploy.OpSame}
 	if metadata != nil {
 		step = *metadata
 	}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1752. This was actually way easier than I thought it would be.

When the display layer sees an event that it doesn't already have a row for (i.e this is the first time it has seen an event with a particular URN), it invents a dummy `engine.StepEventMetadata` for it and then uses it to create a row. If we supply a URN to this dummy metadata node (which we are likely to have, in the case of diagnostic events), we'll identify the resource as normal.

Before:

![screen shot 2018-09-19 at 11 02 50 am](https://user-images.githubusercontent.com/1871912/45772054-9c674880-bbfb-11e8-9564-56354b52ea2c.png)

After:

![screen shot 2018-09-19 at 11 02 05 am](https://user-images.githubusercontent.com/1871912/45772061-a0936600-bbfb-11e8-9c2a-97d2bec88019.png)
