### PR TITLE
Improve error message for missing provider plugins

### DIFF
--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -55,6 +55,12 @@ func NewMissingError(info workspace.PluginInfo) error {
 }
 
 func (err *MissingError) Error() string {
+	if err.Info.Version != nil {
+		return fmt.Sprintf("no %[1]s plugin '%[2]s-v%[3]s' found in the workspace or on your $PATH, "+
+			"install the plugin using `pulumi plugin install %[1]s %[2]s v%[3]s`",
+			err.Info.Kind, err.Info.Name, err.Info.Version)
+	}
+
 	return fmt.Sprintf("no %s plugin '%s' found in the workspace or on your $PATH",
 		err.Info.Kind, err.Info.String())
 }

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -55,8 +55,9 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 		return nil, err
 	} else if path == "" {
 		return nil, NewMissingError(workspace.PluginInfo{
-			Kind: workspace.ResourcePlugin,
-			Name: string(pkg),
+			Kind:    workspace.ResourcePlugin,
+			Name:    string(pkg),
+			Version: version,
 		})
 	}
 


### PR DESCRIPTION
If a version is available, the returned error now includes the version
that was searched for and a command to install the missing plugin.

Fixes https://github.com/pulumi/pulumi/issues/1510, https://github.com/pulumi/pulumi/issues/1200