### PR TITLE
Add some helpful input/output combinators

### DIFF
--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -25,9 +25,10 @@ export * from "./resource";
 // Export submodules individually.
 import * as asset from "./asset";
 import * as dynamic from "./dynamic";
+import * as iterable from "./iterable";
 import * as log from "./log";
 import * as runtime from "./runtime";
-export { asset, dynamic, log, runtime };
+export { asset, dynamic, iterable, log, runtime };
 
 // @pulumi is a deployment-only module.  If someone tries to capture it, and we fail for some reason
 // we want to give a good message about what the problem likely is.  Note that capturing a

--- a/sdk/nodejs/iterable/index.ts
+++ b/sdk/nodejs/iterable/index.ts
@@ -34,10 +34,10 @@ export function toObject<T, V>(
         for (const e of elems) {
             array.push(selector(<any>e));
         }
-        return Output.create(array).apply(a => {
+        return Output.create(array).apply(kvps => {
             const obj: {[key: string]: V} = {};
-            for (const e of a) {
-                obj[<any>e[0]] = <any>e[1];
+            for (const kvp of kvps) {
+                obj[<any>kvp[0]] = <any>kvp[1];
             }
             return obj;
         });
@@ -45,61 +45,37 @@ export function toObject<T, V>(
 }
 
 /**
- * toMap takes an array of T values, and a selector that produces key/value pairs from those inputs,
- * and converts this array into an output map with those keys and values.
- *
- * For instance, given an array as follows
- *
- *     [{ s: "a", n: 1 }, { s: "b", n: 2 }, { s: "c", n: 3 }]
- *
- * and whose selector is roughly `(e) => [e.s, e.n]`, the resulting map will contain
- *
- *     [[ "a", 1 ], [ "b", 2 ], [ "c", 3 ]]
- *
- */
-export function toMap<T, K, V>(
-        iter: Input<Input<T>[]>, selector: (t: T) => [Input<K>, Input<V>]): Output<Map<K, V>> {
-    return Output.create(iter).apply(elems => {
-        const array: [Input<K>, Input<V>][] = [];
-        for (const e of elems) {
-            array.push(selector(<any>e));
-        }
-        return Output.create(array).apply(a => new Map<K, V>(<any>a));
-    });
-}
-
-/**
  * groupBy takes an array of T values, and a selector that prduces key/value pairs from those inputs,
- * and converts this array into an output map, with those keys, and where each entry is an array of values,
+ * and converts this array into an output object, with those keys, and where each property is an array of values,
  * in the case that the same key shows up multiple times in the input.
  *
  * For instance, given an array as follows
  *
  *     [{ s: "a", n: 1 }, { s: "a", n: 2 }, { s: "b", n: 1 }]
  *
- * and whose selector is roughly `(e) => [e.s, e.n]`, the resulting map will contain
+ * and whose selector is roughly `(e) => [e.s, e.n]`, the resulting object will be
  *
- *     [[ "a", [1, 2] ], [ "b", [1] ]]
+ *     { "a": [1, 2], "b": [1] }
  *
  */
-export function groupBy<T, K, V>(
-        iter: Input<Input<T>[]>, selector: (t: T) => [Input<K>, Input<V>]): Output<Map<K, V[]>> {
+export function groupBy<T, V>(
+        iter: Input<Input<T>[]>, selector: (t: T) => [Input<string>, Input<V>]): Output<{[key: string]: V[]}> {
     return Output.create(iter).apply(elems => {
-        const array: [Input<K>, Input<V>][] = [];
+        const array: [Input<string>, Input<V>][] = [];
         for (const e of elems) {
             array.push(selector(<any>e));
         }
         return Output.create(array).apply(kvps => {
-            const m = new Map<K, V[]>();
+            const obj: {[key: string]: V[]} = {};
             for (let kvp of kvps) {
-                let r = m.get(<any>kvp[0]);
+                let r = obj[<any>kvp[0]];
                 if (!r) {
                     r = [];
-                    m.set(<any>kvp[0], r);
+                    obj[<any>kvp[0]] = r;
                 }
                 r.push(<any>kvp[1]);
             }
-            return m;
+            return obj;
         });
     });
 }

--- a/sdk/nodejs/iterable/index.ts
+++ b/sdk/nodejs/iterable/index.ts
@@ -67,7 +67,7 @@ export function groupBy<T, V>(
         }
         return Output.create(array).apply(kvps => {
             const obj: {[key: string]: V[]} = {};
-            for (let kvp of kvps) {
+            for (const kvp of kvps) {
                 let r = obj[<any>kvp[0]];
                 if (!r) {
                     r = [];

--- a/sdk/nodejs/iterable/index.ts
+++ b/sdk/nodejs/iterable/index.ts
@@ -1,0 +1,75 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Input, Output } from "../resource";
+
+/**
+ * toMap takes an array of T values, and a selector that produces key/value pairs from those inputs,
+ * and converts this array into an output map with those keys and values.
+ *
+ * For instance, given an array as follows
+ *
+ *     [{ s: "a", n: 1 }, { s: "b", n: 2 }, { s: "c", n: 3 }]
+ *
+ * and whose selector is roughly `(e) => [e.s, e.n]`, the resulting map will contain
+ *
+ *     [[ "a", 1 ], [ "b", 2 ], [ "c", 3 ]]
+ *
+ */
+export function toMap<T, K, V>(
+        iter: Input<Input<T>[]>, selector: (t: T) => [Input<K>, Input<V>]): Output<Map<K, V>> {
+    return Output.create(iter).apply(elems => {
+        const array: [Input<K>, Input<V>][] = [];
+        for (const e of elems) {
+            array.push(selector(<any>e));
+        }
+        return Output.create(array).apply(a => new Map<K, V>(<any>a));
+    });
+}
+
+/**
+ * groupBy takes an array of T values, and a selector that prduces key/value pairs from those inputs,
+ * and converts this array into an output map, with those keys, and where each entry is an array of values,
+ * in the case that the same key shows up multiple times in the input.
+ *
+ * For instance, given an array as follows
+ *
+ *     [{ s: "a", n: 1 }, { s: "a", n: 2 }, { s: "b", n: 1 }]
+ *
+ * and whose selector is roughly `(e) => [e.s, e.n]`, the resulting map will contain
+ *
+ *     [[ "a", [1, 2] ], [ "b", [1] ]]
+ *
+ */
+export function groupBy<T, K, V>(
+        iter: Input<Input<T>[]>, selector: (t: T) => [Input<K>, Input<V>]): Output<Map<K, V[]>> {
+    return Output.create(iter).apply(elems => {
+        const array: [Input<K>, Input<V>][] = [];
+        for (const e of elems) {
+            array.push(selector(<any>e));
+        }
+        return Output.create(array).apply(kvps => {
+            const m = new Map<K, V[]>();
+            for (let kvp of kvps) {
+                let r = m.get(<any>kvp[0]);
+                if (!r) {
+                    r = [];
+                    m.set(<any>kvp[0], r);
+                }
+                r.push(<any>kvp[1]);
+            }
+            return m;
+        });
+    });
+}

--- a/sdk/nodejs/iterable/index.ts
+++ b/sdk/nodejs/iterable/index.ts
@@ -28,9 +28,9 @@ import { Input, Output } from "../resource";
  *
  */
 export function toObject<T, V>(
-        iter: Input<Input<T>[]>, selector: (t: T) => [Input<string>, Input<V>]): Output<{[key: string]: V}> {
+        iter: Input<Input<T>[]>, selector: (t: T) => Input<[Input<string>, Input<V>]>): Output<{[key: string]: V}> {
     return Output.create(iter).apply(elems => {
-        const array: [Input<string>, Input<V>][] = [];
+        const array: Input<[Input<string>, Input<V>]>[] = [];
         for (const e of elems) {
             array.push(selector(<any>e));
         }
@@ -59,9 +59,9 @@ export function toObject<T, V>(
  *
  */
 export function groupBy<T, V>(
-        iter: Input<Input<T>[]>, selector: (t: T) => [Input<string>, Input<V>]): Output<{[key: string]: V[]}> {
+        iter: Input<Input<T>[]>, selector: (t: T) => Input<[Input<string>, Input<V>]>): Output<{[key: string]: V[]}> {
     return Output.create(iter).apply(elems => {
-        const array: [Input<string>, Input<V>][] = [];
+        const array: Input<[Input<string>, Input<V>]>[] = [];
         for (const e of elems) {
             array.push(selector(<any>e));
         }

--- a/sdk/nodejs/iterable/index.ts
+++ b/sdk/nodejs/iterable/index.ts
@@ -15,6 +15,36 @@
 import { Input, Output } from "../resource";
 
 /**
+ * toObject takes an array of T values, and a selector that produces key/value pairs from those inputs,
+ * and converts this array into an output object with those keys and values.
+ *
+ * For instance, given an array as follows
+ *
+ *     [{ s: "a", n: 1 }, { s: "b", n: 2 }, { s: "c", n: 3 }]
+ *
+ * and whose selector is roughly `(e) => [e.s, e.n]`, the resulting object will be
+ *
+ *     { "a": 1, "b": 2, "c": 3 }
+ *
+ */
+export function toObject<T, V>(
+        iter: Input<Input<T>[]>, selector: (t: T) => [Input<string>, Input<V>]): Output<{[key: string]: V}> {
+    return Output.create(iter).apply(elems => {
+        const array: [Input<string>, Input<V>][] = [];
+        for (const e of elems) {
+            array.push(selector(<any>e));
+        }
+        return Output.create(array).apply(a => {
+            const obj: {[key: string]: V} = {};
+            for (const e of a) {
+                obj[<any>e[0]] = <any>e[1];
+            }
+            return obj;
+        });
+    });
+}
+
+/**
  * toMap takes an array of T values, and a selector that produces key/value pairs from those inputs,
  * and converts this array into an output map with those keys and values.
  *

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -304,66 +304,6 @@ export class Output<T> {
     }
 
     /**
-     * createMap takes an array of T values, and a selector that produces key/value pairs from those inputs,
-     * and converts this array into an output map with those keys and values.
-     *
-     * For instance, given an array as follows
-     *
-     *     [{ s: "a", n: 1 }, { s: "b", n: 2 }, { s: "c", n: 3 }]
-     *
-     * and whose selector is roughly `(e) => [e.s, e.n]`, the resulting map will contain
-     *
-     *     [[ "a", 1 ], [ "b", 2 ], [ "c", 3 ]]
-     *
-     */
-    public static createMap<T, K, V>(
-            iter: Input<Input<T>[]>, selector: (t: T) => [Input<K>, Input<V>]): Output<Map<K, V>> {
-        return Output.create(iter).apply(elems => {
-            const array: [Input<K>, Input<V>][] = [];
-            for (const e of elems) {
-                array.push(selector(<any>e));
-            }
-            return output(array).apply(a => new Map<K, V>(<any>a));
-        });
-    }
-
-    /**
-     * createGroupByMap takes an array of T values, and a selector that prduces key/value pairs from those inputs,
-     * and converts this array into an output map, with those keys, and where each entry is an array of values,
-     * in the case that the same key shows up multiple times in the input.
-     *
-     * For instance, given an array as follows
-     *
-     *     [{ s: "a", n: 1 }, { s: "a", n: 2 }, { s: "b", n: 1 }]
-     *
-     * and whose selector is roughly `(e) => [e.s, e.n]`, the resulting map will contain
-     *
-     *     [[ "a", [1, 2] ], [ "b", [1] ]]
-     *
-     */
-    public static createGroupByMap<T, K, V>(
-            iter: Input<Input<T>[]>, selector: (t: T) => [Input<K>, Input<V>]): Output<Map<K, V[]>> {
-        return Output.create(iter).apply(elems => {
-            const array: [Input<K>, Input<V>][] = [];
-            for (const e of elems) {
-                array.push(selector(<any>e));
-            }
-            return output(array).apply(kvps => {
-                const m = new Map<K, V[]>();
-                for (let kvp of kvps) {
-                    let r = m.get(<any>kvp[0]);
-                    if (!r) {
-                        r = [];
-                        m.set(<any>kvp[0], r);
-                    }
-                    r.push(<any>kvp[1]);
-                }
-                return m;
-            });
-        });
-    }
-
-    /**
      * A private field to help with RTTI that works in SxS scenarios.
      *
      * This is internal instead of being truly private, to support mixins and our serialization model.

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -294,16 +294,6 @@ export const testingOptions = {
  */
 export class Output<T> {
     /**
-     * create takes any Input value and converts it into an Output, deeply unwrapping nested Input
-     * values as necessary.
-     */
-    public static create<T>(val: Input<T>): Output<Unwrap<T>>;
-    public static create<T>(val: Input<T> | undefined): Output<Unwrap<T | undefined>>;
-    public static create<T>(val: Input<T | undefined>): Output<Unwrap<T | undefined>> {
-        return output<T>(<any>val);
-    }
-
-    /**
      * A private field to help with RTTI that works in SxS scenarios.
      *
      * This is internal instead of being truly private, to support mixins and our serialization model.
@@ -375,6 +365,16 @@ export class Output<T> {
     public readonly get: () => T;
 
     // Statics
+
+    /**
+     * create takes any Input value and converts it into an Output, deeply unwrapping nested Input
+     * values as necessary.
+     */
+    public static create<T>(val: Input<T>): Output<Unwrap<T>>;
+    public static create<T>(val: Input<T> | undefined): Output<Unwrap<T | undefined>>;
+    public static create<T>(val: Input<T | undefined>): Output<Unwrap<T | undefined>> {
+        return output<T>(<any>val);
+    }
 
     /**
      * Returns true if the given object is an instance of Output<T>.  This is designed to work even when
@@ -577,7 +577,8 @@ export function all<T>(val: Input<T>[] | Record<string, Input<T>>): Output<any> 
     }
 }
 
-async function getPromisedObject<T>(keysAndOutputs: { key: string, value: Output<Unwrap<T>> }[]): Promise<Record<string, Unwrap<T>>> {
+async function getPromisedObject<T>(
+        keysAndOutputs: { key: string, value: Output<Unwrap<T>> }[]): Promise<Record<string, Unwrap<T>>> {
     const result: Record<string, Unwrap<T>> = {};
     for (const kvp of keysAndOutputs) {
         result[kvp.key] = await kvp.value.promise();

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -534,28 +534,14 @@ function createSimpleOutput(val: any) {
  * In this example, taking a dependency on d3 means a resource will depend on all the resources of
  * d1 and d2.
  */
+// tslint:disable:max-line-length
 export function all<T>(val: Record<string, Input<T>>): Output<Record<string, Unwrap<T>>>;
-export function all<T1, T2, T3, T4, T5, T6, T7, T8>(
-    values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined,
-        Input<T5> | undefined, Input<T6> | undefined, Input<T7> | undefined, Input<T8> | undefined]):
-            Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>, Unwrap<T7>, Unwrap<T8>]>;
-export function all<T1, T2, T3, T4, T5, T6, T7>(
-    values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined,
-        Input<T5> | undefined, Input<T6> | undefined, Input<T7> | undefined]):
-            Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>, Unwrap<T7>]>;
-export function all<T1, T2, T3, T4, T5, T6>(
-    values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined,
-        Input<T5> | undefined, Input<T6> | undefined]):
-            Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>]>;
-export function all<T1, T2, T3, T4, T5>(
-    values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined,
-        Input<T5> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>]>;
-export function all<T1, T2, T3, T4>(
-    values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined]):
-        Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>]>;
-export function all<T1, T2, T3>(
-    values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined]):
-        Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>]>;
+export function all<T1, T2, T3, T4, T5, T6, T7, T8>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined, Input<T5> | undefined, Input<T6> | undefined, Input<T7> | undefined, Input<T8> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>, Unwrap<T7>, Unwrap<T8>]>;
+export function all<T1, T2, T3, T4, T5, T6, T7>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined, Input<T5> | undefined, Input<T6> | undefined, Input<T7> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>, Unwrap<T7>]>;
+export function all<T1, T2, T3, T4, T5, T6>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined, Input<T5> | undefined, Input<T6> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>]>;
+export function all<T1, T2, T3, T4, T5>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined, Input<T5> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>]>;
+export function all<T1, T2, T3, T4>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>]>;
+export function all<T1, T2, T3>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>]>;
 export function all<T1, T2>(values: [Input<T1> | undefined, Input<T2> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>]>;
 export function all<T>(ds: (Input<T> | undefined)[]): Output<Unwrap<T>[]>;
 export function all<T>(val: Input<T>[] | Record<string, Input<T>>): Output<any> {

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -183,7 +183,7 @@ async function prepareResource(label: string, res: Resource, custom: boolean,
     // Note: a resource urn will always get a value, and thus the output property
     // for it can always run .apply calls.
     let resolveURN: (urn: URN) => void;
-    (res as any).urn = Output.create(
+    (res as any).urn = new Output(
         res,
         debuggablePromise(
             new Promise<URN>(resolve => resolveURN = resolve),
@@ -195,7 +195,7 @@ async function prepareResource(label: string, res: Resource, custom: boolean,
     if (custom) {
         let resolveValue: (v: ID) => void;
         let resolvePerformApply: (v: boolean) => void;
-        (res as any).id = Output.create(
+        (res as any).id = new Output(
             res,
             debuggablePromise(new Promise<ID>(resolve => resolveValue = resolve), `resolveID(${label})`),
             debuggablePromise(new Promise<boolean>(

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -56,7 +56,7 @@ export function transferProperties(onto: Resource, label: string, props: Inputs)
             resolveIsKnown(isKnown);
         };
 
-        (<any>onto)[k] = Output.create(
+        (<any>onto)[k] = new Output(
             onto,
             debuggablePromise(
                 new Promise<any>(resolve => resolveValue = resolve),
@@ -159,7 +159,7 @@ export function resolveProperties(
             // are still made available on the object.  This isn't ideal, because any code running
             // prior to the actual resource CRUD operation can't hang computations off of it, but
             // it's better than tossing it.
-            (res as any)[k] = Output.create(
+            (res as any)[k] = new Output(
                 res,
                 debuggablePromise(new Promise<any>(r => resolveValue = r)),
                 debuggablePromise(new Promise<boolean>(r => resolveIsKnown = r)));

--- a/sdk/nodejs/tests/iterable.spec.ts
+++ b/sdk/nodejs/tests/iterable.spec.ts
@@ -33,7 +33,7 @@ describe("iterable", () => {
         const isKnown = await result.isKnown;
         assert.equal(isKnown, true);
         const value = await result.promise();
-        assert.deepEqual(value, {"i-1234":"192.168.1.2","i-5678":"192.168.1.5"});
+        assert.deepEqual(value, { "i-1234": "192.168.1.2", "i-5678": "192.168.1.5" });
     }));
     it("groupBy does its job", asyncTest(async () => {
         interface Instance {
@@ -51,6 +51,6 @@ describe("iterable", () => {
         const isKnown = await result.isKnown;
         assert.equal(isKnown, true);
         const value = await result.promise();
-        assert.deepEqual(value, {"us-east-1a":["i-1234","i-5678"],"us-west-2c":["i-1538"]});
+        assert.deepEqual(value, { "us-east-1a": ["i-1234", "i-5678"], "us-west-2c": ["i-1538"] });
     }));
 });

--- a/sdk/nodejs/tests/iterable.spec.ts
+++ b/sdk/nodejs/tests/iterable.spec.ts
@@ -1,0 +1,56 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as iterable from "../iterable";
+import { Output } from "../resource";
+import { asyncTest } from "./util";
+
+describe("iterable", () => {
+    it("toMap does its job", asyncTest(async () => {
+        interface Instance {
+            id: Output<string>;
+            privateIp: Output<string>;
+        }
+
+        const instances: Instance[] = [
+            { id: Output.create("i-1234"), privateIp: Output.create("192.168.1.2") },
+            { id: Output.create("i-5678"), privateIp: Output.create("192.168.1.5") },
+        ];
+
+        const result = iterable.toObject(instances, i => [i.id, i.privateIp]);
+        const isKnown = await result.isKnown;
+        assert.equal(isKnown, true);
+        const value = await result.promise();
+        assert.deepEqual(value, {"i-1234":"192.168.1.2","i-5678":"192.168.1.5"});
+    }));
+    it("groupBy does its job", asyncTest(async () => {
+        interface Instance {
+            id: Output<string>;
+            availabilityZone: Output<string>;
+        }
+
+        const instances: Instance[] = [
+            { id: Output.create("i-1234"), availabilityZone: Output.create("us-east-1a") },
+            { id: Output.create("i-1538"), availabilityZone: Output.create("us-west-2c") },
+            { id: Output.create("i-5678"), availabilityZone: Output.create("us-east-1a") },
+        ];
+
+        const result = iterable.groupBy(instances, i => [i.availabilityZone, i.id]);
+        const isKnown = await result.isKnown;
+        assert.equal(isKnown, true);
+        const value = await result.promise();
+        assert.deepEqual(value, {"us-east-1a":["i-1234","i-5678"],"us-west-2c":["i-1538"]});
+    }));
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -29,6 +29,8 @@
 
         "dynamic/index.ts",
 
+        "iterable/index.ts",
+
         "log/index.ts",
 
         "runtime/index.ts",

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -53,6 +53,7 @@
 
         "tests/config.spec.ts",
         "tests/init.spec.ts",
+        "tests/iterable.spec.ts",
         "tests/output.spec.ts",
         "tests/unwrap.spec.ts",
         "tests/util.ts",


### PR DESCRIPTION
This change does two things:

* Alias `Output.create` to `output`, more like Promise's various construction methods. This reads better and is more discoverable.

* Create a new `iterable` module with helper methods for iterables of inputs and outputs, which are tricky to apply by hand, including:

  * `toObject` will accept an array of inputs, along with a selector function for key/value pairs, and produces an output object with said property keys and values inside of it.

  * `groupBy` functon will similarly accept an array of inputs and a key/value selector, however it creates an output object with said keys, but where values are arrays of values, and all duplicate keys will lead to appending to said arrays.