### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,25 @@
 
 ## 0.16.6 (Unreleased)
 
+### Major Changes
+
+- When running a python program, pulumi will now run `python3` instead of `python`, since `python` often points at Python 2.7 binary, and Pulumi requires Python 3.6 or later. The environment variable `PULUMI_PYTHON_CMD` can be used to provide a different binary to run.
+
 ### Improvements
+
+- Allow `Output`s in the dependsOn property of `ResourceOptions` (fixes [pulumi/pulumi#991](https://github.com/pulumi/pulumi/issues/991))
+
+- Add a new `StackReference` type to the node SDK which allows referencing an output of another stack (fixes [pulumi/pulumi#109](https://github.com/pulumi/pulumi/issues/109))
+
+- Fix an issue where `pulumi` would not respect common `NO_PROXY` settings (fixes [pulumi/pulumi#2134](https://github.com/pulumi/pulumi/issues/2134))
+
+- The CLI wil now correctly report any output from a python program which writes to sys.stderr (fixes [pulumi/pulumi#1542](https://github.com/pulumi/pulumi/issues/1542))
+
+- Don't install packages by default for Python projects when creating a new project from a template using `pulumi new`. Previously, `pulumi` would install these packages using `pip install` and they would be installed globally when `pulumi` was run outside a virtualenv.
+
+- Fix an issue where `pulumi` could panic during a peview when using a first class provider which was constructed using an output property of another resource (fixes [pulumi/pulumi#2223](https://github.com/pulumi/pulumi/issues/2223))
+
+- Fix an issure where `pulumi` would fail to load resource plugins for newer dev builds.
 
 - Fix an issue where running two copies of `pulumi plugin install` in parallel for the same plugin version could cause one to fail with an error about renaming a directory.
 


### PR DESCRIPTION
We are still building the muscle to do this per commit, so some things
had fallen through the cracks. I walked the output of `git log
v0.16.5...master` and added some small notes for improvements that we
had not documented.