### PR TITLE
Abnormally resolve all outputs on failed resources

### DIFF
--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -3,6 +3,7 @@
 
 import argparse
 import asyncio
+import logging
 import os
 import sys
 import traceback
@@ -61,6 +62,24 @@ if __name__ == "__main__":
 
     successful = False
     loop = asyncio.get_event_loop()
+    
+    # We are (unfortunately) suppressing the log output of asyncio to avoid showing to users some of the bad things we
+    # do in our programming model.
+    #
+    # Fundamentally, Pulumi is a way for users to build asynchronous dataflow graphs that, as their deployments
+    # progress, resolve naturally and eventually result in the complete resolution of the graph. If one node in the
+    # graph fails (i.e. a resource fails to create, there's an exception in an apply, etc.), part of the graph remains
+    # unevaluated at the time that we exit.
+    #
+    # asyncio abhors this. It gets very upset if the process terminates without having observed every future that we
+    # have resolved. If we are terminating abnormally, it is highly likely that we are not going to observe every single
+    # future that we have created. Furthermore, it's *harmless* to do this - asyncio logs errors because it thinks it
+    # needs to tell users that they're doing bad things (which, to their credit, they are), but we are doing this
+    # deliberately.
+    #
+    # In order to paper over this for our users, we simply turn off the logger for asyncio. Users won't see any asyncio
+    # error messages, but if they stick to the Pulumi programming model, they wouldn't be seeing any anyway.
+    logging.getLogger("asyncio").setLevel(logging.CRITICAL)
     try:
         coro = pulumi.runtime.run_in_stack(lambda: runpy.run_path(args.PROGRAM, run_name='__main__'))
         loop.run_until_complete(coro)

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import asyncio
 import sys
+import traceback
 from typing import Optional, Any, Callable, List, NamedTuple, Dict, Set, TYPE_CHECKING
 import grpc
 
@@ -124,19 +125,24 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
     urn_future = asyncio.Future()
     urn_known = asyncio.Future()
     urn_known.set_result(True)
-    resolve_urn: Callable[[str], None] = urn_future.set_result
+    resolve_urn = urn_future.set_result
+    resolve_urn_exn = urn_future.set_exception
     res.urn = known_types.new_output({res}, urn_future, urn_known)
 
     # If a custom resource, make room for the ID property.
-    resolve_id: Optional[Callable[[Any, str], None]] = None
+    resolve_id: Optional[Callable[[Any, str, Optional[Exception]], None]] = None
     if custom:
         resolve_value = asyncio.Future()
         resolve_perform_apply = asyncio.Future()
         res.id = known_types.new_output({res}, resolve_value, resolve_perform_apply)
 
-        def do_resolve(value: Any, perform_apply: bool):
-            resolve_value.set_result(value)
-            resolve_perform_apply.set_result(perform_apply)
+        def do_resolve(value: Any, perform_apply: bool, exn: Optional[Exception]):
+            if exn is not None:
+                resolve_value.set_exception(exn)
+                resolve_perform_apply.set_exception(exn)
+            else:
+                resolve_value.set_result(value)
+                resolve_perform_apply.set_result(perform_apply)
 
         resolve_id = do_resolve
 
@@ -146,39 +152,47 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
     resolvers = rpc.transfer_properties(res, props)
 
     async def do_register():
-        log.debug(f"preparing resource registration: ty={ty}, name={name}")
-        resolver = await prepare_resource(res, ty, custom, props, opts)
-        log.debug(f"resource registration prepared: ty={ty}, name={name}")
-        req = resource_pb2.RegisterResourceRequest(
-            type=ty,
-            name=name,
-            parent=resolver.parent_urn,
-            custom=custom,
-            object=resolver.serialized_props,
-            protect=opts.protect,
-            provider=resolver.provider_ref,
-            dependencies=resolver.dependencies
-        )
+        try:
+            log.debug(f"preparing resource registration: ty={ty}, name={name}")
+            resolver = await prepare_resource(res, ty, custom, props, opts)
+            log.debug(f"resource registration prepared: ty={ty}, name={name}")
+            req = resource_pb2.RegisterResourceRequest(
+                type=ty,
+                name=name,
+                parent=resolver.parent_urn,
+                custom=custom,
+                object=resolver.serialized_props,
+                protect=opts.protect,
+                provider=resolver.provider_ref,
+                dependencies=resolver.dependencies
+            )
 
-        def do_rpc_call():
-            try:
-                return monitor.RegisterResource(req)
-            except grpc.RpcError as exn:
-                # See the comment on invoke for the justification for disabling
-                # this warning
-                # pylint: disable=no-member
-                if exn.code() == grpc.StatusCode.UNAVAILABLE:
-                    sys.exit(0)
+            def do_rpc_call():
+                try:
+                    return monitor.RegisterResource(req)
+                except grpc.RpcError as exn:
+                    # See the comment on invoke for the justification for disabling
+                    # this warning
+                    # pylint: disable=no-member
+                    if exn.code() == grpc.StatusCode.UNAVAILABLE:
+                        sys.exit(0)
 
-                details = exn.details()
-            raise Exception(details)
+                    details = exn.details()
+                raise Exception(details)
+            resp = await asyncio.get_event_loop().run_in_executor(None, do_rpc_call)
+        except Exception as exn:
+            log.debug(f"exception when preparing or executing rpc: {traceback.format_exc()}")
+            rpc.resolve_outputs_due_to_exception(resolvers, exn)
+            resolve_urn_exn(exn)
+            if resolve_id is not None:
+                resolve_id(None, False, exn)
+            raise
 
-        resp = await asyncio.get_event_loop().run_in_executor(None, do_rpc_call)
         log.debug(f"resource registration successful: ty={ty}, urn={resp.urn}")
         resolve_urn(resp.urn)
         if resolve_id:
             is_known = resp.id is not None
-            resolve_id(resp.id, is_known)
+            resolve_id(resp.id, is_known, None)
 
         await rpc.resolve_outputs(res, props, resp.object, resolvers)
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -217,7 +217,18 @@ def deserialize_property(value: Any) -> Any:
     return value
 
 
-Resolver = Callable[[Any, bool], None]
+Resolver = Callable[[Any, bool, Optional[Exception]], None]
+"""
+A Resolver is a function that takes three arguments:
+    1. A value, which represents the "resolved" value of a particular output (from the engine)
+    2. A boolean "is_known", which represents whether or not this value is known to have a particular value at this
+       point in time (not always true for previews), and
+    3. An exception, which (if provided) is an exception that occured when attempting to create the resource to whom
+       this resolver belongs.
+
+If argument 3 is not none, this output is considered to be abnormally resolved and attempts to await its future will
+result in the exception being re-thrown.
+"""
 
 
 def transfer_properties(res: 'Resource', props: 'Inputs') -> Dict[str, Resolver]:
@@ -230,9 +241,19 @@ def transfer_properties(res: 'Resource', props: 'Inputs') -> Dict[str, Resolver]
         resolve_value = asyncio.Future()
         resolve_is_known = asyncio.Future()
 
-        def do_resolve(value_fut: asyncio.Future, known_fut: asyncio.Future, value: Any, is_known: bool):
-            value_fut.set_result(value)
-            known_fut.set_result(is_known)
+        def do_resolve(value_fut: asyncio.Future,
+                       known_fut: asyncio.Future,
+                       value: Any,
+                       is_known: bool,
+                       failed: Optional[Exception]):
+            # Was an exception provided? If so, this is an abnormal (exceptional) resolution. Resolve the futures
+            # using set_exception so that any attempts to wait for their resolution will also fail.
+            if failed is not None:
+                value_fut.set_exception(failed)
+                known_fut.set_exception(failed)
+            else:
+                value_fut.set_result(value)
+                known_fut.set_result(is_known)
 
         # Important to note here is that the resolver's future is assigned to the resource object using the
         # name before translation. When properties are returned from the engine, we must first translate the name
@@ -319,15 +340,28 @@ async def resolve_outputs(res: 'Resource', props: 'Inputs', outputs: struct_pb2.
         if not settings.is_dry_run():
             # normal 'pulumi update'.  resolve the output with the value we got back
             # from the engine.  That output can always run its .apply calls.
-            resolve(value, True)
+            resolve(value, True, None)
         else:
             # We're previewing. If the engine was able to give us a reasonable value back,
             # then use it. Otherwise, inform the Output that the value isn't known.
-            resolve(value, value is not None)
+            resolve(value, value is not None, None)
 
     # `allProps` may not have contained a value for every resolver: for example, optional outputs may not be present.
     # We will resolve all of these values as `None`, and will mark the value as known if we are not running a
     # preview.
     for key, resolve in resolvers.items():
         if key not in all_properties:
-            resolve(None, not settings.is_dry_run())
+            resolve(None, not settings.is_dry_run(), None)
+
+
+def resolve_outputs_due_to_exception(resolvers: Dict[str, Resolver], exn: Exception):
+    """
+    Resolves all outputs with resolvers exceptionally, using the given exception as the reason why the resolver has
+    failed to resolve.
+
+    :param resolvers: Resolvers associated with a resource's outputs.
+    :param exn: The exception that occured when trying (and failing) to create this resource.
+    """
+    for key, resolve in resolvers.items():
+        log.debug(f"sending exception to resolver for {key}")
+        resolve(None, False, exn)

--- a/sdk/python/lib/test/langhost/chained_failure/__main__.py
+++ b/sdk/python/lib/test/langhost/chained_failure/__main__.py
@@ -1,0 +1,45 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import CustomResource, Output, Input
+
+
+class ResourceA(CustomResource):
+    inprop: Output[int]
+    outprop: Output[int]
+
+    def __init__(self, name: str) -> None:
+        CustomResource.__init__(self, "test:index:ResourceA", name, {
+            "inprop": 777,
+            "outprop": None
+        })
+
+class ResourceB(CustomResource):
+    other_in: Output[int]
+    other_out: Output[str]
+
+    def __init__(self, name: str, res: Input[int]) -> None:
+        CustomResource.__init__(self, "test:index:ResourceB", name, {
+            "other_in": res.inprop,
+            "other_out": None
+        })
+
+a = ResourceA("resourceA")
+# Dividing by zero always throws an exception. This will throw whenever ResourceB tries to prepare itself
+# for the RegisterResource RPC.
+b_value = a.outprop.apply(lambda number: number / 0)
+b = ResourceB("resourceB", b_value)
+
+# C depends on B, but B's outputs will never resolve since B fails to initialize.
+# This should NOT deadlock. (pulumi/pulumi#2189)
+c = ResourceB("resourceC", b.other_out)

--- a/sdk/python/lib/test/langhost/chained_failure/test_chained_failure.py
+++ b/sdk/python/lib/test/langhost/chained_failure/test_chained_failure.py
@@ -1,0 +1,48 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class ChainedFailureTest(LanghostTest):
+    """
+    Tests that the language host can tolerate "chained failures" - that is, a failure of an output to resolve when
+    attempting to prepare a resource for registration.
+
+    In this test, the program raises an exception in an apply, which causes the preparation of resourceB to fail. This
+    test asserts that this does not cause a deadlock (as it previously did, pulumi/pulumi#2189) but instead terminates
+    gracefully.
+    """
+    def test_chained_failure(self):
+        self.run_test(
+            program=path.join(self.base_path(), "chained_failure"),
+            expected_error="Program exited with non-zero exit code: 1",
+            expected_resource_count=1)
+
+    def register_resource(self, _ctx, _dry_run, ty, name, res, _deps,
+                          _parent, _custom, _protect, _provider):
+        if ty == "test:index:ResourceA":
+            self.assertEqual(name, "resourceA")
+            self.assertDictEqual(res, {"inprop": 777})
+            return {
+                "urn": self.make_urn(ty, name),
+                "id": name,
+                "object": {
+                    "outprop": 200
+                } 
+            }
+
+        if ty == "test:index:ResourceB":
+            self.fail(f"we should never have gotten here! {res}")
+        self.fail(f"unknown resource type: {ty}")


### PR DESCRIPTION
When is resource is waiting for its dependencies to resolve, it first
informs the RPC_MANAGER that it intends to do an RPC - this is to
prevent premature termination of the program while RPCs are still in
flight or queued to execute.

However, this is a problem whenever a resource fails to create for
whatever reason. The most common ways for this to happen are for invokes
to fail, resource creation itself to fail, or throwing in an apply.
Today, this causes a deadlock, since all consumers of the failed
resources block forever while never decrementing the RPC count.

This commit addresses the issue by deliberately (abnormally) resolving
all futures that are created in the process of preparing a resource.
This solves the problem by immediately terminating all resources that
are waiting for the failed resource's outputs to resolve - they resolve
immediately, and exceptionally.

The end result is now that, instead of deadlocking, a doomed program now
terminates as expected with a single exception message.