### PR TITLE
Inherit custom resource providers

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -105,7 +105,7 @@ export abstract class Resource {
                     const typeComponents = t.split(":");
                     if (typeComponents.length === 3) {
                         const pkg = typeComponents[0];
-                        this.__providers[pkg] = provider;
+                        this.__providers = { ...this.__providers, pkg: provider };
                     }
                 }
             }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -99,6 +99,14 @@ export abstract class Resource {
                 const provider = (<CustomResourceOptions>opts).provider;
                 if (provider === undefined) {
                     (<CustomResourceOptions>opts).provider = opts.parent.getProvider(t);
+                } else {
+                    // If a provider was specified, add it to the providers map under this type's package so that
+                    // any children of this resource inherit its provider.
+                    const typeComponents = t.split(":");
+                    if (typeComponents.length === 3) {
+                        const pkg = typeComponents[0];
+                        this.__providers[pkg] = provider;
+                    }
                 }
             }
         }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -105,7 +105,7 @@ export abstract class Resource {
                     const typeComponents = t.split(":");
                     if (typeComponents.length === 3) {
                         const pkg = typeComponents[0];
-                        this.__providers = { ...this.__providers, pkg: provider };
+                        this.__providers = { ...this.__providers, [pkg]: provider };
                     }
                 }
             }

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -427,11 +427,9 @@ describe("rpc", () => {
                             expectProtect = true;
                             break;
                         case "c3":
+                        case "r3":
                             // Force provider
                             expectProviderName = `${rpath.slice(0, i).join("/")}-p`;
-                            break;
-                        case "r3":
-                            // Do nothing.
                             break;
                         default:
                             assert.fail(`unexpected path element in name: ${rpath[i]}`);
@@ -445,8 +443,8 @@ describe("rpc", () => {
 
                     const providerName = provider!.split("::").reduce((_, v) => v);
 
-                    assert.strictEqual(protect!, expectProtect);
-                    assert.strictEqual(providerName, expectProviderName);
+                    assert.strictEqual(`${name}.protect: ${protect!}`, `${name}.protect: ${expectProtect}`);
+                    assert.strictEqual(`${name}.provider: ${providerName}`, `${name}.provider: ${expectProviderName}`);
                 }
 
                 return { urn: makeUrn(t, name), id: name, props: {} };


### PR DESCRIPTION
If a custom resource has explicitly specified a provider, add that
provider to the resource's provider map under the resource's package.
This allows children of the custom resource to inherit the resource's
provider.

Fixes #2262.