### PR TITLE
Groundwork for stack renaming

### DIFF
--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -210,3 +210,8 @@ type AppendUpdateLogEntryRequest struct {
 	Kind   string                 `json:"kind"`
 	Fields map[string]interface{} `json:"fields"`
 }
+
+// StackRenameRequest is the shape of the request to change an existing stack's name.
+type StackRenameRequest struct {
+	NewName string `json:"newName"`
+}


### PR DESCRIPTION
This change provides both the function to rewrite an existing snapshot as part of a stack rename operation as well as the `apitype` that will be used to do a stack rename when using the Pulumi Service.