### PR TITLE
More helpful toString on Output

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -480,6 +480,13 @@ export class Output<T> {
 To manipulate the value of this Output, use '.apply' instead.`);
         };
     }
+
+    // We override `toString` to provide more useful guidance when `Output`s are converted to strings, instead of just
+    // printing `[object Object]`.
+    toString() {
+        return "<<< Warning: called 'toString' on an Output, use 'apply' instead: https://pulumi.io/help/outputs >>>";
+    }
+
 }
 
 /**

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -64,4 +64,11 @@ describe("output", () => {
 
         assert.fail("Should not read here");
     }));
+
+    it("toStrings to helpful warnning.", asyncTest(async () => {
+        const output = new resource.Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+        const expected = "<<< Warning: called 'toString' on an Output, use 'apply' instead: https://pulumi.io/help/outputs >>>";
+        assert.equal("" + output, expected);
+        assert.equal(`${output}`, expected);
+    }));
 });


### PR DESCRIPTION
It is common for users to intentionally or accidentally try to `toSting` an Output expecting to get the underlying value.  Instead, they currently get `[Object object]` with no clear reason why.

We can't give the actual underlying value because it is only asynchronously availabe, but we can provide a more helpful placeholder value with a pointer to documentation about how to work with Outputs.

Part of #2206.