### PR TITLE
Use both a in-proc and out-of-proc pipenv lock

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -368,10 +368,14 @@ func (rf *regexFlag) Set(v string) error {
 
 var directoryMatcher regexFlag
 var listDirs bool
+var pipenvMutex *fsutil.FileMutex
 
 func init() {
 	flag.Var(&directoryMatcher, "dirs", "optional list of regexes to use to select integration tests to run")
 	flag.BoolVar(&listDirs, "list-dirs", false, "list available integration tests without running them")
+
+	mutexPath := filepath.Join(os.TempDir(), "pipenv-mutex.lock")
+	pipenvMutex = fsutil.NewFileMutex(mutexPath)
 }
 
 // GetLogs retrieves the logs for a given stack in a particular region making the query provided.
@@ -506,6 +510,7 @@ func fprintf(w io.Writer, format string, a ...interface{}) {
 
 // programTester contains state associated with running a single test pass.
 type programTester struct {
+<<<<<<< HEAD
 	t           *testing.T          // the Go tester for this run.
 	opts        *ProgramTestOptions // options that control this test run.
 	bin         string              // the `pulumi` binary we are using.
@@ -524,6 +529,20 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *programTester {
 		t:           t,
 		opts:        opts,
 		pipenvMutex: flock.New(lockFile),
+=======
+	t         *testing.T          // the Go tester for this run.
+	opts      *ProgramTestOptions // options that control this test run.
+	bin       string              // the `pulumi` binary we are using.
+	yarnBin   string              // the `yarn` binary we are using.
+	goBin     string              // the `go` binary we are using.
+	pipenvBin string              // The `pipenv` binary we are using.
+}
+
+func newProgramTester(t *testing.T, opts *ProgramTestOptions) *programTester {
+	return &programTester{
+		t:    t,
+		opts: opts,
+>>>>>>> Use both a in-proc and out-of-proc pipenv lock
 	}
 }
 
@@ -681,13 +700,24 @@ func (pt *programTester) runPipenvCommand(name string, args []string, wd string)
 	// processes. (Furthermore, each test gets an instance of programTester and thus the mutex, so we'd need to be
 	// sharing the mutex globally in each test process if we weren't using the file system to lock.)
 	if name == "pipenv-install-package" {
-		if pt.opts.Verbose {
-			fprintf(pt.opts.Stdout, "serializing pipenv install action\n")
-			defer fprintf(pt.opts.Stdout, "pipenv install action complete\n")
+		if err := pipenvMutex.Lock(); err != nil {
+			panic(err)
 		}
 
+<<<<<<< HEAD
 		contract.IgnoreError(pt.pipenvMutex.Lock())
 		defer contract.IgnoreError(pt.pipenvMutex.Unlock())
+=======
+		if pt.opts.Verbose {
+			fprintf(pt.opts.Stdout, "acquired pipenv install lock\n")
+			defer fprintf(pt.opts.Stdout, "released pipenv install lock\n")
+		}
+		defer func() {
+			if err := pipenvMutex.Unlock(); err != nil {
+				panic(err)
+			}
+		}()
+>>>>>>> Use both a in-proc and out-of-proc pipenv lock
 	}
 
 	cmd, err := pt.pipenvCmd(args)

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -34,8 +34,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gofrs/flock"
-
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -510,26 +508,6 @@ func fprintf(w io.Writer, format string, a ...interface{}) {
 
 // programTester contains state associated with running a single test pass.
 type programTester struct {
-<<<<<<< HEAD
-	t           *testing.T          // the Go tester for this run.
-	opts        *ProgramTestOptions // options that control this test run.
-	bin         string              // the `pulumi` binary we are using.
-	yarnBin     string              // the `yarn` binary we are using.
-	goBin       string              // the `go` binary we are using.
-	pipenvBin   string              // The `pipenv` binary we are using.
-	pipenvMutex *flock.Flock        // Serializes pipenv invocations. See comment in `runPipenvCommand` for details
-}
-
-func newProgramTester(t *testing.T, opts *ProgramTestOptions) *programTester {
-	lockFile := filepath.Join(os.TempDir(), "pulumi-pipenv.lock")
-	if opts.Verbose {
-		fprintf(os.Stdout, "Using Pipenv lock: %s\n", lockFile)
-	}
-	return &programTester{
-		t:           t,
-		opts:        opts,
-		pipenvMutex: flock.New(lockFile),
-=======
 	t         *testing.T          // the Go tester for this run.
 	opts      *ProgramTestOptions // options that control this test run.
 	bin       string              // the `pulumi` binary we are using.
@@ -542,7 +520,6 @@ func newProgramTester(t *testing.T, opts *ProgramTestOptions) *programTester {
 	return &programTester{
 		t:    t,
 		opts: opts,
->>>>>>> Use both a in-proc and out-of-proc pipenv lock
 	}
 }
 
@@ -704,10 +681,6 @@ func (pt *programTester) runPipenvCommand(name string, args []string, wd string)
 			panic(err)
 		}
 
-<<<<<<< HEAD
-		contract.IgnoreError(pt.pipenvMutex.Lock())
-		defer contract.IgnoreError(pt.pipenvMutex.Unlock())
-=======
 		if pt.opts.Verbose {
 			fprintf(pt.opts.Stdout, "acquired pipenv install lock\n")
 			defer fprintf(pt.opts.Stdout, "released pipenv install lock\n")
@@ -717,7 +690,6 @@ func (pt *programTester) runPipenvCommand(name string, args []string, wd string)
 				panic(err)
 			}
 		}()
->>>>>>> Use both a in-proc and out-of-proc pipenv lock
 	}
 
 	cmd, err := pt.pipenvCmd(args)

--- a/pkg/util/fsutil/lock.go
+++ b/pkg/util/fsutil/lock.go
@@ -1,0 +1,71 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fsutil
+
+import (
+	"sync"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
+
+	"github.com/gofrs/flock"
+)
+
+// FileMutex is a mutex that serializes both within and across processes. When acquired, it can be assumed that the
+// caller holds exclusive access over te protected resources, even if there are other consumers both within and outside
+// of the same process.
+type FileMutex struct {
+	proclock sync.Mutex   // lock serializing in-process access to the protected resource
+	fslock   *flock.Flock // lock serializing out-of-process access to the protected resource
+}
+
+// NewFileMutex creates a new FileMutex using the given file as a file lock.
+func NewFileMutex(path string) *FileMutex {
+	return &FileMutex{
+		fslock: flock.New(path),
+	}
+}
+
+// Lock locks the file mutex. It does this in two phases: first, it locks the process lock, which when held guarantees
+// exclusive access to the resource within the current process. Second, with the process lock held, it locks the file
+// lock. The flock system call operates on a process granularity and, if one process attempts to lock the same file
+// multiple times, flock will consider the lock to be held by the process even if different threads are acquiring the
+// lock.
+//
+// Because of this, the two-pronged approach to locking guarantees exclusive access to the resource by locking a process
+// shared mutex and a global shared mutex. Once this method returns without an error, callers can be sure that the
+// calling goroutine completely owns the resource.
+func (fm *FileMutex) Lock() error {
+	fm.proclock.Lock()
+	if err := fm.fslock.Lock(); err != nil {
+		fm.proclock.Unlock()
+		return err
+	}
+
+	contract.Assert(fm.fslock.Locked())
+	return nil
+}
+
+// Unlock unlocks the file mutex. It first unlocks the file lock, which allows other processes to lock the file lock,
+// after which it unlocks the proc lock. Unlocking the file lock first ensures that it is not possible for two
+// goroutines to lock or unlock the file mutex without first holding the proc lock.
+func (fm *FileMutex) Unlock() error {
+	if err := fm.fslock.Unlock(); err != nil {
+		fm.proclock.Unlock()
+		return err
+	}
+
+	fm.proclock.Unlock()
+	return nil
+}


### PR DESCRIPTION
Turns out that flock alone is not sufficient to guarantee exclusive
access to a resource within a single process. To remedy this, a few
FileMutex type wraps both an in-proc mutex and an out-of-proc
file-backed mutex to achieve the goal of exclusive access to a resource
in both in-proc and out-of-proc scenarios.

This commit also uses this lock globally in the integration test
framework in order to globally serialize invocations of pipenv install.