### PR TITLE
[WIP] Azure Blob backend state provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -88,6 +88,12 @@
   version = "v3.5.1"
 
 [[projects]]
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
+  version = "v2.0.0"
+
+[[projects]]
   name = "github.com/cheggaaa/pb"
   packages = ["."]
   revision = "657164d0228d6bebe316fdf725c69f131a50fb10"
@@ -141,6 +147,12 @@
   packages = ["."]
   revision = "a343d9870e3952dd8a0b894f9e221e210189fefe"
   version = "v1.31.0"
+
+[[projects]]
+  name = "github.com/gofrs/flock"
+  packages = ["."]
+  revision = "7f43ea2e6a643ad441fc12d0ecc0d3388b300c53"
+  version = "v0.7.0"
 
 [[projects]]
   branch = "pulumi-master"
@@ -222,6 +234,12 @@
   packages = ["."]
   revision = "fa48d7ff1cfb9f26c514b80d520880394293bf08"
   version = "0.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/lawrencegripper/goazurelocking"
+  packages = ["."]
+  revision = "e671b77be6948847c68293d69112376233f03a5a"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,18 @@
 
 
 [[projects]]
+  name = "github.com/Azure/azure-pipeline-go"
+  packages = ["pipeline"]
+  revision = "b8e3409182fd52e74f7d7bdfbff5833591b3b655"
+  version = "v0.1.8"
+
+[[projects]]
+  name = "github.com/Azure/azure-storage-blob-go"
+  packages = ["2016-05-31/azblob"]
+  revision = "bb46532f68b79e9e1baca8fb19a382ef5d40ed33"
+  version = "0.2.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
   packages = [
@@ -284,6 +296,12 @@
   ]
   revision = "1949ddbfd147afd4d964a9f00b24eb291e0e7c38"
   version = "v1.0.2"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/otiai10/copy"
+  packages = ["."]
+  revision = "7e9a647135a142c2669943d4a4d29be015ce9392"
 
 [[projects]]
   name = "github.com/pelletier/go-buffruneio"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -76,6 +76,12 @@
   version = "v1.12.26"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/b4b4r07/go-pipe"
+  packages = ["."]
+  revision = "eb1d189d6987fab3a0cc3a985419684dccb2bd02"
+
+[[projects]]
   name = "github.com/bgentry/speakeasy"
   packages = ["."]
   revision = "4aabc24848ce5fd31929f7d1e4ea74d3709c14cd"
@@ -629,6 +635,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "eaeb2282f35a265330a240be239886c91ab253b40dc2cf92469c7cbe29c78f9d"
+  inputs-digest = "3cab6ff7b1d49fa521d8d8e382b73c09c588a4346580a31e0c87db3486001082"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -635,6 +635,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "3cab6ff7b1d49fa521d8d8e382b73c09c588a4346580a31e0c87db3486001082"
+  inputs-digest = "7e5ddec2602cc27d95aaca0efdb15c39ff0918cbbde9e9886f94ebf038b1e00d"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -15,3 +15,11 @@
 [[constraint]]
   branch = "master"
   name = "github.com/otiai10/copy"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/lawrencegripper/goazurelocking"
+
+[[constraint]]
+  name = "github.com/gofrs/flock"
+  version = "0.7.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,3 +11,7 @@
   name = "github.com/golang/glog"
   source = "github.com/pulumi/glog"
   branch = "pulumi-master"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/otiai10/copy"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -23,3 +23,7 @@
 [[constraint]]
   name = "github.com/gofrs/flock"
   version = "0.7.0"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/b4b4r07/go-pipe"

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ include build/common.mk
 
 PROJECT         := github.com/pulumi/pulumi
 PROJECT_PKGS    := $(shell go list ./cmd/... ./pkg/... | grep -v /vendor/)
-EXTRA_TEST_PKGS := $(shell go list ./examples/ ./tests/... | grep -v /vendor/)
+EXTRA_TEST_PKGS := $(shell go list ./examples/ ./tests/... ./pkg/backend/filestate/... | grep -v /vendor/)
 VERSION         := $(shell scripts/get-version)
 
 GOMETALINTERBIN := gometalinter
@@ -41,7 +41,7 @@ test_fast::
 	go test -timeout $(TEST_FAST_TIMEOUT) -cover -short -parallel ${TESTPARALLELISM} ${PROJECT_PKGS}
 
 test_all::
-	PATH=$(PULUMI_ROOT)/bin:$(PATH) go test -cover -parallel ${TESTPARALLELISM} ${EXTRA_TEST_PKGS}
+	PATH=$(PULUMI_ROOT)/bin:$(PATH) go test -cover ${EXTRA_TEST_PKGS}
 
 .PHONY: publish_tgz
 publish_tgz:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ lint::
 	$(GOMETALINTER) ./cmd/... | grep -vE ${LINT_SUPPRESS} | sort ; exit $$(($${PIPESTATUS[1]}-1))
 
 test_fast::
-	go test -timeout $(TEST_FAST_TIMEOUT) -cover -parallel ${TESTPARALLELISM} ${PROJECT_PKGS}
+	go test -timeout $(TEST_FAST_TIMEOUT) -cover -short -parallel ${TESTPARALLELISM} ${PROJECT_PKGS}
 
 test_all::
 	PATH=$(PULUMI_ROOT)/bin:$(PATH) go test -cover -parallel ${TESTPARALLELISM} ${EXTRA_TEST_PKGS}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -86,8 +86,8 @@ func newLoginCmd() *cobra.Command {
 
 			var be backend.Backend
 			var err error
-			if filestate.IsLocalBackendURL(cloudURL) {
-				be, err = filestate.Login(cmdutil.Diag(), cloudURL)
+			if filestate.IsFileBackendURL(cloudURL) {
+				be, err = filestate.Login(commandContext(), cmdutil.Diag(), cloudURL)
 			} else {
 				be, err = httpstate.Login(commandContext(), cmdutil.Diag(), cloudURL, displayOptions)
 			}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -68,7 +68,7 @@ func newLogoutCmd() *cobra.Command {
 
 			var be backend.Backend
 			var err error
-			if filestate.IsLocalBackendURL(cloudURL) {
+			if filestate.IsFileBackendURL(cloudURL) {
 				be, err = filestate.New(cmdutil.Diag(), cloudURL)
 			} else {
 				be, err = httpstate.New(cmdutil.Diag(), cloudURL)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -59,8 +59,8 @@ func currentBackend(opts display.Options) (backend.Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	if filestate.IsLocalBackendURL(creds.Current) {
-		return filestate.New(cmdutil.Diag(), creds.Current)
+	if filestate.IsFileBackendURL(creds.Current) {
+		return filestate.Login(commandContext(), cmdutil.Diag(), creds.Current)
 	}
 	return httpstate.Login(commandContext(), cmdutil.Diag(), creds.Current, opts)
 }

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -346,6 +346,8 @@ func (b *fileBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack 
 		return nil, err
 	}
 
+	defer update.unlockFn() // nolint: errcheck
+
 	// Spawn a display loop to show events on the CLI.
 	displayEvents := make(chan engine.Event)
 	displayDone := make(chan bool)
@@ -447,6 +449,8 @@ func (b *fileBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack 
 
 	// Make sure to print a link to the stack's checkpoint before exiting.
 	if opts.ShowLink {
+		update.unlockFn() // nolint: errcheck
+
 		fmt.Printf(
 			op.Opts.Display.Color.Colorize(
 				colors.SpecHeadline+"Permalink: "+

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -449,8 +449,6 @@ func (b *fileBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack 
 
 	// Make sure to print a link to the stack's checkpoint before exiting.
 	if opts.ShowLink {
-		update.unlockFn() // nolint: errcheck
-
 		fmt.Printf(
 			op.Opts.Display.Color.Colorize(
 				colors.SpecHeadline+"Permalink: "+

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -1,0 +1,404 @@
+package filestate
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	copier "github.com/otiai10/copy"
+	"github.com/pulumi/pulumi/pkg/backend/display"
+	"github.com/pulumi/pulumi/pkg/engine"
+	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/workspace"
+
+	"github.com/pulumi/pulumi/pkg/backend"
+	"github.com/pulumi/pulumi/pkg/tokens"
+
+	"github.com/pulumi/pulumi/pkg/util/cancel"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+)
+
+const (
+	localURL         = "file://."
+	localBackendPath = ".pulumi"
+	testDir          = "testdata"
+	testProjectPath  = "testdata/Pulumi.yaml"
+)
+
+type mockCancellationScope struct {
+	context *cancel.Context
+}
+
+func (s *mockCancellationScope) Context() *cancel.Context {
+	return s.context
+}
+
+func (s *mockCancellationScope) Close() {
+}
+
+type mockCancellationScopeSource int
+
+var cancellationScopes = backend.CancellationScopeSource(mockCancellationScopeSource(0))
+
+func (mockCancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bool) backend.CancellationScope {
+	cancelContext, _ := cancel.NewContext(context.Background())
+
+	c := &mockCancellationScope{
+		context: cancelContext,
+	}
+
+	return c
+}
+
+var be Backend
+
+func TestMain(m *testing.M) {
+	var err error
+	be, err = New(cmdutil.Diag(), localURL)
+	if err != nil {
+		panic(fmt.Sprintf("error creating new local backend to test: %+v", err))
+	}
+
+	exCode := m.Run()
+	os.Exit(exCode)
+}
+func TestParseStackReference(t *testing.T) {
+	tt := []struct {
+		stackName string
+	}{
+		{
+			stackName: "test",
+		},
+	}
+	for _, test := range tt {
+		stackRef, err := be.ParseStackReference(test.stackName)
+		if err != nil {
+			t.Fatalf("error parsing stack %s: %+v", test.stackName, err)
+		}
+		name := stackRef.Name()
+		if name != tokens.AsQName(test.stackName) {
+			t.Fatalf("expected name to be %s but got %s", test.stackName, name)
+		}
+	}
+}
+
+func TestCreateStack(t *testing.T) {
+	tt := []struct {
+		stackName string
+	}{
+		{
+			stackName: "test",
+		},
+	}
+
+	tearDown := setUp(t)
+	defer tearDown()
+
+	for _, test := range tt {
+		stackRef, err := be.ParseStackReference(test.stackName)
+		if err != nil {
+			t.Fatalf("error parsing stack %s: %+v", test.stackName, err)
+		}
+		ctx := context.Background()
+		createStack(ctx, stackRef, t)
+		stackExists(stackRef, t)
+
+		tearDownPulumi() // Removes the dirty .pulumi between test cases
+	}
+}
+
+func TestGetStack(t *testing.T) {
+	tt := []struct {
+		stackName   string
+		createStack bool
+	}{
+		{
+			stackName:   "test",
+			createStack: false,
+		},
+		{
+			stackName:   "test",
+			createStack: true,
+		},
+	}
+
+	tearDown := setUp(t)
+	defer tearDown()
+
+	for _, test := range tt {
+		stackRef, err := be.ParseStackReference(test.stackName)
+		if err != nil {
+			t.Fatalf("error parsing stack %s: %+v", test.stackName, err)
+		}
+		ctx := context.Background()
+		if test.createStack {
+			createStack(ctx, stackRef, t)
+			stackExists(stackRef, t)
+		}
+		stack, err := be.GetStack(ctx, stackRef)
+		if err != nil {
+			t.Fatalf("error getting stack %s: %+v", test.stackName, err)
+		}
+		stackCreated := (stack != nil)
+		if test.createStack != stackCreated {
+			t.Fatalf("expected stack to be created and got only when createStack is set to true")
+		}
+
+		tearDownPulumi() // Removes the dirty .pulumi between test cases
+	}
+}
+
+func TestListStacks(t *testing.T) {
+	tt := []struct {
+		numStacks int
+	}{
+		{
+			numStacks: 2,
+		},
+		{
+			numStacks: 5,
+		},
+		{
+			numStacks: 10,
+		},
+	}
+
+	tearDown := setUp(t)
+	defer tearDown()
+
+	for _, test := range tt {
+		ctx := context.Background()
+		for i := 0; i < test.numStacks; i++ {
+			stackName := fmt.Sprintf("stack%d", i)
+			stackRef, err := be.ParseStackReference(stackName)
+			if err != nil {
+				t.Fatalf("error parsing stack %s: %+v", stackName, err)
+			}
+			createStack(ctx, stackRef, t)
+			stackExists(stackRef, t)
+		}
+		stacks, err := be.ListStacks(ctx, nil)
+		if err != nil {
+			t.Fatalf("error listing stacks: %+v", err)
+		}
+		if len(stacks) != test.numStacks {
+			t.Fatalf("expected %d stacks but got %d", test.numStacks, len(stacks))
+		}
+
+		tearDownPulumi() // Removes the dirty .pulumi between test cases
+	}
+}
+
+func TestRemoveStack(t *testing.T) {
+	tt := []struct {
+		stackName string
+	}{
+		{
+			stackName: "test",
+		},
+	}
+
+	tearDown := setUp(t)
+	defer tearDown()
+
+	for _, test := range tt {
+		ctx := context.Background()
+		stackRef, err := be.ParseStackReference(test.stackName)
+		if err != nil {
+			t.Fatalf("error parsing stack %s: %+v", test.stackName, err)
+		}
+		createStack(ctx, stackRef, t)
+		stackExists(stackRef, t)
+		removeStack(ctx, stackRef, t)
+		stackDoesNotExist(stackRef, t)
+
+		tearDownPulumi() // Removes the dirty .pulumi between test cases
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	tt := []struct {
+		stackName string
+	}{
+		{
+			stackName: "test",
+		},
+	}
+
+	tearDown := setUp(t)
+	defer tearDown()
+
+	for _, test := range tt {
+		ctx := context.Background()
+		stackRef, err := be.ParseStackReference(test.stackName)
+		if err != nil {
+			t.Fatalf("error parsing stack %s: %+v", test.stackName, err)
+		}
+
+		createStack(ctx, stackRef, t)
+		stackExists(stackRef, t)
+
+		// Load project and a new project stack
+		proj, err := workspace.LoadProject("Pulumi.yaml")
+		if err != nil {
+			t.Fatalf("error loading project from file %s: %+v", testProjectPath, err)
+		}
+		projStack, err := workspace.DetectProjectStack(stackRef.Name())
+		if err != nil {
+			t.Fatalf("error detecting project stack for stack %s: %+v", stackRef.Name(), err)
+		}
+
+		// os.Chdir() does not update the shell working directory
+		// so we need to pass the test dir path to npm install.
+		testDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("error getting testdata working directory: %+v", err)
+		}
+		installNPMPackages(testDir, t)
+
+		// Set the configuration values (w,x,y) for the test
+		// pulumi project to use.
+		keys := []string{"simple:w", "simple:x", "simple:y"}
+		for _, key := range keys {
+			k, err := config.ParseKey(key)
+			if err != nil {
+				t.Fatalf("error parsing key %s: %+v", key, err)
+			}
+			v := config.NewValue("10")
+			projStack.Config[k] = v
+		}
+		if err := workspace.SaveProjectStack(stackRef.Name(), projStack); err != nil {
+			t.Fatalf("error saving project stack: %+v", err)
+		}
+
+		// Perform two sequential updates and check that
+		// the expected number of changes are detected
+		up1 := applyUpdate(ctx, testDir, proj, stackRef, t)
+		if !up1.HasChanges() {
+			t.Fatalf("expected changes on first update")
+		}
+		up2 := applyUpdate(ctx, testDir, proj, stackRef, t)
+		if up2.HasChanges() {
+			t.Fatalf("expected no changes between first and second update")
+		}
+
+		tearDownPulumi()                // Removes the dirty .pulumi between test cases
+		tearDownProject(test.stackName) // Removes generated project files and node_modules between test cases
+	}
+}
+
+// setUp creates a new temp directory and copies the contents
+// of testdata into it and sets it as the current directory.
+// The test will then run in the temp directory.
+// The temp directory will then be torn down and the current
+// directory set back to the original directory.
+func setUp(t *testing.T) func() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("error getting current working directory: %+v", err)
+	}
+	tmp, err := ioutil.TempDir("", t.Name())
+	if err != nil {
+		t.Fatalf("error creating temp dir: %+v", err)
+	}
+	err = copier.Copy(testDir, tmp)
+	if err != nil {
+		t.Fatalf("error copying %s to %s: %+v", testDir, tmp, err)
+	}
+	err = os.Chdir(tmp)
+	if err != nil {
+		t.Fatalf("error changing to testdata directory: %+v", err)
+	}
+	// This function should be deferred by the caller
+	// to clean up the temp directory after the test
+	// has finished.
+	return func() {
+		_ = os.RemoveAll(tmp)
+		_ = os.Chdir(cwd) // Must run last
+	}
+}
+
+func tearDownPulumi() {
+	_ = os.RemoveAll(localBackendPath)
+}
+
+func tearDownProject(stackName string) {
+	_ = os.RemoveAll(fmt.Sprintf("Pulumi.%s.yaml", stackName))
+	_ = os.RemoveAll("node_modules")
+}
+
+func applyUpdate(ctx context.Context, root string, project *workspace.Project,
+	stackRef backend.StackReference, t *testing.T) engine.ResourceChanges {
+	m := backend.UpdateMetadata{
+		Message:     "",
+		Environment: make(map[string]string),
+	}
+
+	engineOpts := engine.UpdateOptions{
+		Analyzers: []string{},
+		Parallel:  0,
+		Debug:     false,
+		Refresh:   false,
+	}
+
+	res, err := be.Update(ctx, stackRef, backend.UpdateOperation{
+		Proj: project,
+		Root: root,
+		M:    m,
+		Opts: backend.UpdateOptions{
+			Engine: engineOpts,
+			Display: display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			},
+			AutoApprove: true,
+			SkipPreview: true,
+		},
+		Scopes: cancellationScopes,
+	})
+	if err != nil {
+		t.Fatalf("error updating resources: %+v", err)
+	}
+	return res
+}
+
+// installNPMPackages runs npm install in the desired directory.
+// Expect this to take some time.
+func installNPMPackages(dir string, t *testing.T) {
+	if err := exec.Command("npm", "install", dir).Run(); err != nil {
+		t.Fatalf("failed to execute `npm install` in %s: %+v", dir, err)
+	}
+}
+
+func createStack(ctx context.Context, stackRef backend.StackReference, t *testing.T) {
+	stack, err := be.CreateStack(ctx, stackRef, nil)
+	if err != nil {
+		t.Fatalf("error creating stack %s: %+v", stackRef.Name().String(), err)
+	}
+	if stack == nil {
+		t.Fatalf("expected stack to be non nil")
+	}
+}
+
+func stackExists(stackRef backend.StackReference, t *testing.T) {
+	expectStackPath := fmt.Sprintf("%s/stacks/%s.json", localBackendPath, stackRef.Name().String())
+	if _, err := os.Stat(expectStackPath); os.IsNotExist(err) {
+		t.Fatalf("expected file %s to have been created on disk", expectStackPath)
+	}
+}
+
+func stackDoesNotExist(stackRef backend.StackReference, t *testing.T) {
+	expectStackPath := fmt.Sprintf("%s/stacks/%s.json", localBackendPath, stackRef.Name().String())
+	if _, err := os.Stat(expectStackPath); !os.IsNotExist(err) {
+		t.Fatalf("expected file %s to have been removed from disk", expectStackPath)
+	}
+}
+
+func removeStack(ctx context.Context, stackRef backend.StackReference, t *testing.T) {
+	_, err := be.RemoveStack(ctx, stackRef, false)
+	if err != nil {
+		t.Fatalf("error removing stack %s: %+v", stackRef.Name().String(), err)
+	}
+}

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -465,7 +465,7 @@ func UpdateLocking(t *testing.T) {
 		// Take a benchmark from the first goroutine
 		// to complete minus an offset to allow for
 		// the initial goroutine startup cost.
-		base := times[0].Seconds() * 0.7
+		base := times[0].Seconds() * 0.6
 		// Create a range of acceptable times based
 		// on the base benchmark and make sure the
 		// second goroutine falls in it.

--- a/pkg/backend/filestate/snapshot.go
+++ b/pkg/backend/filestate/snapshot.go
@@ -42,7 +42,6 @@ func (sm *fileSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 
 	_, err = sm.backend.saveStack(sm.context, sm.name, config, snapshot)
 	return err
-
 }
 
 func (b *fileBackend) newSnapshotPersister(ctx context.Context, stackName tokens.QName) *fileSnapshotPersister {

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -26,24 +26,24 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 )
 
-// Stack is a local stack.  This simply adds some local-specific properties atop the standard backend stack interface.
+// Stack is a file stack.  This simply adds some file-specific properties atop the standard backend stack interface.
 type Stack interface {
 	backend.Stack
 	Path() string // a path to the stack's checkpoint file on disk.
 }
 
-// localStack is a local stack descriptor.
-type localStack struct {
+// fileStack is a file stack descriptor.
+type fileStack struct {
 	ref      backend.StackReference // the stack's reference (qualified name).
 	path     string                 // a path to the stack's checkpoint file on disk.
 	config   config.Map             // the stack's config bag.
 	snapshot *deploy.Snapshot       // a snapshot representing the latest deployment state.
-	b        *localBackend          // a pointer to the backend this stack belongs to.
+	b        *fileBackend           // a pointer to the backend this stack belongs to.
 }
 
 func newStack(ref backend.StackReference, path string, config config.Map,
-	snapshot *deploy.Snapshot, b *localBackend) Stack {
-	return &localStack{
+	snapshot *deploy.Snapshot, b *fileBackend) Stack {
+	return &fileStack{
 		ref:      ref,
 		path:     path,
 		config:   config,
@@ -52,57 +52,57 @@ func newStack(ref backend.StackReference, path string, config config.Map,
 	}
 }
 
-func (s *localStack) Ref() backend.StackReference                            { return s.ref }
-func (s *localStack) Config() config.Map                                     { return s.config }
-func (s *localStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) { return s.snapshot, nil }
-func (s *localStack) Backend() backend.Backend                               { return s.b }
-func (s *localStack) Path() string                                           { return s.path }
+func (s *fileStack) Ref() backend.StackReference                            { return s.ref }
+func (s *fileStack) Config() config.Map                                     { return s.config }
+func (s *fileStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) { return s.snapshot, nil }
+func (s *fileStack) Backend() backend.Backend                               { return s.b }
+func (s *fileStack) Path() string                                           { return s.path }
 
-func (s *localStack) Remove(ctx context.Context, force bool) (bool, error) {
+func (s *fileStack) Remove(ctx context.Context, force bool) (bool, error) {
 	return backend.RemoveStack(ctx, s, force)
 }
 
-func (s *localStack) Preview(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *fileStack) Preview(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
 	return backend.PreviewStack(ctx, s, op)
 }
 
-func (s *localStack) Update(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *fileStack) Update(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
 	return backend.UpdateStack(ctx, s, op)
 }
 
-func (s *localStack) Refresh(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *fileStack) Refresh(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
 	return backend.RefreshStack(ctx, s, op)
 }
 
-func (s *localStack) Destroy(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *fileStack) Destroy(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
 	return backend.DestroyStack(ctx, s, op)
 }
 
-func (s *localStack) GetLogs(ctx context.Context, query operations.LogQuery) ([]operations.LogEntry, error) {
+func (s *fileStack) GetLogs(ctx context.Context, query operations.LogQuery) ([]operations.LogEntry, error) {
 	return backend.GetStackLogs(ctx, s, query)
 }
 
-func (s *localStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error) {
+func (s *fileStack) ExportDeployment(ctx context.Context) (*apitype.UntypedDeployment, error) {
 	return backend.ExportStackDeployment(ctx, s)
 }
 
-func (s *localStack) ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error {
+func (s *fileStack) ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error {
 	return backend.ImportStackDeployment(ctx, s, deployment)
 }
 
-type localStackSummary struct {
-	s *localStack
+type fileStackSummary struct {
+	s *fileStack
 }
 
-func newLocalStackSummary(s *localStack) localStackSummary {
-	return localStackSummary{s}
+func newFileStackSummary(s *fileStack) fileStackSummary {
+	return fileStackSummary{s}
 }
 
-func (lss localStackSummary) Name() backend.StackReference {
+func (lss fileStackSummary) Name() backend.StackReference {
 	return lss.s.Ref()
 }
 
-func (lss localStackSummary) LastUpdate() *time.Time {
+func (lss fileStackSummary) LastUpdate() *time.Time {
 	snap := lss.s.snapshot
 	if snap != nil {
 		if t := snap.Manifest.Time; !t.IsZero() {
@@ -112,7 +112,7 @@ func (lss localStackSummary) LastUpdate() *time.Time {
 	return nil
 }
 
-func (lss localStackSummary) ResourceCount() *int {
+func (lss fileStackSummary) ResourceCount() *int {
 	snap := lss.s.snapshot
 	if snap != nil {
 		count := len(snap.Resources)

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -72,7 +72,7 @@ func (u *update) GetTarget() *deploy.Target {
 func (b *fileBackend) newUpdate(ctx context.Context, stackName tokens.QName, proj *workspace.Project, root string) (*update, error) { // nolint: lll
 	contract.Require(stackName != "", "stackName")
 
-	unlocker, err := b.bucket.Lock(ctx, stackName.Name().String())
+	unlocker, err := b.bucket.Lock(ctx, stackName.String())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -168,7 +168,7 @@ func (b *fileBackend) saveStack(ctx context.Context, name tokens.QName,
 	bck := backupTarget(ctx, b, file)
 
 	// And now write out the new snapshot file, overwriting that location.
-	if err = b.bucket.WriteFile(context.Background(), file, byts); err != nil {
+	if err = b.bucket.WriteFile(ctx, file, byts); err != nil {
 		return "", errors.Wrap(err, "An IO error occurred during the current operation")
 	}
 
@@ -176,7 +176,7 @@ func (b *fileBackend) saveStack(ctx context.Context, name tokens.QName,
 
 	// And if we are retaining historical checkpoint information, write it out again
 	if cmdutil.IsTruthy(os.Getenv("PULUMI_RETAIN_CHECKPOINTS")) {
-		if err = b.bucket.WriteFile(context.Background(), fmt.Sprintf("%v.%v",
+		if err = b.bucket.WriteFile(ctx, fmt.Sprintf("%v.%v",
 			file, time.Now().UnixNano()), byts); err != nil {
 			return "", errors.Wrap(err, "An IO error occurred during the current operation")
 		}

--- a/pkg/backend/filestate/storage/azure/bucket.go
+++ b/pkg/backend/filestate/storage/azure/bucket.go
@@ -1,0 +1,175 @@
+package azure
+
+import (
+	"context"
+	"io/ioutil"
+	"net/url"
+	"runtime"
+	"strings"
+
+	"github.com/Azure/azure-storage-blob-go/2016-05-31/azblob"
+	"github.com/pulumi/pulumi/pkg/backend/filestate/storage"
+)
+
+const (
+	// URLPrefix is a unique schema used to identify this bucket provider
+	URLPrefix = "azure://"
+
+	accessTokenEnvVar = "AZURE_STORAGE_ACCOUNT_KEY"
+)
+
+var _ storage.Bucket = (*Bucket)(nil) // enforces compile time check for interface compatibility
+
+// Bucket is a blob storage implementation using Azure Blob Storage
+type Bucket struct {
+	url *azblob.ContainerURL
+}
+
+// AccountName returns the buckets associated Azure Blob Storage account name
+func (b *Bucket) AccountName() string {
+	u := b.url.URL()
+	return extractAccountNameFromURL(&u)
+}
+
+func extractAccountNameFromURL(u *url.URL) string {
+	return strings.Split(u.Hostname(), ".")[0]
+}
+
+// NewBucket creates a new Bucket instance
+func NewBucket(url, accountKey string) (storage.Bucket, error) {
+
+	contURL, err := newContainerURL(url, accountKey)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = contURL.Create(context.Background(), azblob.Metadata{}, azblob.PublicAccessNone)
+	if err != nil {
+		if serr, ok := err.(azblob.StorageError); ok {
+			if serr.ServiceCode() != azblob.ServiceCodeContainerAlreadyExists {
+				return nil, err
+			}
+		}
+	}
+
+	bucket := Bucket{
+		url: contURL,
+	}
+
+	return &bucket, nil
+}
+
+func newContainerURL(cloudURL, accountKey string) (*azblob.ContainerURL, error) {
+	URL, err := url.Parse(strings.Replace(cloudURL, URLPrefix, "https://", 1))
+	if err != nil {
+		return nil, err
+	}
+
+	accountName := extractAccountNameFromURL(URL)
+	creds := azblob.NewSharedKeyCredential(accountName, accountKey)
+	pipe := azblob.NewPipeline(creds, azblob.PipelineOptions{
+		Retry: azblob.RetryOptions{
+			Policy:   azblob.RetryPolicyExponential,
+			MaxTries: 3,
+		},
+	})
+
+	cURL := azblob.NewContainerURL(*URL, pipe)
+	return &cURL, nil
+}
+
+// ListFiles will list all blobs under a given prefix. This method will handle paging of
+// responses and create an aggregated array of blob paths. We don't anticipate loading
+// enough blobs to cause any significant memory pressure in Pulumi.
+func (b *Bucket) ListFiles(ctx context.Context, prefix string) ([]string, error) {
+	var blobs []string
+
+	// Page through all the blobs in the container and build a list of blob names
+	for marker := (azblob.Marker{}); marker.NotDone(); {
+		listBlob, err := b.url.ListBlobs(ctx, marker, azblob.ListBlobsOptions{
+			Prefix: prefix,
+		})
+		if err != nil {
+			return nil, err
+		}
+		marker = listBlob.NextMarker
+		for _, blobInfo := range listBlob.Blobs.Blob {
+			blobs = append(blobs, blobInfo.Name)
+		}
+	}
+	return blobs, nil
+}
+
+// WriteFile will create a new block blob
+func (b *Bucket) WriteFile(ctx context.Context, path string, bytes []byte) error {
+	blobURL := b.url.NewBlockBlobURL(path)
+	numCores := uint16(runtime.NumCPU())
+	_, err := azblob.UploadBufferToBlockBlob(ctx, bytes, blobURL, azblob.UploadToBlockBlobOptions{
+		Parallelism: numCores,
+	})
+	return err
+}
+
+// ReadFile will read the specified blob's contents
+func (b *Bucket) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	blobURL := b.url.NewBlockBlobURL(path)
+	res, err := blobURL.GetBlob(ctx, azblob.BlobRange{}, azblob.BlobAccessConditions{}, false)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body().Close() // nolint: errcheck
+	// Caution: This will load the entire blob into memory.
+	blob, err := ioutil.ReadAll(res.Body())
+	if err != nil {
+		return nil, err
+	}
+	return blob, nil
+}
+
+// DeleteFile will delete the specified blob
+func (b *Bucket) DeleteFile(ctx context.Context, path string) error {
+	blboURL := b.url.NewBlockBlobURL(path)
+	_, err := blboURL.Delete(ctx, azblob.DeleteSnapshotsOptionNone, azblob.BlobAccessConditions{})
+	return err
+}
+
+// RenameFile will rename a specified blob with a new name. This method is not handle
+// atomically and failure may result in duplicate blobs.
+func (b *Bucket) RenameFile(ctx context.Context, path, newPath string) error {
+	original, err := b.ReadFile(ctx, path)
+	if err != nil {
+		return err
+	}
+	err = b.WriteFile(ctx, newPath, original)
+	if err != nil {
+		return err
+	}
+	return b.DeleteFile(ctx, path)
+}
+
+// DeleteFiles will delete all the blobs under a given prefix
+func (b *Bucket) DeleteFiles(ctx context.Context, prefix string) error {
+	blobs, err := b.ListFiles(ctx, prefix)
+	if err != nil {
+		return err
+	}
+	for _, blob := range blobs {
+		err = b.DeleteFile(ctx, blob)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IsNotExist will return true if a given error is a blob not found error
+func (b *Bucket) IsNotExist(err error) bool {
+	if err != nil {
+		if serr, ok := err.(azblob.StorageError); ok {
+			if serr.ServiceCode() == azblob.ServiceCodeBlobNotFound {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/pkg/backend/filestate/storage/azure/error.go
+++ b/pkg/backend/filestate/storage/azure/error.go
@@ -1,0 +1,41 @@
+package azure
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-storage-blob-go/2016-05-31/azblob"
+)
+
+// StorageErrorWithoutCause is needed due to a "bug" in
+// https://github.com/Azure/azure-pipeline-go/blob/master/pipeline/error.go
+// which means the StorageError implements the Causer interface even when
+// the cause is nil. This result in an nil error being returned
+// from errors.Cause(err) rather than the root cause error.
+//
+// This issue is being tracked here:
+// https://github.com/Azure/azure-pipeline-go/issues/13
+type StorageErrorWithoutCause struct {
+	msg         string
+	serviceCode string
+	res         *http.Response
+}
+
+func (s *StorageErrorWithoutCause) Error() string {
+	return s.msg
+}
+
+func (s *StorageErrorWithoutCause) ServiceCode() azblob.ServiceCodeType {
+	return azblob.ServiceCodeType(s.serviceCode)
+}
+
+func (s *StorageErrorWithoutCause) Response() *http.Response {
+	return s.res
+}
+
+func (s *StorageErrorWithoutCause) Timeout() bool {
+	return false
+}
+
+func (s *StorageErrorWithoutCause) Temporary() bool {
+	return false
+}

--- a/pkg/backend/filestate/storage/azure/storage.go
+++ b/pkg/backend/filestate/storage/azure/storage.go
@@ -23,6 +23,9 @@ func isValidateCredential(url, accountKey string) bool {
 	if err != nil {
 		return false
 	}
+	// NewBucket should fail if the credentials are invalid but we'll
+	// add a secondary check to make sure we can use the credentials
+	// to list files too.
 	if _, err = bucket.ListFiles(context.Background(), ""); err != nil {
 		return false
 	}

--- a/pkg/backend/filestate/storage/azure/storage.go
+++ b/pkg/backend/filestate/storage/azure/storage.go
@@ -1,0 +1,36 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/workspace"
+)
+
+// Login will handle getting the user's Azure Blob Storage
+// credentials and writing them into the current workspace.
+func Login(ctx context.Context, cloudURL string) error {
+	// If we have a saved access token, and it is valid, use it.
+	existingToken, err := workspace.GetAccessToken(cloudURL)
+	if err == nil && existingToken != "" {
+		//TODO: Validate existing token works
+		return nil
+	}
+
+	accessToken := os.Getenv(accessTokenEnvVar)
+
+	if accessToken != "" {
+		fmt.Printf("Using access token from %s\n", accessTokenEnvVar)
+	} else {
+		// TODO: Support other login modes
+		return errors.Errorf("Please login to your Azure backend using `pulumi login`")
+	}
+
+	if err = workspace.StoreAccessToken(cloudURL, accessToken, true); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/backend/filestate/storage/azure/storage.go
+++ b/pkg/backend/filestate/storage/azure/storage.go
@@ -4,10 +4,19 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 
-	"github.com/pkg/errors"
+	"gopkg.in/AlecAivazis/survey.v1/core"
+
 	"github.com/pulumi/pulumi/pkg/workspace"
+	survey "gopkg.in/AlecAivazis/survey.v1"
 )
+
+var keyRegEx = regexp.MustCompile("^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$")
+
+func isValidAccountKey(key string) bool {
+	return keyRegEx.MatchString(key)
+}
 
 // Login will handle getting the user's Azure Blob Storage
 // credentials and writing them into the current workspace.
@@ -15,17 +24,46 @@ func Login(ctx context.Context, cloudURL string) error {
 	// If we have a saved access token, and it is valid, use it.
 	existingToken, err := workspace.GetAccessToken(cloudURL)
 	if err == nil && existingToken != "" {
-		//TODO: Validate existing token works
+		if !isValidAccountKey(existingToken) {
+			return fmt.Errorf("the format of the existing Azure storage account key is invalid")
+		}
+
+		// TODO: Validate existing token works
+
 		return nil
 	}
 
 	accessToken := os.Getenv(accessTokenEnvVar)
 
 	if accessToken != "" {
+		if !isValidAccountKey(accessToken) {
+			return fmt.Errorf("the format of the provided Azure storage account key is invalid")
+		}
 		fmt.Printf("Using access token from %s\n", accessTokenEnvVar)
 	} else {
-		// TODO: Support other login modes
-		return errors.Errorf("Please login to your Azure backend using `pulumi login`")
+
+		// TODO: Support other login modes.
+		// This will likely mean moving away from
+		// using storage credentials directly and
+		// over to using Azure Active Directory.
+
+		var response string
+
+		core.QuestionIcon = ""
+		prompt := "\bPlease enter your Azure storage account key:\n"
+		if err = survey.AskOne(&survey.Input{
+			Message: prompt,
+		}, &response, nil); err != nil {
+			return fmt.Errorf("no Azure storage account key provided")
+		}
+		if response == "" {
+			return fmt.Errorf("empty Azure storage account key provided")
+		}
+		if !isValidAccountKey(response) {
+			return fmt.Errorf("the format of the provided Azure storage account key is invalid")
+		}
+		accessToken = response
+		// TODO: Validate existing token works
 	}
 
 	if err = workspace.StoreAccessToken(cloudURL, accessToken, true); err != nil {

--- a/pkg/backend/filestate/storage/local/bucket.go
+++ b/pkg/backend/filestate/storage/local/bucket.go
@@ -112,7 +112,7 @@ func (b *bucket) Lock(ctx context.Context, stackName string) (storage.UnlockFn, 
 	// file lock?
 	locked, err := b.lock.flock.TryLockContext(ctx, time.Second)
 	if err != nil {
-		return nil, fmt.Errorf("failed to take lock for stack %s", stackName)
+		return nil, fmt.Errorf("failed to take lock for stack %s: %+v", stackName, err)
 	}
 	if !locked {
 		// If we couldn't take the file lock but we didn't error

--- a/pkg/backend/filestate/storage/local/bucket.go
+++ b/pkg/backend/filestate/storage/local/bucket.go
@@ -1,0 +1,80 @@
+package local
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/pulumi/pulumi/pkg/backend/filestate/storage"
+)
+
+const (
+	// URLPrefix is a unique schema used to identify this bucket provider
+	URLPrefix = "file://"
+)
+
+var _ storage.Bucket = (*Bucket)(nil) // enforces compile time check for interface compatibility
+
+// Bucket is a blob storage implementation using the local file system
+type Bucket struct{}
+
+// NewBucket create a new Bucket instance
+func NewBucket(url, accountKey string) (storage.Bucket, error) {
+	return &Bucket{}, nil
+}
+
+// ListFiles returns a list of all the files in a directory matching a given prefix (directory name)
+func (b *Bucket) ListFiles(ctx context.Context, prefix string) ([]string, error) {
+	files, err := ioutil.ReadDir(prefix)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, f := range files {
+		if f.IsDir() {
+			continue // Ignore directories
+		}
+		names = append(names, f.Name())
+	}
+	return names, nil
+}
+
+// WriteFile will create any directories present in the file path and then write the file itself
+func (b *Bucket) WriteFile(ctx context.Context, path string, bytes []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, bytes, os.ModePerm)
+}
+
+// ReadFile will read the contents of a file
+func (b *Bucket) ReadFile(ctx context.Context, path string) ([]byte, error) {
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+// DeleteFile will delete a file
+func (b *Bucket) DeleteFile(ctx context.Context, path string) error {
+	return os.RemoveAll(path)
+}
+
+// RenameFile will rename a file
+func (b *Bucket) RenameFile(ctx context.Context, path, newPath string) error {
+	return os.Rename(path, newPath)
+}
+
+// DeleteFiles will delete all files under a given prefix (directory name)
+func (b *Bucket) DeleteFiles(ctx context.Context, prefix string) error {
+	return os.RemoveAll(prefix)
+}
+
+// IsNotExist will return true if the provided error is a file or directory not found error
+func (b *Bucket) IsNotExist(err error) bool {
+	return os.IsNotExist(err)
+}

--- a/pkg/backend/filestate/storage/local/storage.go
+++ b/pkg/backend/filestate/storage/local/storage.go
@@ -1,0 +1,13 @@
+package local
+
+import (
+	"context"
+
+	"github.com/pulumi/pulumi/pkg/workspace"
+)
+
+// Login will write a phony entry into the user's workspace
+// to identify the local file provider
+func Login(ctx context.Context, url string) error {
+	return workspace.StoreAccessToken(url, "", true)
+}

--- a/pkg/backend/filestate/storage/storage.go
+++ b/pkg/backend/filestate/storage/storage.go
@@ -19,4 +19,9 @@ type Bucket interface {
 	DeleteFile(ctx context.Context, path string) error
 	RenameFile(ctx context.Context, path, newPath string) error
 	IsNotExist(err error) bool
+
+	Lock(ctx context.Context, stackName string) (UnlockFn, error)
 }
+
+// UnlockFn defines methods to operate on a providers lock
+type UnlockFn func() error

--- a/pkg/backend/filestate/storage/storage.go
+++ b/pkg/backend/filestate/storage/storage.go
@@ -1,0 +1,22 @@
+package storage
+
+import (
+	"context"
+)
+
+// BucketCreater should be implemented by each provider to instantiate
+// a new specialized bucket instance.
+type BucketCreater func(url, accessToken string) (Bucket, error)
+
+// Bucket defines an interface for bucket level operations
+// to be implemented by specialized file providers.
+type Bucket interface {
+	DeleteFiles(ctx context.Context, prefix string) error
+	ListFiles(ctx context.Context, prefix string) ([]string, error)
+
+	WriteFile(ctx context.Context, path string, bytes []byte) error
+	ReadFile(ctx context.Context, path string) ([]byte, error)
+	DeleteFile(ctx context.Context, path string) error
+	RenameFile(ctx context.Context, path, newPath string) error
+	IsNotExist(err error) bool
+}

--- a/pkg/backend/filestate/testdata/Pulumi.yaml
+++ b/pkg/backend/filestate/testdata/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: test-project
+description: A sample pulumi project for testing purposes
+runtime: nodejs

--- a/pkg/backend/filestate/testdata/index.ts
+++ b/pkg/backend/filestate/testdata/index.ts
@@ -1,0 +1,14 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as math from "./math";
+
+let config = new pulumi.Config("simple");
+let w = Number(config.require("w")), x = Number(config.require("x")), y = Number(config.require("y"));
+let sum = new math.Add("sum", x, y);
+let square = new math.Mul("square", sum.sum, sum.sum);
+let diff = new math.Sub("diff", square.product, w);
+let divrem = new math.Div("divrem", diff.difference, sum.sum);
+let result = new math.Add("result", divrem.quotient, divrem.remainder);
+export let outputSum: pulumi.Output<number> = result.sum;
+result.sum.apply(result => {
+    console.log(`((x + y)^2 - w) / (x + y) + ((x + y)^2 - w) %% (x + y) = ${result}`);
+});

--- a/pkg/backend/filestate/testdata/math.ts
+++ b/pkg/backend/filestate/testdata/math.ts
@@ -1,0 +1,72 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
+
+class OperatorProvider implements dynamic.ResourceProvider {
+    private op: (l: number, r: number) => any;
+
+    constructor(op: (l: number, r: number) => any) {
+        this.op = op;
+    }
+
+    public check(olds: any, news: any) { return Promise.resolve({ inputs: news }); }
+    public diff(id: pulumi.ID, olds: any, news: any) { return Promise.resolve({}); }
+    public delete(id: pulumi.ID, props: any) { return Promise.resolve(); }
+    public create(inputs: any) { return Promise.resolve({ id: "0", outs: this.op(Number(inputs.left), Number(inputs.right)) }); }
+    public update(id: string, olds: any, news: any) { return Promise.resolve({ outs: this.op(Number(news.left), Number(news.right)) }); }
+}
+
+class DivProvider extends OperatorProvider {
+    constructor() {
+        super((left: number, right: number) => <any>{ quotient: Math.floor(left / right), remainder: left % right });
+    }
+
+    public async check(olds: any, news: any) {
+        return {
+            inputs: news,
+            failures: news.right == 0 ? [ { property: "right", reason: "divisor must be non-zero" } ] : [],
+        }
+    }
+}
+
+export class Add extends dynamic.Resource {
+    public readonly sum: pulumi.Output<number>;
+
+    private static provider = new OperatorProvider((left: number, right: number) => <any>{ sum: left + right });
+
+    constructor(name: string, left: pulumi.Input<number>, right: pulumi.Input<number>) {
+        super(Add.provider, name, {left: left, right: right, sum: undefined}, undefined);
+    }
+}
+
+export class Mul extends dynamic.Resource {
+    public readonly product: pulumi.Output<number>;
+
+    private static provider = new OperatorProvider((left: number, right: number) => <any>{ product: left * right });
+
+    constructor(name: string, left: pulumi.Input<number>, right: pulumi.Input<number>) {
+        super(Mul.provider, name, {left: left, right: right, product: undefined}, undefined);
+    }
+}
+
+export class Sub extends dynamic.Resource {
+    public readonly difference: pulumi.Output<number>;
+
+    private static provider = new OperatorProvider((left: number, right: number) => <any>{ difference: left - right });
+
+    constructor(name: string, left: pulumi.Input<number>, right: pulumi.Input<number>) {
+        super(Sub.provider, name, {left: left, right: right, difference: undefined}, undefined);
+    }
+}
+
+export class Div extends dynamic.Resource {
+    public readonly quotient: pulumi.Output<number>;
+    public readonly remainder: pulumi.Output<number>;
+
+    private static provider = new DivProvider();
+
+    constructor(name: string, left: pulumi.Input<number>, right: pulumi.Input<number>) {
+        super(Div.provider, name, {left: left, right: right, quotient: undefined, remainder: undefined}, undefined);
+    }
+}

--- a/pkg/backend/filestate/testdata/package.json
+++ b/pkg/backend/filestate/testdata/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "test",
+    "version": "0.1.0",
+    "main": "index.js",
+    "dependencies": {
+        "@pulumi/pulumi": "^0.15.0"
+    }
+}

--- a/pkg/backend/filestate/testdata/tsconfig.json
+++ b/pkg/backend/filestate/testdata/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts",
+        "math.ts"
+    ]
+}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -92,7 +92,7 @@ func ValueOrDefaultURL(cloudURL string) string {
 	// If that didn't work, see if we have a current cloud, and use that. Note we need to be careful
 	// to ignore the local cloud.
 	if creds, err := workspace.GetStoredCredentials(); err == nil {
-		if creds.Current != "" && !filestate.IsLocalBackendURL(creds.Current) {
+		if creds.Current != "" && !filestate.IsFileBackendURL(creds.Current) {
 			return creds.Current
 		}
 	}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -193,6 +193,10 @@ func TestStackOutputsJSON(t *testing.T) {
   "xyz": "ABC"
 }
 `, stdout)
+	// TODO: How to handle this?
+	if strings.Contains(stderr, "warning: A new version of Pulumi is available.") {
+		stderr = ""
+	}
 	assert.Equal(t, "", stderr)
 }
 


### PR DESCRIPTION
**This is WIP and I've submitted it as a PR to get early feedback on the design before I've invested too much time. I appreciate it needs a little more love :)**

### What this PR does?
This PR attempts to abstract out a blob interface from the current `filestate` local backend to allow other blob backends such as Azure Blob Storage, S3, etc. to implement it. I have provided an Azure Blob Storage implementation which does exactly this.

### Status
The code currently supports both local file backend and Azure Blob Storage backend. I've smoked tested both of these implementations but still need to formalise some unit tests and integration tests. I'm looking for some initial feedback and discussion on whether this is a suitable method for extending the current Pulumi backends. I have only spent a day working with the codebase so far so I may have missed some functionality, please let me know and I'll look into it! As this is WIP I'll likely continue to push commits to it.

### Usage
You can use the local file backend as per normal, using `pulumi login --local`.
You can use the Azure Blob Storage backend using the following Cloud URL format:
`pulumi login --cloud-url azure://my-storage-account.blob.core.windows.net/container-name`. Currently, you can pass the associated storage account key as an environment variable `AZURE_STORAGE_ACCOUNT_KEY` or enter the value when prompted by the CLI.
**NOTE:** The storage account must exist but the container is not required as it will be created dynamically. I have kept the full Azure Blob Storage path in the URL to support all Azure environments (public, Government and China).

### TODO
- [x] File/Azure filestate implementations
- [x] Tests
- [x] Access token handling
- [x] State locking/leasing
- [ ] Update docs

### Out of scope
- More login options
- Go-cloud for AWS, GCP
- Key management (Key Vault)

### Related issues:
#1941 
#1966 