### PR TITLE
 Rollback waiting on children of a component when waiting on the component itself.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
-## 0.16.17 (unreleased)
+## 0.16.17 (Released February 27th, 2019)
 
 ### Improvements
 
-- Calling [toString] or [toJSON] on an Output will now throw with a useful error message.
-  This has been a common pain point as it's easy to accidentally try to concat an Output
-  with a string, producing a bogus result, and often leading to lengthy investigations.
+- Rolling back the change:
+    "Depending on a Resource will now depend on all other Resource's parented by that Resource."
+
+  Unforseen problems cropped up that caused deadlocks.  Removing this change until we can
+  have a high quality solution without these issues.
 
 ## 0.16.16 (Released February 24th, 2019)
 

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -35,21 +35,6 @@ export abstract class Resource {
      */
     public readonly urn: Output<URN>;
 
-
-    /**
-     * The optional parent of this resource.
-     */
-    // tslint:disable-next-line:variable-name
-    /* @internal */ public readonly __parentResource: Resource | undefined;
-
-    /**
-     * The child resources of this resource.  Used so that if any resource wants to wait on this
-     * resource being complete, they will logically wait on all our child resources being complete
-     * as well.
-     */
-    // tslint:disable-next-line:variable-name
-    /* @internal */ public __childResources: Set<Resource> | undefined;
-
     /**
      * When set to true, protect ensures this resource cannot be deleted.
      */
@@ -103,10 +88,6 @@ export abstract class Resource {
             if (!Resource.isInstance(opts.parent)) {
                 throw new RunError(`Resource parent is not a valid Resource: ${opts.parent}`);
             }
-
-            this.__parentResource = opts.parent;
-            this.__parentResource.__childResources = this.__parentResource.__childResources || new Set();
-            this.__parentResource.__childResources.add(this);
 
             if (opts.protect === undefined) {
                 opts.protect = opts.parent.__protect;

--- a/sdk/nodejs/tests/runtime/langhost/cases/022.parent_child_dependencies_2/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/022.parent_child_dependencies_2/index.js
@@ -1,0 +1,14 @@
+// Test the ability to invoke provider functions via RPC.
+
+let assert = require("assert");
+let pulumi = require("../../../../../");
+
+class MyResource extends pulumi.CustomResource {
+	constructor(name, args, opts) {
+		super("test:index:MyResource", name, args, opts);
+	}
+}
+
+let resA = new MyResource("resA");
+let resB = new MyResource("resB", { parentId: resA.id }, { parent: resA });
+let resC = new MyResource("resC", { parentId: resA.id }, { parent: resA });

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -604,9 +604,21 @@ describe("rpc", () => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
+        "parent_child_dependencies_2": {
+            pwd: path.join(base, "022.parent_child_dependencies_2"),
+            program: "./index.js",
+            expectResourceCount: 3,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {
+        // if (casename !== "parent_child_dependencies_2") {
+        //     continue;
+        // }
+
         const opts: RunCase = cases[casename];
         it(`run test: ${casename} (pwd=${opts.pwd},prog=${opts.program})`, asyncTest(async () => {
             // For each test case, run it twice: first to preview and then to update.


### PR DESCRIPTION
This causes deadlocks in reasonable code, and customers are hitting this now.  Rolling back until we have confidence we have a solution for this without problems.