### PR TITLE
Require Node 11 run to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: NODE_VERSION=v6.10.3
     - os: linux
       env: NODE_VERSION=v11.0.0
-  allow_failures:
-    - env: NODE_VERSION=v11.0.0
 language: go
 go: 1.9
 sudo: true # give us 7.5GB and >2 bursted cores.


### PR DESCRIPTION
It was alowed to fail when we were bringing up Node 11 support, but
now that we do support it, we should lock in the win.