### PR TITLE
Emit the "using token" login message to stderr

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -260,13 +260,17 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	accountLink := cloudConsoleURL(cloudURL, "account")
 
 	if accessToken != "" {
-		fmt.Printf("Using access token from %s\n", AccessTokenEnvVar)
+		// If there's already a token from the environment, use it.
+		_, err = fmt.Fprintf(os.Stderr, "Logging in using access token from %s\n", AccessTokenEnvVar)
+		contract.IgnoreError(err)
 	} else if !cmdutil.Interactive() {
 		// If interactive mode isn't enabled, the only way to specify a token is through the environment variable.
 		// Fail the attempt to login.
 		return nil, errors.Errorf(
 			"%s must be set for login during non-interactive CLI sessions", AccessTokenEnvVar)
 	} else {
+		// If no access token is available from the environment, and we are interactive, prompt and offer to
+		// open a browser to make it easy to generate and use a fresh token.
 		line1 := fmt.Sprintf("Manage your Pulumi stacks by logging in.")
 		line1len := len(line1)
 		line1 = colors.Highlight(line1, "Pulumi stacks", colors.Underline+colors.Bold)


### PR DESCRIPTION
It's not good practice to dirty up the stdout stream with messages
like this. In fact, I questioned whether we should be emitting
*anything* here, but given that this is often used in unattended
environments, coupled with the fact that it's easy to accidentally set
this and then wonder why `pulumi login` is silently returning, led
me to keep it in (for now, at least).