### PR TITLE
During preview, don't record reads if they didn't actually result in any property changes.

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -311,6 +311,17 @@ func (acts *planActions) OnResourceStepPost(ctx interface{},
 			op, record = step.(*deploy.RefreshStep).ResultOp(), true
 		}
 
+		if step.Op() == deploy.OpRead &&
+			step.Old().Outputs != nil &&
+			step.New().Outputs != nil {
+
+			// If reading a resource didn't result in any change to the resource, we then want to
+			// record this as a 'same'.  That way, when things haven't actually changed, but a user
+			// app did any 'reads' these don't show up in the resource summary at the end.
+			diff := step.Old().Outputs.Diff(step.New().Outputs)
+			record = diff != nil
+		}
+
 		// Track the operation if shown and/or if it is a logically meaningful operation.
 		if record {
 			acts.MapLock.Lock()

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -312,6 +312,8 @@ func (acts *planActions) OnResourceStepPost(ctx interface{},
 		}
 
 		if step.Op() == deploy.OpRead &&
+			step.Old() != nil &&
+			step.New() != nil &&
 			step.Old().Outputs != nil &&
 			step.New().Outputs != nil {
 


### PR DESCRIPTION
This ends up cluttering the resource summary since it looks like something has changed when it really hasn't.
It's also problematic for testing since our --expect-no-changes ends up thinking something has changed when it really hasn't.  

Now, we only record a read during preview it it actually resulted in some change happening. 