### PR TITLE
Fix pulumi/pulumi#1995

### DIFF
--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -715,17 +715,21 @@ func printAssetsDiff(
 
 				switch t := old.(type) {
 				case *resource.Archive:
-					newArchive := new.(*resource.Archive)
-
-					if t.Hash != newArchive.Hash {
+					newArchive, newIsArchive := new.(*resource.Archive)
+					switch {
+					case !newIsArchive:
+						printAssetArchiveDiff(b, titleFunc, t, new, planning, indent, summary, debug)
+					case t.Hash != newArchive.Hash:
 						printArchiveDiff(
 							b, titleFunc, t, newArchive,
 							planning, indent, summary, debug)
 					}
 				case *resource.Asset:
-					newAsset := new.(*resource.Asset)
-
-					if t.Hash != newAsset.Hash {
+					newAsset, newIsAsset := new.(*resource.Asset)
+					switch {
+					case !newIsAsset:
+						printAssetArchiveDiff(b, titleFunc, t, new, planning, indent, summary, debug)
+					case t.Hash != newAsset.Hash:
 						printAssetDiff(
 							b, titleFunc, t, newAsset,
 							planning, indent, summary, debug)
@@ -829,6 +833,12 @@ func printAssetDiff(
 	printAdd(
 		b, assetOrArchiveToPropertyValue(newAsset),
 		titleFunc, planning, indent, debug)
+}
+
+func printAssetArchiveDiff(b *bytes.Buffer, titleFunc func(deploy.StepOp, bool), old interface{}, new interface{},
+	planning bool, indent int, summary bool, debug bool) {
+	printDelete(b, assetOrArchiveToPropertyValue(old), titleFunc, planning, indent, debug)
+	printAdd(b, assetOrArchiveToPropertyValue(new), titleFunc, planning, indent, debug)
 }
 
 func getTextChangeString(old string, new string) string {


### PR DESCRIPTION
The diff display code was not expecting that it would be possible for
resource properties to transition from being an archive to being an
asset, or the other way around. This commit prints out a reasonable diff
if this situation occurs instead of crashing.

Before:

https://asciinema.org/a/r52bFBqeY72wa0wT7KR3eDvJU

After:

https://asciinema.org/a/SFXg09cocPAsCUNQRtoUgAZ74