### PR TITLE
Run fewer jobs for PRs and pushes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
 # It may be tempting to add parens around each individual clause in this expression, but Travis then builds pushes anyway
-if: branch = master OR branch =~ ^features/ OR branch =~ ^release/ OR tag IS present
+if: branch = master OR branch =~ ^features/ OR tag IS present
 matrix:
   include:
     - os: linux
       env: NODE_VERSION=v8.11.1 TRAVIS_PUBLISH_PACKAGES=true
-    - os: linux
-      env: NODE_VERSION=v10.7
-    - os: osx
+    - if: type IN (cron, push)
+      os: osx
       env: NODE_VERSION=v6.10.3
-    - os: linux
+    - if: type = cron
+      os: linux
       env: NODE_VERSION=v11.0.0
+    - if: type = cron
+      os: linux
+      env: NODE_VERSION=v10.7
 language: go
 go: 1.11
 sudo: true # give us 7.5GB and >2 bursted cores.


### PR DESCRIPTION
Today, we run 4 jobs for every push or PR build. Three Linux builds
which only differ by node version and an macOS build that also has a
different node version from the rest.

In practice this ends up generating a great deal of jobs during
development, given some of our workflows and these jobs often don't
find interesting issues.

We're going to start by relaxing things in the following ways:

- For a given PR, we'll just run a single Linux leg (as well as the
  Windows leg we get from AppVeyor).

- For push jobs (which happen either when a PR is merged into master,
  or a branch named `features/*` is pushed, we'll run a Linux leg and
  and macOS leg (the macOS leg is run per push, so we build and
  publish of the CLI for macOS builds)

- For our nightly cron job, we'll continue to run all three Linux
  legs, to get coverage across different versions of nodejs.

If we end up seeing an uptick in regressions found by these jobs after
each commit, we can re-evaluate or pre checkin strategy.