### PR TITLE
Lift dependencies from Output<Output>s

### DIFF
--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -175,7 +175,7 @@ func marshalInput(v interface{}) (interface{}, []Resource, error) {
 
 func marshalInputOutput(out *Output) (interface{}, []Resource, error) {
 	// Await the value and return its raw value.
-	ov, known, err := out.Value()
+	ov, known, deps, err := out.value()
 	if err != nil {
 		return nil, nil, err
 	}
@@ -186,11 +186,11 @@ func marshalInputOutput(out *Output) (interface{}, []Resource, error) {
 		if merr != nil {
 			return nil, nil, merr
 		}
-		return e, append(out.Deps(), d...), nil
+		return e, append(deps, d...), nil
 	}
 
 	// Otherwise, simply return the unknown value sentinel.
-	return rpcTokenUnknownValue, out.Deps(), nil
+	return rpcTokenUnknownValue, deps, nil
 }
 
 // unmarshalOutputs unmarshals all the outputs into a simple map.

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -24,8 +24,11 @@ import (
 
 // TestMarshalRoundtrip ensures that marshaling a complex structure to and from its on-the-wire gRPC format succeeds.
 func TestMarshalRoundtrip(t *testing.T) {
+	resourceURN := "res"
+	resource := newMockResource(resourceURN)
+
 	// Create interesting inputs.
-	out, resolve, _ := NewOutput(nil)
+	out, resolve, _ := NewOutput([]Resource{resource})
 	resolve("outputty", true)
 	input := map[string]interface{}{
 		"s":            "a string",
@@ -52,7 +55,8 @@ func TestMarshalRoundtrip(t *testing.T) {
 	// Marshal those inputs.
 	m, deps, err := marshalInputs(input)
 	if !assert.Nil(t, err) {
-		assert.Equal(t, 0, len(deps))
+		assert.Equal(t, 1, len(deps))
+		assert.Equal(t, URN(resourceURN), deps[0])
 
 		// Now just unmarshal and ensure the resulting map matches.
 		res, err := unmarshalOutputs(m)

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -446,6 +446,7 @@ export class Output<T> {
                             // We didn't actually run the function, our new Output is definitely
                             // **not** known.
                             innerIsKnownResolve(false);
+                            innerResourcesResolve(new Set<Resource>());
                             return <U><any>undefined;
                         }
                     }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -428,7 +428,7 @@ export class Output<T> {
             this.resources = () => new Set<Resource>([resources]);
         }
 
-        this.__asyncResources = asyncResources || Promise.resolve(new Set<Resource>());
+        this.__asyncResources = asyncResources;
 
         this.promise = () => promise;
 
@@ -450,10 +450,10 @@ export class Output<T> {
 
             // Similarly, the set of resources of the output we're returning depends on both our set
             // of resources and the set of resources of the lifted inner output.
-            const resultAsyncResources = Promise.all([this.__asyncResources!, innerAsyncResources])
-                .then(([rs1, rs2]) => {
-                    return new Set<Resource>([...rs1, ...rs2]);
-                });
+            const outerAsyncResources = asyncResources || Promise.resolve(new Set<Resource>());
+            const resultAsyncResources = Promise.all([outerAsyncResources, innerAsyncResources]).then(([rs1, rs2]) => {
+                return new Set<Resource>([...rs1, ...rs2]);
+            });
 
             return new Output<U>(resources, promise.then(async v => {
                 try {

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -191,7 +191,8 @@ interface ClosurePropertyDescriptor {
 class SerializedOutput<T> implements resource.Output<T> {
     /* @internal */ public isKnown: Promise<boolean>;
     /* @internal */ public readonly promise: () => Promise<T>;
-    /* @internal */ public readonly resources: () => Set<resource.Resource>;
+    // tslint:disable-next-line:variable-name
+    /* @internal */ public readonly __resources: Promise<Set<resource.Resource>>;
     /* @internal */ private readonly value: T;
 
     public constructor(value: T) {

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -191,8 +191,9 @@ interface ClosurePropertyDescriptor {
 class SerializedOutput<T> implements resource.Output<T> {
     /* @internal */ public isKnown: Promise<boolean>;
     /* @internal */ public readonly promise: () => Promise<T>;
+    /* @internal */ public readonly resources: () => Set<resource.Resource>;
     // tslint:disable-next-line:variable-name
-    /* @internal */ public readonly __resources: Promise<Set<resource.Resource>>;
+    /* @internal */ public readonly __asyncResources: Promise<Set<resource.Resource>>;
     /* @internal */ private readonly value: T;
 
     public constructor(value: T) {

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -274,7 +274,7 @@ async function gatherExplicitDependencies(
             // Recursively gather dependencies, await the promise, and append the output's dependencies.
             const dos = (dependsOn as Output<Input<Resource>[] | Input<Resource>>).apply(gatherExplicitDependencies);
             const urns = await dos.promise();
-            const implicits = await gatherExplicitDependencies([...(await dos.__resources)]);
+            const implicits = await gatherExplicitDependencies([...(await Output.allResources(dos))]);
             return urns.concat(implicits);
         } else {
             return [await (dependsOn as Resource).urn.promise()];

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -274,7 +274,7 @@ async function gatherExplicitDependencies(
             // Recursively gather dependencies, await the promise, and append the output's dependencies.
             const dos = (dependsOn as Output<Input<Resource>[] | Input<Resource>>).apply(gatherExplicitDependencies);
             const urns = await dos.promise();
-            const implicits = await gatherExplicitDependencies([...dos.resources()]);
+            const implicits = await gatherExplicitDependencies([...(await dos.__resources)]);
             return urns.concat(implicits);
         } else {
             return [await (dependsOn as Resource).urn.promise()];

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -268,7 +268,7 @@ async function serializePropertyWorker(
             log.debug(`Serialize property [${ctx}]: Output<T>`);
         }
 
-        dependentResources.push(...(await prop.__resources));
+        dependentResources.push(...(await Output.allResources(prop)));
 
         // When serializing an Output, we will either serialize it as its resolved value or the "unknown value"
         // sentinel. We will do the former for all outputs created directly by user code (such outputs always

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -268,7 +268,7 @@ async function serializePropertyWorker(
             log.debug(`Serialize property [${ctx}]: Output<T>`);
         }
 
-        dependentResources.push(...prop.resources());
+        dependentResources.push(...(await prop.__resources));
 
         // When serializing an Output, we will either serialize it as its resolved value or the "unknown value"
         // sentinel. We will do the former for all outputs created directly by user code (such outputs always

--- a/sdk/nodejs/tests/runtime/langhost/cases/020.lifted_dependencies/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/020.lifted_dependencies/index.js
@@ -1,0 +1,25 @@
+// This tests the creation of ten propertyless resources.
+
+let pulumi = require("../../../../../");
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name, args) {
+        super("test:index:MyResource", name, args, {});
+    }
+}
+
+let r0 = new MyResource("r0", {});
+let r1 = new MyResource("r1", {});
+let r2 = new MyResource("r2", {});
+
+let o0 = new pulumi.Output(r0, Promise.resolve(42), Promise.resolve(true));
+let o1 = new pulumi.Output(r1, Promise.resolve(24), Promise.resolve(true));
+let o2 = new pulumi.Output(r2, Promise.resolve(99), Promise.resolve(true));
+
+let r3 = new MyResource("r3", {
+	v: o0.apply(_ => o1),
+});
+
+let r4 = new MyResource("r4", {
+	v: o0.apply(_ => o1.apply(_ => o2)),
+});

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -547,6 +547,33 @@ describe("rpc", () => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
+        // A program that allocates several resources that have lifted dependencies in their inputs.
+        "lifted_dependencies": {
+            program: path.join(base, "020.lifted_dependencies"),
+            expectResourceCount: 5,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                assert.strictEqual(t, "test:index:MyResource");
+
+                let expectedDeps;
+                switch (name) {
+                    case "r3":
+                        expectedDeps = new Set<string>([makeUrn(t, "r0"), makeUrn(t, "r1")]);
+                        assert.deepStrictEqual(expectedDeps, new Set<string>(deps));
+                        break;
+
+                    case "r4":
+                        expectedDeps = new Set<string>([makeUrn(t, "r0"), makeUrn(t, "r1"), makeUrn(t, "r2")]);
+                        assert.deepStrictEqual(expectedDeps, new Set<string>(deps));
+                        break;
+
+                    default:
+                        assert.strictEqual(0, deps.length);
+                        break;
+                }
+
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {

--- a/sdk/nodejs/tests/unwrap.spec.ts
+++ b/sdk/nodejs/tests/unwrap.spec.ts
@@ -43,10 +43,12 @@ function testResources(val: any, expected: any, resources: TestResource[]) {
         const unwrapped = output(val);
         const actual = await unwrapped.promise();
 
-        assert.deepStrictEqual(actual, expected);
-        assert.deepStrictEqual(await unwrapped.__resources, new Set(resources));
+        const deps = await Output.allResources(unwrapped);
 
-        const unwrappedResources: TestResource[] = <any>[...(await unwrapped.__resources)];
+        assert.deepStrictEqual(actual, expected);
+        assert.deepStrictEqual(deps, new Set(resources));
+
+        const unwrappedResources: TestResource[] = <any>[...deps];
         unwrappedResources.sort((r1, r2) => r1.name.localeCompare(r2.name));
 
         resources.sort((r1, r2) => r1.name.localeCompare(r2.name));

--- a/sdk/nodejs/tests/unwrap.spec.ts
+++ b/sdk/nodejs/tests/unwrap.spec.ts
@@ -44,9 +44,9 @@ function testResources(val: any, expected: any, resources: TestResource[]) {
         const actual = await unwrapped.promise();
 
         assert.deepStrictEqual(actual, expected);
-        assert.deepStrictEqual(unwrapped.resources(), new Set(resources));
+        assert.deepStrictEqual(await unwrapped.__resources, new Set(resources));
 
-        const unwrappedResources: TestResource[] = <any>[...unwrapped.resources()];
+        const unwrappedResources: TestResource[] = <any>[...(await unwrapped.__resources)];
         unwrappedResources.sort((r1, r2) => r1.name.localeCompare(r2.name));
 
         resources.sort((r1, r2) => r1.name.localeCompare(r2.name));
@@ -190,7 +190,7 @@ describe("unwrap", () => {
             [r1, r2]));
     });
 
-    describe("does not preserve all resources", () => {
+    describe("preserves all resources across promise boundaries", () => {
         const r1 = new TestResource("r1");
         const r2 = new TestResource("r2");
         const r3 = new TestResource("r3");
@@ -203,47 +203,47 @@ describe("unwrap", () => {
         it("inside and outside of array", testResources(
             createOutput([createOutput(3, r1, r2)], r2, r3),
             [3],
-            [r2, r3]));
+            [r1, r2, r3]));
 
         it("inside and outside of object", testResources(
             createOutput({ a: createOutput(3, r1, r2) }, r2, r3),
             { a: 3 },
-            [r2, r3]));
+            [r1, r2, r3]));
 
         it("inside nested object and array", testResources(
             { a: createOutput(1, r1, r2), b: createOutput(2, r2, r3), c: { d: createOutput([createOutput(3, r5)], r6)  } },
             { a: 1, b: 2, c: { d: [3] } },
-            [r1, r2, r3, r6]));
+            [r1, r2, r3, r5, r6]));
 
         it("inside nested array and object", testResources(
             { a: createOutput(1, r1, r2), b: createOutput(2, r2, r3), c: createOutput([{ d: createOutput(3, r5) }], r6) },
             { a: 1, b: 2, c: [{ d: 3 }] },
-            [r1, r2, r3, r6]));
+            [r1, r2, r3, r5, r6]));
 
         it("across outer promise", testResources(
             Promise.resolve(createOutput(3, r1, r2)),
             3,
-            []));
+            [r1, r2]));
 
         it("across inner and outer promise", testResources(
             Promise.resolve(createOutput(Promise.resolve(3), r1, r2)),
             3,
-            []));
+            [r1, r2]));
 
         it("across promise and inner object", testResources(
             Promise.resolve(createOutput(Promise.resolve({ a: createOutput(1, r4, r5)}), r1, r2)),
             { a: 1 },
-            []));
+            [r1, r2, r4, r5]));
 
         it("across promise and inner array and object", testResources(
             Promise.resolve(createOutput([Promise.resolve({ a: createOutput(1, r4, r5)})], r1, r2)),
             [{ a: 1 }],
-            []));
+            [r1, r2, r4, r5]));
 
         it("across inner object", testResources(
             createOutput(Promise.resolve({ a: createOutput(1, r4, r5)}), r1, r2),
             { a: 1 },
-            [r1, r2]));
+            [r1, r2, r4, r5]));
     });
 
 

--- a/sdk/nodejs/tests/unwrap.spec.ts
+++ b/sdk/nodejs/tests/unwrap.spec.ts
@@ -246,6 +246,16 @@ describe("unwrap", () => {
             createOutput(Promise.resolve({ a: createOutput(1, r4, r5)}), r1, r2),
             { a: 1 },
             [r1, r2, r4, r5]));
+
+        it("across a single apply", testResources(
+            createOutput(3, r1, r2).apply(_ => createOutput(4, r2, r3)),
+            4,
+            [r1, r2, r3]));
+
+        it("across multiple applies", testResources(
+            createOutput(3, r1, r2).apply(_ => createOutput(4, r2, r3).apply(_ => createOutput(5, r3, r4))),
+            5,
+            [r1, r2, r3, r4]));
     });
 
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -132,7 +132,7 @@ async def serialize_property(value: 'Input[Any]',
         return await serialize_property(future_return, deps, input_transformer)
 
     if known_types.is_output(value):
-        deps.extend(value.resources())
+        deps.extend(await value._resources)
 
         # When serializing an Output, we will either serialize it as its resolved value or the "unknown value"
         # sentinel. We will do the former for all outputs created directly by user code (such outputs always

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -159,7 +159,7 @@ class NextSerializationTests(unittest.TestCase):
 
         deps = []
         prop = await rpc.serialize_property(out, deps)
-        self.assertListEqual(deps, [outer_dep, inner_dep])
+        self.assertSetEqual(set(deps), {outer_dep, inner_dep})
         self.assertEqual(24, prop)
 
     @async_test


### PR DESCRIPTION
Today, if the callback supplied to Output.apply returns an Output, the
inner Output's dependencies are dropped. This decision was intentional,
as it was originally believed that this scenario would be undesirable,
as it typically arises when resources are created inside of an apply
(which can prevent them from being displayed during a preview).

Unfortunately, this causes dependencies to be dropped in scenarios such
as the Helm integration in `pulumi-kubernetes`, where the set of
resources to be created must be dependent on Input<>s.

This changes update the implementation of Output.apply to lift the
dependencies from any inner output into the result's resources. The code
takes the same approach used by isKnown.