### PR TITLE
Fix getting logs in tests for Lambdas

### DIFF
--- a/pkg/operations/operations_aws.go
+++ b/pkg/operations/operations_aws.go
@@ -97,15 +97,27 @@ func (ops *awsOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
 	switch state.Type {
 	case awsFunctionType:
 		functionName := state.Outputs["name"].StringValue()
-		logResult := ops.awsConnection.getLogsForLogGroupsConcurrently(
+		rawLogs := ops.awsConnection.getLogsForLogGroupsConcurrently(
 			[]string{functionName},
 			[]string{"/aws/lambda/" + functionName},
 			query.StartTime,
 			query.EndTime,
 		)
-		sort.SliceStable(logResult, func(i, j int) bool { return logResult[i].Timestamp < logResult[j].Timestamp })
-		logging.V(5).Infof("GetLogs[%v] return %d logs", state.URN, len(logResult))
-		return &logResult, nil
+		sort.SliceStable(rawLogs, func(i, j int) bool { return rawLogs[i].Timestamp < rawLogs[j].Timestamp })
+		logging.V(5).Infof("GetLogs[%v] produced %d raw-logs", state.URN, len(rawLogs))
+
+		name := string(state.URN.Name())
+
+		var logs []LogEntry
+		for _, rawLog := range rawLogs {
+			extractedLog := extractLambdaLogMessage(rawLog.Message, name)
+			if extractedLog != nil {
+				logs = append(logs, *extractedLog)
+			}
+		}
+		logging.V(5).Infof("GetLogs[%v] return %d logs", state.URN, len(logs))
+
+		return &logs, nil
 	case awsLogGroupType:
 		name := state.Outputs["name"].StringValue()
 		logResult := ops.awsConnection.getLogsForLogGroupsConcurrently(

--- a/pkg/operations/operations_cloud_aws.go
+++ b/pkg/operations/operations_cloud_aws.go
@@ -193,14 +193,15 @@ var (
 	logRegexp = regexp.MustCompile("^(.{23}Z)\t[a-g0-9\\-]{36}\t((?s).*)\n")
 )
 
-// extractLambdaLogMessage extracts out only the log messages associated with user logs, skipping Lambda-specific
-// metadata.  In particular, only the second line below is extracter, and it is extracted with the recorded timestamp.
+// extractLambdaLogMessage extracts out only the log messages associated with user logs, skipping
+// Lambda-specific metadata.  In particular, only the second line below is extracted, and it is
+// extracted with the recorded timestamp.
 //
 // ```
 //  START RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723 Version: $LATEST
-//  2017-11-17T20:30:27.736Z	25e0d1e0-cbd6-11e7-9808-c7085dfe5723	GET /todo
+//  2017-11-17T20:30:27.736Z    25e0d1e0-cbd6-11e7-9808-c7085dfe5723    GET /todo
 //  END RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723
-//  REPORT RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723	Duration: 222.92 ms	Billed Duration: 300 ms 	<snip>
+//  REPORT RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723  Duration: 222.92 ms Billed Duration: 300 ms     <snip>
 // ```
 func extractLambdaLogMessage(message string, id string) *LogEntry {
 	innerMatches := logRegexp.FindAllStringSubmatch(message, -1)


### PR DESCRIPTION
We have a helper for this, but it only worked for aws.serverless.Functions.  Now that we're working to switch people to just use aws.lambda.Function instead, we needed to move that code to use this helper as well.