### PR TITLE
Run `gometalinter` once instead of three times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,7 @@ dist::
 
 LINT_SUPPRESS="or be unexported"
 lint::
-	$(GOMETALINTER) main.go | grep -vE ${LINT_SUPPRESS} | sort ; exit $$(($${PIPESTATUS[1]}-1))
-	$(GOMETALINTER) ./pkg/... | grep -vE ${LINT_SUPPRESS} | sort ; exit $$(($${PIPESTATUS[1]}-1))
-	$(GOMETALINTER) ./cmd/... | grep -vE ${LINT_SUPPRESS} | sort ; exit $$(($${PIPESTATUS[1]}-1))
+	$(GOMETALINTER) main.go ./pkg/... ./cmd/... | grep -vE ${LINT_SUPPRESS} | sort ; exit $$(($${PIPESTATUS[1]}-1))
 
 test_fast::
 	go test -timeout $(TEST_FAST_TIMEOUT) -cover -parallel ${TESTPARALLELISM} ${PROJECT_PKGS}


### PR DESCRIPTION
We end up doing a lot of duplicate work by invoking Gometalinter three
times when we do `make lint`. On my machine this decreases the wall
clock time of `make lint` from ~90 sec to ~15 sec, which is a pretty
drastic speedup.