### PR TITLE
Support specifying template names to `pulumi up`

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -60,7 +60,7 @@ func newNewCmd() *cobra.Command {
 	var yes bool
 
 	cmd := &cobra.Command{
-		Use:        "new [template]",
+		Use:        "new [template|url]",
 		SuggestFor: []string{"init", "create"},
 		Short:      "Create a new Pulumi project",
 		Args:       cmdutil.MaximumNArgs(1),


### PR DESCRIPTION
`pulumi up <arg>` does not currently support template names like `pulumi
new`; `up` is hard-coded to only support URLs to templates. This
prevents us from displaying shorter `$ pulumi up ...` commands in the
Pulumi Console when the URL is to one of our standard Pulumi templates.
In such cases, we'd like to be able to show the command with just the
template name instead of a full URL to the template in the
pulumi/templates repo.

This changes `up` to support the standard Pulumi template names
just like `new`.

Also, while making changes here, if a URL specified to `up` contains
multiple templates in subdirectories, allow the user to choose the
template, just like with `new`.

Fixes #2125