### PR TITLE
Look for language plugins next to `pulumi` when probing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - Fix an issue where running two copies of `pulumi plugin install` in parallel for the same plugin version could cause one to fail with an error about renaming a directory.
 
+- Fix an issue where if the directory containing the `pulumi` executable was not on the `$PATH` we would fail to load language plugins. We now will also search next to the current running copy of Pulumi (fixes [pulumi/pulumi#1956](https://github.com/pulumi/pulumi/issues/1956))
+
 ## 0.16.5 (Released Novemeber 16th, 2018)
 
 ### Improvements


### PR DESCRIPTION
When launching plugins today, `pulumi` looks in two places:

1. It looks to see if the plugin in on the $PATH and if so, uses
   it. This makes it easy to force a specific version of a resource
   provider to be used and is what happens at development time (since
   resource providers make their way onto $PATH via GOBIN).

2. If the above fails, it looks in the "plugin cache" in
   `~/.pulumi/plugins`. This is the location that `pulumi plugin
   install` places plugins.

Unlike resource provider plugins, we don't yet deliver language
plugins via `pulumi plugin install` so the language provider plugins
must be on the `$PATH` to be found. This is okay, because when we ship
the SDK, we include the executables next to `pulumi` itself.

However, if a user chooses to not put `pulumi` on their $PATH, or they
do but it is a symlink to the real `pulumi` binary installed
somewhere, we'd fail to find the language plugins, since they would
not be on the `$PATH`

To address this, when probing for language plugins, also consider
binaries next to the currently running `pulumi` process.

Fixes #1956