### PR TITLE
Export our 'unwrap' types so that downstream packages can refer to them.

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -618,7 +618,7 @@ export type Inputs = Record<string, Input<any>>;
  * In other words, this should not be used as the shape of an object: `{ a: Promise<Output<...>> }`.
  * It should always either be `{ a: Promise<NonOutput> }` or just `{ a: Output<...> }`.
  */
-type Unwrap<T> =
+export type Unwrap<T> =
     // 1. If we have a promise, just get the type it itself is wrapping and recursively unwrap that.
     // 2. Otherwise, if we have an output, do the same as a promise and just unwrap the inner type.
     // 3. Otherwise, we have a basic type.  Just unwrap that.
@@ -631,7 +631,7 @@ type primitive = Function | string | number | boolean | undefined | null;
 /**
  * Handles encountering basic types when unwrapping.
  */
-type UnwrapSimple<T> =
+export type UnwrapSimple<T> =
     // 1. Any of the primitive types just unwrap to themselves.
     // 2. An array of some types unwraps to an array of that type itself unwrapped. Note, due to a
     //    TS limitation we cannot express that as Array<Unwrap<U>> due to how it handles recursive
@@ -646,8 +646,8 @@ type UnwrapSimple<T> =
     T extends object ? UnwrappedObject<T> :
     never;
 
-interface UnwrappedArray<T> extends Array<Unwrap<T>> {}
+export interface UnwrappedArray<T> extends Array<Unwrap<T>> {}
 
-type UnwrappedObject<T> = {
+export type UnwrappedObject<T> = {
     [P in keyof T]: Unwrap<T[P]>;
 };


### PR DESCRIPTION
TS allows one to export functions that then refer to types that are not named.  Ths is not a problem usually as downstream code can use the functions and the return types without necessarily needing to utter their names.  However, users may want their code to be explicit.  They are unable to do so using these names since htey have not been exported.  

There's no great reason for us to not export these guys.  They're not an implementation detail. They are strongly part of the type signature of the combinator helpers we expose.