### PR TITLE
Print the correct console URL in `pulumi stack ls`

### DIFF
--- a/cmd/stack_ls.go
+++ b/cmd/stack_ls.go
@@ -124,12 +124,10 @@ func newStackLsCmd() *cobra.Command {
 				// Render the columns.
 				values := []interface{}{name, lastUpdate, resourceCount}
 				if showURLColumn {
-					var url string
+					url := none
 					if httpBackend, ok := b.(httpstate.Backend); ok {
-						if nameSuffix, err := httpBackend.StackConsoleURL(summary.Name()); err != nil {
-							url = none
-						} else {
-							url = fmt.Sprintf("%s/%s", httpBackend.CloudURL(), nameSuffix)
+						if consoleURL, err := httpBackend.StackConsoleURL(summary.Name()); err == nil {
+							url = consoleURL
 						}
 					}
 					values = append(values, url)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -344,7 +344,13 @@ func (b *cloudBackend) StackConsoleURL(stackRef backend.StackReference) (string,
 		return "", err
 	}
 
-	return b.cloudConsoleStackPath(stackID), nil
+	path := b.cloudConsoleStackPath(stackID)
+
+	url := b.CloudConsoleURL(path)
+	if url == "" {
+		return "", errors.New("could not determine clould console URL")
+	}
+	return url, nil
 }
 
 func (b *cloudBackend) Name() string {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/engine"
@@ -144,15 +143,7 @@ func (s *cloudStack) ImportDeployment(ctx context.Context, deployment *apitype.U
 }
 
 func (s *cloudStack) ConsoleURL() (string, error) {
-	path, err := s.b.StackConsoleURL(s.ref)
-	if err != nil {
-		return "", nil
-	}
-	url := s.b.CloudConsoleURL(path)
-	if url == "" {
-		return "", errors.New("could not determine clould console URL")
-	}
-	return url, nil
+	return s.b.StackConsoleURL(s.ref)
 }
 
 // cloudStackSummary implements the backend.StackSummary interface, by wrapping


### PR DESCRIPTION
The cloudBackend's StackConsoleURL now returns a full URL instead of a path.

Fixes #2043.