### PR TITLE
Implement Invoke for Python 3

### DIFF
--- a/sdk/python/lib/test/langhost/invoke/__init__.py
+++ b/sdk/python/lib/test/langhost/invoke/__init__.py
@@ -11,15 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-"""
-The runtime implementation of the Pulumi Python SDK.
-"""
-
-# Make all module members inside of this package available as package members.
-from .config import *
-from .resource import *
-from .rpc import *
-from .settings import *
-from .stack import *
-from .invoke import *

--- a/sdk/python/lib/test/langhost/invoke/__main__.py
+++ b/sdk/python/lib/test/langhost/invoke/__main__.py
@@ -1,0 +1,39 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import CustomResource, Output, log
+from pulumi.runtime import invoke
+
+def assert_eq(l, r):
+    assert l == r
+
+
+class MyResource(CustomResource):
+    value: Output[int]
+
+    def __init__(self, name, value):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={
+            "value": value,
+        })
+
+
+value = invoke("test:index:MyFunction", props={
+    "value": 41,
+})
+
+async def do_invoke():
+    value = await invoke("test:index:MyFunction", props={"value": 41})
+    return value["value"]
+
+res = MyResource("resourceA", do_invoke())
+res.value.apply(lambda v: assert_eq(v, 42))

--- a/sdk/python/lib/test/langhost/invoke/test_invoke.py
+++ b/sdk/python/lib/test/langhost/invoke/test_invoke.py
@@ -1,0 +1,60 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class TestInvoke(LanghostTest):
+    def test_invoke_success(self):
+        self.run_test(
+            program=path.join(self.base_path(), "invoke"),
+            expected_resource_count=1)
+
+    def invoke(self, _ctx, token, args):
+        self.assertEqual("test:index:MyFunction", token)
+        self.assertDictEqual({
+            "value": 41,
+        }, args)
+
+        return [], {
+            "value": args["value"] + 1
+        }
+
+    def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps):
+        self.assertEqual("test:index:MyResource", ty)
+        self.assertEqual("resourceA", name)
+        self.assertEqual(resource["value"], 42)
+
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": resource,
+        }
+
+
+class TestInvokeWithFailures(LanghostTest):
+    def test_invoke_failure(self):
+        self.run_test(
+            program=path.join(self.base_path(), "invoke"),
+            expected_resource_count=0,
+            expected_error="Program exited with non-zero exit code: 1")
+
+    def invoke(self, _ctx, token, args):
+        self.assertEqual("test:index:MyFunction", token)
+        self.assertDictEqual({
+            "value": 41,
+        }, args)
+
+        return [{"property": "value", "reason": "the invoke failed"}], {}
+


### PR DESCRIPTION
Similar to https://github.com/pulumi/pulumi/pull/2173, this PR fixes the (previously wrong) implementation of Invoke for Python 3.

Its structure is very similar to https://github.com/pulumi/pulumi/pull/2173 in that it does RPCs on a thread pool derived from the current event loop instance.

Fixes https://github.com/pulumi/pulumi/issues/2162