### PR TITLE
Add an option to suppress displaying stack outputs

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -41,6 +41,7 @@ func newDestroyCmd() *cobra.Command {
 	var showReplacementSteps bool
 	var showSames bool
 	var skipPreview bool
+	var suppressOutputs bool
 	var yes bool
 
 	var cmd = &cobra.Command{
@@ -72,6 +73,7 @@ func newDestroyCmd() *cobra.Command {
 				ShowConfig:           showConfig,
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
+				SuppressOutputs:      suppressOutputs,
 				IsInteractive:        interactive,
 				DiffDisplay:          diffDisplay,
 				Debug:                debug,
@@ -147,6 +149,9 @@ func newDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&skipPreview, "skip-preview", false,
 		"Do not perform a preview before performing the destroy")
+	cmd.PersistentFlags().BoolVar(
+		&suppressOutputs, "suppress-outputs", false,
+		"Suppress display of stack outputs (in case they contain sensitive values)")
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the destroy after previewing it")

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -49,14 +49,15 @@ import (
 // nolint: vetshadow, intentionally disabling here for cleaner err declaration/assignment.
 func newNewCmd() *cobra.Command {
 	var configArray []string
-	var name string
 	var description string
-	var stack string
-	var force bool
-	var yes bool
-	var offline bool
-	var generateOnly bool
 	var dir string
+	var force bool
+	var generateOnly bool
+	var name string
+	var offline bool
+	var stack string
+	var suppressOutputs bool
+	var yes bool
 
 	cmd := &cobra.Command{
 		Use:        "new [template]",
@@ -75,8 +76,9 @@ func newNewCmd() *cobra.Command {
 				return err
 			}
 			opts.Display = display.Options{
-				Color:         cmdutil.GetGlobalColorization(),
-				IsInteractive: interactive,
+				Color:           cmdutil.GetGlobalColorization(),
+				SuppressOutputs: suppressOutputs,
+				IsInteractive:   interactive,
 			}
 			opts.Engine = engine.UpdateOptions{
 				Parallel: defaultParallel,
@@ -311,29 +313,32 @@ func newNewCmd() *cobra.Command {
 		&configArray, "config", "c", []string{},
 		"Config to save")
 	cmd.PersistentFlags().StringVarP(
-		&name, "name", "n", "",
-		"The project name; if not specified, a prompt will request it")
-	cmd.PersistentFlags().StringVarP(
 		&description, "description", "d", "",
 		"The project description; if not specified, a prompt will request it")
-	cmd.PersistentFlags().StringVarP(
-		&stack, "stack", "s", "",
-		"The stack name; either an existing stack or stack to create; if not specified, a prompt will request it")
+	cmd.PersistentFlags().StringVar(
+		&dir, "dir", "",
+		"The location to place the generated project; if not specified, the current directory is used")
 	cmd.PersistentFlags().BoolVarP(
 		&force, "force", "f", false,
 		"Forces content to be generated even if it would change existing files")
 	cmd.PersistentFlags().BoolVarP(
-		&yes, "yes", "y", false,
-		"Skip prompts and proceed with default values")
+		&generateOnly, "generate-only", "g", false,
+		"Generate the project only; do not create a stack, save config, or install dependencies")
+	cmd.PersistentFlags().StringVarP(
+		&name, "name", "n", "",
+		"The project name; if not specified, a prompt will request it")
 	cmd.PersistentFlags().BoolVarP(
 		&offline, "offline", "o", false,
 		"Use locally cached templates without making any network requests")
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "",
+		"The stack name; either an existing stack or stack to create; if not specified, a prompt will request it")
+	cmd.PersistentFlags().BoolVar(
+		&suppressOutputs, "suppress-outputs", false,
+		"Suppress display of stack outputs (in case they contain sensitive values)")
 	cmd.PersistentFlags().BoolVarP(
-		&generateOnly, "generate-only", "g", false,
-		"Generate the project only; do not create a stack, save config, or install dependencies")
-	cmd.PersistentFlags().StringVar(
-		&dir, "dir", "",
-		"The location to place the generated project; if not specified, the current directory is used")
+		&yes, "yes", "y", false,
+		"Skip prompts and proceed with default values")
 
 	return cmd
 }

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -37,6 +37,7 @@ func newPreviewCmd() *cobra.Command {
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
+	var suppressOutputs bool
 
 	var cmd = &cobra.Command{
 		Use:        "preview",
@@ -67,6 +68,7 @@ func newPreviewCmd() *cobra.Command {
 					ShowConfig:           showConfig,
 					ShowReplacementSteps: showReplacementSteps,
 					ShowSameResources:    showSames,
+					SuppressOutputs:      suppressOutputs,
 					IsInteractive:        cmdutil.Interactive(),
 					DiffDisplay:          diffDisplay,
 					Debug:                debug,
@@ -139,6 +141,9 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&showSames, "show-sames", false,
 		"Show resources that needn't be updated because they haven't changed, alongside those that do")
+	cmd.PersistentFlags().BoolVar(
+		&suppressOutputs, "suppress-outputs", false,
+		"Suppress display of stack outputs (in case they contain sensitive values)")
 
 	return cmd
 }

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -40,6 +40,7 @@ func newRefreshCmd() *cobra.Command {
 	var showReplacementSteps bool
 	var showSames bool
 	var skipPreview bool
+	var suppressOutputs bool
 	var yes bool
 
 	var cmd = &cobra.Command{
@@ -71,6 +72,7 @@ func newRefreshCmd() *cobra.Command {
 				ShowConfig:           showConfig,
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
+				SuppressOutputs:      suppressOutputs,
 				IsInteractive:        interactive,
 				DiffDisplay:          diffDisplay,
 				Debug:                debug,
@@ -150,6 +152,9 @@ func newRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&skipPreview, "skip-preview", false,
 		"Do not perform a preview before performing the refresh")
+	cmd.PersistentFlags().BoolVar(
+		&suppressOutputs, "suppress-outputs", false,
+		"Suppress display of stack outputs (in case they contain sensitive values)")
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the refresh after previewing it")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -56,6 +56,7 @@ func newUpCmd() *cobra.Command {
 	var showReplacementSteps bool
 	var showSames bool
 	var skipPreview bool
+	var suppressOutputs bool
 	var yes bool
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
@@ -287,6 +288,7 @@ func newUpCmd() *cobra.Command {
 				ShowConfig:           showConfig,
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
+				SuppressOutputs:      suppressOutputs,
 				IsInteractive:        interactive,
 				DiffDisplay:          diffDisplay,
 				Debug:                debug,
@@ -342,6 +344,9 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&skipPreview, "skip-preview", false,
 		"Do not perform a preview before performing the update")
+	cmd.PersistentFlags().BoolVar(
+		&suppressOutputs, "suppress-outputs", false,
+		"Suppress display of stack outputs (in case they contain sensitive values)")
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the update after previewing it")

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -277,12 +277,13 @@ func renderDiffResourceOutputsEvent(
 			fprintIgnoreError(out, opts.Color.Colorize(summary))
 		}
 
-		text := engine.GetResourceOutputsPropertiesString(
-			payload.Metadata, indent+1, payload.Planning, payload.Debug, refresh)
-		if text != "" {
-			fprintfIgnoreError(out, "%v%v--outputs:--%v\n",
-				payload.Metadata.Op.Color(), engine.GetIndentationString(indent+1), colors.Reset)
-			fprintIgnoreError(out, opts.Color.Colorize(text))
+		if !opts.SuppressOutputs {
+			if text := engine.GetResourceOutputsPropertiesString(
+				payload.Metadata, indent+1, payload.Planning, payload.Debug, refresh); text != "" {
+				fprintfIgnoreError(out, "%v%v--outputs:--%v\n",
+					payload.Metadata.Op.Color(), engine.GetIndentationString(indent+1), colors.Reset)
+				fprintIgnoreError(out, opts.Color.Colorize(text))
+			}
 		}
 	}
 	return out.String()

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -22,8 +22,9 @@ type Options struct {
 	ShowConfig           bool                // true if we should show configuration information.
 	ShowReplacementSteps bool                // true to show the replacement steps in the plan.
 	ShowSameResources    bool                // true to show the resources that aren't updated in addition to updates.
+	SuppressOutputs      bool                // true to suppress output summarization, e.g. if contains sensitive info.
 	SummaryDiff          bool                // If the diff display should be summarized
 	IsInteractive        bool                // If we should display things interactively
 	DiffDisplay          bool                // true if we should display things as a rich diff
-	Debug                bool
+	Debug                bool                // true to enable debug output.
 }

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -730,7 +730,7 @@ func (display *ProgressDisplay) processEndSteps() {
 
 	// If we get stack outputs, display them at the end.
 	var wroteOutputs bool
-	if display.stackUrn != "" && display.seenStackOutputs {
+	if display.stackUrn != "" && display.seenStackOutputs && !display.opts.SuppressOutputs {
 		stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
 		props := engine.GetResourceOutputsPropertiesString(
 			stackStep, 1, display.isPreview, display.opts.Debug, false /* refresh */)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -215,6 +215,24 @@ func TestStackOutputsDisplayed(t *testing.T) {
 	})
 }
 
+// TestStackOutputsSuppressed ensures that outputs whose values are intentionally suppresses don't show.
+func TestStackOutputsSuppressed(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:                    "stack_outputs",
+		Dependencies:           []string{"@pulumi/pulumi"},
+		Quick:                  false,
+		Verbose:                true,
+		Stdout:                 stdout,
+		UpdateCommandlineFlags: []string{"--suppress-outputs"},
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			output := stdout.String()
+			assert.NotContains(t, output, "Outputs:\n    foo: 42\n    xyz: \"ABC\"\n")
+			assert.NotContains(t, output, "Outputs:\n    foo: 42\n    xyz: \"ABC\"\n")
+		},
+	})
+}
+
 // TestStackParenting tests out that stacks and components are parented correctly.
 func TestStackParenting(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{


### PR DESCRIPTION
This adds an option, --suppress-outputs, to many commands, to
avoid printing stack outputs for stacks that might contain sensitive
information in their outputs (like key material, and whatnot).

Fixes pulumi/pulumi#2028.