### PR TITLE
Simplify summary text.

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -209,8 +209,8 @@ func TestStackOutputsDisplayed(t *testing.T) {
 			output := stdout.String()
 
 			// ensure we get the outputs info both for the normal update, and for the no-change update.
-			assert.Contains(t, output, "Outputs:\n    foo: 42\n    xyz: \"ABC\"\n\nResources:\n    1 change")
-			assert.Contains(t, output, "Outputs:\n    foo: 42\n    xyz: \"ABC\"\n\nResources:\n    0 changes")
+			assert.Contains(t, output, "Outputs:\n    foo: 42\n    xyz: \"ABC\"\n\nResources:\n    + 1 created")
+			assert.Contains(t, output, "Outputs:\n    foo: 42\n    xyz: \"ABC\"\n\nResources:\n    1 unchanged")
 		},
 	})
 }


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/2051

Tweaks how we output summary text.  Main points:

1. Always one less line than before due to merging 'total changes. unchanged' info into one line.
2. don't show total-changes if it is redundant with the changes we are showing.  i.e. don't show `10 changes` if we only are showing `+ 10 to create`
3. show the total summary after the individual pieces.  i think this just makes more sense since it's the sum of all the little operations we're making.

Multiple changes:

![image](https://user-images.githubusercontent.com/4564579/47759377-963da080-dc6c-11e8-8ae8-ed9067d85f36.png)

One type of change:

![image](https://user-images.githubusercontent.com/4564579/47759406-b40b0580-dc6c-11e8-9283-31b78220cdef.png)

No changes:

![image](https://user-images.githubusercontent.com/4564579/47759535-57f4b100-dc6d-11e8-8d90-01a1aa8163bd.png)

All changes:

![image](https://user-images.githubusercontent.com/4564579/47759578-7c508d80-dc6d-11e8-8427-fe5612d3dc89.png)
