### PR TITLE
Add suggestion for "apply" for "up" command

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -257,7 +257,7 @@ func newUpCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:        "up [url]",
 		Aliases:    []string{"update"},
-		SuggestFor: []string{"deploy", "push"},
+		SuggestFor: []string{"apply", "deploy", "push"},
 		Short:      "Create or update the resources in a stack",
 		Long: "Create or update the resources in a stack.\n" +
 			"\n" +


### PR DESCRIPTION
It is easy to continually type `pulumi apply` from years of muscle memory using Terraform - this commit makes the CLI suggest `up` when the `apply` subcommand is used, similar to how `plan` suggests `preview`.

It might be worth considering making these two actual aliases in future, but in the short term this matches the behaviour for `plan`.