### PR TITLE
Fix, formalize and add tests for property rewrites

### DIFF
--- a/sdk/python/lib/test/langhost/property_renaming/__init__.py
+++ b/sdk/python/lib/test/langhost/property_renaming/__init__.py
@@ -11,21 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from os import path
-from ..util import LanghostTest
-
-
-class StackOutputTest(LanghostTest):
-    """
-    Test that tests Pulumi's ability to register resource outputs.
-    """
-    def test_stack_outputs(self):
-        self.run_test(
-            program=path.join(self.base_path(), "stack_output"),
-            expected_resource_count=0)
-
-    def register_resource_outputs(self, _ctx, _dry_run, _urn, ty, _name, _resource, outputs):
-        self.assertEqual(ty, "pulumi:pulumi:Stack")
-        self.assertDictEqual({
-            "the-coolest": "pulumi"
-        }, outputs)

--- a/sdk/python/lib/test/langhost/property_renaming/__main__.py
+++ b/sdk/python/lib/test/langhost/property_renaming/__main__.py
@@ -1,0 +1,97 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Dict
+
+import pulumi
+from pulumi import CustomResource, Output, Input
+
+def assert_eq(l, r):
+    assert l == r
+
+
+class TranslatedResource(CustomResource):
+    """
+    translate_input_property and translate_output_property provide hooks for resources to control the names of their own
+    properties. The SDK will invoke each hook under the following circumstances:
+
+    1. When preparing a RegisterResource RPC, the engine will call translate_input_property *recursively* on all
+       property keys defined by a resource. The property name that translate_input_property returns will be the name of
+       the property when sent to the engine.
+    2. When returning from a RegisterResource RPC, the engine will call translate_output_property *recursively* on the
+       data object returned from the engine. The property name that translate_output_property returns will be the name
+       of the property on the Python object.
+
+    This is used by providers to project their resource properties into Python using idiomatic snake case, while
+    ensuring that providers themselves always speak over the RPC interface using camel case.
+    """
+    transformed_prop: Output[str]
+    engine_output_prop: Output[str]
+    recursive_prop: Output[Dict[str, str]]
+
+    def __init__(self, name: str, prop: Input[str]) -> None:
+        CustomResource.__init__(self, "test:index:TranslatedResource", name, {
+            "transformed_prop": prop,
+            "recursive_prop": {
+                "recursive_key": "value",
+                "recursive_output": None,
+            },
+            "engine_output_prop": None,
+        })
+
+    # Note: providers tend to implement these functions using lookup tables.
+    def translate_input_property(self, prop: str) -> str:
+        if prop == "transformed_prop":
+            return "engineProp"
+
+        if prop == "recursive_prop":
+            return "recursiveProp"
+
+        if prop == "recursive_key":
+            return "recursiveKey"
+
+        if prop == "recursive_output":
+            return "recursiveOutput"
+
+        if prop == "engine_output_prop":
+            return "engineOutputProp"
+
+        return prop
+
+    def translate_output_property(self, prop: str) -> str:
+        if prop == "engineProp":
+            return "transformed_prop"
+
+        if prop == "recursiveProp":
+            return "recursive_prop"
+
+        if prop == "recursiveKey":
+            return "recursive_key"
+
+        if prop == "recursiveOutput":
+            return "recursive_output"
+
+
+        if prop == "engineOutputProp":
+            return "engine_output_prop"
+
+        return prop
+
+
+res = TranslatedResource("res", "some string")
+res.transformed_prop.apply(lambda s: assert_eq(s, "some string"))
+res.engine_output_prop.apply(lambda s: assert_eq(s, "some output string"))
+
+pulumi.export("transformed_prop", res.transformed_prop)
+pulumi.export("engine_output_prop", res.engine_output_prop)
+pulumi.export("recursive_prop", res.recursive_prop)

--- a/sdk/python/lib/test/langhost/property_renaming/test_property_renaming.py
+++ b/sdk/python/lib/test/langhost/property_renaming/test_property_renaming.py
@@ -1,0 +1,66 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class PropertyRenamingTest(LanghostTest):
+    """
+    Tests that Pulumi resources can override translate_input_property and translate_output_property
+    in order to control the naming of their own properties.
+    """
+    def test_property_renaming(self):
+        self.run_test(
+            program=path.join(self.base_path(), "property_renaming"),
+            expected_resource_count=1)
+
+    def register_resource(self, _ctx, _dry_run, ty, name, res, _deps):
+        # Test:
+        #  1. Everything that we receive from the running program is in camel-case. The engine never sees
+        # the pre-translated names of the input properties.
+        #  2. We return properties back to the running program in camel case. It's the responsibility of the SDK
+        # to translate them back to snake case.
+        self.assertEqual("test:index:TranslatedResource", ty)
+        self.assertEqual("res", name)
+        self.assertIn("engineProp", res)
+        self.assertEqual("some string", res["engineProp"])
+        self.assertIn("recursiveProp", res)
+        self.assertDictEqual({
+            "recursiveKey": "value"
+        }, res["recursiveProp"])
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": {
+                "engineProp": "some string",
+                "engineOutputProp": "some output string",
+                "recursiveProp": {
+                    "recursiveKey": "value",
+                    "recursiveOutput": "some other output"
+                }
+            }
+        }
+
+    def register_resource_outputs(self, _ctx, _dry_run, _urn, ty, _name, _resource, outputs):
+        self.assertEqual(ty, "pulumi:pulumi:Stack")
+        # Despite operating entirely in terms of camelCase above in register resource, the outputs
+        # received from the program are all in snake case.
+        self.assertDictEqual({
+            "transformed_prop": "some string",
+            "engine_output_prop": "some output string",
+            "recursive_prop": {
+                "recursive_key": "value",
+                "recursive_output": "some other output"
+            }
+        }, outputs)

--- a/sdk/python/lib/test/langhost/util.py
+++ b/sdk/python/lib/test/langhost/util.py
@@ -89,6 +89,17 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
                 }
 
             self.reg_count += 1
+        else:
+            # Record the Stack's registration so that it can be the target of register_resource_outputs
+            # later on.
+            urn = self.langhost_test.make_urn(type_, "teststack")
+            self.registrations[urn] = {
+                "type": type_,
+                "name": "somestack",
+                "props": {}
+            }
+
+            return proto.RegisterResourceResponse(urn=urn, id="teststack", object=None)
         if "object" in outs:
             loop = asyncio.new_event_loop()
             obj_proto = loop.run_until_complete(rpc.serialize_properties(outs["object"], []))
@@ -104,7 +115,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
         res = self.registrations.get(urn)
         if res:
             self.langhost_test.register_resource_outputs(
-                context, self.dryrun, urn, res.t, res.name, res.props, outs)
+                context, self.dryrun, urn, res["type"], res["name"], res["props"], outs)
         return empty_pb2.Empty()
 
 


### PR DESCRIPTION
The Python SDK provides two hooks for resources to override how their
properties are communicated to and from the engine. The code that
performs this transformation is subtle and, before this commit, subtly
incorrect.

This commit adds a test that verifies that the SDK correctly transforms
properties recursively according to the two transformation hooks, while
also fixing a smattering of test issues encountered when adding the new
test.

Fixes part of https://github.com/pulumi/pulumi-terraform/issues/276, the remainder of the fix will be in `pulumi-terraform`.