### PR TITLE
Don't show `new` prelude when `-g` is specified

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -188,7 +188,7 @@ func newNewCmd() *cobra.Command {
 			}
 
 			// Show instructions, if we're going to show at least one prompt.
-			hasAtLeastOnePrompt := (name == "") || (description == "") || (stack == "")
+			hasAtLeastOnePrompt := (name == "") || (description == "") || (!generateOnly && stack == "")
 			if !yes && hasAtLeastOnePrompt {
 				fmt.Println("This command will walk you through creating a new Pulumi project.")
 				fmt.Println()


### PR DESCRIPTION
The new command shouldn't show you the "this command will walk you
through" prelude when using the `-g` command -- it's not helpful and
generally looks confusing.

Fixes #2150