### PR TITLE
Record engine events concurrently

### DIFF
--- a/pkg/apitype/events.go
+++ b/pkg/apitype/events.go
@@ -142,7 +142,7 @@ type EngineEvent struct {
 	// Pulumi Service. Since events may be sent concurrently, and/or delayed via network routing,
 	// the sequence number is to ensure events can be placed into a total ordering.
 	//
-	// - No two events can have the same sequence number
+	// - No two events can have the same sequence number.
 	// - Events with a lower sequence number must have been emitted before those with a higher
 	//   sequence number.
 	Sequence int `json:"sequence"`


### PR DESCRIPTION
Record engine events concurrently using Go-routines.

Currently we record all of the engine events (a `POST` request to the Pulumi Service) serially, as we see the events. This is problematic when an update contains hundreds of resources or produces lots of log output. In those cases we emit many engine events, and no matter how quickly the Pulumi Service can handle the requests, the end-to-end network latency adds up. (100ms x 1500 events is 2.5 minutes)

Since each engine event can be recorded independently, we can issue all those requests in separate Go routines. I'm sure there will be a bottleneck elsewhere, as the OS or NIC needs to block queued up requests. But I assume that it won't cause any errors.

In my own testing -- writing an app that just spams `console.log` a few thousand times, emitting `DiagEvent`s in a loop -- I measured the following perf numbers:

```
$ [5000] time pulumi update --skip-preview
Duration: 3m5s

Permalink: https://app.pulumi.com/chrsmith/ee-stress-dev/updates/3

real    3m11.211s
user    0m14.677s
sys     0m3.654s


$ [5000] time /Users/chris/pulumi-root/bin/pulumi update --skip-preview
Duration: 5s

Permalink: https://app.pulumi.com/chrsmith/ee-stress-dev/updates/4

real    0m8.565s
user    0m15.197s
sys     0m2.833s

$ [1000] time pulumi update --skip-preview

Duration: 37s

Permalink: https://app.pulumi.com/chrsmith/ee-stress-dev/updates/5

real    0m39.191s
user    0m3.236s
sys     0m0.796s

Duration: 2s

Permalink: https://app.pulumi.com/chrsmith/ee-stress-dev/updates/6

real    0m3.617s
user    0m2.207s
sys     0m0.567s
```

Fixes #2303 , though I'd like to add an integration test to ensure it stays that way. But I'll leave that for a separate PR in case we want to hotfix the current CLI with this.