### PR TITLE
Show `brew upgrade` when installed with Homebrew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- Show `brew upgrade pulumi` as the upgrade message when the currently running `pulumi` executable
+  is running on macOS from the brew install directory.
+
 ## 0.17.0 (Released March 5, 2019)
 
 This update includes several changes to core `@pulumi/pulumi` constructs that will not play nicely


### PR DESCRIPTION
Show `brew upgrade pulumi` as the upgrade message when the currently running pulumi executable is on macOS and running from the brew install directory.

I manually tested this by copying a local build into `/usr/local/Cellar/pulumi/0.16.19/bin` (with `curVer` hardcoded to `"0.1.0"` and the `isDevVersion` check commented out).

https://github.com/pulumi/pulumi/blob/f0d8cd89cd8fe2ee70d91a1a200d028be6abd21e/cmd/pulumi.go#L191-L210

Fixes #2518