### PR TITLE
Change gRPC ready logic slightly

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -593,6 +593,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "eaeb2282f35a265330a240be239886c91ab253b40dc2cf92469c7cbe29c78f9d"
+  inputs-digest = "456d828216d46de56a5b86612a76a0d028b2517aec618c24d6b8bd557cbc2bcd"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Since we have had some issues related to gRPC startup (namely
pulumi/pulumi#1934), this commit adds additional logging to the "is the
gRPC client ready" codepath.

In addition, this commit changes the logic slightly to do an invoke to
the target gRPC server with the "FailFast" option set to "false", which
will instruct the gRPC client to wait for the transport to become ready
before issuing the RPC, where previously it would have failed
immediately.

If we continue to have issues with gRPC startup, we can use the logs
from this commit to have a much better understanding of what went wrong.