### PR TITLE
Write `.yarnrc` with both test frameworks

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/filestate"
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource"
+	pulumi_testing "github.com/pulumi/pulumi/pkg/testing"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/ciutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -1114,14 +1115,7 @@ func (pt *programTester) prepareProjectDir(projectDir string) error {
 
 // prepareNodeJSProject runs setup necessary to get a Node.js project ready for `pulumi` commands.
 func (pt *programTester) prepareNodeJSProject(projinfo *engine.Projinfo) error {
-	// Write a .yarnrc file to pass --mutex network to all yarn invocations, since tests
-	// may run concurrently and yarn may fail if invoked concurrently
-	// https://github.com/yarnpkg/yarn/issues/683
-	// Also add --network-concurrency 1 since we've been seeing
-	// https://github.com/yarnpkg/yarn/issues/4563 as well
-	if err := ioutil.WriteFile(
-		filepath.Join(projinfo.Root, ".yarnrc"),
-		[]byte("--mutex network\n--network-concurrency 1\n"), 0644); err != nil {
+	if err := pulumi_testing.WriteYarnRCForTest(projinfo.Root); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
While the lifecycle tests wrote a `.yarnrc` file to ensure that copies
of `yarn` did not race with one another, the more barebones testing
framework did not.

This should address some of the yarn issues we've been seeing in CI
recently