### PR TITLE
Revert "Include TLS1.2 dance in copy pastable upgrade command on Wind…

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -338,8 +338,7 @@ func getUpgradeCommand() string {
 		powershellCmd = "powershell"
 	}
 
-	return "> " + powershellCmd + ` -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "` +
-		`[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; iex ` +
+	return "> " + powershellCmd + ` -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "iex ` +
 		`((New-Object System.Net.WebClient).DownloadString('https://get.pulumi.com/install.ps1'))"`
 }
 


### PR DESCRIPTION
…ows"

This reverts commit fe6567a9a76bd22f04ec35faae42b01df8afec19.

We've decided to change get.pulumi.com to not require this, so
reverting the change to make the already long command no longer than
needed.