### PR TITLE
Use "discard" when deleting read resources

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1043,8 +1043,8 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return "reading failed"
 			case deploy.OpRefresh:
 				return "refreshing failed"
-			case deploy.OpReadRemove:
-				return "removing failed"
+			case deploy.OpReadDiscard:
+				return "discarding failed"
 			}
 		} else {
 			switch op {
@@ -1069,8 +1069,8 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return "read for replacement"
 			case deploy.OpRefresh:
 				return "refresh"
-			case deploy.OpReadRemove:
-				return "removed"
+			case deploy.OpReadDiscard:
+				return "discarded"
 			}
 		}
 
@@ -1108,8 +1108,8 @@ func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) st
 		return "read for replacement"
 	case deploy.OpRefresh:
 		return "refreshing"
-	case deploy.OpReadRemove:
-		return "removing"
+	case deploy.OpReadDiscard:
+		return "discarding"
 	}
 
 	contract.Failf("Unrecognized resource step op: %v", step.Op)
@@ -1135,8 +1135,8 @@ func (display *ProgressDisplay) getPreviewDoneText(step engine.StepEventMetadata
 		return "read"
 	case deploy.OpRefresh:
 		return "refresh"
-	case deploy.OpReadRemove:
-		return "remove"
+	case deploy.OpReadDiscard:
+		return "discard"
 	}
 
 	contract.Failf("Unrecognized resource step op: %v", step.Op)
@@ -1207,8 +1207,8 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 			return "reading for replacement"
 		case deploy.OpRefresh:
 			return "refreshing"
-		case deploy.OpReadRemove:
-			return "removing"
+		case deploy.OpReadDiscard:
+			return "discarding"
 		}
 
 		contract.Failf("Unrecognized resource step op: %v", op)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1043,7 +1043,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return "reading failed"
 			case deploy.OpRefresh:
 				return "refreshing failed"
-			case deploy.OpReadDiscard:
+			case deploy.OpReadDiscard, deploy.OpDiscardReplaced:
 				return "discarding failed"
 			}
 		} else {
@@ -1071,6 +1071,8 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return "refresh"
 			case deploy.OpReadDiscard:
 				return "discarded"
+			case deploy.OpDiscardReplaced:
+				return "discarded original"
 			}
 		}
 
@@ -1109,7 +1111,9 @@ func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) st
 	case deploy.OpRefresh:
 		return "refreshing"
 	case deploy.OpReadDiscard:
-		return "discarding"
+		return "discard"
+	case deploy.OpDiscardReplaced:
+		return "discard origina;"
 	}
 
 	contract.Failf("Unrecognized resource step op: %v", step.Op)
@@ -1128,7 +1132,7 @@ func (display *ProgressDisplay) getPreviewDoneText(step engine.StepEventMetadata
 		return "update"
 	case deploy.OpDelete:
 		return "delete"
-	case deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced, deploy.OpReadReplacement:
+	case deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced, deploy.OpReadReplacement, deploy.OpDiscardReplaced:
 		return "replace"
 	case deploy.OpRead:
 		// nolint: goconst
@@ -1159,7 +1163,7 @@ func (display *ProgressDisplay) getStepOp(step engine.StepEventMetadata) deploy.
 		// Once done, show the steps for replacing as a single 'replaced' step.
 		// During update, we'll show these individual steps.
 		if display.isPreview || display.done {
-			if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced {
+			if op == deploy.OpCreateReplacement || op == deploy.OpDeleteReplaced || op == deploy.OpDiscardReplaced {
 				return deploy.OpReplace
 			}
 		}
@@ -1209,6 +1213,8 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 			return "refreshing"
 		case deploy.OpReadDiscard:
 			return "discarding"
+		case deploy.OpDiscardReplaced:
+			return "discarding original"
 		}
 
 		contract.Failf("Unrecognized resource step op: %v", op)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1132,7 +1132,8 @@ func (display *ProgressDisplay) getPreviewDoneText(step engine.StepEventMetadata
 		return "update"
 	case deploy.OpDelete:
 		return "delete"
-	case deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced, deploy.OpReadReplacement, deploy.OpDiscardReplaced:
+	case deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced, deploy.OpReadReplacement,
+		deploy.OpDiscardReplaced:
 		return "replace"
 	case deploy.OpRead:
 		// nolint: goconst

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1043,6 +1043,8 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return "reading failed"
 			case deploy.OpRefresh:
 				return "refreshing failed"
+			case deploy.OpReadRemove:
+				return "removing failed"
 			}
 		} else {
 			switch op {
@@ -1067,6 +1069,8 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return "read for replacement"
 			case deploy.OpRefresh:
 				return "refresh"
+			case deploy.OpReadRemove:
+				return "removed"
 			}
 		}
 
@@ -1104,6 +1108,8 @@ func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) st
 		return "read for replacement"
 	case deploy.OpRefresh:
 		return "refreshing"
+	case deploy.OpReadRemove:
+		return "removing"
 	}
 
 	contract.Failf("Unrecognized resource step op: %v", step.Op)
@@ -1129,6 +1135,8 @@ func (display *ProgressDisplay) getPreviewDoneText(step engine.StepEventMetadata
 		return "read"
 	case deploy.OpRefresh:
 		return "refresh"
+	case deploy.OpReadRemove:
+		return "remove"
 	}
 
 	contract.Failf("Unrecognized resource step op: %v", step.Op)
@@ -1199,6 +1207,8 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 			return "reading for replacement"
 		case deploy.OpRefresh:
 			return "refreshing"
+		case deploy.OpReadRemove:
+			return "removing"
 		}
 
 		contract.Failf("Unrecognized resource step op: %v", op)

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -143,7 +143,7 @@ func (sm *SnapshotManager) BeginMutation(step deploy.Step) (engine.SnapshotMutat
 		return sm.doCreate(step)
 	case deploy.OpUpdate:
 		return sm.doUpdate(step)
-	case deploy.OpDelete, deploy.OpDeleteReplaced:
+	case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadRemove:
 		return sm.doDelete(step)
 	case deploy.OpReplace:
 		return &replaceSnapshotMutation{sm}, nil

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -143,7 +143,7 @@ func (sm *SnapshotManager) BeginMutation(step deploy.Step) (engine.SnapshotMutat
 		return sm.doCreate(step)
 	case deploy.OpUpdate:
 		return sm.doUpdate(step)
-	case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard:
+	case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
 		return sm.doDelete(step)
 	case deploy.OpReplace:
 		return &replaceSnapshotMutation{sm}, nil

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -143,7 +143,7 @@ func (sm *SnapshotManager) BeginMutation(step deploy.Step) (engine.SnapshotMutat
 		return sm.doCreate(step)
 	case deploy.OpUpdate:
 		return sm.doUpdate(step)
-	case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadRemove:
+	case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard:
 		return sm.doDelete(step)
 	case deploy.OpReplace:
 		return &replaceSnapshotMutation{sm}, nil

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -310,7 +310,7 @@ func GetResourceOutputsPropertiesString(
 }
 
 func considerSameIfNotCreateOrDelete(op deploy.StepOp) deploy.StepOp {
-	if op == deploy.OpCreate || op == deploy.OpDelete || op == deploy.OpDeleteReplaced {
+	if op == deploy.OpCreate || op == deploy.OpDelete || op == deploy.OpDeleteReplaced || op == deploy.OpReadRemove {
 		return op
 	}
 

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -310,11 +310,12 @@ func GetResourceOutputsPropertiesString(
 }
 
 func considerSameIfNotCreateOrDelete(op deploy.StepOp) deploy.StepOp {
-	if op == deploy.OpCreate || op == deploy.OpDelete || op == deploy.OpDeleteReplaced || op == deploy.OpReadDiscard || op == deploy.OpDiscardReplaced {
+	switch op {
+	case deploy.OpCreate, deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
 		return op
+	default:
+		return deploy.OpSame
 	}
-
-	return deploy.OpSame
 }
 
 func shouldPrintPropertyValue(v resource.PropertyValue, outs bool) bool {

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -310,7 +310,7 @@ func GetResourceOutputsPropertiesString(
 }
 
 func considerSameIfNotCreateOrDelete(op deploy.StepOp) deploy.StepOp {
-	if op == deploy.OpCreate || op == deploy.OpDelete || op == deploy.OpDeleteReplaced || op == deploy.OpReadDiscard {
+	if op == deploy.OpCreate || op == deploy.OpDelete || op == deploy.OpDeleteReplaced || op == deploy.OpReadDiscard || op == deploy.OpDiscardReplaced {
 		return op
 	}
 

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -310,7 +310,7 @@ func GetResourceOutputsPropertiesString(
 }
 
 func considerSameIfNotCreateOrDelete(op deploy.StepOp) deploy.StepOp {
-	if op == deploy.OpCreate || op == deploy.OpDelete || op == deploy.OpDeleteReplaced || op == deploy.OpReadRemove {
+	if op == deploy.OpCreate || op == deploy.OpDelete || op == deploy.OpDeleteReplaced || op == deploy.OpReadDiscard {
 		return op
 	}
 

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -123,7 +123,7 @@ func (j *Journal) Snap(base *deploy.Snapshot) *deploy.Snapshot {
 			switch e.Step.Op() {
 			case deploy.OpCreate, deploy.OpCreateReplacement:
 				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeCreating))
-			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard:
+			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
 				ops = append(ops, resource.NewOperation(e.Step.Old(), resource.OperationTypeDeleting))
 			case deploy.OpRead, deploy.OpReadReplacement:
 				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeReading))
@@ -135,7 +135,7 @@ func (j *Journal) Snap(base *deploy.Snapshot) *deploy.Snapshot {
 			// nolint: lll
 			case deploy.OpCreate, deploy.OpCreateReplacement, deploy.OpRead, deploy.OpReadReplacement, deploy.OpUpdate:
 				doneOps[e.Step.New()] = true
-			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard:
+			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
 				doneOps[e.Step.Old()] = true
 			}
 		}
@@ -151,7 +151,7 @@ func (j *Journal) Snap(base *deploy.Snapshot) *deploy.Snapshot {
 				if old := e.Step.Old(); old != nil && old.PendingReplacement {
 					dones[old] = true
 				}
-			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard:
+			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
 				if old := e.Step.Old(); !old.PendingReplacement {
 					dones[old] = true
 				}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -262,7 +262,7 @@ func (s *DeleteStep) Op() StepOp {
 	if s.replacing {
 		return OpDeleteReplaced
 	} else if s.old.External {
-		return OpReadRemove
+		return OpReadDiscard
 	}
 	return OpDelete
 }
@@ -681,7 +681,7 @@ const (
 	OpRead              StepOp = "read"               // reading an existing resource.
 	OpReadReplacement   StepOp = "read-replacement"   // reading an existing resource for a replacement.
 	OpRefresh           StepOp = "refresh"            // refreshing an existing resource.
-	OpReadRemove        StepOp = "remove"             // removing a resource that was read.
+	OpReadDiscard       StepOp = "discard"            // removing a resource that was read.
 
 	OpRemovePendingReplace StepOp = "remove-pending-replace" // removing a pending replace resource.
 )
@@ -698,7 +698,7 @@ var StepOps = []StepOp{
 	OpRead,
 	OpReadReplacement,
 	OpRefresh,
-	OpReadRemove,
+	OpReadDiscard,
 	OpRemovePendingReplace,
 }
 
@@ -725,7 +725,7 @@ func (op StepOp) Color() string {
 		return colors.SpecReplace
 	case OpRefresh:
 		return colors.SpecUpdate
-	case OpReadRemove:
+	case OpReadDiscard:
 		return colors.SpecDelete
 	default:
 		contract.Failf("Unrecognized resource step op: '%v'", op)
@@ -761,7 +761,7 @@ func (op StepOp) RawPrefix() string {
 		return ">>"
 	case OpRefresh:
 		return "~ "
-	case OpReadRemove:
+	case OpReadDiscard:
 		return "< "
 	default:
 		contract.Failf("Unrecognized resource step op: %v", op)
@@ -777,8 +777,8 @@ func (op StepOp) PastTense() string {
 		return "refreshed"
 	case OpRead:
 		return "read"
-	case OpReadRemove:
-		return "removed"
+	case OpReadDiscard:
+		return "discarded"
 	default:
 		contract.Failf("Unexpected resource step op: %v", op)
 		return ""


### PR DESCRIPTION
In general, a "delete" in Pulumi is destroying an actual physical
resource. In the case of a read resource, however, the delete is
merely removing the resource from the stack; the physical resource
is not affected. These changes attempt to clarify this situation by
using the term "discard" rather than "delete".

Fixes #2015.