### PR TITLE
Converting an Output to a string or JSON now produces a warning .

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Improvements
 
-- Attempting to convert an [Output<T>] to a string or to JSON will not result in a warning
+- Attempting to convert an [Output<T>] to a string or to JSON will now result in a warning
   message being printed, as well as information on how to rectify the situation.  This is
   to help with diagnosing cryptic problems that can occur when Outputs are accidentally
   concatenated into a string in some part of the program.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### Improvements
 
+- Attempting to convert an [Output<T>] to a string or to JSON will not result in a warning
+  message being printed, as well as information on how to rectify the situation.  This is
+  to help with diagnosing cryptic problems that can occur when Outputs are accidentally
+  concatenated into a string in some part of the program.
+
 ## 0.16.17 (Released February 27th, 2019)
 
 ### Improvements

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -126,7 +126,7 @@ export class Output<T> {
      * This will return an Output with the inner computed value and all resources still tracked.
      * See https://pulumi.io/help/outputs for more details
      */
-    public toString(): string {
+    /** @internal */ public toString(): string {
         const errorMessage =
 `Calling [toString] on an [Output<T>] is not supported
 To get the value of an Output<T> as an Output<string> consider either:
@@ -148,7 +148,7 @@ See https://pulumi.io/help/outputs for more details`;
      * This will return an Output with the inner computed value and all resources still tracked.
      * See https://pulumi.io/help/outputs for more details
      */
-    public toJSON(): any {
+    /** @internal */ public toJSON(): any {
         // Note: i've mixed/matched `` and "" strings because I could not find a way to
         // properly embed literals with `` inside another `` string.
         const errorMessage =

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -166,11 +166,14 @@ export class Output<T> {
 
         this.toString = () => {
             const message =
-`Calling [toString] on an [Output<T>] is not supported
+`Calling [toString] on an [Output<T>] is not supported.
+
 To get the value of an Output<T> as an Output<string> consider either:
 1: o.apply(v => \`prefix\${v}suffix\`)
 2: pulumi.interpolate \`prefix\${v}suffix\`
-See https://pulumi.io/help/outputs for more details`;
+
+See https://pulumi.io/help/outputs for more details.
+This function may throw in a future version of @pulumi/pulumi.`;
             log.warn(message, firstResource);
             return message;
         };
@@ -178,10 +181,13 @@ See https://pulumi.io/help/outputs for more details`;
         this.toJSON = () => {
             const message =
 `Calling [toJSON] on an [Output<T>] is not supported.
+
 To get the value of an Output as a JSON value or JSON string consider either:
     1: o.apply(v => v.toJSON())
     2: o.apply(v => JSON.stringify(v))
-See https://pulumi.io/help/outputs for more details`;
+
+See https://pulumi.io/help/outputs for more details.
+This function may throw in a future version of @pulumi/pulumi.`;
             log.warn(message, firstResource);
             return message;
         };

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -124,15 +124,14 @@ export class Output<T> {
      * 2. `pulumi.interpolate ``prefix${v}suffix`` `
      *
      * This will return an Output with the inner computed value and all resources still tracked.
-     * See https://pulumi.io/help/outputs for more details
      */
     public toString(): string {
         const errorMessage =
-`Calling [toString] on an [Output<T>] is not supported
+`Calling [toString] on an [Output<T>] is not supported.
 To get the value of an Output<T> as an Output<string> consider either:
   1: o.apply(v => \`prefix\${v}suffix\`)
   2: pulumi.interpolate \`prefix\${v}suffix\`
-See https://pulumi.io/help/outputs for more details`;
+This will return an Output with the inner computed value and all resources still tracked.`;
         throw new Error(errorMessage);
     }
 
@@ -146,7 +145,6 @@ See https://pulumi.io/help/outputs for more details`;
      * 2. `o.apply(v => JSON.stringify(v))`
      *
      * This will return an Output with the inner computed value and all resources still tracked.
-     * See https://pulumi.io/help/outputs for more details
      */
     public toJSON(): any {
         // Note: i've mixed/matched `` and "" strings because I could not find a way to
@@ -156,7 +154,7 @@ See https://pulumi.io/help/outputs for more details`;
 To get the value of an Output as a JSON value or JSON string consider either:
   1: o.apply(v => v.toJSON())
   2: o.apply(v => JSON.stringify(v))
-See https://pulumi.io/help/outputs for more details`;
+This will return an Output with the inner computed value and all resources still tracked.`;
         throw new Error(errorMessage);
     }
 

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -114,50 +114,6 @@ export class Output<T> {
         return obj && obj.__pulumiOutput ? true : false;
     }
 
-    /**
-     * [toString] on an [Output<T>] is not supported.  This is because the value an [Output] points
-     * to is asynchronously computed (and thus, this is akin to calling [toString] on a [Promise]).
-     * As such, this method only throws if called.
-     *
-     * To get the value of an Output<T> as an Output<string> consider either:
-     * 1. `o.apply(v => ``prefix${v}suffix``)` or
-     * 2. `pulumi.interpolate ``prefix${v}suffix`` `
-     *
-     * This will return an Output with the inner computed value and all resources still tracked.
-     */
-    public toString(): string {
-        const errorMessage =
-`Calling [toString] on an [Output<T>] is not supported.
-To get the value of an Output<T> as an Output<string> consider either:
-  1: o.apply(v => \`prefix\${v}suffix\`)
-  2: pulumi.interpolate \`prefix\${v}suffix\`
-This will return an Output with the inner computed value and all resources still tracked.`;
-        throw new Error(errorMessage);
-    }
-
-    /**
-     * [toJSON] on an [Output<T>] is not supported.  This is because the value an [Output] points
-     * to is asynchronously computed (and thus, this is akin to calling [toJSON] on a [Promise]).
-     * As such, this method only throws if called.
-     *
-     * To get the value of an Output as a JSON value or JSON string consider either:
-     * 1. `o.apply(v => v.toJSON())` or
-     * 2. `o.apply(v => JSON.stringify(v))`
-     *
-     * This will return an Output with the inner computed value and all resources still tracked.
-     */
-    public toJSON(): any {
-        // Note: i've mixed/matched `` and "" strings because I could not find a way to
-        // properly embed literals with `` inside another `` string.
-        const errorMessage =
-`Calling [toJSON] on an [Output<T>] is not supported.
-To get the value of an Output as a JSON value or JSON string consider either:
-  1: o.apply(v => v.toJSON())
-  2: o.apply(v => JSON.stringify(v))
-This will return an Output with the inner computed value and all resources still tracked.`;
-        throw new Error(errorMessage);
-    }
-
     /* @internal */ public constructor(
             resources: Set<Resource> | Resource[] | Resource, promise: Promise<T>, isKnown: Promise<boolean>) {
         this.isKnown = isKnown;

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -126,7 +126,7 @@ export class Output<T> {
      * This will return an Output with the inner computed value and all resources still tracked.
      * See https://pulumi.io/help/outputs for more details
      */
-    /** @internal */ public toString(): string {
+    public toString(): string {
         const errorMessage =
 `Calling [toString] on an [Output<T>] is not supported
 To get the value of an Output<T> as an Output<string> consider either:
@@ -148,7 +148,7 @@ See https://pulumi.io/help/outputs for more details`;
      * This will return an Output with the inner computed value and all resources still tracked.
      * See https://pulumi.io/help/outputs for more details
      */
-    /** @internal */ public toJSON(): any {
+    public toJSON(): any {
         // Note: i've mixed/matched `` and "" strings because I could not find a way to
         // properly embed literals with `` inside another `` string.
         const errorMessage =

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -114,6 +114,50 @@ export class Output<T> {
         return obj && obj.__pulumiOutput ? true : false;
     }
 
+    /**
+     * [toString] on an [Output<T>] is not supported.  This is because the value an [Output] points
+     * to is asynchronously computed (and thus, this is akin to calling [toString] on a [Promise]).
+     * As such, this method only throws if called.
+     *
+     * To get the value of an Output<T> as an Output<string> consider either:
+     * 1. `o.apply(v => ``prefix${v}suffix``)` or
+     * 2. `pulumi.interpolate ``prefix${v}suffix`` `
+     *
+     * This will return an Output with the inner computed value and all resources still tracked.
+     */
+    public toString(): string {
+        const errorMessage =
+`Calling [toString] on an [Output<T>] is not supported.
+To get the value of an Output<T> as an Output<string> consider either:
+  1: o.apply(v => \`prefix\${v}suffix\`)
+  2: pulumi.interpolate \`prefix\${v}suffix\`
+This will return an Output with the inner computed value and all resources still tracked.`;
+        throw new Error(errorMessage);
+    }
+
+    /**
+     * [toJSON] on an [Output<T>] is not supported.  This is because the value an [Output] points
+     * to is asynchronously computed (and thus, this is akin to calling [toJSON] on a [Promise]).
+     * As such, this method only throws if called.
+     *
+     * To get the value of an Output as a JSON value or JSON string consider either:
+     * 1. `o.apply(v => v.toJSON())` or
+     * 2. `o.apply(v => JSON.stringify(v))`
+     *
+     * This will return an Output with the inner computed value and all resources still tracked.
+     */
+    public toJSON(): any {
+        // Note: i've mixed/matched `` and "" strings because I could not find a way to
+        // properly embed literals with `` inside another `` string.
+        const errorMessage =
+`Calling [toJSON] on an [Output<T>] is not supported.
+To get the value of an Output as a JSON value or JSON string consider either:
+  1: o.apply(v => v.toJSON())
+  2: o.apply(v => JSON.stringify(v))
+This will return an Output with the inner computed value and all resources still tracked.`;
+        throw new Error(errorMessage);
+    }
+
     /* @internal */ public constructor(
             resources: Set<Resource> | Resource[] | Resource, promise: Promise<T>, isKnown: Promise<boolean>) {
         this.isKnown = isKnown;

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -124,14 +124,15 @@ export class Output<T> {
      * 2. `pulumi.interpolate ``prefix${v}suffix`` `
      *
      * This will return an Output with the inner computed value and all resources still tracked.
+     * See https://pulumi.io/help/outputs for more details
      */
     public toString(): string {
         const errorMessage =
-`Calling [toString] on an [Output<T>] is not supported.
+`Calling [toString] on an [Output<T>] is not supported
 To get the value of an Output<T> as an Output<string> consider either:
   1: o.apply(v => \`prefix\${v}suffix\`)
   2: pulumi.interpolate \`prefix\${v}suffix\`
-This will return an Output with the inner computed value and all resources still tracked.`;
+See https://pulumi.io/help/outputs for more details`;
         throw new Error(errorMessage);
     }
 
@@ -145,6 +146,7 @@ This will return an Output with the inner computed value and all resources still
      * 2. `o.apply(v => JSON.stringify(v))`
      *
      * This will return an Output with the inner computed value and all resources still tracked.
+     * See https://pulumi.io/help/outputs for more details
      */
     public toJSON(): any {
         // Note: i've mixed/matched `` and "" strings because I could not find a way to
@@ -154,7 +156,7 @@ This will return an Output with the inner computed value and all resources still
 To get the value of an Output as a JSON value or JSON string consider either:
   1: o.apply(v => v.toJSON())
   2: o.apply(v => JSON.stringify(v))
-This will return an Output with the inner computed value and all resources still tracked.`;
+See https://pulumi.io/help/outputs for more details`;
         throw new Error(errorMessage);
     }
 

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -162,8 +162,10 @@ export class Output<T> {
             resourcesArray = [resources];
         }
 
-        const firstResource = resourcesArray[0];
+        this.resources = () => new Set<Resource>(resourcesArray);
+        this.promise = () => promise;
 
+        const firstResource = resourcesArray[0];
         this.toString = () => {
             const message =
 `Calling [toString] on an [Output<T>] is not supported.
@@ -191,9 +193,6 @@ This function may throw in a future version of @pulumi/pulumi.`;
             log.warn(message, firstResource);
             return message;
         };
-
-        this.resources = () => new Set<Resource>(resourcesArray);
-        this.promise = () => promise;
 
         this.apply = <U>(func: (t: T) => Input<U>) => {
             let innerIsKnownResolve: (val: boolean) => void;

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as log from "./log";
 import { Resource } from "./resource";
 import * as runtime from "./runtime";
 
@@ -94,6 +95,38 @@ export class Output<T> {
      */
     public readonly get: () => T;
 
+    /**
+     * [toString] on an [Output<T>] is not supported.  This is because the value an [Output] points
+     * to is asynchronously computed (and thus, this is akin to calling [toString] on a [Promise]).
+     *
+     * Calling this will simply return useful text about the issue, and will log a warning. In a
+     * future version of `@pulumi/pulumi` this will be changed to throw an error when this occurs.
+     *
+     * To get the value of an Output<T> as an Output<string> consider either:
+     * 1. `o.apply(v => ``prefix${v}suffix``)` or
+     * 2. `pulumi.interpolate ``prefix${v}suffix`` `
+     *
+     * This will return an Output with the inner computed value and all resources still tracked. See
+     * https://pulumi.io/help/outputs for more details
+     */
+    /** @internal */ public toString: () => string;
+
+    /**
+     * [toJSON] on an [Output<T>] is not supported.  This is because the value an [Output] points
+     * to is asynchronously computed (and thus, this is akin to calling [toJSON] on a [Promise]).
+     *
+     * Calling this will simply return useful text about the issue, and will log a warning. In a
+     * future version of `@pulumi/pulumi` this will be changed to throw an error when this occurs.
+     *
+     * To get the value of an Output as a JSON value or JSON string consider either:
+     * 1. `o.apply(v => v.toJSON())` or
+     * 2. `o.apply(v => JSON.stringify(v))`
+     *
+     * This will return an Output with the inner computed value and all resources still tracked.
+     * See https://pulumi.io/help/outputs for more details
+     */
+    /** @internal */ public toJSON: () => any;
+
     // Statics
 
     /**
@@ -114,65 +147,46 @@ export class Output<T> {
         return obj && obj.__pulumiOutput ? true : false;
     }
 
-    /**
-     * [toString] on an [Output<T>] is not supported.  This is because the value an [Output] points
-     * to is asynchronously computed (and thus, this is akin to calling [toString] on a [Promise]).
-     * As such, this method only throws if called.
-     *
-     * To get the value of an Output<T> as an Output<string> consider either:
-     * 1. `o.apply(v => ``prefix${v}suffix``)` or
-     * 2. `pulumi.interpolate ``prefix${v}suffix`` `
-     *
-     * This will return an Output with the inner computed value and all resources still tracked.
-     * See https://pulumi.io/help/outputs for more details
-     */
-    /** @internal */ public toString(): string {
-        const errorMessage =
-`Calling [toString] on an [Output<T>] is not supported
-To get the value of an Output<T> as an Output<string> consider either:
-  1: o.apply(v => \`prefix\${v}suffix\`)
-  2: pulumi.interpolate \`prefix\${v}suffix\`
-See https://pulumi.io/help/outputs for more details`;
-        throw new Error(errorMessage);
-    }
-
-    /**
-     * [toJSON] on an [Output<T>] is not supported.  This is because the value an [Output] points
-     * to is asynchronously computed (and thus, this is akin to calling [toJSON] on a [Promise]).
-     * As such, this method only throws if called.
-     *
-     * To get the value of an Output as a JSON value or JSON string consider either:
-     * 1. `o.apply(v => v.toJSON())` or
-     * 2. `o.apply(v => JSON.stringify(v))`
-     *
-     * This will return an Output with the inner computed value and all resources still tracked.
-     * See https://pulumi.io/help/outputs for more details
-     */
-    /** @internal */ public toJSON(): any {
-        // Note: i've mixed/matched `` and "" strings because I could not find a way to
-        // properly embed literals with `` inside another `` string.
-        const errorMessage =
-`Calling [toJSON] on an [Output<T>] is not supported.
-To get the value of an Output as a JSON value or JSON string consider either:
-  1: o.apply(v => v.toJSON())
-  2: o.apply(v => JSON.stringify(v))
-See https://pulumi.io/help/outputs for more details`;
-        throw new Error(errorMessage);
-    }
-
     /* @internal */ public constructor(
             resources: Set<Resource> | Resource[] | Resource, promise: Promise<T>, isKnown: Promise<boolean>) {
         this.isKnown = isKnown;
 
+        let resourcesArray: Resource[];
+
         // Always create a copy so that no one accidentally modifies our Resource list.
         if (Array.isArray(resources)) {
-            this.resources = () => new Set<Resource>(resources);
+            resourcesArray = resources;
         } else if (resources instanceof Set) {
-            this.resources = () => new Set<Resource>(resources);
+            resourcesArray = [...resources];
         } else {
-            this.resources = () => new Set<Resource>([resources]);
+            resourcesArray = [resources];
         }
 
+        const firstResource = resourcesArray[0];
+
+        this.toString = () => {
+            const message =
+`Calling [toString] on an [Output<T>] is not supported
+To get the value of an Output<T> as an Output<string> consider either:
+1: o.apply(v => \`prefix\${v}suffix\`)
+2: pulumi.interpolate \`prefix\${v}suffix\`
+See https://pulumi.io/help/outputs for more details`;
+            log.warn(message, firstResource);
+            return message;
+        };
+
+        this.toJSON = () => {
+            const message =
+`Calling [toJSON] on an [Output<T>] is not supported.
+To get the value of an Output as a JSON value or JSON string consider either:
+    1: o.apply(v => v.toJSON())
+    2: o.apply(v => JSON.stringify(v))
+See https://pulumi.io/help/outputs for more details`;
+            log.warn(message, firstResource);
+            return message;
+        };
+
+        this.resources = () => new Set<Resource>(resourcesArray);
         this.promise = () => promise;
 
         this.apply = <U>(func: (t: T) => Input<U>) => {

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -193,10 +193,6 @@ class SerializedOutput<T> implements Output<T> {
     /* @internal */ public isKnown: Promise<boolean>;
     /* @internal */ public readonly promise: () => Promise<T>;
     /* @internal */ public readonly resources: () => Set<resource.Resource>;
-
-    /* @internal */ public readonly toString: () => string;
-    /* @internal */ public readonly toJSON: () => any;
-
     /* @internal */ private readonly value: T;
 
     public constructor(value: T) {

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -193,6 +193,10 @@ class SerializedOutput<T> implements Output<T> {
     /* @internal */ public isKnown: Promise<boolean>;
     /* @internal */ public readonly promise: () => Promise<T>;
     /* @internal */ public readonly resources: () => Set<resource.Resource>;
+
+    /* @internal */ public readonly toString: () => string;
+    /* @internal */ public readonly toJSON: () => any;
+
     /* @internal */ private readonly value: T;
 
     public constructor(value: T) {

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -65,7 +65,7 @@ export function readResource(res: Resource, t: string, name: string, props: Inpu
     }
 
     const label = `resource:${name}[${t}]#...`;
-    log.debug(`Reading resource: id=${Output.isInstance(id) ? "Output<T>" : id}, t=${t}, name=${name}`);
+    log.debug(`Reading resource: id=${id}, t=${t}, name=${name}`);
 
     const monitor: any = getMonitor();
     const resopAsync = prepareResource(label, res, true, props, opts);

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -65,7 +65,7 @@ export function readResource(res: Resource, t: string, name: string, props: Inpu
     }
 
     const label = `resource:${name}[${t}]#...`;
-    log.debug(`Reading resource: id=${id}, t=${t}, name=${name}`);
+    log.debug(`Reading resource: id=${Output.isInstance(id) ? "Output<T>" : id}, t=${t}, name=${name}`);
 
     const monitor: any = getMonitor();
     const resopAsync = prepareResource(label, res, true, props, opts);

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -56,15 +56,14 @@ export function transferProperties(onto: Resource, label: string, props: Inputs)
             resolveIsKnown(isKnown);
         };
 
-        const propString = Output.isInstance(props[k]) ? "Output<T>" : `${props[k]}`;
         (<any>onto)[k] = new Output(
             onto,
             debuggablePromise(
                 new Promise<any>(resolve => resolveValue = resolve),
-                `transferProperty(${label}, ${k}, ${propString})`),
+                `transferProperty(${label}, ${k}, ${props[k]})`),
             debuggablePromise(
                 new Promise<boolean>(resolve => resolveIsKnown = resolve),
-                `transferIsStable(${label}, ${k}, ${propString})`));
+                `transferIsStable(${label}, ${k}, ${props[k]})`));
     }
 
     return resolvers;

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -56,14 +56,15 @@ export function transferProperties(onto: Resource, label: string, props: Inputs)
             resolveIsKnown(isKnown);
         };
 
+        const propString = Output.isInstance(props[k]) ? "Output<T>" : `${props[k]}`;
         (<any>onto)[k] = new Output(
             onto,
             debuggablePromise(
                 new Promise<any>(resolve => resolveValue = resolve),
-                `transferProperty(${label}, ${k}, ${props[k]})`),
+                `transferProperty(${label}, ${k}, ${propString})`),
             debuggablePromise(
                 new Promise<boolean>(resolve => resolveIsKnown = resolve),
-                `transferIsStable(${label}, ${k}, ${props[k]})`));
+                `transferIsStable(${label}, ${k}, ${propString})`));
     }
 
     return resolvers;

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -20,53 +20,53 @@ import * as runtime from "../runtime";
 import { asyncTest } from "./util";
 
 describe("output", () => {
-    it("throws on toString in string concat", () => {
-        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
-        try {
-            const str = "" + output;
-        }
-        catch (e) {
-            return;
-        }
+    // it("throws on toString in string concat", () => {
+    //     const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+    //     try {
+    //         const str = "" + output;
+    //     }
+    //     catch (e) {
+    //         return;
+    //     }
 
-        throw new Error("Should have gotten error above!");
-    });
+    //     throw new Error("Should have gotten error above!");
+    // });
 
-    it("throws on toString in normal interpolation", () => {
-        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
-        try {
-            const str = `${output}`;
-        }
-        catch (e) {
-            return;
-        }
+    // it("throws on toString in normal interpolation", () => {
+    //     const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+    //     try {
+    //         const str = `${output}`;
+    //     }
+    //     catch (e) {
+    //         return;
+    //     }
 
-        throw new Error("Should have gotten error above!");
-    });
+    //     throw new Error("Should have gotten error above!");
+    // });
 
-    it("throws on JSON.stringify", () => {
-        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
-        try {
-            const str = JSON.stringify(output);
-        }
-        catch (e) {
-            return;
-        }
+    // it("throws on JSON.stringify", () => {
+    //     const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+    //     try {
+    //         const str = JSON.stringify(output);
+    //     }
+    //     catch (e) {
+    //         return;
+    //     }
 
-        throw new Error("Should have gotten error above!");
-    });
+    //     throw new Error("Should have gotten error above!");
+    // });
 
-    it("throws on JSON.stringify even when nested", () => {
-        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
-        try {
-            const str = JSON.stringify({ o: output });
-        }
-        catch (e) {
-            return;
-        }
+    // it("throws on JSON.stringify even when nested", () => {
+    //     const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+    //     try {
+    //         const str = JSON.stringify({ o: output });
+    //     }
+    //     catch (e) {
+    //         return;
+    //     }
 
-        throw new Error("Should have gotten error above!");
-    });
+    //     throw new Error("Should have gotten error above!");
+    // });
 
     it("propagates true isKnown bit from inner Output", asyncTest(async () => {
         runtime.setIsDryRun(true);

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -20,6 +20,54 @@ import * as runtime from "../runtime";
 import { asyncTest } from "./util";
 
 describe("output", () => {
+    it("throws on toString in string concat", () => {
+        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+        try {
+            const str = "" + output;
+        }
+        catch (e) {
+            return;
+        }
+
+        throw new Error("Should have gotten error above!");
+    });
+
+    it("throws on toString in normal interpolation", () => {
+        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+        try {
+            const str = `${output}`;
+        }
+        catch (e) {
+            return;
+        }
+
+        throw new Error("Should have gotten error above!");
+    });
+
+    it("throws on JSON.stringify", () => {
+        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+        try {
+            const str = JSON.stringify(output);
+        }
+        catch (e) {
+            return;
+        }
+
+        throw new Error("Should have gotten error above!");
+    });
+
+    it("throws on JSON.stringify even when nested", () => {
+        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
+        try {
+            const str = JSON.stringify({ o: output });
+        }
+        catch (e) {
+            return;
+        }
+
+        throw new Error("Should have gotten error above!");
+    });
+
     it("propagates true isKnown bit from inner Output", asyncTest(async () => {
         runtime.setIsDryRun(true);
 

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -20,54 +20,6 @@ import * as runtime from "../runtime";
 import { asyncTest } from "./util";
 
 describe("output", () => {
-    it("throws on toString in string concat", () => {
-        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
-        try {
-            const str = "" + output;
-        }
-        catch (e) {
-            return;
-        }
-
-        throw new Error("Should have gotten error above!");
-    });
-
-    it("throws on toString in normal interpolation", () => {
-        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
-        try {
-            const str = `${output}`;
-        }
-        catch (e) {
-            return;
-        }
-
-        throw new Error("Should have gotten error above!");
-    });
-
-    it("throws on JSON.stringify", () => {
-        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
-        try {
-            const str = JSON.stringify(output);
-        }
-        catch (e) {
-            return;
-        }
-
-        throw new Error("Should have gotten error above!");
-    });
-
-    it("throws on JSON.stringify even when nested", () => {
-        const output = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
-        try {
-            const str = JSON.stringify({ o: output });
-        }
-        catch (e) {
-            return;
-        }
-
-        throw new Error("Should have gotten error above!");
-    });
-
     it("propagates true isKnown bit from inner Output", asyncTest(async () => {
         runtime.setIsDryRun(true);
 

--- a/sdk/nodejs/tests/runtime/tsClosureCases.ts
+++ b/sdk/nodejs/tests/runtime/tsClosureCases.ts
@@ -5044,10 +5044,10 @@ return function () { typescript.parseCommandLine([""]); };
 
 function 'func': tsClosureCases.js(0,0): captured
   module './bin/index.js' which indirectly referenced
-    function 'debug':(...)
-      module './bin/runtime/settings.js' which indirectly referenced
-        function 'getEngine':(...)
-          module './bin/proto/engine_grpc_pb.js' which indirectly referenced
+    function 'Output':(...)
+      module './bin/log/index.js' which indirectly referenced
+        function 'warn':(...)
+          module './bin/runtime/settings.js' which indirectly referenced
 (...)
 Function code:
 (...)
@@ -5485,7 +5485,7 @@ return function () { console.log(regex); foo(); };
             return;
         }
 
-        // if (test.title !== "Output capture") {
+        // if (test.title !== "Fail to capture non-deployment module due to native code") {
         //     continue;
         // }
 


### PR DESCRIPTION
Helper text is also provided informing the user on how to deal with this.