### PR TITLE
Add a pulumi template tag.

### DIFF
--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -22,6 +22,7 @@ export * from "./invoke";
 export * from "./metadata";
 export * from "./resource";
 export * from "./stackReference";
+export * from "./string";
 
 // Export submodules individually.
 import * as asset from "./asset";

--- a/sdk/nodejs/string.ts
+++ b/sdk/nodejs/string.ts
@@ -1,0 +1,28 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Output, output } from "./resource";
+
+export function string(strings: TemplateStringsArray, ...args: any[]): Output<string> {
+    return output(args).apply(resolved => {
+        let acc: string = "";
+        for (let i = 0; i < strings.length; i++) {
+            acc += strings[i];
+            if (i < args.length) {
+                acc += `${resolved[i]}`;
+            }
+        }
+        return acc;
+    });
+}

--- a/sdk/nodejs/tests/string.spec.ts
+++ b/sdk/nodejs/tests/string.spec.ts
@@ -1,0 +1,57 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// tslint:disable
+
+import * as assert from "assert";
+import * as resource from "../resource";
+import * as runtime from "../runtime";
+import { string as ps } from "../string";
+import { asyncTest } from "./util";
+
+describe("string", () => {
+    it("awaits outputs correctly", asyncTest(async () => {
+        const outer = "outer";
+        const inner = "inner";
+
+        const output1 = resource.output(Promise.resolve(outer));
+        const output2 = output1.apply(_ => resource.output(Promise.resolve(inner)));
+        const output3 = ps`${output1} ${output2}`;
+
+        const value = await output3.promise();
+        assert.equal(value, `${outer} ${inner}`);
+    }));
+    it("handles undefined and null correctly", asyncTest(async () => {
+        const outer = undefined;
+        const inner = null;
+
+        const output1 = resource.output(Promise.resolve(outer));
+        const output2 = output1.apply(_ => resource.output(Promise.resolve(inner)));
+        const output3 = ps`${output1} ${output2}`;
+
+        const value = await output3.promise();
+        assert.equal(value, `${outer} ${inner}`);
+    }));
+    it("handles complex objects correctly", asyncTest(async () => {
+        const outer = [ "foo" ];
+        const inner = { "foo": "bar" };
+
+        const output1 = resource.output(Promise.resolve(outer));
+        const output2 = output1.apply(_ => resource.output(Promise.resolve(inner)));
+        const output3 = ps`${output1} ${output2}`;
+
+        const value = await output3.promise();
+        assert.equal(value, `${outer} ${inner}`);
+    }));
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -21,6 +21,8 @@
         "errors.ts",
         "metadata.ts",
         "resource.ts",
+        "stackReference.ts",
+        "string.ts",
         "version.ts",
 
         "asset/index.ts",
@@ -55,6 +57,7 @@
         "tests/init.spec.ts",
         "tests/iterable.spec.ts",
         "tests/output.spec.ts",
+        "tests/string.spec.ts",
         "tests/unwrap.spec.ts",
         "tests/util.ts",
         "tests/runtime/closureLoader.spec.ts",


### PR DESCRIPTION
This template tag allows the user to take code like this:

```
pulumi.all([res.foo, res.bar]).apply(([foo, bar]) => `${foo} ${bar}`);
```

and instead write it like this:

```
pulumi.string`${res.foo} ${res.bar}`;
```