### PR TITLE
Pass new inputs as default check return

### DIFF
--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -81,6 +81,9 @@ async function checkRPC(call: any, callback: any): Promise<void> {
             if (result.failures) {
                 failures = result.failures;
             }
+        } else {
+            // If no check method was provided, propagate the new inputs as-is.
+            inputs = news;
         }
 
         inputs[providerKey] = news[providerKey];


### PR DESCRIPTION
If you forget to implement check on a dynamic provider, all your
inputs mysteriously disappear. It's doubly odd because many providers
don't need to perform any checking on transformation of their inputs.
This change simply propagates the new inputs as-is by default when
a user-supplied check method isn't provided. This would have saved
me 20 minutes just now ... :-)