### PR TITLE
Fix rendering of the 'outputs:' header in the diff view.

### DIFF
--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -271,7 +271,11 @@ func renderResourceOutputsEvent(
 
 		text := engine.GetResourceOutputsPropertiesString(
 			payload.Metadata, indent+1, payload.Planning, payload.Debug, refresh)
-		fprintIgnoreError(out, opts.Color.Colorize(text))
+		if text != "" {
+			fprintfIgnoreError(out, "%v%v--outputs:--%v\n",
+				payload.Metadata.Op.Color(), engine.GetIndentationString(indent+1), colors.Reset)
+			fprintIgnoreError(out, opts.Color.Colorize(text))
+		}
 	}
 	return out.String()
 }

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -114,20 +114,28 @@ func RenderDiffEvent(action apitype.UpdateKind, event engine.Event,
 	switch event.Type {
 	case engine.CancelEvent:
 		return ""
+
+		// Currently, prelude, summar, and stdout events are printed the same for both the diff and
+		// progress displays.
 	case engine.PreludeEvent:
 		return renderPreludeEvent(event.Payload.(engine.PreludeEventPayload), opts)
 	case engine.SummaryEvent:
 		return renderSummaryEvent(action, event.Payload.(engine.SummaryEventPayload), opts)
-	case engine.ResourceOperationFailed:
-		return renderResourceOperationFailedEvent(event.Payload.(engine.ResourceOperationFailedPayload), opts)
-	case engine.ResourceOutputsEvent:
-		return renderResourceOutputsEvent(event.Payload.(engine.ResourceOutputsEventPayload), seen, opts)
-	case engine.ResourcePreEvent:
-		return renderResourcePreEvent(event.Payload.(engine.ResourcePreEventPayload), seen, opts)
 	case engine.StdoutColorEvent:
 		return renderStdoutColorEvent(event.Payload.(engine.StdoutEventPayload), opts)
+
+		// Resource operations have very specific displays for either diff or progress displays.
+		// These functions should not be directly used by the progress display without validating
+		// that the display is appropriate for both.
+	case engine.ResourceOperationFailed:
+		return renderDiffResourceOperationFailedEvent(event.Payload.(engine.ResourceOperationFailedPayload), opts)
+	case engine.ResourceOutputsEvent:
+		return renderDiffResourceOutputsEvent(event.Payload.(engine.ResourceOutputsEventPayload), seen, opts)
+	case engine.ResourcePreEvent:
+		return renderDiffResourcePreEvent(event.Payload.(engine.ResourcePreEventPayload), seen, opts)
 	case engine.DiagEvent:
 		return renderDiffDiagEvent(event.Payload.(engine.DiagEventPayload), opts)
+
 	default:
 		contract.Failf("unknown event type '%s'", event.Type)
 		return ""
@@ -216,7 +224,7 @@ func renderPreludeEvent(event engine.PreludeEventPayload, opts Options) string {
 	return out.String()
 }
 
-func renderResourceOperationFailedEvent(
+func renderDiffResourceOperationFailedEvent(
 	payload engine.ResourceOperationFailedPayload, opts Options) string {
 
 	// It's not actually useful or interesting to print out any details about
@@ -229,7 +237,7 @@ func renderResourceOperationFailedEvent(
 	return ""
 }
 
-func renderResourcePreEvent(
+func renderDiffResourcePreEvent(
 	payload engine.ResourcePreEventPayload,
 	seen map[resource.URN]engine.StepEventMetadata,
 	opts Options) string {
@@ -253,7 +261,7 @@ func renderResourcePreEvent(
 	return out.String()
 }
 
-func renderResourceOutputsEvent(
+func renderDiffResourceOutputsEvent(
 	payload engine.ResourceOutputsEventPayload,
 	seen map[resource.URN]engine.StepEventMetadata,
 	opts Options) string {

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -732,6 +732,7 @@ func (display *ProgressDisplay) processEndSteps() {
 			}
 
 			wroteOutputs = true
+			display.writeSimpleMessage(colors.SpecHeadline + "Outputs:" + colors.Reset)
 			display.writeSimpleMessage(props)
 		}
 	}

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -62,10 +62,19 @@ func printStepHeader(b *bytes.Buffer, step StepEventMetadata) {
 	writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.Type), step.Op, extra))
 }
 
-func getIndentationString(indent int, op deploy.StepOp, prefix bool) string {
+func GetIndentationString(indent int) string {
 	var result string
 	for i := 0; i < indent; i++ {
 		result += "    "
+	}
+	return result
+}
+
+func getIndentationString(indent int, op deploy.StepOp, prefix bool) string {
+	var result = GetIndentationString(indent)
+
+	if !prefix {
+		return result
 	}
 
 	if result == "" {
@@ -73,12 +82,7 @@ func getIndentationString(indent int, op deploy.StepOp, prefix bool) string {
 		return result
 	}
 
-	var rp string
-	if prefix {
-		rp = op.RawPrefix()
-	} else {
-		rp = "  "
-	}
+	rp := op.RawPrefix()
 	contract.Assert(len(rp) == 2)
 	contract.Assert(len(result) >= 2)
 	return result[:len(result)-2] + rp
@@ -281,7 +285,6 @@ func GetResourceOutputsPropertiesString(
 	maxkey := maxKey(keys)
 
 	// Now sort the keys and enumerate each output property in a deterministic order.
-	firstout := true
 	for _, k := range keys {
 		out := outs[k]
 
@@ -293,10 +296,6 @@ func GetResourceOutputsPropertiesString(
 			}
 
 			if print {
-				if firstout {
-					writeString(b, colors.SpecHeadline+"Outputs:"+colors.Reset+"\n")
-					firstout = false
-				}
 				if outputDiff != nil {
 					printObjectPropertyDiff(b, k, maxkey, *outputDiff, planning, indent, false, debug)
 				} else {


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/2010

Diff view returns to looking like so:

![image](https://user-images.githubusercontent.com/4564579/46434679-2984c400-c709-11e8-9a83-29f378a8ad16.png)

Main stack 'outputs:' still looks like:

![image](https://user-images.githubusercontent.com/4564579/46434714-43bea200-c709-11e8-8d9f-07445c4a3a52.png)
