### PR TITLE
Return error from stack tag commands in local mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enabled Python programs to delete resources in parallel (fixes [pulumi/pulumi#2382](https://github.com/pulumi/pulumi/issues/2382)). If you are using Python 2, you should upgrade to Python 3 or else you may experience problems when deleting resources.
 - Fixed an issue where Python programs would occasionally fail during preview with errors about empty IDs being passed
   to resources. ([pulumi/pulumi#2450](https://github.com/pulumi/pulumi/issues/2450))
+- Return an error from `pulumi stack tag` commands when using the `--local` mode.
 
 ## 0.16.14 (Released January 31st, 2019)
 

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -544,7 +544,7 @@ func (b *localBackend) GetStackTags(ctx context.Context,
 	stackRef backend.StackReference) (map[apitype.StackTagName]string, error) {
 
 	// The local backend does not currently persist tags.
-	return nil, nil
+	return nil, errors.New("stack tags not supported in --local mode")
 }
 
 // UpdateStackTags updates the stacks's tags, replacing all existing tags.
@@ -552,5 +552,5 @@ func (b *localBackend) UpdateStackTags(ctx context.Context,
 	stackRef backend.StackReference, tags map[apitype.StackTagName]string) error {
 
 	// The local backend does not currently persist tags.
-	return nil
+	return errors.New("stack tags not supported in --local mode")
 }


### PR DESCRIPTION
Instead of operating as no-ops, return an error to make it more clear that these commands are not currently implemented when using --local mode.

Fixes #2456