### PR TITLE
Allow derived classes to call registerOutputs with no args.

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -292,9 +292,7 @@ export class ComponentResource extends Resource {
     // experience by ensuring the UI transitions the ComponentResource to the 'complete' state as
     // quickly as possible (instead of waiting until the entire application completes).
     protected registerOutputs(outputs?: Inputs | Promise<Inputs> | Output<Inputs>): void {
-        if (outputs) {
-            registerResourceOutputs(this, outputs);
-        }
+        registerResourceOutputs(this, outputs || {});
     }
 }
 


### PR DESCRIPTION
We have a bunch of downstream classes that call `.registerOutputs()` to signal that they're done.  However, this actually ends up doing nothing since the impl skips 'undefined' being passed to it.