### PR TITLE
Relax baseline for the TestEngineEventPerf test

### DIFF
--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -84,11 +84,13 @@ func TestEmptyGo(t *testing.T) {
 // Tests emitting many engine events doesn't result in a performance problem.
 func TestEngineEventPerf(t *testing.T) {
 	// Prior to pulumi/pulumi#2303, a preview or update would take ~40s.
-	// Since then, it should now be down to ~4s, with additional padding.
+	// Since then, it should now be down to ~4s, with additional padding,
+	// since some travis machines (espically the OSX ones) seem quite slow
+	// to begin with.
 	benchmarkEnforcer := &assertPerfBenchmark{
 		T:                  t,
-		MaxPreviewDuration: 6 * time.Second,
-		MaxUpdateDuration:  6 * time.Second,
+		MaxPreviewDuration: 8 * time.Second,
+		MaxUpdateDuration:  8 * time.Second,
 	}
 
 	integration.ProgramTest(t, &integration.ProgramTestOptions{

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -85,7 +85,7 @@ func TestEmptyGo(t *testing.T) {
 func TestEngineEventPerf(t *testing.T) {
 	// Prior to pulumi/pulumi#2303, a preview or update would take ~40s.
 	// Since then, it should now be down to ~4s, with additional padding,
-	// since some travis machines (espically the OSX ones) seem quite slow
+	// since some travis machines (especially the OSX ones) seem quite slow
 	// to begin with.
 	benchmarkEnforcer := &assertPerfBenchmark{
 		T:                  t,


### PR DESCRIPTION
The mesurments we used to compute the baseline were on a local recent
MacBook. We added some slack, but we've already seen instances of the
baseline being too tight, even with no changes in product code.

This is most common on the OSX machines in Travis, which in general
seem quite slow for many workloads.

We'll bump it up to 8 seconds and if we start hitting that as well,
we'll need to do something more serious.