### PR TITLE
Add git head ref name to update metadata

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -398,6 +398,12 @@ func addGitCommitMetadata(repo *git.Repository, repoRoot string, m *backend.Upda
 		return errors.Wrap(commitErr, "getting HEAD commit info")
 	}
 
+	headName := head.Name().String()
+	// Ignore when in detached HEAD state, should be "re"
+	if headName != "HEAD" {
+		m.Environment[backend.GitHeadName] = head.Name().String()
+	}
+
 	// If there is no message set manually, default to the Git title.
 	if m.Message == "" {
 		m.Message = gitCommitTitle(commit.Message)

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -1,0 +1,149 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/backend"
+	pul_testing "github.com/pulumi/pulumi/pkg/testing"
+	"github.com/stretchr/testify/assert"
+)
+
+// assertEnvValue assert the update metadata's Environment map contains the given value.
+func assertEnvValue(t *testing.T, md *backend.UpdateMetadata, key, val string) {
+	t.Helper()
+	got, ok := md.Environment[key]
+	if !ok {
+		t.Errorf("Didn't find expected update metadata key %q (full env %+v)", key, md.Environment)
+	} else {
+		assert.EqualValues(t, val, got, "got different value for update metadata %v than expected", key)
+	}
+}
+
+// TestReadingGitRepo tests the functions which read data fom the local Git repo
+// to add metadata to any updates.
+func TestReadingGitRepo(t *testing.T) {
+	e := pul_testing.NewEnvironment(t)
+	defer e.DeleteIfNotFailed()
+
+	e.RunCommand("git", "init")
+	e.RunCommand("git", "remote", "add", "origin", "git@github.com:owner-name/repo-name")
+	e.RunCommand("git", "checkout", "-b", "master")
+
+	// Commit alpha
+	e.WriteTestFile("alpha.txt", "")
+	e.RunCommand("git", "add", ".")
+	e.RunCommand("git", "commit", "-m", "message for commit alpha\n\nDescription for commit alpha")
+
+	// Test the state of the world from an empty git repo
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		assert.NoError(t, addGitMetadata(e.RootPath, test))
+
+		assert.EqualValues(t, test.Message, "message for commit alpha")
+		_, ok := test.Environment[backend.GitHead]
+		assert.True(t, ok, "Expected to find Git SHA in update environment map")
+
+		assertEnvValue(t, test, backend.GitHeadName, "refs/heads/master")
+		assertEnvValue(t, test, backend.GitDirty, "false")
+
+		assertEnvValue(t, test, backend.GitHubLogin, "owner-name")
+		assertEnvValue(t, test, backend.GitHubRepo, "repo-name")
+	}
+
+	// Change branch, Commit beta
+	e.RunCommand("git", "checkout", "-b", "feature/branch1")
+	e.WriteTestFile("beta.txt", "")
+	e.RunCommand("git", "add", ".")
+	e.RunCommand("git", "commit", "-m", "message for commit beta\nDescription for commit beta")
+	e.WriteTestFile("beta-unsubmitted.txt", "")
+
+	var featureBranch1SHA string
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		assert.NoError(t, addGitMetadata(e.RootPath, test))
+
+		assert.EqualValues(t, test.Message, "message for commit beta")
+		featureBranch1SHA = test.Environment[backend.GitHead]
+		_, ok := test.Environment[backend.GitHead]
+		assert.True(t, ok, "Expected to find Git SHA in update environment map")
+		assertEnvValue(t, test, backend.GitHeadName, "refs/heads/feature/branch1")
+		assertEnvValue(t, test, backend.GitDirty, "true") // Because beta-unsubmitted.txt, after commit
+
+		assertEnvValue(t, test, backend.GitHubLogin, "owner-name")
+		assertEnvValue(t, test, backend.GitHubRepo, "repo-name")
+	}
+
+	// Two branches sharing the same commit. But head ref will differ.
+	e.RunCommand("git", "checkout", "-b", "feature/branch2") // Same commit as feature/branch1.
+
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		assert.NoError(t, addGitMetadata(e.RootPath, test))
+
+		assert.EqualValues(t, test.Message, "message for commit beta")
+		featureBranch2SHA := test.Environment[backend.GitHead]
+		assert.EqualValues(t, featureBranch1SHA, featureBranch2SHA)
+		assertEnvValue(t, test, backend.GitHeadName, "refs/heads/feature/branch2")
+	}
+
+	// Detached HEAD
+	e.RunCommand("git", "checkout", "HEAD^1")
+
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		assert.NoError(t, addGitMetadata(e.RootPath, test))
+
+		assert.EqualValues(t, test.Message, "message for commit alpha") // The prior commit
+		_, ok := test.Environment[backend.GitHead]
+		assert.True(t, ok, "Expected to find Git SHA in update environment map")
+		_, ok = test.Environment[backend.GitHeadName]
+		assert.False(t, ok, "Expected no 'git.headName' key, since in detached head state.")
+	}
+
+	// Tag the commit
+	e.RunCommand("git", "checkout", "feature/branch2")
+	e.RunCommand("git", "tag", "v0.0.0")
+
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		assert.NoError(t, addGitMetadata(e.RootPath, test))
+		// Ref is still branch2, since `git tag` didn't change anything.
+		assertEnvValue(t, test, backend.GitHeadName, "refs/heads/feature/branch2")
+	}
+
+	// Change refs by checkingout a tagged commit.
+	// But since we'll be in a detached HEAD state, the git.headName isn't provided.
+	e.RunCommand("git", "checkout", "v0.0.0")
+
+	{
+		test := &backend.UpdateMetadata{
+			Environment: make(map[string]string),
+		}
+		assert.NoError(t, addGitMetadata(e.RootPath, test))
+		_, ok := test.Environment[backend.GitHeadName]
+		assert.False(t, ok, "Expected no 'git.headName' key, since in detached head state.")
+	}
+}

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -45,6 +45,8 @@ const (
 const (
 	// GitHead is the commit hash of HEAD.
 	GitHead = "git.head"
+	// GitHeadName is the name of the HEAD ref. e.g. "refs/heads/master" or "refs/tags/v1.0.0".
+	GitHeadName = "git.headName"
 	// GitDirty ("true", "false") indiciates if there are any unstaged or modified files in the local repo.
 	GitDirty = "git.dirty"
 

--- a/pkg/util/gitutil/git_test.go
+++ b/pkg/util/gitutil/git_test.go
@@ -15,7 +15,6 @@
 package gitutil
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,7 +76,7 @@ func TestParseGitRepoURL(t *testing.T) {
 
 func TestGetGitReferenceNameOrHashAndSubDirectory(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
-	defer deleteIfNotFailed(e)
+	defer e.DeleteIfNotFailed()
 
 	// Create local test repository.
 	repoPath := filepath.Join(e.RootPath, "repo")
@@ -190,37 +189,18 @@ func TestGetGitReferenceNameOrHashAndSubDirectory(t *testing.T) {
 func createTestRepo(e *ptesting.Environment) {
 	e.RunCommand("git", "init")
 
-	writeTestFile(e, "README.md", "test repo")
+	e.WriteTestFile("README.md", "test repo")
 	e.RunCommand("git", "add", "*")
 	e.RunCommand("git", "commit", "-m", "'Initial commit'")
 
-	writeTestFile(e, "foo/bar.md", "foo-bar.md")
+	e.WriteTestFile("foo/bar.md", "foo-bar.md")
 	e.RunCommand("git", "add", "*")
 	e.RunCommand("git", "commit", "-m", "'foo dir'")
 
-	writeTestFile(e, "content/foo/bar.md", "content-foo-bar.md")
+	e.WriteTestFile("content/foo/bar.md", "content-foo-bar.md")
 	e.RunCommand("git", "add", "*")
 	e.RunCommand("git", "commit", "-m", "'content-foo dir'")
 
 	e.RunCommand("git", "branch", "my/content")
 	e.RunCommand("git", "tag", "my")
-}
-
-func writeTestFile(e *ptesting.Environment, filename string, contents string) {
-	filename = filepath.Join(e.CWD, filename)
-
-	dir := filepath.Dir(filename)
-	err := os.MkdirAll(dir, os.ModePerm)
-	assert.NoError(e, err, "making all directories %s", dir)
-
-	err = ioutil.WriteFile(filename, []byte(contents), os.ModePerm)
-	assert.NoError(e, err, "writing %s file", filename)
-}
-
-// deleteIfNotFailed deletes the files in the testing environment if the testcase has
-// not failed. (Otherwise they are left to aid debugging.)
-func deleteIfNotFailed(e *ptesting.Environment) {
-	if !e.T.Failed() {
-		e.DeleteEnvironment()
-	}
 }


### PR DESCRIPTION
(Built on top of #2032)

Adds a new `backend.GitHeadName` metadata key that is optionally added to the update environment map. This will allow the Pulumi service to do a better job sorting and grouping the previews for a stack.