### PR TITLE
Improve error message when failing to load plugins

### DIFF
--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -47,7 +47,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	if err != nil {
 		return nil, rpcerror.Convert(err)
 	} else if path == "" {
-		return nil, NewMissingError(workspace.PluginInfo{
+		return nil, workspace.NewMissingError(workspace.PluginInfo{
 			Kind: workspace.AnalyzerPlugin,
 			Name: string(name),
 		})

--- a/pkg/resource/plugin/langruntime_plugin.go
+++ b/pkg/resource/plugin/langruntime_plugin.go
@@ -49,7 +49,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime string,
 	if err != nil {
 		return nil, err
 	} else if path == "" {
-		return nil, NewMissingError(workspace.PluginInfo{
+		return nil, workspace.NewMissingError(workspace.PluginInfo{
 			Kind: workspace.LanguagePlugin,
 			Name: runtime,
 		})

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -16,7 +16,6 @@ package plugin
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -38,32 +37,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/logging"
 	"github.com/pulumi/pulumi/pkg/util/rpcutil"
-	"github.com/pulumi/pulumi/pkg/workspace"
 )
-
-// MissingError is returned if a plugin is missing.
-type MissingError struct {
-	// Info contains information about the plugin that was not found.
-	Info workspace.PluginInfo
-}
-
-// NewMissingError allocates a new error indicating the given plugin info was not found.
-func NewMissingError(info workspace.PluginInfo) error {
-	return &MissingError{
-		Info: info,
-	}
-}
-
-func (err *MissingError) Error() string {
-	if err.Info.Version != nil {
-		return fmt.Sprintf("no %[1]s plugin '%[2]s-v%[3]s' found in the workspace or on your $PATH, "+
-			"install the plugin using `pulumi plugin install %[1]s %[2]s v%[3]s`",
-			err.Info.Kind, err.Info.Name, err.Info.Version)
-	}
-
-	return fmt.Sprintf("no %s plugin '%s' found in the workspace or on your $PATH",
-		err.Info.Kind, err.Info.String())
-}
 
 type plugin struct {
 	stdoutDone <-chan bool

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -54,7 +54,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 	if err != nil {
 		return nil, err
 	} else if path == "" {
-		return nil, NewMissingError(workspace.PluginInfo{
+		return nil, workspace.NewMissingError(workspace.PluginInfo{
 			Kind:    workspace.ResourcePlugin,
 			Name:    string(pkg),
 			Version: version,

--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -45,6 +45,30 @@ var (
 	enableLegacyPluginBehavior = os.Getenv("PULUMI_ENABLE_LEGACY_PLUGIN_SEARCH") != ""
 )
 
+// MissingError is returned by functions that attempt to load plugins if a plugin can't be located.
+type MissingError struct {
+	// Info contains information about the plugin that was not found.
+	Info PluginInfo
+}
+
+// NewMissingError allocates a new error indicating the given plugin info was not found.
+func NewMissingError(info PluginInfo) error {
+	return &MissingError{
+		Info: info,
+	}
+}
+
+func (err *MissingError) Error() string {
+	if err.Info.Version != nil {
+		return fmt.Sprintf("no %[1]s plugin '%[2]s-v%[3]s' found in the workspace or on your $PATH, "+
+			"install the plugin using `pulumi plugin install %[1]s %[2]s v%[3]s`",
+			err.Info.Kind, err.Info.Name, err.Info.Version)
+	}
+
+	return fmt.Sprintf("no %s plugin '%s' found in the workspace or on your $PATH",
+		err.Info.Kind, err.Info.String())
+}
+
 // PluginInfo provides basic information about a plugin.  Each plugin gets installed into a system-wide
 // location, by default `~/.pulumi/plugins/<kind>-<name>-<version>/`.  A plugin may contain multiple files,
 // however the primary loadable executable must be named `pulumi-<kind>-<name>`.
@@ -387,7 +411,11 @@ func GetPluginPath(kind PluginKind, name string, version *semver.Version) (strin
 		logging.V(6).Infof("GetPluginPath(%s, %s, %s): enabling new plugin behavior", kind, name, version)
 		candidate, err := SelectCompatiblePlugin(plugins, kind, name, semver.MustParseRange(version.String()))
 		if err != nil {
-			return "", "", err
+			return "", "", NewMissingError(PluginInfo{
+				Name:    name,
+				Kind:    kind,
+				Version: version,
+			})
 		}
 		match = &candidate
 	} else {


### PR DESCRIPTION
This commit re-uses an error reporting mechanism previously used when
the plugin loader fails to locate a plugin that is compatible with the
requested plugin version. In addition to specifying what version we
attempted to load, it also outputs a command that will install the
missing plugin.

Provides an actionable error message message for https://github.com/pulumi/pulumi-azure/issues/200:

```
▶ pulumi preview
Previewing update (dev):
Permalink: https://app.pulumi.com/swgillespie/node/dev/previews/bdfb25c0-dd5e-4c6d-a784-3700b3327e87
error: could not load plugin for aws provider 'urn:pulumi:dev::node::pulumi:providers:aws::default': no resource plugin 'aws-v0.17.1' found in the workspace or on your $PATH, install the plugin using `pulumi plugin install resource aws v0.17.1`
```