### PR TITLE
Close plugin context on plan creation failure

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -138,6 +138,7 @@ func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*plan
 	// for example, loading any plugins which will be required to execute a program, among other things.
 	source, err := opts.SourceFunc(opts, proj, pwd, main, target, plugctx, dryRun)
 	if err != nil {
+		contract.IgnoreClose(plugctx)
 		return nil, err
 	}
 
@@ -157,6 +158,7 @@ func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*plan
 	// Generate a plan; this API handles all interesting cases (create, update, delete).
 	plan, err := deploy.NewPlan(plugctx, target, target.Snapshot, source, analyzers, dryRun, ctx.BackendClient)
 	if err != nil {
+		contract.IgnoreClose(plugctx)
 		return nil, err
 	}
 	return &planResult{

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -28,11 +28,13 @@ import (
 )
 
 type LoadProviderFunc func() (plugin.Provider, error)
+type LoadProviderWithHostFunc func(host plugin.Host) (plugin.Provider, error)
 
 type ProviderLoader struct {
-	pkg     tokens.Package
-	version semver.Version
-	load    LoadProviderFunc
+	pkg          tokens.Package
+	version      semver.Version
+	load         LoadProviderFunc
+	loadWithHost LoadProviderWithHostFunc
 }
 
 func NewProviderLoader(pkg tokens.Package, version semver.Version, load LoadProviderFunc) *ProviderLoader {
@@ -43,6 +45,14 @@ func NewProviderLoader(pkg tokens.Package, version semver.Version, load LoadProv
 	}
 }
 
+func NewProviderLoaderWithHost(pkg tokens.Package, version semver.Version, load LoadProviderWithHostFunc) *ProviderLoader {
+	return &ProviderLoader{
+		pkg:          pkg,
+		version:      version,
+		loadWithHost: load,
+	}
+}
+
 type pluginHost struct {
 	providerLoaders []*ProviderLoader
 	languageRuntime plugin.LanguageRuntime
@@ -50,6 +60,7 @@ type pluginHost struct {
 	statusSink      diag.Sink
 
 	providers map[plugin.Provider]struct{}
+	closed    bool
 	m         sync.Mutex
 }
 
@@ -63,6 +74,12 @@ func NewPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRu
 		statusSink:      statusSink,
 		providers:       make(map[plugin.Provider]struct{}),
 	}
+}
+
+func (host *pluginHost) isClosed() bool {
+	host.m.Lock()
+	defer host.m.Unlock()
+	return host.closed
 }
 
 func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
@@ -83,7 +100,14 @@ func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (p
 		return nil, nil
 	}
 
-	prov, err := best.load()
+	load := best.load
+	if load == nil {
+		load = func() (plugin.Provider, error) {
+			return best.loadWithHost(host)
+		}
+	}
+
+	prov, err := load()
 	if err != nil {
 		return nil, err
 	}
@@ -112,16 +136,24 @@ func (host *pluginHost) SignalCancellation() error {
 	return err
 }
 func (host *pluginHost) Close() error {
+	host.m.Lock()
+	defer host.m.Unlock()
+
+	host.closed = true
 	return nil
 }
 func (host *pluginHost) ServerAddr() string {
 	panic("Host RPC address not available")
 }
 func (host *pluginHost) Log(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
-	host.sink.Logf(sev, diag.StreamMessage(urn, msg, streamID))
+	if !host.isClosed() {
+		host.sink.Logf(sev, diag.StreamMessage(urn, msg, streamID))
+	}
 }
 func (host *pluginHost) LogStatus(sev diag.Severity, urn resource.URN, msg string, streamID int32) {
-	host.statusSink.Logf(sev, diag.StreamMessage(urn, msg, streamID))
+	if !host.isClosed() {
+		host.statusSink.Logf(sev, diag.StreamMessage(urn, msg, streamID))
+	}
 }
 func (host *pluginHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
 	return nil, errors.New("unsupported")


### PR DESCRIPTION
This ensures that the gRPC server is properly shut down. This fixes an
issue in which a resource plugin that is still configuring could report
log messages to the plugin host, which would in turn attempt to send
diagnostic packets over a closed channel, causing a panic.

Fixes #2170.