### PR TITLE
Bring back support for the 'auto' value for colorization.

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -54,7 +54,7 @@ func NewPulumiCmd() *cobra.Command {
 	var tracingHeaderFlag string
 	var profiling string
 	var verbose int
-	var color colorFlag
+	var color string
 
 	cmd := &cobra.Command{
 		Use:   "pulumi",
@@ -81,12 +81,10 @@ func NewPulumiCmd() *cobra.Command {
 			// get DisplayOptions passed in.
 			cmdFlag := cmd.Flag("color")
 			if cmdFlag != nil {
-				err := color.Set(cmdFlag.Value.String())
+				err := cmdutil.SetGlobalColorization(cmdFlag.Value.String())
 				if err != nil {
 					return err
 				}
-
-				cmdutil.SetGlobalColorization(color.Colorization())
 			}
 
 			if cwd != "" {
@@ -142,8 +140,8 @@ func NewPulumiCmd() *cobra.Command {
 		"Emit CPU and memory profiles and an execution trace to '[filename].[pid].{cpu,mem,trace}', respectively")
 	cmd.PersistentFlags().IntVarP(&verbose, "verbose", "v", 0,
 		"Enable verbose logging (e.g., v=3); anything >3 is very verbose")
-	cmd.PersistentFlags().Var(
-		&color, "color", "Colorize output. Choices are: always, never, raw, auto")
+	cmd.PersistentFlags().StringVar(
+		&color, "color", "auto", "Colorize output. Choices are: always, never, raw, auto")
 
 	// Common commands:
 	//     - Getting Started Commands

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -296,48 +296,6 @@ func readProject() (*workspace.Project, string, error) {
 	return proj, filepath.Dir(path), nil
 }
 
-type colorFlag struct {
-	value colors.Colorization
-}
-
-func (cf *colorFlag) String() string {
-	return string(cf.Colorization())
-}
-
-func (cf *colorFlag) Set(value string) error {
-	switch value {
-	case "always":
-		cf.value = colors.Always
-	case "never":
-		cf.value = colors.Never
-	case "raw":
-		cf.value = colors.Raw
-	// Backwards compat for old flag values.
-	case "auto":
-		cf.value = colors.Always
-	default:
-		return errors.Errorf("unsupported color option: '%s'.  Supported values are: always, never, raw", value)
-	}
-
-	return nil
-}
-
-func (cf *colorFlag) Type() string {
-	return "colors.Colorization"
-}
-
-func (cf *colorFlag) Colorization() colors.Colorization {
-	if _, ok := os.LookupEnv("NO_COLOR"); ok {
-		return colors.Never
-	}
-
-	if cf.value == "" {
-		return colors.Always
-	}
-
-	return cf.value
-}
-
 // anyWriter is an io.Writer that will set itself to `true` iff any call to `anyWriter.Write` is made with a
 // non-zero-length slice. This can be used to determine whether or not any data was ever written to the writer.
 type anyWriter bool

--- a/pkg/diag/colors/diag.go
+++ b/pkg/diag/colors/diag.go
@@ -26,6 +26,8 @@ var tagRegexp = regexp.MustCompile(`<\{%(.*?)%\}>`)
 type Colorization string
 
 const (
+	// Determine if we should colorize depending on the environment we're in.
+	Auto Colorization = "auto"
 	// Always colorizes text.
 	Always Colorization = "always"
 	// Never colorizes text.

--- a/pkg/diag/colors/diag.go
+++ b/pkg/diag/colors/diag.go
@@ -26,7 +26,7 @@ var tagRegexp = regexp.MustCompile(`<\{%(.*?)%\}>`)
 type Colorization string
 
 const (
-	// Determine if we should colorize depending on the environment we're in.
+	// Auto determines if we should colorize depending on the surrounding environment we're in.
 	Auto Colorization = "auto"
 	// Always colorizes text.
 	Always Colorization = "always"

--- a/pkg/util/cmdutil/console.go
+++ b/pkg/util/cmdutil/console.go
@@ -50,7 +50,11 @@ func Interactive() bool {
 
 // InteractiveTerminal returns true if the current terminal session is interactive.
 func InteractiveTerminal() bool {
-	return terminal.IsTerminal(int(os.Stdin.Fd()))
+	// if we're piping in stdin, we're clearly not interactive, as there's no way for a user to
+	// provide input.  If we're piping stdout, we also can't be interactive as there's no way for
+	// users to see prompts to interact with them.
+	return terminal.IsTerminal(int(os.Stdin.Fd())) &&
+		terminal.IsTerminal(int(os.Stdout.Fd()))
 }
 
 // ReadConsole reads the console with the given prompt text.

--- a/pkg/util/cmdutil/diag.go
+++ b/pkg/util/cmdutil/diag.go
@@ -17,8 +17,7 @@ package cmdutil
 import (
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
-
+	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -26,30 +25,53 @@ import (
 
 var snk diag.Sink
 
-var globalColorization = colors.Always
+var globalColorization = colors.Auto
 
 // GetGlobalColorization gets the global setting for how things should be colored.
 // This is helpful for the parts of our stack that do not take a DisplayOptions struct.
 func GetGlobalColorization() colors.Colorization {
+	if globalColorization != colors.Auto {
+		// User has set an explicit colorization preference.  We'll respect whatever they asked for,
+		// no matter what.
+		return globalColorization
+	}
+
+	// Colorization is set to 'auto' (either explicit set to that by the user, or not set at all).
+	// Figure out the best thing to do here.
+
+	// If the external environment has requested no colors, then turn off all colors when in 'auto'
+	// mode.
 	if _, ok := os.LookupEnv("NO_COLOR"); ok {
 		return colors.Never
 	}
 
-	// Only have colors when we're in an interactive session.  If we're non-interactive (i.e.
-	// redirecting stdout), then disable colors as well.  We don't want to put color tags into the
-	// stream.  We only do this if the color is set to be on.  If it was set to 'raw' then we don't
-	// touch it.
-	if globalColorization == colors.Always && !terminal.IsTerminal(int(os.Stdout.Fd())) {
+	// Disable colors if we're not in an interactive session (i.e. we're redirecting stdout).  This
+	// will just inject color tags into the stream which are not desirable here.
+	if !InteractiveTerminal() {
 		return colors.Never
 	}
 
-	return globalColorization
+	// Things otherwise look good.  Turn on colors in auto-mode.
+	return colors.Always
 }
 
 // SetGlobalColorization sets the global setting for how things should be colored.
 // This is helpful for the parts of our stack that do not take a DisplayOptions struct.
-func SetGlobalColorization(color colors.Colorization) {
-	globalColorization = color
+func SetGlobalColorization(value string) error {
+	switch value {
+	case "auto":
+		globalColorization = colors.Auto
+	case "always":
+		globalColorization = colors.Always
+	case "never":
+		globalColorization = colors.Never
+	case "raw":
+		globalColorization = colors.Raw
+	default:
+		return errors.Errorf("unsupported color option: '%s'.  Supported values are: auto, always, never, raw", value)
+	}
+
+	return nil
 }
 
 // Diag lazily allocates a sink to be used if we can't create a compiler.

--- a/pkg/util/cmdutil/diag.go
+++ b/pkg/util/cmdutil/diag.go
@@ -25,6 +25,8 @@ import (
 
 var snk diag.Sink
 
+// By default we'll attempt to figure out if we should have colors or not. This can be overridden
+// for any command by passing --color=... at the command line.
 var globalColorization = colors.Auto
 
 // GetGlobalColorization gets the global setting for how things should be colored.
@@ -39,8 +41,7 @@ func GetGlobalColorization() colors.Colorization {
 	// Colorization is set to 'auto' (either explicit set to that by the user, or not set at all).
 	// Figure out the best thing to do here.
 
-	// If the external environment has requested no colors, then turn off all colors when in 'auto'
-	// mode.
+	// If the external environment has requested no colors, then turn off all colors when in 'auto' mode.
 	if _, ok := os.LookupEnv("NO_COLOR"); ok {
 		return colors.Never
 	}
@@ -51,7 +52,7 @@ func GetGlobalColorization() colors.Colorization {
 		return colors.Never
 	}
 
-	// Things otherwise look good.  Turn on colors in auto-mode.
+	// Things otherwise look good.  Turn on colors.
 	return colors.Always
 }
 

--- a/pkg/util/cmdutil/spinner.go
+++ b/pkg/util/cmdutil/spinner.go
@@ -16,11 +16,8 @@ package cmdutil
 
 import (
 	"fmt"
-	"os"
 	"time"
 	"unicode/utf8"
-
-	"golang.org/x/crypto/ssh/terminal"
 )
 
 // NewSpinnerAndTicker returns a new Spinner and a ticker that will fire an event when the next call
@@ -38,7 +35,7 @@ func NewSpinnerAndTicker(prefix string, ttyFrames []string, timesPerSecond time.
 		}
 	}
 
-	if terminal.IsTerminal(int(os.Stdout.Fd())) {
+	if InteractiveTerminal() {
 		return &ttySpinner{
 			prefix: prefix,
 			frames: ttyFrames,


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/2021

'auto' is the default value when --color is not provided.  it means "figure out the best thing to do based on heuristics".  If the value is provided by thte user and is *not* auto, then we always respect it.  That way, you can turn on --color=always, and we'll print colors, even if we would normally think it was not right to.

In 'auto' mode we will normally print colors.  The only exceptions are if NO_COLOR is set in the environment, or if the user is not in an interactive session.  As per above, this can be overridden though if the user explicitly asks for colors.