### PR TITLE
Use prefered `new pulumi.Config()` form

### DIFF
--- a/tests/integration/ee_perf/index.js
+++ b/tests/integration/ee_perf/index.js
@@ -3,7 +3,7 @@
 "use strict";
 const pulumi = require("@pulumi/pulumi");
 
-const config = new pulumi.Config("ee-perf");
+const config = new pulumi.Config();
 const iterations = config.getNumber("count") || 1000;
 
 // Emit many, many diagnostic events from the engine to stress test the


### PR DESCRIPTION
In #2330 there was a case where if you didn't pass a value to the
`pulumi.Config()` constructor, things would fail in a weird manner.

This shouldn't be the case, and I'm unable to reproduce the issue. So
I'm updating the test to use the form that didn't work at one point so
we can lock in the win.

Fixes #2330