### PR TITLE
Run 'dep ensure --update github.com/uber/jaeger-client-go'

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -23,12 +23,6 @@
   version = "v1.0.5"
 
 [[projects]]
-  name = "github.com/apache/thrift"
-  packages = ["lib/go/thrift"]
-  revision = "b2a4d4ae21c789b689dd162deb819665567f481c"
-  version = "0.10.0"
-
-[[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -375,8 +369,11 @@
   name = "github.com/uber/jaeger-client-go"
   packages = [
     ".",
+    "internal/baggage",
     "internal/spanlog",
+    "internal/throttler",
     "log",
+    "thrift",
     "thrift-gen/agent",
     "thrift-gen/jaeger",
     "thrift-gen/sampling",
@@ -384,14 +381,14 @@
     "transport/zipkin",
     "utils"
   ]
-  revision = "3e3870040def0ebdaf65a003863fa64f5cb26139"
-  version = "v2.9.0"
+  revision = "1a782e2da844727691fef1757c72eb190c2909f0"
+  version = "v2.15.0"
 
 [[projects]]
   name = "github.com/uber/jaeger-lib"
   packages = ["metrics"]
-  revision = "3b2a9ad2a045881ab7a0f81d465be54c8292ee4f"
-  version = "v1.1.0"
+  revision = "ed3a127ec5fef7ae9ea95b01b542c47fbd999ce5"
+  version = "v1.5.0"
 
 [[projects]]
   name = "github.com/xanzy/ssh-agent"


### PR DESCRIPTION
While looking at #2323 I noticed we have a bug in our Jaeger client. While the bug didn't appear to be caused specifically by that, bumping up the Jaeger client version anyways is probably good for business.