### PR TITLE
Clean up documentation for Python SDK

### DIFF
--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -13,23 +13,63 @@
 # limitations under the License.
 
 """
-The primary Pulumi Python SDK package, targeting Python 3.6 and above.
-
-The pulumi.next package is a point-in-time subpackage to facilitate the
-upgrade of the Pulumi Python SDK to Python 3.6. It provides Python 3-only
-implementations of different parts of the SDK that are being used to replace
-the Python 2 implementations in a piecemeal fashion.
+The Pulumi Core SDK for Python. This package defines the core primitives that
+providers and libraries in the Pulumi ecosystem use to create and manage
+resources.
 """
 
 # Make subpackages available.
 __all__ = ['runtime']
 
 # Make all module members inside of this package available as package members.
-from .asset import *
-from .config import *
-from .errors import *
-from .invoke import *
-from .metadata import *
-from .resource import *
-from .output import *
-from .log import *
+from .asset import (
+    Asset,
+    Archive,
+    AssetArchive,
+    FileArchive,
+    FileAsset,
+    RemoteArchive,
+    RemoteAsset,
+    StringAsset,
+)
+
+from .config import (
+    Config,
+    ConfigMissingError,
+    ConfigTypeError,
+)
+
+from .errors import (
+    RunError,
+)
+
+from .invoke import (
+    InvokeOptions,
+)
+
+from .metadata import (
+    get_project,
+    get_stack,
+)
+
+from .resource import (
+    Resource,
+    CustomResource,
+    ComponentResource,
+    ProviderResource,
+    ResourceOptions,
+    export,
+)
+
+from .output import (
+    Output,
+    Input,
+    Inputs,
+)
+
+from .log import (
+    debug,
+    info,
+    warn,
+    error,
+)

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -32,19 +32,28 @@ class Config:
     """
 
     name: str
+    """
+    The configuration bag's logical name that uniquely identifies it.  The default is the name of the current project.
+    """
 
     def __init__(self, name: str) -> None:
+        """
+        :param str name: The configuration bag's logical name that uniquely identifies it.  The default is the name of
+               the current project.
+        """
         if not name:
             name = get_project()
         if not isinstance(name, str):
             raise TypeError('Expected name to be a string')
         self.name = name
-        """The configuration bag's logical name that uniquely identifies it.  The default is the name of the current
-        project."""
-
+        
     def get(self, key: str) -> Optional[str]:
         """
         Returns an optional configuration value by its key, or None if it doesn't exist.
+
+        :param str key: The requested configuration key.
+        :return: The configuration key's value, or None if one does not exist.
+        :rtype: Optional[str]
         """
         return get_config(self.full_key(key))
 
@@ -52,6 +61,11 @@ class Config:
         """
         Returns an optional configuration value, as a bool, by its key, or None if it doesn't exist.
         If the configuration value isn't a legal boolean, this function will throw an error.
+
+        :param str key: The requested configuration key.
+        :return: The configuration key's value, or None if one does not exist.
+        :rtype: Optional[bool]
+        :raises ConfigTypeError: The configuration value existed but couldn't be coerced to bool.
         """
         v = self.get(key)
         if v is None:
@@ -66,6 +80,11 @@ class Config:
         """
         Returns an optional configuration value, as an int, by its key, or None if it doesn't exist.
         If the configuration value isn't a legal int, this function will throw an error.
+
+        :param str key: The requested configuration key.
+        :return: The configuration key's value, or None if one does not exist.
+        :rtype: Optional[int]
+        :raises ConfigTypeError: The configuration value existed but couldn't be coerced to int.
         """
         v = self.get(key)
         if v is None:
@@ -79,6 +98,11 @@ class Config:
         """
         Returns an optional configuration value, as a float, by its key, or None if it doesn't exist.
         If the configuration value isn't a legal float, this function will throw an error.
+
+        :param str key: The requested configuration key.
+        :return: The configuration key's value, or None if one does not exist.
+        :rtype: Optional[float]
+        :raises ConfigTypeError: The configuration value existed but couldn't be coerced to float.
         """
         v = self.get(key)
         if v is None:
@@ -91,6 +115,11 @@ class Config:
     def require(self, key: str) -> str:
         """
         Returns a configuration value by its given key.  If it doesn't exist, an error is thrown.
+
+        :param str key: The requested configuration key.
+        :return: The configuration key's value.
+        :rtype: str
+        :raises ConfigMissingError: The configuration value did not exist.
         """
         v = self.get(key)
         if v is None:
@@ -101,6 +130,12 @@ class Config:
         """
         Returns a configuration value, as a bool, by its given key.  If it doesn't exist, or the
         configuration value is not a legal bool, an error is thrown.
+        
+        :param str key: The requested configuration key.
+        :return: The configuration key's value.
+        :rtype: bool
+        :raises ConfigMissingError: The configuration value did not exist.
+        :raises ConfigTypeError: The configuration value existed but couldn't be coerced to bool.
         """
         v = self.get_bool(key)
         if v is None:
@@ -111,6 +146,12 @@ class Config:
         """
         Returns a configuration value, as an int, by its given key.  If it doesn't exist, or the
         configuration value is not a legal int, an error is thrown.
+
+        :param str key: The requested configuration key.
+        :return: The configuration key's value.
+        :rtype: int
+        :raises ConfigMissingError: The configuration value did not exist.
+        :raises ConfigTypeError: The configuration value existed but couldn't be coerced to int.
         """
         v = self.get_int(key)
         if v is None:
@@ -121,6 +162,12 @@ class Config:
         """
         Returns a configuration value, as a float, by its given key.  If it doesn't exist, or the
         configuration value is not a legal number, an error is thrown.
+
+        :param str key: The requested configuration key.
+        :return: The configuration key's value.
+        :rtype: float
+        :raises ConfigMissingError: The configuration value did not exist.
+        :raises ConfigTypeError: The configuration value existed but couldn't be coerced to float.
         """
         v = self.get_float(key)
         if v is None:
@@ -130,6 +177,10 @@ class Config:
     def full_key(self, key: str) -> str:
         """
         Turns a simple configuration key into a fully resolved one, by prepending the bag's name.
+
+        :param str key: The name of the configuration key.
+        :return: The name of the configuration key, prefixed with the bag's name.
+        :rtype: str
         """
         return '%s:%s' % (self.name, key)
 
@@ -140,8 +191,19 @@ class ConfigTypeError(errors.RunError):
     """
 
     key: str
+    """
+    The name of the key whose value was ill-typed.
+    """
+
     value: str
+    """
+    The ill-typed value.
+    """
+
     expect_type: str
+    """
+    The expected type of this value.
+    """
 
     def __init__(self, key: str, value: str, expect_type: str) -> None:
         self.key = key
@@ -157,6 +219,9 @@ class ConfigMissingError(errors.RunError):
     """
 
     key: str
+    """
+    The name of the missing configuration key.
+    """
 
     def __init__(self, key: str) -> None:
         self.key = key

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -46,7 +46,7 @@ class Config:
         if not isinstance(name, str):
             raise TypeError('Expected name to be a string')
         self.name = name
-        
+
     def get(self, key: str) -> Optional[str]:
         """
         Returns an optional configuration value by its key, or None if it doesn't exist.
@@ -130,7 +130,7 @@ class Config:
         """
         Returns a configuration value, as a bool, by its given key.  If it doesn't exist, or the
         configuration value is not a legal bool, an error is thrown.
-        
+
         :param str key: The requested configuration key.
         :return: The configuration key's value.
         :rtype: bool

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -28,5 +28,11 @@ class InvokeOptions:
     """
 
     def __init__(self, parent: Optional['Resource'] = None, provider: Optional['ProviderResource'] = None) -> None:
+        """
+        :param Optional[Resource] parent: An optional parent to use for default options for this invoke (e.g. the
+               default provider to use).
+        :param Optional[ProviderResource] provider: An optional provider to use for this invocation. If no provider is
+               supplied, the default provider for the invoked function's package will be used.
+        """
         self.parent = parent
         self.provider = provider

--- a/sdk/python/lib/pulumi/log.py
+++ b/sdk/python/lib/pulumi/log.py
@@ -30,6 +30,10 @@ def debug(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[i
     """
     Logs a message to the Pulumi CLI's debug channel, associating it with a resource
     and stream_id if provided.
+
+    :param str msg: The message to send to the Pulumi CLI.
+    :param Optional[Resource] resource: If provided, associate this message with the given resource in the Pulumi CLI.
+    :param Optional[int] stream_id: If provided, associate this message with a stream of other messages.
     """
     engine = get_engine()
     if engine is not None:
@@ -42,6 +46,10 @@ def info(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[in
     """
     Logs a message to the Pulumi CLI's info channel, associating it with a resource
     and stream_id if provided.
+
+    :param str msg: The message to send to the Pulumi CLI.
+    :param Optional[Resource] resource: If provided, associate this message with the given resource in the Pulumi CLI.
+    :param Optional[int] stream_id: If provided, associate this message with a stream of other messages.
     """
     engine = get_engine()
     if engine is not None:
@@ -54,6 +62,10 @@ def warn(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[in
     """
     Logs a message to the Pulumi CLI's warning channel, associating it with a resource
     and stream_id if provided.
+
+    :param str msg: The message to send to the Pulumi CLI.
+    :param Optional[Resource] resource: If provided, associate this message with the given resource in the Pulumi CLI.
+    :param Optional[int] stream_id: If provided, associate this message with a stream of other messages.
     """
     engine = get_engine()
     if engine is not None:
@@ -66,6 +78,10 @@ def error(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[i
     """
     Logs a message to the Pulumi CLI's error channel, associating it with a resource
     and stream_id if provided.
+
+    :param str msg: The message to send to the Pulumi CLI.
+    :param Optional[Resource] resource: If provided, associate this message with the given resource in the Pulumi CLI.
+    :param Optional[int] stream_id: If provided, associate this message with a stream of other messages.
     """
     engine = get_engine()
     if engine is not None:

--- a/sdk/python/lib/pulumi/metadata.py
+++ b/sdk/python/lib/pulumi/metadata.py
@@ -12,18 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import runtime
+from .runtime.settings import get_project as runtime_gp
+from .runtime.settings import get_stack as runtime_gs
 
 
 def get_project() -> str:
     """
     Returns the current project name.
     """
-    return runtime.get_project()
+    return runtime_gp()
 
 
 def get_stack() -> str:
     """
     Returns the current stack name.
     """
-    return runtime.get_stack()
+    return runtime_gs()

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -16,10 +16,24 @@
 The runtime implementation of the Pulumi Python SDK.
 """
 
-# Make all module members inside of this package available as package members.
-from .config import *
-from .resource import *
-from .rpc import *
-from .settings import *
-from .stack import *
-from .invoke import *
+from .config import (
+    set_config,
+    get_config,
+    get_config_env,
+    get_config_env_key,
+)
+
+from .settings import (
+    Settings,
+    configure,
+    is_dry_run,
+)
+
+from .stack import (
+    run_in_stack,
+    get_root_resource,
+)
+
+from .invoke import (
+    invoke,
+)


### PR DESCRIPTION
The Python SDK currently does a couple of bad things that make it
difficult to generate documentation:

1. It "wildcard-imports" submodules without each module specifying an
__all__ member
2. Documentation strings don't have a consistent format
3. Documentation strings are in Markdown and not reStructuredText

To remedy this, this commit addresses 1 by explicitly specifying which
members are being exported from submodules, so that we can see in one
place exactly what the public surface area of the pulumi package is. For
2 and 3, this commit fixes a large number of documentation strings to
contain metadata tags that Sphinx is capable of reading. This allows us
to generate high-quality documentation directly from the source without
having to manually parse docstrings.

Part 1 of 2 for https://github.com/pulumi/docs/issues/791 (the rest of the work is in the docs repo).