### PR TITLE
Don't prompt if you want to continue when --skip-preview is passed

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -69,7 +69,7 @@ func TestProjectMain(t *testing.T) {
 		e.ImportDirectory("project_main_abs")
 		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", "main-abs")
-		stdout, stderr := e.RunCommandExpectError("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
+		stdout, stderr := e.RunCommandExpectError("pulumi", "up", "--non-interactive", "--skip-preview")
 		assert.Equal(t, "Updating (main-abs):\n", stdout)
 		assert.Contains(t, stderr, "project 'main' must be a relative path")
 		e.RunCommand("pulumi", "stack", "rm", "--yes")
@@ -85,7 +85,7 @@ func TestProjectMain(t *testing.T) {
 		e.ImportDirectory("project_main_parent")
 		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", "main-parent")
-		stdout, stderr := e.RunCommandExpectError("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
+		stdout, stderr := e.RunCommandExpectError("pulumi", "up", "--non-interactive", "--skip-preview")
 		assert.Equal(t, "Updating (main-parent):\n", stdout)
 		assert.Contains(t, stderr, "project 'main' must be a subfolder")
 		e.RunCommand("pulumi", "stack", "rm", "--yes")
@@ -186,7 +186,7 @@ func TestStackOutputsJSON(t *testing.T) {
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
 	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 	e.RunCommand("pulumi", "stack", "init", "stack-outs")
-	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
+	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 	stdout, stderr := e.RunCommand("pulumi", "stack", "output", "--json")
 	assert.Equal(t, `{
   "foo": 42,

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -207,7 +207,7 @@ func TestStackCommands(t *testing.T) {
 		e.RunCommand("pulumi", "stack", "init", stackName)
 		e.RunCommand("yarn", "install")
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
-		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview", "--yes")
+		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview")
 		// We're going to futz with the stack a little so that one of the resources we just created
 		// becomes invalid.
 		stackFile := path.Join(e.RootPath, "stack.json")
@@ -249,7 +249,7 @@ func TestStackCommands(t *testing.T) {
 		_, stderr := e.RunCommand("pulumi", "stack", "import", "--file", "stack.json")
 		assert.Contains(t, stderr, fmt.Sprintf("removing pending operation 'deleting' on '%s'", res.URN))
 		// The engine should be happy now that there are no invalid resources.
-		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview", "--yes")
+		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview")
 		e.RunCommand("pulumi", "stack", "rm", "--yes", "--force")
 	})
 }
@@ -293,7 +293,7 @@ func TestStackBackups(t *testing.T) {
 
 		// Now run pulumi update.
 		before := time.Now().UnixNano()
-		e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
+		e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 		after := time.Now().UnixNano()
 
 		// Verify the backup directory contains a single backup.
@@ -307,7 +307,7 @@ func TestStackBackups(t *testing.T) {
 
 		// Now run pulumi destroy.
 		before = time.Now().UnixNano()
-		e.RunCommand("pulumi", "destroy", "--non-interactive", "--skip-preview", "--yes")
+		e.RunCommand("pulumi", "destroy", "--non-interactive", "--skip-preview")
 		after = time.Now().UnixNano()
 
 		// Verify the backup directory has been updated with 1 additional backups.


### PR DESCRIPTION
If you took the time to type out `--skip-preview`, we should have high
confidence that you don't want a preview and you're okay with the
operation just happening without a prompt.

Fixes #1448