### PR TITLE
Only show upgrade message when installed from get.pulumi.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- The CLI now only warns about a newer version being present if it looks like it was installed from `https://get.pulumi.com` (i.e it is located in `~/.pulumi/bin`). This should prevent cases where package managers like `brew` have not yet upgraded to a newer version yet the CLI warns a newer version is present on every invocation (fixes [pulumi/pulumi#2426](https://github.com/pulumi/pulumi/issues/2426)).
+
 ## 0.16.14 (Released January 31th, 2019)
 
 ### Improvements


### PR DESCRIPTION
In general, we can't know what the latest version of `pulumi` in a
package manager might be and we've seen in practice that `brew` can
often take some time to pick up a new version.

For now, we'll just notify users there's a newer version present when
we are pretty confident it was installed from get.pulumi.com. For
folks installing `pulumi` from their package manager, we'll just let
their package manager advertise an update.