### PR TITLE
Stop running `up` as part of `pulumi new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   is running on macOS from the brew install directory.
 - Resource diffs that are rendered to the console are now filtered to properties that have semantically-meaningful
   changes where possible.
+- `pulumi new` no longer runs an initial deployment after a project is generated for nodejs projects.
+  Instead, instructions are printed indicating that `pulumi up` can be used to deploy the project.
 
 ## 0.17.1 (Released March 6, 2019)
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -220,7 +220,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// Install dependencies.
-		if err = installDependencies("Installing dependencies..."); err != nil {
+		if err = installDependencies(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Originally, `pulumi new` did not run `up` after generating a project. To
help users get a deployed stack as quickly as possible, we changed
`pulumi new` to run an initial deployment at the end of its operation.
Users would first see a preview and get to decide whether to proceed
with an initial deployment, and then continue to iterate from there.

Note that this would only happen for nodejs projects
(TypeScript/JavaScript). We would not run `up` for Python projects as we
require the user to run `pip install` in a virtualenv, so we'd print
instructions with the necessary commands the user must run instead.

Running `up` as part of `pulumi new` for nodejs projects has ended up
being more confusing than helpful for new users, and annoying for
experienced users. New users aren't expecting `pulumi new` to run an
initial deployment after generating the project (they haven't even
looked at the project source yet). Experienced users find it frustrating
as you typically want to just generate the project, and don't want to
have to wait for the preview just to decline running the update.

This change reverts `pulumi new` back to not running `up` automatically
for nodejs projects. Instead, like with Python projects, at the end of
the operation, we print instructions to the user to run `pulumi up` to
deploy the project.

Fixes #2424