### PR TITLE
Record engine events

### DIFF
--- a/pkg/apitype/events.go
+++ b/pkg/apitype/events.go
@@ -1,0 +1,148 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apitype
+
+// The "engine events" defined here are a fork of the types and enums defined in the engine
+// package. The duplication is intentional to insulate the Pulumi service from various kinds of
+// breaking changes.
+//
+// The types aren't versioned in the same manner as Resource, Deployment, and Checkpoint (see
+// apitype/migrate). So care must be taken if these are ever returned from the service to the CLI.
+
+// CancelEvent is emitted when the user initiates a cancellation of the update in progress, or
+// the update successfully completes.
+type CancelEvent struct{}
+
+// StdoutEngineEvent is emitted whenever a generic message is written, for example warnings
+// from the pulumi CLI itself. Less common that DiagnosticEvent
+type StdoutEngineEvent struct {
+	Message string `json:"message"`
+	Color   string `json:"color"`
+}
+
+// DiagnosticEvent is emitted whenever a diagnostic message is provided, for example errors from
+// a cloud resource provider while trying to create or update a resource.
+type DiagnosticEvent struct {
+	URN     string `json:"urn"`
+	Prefix  string `json:"prefix"`
+	Message string `json:"message"`
+	Color   string `json:"color"`
+	// Severity is one of "info", "info#err", "warning", or "error".
+	Severity  string `json:"severity"`
+	Ephemeral bool   `json:"ephemeral"`
+}
+
+// PreludeEvent is emitted at the start of an update.
+type PreludeEvent struct {
+	// Config contains the keys and values for the update.
+	// Encrypted configuration values may be blinded.
+	Config map[string]string `json:"config"`
+}
+
+// SummaryEvent is emitted at the end of an update, with a summary of the changes made.
+type SummaryEvent struct {
+	// MaybeCorrupt is set if one or more of the resources is in an invalid state.
+	MaybeCorrupt bool `json:"maybeCorrupt"`
+	// Duration is the number of seconds the update was executing.
+	DurationSeconds int
+	// ResourceChanges contains the count for resource change by type. The keys are deploy.StepOp,
+	// which is not exported in this package.
+	ResourceChanges map[string]int `json:"resourceChanges"`
+}
+
+// StepEventMetadata describes a "step" within the Pulumi engine, which is any concrete action
+// to migrate a set of cloud resources from one state to another.
+type StepEventMetadata struct {
+	// Op is the operation being performed, a deploy.StepOp.
+	Op   string `json:"op"`
+	URN  string `json:"urn"`
+	Type string `json:"type"`
+
+	// Old is the state of the resource before performing the step.
+	Old *StepEventStateMetadata `json:"old"`
+	// New is the state of the resource after performing the step.
+	New *StepEventStateMetadata `json:"new"`
+	// Res is the current state of the resource as known. (e.g. equal to old or new depending on
+	// circumstance.)
+	Res *StepEventStateMetadata `json:"res"`
+
+	// Keys causing a replacement (only applicable for "create" and "replace" Ops).
+	Keys []string `json:"keys,omitempty"`
+	// Logical is set if the step is a logical operation in the program.
+	Logical bool `json:"logical"`
+	// Provider actually performing the step.
+	Provider string `json:"provider"`
+}
+
+// StepEventStateMetadata is the more detailed state information for a resource as it relates to
+// a step(s) being performed.
+type StepEventStateMetadata struct {
+	Type string `json:"type"`
+	URN  string `json:"urn"`
+
+	// Custom indicates if the resource is managed by a plugin.
+	Custom bool `json:"custom"`
+	// Delete is true when the resource is pending deletion due to a replacement.
+	Delete bool `json:"delete"`
+	// ID is the resource's unique ID, assigned by the resource provider (or blank if none/uncreated).
+	ID string `json:"id"`
+	// Parent is an optional parent URN that this resource belongs to.
+	Parent string `json:"parent"`
+	// Protect is true to "protect" this resource (protected resources cannot be deleted).
+	Protect bool `json:"protect"`
+	// Inputs contains the resource's input properties (as specified by the program). Secrets have
+	// filtered out, and large assets have been replaced by hashes as applicable.
+	Inputs map[string]interface{} `json:"inputs"`
+	// Outputs contains the resource's complete output state (as returned by the resource provider).
+	Outputs map[string]interface{} `json:"outputs"`
+	// Provider is the resource's provider reference
+	Provider string `json:"provider"`
+	// InitErrors is the set of errors encountered in the process of initializing resource.
+	InitErrors []string `json:"initErrors"`
+}
+
+// ResourcePreEvent is emitted before a resource is modified.
+type ResourcePreEvent struct {
+	Metadata StepEventMetadata `json:"metadata"`
+	Planning bool              `json:"planning"`
+}
+
+// ResOutputsEvent is emitted when a resource is finished being provisioned.
+type ResOutputsEvent struct {
+	Metadata StepEventMetadata `json:"metadata"`
+	Planning bool              `json:"planning"`
+}
+
+// ResOpFailedEvent is emitted when a resource operation fails. Typically a DiagnosticEvent is
+// emitted before this event, indiciating what the root cause of the error.
+type ResOpFailedEvent struct {
+	Metadata StepEventMetadata `json:"metadata"`
+	Status   int               `json:"status"`
+	Steps    int               `json:"steps"`
+}
+
+// EngineEvent describes a Pulumi engine event, such as a change to a resource or diagnostic
+// message. EngineEvent is a discriminated union of all possible event types, and exactly one
+// field will be non-nil.
+type EngineEvent struct {
+	CancelEvent      *CancelEvent       `json:"cancelEvent,omitempty"`
+	StdoutEvent      *StdoutEngineEvent `json:"stdoutEvent,omitempty"`
+	DiagnosticEvent  *DiagnosticEvent   `json:"diagnosticEvent,omitempty"`
+	PreludeEvent     *PreludeEvent      `json:"preludeEvent,omitempty"`
+	SummaryEvent     *SummaryEvent      `json:"summaryEvent,omitempty"`
+	ResourcePreEvent *ResourcePreEvent  `json:"resourcePreEvent,omitempty"`
+	ResOutputsEvent  *ResOutputsEvent   `json:"resOutputsEvent,omitempty"`
+	ResOpFailedEvent *ResOpFailedEvent  `json:"resOpFailedEvent,omitempty"`
+}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -732,24 +732,21 @@ func (b *cloudBackend) runEngineAction(
 		return nil, err
 	}
 
-	persister := b.newSnapshotPersister(ctx, u.update, u.tokenSource)
-	manager := backend.NewSnapshotManager(persister, u.GetTarget().Snapshot)
+	// displayEvents renders the event to the console and Pulumi service. The processor for the
+	// will signal all events have been proceed when a value is written to the displayDone channel.
 	displayEvents := make(chan engine.Event)
 	displayDone := make(chan bool)
-
 	go u.RecordAndDisplayEvents(
 		backend.ActionLabel(kind, dryRun), kind, stackRef, op,
 		displayEvents, displayDone, op.Opts.Display, dryRun)
 
+	// The engineEvents channel receives all events from the engine, which we then forward onto other
+	// channels for actual processing. (displayEvents and callerEventsOpt.)
 	engineEvents := make(chan engine.Event)
-
-	scope := op.Scopes.NewScope(engineEvents, dryRun)
 	eventsDone := make(chan bool)
 	go func() {
-		// Pull in all events from the engine and send to them to the two listeners.
 		for e := range engineEvents {
 			displayEvents <- e
-
 			if callerEventsOpt != nil {
 				callerEventsOpt <- e
 			}
@@ -758,9 +755,19 @@ func (b *cloudBackend) runEngineAction(
 		close(eventsDone)
 	}()
 
+	// The backend.SnapshotManager and backend.SnapshotPersister will keep track of any changes to
+	// the Snapshot (checkpoint file) in the HTTP backend.
+	persister := b.newSnapshotPersister(ctx, u.update, u.tokenSource)
+	snapshotManager := backend.NewSnapshotManager(persister, u.GetTarget().Snapshot)
+
 	// Depending on the action, kick off the relevant engine activity.  Note that we don't immediately check and
 	// return error conditions, because we will do so below after waiting for the display channels to close.
-	engineCtx := &engine.Context{Cancel: scope.Context(), Events: engineEvents, SnapshotManager: manager}
+	cancellationScope := op.Scopes.NewScope(engineEvents, dryRun)
+	engineCtx := &engine.Context{
+		Cancel:          cancellationScope.Context(),
+		Events:          engineEvents,
+		SnapshotManager: snapshotManager,
+	}
 	if parentSpan := opentracing.SpanFromContext(ctx); parentSpan != nil {
 		engineCtx.ParentSpan = parentSpan.Context()
 	}
@@ -779,23 +786,23 @@ func (b *cloudBackend) runEngineAction(
 		contract.Failf("Unrecognized update kind: %s", kind)
 	}
 
-	// Wait for the display to finish showing all the events.
+	// Wait for dependent channels to finish processing engineEvents before closing.
 	<-displayDone
-	scope.Close() // Don't take any cancellations anymore, we're shutting down.
+	cancellationScope.Close() // Don't take any cancellations anymore, we're shutting down.
 	close(engineEvents)
 	close(displayDone)
-	contract.IgnoreClose(manager)
+	contract.IgnoreClose(snapshotManager)
 
 	// Make sure that the goroutine writing to displayEvents and callerEventsOpt
 	// has exited before proceeding
 	<-eventsDone
 	close(displayEvents)
 
+	// Mark the update as complete.
 	status := apitype.UpdateStatusSucceeded
 	if err != nil {
 		status = apitype.UpdateStatusFailed
 	}
-
 	completeErr := u.Complete(status)
 	if completeErr != nil {
 		err = multierror.Append(err, errors.Wrap(completeErr, "failed to complete update"))

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -519,3 +519,12 @@ func (pc *Client) AppendUpdateLogEntry(ctx context.Context, update UpdateIdentif
 	return pc.updateRESTCall(ctx, "POST", getUpdatePath(update, "log"), nil, req, nil,
 		updateAccessToken(token), httpCallOptions{RetryAllMethods: true})
 }
+
+// RecordEngineEvent posts an engine event to the Pulumi service.
+func (pc *Client) RecordEngineEvent(
+	ctx context.Context, update UpdateIdentifier, event apitype.EngineEvent, token string) error {
+	return pc.updateRESTCall(
+		ctx, "POST", getUpdatePath(update, "events"),
+		nil, event, nil,
+		updateAccessToken(token), httpCallOptions{GzipCompress: true})
+}

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -17,7 +17,10 @@ package httpstate
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/apitype"
@@ -136,15 +139,33 @@ func (u *cloudUpdate) Complete(status apitype.UpdateStatus) error {
 	return u.backend.client.CompleteUpdate(u.context, u.update, status, token)
 }
 
+// recordEvent will record the event with the Pulumi service, enabling things like viewing
+// the rendered update logs or drilling into the timeline of an update.
 func (u *cloudUpdate) recordEvent(
 	action apitype.UpdateKind, event engine.Event, seen map[resource.URN]engine.StepEventMetadata,
 	opts display.Options) error {
-
-	// If we don't have a token source, we can't perform any mutations.
-	if u.tokenSource == nil {
-		return nil
+	contract.Assert(u.tokenSource != nil)
+	token, err := u.tokenSource.GetToken()
+	if err != nil {
+		return err
 	}
 
+	// Send the event to the Pulumi Service to power things like the update summary page.
+	// Currently opt-in via flag to allow for gathering per data before the service-side changes
+	// are available in production.
+	if os.Getenv("PULUMI_RECORD_ENGINE_EVENTS") != "" {
+		apiEvent, convErr := convertEngineEvent(event)
+		if convErr != nil {
+			return errors.Wrap(convErr, "converting engine event")
+		}
+		if err = u.backend.client.RecordEngineEvent(u.context, u.update, apiEvent, token); err != nil {
+			return err
+		}
+	}
+
+	// We also pre-render the event using the DiffView and post as applicable. Ideally this data
+	// is redundant because we could produce the same log from the raw engine event stream, which
+	// is stored above.
 	fields := make(map[string]interface{})
 	kind := string(apitype.StdoutEvent)
 	if event.Type == engine.DiagEvent {
@@ -169,11 +190,6 @@ func (u *cloudUpdate) recordEvent(
 		}
 		msg = msg[len(chunk):]
 
-		token, err := u.tokenSource.GetToken()
-		if err != nil {
-			return err
-		}
-
 		fields["text"] = chunk
 		fields["colorize"] = colors.Always
 		if err = u.backend.client.AppendUpdateLogEntry(u.context, u.update, kind, fields, token); err != nil {
@@ -183,6 +199,8 @@ func (u *cloudUpdate) recordEvent(
 	return nil
 }
 
+// RecordAndDisplayEvents inspects engine events from the given channel, and prints them to the CLI as well as
+// posting them to the Pulumi service. Any failures will post DiaogEvents to be displayed in the CLI.
 func (u *cloudUpdate) RecordAndDisplayEvents(
 	label string, action apitype.UpdateKind, stackRef backend.StackReference, op backend.UpdateOperation,
 	events <-chan engine.Event, done chan<- bool, opts display.Options, isPreview bool) {
@@ -291,4 +309,158 @@ func (b *cloudBackend) getTarget(ctx context.Context, stackRef backend.StackRefe
 		Decrypter: decrypter,
 		Snapshot:  snapshot,
 	}, nil
+}
+
+func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMetadata {
+	keys := make([]string, 0, len(md.Keys))
+	for i, v := range md.Keys {
+		keys[i] = string(v)
+	}
+
+	return apitype.StepEventMetadata{
+		Op:   string(md.Op),
+		URN:  string(md.URN),
+		Type: string(md.Type),
+
+		Old: convertStepEventStateMetadata(md.Old),
+		New: convertStepEventStateMetadata(md.New),
+		Res: convertStepEventStateMetadata(md.Res),
+
+		Keys:     keys,
+		Logical:  md.Logical,
+		Provider: md.Provider,
+	}
+}
+
+func convertStepEventStateMetadata(md *engine.StepEventStateMetadata) *apitype.StepEventStateMetadata {
+	if md == nil {
+		return nil
+	}
+
+	inputs := make(map[string]interface{})
+	for k, v := range md.Inputs {
+		inputs[string(k)] = v
+	}
+	outputs := make(map[string]interface{})
+	for k, v := range md.Outputs {
+		outputs[string(k)] = v
+	}
+
+	return &apitype.StepEventStateMetadata{
+		Type: string(md.Type),
+		URN:  string(md.URN),
+
+		Custom:     md.Custom,
+		Delete:     md.Delete,
+		ID:         string(md.ID),
+		Parent:     string(md.Parent),
+		Protect:    md.Protect,
+		Inputs:     inputs,
+		Outputs:    outputs,
+		InitErrors: md.InitErrors,
+	}
+}
+
+// convertEngineEvent converts a raw engine.Event into an apitype.EngineEvent used in the Pulumi
+// REST API. Returns an error if the engine event is unknown or not in an expected format.
+func convertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
+	var apiEvent apitype.EngineEvent
+
+	// Error to return if the payload doesn't match expected.
+	eventTypePayloadMismatch := errors.Errorf("unexpected payload for event type %v", e.Type)
+
+	switch e.Type {
+	case engine.CancelEvent:
+		apiEvent.CancelEvent = &apitype.CancelEvent{}
+
+	case engine.StdoutColorEvent:
+		p, ok := e.Payload.(engine.StdoutEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.StdoutEvent = &apitype.StdoutEngineEvent{
+			Message: p.Message,
+			Color:   string(p.Color),
+		}
+
+	case engine.DiagEvent:
+		p, ok := e.Payload.(engine.DiagEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.DiagnosticEvent = &apitype.DiagnosticEvent{
+			URN:       string(p.URN),
+			Prefix:    p.Prefix,
+			Message:   p.Message,
+			Color:     string(p.Color),
+			Severity:  string(p.Severity),
+			Ephemeral: p.Ephemeral,
+		}
+
+	case engine.PreludeEvent:
+		p, ok := e.Payload.(engine.PreludeEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		// Convert the config bag.
+		cfg := make(map[string]string)
+		for k, v := range p.Config {
+			cfg[k] = v
+		}
+		apiEvent.PreludeEvent = &apitype.PreludeEvent{
+			Config: cfg,
+		}
+
+	case engine.SummaryEvent:
+		p, ok := e.Payload.(engine.SummaryEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		// Convert the resource changes.
+		changes := make(map[string]int)
+		for op, count := range p.ResourceChanges {
+			changes[string(op)] = count
+		}
+		apiEvent.SummaryEvent = &apitype.SummaryEvent{
+			MaybeCorrupt:    p.MaybeCorrupt,
+			DurationSeconds: int(p.Duration.Seconds()),
+			ResourceChanges: changes,
+		}
+
+	case engine.ResourcePreEvent:
+		p, ok := e.Payload.(engine.ResourcePreEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.ResourcePreEvent = &apitype.ResourcePreEvent{
+			Metadata: convertStepEventMetadata(p.Metadata),
+			Planning: p.Planning,
+		}
+
+	case engine.ResourceOutputsEvent:
+		p, ok := e.Payload.(engine.ResourceOutputsEventPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.ResOutputsEvent = &apitype.ResOutputsEvent{
+			Metadata: convertStepEventMetadata(p.Metadata),
+			Planning: p.Planning,
+		}
+
+	case engine.ResourceOperationFailed:
+		p, ok := e.Payload.(engine.ResourceOperationFailedPayload)
+		if !ok {
+			return apiEvent, eventTypePayloadMismatch
+		}
+		apiEvent.ResOpFailedEvent = &apitype.ResOpFailedEvent{
+			Metadata: convertStepEventMetadata(p.Metadata),
+			Status:   int(p.Status),
+			Steps:    p.Steps,
+		}
+
+	default:
+		return apiEvent, errors.Errorf("unknown event type %q", e.Type)
+	}
+
+	return apiEvent, nil
 }

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pkg/errors"
@@ -153,7 +154,7 @@ func (u *cloudUpdate) recordEvent(
 	// Send the event to the Pulumi Service to power things like the update summary page.
 	// Currently opt-in via flag to allow for gathering per data before the service-side changes
 	// are available in production.
-	if os.Getenv("PULUMI_RECORD_ENGINE_EVENTS") != "" {
+	if cmdutil.IsTruthy(os.Getenv("PULUMI_RECORD_ENGINE_EVENTS")) {
 		apiEvent, convErr := convertEngineEvent(event)
 		if convErr != nil {
 			return errors.Wrap(convErr, "converting engine event")


### PR DESCRIPTION
This PR duplicates the `engine.Event` and payload types into the `apitypes` package, and starts posting the event stream to the Pulumi Service. (Though posting the event stream is behind a `PULUMI_RECORD_ENGINE_EVENTS ` flag for the time being, as the service doesn't support it just yet. After I do some testing and rollout the Pulumi Service changes, we'll enable it by default.)

There are some subtle design issues here, so I'll call them out explicitly. (Feel free to grab me in-person if that would be more effective to hammer out any specific issues.)

- We duplicate the `engine.Event` types into `apitypes` to in theory insulate from breaking changes. If we were to expose the `engine.Event` payloads directly, then any field renames would lead to a breaking change. e.g. the Pulumi Service would return corrupted data if trying to unmarshall data serialized in an older format.

Alternatively, we could socialize that the engine events are "locked" and just be careful to not make breaking changes. IMHO, keeping the types that we need to remain stable in the same package makes more sense.

As far as API-shape stable types in the `apitypes` package go, we could proactively version them like we do with `ResourceV1`, `ResourceV2`, etc. However, since we don't have any near-term plans to "round trip" the engine events, I didn't bother creating the `UntypedEngineEvent` or `EngineEventV1` types. Though if we ever (1) send the events from the service to the CLI and (2) make a breaking change, we'll need to do that work.

- Even with recording engine events in the service, we still _also_ record the update's raw log. i.e. we still call `display.RenderDiffEvent` and post the results via `client.AppendUpdateLogEntry`.

In theory, with all of the engine events we could render the same update log from just the engine events. So uploading the output of `display.RenderDiffEvent` is redundant. However, I am not sure we'll be able append new log messages "online". The `display` package maintains a list of "seen resources" (`var seen map[resource.URN]engine.StepEventMetadata)`). And if that is required to produce the full log, we'd need to load all previous engine events to know what the new log message would be. (Read: maybe we could remove uploading the update logs too, but I'm not sure yet and will need to do more investigation first.)



