### PR TITLE
Remove dependency on Six

### DIFF
--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -29,7 +29,6 @@ setup(name='pulumi',
       packages=find_packages(),
       install_requires=[
           'protobuf>=3.6.0',
-          'grpcio>=1.9.1',
-          'six>=1.11.0'
+          'grpcio>=1.9.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
Super simple - we don't need `six` (a Python 2 and 3 compatibility shim library) because we no longer support Python 2.

Fixes https://github.com/pulumi/pulumi/issues/2236.