### PR TITLE
Don't print out the 'info' column when there is nothing to display.

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -587,20 +587,7 @@ func (display *ProgressDisplay) refreshAllRowsIfInTerminal() {
 		var maxColumnLengths []int
 		display.convertNodesToRows(rootNodes, maxSuffixLength, &rows, &maxColumnLengths)
 
-		// If there have been no info messages, then don't print out the info column header.
-		includesInfo := false
-		for i := 1; i < len(rows); i++ {
-			row := rows[i]
-			if row[len(row)-1] != "" {
-				includesInfo = true
-				break
-			}
-		}
-
-		if !includesInfo {
-			firstRow := rows[0]
-			firstRow[len(firstRow)-1] = ""
-		}
+		removeInfoColumnIfUnneeded(rows)
 
 		for i, row := range rows {
 			display.refreshColumns(fmt.Sprintf("%v", i), row, maxColumnLengths)
@@ -636,6 +623,19 @@ func (display *ProgressDisplay) refreshAllRowsIfInTerminal() {
 			}
 		}
 	}
+}
+
+func removeInfoColumnIfUnneeded(rows [][]string) {
+	// If there have been no info messages, then don't print out the info column header.
+	for i := 1; i < len(rows); i++ {
+		row := rows[i]
+		if row[len(row)-1] != "" {
+			return
+		}
+	}
+
+	firstRow := rows[0]
+	firstRow[len(firstRow)-1] = ""
 }
 
 // Performs all the work at the end once we've heard about the last message from the engine.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -587,15 +587,23 @@ func (display *ProgressDisplay) refreshAllRowsIfInTerminal() {
 		var maxColumnLengths []int
 		display.convertNodesToRows(rootNodes, maxSuffixLength, &rows, &maxColumnLengths)
 
-		for i, row := range rows {
-			var id string
-			if i == 0 {
-				id = "#"
-			} else {
-				id = fmt.Sprintf("%v", i)
+		// If there have been no info messages, then don't print out the info column header.
+		includesInfo := false
+		for i := 1; i < len(rows); i++ {
+			row := rows[i]
+			if row[len(row)-1] != "" {
+				includesInfo = true
+				break
 			}
+		}
 
-			display.refreshColumns(id, row, maxColumnLengths)
+		if !includesInfo {
+			firstRow := rows[0]
+			firstRow[len(firstRow)-1] = ""
+		}
+
+		for i, row := range rows {
+			display.refreshColumns(fmt.Sprintf("%v", i), row, maxColumnLengths)
 		}
 
 		systemID := len(rows)


### PR DESCRIPTION
Makes things look much cleaner.  Like so:

![image](https://user-images.githubusercontent.com/4564579/46556246-e78b8780-c89a-11e8-89bc-1f0c4ecefbcf.png)
