### PR TITLE
Allow depending on a component to mean you depend on it's transitively reachable custom resource children. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Improvements
 
+- Depending on a ComponentResource will now depend on all other Resource's parented by that Resource.
+  This will help out the programming model for Component Resources as your consumers can just
+  depend on a Component instead of having to know to depend on all its children.
+
 ## 0.16.18 (Released March 1, 2019)
 
 - Fix an issue where the Pulumi CLI would load the newest plugin for a resource provider instead of the version that was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Improvements
 
+- Depending on a **Component** Resource will now depend on all other Resource's parented by that
+  Resource. This will help out the programming model for Component Resources as your consumers can
+  just depend on a Component and have that automatically depend on all the child Resources created
+  by that Component.  Note: this does not apply to a **Custom** resource.  Depending on a
+  CustomResource will still only wait on that single resource being created, not any other
+  Resources that consider that CustomResource to be a parent.
+
 ## 0.16.17 (Released February 27th, 2019)
 
 ### Improvements

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -30,6 +30,20 @@ export abstract class Resource {
      /* @internal */ private readonly __pulumiResource: boolean = true;
 
     /**
+     * The parent of this Resource, if and only if it is a [ComponentResource].  This allows us to
+     * form a tree that has the following properties:
+     *
+     * 1. All non-leaf nodes are ComponentResources.
+     * 2. All leaf nodes are CustomResources.  Technically, you could have a leaf Component, but
+     *    that should be very rare, and can be thought of as a non-leaf node component with 0 leaf
+     *    CustomResources.
+     *
+     * Now, when any node has a dependency on another node, 
+     */
+     // tslint:disable-next-line:variable-name
+     /* @internal */ private readonly __parentComponentResource: ComponentResource;
+
+    /**
      * urn is the stable logical URN used to distinctly address a resource, both before and after
      * deployments.
      */

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -48,7 +48,7 @@ export abstract class Resource {
     /* @internal */ private readonly __providers: Record<string, ProviderResource>;
 
     public static isInstance(obj: any): obj is Resource {
-        return obj && obj.__pulumiResource;
+        return obj && (<Resource>obj).__pulumiResource === true;
     }
 
     // getProvider fetches the provider for the given module member, if any.
@@ -211,7 +211,7 @@ export abstract class CustomResource extends Resource {
      * multiple copies of the Pulumi SDK have been loaded into the same process.
      */
     public static isInstance(obj: any): obj is CustomResource {
-        return obj && obj.__pulumiCustomResource;
+        return obj && (<CustomResource>obj).__pulumiCustomResource === true;
     }
 
     /**
@@ -263,6 +263,20 @@ export abstract class ProviderResource extends CustomResource {
  */
 export class ComponentResource extends Resource {
     /**
+     * A private field to help with RTTI that works in SxS scenarios.
+     */
+    // tslint:disable-next-line:variable-name
+    /* @internal */ private readonly __pulumiComponentResource: boolean;
+
+    /**
+     * Returns true if the given object is an instance of CustomResource.  This is designed to work even when
+     * multiple copies of the Pulumi SDK have been loaded into the same process.
+     */
+    public static isInstance(obj: any): obj is ComponentResource {
+        return obj && (<ComponentResource>obj).__pulumiComponentResource === true;
+    }
+
+    /**
      * Creates and registers a new component resource.  [type] is the fully qualified type token and
      * [name] is the "name" part to use in creating a stable and globally unique URN for the object.
      * [opts.parent] is the optional parent for this component, and [opts.dependsOn] is an optional
@@ -289,6 +303,7 @@ export class ComponentResource extends Resource {
         // not correspond to a real piece of cloud infrastructure.  As such, changes to it *itself*
         // do not have any effect on the cloud side of things at all.
         super(type, name, /*custom:*/ false, /*props:*/ {}, opts);
+        this.__pulumiComponentResource = true;
     }
 
     // registerOutputs registers synthetic outputs that a component has initialized, usually by

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -58,8 +58,8 @@ export abstract class Resource {
      * will walk to the children and wait on them.  This will mean it will wait on 'c3'.  But 'c3'
      * will be waiting in the same manner on 'c2', and a cycle forms.
      *
-     * This cannot happen with ComponentResources as they do not have any data flowing into them.
-     * The only way you would be able to have a problem is if you had this very specific coding
+     * This normally does not happen with ComponentResources as they do not have any data flowing
+     * into them. The only way you would be able to have a problem is if you had this sort of coding
      * pattern:
      *
      * ```ts

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -15,7 +15,7 @@
 import * as grpc from "grpc";
 import * as log from "../log";
 import { Input, Inputs, Output } from "../output";
-import { CustomResourceOptions, ID, Resource, ResourceOptions, URN } from "../resource";
+import { ComponentResource, CustomResource, CustomResourceOptions, ID, Resource, ResourceOptions, URN } from "../resource";
 import { debuggablePromise } from "./debuggable";
 
 import {
@@ -47,10 +47,12 @@ interface ResourceResolverOperation {
     providerRef: string | undefined;
     // All serialized properties, fully awaited, serialized, and ready to go.
     serializedProps: Record<string, any>;
-    // A set of URNs that this resource is directly dependent upon.
+    // A set of URNs that this resource is directly dependent upon.  These will all be URNs of
+    // custom resources, not component resources.
     allDirectDependencyURNs: Set<URN>;
-    // Set of URNs that this resource is directly dependent upon, keyed by the property that
-    // causes the dependency.  All urns in this map must exist in [allDirectDependencyURNs]
+    // Set of URNs that this resource is directly dependent upon, keyed by the property that causes
+    // the dependency.  All urns in this map must exist in [allDirectDependencyURNs].  These will
+    // all be URNs of custom resources, not component resources.
     propertyToDirectDependencyURNs: Map<string, Set<URN>>;
 }
 
@@ -258,16 +260,34 @@ async function prepareResource(label: string, res: Resource, custom: boolean,
     // The list of all dependencies (implicit or explicit).
     const allDirectDependencies = new Set<Resource>(explicitDirectDependencies);
 
-    const allDirectDependencyURNs = await getResourceURNs(explicitDirectDependencies);
+    const allDirectDependencyURNs = await getCustomResourceURNs(explicitDirectDependencies);
     const propertyToDirectDependencyURNs = new Map<string, Set<URN>>();
 
     for (const [propertyName, directDependencies] of propertyToDirectDependencies) {
         addAll(allDirectDependencies, directDependencies);
 
-        const urns = await getResourceURNs(directDependencies);
+        const urns = await getCustomResourceURNs(directDependencies);
         addAll(allDirectDependencyURNs, urns);
         propertyToDirectDependencyURNs.set(propertyName, urns);
     }
+
+    // Now, transitively walk through **Component** resources, collecting any of their
+    // child resources.  This way, a Component acts as an aggregation really of all the
+    // reachable custom resources it parents.  This walking will transitively walk through
+    // other child ComponentResources, but will stop when it hits custom resources.  in
+    // other words, if we had:
+    //
+    //              Comp1
+    //              /   \
+    //          Cust1   Comp2
+    //                  /   \
+    //              Cust2   Cust3
+    //              /
+    //          Cust4
+    //
+    // Then the transitively reachable custom resources of Comp1 will be [Cust1, Cust2, Cust3].
+    // It will *not* include `Cust4`.
+    await getCustomResourceURNs(getTransitivelyReferencedChildResourceOfComponentResources(allDirectDependencies));
 
     return {
         resolveURN: resolveURN!,
@@ -287,13 +307,40 @@ function addAll<T>(to: Set<T>, from: Set<T>) {
     }
 }
 
-async function getResourceURNs(resources: Set<Resource>) {
+async function getCustomResourceURNs(resources: Set<Resource>) {
     const result = new Set<URN>();
     for (const resource of resources) {
-        result.add(await resource.urn.promise());
+        if (CustomResource.isInstance(resource)) {
+            result.add(await resource.urn.promise());
+        }
     }
 
     return result;
+}
+
+/**
+ * Recursively walk the resources passed in, returning them and all resources reachable from
+ * [Resource.__childResources] through any **Component** resources we encounter.
+ */
+function getTransitivelyReferencedChildResourceOfComponentResources(resources: Set<Resource>) {
+    // Recursively walk the dependent resources through their children, adding them to the result set.
+    const result = new Set<Resource>();
+    addTransitivelyReferencedChildResourceOfComponentResources(resources, result);
+    return result;
+}
+
+function addTransitivelyReferencedChildResourceOfComponentResources(resources: Set<Resource> | undefined, result: Set<Resource>) {
+    if (resources) {
+        for (const resource of resources) {
+            if (!result.has(resource)) {
+                result.add(resource);
+
+                if (ComponentResource.isInstance(resource)) {
+                    addTransitivelyReferencedChildResourceOfComponentResources(resource.__childResources, result);
+                }
+            }
+        }
+    }
 }
 
 /**

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -260,13 +260,13 @@ async function prepareResource(label: string, res: Resource, custom: boolean,
     // The list of all dependencies (implicit or explicit).
     const allDirectDependencies = new Set<Resource>(explicitDirectDependencies);
 
-    const allDirectDependencyURNs = await getCustomResourceURNs(explicitDirectDependencies);
+    const allDirectDependencyURNs = await filterToCustomResourcesAndGetURNs(explicitDirectDependencies);
     const propertyToDirectDependencyURNs = new Map<string, Set<URN>>();
 
     for (const [propertyName, directDependencies] of propertyToDirectDependencies) {
         addAll(allDirectDependencies, directDependencies);
 
-        const urns = await getCustomResourceURNs(directDependencies);
+        const urns = await filterToCustomResourcesAndGetURNs(directDependencies);
         addAll(allDirectDependencyURNs, urns);
         propertyToDirectDependencyURNs.set(propertyName, urns);
     }
@@ -287,7 +287,7 @@ async function prepareResource(label: string, res: Resource, custom: boolean,
     //
     // Then the transitively reachable custom resources of Comp1 will be [Cust1, Cust2, Cust3].
     // It will *not* include `Cust4`.
-    await getCustomResourceURNs(getTransitivelyReferencedChildResourceOfComponentResources(allDirectDependencies));
+    await filterToCustomResourcesAndGetURNs(getTransitivelyReferencedChildResourceOfComponentResources(allDirectDependencies));
 
     return {
         resolveURN: resolveURN!,
@@ -307,7 +307,7 @@ function addAll<T>(to: Set<T>, from: Set<T>) {
     }
 }
 
-async function getCustomResourceURNs(resources: Set<Resource>) {
+async function filterToCustomResourcesAndGetURNs(resources: Set<Resource>) {
     const result = new Set<URN>();
     for (const resource of resources) {
         if (CustomResource.isInstance(resource)) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/021.parent_child_dependencies/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/021.parent_child_dependencies/index.js
@@ -9,5 +9,9 @@ class MyResource extends pulumi.CustomResource {
 	}
 }
 
-let resA = new MyResource("resA", {});
-let resB = new MyResource("resB", { parentId: resA.id }, { parent: resA });
+//            cust1
+//                \
+//                 cust2
+
+let cust1 = new MyResource("cust1", {});
+let cust2 = new MyResource("cust2", { parentId: cust1.id }, { parent: cust1 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/021.parent_child_dependencies/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/021.parent_child_dependencies/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/022.parent_child_dependencies_2/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/022.parent_child_dependencies_2/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/022.parent_child_dependencies_2/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/022.parent_child_dependencies_2/index.js
@@ -9,6 +9,10 @@ class MyResource extends pulumi.CustomResource {
 	}
 }
 
-let resA = new MyResource("resA");
-let resB = new MyResource("resB", { parentId: resA.id }, { parent: resA });
-let resC = new MyResource("resC", { parentId: resA.id }, { parent: resA });
+//            cust1
+//            /   \
+//       cust2    cust3
+
+let cust1 = new MyResource("cust1");
+let cust2 = new MyResource("cust2", { parentId: cust1.id }, { parent: cust1 });
+let cust3 = new MyResource("cust3", { parentId: cust1.id }, { parent: cust1 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/023.parent_child_dependencies_3/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/023.parent_child_dependencies_3/index.js
@@ -1,0 +1,20 @@
+// Test the ability to invoke provider functions via RPC.
+
+let assert = require("assert");
+let pulumi = require("../../../../../");
+
+class MyCustomResource extends pulumi.CustomResource {
+	constructor(name, args, opts) {
+		super("test:index:MyCustomResource", name, args, opts);
+	}
+}
+
+class MyComponentResource extends pulumi.ComponentResource {
+	constructor(name, args, opts) {
+		super("test:index:MyComponentResource", name, args, opts);
+	}
+}
+
+let resA = new MyComponentResource("resA");
+let resB = new MyCustomResource("resB", { parentId: resA.urn }, { parent: resA });
+let resC = new MyCustomResource("resC", { parentId: resA.urn }, { parent: resA });

--- a/sdk/nodejs/tests/runtime/langhost/cases/023.parent_child_dependencies_3/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/023.parent_child_dependencies_3/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/024.parent_child_dependencies_4/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/024.parent_child_dependencies_4/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/024.parent_child_dependencies_4/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/024.parent_child_dependencies_4/index.js
@@ -20,11 +20,5 @@ class MyComponentResource extends pulumi.ComponentResource {
 //       cust1    cust2
 
 let comp1 = new MyComponentResource("comp1");
-
-// this represents a nonsensical program where a custom resource references the urn
-// of a component.  There is no good need for the urn to be used there.  To represent
-// a component dependency, 'dependsOn' should be used instead.
-//
-// This test just documents our behavior here (which is that we deadlock).
-let cust1 = new MyCustomResource("cust1", { parentId: comp1.urn }, { parent: comp1 });
-let cust2 = new MyCustomResource("cust2", { parentId: comp1.urn }, { parent: comp1 });
+let cust1 = new MyCustomResource("cust1", { }, { parent: comp1 });
+let cust2 = new MyCustomResource("cust2", { }, { parent: comp1 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/025.parent_child_dependencies_5/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/025.parent_child_dependencies_5/index.js
@@ -17,14 +17,10 @@ class MyComponentResource extends pulumi.ComponentResource {
 
 //            comp1
 //            /   \
-//       cust1    cust2
+//        cust1   cust2
 
 let comp1 = new MyComponentResource("comp1");
+let cust1 = new MyCustomResource("cust1", { }, { parent: comp1 });
+let cust2 = new MyCustomResource("cust2", { }, { parent: comp1 });
 
-// this represents a nonsensical program where a custom resource references the urn
-// of a component.  There is no good need for the urn to be used there.  To represent
-// a component dependency, 'dependsOn' should be used instead.
-//
-// This test just documents our behavior here (which is that we deadlock).
-let cust1 = new MyCustomResource("cust1", { parentId: comp1.urn }, { parent: comp1 });
-let cust2 = new MyCustomResource("cust2", { parentId: comp1.urn }, { parent: comp1 });
+let res1 = new MyCustomResource("res1", { }, { dependsOn: comp1 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/025.parent_child_dependencies_5/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/025.parent_child_dependencies_5/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/026.parent_child_dependencies_6/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/026.parent_child_dependencies_6/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/026.parent_child_dependencies_6/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/026.parent_child_dependencies_6/index.js
@@ -17,14 +17,15 @@ class MyComponentResource extends pulumi.ComponentResource {
 
 //            comp1
 //            /   \
-//       cust1    cust2
+//        cust1   comp2
+//                /   \
+//            cust2    cust3
 
 let comp1 = new MyComponentResource("comp1");
+let cust1 = new MyCustomResource("cust1", { }, { parent: comp1 });
 
-// this represents a nonsensical program where a custom resource references the urn
-// of a component.  There is no good need for the urn to be used there.  To represent
-// a component dependency, 'dependsOn' should be used instead.
-//
-// This test just documents our behavior here (which is that we deadlock).
-let cust1 = new MyCustomResource("cust1", { parentId: comp1.urn }, { parent: comp1 });
-let cust2 = new MyCustomResource("cust2", { parentId: comp1.urn }, { parent: comp1 });
+let comp2 = new MyComponentResource("comp2", { }, { parent: comp1 });
+let cust2 = new MyCustomResource("cust2", { }, { parent: comp2 });
+let cust3 = new MyCustomResource("cust3", { }, { parent: comp2 });
+
+let res1 = new MyCustomResource("res1", { }, { dependsOn: comp1 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/027.parent_child_dependencies_7/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/027.parent_child_dependencies_7/index.js
@@ -1,0 +1,38 @@
+// Test the ability to invoke provider functions via RPC.
+
+let assert = require("assert");
+let pulumi = require("../../../../../");
+
+class MyCustomResource extends pulumi.CustomResource {
+	constructor(name, args, opts) {
+		super("test:index:MyCustomResource", name, args, opts);
+	}
+}
+
+class MyComponentResource extends pulumi.ComponentResource {
+	constructor(name, args, opts) {
+		super("test:index:MyComponentResource", name, args, opts);
+	}
+}
+
+//            comp1
+//            /   \
+//        cust1   comp2
+//                /   \
+//            cust2    cust3
+//            /
+//       cust4
+
+let comp1 = new MyComponentResource("comp1");
+let cust1 = new MyCustomResource("cust1", { }, { parent: comp1 });
+
+let comp2 = new MyComponentResource("comp2", { }, { parent: comp1 });
+let cust2 = new MyCustomResource("cust2", { }, { parent: comp2 });
+let cust3 = new MyCustomResource("cust3", { }, { parent: comp2 });
+
+let cust4 = new MyCustomResource("cust4", { parentId: cust2.id }, { parent: cust2 });
+
+let res1 = new MyCustomResource("res1", { }, { dependsOn: comp1 });
+// let res2 = new MyCustomResource("res2", { }, { dependsOn: comp2 });
+// let res3 = new MyCustomResource("res3", { }, { dependsOn: cust2 });
+// let res4 = new MyCustomResource("res4", { }, { dependsOn: cust4 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/027.parent_child_dependencies_7/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/027.parent_child_dependencies_7/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/027.parent_child_dependencies_7/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/027.parent_child_dependencies_7/index.js
@@ -33,6 +33,6 @@ let cust3 = new MyCustomResource("cust3", { }, { parent: comp2 });
 let cust4 = new MyCustomResource("cust4", { parentId: cust2.id }, { parent: cust2 });
 
 let res1 = new MyCustomResource("res1", { }, { dependsOn: comp1 });
-// let res2 = new MyCustomResource("res2", { }, { dependsOn: comp2 });
-// let res3 = new MyCustomResource("res3", { }, { dependsOn: cust2 });
-// let res4 = new MyCustomResource("res4", { }, { dependsOn: cust4 });
+let res2 = new MyCustomResource("res2", { }, { dependsOn: comp2 });
+let res3 = new MyCustomResource("res3", { }, { dependsOn: cust2 });
+let res4 = new MyCustomResource("res4", { }, { dependsOn: cust4 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/028.parent_child_dependencies_8/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/028.parent_child_dependencies_8/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/028.parent_child_dependencies_8/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/028.parent_child_dependencies_8/index.js
@@ -26,6 +26,5 @@ let cust1 = new MyCustomResource("cust1", { }, { parent: comp1 });
 let cust2 = new MyCustomResource("cust2", { parentId: cust1.id }, { parent: cust1 });
 
 let res1 = new MyCustomResource("res1", { }, { dependsOn: comp1 });
-// let res2 = new MyCustomResource("res2", { }, { dependsOn: comp2 });
-// let res3 = new MyCustomResource("res3", { }, { dependsOn: cust2 });
-// let res4 = new MyCustomResource("res4", { }, { dependsOn: cust4 });
+let res2 = new MyCustomResource("res2", { }, { dependsOn: cust1 });
+let res3 = new MyCustomResource("res3", { }, { dependsOn: cust2 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/028.parent_child_dependencies_8/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/028.parent_child_dependencies_8/index.js
@@ -1,0 +1,31 @@
+// Test the ability to invoke provider functions via RPC.
+
+let assert = require("assert");
+let pulumi = require("../../../../../");
+
+class MyCustomResource extends pulumi.CustomResource {
+	constructor(name, args, opts) {
+		super("test:index:MyCustomResource", name, args, opts);
+	}
+}
+
+class MyComponentResource extends pulumi.ComponentResource {
+	constructor(name, args, opts) {
+		super("test:index:MyComponentResource", name, args, opts);
+	}
+}
+
+//            comp1
+//                \
+//                cust1
+//                    \
+//                    cust2
+
+let comp1 = new MyComponentResource("comp1");
+let cust1 = new MyCustomResource("cust1", { }, { parent: comp1 });
+let cust2 = new MyCustomResource("cust2", { parentId: cust1.id }, { parent: cust1 });
+
+let res1 = new MyCustomResource("res1", { }, { dependsOn: comp1 });
+// let res2 = new MyCustomResource("res2", { }, { dependsOn: comp2 });
+// let res3 = new MyCustomResource("res3", { }, { dependsOn: cust2 });
+// let res4 = new MyCustomResource("res4", { }, { dependsOn: cust4 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/029.parent_child_dependencies_9/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/029.parent_child_dependencies_9/index.js
@@ -1,0 +1,28 @@
+// Test the ability to invoke provider functions via RPC.
+
+let assert = require("assert");
+let pulumi = require("../../../../../");
+
+class MyCustomResource extends pulumi.CustomResource {
+	constructor(name, args, opts) {
+		super("test:index:MyCustomResource", name, args, opts);
+	}
+}
+
+class MyComponentResource extends pulumi.ComponentResource {
+	constructor(name, args, opts) {
+		super("test:index:MyComponentResource", name, args, opts);
+	}
+}
+
+//                cust1
+//                    \
+//                    cust2
+
+let cust1 = new MyCustomResource("cust1", { }, { parent: comp1 });
+let cust2 = new MyCustomResource("cust2", { parentId: cust1.id }, { parent: cust1 });
+
+let res1 = new MyCustomResource("res1", { }, { dependsOn: cust1 });
+// let res2 = new MyCustomResource("res2", { }, { dependsOn: comp2 });
+// let res3 = new MyCustomResource("res3", { }, { dependsOn: cust2 });
+// let res4 = new MyCustomResource("res4", { }, { dependsOn: cust4 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/029.parent_child_dependencies_9/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/029.parent_child_dependencies_9/index.js
@@ -23,6 +23,3 @@ let cust1 = new MyCustomResource("cust1", { }, { });
 let cust2 = new MyCustomResource("cust2", { parentId: cust1.id }, { parent: cust1 });
 
 let res1 = new MyCustomResource("res1", { }, { dependsOn: cust1 });
-// let res2 = new MyCustomResource("res2", { }, { dependsOn: comp2 });
-// let res3 = new MyCustomResource("res3", { }, { dependsOn: cust2 });
-// let res4 = new MyCustomResource("res4", { }, { dependsOn: cust4 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/029.parent_child_dependencies_9/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/029.parent_child_dependencies_9/index.js
@@ -19,7 +19,7 @@ class MyComponentResource extends pulumi.ComponentResource {
 //                    \
 //                    cust2
 
-let cust1 = new MyCustomResource("cust1", { }, { parent: comp1 });
+let cust1 = new MyCustomResource("cust1", { }, { });
 let cust2 = new MyCustomResource("cust2", { parentId: cust1.id }, { parent: cust1 });
 
 let res1 = new MyCustomResource("res1", { }, { dependsOn: cust1 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/029.parent_child_dependencies_9/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/029.parent_child_dependencies_9/index.js
@@ -1,5 +1,3 @@
-// Test the ability to invoke provider functions via RPC.
-
 let assert = require("assert");
 let pulumi = require("../../../../../");
 

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -600,7 +600,12 @@ describe("rpc", () => {
             pwd: path.join(base, "021.parent_child_dependencies"),
             program: "./index.js",
             expectResourceCount: 2,
-            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                switch (name) {
+                    case "cust1": assert.deepStrictEqual(deps, []); break;
+                    case "cust2": assert.deepStrictEqual(deps, ["test:index:MyResource::cust1"]); break;
+                    default: throw new Error("Didn't check: " + name);
+                }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
@@ -608,7 +613,13 @@ describe("rpc", () => {
             pwd: path.join(base, "022.parent_child_dependencies_2"),
             program: "./index.js",
             expectResourceCount: 3,
-            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                switch (name) {
+                    case "cust1": assert.deepStrictEqual(deps, []); break;
+                    case "cust2": assert.deepStrictEqual(deps, ["test:index:MyResource::cust1"]); break;
+                    case "cust3": assert.deepStrictEqual(deps, ["test:index:MyResource::cust1"]); break;
+                    default: throw new Error("Didn't check: " + name);
+                }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
@@ -622,7 +633,13 @@ describe("rpc", () => {
             pwd: path.join(base, "024.parent_child_dependencies_4"),
             program: "./index.js",
             expectResourceCount: 3,
-            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                switch (name) {
+                    case "cust1": assert.deepStrictEqual(deps, []); break;
+                    case "cust2": assert.deepStrictEqual(deps, []); break;
+                    case "comp1": assert.deepStrictEqual(deps, []); break;
+                    default: throw new Error("Didn't check: " + name);
+                }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
@@ -630,7 +647,14 @@ describe("rpc", () => {
             pwd: path.join(base, "025.parent_child_dependencies_5"),
             program: "./index.js",
             expectResourceCount: 4,
-            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                switch (name) {
+                    case "cust1": assert.deepStrictEqual(deps, []); break;
+                    case "cust2": assert.deepStrictEqual(deps, []); break;
+                    case "comp1": assert.deepStrictEqual(deps, []); break;
+                    case "res1": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust1", "test:index:MyCustomResource::cust2"]); break;
+                    default: throw new Error("Didn't check: " + name);
+                }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
@@ -638,7 +662,16 @@ describe("rpc", () => {
             pwd: path.join(base, "026.parent_child_dependencies_6"),
             program: "./index.js",
             expectResourceCount: 6,
-            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                switch (name) {
+                    case "comp1": assert.deepStrictEqual(deps, []); break;
+                    case "cust1": assert.deepStrictEqual(deps, []); break;
+                    case "comp2": assert.deepStrictEqual(deps, []); break;
+                    case "cust2": assert.deepStrictEqual(deps, []); break;
+                    case "cust3": assert.deepStrictEqual(deps, []); break;
+                    case "res1": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust1", "test:index:MyCustomResource::cust2", "test:index:MyCustomResource::cust3"]); break;
+                    default: throw new Error("Didn't check: " + name);
+                }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
@@ -646,7 +679,20 @@ describe("rpc", () => {
             pwd: path.join(base, "027.parent_child_dependencies_7"),
             program: "./index.js",
             expectResourceCount: 10,
-            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                switch (name) {
+                    case "comp1": assert.deepStrictEqual(deps, []); break;
+                    case "cust1": assert.deepStrictEqual(deps, []); break;
+                    case "comp2": assert.deepStrictEqual(deps, []); break;
+                    case "cust2": assert.deepStrictEqual(deps, []); break;
+                    case "cust3": assert.deepStrictEqual(deps, []); break;
+                    case "cust4": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust2"]); break;
+                    case "res1": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust1", "test:index:MyCustomResource::cust2", "test:index:MyCustomResource::cust3"]); break;
+                    case "res2": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust2", "test:index:MyCustomResource::cust3"]); break;
+                    case "res3": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust2"]); break;
+                    case "res4": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust4"]); break;
+                    default: throw new Error("Didn't check: " + name);
+                }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
@@ -654,7 +700,16 @@ describe("rpc", () => {
             pwd: path.join(base, "028.parent_child_dependencies_8"),
             program: "./index.js",
             expectResourceCount: 6,
-            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                switch (name) {
+                    case "comp1": assert.deepStrictEqual(deps, []); break;
+                    case "cust1": assert.deepStrictEqual(deps, []); break;
+                    case "cust2": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust1"]); break;
+                    case "res1": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust1"]); break;
+                    case "res2": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust1"]); break;
+                    case "res3": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust2"]); break;
+                    default: throw new Error("Didn't check: " + name);
+                }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
@@ -662,14 +717,20 @@ describe("rpc", () => {
             pwd: path.join(base, "029.parent_child_dependencies_9"),
             program: "./index.js",
             expectResourceCount: 3,
-            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, deps: string[]) => {
+                switch (name) {
+                    case "cust1": assert.deepStrictEqual(deps, []); break;
+                    case "cust2": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust1"]); break;
+                    case "res1": assert.deepStrictEqual(deps, ["test:index:MyCustomResource::cust1"]); break;
+                    default: throw new Error("Didn't check: " + name);
+                }
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
     };
 
     for (const casename of Object.keys(cases)) {
-        // if (casename.indexOf("parent_child") < 0) {
+        // if (casename.indexOf("parent_child_dependencies") < 0) {
         //     continue;
         // }
 

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -643,9 +643,9 @@ describe("rpc", () => {
             },
         },
         "parent_child_dependencies_7": {
-            pwd: path.join(base, "026.parent_child_dependencies_7"),
+            pwd: path.join(base, "027.parent_child_dependencies_7"),
             program: "./index.js",
-            expectResourceCount: 3,
+            expectResourceCount: 10,
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
@@ -670,9 +670,8 @@ describe("rpc", () => {
 
     for (const casename of Object.keys(cases)) {
         // if (casename.indexOf("parent_child") < 0) {
-        if (casename.indexOf("parent_child_dependencies_8") < 0) {
-            continue;
-        }
+        //     continue;
+        // }
 
         const opts: RunCase = cases[casename];
         it(`run test: ${casename} (pwd=${opts.pwd},prog=${opts.program})`, asyncTest(async () => {

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -661,7 +661,7 @@ describe("rpc", () => {
         "parent_child_dependencies_9": {
             pwd: path.join(base, "029.parent_child_dependencies_9"),
             program: "./index.js",
-            expectResourceCount: 2,
+            expectResourceCount: 3,
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -653,7 +653,7 @@ describe("rpc", () => {
         "parent_child_dependencies_8": {
             pwd: path.join(base, "028.parent_child_dependencies_8"),
             program: "./index.js",
-            expectResourceCount: 3,
+            expectResourceCount: 6,
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
@@ -670,7 +670,7 @@ describe("rpc", () => {
 
     for (const casename of Object.keys(cases)) {
         // if (casename.indexOf("parent_child") < 0) {
-        if (casename.indexOf("parent_child_dependencies_9") < 0) {
+        if (casename.indexOf("parent_child_dependencies_8") < 0) {
             continue;
         }
 

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -612,12 +612,67 @@ describe("rpc", () => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
+        "parent_child_dependencies_3": {
+            pwd: path.join(base, "023.parent_child_dependencies_3"),
+            program: "./index.js",
+            expectResourceCount: 1,
+            expectError: "Program exited with non-zero exit code: 1",
+        },
+        "parent_child_dependencies_4": {
+            pwd: path.join(base, "024.parent_child_dependencies_4"),
+            program: "./index.js",
+            expectResourceCount: 3,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
+        "parent_child_dependencies_5": {
+            pwd: path.join(base, "025.parent_child_dependencies_5"),
+            program: "./index.js",
+            expectResourceCount: 4,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
+        "parent_child_dependencies_6": {
+            pwd: path.join(base, "026.parent_child_dependencies_6"),
+            program: "./index.js",
+            expectResourceCount: 6,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
+        "parent_child_dependencies_7": {
+            pwd: path.join(base, "026.parent_child_dependencies_7"),
+            program: "./index.js",
+            expectResourceCount: 3,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
+        "parent_child_dependencies_8": {
+            pwd: path.join(base, "028.parent_child_dependencies_8"),
+            program: "./index.js",
+            expectResourceCount: 3,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
+        "parent_child_dependencies_9": {
+            pwd: path.join(base, "029.parent_child_dependencies_9"),
+            program: "./index.js",
+            expectResourceCount: 2,
+            registerResource: (ctx: any, dryrun: boolean, t: string, name: string) => {
+                return { urn: makeUrn(t, name), id: undefined, props: undefined };
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {
-        // if (casename !== "parent_child_dependencies_2") {
-        //     continue;
-        // }
+        // if (casename.indexOf("parent_child") < 0) {
+        if (casename.indexOf("parent_child_dependencies_9") < 0) {
+            continue;
+        }
 
         const opts: RunCase = cases[casename];
         it(`run test: ${casename} (pwd=${opts.pwd},prog=${opts.program})`, asyncTest(async () => {


### PR DESCRIPTION
Fixes #2494

Will be part of 0.17.x

This was moved from https://github.com/pulumi/pulumi/pull/2494 to make it possible to do this in a feature branch.