### PR TITLE
Add new 'pulumi state' command for editing state

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -162,6 +162,7 @@ func NewPulumiCmd() *cobra.Command {
 	//     - Advanced Commands:
 	cmd.AddCommand(newCancelCmd())
 	cmd.AddCommand(newRefreshCmd())
+	cmd.AddCommand(newStateCmd())
 	//     - Other Commands:
 	cmd.AddCommand(newLogsCmd())
 	cmd.AddCommand(newPluginCmd())

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -139,8 +139,10 @@ func runTotalStateEdit(operation func(opts display.Options, snap *deploy.Snapsho
 		surveycore.DisableColor = true
 		surveycore.QuestionIcon = ""
 		surveycore.SelectFocusIcon = opts.Color.Colorize(colors.BrightGreen + ">" + colors.Reset)
+		prompt := opts.Color.Colorize(colors.Yellow + "warning" + colors.Reset + ": ")
+		prompt += "This command will edit your stack's state directly. Confirm?"
 		if err = survey.AskOne(&survey.Confirm{
-			Message: "This command will edit your stack's state directly. Confirm?",
+			Message: prompt,
 		}, &confirm, nil); err != nil || !confirm {
 			return errors.New("confirmation declined")
 		}

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -1,0 +1,167 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/backend/display"
+	"github.com/pulumi/pulumi/pkg/diag/colors"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/resource/edit"
+	"github.com/pulumi/pulumi/pkg/resource/stack"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
+	survey "gopkg.in/AlecAivazis/survey.v1"
+	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
+)
+
+func newStateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "state",
+		Short: "Edit the current stack's state",
+		Long: `Edit the current stack's state
+		
+Subcommands of this command can be used to surgically edit parts of a stack's state. These can be useful when
+troubleshooting a stack or when performing specific edits that otherwise would require editing the state file by hand.`,
+		Args: cmdutil.NoArgs,
+	}
+
+	cmd.AddCommand(newStateDeleteCommand())
+	cmd.AddCommand(newStateUnprotectCommand())
+	return cmd
+}
+
+// locateStackResource attempts to find a unique resource associated with the given URN in the given snapshot. If the
+// given URN is ambiguous and this is an interactive terminal, it prompts the user to select one of the resources in
+// the list of resources with identical URNs to operate upon.
+func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resource.URN) (*resource.State, error) {
+	res, err := edit.LocateResource(snap, urn)
+	if err == nil {
+		return res, nil
+	}
+
+	switch e := err.(type) {
+	case edit.AmbiguousResourceError:
+		if !cmdutil.Interactive() {
+			return nil, e
+		}
+
+		surveycore.DisableColor = true
+		surveycore.QuestionIcon = ""
+		surveycore.SelectFocusIcon = opts.Color.Colorize(colors.BrightGreen + ">" + colors.Reset)
+		prompt := "Multiple resources with the given URN exist, please select the one to edit:"
+		prompt = opts.Color.Colorize(colors.SpecPrompt + prompt + colors.Reset)
+
+		var options []string
+		optionMap := make(map[string]*resource.State)
+		for _, ambiguousResource := range e.Resources {
+			// Prompt the user to select from a list of IDs, since these resources are known to all have the same URN.
+			message := fmt.Sprintf("Resource %q", ambiguousResource.ID)
+			if ambiguousResource.Protect {
+				message += " (Protected)"
+			}
+
+			if ambiguousResource.Delete {
+				message += " (Pending Deletion)"
+			}
+
+			options = append(options, message)
+			optionMap[message] = ambiguousResource
+		}
+
+		var option string
+		if err := survey.AskOne(&survey.Select{
+			Message:  prompt,
+			Options:  options,
+			PageSize: len(options),
+		}, &option, nil); err != nil {
+			return nil, errors.New("no resource selected")
+		}
+
+		return optionMap[option], nil
+	default:
+		return nil, e
+	}
+}
+
+// runStateEdit runs the given state edit function on a resource with the given URN in the current stack.
+func runStateEdit(urn resource.URN, operation func(snap *deploy.Snapshot, res *resource.State) error) error {
+	return runTotalStateEdit(func(opts display.Options, snap *deploy.Snapshot) error {
+		res, err := locateStackResource(opts, snap, urn)
+		if err != nil {
+			return err
+		}
+
+		if res == nil {
+			return errors.Errorf("No such resource %q exists in the current state", urn)
+		}
+
+		return operation(snap, res)
+	})
+}
+
+// runTotalStateEdit runs a snapshot-mutating function on the entirity of the current stack's snapshot. Before mutating
+// the snapshot, the user is prompted for confirmation if the current session is interactive.
+func runTotalStateEdit(operation func(opts display.Options, snap *deploy.Snapshot) error) error {
+	opts := display.Options{
+		Color: cmdutil.GetGlobalColorization(),
+	}
+	s, err := requireCurrentStack(true, opts, true /*setCurrent*/)
+	if err != nil {
+		return err
+	}
+	snap, err := s.Snapshot(commandContext())
+	if err != nil {
+		return err
+	}
+
+	if cmdutil.Interactive() {
+		confirm := false
+		surveycore.DisableColor = true
+		surveycore.QuestionIcon = ""
+		surveycore.SelectFocusIcon = opts.Color.Colorize(colors.BrightGreen + ">" + colors.Reset)
+		if err = survey.AskOne(&survey.Confirm{
+			Message: "This command will edit your stack's state directly. Confirm?",
+		}, &confirm, nil); err != nil || !confirm {
+			return errors.New("confirmation declined")
+		}
+	}
+
+	stackIsAlreadyHosed := snap.VerifyIntegrity() != nil
+	if err = operation(opts, snap); err != nil {
+		return err
+	}
+
+	// If the stack is already broken, don't bother verifying the integrity here.
+	if !stackIsAlreadyHosed {
+		contract.AssertNoErrorf(snap.VerifyIntegrity(), "state edit produced an invalid snapshot")
+	}
+	bytes, err := json.Marshal(stack.SerializeDeployment(snap))
+	if err != nil {
+		return err
+	}
+	dep := apitype.UntypedDeployment{
+		Version:    apitype.DeploymentSchemaVersionCurrent,
+		Deployment: bytes,
+	}
+	return s.ImportDeployment(commandContext(), &dep)
+}

--- a/cmd/state_delete.go
+++ b/cmd/state_delete.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/resource"
-	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/edit"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/spf13/cobra"
@@ -36,16 +35,11 @@ there exist other resources that depend on it or are parented to it.`,
 		Args: cmdutil.ExactArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			urn := resource.URN(args[0])
-			err := runStateEdit(urn, func(snap *deploy.Snapshot, res *resource.State) error {
-				return edit.DeleteResource(snap, res)
-			})
-
+			err := runStateEdit(urn, edit.DeleteResource)
 			if err != nil {
 				switch e := err.(type) {
 				case edit.ResourceHasDependenciesError:
-					message := fmt.Sprintf(
-						"Resource %q can't be safely deleted because the following resources depend on it:\n",
-						urn)
+					message := "This resource can't be safely deleted because the following resources depend on it:\n"
 					for _, dependentResource := range e.Dependencies {
 						depUrn := dependentResource.URN
 						message += fmt.Sprintf(" * %-15q (%s)\n", depUrn.Name(), depUrn)
@@ -57,7 +51,7 @@ there exist other resources that depend on it or are parented to it.`,
 					return err
 				}
 			}
-			fmt.Printf("Deleted resource %q\n", urn)
+			fmt.Println("Resource deleted successfully")
 			return nil
 		}),
 	}

--- a/cmd/state_delete.go
+++ b/cmd/state_delete.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/resource/edit"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newStateDeleteCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Deletes a resource from a stack's state",
+		Long: `Deletes a resource from a stack's state
+		
+This command deletes a resource from a stack's state, as long as it is safe to do so. Resources can't be deleted if
+there exist other resources that depend on it or are parented to it.`,
+		Args: cmdutil.ExactArgs(1),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			urn := resource.URN(args[0])
+			err := runStateEdit(urn, func(snap *deploy.Snapshot, res *resource.State) error {
+				return edit.DeleteResource(snap, res)
+			})
+
+			if err != nil {
+				switch e := err.(type) {
+				case edit.ResourceHasDependenciesError:
+					message := fmt.Sprintf(
+						"Resource %q can't be safely deleted because the following resources depend on it:\n",
+						urn)
+					for _, dependentResource := range e.Dependencies {
+						depUrn := dependentResource.URN
+						message += fmt.Sprintf(" * %-15q (%s)\n", depUrn.Name(), depUrn)
+					}
+
+					message += "\nDelete those resources first before deleting this one."
+					return errors.New(message)
+				default:
+					return err
+				}
+			}
+			fmt.Printf("Deleted resource %q\n", urn)
+			return nil
+		}),
+	}
+
+	return cmd
+}

--- a/cmd/state_unprotect.go
+++ b/cmd/state_unprotect.go
@@ -1,0 +1,77 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/backend/display"
+	"github.com/pulumi/pulumi/pkg/resource/deploy"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/edit"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+
+	"github.com/spf13/cobra"
+)
+
+func newStateUnprotectCommand() *cobra.Command {
+	var unprotectAll bool
+	cmd := &cobra.Command{
+		Use:   "unprotect",
+		Short: "Unprotect resources in a stack's state",
+		Long: `Unprotect resource in a stack's state
+		
+This command clears the 'protect' bit on one or more resources, allowing those resources to be deleted.`,
+		Args: cmdutil.MaximumNArgs(1),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			if unprotectAll {
+				err := runTotalStateEdit(func(_ display.Options, snap *deploy.Snapshot) error {
+					for _, res := range snap.Resources {
+						edit.UnprotectResource(snap, res)
+					}
+
+					return nil
+				})
+
+				if err != nil {
+					return err
+				}
+				fmt.Printf("Unprotected all resources\n")
+				return nil
+			}
+
+			if len(args) != 1 {
+				return errors.New("must provide a URN corresponding to a resource")
+			}
+
+			urn := resource.URN(args[0])
+			err := runStateEdit(urn, func(snap *deploy.Snapshot, res *resource.State) error {
+				edit.UnprotectResource(snap, res)
+				return nil
+			})
+
+			if err != nil {
+				return err
+			}
+			fmt.Printf("Unprotected resource %q\n", urn)
+			return nil
+		}),
+	}
+
+	cmd.Flags().BoolVar(&unprotectAll, "all", false, "Unprotect all resources in the checkpoint")
+	return cmd
+}

--- a/pkg/resource/edit/doc.go
+++ b/pkg/resource/edit/doc.go
@@ -1,0 +1,17 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package edit contains functions suitable for editing a snapshot in-place. It is designed to be used by higher-level
+// tools that present a means for users to surgically edit their state.
+package edit

--- a/pkg/resource/edit/errors.go
+++ b/pkg/resource/edit/errors.go
@@ -30,3 +30,12 @@ type ResourceHasDependenciesError struct {
 func (r ResourceHasDependenciesError) Error() string {
 	return fmt.Sprintf("Can't delete resource %q due to dependent resources", r.Condemned.URN)
 }
+
+// ResourceProtectedError is returned by DeleteResource if a resource is protected.
+type ResourceProtectedError struct {
+	Condemned *resource.State
+}
+
+func (ResourceProtectedError) Error() string {
+	return "Can't delete protected resource"
+}

--- a/pkg/resource/edit/errors.go
+++ b/pkg/resource/edit/errors.go
@@ -1,0 +1,43 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edit
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+)
+
+// AmbiguousResourceError is returned by LocateResource if the given URN could possibly refer to more than one resource
+// in the current snapshot. The `Resources` field contains all such resources in the snapshot.
+type AmbiguousResourceError struct {
+	URN       resource.URN
+	Resources []*resource.State
+}
+
+func (a AmbiguousResourceError) Error() string {
+	return fmt.Sprintf("URN %s is ambiguous among %d resources in the snapshot", a.URN, len(a.Resources))
+}
+
+// ResourceHasDependenciesError is returned by DeleteResource if a resource can't be deleted due to the presence of
+// resources that depend directly or indirectly upon it.
+type ResourceHasDependenciesError struct {
+	Condemned    *resource.State
+	Dependencies []*resource.State
+}
+
+func (r ResourceHasDependenciesError) Error() string {
+	return fmt.Sprintf("Can't delete resource %q due to dependent resources", r.Condemned.URN)
+}

--- a/pkg/resource/edit/errors.go
+++ b/pkg/resource/edit/errors.go
@@ -20,17 +20,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource"
 )
 
-// AmbiguousResourceError is returned by LocateResource if the given URN could possibly refer to more than one resource
-// in the current snapshot. The `Resources` field contains all such resources in the snapshot.
-type AmbiguousResourceError struct {
-	URN       resource.URN
-	Resources []*resource.State
-}
-
-func (a AmbiguousResourceError) Error() string {
-	return fmt.Sprintf("URN %s is ambiguous among %d resources in the snapshot", a.URN, len(a.Resources))
-}
-
 // ResourceHasDependenciesError is returned by DeleteResource if a resource can't be deleted due to the presence of
 // resources that depend directly or indirectly upon it.
 type ResourceHasDependenciesError struct {

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -1,0 +1,90 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edit
+
+import (
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/resource/graph"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+)
+
+// DeleteResource deletes a given resource from the snapshot, if it is possible to do so. A resource can only be deleted
+// from a stack if there do not exist any resources that depend on it or descend from it. If such a resource does exist,
+// DeleteResource will return an error instance of `ResourceHasDependenciesError`.
+func DeleteResource(snapshot *deploy.Snapshot, condemnedRes *resource.State) error {
+	contract.Require(snapshot != nil, "snapshot")
+	contract.Require(condemnedRes != nil, "state")
+
+	dg := graph.NewDependencyGraph(snapshot.Resources)
+	dependencies := dg.DependingOn(condemnedRes)
+	if len(dependencies) != 0 {
+		return ResourceHasDependenciesError{Condemned: condemnedRes, Dependencies: dependencies}
+	}
+
+	// If there are no resources that depend on condemnedRes, iterate through the snapshot and keep everything that's
+	// not condemnedRes while keeping track of every resource's parent.
+	var newSnapshot []*resource.State
+	var children []*resource.State
+	for _, res := range snapshot.Resources {
+		if res.Parent == condemnedRes.URN {
+			children = append(children, res)
+		}
+
+		if res != condemnedRes {
+			newSnapshot = append(newSnapshot, res)
+		}
+	}
+
+	// If there exists a resource that is the child of condemnedRes, we can't delete it.
+	if len(children) != 0 {
+		return ResourceHasDependenciesError{Condemned: condemnedRes, Dependencies: children}
+	}
+
+	// Otherwise, we're good to go.
+	snapshot.Resources = newSnapshot
+	return nil
+}
+
+// UnprotectResource unprotects a resource.
+func UnprotectResource(_ *deploy.Snapshot, res *resource.State) {
+	res.Protect = false
+}
+
+// LocateResource locates a resource with the given URN within the given snapshot. If the resource exists and is
+// uniquely named by the given URN, it is returned with a nil error. If the resource does not exist, LocateResource
+// returns nil. If there exist multiple resources in the snapshot with the given URN, an instance of
+// AmbiguousResourceError is returned with the full list of ambiguous resources attached to it.
+func LocateResource(snap *deploy.Snapshot, urn resource.URN) (*resource.State, error) {
+	contract.Require(snap != nil, "snap")
+
+	urnMap := make(map[resource.URN][]*resource.State)
+	for _, res := range snap.Resources {
+		urnMap[res.URN] = append(urnMap[res.URN], res)
+	}
+
+	resources := urnMap[urn]
+	switch {
+	case len(resources) == 0:
+		return nil, nil
+	case len(resources) == 1:
+		return resources[0], nil
+	case len(resources) > 1:
+		return nil, AmbiguousResourceError{URN: urn, Resources: resources}
+	default:
+		contract.Failf("unreachable")
+		return nil, nil
+	}
+}

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -32,6 +32,10 @@ func DeleteResource(snapshot *deploy.Snapshot, condemnedRes *resource.State) err
 	contract.Require(snapshot != nil, "snapshot")
 	contract.Require(condemnedRes != nil, "state")
 
+	if condemnedRes.Protect {
+		return ResourceProtectedError{condemnedRes}
+	}
+
 	dg := graph.NewDependencyGraph(snapshot.Resources)
 	dependencies := dg.DependingOn(condemnedRes)
 	if len(dependencies) != 0 {

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -63,28 +63,16 @@ func UnprotectResource(_ *deploy.Snapshot, res *resource.State) {
 	res.Protect = false
 }
 
-// LocateResource locates a resource with the given URN within the given snapshot. If the resource exists and is
-// uniquely named by the given URN, it is returned with a nil error. If the resource does not exist, LocateResource
-// returns nil. If there exist multiple resources in the snapshot with the given URN, an instance of
-// AmbiguousResourceError is returned with the full list of ambiguous resources attached to it.
-func LocateResource(snap *deploy.Snapshot, urn resource.URN) (*resource.State, error) {
+// LocateResource returns all resources in the given shapshot that have the given URN.
+func LocateResource(snap *deploy.Snapshot, urn resource.URN) []*resource.State {
 	contract.Require(snap != nil, "snap")
 
-	urnMap := make(map[resource.URN][]*resource.State)
+	var resources []*resource.State
 	for _, res := range snap.Resources {
-		urnMap[res.URN] = append(urnMap[res.URN], res)
+		if res.URN == urn {
+			resources = append(resources, res)
+		}
 	}
 
-	resources := urnMap[urn]
-	switch {
-	case len(resources) == 0:
-		return nil, nil
-	case len(resources) == 1:
-		return resources[0], nil
-	case len(resources) > 1:
-		return nil, AmbiguousResourceError{URN: urn, Resources: resources}
-	default:
-		contract.Failf("unreachable")
-		return nil, nil
-	}
+	return resources
 }

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -201,9 +201,8 @@ func TestLocateResourceNotFound(t *testing.T) {
 
 	ty := tokens.Type("a:b:c")
 	urn := resource.NewURN("test", "test", "", ty, "not-present")
-	res, err := LocateResource(snap, urn)
-	assert.NoError(t, err)
-	assert.Nil(t, res)
+	resList := LocateResource(snap, urn)
+	assert.Nil(t, resList)
 }
 
 func TestLocateResourceAmbiguous(t *testing.T) {
@@ -219,17 +218,12 @@ func TestLocateResourceAmbiguous(t *testing.T) {
 		aPending,
 	})
 
-	_, err := LocateResource(snap, a.URN)
-	assert.Error(t, err)
-	ambigErr, ok := err.(AmbiguousResourceError)
-	if !assert.True(t, ok) {
-		t.FailNow()
-	}
-
-	assert.Contains(t, ambigErr.Resources, a)
-	assert.Contains(t, ambigErr.Resources, aPending)
-	assert.NotContains(t, ambigErr.Resources, pA)
-	assert.NotContains(t, ambigErr.Resources, b)
+	resList := LocateResource(snap, a.URN)
+	assert.Len(t, resList, 2)
+	assert.Contains(t, resList, a)
+	assert.Contains(t, resList, aPending)
+	assert.NotContains(t, resList, pA)
+	assert.NotContains(t, resList, b)
 }
 
 func TestLocateResourceExact(t *testing.T) {
@@ -244,7 +238,7 @@ func TestLocateResourceExact(t *testing.T) {
 		c,
 	})
 
-	res, err := LocateResource(snap, a.URN)
-	assert.NoError(t, err)
-	assert.Equal(t, a, res)
+	resList := LocateResource(snap, a.URN)
+	assert.Len(t, resList, 1)
+	assert.Contains(t, resList, a)
 }

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -139,6 +139,21 @@ func TestFailedDeletionRegularDependency(t *testing.T) {
 	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
 }
 
+func TestFailedDeletionProtected(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	a.Protect = true
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+	})
+
+	err := DeleteResource(snap, a)
+	assert.Error(t, err)
+	_, ok := err.(ResourceProtectedError)
+	assert.True(t, ok)
+}
+
 func TestFailedDeletionParentDependency(t *testing.T) {
 	pA := NewProviderResource("a", "p1", "0")
 	a := NewResource("a", pA)

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -1,0 +1,250 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package edit
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/version"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func NewResource(name string, provider *resource.State, deps ...resource.URN) *resource.State {
+	prov := ""
+	if provider != nil {
+		p, err := providers.NewReference(provider.URN, provider.ID)
+		if err != nil {
+			panic(err)
+		}
+		prov = p.String()
+	}
+
+	t := tokens.Type("a:b:c")
+	return &resource.State{
+		Type:         t,
+		URN:          resource.NewURN("test", "test", "", t, tokens.QName(name)),
+		Inputs:       resource.PropertyMap{},
+		Outputs:      resource.PropertyMap{},
+		Dependencies: deps,
+		Provider:     prov,
+	}
+}
+
+func NewProviderResource(pkg, name, id string, deps ...resource.URN) *resource.State {
+	t := providers.MakeProviderType(tokens.Package(pkg))
+	return &resource.State{
+		Type:         t,
+		URN:          resource.NewURN("test", "test", "", t, tokens.QName(name)),
+		ID:           resource.ID(id),
+		Inputs:       resource.PropertyMap{},
+		Outputs:      resource.PropertyMap{},
+		Dependencies: deps,
+	}
+}
+
+func NewSnapshot(resources []*resource.State) *deploy.Snapshot {
+	return deploy.NewSnapshot(deploy.Manifest{
+		Time:    time.Now(),
+		Version: version.Version,
+		Plugins: nil,
+	}, resources, nil)
+}
+
+func TestDeletion(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	b := NewResource("b", pA)
+	c := NewResource("c", pA)
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+		b,
+		c,
+	})
+
+	err := DeleteResource(snap, b)
+	assert.NoError(t, err)
+	assert.Len(t, snap.Resources, 3)
+	assert.Equal(t, []*resource.State{pA, a, c}, snap.Resources)
+}
+
+func TestFailedDeletionProviderDependency(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	b := NewResource("b", pA)
+	c := NewResource("c", pA)
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+		b,
+		c,
+	})
+
+	err := DeleteResource(snap, pA)
+	assert.Error(t, err)
+	depErr, ok := err.(ResourceHasDependenciesError)
+	if !assert.True(t, ok) {
+		t.FailNow()
+	}
+
+	assert.Contains(t, depErr.Dependencies, a)
+	assert.Contains(t, depErr.Dependencies, b)
+	assert.Contains(t, depErr.Dependencies, c)
+	assert.Len(t, snap.Resources, 4)
+	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
+}
+
+func TestFailedDeletionRegularDependency(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	b := NewResource("b", pA, a.URN)
+	c := NewResource("c", pA)
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+		b,
+		c,
+	})
+
+	err := DeleteResource(snap, a)
+	assert.Error(t, err)
+	depErr, ok := err.(ResourceHasDependenciesError)
+	if !assert.True(t, ok) {
+		t.FailNow()
+	}
+
+	assert.NotContains(t, depErr.Dependencies, pA)
+	assert.NotContains(t, depErr.Dependencies, a)
+	assert.Contains(t, depErr.Dependencies, b)
+	assert.NotContains(t, depErr.Dependencies, c)
+	assert.Len(t, snap.Resources, 4)
+	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
+}
+
+func TestFailedDeletionParentDependency(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	b := NewResource("b", pA)
+	b.Parent = a.URN
+	c := NewResource("c", pA)
+	c.Parent = a.URN
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+		b,
+		c,
+	})
+
+	err := DeleteResource(snap, a)
+	assert.Error(t, err)
+	depErr, ok := err.(ResourceHasDependenciesError)
+	if !assert.True(t, ok) {
+		t.FailNow()
+	}
+
+	assert.NotContains(t, depErr.Dependencies, pA)
+	assert.NotContains(t, depErr.Dependencies, a)
+	assert.Contains(t, depErr.Dependencies, b)
+	assert.Contains(t, depErr.Dependencies, c)
+	assert.Len(t, snap.Resources, 4)
+	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
+}
+
+func TestUnprotectResource(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	a.Protect = true
+	b := NewResource("b", pA)
+	c := NewResource("c", pA)
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+		b,
+		c,
+	})
+
+	UnprotectResource(snap, a)
+	assert.Len(t, snap.Resources, 4)
+	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
+	assert.False(t, a.Protect)
+}
+
+func TestLocateResourceNotFound(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	b := NewResource("b", pA)
+	c := NewResource("c", pA)
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+		b,
+		c,
+	})
+
+	ty := tokens.Type("a:b:c")
+	urn := resource.NewURN("test", "test", "", ty, "not-present")
+	res, err := LocateResource(snap, urn)
+	assert.NoError(t, err)
+	assert.Nil(t, res)
+}
+
+func TestLocateResourceAmbiguous(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	b := NewResource("b", pA)
+	aPending := NewResource("a", pA)
+	aPending.Delete = true
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+		b,
+		aPending,
+	})
+
+	_, err := LocateResource(snap, a.URN)
+	assert.Error(t, err)
+	ambigErr, ok := err.(AmbiguousResourceError)
+	if !assert.True(t, ok) {
+		t.FailNow()
+	}
+
+	assert.Contains(t, ambigErr.Resources, a)
+	assert.Contains(t, ambigErr.Resources, aPending)
+	assert.NotContains(t, ambigErr.Resources, pA)
+	assert.NotContains(t, ambigErr.Resources, b)
+}
+
+func TestLocateResourceExact(t *testing.T) {
+	pA := NewProviderResource("a", "p1", "0")
+	a := NewResource("a", pA)
+	b := NewResource("b", pA)
+	c := NewResource("c", pA)
+	snap := NewSnapshot([]*resource.State{
+		pA,
+		a,
+		b,
+		c,
+	})
+
+	res, err := LocateResource(snap, a.URN)
+	assert.NoError(t, err)
+	assert.Equal(t, a, res)
+}

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -181,7 +181,8 @@ func TestUnprotectResource(t *testing.T) {
 		c,
 	})
 
-	UnprotectResource(snap, a)
+	err := UnprotectResource(snap, a)
+	assert.NoError(t, err)
 	assert.Len(t, snap.Resources, 4)
 	assert.Equal(t, []*resource.State{pA, a, b, c}, snap.Resources)
 	assert.False(t, a.Protect)


### PR DESCRIPTION
This commit adds 'pulumi state unprotect' and 'pulumi state delete', two
commands that can be used to unprotect and delete resources from a
stack's state, respectively.

Fixes https://github.com/pulumi/pulumi/issues/1597, part of https://github.com/pulumi/pulumi/issues/1909.

Here are some example workflows for this command:

1. User's stack is in a state where there exists a resource that is protected but also pending deletion. This can happen if a user skips a preview and replaces a protected resource. User can use `pulumi state unprotect` to unprotect the pending-delete protected resource:

[![asciicast](https://asciinema.org/a/D3cCkzSiSrwsGywjOpMUuNAKi.png)](https://asciinema.org/a/D3cCkzSiSrwsGywjOpMUuNAKi)

2. User just wants to delete their stack and doesn't care about things that are protected. User can use `pulumi state unprotect --all` to unprotect all resources in their stack:

[![asciicast](https://asciinema.org/a/P0NF6Du75pECzFGskuit5KRtz.png)](https://asciinema.org/a/P0NF6Du75pECzFGskuit5KRtz)

3. User has a pending-delete resource that they want to delete but can't (#1597). User can use `pulumi state delete` to remove a resource from their state:

[![asciicast](https://asciinema.org/a/Kp3DU8tS3FD8Wlnj3Fkuyuppn.png)](https://asciinema.org/a/Kp3DU8tS3FD8Wlnj3Fkuyuppn)

Note that in each case, if the choice of URN is ambiguous (there are multiple resources with the same URN in the state), the user is prompted to pick which one they'd like to operate on.