### PR TITLE
Publish SDK binaries with same filename format as NPM packages

### DIFF
--- a/scripts/build-sdk.ps1
+++ b/scripts/build-sdk.ps1
@@ -38,7 +38,7 @@ function Download-Release ($repoName, $repoCommit, [ValidateSet("zip", "tgz")]$e
 if (!$VersionTag) { $VersionTag=Get-Date -UFormat '%Y%m%d_%H%M%S' }
 if (!$PulumiRef) { $PulumiRef="master" }
 
-$SdkFileName="pulumi-$VersionTag-windows-x64.zip"
+$SdkFileName="pulumi-$($VersionTag -replace '\+.', '')-windows-x64.zip"
 
 $PulumiFolder=(Join-Path (New-TemporaryDirectory) "Pulumi")
 

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -27,6 +27,8 @@ if [[ "${TRAVIS_PUBLISH_PACKAGES:-}" == "true" ]]; then
         "${ROOT}/sdk/python/env/src/dist"/*.whl
 fi
 
-"${ROOT}/scripts/build-sdk.sh" $("${ROOT}/scripts/get-version") $(git rev-parse HEAD)
+NPM_VERSION=$("${ROOT}/scripts/get-version")
+
+"${ROOT}/scripts/build-sdk.sh" $(echo ${NPM_VERSION} | sed -e 's/\+.*//g') $(git rev-parse HEAD)
 
 exit 0


### PR DESCRIPTION
With this change, you can now use the `dev` tag of `@pulumi/pulumi` to
get the latest version of the SDK and install it from get.pulumi.com

This is helpful for some of our internal testing.