### PR TITLE
Only publish some artifacts from a single Linux leg

### DIFF
--- a/scripts/publish_tgz.sh
+++ b/scripts/publish_tgz.sh
@@ -4,6 +4,13 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# We run multiple legs on Linux, but only want to publish the tgz's from the one that publishes
+# our NPM and PyPI packages. Otherwise, we may race with other legs when publishing to S3 which
+# leads to issues about values being out of range.
+if [ "${TRAVIS_OS_NAME:-}" = "linux" ] && [ "${TRAVIS_PUBLISH_PACKAGES:-}" != "true" ]; then
+    exit 0
+fi
+
 readonly ROOT=$(dirname "${0}")/..
 readonly PUBLISH="${GOPATH}/src/github.com/pulumi/scripts/ci/publish.sh"
 readonly PUBLISH_GOARCH=("amd64")


### PR DESCRIPTION
We publish some artifacts from this repository, which are specific to
an OS. In the past, we only had a single Linux leg and so we did not
need any additional conditional logic.

However, we now have multiple Linux legs (across different node
versions) running in parallel, so if we try to publish the same
artifacts at the same time, we can run into issues because two `aws s3
cp` jobs try to write to the same file at the same time.

Follow similar logic to our skips we do around publishing NPM and PyPI
packages here, as well.