### PR TITLE
Do not use relative path when launching dynamic provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   
 - Fix an error about a bad icotl when trying to read sensitive input from the console and standard in was not connected to a terminal.
 
+- The dynamic provider would fail to launch if your `node_modules` folder was non in the default location or had a non standard layout. This has been fixed so we correctly find your `node_modules` folder in the same way node does. (fixes [pulumi/pulumi#2261](https://github.com/pulumi/pulumi/issues/2261))
+
 ## 0.16.6 (Released November 28th, 2018)
 
 ### Major Changes

--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
@@ -1,2 +1,5 @@
 #!/bin/sh
-node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider $@
+PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH=$(node -e "console.log(require.resolve('@pulumi/pulumi/cmd/dynamic-provider'))")
+if [ ! -z "$PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH" ]; then
+    node "$PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH" $@
+fi

--- a/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
+++ b/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
@@ -1,1 +1,6 @@
-@node ./node_modules/@pulumi/pulumi/cmd/dynamic-provider %*
+@echo off
+setlocal
+for /f "delims=" %%i in ('node -e "console.log(require.resolve('@pulumi/pulumi/cmd/dynamic-provider'))"') do set PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH=%%i
+if DEFINED PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH (
+   @node "%PULUMI_DYNAMIC_PROVIDER_SCRIPT_PATH%" %*
+)


### PR DESCRIPTION
Previously, we assumed that the dynamic provider was located in
`./node_modules/@pulumi/pulumi/../` which is correct in the majority
of cases. However, tools like lerna or yarn workspaces (or custom
workflows) allow the node_modules folder to be located elsewhere on
disk, and node will still find it because of its algorithm for module
resolution.

So, do what we do in the language host itself, first launch node and
ask it to tell us where it resolves a require statement to on disk and
then launch node against that script.

Fixes #2261