### PR TITLE
Handle unconfigured plugins in Diff.

### DIFF
--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -277,8 +277,8 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, *re
 			if diffErr != nil {
 				// If the plugin indicated that the diff is unavailable, assume that the resource will be updated and
 				// report the message contained in the error.
-				if d.Changes == plugin.DiffUnavailable {
-					d.Changes = plugin.DiffSome
+				if _, ok := diffErr.(plugin.DiffUnavailableError); ok {
+					d = plugin.DiffResult{Changes: plugin.DiffSome}
 					sg.plan.ctx.Diag.Warningf(diag.RawMessage(urn, diffErr.Error()))
 				} else {
 					return nil, result.FromError(diffErr)

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -93,6 +93,9 @@ const (
 	DiffNone DiffChanges = 1
 	// DiffSome indicates the provider performed a diff and concluded that an update or replacement is needed.
 	DiffSome DiffChanges = 2
+	// DiffUnavailable indicates that the provider is unable to diff a resource, usually because the provider has
+	// some unknown configuration values.
+	DiffUnavailable DiffChanges = 3
 )
 
 // DiffResult indicates whether an operation should replace or update an existing resource.

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -93,9 +93,6 @@ const (
 	DiffNone DiffChanges = 1
 	// DiffSome indicates the provider performed a diff and concluded that an update or replacement is needed.
 	DiffSome DiffChanges = 2
-	// DiffUnavailable indicates that the provider is unable to diff a resource, usually because the provider has
-	// some unknown configuration values.
-	DiffUnavailable DiffChanges = 3
 )
 
 // DiffResult indicates whether an operation should replace or update an existing resource.
@@ -109,4 +106,19 @@ type DiffResult struct {
 // Replace returns true if this diff represents a replacement.
 func (r DiffResult) Replace() bool {
 	return len(r.ReplaceKeys) > 0
+}
+
+// DiffUnavailableError may be returned by a provider if the provider is unable to diff a resource.
+type DiffUnavailableError struct {
+	reason string
+}
+
+// DiffUnavailable creates a new DiffUnavailableError with the given message.
+func DiffUnavailable(reason string) DiffUnavailableError {
+	return DiffUnavailableError{reason: reason}
+}
+
+// Error returns the error message for this DiffUnavailableError.
+func (e DiffUnavailableError) Error() string {
+	return e.reason
 }

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -262,7 +262,7 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 	// Instead, indicate that the diff is unavailable and write a message
 	if !p.cfgknown {
 		logging.V(7).Infof("%s: cannot diff due to unknown config", label)
-		const message = "The provider for this resource has inputs that are not known during preview." +
+		const message = "The provider for this resource has inputs that are not known during preview.\n" +
 			"This preview may not correctly represent the changes that will be applied during an update."
 		return DiffResult{}, DiffUnavailable(message)
 	}

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -262,8 +262,9 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 	// Instead, indicate that the diff is unavailable and write a message
 	if !p.cfgknown {
 		logging.V(7).Infof("%s: cannot diff due to unknown config", label)
-		err := errors.New("cannot diff: this resource's provider has unknown configuration values")
-		return DiffResult{Changes: DiffUnavailable}, err
+		const message = "The provider for this resource has inputs that are not known during preview." +
+			"This preview may not correctly represent the changes that will be applied during an update."
+		return DiffResult{}, DiffUnavailable(message)
 	}
 
 	molds, err := MarshalProperties(olds, MarshalOptions{


### PR DESCRIPTION
After #2088, we began calling `Diff` on providers that are not configured
due to unknown configuration values. This hit an assertion intended to
detect exactly this scenario, which was previously unexpected.

These changes adjust `Diff` to indicate that a Diff is unavailable and
return an error message that describes why. The step generator then
interprets the diff as indicating a normal update and issues the error
message to the diagnostic stream.

Fixes #2223.