### PR TITLE
Link directly to /account/tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.16.10 (Unreleased)
 
+### Improvements
+
+- Link directly to /account/tokens when prompting for an access token.
+
 ## 0.16.9 (Released December 24th, 2018)
 
 ### Improvements
@@ -13,7 +17,7 @@
 - During previews and updates, read operations (i.e. calls to `.get` methods) are no longer shown in the output unless they cause any changes.
 
 - Fix a performance regression where `pulumi preview` and `pulumi update` would hang for a few moments at the end of a preview or update, in additon to the overall operation being slower.
-	
+
 ## 0.16.8 (Released December 14th, 2018)
 
 ### Improvements

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -257,7 +257,7 @@ func Login(ctx context.Context, d diag.Sink, cloudURL, stackConfigFile string, o
 	// We intentionally don't accept command-line args for the user's access token. Having it in
 	// .bash_history is not great, and specifying it via flag isn't of much use.
 	accessToken := os.Getenv(AccessTokenEnvVar)
-	accountLink := cloudConsoleURL(cloudURL, "account")
+	accountLink := cloudConsoleURL(cloudURL, "account", "tokens")
 
 	if accessToken != "" {
 		// If there's already a token from the environment, use it.


### PR DESCRIPTION
We're changing /account to redirect to /account/profile instead of
/account/tokens as the user profile settings are a more natural place
to land when going into account settings.

This commit changes the CLI to link
directly to /account/tokens, avoiding having to click on
"Access Tokens" to go to the tokens page to get an access token when
coming from the URL outputted by the CLI.