### PR TITLE
fix: overhaul the Dockerfile

### DIFF
--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -1,68 +1,66 @@
-# This Dockerfile describes a base image that includes nodejs, python3,
-# as well as the cli for the major clour providers Pulumi supports
-# (aws, azure, gcp, kubernetes) as well as the Pulumi CLI itself.
-#
-# It is suitable as a general base image for an environment for deploying
-# infrastructure written with Pulumi.
-FROM debian:stretch
+FROM python:3.7-slim
+
+LABEL "com.github.actions.name"="Pulumi"
+LABEL "com.github.actions.description"="Deploy apps and infra to your favorite cloud!"
+LABEL "com.github.actions.icon"="cloud-lightning"
+LABEL "com.github.actions.color"="purple"
+LABEL "repository"="https://github.com/pulumi/pulumi"
+LABEL "homepage"="http://pulumi.io/reference/gh-actions.html"
+LABEL "maintainer"="Pulumi Team <team@pulumi.com>"
+
+# Install deps all in one step
+RUN apt-get update -y && \
+  apt-get install -y \
+    apt-transport-https \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    software-properties-common \
+  && \
+  # Get all of the signatures we need all at once
+  curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+  curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+  curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add && \
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+  curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+  # IAM Authenticator for EKS
+  curl -fsSLo /usr/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
+  chmod +x /usr/bin/aws-iam-authenticator && \
+  # Add additional apt repos all at once
+  echo "deb https://deb.nodesource.com/node_11.x $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/node.list && \
+  echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
+  echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list && \
+  echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -cs) main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list && \
+  echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list &&\
+  echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/azure.list && \
+  # Install second wave of dependencies
+  apt-get update -y && \
+    apt-get install -y \
+    azure-cli \
+    docker-ce \
+    google-cloud-sdk \
+    kubectl \
+    nodejs \
+    yarn \
+  && \
+  pip install awscli --upgrade && \
+  # Clean up the lists work
+  rm -rf /var/lib/apt/lists/*
 
 # Passing --build-arg PULUMI_VERSION=vX.Y.Z will use that version
 # of the SDK. Otherwise, we use whatever get.pulumi.com thinks is
 # the latest
 ARG PULUMI_VERSION=latest
 
-# Install some runtime pre-reqs.
-RUN apt-get update -y
-RUN apt-get install -y ca-certificates curl software-properties-common gnupg jq git
-
 # Install the Pulumi SDK, including the CLI and language runtimes.
 RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
-       curl -fsSL https://get.pulumi.com/ | bash; \
-    else \
-        curl -fsSL https://get.pulumi.com/ | bash -s -- --version $(echo $PULUMI_VERSION | cut -c 2-); \
-    fi && \
-    mv ~/.pulumi/bin/* /usr/bin
+    curl -fsSL https://get.pulumi.com/ | bash; \
+  else \
+    curl -fsSL https://get.pulumi.com/ | bash -s -- --version $(echo $PULUMI_VERSION | cut -c 2-); \
+  fi && \
+  mv ~/.pulumi/bin/* /usr/bin
 
-# Install the necessary runtimes to support Pulumi languages.
-#     - Python 3
-RUN apt install -y python3-pip
-
-#     - Node.js 10.x
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get install -y nodejs build-essential
-
-#     - Yarn
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
-    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list && \
-    apt-get update -y && \
-    apt-get install -y yarn
-
-# Install Docker so we can build and publish containers.
-RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -  && \
-    add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" && \
-    apt-get update -y && \
-    apt-get install -y docker-ce
-
-# Install AWS IAM Authenticator, so AWS services like EKS can be used.
-RUN curl -Lso /usr/bin/aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator && \
-    chmod +x /usr/bin/aws-iam-authenticator
-
-# Install all the cloud CLIs, so we are prepared to deploy to them.
-#     - AWS
-RUN pip3 install awscli --upgrade
-#     - Azure
-RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" | \
-        tee /etc/apt/sources.list.d/azure-cli.list && \
-    curl -L https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    apt-get update -y && apt-get install -y azure-cli
-
-#     - Google Cloud
-RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | \
-        tee -a /etc/apt/sources.list.d/google-cloud-sdk.list && \
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    apt-get update -y && apt-get install -y google-cloud-sdk
-#     - Kubernetes
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - && \
-    echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | \
-        tee -a /etc/apt/sources.list.d/kubernetes.list && \
-    apt-get update -y && apt-get install -y kubectl
+# I think it's safe to say if we're using this mega image, we want pulumi
+ENTRYPOINT ["pulumi"]


### PR DESCRIPTION
- Pick python as a base image. Debian build tools depend on 3.5, so don't fight that battle, just use an existing solution
- Fixes #2435
- Move the pulumi install to the bottom. Rule of thumb is you always install deps first then your software so you're not thrashing the dockerfile build because you only build images when your code changes, not when deps change.
- Do all of the dep work in one step and clean up. This makes the image have way fewer layers and makes the image a bit smaller
- Get consistent with repo addition. I'm not sure if this is the best way, but it's better.
- Add some failure handling to curl commands
- Avoid crazy ass curl-pipe-bash install scripts when possible in favor of crazy ass curl-pipe-apt-key 😨 
- Add some github actions stuff in case people want to use this for actions. I'm here because the github action is wack, and I'm trying to align your dockerfiles across both repos.