### PR TITLE
Add functions to help make strings from values that may include Outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - Exporting a Resource from an application Stack now exports it as a rich recursive pojo instead of just being an opaque URN (fixes https://github.com/pulumi/pulumi/issues/1858).
 
+- pulumi.interpolate and pulumi.concat have been added as convenient ways to combine Output values into strings.
+
 ## 0.16.9 (Released December 24th, 2018)
 
 ### Improvements

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -64,4 +64,68 @@ describe("output", () => {
 
         assert.fail("Should not read here");
     }));
+
+    describe("concat", () => {
+        it ("handles no args", asyncTest(async () => {
+            const result = resource.concat();
+            assert.equal(await result.promise(), "");
+        }));
+
+        it ("handles empty string arg", asyncTest(async () => {
+            const result = resource.concat("");
+            assert.equal(await result.promise(), "");
+        }));
+
+        it ("handles non-empty string arg", asyncTest(async () => {
+            const result = resource.concat("a");
+            assert.equal(await result.promise(), "a");
+        }));
+
+        it ("handles promise string arg", asyncTest(async () => {
+            const result = resource.concat(Promise.resolve("a"));
+            assert.equal(await result.promise(), "a");
+        }));
+
+        it ("handles output string arg", asyncTest(async () => {
+            const result = resource.concat(resource.output("a"));
+            assert.equal(await result.promise(), "a");
+        }));
+
+        it ("handles multiple args", asyncTest(async () => {
+            const result = resource.concat("http://", resource.output("a"), ":", 80);
+            assert.equal(await result.promise(), "http://a:80");
+        }));
+    });
+
+    describe("interpolate", () => {
+        it ("handles empty interpolation", asyncTest(async () => {
+            const result = resource.interpolate ``;
+            assert.equal(await result.promise(), "");
+        }));
+
+        it ("handles no placeholders arg", asyncTest(async () => {
+            const result = resource.interpolate `a`;
+            assert.equal(await result.promise(), "a");
+        }));
+
+        it ("handles string placeholders arg", asyncTest(async () => {
+            const result = resource.interpolate `${"a"}`;
+            assert.equal(await result.promise(), "a");
+        }));
+
+        it ("handles promise placeholders arg", asyncTest(async () => {
+            const result = resource.interpolate `${Promise.resolve("a")}`;
+            assert.equal(await result.promise(), "a");
+        }));
+
+        it ("handles output placeholders arg", asyncTest(async () => {
+            const result = resource.interpolate `${resource.output("a")}`;
+            assert.equal(await result.promise(), "a");
+        }));
+
+        it ("handles multiple args", asyncTest(async () => {
+            const result = resource.interpolate `http://${resource.output("a")}:${80}/`;
+            assert.equal(await result.promise(), "http://a:80/");
+        }));
+    });
 });


### PR DESCRIPTION
This is just extracting the string-function portion of https://github.com/pulumi/pulumi/pull/2353/ into its own PR.  These are safe to add functions and are useful downstream.  So we can get them in earlier and push downstream accordingly.