### PR TITLE
Follow up on #2369

### DIFF
--- a/pkg/resource/plugin/rpc_test.go
+++ b/pkg/resource/plugin/rpc_test.go
@@ -134,3 +134,24 @@ func TestComputedReject(t *testing.T) {
 		assert.Nil(t, cpropU)
 	}
 }
+
+func TestUnsupportedSecret(t *testing.T) {
+	rawProp := resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+		resource.SigKey: resource.SecretSig,
+	}))
+	prop, err := MarshalPropertyValue(rawProp, MarshalOptions{})
+	assert.Nil(t, err)
+	_, err = UnmarshalPropertyValue(prop, MarshalOptions{})
+	assert.Error(t, err)
+}
+
+func TestUnknownSig(t *testing.T) {
+	rawProp := resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+		resource.SigKey: "foobar",
+	}))
+	prop, err := MarshalPropertyValue(rawProp, MarshalOptions{})
+	assert.Nil(t, err)
+	_, err = UnmarshalPropertyValue(prop, MarshalOptions{})
+	assert.Error(t, err)
+
+}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -170,3 +170,19 @@ func TestLoadTooOldDeployment(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, ErrDeploymentSchemaVersionTooOld, err)
 }
+
+func TestUnsupportedSecret(t *testing.T) {
+	rawProp := map[string]interface{}{
+		resource.SigKey: resource.SecretSig,
+	}
+	_, err := DeserializePropertyValue(rawProp)
+	assert.Error(t, err)
+}
+
+func TestUnknownSig(t *testing.T) {
+	rawProp := map[string]interface{}{
+		resource.SigKey: "foobar",
+	}
+	_, err := DeserializePropertyValue(rawProp)
+	assert.Error(t, err)
+}

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -50,8 +50,9 @@ func TestMarshalRoundtrip(t *testing.T) {
 	}
 
 	// Marshal those inputs.
-	m, deps, err := marshalInputs(input)
+	m, pdeps, deps, err := marshalInputs(input)
 	if !assert.Nil(t, err) {
+		assert.Equal(t, len(input), len(pdeps))
 		assert.Equal(t, 0, len(deps))
 
 		// Now just unmarshal and ensure the resulting map matches.
@@ -85,4 +86,22 @@ func TestMarshalRoundtrip(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestUnmarshalUnsupportedSecret(t *testing.T) {
+	m, _, err := marshalInput(map[string]interface{}{
+		rpcTokenSpecialSigKey: rpcTokenSpecialSecretSig,
+	})
+	assert.NoError(t, err)
+	_, err = unmarshalOutput(m)
+	assert.Error(t, err)
+}
+
+func TestUnmarshalUnknownSig(t *testing.T) {
+	m, _, err := marshalInput(map[string]interface{}{
+		rpcTokenSpecialSigKey: "foobar",
+	})
+	assert.NoError(t, err)
+	_, err = unmarshalOutput(m)
+	assert.Error(t, err)
 }

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -41,5 +41,17 @@ describe("runtime", () => {
             assert.equal(result.urn, "bar");
         }));
     });
-});
 
+    describe("deserializeProperty", () => {
+        it("fails on unsupported secret values", () => {
+            assert.throws(() => runtime.deserializeProperty({
+                [runtime.specialSigKey]: runtime.specialSecretSig,
+            }));
+        });
+        it("fails on unknown signature keys", () => {
+            assert.throws(() => runtime.deserializeProperty({
+                [runtime.specialSigKey]: "foobar",
+            }));
+        });
+    });
+});


### PR DESCRIPTION
- Add support for per-property dependencies to the Go SDK
- Add tests for first-class secret rejection in the checkpoint and RPC
  layers and language SDKs