### PR TITLE
Add API types for the V3 checkpoint

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -24,6 +24,8 @@
 // In the event that this is not possible, a breaking change is implied.  The preferred approach is to never make
 // breaking changes.  If that isn't possible, the next best approach is to support both the old and new formats
 // side-by-side (for instance, by using a union type for the property in question).
+//
+// nolint: lll
 package apitype
 
 import (
@@ -70,6 +72,17 @@ type CheckpointV2 struct {
 	Latest *DeploymentV2 `json:"latest,omitempty" yaml:"latest,omitempty"`
 }
 
+// CheckpointV3 is the third version of the Checkpoint. It contains a newer version of
+// the latest deployment.
+type CheckpointV3 struct {
+	// Stack is the stack to update.
+	Stack tokens.QName `json:"stack" yaml:"stack"`
+	// Config contains a bag of optional configuration keys/values.
+	Config config.Map `json:"config,omitempty" yaml:"config,omitempty"`
+	// Latest is the latest/current deployment (if an update has occurred).
+	Latest *DeploymentV3 `json:"latest,omitempty" yaml:"latest,omitempty"`
+}
+
 // DeploymentV1 represents a deployment that has actually occurred. It is similar to the engine's snapshot structure,
 // except that it flattens and rearranges a few data structures for serializability.
 type DeploymentV1 struct {
@@ -79,7 +92,7 @@ type DeploymentV1 struct {
 	Resources []ResourceV1 `json:"resources,omitempty" yaml:"resources,omitempty"`
 }
 
-// DeploymentV2 is the second version of the Deployment. It contains never versions of the
+// DeploymentV2 is the second version of the Deployment. It contains newer versions of the
 // Resource API type.
 type DeploymentV2 struct {
 	// Manifest contains metadata about this deployment.
@@ -88,6 +101,19 @@ type DeploymentV2 struct {
 	Resources []ResourceV2 `json:"resources,omitempty" yaml:"resources,omitempty"`
 	// PendingOperations are all operations that were known by the engine to be currently executing.
 	PendingOperations []OperationV1 `json:"pending_operations,omitempty" yaml:"pending_operations,omitempty"`
+}
+
+// DeploymentV3 is the third version of the Deployment. It contains newer versions of the
+// Resource and Operation API types and a placeholder for a stack's secrets configuration.
+type DeploymentV3 struct {
+	// Manifest contains metadata about this deployment.
+	Manifest ManifestV1 `json:"manifest" yaml:"manifest"`
+	// SecretsProviders is a placeholder for secret provider configuration.
+	SecretsProviders interface{} `json:"secrets_providers,omitempty" yaml:"secrets_providers,omitempty"`
+	// Resources contains all resources that are currently part of this stack after this deployment has finished.
+	Resources []ResourceV3 `json:"resources,omitempty" yaml:"resources,omitempty"`
+	// PendingOperations are all operations that were known by the engine to be currently executing.
+	PendingOperations []OperationV2 `json:"pending_operations,omitempty" yaml:"pending_operations,omitempty"`
 }
 
 // OperationType is the type of an operation initiated by the engine. Its value indicates the type of operation
@@ -111,6 +137,16 @@ const (
 type OperationV1 struct {
 	// Resource is the state that the engine used to initiate this operation.
 	Resource ResourceV2 `json:"resource" yaml:"resource"`
+	// Status is a string representation of the operation that the engine is performing.
+	Type OperationType `json:"type" yaml:"type"`
+}
+
+// OperationV2 represents an operation that the engine is performing. It consists of a Resource, which is the state
+// that the engine used to initiate the operation, and a Status, which is a string representation of the operation
+// that the engine initiated.
+type OperationV2 struct {
+	// Resource is the state that the engine used to initiate this operation.
+	Resource ResourceV3 `json:"resource" yaml:"resource"`
 	// Status is a string representation of the operation that the engine is performing.
 	Type OperationType `json:"type" yaml:"type"`
 }
@@ -198,6 +234,50 @@ type ResourceV2 struct {
 	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
 }
 
+// ResourceV3 is the third version of the Resource API type. It absorbs a few breaking changes:
+//   1. It adds a map from input property names to the dependencies that affect that input property. This is used to
+//      improve the precision of delete-before-create operations.
+//   2. It adds a new boolean field, `PendingReplacement`, that marks resources that have been deleted as part of a
+//      delete-before-create operation but have not yet been recreated.
+//
+// Migrating from ResourceV2 to ResourceV3 involves:
+//   1. Populating the map from input property names to dependencies by assuming that every dependency listed in
+//      `Dependencies` affects every input property.
+type ResourceV3 struct {
+	// URN uniquely identifying this resource.
+	URN resource.URN `json:"urn" yaml:"urn"`
+	// Custom is true when it is managed by a plugin.
+	Custom bool `json:"custom" yaml:"custom"`
+	// Delete is true when the resource should be deleted during the next update.
+	Delete bool `json:"delete,omitempty" yaml:"delete,omitempty"`
+	// ID is the provider-assigned resource, if any, for custom resources.
+	ID resource.ID `json:"id,omitempty" yaml:"id,omitempty"`
+	// Type is the resource's full type token.
+	Type tokens.Type `json:"type" yaml:"type"`
+	// Inputs are the input properties supplied to the provider.
+	Inputs map[string]interface{} `json:"inputs,omitempty" yaml:"inputs,omitempty"`
+	// Outputs are the output properties returned by the provider after provisioning.
+	Outputs map[string]interface{} `json:"outputs,omitempty" yaml:"outputs,omitempty"`
+	// Parent is an optional parent URN if this resource is a child of it.
+	Parent resource.URN `json:"parent,omitempty" yaml:"parent,omitempty"`
+	// Protect is set to true when this resource is "protected" and may not be deleted.
+	Protect bool `json:"protect,omitempty" yaml:"protect,omitempty"`
+	// External is set to true when the lifecycle of this resource is not managed by Pulumi.
+	External bool `json:"external,omitempty" yaml:"external,omitempty"`
+	// Dependencies contains the dependency edges to other resources that this depends on.
+	Dependencies []resource.URN `json:"dependencies,omitempty" yaml:"dependencies,omitempty"`
+	// InitErrors is the set of errors encountered in the process of initializing resource (i.e.,
+	// during create or update).
+	InitErrors []string `json:"initErrors,omitempty" yaml:"initErrors,omitempty"`
+	// Provider is a reference to the provider that is associated with this resource.
+	Provider string `json:"provider,omitempty" yaml:"provider,omitempty"`
+	// PropertyDependencies maps from an input property name to the set of resources that property depends on.
+	PropertyDependencies map[resource.PropertyKey][]resource.URN `json:"propertyDependencies,omitempty" yaml:"property_dependencies,omitempty"`
+	// PendingReplacement is used to track delete-before-replace resources that have been deleted but not yet
+	// recreated.
+	PendingReplacement bool `json:"pendingReplacement,omitempty" yaml:"pendingReplacement,omitempty"`
+}
+
 // ManifestV1 captures meta-information about this checkpoint file, such as versions of binaries, etc.
 type ManifestV1 struct {
 	// Time of the update.
@@ -216,6 +296,14 @@ type PluginInfoV1 struct {
 	Path    string               `json:"path" yaml:"path"`
 	Type    workspace.PluginKind `json:"type" yaml:"type"`
 	Version string               `json:"version" yaml:"version"`
+}
+
+// SecretV1 captures the information that a particular value is secret and must be decrypted before use.
+//
+// NOTE: nothing produces these values yet. This type is merely a placeholder for future use.
+type SecretV1 struct {
+	Sig        string `json:"4dabf18193072939515e22adb298388d" yaml:"4dabf18193072939515e22adb298388d"`
+	Ciphertext string `json:"ciphertext" yaml:"ciphertext"`
 }
 
 // ConfigValue describes a single (possibly secret) configuration value.

--- a/pkg/apitype/migrate/checkpoint.go
+++ b/pkg/apitype/migrate/checkpoint.go
@@ -36,3 +36,18 @@ func UpToCheckpointV2(v1 apitype.CheckpointV1) apitype.CheckpointV2 {
 	v2.Latest = v2deploy
 	return v2
 }
+
+// UpToCheckpointV3 migrates a CheckpointV2 to a CheckpointV3.
+func UpToCheckpointV3(v2 apitype.CheckpointV2) apitype.CheckpointV3 {
+	var v3 apitype.CheckpointV3
+	v3.Stack = v2.Stack
+	v3.Config = v2.Config
+
+	var v3deploy *apitype.DeploymentV3
+	if v2.Latest != nil {
+		deploy := UpToDeploymentV3(*v2.Latest)
+		v3deploy = &deploy
+	}
+	v3.Latest = v3deploy
+	return v3
+}

--- a/pkg/apitype/migrate/deployment.go
+++ b/pkg/apitype/migrate/deployment.go
@@ -27,3 +27,18 @@ func UpToDeploymentV2(v1 apitype.DeploymentV1) apitype.DeploymentV2 {
 
 	return v2
 }
+
+// UpToDeploymentV3 migrates a deployment from DeploymentV2 to DeploymentV3.
+func UpToDeploymentV3(v2 apitype.DeploymentV2) apitype.DeploymentV3 {
+	var v3 apitype.DeploymentV3
+	// The manifest format did not change between V2 and V3.
+	v3.Manifest = v2.Manifest
+	for _, res := range v2.Resources {
+		v3.Resources = append(v3.Resources, UpToResourceV3(res))
+	}
+	for _, op := range v2.PendingOperations {
+		v3.PendingOperations = append(v3.PendingOperations, UpToOperationV2(op))
+	}
+
+	return v3
+}

--- a/pkg/apitype/migrate/operation.go
+++ b/pkg/apitype/migrate/operation.go
@@ -1,0 +1,25 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migrate
+
+import "github.com/pulumi/pulumi/pkg/apitype"
+
+// UpToOperationV2 migrates a resource from OperationV1 to OperationV2.
+func UpToOperationV2(v1 apitype.OperationV1) apitype.OperationV2 {
+	return apitype.OperationV2{
+		Resource: UpToResourceV3(v1.Resource),
+		Type:     v1.Type,
+	}
+}

--- a/pkg/apitype/migrate/resource.go
+++ b/pkg/apitype/migrate/resource.go
@@ -16,6 +16,7 @@ package migrate
 
 import (
 	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/pulumi/pulumi/pkg/resource"
 )
 
 // UpToResourceV2 migrates a resource from ResourceV1 to ResourceV2.
@@ -46,4 +47,32 @@ func UpToResourceV2(v1 apitype.ResourceV1) apitype.ResourceV2 {
 	v2.Dependencies = append(v2.Dependencies, v1.Dependencies...)
 	v2.InitErrors = append(v2.InitErrors, v1.InitErrors...)
 	return v2
+}
+
+// UpToResourceV3 migrates a resource from ResourceV2 to ResourceV3.
+func UpToResourceV3(v2 apitype.ResourceV2) apitype.ResourceV3 {
+	var v3 apitype.ResourceV3
+	v3.URN = v2.URN
+	v3.Custom = v2.Custom
+	v3.Delete = v2.Delete
+	v3.ID = v2.ID
+	v3.Type = v2.Type
+	v3.Inputs = v2.Inputs
+	v3.Outputs = v2.Outputs
+	v3.Parent = v2.Parent
+	v3.Protect = v2.Protect
+	v3.External = v2.External
+	v3.Dependencies = v2.Dependencies
+	v3.InitErrors = v2.InitErrors
+	v3.Provider = v2.Provider
+
+	// v3.PropertyDependencies tracks dependencies on a per-input-property basis. We conservatively assume that all
+	// properties depend on all of the resource's dependencies.
+	propertyDependencies := make(map[resource.PropertyKey][]resource.URN)
+	for pk := range v3.Inputs {
+		propertyDependencies[resource.PropertyKey(pk)] = v3.Dependencies
+	}
+	v3.PropertyDependencies = propertyDependencies
+
+	return v3
 }

--- a/pkg/resource/properties.go
+++ b/pkg/resource/properties.go
@@ -525,7 +525,7 @@ type Property struct {
 
 // SigKey is sometimes used to encode type identity inside of a map.  This is required when flattening into ordinary
 // maps, like we do when performing serialization, to ensure recoverability of type identities later on.
-const SigKey = PropertyKey("4dabf18193072939515e22adb298388d")
+const SigKey = "4dabf18193072939515e22adb298388d"
 
 // HasSig checks to see if the given property map contains the specific signature match.
 func HasSig(obj PropertyMap, match string) bool {
@@ -534,3 +534,6 @@ func HasSig(obj PropertyMap, match string) bool {
 	}
 	return false
 }
+
+// SecretSig is the unique secret signature.
+const SecretSig = "1b47061264138c4ac30d75fd1eb44270"


### PR DESCRIPTION
Resources gain two new fields: `PropertyDependencies` and
`PendingReplacement`. The former maps an input property's name to the
dependencies that may affect the value of that property. The latter is
used to track resources that have been deleted as part of a
delete-before-replace operation but have not yet been recreated.

In addition to the new fields, resource properties may now contain
encrypted first-class secret values. These values are of type `SecretV1`,
where the `Sig` field is set to `resource.SecretSig`.

Finally, the deployment type gains a new field, `SecretsProviders`,
which contains any configuration necessary to handle secrets that may be
present in resource properties.