### PR TITLE
Print warnings returned from the service to the CLI

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -212,7 +212,7 @@ func getCLIVersionInfo() (semver.Version, semver.Version, error) {
 		return latest, oldest, err
 	}
 
-	client := client.NewClient(httpstate.DefaultURL(), "")
+	client := client.NewClient(httpstate.DefaultURL(), "", cmdutil.Diag())
 	latest, oldest, err = client.GetCLIVersionInfo(commandContext())
 	if err != nil {
 		return semver.Version{}, semver.Version{}, err

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -157,7 +157,7 @@ func New(d diag.Sink, cloudURL string) (Backend, error) {
 	return &cloudBackend{
 		d:      d,
 		url:    cloudURL,
-		client: client.NewClient(cloudURL, apiToken),
+		client: client.NewClient(cloudURL, apiToken, d),
 	}, nil
 }
 
@@ -1160,7 +1160,7 @@ func IsValidAccessToken(ctx context.Context, cloudURL, accessToken string) (bool
 	// Make a request to get the authenticated user. If it returns a successful response,
 	// we know the access token is legit. We also parse the response as JSON and confirm
 	// it has a githubLogin field that is non-empty (like the Pulumi Service would return).
-	_, err := client.NewClient(cloudURL, accessToken).GetPulumiAccountName(ctx)
+	_, err := client.NewClient(cloudURL, accessToken, cmdutil.Diag()).GetPulumiAccountName(ctx)
 	if err != nil {
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == 401 {
 			return false, nil

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -24,6 +24,8 @@ import (
 	"path"
 	"time"
 
+	"github.com/pulumi/pulumi/pkg/diag"
+
 	"github.com/blang/semver"
 
 	"github.com/pkg/errors"
@@ -44,32 +46,34 @@ type Client struct {
 	apiURL   string
 	apiToken apiAccessToken
 	apiUser  string
+	diag     diag.Sink
 }
 
 // NewClient creates a new Pulumi API client with the given URL and API token.
-func NewClient(apiURL, apiToken string) *Client {
+func NewClient(apiURL, apiToken string, d diag.Sink) *Client {
 	return &Client{
 		apiURL:   apiURL,
 		apiToken: apiAccessToken(apiToken),
+		diag:     d,
 	}
 }
 
 // apiCall makes a raw HTTP request to the Pulumi API using the given method, path, and request body.
 func (pc *Client) apiCall(ctx context.Context, method, path string, body []byte) (string, *http.Response, error) {
-	return pulumiAPICall(ctx, pc.apiURL, method, path, body, pc.apiToken, httpCallOptions{})
+	return pulumiAPICall(ctx, pc.diag, pc.apiURL, method, path, body, pc.apiToken, httpCallOptions{})
 }
 
 // restCall makes a REST-style request to the Pulumi API using the given method, path, query object, and request
 // object. If a response object is provided, the server's response is deserialized into that object.
 func (pc *Client) restCall(ctx context.Context, method, path string, queryObj, reqObj, respObj interface{}) error {
-	return pulumiRESTCall(ctx, pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken, httpCallOptions{})
+	return pulumiRESTCall(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken, httpCallOptions{})
 }
 
 // restCall makes a REST-style request to the Pulumi API using the given method, path, query object, and request
 // object. If a response object is provided, the server's response is deserialized into that object.
 func (pc *Client) restCallWithOptions(ctx context.Context, method, path string, queryObj, reqObj,
 	respObj interface{}, opts httpCallOptions) error {
-	return pulumiRESTCall(ctx, pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken, opts)
+	return pulumiRESTCall(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, pc.apiToken, opts)
 }
 
 // updateRESTCall makes a REST-style request to the Pulumi API using the given method, path, query object, and request
@@ -78,7 +82,7 @@ func (pc *Client) restCallWithOptions(ctx context.Context, method, path string, 
 func (pc *Client) updateRESTCall(ctx context.Context, method, path string, queryObj, reqObj, respObj interface{},
 	token updateAccessToken, httpOptions httpCallOptions) error {
 
-	return pulumiRESTCall(ctx, pc.apiURL, method, path, queryObj, reqObj, respObj, token, httpOptions)
+	return pulumiRESTCall(ctx, pc.diag, pc.apiURL, method, path, queryObj, reqObj, respObj, token, httpOptions)
 }
 
 // getStackPath returns the API path to for the given stack with the given components joined with path separators


### PR DESCRIPTION
This doesn't actually do anything yet, because the service does not return any metadata about the number of stacks used or the soft limit for an organization. But once that work is done, the message will be printed.