### PR TITLE
fix: typo in yarn installation

### DIFF
--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -34,6 +34,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 #     - Yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
     echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+    apt-get update -y && \
     apt-get install -y yarn
 
 # Install Docker so we can build and publish containers.

--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
 
 #     - Yarn
 RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.lis && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
     apt-get install -y yarn
 
 # Install Docker so we can build and publish containers.


### PR DESCRIPTION
- per documentation, looks like you missed a character https://yarnpkg.com/lang/en/docs/install/#debian-stable