### PR TITLE
Remove template section from Pulumi.yaml

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -226,13 +226,14 @@ func newNewCmd() *cobra.Command {
 
 			fmt.Printf("Created project '%s'.\n", name)
 
-			// Load the project, update the name & description, and save it.
+			// Load the project, update the name & description, remove the template section, and save it.
 			proj, _, err := readProject()
 			if err != nil {
 				return err
 			}
 			proj.Name = tokens.PackageName(name)
 			proj.Description = &description
+			proj.Template = nil
 			if err = workspace.SaveProject(proj); err != nil {
 				return errors.Wrap(err, "saving project")
 			}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -191,13 +191,14 @@ func newUpCmd() *cobra.Command {
 			return err
 		}
 
-		// Load the project, update the name & description, and save it.
+		// Load the project, update the name & description, remove the template section, and save it.
 		proj, root, err := readProject()
 		if err != nil {
 			return err
 		}
 		proj.Name = tokens.PackageName(name)
 		proj.Description = &description
+		proj.Template = nil
 		if err = workspace.SaveProject(proj); err != nil {
 			return errors.Wrap(err, "saving project")
 		}


### PR DESCRIPTION
We currently leave behind the template section inside Pulumi.yaml after `pulumi new`. While we _may_ eventually make use of it, we're not currently using it, so it's cleaner to just remove it for now.

Fixes #2044