### PR TITLE
Add commands for managing stack tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- Added `pulumi stack tag` commands for managing stack tags stored in the cloud backend.
+
 - Link directly to /account/tokens when prompting for an access token.
 
 ## 0.16.9 (Released December 24th, 2018)

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -173,6 +173,7 @@ func newStackCmd() *cobra.Command {
 	cmd.AddCommand(newStackOutputCmd())
 	cmd.AddCommand(newStackRmCmd())
 	cmd.AddCommand(newStackSelectCmd())
+	cmd.AddCommand(newStackTagCmd())
 
 	return cmd
 }

--- a/cmd/stack_tag.go
+++ b/cmd/stack_tag.go
@@ -1,0 +1,203 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/backend"
+	"github.com/pulumi/pulumi/pkg/backend/display"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+)
+
+func newStackTagCmd() *cobra.Command {
+	var stack string
+
+	cmd := &cobra.Command{
+		Use:   "tag",
+		Short: "Manage stack tags",
+		Long: "Manage stack tags\n" +
+			"\n" +
+			"Stacks have associated metadata in the form of tags. Each tag consists of a name\n" +
+			"and value. The `get`, `ls`, `rm`, and `set` commands can be used to manage tags.\n" +
+			"Some tags are automatically assigned based on the environment each time a stack\n" +
+			"is updated.\n",
+		Args: cmdutil.NoArgs,
+	}
+
+	cmd.PersistentFlags().StringVarP(
+		&stack, "stack", "s", "", "The name of the stack to operate on. Defaults to the current stack")
+
+	cmd.AddCommand(newStackTagGetCmd(&stack))
+	cmd.AddCommand(newStackTagLsCmd(&stack))
+	cmd.AddCommand(newStackTagRmCmd(&stack))
+	cmd.AddCommand(newStackTagSetCmd(&stack))
+
+	return cmd
+}
+
+func newStackTagGetCmd(stack *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <name>",
+		Short: "Get a single stack tag value",
+		Args:  cmdutil.SpecificArgs([]string{"name"}),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			opts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			if err != nil {
+				return err
+			}
+
+			tags, err := backend.GetStackTags(commandContext(), s)
+			if err != nil {
+				return err
+			}
+
+			if value, ok := tags[name]; ok {
+				fmt.Printf("%v\n", value)
+				return nil
+			}
+
+			return errors.Errorf(
+				"stack tag '%s' not found for stack '%s'", name, s.Ref())
+		}),
+	}
+}
+
+func newStackTagLsCmd(stack *string) *cobra.Command {
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "ls",
+		Short: "List all stack tags",
+		Args:  cmdutil.NoArgs,
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			opts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			if err != nil {
+				return err
+			}
+
+			tags, err := backend.GetStackTags(commandContext(), s)
+			if err != nil {
+				return err
+			}
+
+			if jsonOut {
+				return printJSON(tags)
+			}
+
+			printStackTags(tags)
+			return nil
+		}),
+	}
+
+	cmd.PersistentFlags().BoolVarP(
+		&jsonOut, "json", "j", false, "Emit stack tags as JSON")
+
+	return cmd
+}
+
+func printStackTags(tags map[apitype.StackTagName]string) {
+	var names []string
+	for n := range tags {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	rows := []cmdutil.TableRow{}
+	for _, name := range names {
+		rows = append(rows, cmdutil.TableRow{Columns: []string{name, tags[name]}})
+	}
+
+	cmdutil.PrintTable(cmdutil.Table{
+		Headers: []string{"NAME", "VALUE"},
+		Rows:    rows,
+	})
+}
+
+func newStackTagRmCmd(stack *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "rm <name>",
+		Short: "Remove a stack tag",
+		Args:  cmdutil.SpecificArgs([]string{"name"}),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+
+			opts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			if err != nil {
+				return err
+			}
+
+			ctx := commandContext()
+
+			tags, err := backend.GetStackTags(ctx, s)
+			if err != nil {
+				return err
+			}
+
+			delete(tags, name)
+
+			return backend.UpdateStackTags(ctx, s, tags)
+		}),
+	}
+}
+
+func newStackTagSetCmd(stack *string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <name> <value>",
+		Short: "Set a stack tag",
+		Args:  cmdutil.SpecificArgs([]string{"name", "value"}),
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			value := args[1]
+
+			opts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			if err != nil {
+				return err
+			}
+
+			ctx := commandContext()
+
+			tags, err := backend.GetStackTags(ctx, s)
+			if err != nil {
+				return err
+			}
+
+			if tags == nil {
+				tags = make(map[apitype.StackTagName]string)
+			}
+			tags[name] = value
+
+			return backend.UpdateStackTags(ctx, s, tags)
+		}),
+	}
+}

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -115,6 +115,11 @@ type Backend interface {
 	// Get the configuration from the most recent deployment of the stack.
 	GetLatestConfiguration(ctx context.Context, stackRef StackReference) (config.Map, error)
 
+	// GetStackTags fetches the stack's existing tags.
+	GetStackTags(ctx context.Context, stackRef StackReference) (map[apitype.StackTagName]string, error)
+	// UpdateStackTags updates the stacks's tags, replacing all existing tags.
+	UpdateStackTags(ctx context.Context, stackRef StackReference, tags map[apitype.StackTagName]string) error
+
 	// ExportDeployment exports the deployment for the given stack as an opaque JSON message.
 	ExportDeployment(ctx context.Context, stackRef StackReference) (*apitype.UntypedDeployment, error)
 	// ImportDeployment imports the given deployment into the indicated stack.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -146,7 +146,7 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 		return nil, &backend.StackAlreadyExistsError{StackName: string(stackName)}
 	}
 
-	tags, err := backend.GetStackTags()
+	tags, err := backend.GetEnvironmentTagsForCurrentStack()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting stack tags")
 	}
@@ -537,4 +537,20 @@ func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
 	}
 
 	return stacks, nil
+}
+
+// GetStackTags fetches the stack's existing tags.
+func (b *localBackend) GetStackTags(ctx context.Context,
+	stackRef backend.StackReference) (map[apitype.StackTagName]string, error) {
+
+	// The local backend does not currently persist tags.
+	return nil, nil
+}
+
+// UpdateStackTags updates the stacks's tags, replacing all existing tags.
+func (b *localBackend) UpdateStackTags(ctx context.Context,
+	stackRef backend.StackReference, tags map[apitype.StackTagName]string) error {
+
+	// The local backend does not currently persist tags.
+	return nil
 }

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -516,3 +516,15 @@ func (pc *Client) RecordEngineEvent(
 		nil, event, nil,
 		updateAccessToken(token), callOpts)
 }
+
+// UpdateStackTags updates the stacks's tags, replacing all existing tags.
+func (pc *Client) UpdateStackTags(
+	ctx context.Context, stack StackIdentifier, tags map[apitype.StackTagName]string) error {
+
+	// Validate stack tags.
+	if err := backend.ValidateStackTags(tags); err != nil {
+		return err
+	}
+
+	return pc.restCall(ctx, "PATCH", getStackPath(stack, "tags"), nil, tags, nil)
+}


### PR DESCRIPTION
This adds `pulumi stack tag` commands for managing stack tags stored in the cloud backend.

Some follow-ups to consider after this PR:

 - Consider persisting stack tags for the local backend (the tags aren't currently persisted for the local backend, so the commands are no-ops).
 - Consider exposing stack tags to Pulumi programs (e.g. providing `getStackTag` / `getStackTags` functions for node, and similar APIs for Python and Go).
 - Tests -- I was going to add some tests for the new CLI commands, but looks like most of our tests run using the local backend, and support for persisting tags isn't currently implemented there.

Part of #2144