### PR TITLE
Flush stdout and stderr on abnormal lang shutdown

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -37,6 +37,7 @@ import (
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/logging"
 	"github.com/pulumi/pulumi/pkg/util/rpcutil"
 	"github.com/pulumi/pulumi/pkg/version"
@@ -171,6 +172,14 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 		cmd.Env = append(os.Environ(), pulumiConfigVar+"="+config)
 	}
 	if err := cmd.Run(); err != nil {
+		// Python does not explicitly flush standard out or standard error when exiting abnormally. For this reason, we
+		// need to explicitly flush our output streams so that, when we exit, the engine picks up the child Python
+		// process's stdout and stderr writes.
+		//
+		// This is especially crucial for Python because it is possible for the child Python process to crash very fast
+		// if Pulumi is misconfigured, so we must be sure to present a high-quality error message to the user.
+		contract.IgnoreError(os.Stdout.Sync())
+		contract.IgnoreError(os.Stderr.Sync())
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			// If the program ran, but exited with a non-zero error code.  This will happen often, since user
 			// errors will trigger this.  So, the error message should look as nice as possible.


### PR DESCRIPTION
The langhost shares its standard out and standard error with the
language executor that it is used (python/nodejs), so we must be sure to
flush our stdout and stderr before reporting a Run failure to the
engine.