### PR TITLE
Include project name in stack's identity.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.16.12 (Unreleased)
 
-- Stack names are now scoped within the context of a project, so you may duplicate stack names across different projects.
+### Major Changes
+
+- When using the cloud backend, stack names now must only be unique within a project, instead of across your entire account. Starting with version of 0.16.12 the CLI, you can create stacks with duplicate names. If an account has multiple stacks with the same name across different projects, you must use 0.16.12 or later of the CLI to manage them.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.16.12 (Unreleased)
 
+- Stack names are now scoped within the context of a project, so you may duplicate stack names across different projects.
+
 ### Improvements
 
 - Add `--json` to `pulumi config`, `pulumi config get`, `pulumi history` and `pulumi plugin ls` to request the output be in JSON.

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -417,10 +417,8 @@ func promptAndCreateStack(
 		return s, nil
 	}
 
-	defaultValue := getDevStackName(projectName)
-
 	for {
-		stackName, err := promptForValue(yes, "stack name", defaultValue, false, workspace.ValidateStackName, opts)
+		stackName, err := promptForValue(yes, "stack name", "dev", false, workspace.ValidateStackName, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -435,14 +433,6 @@ func promptAndCreateStack(
 		}
 		return s, nil
 	}
-}
-
-// getDevStackName returns the stack name suffixed with -dev.
-func getDevStackName(name string) string {
-	const suffix = "-dev"
-	// Strip the suffix so we don't include two -dev suffixes
-	// if the name already has it.
-	return strings.TrimSuffix(name, suffix) + suffix
 }
 
 // stackInit creates the stack.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -390,16 +390,17 @@ func (b *cloudBackend) ParseStackReference(s string) (backend.StackReference, er
 	var projectName string
 	var stackName string
 
-	if len(split) == 1 {
+	switch len(split) {
+	case 1:
 		stackName = split[0]
-	} else if len(split) == 2 {
+	case 2:
 		owner = split[0]
 		stackName = split[1]
-	} else if len(split) == 3 {
+	case 3:
 		owner = split[0]
 		projectName = split[1]
 		stackName = split[2]
-	} else {
+	default:
 		return nil, errors.Errorf("could not parse stack name '%s'", s)
 	}
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1007,8 +1007,8 @@ var (
 	projectNameCleanRegexp = regexp.MustCompile("[^a-zA-Z0-9-_.]")
 )
 
-// cleanProjectName replaces undesirable characters in project names with hypens. At some point, these restrictions
-// will be further enfornced by the service, but for now we need to ensure that if we are making a rest call, we
+// cleanProjectName replaces undesirable characters in project names with hyphens. At some point, these restrictions
+// will be further enforced by the service, but for now we need to ensure that if we are making a rest call, we
 // do this cleaning on our end.
 func cleanProjectName(projectName string) string {
 	return projectNameCleanRegexp.ReplaceAllString(projectName, "-")

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -979,22 +979,16 @@ func (b *cloudBackend) ImportDeployment(ctx context.Context, stackRef backend.St
 	return nil
 }
 
-// getCloudStackIdentifier returns information about the given stack in the current repository and project, based on
-// the current working directory.
+// getCloudStackIdentifier converts a backend.StackReference to a client.StackIdentifier for the same logical stack
 func (b *cloudBackend) getCloudStackIdentifier(stackRef backend.StackReference) (client.StackIdentifier, error) {
-	owner := stackRef.(cloudBackendReference).owner
-	var err error
-
-	if owner == "" {
-		owner, err = b.client.GetPulumiAccountName(context.Background())
-		if err != nil {
-			return client.StackIdentifier{}, err
-		}
+	cloudBackendStackRef, ok := stackRef.(cloudBackendReference)
+	if !ok {
+		return client.StackIdentifier{}, errors.New("bad stack reference type")
 	}
 
 	return client.StackIdentifier{
-		Owner: owner,
-		Stack: string(stackRef.Name()),
+		Owner: cloudBackendStackRef.owner,
+		Stack: string(cloudBackendStackRef.name),
 	}, nil
 }
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -555,7 +555,14 @@ func (b *cloudBackend) CreateStack(
 
 func (b *cloudBackend) ListStacks(
 	ctx context.Context, projectFilter *tokens.PackageName) ([]backend.StackSummary, error) {
-	apiSummaries, err := b.client.ListStacks(ctx, projectFilter)
+
+	var cleanedProjectName *string
+	if projectFilter != nil {
+		clean := cleanProjectName(string(*projectFilter))
+		cleanedProjectName = &clean
+	}
+
+	apiSummaries, err := b.client.ListStacks(ctx, cleanedProjectName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -42,8 +42,9 @@ import (
 
 // StackIdentifier is the set of data needed to identify a Pulumi Cloud stack.
 type StackIdentifier struct {
-	Owner string
-	Stack string
+	Owner   string
+	Project string
+	Stack   string
 }
 
 // UpdateIdentifier is the set of data needed to identify an update to a Pulumi Cloud stack.
@@ -158,7 +159,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 	userAgent := fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)
 	req.Header.Set("User-Agent", userAgent)
 	// Specify the specific API version we accept.
-	req.Header.Set("Accept", "application/vnd.pulumi+2")
+	req.Header.Set("Accept", "application/vnd.pulumi+3")
 
 	// Apply credentials if provided.
 	if tok.String() != "" {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -85,7 +85,8 @@ func (pc *Client) updateRESTCall(ctx context.Context, method, path string, query
 // getStackPath returns the API path to for the given stack with the given components joined with path separators
 // and appended to the stack root.
 func getStackPath(stack StackIdentifier, components ...string) string {
-	return path.Join(append([]string{fmt.Sprintf("/api/stacks/%s/%s", stack.Owner, stack.Stack)}, components...)...)
+	prefix := fmt.Sprintf("/api/stacks/%s/%s/%s", stack.Owner, stack.Project, stack.Stack)
+	return path.Join(append([]string{prefix}, components...)...)
 }
 
 // getUpdatePath returns the API path to for the given stack with the given components joined with path separators
@@ -218,9 +219,10 @@ func (pc *Client) CreateStack(
 	}
 
 	stack := apitype.Stack{
-		StackName: tokens.QName(stackID.Stack),
-		OrgName:   stackID.Owner,
-		Tags:      tags,
+		StackName:   tokens.QName(stackID.Stack),
+		ProjectName: stackID.Project,
+		OrgName:     stackID.Owner,
+		Tags:        tags,
 	}
 	createStackReq := apitype.CreateStackRequest{
 		StackName: stackID.Stack,
@@ -228,8 +230,10 @@ func (pc *Client) CreateStack(
 	}
 
 	var createStackResp apitype.CreateStackResponse
+
+	endpoint := fmt.Sprintf("/api/stacks/%s/%s", stackID.Owner, stackID.Project)
 	if err := pc.restCall(
-		ctx, "POST", fmt.Sprintf("/api/stacks/%s", stackID.Owner), nil, &createStackReq, &createStackResp); err != nil {
+		ctx, "POST", endpoint, nil, &createStackReq, &createStackResp); err != nil {
 		return apitype.Stack{}, err
 	}
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -152,14 +152,14 @@ func (pc *Client) GetCLIVersionInfo(ctx context.Context) (semver.Version, semver
 }
 
 // ListStacks lists all stacks the current user has access to, optionally filtered by project.
-func (pc *Client) ListStacks(ctx context.Context, projectFilter *tokens.PackageName) ([]apitype.StackSummary, error) {
+func (pc *Client) ListStacks(ctx context.Context, projectFilter *string) ([]apitype.StackSummary, error) {
 
 	var resp apitype.ListStacksResponse
 	var queryFilter interface{}
 	if projectFilter != nil {
 		queryFilter = struct {
 			ProjectFilter string `url:"project"`
-		}{ProjectFilter: string(*projectFilter)}
+		}{ProjectFilter: *projectFilter}
 	}
 
 	if err := pc.restCall(ctx, "GET", "/api/user/stacks", queryFilter, nil, &resp); err != nil {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -51,11 +51,11 @@ func (c cloudBackendReference) String() string {
 		curUser = ""
 	}
 
-	if c.owner == curUser && c.b.currentProject != nil && c.project == string(c.b.currentProject.Name) {
-		return string(c.name)
-	}
-
+	// If the project names match, we can elide them.
 	if c.b.currentProject != nil && c.project == string(c.b.currentProject.Name) {
+		if c.owner == curUser {
+			return string(c.name) // Elide owner too, if it is the current user.
+		}
 		return fmt.Sprintf("%s/%s", c.owner, c.name)
 	}
 


### PR DESCRIPTION
This change starts to use a stack's project name as part of it's
identity when talking to the cloud backend, which the Pulumi Service
now supports.

When displaying or parsing stack names for the cloud backend, we now
support the following schemes:

`<stack-name>`
`<owner-name>/<stack-name>`
`<owner-name>/<project-name>/<stack-name>`

When the owner is not specificed, we assume the currently logged in
user (as we did before). When the project name is not specificed, we
use the current project (and fail if we can't find a `Pulumi.yaml`)

Fixes #2039