### PR TITLE
Remove Error When User Cancels

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -174,7 +174,8 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 		}
 
 		if response == string(no) {
-			return errors.Errorf("confirmation declined, not proceeding with the %s", kind)
+			fmt.Printf("Confirmation declined, not processing with the %s\n", kind)
+			os.Exit(0)
 		}
 
 		if response == string(yes) {


### PR DESCRIPTION
The previous behaviour was to return an error that the user declined the
prompt. Instead, lets just exit with a simple message.

Closes #2070