### PR TITLE
 Convert resource to pojo objects when used as stack outputs. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.16.9 (Unreleased)
 
+- Exporting a Resource from an application Stack now exports it as a rich recursive pojo instead of just being an opaque URN (fixes https://github.com/pulumi/pulumi/issues/1858).
+
 ### Improvements
 
 - Update the error message when When `pulumi` commands fail to detect your project to mention that `pulumi new` can be used to create a new project (fixes [pulumi/pulumi#2234](https://github.com/pulumi/pulumi/issues/2234))

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -220,8 +220,10 @@ func (acts *updateActions) OnResourceStepPre(step deploy.Step) (interface{}, err
 	return acts.Context.SnapshotManager.BeginMutation(step)
 }
 
-func (acts *updateActions) OnResourceStepPost(ctx interface{},
-	step deploy.Step, status resource.Status, err error) error {
+func (acts *updateActions) OnResourceStepPost(
+	ctx interface{}, step deploy.Step,
+	status resource.Status, err error) error {
+
 	acts.MapLock.Lock()
 	assertSeen(acts.Seen, step)
 	acts.MapLock.Unlock()
@@ -255,6 +257,10 @@ func (acts *updateActions) OnResourceStepPost(ctx interface{},
 		if acts.Opts.isRefresh && op == deploy.OpRefresh {
 			// Refreshes are handled specially.
 			op, record = step.(*deploy.RefreshStep).ResultOp(), true
+		}
+
+		if step.Op() == deploy.OpRead {
+			record = ShouldRecordReadStep(step)
 		}
 
 		if record {

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -96,9 +96,15 @@ async function massage(prop: any, seenObjects: Set<any>): Promise<any> {
     }
 
     // from this point on, we have complex objects.  If we see them again, we don't want to emit
-    // them again or else we'd loop infinitely.
+    // them again fully or else we'd loop infinitely.
     if (seenObjects.has(prop)) {
-        return;
+        // Note: for Resources we hit again, emit their urn so cycles can be easily understood
+        // in the pojo objects.
+        if (Resource.isInstance(prop)) {
+            return await massage(prop.urn, seenObjects);
+        }
+
+        return undefined;
     }
 
     seenObjects.add(prop);

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as asset from "../asset";
 import { getProject, getStack } from "../metadata";
-import { ComponentResource, Inputs, Output, output } from "../resource";
+import { ComponentResource, Inputs, Output, output, Resource } from "../resource";
 import { getRootResource, setRootResource } from "./settings";
 
 /**
@@ -64,9 +65,97 @@ class Stack extends ComponentResource {
         try {
             outputs = init();
         } finally {
-            super.registerOutputs(outputs);
+            // We want to expose stack outputs as simple pojo objects (including Resources).  This
+            // helps ensure that outputs can point to resources, and that that is stored and
+            // presented as something reasonable, and not as just an id/urn in the case of
+            // Resources.
+            const massaged = output(outputs).apply(v => massage(v, new Set()));
+            super.registerOutputs(massaged);
         }
 
         return outputs;
+    }
+}
+
+async function massage(prop: any, seenObjects: Set<any>): Promise<any> {
+    if (prop === undefined ||
+        prop === null ||
+        typeof prop === "boolean" ||
+        typeof prop === "number" ||
+        typeof prop === "string") {
+
+        return prop;
+    }
+
+    if (prop instanceof Promise) {
+        return await massage(await prop, seenObjects);
+    }
+
+    if (Output.isInstance(prop)) {
+        return await massage(await prop.promise(), seenObjects);
+    }
+
+    // from this point on, we have complex objects.  If we see them again, we don't want to emit
+    // them again or else we'd loop infinitely.
+    if (seenObjects.has(prop)) {
+        return;
+    }
+
+    seenObjects.add(prop);
+
+    if (asset.Asset.isInstance(prop)) {
+        if ((<asset.FileAsset>prop).path !== undefined) {
+            return { path: (<asset.FileAsset>prop).path };
+        }
+        else if ((<asset.RemoteAsset>prop).uri !== undefined) {
+            return { uri: (<asset.RemoteAsset>prop).uri };
+        }
+        else if ((<asset.StringAsset>prop).text !== undefined) {
+            return { text: "..." };
+        }
+
+        return undefined;
+    }
+
+    if (asset.Archive.isInstance(prop)) {
+        if ((<asset.AssetArchive>prop).assets) {
+            return { assets: massage((<asset.AssetArchive>prop).assets, seenObjects) };
+        }
+        else if ((<asset.FileArchive>prop).path !== undefined) {
+            return { path: (<asset.FileArchive>prop).path };
+        }
+        else if ((<asset.RemoteArchive>prop).uri !== undefined) {
+            return { uri: (<asset.RemoteArchive>prop).uri };
+        }
+
+        return undefined;
+    }
+
+    if (Resource.isInstance(prop)) {
+        // Emit a resource as a normal pojo.  But filter out all our internal properties so that
+        // they don't clutter the display/checkpoint with values not relevant to the application.
+        return serializeAllKeys(n => !n.startsWith("__"));
+    }
+
+    if (prop instanceof Array) {
+        const result = [];
+        for (let i = 0; i < prop.length; i++) {
+            result[i] = await massage(prop[i], seenObjects);
+        }
+
+        return result;
+    }
+
+    return await serializeAllKeys(n => true);
+
+    async function serializeAllKeys(include: (name: string) => boolean) {
+        const obj: Record<string, any> = {};
+        for (const k of Object.keys(prop)) {
+            if (include(k)) {
+                obj[k] = await massage(prop[k], seenObjects);
+            }
+        }
+
+        return obj;
     }
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1858

Previously, a stack output that was a resource would look like:

```
vpcInstance    : "urn:pulumi:cyfg::containers-fargate::awsinfra:x:ec2:Vpc::default-vpc"
```

Now it will look like:

```
  + vpcInstance    : {
      + instance         : {
          + arn                         : "arn:aws:ec2:us-west-1:153052954103:vpc/vpc-f006bd94"
          + assignGeneratedIpv6CidrBlock: false
          + cidrBlock                   : "172.31.0.0/16"
          + defaultNetworkAclId         : "acl-df3d56bb"
          + defaultRouteTableId         : "rtb-ce255aaa"
          + defaultSecurityGroupId      : "sg-11134f76"
          + dhcpOptionsId               : "dopt-68ea3e0c"
          + enableClassiclink           : false
          + enableClassiclinkDnsSupport : false
          + enableDnsHostnames          : true
          + enableDnsSupport            : true
          + id                          : "vpc-f006bd94"
          + instanceTenancy             : "default"
          + mainRouteTableId            : "rtb-ce255aaa"
          + ownerId                     : "153052954103"
          + urn                         : "urn:pulumi:cyfg::containers-fargate::aws:ec2/vpc:Vpc::default-vpc"
        }
      + publicSubnetIds  : [
      +     [0]: "subnet-b0dbbbe8"
      +     [1]: "subnet-10025474"
        ]
      + publicSubnets    : [
      +     [0]: {
              + instance  : {
                  + arn                        : "arn:aws:ec2:us-west-1:153052954103:subnet/subnet-b0dbbbe8"
                  + assignIpv6AddressOnCreation: false
                  + availabilityZone           : "us-west-1c"
                  + availabilityZoneId         : "usw1-az3"
                  + cidrBlock                  : "172.31.0.0/20"
                  + id                         : "subnet-b0dbbbe8"
                  + mapPublicIpOnLaunch        : true
                  + ownerId                    : "153052954103"
                  + urn                        : "urn:pulumi:cyfg::containers-fargate::awsinfra:x:ec2:Vpc$aws:ec2/subnet:Subnet::public-0"
                  + vpcId                      : "vpc-f006bd94"
                  + vpc                        : "urn:pulumi:cyfg::containers-fargate::awsinfra:x:ec2:Vpc::default-vpc"
                }
              + subnetId  : "subnet-b0dbbbe8"
              + subnetName: "public-0"
              + urn       : "urn:pulumi:cyfg::containers-fargate::awsinfra:x:ec2:Vpc$awsinfra:x:ec2:Subnet::public-0"
            }
      +     [1]: {
              + instance  : {
                  + arn                        : "arn:aws:ec2:us-west-1:153052954103:subnet/subnet-10025474"
                  + assignIpv6AddressOnCreation: false
                  + availabilityZone           : "us-west-1a"
                  + availabilityZoneId         : "usw1-az1"
                  + cidrBlock                  : "172.31.16.0/20"
                  + id                         : "subnet-10025474"
                  + mapPublicIpOnLaunch        : true
                  + ownerId                    : "153052954103"
                  + urn                        : "urn:pulumi:cyfg::containers-fargate::awsinfra:x:ec2:Vpc$aws:ec2/subnet:Subnet::public-1"
                  + vpcId                      : "vpc-f006bd94"
                  + vpc                        : "urn:pulumi:cyfg::containers-fargate::awsinfra:x:ec2:Vpc::default-vpc"
                }
              + subnetId  : "subnet-10025474"
              + subnetName: "public-1"
              + urn       : "urn:pulumi:cyfg::containers-fargate::awsinfra:x:ec2:Vpc$awsinfra:x:ec2:Subnet::public-1"
            }
        ]
      + urn              : "urn:pulumi:cyfg::containers-fargate::awsinfra:x:ec2:Vpc::default-vpc"
    }
```

Large, but actually useful detailed information that is more in line with the intuition someone wants here.