### PR TITLE
Make --non-interactive a global flag

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -57,7 +57,7 @@ func newDestroyCmd() *cobra.Command {
 			"is generally irreversible and should be used with great care.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			interactive := isInteractive()
+			interactive := cmdutil.Interactive()
 			if !interactive {
 				yes = true // auto-approve changes, since we cannot prompt.
 			}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -40,7 +40,6 @@ func newDestroyCmd() *cobra.Command {
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
-	var nonInteractive bool
 	var skipPreview bool
 	var yes bool
 
@@ -58,7 +57,7 @@ func newDestroyCmd() *cobra.Command {
 			"is generally irreversible and should be used with great care.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			interactive := isInteractive(nonInteractive)
+			interactive := isInteractive()
 			if !interactive {
 				yes = true // auto-approve changes, since we cannot prompt.
 			}
@@ -130,8 +129,6 @@ func newDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,
 		"Display operation as a rich diff showing the overall change")
-	cmd.PersistentFlags().BoolVar(
-		&nonInteractive, "non-interactive", false, "Disable interactive mode")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -64,7 +64,7 @@ func newNewCmd() *cobra.Command {
 		Short:      "Create a new Pulumi project",
 		Args:       cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			interactive := isInteractive()
+			interactive := cmdutil.Interactive()
 			if !interactive {
 				yes = true // auto-approve changes, since we cannot prompt.
 			}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -57,7 +57,6 @@ func newNewCmd() *cobra.Command {
 	var offline bool
 	var generateOnly bool
 	var dir string
-	var nonInteractive bool
 
 	cmd := &cobra.Command{
 		Use:        "new [template]",
@@ -65,7 +64,7 @@ func newNewCmd() *cobra.Command {
 		Short:      "Create a new Pulumi project",
 		Args:       cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			interactive := isInteractive(nonInteractive)
+			interactive := isInteractive()
 			if !interactive {
 				yes = true // auto-approve changes, since we cannot prompt.
 			}
@@ -335,8 +334,6 @@ func newNewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&dir, "dir", "",
 		"The location to place the generated project; if not specified, the current directory is used")
-	cmd.PersistentFlags().BoolVar(
-		&nonInteractive, "non-interactive", false, "Disable interactive mode")
 
 	return cmd
 }

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -33,7 +33,6 @@ func newPreviewCmd() *cobra.Command {
 	// Flags for engine.UpdateOptions.
 	var analyzers []string
 	var diffDisplay bool
-	var nonInteractive bool
 	var parallel int
 	var showConfig bool
 	var showReplacementSteps bool
@@ -68,7 +67,7 @@ func newPreviewCmd() *cobra.Command {
 					ShowConfig:           showConfig,
 					ShowReplacementSteps: showReplacementSteps,
 					ShowSameResources:    showSames,
-					IsInteractive:        isInteractive(nonInteractive),
+					IsInteractive:        isInteractive(),
 					DiffDisplay:          diffDisplay,
 					Debug:                debug,
 				},
@@ -128,8 +127,6 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,
 		"Display operation as a rich diff showing the overall change")
-	cmd.PersistentFlags().BoolVar(
-		&nonInteractive, "non-interactive", false, "Disable interactive mode")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -67,7 +67,7 @@ func newPreviewCmd() *cobra.Command {
 					ShowConfig:           showConfig,
 					ShowReplacementSteps: showReplacementSteps,
 					ShowSameResources:    showSames,
-					IsInteractive:        isInteractive(),
+					IsInteractive:        cmdutil.Interactive(),
 					DiffDisplay:          diffDisplay,
 					Debug:                debug,
 				},

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -134,7 +134,7 @@ func NewPulumiCmd() *cobra.Command {
 		"Flow log settings to child processes (like plugins)")
 	cmd.PersistentFlags().BoolVar(&logToStderr, "logtostderr", false,
 		"Log to stderr instead of to files")
-	cmd.PersistentFlags().BoolVar(&nonInteractive, "non-interactive", false,
+	cmd.PersistentFlags().BoolVar(&cmdutil.DisableInteractive, "non-interactive", false,
 		"Disable interactive mode for all commands")
 	cmd.PersistentFlags().StringVar(&tracing, "tracing", "",
 		"Emit tracing to a Zipkin-compatible tracing endpoint")

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -134,6 +134,8 @@ func NewPulumiCmd() *cobra.Command {
 		"Flow log settings to child processes (like plugins)")
 	cmd.PersistentFlags().BoolVar(&logToStderr, "logtostderr", false,
 		"Log to stderr instead of to files")
+	cmd.PersistentFlags().BoolVar(&nonInteractive, "non-interactive", false,
+		"Disable interactive mode for all commands")
 	cmd.PersistentFlags().StringVar(&tracing, "tracing", "",
 		"Emit tracing to a Zipkin-compatible tracing endpoint")
 	cmd.PersistentFlags().StringVar(&profiling, "profiling", "",

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -39,7 +39,6 @@ func newRefreshCmd() *cobra.Command {
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
-	var nonInteractive bool
 	var skipPreview bool
 	var yes bool
 
@@ -57,7 +56,7 @@ func newRefreshCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			interactive := isInteractive(nonInteractive)
+			interactive := isInteractive()
 			if !interactive {
 				yes = true // auto-approve changes, since we cannot prompt.
 			}
@@ -139,8 +138,6 @@ func newRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,
 		"Display operation as a rich diff showing the overall change")
-	cmd.PersistentFlags().BoolVar(
-		&nonInteractive, "non-interactive", false, "Disable interactive mode")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -56,7 +56,7 @@ func newRefreshCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			interactive := isInteractive()
+			interactive := cmdutil.Interactive()
 			if !interactive {
 				yes = true // auto-approve changes, since we cannot prompt.
 			}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -272,7 +272,7 @@ func newUpCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			interactive := isInteractive()
+			interactive := cmdutil.Interactive()
 			if !interactive {
 				yes = true // auto-approve changes, since we cannot prompt.
 			}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -50,7 +50,6 @@ func newUpCmd() *cobra.Command {
 	// Flags for engine.UpdateOptions.
 	var analyzers []string
 	var diffDisplay bool
-	var nonInteractive bool
 	var parallel int
 	var refresh bool
 	var showConfig bool
@@ -273,7 +272,7 @@ func newUpCmd() *cobra.Command {
 			"`--cwd` flag to use a different directory.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
-			interactive := isInteractive(nonInteractive)
+			interactive := isInteractive()
 			if !interactive {
 				yes = true // auto-approve changes, since we cannot prompt.
 			}
@@ -325,8 +324,6 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,
 		"Display operation as a rich diff showing the overall change")
-	cmd.PersistentFlags().BoolVar(
-		&nonInteractive, "non-interactive", false, "Disable interactive mode")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -578,9 +578,13 @@ func printJSON(v interface{}) error {
 	return nil
 }
 
-// isInteractive returns true if the environment and command line options indicate we should
-// do things interactively
-func isInteractive(nonInteractive bool) bool {
+// nonInteractive may be set to true in order to disable prompts. This is useful when running in a non-attended
+// scenario, such as in continuous integration, or when using the Pulumi CLI/SDK in a programmatic way.
+var nonInteractive bool
+
+// isInteractive returns true if the environment and command line options indicate we should do things interactively.
+// It respects the nonInteractive flag as an override, but otherwise defaults by reading the terminal and CI settings.
+func isInteractive() bool {
 	return !nonInteractive && terminal.IsTerminal(int(os.Stdout.Fd())) && !testutil.IsCI()
 }
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -29,7 +29,6 @@ import (
 	multierror "github.com/hashicorp/go-multierror"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/ssh/terminal"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 	git "gopkg.in/src-d/go-git.v4"
@@ -45,7 +44,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/gitutil"
-	"github.com/pulumi/pulumi/pkg/util/testutil"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -576,16 +574,6 @@ func printJSON(v interface{}) error {
 	}
 	fmt.Println(string(out))
 	return nil
-}
-
-// nonInteractive may be set to true in order to disable prompts. This is useful when running in a non-attended
-// scenario, such as in continuous integration, or when using the Pulumi CLI/SDK in a programmatic way.
-var nonInteractive bool
-
-// isInteractive returns true if the environment and command line options indicate we should do things interactively.
-// It respects the nonInteractive flag as an override, but otherwise defaults by reading the terminal and CI settings.
-func isInteractive() bool {
-	return !nonInteractive && terminal.IsTerminal(int(os.Stdout.Fd())) && !testutil.IsCI()
 }
 
 // updateFlagsToOptions ensures that the given update flags represent a valid combination.  If so, an UpdateOptions

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -261,6 +261,11 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 
 	if accessToken != "" {
 		fmt.Printf("Using access token from %s\n", AccessTokenEnvVar)
+	} else if !cmdutil.Interactive() {
+		// If interactive mode isn't enabled, the only way to specify a token is through the environment variable.
+		// Fail the attempt to login.
+		return nil, errors.Errorf(
+			"%s must be set for login during non-interactive CLI sessions", AccessTokenEnvVar)
 	} else {
 		line1 := fmt.Sprintf("Manage your Pulumi stacks by logging in.")
 		line1len := len(line1)

--- a/pkg/util/cmdutil/console.go
+++ b/pkg/util/cmdutil/console.go
@@ -22,6 +22,8 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/ssh/terminal"
+
+	"github.com/pulumi/pulumi/pkg/util/testutil"
 )
 
 // Emoji controls whether emojis will by default be printed in the output.
@@ -36,8 +38,18 @@ func EmojiOr(e, or string) string {
 	return or
 }
 
-// Interactive returns true if we're in an interactive terminal session.
+// DisableInteractive may be set to true in order to disable prompts. This is useful when running in a non-attended
+// scenario, such as in continuous integration, or when using the Pulumi CLI/SDK in a programmatic way.
+var DisableInteractive bool
+
+// Interactive returns true if we should be running in interactive mode. That is, we have an interactive terminal
+// session, interactivity hasn't been explicitly disabled, and we're not running in a known CI system.
 func Interactive() bool {
+	return !DisableInteractive && InteractiveTerminal() && !testutil.IsCI()
+}
+
+// InteractiveTerminal returns true if the current terminal session is interactive.
+func InteractiveTerminal() bool {
 	return terminal.IsTerminal(int(os.Stdin.Fd()))
 }
 


### PR DESCRIPTION
Right now, we only support --non-interactive in a few places (up,
refresh, destroy, etc). Over time, we've added it to more (like new).
And now, as we're working on better Docker support (pulumi/pulumi#1991),
we want to support this more globally, so we can, for example, avoid
popping up a web browser inside a Docker contain for logging in.

So, this change makes --non-interactive a global flag. Because it is
a persistent flag, it still works in the old positions, so this isn't
a breaking change to existing commands that use it.