### PR TITLE
Ensure method always returns a boolean.

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -381,7 +381,7 @@ export class Output<T> {
      * multiple copies of the Pulumi SDK have been loaded into the same process.
      */
     public static isInstance<T>(obj: any): obj is Output<T> {
-        return obj && obj.__pulumiOutput;
+        return obj && obj.__pulumiOutput ? true : false;
     }
 
     /* @internal */ public constructor(


### PR DESCRIPTION
This helps the node11 work, were we have to call these methods dynamically through the Inspector interface.  Returning 'undefined' values makes this more complex.