### PR TITLE
Fix Python support in integration test framework

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1196,16 +1196,8 @@ func (pt *programTester) preparePythonProject(projinfo *engine.Projinfo) error {
 			}
 		}
 
-		if !strings.ContainsRune(dep, os.PathSeparator) {
-			// This is a package. Install it from pypi.
-			if err := pt.runPipenvCommand("pipenv-install-package", []string{"install", dep}, cwd); err != nil {
-				return err
-			}
-		} else {
-			// This is a filepath. Install it from the filesystem.
-			if err := pt.runPipenvCommand("pipenv-install-package", []string{"install", "-e", dep}, cwd); err != nil {
-				return err
-			}
+		if err := pt.runPipenvCommand("pipenv-install-package", []string{"install", "-e", dep}, cwd); err != nil {
+			return err
 		}
 	}
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -32,7 +32,6 @@ func TestEmptyNodeJS(t *testing.T) {
 
 // TestEmptyPython simply tests that we can run an empty Python project.
 func TestEmptyPython(t *testing.T) {
-	t.Skip("pulumi/pulumi#2138")
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:   filepath.Join("empty", "python"),
 		Quick: true,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -33,7 +33,10 @@ func TestEmptyNodeJS(t *testing.T) {
 // TestEmptyPython simply tests that we can run an empty Python project.
 func TestEmptyPython(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:   filepath.Join("empty", "python"),
+		Dir: filepath.Join("empty", "python"),
+		Dependencies: []string{
+			path.Join("..", "..", "sdk", "python", "env", "src"),
+		},
 		Quick: true,
 	})
 }


### PR DESCRIPTION
Update the integratino test framework to use pipenv to bootstrap new
virtual environments for tests and use those virtual environments to run
pulumi update and pulumi preview.

Fixes pulumi/pulumi#2138