### PR TITLE
Implement first-class providers for invokes (Python)

### DIFF
--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -28,6 +28,7 @@ __all__ = ['runtime']
 from .asset import *
 from .config import *
 from .errors import *
+from .invoke import *
 from .metadata import *
 from .resource import *
 from .output import *

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -1,0 +1,32 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional
+
+class InvokeOptions:
+    """
+    InvokeOptions is a bag of options that control the behavior of a call to runtime.invoke.
+    """
+    parent: Optional['Resource']
+    """
+    An optional parent to use for default options for this invoke (e.g. the default provider to use).
+    """
+    provider: Optional['ProviderResource']
+    """
+    An optional provider to use for this invocation. If no provider is supplied, the default provider for the
+    invoked function's package will be used.
+    """
+
+    def __init__(self, parent: Optional['Resource'] = None, provider: Optional['ProviderResource'] = None) -> None:
+        self.parent = parent
+        self.provider = provider

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -17,6 +17,7 @@ from typing import Any, Awaitable
 import grpc
 
 from ..output import Inputs
+from ..invoke import InvokeOptions
 from .. import log
 from .settings import get_monitor
 from ..runtime.proto import provider_pb2
@@ -24,20 +25,33 @@ from . import rpc
 from .rpc_manager import RPC_MANAGER
 
 
-def invoke(tok: str, props: Inputs) -> Awaitable[Any]:
+def invoke(tok: str, props: Inputs, opts: InvokeOptions = None) -> Awaitable[Any]:
     """
     invoke dynamically invokes the function, tok, which is offered by a provider plugin.  The inputs
     can be a bag of computed values (Ts or Awaitable[T]s), and the result is a Awaitable[Any] that
     resolves when the invoke finishes.
     """
     log.debug(f"Invoking function: tok={tok}")
+    if opts is None:
+        opts = InvokeOptions()
 
     async def do_invoke():
-        # TODO(swgillespie, first class providers pulumi/pulumi#1713) here
+        # If a parent was provided, but no provider was provided, use the parent's provider if one was specified.
+        if opts.parent is not None and opts.provider is None:
+            opts.provider = opts.parent.get_provider(tok)
+
+        # Construct a provider reference from the given provider, if one was provided to us.
+        provider_ref = None
+        if opts.provider is not None:
+            provider_urn = await opts.provider.urn.future()
+            provider_id = (await opts.provider.id.future()) or rpc.UNKNOWN
+            provider_ref = f"{provider_urn}::{provider_id}"
+            log.debug(f"Invoke using provider {provider_ref}")
+
         monitor = get_monitor()
         inputs = await rpc.serialize_properties(props, [])
         log.debug(f"Invoking function prepared: tok={tok}")
-        req = provider_pb2.InvokeRequest(tok=tok, args=inputs)
+        req = provider_pb2.InvokeRequest(tok=tok, args=inputs, provider=provider_ref)
 
         def do_invoke():
             try:

--- a/sdk/python/lib/test/langhost/first_class_provider_invoke/__init__.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_invoke/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/first_class_provider_invoke/__main__.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_invoke/__main__.py
@@ -1,0 +1,60 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import ProviderResource, ComponentResource, CustomResource, Output, InvokeOptions, ResourceOptions, log
+from pulumi.runtime import invoke
+
+def assert_eq(l, r):
+    assert l == r
+
+
+class MyResource(CustomResource):
+    value: Output[int]
+
+    def __init__(self, name, value, opts=None):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={
+            "value": value,
+        }, opts=opts)
+
+class MyProvider(ProviderResource):
+    def __init__(self, name, opts=None):
+        ProviderResource.__init__(self, "test", name, {}, opts)
+
+
+class MyComponent(ComponentResource):
+    def __init__(self, name, opts=None):
+        ComponentResource.__init__(self, "test:index:MyComponent", name, {}, opts)
+
+
+# Explicitly use a provider for an Invoke.
+prov = MyProvider("testprov")
+async def do_provider_invoke():
+    value = await invoke("test:index:MyFunction", props={"value": 9000}, opts=InvokeOptions(provider=prov))
+    return value["value"]
+
+res = MyResource("resourceA", do_provider_invoke())
+res.value.apply(lambda v: assert_eq(v, 9001))
+# The Invoke RPC call should contain a reference to prov.
+
+
+# Implicitly use a provider for an Invoke by passing a parent to InvokeOptions. The parent's provider is used when
+# performing the invoke.
+componentRes = MyComponent("resourceB", opts=ResourceOptions(providers={"test": prov}))
+
+async def do_provider_invoke_with_parent(parent):
+    value = await invoke("test:index:MyFunctionWithParent", props={"value": 41}, opts=InvokeOptions(parent=parent))
+    return value["value"]
+
+res2 = MyResource("resourceC", do_provider_invoke_with_parent(componentRes))
+res2.value.apply(lambda v: assert_eq(v, 42))
+# The Invoke RPC call should again contain a reference to prov.

--- a/sdk/python/lib/test/langhost/first_class_provider_invoke/test_first_class_provider_invoke.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_invoke/test_first_class_provider_invoke.py
@@ -1,0 +1,90 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class TestFirstClassProviderInvoke(LanghostTest):
+    """
+    Tests that Invoke passes provider references to the engine, both with and without the presence of a "parent" from
+    which to derive a provider.
+    """
+    def setUp(self):
+        self.prov_id = None
+        self.prov_urn = None
+
+    def test_first_class_provider_invoke(self):
+        self.run_test(
+            program=path.join(self.base_path(), "first_class_provider_invoke"),
+            expected_resource_count=4)
+
+
+    def invoke(self, _ctx, token, args, provider):
+        # MyFunction explicitly receives a provider reference.
+        if token == "test:index:MyFunction":
+            self.assertDictEqual({
+                "value": 9000,
+            }, args)
+            self.assertEqual(f"{self.prov_urn}::{self.prov_id}", provider)
+        # MyFunctionWithParent implicitly receives a provider reference because it is the child of a resource that
+        # overrides the provider for "test".
+        elif token == "test:index:MyFunctionWithParent":
+            self.assertDictEqual({
+                "value": 41
+            }, args)
+            self.assertEqual(f"{self.prov_urn}::{self.prov_id}", provider)
+        else:
+            self.fail(f"unexpected token: {token}")
+
+        # Return the value + 1. This value is roundtripped to `register_resource` below.
+        return [], {
+            "value": args["value"] + 1
+        }
+
+    def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps,
+                          _parent, _custom, _protect, _provider):
+        if name == "testprov":
+            self.assertEqual("pulumi:providers:test", ty)
+            self.prov_urn = self.make_urn(ty, name)
+            self.prov_id = name
+            return {
+                "urn": self.prov_urn,
+                "id": self.prov_id,
+            }
+
+        if name == "resourceA":
+            self.assertEqual("test:index:MyResource", ty)
+            self.assertEqual(resource["value"], 9001)
+            return {
+                "urn": self.make_urn(ty, name),
+                "id": name,
+                "object": resource,
+            }
+
+        if name == "resourceB":
+            self.assertEqual("test:index:MyComponent", ty)
+            return {
+                "urn": self.make_urn(ty, name),
+            }
+
+        if name == "resourceC":
+            self.assertEqual("test:index:MyResource", ty)
+            self.assertEqual(resource["value"], 42)
+            return {
+                "urn": self.make_urn(ty, name),
+                "id": name,
+                "object": resource,
+            }
+
+        self.fail(f"unexpected resource: {name}")

--- a/sdk/python/lib/test/langhost/invoke/test_invoke.py
+++ b/sdk/python/lib/test/langhost/invoke/test_invoke.py
@@ -21,8 +21,9 @@ class TestInvoke(LanghostTest):
             program=path.join(self.base_path(), "invoke"),
             expected_resource_count=1)
 
-    def invoke(self, _ctx, token, args):
+    def invoke(self, _ctx, token, args, provider):
         self.assertEqual("test:index:MyFunction", token)
+        self.assertEqual("", provider)
         self.assertDictEqual({
             "value": 41,
         }, args)
@@ -51,7 +52,7 @@ class TestInvokeWithFailures(LanghostTest):
             expected_resource_count=0,
             expected_error="Program exited with non-zero exit code: 1")
 
-    def invoke(self, _ctx, token, args):
+    def invoke(self, _ctx, token, args, _provider):
         self.assertEqual("test:index:MyFunction", token)
         self.assertDictEqual({
             "value": 41,

--- a/sdk/python/lib/test/langhost/util.py
+++ b/sdk/python/lib/test/langhost/util.py
@@ -51,7 +51,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
 
     def Invoke(self, request, context):
         args = rpc.deserialize_properties(request.args)
-        failures, ret = self.langhost_test.invoke(context, request.tok, args)
+        failures, ret = self.langhost_test.invoke(context, request.tok, args, request.provider)
         failures_rpc = list(map(
             lambda fail: provider_pb2.CheckFailure(property=fail["property"], reason=fail["reason"]), failures))
 
@@ -228,7 +228,7 @@ class LanghostTest(unittest.TestCase):
 
             monitor.server.stop(0)
 
-    def invoke(self, _ctx, _token, _args):
+    def invoke(self, _ctx, _token, _args, _provider):
         """
         Method corresponding to the `Invoke` resource monitor RPC call.
         Override for custom behavior or assertions.


### PR DESCRIPTION
Invoke in Node.js allows users to optionally pass a parent or a provider
to the invoke, which dictates either explicitly or implicitly which
provider to use when performing an invoke. If a provider is specified
explicitly, that provider is used to perform the invoke. If a parent is
specified, that parent's provider is used to perform the invoke.

Fixes https://github.com/pulumi/pulumi/issues/1735