### PR TITLE
Make toString and toJSON internal

### DIFF
--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -126,7 +126,7 @@ export class Output<T> {
      * This will return an Output with the inner computed value and all resources still tracked.
      * See https://pulumi.io/help/outputs for more details
      */
-    public toString(): string {
+    /** @internal */ public toString(): string {
         const errorMessage =
 `Calling [toString] on an [Output<T>] is not supported
 To get the value of an Output<T> as an Output<string> consider either:
@@ -148,7 +148,7 @@ See https://pulumi.io/help/outputs for more details`;
      * This will return an Output with the inner computed value and all resources still tracked.
      * See https://pulumi.io/help/outputs for more details
      */
-    public toJSON(): any {
+    /** @internal */ public toJSON(): any {
         // Note: i've mixed/matched `` and "" strings because I could not find a way to
         // properly embed literals with `` inside another `` string.
         const errorMessage =


### PR DESCRIPTION
This is needed to prevent breakages when different libraries reference different versions of `@pulumi/pulumi`.  We can't have new public members on `Output` (like toJSON), as that makes another Output from a library referencing a prior version incompatible.