### PR TITLE
Restore the `CloudName` field of `apitype.Stack`.

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -257,7 +257,8 @@ const (
 
 // Stack describes a Stack running on a Pulumi Cloud.
 type Stack struct {
-	OrgName string `json:"orgName"`
+	CloudName string `json:"cloudName"`
+	OrgName   string `json:"orgName"`
 
 	RepoName    string       `json:"repoName"`
 	ProjectName string       `json:"projName"`


### PR DESCRIPTION
This field is necessary in order to support downlevel CLIs.