### PR TITLE
Use a file lock for serializing pipenv installs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -119,6 +119,12 @@
   version = "v1.31.0"
 
 [[projects]]
+  name = "github.com/gofrs/flock"
+  packages = ["."]
+  revision = "7f43ea2e6a643ad441fc12d0ecc0d3388b300c53"
+  version = "v0.7.0"
+
+[[projects]]
   branch = "pulumi-master"
   name = "github.com/golang/glog"
   packages = ["."]
@@ -584,6 +590,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6767608d8cb6e96b1a0e0dbb5a2ad5b7e3cd07d6d9a5bcfe32c68b10358db62c"
+  inputs-digest = "20441aca93b203c1c03aed0d53e1469ef6bfe48f6193e91a22c5c93f9262704e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -686,8 +686,8 @@ func (pt *programTester) runPipenvCommand(name string, args []string, wd string)
 			defer fprintf(pt.opts.Stdout, "pipenv install action complete\n")
 		}
 
-		pt.pipenvMutex.Lock()
-		defer pt.pipenvMutex.Unlock()
+		contract.IgnoreError(pt.pipenvMutex.Lock())
+		defer contract.IgnoreError(pt.pipenvMutex.Unlock())
 	}
 
 	cmd, err := pt.pipenvCmd(args)


### PR DESCRIPTION
A in-process mutex is not sufficient for serializing pipenv installs
because the 1) go test runner occasionally will split test executions
into multiple processes and 2) each test gets an instance of a
programTester and we'd need to share the mutex globally if we wanted to
successfully serialize access to the pipenv install command.