### PR TITLE
Revert https://github.com/pulumi/pulumi/pull/2281

### DIFF
--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -247,6 +247,7 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
         if (excessiveDebugOutput) {
             log.debug(`Serialize property [${ctx}]: Promise<T>`);
         }
+
         const subctx = `Promise<${ctx}>`;
         return serializeProperty(subctx,
             await debuggablePromise(prop, `serializeProperty.await(${subctx})`), dependentResources);
@@ -300,16 +301,16 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
     }
 
     if (prop instanceof Array) {
-        const elems: any[] = [];
+        const result: any[] = [];
         for (let i = 0; i < prop.length; i++) {
             if (excessiveDebugOutput) {
                 log.debug(`Serialize property [${ctx}]: array[${i}] element`);
             }
             // When serializing arrays, we serialize any undefined values as `null`. This matches JSON semantics.
             const elem = await serializeProperty(`${ctx}[${i}]`, prop[i], dependentResources);
-            elems.push(elem === undefined ? null : elem);
+            result.push(elem === undefined ? null : elem);
         }
-        return elems;
+        return result;
     }
 
     return await serializeAllKeys(prop, {});

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -231,7 +231,8 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
         }
         return prop;
     }
-    else if (prop instanceof Array) {
+
+    if (prop instanceof Array) {
         const elems: any[] = [];
         for (let i = 0; i < prop.length; i++) {
             if (excessiveDebugOutput) {
@@ -243,7 +244,8 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
         }
         return elems;
     }
-    else if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
+
+    if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
         // Serializing an asset or archive requires the use of a magical signature key, since otherwise it would look
         // like any old weakly typed object/map when received by the other side of the RPC boundary.
         const obj: any = {
@@ -252,7 +254,8 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
 
         return await serializeAllKeys(prop, obj);
     }
-    else if (prop instanceof Promise) {
+
+    if (prop instanceof Promise) {
         // For a promise input, await the property and then serialize the result.
         if (excessiveDebugOutput) {
             log.debug(`Serialize property [${ctx}]: Promise<T>`);
@@ -261,7 +264,8 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
         return serializeProperty(subctx,
             await debuggablePromise(prop, `serializeProperty.await(${subctx})`), dependentResources);
     }
-    else if (Output.isInstance(prop)) {
+
+    if (Output.isInstance(prop)) {
         if (excessiveDebugOutput) {
             log.debug(`Serialize property [${ctx}]: Output<T>`);
         }

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -219,16 +219,7 @@ export const specialArchiveSig = "0def7320c3a5731c473e5ecbe6d01bc7";
  * serializeProperty serializes properties deeply.  This understands how to wait on any unresolved promises, as
  * appropriate, in addition to translating certain "special" values so that they are ready to go on the wire.
  */
-export function serializeProperty(ctx: string, prop: Input<any>, dependentResources: Resource[]): Promise<any> {
-    return serializePropertyWorker(ctx, prop, dependentResources, new Set());
-}
-
-async function serializePropertyWorker(
-    ctx: string, prop: Input<any>,
-    dependentResources: Resource[],
-    seenObjects: Set<any>): Promise<any> {
-
-    // Simple values, always serialize fully.
+export async function serializeProperty(ctx: string, prop: Input<any>, dependentResources: Resource[]): Promise<any> {
     if (prop === undefined ||
         prop === null ||
         typeof prop === "boolean" ||
@@ -240,8 +231,19 @@ async function serializePropertyWorker(
         }
         return prop;
     }
-
-    if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
+    else if (prop instanceof Array) {
+        const elems: any[] = [];
+        for (let i = 0; i < prop.length; i++) {
+            if (excessiveDebugOutput) {
+                log.debug(`Serialize property [${ctx}]: array[${i}] element`);
+            }
+            // When serializing arrays, we serialize any undefined values as `null`. This matches JSON semantics.
+            const elem = await serializeProperty(`${ctx}[${i}]`, prop[i], dependentResources);
+            elems.push(elem === undefined ? null : elem);
+        }
+        return elems;
+    }
+    else if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
         // Serializing an asset or archive requires the use of a magical signature key, since otherwise it would look
         // like any old weakly typed object/map when received by the other side of the RPC boundary.
         const obj: any = {
@@ -250,20 +252,16 @@ async function serializePropertyWorker(
 
         return await serializeAllKeys(prop, obj);
     }
-
-    if (prop instanceof Promise) {
+    else if (prop instanceof Promise) {
         // For a promise input, await the property and then serialize the result.
         if (excessiveDebugOutput) {
             log.debug(`Serialize property [${ctx}]: Promise<T>`);
         }
-
         const subctx = `Promise<${ctx}>`;
-        return serializePropertyWorker(subctx,
-            await debuggablePromise(prop, `serializeProperty.await(${subctx})`),
-            dependentResources, seenObjects);
+        return serializeProperty(subctx,
+            await debuggablePromise(prop, `serializeProperty.await(${subctx})`), dependentResources);
     }
-
-    if (Output.isInstance(prop)) {
+    else if (Output.isInstance(prop)) {
         if (excessiveDebugOutput) {
             log.debug(`Serialize property [${ctx}]: Output<T>`);
         }
@@ -274,8 +272,7 @@ async function serializePropertyWorker(
         // sentinel. We will do the former for all outputs created directly by user code (such outputs always
         // resolve isKnown to true) and for any resource outputs that were resolved with known values.
         const isKnown = await prop.isKnown;
-        const value = await serializePropertyWorker(
-            `${ctx}.id`, prop.promise(), dependentResources, seenObjects);
+        const value = await serializeProperty(`${ctx}.id`, prop.promise(), dependentResources);
         return isKnown ? value : unknownValue;
     }
 
@@ -286,7 +283,7 @@ async function serializePropertyWorker(
         }
 
         dependentResources.push(prop);
-        return serializePropertyWorker(`${ctx}.id`, prop.id, dependentResources, seenObjects);
+        return serializeProperty(`${ctx}.id`, prop.id, dependentResources);
     }
 
     if (ComponentResource.isInstance(prop)) {
@@ -308,31 +305,7 @@ async function serializePropertyWorker(
             log.debug(`Serialize property [${ctx}]: component resource urnid`);
         }
 
-        return serializePropertyWorker(`${ctx}.urn`, prop.urn, dependentResources, seenObjects);
-    }
-
-    // We're now getting to complex objects where we are recursing into them.  Prevent infinite
-    // recursion if we've already seen this object before.
-    if (seenObjects.has(prop)) {
-        return undefined;
-    }
-
-    seenObjects.add(prop);
-
-    if (prop instanceof Array) {
-        const result: any[] = [];
-        for (let i = 0; i < prop.length; i++) {
-            if (excessiveDebugOutput) {
-                log.debug(`Serialize property [${ctx}]: array[${i}] element`);
-            }
-
-            // When serializing arrays, we serialize any undefined values as `null`. This matches
-            // JSON semantics.
-            const elem = await serializePropertyWorker(
-                `${ctx}[${i}]`, prop[i], dependentResources, seenObjects);
-            result.push(elem === undefined ? null : elem);
-        }
-        return result;
+        return serializeProperty(`${ctx}.urn`, prop.urn, dependentResources);
     }
 
     return await serializeAllKeys(prop, {});
@@ -344,8 +317,7 @@ async function serializePropertyWorker(
             }
 
             // When serializing an object, we omit any keys with undefined values. This matches JSON semantics.
-            const v = await serializePropertyWorker(
-                `${ctx}.${k}`, innerProp[k], dependentResources, seenObjects);
+            const v = await serializeProperty(`${ctx}.${k}`, innerProp[k], dependentResources);
             if (v !== undefined) {
                 obj[k] = v;
             }

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -232,19 +232,6 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
         return prop;
     }
 
-    if (prop instanceof Array) {
-        const elems: any[] = [];
-        for (let i = 0; i < prop.length; i++) {
-            if (excessiveDebugOutput) {
-                log.debug(`Serialize property [${ctx}]: array[${i}] element`);
-            }
-            // When serializing arrays, we serialize any undefined values as `null`. This matches JSON semantics.
-            const elem = await serializeProperty(`${ctx}[${i}]`, prop[i], dependentResources);
-            elems.push(elem === undefined ? null : elem);
-        }
-        return elems;
-    }
-
     if (asset.Asset.isInstance(prop) || asset.Archive.isInstance(prop)) {
         // Serializing an asset or archive requires the use of a magical signature key, since otherwise it would look
         // like any old weakly typed object/map when received by the other side of the RPC boundary.
@@ -310,6 +297,19 @@ export async function serializeProperty(ctx: string, prop: Input<any>, dependent
         }
 
         return serializeProperty(`${ctx}.urn`, prop.urn, dependentResources);
+    }
+
+    if (prop instanceof Array) {
+        const elems: any[] = [];
+        for (let i = 0; i < prop.length; i++) {
+            if (excessiveDebugOutput) {
+                log.debug(`Serialize property [${ctx}]: array[${i}] element`);
+            }
+            // When serializing arrays, we serialize any undefined values as `null`. This matches JSON semantics.
+            const elem = await serializeProperty(`${ctx}[${i}]`, prop[i], dependentResources);
+            elems.push(elem === undefined ? null : elem);
+        }
+        return elems;
     }
 
     return await serializeAllKeys(prop, {});

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -40,22 +40,6 @@ describe("runtime", () => {
             assert.equal(result.id, "foo");
             assert.equal(result.urn, "bar");
         }));
-
-        it("handles cycles", asyncTest(async () => {
-            const inputs: Inputs = {
-                array: <any[]>[1, "str", true],
-                obj: { a: "str" },
-            };
-
-            inputs.array.push(inputs.array);
-            inputs.obj.cycle1 = inputs.obj;
-
-            // Serialize and then deserialize all the properties, checking that they round-trip as expected.
-            const transfer = gstruct.Struct.fromJavaScript(
-                await runtime.serializeProperties("test", inputs));
-            const result = runtime.deserializeProperties(transfer);
-            assert.deepEqual(result.array, [ 1, "str", true, undefined ]);
-            assert.deepEqual(result.obj, { a: "str" });
-        }));
     });
 });
+


### PR DESCRIPTION
As per our friday meeting.  We don't think we need this.  ComponentProperties no longer have properties, and we also just await a component prop by awaiting it's urn.   so we should not be getting cycles between resources.