### PR TITLE
Add gitlab metadata - Part 1

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -393,6 +393,8 @@ func AddGitRemoteMetadataToMap(repo *git.Repository, env map[string]string) erro
 
 	// If the environment map contains the vcs kind and if it is GitHub,
 	// then let's set the old metadata keys as well, so that the UI can continue to read those.
+	// As of this writing, none of the other VCS are detected and only the `github` keys are set
+	// when the origin remote is truly a github remote.
 	// TODO once the UI is updated and we no longer need these keys, we can remove them.
 	if env[backend.VCSRepoKind] == gitutil.GitHubHostName && env[backend.VCSRepoOwner] != "" {
 		addOldGitHubMetadataToEnvironment(env)
@@ -408,7 +410,8 @@ func addOldGitHubMetadataToEnvironment(env map[string]string) {
 }
 
 func addVCSMetadataToEnvironment(remoteURL string, env map[string]string) error {
-	// GitLab repo slug if applicable. We don't require a cloud-hosted VCS, so swallow errors.
+	// GitLab, Bitbucket, Azure DevOps etc. repo slug if applicable.
+	// We don't require a cloud-hosted VCS, so swallow errors.
 	vcsLogin, vcsRepo, vcsRepoKind, err := gitutil.TryGetVCSInfo(remoteURL)
 	if err != nil {
 		return errors.Wrap(err, "detecting VCS project information")

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -396,7 +396,6 @@ func AddGitRemoteMetadataToMap(repo *git.Repository, env map[string]string) erro
 	// when the origin remote was truly a github remote.
 	// TODO [pulumi/pulumi-service#2306] Once the UI is updated and we no longer need these keys, we can remove this block.
 	if env[backend.VCSRepoKind] == gitutil.GitHubHostName && env[backend.VCSRepoOwner] != "" {
-		// For backwards compatibility, let's set the old GitHub keys as well.
 		env[backend.GitHubLogin] = env[backend.VCSRepoOwner]
 		env[backend.GitHubRepo] = env[backend.VCSRepoName]
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -373,7 +373,7 @@ func addGitMetadata(repoRoot string, m *backend.UpdateMetadata) error {
 }
 
 // AddGitRemoteMetadataToMap reads the given git repo and adds its metadata to the given map bag
-func AddGitRemoteMetadataToMap(repo *git.Repository, bag map[string]string) error {
+func AddGitRemoteMetadataToMap(repo *git.Repository, env map[string]string) error {
 	var allErrors *multierror.Error
 
 	// Get the remote URL for this repo
@@ -384,11 +384,11 @@ func AddGitRemoteMetadataToMap(repo *git.Repository, bag map[string]string) erro
 
 	// check if the remote URL is a GitHub or a GitLab URL
 	if gitutil.IsGitOriginURLGitHub(remoteURL) {
-		if err := addGitHubMetadataToEnvironment(remoteURL, bag); err != nil {
+		if err := addGitHubMetadataToEnvironment(remoteURL, env); err != nil {
 			allErrors = multierror.Append(allErrors, err)
 		}
 	} else if gitutil.IsGitOriginURLGitLab(remoteURL) {
-		if err := addGitLabMetadataToEnvironment(remoteURL, bag); err != nil {
+		if err := addGitLabMetadataToEnvironment(remoteURL, env); err != nil {
 			allErrors = multierror.Append(allErrors, err)
 		}
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -360,7 +360,7 @@ func addGitMetadata(repoRoot string, m *backend.UpdateMetadata) error {
 		return nil
 	}
 
-	// Add the relevant git metadata from the git repo
+	// Add the relevant git metadata from the git repo.
 	if err := AddGitRemoteMetadataToMap(repo, m.Environment); err != nil {
 		allErrors = multierror.Append(allErrors, err)
 	}
@@ -372,11 +372,11 @@ func addGitMetadata(repoRoot string, m *backend.UpdateMetadata) error {
 	return allErrors.ErrorOrNil()
 }
 
-// AddGitRemoteMetadataToMap reads the given git repo and adds its metadata to the given map bag
+// AddGitRemoteMetadataToMap reads the given git repo and adds its metadata to the given map bag.
 func AddGitRemoteMetadataToMap(repo *git.Repository, env map[string]string) error {
 	var allErrors *multierror.Error
 
-	// Get the remote URL for this repo
+	// Get the remote URL for this repo.
 	remoteURL, err := gitutil.GetGitRemoteURL(repo, "origin")
 	if err != nil {
 		return errors.Wrap(err, "detecting Git remote URL")
@@ -386,7 +386,7 @@ func AddGitRemoteMetadataToMap(repo *git.Repository, env map[string]string) erro
 		return nil
 	}
 
-	// check if the remote URL is a GitHub or a GitLab URL
+	// Check if the remote URL is a GitHub or a GitLab URL.
 	if gitutil.IsGitOriginURLGitHub(remoteURL) {
 		if err := addGitHubMetadataToEnvironment(remoteURL, env); err != nil {
 			allErrors = multierror.Append(allErrors, err)
@@ -402,7 +402,7 @@ func AddGitRemoteMetadataToMap(repo *git.Repository, env map[string]string) erro
 
 func addGitHubMetadataToEnvironment(remoteURL string, env map[string]string) error {
 	// GitHub repo slug if applicable. We don't require GitHub, so swallow errors.
-	ghLogin, ghRepo, err := gitutil.GetGitHubProjectForOriginByURL(remoteURL)
+	ghLogin, ghRepo, err := gitutil.TryGetCloudSourceControlOwnerAndRepoName(remoteURL)
 	if err != nil {
 		return errors.Wrap(err, "detecting GitHub project information")
 	}
@@ -414,7 +414,7 @@ func addGitHubMetadataToEnvironment(remoteURL string, env map[string]string) err
 
 func addGitLabMetadataToEnvironment(remoteURL string, env map[string]string) error {
 	// GitLab repo slug if applicable. We don't require GitLab, so swallow errors.
-	glLogin, glRepo, err := gitutil.GetGitLabProjectForOriginByURL(remoteURL)
+	glLogin, glRepo, err := gitutil.TryGetCloudSourceControlOwnerAndRepoName(remoteURL)
 	if err != nil {
 		return errors.Wrap(err, "detecting GitLab project information")
 	}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -382,6 +382,10 @@ func AddGitRemoteMetadataToMap(repo *git.Repository, env map[string]string) erro
 		return errors.Wrap(err, "detecting Git remote URL")
 	}
 
+	if remoteURL == "" {
+		return nil
+	}
+
 	// check if the remote URL is a GitHub or a GitLab URL
 	if gitutil.IsGitOriginURLGitHub(remoteURL) {
 		if err := addGitHubMetadataToEnvironment(remoteURL, env); err != nil {

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -220,7 +220,8 @@ func TestReadingGitLabMetadata(t *testing.T) {
 		_, ok := test.Environment[backend.GitHead]
 		assert.True(t, ok, "Expected to find Git SHA in update environment map")
 
-		assertEnvValue(t, test, backend.GitLabLogin, "owner-name")
-		assertEnvValue(t, test, backend.GitLabRepo, "repo-name")
+		assertEnvValue(t, test, backend.VCSRepoOwner, "owner-name")
+		assertEnvValue(t, test, backend.VCSRepoName, "repo-name")
+		assertEnvValue(t, test, backend.VCSRepoKind, "gitlab.com")
 	}
 }

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/backend"
 	pul_testing "github.com/pulumi/pulumi/pkg/testing"
+	"github.com/pulumi/pulumi/pkg/util/gitutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -222,6 +223,6 @@ func TestReadingGitLabMetadata(t *testing.T) {
 
 		assertEnvValue(t, test, backend.VCSRepoOwner, "owner-name")
 		assertEnvValue(t, test, backend.VCSRepoName, "repo-name")
-		assertEnvValue(t, test, backend.VCSRepoKind, "gitlab.com")
+		assertEnvValue(t, test, backend.VCSRepoKind, gitutil.GitLabHostName)
 	}
 }

--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -243,6 +243,12 @@ const (
 	// GitHubRepositoryNameTag is a tag that represents the name of a repository on GitHub that this stack
 	// may be associated with (inferred by the CLI based on git remote info).
 	GitHubRepositoryNameTag StackTagName = "gitHub:repo"
+	// GitLabOwnerNameTag is a tag that represents the name of the owner on GitLab that this stack
+	// may be associated with (inferred by the CLI based on git remote info).
+	GitLabOwnerNameTag StackTagName = "gitlab:owner"
+	// GitLabRepositoryNameTag is a tag that represents the name of a repository on GitLab that this stack
+	// may be associated with (inferred by the CLI based on git remote info).
+	GitLabRepositoryNameTag StackTagName = "gitlab:repo"
 )
 
 // Stack describes a Stack running on a Pulumi Cloud.

--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -239,6 +239,7 @@ const (
 	ProjectDescriptionTag StackTagName = "pulumi:description"
 	// GitHubOwnerNameTag is a tag that represents the name of the owner on GitHub that this stack
 	// may be associated with (inferred by the CLI based on git remote info).
+	// TODO [pulumi/pulumi-service#2306] Once the UI is updated, we would no longer need the GitHub specific keys.
 	GitHubOwnerNameTag StackTagName = "gitHub:owner"
 	// GitHubRepositoryNameTag is a tag that represents the name of a repository on GitHub that this stack
 	// may be associated with (inferred by the CLI based on git remote info).

--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -243,12 +243,15 @@ const (
 	// GitHubRepositoryNameTag is a tag that represents the name of a repository on GitHub that this stack
 	// may be associated with (inferred by the CLI based on git remote info).
 	GitHubRepositoryNameTag StackTagName = "gitHub:repo"
-	// GitLabOwnerNameTag is a tag that represents the name of the owner on GitLab that this stack
+	// VCSOwnerNameTag is a tag that represents the name of the owner on the cloud VCS that this stack
 	// may be associated with (inferred by the CLI based on git remote info).
-	GitLabOwnerNameTag StackTagName = "gitlab:owner"
-	// GitLabRepositoryNameTag is a tag that represents the name of a repository on GitLab that this stack
+	VCSOwnerNameTag StackTagName = "vcs:owner"
+	// VCSRepositoryNameTag is a tag that represents the name of a repository on the cloud VCS that this stack
 	// may be associated with (inferred by the CLI based on git remote info).
-	GitLabRepositoryNameTag StackTagName = "gitlab:repo"
+	VCSRepositoryNameTag StackTagName = "vcs:repo"
+	// VCSRepositoryKindTag is a tag that represents the kind of the cloud VCS that this stack
+	// may be associated with (inferred by the CLI based on the git remote info).
+	VCSRepositoryKindTag StackTagName = "vcs:kind"
 )
 
 // Stack describes a Stack running on a Pulumi Cloud.

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -152,15 +152,14 @@ func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath st
 	if err != nil {
 		return err
 	}
-
 	if remoteURL == "" {
 		return nil
 	}
 
-	if owner, repo, kind, err := gitutil.TryGetVCSInfo(remoteURL); err == nil {
-		tags[apitype.VCSOwnerNameTag] = owner
-		tags[apitype.VCSRepositoryNameTag] = repo
-		tags[apitype.VCSRepositoryKindTag] = kind
+	if vcsInfo, err := gitutil.TryGetVCSInfo(remoteURL); err == nil {
+		tags[apitype.VCSOwnerNameTag] = vcsInfo.Owner
+		tags[apitype.VCSRepositoryNameTag] = vcsInfo.Repo
+		tags[apitype.VCSRepositoryKindTag] = vcsInfo.Kind
 	} else {
 		return errors.Wrapf(err, "detecting VCS info for stack tags for remote %v", remoteURL)
 	}

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -157,17 +157,16 @@ func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath st
 		return nil
 	}
 
-	// Check if the remote URL is a GitHub or a GitLab URL.
-	if gitutil.IsGitOriginURLGitHub(remoteURL) {
-		if owner, repo, err := gitutil.TryGetCloudSourceControlOwnerAndRepoName(remoteURL); err != nil {
-			tags[apitype.GitHubOwnerNameTag] = owner
-			tags[apitype.GitHubRepositoryNameTag] = repo
-		}
-	} else if gitutil.IsGitOriginURLGitLab(remoteURL) {
-		if owner, repo, err := gitutil.TryGetCloudSourceControlOwnerAndRepoName(remoteURL); err != nil {
-			tags[apitype.GitLabOwnerNameTag] = owner
-			tags[apitype.GitLabRepositoryNameTag] = repo
-		}
+	if owner, repo, kind, err := gitutil.TryGetVCSInfo(remoteURL); err != nil {
+		tags[apitype.VCSOwnerNameTag] = owner
+		tags[apitype.VCSRepositoryNameTag] = repo
+		tags[apitype.VCSRepositoryKindTag] = kind
+	}
+	// Check if the remote URL is a GitHub URL and set the old stack tags keys for GitHub.
+	// TODO remove these when the UI no longer needs them.
+	if tags[apitype.VCSRepositoryKindTag] == gitutil.GitHubHostName && tags[apitype.VCSOwnerNameTag] != "" {
+		tags[apitype.GitHubOwnerNameTag] = tags[apitype.VCSOwnerNameTag]
+		tags[apitype.GitHubRepositoryNameTag] = tags[apitype.VCSRepositoryNameTag]
 	}
 
 	return nil

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -157,10 +157,12 @@ func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath st
 		return nil
 	}
 
-	if owner, repo, kind, err := gitutil.TryGetVCSInfo(remoteURL); err != nil {
+	if owner, repo, kind, err := gitutil.TryGetVCSInfo(remoteURL); err == nil {
 		tags[apitype.VCSOwnerNameTag] = owner
 		tags[apitype.VCSRepositoryNameTag] = repo
 		tags[apitype.VCSRepositoryKindTag] = kind
+	} else {
+		return errors.Wrapf(err, "detecting VCS info for stack tags for remote %v", remoteURL)
 	}
 	// Check if the remote URL is a GitHub URL and set the old stack tags keys for GitHub.
 	// TODO remove these when the UI no longer needs them.

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -129,9 +129,8 @@ func GetStackTags() (map[apitype.StackTagName]string, error) {
 		}
 
 		// Add the git metadata to the tags, ignoring any errors that come from it.
-		if err := addGitMetadataToStackTags(tags, projPath); err != nil {
-			contract.IgnoreError(err)
-		}
+		ignoredErr := addGitMetadataToStackTags(tags, projPath)
+		contract.IgnoreError(ignoredErr)
 	}
 
 	return tags, nil

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -17,6 +17,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 	"path/filepath"
 	"regexp"
 
@@ -127,9 +128,9 @@ func GetStackTags() (map[apitype.StackTagName]string, error) {
 			tags[apitype.ProjectDescriptionTag] = *proj.Description
 		}
 
-		// Add the git metadata to the tags.
-		if err := addGitMetadataToStackTags(tags, projPath); err != nil { // nolint
-			// Intentionally ignore errors adding git metadata to stack tags.
+		// Add the git metadata to the tags, ignoring any errors that come from it.
+		if err := addGitMetadataToStackTags(tags, projPath); err != nil {
+			contract.IgnoreError(err)
 		}
 	}
 

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -127,7 +127,7 @@ func GetStackTags() (map[apitype.StackTagName]string, error) {
 			tags[apitype.ProjectDescriptionTag] = *proj.Description
 		}
 
-		// Add the git metadata to the tags
+		// Add the git metadata to the tags.
 		if err := addGitMetadataToStackTags(tags, projPath); err != nil { // nolint
 			// Intentionally ignore errors adding git metadata to stack tags.
 		}
@@ -137,7 +137,7 @@ func GetStackTags() (map[apitype.StackTagName]string, error) {
 }
 
 // addGitMetadataToStackTags fetches the git repository from the directory, and attempts to detect
-// and add any relevant git metadata as stack tags
+// and add any relevant git metadata as stack tags.
 func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath string) error {
 	repo, err := gitutil.GetGitRepository(filepath.Dir(projPath))
 	if repo == nil {
@@ -153,14 +153,18 @@ func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath st
 		return err
 	}
 
-	// check if the remote URL is a GitHub or a GitLab URL
+	if remoteURL == "" {
+		return nil
+	}
+
+	// Check if the remote URL is a GitHub or a GitLab URL.
 	if gitutil.IsGitOriginURLGitHub(remoteURL) {
-		if owner, repo, err := gitutil.GetGitHubProjectForOriginByURL(remoteURL); err != nil {
+		if owner, repo, err := gitutil.TryGetCloudSourceControlOwnerAndRepoName(remoteURL); err != nil {
 			tags[apitype.GitHubOwnerNameTag] = owner
 			tags[apitype.GitHubRepositoryNameTag] = repo
 		}
 	} else if gitutil.IsGitOriginURLGitLab(remoteURL) {
-		if owner, repo, err := gitutil.GetGitLabProjectForOriginByURL(remoteURL); err != nil {
+		if owner, repo, err := gitutil.TryGetCloudSourceControlOwnerAndRepoName(remoteURL); err != nil {
 			tags[apitype.GitLabOwnerNameTag] = owner
 			tags[apitype.GitLabRepositoryNameTag] = repo
 		}

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -164,9 +164,10 @@ func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath st
 	} else {
 		return errors.Wrapf(err, "detecting VCS info for stack tags for remote %v", remoteURL)
 	}
-	// Check if the remote URL is a GitHub URL and set the old stack tags keys for GitHub.
+	// Set the old stack tags keys as GitHub so that the UI will continue to work,
+	// regardless of whether the remote URL is a GitHub URL or not.
 	// TODO remove these when the UI no longer needs them.
-	if tags[apitype.VCSRepositoryKindTag] == gitutil.GitHubHostName && tags[apitype.VCSOwnerNameTag] != "" {
+	if tags[apitype.VCSOwnerNameTag] != "" {
 		tags[apitype.GitHubOwnerNameTag] = tags[apitype.VCSOwnerNameTag]
 		tags[apitype.GitHubRepositoryNameTag] = tags[apitype.VCSRepositoryNameTag]
 	}

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -127,16 +127,10 @@ func GetStackTags() (map[apitype.StackTagName]string, error) {
 			tags[apitype.ProjectDescriptionTag] = *proj.Description
 		}
 
-		if owner, repo, err := gitutil.GetGitHubProjectForOrigin(filepath.Dir(projPath)); err == nil {
-			tags[apitype.GitHubOwnerNameTag] = owner
-			tags[apitype.GitHubRepositoryNameTag] = repo
-		}
-
 		// Add the git metadata to the tags
-		if err := addGitMetadataToStackTags(tags, projPath); err != nil {
+		if err := addGitMetadataToStackTags(tags, projPath); err != nil { // nolint
 			// Intentionally ignore errors adding git metadata to stack tags.
 		}
-
 	}
 
 	return tags, nil

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -64,6 +64,11 @@ const (
 	// GitHubRepo is the name of the GitHub repo, if the local git repo's remote origin is hosted on GitHub.com.
 	GitHubRepo = "github.repo"
 
+	// GitLabLogin is the user who owns the local repo, if the origin remote is hosted on gitlab.com.
+	GitLabLogin = "gitlab.login"
+	// GitLabRepo is the name of the GitLab repo, if the local git repo's remote origin is hosted on gitlab.com.
+	GitLabRepo = "gitlab.repo"
+
 	// CISystem is the name of the CI system running the pulumi operation.
 	CISystem = "ci.system"
 	// CIBuildID is an opaque ID of the build in the CI system.

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -60,6 +60,7 @@ const (
 	GitAuthorEmail = "git.author.email"
 
 	// GitHubLogin is the user/organization who owns the local repo, if the origin remote is hosted on GitHub.com.
+	// TODO [pulumi/pulumi-service#2306] Once the UI is updated, we would no longer need the GitHub specific keys.
 	GitHubLogin = "github.login"
 	// GitHubRepo is the name of the GitHub repo, if the local git repo's remote origin is hosted on GitHub.com.
 	GitHubRepo = "github.repo"

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -64,10 +64,12 @@ const (
 	// GitHubRepo is the name of the GitHub repo, if the local git repo's remote origin is hosted on GitHub.com.
 	GitHubRepo = "github.repo"
 
-	// GitLabLogin is the user who owns the local repo, if the origin remote is hosted on gitlab.com.
-	GitLabLogin = "gitlab.login"
-	// GitLabRepo is the name of the GitLab repo, if the local git repo's remote origin is hosted on gitlab.com.
-	GitLabRepo = "gitlab.repo"
+	// VCSRepoOwner is the user who owns the local repo, if the origin remote is a cloud host.
+	VCSRepoOwner = "vcs.owner"
+	// VCSRepoName is the name of the repo, if the local git repo's remote origin is a cloud host.
+	VCSRepoName = "vcs.repo"
+	//VCSRepoKind is the cloud host where the repo is hosted.
+	VCSRepoKind = "vcs.kind"
 
 	// CISystem is the name of the CI system running the pulumi operation.
 	CISystem = "ci.system"

--- a/pkg/util/gitutil/git.go
+++ b/pkg/util/gitutil/git.go
@@ -42,7 +42,7 @@ const (
 // The pre-compiled regex used to extract owner and repo name from an SSH git remote URL.
 // CAUTION! If you are renaming the group name owner_and_repo to something else,
 // be sure to update its usage in this package as well.
-var cloudSourceControlSSHRegex = regexp.MustCompile(`git@[a-zA-Z]*\.com:(?P<owner_and_repo>.*)\.git`)
+var cloudSourceControlSSHRegex = regexp.MustCompile(`git@[a-zA-Z]*\.com:(?P<owner_and_repo>.*)`)
 
 // GetGitRepository returns the git repository by walking up from the provided directory.
 // If no repository is found, will return (nil, nil).
@@ -126,6 +126,7 @@ func TryGetCloudSourceControlOwnerAndRepoName(remoteURL string) (string, string,
 		}
 		// The named group that we are interested in, is the owner_and_repo group
 		project = groups["owner_and_repo"]
+		project = strings.TrimSuffix(project, defaultGitCloudRepositorySuffix)
 	} else {
 		if parsedURL, err := url.Parse(remoteURL); err == nil {
 			project = parsedURL.Path

--- a/pkg/util/gitutil/git.go
+++ b/pkg/util/gitutil/git.go
@@ -59,7 +59,8 @@ var (
 )
 
 // VCSInfo describes a cloud-hosted version control system.
-// Cloud hosted VCS' typically have
+// Cloud hosted VCS' typically have an owner (could be an organization),
+// to whom the repo belongs.
 type VCSInfo struct {
 	Owner string
 	Repo  string
@@ -99,7 +100,6 @@ func GetGitHubProjectForOrigin(dir string) (*VCSInfo, error) {
 		return nil, err
 	}
 	remoteURL, err := GetGitRemoteURL(repo, "origin")
-
 	if err != nil {
 		return nil, err
 	}
@@ -167,20 +167,20 @@ func TryGetVCSInfo(remoteURL string) (*VCSInfo, error) {
 		return nil, errors.Errorf("detecting the VCS info from the remote URL %v", remoteURL)
 	}
 
-	// At this point, project is either an empty string or contains the information that we want.
-	// It is OK to run the split on the empty string anyway.
-	split := strings.Split(project, "/")
-
 	// For Azure, we will have more than 2 parts in the array.
 	// Ex: owner/project/repo.git
-	if len(split) > 2 {
+	if vcsKind == AzureDevOpsHostName {
 		azureSplit := strings.SplitN(project, "/", 2)
 		return &VCSInfo{
 			Owner: azureSplit[0],
 			Repo:  azureSplit[1],
 			Kind:  vcsKind,
 		}, nil
-	} else if len(split) != 2 {
+	}
+
+	// Since the vcsKind is not Azure, we can try to detect the other kinds of VCS.
+	split := strings.Split(project, "/")
+	if len(split) != 2 {
 		return nil, errors.Errorf("could not detect VCS project from url: %v", remoteURL)
 	}
 

--- a/pkg/util/gitutil/git.go
+++ b/pkg/util/gitutil/git.go
@@ -50,8 +50,8 @@ const (
 )
 
 // The pre-compiled regex used to extract owner and repo name from an SSH git remote URL.
-// CAUTION! If you are renaming any of the group names in the regex (the ?P<group_name> part) to something else,
-// be sure to update its usage in this package as well.
+// Note: If you are renaming any of the group names in the regex (the ?P<group_name> part) to something else,
+// be sure to update its usage elsewhere in the code as well.
 // The nolint instruction prevents gometalinter from complaining about the length of the line.
 var (
 	cloudSourceControlSSHRegex = regexp.MustCompile(`git@(?P<host_name>[a-zA-Z]*\.com|[a-zA-Z]*\.org):(?P<owner_and_repo>.*)`)                           //nolint

--- a/pkg/util/gitutil/git.go
+++ b/pkg/util/gitutil/git.go
@@ -31,7 +31,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/storage/memory"
 )
 
-// Constants related to detecting the right type of source control provider for git
+// Constants related to detecting the right type of source control provider for git.
 const (
 	defaultGitCloudRepositorySuffix = ".git"
 
@@ -84,7 +84,7 @@ func GetGitHubProjectForOrigin(dir string) (string, string, error) {
 	return TryGetCloudSourceControlOwnerAndRepoName(remoteURL)
 }
 
-// GetGitRemoteURL returns the remote URL for the given remoteName in the repo
+// GetGitRemoteURL returns the remote URL for the given remoteName in the repo.
 func GetGitRemoteURL(repo *git.Repository, remoteName string) (string, error) {
 	remote, err := repo.Remote(remoteName)
 	if err != nil {
@@ -99,12 +99,12 @@ func GetGitRemoteURL(repo *git.Repository, remoteName string) (string, error) {
 	return remoteURL, nil
 }
 
-// IsGitOriginURLGitHub returns true if the provided remoteURL is detected as GitHub
+// IsGitOriginURLGitHub returns true if the provided remoteURL is detected as GitHub.
 func IsGitOriginURLGitHub(remoteURL string) bool {
 	return strings.Contains(remoteURL, githubHostName)
 }
 
-// IsGitOriginURLGitLab returns true if the provided remoteURL is detected as GitHub
+// IsGitOriginURLGitLab returns true if the provided remoteURL is detected as GitLab.
 func IsGitOriginURLGitLab(remoteURL string) bool {
 	return strings.Contains(remoteURL, gitlabHostName)
 }

--- a/pkg/util/gitutil/git.go
+++ b/pkg/util/gitutil/git.go
@@ -42,7 +42,7 @@ const (
 // The pre-compiled regex used to extract owner and repo name from an SSH git remote URL.
 // CAUTION! If you are renaming the group name owner_and_repo to something else,
 // be sure to update its usage in this package as well.
-var cloudSourceControlSSHRegex = regexp.MustCompile("git@[a-zA-Z]*\\.com:(?P<owner_and_repo>.*)\\.git")
+var cloudSourceControlSSHRegex = regexp.MustCompile(`git@[a-zA-Z]*\.com:(?P<owner_and_repo>.*)\.git`)
 
 // GetGitRepository returns the git repository by walking up from the provided directory.
 // If no repository is found, will return (nil, nil).
@@ -130,7 +130,7 @@ func TryGetCloudSourceControlOwnerAndRepoName(remoteURL string) (string, string,
 		if parsedURL, err := url.Parse(remoteURL); err == nil {
 			project = parsedURL.Path
 			// Replace the .git extension from the path.
-			project = strings.Replace(project, defaultGitCloudRepositorySuffix, "", -1)
+			project = strings.TrimSuffix(project, defaultGitCloudRepositorySuffix)
 			// Remove the prefix "/". TrimPrefix returns the same value if there is no prefix.
 			// So it is safe to use it instead of doing any sort of substring matches.
 			project = strings.TrimPrefix(project, "/")
@@ -376,10 +376,6 @@ func GitListBranchesAndTags(url string) ([]plumbing.ReferenceName, error) {
 	sort.Sort(byShortNameLengthDesc(results))
 
 	return results, nil
-}
-
-func trimGitRemoteURL(url string, prefix string, suffix string) string {
-	return strings.TrimSuffix(strings.TrimPrefix(url, prefix), suffix)
 }
 
 type byShortNameLengthDesc []plumbing.ReferenceName

--- a/pkg/util/gitutil/git_test.go
+++ b/pkg/util/gitutil/git_test.go
@@ -224,7 +224,14 @@ func TestTryGetVCSInfoFromSSHRemote(t *testing.T) {
 
 	assert.Equal(t, "owner-name", bitbucketOwner)
 	assert.Equal(t, "repo-name", bitbucketRepo)
-	assert.Equal(t, "bitbucket.org", kind)
+	assert.Equal(t, BitbucketHostName, kind)
+
+	azureRepoOwner, azureRepo, kind, err := TryGetVCSInfo("git@ssh.dev.azure.com:v3/owner-name/project/repo-name.git")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "owner-name", azureRepoOwner)
+	assert.Equal(t, "project/repo-name", azureRepo)
+	assert.Equal(t, AzureDevOpsHostName, kind)
 }
 
 func TestTryGetVCSInfoFromHTTPSRemote(t *testing.T) {
@@ -247,5 +254,12 @@ func TestTryGetVCSInfoFromHTTPSRemote(t *testing.T) {
 
 	assert.Equal(t, "owner-name", bitbucketOwner)
 	assert.Equal(t, "repo-name", bitbucketRepo)
-	assert.Equal(t, "bitbucket.org", kind)
+	assert.Equal(t, BitbucketHostName, kind)
+
+	azureRepoOwner, azureRepo, kind, err := TryGetVCSInfo("https://user@dev.azure.com/owner-name/project/_git/repo-name")
+	assert.Nil(t, err)
+
+	assert.Equal(t, "owner-name", azureRepoOwner)
+	assert.Equal(t, "project/_git/repo-name", azureRepo)
+	assert.Equal(t, AzureDevOpsHostName, kind)
 }

--- a/pkg/util/gitutil/git_test.go
+++ b/pkg/util/gitutil/git_test.go
@@ -208,44 +208,44 @@ func TestTryGetVCSInfoFromSSHRemote(t *testing.T) {
 	glOwner, glRepo, kind, err := TryGetVCSInfo("git@gitlab.com:owner-name/repo-name.git")
 	assert.Nil(t, err)
 
-	assert.Equal(t, glOwner, "owner-name")
-	assert.Equal(t, glRepo, "repo-name")
-	assert.Equal(t, kind, GitLabHostName)
+	assert.Equal(t, "owner-name", glOwner)
+	assert.Equal(t, "repo-name", glRepo)
+	assert.Equal(t, GitLabHostName, kind)
 
 	ghOwner, ghRepo, kind, err := TryGetVCSInfo("git@github.com:owner-name/repo-name.git")
 	assert.Nil(t, err)
 
-	assert.Equal(t, ghOwner, "owner-name")
-	assert.Equal(t, ghRepo, "repo-name")
-	assert.Equal(t, kind, GitHubHostName)
+	assert.Equal(t, "owner-name", ghOwner)
+	assert.Equal(t, "repo-name", ghRepo)
+	assert.Equal(t, GitHubHostName, kind)
 
 	bitbucketOwner, bitbucketRepo, kind, err := TryGetVCSInfo("git@bitbucket.org:owner-name/repo-name.git")
 	assert.Nil(t, err)
 
-	assert.Equal(t, bitbucketOwner, "owner-name")
-	assert.Equal(t, bitbucketRepo, "repo-name")
-	assert.Equal(t, kind, "bitbucket.org")
+	assert.Equal(t, "owner-name", bitbucketOwner)
+	assert.Equal(t, "repo-name", bitbucketRepo)
+	assert.Equal(t, "bitbucket.org", kind)
 }
 
 func TestTryGetVCSInfoFromHTTPSRemote(t *testing.T) {
 	glOwner, glRepo, kind, err := TryGetVCSInfo("https://gitlab-ci-token:dummytoken@gitlab.com/owner-name/repo-name.git") //nolint
 	assert.Nil(t, err)
 
-	assert.Equal(t, glOwner, "owner-name")
-	assert.Equal(t, glRepo, "repo-name")
-	assert.Equal(t, kind, GitLabHostName)
+	assert.Equal(t, "owner-name", glOwner)
+	assert.Equal(t, "repo-name", glRepo)
+	assert.Equal(t, GitLabHostName, kind)
 
 	ghOwner, ghRepo, kind, err := TryGetVCSInfo("https://github.com/owner-name/repo-name.git")
 	assert.Nil(t, err)
 
-	assert.Equal(t, ghOwner, "owner-name")
-	assert.Equal(t, ghRepo, "repo-name")
-	assert.Equal(t, kind, GitHubHostName)
+	assert.Equal(t, "owner-name", ghOwner)
+	assert.Equal(t, "repo-name", ghRepo)
+	assert.Equal(t, GitHubHostName, kind)
 
 	bitbucketOwner, bitbucketRepo, kind, err := TryGetVCSInfo("https://ploke@bitbucket.org/owner-name/repo-name.git")
 	assert.Nil(t, err)
 
-	assert.Equal(t, bitbucketOwner, "owner-name")
-	assert.Equal(t, bitbucketRepo, "repo-name")
-	assert.Equal(t, kind, "bitbucket.org")
+	assert.Equal(t, "owner-name", bitbucketOwner)
+	assert.Equal(t, "repo-name", bitbucketRepo)
+	assert.Equal(t, "bitbucket.org", kind)
 }

--- a/pkg/util/gitutil/git_test.go
+++ b/pkg/util/gitutil/git_test.go
@@ -20,9 +20,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	ptesting "github.com/pulumi/pulumi/pkg/testing"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseGitRepoURL(t *testing.T) {
@@ -203,4 +202,37 @@ func createTestRepo(e *ptesting.Environment) {
 
 	e.RunCommand("git", "branch", "my/content")
 	e.RunCommand("git", "tag", "my")
+}
+
+func TestIsGitOriginURLGitLab(t *testing.T) {
+	isGitLab := IsGitOriginURLGitLab("https://gitlab-ci-token:dummytoken@gitlab.com/owner-name/repo-name.git")
+	assert.True(t, isGitLab)
+}
+
+func TestTryGetCloudSourceControlOwnerAndRepoNameFromSSHRemote(t *testing.T) {
+	glOwner, glRepo, err := TryGetCloudSourceControlOwnerAndRepoName("git@gitlab.com:owner-name/repo-name.git")
+	assert.Nil(t, err)
+
+	assert.Equal(t, glOwner, "owner-name")
+	assert.Equal(t, glRepo, "repo-name")
+
+	ghOwner, ghRepo, err := TryGetCloudSourceControlOwnerAndRepoName("git@github.com:owner-name/repo-name.git")
+	assert.Nil(t, err)
+
+	assert.Equal(t, ghOwner, "owner-name")
+	assert.Equal(t, ghRepo, "repo-name")
+}
+
+func TestTryGetCloudSourceControlOwnerAndRepoNameFromHTTPSRemote(t *testing.T) {
+	glOwner, glRepo, err := TryGetCloudSourceControlOwnerAndRepoName("https://gitlab-ci-token:dummytoken@gitlab.com/owner-name/repo-name.git")
+	assert.Nil(t, err)
+
+	assert.Equal(t, glOwner, "owner-name")
+	assert.Equal(t, glRepo, "repo-name")
+
+	ghOwner, ghRepo, err := TryGetCloudSourceControlOwnerAndRepoName("https://github.com/owner-name/repo-name.git")
+	assert.Nil(t, err)
+
+	assert.Equal(t, ghOwner, "owner-name")
+	assert.Equal(t, ghRepo, "repo-name")
 }

--- a/pkg/util/gitutil/git_test.go
+++ b/pkg/util/gitutil/git_test.go
@@ -204,35 +204,48 @@ func createTestRepo(e *ptesting.Environment) {
 	e.RunCommand("git", "tag", "my")
 }
 
-func TestIsGitOriginURLGitLab(t *testing.T) {
-	isGitLab := IsGitOriginURLGitLab("https://gitlab-ci-token:dummytoken@gitlab.com/owner-name/repo-name.git")
-	assert.True(t, isGitLab)
-}
-
-func TestTryGetCloudSourceControlOwnerAndRepoNameFromSSHRemote(t *testing.T) {
-	glOwner, glRepo, err := TryGetCloudSourceControlOwnerAndRepoName("git@gitlab.com:owner-name/repo-name.git")
+func TestTryGetVCSInfoFromSSHRemote(t *testing.T) {
+	glOwner, glRepo, kind, err := TryGetVCSInfo("git@gitlab.com:owner-name/repo-name.git")
 	assert.Nil(t, err)
 
 	assert.Equal(t, glOwner, "owner-name")
 	assert.Equal(t, glRepo, "repo-name")
+	assert.Equal(t, kind, GitLabHostName)
 
-	ghOwner, ghRepo, err := TryGetCloudSourceControlOwnerAndRepoName("git@github.com:owner-name/repo-name.git")
+	ghOwner, ghRepo, kind, err := TryGetVCSInfo("git@github.com:owner-name/repo-name.git")
 	assert.Nil(t, err)
 
 	assert.Equal(t, ghOwner, "owner-name")
 	assert.Equal(t, ghRepo, "repo-name")
+	assert.Equal(t, kind, GitHubHostName)
+
+	bitbucketOwner, bitbucketRepo, kind, err := TryGetVCSInfo("git@bitbucket.org:owner-name/repo-name.git")
+	assert.Nil(t, err)
+
+	assert.Equal(t, bitbucketOwner, "owner-name")
+	assert.Equal(t, bitbucketRepo, "repo-name")
+	assert.Equal(t, kind, "bitbucket.org")
 }
 
-func TestTryGetCloudSourceControlOwnerAndRepoNameFromHTTPSRemote(t *testing.T) {
-	glOwner, glRepo, err := TryGetCloudSourceControlOwnerAndRepoName("https://gitlab-ci-token:dummytoken@gitlab.com/owner-name/repo-name.git") //nolint
+func TestTryGetVCSInfoFromHTTPSRemote(t *testing.T) {
+	glOwner, glRepo, kind, err := TryGetVCSInfo("https://gitlab-ci-token:dummytoken@gitlab.com/owner-name/repo-name.git") //nolint
 	assert.Nil(t, err)
 
 	assert.Equal(t, glOwner, "owner-name")
 	assert.Equal(t, glRepo, "repo-name")
+	assert.Equal(t, kind, GitLabHostName)
 
-	ghOwner, ghRepo, err := TryGetCloudSourceControlOwnerAndRepoName("https://github.com/owner-name/repo-name.git")
+	ghOwner, ghRepo, kind, err := TryGetVCSInfo("https://github.com/owner-name/repo-name.git")
 	assert.Nil(t, err)
 
 	assert.Equal(t, ghOwner, "owner-name")
 	assert.Equal(t, ghRepo, "repo-name")
+	assert.Equal(t, kind, GitHubHostName)
+
+	bitbucketOwner, bitbucketRepo, kind, err := TryGetVCSInfo("https://ploke@bitbucket.org/owner-name/repo-name.git")
+	assert.Nil(t, err)
+
+	assert.Equal(t, bitbucketOwner, "owner-name")
+	assert.Equal(t, bitbucketRepo, "repo-name")
+	assert.Equal(t, kind, "bitbucket.org")
 }

--- a/pkg/util/gitutil/git_test.go
+++ b/pkg/util/gitutil/git_test.go
@@ -247,7 +247,7 @@ func TestTryGetVCSInfoFromSSHRemote(t *testing.T) {
 
 		//Unknown or bad remotes
 		{"", nil},
-		{"dummy", nil},
+		{"asdf", nil},
 		{"svn:something.com/owner/repo", nil},
 	}
 

--- a/pkg/util/gitutil/git_test.go
+++ b/pkg/util/gitutil/git_test.go
@@ -224,7 +224,7 @@ func TestTryGetCloudSourceControlOwnerAndRepoNameFromSSHRemote(t *testing.T) {
 }
 
 func TestTryGetCloudSourceControlOwnerAndRepoNameFromHTTPSRemote(t *testing.T) {
-	glOwner, glRepo, err := TryGetCloudSourceControlOwnerAndRepoName("https://gitlab-ci-token:dummytoken@gitlab.com/owner-name/repo-name.git")
+	glOwner, glRepo, err := TryGetCloudSourceControlOwnerAndRepoName("https://gitlab-ci-token:dummytoken@gitlab.com/owner-name/repo-name.git") //nolint
 	assert.Nil(t, err)
 
 	assert.Equal(t, glOwner, "owner-name")


### PR DESCRIPTION
**Note**: Do not merge yet.

- Fix #2063 
- Added new stack tag constants for GitLab, as well as added new keys for use with `UpdateMetadata`.
- Refactored some of the logic around git repo detection and how we extract metadata from the repo.
- Updated the stack tag manipulation code to use the new way of working with the git repo instead of calling the all encompassing `GetGitHubProjectForOrigin` func from `util/gitutil/git.go`, which always assumed GitHub as the cloud source control provider.
- Also, note that this is just the first part of the change to show metadata for gitlab. The UI needs to be updated to use the metadata keys to build the necessary URLs.