### PR TITLE
Wait until all EEs are recorded after CancelEvent

### DIFF
--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -207,7 +207,7 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 		go recordEngineEvent(e, eventIdx)
 
 		if e.Type == engine.CancelEvent {
-			return
+			break
 		}
 	}
 


### PR DESCRIPTION
When returning immediately from the loop, we are closing the `done` channel early. This signals that we have finished processing every engine event, however that isn't true. Since some events may still be in-flight in `recordEngineEvent`. (This could potentially lead to a race condition in the `diag.Sink` passed to the API client used to record the call.)