### PR TITLE
Return errors for unknown/invalid path archives.

### DIFF
--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -637,7 +637,7 @@ func (a *Archive) Open() (ArchiveReader, error) {
 	} else if a.IsURI() {
 		return a.readURI()
 	}
-	return nil, nil
+	return nil, errors.New("unrecognized archive type")
 }
 
 // assetsArchiveReader is used to read an Assets archive.
@@ -771,7 +771,7 @@ func (a *Archive) readPath() (ArchiveReader, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "couldn't read archive path '%v'", path)
 		} else if !info.IsDir() {
-			return nil, errors.Wrapf(err, "'%v' is neither a recognized archive type nor a directory", path)
+			return nil, errors.Errorf("'%v' is neither a recognized archive type nor a directory", path)
 		}
 
 		// Accumulate the list of asset paths. This list is ordered deterministically by filepath.Walk.

--- a/pkg/resource/asset_test.go
+++ b/pkg/resource/asset_test.go
@@ -406,6 +406,19 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	assert.Equal(t, "foo/bar/b.txt", files[0].Name)
 }
 
+func TestInvalidPathArchive(t *testing.T) {
+	// Create a temp file that is not an asset.
+	tmpFile, err := ioutil.TempFile("", "")
+	fileName := tmpFile.Name()
+	assert.NoError(t, err)
+	fmt.Fprintf(tmpFile, "foo\n")
+	tmpFile.Close()
+
+	// Attempt to construct a PathArchive with the temp file.
+	_, err = NewPathArchive(fileName)
+	assert.Error(t, err)
+}
+
 func validateTestDirArchive(t *testing.T, arch *Archive) {
 	r, err := arch.Open()
 	assert.Nil(t, err)


### PR DESCRIPTION
- Attempting to read an archive with an unknown type now returns an
  error
- Attempting to read a path archive that is neither a known archive
  format or a directory now returns an error