### PR TITLE
Don't write a lock file when installing test packages

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1167,7 +1167,7 @@ func (pt *programTester) preparePythonProject(projinfo *engine.Projinfo) error {
 	}
 
 	// Install the package's dependencies, which Pipenv infers from a requirements.txt file in the root of the project.
-	if err = pt.runPipenvCommand("pipenv-install", []string{"install"}, cwd); err != nil {
+	if err = pt.runPipenvCommand("pipenv-install", []string{"install", "--skip-lock"}, cwd); err != nil {
 		return err
 	}
 
@@ -1183,7 +1183,8 @@ func (pt *programTester) preparePythonProject(projinfo *engine.Projinfo) error {
 			}
 		}
 
-		if err := pt.runPipenvCommand("pipenv-install-package", []string{"install", "-e", dep}, cwd); err != nil {
+		err = pt.runPipenvCommand("pipenv-install-package", []string{"install", "--skip-lock", "-e", dep}, cwd)
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The lockfile is not super interesting when running the lifecycle
tests, since the test project is not a long lived artifact. There was
no real harm in writing it, exepct that in some cases `pipenv` gets
very confused when you have dependencies on pre-release
versions (which is the case right now as we are brining up Python 3).

The packages are still installed correctly, even when we don't write a
lock file.