### PR TITLE
Don't `unwrap` functions

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -614,7 +614,7 @@ type Unwrap<T> =
     T extends Output<infer U2> ? UnwrapSimple<U2> :
     UnwrapSimple<T>;
 
-type primitive = string | number | boolean | undefined | null;
+type primitive = Function | string | number | boolean | undefined | null;
 
 /**
  * Handles encountering basic types when unwrapping.

--- a/sdk/nodejs/tests/unwrap.spec.ts
+++ b/sdk/nodejs/tests/unwrap.spec.ts
@@ -83,6 +83,7 @@ describe("unwrap", () => {
         it("strings", testUntouched("foo"));
         it("arrays", testUntouched([]));
         it("object", testUntouched({}));
+        it("function", testUntouched(() => {}));
     });
 
     describe("handles promises", () => {
@@ -96,6 +97,7 @@ describe("unwrap", () => {
         it("with strings", testPromise("foo"));
         it("with array", testPromise([]));
         it("with object", testPromise({}));
+        it("with function", testPromise(() => {}));
         it("with nested promise", test(Promise.resolve(Promise.resolve(4)), 4))
     });
 
@@ -110,6 +112,7 @@ describe("unwrap", () => {
         it("with strings", testOutput("foo"));
         it("with array", testOutput([]));
         it("with object", testOutput({}));
+        it("with function", testOutput(() => {}));
         it("with nested output", test(output(output(4)), 4));
         it("with output of promise", test(output(Promise.resolve(4)), 4));
     });
@@ -124,7 +127,7 @@ describe("unwrap", () => {
 
     describe("handles complex object", () => {
         it("empty", testUntouched({}));
-        it("with primitives", testUntouched({ a: 1, b: true }));
+        it("with primitives", testUntouched({ a: 1, b: true, c: () => {} }));
         it("with inner promise", test({ a: 1, b: true, c: Promise.resolve("") }, { a: 1, b: true, c: "" }));
         it("with inner and outer promise", test(Promise.resolve({ a: 1, b: true, c: Promise.resolve("") }), { a: 1, b: true, c: "" }));
         it("recursion", test({ a: 1, b: Promise.resolve(""), c: { d: true, e: Promise.resolve(4) } }, { a: 1, b: "", c: { d: true, e: 4 } }));
@@ -315,6 +318,13 @@ describe("unwrap", () => {
 
             // The runtime value better be a number[]
             x.c.e.push(1);
+        }));
+
+        it ("does not wrap functions", asyncTest(async () => {
+            var sentinel = function(_: () => void) {}
+
+            // `v` should be type `() => void` rather than `UnwrappedObject<void>`.
+            output(function() {}).apply(v => sentinel(v));
         }));
     });
 


### PR DESCRIPTION
Suppose I have `pulumi.output(o).apply(foo)`, with `o` being type `O`
and `foo` taking type `O` as an argument. If `O` is a type with methods,
this will fail to type check.

The reason is that `UnwrappedObject<T>` (as well as the other
`Unwrapped*` types) will recursively box the field values whose type is
`Function`. Since `UnwrappedObject<Function>` is not the same as
`Function`, we fail to type check.

This commit resolves this by considering `Function` a primitive type,
which will cause us to not box these field values, instead leaving them
as `Function`.