### PR TITLE
Rework get-version scripts

### DIFF
--- a/pkg/util/buildutil/semver.go
+++ b/pkg/util/buildutil/semver.go
@@ -26,11 +26,11 @@ import (
 
 var (
 	releaseVersionRegex = regexp.MustCompile(
-		`^v(?P<version>\d+\.\d+\.\d+)(-(?P<time>\d+)-(?P<gitInfo>g[a-z0-9]+))?(?P<dirty>-dirty)?$`)
+		`^v(?P<version>\d+\.\d+\.\d+)(?P<dirty>\+dirty)?$`)
 	rcVersionRegex = regexp.MustCompile(
-		`^v(?P<version>\d+\.\d+\.\d+)-rc(?P<rcN>\d+)(-(?P<time>\d+)-(?P<gitInfo>g[a-z0-9]+))?(?P<dirty>-dirty)?$`)
+		`^v(?P<version>\d+\.\d+\.\d+)-rc\.(?P<rcN>\d+)(?P<dirty>\+dirty)?$`)
 	devVersionRegex = regexp.MustCompile(
-		`^v(?P<version>\d+\.\d+\.\d+)-dev-(?P<time>\d+)-(?P<gitInfo>g[a-z0-9]+)(?P<dirty>-dirty)?$`)
+		`^v(?P<version>\d+\.\d+\.\d+)-dev\.(?P<time>\d+)\+(?P<gitInfo>g[a-z0-9]+)(?P<dirty>.dirty)?$`)
 )
 
 // PyPiVersionFromNpmVersion returns a PEP-440 compliant version for a given semver version. This method does not
@@ -45,12 +45,16 @@ func PyPiVersionFromNpmVersion(s string) (string, error) {
 	if releaseVersionRegex.MatchString(s) {
 		capMap := captureToMap(releaseVersionRegex, s)
 		mustFprintf(&b, "%s", capMap["version"])
-		writePostBuildAndDirtyInfoToReleaseVersion(&b, capMap)
+		if capMap["dirty"] != "" {
+			mustFprintf(&b, "+dirty")
+		}
 		return b.String(), nil
 	} else if rcVersionRegex.MatchString(s) {
 		capMap := captureToMap(rcVersionRegex, s)
 		mustFprintf(&b, "%src%s", capMap["version"], capMap["rcN"])
-		writePostBuildAndDirtyInfoToReleaseVersion(&b, capMap)
+		if capMap["dirty"] != "" {
+			mustFprintf(&b, "+dirty")
+		}
 		return b.String(), nil
 	} else if devVersionRegex.MatchString(s) {
 		capMap := captureToMap(devVersionRegex, s)
@@ -74,21 +78,6 @@ func captureToMap(r *regexp.Regexp, s string) map[string]string {
 	}
 
 	return capMap
-}
-
-// While the version string for dev builds always contain timestamp and commit information, release and release
-// release candidate builds do not. In the case where we do have this information, it is for a build newer than
-// the actual release build, and we'll use the PEP-440 .post notation to show this. We also handle adding the dirty
-// tag in the local version if we need it.
-func writePostBuildAndDirtyInfoToReleaseVersion(w io.Writer, capMap map[string]string) {
-	if capMap["time"] != "" {
-		mustFprintf(w, ".post%s", capMap["time"])
-		if capMap["dirty"] != "" {
-			mustFprintf(w, "+dirty")
-		}
-	} else if capMap["dirty"] != "" {
-		mustFprintf(w, "+dirty")
-	}
 }
 
 func mustFprintf(w io.Writer, format string, a ...interface{}) {

--- a/pkg/util/buildutil/semver_test.go
+++ b/pkg/util/buildutil/semver_test.go
@@ -23,14 +23,11 @@ import (
 func TestVersions(t *testing.T) {
 	cases := map[string]string{
 		"v0.12.0":                                "0.12.0",
-		"v0.12.0-dirty":                          "0.12.0+dirty",
-		"v0.12.0-1524606809-gf2f1178b":           "0.12.0.post1524606809",
-		"v0.12.0-1524606809-gf2f1178b-dirty":     "0.12.0.post1524606809+dirty",
-		"v0.12.0-rc1":                            "0.12.0rc1",
-		"v0.12.0-rc1-1524606809-gf2f1178b":       "0.12.0rc1.post1524606809",
-		"v0.12.0-rc1-1524606809-gf2f1178b-dirty": "0.12.0rc1.post1524606809+dirty",
-		"v0.12.1-dev-1524606809-gf2f1178b":       "0.12.1.dev1524606809",
-		"v0.12.1-dev-1524606809-gf2f1178b-dirty": "0.12.1.dev1524606809+dirty",
+		"v0.12.0+dirty":                          "0.12.0+dirty",
+		"v0.12.0-rc.1":                           "0.12.0rc1",
+		"v0.12.0-rc.1+dirty":                     "0.12.0rc1+dirty",
+		"v0.12.1-dev.1524606809+gf2f1178b":       "0.12.1.dev1524606809",
+		"v0.12.1-dev.1524606809+gf2f1178b.dirty": "0.12.1.dev1524606809+dirty",
 	}
 
 	for ver, expected := range cases {

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -9,20 +9,43 @@ DIRTY_TAG=""
 # treat the worktree as dirty when it is not.
 git update-index -q --refresh
 if ! git diff-files --quiet; then
-    DIRTY_TAG="-dirty"
+    DIRTY_TAG="dirty"
 fi
 
-# If we have an exact tag, and it is not a -dev tag, just use it.
+# If we have an exact tag, just use it.
 if git describe --tags --exact-match "${COMMITISH}" >/dev/null 2>&1; then
-    TAG="$(git describe --tags --exact-match "${COMMITISH}")"
-    if [[ ! "${TAG}" =~ -dev$ ]]; then
-        echo "$(git describe --tags --exact-match "${COMMITISH}")${DIRTY_TAG}"
-        exit 0
+    echo -n "$(git describe --tags --exact-match "${COMMITISH}")"
+    if [ ! -z "${DIRTY_TAG}" ]; then
+        echo -n "+${DIRTY_TAG}"
     fi
+
+    echo ""
+    exit 0
 fi
 
-# Otherwise we want to include some additional information. To the
-# base tag we add a timestamp and commit hash. We use the timestamp of
-# the commit itself, not the date it was authored (so it will change
-# when someone rebases a PR into master, for example).
-echo "$(git describe --tags --abbrev=0 ${COMMITISH})-$(git show -s --format='%ct-g%h' ${COMMITISH})${DIRTY_TAG}"
+# Otherwise, increment the patch version, add the -dev tag and some
+# commit metadata. If there's no existing tag, pretend a v0.0.0 was
+# there so we'll produce v0.0.1-dev builds.
+if git describe --tags --abbrev=0 "${COMMITISH}" > /dev/null 2>&1; then
+    TAG=$(git describe --tags --abbrev=0 "${COMMITISH}")
+else
+    TAG="v0.0.0"
+fi
+
+# Strip off any pre-release tag we might have (e.g. from doing a -rc build)
+TAG=${TAG%%-*}
+
+MAJOR=$(cut -d. -f1 <<< "${TAG}")
+MINOR=$(cut -d. -f2 <<< "${TAG}")
+PATCH=$(cut -d. -f3 <<< "${TAG}")
+
+# We want to include some additional information. To the base tag we
+# add a timestamp and commit hash. We use the timestamp of the commit
+# itself, not the date it was authored (so it will change when someone
+# rebases a PR into master, for example).
+echo -n "${MAJOR}.${MINOR}.$((${PATCH}+1))-dev.$(git show -s --format='%ct+g%h' ${COMMITISH})"
+if [ ! -z "${DIRTY_TAG}" ]; then
+    echo -n ".${DIRTY_TAG}"
+fi
+
+echo ""

--- a/scripts/get-version.ps1
+++ b/scripts/get-version.ps1
@@ -4,17 +4,42 @@ $ErrorActionPreference="Stop"
 git update-index -q --refresh
 git diff-files --quiet | Out-Null
 
-$dirtyTag=""
-if ($LASTEXITCODE -ne 0) {
-    $dirtyTag = "-dirty"
-}
+$dirty=($LASTEXITCODE -ne 0)
 
 try { 
   git describe --tags --exact-match >$null 2>$null
   # If we get here the above did not throw, so we can use the exact tag
-  Write-Output "$(git describe --tags --exact-match)$dirtyTag"
+  if ($dirty) {
+      Write-Output "$(git describe --tags --exact-match)"
+  } else {
+      Write-Output "$(git describe --tags --exact-match)+dirty"
+  }
 } catch {
-  # Otherwise, append the timestamp of the commit and the hash
-  Write-Output "$(git describe --tags --abbrev=0)-$(git show -s --format='%ct-g%h')$dirtyTag"
+    # Otherwise, take the existing tag, increment the patch version and append the timestamp of the commit and hash
+    $tag=""
+
+    try {
+        git describe --tags --abbrev=0 >$null 2>$null
+        $tag="$(git describe --tags --abbrev=0)"
+    } catch {
+        $tag="v0.0.0"
+    }
+
+    # Remove any pre-release tag
+    if ($tag.LastIndexOf("-") -ne -1) {
+        $tag=$tag.Substring(0, $tag.LastIndexOf("-"))
+    }
+
+    $tagParts = $tag.Split('.');
+    $major = $tagParts[0];
+    $minor = $tagParts[1];
+    $patch = $tagParts[2];
+
+    $patch = ([int]$patch + 1);
+    if ($dirty) {
+        Write-Output "$major.$minor.$patch-dev.$(git show -s --format='%ct+g%h').dirty"
+    } else {
+        Write-Output "$major.$minor.$patch-dev.$(git show -s --format='%ct+g%h')"
+    }
 }
 


### PR DESCRIPTION
Under our old versioning system, when we started a new point release,
we'd tag the HEAD commit of master with a tag like `v0.16.6-dev` and
our scripts would use this to generate a new version number. This
required a great deal of gymnastics when producing a release and
caused us to litter these -dev tags everywhere.

To improve this, we change version number generation to the following
strategy:

1. If the commit we are building has a tag applied to it, use that tag
as the version (appending the dirty bit metadata to the version, if
needed).

2. If the commit we are bulding does not have a tag applied to it,
take the version from the next reachable tag, increment the patch
version and then append the `-dev` pre-release tag. As part of this,
we also make a slight tweek to our semver generation such that instead
of `-dev<TIMESTAMP>` we use `-dev.<TIMESTAMP>` which is more in line
with what semver recommends.