### PR TITLE
Fix a few issues in the Go language provider

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -117,14 +117,27 @@ func (ctx *Context) GetConfig(key string) (string, bool) {
 }
 
 // Invoke will invoke a provider's function, identified by its token tok.  This function call is synchronous.
-func (ctx *Context) Invoke(tok string, args map[string]interface{}) (map[string]interface{}, error) {
+func (ctx *Context) Invoke(tok string, args map[string]interface{}, opts ...InvokeOpt) (map[string]interface{}, error) {
 	if tok == "" {
 		return nil, errors.New("invoke token must not be empty")
 	}
 
+	// Check for a provider option.
+	var provider string
+	for _, opt := range opts {
+		if opt.Provider != nil {
+			pr, err := ctx.resolveProviderReference(opt.Provider)
+			if err != nil {
+				return nil, err
+			}
+			provider = pr
+			break
+		}
+	}
+
 	// Serialize arguments, first by awaiting them, and then marshaling them to the requisite gRPC values.
 	// TODO[pulumi/pulumi#1483]: feels like we should be propagating dependencies to the outputs, instead of ignoring.
-	_, rpcArgs, _, err := marshalInputs(args)
+	rpcArgs, _, err := marshalInputs(args)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshaling arguments")
 	}
@@ -138,8 +151,9 @@ func (ctx *Context) Invoke(tok string, args map[string]interface{}) (map[string]
 	// Now, invoke the RPC to the provider synchronously.
 	glog.V(9).Infof("Invoke(%s, #args=%d): RPC call being made synchronously", tok, len(args))
 	resp, err := ctx.monitor.Invoke(ctx.ctx, &pulumirpc.InvokeRequest{
-		Tok:  tok,
-		Args: rpcArgs,
+		Tok:      tok,
+		Args:     rpcArgs,
+		Provider: provider,
 	})
 	if err != nil {
 		glog.V(9).Infof("Invoke(%s, ...): error: %v", tok, err)
@@ -175,52 +189,57 @@ func (ctx *Context) ReadResource(
 		return nil, errors.New("resource ID is required for lookup and cannot be empty")
 	}
 
-	// Prepare the inputs for an impending operation.
-	op, err := ctx.newResourceOperation(true, props, opts...)
-	if err != nil {
+	// Note that we're about to make an outstanding RPC request, so that we can rendezvous during shutdown.
+	if err := ctx.beginRPC(); err != nil {
 		return nil, err
 	}
 
-	// Note that we're about to make an outstanding RPC request, so that we can rendezvous during shutdown.
-	if err = ctx.beginRPC(); err != nil {
-		return nil, err
-	}
+	// Create resolvers for the resource's outputs.
+	outputs := makeResourceOutputs(true, props)
 
 	// Kick off the resource read operation.  This will happen asynchronously and resolve the above properties.
 	go func() {
+		// No matter the outcome, make sure all promises are resolved and that we've signaled completion of this RPC.
+		var urn, resID string
+		var state *structpb.Struct
+		var err error
+		defer func() {
+			outputs.resolve(ctx.DryRun(), err, props, urn, resID, state)
+			ctx.endRPC()
+		}()
+
+		// Prepare the inputs for an impending operation.
+		inputs, err := ctx.prepareResourceInputs(props, opts...)
+		if err != nil {
+			return
+		}
+
 		glog.V(9).Infof("ReadResource(%s, %s): Goroutine spawned, RPC call being made", t, name)
 		resp, err := ctx.monitor.ReadResource(ctx.ctx, &pulumirpc.ReadResourceRequest{
 			Type:       t,
 			Name:       name,
-			Parent:     op.parent,
-			Properties: op.rpcProps,
+			Parent:     inputs.parent,
+			Properties: inputs.rpcProps,
+			Provider:   inputs.provider,
 		})
 		if err != nil {
 			glog.V(9).Infof("RegisterResource(%s, %s): error: %v", t, name, err)
 		} else {
 			glog.V(9).Infof("RegisterResource(%s, %s): success: %s %s ...", t, name, resp.Urn, id)
 		}
-
-		// No matter the outcome, make sure all promises are resolved.
-		var urn, resID string
-		var props *structpb.Struct
 		if resp != nil {
 			urn, resID = resp.Urn, string(id)
-			props = resp.Properties
+			state = resp.Properties
 		}
-		op.complete(err, urn, resID, props)
-
-		// Signal the completion of this RPC and notify any potential awaiters.
-		ctx.endRPC()
 	}()
 
 	outs := make(map[string]*Output)
-	for k, s := range op.outState {
+	for k, s := range outputs.state {
 		outs[k] = s.out
 	}
 	return &ResourceState{
-		URN:   (*URNOutput)(op.outURN.out),
-		ID:    (*IDOutput)(op.outID.out),
+		urn:   (*URNOutput)(outputs.urn.out),
+		id:    (*IDOutput)(outputs.id.out),
 		State: outs,
 	}, nil
 }
@@ -236,86 +255,172 @@ func (ctx *Context) RegisterResource(
 		return nil, errors.New("resource name argument (for URN creation) cannot be empty")
 	}
 
-	// Prepare the inputs for an impending operation.
-	op, err := ctx.newResourceOperation(custom, props, opts...)
-	if err != nil {
+	// Note that we're about to make an outstanding RPC request, so that we can rendezvous during shutdown.
+	if err := ctx.beginRPC(); err != nil {
 		return nil, err
 	}
 
-	// Note that we're about to make an outstanding RPC request, so that we can rendezvous during shutdown.
-	if err = ctx.beginRPC(); err != nil {
-		return nil, err
-	}
+	// Create resolvers for the resource's outputs.
+	outputs := makeResourceOutputs(custom, props)
 
 	// Kick off the resource registration.  If we are actually performing a deployment, the resulting properties
 	// will be resolved asynchronously as the RPC operation completes.  If we're just planning, values won't resolve.
 	go func() {
+		// No matter the outcome, make sure all promises are resolved and that we've signaled completion of this RPC.
+		var urn, resID string
+		var state *structpb.Struct
+		var err error
+		defer func() {
+			outputs.resolve(ctx.DryRun(), err, props, urn, resID, state)
+			ctx.endRPC()
+		}()
+
+		// Prepare the inputs for an impending operation.
+		inputs, err := ctx.prepareResourceInputs(props, opts...)
+		if err != nil {
+			return
+		}
+
 		glog.V(9).Infof("RegisterResource(%s, %s): Goroutine spawned, RPC call being made", t, name)
 		resp, err := ctx.monitor.RegisterResource(ctx.ctx, &pulumirpc.RegisterResourceRequest{
 			Type:         t,
 			Name:         name,
-			Parent:       op.parent,
-			Object:       op.rpcProps,
+			Parent:       inputs.parent,
+			Object:       inputs.rpcProps,
 			Custom:       custom,
-			Protect:      op.protect,
-			Dependencies: op.deps,
+			Protect:      inputs.protect,
+			Dependencies: inputs.deps,
+			Provider:     inputs.provider,
 		})
 		if err != nil {
 			glog.V(9).Infof("RegisterResource(%s, %s): error: %v", t, name, err)
 		} else {
 			glog.V(9).Infof("RegisterResource(%s, %s): success: %s %s ...", t, name, resp.Urn, resp.Id)
 		}
-
-		// No matter the outcome, make sure all promises are resolved.
-		var urn, resID string
-		var props *structpb.Struct
 		if resp != nil {
 			urn, resID = resp.Urn, resp.Id
-			props = resp.Object
+			state = resp.Object
 		}
-		op.complete(err, urn, resID, props)
-
-		// Signal the completion of this RPC and notify any potential awaiters.
-		ctx.endRPC()
 	}()
 
 	var id *IDOutput
-	if op.outID != nil {
-		id = (*IDOutput)(op.outID.out)
+	if outputs.id != nil {
+		id = (*IDOutput)(outputs.id.out)
 	}
 	outs := make(map[string]*Output)
-	for k, s := range op.outState {
+	for k, s := range outputs.state {
 		outs[k] = s.out
 	}
 	return &ResourceState{
-		URN:   (*URNOutput)(op.outURN.out),
-		ID:    id,
+		urn:   (*URNOutput)(outputs.urn.out),
+		id:    id,
 		State: outs,
 	}, nil
 }
 
-// resourceOperation reflects all of the inputs necessary to perform core resource RPC operations.
-type resourceOperation struct {
-	ctx      *Context
+// resourceOutputs captures the outputs and resolvers for a resource operation.
+type resourceOutputs struct {
+	urn   *resourceOutput
+	id    *resourceOutput
+	state map[string]*resourceOutput
+}
+
+// makeResourceOutputs creates a set of resolvers that we'll use to finalize state, for URNs, IDs, and output
+// properties.
+func makeResourceOutputs(custom bool, props map[string]interface{}) *resourceOutputs {
+	outURN, resolveURN, rejectURN := NewOutput(nil)
+	urn := &resourceOutput{out: outURN, resolve: resolveURN, reject: rejectURN}
+
+	var id *resourceOutput
+	if custom {
+		outID, resolveID, rejectID := NewOutput(nil)
+		id = &resourceOutput{out: outID, resolve: resolveID, reject: rejectID}
+	}
+
+	state := make(map[string]*resourceOutput)
+	for key := range props {
+		outState, resolveState, rejectState := NewOutput(nil)
+		state[key] = &resourceOutput{
+			out:     outState,
+			resolve: resolveState,
+			reject:  rejectState,
+		}
+	}
+
+	return &resourceOutputs{
+		urn:   urn,
+		id:    id,
+		state: state,
+	}
+}
+
+// resolve resolves the resource outputs using the given error and/or values.
+func (outputs *resourceOutputs) resolve(dryrun bool, err error, inputs map[string]interface{}, urn, id string,
+	result *structpb.Struct) {
+
+	var outprops map[string]interface{}
+	if err == nil {
+		outprops, err = unmarshalOutputs(result)
+	}
+	if err != nil {
+		// If there was an error, we must reject everything: URN, ID, and state properties.
+		outputs.urn.reject(err)
+		if outputs.id != nil {
+			outputs.id.reject(err)
+		}
+		for _, s := range outputs.state {
+			s.reject(err)
+		}
+	} else {
+		// Resolve the URN and ID.
+		outputs.urn.resolve(URN(urn), true)
+		if outputs.id != nil {
+			if id == "" && dryrun {
+				outputs.id.resolve("", false)
+			} else {
+				outputs.id.resolve(ID(id), true)
+			}
+		}
+
+		// During previews, it's possible that nils will be returned due to unknown values.  This function
+		// determines the known-ed-ness of a given value below.
+		isKnown := func(v interface{}) bool {
+			return !dryrun || v != nil
+		}
+
+		// Now resolve all output properties.
+		for k, s := range outputs.state {
+			v, has := outprops[k]
+			if !has {
+				// If we did not receive a value for a particular property, resolve it to the corresponding input
+				// if any exists.
+				v = inputs[k]
+			}
+			s.resolve(v, isKnown(v))
+		}
+	}
+}
+
+// resourceInputs reflects all of the inputs necessary to perform core resource RPC operations.
+type resourceInputs struct {
 	parent   string
 	deps     []string
 	protect  bool
-	props    map[string]interface{}
+	provider string
 	rpcProps *structpb.Struct
-	outURN   *resourceOutput
-	outID    *resourceOutput
-	outState map[string]*resourceOutput
 }
 
-// newResourceOperation prepares the inputs for a resource operation, shared between read and register.
-func (ctx *Context) newResourceOperation(custom bool, props map[string]interface{},
-	opts ...ResourceOpt) (*resourceOperation, error) {
+// prepareResourceInputs prepares the inputs for a resource operation, shared between read and register.
+func (ctx *Context) prepareResourceInputs(props map[string]interface{}, opts ...ResourceOpt) (*resourceInputs, error) {
 	// Get the parent and dependency URNs from the options, in addition to the protection bit.  If there wasn't an
 	// explicit parent, and a root stack resource exists, we will automatically parent to that.
-	parent, optDeps, protect := ctx.getOpts(opts...)
+	parent, optDeps, protect, provider, err := ctx.getOpts(opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "resolving options")
+	}
 
 	// Serialize all properties, first by awaiting them, and then marshaling them to the requisite gRPC values.
-	keys, rpcProps, rpcDeps, err := marshalInputs(props)
+	rpcProps, rpcDeps, err := marshalInputs(props)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshaling properties")
 	}
@@ -331,88 +436,13 @@ func (ctx *Context) newResourceOperation(custom bool, props map[string]interface
 	}
 	sort.Strings(deps)
 
-	// Create a set of resolvers that we'll use to finalize state, for URNs, IDs, and output properties.
-	outURN, resolveURN, rejectURN := NewOutput(nil)
-	urn := &resourceOutput{out: outURN, resolve: resolveURN, reject: rejectURN}
-
-	var id *resourceOutput
-	if custom {
-		outID, resolveID, rejectID := NewOutput(nil)
-		id = &resourceOutput{out: outID, resolve: resolveID, reject: rejectID}
-	}
-
-	state := make(map[string]*resourceOutput)
-	for _, key := range keys {
-		outState, resolveState, rejectState := NewOutput(nil)
-		state[key] = &resourceOutput{
-			out:     outState,
-			resolve: resolveState,
-			reject:  rejectState,
-		}
-	}
-
-	return &resourceOperation{
-		ctx:      ctx,
+	return &resourceInputs{
 		parent:   string(parent),
 		deps:     deps,
 		protect:  protect,
-		props:    props,
+		provider: provider,
 		rpcProps: rpcProps,
-		outURN:   urn,
-		outID:    id,
-		outState: state,
 	}, nil
-}
-
-// complete finishes a resource operation given the set of RPC results.
-func (op *resourceOperation) complete(err error, urn string, id string, result *structpb.Struct) {
-	var outprops map[string]interface{}
-	if err == nil {
-		outprops, err = unmarshalOutputs(result)
-	}
-	if err != nil {
-		// If there was an error, we must reject everything: URN, ID, and state properties.
-		op.outURN.reject(err)
-		if op.outID != nil {
-			op.outID.reject(err)
-		}
-		for _, s := range op.outState {
-			s.reject(err)
-		}
-	} else {
-		// Resolve the URN and ID.
-		op.outURN.resolve(URN(urn), true)
-		if op.outID != nil {
-			if id == "" && op.ctx.DryRun() {
-				op.outID.resolve("", false)
-			} else {
-				op.outID.resolve(ID(id), true)
-			}
-		}
-
-		// During previews, it's possible that nils will be returned due to unknown values.  This function
-		// determines the known-ed-ness of a given value below.
-		isKnown := func(v interface{}) bool {
-			return !op.ctx.DryRun() || v != nil
-		}
-
-		// Now resolve all output properties.
-		seen := make(map[string]bool)
-		for k, v := range outprops {
-			if s, has := op.outState[k]; has {
-				s.resolve(v, isKnown(v))
-				seen[k] = true
-			}
-		}
-
-		// If we didn't get back any inputs as outputs, resolve them to the inputs.
-		for k, s := range op.outState {
-			if !seen[k] {
-				v := op.props[k]
-				s.resolve(v, isKnown(v))
-			}
-		}
-	}
 }
 
 type resourceOutput struct {
@@ -421,43 +451,76 @@ type resourceOutput struct {
 	reject  func(error)
 }
 
-// getOpts returns a set of resource options from an array of them.  This includes the parent URN, any
-// dependency URNs, and a boolean indicating whether the resource is to be protected.
-func (ctx *Context) getOpts(opts ...ResourceOpt) (URN, []URN, bool) {
-	return ctx.getOptsParentURN(opts...),
-		ctx.getOptsDepURNs(opts...),
-		ctx.getOptsProtect(opts...)
-}
-
-// getOptsParentURN returns a URN to use for a resource, given its options, defaulting to the current stack resource.
-func (ctx *Context) getOptsParentURN(opts ...ResourceOpt) URN {
+// getOpts returns a set of resource options from an array of them. This includes the parent URN, any dependency URNs,
+// a boolean indicating whether the resource is to be protected, and the URN and ID of the resource's provider, if any.
+func (ctx *Context) getOpts(opts ...ResourceOpt) (URN, []URN, bool, string, error) {
+	var parent Resource
+	var deps []Resource
+	var protect bool
+	var provider ProviderResource
 	for _, opt := range opts {
-		if opt.Parent != nil {
-			return opt.Parent.URN()
+		if parent == nil && opt.Parent != nil {
+			parent = opt.Parent
+		}
+		if deps == nil && opt.DependsOn != nil {
+			deps = opt.DependsOn
+		}
+		if !protect && opt.Protect {
+			protect = true
+		}
+		if provider == nil && opt.Provider != nil {
+			provider = opt.Provider
 		}
 	}
-	return ctx.stackR
-}
 
-// getOptsDepURNs returns the set of dependency URNs in a resource's options.
-func (ctx *Context) getOptsDepURNs(opts ...ResourceOpt) []URN {
-	var urns []URN
-	for _, opt := range opts {
-		for _, dep := range opt.DependsOn {
-			urns = append(urns, dep.URN())
+	var parentURN URN
+	if parent == nil {
+		parentURN = ctx.stackR
+	} else {
+		urn, err := parent.URN().Value()
+		if err != nil {
+			return "", nil, false, "", err
+		}
+		parentURN = urn
+	}
+
+	var depURNs []URN
+	if deps != nil {
+		depURNs = make([]URN, len(deps))
+		for i, r := range deps {
+			urn, err := r.URN().Value()
+			if err != nil {
+				return "", nil, false, "", err
+			}
+			depURNs[i] = urn
 		}
 	}
-	return urns
+
+	var providerRef string
+	if provider != nil {
+		pr, err := ctx.resolveProviderReference(provider)
+		if err != nil {
+			return "", nil, false, "", err
+		}
+		providerRef = pr
+	}
+
+	return parentURN, depURNs, protect, providerRef, nil
 }
 
-// getOptsProtect returns true if a resource's options indicate that it is to be protected.
-func (ctx *Context) getOptsProtect(opts ...ResourceOpt) bool {
-	for _, opt := range opts {
-		if opt.Protect {
-			return true
-		}
+func (ctx *Context) resolveProviderReference(provider ProviderResource) (string, error) {
+	urn, err := provider.URN().Value()
+	if err != nil {
+		return "", err
 	}
-	return false
+	id, known, err := provider.ID().Value()
+	if err != nil {
+		return "", err
+	}
+	if !known {
+		id = rpcTokenUnknownValue
+	}
+	return string(urn) + "::" + string(id), nil
 }
 
 // noMoreRPCs is a sentinel value used to stop subsequent RPCs from occurring.
@@ -507,17 +570,32 @@ func (ctx *Context) waitForRPCs() {
 
 // ResourceState contains the results of a resource registration operation.
 type ResourceState struct {
-	// URN will resolve to the resource's URN after registration has completed.
-	URN *URNOutput
-	// ID will resolve to the resource's ID after registration, provided this is for a custom resource.
-	ID *IDOutput
+	// urn will resolve to the resource's URN after registration has completed.
+	urn *URNOutput
+	// id will resolve to the resource's ID after registration, provided this is for a custom resource.
+	id *IDOutput
 	// State contains the full set of expected output properties and will resolve after completion.
 	State Outputs
 }
 
+// URN will resolve to the resource's URN after registration has completed.
+func (s *ResourceState) URN() *URNOutput {
+	return s.urn
+}
+
+// ID will resolve to the resource's ID after registration, provided this is for a custom resource.
+func (s *ResourceState) ID() *IDOutput {
+	return s.id
+}
+
+var _ Resource = (*ResourceState)(nil)
+var _ CustomResource = (*ResourceState)(nil)
+var _ ComponentResource = (*ResourceState)(nil)
+var _ ProviderResource = (*ResourceState)(nil)
+
 // RegisterResourceOutputs completes the resource registration, attaching an optional set of computed outputs.
 func (ctx *Context) RegisterResourceOutputs(urn URN, outs map[string]interface{}) error {
-	_, outsMarshalled, _, err := marshalInputs(outs)
+	outsMarshalled, _, err := marshalInputs(outs)
 	if err != nil {
 		return errors.Wrap(err, "marshaling outputs")
 	}

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -24,7 +24,7 @@ type (
 // Resource represents a cloud resource managed by Pulumi.
 type Resource interface {
 	// URN is this resource's stable logical URN used to distinctly address it before, during, and after deployments.
-	URN() URN
+	URN() *URNOutput
 }
 
 // CustomResource is a cloud resource whose create, read, update, and delete (CRUD) operations are managed by performing
@@ -34,13 +34,20 @@ type CustomResource interface {
 	Resource
 	// ID is the provider-assigned unique identifier for this managed resource.  It is set during deployments,
 	// but might be missing ("") during planning phases.
-	ID() ID
+	ID() *IDOutput
 }
 
 // ComponentResource is a resource that aggregates one or more other child resources into a higher level abstraction.
 // The component resource itself is a resource, but does not require custom CRUD operations for provisioning.
 type ComponentResource interface {
 	Resource
+}
+
+// ProviderResource is a resource that represents a configured instance of a particular package's provider plugin.
+// These resources are supply the implementations of their package's CRUD operations. A specific provider instance can
+// be used for a given resource by passing it in ResourceOpt.Provider.
+type ProviderResource interface {
+	CustomResource
 }
 
 // ResourceOpt contains optional settings that control a resource's behavior.
@@ -51,4 +58,12 @@ type ResourceOpt struct {
 	DependsOn []Resource
 	// Protect, when set to true, ensures that this resource cannot be deleted (without first setting it to false).
 	Protect bool
+	// Provider is an optional provider resource to use for this resource's CRUD operations.
+	Provider ProviderResource
+}
+
+// InvokeOpt contains optional settings that control an invoke's behavior.
+type InvokeOpt struct {
+	// Provider is an optional provider resource to use for this invoke.
+	Provider ProviderResource
 }

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -50,7 +50,7 @@ func TestMarshalRoundtrip(t *testing.T) {
 	}
 
 	// Marshal those inputs.
-	_, m, deps, err := marshalInputs(input)
+	m, deps, err := marshalInputs(input)
 	if !assert.Nil(t, err) {
 		assert.Equal(t, 0, len(deps))
 

--- a/sdk/go/pulumi/run.go
+++ b/sdk/go/pulumi/run.go
@@ -63,13 +63,21 @@ func RunErr(body RunFunc) error {
 	}
 	defer contract.IgnoreClose(ctx)
 
+	return RunWithContext(ctx, body)
+}
+
+// RunWithContext runs the body of a Pulumi program using the given Context for information about the target stack,
+// configuration, and engine connection.
+func RunWithContext(ctx *Context, body RunFunc) error {
+	info := ctx.info
+
 	// Create a root stack resource that we'll parent everything to.
 	reg, err := ctx.RegisterResource(
 		"pulumi:pulumi:Stack", fmt.Sprintf("%s-%s", info.Project, info.Stack), false, nil)
 	if err != nil {
 		return err
 	}
-	ctx.stackR, err = reg.URN.Value()
+	ctx.stackR, err = reg.URN().Value()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
1. Add support for first-class providers
2. Make `pulumi.ResourceState` conform to the `pulumi.Resource` interface
3. Wait for inputs to resolve inside RPC goroutines rather than doing so
   before starting the goroutines

Note that (2) involves a breaking change to `pulumi.ResourceState` that
will require adjusting `tfgen`'s code generation.

Fixes https://github.com/pulumi/pulumi-terraform/issues/256
Contributes to #1713