### PR TITLE
Exclude the unscriptable-object rule

### DIFF
--- a/sdk/python/.pylintrc
+++ b/sdk/python/.pylintrc
@@ -152,7 +152,8 @@ disable=print-statement,
         fixme,
         broad-except,
         no-self-use,
-        unused-import
+        unused-import,
+        unsubscriptable-object
 
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
Python 3.7 gets this rule wrong for `Generic[]`.

https://github.com/PyCQA/pylint/issues/2416 tracks this issue in pylint.