### PR TITLE
Reorder an error check in the provider registry.

### DIFF
--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -103,11 +103,11 @@ func NewRegistry(host plugin.Host, prev []*resource.State, isPreview bool) (*Reg
 			return nil, errors.Errorf("could not parse version for provider '%v': %v", urn, err)
 		}
 		provider, err := host.Provider(getProviderPackage(urn.Type()), version)
-		if provider == nil {
-			return nil, errors.Errorf("could not find plugin for provider '%v'", urn)
-		}
 		if err != nil {
 			return nil, errors.Errorf("could not load plugin for provider '%v': %v", urn, err)
+		}
+		if provider == nil {
+			return nil, errors.Errorf("could not find plugin for provider '%v'", urn)
 		}
 		if err := provider.Configure(res.Inputs); err != nil {
 			closeErr := host.CloseProvider(provider)


### PR DESCRIPTION
The provider registry was checking for a `nil` provider instance before
checking for a non-nil error. This caused the CLI to fail to report
important errors during the plugin load process (e.g. invalid checkpoint
errors) and instead report a failure to find a matching plugin.