### PR TITLE
Enable delete parallelism for Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Improvements
 
 - When trying to `stack rm` a stack managed by pulumi.com that has resources, the error message now informs you to pass `--force` if you really want to remove a stack that still has resources under management, as this would orphan these resources (fixes [pulumi/pulumi#2431](https://github.com/pulumi/pulumi/issues/2431)).
+- Enabled Python programs to delete resources in parallel (fixes [pulumi/pulumi#2382](https://github.com/pulumi/pulumi/issues/2382))
 
 ## 0.16.14 (Released January 31th, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Improvements
 
 - When trying to `stack rm` a stack managed by pulumi.com that has resources, the error message now informs you to pass `--force` if you really want to remove a stack that still has resources under management, as this would orphan these resources (fixes [pulumi/pulumi#2431](https://github.com/pulumi/pulumi/issues/2431)).
-- Enabled Python programs to delete resources in parallel (fixes [pulumi/pulumi#2382](https://github.com/pulumi/pulumi/issues/2382))
+- Enabled Python programs to delete resources in parallel (fixes [pulumi/pulumi#2382](https://github.com/pulumi/pulumi/issues/2382)). If you are using Python 2, you should upgrade to Python 3 or else you may experience problems when deleting resources.
 
 ## 0.16.14 (Released January 31th, 2019)
 

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -98,9 +98,10 @@ func (proj *Project) Validate() error {
 }
 
 // TrustResourceDependencies returns whether or not this project's runtime can be trusted to accurately report
-// dependencies. Not all languages supported by Pulumi do this correctly.
+// dependencies. All languages supported by Pulumi today do this correctly. This option remains useful when bringing
+// up new Pulumi languages.
 func (proj *Project) TrustResourceDependencies() bool {
-	return proj.Runtime.Name() != "python"
+	return true
 }
 
 // Save writes a project definition to a file.

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -224,7 +224,7 @@ func TestRemoveWithResourcesBlocked(t *testing.T) {
 	stackName, err := resource.NewUniqueHex("rm-test-", 8, -1)
 	contract.AssertNoErrorf(err, "resource.NewUniqueHex sould not fail with no maximum length is set")
 
-	e.ImportDirectory(filepath.Join("empty", "nodejs"))
+	e.ImportDirectory("single_resource")
 	e.RunCommand("pulumi", "stack", "init", stackName)
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
 	e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")

--- a/tests/integration/single_resource/Pulumi.yaml
+++ b/tests/integration/single_resource/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: protect_resources
+description: A program that ensures we cannot delete protected resources.
+runtime: nodejs

--- a/tests/integration/single_resource/index.ts
+++ b/tests/integration/single_resource/index.ts
@@ -1,0 +1,7 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import { Resource } from "./resource";
+
+// Allocate a new resource. When this exists, we should not allow
+// the stack holding it to be `rm`'d without `--force`.
+let a = new Resource("res", { state: 1 });

--- a/tests/integration/single_resource/package.json
+++ b/tests/integration/single_resource/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "steps",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/single_resource/resource.ts
+++ b/tests/integration/single_resource/resource.ts
@@ -1,0 +1,30 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+let currentID = 0;
+
+export class Provider implements pulumi.dynamic.ResourceProvider {
+    public static readonly instance = new Provider();
+
+    public readonly create: (inputs: any) => Promise<pulumi.dynamic.CreateResult>;
+
+    constructor() {
+        this.create = async (inputs: any) => {
+            return {
+                id: (currentID++).toString(),
+                outs: undefined,
+            };
+        };
+    }
+}
+
+export class Resource extends pulumi.dynamic.Resource {
+    constructor(name: string, props: ResourceProps, opts?: pulumi.ResourceOptions) {
+        super(Provider.instance, name, props, opts);
+    }
+}
+
+export interface ResourceProps {
+    state?: any; // arbitrary state bag that can be updated without replacing.
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/2382.

This is a backcompat hazard - any programs using the "old" Python 2 SDK will break when run with this change. However, we have no real way of detecting this from within the CLI. That said, it has been 10 releases of the Pulumi Python SDK since we implemented the necessary support for delete parallelism and we have officially deprecated the Python 2 SDK, so I believe that now is a reasonable time to take this change.

I do think that this change would be a good fit for a `0.17.0`, but I'm not sure when we would be doing that.