### PR TITLE
Explicitly convert dry_run parameter to a bool

### DIFF
--- a/sdk/python/cmd/pulumi-language-python-exec
+++ b/sdk/python/cmd/pulumi-language-python-exec
@@ -49,8 +49,8 @@ if __name__ == "__main__":
             engine=args.engine,
             project=args.project,
             stack=args.stack,
-            parallel=args.parallel,
-            dry_run=args.dry_run
+            parallel=int(args.parallel),
+            dry_run=args.dry_run == "true"
         )
     )
 

--- a/sdk/python/lib/test/langhost/preview/__init__.py
+++ b/sdk/python/lib/test/langhost/preview/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/preview/__main__.py
+++ b/sdk/python/lib/test/langhost/preview/__main__.py
@@ -1,0 +1,24 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import CustomResource
+from pulumi.runtime import is_dry_run
+
+class MyResource(CustomResource):
+    def __init__(self, name):
+        CustomResource.__init__(self, "test:index:MyResource", name, {
+            "is_preview": is_dry_run()
+        })
+
+
+MyResource("foo")

--- a/sdk/python/lib/test/langhost/preview/test_preview.py
+++ b/sdk/python/lib/test/langhost/preview/test_preview.py
@@ -1,0 +1,41 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class PreviewTest(LanghostTest):
+    """
+    Test that tests that pulumi.runtime.is_dry_run actually returns True on previews and False on updates.
+    """
+    def test_preview(self):
+        self.run_test(
+            program=path.join(self.base_path(), "preview"),
+            expected_resource_count=1)
+
+    def register_resource(self, _ctx, dry_run, ty, name, resource,
+                          _dependencies, _parent, _custom, _protect, _provider):
+        self.assertEqual(ty, "test:index:MyResource")
+        self.assertEqual(name, "foo")
+        if dry_run:
+            self.assertDictEqual({
+                "is_preview": True
+            }, resource)
+        else:
+            self.assertDictEqual({
+                "is_preview": False
+            }, resource)
+        return {
+            "urn": self.make_urn(ty, name),
+        }


### PR DESCRIPTION
On startup, when we were populating the Settings object, we failed to
coerce the dry_run parameter from a string to a boolean, which resulted
in is_dry_run always believing that it was a preview. This PR fixes this
oversight by explicitly coercing to a boolean prior to sending the value
to Settings.

Fixes https://github.com/pulumi/pulumi/issues/2360