### PR TITLE
Revert RunError behavior.  Introduce new ResourceError for errors assiated with a resource.

### DIFF
--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -19,7 +19,7 @@ import * as minimist from "minimist";
 import * as path from "path";
 import * as tsnode from "ts-node";
 import * as util from "util";
-import { RunError } from "../../errors";
+import { RunError, ResourceError } from "../../errors";
 import * as log from "../../log";
 import * as runtime from "../../runtime";
 
@@ -169,7 +169,11 @@ export function run(argv: minimist.ParsedArgs): void {
 
         // First, log the error.
         if (RunError.isInstance(err)) {
-            // Hide the stack if requested to by the RunError creator.
+            // Always hide the stack for RunErrors.
+            log.error(err.message);
+        }
+        else if (ResourceError.isInstance(err)) {
+            // Hide the stack if requested to by the ResourceError creator.
             const message = err.hideStack ? err.message : defaultMessage;
             log.error(message, err.resource);
         }

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -165,10 +165,10 @@ export function run(argv: minimist.ParsedArgs): void {
     const errorSet = new Set<Error>();
 
     const uncaughtHandler = (err: Error) => {
-        // We have seen the uncaughtHandler get called multiple times for the same error. We haven't
-        // been able to figure out what causes this (i.e. a bug somewhere else in pulumi), or
-        // something with how Node itself works.  So, for now, we just ensure that we only report
-        // issues the first time we encounter any specific error.
+        // In node, if you throw an error in a chained promise, but the exception is not finally
+        // handled, then you can end up getting an unhandledRejection for each exception/promise
+        // pair.  Because the exception is the same through all of these, we keep track of it and
+        // only report it once so the user doesn't get N messages for the same thing.
         if (errorSet.has(err)) {
             return;
         }

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -19,7 +19,7 @@ import * as minimist from "minimist";
 import * as path from "path";
 import * as tsnode from "ts-node";
 import * as util from "util";
-import { RunError, ResourceError } from "../../errors";
+import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
 import * as runtime from "../../runtime";
 

--- a/sdk/nodejs/errors.ts
+++ b/sdk/nodejs/errors.ts
@@ -61,7 +61,7 @@ export class ResourceError extends Error {
         return obj && obj.__pulumiRunError;
     }
 
-    constructor(message: string, public resource: Resource, public hideStack?: boolean) {
+    constructor(message: string, public resource: Resource | undefined, public hideStack?: boolean) {
         super(message);
     }
 }

--- a/sdk/nodejs/errors.ts
+++ b/sdk/nodejs/errors.ts
@@ -15,10 +15,10 @@
 import { Resource } from "./resource";
 
 /**
- * RunError can be used for terminating a program abruptly, optionally associating the problem with
- * a Resource.  Depending on the nature of the problem, clients can choose whether or not a
- * callstack should be returned as well.  This should be very rare, and would only indicate no
- * usefulness of presenting that stack to the user.
+ * RunError can be used for terminating a program abruptly, but resulting in a clean exit rather
+ * than the usual verbose unhandled error logic which emits the source program text and complete
+ * stack trace.  This type should be rarely used.  Ideally ResourceError should always be used so
+ * that as many errors as possible can be associated with a Resource.
  */
 export class RunError extends Error {
     /**
@@ -35,7 +35,33 @@ export class RunError extends Error {
         return obj && obj.__pulumiRunError;
     }
 
-    constructor(message: string, public resource?: Resource, public hideStack?: boolean) {
+    constructor(message: string) {
+        super(message);
+    }
+}
+
+/**
+ * ResourceError can be used for terminating a program abruptly, optionally associating the problem with
+ * a Resource.  Depending on the nature of the problem, clients can choose whether or not a
+ * callstack should be returned as well.  This should be very rare, and would only indicate no
+ * usefulness of presenting that stack to the user.
+ */
+export class ResourceError extends Error {
+    /**
+     * A private field to help with RTTI that works in SxS scenarios.
+     */
+    // tslint:disable-next-line:variable-name
+    /* @internal */ private readonly __pulumResourceError: boolean = true;
+
+    /**
+     * Returns true if the given object is an instance of a ResourceError.  This is designed to work even when
+     * multiple copies of the Pulumi SDK have been loaded into the same process.
+     */
+    public static isInstance(obj: any): obj is ResourceError {
+        return obj && obj.__pulumiRunError;
+    }
+
+    constructor(message: string, public resource: Resource, public hideStack?: boolean) {
         super(message);
     }
 }

--- a/sdk/nodejs/errors.ts
+++ b/sdk/nodejs/errors.ts
@@ -41,10 +41,10 @@ export class RunError extends Error {
 }
 
 /**
- * ResourceError can be used for terminating a program abruptly, optionally associating the problem with
- * a Resource.  Depending on the nature of the problem, clients can choose whether or not a
- * callstack should be returned as well.  This should be very rare, and would only indicate no
- * usefulness of presenting that stack to the user.
+ * ResourceError can be used for terminating a program abruptly, specifically associating the
+ * problem with a Resource.  Depending on the nature of the problem, clients can choose whether or
+ * not a call stack should be returned as well.  This should be very rare, and would only indicate
+ * no usefulness of presenting that stack to the user.
  */
 export class ResourceError extends Error {
     /**

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -79,7 +79,7 @@ export abstract class Resource {
             throw new ResourceError("Missing resource type argument", opts.parent);
         }
         if (!name) {
-            throw new ResourceError("Missing resource name argument (for URN creation)", opts.parent;
+            throw new ResourceError("Missing resource name argument (for URN creation)", opts.parent);
         }
 
         // Check the parent type if one exists and fill in any default options.

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { ResourceError } from "./errors";
 import * as runtime from "./runtime";
 import { readResource, registerResource, registerResourceOutputs } from "./runtime/resource";
 
@@ -75,17 +76,17 @@ export abstract class Resource {
      */
     constructor(t: string, name: string, custom: boolean, props: Inputs = {}, opts: ResourceOptions = {}) {
         if (!t) {
-            throw new Error("Missing resource type argument");
+            throw new ResourceError("Missing resource type argument", opts.parent);
         }
         if (!name) {
-            throw new Error("Missing resource name argument (for URN creation)");
+            throw new ResourceError("Missing resource name argument (for URN creation)", opts.parent;
         }
 
         // Check the parent type if one exists and fill in any default options.
         this.__providers = {};
         if (opts.parent) {
             if (!Resource.isInstance(opts.parent)) {
-                throw new Error(`Resource parent is not a valid Resource: ${opts.parent}`);
+                throw new ResourceError(`Resource parent is not a valid Resource: ${opts.parent}`, opts.parent);
             }
 
             if (opts.protect === undefined) {
@@ -112,7 +113,8 @@ export abstract class Resource {
         if (opts.id) {
             // If this resource already exists, read its state rather than registering it anew.
             if (!custom) {
-                throw new Error("Cannot read an existing resource unless it has a custom provider");
+                throw new ResourceError(
+                    "Cannot read an existing resource unless it has a custom provider", opts.parent);
             }
             readResource(this, t, name, props, opts);
         } else {
@@ -231,9 +233,9 @@ export abstract class ProviderResource extends CustomResource {
      * @param props The configuration to use for this provider.
      * @param opts A bag of options that control this provider's behavior.
      */
-    constructor(pkg: string, name: string, props?: Inputs, opts?: ResourceOptions) {
-        if (opts && (<any>opts).provider !== undefined) {
-            throw new Error("Explicit providers may not be used with provider resources");
+    constructor(pkg: string, name: string, props?: Inputs, opts: ResourceOptions = {}) {
+        if ((<any>opts).provider !== undefined) {
+            throw new ResourceError("Explicit providers may not be used with provider resources", opts.parent);
         }
 
         super(`pulumi:providers:${pkg}`, name, props, opts);
@@ -258,9 +260,9 @@ export class ComponentResource extends Resource {
      * @param props The arguments to use to populate the new resource.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(t: string, name: string, props?: Inputs, opts?: ComponentResourceOptions) {
-        if (opts && (<any>opts).provider !== undefined) {
-            throw new Error("Explicit providers may not be used with component resources");
+    constructor(t: string, name: string, props?: Inputs, opts: ComponentResourceOptions = {}) {
+        if ((<any>opts).provider !== undefined) {
+            throw new ResourceError("Explicit providers may not be used with component resources", opts.parent);
         }
 
         super(t, name, false, props, opts);

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { RunError } from "./errors";
 import * as runtime from "./runtime";
 import { readResource, registerResource, registerResourceOutputs } from "./runtime/resource";
-import { getRootResource } from "./runtime/settings";
 
 export type ID = string;  // a provider-assigned ID.
 export type URN = string; // an automatically generated logical URN, used to stably identify resources.
@@ -77,17 +75,17 @@ export abstract class Resource {
      */
     constructor(t: string, name: string, custom: boolean, props: Inputs = {}, opts: ResourceOptions = {}) {
         if (!t) {
-            throw new RunError("Missing resource type argument");
+            throw new Error("Missing resource type argument");
         }
         if (!name) {
-            throw new RunError("Missing resource name argument (for URN creation)");
+            throw new Error("Missing resource name argument (for URN creation)");
         }
 
         // Check the parent type if one exists and fill in any default options.
         this.__providers = {};
         if (opts.parent) {
             if (!Resource.isInstance(opts.parent)) {
-                throw new RunError(`Resource parent is not a valid Resource: ${opts.parent}`);
+                throw new Error(`Resource parent is not a valid Resource: ${opts.parent}`);
             }
 
             if (opts.protect === undefined) {
@@ -114,7 +112,7 @@ export abstract class Resource {
         if (opts.id) {
             // If this resource already exists, read its state rather than registering it anew.
             if (!custom) {
-                throw new RunError("Cannot read an existing resource unless it has a custom provider");
+                throw new Error("Cannot read an existing resource unless it has a custom provider");
             }
             readResource(this, t, name, props, opts);
         } else {
@@ -235,7 +233,7 @@ export abstract class ProviderResource extends CustomResource {
      */
     constructor(pkg: string, name: string, props?: Inputs, opts?: ResourceOptions) {
         if (opts && (<any>opts).provider !== undefined) {
-            throw new RunError("Explicit providers may not be used with provider resources");
+            throw new Error("Explicit providers may not be used with provider resources");
         }
 
         super(`pulumi:providers:${pkg}`, name, props, opts);
@@ -262,7 +260,7 @@ export class ComponentResource extends Resource {
      */
     constructor(t: string, name: string, props?: Inputs, opts?: ComponentResourceOptions) {
         if (opts && (<any>opts).provider !== undefined) {
-            throw new RunError("Explicit providers may not be used with component resources");
+            throw new Error("Explicit providers may not be used with component resources");
         }
 
         super(t, name, false, props, opts);
@@ -407,7 +405,7 @@ export class Output<T> {
         };
 
         this.get = () => {
-            throw new RunError(`Cannot call '.get' during update or preview.
+            throw new Error(`Cannot call '.get' during update or preview.
 To manipulate the value of this Output, use '.apply' instead.`);
         };
     }

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -19,7 +19,6 @@ import * as normalize from "normalize-package-data";
 import * as filepath from "path";
 import * as readPackageTree from "read-package-tree";
 import * as asset from "../../asset";
-import { RunError } from "../../errors";
 
 /**
  * Options for controlling what gets returned by [computeCodePaths].
@@ -168,7 +167,7 @@ function allFoldersForPackages(includedPackages: Set<string>, excludedPackages: 
                 // as this is not an actual problem for determining the set of dependencies.
                 if (root.error) {
                     if (!root.realpath) {
-                        throw new RunError(
+                        throw new Error(
                             "Failed to parse package.json. Underlying issue:\n  " + root.error.toString());
                     }
 
@@ -226,7 +225,7 @@ function computeDependenciesDirectlyFromPackageFile(path: string): any {
         try {
             return fs.readFileSync(path);
         } catch (err) {
-            throw new RunError(`Error reading file '${path}' when computing package dependencies. ${err}`);
+            throw new Error(`Error reading file '${path}' when computing package dependencies. ${err}`);
         }
     }
 
@@ -234,7 +233,7 @@ function computeDependenciesDirectlyFromPackageFile(path: string): any {
         try {
             return JSON.parse(contents.toString());
         } catch (err) {
-            throw new RunError(`Error parsing file '${path}' when computing package dependencies. ${err}`);
+            throw new Error(`Error parsing file '${path}' when computing package dependencies. ${err}`);
         }
     }
 }

--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -19,6 +19,8 @@ import * as normalize from "normalize-package-data";
 import * as filepath from "path";
 import * as readPackageTree from "read-package-tree";
 import * as asset from "../../asset";
+import { ResourceError } from "../../errors";
+import { Resource } from "../../resource";
 
 /**
  * Options for controlling what gets returned by [computeCodePaths].
@@ -45,6 +47,11 @@ export interface CodePathOptions {
      * used at runtime.
      */
     extraExcludePackages?: string[];
+
+    /**
+     * The resource to log any errors we encounter against.
+     */
+    logResource?: Resource;
 }
 
 // computeCodePaths computes the local node_module paths to include in an uploaded cloud 'Lambda'.
@@ -102,7 +109,8 @@ async function computeCodePathsWorker(options: CodePathOptions): Promise<Map<str
     // Find folders for all packages requested by the user
     const pathSet = await allFoldersForPackages(
         new Set<string>(options.extraIncludePackages || []),
-        new Set<string>(options.extraExcludePackages || []));
+        new Set<string>(options.extraExcludePackages || []),
+        options.logResource);
 
     // Add all paths explicitly requested by the user
     const extraIncludePaths = options.extraIncludePaths || [];
@@ -152,7 +160,10 @@ function isSubsumedByHigherPath(path: string, pathSet: Set<string>): boolean {
 
 // allFolders computes the set of package folders that are transitively required by the root
 // 'dependencies' node in the client's project.json file.
-function allFoldersForPackages(includedPackages: Set<string>, excludedPackages: Set<string>): Promise<Set<string>> {
+function allFoldersForPackages(
+        includedPackages: Set<string>,
+        excludedPackages: Set<string>,
+        logResource: Resource | undefined): Promise<Set<string>> {
     return new Promise((resolve, reject) => {
         readPackageTree(".", <any>undefined, (err: any, root: readPackageTree.Node) => {
             try {
@@ -167,13 +178,13 @@ function allFoldersForPackages(includedPackages: Set<string>, excludedPackages: 
                 // as this is not an actual problem for determining the set of dependencies.
                 if (root.error) {
                     if (!root.realpath) {
-                        throw new Error(
-                            "Failed to parse package.json. Underlying issue:\n  " + root.error.toString());
+                        throw new ResourceError(
+                            "Failed to parse package.json. Underlying issue:\n  " + root.error.toString(), logResource);
                     }
 
                     // From: https://github.com/npm/read-package-tree/blob/5245c6e50d7f46ae65191782622ec75bbe80561d/rpt.js#L121
                     root.package = computeDependenciesDirectlyFromPackageFile(
-                        filepath.join(root.realpath, "package.json"));
+                        filepath.join(root.realpath, "package.json"), logResource);
                 }
 
                 // This is the core starting point of the algorithm.  We use readPackageTree to get
@@ -201,7 +212,7 @@ function allFoldersForPackages(includedPackages: Set<string>, excludedPackages: 
     });
 }
 
-function computeDependenciesDirectlyFromPackageFile(path: string): any {
+function computeDependenciesDirectlyFromPackageFile(path: string, logResource: Resource | undefined): any {
     // read the package.json file in directly.  if any of these fail an error will be thrown
     // and bubbled back out to user.
     const contents = readFile();
@@ -225,7 +236,7 @@ function computeDependenciesDirectlyFromPackageFile(path: string): any {
         try {
             return fs.readFileSync(path);
         } catch (err) {
-            throw new Error(`Error reading file '${path}' when computing package dependencies. ${err}`);
+            throw new ResourceError(`Error reading file '${path}' when computing package dependencies. ${err}`, logResource);
         }
     }
 
@@ -233,7 +244,7 @@ function computeDependenciesDirectlyFromPackageFile(path: string): any {
         try {
             return JSON.parse(contents.toString());
         } catch (err) {
-            throw new Error(`Error parsing file '${path}' when computing package dependencies. ${err}`);
+            throw new ResourceError(`Error parsing file '${path}' when computing package dependencies. ${err}`, logResource);
         }
     }
 }

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -154,7 +154,7 @@ interface Context {
     /**
      * The resource to log any errors we encounter against.
      */
-    logResource?: resource.Resource;
+    logResource: resource.Resource | undefined;
 }
 
 interface FunctionLocation {

--- a/sdk/nodejs/runtime/closure/serializeClosure.ts
+++ b/sdk/nodejs/runtime/closure/serializeClosure.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { Resource } from "../../resource";
 import * as closure from "./createClosure";
 
 /**
@@ -39,6 +40,11 @@ export interface SerializeFunctionArgs {
      * be what is exported.
      */
     isFactoryFunction?: boolean;
+
+    /**
+     * The resource to log any errors we encounter against.
+     */
+    logResource?: Resource;
 }
 
 /**
@@ -80,15 +86,15 @@ export interface SerializedFunction {
  * @param func The JavaScript function to serialize.
  * @param args Arguments to use to control the serialization of the JavaScript function.
  */
-export async function serializeFunction(func: Function, args?: SerializeFunctionArgs): Promise<SerializedFunction> {
-    if (!args) {
-        args = {};
-    }
+export async function serializeFunction(
+        func: Function,
+        args: SerializeFunctionArgs = {}): Promise<SerializedFunction> {
+
     const exportName = args.exportName || "handler";
     const serialize = args.serialize || (_ => true);
     const isFactoryFunction = args.isFactoryFunction === undefined ? false : args.isFactoryFunction;
 
-    const functionInfo = await closure.createFunctionInfoAsync(func, serialize);
+    const functionInfo = await closure.createFunctionInfoAsync(func, serialize, args.logResource);
     return serializeJavaScriptText(functionInfo, exportName, isFactoryFunction);
 }
 
@@ -100,7 +106,7 @@ export async function serializeFunctionAsync(
         func: Function,
         serialize?: (o: any) => boolean): Promise<string> {
     serialize = serialize || (_ => true);
-    const functionInfo = await closure.createFunctionInfoAsync(func, serialize);
+    const functionInfo = await closure.createFunctionInfoAsync(func, serialize, /*logResource:*/ undefined);
     return serializeJavaScriptText(functionInfo, "handler", /*isFactoryFunction*/ false).text;
 }
 

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as grpc from "grpc";
+import { ResourceError } from "../errors";
 import * as log from "../log";
 import { CustomResourceOptions, ID, Input, Inputs, Output, Resource, ResourceOptions, URN } from "../resource";
 import { debuggablePromise, errorString } from "./debuggable";
@@ -56,7 +57,7 @@ interface ResourceResolverOperation {
 export function readResource(res: Resource, t: string, name: string, props: Inputs, opts: ResourceOptions): void {
     const id: Input<ID> | undefined = opts.id;
     if (!id) {
-        throw new Error("Cannot read resource whose options are lacking an ID value");
+        throw new ResourceError("Cannot read resource whose options are lacking an ID value", res);
     }
 
     const label = `resource:${name}[${t}]#...`;

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as grpc from "grpc";
-import { ResourceError } from "../errors";
 import * as log from "../log";
 import { CustomResourceOptions, ID, Input, Inputs, Output, Resource, ResourceOptions, URN } from "../resource";
 import { debuggablePromise, errorString } from "./debuggable";
@@ -57,7 +56,7 @@ interface ResourceResolverOperation {
 export function readResource(res: Resource, t: string, name: string, props: Inputs, opts: ResourceOptions): void {
     const id: Input<ID> | undefined = opts.id;
     if (!id) {
-        throw new ResourceError("Cannot read resource whose options are lacking an ID value", res);
+        throw new Error("Cannot read resource whose options are lacking an ID value");
     }
 
     const label = `resource:${name}[${t}]#...`;


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1291

Note: i've moved over almost all code that used to throw RunError to use ResourceError. The only code i didn't change was config-related code. I didn't want to necessarily change that behavior without us thinking through it.