### PR TITLE
Several gardening tasks for Python

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -16,7 +16,7 @@ else
 	PIPENV_PYTHON_VERSION := --three
 endif
 
-PIPENV_VERSION := 2018.05.18
+PIPENV_VERSION := 2018.7.1
 PYENV := ./env
 PYENVSRC := $(PYENV)/src
 
@@ -47,8 +47,7 @@ build_plugin::
 build:: build_package build_plugin
 
 lint::
-    # Temporarily disabled, we've got some Python version-specific code in this package that trips up pylint.
-	# pipenv run pylint -E ./lib/pulumi --ignore-patterns '.*_pb2_.*.py'
+	pipenv run pylint -E ./lib/pulumi --ignore-patterns '.*_pb2_.*.py'
 	$(GOMETALINTER) ./cmd/pulumi-language-python/... | sort ; exit $${PIPESTATUS[0]}
 	$(GOMETALINTER) ./pkg/... | sort ; exit $${PIPESTATUS[0]}
 

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -16,7 +16,7 @@ else
 	PIPENV_PYTHON_VERSION := --three
 endif
 
-PIPENV_VERSION := 2018.7.1
+PIPENV_VERSION := 2018.05.18
 PYENV := ./env
 PYENVSRC := $(PYENV)/src
 

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 protobuf = ">=3.6.0"
 grpcio = ">=1.9.1"
-six = ">=1.11.0"
 
 [dev-packages]
-pylint = ">=1.8.2"
+pylint = ">=1.9"

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -8,4 +8,4 @@ protobuf = ">=3.6.0"
 grpcio = ">=1.9.1"
 
 [dev-packages]
-pylint = ">=1.9"
+pylint = ">=2.1"

--- a/sdk/python/Pipfile.lock
+++ b/sdk/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6908791f07ff6d99e12c69884b4d9b49e7803e28ecb1f9f0c1bb6def5b8fdd80"
+            "sha256": "e613d73573b2806e998517f0dd4636d6bda19b2932121509deac6c3a69f34b72"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -80,7 +80,6 @@
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
-            "index": "pypi",
             "version": "==1.11.0"
         }
     },
@@ -154,7 +153,6 @@
                 "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
                 "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
             ],
-            "index": "pypi",
             "version": "==1.11.0"
         },
         "typed-ast": {

--- a/sdk/python/Pipfile.lock
+++ b/sdk/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e613d73573b2806e998517f0dd4636d6bda19b2932121509deac6c3a69f34b72"
+            "sha256": "104ffa1339c300f397b9143b4d0b6b75c2fb7310c299cde480dbdaed9a892e71"
         },
         "pipfile-spec": 6,
         "requires": {},

--- a/sdk/python/lib/.pylintrc
+++ b/sdk/python/lib/.pylintrc
@@ -1,3 +1,6 @@
+[MASTER]
+ignore=pulumi.runtime.proto
+
 [DESIGN]
 max-args=10
 min-public-methods=0

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -52,7 +52,7 @@ async def serialize_properties(inputs: 'Inputs',
     struct = struct_pb2.Struct()
     for k, v in inputs.items():
         # pylint: disable=unsupported-assignment-operation
-        struct[k] = await serialize_property(v, deps)
+        struct[k] = await serialize_property(v, deps, transform)
 
     return struct
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -51,7 +51,8 @@ async def serialize_properties(inputs: 'Inputs',
     """
     struct = struct_pb2.Struct()
     for k, v in inputs.items():
-        struct[k] = await serialize_property(v, deps, transform)
+        # pylint: disable=unsupported-assignment-operation
+        struct[k] = await serialize_property(v, deps)
 
     return struct
 


### PR DESCRIPTION
1. Update pipenv to 2018.7.1, which is the most recent release that
isn't broken on Python 2
2. Update our pylint dependency to 1.9, the most recently released
version
3. Re-enable pylint for the Pulumi package

Part of an ongoing task to crank up the intensity of our Python linting.