### PR TITLE
Add "Overrides" support to test harness

### DIFF
--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -21,26 +21,23 @@ func TestExamples(t *testing.T) {
 		return
 	}
 
-	var minimal integration.ProgramTestOptions
-	minimal = integration.ProgramTestOptions{
-		Dir:          path.Join(cwd, "minimal"),
-		Dependencies: []string{"@pulumi/pulumi"},
-		Config: map[string]string{
-			"name": "Pulumi",
-		},
-		Secrets: map[string]string{
-			"secret": "this is my secret message",
-		},
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			// Simple runtime validation that just ensures the checkpoint was written and read.
-			assert.NotNil(t, stackInfo.Deployment)
-		},
-		RunBuild: true,
-	}
-
 	var formattableStdout, formattableStderr bytes.Buffer
 	examples := []integration.ProgramTestOptions{
-		minimal,
+		{
+			Dir:          path.Join(cwd, "minimal"),
+			Dependencies: []string{"@pulumi/pulumi"},
+			Config: map[string]string{
+				"name": "Pulumi",
+			},
+			Secrets: map[string]string{
+				"secret": "this is my secret message",
+			},
+			ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+				// Simple runtime validation that just ensures the checkpoint was written and read.
+				assert.NotNil(t, stackInfo.Deployment)
+			},
+			RunBuild: true,
+		},
 		{
 			Dir:          path.Join(cwd, "dynamic-provider/simple"),
 			Dependencies: []string{"@pulumi/pulumi"},
@@ -82,8 +79,7 @@ func TestExamples(t *testing.T) {
 			Dependencies: []string{"@pulumi/pulumi"},
 		},
 		{
-			Dir:          path.Join(cwd, "compat/v0.10.0/minimal"),
-			Dependencies: []string{"@pulumi/pulumi"},
+			Dir: path.Join(cwd, "compat/v0.10.0/minimal"),
 			Config: map[string]string{
 				"name": "Pulumi",
 			},

--- a/examples/examples_test.go
+++ b/examples/examples_test.go
@@ -5,9 +5,13 @@ package examples
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
 
@@ -78,7 +82,12 @@ func TestExamples(t *testing.T) {
 			Dir:          path.Join(cwd, "dynamic-provider/multiple-turns-2"),
 			Dependencies: []string{"@pulumi/pulumi"},
 		},
-		{
+	}
+
+	// The compat test only works on Node 6.10.X because its uses the old 0.10.0 pulumi package, which only supported
+	// a single node version, since it had the native runtime component.
+	if nodeVer, err := getNodeVersion(); err != nil && nodeVer.Major == 6 && nodeVer.Minor == 10 {
+		examples = append(examples, integration.ProgramTestOptions{
 			Dir: path.Join(cwd, "compat/v0.10.0/minimal"),
 			Config: map[string]string{
 				"name": "Pulumi",
@@ -87,7 +96,9 @@ func TestExamples(t *testing.T) {
 				"secret": "this is my secret message",
 			},
 			RunBuild: true,
-		},
+		})
+	} else {
+		t.Log("Skipping 0.10.0 compat tests, because current node version is not 6.10.X")
 	}
 
 	for _, example := range examples {
@@ -96,4 +107,16 @@ func TestExamples(t *testing.T) {
 			integration.ProgramTest(t, &ex)
 		})
 	}
+}
+
+func getNodeVersion() (semver.Version, error) {
+	var buf bytes.Buffer
+
+	nodeVersionCmd := exec.Command("node", "--version")
+	nodeVersionCmd.Stdout = &buf
+	if err := nodeVersionCmd.Run(); err != nil {
+		return semver.Version{}, errors.Wrap(err, "running node --version")
+	}
+
+	return semver.ParseTolerant(buf.String())
 }

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1172,7 +1172,7 @@ func (pt *programTester) prepareNodeJSProject(projinfo *engine.Projinfo) error {
 	}
 
 	// Now ensure dependencies are present.
-	if err = pt.runYarnCommand("yarn-install", []string{"install", "--verbose"}, cwd); err != nil {
+	if err = pt.runYarnCommand("yarn-install", []string{"install"}, cwd); err != nil {
 		return err
 	}
 

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -30,6 +30,26 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
+// DecodeMapString takes a string of the form key1=value1:key2=value2 and returns a go map.
+func DecodeMapString(val string) (map[string]string, error) {
+	newMap := make(map[string]string)
+
+	if val != "" {
+		for _, overrideClause := range strings.Split(val, ":") {
+			data := strings.Split(overrideClause, "=")
+			if len(data) != 2 {
+				return nil, errors.Errorf(
+					"could not decode %s as an override, should be of the form <package>=<version>", overrideClause)
+			}
+			packageName := data[0]
+			packageVersion := data[1]
+			newMap[packageName] = packageVersion
+		}
+	}
+
+	return newMap, nil
+}
+
 // ReplaceInFile does a find and replace for a given string within a file.
 func ReplaceInFile(old, new, path string) error {
 	rawContents, err := ioutil.ReadFile(path)


### PR DESCRIPTION
This is just the overrides part of #2212.  Landing this as is lets us unblock testing in home and examples at head.

#2212 is going to take a little longer to land because the move to install the package under test using `yarn install` is causing slowdown in CI and the problem seems to be much worse on Node 11 (presumably due to the gRPC issues there where we end up having to build multiple times).

So landing this other part first so we can at least start getting a fair amount of coverage.