### PR TITLE
[WIP] Add GitLab metadata keys to UpdateMetadata, as well as to the StackTags

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -243,6 +243,12 @@ const (
 	// GitHubRepositoryNameTag is a tag that represents the name of a repository on GitHub that this stack
 	// may be associated with (inferred by the CLI based on git remote info).
 	GitHubRepositoryNameTag StackTagName = "gitHub:repo"
+	// GitLabOwnerNameTag is a tag that represents the name of the owner on GitLab that this stack
+	// may be associated with (inferred by the CLI based on git remote info).
+	GitLabOwnerNameTag StackTagName = "gitlab:owner"
+	// GitLabRepositoryNameTag is a tag that represents the name of a repository on GitLab that this stack
+	// may be associated with (inferred by the CLI based on git remote info).
+	GitLabRepositoryNameTag StackTagName = "gitlab:repo"
 )
 
 // Stack describes a Stack running on a Pulumi Cloud.

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -127,16 +127,10 @@ func GetStackTags() (map[apitype.StackTagName]string, error) {
 			tags[apitype.ProjectDescriptionTag] = *proj.Description
 		}
 
-		if owner, repo, err := gitutil.GetGitHubProjectForOrigin(filepath.Dir(projPath)); err == nil {
-			tags[apitype.GitHubOwnerNameTag] = owner
-			tags[apitype.GitHubRepositoryNameTag] = repo
-		}
-
 		// Add the git metadata to the tags
-		if err := addGitMetadataToStackTags(tags, projPath); err != nil {
+		if err := addGitMetadataToStackTags(tags, projPath); err != nil { // nolint
 			// Intentionally ignore errors adding git metadata to stack tags.
 		}
-
 	}
 
 	return tags, nil

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -64,6 +64,11 @@ const (
 	// GitHubRepo is the name of the GitHub repo, if the local git repo's remote origin is hosted on GitHub.com.
 	GitHubRepo = "github.repo"
 
+	// GitLabLogin is the user who owns the local repo, if the origin remote is hosted on gitlab.com.
+	GitLabLogin = "gitlab.login"
+	// GitLabRepo is the name of the GitLab repo, if the local git repo's remote origin is hosted on gitlab.com.
+	GitLabRepo = "gitlab.repo"
+
 	// CISystem is the name of the CI system running the pulumi operation.
 	CISystem = "ci.system"
 	// CIBuildID is an opaque ID of the build in the CI system.


### PR DESCRIPTION
**Note**: Do not merge yet. Opening this PR to facilitate testing the dev build of the CLI. But please feel free to review the changes made thus far.

- Added new stack tag constants for GitLab, as well as added new keys for use with `UpdateMetadata`.
- Refactored some of the logic around git repo detection and how we extract metadata from the repo.
- Updated the stack tag manipulation code to use the new way of working with the git repo instead of calling the all encompassing `GetGitHubProjectForOrigin` func from `util/gitutil/git.go`, which always assumed GitHub as the cloud source control provider.
- Fix #2063 