### PR TITLE
Better log messages for replaces/changes

### DIFF
--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -300,8 +300,8 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 	}
 	changes := resp.GetChanges()
 	deleteBeforeReplace := resp.GetDeleteBeforeReplace()
-	logging.V(7).Infof("%s success: changes=%d #replaces=%d #stables=%d delbefrepl=%v",
-		label, changes, len(replaces), len(stables), deleteBeforeReplace)
+	logging.V(7).Infof("%s success: changes=%d #replaces=%v #stables=%v delbefrepl=%v",
+		label, changes, replaces, stables, deleteBeforeReplace)
 	return DiffResult{
 		Changes:             DiffChanges(changes),
 		ReplaceKeys:         replaces,


### PR DESCRIPTION
We previously logged the number of replaces and changes returned from a call to Diff, but not the actual properties that were forcing replace.  Several times we've had to debug issues with unexpected replaces being proposed, and this information is very useful to have access to.

Changes the verbose logging to include the property names for both replaces and changes instead of just the count.