### PR TITLE
Use proj description when there's no template desc

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -800,7 +800,8 @@ func templatesToOptionArrayAndMap(templates []workspace.Template) ([]string, map
 	nameToTemplateMap := make(map[string]workspace.Template)
 	for _, template := range templates {
 		// Create the option string that combines the name, padding, and description.
-		option := fmt.Sprintf(fmt.Sprintf("%%%ds    %%s", -maxNameLength), template.Name, template.Description)
+		desc := workspace.ValueOrDefaultProjectDescription("", template.ProjectDescription, template.Description)
+		option := fmt.Sprintf(fmt.Sprintf("%%%ds    %%s", -maxNameLength), template.Name, desc)
 
 		// Add it to the array and map.
 		options = append(options, option)


### PR DESCRIPTION
Whenever we need to display a template description, if the Pulumi.yaml
doesn't have it, but has a project description, just use the project
description. This will allow us to avoid having the same description for
both the project and template in our examples.

Fixes #2172