### PR TITLE
Default to unbounded parallelism

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -133,7 +133,7 @@ func newDestroyCmd() *cobra.Command {
 		"Display operation as a rich diff showing the overall change")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
-		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism, 0 for unbounded parallelism)")
 	cmd.PersistentFlags().BoolVarP(
 		&refresh, "refresh", "r", false,
 		"Refresh the state of the stack's resources before this update")

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -131,7 +131,7 @@ func newPreviewCmd() *cobra.Command {
 		"Display operation as a rich diff showing the overall change")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
-		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism, 0 for unbounded parallelism)")
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,
 		"Show configuration keys and variables")

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -142,7 +142,7 @@ func newRefreshCmd() *cobra.Command {
 		"Display operation as a rich diff showing the overall change")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
-		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism, 0 for unbounded parallelism)")
 	cmd.PersistentFlags().BoolVar(
 		&showReplacementSteps, "show-replacement-steps", false,
 		"Show detailed resource replacement creates and deletes instead of a single step")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	defaultParallel = 10
+	defaultParallel = 0
 )
 
 // nolint: vetshadow, intentionally disabling here for cleaner err declaration/assignment.
@@ -328,7 +328,7 @@ func newUpCmd() *cobra.Command {
 		"Display operation as a rich diff showing the overall change")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
-		"Allow P resource operations to run in parallel at once (<=1 for no parallelism)")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism, 0 for unbounded parallelism)")
 	cmd.PersistentFlags().BoolVarP(
 		&refresh, "refresh", "r", false,
 		"Refresh the state of the stack's resources before this update")

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -48,6 +48,11 @@ func (o Options) DegreeOfParallelism() int {
 	return o.Parallel
 }
 
+// InfiniteParallelism returns whether or not the requested level of parallelism is unbounded.
+func (o Options) InfiniteParallelism() bool {
+	return o.Parallel == 0
+}
+
 // Events is an interface that can be used to hook interesting engine/planning events.
 type Events interface {
 	OnResourceStepPre(step Step) (interface{}, error)

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -123,8 +123,7 @@ export function getEngine(): Object | undefined {
  * serialize returns true if resource operations should be serialized.
  */
 export function serialize(): boolean {
-    const p = options.parallel;
-    return !p || p <= 1;
+    return options.parallel === 1;
 }
 
 /**


### PR DESCRIPTION
Some providers (namely Kubernetes) require unbounded parallelism in
order to function correctly. This commit enables the engine to operate
in a mode with unbounded parallelism and switches to that mode by
default.

Fixes https://github.com/pulumi/pulumi/issues/1758.