### PR TITLE
Fix issue with malformed commit messages

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -414,7 +414,7 @@ func addGitCommitMetadata(repo *git.Repository, repoRoot string, m *backend.Upda
 	}
 
 	// If there is no message set manually, default to the Git commit's title.
-	msg := commit.Message
+	msg := strings.TrimSpace(commit.Message)
 	if msg == "" && ciVars.CommitMessage != "" {
 		msg = ciVars.CommitMessage
 	}


### PR DESCRIPTION
If no update message is provided we default to the title of the last commit. The way we determine the commit title is the first line, however if we are passed a commit message that beings with a newline character we end up passing the empty string as the commit message. (Here's looking at you, GitHub merge commits that are created for pull request.)