### PR TITLE
Allow previews when operations are pending.

### DIFF
--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -185,7 +185,7 @@ func NewPlan(ctx *plugin.Context, target *Target, prev *Snapshot, source Source,
 	// planExecutor.refresh for details.
 	olds := make(map[resource.URN]*resource.State)
 	if prev != nil {
-		if prev.PendingOperations != nil {
+		if prev.PendingOperations != nil && !preview {
 			return nil, PlanPendingOperationsError{prev.PendingOperations}
 		}
 		oldResources = prev.Resources


### PR DESCRIPTION
The preview will proceed as if the operations had not been issued (i.e.
we will not speculate on a new state for the stack). This is consistent
with our behavior prior to the changes that added pending operations to
the checkpoint.