### PR TITLE
Fix error when canceling update

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -822,6 +822,10 @@ func (b *cloudBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend
 		return err
 	}
 
+	if stack.ActiveUpdate == "" {
+		return errors.Errorf("%v has never been updated", stackRef)
+	}
+
 	// Compute the update identifier and attempt to cancel the update.
 	//
 	// NOTE: the update kind is not relevant; the same endpoint will work for updates of all kinds.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -823,7 +823,7 @@ func (b *cloudBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend
 	}
 
 	if stack.ActiveUpdate == "" {
-		return errors.Errorf("%v has never been updated", stackRef)
+		return errors.Errorf("stack %v has never been updated", stackRef)
 	}
 
 	// Compute the update identifier and attempt to cancel the update.

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -34,11 +34,11 @@ type UpdateResult string
 
 const (
 	// InProgressResult is for updates that have not yet completed.
-	InProgressResult = "in-progress"
+	InProgressResult UpdateResult = "in-progress"
 	// SucceededResult is for updates that completed successfully.
 	SucceededResult UpdateResult = "succeeded"
 	// FailedResult is for updates that have failed.
-	FailedResult = "failed"
+	FailedResult UpdateResult = "failed"
 )
 
 // Keys we use for values put into UpdateInfo.Environment.


### PR DESCRIPTION
When running `pulumi cancel` on a stack that has never actually been updated, currently we emit the odd: `error: [400] Bad Request: decoding JSON: EOF`. It seems like we should still consider this case an error, but we now at least fail with `error: super-stack has never been updated`.

Also types some enum values. Obviously unrelated to this PR, and just something I noticed while looking into a separate issue.

Fixes https://github.com/pulumi/pulumi-service/issues/2547
