### PR TITLE
Fix a Python issue when previewing providers

### DIFF
--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -89,7 +89,7 @@ async def prepare_resource(res: 'Resource',
         # If we were given a provider, wait for it to resolve and construct a provider reference from it.
         # A provider reference is a well-known string (two ::-separated values) that the engine interprets.
         provider_urn = await provider.urn.future()
-        provider_id = await provider.id.future()
+        provider_id = await provider.id.future() or rpc.UNKNOWN
         provider_ref = f"{provider_urn}::{provider_id}"
 
     dependencies = set(explicit_urn_dependencies)

--- a/sdk/python/lib/test/langhost/first_class_provider_unknown/__init__.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_unknown/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/first_class_provider_unknown/__main__.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_unknown/__main__.py
@@ -1,0 +1,29 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import CustomResource, ProviderResource, ResourceOptions, Output
+
+class MyResource(CustomResource):
+    value: Output[int]
+
+    def __init__(self, name, value, opts=None):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={
+            "value": value,
+        }, opts=opts)
+
+class MyProvider(ProviderResource):
+    def __init__(self, name, opts=None):
+        ProviderResource.__init__(self, "test", name, {}, opts)
+
+prov = MyProvider("testprov")
+res = MyResource("res", 42, ResourceOptions(provider=prov))

--- a/sdk/python/lib/test/langhost/first_class_provider_unknown/test_first_class_provider_unknown.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_unknown/test_first_class_provider_unknown.py
@@ -1,0 +1,65 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from pulumi.runtime import rpc
+from ..util import LanghostTest
+
+
+class FirstClassProviderUnknown(LanghostTest):
+    """
+    Tests that when a first class provider's ID isn't known in a preview, the language host passes a provider reference
+    to the engine using the rpc UNKNOWN sentinel in place of the ID.
+    """
+    def setUp(self):
+        self.prov_id = None
+        self.prov_urn = None
+
+    def test_first_class_provider_unknown(self):
+        self.run_test(
+            program=path.join(self.base_path(), "first_class_provider_unknown"),
+            expected_resource_count=2)
+
+    def register_resource(self, _ctx, dry_run, ty, name, resource, _deps,
+                          _parent, _custom, _protect, provider):
+        if name == "testprov":
+            self.assertEqual("pulumi:providers:test", ty)
+            # Only provide an ID when doing an update. When doing a preview the ID will be unknown
+            # and resources referencing this resource will need to use the unknown sentinel to do so.
+            self.prov_urn = self.make_urn(ty, name)
+            if dry_run:
+                return {
+                    "urn": self.prov_urn
+                }
+
+            self.prov_id = name
+            return {
+                "urn": self.prov_urn,
+                "id": self.prov_id
+            }
+
+        if name == "res":
+            self.assertEqual("test:index:MyResource", ty)
+            if dry_run:
+                # During a preview, the ID of the pulumi:providers:test resource is unknown.
+                self.assertEqual(f"{self.prov_urn}::{rpc.UNKNOWN}", provider)
+            else:
+                # Otherwise, it's known to be exactly the above provider's ID.
+                self.assertEqual(f"{self.prov_urn}::{self.prov_id}", provider)
+            return {
+                "urn": self.make_urn(ty, name),
+                "id": name,
+                "object": resource
+            }
+
+        self.fail(f"unknown resource: {name} ({ty})")


### PR DESCRIPTION
When previewing a real first-class provider, it is often the case that
the provider's ID is unknown during a preview. This commit fixes a bug
where we did not translate an unknown ID into the rpc layer's sentinel
UNKNOWN value where we should have, which caused the engine to fail to
resolve the provider reference.