### PR TITLE
Implement log functions for the Python SDK

### DIFF
--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -4,6 +4,7 @@
 import argparse
 import os
 import sys
+import traceback
 import runpy
 
 try:
@@ -50,12 +51,19 @@ if __name__ == "__main__":
     sys.argv = [args.PROGRAM] + args.ARGS
     if not args.pwd is None:
         os.chdir(args.pwd)
+
+    successful = False
     try:
-        try:
-            pulumi.runtime.run_in_stack(lambda: runpy.run_path(args.PROGRAM, run_name='__main__'))
-        finally:
-            sys.stdout.flush()
-            sys.stderr.flush()
+        pulumi.runtime.run_in_stack(lambda: runpy.run_path(args.PROGRAM, run_name='__main__'))
+        successful = True
     except pulumi.RunError as e:
-        sys.stderr.write(e.message)
-        sys.exit(1)
+        pulumi.log.error(e.message)
+    except Exception as e:
+        pulumi.log.error("Program failed with an unhandled exception:")
+        pulumi.log.error(traceback.format_exc())
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+    exit_code = 0 if successful else 1
+    sys.exit(exit_code)

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -26,3 +26,4 @@ from .config import *
 from .errors import *
 from .metadata import *
 from .resource import *
+from .log import *

--- a/sdk/python/lib/pulumi/log.py
+++ b/sdk/python/lib/pulumi/log.py
@@ -1,0 +1,78 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Utility functions for logging messages to the diagnostic stream of the Pulumi CLI.
+"""
+
+from __future__ import print_function
+
+import sys
+from pulumi.runtime import get_engine
+from pulumi.runtime.proto import engine_pb2
+
+def debug(msg, resource=None, stream_id=None):
+    """
+    Logs a message to the Pulumi CLI's debug channel, associating it with a resource
+    and stream_id if provided.
+    """
+    engine = get_engine()
+    if engine is not None:
+        _log(engine, engine_pb2.DEBUG, msg, resource, stream_id)
+    else:
+        print("debug: " + msg, file=sys.stderr)
+
+def info(msg, resource=None, stream_id=None):
+    """
+    Logs a message to the Pulumi CLI's info channel, associating it with a resource
+    and stream_id if provided.
+    """
+    engine = get_engine()
+    if engine is not None:
+        _log(engine, engine_pb2.INFO, msg, resource, stream_id)
+    else:
+        print("info: " + msg, file=sys.stderr)
+
+def warn(msg, resource=None, stream_id=None):
+    """
+    Logs a message to the Pulumi CLI's warning channel, associating it with a resource
+    and stream_id if provided.
+    """
+    engine = get_engine()
+    if engine is not None:
+        _log(engine, engine_pb2.WARNING, msg, resource, stream_id)
+    else:
+        print("warning: " + msg, file=sys.stderr)
+
+def error(msg, resource=None, stream_id=None):
+    """
+    Logs a message to the Pulumi CLI's error channel, associating it with a resource
+    and stream_id if provided.
+    """
+    engine = get_engine()
+    if engine is not None:
+        _log(engine, engine_pb2.ERROR, msg, resource, stream_id)
+    else:
+        print("error: " + msg, file=sys.stderr)
+
+def _log(engine, severity, message, resource, stream_id):
+    if resource is not None:
+        urn = resource.urn
+    else:
+        urn = ""
+
+    if stream_id is None:
+        stream_id = 0
+
+    req = engine_pb2.LogRequest(severity=severity, message=message, urn=urn, streamId=stream_id)
+    engine.Log(req)

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -75,6 +75,12 @@ def get_monitor():
         raise RunError('Pulumi program not connected to the engine -- are you running with the `pulumi` CLI?')
     return monitor
 
+def get_engine():
+    """
+    Returns the current engine service client for RPC communications.
+    """
+    return SETTINGS.engine
+
 ROOT = None
 
 def get_root_resource():


### PR DESCRIPTION
With this commit, the functions in 'pulumi.log' can be used to send
diagnostic messages to the Pulumi CLI. The Pulumi SDK bootstrap script
now also uses this feature to send diagnostic information on unhandled
exceptions to the Pulumi CLI.