### PR TITLE
 Do not pass component resource properties to the engine. 

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -265,11 +265,11 @@ export class ComponentResource extends Resource {
      *
      * @param t The type of the resource.
      * @param name The _unique_ name of the resource.
-     * @param props [Deprecated].  Component resources do not communicate or store their properties
-     *              with the Pulumi engine.
+     * @param unused [Deprecated].  Component resources do not communicate or store their properties
+     *               with the Pulumi engine.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(type: string, name: string, props?: Inputs, opts: ComponentResourceOptions = {}) {
+    constructor(type: string, name: string, unused?: Inputs, opts: ComponentResourceOptions = {}) {
         if ((<any>opts).provider !== undefined) {
             throw new ResourceError("Explicit providers may not be used with component resources", opts.parent);
         }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -291,7 +291,7 @@ export class ComponentResource extends Resource {
     // they are done creating child resources.  While not strictly necessary, this helps the
     // experience by ensuring the UI transitions the ComponentResource to the 'complete' state as
     // quickly as possible (instead of waiting until the entire application completes).
-    protected registerOutputs(outputs: Inputs | Promise<Inputs> | Output<Inputs> | undefined): void {
+    protected registerOutputs(outputs?: Inputs | Promise<Inputs> | Output<Inputs>): void {
         if (outputs) {
             registerResourceOutputs(this, outputs);
         }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -257,23 +257,32 @@ export abstract class ProviderResource extends CustomResource {
  */
 export class ComponentResource extends Resource {
     /**
-     * Creates and registers a new component resource.  t is the fully qualified type token and name
-     * is the "name" part to use in creating a stable and globally unique URN for the object. parent
-     * is the optional parent for this component, and dependsOn is an optional list of other
-     * resources that this resource depends on, controlling the order in which we perform resource
-     * operations.
+     * Creates and registers a new component resource.  [type] is the fully qualified type token and
+     * [name] is the "name" part to use in creating a stable and globally unique URN for the object.
+     * [opts.parent] is the optional parent for this component, and [opts.dependsOn] is an optional
+     * list of other resources that this resource depends on, controlling the order in which we
+     * perform resource operations.
      *
      * @param t The type of the resource.
      * @param name The _unique_ name of the resource.
-     * @param props The arguments to use to populate the new resource.
+     * @param props [Deprecated].  Component resources do not communicate or store their properties
+     *              with the Pulumi engine.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(t: string, name: string, props?: Inputs, opts: ComponentResourceOptions = {}) {
+    constructor(type: string, name: string, props?: Inputs, opts: ComponentResourceOptions = {}) {
         if ((<any>opts).provider !== undefined) {
             throw new ResourceError("Explicit providers may not be used with component resources", opts.parent);
         }
 
-        super(t, name, false, props, opts);
+        // Explicitly ignore the props passed in.  We allow them for back compat reasons.  However,
+        // we explicitly do not want to pass them along to the engine.  The ComponentResource acts
+        // only as a container for other resources.  Another way to think about this is that a normal
+        // 'custom resource' corresponds to real piece of cloud infrastructure.  So, when it changes
+        // in some way, the cloud resource needs to be updated (and vice versa).  That is not true
+        // for a component resource.  The component is just used for organizational purposes and does
+        // not correspond to a real piece of cloud infrastructure.  As such, changes to it *itself*
+        // do not have any effect on the cloud side of things at all.
+        super(type, name, /*custom:*/ false, /*props:*/ {}, opts);
     }
 
     // registerOutputs registers synthetic outputs that a component has initialized, usually by allocating

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -285,8 +285,12 @@ export class ComponentResource extends Resource {
         super(type, name, /*custom:*/ false, /*props:*/ {}, opts);
     }
 
-    // registerOutputs registers synthetic outputs that a component has initialized, usually by allocating
-    // other child sub-resources and propagating their resulting property values.
+    // registerOutputs registers synthetic outputs that a component has initialized, usually by
+    // allocating other child sub-resources and propagating their resulting property values.
+    // ComponentResources should always call this at the end of their constructor to indicate that
+    // they are done creating child resources.  While not strictly necessary, this helps the
+    // experience by ensuring the UI transitions the ComponentResource to the 'complete' state as
+    // quickly as possible (instead of waiting until the entire application completes).
     protected registerOutputs(outputs: Inputs | Promise<Inputs> | Output<Inputs> | undefined): void {
         if (outputs) {
             registerResourceOutputs(this, outputs);


### PR DESCRIPTION
As per our friday discussion, we will no longer be storing component resource properties in the engine/checkpoint.