### PR TITLE
Turn off warning for toString/toJSON on an Output

### DIFF
--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -177,7 +177,6 @@ To get the value of an Output<T> as an Output<string> consider either:
 
 See https://pulumi.io/help/outputs for more details.
 This function may throw in a future version of @pulumi/pulumi.`;
-            log.warn(message, firstResource);
             return message;
         };
 
@@ -191,7 +190,6 @@ To get the value of an Output as a JSON value or JSON string consider either:
 
 See https://pulumi.io/help/outputs for more details.
 This function may throw in a future version of @pulumi/pulumi.`;
-            log.warn(message, firstResource);
             return message;
         };
 

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as log from "./log";
 import { Resource } from "./resource";
 import * as runtime from "./runtime";
 import * as utils from "./utils";

--- a/sdk/nodejs/tests/runtime/tsClosureCases.ts
+++ b/sdk/nodejs/tests/runtime/tsClosureCases.ts
@@ -5360,10 +5360,10 @@ return function () { typescript.parseCommandLine([""]); };
 
 function 'func': tsClosureCases.js(0,0): captured
   module './bin/index.js' which indirectly referenced
-    function 'Output':(...)
-      module './bin/log/index.js' which indirectly referenced
-        function 'warn':(...)
-          module './bin/runtime/settings.js' which indirectly referenced
+    function 'debug':(...)
+      module './bin/runtime/settings.js' which indirectly referenced
+        function 'getEngine':(...)
+          module './bin/proto/engine_grpc_pb.js' which indirectly referenced
 (...)
 Function code:
 (...)


### PR DESCRIPTION
This affects people running against earlier versions of `@pulumi/pulumi`.  We only want to turn this on once we also have the check turned on that you are not mixing/matching minor version of Pulumi.