### PR TITLE
Add `projectName` member of StackSummary API type

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -261,7 +261,7 @@ type Stack struct {
 	OrgName   string `json:"orgName"`
 
 	RepoName    string       `json:"repoName"`
-	ProjectName string       `json:"projName"`
+	ProjectName string       `json:"projectName"`
 	StackName   tokens.QName `json:"stackName"`
 
 	ActiveUpdate string                  `json:"activeUpdate"`

--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -18,6 +18,8 @@ package apitype
 type StackSummary struct {
 	// OrgName is the organization name the stack is found in.
 	OrgName string `json:"orgName"`
+	// ProjectName is the name of the project the stack is associated with.
+	ProjectName string `json:"projectName"`
 	// StackName is the name of the stack.
 	StackName string `json:"stackName"`
 


### PR DESCRIPTION
This will allow the service to include information about what project
a stack is assocated with when listing all stacks a user has access
to.

This was not previously needed because the project did not play into
the stack identity, but it will shortly.