### PR TITLE
Fix various things related to CI project

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ FROM debian:stretch
 
 # Install some runtime pre-reqs.
 RUN apt-get update -y
-RUN apt-get install -y ca-certificates curl gnupg
+RUN apt-get install -y ca-certificates curl gnupg jq
 
 # Install the necessary runtimes.
 #     - Node.js 10.x

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,11 @@ FROM debian:stretch
 RUN apt-get update -y
 RUN apt-get install -y ca-certificates
 
+# Install the necessary runtimes.
+#     - Node.js 10.x
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
+    apt-get install -y nodejs build-essential
+
 # Copy over the binaries built during the prior stage.
 COPY --from=builder /opt/pulumi/* /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,10 +40,11 @@ RUN apt-get install -y ca-certificates
 # Install the necessary runtimes.
 #     - Node.js 10.x
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get install -y nodejs build-essential
+    apt-get install -y nodejs build-essential && \
+    ln -s `which nodejs` /usr/bin/node
 
 # Copy over the binaries built during the prior stage.
-COPY --from=builder /opt/pulumi/* /usr/local/bin/
+COPY --from=builder /opt/pulumi/* /usr/bin/
 
 # The app directory should contain the Pulumi program and is the pwd for the CLI.
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,9 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get install -y nodejs build-essential && \
     ln -s `which nodejs` /usr/bin/node
 
+# Copy the entrypoint script.
+COPY ./scripts/docker-entry.sh /usr/bin/run-pulumi
+
 # Copy over the binaries built during the prior stage.
 COPY --from=builder /opt/pulumi/* /usr/bin/
 
@@ -55,6 +58,6 @@ VOLUME ["/app"]
 # running the Docker container using `docker run pulumi/pulumi -e "PULUMI_ACCESS_TOKEN=a1b2c2def9"`.
 # ENV PULUMI_ACCESS_TOKEN
 
-# This image uses the `pulumi` CLI as an entrypoint. As a result, you may run commands simply by
-# running `docker run pulumi/pulumi up` to run the program mounted in the `/app` volume location.
-ENTRYPOINT ["pulumi", "--non-interactive"]
+# This image uses a thin wrapper over the Pulumi CLI as its entrypoint. As a result, you may run commands
+# simply by running `docker run pulumi/pulumi up` to run the program mounted in the `/app` volume location.
+ENTRYPOINT ["run-pulumi", "--non-interactive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,13 +35,12 @@ FROM debian:stretch
 
 # Install some runtime pre-reqs.
 RUN apt-get update -y
-RUN apt-get install -y ca-certificates
+RUN apt-get install -y ca-certificates curl gnupg
 
 # Install the necessary runtimes.
 #     - Node.js 10.x
 RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get install -y nodejs build-essential && \
-    ln -s `which nodejs` /usr/bin/node
+    apt-get install -y nodejs build-essential
 
 # Copy the entrypoint script.
 COPY ./scripts/docker-entry.sh /usr/bin/run-pulumi

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,12 @@ VOLUME ["/app"]
 # running the Docker container using `docker run pulumi/pulumi -e "PULUMI_ACCESS_TOKEN=a1b2c2def9"`.
 # ENV PULUMI_ACCESS_TOKEN
 
+# Add some fixed labels for various integrations.
+LABEL "com.github.actions.name"="Pulumi"
+LABEL "com.github.actions.description"="Deploy apps and infra to any cloud!"
+LABEL "com.github.actions.icon"="cloud-lightning"
+LABEL "com.github.actions.color"="purple"
+
 # This image uses a thin wrapper over the Pulumi CLI as its entrypoint. As a result, you may run commands
 # simply by running `docker run pulumi/pulumi up` to run the program mounted in the `/app` volume location.
 ENTRYPOINT ["run-pulumi", "--non-interactive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,10 @@ RUN cd sdk/python && make install_plugin
 # TODO[pulumi/pulumi#1986]: consider switching to, or supporting, Alpine Linux for smaller image sizes.
 FROM debian:stretch
 
+# Install some runtime pre-reqs.
+RUN apt-get update -y
+RUN apt-get install -y ca-certificates
+
 # Copy over the binaries built during the prior stage.
 COPY --from=builder /opt/pulumi/* /usr/local/bin/
 

--- a/pkg/util/testutil/ci.go
+++ b/pkg/util/testutil/ci.go
@@ -57,24 +57,25 @@ func (c envValueDetector) IsCI() bool {
 }
 
 var detectors = map[string]ciSystemDetector{
-	"Travis CI":              envVarDetector{envVar: []string{"TRAVIS"}},
-	"CircleCI":               envVarDetector{envVar: []string{"CIRCLECI"}},
-	"GitLab CI":              envVarDetector{envVar: []string{"GITLAB_CI"}},
 	"AppVeyor":               envVarDetector{envVar: []string{"APPVEYOR"}},
+	"AWS CodeBuild":          envVarDetector{envVar: []string{"CODEBUILD_BUILD_ARN"}},
+	"Bamboo":                 envVarDetector{envVar: []string{"bamboo_planKey"}},
+	"Bitbucket Pipelines":    envVarDetector{envVar: []string{"BITBUCKET_COMMIT"}},
+	"Buildkite":              envVarDetector{envVar: []string{"BUILDKITE"}},
+	"CircleCI":               envVarDetector{envVar: []string{"CIRCLECI"}},
+	"Codeship":               envValueDetector{envMap: map[string]string{"CI_NAME": "codeship"}},
 	"Drone":                  envVarDetector{envVar: []string{"DRONE"}},
+	"GitHub":                 envVarDetector{envVar: []string{"GITHUB_WORKFLOW"}},
+	"GitLab CI":              envVarDetector{envVar: []string{"GITLAB_CI"}},
+	"GoCD":                   envVarDetector{envVar: []string{"GO_PIPELINE_LABEL"}},
+	"Hudson":                 envVarDetector{envVar: []string{"HUDSON_URL"}},
+	"Jenkins":                envVarDetector{envVar: []string{"JENKINS_URL", "BUILD_ID"}},
 	"Magnum CI":              envVarDetector{envVar: []string{"MAGNUM"}},
 	"Semaphore":              envVarDetector{envVar: []string{"SEMAPHORE"}},
-	"Jenkins":                envVarDetector{envVar: []string{"JENKINS_URL", "BUILD_ID"}},
-	"Bamboo":                 envVarDetector{envVar: []string{"bamboo_planKey"}},
+	"TaskCluster":            envVarDetector{envVar: []string{"TASK_ID", "RUN_ID"}},
 	"Team Foundation Server": envVarDetector{envVar: []string{"TF_BUILD"}},
 	"TeamCity":               envVarDetector{envVar: []string{"TEAMCITY_VERSION"}},
-	"Buildkite":              envVarDetector{envVar: []string{"BUILDKITE"}},
-	"Hudson":                 envVarDetector{envVar: []string{"HUDSON_URL"}},
-	"TaskCluster":            envVarDetector{envVar: []string{"TASK_ID", "RUN_ID"}},
-	"GoCD":                   envVarDetector{envVar: []string{"GO_PIPELINE_LABEL"}},
-	"Bitbucket Pipelines":    envVarDetector{envVar: []string{"BITBUCKET_COMMIT"}},
-	"AWS CodeBuild":          envVarDetector{envVar: []string{"CODEBUILD_BUILD_ARN"}},
-	"CODESHIP":               envValueDetector{envMap: map[string]string{"CI_NAME": "codeship"}},
+	"Travis CI":              envVarDetector{envVar: []string{"TRAVIS"}},
 }
 
 // IsCI returns true when the current system looks like a CI system. Detection is based on environment variables

--- a/scripts/docker-entry.sh
+++ b/scripts/docker-entry.sh
@@ -21,6 +21,7 @@ if [ ! -z "$PULUMI_CI" ]; then
         else
             BRANCH="$GITHUB_REF"
         fi
+        BRANCH=$(echo $BRANCH | sed "s/refs\/heads\///g")
     fi
 
     # Respect the branch mappings file for stack selection. Note that this is *not* required, but if the file

--- a/scripts/docker-entry.sh
+++ b/scripts/docker-entry.sh
@@ -1,13 +1,41 @@
 #!/bin/bash
 # This is an entrypoint for our Docker image that does some minimal bootstrapping before executing.
 
-# Detect the CI system and configure variables so that we get good Pulumi workflow and GitHub App support.
-if [ ! -z "${GITHUB_WORKFLOW}" ]; then
-    export PULUMI_CI_SYSTEM="GitHub"
-    export PULUMI_CI_BUILD_ID=
-    export PULUMI_CI_BUILD_TYPE=
-    export PULUMI_CI_BUILD_URL=
-    export PULUMI_CI_PULL_REQUEST_SHA="${GITHUB_SHA}"
+set -e
+
+# If the PULUMI_CI variable is set, we'll do some extra things to make common tasks easier.
+if [ ! -z "$PULUMI_CI" ]; then
+    # Detect the CI system and configure variables so that we get good Pulumi workflow and GitHub App support.
+    if [ ! -z "$GITHUB_WORKFLOW" ]; then
+        REF="$GITHUB_REF"
+        export PULUMI_CI_SYSTEM="GitHub"
+        export PULUMI_CI_BUILD_ID=
+        export PULUMI_CI_BUILD_TYPE=
+        export PULUMI_CI_BUILD_URL=
+        export PULUMI_CI_PULL_REQUEST_SHA="$GITHUB_SHA"
+    fi
+
+    # Respect the branch mappings file for stack selection. Note that this is *not* required, but if the file
+    # is missing, the caller of this script will need to pass `-s <stack-name>` to specify the stack explicitly.
+    if [ ! -z "$REF" ] && [ -e .pulumi/ci.json ]; then
+        PULUMI_STACK_NAME=$(cat .pulumi/ci.json | jq -r ".\"$REF\"")
+        if [ "$PULUMI_STACK_NAME" != "null" ]; then
+            pulumi stack select $PULUMI_STACK_NAME
+        else
+            echo "No stack configured for branch '$REF'"
+            echo ""
+            echo "To configure this branch, please"
+            echo "\t1) Run 'pulumi stack init <stack-name>'"
+            echo "\t2) Associated the stack with the branch by adding"
+            echo "\t\t{"
+            echo "\t\t\t\"$REF\": \"<stack-name>\""
+            echo "\t\t}"
+            echo "\tto your .pulumi/ci.json file"
+            echo ""
+            echo "For now, exiting cleanly without doing anything..."
+            exit 0
+        fi
+    fi
 fi
 
 # Next, lazily install packages if required.

--- a/scripts/docker-entry.sh
+++ b/scripts/docker-entry.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# This is an entrypoint for our Docker image that does some minimal bootstrapping before executing.
+
+# First, lazily install packages if required.
+if [ -e package.json ] && [ ! -d node_modules ]; then
+    npm install
+fi
+
+# Now just pass along all arguments to the Pulumi CLI.
+pulumi "$@"

--- a/scripts/docker-entry.sh
+++ b/scripts/docker-entry.sh
@@ -7,32 +7,40 @@ set -e
 if [ ! -z "$PULUMI_CI" ]; then
     # Detect the CI system and configure variables so that we get good Pulumi workflow and GitHub App support.
     if [ ! -z "$GITHUB_WORKFLOW" ]; then
-        REF="$GITHUB_REF"
         export PULUMI_CI_SYSTEM="GitHub"
         export PULUMI_CI_BUILD_ID=
         export PULUMI_CI_BUILD_TYPE=
         export PULUMI_CI_BUILD_URL=
         export PULUMI_CI_PULL_REQUEST_SHA="$GITHUB_SHA"
+
+        # For PR events, we want to take the ref of the target branch, not the current. This ensures, for
+        # instance, that a PR for a topic branch merging into `master` will use the `master` branch as the
+        # target for a preview. Note that for push events, we of course want to use the actual branch.
+        if [ "$PULUMI_CI" = "pr" ]; then
+            BRANCH=$(cat $GITHUB_EVENT_PATH | jq -r ".pull_request.base.ref")
+        else
+            BRANCH="$GITHUB_REF"
+        fi
     fi
 
     # Respect the branch mappings file for stack selection. Note that this is *not* required, but if the file
     # is missing, the caller of this script will need to pass `-s <stack-name>` to specify the stack explicitly.
-    if [ ! -z "$REF" ] && [ -e .pulumi/ci.json ]; then
-        PULUMI_STACK_NAME=$(cat .pulumi/ci.json | jq -r ".\"$REF\"")
+    if [ ! -z "$BRANCH" ] && [ -e .pulumi/ci.json ]; then
+        PULUMI_STACK_NAME=$(cat .pulumi/ci.json | jq -r ".\"$BRANCH\"")
         if [ "$PULUMI_STACK_NAME" != "null" ]; then
             pulumi stack select $PULUMI_STACK_NAME
         else
-            echo "No stack configured for branch '$REF'"
-            echo ""
-            echo "To configure this branch, please"
-            echo "\t1) Run 'pulumi stack init <stack-name>'"
-            echo "\t2) Associated the stack with the branch by adding"
-            echo "\t\t{"
-            echo "\t\t\t\"$REF\": \"<stack-name>\""
-            echo "\t\t}"
-            echo "\tto your .pulumi/ci.json file"
-            echo ""
-            echo "For now, exiting cleanly without doing anything..."
+            echo -e "No stack configured for branch '$BRANCH'"
+            echo -e ""
+            echo -e "To configure this branch, please"
+            echo -e "\t1) Run 'pulumi stack init <stack-name>'"
+            echo -e "\t2) Associated the stack with the branch by adding"
+            echo -e "\t\t{"
+            echo -e "\t\t\t\"$BRANCH\": \"<stack-name>\""
+            echo -e "\t\t}"
+            echo -e "\tto your .pulumi/ci.json file"
+            echo -e ""
+            echo -e "For now, exiting cleanly without doing anything..."
             exit 0
         fi
     fi

--- a/scripts/docker-entry.sh
+++ b/scripts/docker-entry.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 # This is an entrypoint for our Docker image that does some minimal bootstrapping before executing.
 
-# First, lazily install packages if required.
+# Detect the CI system and configure variables so that we get good Pulumi workflow and GitHub App support.
+if [ ! -z "${GITHUB_WORKFLOW}" ]; then
+    export PULUMI_CI_SYSTEM="GitHub"
+    export PULUMI_CI_BUILD_ID=
+    export PULUMI_CI_BUILD_TYPE=
+    export PULUMI_CI_BUILD_URL=
+    export PULUMI_CI_PULL_REQUEST_SHA="${GITHUB_SHA}"
+fi
+
+# Next, lazily install packages if required.
 if [ -e package.json ] && [ ! -d node_modules ]; then
     npm install
 fi


### PR DESCRIPTION
This PR includes a handful of fixes necessary for the current CI project:

* Install `ca-certificates` so we don't get cert validation errors for https://api.pulumi.com
* Install Node.js 10.x into the runtime stage, so that we can run Node.js Pulumi projects
* Make the container usable for projects (detect and install NPM packages as necessary)

The third is a little funny, and I'm still unsure about this. It feels like eventually we could end up with many container images: one for the base Pulumi engine, and derived ones for specific runtime environments (Node.js), etc. For now, I propose we stay simple and just have one mega image.