### PR TITLE
Sort updates from httpstate backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- `pulumi history` now shows updates from newest to oldest instead of an unsorted list of updates.
+
 ## 0.16.12 (Released January 25th, 2019)
 
 ### Major Changes

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -28,6 +28,7 @@ import (
 	"path"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -912,7 +913,29 @@ func (b *cloudBackend) GetHistory(ctx context.Context, stackRef backend.StackRef
 		})
 	}
 
-	return beUpdates, nil
+	// Sort the updates, so the newest ones are first.
+	sortableUpdates := sortableUpdates{updates: beUpdates}
+	sort.Sort(sortableUpdates)
+
+	return sortableUpdates.updates, nil
+}
+
+type sortableUpdates struct {
+	updates []backend.UpdateInfo
+}
+
+func (su sortableUpdates) Len() int {
+	return len(su.updates)
+}
+
+func (su sortableUpdates) Less(i int, j int) bool {
+	return su.updates[i].StartTime > su.updates[j].StartTime
+}
+
+func (su sortableUpdates) Swap(i int, j int) {
+	tmp := su.updates[i]
+	su.updates[i] = su.updates[j]
+	su.updates[j] = tmp
 }
 
 func (b *cloudBackend) GetLatestConfiguration(ctx context.Context,


### PR DESCRIPTION
The backend interface says that the slice returned by GetHistory will
be sorted with the newest update first. Our implementation was not
sorting this and the service does not return history data in sorted
order.

Do the sorting, so commands like `pulumi history` have reasonable
output.