### PR TITLE
Filter diff keys based on provider info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Show `brew upgrade pulumi` as the upgrade message when the currently running `pulumi` executable
   is running on macOS from the brew install directory.
+- Resource diffs that are rendered to the console are now filtered to properties that have semantically-meaningful
+  changes where possible.
 
 ## 0.17.1 (Released March 6, 2019)
 

--- a/pkg/apitype/events.go
+++ b/pkg/apitype/events.go
@@ -81,6 +81,8 @@ type StepEventMetadata struct {
 
 	// Keys causing a replacement (only applicable for "create" and "replace" Ops).
 	Keys []string `json:"keys,omitempty"`
+	// Keys that changed with this step.
+	Diffs []string `json:"diffs"`
 	// Logical is set if the step is a logical operation in the program.
 	Logical bool `json:"logical"`
 	// Provider actually performing the step.

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -425,9 +425,32 @@ func (data *resourceRowData) getDiffInfo(step engine.StepEventMetadata) string {
 				updates[k] = resource.PropertyValue{}
 			}
 
-			writePropertyKeys(changesBuf, diff.Adds, deploy.OpCreate)
-			writePropertyKeys(changesBuf, diff.Deletes, deploy.OpDelete)
-			writePropertyKeys(changesBuf, updates, deploy.OpUpdate)
+			filteredKeys := func(m resource.PropertyMap) []string {
+				keys := make([]string, 0, len(m))
+				for k := range m {
+					keys = append(keys, string(k))
+				}
+				return keys
+			}
+			if include := step.Diffs; include != nil {
+				includeSet := make(map[resource.PropertyKey]bool)
+				for _, k := range include {
+					includeSet[k] = true
+				}
+				filteredKeys = func(m resource.PropertyMap) []string {
+					var filteredKeys []string
+					for k := range m {
+						if includeSet[k] {
+							filteredKeys = append(filteredKeys, string(k))
+						}
+					}
+					return filteredKeys
+				}
+			}
+
+			writePropertyKeys(changesBuf, filteredKeys(diff.Adds), deploy.OpCreate)
+			writePropertyKeys(changesBuf, filteredKeys(diff.Deletes), deploy.OpDelete)
+			writePropertyKeys(changesBuf, filteredKeys(updates), deploy.OpUpdate)
 		}
 	}
 
@@ -435,23 +458,17 @@ func (data *resourceRowData) getDiffInfo(step engine.StepEventMetadata) string {
 	return changesBuf.String()
 }
 
-func writePropertyKeys(b *bytes.Buffer, propMap resource.PropertyMap, op deploy.StepOp) {
-	if len(propMap) > 0 {
+func writePropertyKeys(b *bytes.Buffer, keys []string, op deploy.StepOp) {
+	if len(keys) > 0 {
 		writeString(b, strings.Trim(op.Prefix(), " "))
 
-		keys := make([]string, 0, len(propMap))
-		for k := range propMap {
-			keys = append(keys, string(k))
-		}
 		sort.Strings(keys)
 
-		index := 0
-		for _, k := range keys {
+		for index, k := range keys {
 			if index != 0 {
 				writeString(b, ",")
 			}
 			writeString(b, k)
-			index++
 		}
 
 		writeString(b, colors.Reset)

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -316,6 +316,10 @@ func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMeta
 	for i, v := range md.Keys {
 		keys[i] = string(v)
 	}
+	var diffs []string
+	for _, v := range md.Diffs {
+		diffs = append(diffs, string(v))
+	}
 
 	return apitype.StepEventMetadata{
 		Op:   string(md.Op),
@@ -327,6 +331,7 @@ func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMeta
 		Res: convertStepEventStateMetadata(md.Res),
 
 		Keys:     keys,
+		Diffs:    diffs,
 		Logical:  md.Logical,
 		Provider: md.Provider,
 	}

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -328,8 +328,8 @@ func TestVexingDeployment(t *testing.T) {
 	cPrime := NewResource(string(c.URN), bPrime.URN)
 
 	// mocking out the behavior of a provider indicating that this resource needs to be deleted
-	createReplacement := deploy.NewCreateReplacementStep(nil, MockRegisterResourceEvent{}, c, cPrime, nil, true)
-	replace := deploy.NewReplaceStep(nil, c, cPrime, nil, true)
+	createReplacement := deploy.NewCreateReplacementStep(nil, MockRegisterResourceEvent{}, c, cPrime, nil, nil, true)
+	replace := deploy.NewReplaceStep(nil, c, cPrime, nil, nil, true)
 	c.Delete = true
 
 	applyStep(createReplacement)
@@ -338,7 +338,7 @@ func TestVexingDeployment(t *testing.T) {
 	// cPrime now exists, c is now pending deletion
 	// dPrime now depends on cPrime, which got replaced
 	dPrime := NewResource(string(d.URN), cPrime.URN)
-	applyStep(deploy.NewUpdateStep(nil, MockRegisterResourceEvent{}, d, dPrime, nil))
+	applyStep(deploy.NewUpdateStep(nil, MockRegisterResourceEvent{}, d, dPrime, nil, nil))
 
 	lastSnap := sp.SavedSnapshots[len(sp.SavedSnapshots)-1]
 	assert.Len(t, lastSnap.Resources, 6)
@@ -498,7 +498,7 @@ func TestRecordingUpdateSuccess(t *testing.T) {
 	})
 
 	manager, sp := MockSetup(t, snap)
-	step := deploy.NewUpdateStep(nil, &MockRegisterResourceEvent{}, resourceA, resourceANew, nil)
+	step := deploy.NewUpdateStep(nil, &MockRegisterResourceEvent{}, resourceA, resourceANew, nil, nil)
 	mutation, err := manager.BeginMutation(step)
 	if !assert.NoError(t, err) {
 		t.FailNow()
@@ -537,7 +537,7 @@ func TestRecordingUpdateFailure(t *testing.T) {
 	})
 
 	manager, sp := MockSetup(t, snap)
-	step := deploy.NewUpdateStep(nil, &MockRegisterResourceEvent{}, resourceA, resourceANew, nil)
+	step := deploy.NewUpdateStep(nil, &MockRegisterResourceEvent{}, resourceA, resourceANew, nil, nil)
 	mutation, err := manager.BeginMutation(step)
 	if !assert.NoError(t, err) {
 		t.FailNow()

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -218,7 +218,7 @@ func printObject(
 	b *bytes.Buffer, props resource.PropertyMap, planning bool,
 	indent int, op deploy.StepOp, prefix bool, debug bool) {
 
-	// Compute the maximum with of property keys so we can justify everything.
+	// Compute the maximum width of property keys so we can justify everything.
 	keys := props.StableKeys()
 	maxkey := maxKey(keys)
 
@@ -462,7 +462,7 @@ func printObjectDiff(b *bytes.Buffer, diff resource.ObjectDiff, include []resour
 
 	contract.Assert(indent > 0)
 
-	// Compute the maximum with of property keys so we can justify everything. If an include set was given, filter out
+	// Compute the maximum width of property keys so we can justify everything. If an include set was given, filter out
 	// any properties that are not in the set.
 	keys := diff.Keys()
 	if include != nil {

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -100,6 +100,7 @@ type DiffResult struct {
 	Changes             DiffChanges            // true if this diff represents a changed resource.
 	ReplaceKeys         []resource.PropertyKey // an optional list of replacement keys.
 	StableKeys          []resource.PropertyKey // an optional list of property keys that are stable.
+	ChangedKeys         []resource.PropertyKey // an optional list of keys that changed.
 	DeleteBeforeReplace bool                   // if true, this resource must be deleted before recreating it.
 }
 

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -298,14 +298,21 @@ func (p *provider) Diff(urn resource.URN, id resource.ID,
 	for _, stable := range resp.GetStables() {
 		stables = append(stables, resource.PropertyKey(stable))
 	}
+	var diffs []resource.PropertyKey
+	for _, diff := range resp.GetDiffs() {
+		diffs = append(diffs, resource.PropertyKey(diff))
+	}
+
 	changes := resp.GetChanges()
 	deleteBeforeReplace := resp.GetDeleteBeforeReplace()
-	logging.V(7).Infof("%s success: changes=%d #replaces=%v #stables=%v delbefrepl=%v",
-		label, changes, replaces, stables, deleteBeforeReplace)
+	logging.V(7).Infof("%s success: changes=%d #replaces=%v #stables=%v delbefrepl=%v, diffs=#%v",
+		label, changes, replaces, stables, deleteBeforeReplace, diffs)
+
 	return DiffResult{
 		Changes:             DiffChanges(changes),
 		ReplaceKeys:         replaces,
 		StableKeys:          stables,
+		ChangedKeys:         diffs,
 		DeleteBeforeReplace: deleteBeforeReplace,
 	}, nil
 }


### PR DESCRIPTION
If a provider returns information about the top-level properties that
differ, use those keys to filter the diffs that are rendered to the
user.

Fixes #2453.