### PR TITLE
Permit dependsOn that are Outputs (of Outputs)

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -144,7 +144,7 @@ export interface ResourceOptions {
     /**
      * An optional additional explicit dependencies on other resources.
      */
-    dependsOn?: Resource[] | Resource;
+    dependsOn?: Input<Input<Resource>[]> | Input<Resource>;
     /**
      * When set to true, protect ensures this resource cannot be deleted.
      */

--- a/sdk/nodejs/tests/runtime/langhost/cases/008.ten_depends_on_resources/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/008.ten_depends_on_resources/index.js
@@ -9,7 +9,30 @@ class MyResource extends pulumi.CustomResource {
 }
 
 let all = [];
+let last = undefined;
 for (let i = 0; i < 10; i++) {
-    all.push(new MyResource("testResource" + i, all));
+    // Test all permutations of accepted dependsOn input:
+    //     - undefined
+    //     - Resource
+    //     - Resource[]
+    //     - Promise<Resource>
+    //     - Output<Resource>
+    //     - Promise<Resource[]>
+    //     - Output<Resource[]>
+    //     - Promise<Promise<Resource>[]>
+    //     - Promise<Output<Resource>[]>
+    //     - Output<Promise<Resource>[]>
+    //     - Output<Output<Resource>[]>
+    let r0 = new MyResource("testResource" + i*10, { dependsOn: last });
+    let r1 = new MyResource("testResource" + i*10+1, { dependsOn: all });
+    let r2 = new MyResource("testResource" + i*10+2, { dependsOn: Promise.resolve(last) });
+    let r3 = new MyResource("testResource" + i*10+3, { dependsOn: pulumi.Output.create(last) });
+    let r4 = new MyResource("testResource" + i*10+4, { dependsOn: Promise.resolve(all) });
+    let r5 = new MyResource("testResource" + i*10+5, { dependsOn: pulumi.Output.create(all) });
+    let r6 = new MyResource("testResource" + i*10+6, { dependsOn: Promise.resolve(all.map(a => Promise.resolve(a))) });
+    let r7 = new MyResource("testResource" + i*10+7, { dependsOn: Promise.resolve(all.map(a => pulumi.Output.create(a))) });
+    let r8 = new MyResource("testResource" + i*10+8, { dependsOn: pulumi.Output.create(all).apply(a => Promise.resolve(a)) });
+    let r9 = new MyResource("testResource" + i*10+9, { dependsOn: pulumi.Output.create(all).apply(a => pulumi.Output.create(a)) });
+    all = all.concat([ r0, r1, r2, r3, r4, r5, r6, r7, r8, r9 ]);
+    last = r0;
 }
-

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -277,10 +277,10 @@ describe("rpc", () => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
-        // A program that allocates ten simple resources that use dependsOn to depend on one another.
+        // A program that allocates ten simple resources that use dependsOn to depend on one another, 10 different ways.
         "ten_depends_on_resources": {
             program: path.join(base, "008.ten_depends_on_resources"),
-            expectResourceCount: 10,
+            expectResourceCount: 100,
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any) => {
                 assert.strictEqual(t, "test:index:MyResource");
                 if (ctx.seen) {


### PR DESCRIPTION
This changes the input type for dependsOn from simply
`Resource[] | Resource` to `Input<Input<Resource>[]> | Input<Resource>`.
This permits `Output<Resource>`s, etc in addition to
`Promise<Resource>`s. The logic for dynamically unpicking the right
types and recursing through the data structures isn't straightforward,
but I've written a test for all of the interesting permutations.

This fixes pulumi/pulumi#991.