### PR TITLE
Force rebuild of this package to wipe out previously published 'dev' package.

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -63,8 +63,8 @@ export abstract class Resource {
     }
 
     /**
-     * Creates and registers a new resource object.  t is the fully qualified type token and name is
-     * the "name" part to use in creating a stable and globally unique URN for the object.
+     * Creates and registers a new resource object.  [t] is the fully qualified type token and
+     * [name] is the "name" part to use in creating a stable and globally unique URN for the object.
      * dependsOn is an optional list of other resources that this resource depends on, controlling
      * the order in which we perform resource operations.
      *


### PR DESCRIPTION
I was testing out some changes using 'feature' branches.  These help us by allowing us to publish 'dev' builds that we can test downstream.  however, if we decide we don't want the feature, the dev build stays around and (if buggy) can effectively poison downstream packages.  

Pushing through a simple change here to simply bump the pusblished 'dev' version of this library.  Note:  this will also need to be done in 'pulumi/aws' as well.