### PR TITLE
Implement Output for Python 3

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.mypy_cache/
 *.pyc
 /env/
 /*.egg-info

--- a/sdk/python/lib/pulumi/next/output.py
+++ b/sdk/python/lib/pulumi/next/output.py
@@ -1,0 +1,157 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+from inspect import isawaitable
+from typing import (
+    TypeVar,
+    Generic,
+    Set,
+    Callable,
+    Awaitable,
+    Union,
+    cast,
+    Mapping,
+    Any,
+    TYPE_CHECKING
+)
+
+from . import runtime
+if TYPE_CHECKING:
+    from .resource import Resource
+
+T = TypeVar('T')
+U = TypeVar('U')
+
+Input = Union[T, Awaitable[T], 'Output[T]']
+Inputs = Mapping[str, Input[Any]]
+
+
+class Output(Generic[T]):
+    """
+    Output helps encode the relationship between Resources in a Pulumi application. Specifically an
+    Output holds onto a piece of Data and the Resource it was generated from. An Output value can
+    then be provided when constructing new Resources, allowing that new Resource to know both the
+    value as well as the Resource the value came from.  This allows for a precise 'Resource
+    dependency graph' to be created, which properly tracks the relationship between resources.
+    """
+
+    _is_known: Awaitable[bool]
+    """
+    Whether or not this 'Output' should actually perform .apply calls.  During a preview,
+    an Output value may not be known (because it would have to actually be computed by doing an
+    'update').  In that case, we don't want to perform any .apply calls as the callbacks
+    may not expect an undefined value.  So, instead, we just transition to another Output
+    value that itself knows it should not perform .apply calls.
+    """
+
+    _future: Awaitable[T]
+    """
+    Future that actually produces the concrete value of this output.
+    """
+
+    _resources: Set[Resource]
+    """
+    The list of resources that this output value depends on.
+    """
+
+    def __init__(self, resources: Set[Resource], future: Awaitable[T], is_known: Awaitable[bool]) -> None:
+        self._resources = resources
+        self._future = future
+        self._is_known = is_known
+
+    def resources(self) -> Set[Resource]:
+        return self._resources
+
+    def future(self) -> Awaitable[T]:
+        return self._future
+
+    def apply(self, func: Callable[[T], Input[U]]) -> 'Output[U]':
+        """
+        Transforms the data of the output with the provided func.  The result remains a
+        Output so that dependent resources can be properly tracked.
+
+        'func' is not allowed to make resources.
+
+        'func' can return other Outputs.  This can be handy if you have a Output<SomeVal>
+        and you want to get a transitive dependency of it.  i.e.
+        ```python
+        d1: Output[SomeVal];
+        d2 = d1.apply(lambda x: v.x.y.OtherOutput); # getting an output off of 'v'.
+        (or, equivalently:)
+        d2 = d1.x.y.OtherOutput
+        ```
+
+        In this example, taking a dependency on d2 means a resource will depend on all the resources
+        of d1.  It will *not* depend on the resources of v.x.y.OtherDep.
+
+        Importantly, the Resources that d2 feels like it will depend on are the same resources as d1.
+        If you need have multiple Outputs and a single Output is needed that combines both
+        set of resources, then 'pulumi.all' should be used instead.
+
+        This function will only be called execution of a 'pulumi update' request.  It will not run
+        during 'pulumi preview' (as the values of resources are of course not known then).
+        """
+        inner_is_known: asyncio.Future = asyncio.Future()
+
+        # The "is_known" coroutine that we pass to the output we're about to create is derived from
+        # the conjunction of the two is_knowns that we know about: our own (self._is_known) and a future
+        # that we will resolve when running the apply.
+        async def is_known() -> bool:
+            inner = await inner_is_known
+            known = await self._is_known
+            return inner and known
+
+        # The "run" coroutine actually runs the apply.
+        async def run() -> U:
+            try:
+                value = await self._future
+                if runtime.is_dry_run():
+                    # During previews only perform the apply if the engine was able to
+                    # give us an actual value for this Output.
+                    apply_during_preview = await self._is_known
+                    if not apply_during_preview:
+                        # We didn't actually run the function, our new Output is definitely
+                        # **not** known.
+                        inner_is_known.set_result(False)
+                        return cast(U, None)
+
+                transformed: Input[U] = func(value)
+                # Transformed is an Input, meaning there are three cases:
+                #  1. transformed is an Output[U]
+                if isinstance(transformed, Output):
+                    # The inner Output is known if this returned output is known.
+                    inner_is_known.set_result(await self._is_known)
+                    return await transformed.future()
+
+                #  2. transformed is an Awaitable[U]
+                if isawaitable(transformed):
+                    # The inner Output is known.
+                    inner_is_known.set_result(True)
+                    return await cast(Awaitable[U], transformed)
+
+                #  3. transformed is U. It is trivially known.
+                inner_is_known.set_result(True)
+                return cast(U, transformed)
+            finally:
+                # Always resolve the future if it hasn't been done already.
+                if not inner_is_known.done():
+                    inner_is_known.set_result(False)
+
+        return Output(self._resources, run(), is_known())
+
+    def __getattribute__(self, item: str) -> 'Output[Any]':
+        """
+        Syntax sugar for retrieving attributes off of outputs.
+        """
+        return self.apply(lambda v: getattr(v, item))

--- a/sdk/python/lib/pulumi/next/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/next/runtime/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The runtime implementation of the Pulumi Python SDK.
+"""
+
+from .config import *
+from .known_types import *
+from .settings import *
+from .stack import *

--- a/sdk/python/lib/pulumi/next/runtime/config.py
+++ b/sdk/python/lib/pulumi/next/runtime/config.py
@@ -1,0 +1,78 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Runtime support for the Pulumi configuration system.  Please use pulumi.Config instead.
+"""
+from typing import Dict, Any
+
+import json
+import os
+
+# default to an empty map for config.
+CONFIG: Dict[str, Any] = dict()
+
+
+def set_config(k: str, v: Any):
+    """
+    Sets a configuration variable.  Meant for internal use only.
+    """
+    CONFIG[k] = v
+
+
+def get_config_env() -> Dict[str, Any]:
+    """
+    Returns the environment map that will be used for config checking when variables aren't set.
+    """
+    if 'PULUMI_CONFIG' in os.environ:
+        env_config = os.environ['PULUMI_CONFIG']
+        return json.loads(env_config)
+    return dict()
+
+
+def get_config_env_key(k: str) -> str:
+    """
+    Returns a scrubbed environment variable key, PULUMI_CONFIG_<k>, that can be used for
+    setting explicit varaibles.  This is unlike PULUMI_CONFIG which is just a JSON-serialized bag.
+    """
+    env_key = ''
+    for c in k:
+        if c == '_' or 'A' <= c <= 'Z' or '0' <= c <= '9':
+            env_key += c
+        elif 'a' <= c <= 'z':
+            env_key += c.upper()
+        else:
+            env_key += '_'
+    return 'PULUMI_CONFIG_%s' % env_key
+
+
+def get_config(k: str) -> Any:
+    """
+    Returns a configuration variable's value or None if it is unset.
+    """
+    # If the config has been set explicitly, use it.
+    if k in list(CONFIG.keys()):
+        return CONFIG[k]
+
+    # If there is a specific PULUMI_CONFIG_<k> environment variable, use it.
+    env_key = get_config_env_key(k)
+    if env_key in os.environ:
+        return os.environ[env_key]
+
+    # If the config hasn't been set, but there is a process-wide PULUMI_CONFIG environment variable, use it.
+    env_dict = get_config_env()
+    if env_dict is not None and k in list(env_dict.keys()):
+        return env_dict[k]
+
+    return None

--- a/sdk/python/lib/pulumi/next/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/next/runtime/known_types.py
@@ -1,0 +1,222 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+The known_types module contains state for keeping track of types that
+are known to be special in the Pulumi type system.
+
+Python strictly disallows circular references between imported packages.
+Because the Pulumi top-level module depends on the `pulumi.runtime` submodule,
+it is not allowed for `pulumi.runtime` to reach back to the `pulumi` top-level
+to reference types that are defined there.
+
+In order to break this circular reference, and to be clear about what types
+the runtime knows about and treats specially, this module exports a number of
+"known type" decorators that can be applied to types in `pulumi` to indicate
+that they are specially treated.
+
+The implementation of this mechanism is that, for every known type, that type
+is stashed away in a global variable. Whenever the runtime wants to do a type
+test using that type (or instantiate an instance of this type), it uses the
+functions defined in this module to do so.
+"""
+from typing import Any, Optional
+
+_custom_resource_type: Optional[type] = None
+"""The type of CustomResource. Filled-in as the Pulumi package is initializing."""
+
+_asset_resource_type: Optional[type] = None
+"""The type of Asset. Filled-in as the Pulumi package is initializing."""
+
+_file_asset_resource_type: Optional[type] = None
+"""The type of FileAsset. Filled-in as the Pulumi package is initializing."""
+
+_string_asset_resource_type: Optional[type] = None
+"""The type of StringAsset. Filled-in as the Pulumi package is initializing."""
+
+_remote_asset_resource_type: Optional[type] = None
+"""The type of RemoteAsset. Filled-in as the Pulumi package is initializing."""
+
+_archive_resource_type: Optional[type] = None
+"""The type of Archive. Filled-in as the Pulumi package is initializing."""
+
+_asset_archive_resource_type: Optional[type] = None
+"""The type of AssetArchive. Filled-in as the Pulumi package is initializing."""
+
+_file_archive_resource_type: Optional[type] = None
+"""The type of FileArchive. Filled-in as the Pulumi package is initializing."""
+
+_remote_archive_resource_type: Optional[type] = None
+"""The type of RemoteArchive. Filled-in as the Pulumi package is initializing."""
+
+
+def asset(class_obj: type) -> type:
+    """
+    Decorator to annotate the Asset class. Registers the decorated class
+    as the Asset known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _asset_resource_type
+    _asset_resource_type = class_obj
+    return class_obj
+
+
+def file_asset(class_obj: type) -> type:
+    """
+    Decorator to annotate the FileAsset class. Registers the decorated class
+    as the FileAsset known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _file_asset_resource_type
+    _file_asset_resource_type = class_obj
+    return class_obj
+
+
+def string_asset(class_obj: type) -> type:
+    """
+    Decorator to annotate the StringAsset class. Registers the decorated class
+    as the StringAsset known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _string_asset_resource_type
+    _string_asset_resource_type = class_obj
+    return class_obj
+
+
+def remote_asset(class_obj: type) -> type:
+    """
+    Decorator to annotate the RemoteAsset class. Registers the decorated class
+    as the RemoteAsset known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _remote_asset_resource_type
+    _remote_asset_resource_type = class_obj
+    return class_obj
+
+
+def archive(class_obj: type) -> type:
+    """
+    Decorator to annotate the Archive class. Registers the decorated class
+    as the Archive known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _archive_resource_type
+    _archive_resource_type = class_obj
+    return class_obj
+
+
+def asset_archive(class_obj: type) -> type:
+    """
+    Decorator to annotate the AssetArchive class. Registers the decorated class
+    as the AssetArchive known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _asset_archive_resource_type
+    _asset_archive_resource_type = class_obj
+    return class_obj
+
+
+def file_archive(class_obj: type) -> type:
+    """
+    Decorator to annotate the FileArchive class. Registers the decorated class
+    as the FileArchive known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _file_archive_resource_type
+    _file_archive_resource_type = class_obj
+    return class_obj
+
+
+def remote_archive(class_obj: type) -> type:
+    """
+    Decorator to annotate the RemoteArchive class. Registers the decorated class
+    as the RemoteArchive known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _remote_archive_resource_type
+    _remote_archive_resource_type = class_obj
+    return class_obj
+
+
+def custom_resource(class_obj: type) -> type:
+    """
+    Decorator to annotate the CustomResource class. Registers the decorated class
+    as the CustomResource known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _custom_resource_type
+    _custom_resource_type = class_obj
+    return class_obj
+
+
+def new_file_asset(*args: Any) -> Any:
+    """
+    Instantiates a new FileAsset, passing the given arguments to the constructor.
+    """
+    return _file_asset_resource_type(*args)
+
+
+def new_string_asset(*args: Any) -> Any:
+    """
+    Instantiates a new StringAsset, passing the given arguments to the constructor.
+    """
+    return _string_asset_resource_type(*args)
+
+
+def new_remote_asset(*args: Any) -> Any:
+    """
+    Instantiates a new StringAsset, passing the given arguments to the constructor.
+    """
+    return _remote_asset_resource_type(*args)
+
+
+def new_asset_archive(*args: Any) -> Any:
+    """
+    Instantiates a new AssetArchive, passing the given arguments to the constructor.
+    """
+    return _asset_archive_resource_type(*args)
+
+
+def new_file_archive(*args: Any) -> Any:
+    """
+    Instantiates a new FileArchive, passing the given arguments to the constructor.
+    """
+    return _file_archive_resource_type(*args)
+
+
+def new_remote_archive(*args: Any) -> Any:
+    """
+    Instantiates a new StringArchive, passing the given arguments to the constructor.
+    """
+    return _remote_archive_resource_type(*args)
+
+
+def is_asset(obj: Any) -> bool:
+    """
+    Returns true if the given type is an Asset, false otherwise.
+    """
+    return _asset_resource_type is not None and isinstance(obj, _asset_resource_type)
+
+
+def is_archive(obj: Any) -> bool:
+    """
+    Returns true if the given type is an Archive, false otherwise.
+    """
+    return _archive_resource_type is not None and isinstance(obj, _archive_resource_type)
+
+
+def is_custom_resource(obj: Any) -> bool:
+    """
+    Returns true if the given type is a CustomResource, false otherwise.
+    """
+    return _custom_resource_type is not None and isinstance(obj, _custom_resource_type)

--- a/sdk/python/lib/pulumi/next/runtime/settings.py
+++ b/sdk/python/lib/pulumi/next/runtime/settings.py
@@ -1,0 +1,129 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Runtime settings and configuration.
+"""
+from typing import Optional
+
+import grpc
+from ...runtime.proto import engine_pb2_grpc, resource_pb2_grpc
+from ..errors import RunError
+from ..resource import Resource
+
+
+class Settings:
+    monitor: Optional[resource_pb2_grpc.ResourceMonitorStub]
+    engine: Optional[engine_pb2_grpc.EngineStub]
+    project: Optional[str]
+    stack: Optional[str]
+    parallel: Optional[str]
+    dry_run: Optional[bool]
+
+    """
+    A bag of properties for configuring the Pulumi Python language runtime.
+    """
+    def __init__(self,
+                 monitor: Optional[str] = None,
+                 engine: Optional[str] = None,
+                 project: Optional[str] = None,
+                 stack: Optional[str] = None,
+                 parallel: Optional[str] = None,
+                 dry_run: Optional[bool] = None):
+        # Save the metadata information.
+        self.project = project
+        self.stack = stack
+        self.parallel = parallel
+        self.dry_run = dry_run
+
+        # Actually connect to the monitor/engine over gRPC.
+        if monitor:
+            self.monitor = resource_pb2_grpc.ResourceMonitorStub(grpc.insecure_channel(monitor))
+        else:
+            self.monitor = None
+        if engine:
+            self.engine = engine_pb2_grpc.EngineStub(grpc.insecure_channel(engine))
+        else:
+            self.engine = None
+
+
+# default to "empty" settings.
+SETTINGS = Settings()
+
+
+def configure(settings: Settings):
+    """
+    Configure sets the current ambient settings bag to the one given.
+    """
+    if not settings or not isinstance(settings, Settings):
+        raise TypeError('Settings is expected to be non-None and of type Settings')
+    global SETTINGS  # pylint: disable=global-statement
+    SETTINGS = settings
+
+
+def is_dry_run() -> bool:
+    """
+    Returns whether or not we are currently doing a preview.
+    """
+    return True if SETTINGS.dry_run else False
+
+
+def get_project() -> Optional[str]:
+    """
+    Returns the current project name.
+    """
+    return SETTINGS.project
+
+
+def get_stack() -> Optional[str]:
+    """
+    Returns the current stack name.
+    """
+    return SETTINGS.stack
+
+
+def get_monitor() -> Optional[resource_pb2_grpc.ResourceMonitorStub]:
+    """
+    Returns the current resource monitoring service client for RPC communications.
+    """
+    monitor = SETTINGS.monitor
+    if not monitor:
+        raise RunError('Pulumi program not connected to the engine -- are you running with the `pulumi` CLI?')
+    return monitor
+
+
+def get_engine() -> Optional[engine_pb2_grpc.EngineStub]:
+    """
+    Returns the current engine service client for RPC communications.
+    """
+    return SETTINGS.engine
+
+
+ROOT: Optional[Resource] = None
+
+
+def get_root_resource() -> Optional[Resource]:
+    """
+    Returns the implicit root stack resource for all resources created in this program.
+    """
+    global ROOT
+    return ROOT
+
+
+def set_root_resource(root: Resource):
+    """
+    Sets the current root stack resource for all resources subsequently to be created in this program.
+    """
+    global ROOT
+    ROOT = root

--- a/sdk/python/lib/pulumi/next/runtime/stack.py
+++ b/sdk/python/lib/pulumi/next/runtime/stack.py
@@ -1,0 +1,62 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Support for automatic stack components.
+"""
+from typing import Callable, Any, Dict
+
+from ..resource import ComponentResource
+from .settings import get_project, get_stack, get_root_resource, set_root_resource
+
+
+def run_in_stack(func: Callable):
+    """
+    Run the given function inside of a new stack resource.  This ensures that any stack export calls will end
+    up as output properties on the resulting stack component in the checkpoint file.  This is meant for internal
+    runtime use only and is used by the Python SDK entrypoint program.
+    """
+    Stack(func)
+
+
+class Stack(ComponentResource):
+    """
+    A synthetic stack component that automatically parents resources as the program runs.
+    """
+
+    outputs: Dict[str, Any]
+
+    def __init__(self, func: Callable) -> None:
+        # Ensure we don't already have a stack registered.
+        if get_root_resource() is not None:
+            raise Exception('Only one root Pulumi Stack may be active at once')
+
+        # Now invoke the registration to begin creating this resource.
+        name = '%s-%s' % (get_project(), get_stack())
+        super(Stack, self).__init__('pulumi:pulumi:Stack', name, None, None)
+
+        # Invoke the function while this stack is active and then register its outputs.
+        self.outputs = dict()
+        set_root_resource(self)
+        try:
+            func()
+        finally:
+            self.register_outputs(self.outputs)
+            # Intentionally leave this resource installed in case subsequent async work uses it.
+
+    def output(self, name: str, value: Any):
+        """
+        Export a stack output with a given name and value.
+        """
+        self.outputs[name] = value


### PR DESCRIPTION
Next stage of the Python 3 conversion. This PR adds most of the `runtime` module (sans `rpc` and `resource`, which are tricky and will come in subsequent PRs, as well as the `output` module, which implements `Output[T]`.

Again, there's a lot of code here, so I apologize for that.