### PR TITLE
Don't error in `pulumi stack output` when there is no root resource

### DIFF
--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -52,9 +52,9 @@ func newStackOutputCmd() *cobra.Command {
 				return err
 			}
 
-			res, outputs := stack.GetRootStackResource(snap)
-			if res == nil || outputs == nil {
-				return errors.New("current stack has no output properties")
+			_, outputs := stack.GetRootStackResource(snap)
+			if outputs == nil {
+				outputs = make(map[string]interface{})
 			}
 
 			// If there is an argument, just print that property.  Else, print them all (similar to `pulumi stack`).


### PR DESCRIPTION
We used to issue an error when you ran `pulumi stack output` for a
stack with with no root resource (e.g. one that hadn't been stood up
yet or one that had been stood up but then destoryed).

Instead, just follow the normal case for a stack that has a root
resource, but has no outputs.

Fixes #2016