### PR TITLE
Don't record reads as changes during updates unless something actually changed

### DIFF
--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -220,8 +220,10 @@ func (acts *updateActions) OnResourceStepPre(step deploy.Step) (interface{}, err
 	return acts.Context.SnapshotManager.BeginMutation(step)
 }
 
-func (acts *updateActions) OnResourceStepPost(ctx interface{},
-	step deploy.Step, status resource.Status, err error) error {
+func (acts *updateActions) OnResourceStepPost(
+	ctx interface{}, step deploy.Step,
+	status resource.Status, err error) error {
+
 	acts.MapLock.Lock()
 	assertSeen(acts.Seen, step)
 	acts.MapLock.Unlock()
@@ -255,6 +257,10 @@ func (acts *updateActions) OnResourceStepPost(ctx interface{},
 		if acts.Opts.isRefresh && op == deploy.OpRefresh {
 			// Refreshes are handled specially.
 			op, record = step.(*deploy.RefreshStep).ResultOp(), true
+		}
+
+		if step.Op() == deploy.OpRead {
+			record = ShouldRecordReadStep(step)
 		}
 
 		if record {


### PR DESCRIPTION
Followup to https://github.com/pulumi/pulumi/pull/2305

We want to perform the same logic during update as well as preview.  At the end of an update we don't want to make it seem as if something happened if we did a read and it happened to just give us the same values as before.