### PR TITLE
Add two new Python tests and fix bugs

### DIFF
--- a/sdk/python/lib/test/langhost/future_input/__init__.py
+++ b/sdk/python/lib/test/langhost/future_input/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/future_input/__main__.py
+++ b/sdk/python/lib/test/langhost/future_input/__main__.py
@@ -1,0 +1,35 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+from pulumi import CustomResource, Output, Input
+
+async def read_a_file_or_something():
+    await asyncio.sleep(0)
+    return "here's a file"
+
+def assert_eq(l, r):
+    assert l == r
+
+class FileResource(CustomResource):
+    contents: Output[str]
+
+    def __init__(self, name: str, file_contents: Input[str]) -> None:
+        CustomResource.__init__(self, "test:index:FileResource", name, {
+            "contents": file_contents
+        })
+
+# read_a_file_or_something returns a coroutine when called, which needs to be scheduled
+# and awaited in order to yield a value.
+file_res = FileResource("file", read_a_file_or_something())
+file_res.contents.apply(lambda c: assert_eq(c, "here's a file"))

--- a/sdk/python/lib/test/langhost/future_input/test_future_input.py
+++ b/sdk/python/lib/test/langhost/future_input/test_future_input.py
@@ -1,0 +1,39 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class FutureInputTest(LanghostTest):
+    """
+    Tests that Pulumi resources can accept awaitable objects as inputs
+    to resources.
+    """
+    def test_future_input(self):
+        self.run_test(
+            program=path.join(self.base_path(), "future_input"),
+            expected_resource_count=1)
+
+    def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps):
+        self.assertEqual(ty, "test:index:FileResource")
+        self.assertEqual(name, "file")
+        self.assertDictEqual(resource, {
+            "contents": "here's a file"
+        })
+
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": resource
+        }

--- a/sdk/python/lib/test/langhost/resource_thens/__init__.py
+++ b/sdk/python/lib/test/langhost/resource_thens/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/resource_thens/__main__.py
+++ b/sdk/python/lib/test/langhost/resource_thens/__main__.py
@@ -1,0 +1,48 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from functools import partial
+from pulumi import CustomResource, Output
+
+def assert_eq(l, r):
+    assert l == r
+
+class ResourceA(CustomResource):
+    inprop: Output[int]
+    outprop: Output[str]
+
+    def __init__(self, name: str) -> None:
+        CustomResource.__init__(self, "test:index:ResourceA", name, {
+            "inprop": 777,
+            "outprop": None
+        })
+
+class ResourceB(CustomResource):
+    other_in: Output[int]
+    other_out: Output[str]
+
+    def __init__(self, name: str, res: ResourceA) -> None:
+        CustomResource.__init__(self, "test:index:ResourceB", name, {
+            "other_in": res.inprop,
+            "other_out": res.outprop
+        })
+
+a = ResourceA("resourceA")
+a.urn.apply(lambda urn: assert_eq(urn, "test:index:ResourceA::resourceA"))
+a.inprop.apply(lambda v: assert_eq(v, 777))
+a.outprop.apply(lambda v: assert_eq(v, "output yeah"))
+
+b = ResourceB("resourceB", a)
+b.urn.apply(lambda urn: assert_eq(urn, "test:index:ResourceB::resourceB"))
+b.other_in.apply(lambda v: assert_eq(v, 777))
+b.other_out.apply(lambda v: assert_eq(v, "output yeah"))

--- a/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
+++ b/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
@@ -1,0 +1,73 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class ResourceThensTest(LanghostTest):
+    """
+    Test that tests Pulumi's ability to track dependencies between resources.
+
+    ResourceA has an (unknown during preview) output property that ResourceB
+    depends on. In all cases, the SDK must inform the engine that ResourceB
+    depends on ResourceA. When not doing previews, ResourceB has a partial view
+    of ResourceA's properties. 
+    """
+    def test_resource_thens(self):
+        self.run_test(
+            program=path.join(self.base_path(), "resource_thens"),
+            expected_resource_count=2)
+
+    def register_resource(self, _ctx, dry_run, ty, name, res, deps):
+        if ty == "test:index:ResourceA":
+            self.assertEqual(name, "resourceA")
+            self.assertDictEqual(res, {"inprop": 777})
+            urn = self.make_urn(ty, name)
+            res_id = None
+            props = {}
+            if not dry_run:
+                res_id = name
+                props["outprop"] = "output yeah"
+
+            return {
+                "urn": urn,
+                "id": res_id,
+                "object": props
+            }
+
+        if ty == "test:index:ResourceB":
+            self.assertEqual(name, "resourceB")
+            self.assertListEqual(deps, ["test:index:ResourceA::resourceA"])
+            if dry_run:
+                self.assertDictEqual(res, {
+                    "other_in": 777,
+                    # other_out is unknown, so it is not in the dictionary.
+                })
+            else:
+                self.assertDictEqual(res, {
+                    "other_in": 777,
+                    "other_out": "output yeah"
+                })
+
+            res_id = None
+            if not dry_run:
+                res_id = name
+
+            return {
+                "urn": self.make_urn(ty, name),
+                "id": res_id,
+                "object": {}
+            }
+
+        self.fail(f"unknown resource type: {ty}")

--- a/sdk/python/lib/test/langhost/util.py
+++ b/sdk/python/lib/test/langhost/util.py
@@ -75,7 +75,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
         type_ = request.type
         name = request.name
         props = rpc.deserialize_properties(request.object)
-        deps = request.dependencies
+        deps = list(request.dependencies)
         outs = {}
         if type_ != "pulumi:pulumi:Stack":
             outs = self.langhost_test.register_resource(


### PR DESCRIPTION
future_input tests that it's possible to use coroutines as inputs to
Pulumi resources. resource_thens tests that it's possible to use outputs
to chain resource inputs and outputs together and that the SDK reports
correct dependencies to the engine.

This PR also fixes two bugs exposed by the new tests: first, coroutines
needed to be scheduled before awaiting (otherwise we'd deadlock) and
Nones in maps needed to be ignored when serializing and deserializing.