### PR TITLE
`pulumi new` improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Add `--JSON` to `pulumi config` and `pulumi config get` to request the output be in JSON.
 
+- Changes to `pulumi new`'s output to improve the experience.
+
 ## 0.16.11 (Released January 16th, 2019)
 
 ### Improvements

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
 	"math"
 	"os"
@@ -407,10 +408,13 @@ func handleConfig(
 	}
 
 	// Save the config.
-	if c != nil {
+	if len(c) > 0 {
 		if err = saveConfig(s, c); err != nil {
 			return errors.Wrap(err, "saving config")
 		}
+
+		fmt.Println("Saved config")
+		fmt.Println()
 	}
 
 	return nil


### PR DESCRIPTION
Some changes to `pulumi new` to improve the experience:

 - Color the default values for config differently to make them stand out better
 - Mention that `new` will also perform an initial deployment
 - Add more vertical whitespace between steps in the process
 - Print message indicating the "Installing dependencies" step is complete
 - After "project is ready to go", add a note about doing an inital deployment
 - Output follow-up command to run when an update fails
 - Go back to showing the `npm install` output as `npm` doesn't always return an error code when it runs into problems

Before:

![screen shot 2018-09-11 at 12 54 53 pm](https://user-images.githubusercontent.com/223467/45384113-ef207f00-b5c1-11e8-9670-fc49a36f78e1.png)

After:

<img width="1223" alt="screen shot 2019-01-22 at 9 41 12 am" src="https://user-images.githubusercontent.com/710598/51554553-6a285a80-1e2a-11e9-89d3-cd82e91f34b6.png">

FWIW, going back to showing the `npm install` output still isn't great. It shows a warning about `Using needle for node-pre-gyp` and warnings for missing `description`, `repository`, and `license` fields. Wondering if we should hold off on showing NPM output until we can either workaround these warnings, or be smarter about showing the output _only_ when warnings of note are detected.

Aside: I've been wondering if we should have a way to opt-in to using `yarn` instead of `npm` (possibly prompting to ask whether to use `yarn` or `npm` if we detect `yarn` is available), and perhaps remembering the user's choice for subsequent runs (and/or having a way to set the choice globally for the user).

/cc @lukehoban

Fixes https://github.com/pulumi/pulumi/issues/1920