### PR TITLE
Don't install the just built package into user's site-packages

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -40,7 +40,6 @@ lint::
 	golangci-lint run
 
 install_package::
-	cd $(PYENVSRC) && $(PIP) install --user -e .
 	cp ./cmd/pulumi-language-python-exec "$(PULUMI_BIN)"
 
 install_plugin::


### PR DESCRIPTION
We do all our work in a virtualenv and across repositories we now
consume dependencies via pypi (also installed in a virtualenv) so best
case install into the user site packages wastes time and maybe prints
some warnings and worse case it clobbers something they've installed
for real.