### PR TITLE
Use an explicit address when dialing plugins

### DIFF
--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -176,7 +176,7 @@ func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin,
 	go runtrace(plug.Stdout, false, stdoutDone)
 
 	// Now that we have the port, go ahead and create a gRPC client connection to it.
-	conn, err := grpc.Dial(":"+port, grpc.WithInsecure(), grpc.WithUnaryInterceptor(
+	conn, err := grpc.Dial("127.0.0.1:"+port, grpc.WithInsecure(), grpc.WithUnaryInterceptor(
 		rpcutil.OpenTracingClientInterceptor(),
 	))
 	if err != nil {


### PR DESCRIPTION
This is necessary in order for gRPC's proxy support to properly respect
NO_PROXY.

Fixes #2134.