### PR TITLE
Default an update's message to the Git commit title

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -126,7 +126,7 @@ type Backend interface {
 type UpdateOperation struct {
 	Proj   *workspace.Project
 	Root   string
-	M      UpdateMetadata
+	M      *UpdateMetadata
 	Opts   UpdateOptions
 	Scopes CancellationScopeSource
 }


### PR DESCRIPTION
There is a seldom-used capability in our CLI, the ability to pass
-m to specify an update message, which we will then show prominently.

At the same time, we already scrape some interesting information from
the Git repo from which an update is performed, like the SHA hash,
committer, and author information. We explicitly didn't want to scrape
the entire message just in case someone put sensitive info inside of it.

It seems safe -- indeed, appealing -- to use just the title portion
as the default update message when no other has been provided (the
majority case). We'll work on displaying it in a better way, but this
strengthens our GitOps/CI/CD story.

Fixes pulumi/pulumi#2008.