### PR TITLE
Process deletions conservatively in parallel

### DIFF
--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -32,10 +32,11 @@ import (
 
 // Options controls the planning and deployment process.
 type Options struct {
-	Events      Events // an optional events callback interface.
-	Parallel    int    // the degree of parallelism for resource operations (<=1 for serial).
-	Refresh     bool   // whether or not to refresh before executing the plan.
-	RefreshOnly bool   // whether or not to exit after refreshing.
+	Events            Events // an optional events callback interface.
+	Parallel          int    // the degree of parallelism for resource operations (<=1 for serial).
+	Refresh           bool   // whether or not to refresh before executing the plan.
+	RefreshOnly       bool   // whether or not to exit after refreshing.
+	TrustDependencies bool   // whether or not to trust the resource dependency graph.
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -41,8 +41,39 @@ var (
 	errStepApplyFailed = errors.New("step application failed")
 )
 
+// The step executor operates in terms of "chains" and "antichains". A chain is set of steps that are totally ordered
+// when ordered by dependency; each step in a chain depends directly on the step that comes before it. An antichain
+// is a set of steps that is completely incomparable when ordered by dependency. The step executor is aware that chains
+// must be executed serially and antichains can be executed concurrently.
+//
+// See https://en.wikipedia.org/wiki/Antichain for more complete definitions. The below type aliases are useful for
+// documentation purposes.
+
 // A Chain is a sequence of Steps that must be executed in the given order.
 type Chain = []Step
+
+// An Antichain is a set of Steps that can be executed in parallel.
+type Antichain = []Step
+
+// A CompletionToken is a token returned by the step executor that is completed when the chain has completed execution.
+// Callers can use it to optionally wait synchronously on the completion of a chain.
+type CompletionToken struct {
+	channel chan bool
+}
+
+// Wait blocks until the completion token is signalled or until the given context completes, whatever occurs first.
+func (c CompletionToken) Wait(ctx context.Context) {
+	select {
+	case <-c.channel:
+	case <-ctx.Done():
+	}
+}
+
+// incomingChain represents a request to the step executor to execute a chain.
+type incomingChain struct {
+	Chain          Chain     // The chain we intend to execute
+	CompletionChan chan bool // A completion channel to be closed when the chain has completed execution
+}
 
 // stepExecutor is the component of the engine responsible for taking steps and executing
 // them, possibly in parallel if requested. The step generator operates on the granularity
@@ -58,8 +89,8 @@ type stepExecutor struct {
 	pendingNews     sync.Map // Resources that have been created but are pending a RegisterResourceOutputs.
 	continueOnError bool     // True if we want to continue the plan after a step error.
 
-	workers        sync.WaitGroup // WaitGroup tracking the worker goroutines that are owned by this step executor.
-	incomingChains chan Chain     // Incoming chains that we are to execute
+	workers        sync.WaitGroup     // WaitGroup tracking the worker goroutines that are owned by this step executor.
+	incomingChains chan incomingChain // Incoming chains that we are to execute
 
 	ctx      context.Context    // cancellation context for the current plan.
 	cancel   context.CancelFunc // CancelFunc that cancels the above context.
@@ -74,13 +105,43 @@ type stepExecutor struct {
 
 // Execute submits a Chain for asynchronous execution. The execution of the chain will begin as soon as there
 // is a worker available to execute it.
-func (se *stepExecutor) Execute(chain Chain) {
+func (se *stepExecutor) ExecuteSerial(chain Chain) CompletionToken {
 	// The select here is to avoid blocking on a send to se.incomingChains if a cancellation is pending.
 	// If one is pending, we should exit early - we will shortly be tearing down the engine and exiting.
+
+	completion := make(chan bool)
 	select {
-	case se.incomingChains <- chain:
+	case se.incomingChains <- incomingChain{Chain: chain, CompletionChan: completion}:
 	case <-se.ctx.Done():
+		close(completion)
 	}
+
+	return CompletionToken{channel: completion}
+}
+
+// ExecuteParallel submits an antichain for parallel execution. All of the steps within the antichain are submitted for
+// concurrent execution.
+func (se *stepExecutor) ExecuteParallel(antichain Antichain) CompletionToken {
+	var wg sync.WaitGroup
+
+	// ExecuteParallel is implemented in terms of ExecuteSerial - it executes each step individually and waits for all
+	// of the steps to complete.
+	wg.Add(len(antichain))
+	for _, step := range antichain {
+		tok := se.ExecuteSerial(Chain{step})
+		go func() {
+			defer wg.Done()
+			tok.Wait(se.ctx)
+		}()
+	}
+
+	done := make(chan bool)
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	return CompletionToken{channel: done}
 }
 
 // ExecuteRegisterResourceOutputs services a RegisterResourceOutputsEvent synchronously on the calling goroutine.
@@ -272,14 +333,15 @@ func (se *stepExecutor) worker(workerID int) {
 	for {
 		se.log(workerID, "worker waiting for incoming chains")
 		select {
-		case chain := <-se.incomingChains:
-			if chain == nil {
+		case request := <-se.incomingChains:
+			if request.Chain == nil {
 				se.log(workerID, "worker received nil chain, exiting")
 				return
 			}
 
 			se.log(workerID, "worker received chain for execution")
-			se.executeChain(workerID, chain)
+			se.executeChain(workerID, request.Chain)
+			close(request.CompletionChan)
 		case <-se.ctx.Done():
 			se.log(workerID, "worker exiting due to cancellation")
 			return
@@ -294,7 +356,7 @@ func newStepExecutor(ctx context.Context, cancel context.CancelFunc, plan *Plan,
 		opts:            opts,
 		preview:         preview,
 		continueOnError: continueOnError,
-		incomingChains:  make(chan Chain),
+		incomingChains:  make(chan incomingChain),
 		ctx:             ctx,
 		cancel:          cancel,
 	}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -527,9 +527,8 @@ func (sg *stepGenerator) ScheduleDeletes(deleteSteps []Step) []antichain {
 		logging.V(7).Infof("Planner beginning schedule of new deletion antichain")
 		for res := range condemned {
 			// Does res have any outgoing edges to resources that haven't already been removed from the graph?
-			// For the purposes of deletion calculation, res.Parent counts as an outgoing edge.
 			condemnedDependencies := dg.DependenciesOf(res).Intersect(condemned)
-			if len(condemnedDependencies) == 0 && !condemned[dg.ParentOf(res)] {
+			if len(condemnedDependencies) == 0 {
 				// If not, it's safe to delete res at this stage.
 				logging.V(7).Infof("Planner scheduling deletion of '%v'", res.URN)
 				steps = append(steps, stepMap[res])

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -469,7 +469,7 @@ func (sg *stepGenerator) GenerateDeletes() []Antichain {
 	}
 
 	if sg.opts.TrustDependencies {
-		return sg.scheduleDeletes(condemnedResources, false /* pendingDeletesAreReplaces */)
+		return sg.scheduleDeletes(condemnedResources, true /* pendingDeletesAreReplaces */)
 	}
 	return steps
 }
@@ -504,7 +504,7 @@ func (sg *stepGenerator) GeneratePendingDeletes() []Antichain {
 	}
 
 	if sg.opts.TrustDependencies {
-		return sg.scheduleDeletes(condemnedResources, true /* pendingDeletesAreReplaces */)
+		return sg.scheduleDeletes(condemnedResources, false /* pendingDeletesAreReplaces */)
 	}
 	return steps
 }
@@ -547,7 +547,7 @@ func (sg *stepGenerator) scheduleDeletes(condemned graph.ResourceSet, pendingDel
 			if len(condemnedDependencies) == 0 && !condemned[dg.ParentOf(res)] {
 				// If not, it's safe to delete res at this stage.
 				logging.V(7).Infof("Planner scheduling deletion of '%v'", res.URN)
-				if res.Delete && !pendingDeletesAreReplaces {
+				if res.Delete && pendingDeletesAreReplaces {
 					antichain = append(antichain, NewDeleteReplacementStep(sg.plan, res, true))
 				} else {
 					antichain = append(antichain, NewDeleteStep(sg.plan, res))

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -69,7 +69,8 @@ func (dg *DependencyGraph) DependingOn(res *resource.State) []*resource.State {
 	return dependents
 }
 
-// DependenciesOf returns a ResourceSet of resources upon which the given resource depends.
+// DependenciesOf returns a ResourceSet of resources upon which the given resource depends. The resource's parent is
+// included in the returned set.
 func (dg *DependencyGraph) DependenciesOf(res *resource.State) ResourceSet {
 	set := make(ResourceSet)
 
@@ -86,13 +87,14 @@ func (dg *DependencyGraph) DependenciesOf(res *resource.State) ResourceSet {
 
 	cursorIndex, ok := dg.index[res]
 	contract.Assert(ok)
-	for i := cursorIndex; i >= 0; i-- {
+	for i := cursorIndex - 1; i >= 0; i-- {
 		candidate := dg.resources[i]
 		if dependentUrns[candidate.URN] {
 			set[candidate] = true
 		}
 	}
 
+	set[dg.ParentOf(res)] = true
 	return set
 }
 

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -89,33 +89,12 @@ func (dg *DependencyGraph) DependenciesOf(res *resource.State) ResourceSet {
 	contract.Assert(ok)
 	for i := cursorIndex - 1; i >= 0; i-- {
 		candidate := dg.resources[i]
-		if dependentUrns[candidate.URN] {
+		if dependentUrns[candidate.URN] || candidate.URN == res.Parent {
 			set[candidate] = true
 		}
 	}
 
-	set[dg.ParentOf(res)] = true
 	return set
-}
-
-// ParentOf returns the resource that is the direct parent of the provided resource, or nil if the provided resource
-// does not have a parent.
-func (dg *DependencyGraph) ParentOf(res *resource.State) *resource.State {
-	if res.Parent == "" {
-		return nil
-	}
-
-	cursorIndex, ok := dg.index[res]
-	contract.Assert(ok)
-	for i := cursorIndex; i >= 0; i-- {
-		candidate := dg.resources[i]
-		if candidate.URN == res.Parent {
-			return candidate
-		}
-	}
-
-	contract.Failf("Failed to find parent urn '%v' for resource '%v'", res.Parent, res.URN)
-	return nil
 }
 
 // NewDependencyGraph creates a new DependencyGraph from a list of resources.

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -71,7 +71,7 @@ func (dg *DependencyGraph) DependingOn(res *resource.State) []*resource.State {
 
 // DependenciesOf returns a ResourceSet of resources upon which the given resource depends.
 func (dg *DependencyGraph) DependenciesOf(res *resource.State) ResourceSet {
-	set := NewResourceSet()
+	set := make(ResourceSet)
 
 	dependentUrns := make(map[resource.URN]bool)
 	for _, dep := range res.Dependencies {
@@ -89,7 +89,7 @@ func (dg *DependencyGraph) DependenciesOf(res *resource.State) ResourceSet {
 	for i := cursorIndex; i >= 0; i-- {
 		candidate := dg.resources[i]
 		if dependentUrns[candidate.URN] {
-			set.Add(candidate)
+			set[candidate] = true
 		}
 	}
 

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -114,19 +114,19 @@ func TestDependenciesOf(t *testing.T) {
 	})
 
 	aDepends := dg.DependenciesOf(a)
-	assert.True(t, aDepends.Test(pA))
-	assert.False(t, aDepends.Test(a))
-	assert.False(t, aDepends.Test(b))
+	assert.True(t, aDepends[pA])
+	assert.False(t, aDepends[a])
+	assert.False(t, aDepends[b])
 
 	bDepends := dg.DependenciesOf(b)
-	assert.True(t, bDepends.Test(pA))
-	assert.True(t, bDepends.Test(a))
-	assert.False(t, bDepends.Test(b))
+	assert.True(t, bDepends[pA])
+	assert.True(t, bDepends[a])
+	assert.False(t, bDepends[b])
 
 	cDepends := dg.DependenciesOf(c)
-	assert.True(t, cDepends.Test(pA))
-	assert.False(t, cDepends.Test(a))
-	assert.False(t, cDepends.Test(b))
+	assert.True(t, cDepends[pA])
+	assert.False(t, cDepends[a])
+	assert.False(t, cDepends[b])
 }
 
 func TestParentOf(t *testing.T) {

--- a/pkg/resource/graph/resource_set.go
+++ b/pkg/resource/graph/resource_set.go
@@ -1,0 +1,79 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import "github.com/pulumi/pulumi/pkg/resource"
+
+// ResourceSet represents a set of Resources.
+type ResourceSet struct {
+	m map[*resource.State]bool
+}
+
+// NewResourceSet creates a new empty set of Resources.
+func NewResourceSet() ResourceSet {
+	return ResourceSet{
+		m: make(map[*resource.State]bool),
+	}
+}
+
+// Empty returns whether or not this set is empty.
+func (s ResourceSet) Empty() bool {
+	return len(s.m) == 0
+}
+
+// Test returns whether or not the given resource is an element of this set.
+func (s ResourceSet) Test(state *resource.State) bool {
+	if state == nil {
+		return false
+	}
+
+	return s.m[state]
+}
+
+// Add inserts a resource into this set.
+func (s ResourceSet) Add(state *resource.State) {
+	if state != nil {
+		s.m[state] = true
+	}
+}
+
+// Remove removes a resource from this set.
+func (s ResourceSet) Remove(state *resource.State) {
+	if state != nil {
+		delete(s.m, state)
+	}
+}
+
+// Elements returns an array containing all resources contained in this set.
+func (s ResourceSet) Elements() []*resource.State {
+	var keys []*resource.State
+	for key := range s.m {
+		keys = append(keys, key)
+	}
+
+	return keys
+}
+
+// Intersect returns a new set that is the intersection of the two given resource sets.
+func (s ResourceSet) Intersect(other ResourceSet) ResourceSet {
+	newSet := NewResourceSet()
+	for _, elem := range s.Elements() {
+		if other.Test(elem) {
+			newSet.Add(elem)
+		}
+	}
+
+	return newSet
+}

--- a/pkg/resource/graph/resource_set.go
+++ b/pkg/resource/graph/resource_set.go
@@ -17,61 +17,14 @@ package graph
 import "github.com/pulumi/pulumi/pkg/resource"
 
 // ResourceSet represents a set of Resources.
-type ResourceSet struct {
-	m map[*resource.State]bool
-}
-
-// NewResourceSet creates a new empty set of Resources.
-func NewResourceSet() ResourceSet {
-	return ResourceSet{
-		m: make(map[*resource.State]bool),
-	}
-}
-
-// Empty returns whether or not this set is empty.
-func (s ResourceSet) Empty() bool {
-	return len(s.m) == 0
-}
-
-// Test returns whether or not the given resource is an element of this set.
-func (s ResourceSet) Test(state *resource.State) bool {
-	if state == nil {
-		return false
-	}
-
-	return s.m[state]
-}
-
-// Add inserts a resource into this set.
-func (s ResourceSet) Add(state *resource.State) {
-	if state != nil {
-		s.m[state] = true
-	}
-}
-
-// Remove removes a resource from this set.
-func (s ResourceSet) Remove(state *resource.State) {
-	if state != nil {
-		delete(s.m, state)
-	}
-}
-
-// Elements returns an array containing all resources contained in this set.
-func (s ResourceSet) Elements() []*resource.State {
-	var keys []*resource.State
-	for key := range s.m {
-		keys = append(keys, key)
-	}
-
-	return keys
-}
+type ResourceSet map[*resource.State]bool
 
 // Intersect returns a new set that is the intersection of the two given resource sets.
 func (s ResourceSet) Intersect(other ResourceSet) ResourceSet {
-	newSet := NewResourceSet()
-	for _, elem := range s.Elements() {
-		if other.Test(elem) {
-			newSet.Add(elem)
+	newSet := make(ResourceSet)
+	for key := range s {
+		if other[key] {
+			newSet[key] = true
 		}
 	}
 

--- a/pkg/resource/graph/resource_set_test.go
+++ b/pkg/resource/graph/resource_set_test.go
@@ -20,59 +20,20 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestEmptySet(t *testing.T) {
-	set := NewResourceSet()
-	assert.True(t, set.Empty())
-	assert.Nil(t, set.Elements())
-}
-
-func TestSingleton(t *testing.T) {
-	r := NewResource("a", nil)
-	set := NewResourceSet()
-	set.Add(r)
-	assert.False(t, set.Empty())
-	assert.Len(t, set.Elements(), 1)
-	assert.Contains(t, set.Elements(), r)
-	assert.True(t, set.Test(r))
-}
-
-func TestRemove(t *testing.T) {
-	r := NewResource("a", nil)
-	set := NewResourceSet()
-	set.Add(r)
-	assert.False(t, set.Empty())
-	assert.Len(t, set.Elements(), 1)
-	assert.Contains(t, set.Elements(), r)
-	assert.True(t, set.Test(r))
-	set.Remove(r)
-	assert.True(t, set.Empty())
-	assert.Nil(t, set.Elements())
-	assert.False(t, set.Test(r))
-}
-
 func TestIntersect(t *testing.T) {
 	a := NewResource("a", nil)
 	b := NewResource("b", nil)
 	c := NewResource("c", nil)
 
-	setA := NewResourceSet()
-	setA.Add(a)
-	setA.Add(b)
-	setB := NewResourceSet()
-	setB.Add(b)
-	setB.Add(c)
+	setA := make(ResourceSet)
+	setA[a] = true
+	setA[b] = true
+	setB := make(ResourceSet)
+	setB[b] = true
+	setB[c] = true
 
 	setC := setA.Intersect(setB)
-	assert.False(t, setC.Test(a))
-	assert.True(t, setC.Test(b))
-	assert.False(t, setC.Test(c))
-}
-
-func TestNilInMap(t *testing.T) {
-	set := NewResourceSet()
-	set.Add(nil)
-	assert.True(t, set.Empty())
-	assert.False(t, set.Test(nil))
-	set.Remove(nil)
-	assert.True(t, set.Empty())
+	assert.False(t, setC[a])
+	assert.True(t, setC[b])
+	assert.False(t, setC[c])
 }

--- a/pkg/resource/graph/resource_set_test.go
+++ b/pkg/resource/graph/resource_set_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package graph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptySet(t *testing.T) {
+	set := NewResourceSet()
+	assert.True(t, set.Empty())
+	assert.Nil(t, set.Elements())
+}
+
+func TestSingleton(t *testing.T) {
+	r := NewResource("a", nil)
+	set := NewResourceSet()
+	set.Add(r)
+	assert.False(t, set.Empty())
+	assert.Len(t, set.Elements(), 1)
+	assert.Contains(t, set.Elements(), r)
+	assert.True(t, set.Test(r))
+}
+
+func TestRemove(t *testing.T) {
+	r := NewResource("a", nil)
+	set := NewResourceSet()
+	set.Add(r)
+	assert.False(t, set.Empty())
+	assert.Len(t, set.Elements(), 1)
+	assert.Contains(t, set.Elements(), r)
+	assert.True(t, set.Test(r))
+	set.Remove(r)
+	assert.True(t, set.Empty())
+	assert.Nil(t, set.Elements())
+	assert.False(t, set.Test(r))
+}
+
+func TestIntersect(t *testing.T) {
+	a := NewResource("a", nil)
+	b := NewResource("b", nil)
+	c := NewResource("c", nil)
+
+	setA := NewResourceSet()
+	setA.Add(a)
+	setA.Add(b)
+	setB := NewResourceSet()
+	setB.Add(b)
+	setB.Add(c)
+
+	setC := setA.Intersect(setB)
+	assert.False(t, setC.Test(a))
+	assert.True(t, setC.Test(b))
+	assert.False(t, setC.Test(c))
+}
+
+func TestNilInMap(t *testing.T) {
+	set := NewResourceSet()
+	set.Add(nil)
+	assert.True(t, set.Empty())
+	assert.False(t, set.Test(nil))
+	set.Remove(nil)
+	assert.True(t, set.Empty())
+}

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -95,6 +95,12 @@ func (proj *Project) UseDefaultIgnores() bool {
 	return !(*proj.NoDefaultIgnores)
 }
 
+// TrustResourceDependencies returns whether or not this project's runtime can be trusted to accurately report
+// dependencies. Not all languages supported by Pulumi do this correctly.
+func (proj *Project) TrustResourceDependencies() bool {
+	return proj.RuntimeInfo.Name() != "python"
+}
+
 // Save writes a project definition to a file.
 func (proj *Project) Save(path string) error {
 	contract.Require(path != "", "path")


### PR DESCRIPTION
This commit allows the engine to conservatively delete resources in
parallel when it is sure that it is legal to do so. In the absence of a
true data-flow oriented step scheduler, this approach provides a
significant improvement over the existing serial deletion mechanism.

Instead of processing deletes serially, this commit will partition the
set of condemned resources into sets of resources that are known to be
legally deletable in parallel. The step executor will then execute those
independent lists of steps one-by-one until all steps are complete.