### PR TITLE
Use math.MaxInt32 to signal unbounded parallelism

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -133,7 +133,7 @@ func newDestroyCmd() *cobra.Command {
 		"Display operation as a rich diff showing the overall change")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
-		"Allow P resource operations to run in parallel at once (1 for no parallelism, 0 for unbounded parallelism)")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
 	cmd.PersistentFlags().BoolVarP(
 		&refresh, "refresh", "r", false,
 		"Refresh the state of the stack's resources before this update")

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -131,7 +131,7 @@ func newPreviewCmd() *cobra.Command {
 		"Display operation as a rich diff showing the overall change")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
-		"Allow P resource operations to run in parallel at once (1 for no parallelism, 0 for unbounded parallelism)")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,
 		"Show configuration keys and variables")

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -142,7 +142,7 @@ func newRefreshCmd() *cobra.Command {
 		"Display operation as a rich diff showing the overall change")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
-		"Allow P resource operations to run in parallel at once (1 for no parallelism, 0 for unbounded parallelism)")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
 	cmd.PersistentFlags().BoolVar(
 		&showReplacementSteps, "show-replacement-steps", false,
 		"Show detailed resource replacement creates and deletes instead of a single step")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"context"
 	"io/ioutil"
+	"math"
 	"os"
 
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -36,7 +37,7 @@ import (
 )
 
 const (
-	defaultParallel = 0
+	defaultParallel = math.MaxInt32
 )
 
 // nolint: vetshadow, intentionally disabling here for cleaner err declaration/assignment.
@@ -328,7 +329,7 @@ func newUpCmd() *cobra.Command {
 		"Display operation as a rich diff showing the overall change")
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
-		"Allow P resource operations to run in parallel at once (1 for no parallelism, 0 for unbounded parallelism)")
+		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
 	cmd.PersistentFlags().BoolVarP(
 		&refresh, "refresh", "r", false,
 		"Refresh the state of the stack's resources before this update")

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -16,6 +16,7 @@ package deploy
 
 import (
 	"context"
+	"math"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -50,7 +51,7 @@ func (o Options) DegreeOfParallelism() int {
 
 // InfiniteParallelism returns whether or not the requested level of parallelism is unbounded.
 func (o Options) InfiniteParallelism() bool {
-	return o.Parallel == 0
+	return o.Parallel == math.MaxInt32
 }
 
 // Events is an interface that can be used to hook interesting engine/planning events.


### PR DESCRIPTION
Downlevel versions of the Pulumi Node SDK assumed that a parallelism
level of zero implied serial execution, which current CLIs use to signal
unbounded parallelism. This commit works around the downlevel issue by
using math.MaxInt32 to signal unbounded parallelism.

Fixes https://github.com/pulumi/pulumi/issues/2108.