### PR TITLE
Always read StackReference resources

### DIFF
--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -44,7 +44,7 @@ export class StackReference extends CustomResource {
         super("pulumi:pulumi:StackReference", name, {
             name: args.name || name,
             outputs: undefined,
-        }, opts);
+        }, { ...opts, id: args.name || name });
     }
 
     /**


### PR DESCRIPTION
This is something of a quick hack to work around the limitations that
are at the root of #2310. In short, `StackReference` resources do not
change during a update because their inputs have not changed and we do
not refresh resources as part of the update by default. We want
`StackReference` to remain a resource for myriad reasons (not the least
of which is to avoid a breaking change), but it does seem correct for it
to refresh its state during each update. Because there is no actual CRUD
operation associated with a `StackReferece`, we can obtain this behavior
by changing the implementation of its ctor in the various SDKs s.t. its
options bag always contains an appropriate `id`, thus indicating a
`Read`.

Fixes #2310.