### PR TITLE
Remember lazy stack selection

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -257,6 +257,13 @@ func chooseStack(
 		return nil, errors.Wrap(err, "getting selected stack")
 	}
 
+	// If setCurrent is true, we'll persist this choice so it'll be used for future CLI operations.
+	if setCurrent {
+		if err = state.SetCurrentStack(stackRef.String()); err != nil {
+			return nil, err
+		}
+	}
+
 	return stack, nil
 }
 


### PR DESCRIPTION
If you run an operation that requires a stack, but you don't have
one selected, you'll be prompted. This happens all over the place.
Sadly, your selection at this prompt is not remembered (unless you
opt to create a new one), meaning you'll just keep getting prompted.

The fix is simple: we just ignored the setCurrent bool previously;
we need to respect it and call the SetCurrentStack function.

This fixes pulumi/pulumi#1831.