### PR TITLE
Include TLS1.2 dance in copy pastable upgrade command on Windows

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -338,7 +338,8 @@ func getUpgradeCommand() string {
 		powershellCmd = "powershell"
 	}
 
-	return "> " + powershellCmd + ` -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ` +
+	return "> " + powershellCmd + ` -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "` +
+		`[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ` +
 		`((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))"`
 }
 


### PR DESCRIPTION
We upgraded get.pulumi.com to require TLS1.2. Because powershell does
not support this out of the box, we had to augment the install command
to also enable support for TLS1.2. While we did this on pulumi.io in
our documentation, we also print a similar message on Windows when the
CLI is out of date.

This change augments the message to include enabiling TLS 1.2 during
the invocation.