### PR TITLE
Fix a panic on shutdown

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -342,12 +342,12 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 	<-displayDone
 	scope.Close() // Don't take any cancellations anymore, we're shutting down.
 	close(engineEvents)
-	close(displayEvents)
 	close(displayDone)
 	contract.IgnoreClose(manager)
 
 	// Make sure the goroutine writing to displayEvents and events has exited before proceeding.
 	<-eventsDone
+	close(displayEvents)
 
 	// Save update results.
 	result := backend.SucceededResult

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -828,13 +828,13 @@ func (b *cloudBackend) runEngineAction(
 	<-displayDone
 	scope.Close() // Don't take any cancellations anymore, we're shutting down.
 	close(engineEvents)
-	close(displayEvents)
 	close(displayDone)
 	contract.IgnoreClose(manager)
 
 	// Make sure that the goroutine writing to displayEvents and callerEventsOpt
 	// has exited before proceeding
 	<-eventsDone
+	close(displayEvents)
 
 	status := apitype.UpdateStatusSucceeded
 	if err != nil {


### PR DESCRIPTION
Last-minute events coming through the engine could cause the goroutine
iterating over engineEvents to write to displayEvents after it has
already been closed by the main goroutine.