### PR TITLE
Properly serialize certain special JavaScript number values that JSON serialization cannot handle.

### DIFF
--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -739,6 +739,21 @@ function getOrCreateEntry(
         serialize: (o: any) => boolean,
         logInfo: boolean | undefined): Entry {
 
+    // Check if this is a special number that we cannot json serialize.  Instead, we'll just inject
+    // the code necessary to represent the number on the other side.  Note: we have to do this
+    // before we do *anything* else.  This is because these special numbers don't even work in maps
+    // properly.  So, if we lookup the value in a map, we may get the cached value for something
+    // else *entirely*.  For example, 0 and -0 will map to the same entry.
+    if (typeof obj === "number") {
+        if (Object.is(obj, -0)) { return { expr: "-0" }; }
+        if (Object.is(obj, Number.NaN)) { return { expr: "Number.NaN" }; }
+        if (Object.is(obj, Number.POSITIVE_INFINITY)) { return { expr: "Number.POSITIVE_INFINITY"}; }
+        if (Object.is(obj, Number.NEGATIVE_INFINITY)) { return { expr: "Number.NEGATIVE_INFINITY"}; }
+
+        // Not special, just use normal json serialization.
+        return { json: obj };
+    }
+
     // See if we have a cache hit.  If yes, use the object as-is.
     let entry = context.cache.get(obj)!;
     if (entry) {
@@ -804,8 +819,11 @@ function getOrCreateEntry(
             return;
         }
 
-        if (obj === undefined || obj === null ||
-            typeof obj === "boolean" || typeof obj === "number" || typeof obj === "string") {
+        if (obj === undefined ||
+            obj === null ||
+            typeof obj === "boolean" ||
+            typeof obj === "string") {
+
             // Serialize primitives as-is.
             entry.json = obj;
             return;

--- a/sdk/nodejs/tests/runtime/closure.spec.ts
+++ b/sdk/nodejs/tests/runtime/closure.spec.ts
@@ -569,6 +569,34 @@ return () => { console.log("Just a global object reference"); };
 `,
     });
     {
+        const a = -0;
+        const b = -0.0;
+        const c = Infinity;
+        const d = -Infinity;
+        const e = NaN;
+        const f = Number.MAX_SAFE_INTEGER;
+        const g = Number.MAX_VALUE;
+        const h = Number.MIN_SAFE_INTEGER;
+        const i = Number.MIN_VALUE;
+
+        cases.push({
+            title: "Handle edge-case literals",
+            func: () => { const x = [a, b, c, d, e, f, g, h, i]; },
+            expectText: `exports.handler = __f0;
+
+function __f0() {
+  return (function() {
+    with({ a: -0, b: -0, c: Number.POSITIVE_INFINITY, d: Number.NEGATIVE_INFINITY, e: Number.NaN, f: 9007199254740991, g: 1.7976931348623157e+308, h: -9007199254740991, i: 5e-324 }) {
+
+return () => { const x = [a, b, c, d, e, f, g, h, i]; };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+`,
+        });
+    }
+    {
         const wcap = "foo";
         const xcap = 97;
         const ycap = [ true, -1, "yup" ];


### PR DESCRIPTION
Discovered while doing the Node11 work, and discovering the Inspector API has a special way to represent these values.