### PR TITLE
Don't emit pre-rendered update logs

### DIFF
--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -205,6 +205,7 @@ type PatchUpdateCheckpointRequest struct {
 }
 
 // AppendUpdateLogEntryRequest defines the body of a request to the append update log entry endpoint of the service API.
+// No longer sent from, but the type definition is still required for backwards compat with older clients.
 type AppendUpdateLogEntryRequest struct {
 	Kind   string                 `json:"kind"`
 	Fields map[string]interface{} `json:"fields"`

--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -205,7 +205,7 @@ type PatchUpdateCheckpointRequest struct {
 }
 
 // AppendUpdateLogEntryRequest defines the body of a request to the append update log entry endpoint of the service API.
-// No longer sent from, but the type definition is still required for backwards compat with older clients.
+// No longer sent from the CLI, but the type definition is still required for backwards compat with older clients.
 type AppendUpdateLogEntryRequest struct {
 	Kind   string                 `json:"kind"`
 	Fields map[string]interface{} `json:"fields"`

--- a/pkg/backend/httpstate/client/api_endpoints.go
+++ b/pkg/backend/httpstate/client/api_endpoints.go
@@ -97,7 +97,6 @@ func init() {
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/destroy/{updateID}", "startDestroy")
 	addEndpoint("PATCH", "/api/stacks/{orgName}/{stackName}/destroy/{updateID}/checkpoint", "patchUpdateCheckpoint")
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/destroy/{updateID}/complete", "completeUpdate")
-	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/destroy/{updateID}/log", "appendUpdateLogEntry")
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/destroy/{updateID}/renew_lease", "renewUpdateLease")
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/preview", "previewUpdate")
 	addEndpoint("GET", "/api/stacks/{orgName}/{stackName}/preview/{updateID}", "getPreviewStatus")
@@ -107,6 +106,5 @@ func init() {
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/update/{updateID}", "startUpdate")
 	addEndpoint("PATCH", "/api/stacks/{orgName}/{stackName}/update/{updateID}/checkpoint", "patchUpdateCheckpoint")
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/update/{updateID}/complete", "completeUpdate")
-	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/update/{updateID}/log", "appendUpdateLogEntry")
 	addEndpoint("POST", "/api/stacks/{orgName}/{stackName}/update/{updateID}/renew_lease", "renewUpdateLease")
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -507,8 +507,12 @@ func (pc *Client) CompleteUpdate(ctx context.Context, update UpdateIdentifier, s
 // RecordEngineEvent posts an engine event to the Pulumi service.
 func (pc *Client) RecordEngineEvent(
 	ctx context.Context, update UpdateIdentifier, event apitype.EngineEvent, token string) error {
+	callOpts := httpCallOptions{
+		GzipCompress:    true,
+		RetryAllMethods: true,
+	}
 	return pc.updateRESTCall(
 		ctx, "POST", getUpdatePath(update, "events"),
 		nil, event, nil,
-		updateAccessToken(token), httpCallOptions{GzipCompress: true})
+		updateAccessToken(token), callOpts)
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -504,22 +504,6 @@ func (pc *Client) CompleteUpdate(ctx context.Context, update UpdateIdentifier, s
 		updateAccessToken(token), httpCallOptions{RetryAllMethods: true})
 }
 
-// AppendUpdateLogEntry appends the given entry to the indicated update's logs.
-func (pc *Client) AppendUpdateLogEntry(ctx context.Context, update UpdateIdentifier, kind string,
-	fields map[string]interface{}, token string) error {
-
-	req := apitype.AppendUpdateLogEntryRequest{
-		Kind:   kind,
-		Fields: fields,
-	}
-
-	// Retrying this POST operation could cause us to have multiple copies of the same log message for a given
-	// operation. The alternative, however, is worse. A failure in this call will fail the entire update, so we're
-	// forcing retry of these operations, at the expense of duplicated log messages in some cases.
-	return pc.updateRESTCall(ctx, "POST", getUpdatePath(update, "log"), nil, req, nil,
-		updateAccessToken(token), httpCallOptions{RetryAllMethods: true})
-}
-
 // RecordEngineEvent posts an engine event to the Pulumi service.
 func (pc *Client) RecordEngineEvent(
 	ctx context.Context, update UpdateIdentifier, event apitype.EngineEvent, token string) error {


### PR DESCRIPTION
When the Pulumi Service is able to render update logs entirely from the raw engine event stream, we won't need to upload pre-rendered log data. The Pulumi Service release this week will have this capability, so we just need to hold off on submitting until then. 

See https://github.com/pulumi/pulumi/pull/2256