### PR TITLE
Add `--json` to pulumi logs

### DIFF
--- a/cmd/stack_ls.go
+++ b/cmd/stack_ls.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"sort"
 	"strconv"
-	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/pkg/errors"
@@ -117,7 +116,7 @@ func formatJSON(b backend.Backend, currentStack string, stackSummaries []backend
 		}
 
 		if summary.LastUpdate() != nil {
-			summaryJSON.LastUpdate = summary.LastUpdate().UTC().Format(time.RFC3339)
+			summaryJSON.LastUpdate = summary.LastUpdate().UTC().Format(timeFormat)
 		}
 
 		if httpBackend, ok := b.(httpstate.Backend); ok {


### PR DESCRIPTION
When outputing JSON, if we have a fixed number of log entries (i.e. we
are not `--follow`'ing, we wrap each entry in array. Otherwise, we
just emit each log entry as an object at top level.

As part of this change, I've adopted a slightly more precise time
output format in `pulumi stack ls` when using JSON output. These times
now match the default output from `console.log(new Date())`