### PR TITLE
Cleanup Summary of Changes

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -125,6 +125,12 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 		return changes, nil
 	}
 
+	if !changes.HasChanges() {
+		close(eventsChannel)
+
+		os.Exit(0)
+	}
+
 	// Otherwise, ensure the user wants to proceed.
 	err := confirmBeforeUpdating(kind, stack, events, op.Opts)
 	close(eventsChannel)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -16,7 +16,6 @@ package deploy
 
 import (
 	"github.com/pkg/errors"
-
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
@@ -688,7 +687,7 @@ func (op StepOp) Prefix() string {
 func (op StepOp) RawPrefix() string {
 	switch op {
 	case OpSame:
-		return "  "
+		return "= "
 	case OpCreate:
 		return "+ "
 	case OpDelete:


### PR DESCRIPTION
- Don't prompt for input when there are no changes
- Format summary so it's a little easier to read
- Use `=` for unchanged resources

Closes #2051