### PR TITLE
Fix issue with converting keys

### DIFF
--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -313,7 +313,7 @@ func (b *cloudBackend) getTarget(ctx context.Context, stackRef backend.StackRefe
 }
 
 func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMetadata {
-	keys := make([]string, 0, len(md.Keys))
+	keys := make([]string, len(md.Keys))
 	for i, v := range md.Keys {
 		keys[i] = string(v)
 	}


### PR DESCRIPTION
Fixes panic related to initiating a slice with the right _capacity_, but not the right _length_.
https://golang.org/doc/effective_go.html#allocation_make