### PR TITLE
Prevent the same resource header from appearing multiple times during diagnostics.

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -666,6 +666,8 @@ func (display *ProgressDisplay) processEndSteps() {
 	wroteDiagnosticHeader := false
 
 	for _, row := range display.eventUrnToResourceRow {
+		wroteResourceHeader := false
+
 		for id, payloads := range row.DiagInfo().StreamIDToDiagPayloads {
 			if len(payloads) > 0 {
 				if id != 0 {
@@ -676,7 +678,6 @@ func (display *ProgressDisplay) processEndSteps() {
 				}
 
 				wrote := false
-				wroteResourceHeader := false
 				for _, v := range payloads {
 					if v.Ephemeral {
 						continue


### PR DESCRIPTION
Goes from this:

![image](https://user-images.githubusercontent.com/4564579/46003324-187ee780-c065-11e8-9a88-a64855a1fa81.png)

To this:

![image](https://user-images.githubusercontent.com/4564579/46003347-26346d00-c065-11e8-91fa-e8a7f289bbca.png)

