### PR TITLE
Pass environment through to go language programs

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -179,7 +179,7 @@ func (host *goLanguageHost) constructEnv(req *pulumirpc.RunRequest) ([]string, e
 		return nil, err
 	}
 
-	var env []string
+	env := os.Environ()
 	maybeAppendEnv := func(k, v string) {
 		if v != "" {
 			env = append(env, fmt.Sprintf("%s=%s", k, v))


### PR DESCRIPTION
This allows those programs to use authentication credentials that are
in the environment to perform extra work.