### PR TITLE
Ensure we show the properties that changed when doing a multi-stage replace

### DIFF
--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -327,7 +327,7 @@ func (data *resourceRowData) getInfoColumn() string {
 		diagMsg += msg
 	}
 
-	changes := data.getDiffInfo()
+	changes := data.getDiffInfo(step)
 	if colors.Never.Colorize(changes) != "" {
 		appendDiagMessage("[" + changes + "]")
 	}
@@ -383,8 +383,7 @@ func (data *resourceRowData) getInfoColumn() string {
 	return diagMsg
 }
 
-func (data *resourceRowData) getDiffInfo() string {
-	step := data.step
+func (data *resourceRowData) getDiffInfo(step engine.StepEventMetadata) string {
 	changesBuf := &bytes.Buffer{}
 	if step.Old != nil && step.New != nil {
 		var diff *resource.ObjectDiff


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1824

Normal interactive display will end with this:

![image](https://user-images.githubusercontent.com/4564579/47946281-e617a400-dec6-11e8-85e7-c92b883a9c15.png)

`--diff` display will show:

![image](https://user-images.githubusercontent.com/4564579/47946284-fb8cce00-dec6-11e8-9bc0-db4e0bff4519.png)
