### PR TITLE
Provide opt-out for CLI version checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- When `PULUMI_SKIP_UPDATE_CHECK` is set to `true`, `pulumi` will not warn if it is out of date.
+
 ## 0.16.16 (Released February 24th, 2019)
 
 ### Improvements

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -189,6 +189,10 @@ func NewPulumiCmd() *cobra.Command {
 // checkForUpdate checks to see if the CLI needs to be updated, and if so emits a warning, as well as information
 // as to how it can be upgraded.
 func checkForUpdate() {
+	if cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_UPDATE_CHECK")) {
+		return
+	}
+
 	curVer, err := semver.ParseTolerant(version.Version)
 	if err != nil {
 		glog.V(3).Infof("error parsing current version: %s", err)


### PR DESCRIPTION
This could be useful in CI where you do want to lock to a specific
version and don't want your logs overflowing with notices that
`pulumi` is out of date.