### PR TITLE
Move to an options-bag for computeCodePaths.

### DIFF
--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -70,7 +70,7 @@ interface CodePathOptions {
 export async function computeCodePaths(options?: CodePathOptions): Promise<Map<string, asset.Asset | asset.Archive>>;
 
 /**
- * @deprecated Use the [computeCodePaths] that takes a [CodePathOptions] instead.
+ * @deprecated Use the [computeCodePaths] overload that takes a [CodePathOptions] instead.
  */
 export async function computeCodePaths(extraIncludePaths?: string[], extraIncludePackages?: string[], extraExcludePackages?: string[]): Promise<Map<string, asset.Asset | asset.Archive>>;
 

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -83,8 +83,8 @@ export async function computeCodePaths(
     if (Array.isArray(optionsOrExtraIncludePaths)) {
         options = {
             extraIncludePaths: optionsOrExtraIncludePaths,
-            extraExcludePackages: extraIncludePackages,
-            extraIncludePackages: extraExcludePackages,
+            extraIncludePackages,
+            extraExcludePackages,
         };
     }
     else if (optionsOrExtraIncludePaths) {


### PR DESCRIPTION
This approach is more future proofed as we can easily add to the options back without it being a problem.  This is desirable because at the higher layers we want to just reference this type and allow clients to igve us an instance htat we will just pass through to this layer.  Otherwise, we have to duplicate all the parameters needed here through all higher types (like https://github.com/pulumi/pulumi-aws/blob/65c47e93776a7d710194e4a13aca207913418328/overlays/nodejs/serverless/function.ts#L107-L121) in order to allow this information to be passed down.