### PR TITLE
Get commit message and branch from CI if unavailable

### DIFF
--- a/pkg/util/ciutil/detect.go
+++ b/pkg/util/ciutil/detect.go
@@ -88,6 +88,11 @@ func IsCI() bool {
 // DetectSystem returns a CI system name when the current system looks like a CI system. Detection is based on
 // environment variables that CI vendors we know about set.
 func DetectSystem() System {
+	// Provide a way to disable CI/CD detection, as it can interfere with the ability to test.
+	if os.Getenv("PULUMI_DISABLE_CI_DETECTION") != "" {
+		return ""
+	}
+
 	for sys, d := range detectors {
 		if d.IsCI() {
 			return sys

--- a/pkg/util/ciutil/vars.go
+++ b/pkg/util/ciutil/vars.go
@@ -30,6 +30,10 @@ type Vars struct {
 	BuildURL string
 	// SHA is the SHA hash of the code repo at which this build/job is running.
 	SHA string
+	// BranchName is the name of the feature branch currently being built.
+	BranchName string
+	// CommitMessage is the full message of the Git commit being built.
+	CommitMessage string
 }
 
 // DetectVars detects and returns the CI variables for the current environment.
@@ -44,12 +48,16 @@ func DetectVars() Vars {
 		v.BuildID = os.Getenv("CI_JOB_ID")
 		v.BuildURL = os.Getenv("CI_JOB_URL")
 		v.SHA = os.Getenv("CI_COMMIT_SHA")
+		v.BranchName = os.Getenv("CI_COMMIT_REF_NAME")
+		v.CommitMessage = os.Getenv("CI_COMMIT_MESSAGE")
 	case Travis:
 		// We are running in Travis. See https://docs.travis-ci.com/user/environment-variables/. Travis doesn't
 		// set a build URL in its environment -- see  https://github.com/travis-ci/travis-ci/issues/8935.
 		v.BuildID = os.Getenv("TRAVIS_JOB_ID")
 		v.BuildType = os.Getenv("TRAVIS_EVENT_TYPE")
 		v.SHA = os.Getenv("TRAVIS_PULL_REQUEST_SHA")
+		v.BranchName = os.Getenv("TRAVIS_BRANCH")
+		v.CommitMessage = os.Getenv("TRAVIS_COMMIT_MESSAGE")
 	}
 	return v
 }


### PR DESCRIPTION
We use the Git commit title as the default message for a stack update, and recently started using the branch to group related previews. This works great, except that in CI/CD environments the commit message and branch aren't available.

I don't know the specifics of why or now, but CI systems appear run at a detached head. (Perhaps because it can then only sync a subset of the Git repo?) Anyways, rather than omitting the data, we set the values from CI-system provided environment variables if possible.

Fixes #2045.