### PR TITLE
Fix synchronization with the event renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Added a `--stack` argument (short form `-s`) to `pulumi stack`, `pulumi stack init`, `pulumi state delete` and `pulumi state unprotect` to allow operating on a different stack than the currently selected stack. This brings these commands in line with the other commands that operate on stacks and already provided a `--stack` option (fixes [pulumi/pulumi#1648](https://github.com/pulumi/pulumi/issues/1648))
 
+- Fix an issue that caused panics due to shutting the Jaeger tracing infrastructure down before all traces had finished ([pulumi/pulumi#1850](https://github.com/pulumi/pulumi/issues/1850))
+
 ## 0.16.7 (Release December 5th, 2018)
 
 ### Improvements

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -78,7 +78,7 @@ func ShowDiffEvents(op string, action apitype.UpdateKind,
 	defer func() {
 		spinner.Reset()
 		ticker.Stop()
-		done <- true
+		close(done)
 	}()
 
 	seen := make(map[resource.URN]engine.StepEventMetadata)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -282,7 +282,7 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName
 	ticker.Stop()
 
 	// let our caller know we're done.
-	done <- true
+	close(done)
 }
 
 // Gets the padding necessary to prepend to a message in order to keep it aligned in the

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -350,7 +350,6 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 	<-displayDone
 	scope.Close() // Don't take any cancellations anymore, we're shutting down.
 	close(engineEvents)
-	close(displayDone)
 	contract.IgnoreClose(manager)
 
 	// Make sure the goroutine writing to displayEvents and events has exited before proceeding.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -801,7 +801,6 @@ func (b *cloudBackend) runEngineAction(
 	<-displayDone
 	cancellationScope.Close() // Don't take any cancellations anymore, we're shutting down.
 	close(engineEvents)
-	close(displayDone)
 	contract.IgnoreClose(snapshotManager)
 
 	// Make sure that the goroutine writing to displayEvents and callerEventsOpt

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -169,7 +169,7 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	// Create a new channel to synchronize with the event renderer.
 	innerDone := make(chan bool)
 	defer func() {
-		// Wait for the display routime to exit, then notify the
+		// Wait for the display routime to exit, then notify any listeners that this routine is finished.
 		<-innerDone
 		close(done)
 	}()

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -166,10 +166,18 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	label string, action apitype.UpdateKind, stackRef backend.StackReference, op backend.UpdateOperation,
 	events <-chan engine.Event, done chan<- bool, opts display.Options, isPreview bool) {
 
+	// Create a new channel to synchronize with the event renderer.
+	innerDone := make(chan bool)
+	defer func() {
+		// Wait for the display routime to exit, then notify the
+		<-innerDone
+		close(done)
+	}()
+
 	// Start the local display processor.  Display things however the options have been
 	// set to display (i.e. diff vs progress).
 	displayEvents := make(chan engine.Event)
-	go display.ShowEvents(label, action, stackRef.Name(), op.Proj.Name, displayEvents, done, opts, isPreview)
+	go display.ShowEvents(label, action, stackRef.Name(), op.Proj.Name, displayEvents, innerDone, opts, isPreview)
 
 	seen := make(map[resource.URN]engine.StepEventMetadata)
 


### PR DESCRIPTION
The event rendering goroutine in the remote backend was not properly
synchronizing with the goroutine that created it, and could continue
executing after its creator finished. I believe that this is the root
cause of #1850.