### PR TITLE
Work around commonjs protoc bug

### DIFF
--- a/sdk/nodejs/proto/analyzer_pb.js
+++ b/sdk/nodejs/proto/analyzer_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var proto = { pulumirpc: {} }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/analyzer_pb.js
+++ b/sdk/nodejs/proto/analyzer_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/analyzer_pb.js
+++ b/sdk/nodejs/proto/analyzer_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
+var proto = { pulumirpc: {} }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/engine_pb.js
+++ b/sdk/nodejs/proto/engine_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');

--- a/sdk/nodejs/proto/engine_pb.js
+++ b/sdk/nodejs/proto/engine_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var proto = { pulumirpc: {} }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');

--- a/sdk/nodejs/proto/engine_pb.js
+++ b/sdk/nodejs/proto/engine_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
+var proto = { pulumirpc: {} }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');

--- a/sdk/nodejs/proto/errors_pb.js
+++ b/sdk/nodejs/proto/errors_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var proto = { pulumirpc: {} }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.ErrorCause', null, global);
 

--- a/sdk/nodejs/proto/errors_pb.js
+++ b/sdk/nodejs/proto/errors_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.ErrorCause', null, global);
 

--- a/sdk/nodejs/proto/errors_pb.js
+++ b/sdk/nodejs/proto/errors_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
+var proto = { pulumirpc: {} }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.ErrorCause', null, global);
 

--- a/sdk/nodejs/proto/language_pb.js
+++ b/sdk/nodejs/proto/language_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var proto = { pulumirpc: {} }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/language_pb.js
+++ b/sdk/nodejs/proto/language_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/language_pb.js
+++ b/sdk/nodejs/proto/language_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
+var proto = { pulumirpc: {} }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/plugin_pb.js
+++ b/sdk/nodejs/proto/plugin_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.PluginDependency', null, global);
 goog.exportSymbol('proto.pulumirpc.PluginInfo', null, global);

--- a/sdk/nodejs/proto/plugin_pb.js
+++ b/sdk/nodejs/proto/plugin_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
+var proto = { pulumirpc: {} }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.PluginDependency', null, global);
 goog.exportSymbol('proto.pulumirpc.PluginInfo', null, global);

--- a/sdk/nodejs/proto/plugin_pb.js
+++ b/sdk/nodejs/proto/plugin_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var proto = { pulumirpc: {} }, global = proto;
 
 goog.exportSymbol('proto.pulumirpc.PluginDependency', null, global);
 goog.exportSymbol('proto.pulumirpc.PluginInfo', null, global);

--- a/sdk/nodejs/proto/provider_pb.js
+++ b/sdk/nodejs/proto/provider_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var proto = { pulumirpc: {} }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/provider_pb.js
+++ b/sdk/nodejs/proto/provider_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/provider_pb.js
+++ b/sdk/nodejs/proto/provider_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
+var proto = { pulumirpc: {} }, global = proto;
 
 var plugin_pb = require('./plugin_pb.js');
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');

--- a/sdk/nodejs/proto/resource_pb.js
+++ b/sdk/nodejs/proto/resource_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');

--- a/sdk/nodejs/proto/resource_pb.js
+++ b/sdk/nodejs/proto/resource_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var proto = { pulumirpc: {} }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');

--- a/sdk/nodejs/proto/resource_pb.js
+++ b/sdk/nodejs/proto/resource_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
+var proto = { pulumirpc: {} }, global = proto;
 
 var google_protobuf_empty_pb = require('google-protobuf/google/protobuf/empty_pb.js');
 var google_protobuf_struct_pb = require('google-protobuf/google/protobuf/struct_pb.js');

--- a/sdk/nodejs/proto/status_pb.js
+++ b/sdk/nodejs/proto/status_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
+var global = Function('return this')();
 
 var google_protobuf_any_pb = require('google-protobuf/google/protobuf/any_pb.js');
 goog.exportSymbol('proto.google.rpc.Status', null, global);

--- a/sdk/nodejs/proto/status_pb.js
+++ b/sdk/nodejs/proto/status_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var global = Function('return this')();
+var proto = { pulumirpc: {} }, global = proto;
 
 var google_protobuf_any_pb = require('google-protobuf/google/protobuf/any_pb.js');
 goog.exportSymbol('proto.google.rpc.Status', null, global);

--- a/sdk/nodejs/proto/status_pb.js
+++ b/sdk/nodejs/proto/status_pb.js
@@ -9,7 +9,7 @@
 
 var jspb = require('google-protobuf');
 var goog = jspb;
-var proto = { pulumirpc: {} }, global = proto;
+var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 
 var google_protobuf_any_pb = require('google-protobuf/google/protobuf/any_pb.js');
 goog.exportSymbol('proto.google.rpc.Status', null, global);

--- a/sdk/proto/generate.sh
+++ b/sdk/proto/generate.sh
@@ -42,7 +42,7 @@ $PROTOC --go_out=$GO_PROTOFLAGS:$GO_PULUMIRPC $PROTO_FILES
 # We're replacing the literal code string
 #   var global = Function('return this')();
 # with
-#   var proto = { pulumirpc: {} }, global = proto;
+#   var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;
 #
 # This sets up the remainder of the protobuf file so that it works fine, but doesn't mess with global.
 $DOCKER_RUN /bin/bash -c 'JS_PULUMIRPC=/nodejs/proto && \
@@ -52,7 +52,7 @@ $DOCKER_RUN /bin/bash -c 'JS_PULUMIRPC=/nodejs/proto && \
     echo -e "\tJS temp dir: $TEMP_DIR"              && \
     mkdir -p "$TEMP_DIR"                            && \
     protoc --js_out=$JS_PROTOFLAGS:$TEMP_DIR --grpc_out=minimum_node_version=6:$TEMP_DIR --plugin=protoc-gen-grpc=/usr/local/bin/grpc_tools_node_protoc_plugin *.proto && \
-    sed -i "s/^var global = .*;/var proto = { pulumirpc: {} }, global = proto;/" "$TEMP_DIR"/*.js && \
+    sed -i "s/^var global = .*;/var proto = { pulumirpc: {}, google: { rpc: {} } }, global = proto;/" "$TEMP_DIR"/*.js && \
     cp "$TEMP_DIR"/*.js "$JS_PULUMIRPC"'
 
 


### PR DESCRIPTION
When compiling with the commonjs target, the protoc compiler still emits
references to Closure Compiler-isms that whack global state onto the
global object. This is particularly bad for us since we expect to be
able to make backwards-compatible changes to our Protobuf definitions
without breaking things, and this bug makes it impossible to do so.

To remedy the bug, this commit hacks the output of protoc (again) with
sed in order to avoid ever touching the global object. Everything still
works fine because the commonjs target (correctly) exports the protobuf
message types via the module system - it's just not writing to global
anymore.