### PR TITLE
Prevent cycles when serializing props.

### DIFF
--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -21,6 +21,7 @@ export * from "./errors";
 export * from "./invoke";
 export * from "./metadata";
 export * from "./resource";
+export * from "./stackReference";
 
 // Export submodules individually.
 import * as asset from "./asset";

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -21,7 +21,6 @@ export * from "./errors";
 export * from "./invoke";
 export * from "./metadata";
 export * from "./resource";
-export * from "./stackReference";
 
 // Export submodules individually.
 import * as asset from "./asset";

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -15,7 +15,7 @@
 import * as assert from "assert";
 import * as asset from "../asset";
 import * as log from "../log";
-import { CustomResource, Input, Inputs, Output, Resource } from "../resource";
+import { ComponentResource, CustomResource, Input, Inputs, Output, Resource } from "../resource";
 import { debuggablePromise, errorString } from "./debuggable";
 import { excessiveDebugOutput, isDryRun } from "./settings";
 
@@ -219,7 +219,16 @@ export const specialArchiveSig = "0def7320c3a5731c473e5ecbe6d01bc7";
  * serializeProperty serializes properties deeply.  This understands how to wait on any unresolved promises, as
  * appropriate, in addition to translating certain "special" values so that they are ready to go on the wire.
  */
-export async function serializeProperty(ctx: string, prop: Input<any>, dependentResources: Resource[]): Promise<any> {
+export function serializeProperty(ctx: string, prop: Input<any>, dependentResources: Resource[]): Promise<any> {
+    return serializePropertyWorker(ctx, prop, dependentResources, new Set());
+}
+
+async function serializePropertyWorker(
+    ctx: string, prop: Input<any>,
+    dependentResources: Resource[],
+    seenObjects: Set<any>): Promise<any> {
+
+    // Simple values, always serialize fully.
     if (prop === undefined ||
         prop === null ||
         typeof prop === "boolean" ||
@@ -231,28 +240,23 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
         }
         return prop;
     }
-    else if (prop instanceof Array) {
-        const elems: any[] = [];
+
+    if (prop instanceof Array) {
+        const result: any[] = [];
         for (let i = 0; i < prop.length; i++) {
             if (excessiveDebugOutput) {
                 log.debug(`Serialize property [${ctx}]: array[${i}] element`);
             }
-            // When serializing arrays, we serialize any undefined values as `null`. This matches JSON semantics.
-            const elem = await serializeProperty(`${ctx}[${i}]`, prop[i], dependentResources);
-            elems.push(elem === undefined ? null : elem);
-        }
-        return elems;
-    }
-    else if (CustomResource.isInstance(prop)) {
-        // Resources aren't serializable; instead, we serialize them as references to the ID property.
-        if (excessiveDebugOutput) {
-            log.debug(`Serialize property [${ctx}]: resource ID`);
-        }
 
-        dependentResources.push(prop);
-        return serializeProperty(`${ctx}.id`, prop.id, dependentResources);
+            // When serializing arrays, we serialize any undefined values as `null`. This matches
+            // JSON semantics.
+            const elem = await serializeProperty(`${ctx}[${i}]`, prop[i], dependentResources);
+            result.push(elem === undefined ? null : elem);
+        }
+        return result;
     }
-    else if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
+
+    if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
         // Serializing an asset or archive requires the use of a magical signature key, since otherwise it would look
         // like any old weakly typed object/map when received by the other side of the RPC boundary.
         const obj: any = {
@@ -261,16 +265,19 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
 
         return await serializeAllKeys(prop, obj);
     }
-    else if (prop instanceof Promise) {
+
+    if (prop instanceof Promise) {
         // For a promise input, await the property and then serialize the result.
         if (excessiveDebugOutput) {
             log.debug(`Serialize property [${ctx}]: Promise<T>`);
         }
+
         const subctx = `Promise<${ctx}>`;
         return serializeProperty(subctx,
             await debuggablePromise(prop, `serializeProperty.await(${subctx})`), dependentResources);
     }
-    else if (Output.isInstance(prop)) {
+
+    if (Output.isInstance(prop)) {
         if (excessiveDebugOutput) {
             log.debug(`Serialize property [${ctx}]: Output<T>`);
         }
@@ -283,9 +290,27 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
         const isKnown = await prop.isKnown;
         const value = await serializeProperty(`${ctx}.id`, prop.promise(), dependentResources);
         return isKnown ? value : unknownValue;
-    } else {
-        return await serializeAllKeys(prop, {});
     }
+
+    if (CustomResource.isInstance(prop)) {
+        // Resources aren't serializable; instead, we serialize them as references to the ID property.
+        if (excessiveDebugOutput) {
+            log.debug(`Serialize property [${ctx}]: custom resource id`);
+        }
+
+        dependentResources.push(prop);
+        return serializeProperty(`${ctx}.id`, prop.id, dependentResources);
+    }
+
+    // We're now getting to complex objects where we are recursing into them.  Prevent infinite
+    // recursion if we've already seen this object before.
+    if (seenObjects.has(prop)) {
+        return undefined;
+    }
+
+    seenObjects.add(prop);
+
+    return await serializeAllKeys(prop, {});
 
     async function serializeAllKeys(innerProp: any, obj: any) {
         for (const k of Object.keys(innerProp)) {

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -15,7 +15,7 @@
 import * as assert from "assert";
 import * as asset from "../asset";
 import * as log from "../log";
-import { ComponentResource, CustomResource, Input, Inputs, Output, Resource } from "../resource";
+import { CustomResource, Input, Inputs, Output, Resource } from "../resource";
 import { debuggablePromise, errorString } from "./debuggable";
 import { excessiveDebugOutput, isDryRun } from "./settings";
 

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -241,22 +241,6 @@ async function serializePropertyWorker(
         return prop;
     }
 
-    if (prop instanceof Array) {
-        const result: any[] = [];
-        for (let i = 0; i < prop.length; i++) {
-            if (excessiveDebugOutput) {
-                log.debug(`Serialize property [${ctx}]: array[${i}] element`);
-            }
-
-            // When serializing arrays, we serialize any undefined values as `null`. This matches
-            // JSON semantics.
-            const elem = await serializePropertyWorker(
-                `${ctx}[${i}]`, prop[i], dependentResources, seenObjects);
-            result.push(elem === undefined ? null : elem);
-        }
-        return result;
-    }
-
     if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
         // Serializing an asset or archive requires the use of a magical signature key, since otherwise it would look
         // like any old weakly typed object/map when received by the other side of the RPC boundary.
@@ -312,6 +296,22 @@ async function serializePropertyWorker(
     }
 
     seenObjects.add(prop);
+
+    if (prop instanceof Array) {
+        const result: any[] = [];
+        for (let i = 0; i < prop.length; i++) {
+            if (excessiveDebugOutput) {
+                log.debug(`Serialize property [${ctx}]: array[${i}] element`);
+            }
+
+            // When serializing arrays, we serialize any undefined values as `null`. This matches
+            // JSON semantics.
+            const elem = await serializePropertyWorker(
+                `${ctx}[${i}]`, prop[i], dependentResources, seenObjects);
+            result.push(elem === undefined ? null : elem);
+        }
+        return result;
+    }
 
     return await serializeAllKeys(prop, {});
 

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -40,6 +40,22 @@ describe("runtime", () => {
             assert.equal(result.id, "foo");
             assert.equal(result.urn, "bar");
         }));
+
+        it("handles cycles", asyncTest(async () => {
+            const inputs: Inputs = {
+                array: <any[]>[1, "str", true],
+                obj: { a: "str" },
+            };
+
+            inputs.array.push(inputs.array);
+            inputs.obj.cycle1 = inputs.obj;
+
+            // Serialize and then deserialize all the properties, checking that they round-trip as expected.
+            const transfer = gstruct.Struct.fromJavaScript(
+                await runtime.serializeProperties("test", inputs));
+            const result = runtime.deserializeProperties(transfer);
+            assert.deepEqual(result.array, [ 1, "str", true, undefined ]);
+            assert.deepEqual(result.obj, { a: "str" });
+        }));
     });
 });
-


### PR DESCRIPTION
This came up in aws-infra, where we want to have components that both point at a logical parent, and have that parent expose a list of those logical children.  For example, a SecurityGroup might expose a list of 'egressRules' adn 'ingressRules', and those rules would point back at the SecurityGroup itself.  

This circularity forms a problem when serializing.  So we now detect the cycle and just snip things off.