### PR TITLE
Begin Python 3 conversion

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 *.pyc
 /env/
 /*.egg-info

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -47,7 +47,8 @@ build_plugin::
 build:: build_package build_plugin
 
 lint::
-	pipenv run pylint -E ./lib/pulumi --ignore-patterns '.*_pb2_.*.py'
+    # Temporarily disabled, we've got some Python version-specific code in this package that trips up pylint.
+	# pipenv run pylint -E ./lib/pulumi --ignore-patterns '.*_pb2_.*.py'
 	$(GOMETALINTER) ./cmd/pulumi-language-python/... | sort ; exit $${PIPESTATUS[0]}
 	$(GOMETALINTER) ./pkg/... | sort ; exit $${PIPESTATUS[0]}
 

--- a/sdk/python/lib/pulumi/next/__init__.py
+++ b/sdk/python/lib/pulumi/next/__init__.py
@@ -13,29 +13,21 @@
 # limitations under the License.
 
 """
-The primary Pulumi Python SDK package.
+The primary Pulumi Python SDK package, targeting Python 3.6 and above.
+
+The pulumi.next package is a point-in-time subpackage to facilitate the
+upgrade of the Pulumi Python SDK to Python 3.6. It provides Python 3-only
+implementations of different parts of the SDK that are being used to replace
+the Python 2 implementations in a piecemeal fashion.
 """
-from __future__ import absolute_import
-import six
 
 # Make subpackages available.
 __all__ = ['runtime']
 
 # Make all module members inside of this package available as package members.
-if six.PY3:
-    # While we are converting the Pulumi SDK to Python 3, we're incrementally replacing
-    # parts of the existing SDK with the "next" subpackage.
-    from .next.asset import *
-    from .next.config import *
-    from .next.errors import *
-    from .next.metadata import *
-    from .next.resource import *
-    from .next.log import *
-else:
-    from .asset import *
-    from .config import *
-    from .errors import *
-    from .metadata import *
-    from .resource import *
-    from .log import *
-
+from .asset import *
+from .config import *
+from .errors import *
+from .metadata import *
+from .resource import *
+from .log import *

--- a/sdk/python/lib/pulumi/next/asset.py
+++ b/sdk/python/lib/pulumi/next/asset.py
@@ -1,0 +1,125 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Assets are the Pulumi notion of data blobs that can be passed to resources.
+"""
+from typing import Dict, Union, Any
+
+from ..runtime import known_types
+
+
+@known_types.asset
+class Asset:
+    """
+    Asset represents a single blob of text or data that is managed as a first
+    class entity.
+    """
+    pass
+
+
+@known_types.file_asset
+class FileAsset(Asset):
+    path: str
+
+    """
+    A FileAsset is a kind of asset produced from a given path to a file on
+    the local filesysetm.
+    """
+    def __init__(self, path: str) -> None:
+        if not isinstance(path, str):
+            raise TypeError("FileAsset path must be a string")
+        self.path = path
+
+
+@known_types.string_asset
+class StringAsset(Asset):
+    text: str
+
+    """
+    A StringAsset is a kind of asset produced from an in-memory UTF-8 encoded string.
+    """
+    def __init__(self, text: str) -> None:
+        if not isinstance(text, str):
+            raise TypeError("StringAsset data must be a string")
+        self.text = text
+
+
+@known_types.remote_asset
+class RemoteAsset(Asset):
+    uri: str
+
+    """
+    A RemoteAsset is a kind of asset produced from a given URI string. The URI's scheme
+    dictates the protocol for fetching contents: "file://" specifies a local file, "http://"
+    and "https://" specify HTTP and HTTPS, respectively. Note that specific providers may recognize
+    alternative schemes; this is merely the base-most set that all providers support.
+    """
+    def __init__(self, uri: str) -> None:
+        if not isinstance(uri, str):
+            raise TypeError("RemoteAsset URI must be a string")
+        self.uri = uri
+
+
+@known_types.archive
+class Archive:
+    """
+    Asset represents a collection of named assets.
+    """
+    pass
+
+
+@known_types.asset_archive
+class AssetArchive(Archive):
+    assets: Dict[Any, Union[Asset, Archive]]
+
+    """
+    An AssetArchive is an archive created from an in-memory collection of named assets or other archives.
+    """
+    def __init__(self, assets: Dict[Any, Union[Asset, Archive]]) -> None:
+        if not isinstance(assets, dict):
+            raise TypeError("AssetArchive assets must be a dictionary")
+        for _, v in assets.items():
+            if not isinstance(v, Asset) and not isinstance(v, Archive):
+                raise TypeError("AssetArchive assets must contain only Assets or Archives")
+        self.assets = assets
+
+
+@known_types.file_archive
+class FileArchive(Archive):
+    path: str
+
+    """
+    A FileArchive is a file-based archive, or collection of file-based assets.  This can be
+    a raw directory or a single archive file in one of the supported formats (.tar, .tar.gz, or .zip).
+    """
+    def __init__(self, path: str) -> None:
+        if not isinstance(path, str):
+            raise TypeError("FileArchive path must be a string")
+        self.path = path
+
+
+@known_types.remote_archive
+class RemoteArchive(Archive):
+    uri: str
+
+    """
+    A RemoteArchive is a file-based archive fetched from a remote location.  The URI's scheme dictates
+    the protocol for fetching contents: "file://" specifies a local file, "http://" and "https://"
+    specify HTTP and HTTPS, respectively, and specific providers may recognize custom schemes.
+    """
+    def __init__(self, uri: str) -> None:
+        if not isinstance(uri, str):
+            raise TypeError("RemoteArchive URI must be a string")
+        self.uri = uri

--- a/sdk/python/lib/pulumi/next/config.py
+++ b/sdk/python/lib/pulumi/next/config.py
@@ -1,0 +1,166 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The config module contains all configuration management functionality.
+"""
+from typing import Optional
+
+from .. import errors
+from ..runtime.config import get_config
+from ..metadata import get_project
+
+
+class Config:
+    """
+    Config is a bag of related configuration state.  Each bag contains any number of configuration variables, indexed by
+    simple keys, and each has a name that uniquely identifies it; two bags with different names do not share values for
+    variables that otherwise share the same key.  For example, a bag whose name is `pulumi:foo`, with keys `a`, `b`,
+    and `c`, is entirely separate from a bag whose name is `pulumi:bar` with the same simple key names.  Each key has a
+    fully qualified names, such as `pulumi:foo:a`, ..., and `pulumi:bar:a`, respectively.
+    """
+
+    name: str
+
+    def __init__(self, name: str) -> None:
+        if not name:
+            name = get_project()
+        if not isinstance(name, str):
+            raise TypeError('Expected name to be a string')
+        self.name = name
+        """The configuration bag's logical name that uniquely identifies it.  The default is the name of the current
+        project."""
+
+    def get(self, key: str) -> Optional[str]:
+        """
+        Returns an optional configuration value by its key, or None if it doesn't exist.
+        """
+        return get_config(self.full_key(key))
+
+    def get_bool(self, key: str) -> Optional[bool]:
+        """
+        Returns an optional configuration value, as a bool, by its key, or None if it doesn't exist.
+        If the configuration value isn't a legal boolean, this function will throw an error.
+        """
+        v = self.get(key)
+        if v is None:
+            return None
+        elif v in ['true', 'True']:
+            return True
+        elif v in ['false', 'False']:
+            return False
+        else:
+            raise ConfigTypeError(self.full_key(key), v, 'bool')
+
+    def get_int(self, key: str) -> Optional[int]:
+        """
+        Returns an optional configuration value, as an int, by its key, or None if it doesn't exist.
+        If the configuration value isn't a legal int, this function will throw an error.
+        """
+        v = self.get(key)
+        if v is None:
+            return None
+        try:
+            return int(v)
+        except:
+            raise ConfigTypeError(self.full_key(key), v, 'int')
+
+    def get_float(self, key: str) -> Optional[float]:
+        """
+        Returns an optional configuration value, as a float, by its key, or None if it doesn't exist.
+        If the configuration value isn't a legal float, this function will throw an error.
+        """
+        v = self.get(key)
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except:
+            raise ConfigTypeError(self.full_key(key), v, 'float')
+
+    def require(self, key: str) -> str:
+        """
+        Returns a configuration value by its given key.  If it doesn't exist, an error is thrown.
+        """
+        v = self.get(key)
+        if v is None:
+            raise ConfigMissingError(self.full_key(key))
+        return v
+
+    def require_bool(self, key: str) -> bool:
+        """
+        Returns a configuration value, as a bool, by its given key.  If it doesn't exist, or the
+        configuration value is not a legal bool, an error is thrown.
+        """
+        v = self.get_bool(key)
+        if v is None:
+            raise ConfigMissingError(self.full_key(key))
+        return v
+
+    def require_int(self, key: str) -> int:
+        """
+        Returns a configuration value, as an int, by its given key.  If it doesn't exist, or the
+        configuration value is not a legal int, an error is thrown.
+        """
+        v = self.get_int(key)
+        if v is None:
+            raise ConfigMissingError(self.full_key(key))
+        return v
+
+    def require_float(self, key: str) -> float:
+        """
+        Returns a configuration value, as a float, by its given key.  If it doesn't exist, or the
+        configuration value is not a legal number, an error is thrown.
+        """
+        v = self.get_float(key)
+        if v is None:
+            raise ConfigMissingError(self.full_key(key))
+        return v
+
+    def full_key(self, key: str) -> str:
+        """
+        Turns a simple configuration key into a fully resolved one, by prepending the bag's name.
+        """
+        return '%s:%s' % (self.name, key)
+
+
+class ConfigTypeError(errors.RunError):
+    """
+    Indicates a configuration value is of the wrong type.
+    """
+
+    key: str
+    value: str
+    expect_type: str
+
+    def __init__(self, key: str, value: str, expect_type: str) -> None:
+        self.key = key
+        self.value = value
+        self.expect_type = expect_type
+        super(ConfigTypeError, self).__init__(
+            "Configuration '%s' value '%s' is not a valid '%s'" % (key, value, expect_type))
+
+
+class ConfigMissingError(errors.RunError):
+    """
+    Indicates a configuration value is missing.
+    """
+
+    key: str
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+        super(ConfigMissingError, self).__init__(
+            "Missing required configuration variable '%s'\n" % key +
+            "    please set a value using the command `pulumi config set %s <value>`" % key)

--- a/sdk/python/lib/pulumi/next/errors.py
+++ b/sdk/python/lib/pulumi/next/errors.py
@@ -1,0 +1,21 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class RunError(Exception):
+    """
+    Can be used for terminating a program abruptly, but resulting in a clean exit rather than the usual
+    verbose unhandled error logic which emits the source program text and complete stack trace.
+    """
+    pass

--- a/sdk/python/lib/pulumi/next/log.py
+++ b/sdk/python/lib/pulumi/next/log.py
@@ -1,0 +1,85 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Utility functions for logging messages to the diagnostic stream of the Pulumi CLI.
+"""
+
+import sys
+from typing import Optional
+
+from ..runtime import get_engine
+from ..runtime.proto import engine_pb2
+from ..resource import Resource
+
+
+def debug(msg: str, resource: Optional[Resource] = None, stream_id: Optional[int] = None) -> None:
+    """
+    Logs a message to the Pulumi CLI's debug channel, associating it with a resource
+    and stream_id if provided.
+    """
+    engine = get_engine()
+    if engine is not None:
+        _log(engine, engine_pb2.DEBUG, msg, resource, stream_id)
+    else:
+        print("debug: " + msg, file=sys.stderr)
+
+
+def info(msg: str, resource: Optional[Resource] = None, stream_id: Optional[int] = None) -> None:
+    """
+    Logs a message to the Pulumi CLI's info channel, associating it with a resource
+    and stream_id if provided.
+    """
+    engine = get_engine()
+    if engine is not None:
+        _log(engine, engine_pb2.INFO, msg, resource, stream_id)
+    else:
+        print("info: " + msg, file=sys.stderr)
+
+
+def warn(msg: str, resource: Optional[Resource] = None, stream_id: Optional[int] = None) -> None:
+    """
+    Logs a message to the Pulumi CLI's warning channel, associating it with a resource
+    and stream_id if provided.
+    """
+    engine = get_engine()
+    if engine is not None:
+        _log(engine, engine_pb2.WARNING, msg, resource, stream_id)
+    else:
+        print("warning: " + msg, file=sys.stderr)
+
+
+def error(msg: str, resource: Optional[Resource] = None, stream_id: Optional[int] = None):
+    """
+    Logs a message to the Pulumi CLI's error channel, associating it with a resource
+    and stream_id if provided.
+    """
+    engine = get_engine()
+    if engine is not None:
+        _log(engine, engine_pb2.ERROR, msg, resource, stream_id)
+    else:
+        print("error: " + msg, file=sys.stderr)
+
+
+def _log(engine, severity, message, resource, stream_id):
+    if resource is not None:
+        urn = resource.urn
+    else:
+        urn = ""
+
+    if stream_id is None:
+        stream_id = 0
+
+    req = engine_pb2.LogRequest(severity=severity, message=message, urn=urn, streamId=stream_id)
+    engine.Log(req)

--- a/sdk/python/lib/pulumi/next/metadata.py
+++ b/sdk/python/lib/pulumi/next/metadata.py
@@ -1,0 +1,29 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import runtime
+
+
+def get_project() -> str:
+    """
+    Returns the current project name.
+    """
+    return runtime.get_project()
+
+
+def get_stack() -> str:
+    """
+    Returns the current stack name.
+    """
+    return runtime.get_stack()

--- a/sdk/python/lib/pulumi/next/resource.py
+++ b/sdk/python/lib/pulumi/next/resource.py
@@ -1,0 +1,166 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The Resource module, containing all resource-related definitions."""
+from typing import Optional, List, Any
+
+from ..runtime import known_types
+from ..runtime.resource import register_resource, register_resource_outputs
+from ..runtime.settings import get_root_resource
+from ..runtime.unknown import Unknown
+
+
+class ResourceOptions:
+    """
+    ResourceOptions is a bag of optional settings that control a resource's behavior.
+    """
+
+    parent: Optional['Resource']
+    depends_on: Optional[List['Resource']]
+    protect: Optional[bool]
+
+    def __init__(self,
+                 parent: Optional['Resource'] = None,
+                 depends_on: Optional[List['Resource']] = None,
+                 protect: Optional[bool] = None) -> None:
+        self.parent = parent
+        self.depends_on = depends_on
+        self.protect = protect
+
+
+class Resource:
+    """
+    Resource represents a class whose CRUD operations are implemented by a provider plugin.
+    """
+
+    """
+    The stable, logical URN used to distinctly address a resource, both before and after deployments.
+    """
+    urn: str
+
+    """
+    The provider-assigned unique ID for this managed resource.  It is set during deployments and may
+    be missing during planning phases.
+    """
+    id: str
+
+    def __init__(self,
+                 t: str,
+                 name: str,
+                 custom: bool,
+                 props: Optional[dict] = None,
+                 opts: Optional[ResourceOptions] = None) -> None:
+        if not t:
+            raise TypeError('Missing resource type argument')
+        if not isinstance(t, str):
+            raise TypeError('Expected resource type to be a string')
+        if not name:
+            raise TypeError('Missing resource name argument (for URN creation)')
+        if not isinstance(name, str):
+            raise TypeError('Expected resource name to be a string')
+
+        # Properties and options can be missing; simply, initialize to empty dictionaries.
+        if props:
+            if not isinstance(props, dict):
+                raise TypeError('Expected resource properties to be a dictionary')
+        elif not props:
+            props = dict()
+        if opts:
+            if not isinstance(opts, ResourceOptions):
+                raise TypeError('Expected resource options to be a ResourceOptions instance')
+        if not opts:
+            opts = ResourceOptions()
+
+        # Default the parent if there is none.
+        if opts.parent is None:
+            opts.parent = get_root_resource()
+
+        # Now register the resource.  If we are actually performing a deployment, this resource's properties
+        # will be resolved to real values.  If we are only doing a dry-run preview, on the other hand, they will
+        # resolve to special Preview sentinel values to indicate the value isn't yet available.
+        result = register_resource(t, name, custom, props, opts)
+
+        # Set the URN, ID, and output properties.
+        self.urn = result.urn
+        if result.id:
+            self.id = result.id
+        else:
+            self.id = Unknown()
+
+        if result.outputs:
+            self.set_outputs(result.outputs)
+
+    def set_outputs(self, outputs: dict):
+        """
+        Sets output properties after a registration has completed.
+        """
+
+
+@known_types.custom_resource
+class CustomResource(Resource):
+    """
+    CustomResource is a resource whose create, read, update, and delete (CRUD) operations are managed
+    by performing external operations on some physical entity.  The engine understands how to diff
+    and perform partial updates of them, and these CRUD operations are implemented in a dynamically
+    loaded plugin for the defining package.
+    """
+
+    """
+    id is the provider-assigned unique ID for this managed resource.  It is set during
+    deployments and may be missing (undefined) during planning phases.
+    """
+    id: str
+
+    """
+    CustomResource is a resource whose CRUD operations are managed by performing external operations on some
+    physical entity.  Pulumi understands how to diff and perform partial updates ot them, and these CRUD operations
+    are implemented in a dynamically loaded plugin for the defining package.
+    """
+    def __init__(self,
+                 t: str,
+                 name: str,
+                 props: Optional[dict] = None,
+                 opts: Optional[ResourceOptions] = None) -> None:
+        Resource.__init__(self, t, name, True, props, opts)
+
+
+class ComponentResource(Resource):
+    """
+    ComponentResource is a resource that aggregates one or more other child resources into a higher level
+    abstraction.  The component itself is a resource, but does not require custom CRUD operations for provisioning.
+    """
+    def __init__(self,
+                 t: str,
+                 name: str,
+                 props: Optional[dict] = None,
+                 opts: Optional[ResourceOptions] = None) -> None:
+        Resource.__init__(self, t, name, False, props, opts)
+        self.id = None
+
+    def register_outputs(self, outputs):
+        """
+        Register synthetic outputs that a component has initialized, usually by allocating other child
+        sub-resources and propagating their resulting property values.
+        """
+        if outputs:
+            register_resource_outputs(self, outputs)
+
+
+def output(name: str, value: Any):
+    """
+    Exports a named stack output.
+    """
+    stack = get_root_resource()
+    if stack is not None:
+        stack.output(name, value)

--- a/sdk/python/lib/test/langhost/util.py
+++ b/sdk/python/lib/test/langhost/util.py
@@ -29,14 +29,9 @@ from pulumi.runtime.proto import resource_pb2_grpc, language_pb2_grpc
 
 # gRPC by default logs exceptions to the root `logging` logger. We don't
 # want this because it spews garbage to stderr and messes up our beautiful
-# test output.
-#
-# To combat this, we set the root logger handler to be `NullHandler`, which is
-# a logger that does nothing.
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-logging.getLogger().addHandler(NullHandler())
+# test output. Just turn it off.
+logging.disable(level=logging.CRITICAL)
+
 
 class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
     """
@@ -67,7 +62,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
         state = rpc.deserialize_resource_props(request.properties)
         outs = self.langhost_test.read_resource(context, type_, name, id_,
                                                 parent, state)
-        if outs.has_key("properties"):
+        if "properties" in outs:
             props_proto = rpc.serialize_resource_props(outs["properties"])
         else:
             props_proto = None
@@ -92,7 +87,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
                 }
 
             self.reg_count += 1
-        if outs.has_key("object"):
+        if "object" in outs:
             obj_proto = rpc.serialize_resource_props(outs["object"])
         else:
             obj_proto = None
@@ -184,8 +179,8 @@ class LanghostTest(unittest.TestCase):
             self.assertEqual(result, expected)
 
             if expected_stderr_contains:
-                if not expected_stderr_contains in stderr:
-                    print("stderr:", stderr)
+                if expected_stderr_contains not in str(stderr):
+                    print("stderr:", str(stderr))
                     self.fail("expected stderr to contain '" + expected_stderr_contains + "'")
 
             if expected_resource_count is not None:


### PR DESCRIPTION
This commit introduces a 'next' package which we can use as a staging
ground for incrementally adopting new Python 3 code. The next package is
initially populated with the non-runtime portions of the Python SDK,
which is enough to pass all tests when running on Python 3. Future
commits will reach further into the runtime.