### PR TITLE
Fix error codes for early exceptions

### DIFF
--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -23,7 +23,7 @@ const uncaughtHandler = (err: Error) => {
     if (!programRunning) {
         console.error(err.stack || err.message);
     }
-}
+};
 process.on("uncaughtException", uncaughtHandler);
 process.on("unhandledRejection", uncaughtHandler);
 process.on("exit", (code: number) => {

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -12,7 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// As the very first thing we do, ensure that we're connected to v8's inspector API.  We need to do
+// The very first thing we do is set up unhandled exception and rejection hooks to ensure that these events cause us to
+// exit with a non-zero code. It is criticially important that we do this early: if we do not, unhandled rejections in
+// particular may cause us to exit with a 0 exit code, which will trick the engine into thinking that the program ran
+// successfully. This can cause the engine to decide to delete all of a stack's resources.
+let uncaught: Error | undefined;
+let programRunning = false;
+const uncaughtHandler = (err: Error) => {
+    uncaught = err;
+    if (!programRunning) {
+        console.error(err.stack || err.message);
+    }
+}
+process.on("uncaughtException", uncaughtHandler);
+process.on("unhandledRejection", uncaughtHandler);
+process.on("exit", (code: number) => {
+    // If we don't already have an exit code, and we had an unhandled error, exit with a non-success.
+    if (code === 0 && uncaught) {
+        process.exitCode = 1;
+    }
+});
+
+// As the second thing we do, ensure that we're connected to v8's inspector API.  We need to do
 // this as some information is only sent out as events, without any way to query for it after the
 // fact.  For example, we want to keep track of ScriptId->FileNames so that we can appropriately
 // report errors for Functions we cannot serialize.  This can only be done (up to Node11 at least)
@@ -88,7 +109,10 @@ function main(args: string[]): void {
 
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
     v8Hooks.isInitializedAsync().then(() => {
-        require("./run").run(argv);
+        require("./run").run(argv, () => {
+            programRunning = true;
+        });
+        programRunning = false;
     });
 }
 


### PR DESCRIPTION
It is possible for the sub-process responsible for running a NodeJS
Pulumi program to exit with a success code before the user's program has
run if the process of loading the runtime generates an unhandled promise
rejection. These changes fix this by registering the unhandled exception
and rejection handlers that are responsible for ensuring a non-zero exit
code in these cases before any other action is taken.

Note that this issue is really only possible because the Node language
host (like the Python language host) is composed of two processes: one
that serves the language host gRPC service and one that loads and runs
the user's program. The former launches the latter in response to a call
to its `Run` gRPC endpoint. The lifetime of the user's program is
considered to be bounded by the lifetime of the `Run` invocation. The
NodeJS process maintains its own connection to the engine over which
resource registrations are communicated. It is tempting to add a message
to the resource monitor RPC interface that signals that no further
registrations are performed, but this is complicated due to the
three-party topology and the possibility that such an RPC may never be
sent (e.g. due to a crash or a downlevel version of the Pulumi Node
runtime).

Fixes #2316.