### PR TITLE
Minor typo & missing args edits

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -45,7 +45,7 @@ func newConfigCmd() *cobra.Command {
 		Use:   "config",
 		Short: "Manage configuration",
 		Long: "Lists all configuration values for a specific stack. To add a new configuration value, run\n" +
-			"'pulumi config set', to remove and existing value run 'pulumi config rm'. To get the value of\n" +
+			"'pulumi config set'. To remove and existing value run 'pulumi config rm'. To get the value of\n" +
 			"for a specific configuration key, use 'pulumi config get <key-name>'.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -51,10 +51,10 @@ func newDestroyCmd() *cobra.Command {
 		Long: "Destroy an existing stack and its resources\n" +
 			"\n" +
 			"This command deletes an entire existing stack by name.  The current state is\n" +
-			"loaded from the associated snapshot file in the workspace.  After running to completion,\n" +
+			"loaded from the associated configuration snapshot file in the workspace.  After running to completion,\n" +
 			"all of this stack's resources and associated state will be gone.\n" +
 			"\n" +
-			"Warning: although old snapshots can be used to recreate a stack, this command\n" +
+			"Warning: although old snapshots can be used to attempt to recreate a stack, this command\n" +
 			"is generally irreversible and should be used with great care.",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -48,10 +48,8 @@ func newRefreshCmd() *cobra.Command {
 		Short: "Refresh the resources in a stack",
 		Long: "Refresh the resources in a stack.\n" +
 			"\n" +
-			"This command compares the current stack's resource state with the state known to exist in\n" +
-			"the actual cloud provider. Any such changes are adopted into the current stack. Note that if\n" +
-			"the program text isn't updated accordingly, subsequent updates may still appear to be out of\n" +
-			"synch with respect to the cloud provider's source of truth.\n" +
+			"This command resets the 'Pulumi.<stack name>.yaml' file to match the snapshot copy from the last\n" +
+			"'pulumi up' command.\n" +
 			"\n" +
 			"The program to run is loaded from the project in the current directory. Use the `-C` or\n" +
 			"`--cwd` flag to use a different directory.",

--- a/cmd/state.go
+++ b/cmd/state.go
@@ -40,7 +40,7 @@ func newStateCmd() *cobra.Command {
 		Short: "Edit the current stack's state",
 		Long: `Edit the current stack's state
 
-Subcommands of this command can be used to surgically edit parts of a stack's state. These can be useful when
+Subcommands of this command can be used to surgically edit parts of a stack's deployment state. These can be useful when
 troubleshooting a stack or when performing specific edits that otherwise would require editing the state file by hand.`,
 		Args: cmdutil.NoArgs,
 	}

--- a/cmd/state_delete.go
+++ b/cmd/state_delete.go
@@ -32,7 +32,7 @@ func newStateDeleteCommand() *cobra.Command {
 	var stack string
 
 	cmd := &cobra.Command{
-		Use:   "delete",
+		Use:   "delete [resource URN]",
 		Short: "Deletes a resource from a stack's state",
 		Long: `Deletes a resource from a stack's state
 

--- a/cmd/state_unprotect.go
+++ b/cmd/state_unprotect.go
@@ -35,7 +35,7 @@ func newStateUnprotectCommand() *cobra.Command {
 	var stack string
 
 	cmd := &cobra.Command{
-		Use:   "unprotect",
+		Use:   "unprotect [resource URN]",
 		Short: "Unprotect resources in a stack's state",
 		Long: `Unprotect resource in a stack's state
 


### PR DESCRIPTION
Fix typos and missing arguments in CLI documentation 