### PR TITLE
Fix some linter errors. which appear with Go 1.11

### DIFF
--- a/pkg/backend/filestate/crypto.go
+++ b/pkg/backend/filestate/crypto.go
@@ -50,7 +50,7 @@ func defaultCrypter(stackName tokens.QName, cfg config.Map) (config.Crypter, err
 
 // symmetricCrypter gets the right value encrypter/decrypter for this project.
 func symmetricCrypter(stackName tokens.QName) (config.Crypter, error) {
-	contract.Assertf(stackName != "", "stackName", "!= \"\"")
+	contract.Assertf(stackName != "", "stackName %s", "!= \"\"")
 
 	info, err := workspace.DetectProjectStack(stackName)
 	if err != nil {

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -277,7 +277,7 @@ func (csm *createSnapshotMutation) End(step deploy.Step, successful bool) error 
 }
 
 func (sm *SnapshotManager) doUpdate(step deploy.Step) (engine.SnapshotMutation, error) {
-	logging.V(9).Info("SnapshotManager.doUpdate(%s)", step.URN())
+	logging.V(9).Infof("SnapshotManager.doUpdate(%s)", step.URN())
 	err := sm.mutate(func() bool {
 		sm.markOperationPending(step.New(), resource.OperationTypeUpdating)
 		return true

--- a/pkg/util/rpcutil/rpcerror/rpcerror.go
+++ b/pkg/util/rpcutil/rpcerror/rpcerror.go
@@ -139,7 +139,7 @@ func Wrap(code codes.Code, err error, message string) error {
 // It is a logic error to call this function on an error previously
 // returned by `rpcerrors.Wrap`.
 func Wrapf(code codes.Code, err error, messageFormat string, args ...interface{}) error {
-	status := status.Newf(code, messageFormat, args)
+	status := status.Newf(code, messageFormat, args...)
 	cause := serializeErrorCause(err)
 	status, newErr := status.WithDetails(cause)
 	contract.AssertNoError(newErr)


### PR DESCRIPTION
These are all minor, but allow a clean run of the linter with Go 1.11.