### PR TITLE
Enable stack outputs to be JSON formatted

### DIFF
--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -15,7 +15,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/pkg/errors"
@@ -64,11 +63,9 @@ func newStackOutputCmd() *cobra.Command {
 				v, has := outputs[name]
 				if has {
 					if jsonOut {
-						out, err := json.MarshalIndent(v, "", "    ")
-						if err != nil {
+						if err := printJSON(v); err != nil {
 							return err
 						}
-						fmt.Println(string(out))
 					} else {
 						fmt.Printf("%v\n", stringifyOutput(v))
 					}
@@ -76,11 +73,9 @@ func newStackOutputCmd() *cobra.Command {
 					return errors.Errorf("current stack does not have output property '%v'", name)
 				}
 			} else if jsonOut {
-				out, err := json.MarshalIndent(outputs, "", "    ")
-				if err != nil {
+				if err := printJSON(outputs); err != nil {
 					return err
 				}
-				fmt.Println(string(out))
 			} else {
 				printStackOutputs(outputs)
 			}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -565,6 +566,16 @@ func (cancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bo
 	signal.Notify(c.sigint, os.Interrupt)
 
 	return c
+}
+
+// printJSON simply prints out some object, formatted as JSON, using standard indentation.
+func printJSON(v interface{}) error {
+	out, err := json.MarshalIndent(v, "", "    ")
+	if err != nil {
+		return err
+	}
+	fmt.Println(string(out))
+	return nil
 }
 
 // isInteractive returns true if the environment and command line options indicate we should

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -174,6 +174,28 @@ func TestStackOutputs(t *testing.T) {
 	})
 }
 
+// TestStackOutputsJSON ensures the CLI properly formats stack outputs as JSON when requested.
+func TestStackOutputsJSON(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	defer func() {
+		if !t.Failed() {
+			e.DeleteEnvironment()
+		}
+	}()
+	e.ImportDirectory("stack_outputs")
+	e.RunCommand("yarn", "link", "@pulumi/pulumi")
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", "stack-outs")
+	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
+	stdout, stderr := e.RunCommand("pulumi", "stack", "output", "--json")
+	assert.Equal(t, `{
+    "foo": 42,
+    "xyz": "ABC"
+}
+`, stdout)
+	assert.Equal(t, "", stderr)
+}
+
 // TestStackOutputsDisplayed ensures that outputs are printed at the end of an update
 func TestStackOutputsDisplayed(t *testing.T) {
 	stdout := &bytes.Buffer{}


### PR DESCRIPTION
This change adds a --json (short -j) flag for `pulumi stack output`
that prints the results as JSON, rather than our ad-hoc format.

Fixes pulumi/pulumi#1863.