### PR TITLE
Improve StackReference error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ### Improvements
 
+- Issue a more perscriptive error when using StackReference and the name of the stack to reference is not of the form `<organization>/<project>/<stack>`.
+
 ## 0.16.12 (Released January 25th, 2019)
 
 ### Major Changes
 
 - When using the cloud backend, stack names now must only be unique within a project, instead of across your entire account. Starting with version of 0.16.12 the CLI, you can create stacks with duplicate names. If an account has multiple stacks with the same name across different projects, you must use 0.16.12 or later of the CLI to manage them.
+
+**BREAKING CHANGE NOTICE**: As part of the above change, when using the 0.16.12 CLI (or a later version) the names passed to `StackReference` must be updated to be of the form (`<organization>/<project>/<stack>`) e.g. `acmecorp/infra/dev` to refer to the `dev` stack of the `infra` project in the `acmecorp` organization.
 
 ### Improvements
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -610,15 +610,17 @@ func TestGetCreated(t *testing.T) {
 
 // Tests that stack references work.
 func TestStackReference(t *testing.T) {
+	if owner := os.Getenv("PULUMI_TEST_OWNER"); owner != "" {
+		t.Skipf("Skipping: PULUMI_TEST_OWNER is not set")
+	}
+
 	opts := &integration.ProgramTestOptions{
 		Dir:          "stack_reference",
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
-	}
-	if owner := os.Getenv("PULUMI_TEST_OWNER"); owner != "" {
-		opts.Config = map[string]string{
-			"org": owner,
-		}
+		Config: map[string]string{
+			"org": os.Getenv("PULUMI_TEST_OWNER"),
+		},
 	}
 	integration.ProgramTest(t, opts)
 }

--- a/tests/integration/stack_reference/index.ts
+++ b/tests/integration/stack_reference/index.ts
@@ -3,6 +3,6 @@
 import * as pulumi from "@pulumi/pulumi";
 
 let config = new pulumi.Config();
-let org = config.get("org");
-let slug = org ? `${org}/${pulumi.getStack()}` : pulumi.getStack();
+let org = config.require("org");
+let slug = `${org}/${pulumi.getProject()}/${pulumi.getStack()}`;
 let a = new pulumi.StackReference(slug);


### PR DESCRIPTION
Because of the change to include a stack's project as part of its
identity in the service, the names passed to StackReference now
require the project name as well.

Improve the error message when they do not include them.