### PR TITLE
WIP: Allow the nodejs runtime to tell the language host that it should "bail" and immediately stop doing work.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := Pulumi SDK
-SUB_PROJECTS := sdk/nodejs sdk/python sdk/go
+SUB_PROJECTS := sdk/nodejs sdk/go
 include build/common.mk
 
 PROJECT         := github.com/pulumi/pulumi

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PROJECT_NAME := Pulumi SDK
-SUB_PROJECTS := sdk/nodejs sdk/go
+SUB_PROJECTS := sdk/nodejs sdk/python sdk/go
 include build/common.mk
 
 PROJECT         := github.com/pulumi/pulumi

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -99,17 +99,18 @@ func newDestroyCmd() *cobra.Command {
 				Refresh:   refresh,
 			}
 
-			_, err = s.Destroy(commandContext(), backend.UpdateOperation{
+			_, res := s.Destroy(commandContext(), backend.UpdateOperation{
 				Proj:   proj,
 				Root:   root,
 				M:      m,
 				Opts:   opts,
 				Scopes: cancellationScopes,
 			})
-			if err == context.Canceled {
+			if res != nil && res.Error() == context.Canceled {
 				return errors.New("destroy cancelled")
 			}
-			return PrintEngineError(err)
+
+			return PrintEngineResult(res)
 		}),
 	}
 

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"io"
 
 	"github.com/pulumi/pulumi/pkg/diag"
@@ -12,6 +13,14 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
+
+func PrintEngineResult(res *result.Result) error {
+	if res == nil || res.Error() == nil {
+		return nil
+	}
+
+	return PrintEngineError(res.Error())
+}
 
 // PrintEngineError optionally provides a place for the CLI to provide human-friendly error
 // messages for messages that can happen during normal engine operation.

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/pulumi/pulumi/pkg/util/result"
 	"io"
 
 	"github.com/pulumi/pulumi/pkg/diag"
@@ -12,6 +11,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 func PrintEngineResult(res *result.Result) error {

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -14,22 +14,16 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
+// PrintEngineResult optionally provides a place for the CLI to provide human-friendly error
+// messages for messages that can happen during normal engine operation.
 func PrintEngineResult(res *result.Result) error {
-	// If we had no actual result, or the result was a request to 'Bail', then we have
-	// nothing to actually print to the user.
+	// If we had no actual result, or the result was a request to 'Bail', then we have nothing to
+	// actually print to the user.
 	if res == nil || res.Error() == nil {
 		return nil
 	}
 
-	return PrintEngineError(res.Error())
-}
-
-// PrintEngineError optionally provides a place for the CLI to provide human-friendly error
-// messages for messages that can happen during normal engine operation.
-func PrintEngineError(err error) error {
-	if err == nil {
-		return nil
-	}
+	err := res.Error()
 
 	switch e := err.(type) {
 	case deploy.PlanPendingOperationsError:

--- a/cmd/errors.go
+++ b/cmd/errors.go
@@ -15,6 +15,8 @@ import (
 )
 
 func PrintEngineResult(res *result.Result) error {
+	// If we had no actual result, or the result was a request to 'Bail', then we have
+	// nothing to actually print to the user.
 	if res == nil || res.Error() == nil {
 		return nil
 	}

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -90,21 +90,23 @@ func newPreviewCmd() *cobra.Command {
 				return errors.Wrap(err, "gathering environment metadata")
 			}
 
-			changes, err := s.Preview(commandContext(), backend.UpdateOperation{
+			changes, res := s.Preview(commandContext(), backend.UpdateOperation{
 				Proj:   proj,
 				Root:   root,
 				M:      m,
 				Opts:   opts,
 				Scopes: cancellationScopes,
 			})
-			switch {
-			case err != nil:
-				return PrintEngineError(err)
-			case expectNop && changes != nil && changes.HasChanges():
-				return errors.New("error: no changes were expected but changes were proposed")
-			default:
-				return nil
+
+			if res != nil {
+				return PrintEngineResult(res)
 			}
+
+			if expectNop && changes != nil && changes.HasChanges() {
+				return errors.New("error: no changes were expected but changes were proposed")
+			}
+
+			return nil
 		}),
 	}
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -303,7 +303,11 @@ func newUpCmd() *cobra.Command {
 				return upTemplateNameOrURL(args[0], opts)
 			}
 
-			return upWorkingDirectory(opts)
+			result := upWorkingDirectory(opts)
+			if result.Error() == "A97455BA-8A80-42A5-8639-53CD49E88D75" {
+				return nil
+			}
+			return result
 		}),
 	}
 

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/pulumi/pulumi/pkg/util/result"
 	"os"
 	"strings"
 
@@ -32,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/engine"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // ApplierOptions is a bag of configuration settings for an Applier.

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"os"
 	"strings"
 
@@ -35,15 +36,15 @@ import (
 
 // ApplierOptions is a bag of configuration settings for an Applier.
 type ApplierOptions struct {
-	// DryRun indiciates if the update should not change any resource state and instead just preview changes.
+	// DryRun indicates if the update should not change any resource state and instead just preview changes.
 	DryRun bool
-	// ShowLink indiciates if a link to the update persisted result should be displayed.
+	// ShowLink indicates if a link to the update persisted result should be displayed.
 	ShowLink bool
 }
 
 // Applier applies the changes specified by this update operation against the target stack.
 type Applier func(ctx context.Context, kind apitype.UpdateKind, stack Stack, op UpdateOperation,
-	opts ApplierOptions, events chan<- engine.Event) (engine.ResourceChanges, error)
+	opts ApplierOptions, events chan<- engine.Event) (engine.ResourceChanges, *result.Result)
 
 func ActionLabel(kind apitype.UpdateKind, dryRun bool) string {
 	v := updateTextMap[kind]
@@ -77,7 +78,7 @@ const (
 )
 
 func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack,
-	op UpdateOperation, apply Applier) (engine.ResourceChanges, error) {
+	op UpdateOperation, apply Applier) (engine.ResourceChanges, *result.Result) {
 	// create a channel to hear about the update events from the engine. this will be used so that
 	// we can build up the diff display in case the user asks to see the details of the diff
 
@@ -109,10 +110,10 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 		ShowLink: false,
 	}
 
-	changes, err := apply(ctx, kind, stack, op, opts, eventsChannel)
-	if err != nil {
+	changes, res := apply(ctx, kind, stack, op, opts, eventsChannel)
+	if res != nil {
 		close(eventsChannel)
-		return changes, err
+		return changes, res
 	}
 
 	// If there are no changes, or we're auto-approving or just previewing, we can skip the confirmation prompt.
@@ -122,9 +123,9 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	}
 
 	// Otherwise, ensure the user wants to proceed.
-	err = confirmBeforeUpdating(kind, stack, events, op.Opts)
+	err := confirmBeforeUpdating(kind, stack, events, op.Opts)
 	close(eventsChannel)
-	return changes, err
+	return changes, result.WrapIfNonNil(err)
 }
 
 // confirmBeforeUpdating asks the user whether to proceed. A nil error means yes.
@@ -187,13 +188,13 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 }
 
 func PreviewThenPromptThenExecute(ctx context.Context, kind apitype.UpdateKind, stack Stack,
-	op UpdateOperation, apply Applier) (engine.ResourceChanges, error) {
+	op UpdateOperation, apply Applier) (engine.ResourceChanges, *result.Result) {
 	// Preview the operation to the user and ask them if they want to proceed.
 
 	if !op.Opts.SkipPreview {
-		changes, err := PreviewThenPrompt(ctx, kind, stack, op, apply)
-		if err != nil || kind == apitype.PreviewUpdate {
-			return changes, err
+		changes, res := PreviewThenPrompt(ctx, kind, stack, op, apply)
+		if res != nil || kind == apitype.PreviewUpdate {
+			return changes, res
 		}
 	}
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cancel"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -99,13 +100,13 @@ type Backend interface {
 	GetStackCrypter(stackRef StackReference) (config.Crypter, error)
 
 	// Preview shows what would be updated given the current workspace's contents.
-	Preview(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, error)
+	Preview(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, *result.Result)
 	// Update updates the target stack with the current workspace's contents (config and code).
-	Update(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, error)
+	Update(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, *result.Result)
 	// Refresh refreshes the stack's state from the cloud provider.
-	Refresh(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, error)
+	Refresh(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, *result.Result)
 	// Destroy destroys all of this stack's resources.
-	Destroy(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, error)
+	Destroy(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, *result.Result)
 
 	// GetHistory returns all updates for the stack. The returned UpdateInfo slice will be in
 	// descending order (newest first).

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -277,8 +277,11 @@ func (b *localBackend) Destroy(ctx context.Context, stackRef backend.StackRefere
 }
 
 // apply actually performs the provided type of update on a locally hosted stack.
-func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack backend.Stack,
-	op backend.UpdateOperation, opts backend.ApplierOptions, events chan<- engine.Event) (engine.ResourceChanges, *result.Result) {
+func (b *localBackend) apply(
+	ctx context.Context, kind apitype.UpdateKind, stack backend.Stack,
+	op backend.UpdateOperation, opts backend.ApplierOptions,
+	events chan<- engine.Event) (engine.ResourceChanges, *result.Result) {
+
 	stackRef := stack.Ref()
 	stackName := stackRef.Name()
 

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/logging"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -233,11 +234,11 @@ func (b *localBackend) GetLatestConfiguration(ctx context.Context,
 }
 
 func (b *localBackend) Preview(ctx context.Context, stackRef backend.StackReference,
-	op backend.UpdateOperation) (engine.ResourceChanges, error) {
+	op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	// Get the stack.
 	stack, err := b.GetStack(ctx, stackRef)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 
 	// We can skip PreviewThenPromptThenExecute and just go straight to Execute.
@@ -249,35 +250,35 @@ func (b *localBackend) Preview(ctx context.Context, stackRef backend.StackRefere
 }
 
 func (b *localBackend) Update(ctx context.Context, stackRef backend.StackReference,
-	op backend.UpdateOperation) (engine.ResourceChanges, error) {
+	op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	stack, err := b.GetStack(ctx, stackRef)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply)
 }
 
 func (b *localBackend) Refresh(ctx context.Context, stackRef backend.StackReference,
-	op backend.UpdateOperation) (engine.ResourceChanges, error) {
+	op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	stack, err := b.GetStack(ctx, stackRef)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply)
 }
 
 func (b *localBackend) Destroy(ctx context.Context, stackRef backend.StackReference,
-	op backend.UpdateOperation) (engine.ResourceChanges, error) {
+	op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	stack, err := b.GetStack(ctx, stackRef)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply)
 }
 
 // apply actually performs the provided type of update on a locally hosted stack.
 func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack backend.Stack,
-	op backend.UpdateOperation, opts backend.ApplierOptions, events chan<- engine.Event) (engine.ResourceChanges, error) {
+	op backend.UpdateOperation, opts backend.ApplierOptions, events chan<- engine.Event) (engine.ResourceChanges, *result.Result) {
 	stackRef := stack.Ref()
 	stackName := stackRef.Name()
 
@@ -289,7 +290,7 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 	// Start the update.
 	update, err := b.newUpdate(stackName, op.Proj, op.Root)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 
 	// Spawn a display loop to show events on the CLI.
@@ -331,16 +332,16 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 	// Perform the update
 	start := time.Now().Unix()
 	var changes engine.ResourceChanges
-	var updateErr error
+	var updateRes *result.Result
 	switch kind {
 	case apitype.PreviewUpdate:
-		changes, updateErr = engine.Update(update, engineCtx, op.Opts.Engine, true)
+		changes, updateRes = engine.Update(update, engineCtx, op.Opts.Engine, true)
 	case apitype.UpdateUpdate:
-		changes, updateErr = engine.Update(update, engineCtx, op.Opts.Engine, opts.DryRun)
+		changes, updateRes = engine.Update(update, engineCtx, op.Opts.Engine, opts.DryRun)
 	case apitype.RefreshUpdate:
-		changes, updateErr = engine.Refresh(update, engineCtx, op.Opts.Engine, opts.DryRun)
+		changes, updateRes = engine.Refresh(update, engineCtx, op.Opts.Engine, opts.DryRun)
 	case apitype.DestroyUpdate:
-		changes, updateErr = engine.Destroy(update, engineCtx, op.Opts.Engine, opts.DryRun)
+		changes, updateRes = engine.Destroy(update, engineCtx, op.Opts.Engine, opts.DryRun)
 	default:
 		contract.Failf("Unrecognized update kind: %s", kind)
 	}
@@ -357,9 +358,9 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 	close(displayEvents)
 
 	// Save update results.
-	result := backend.SucceededResult
-	if updateErr != nil {
-		result = backend.FailedResult
+	backendResult := backend.SucceededResult
+	if updateRes != nil {
+		backendResult = backend.FailedResult
 	}
 	info := backend.UpdateInfo{
 		Kind:        kind,
@@ -367,7 +368,7 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 		Message:     op.M.Message,
 		Environment: op.M.Environment,
 		Config:      update.GetTarget().Config,
-		Result:      result,
+		Result:      backendResult,
 		EndTime:     end,
 		// IDEA: it would be nice to populate the *Deployment, so that addToHistory below doesn't need to
 		//     rudely assume it knows where the checkpoint file is on disk as it makes a copy of it.  This isn't
@@ -382,18 +383,18 @@ func (b *localBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack
 		backupErr = b.backupStack(stackName)
 	}
 
-	if updateErr != nil {
+	if updateRes != nil {
 		// We swallow saveErr and backupErr as they are less important than the updateErr.
-		return changes, updateErr
+		return changes, updateRes
 	}
 
 	if saveErr != nil {
 		// We swallow backupErr as it is less important than the saveErr.
-		return changes, errors.Wrap(saveErr, "saving update info")
+		return changes, result.FromError(errors.Wrap(saveErr, "saving update info"))
 	}
 
 	if backupErr != nil {
-		return changes, errors.Wrap(backupErr, "saving backup")
+		return changes, result.FromError(errors.Wrap(backupErr, "saving backup"))
 	}
 
 	// Make sure to print a link to the stack's checkpoint before exiting.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -362,7 +362,7 @@ func (b *localBackend) apply(
 
 	// Save update results.
 	backendUpdateResult := backend.SucceededResult
-	if updateErr != nil {
+	if updateRes != nil {
 		backendUpdateResult = backend.FailedResult
 	}
 	info := backend.UpdateInfo{

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/operations"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // Stack is a local stack.  This simply adds some local-specific properties atop the standard backend stack interface.
@@ -62,19 +63,19 @@ func (s *localStack) Remove(ctx context.Context, force bool) (bool, error) {
 	return backend.RemoveStack(ctx, s, force)
 }
 
-func (s *localStack) Preview(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *localStack) Preview(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return backend.PreviewStack(ctx, s, op)
 }
 
-func (s *localStack) Update(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *localStack) Update(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return backend.UpdateStack(ctx, s, op)
 }
 
-func (s *localStack) Refresh(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *localStack) Refresh(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return backend.RefreshStack(ctx, s, op)
 }
 
-func (s *localStack) Destroy(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *localStack) Destroy(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return backend.DestroyStack(ctx, s, op)
 }
 

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -732,8 +732,11 @@ func (b *cloudBackend) createAndStartUpdate(
 }
 
 // apply actually performs the provided type of update on a stack hosted in the Pulumi Cloud.
-func (b *cloudBackend) apply(ctx context.Context, kind apitype.UpdateKind, stack backend.Stack,
-	op backend.UpdateOperation, opts backend.ApplierOptions, events chan<- engine.Event) (engine.ResourceChanges, *result.Result) {
+func (b *cloudBackend) apply(
+	ctx context.Context, kind apitype.UpdateKind, stack backend.Stack,
+	op backend.UpdateOperation, opts backend.ApplierOptions,
+	events chan<- engine.Event) (engine.ResourceChanges, *result.Result) {
+
 	// Print a banner so it's clear this is going to the cloud.
 	actionLabel := backend.ActionLabel(kind, opts.DryRun)
 	fmt.Printf(op.Opts.Display.Color.Colorize(

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // Stack is a cloud stack.  This simply adds some cloud-specific properties atop the standard backend stack interface.
@@ -127,19 +128,19 @@ func (s *cloudStack) Remove(ctx context.Context, force bool) (bool, error) {
 	return backend.RemoveStack(ctx, s, force)
 }
 
-func (s *cloudStack) Preview(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *cloudStack) Preview(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return backend.PreviewStack(ctx, s, op)
 }
 
-func (s *cloudStack) Update(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *cloudStack) Update(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return backend.UpdateStack(ctx, s, op)
 }
 
-func (s *cloudStack) Refresh(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *cloudStack) Refresh(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return backend.RefreshStack(ctx, s, op)
 }
 
-func (s *cloudStack) Destroy(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, error) {
+func (s *cloudStack) Destroy(ctx context.Context, op backend.UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return backend.DestroyStack(ctx, s, op)
 }
 

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/util/gitutil"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -40,13 +41,13 @@ type Stack interface {
 	Backend() Backend                                       // the backend this stack belongs to.
 
 	// Preview changes to this stack.
-	Preview(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, error)
+	Preview(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, *result.Result)
 	// Update this stack.
-	Update(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, error)
+	Update(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, *result.Result)
 	// Refresh this stack's state from the cloud provider.
-	Refresh(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, error)
+	Refresh(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, *result.Result)
 	// Destroy this stack's resources.
-	Destroy(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, error)
+	Destroy(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, *result.Result)
 
 	// remove this stack.
 	Remove(ctx context.Context, force bool) (bool, error)
@@ -64,22 +65,22 @@ func RemoveStack(ctx context.Context, s Stack, force bool) (bool, error) {
 }
 
 // PreviewStack previews changes to this stack.
-func PreviewStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, error) {
+func PreviewStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return s.Backend().Preview(ctx, s.Ref(), op)
 }
 
 // UpdateStack updates the target stack with the current workspace's contents (config and code).
-func UpdateStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, error) {
+func UpdateStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return s.Backend().Update(ctx, s.Ref(), op)
 }
 
 // RefreshStack refresh's the stack's state from the cloud provider.
-func RefreshStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, error) {
+func RefreshStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return s.Backend().Refresh(ctx, s.Ref(), op)
 }
 
 // DestroyStack destroys all of this stack's resources.
-func DestroyStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, error) {
+func DestroyStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, *result.Result) {
 	return s.Backend().Destroy(ctx, s.Ref(), op)
 }
 

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -18,10 +18,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
-func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (ResourceChanges, error) {
+func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (ResourceChanges, *result.Result) {
 	contract.Require(u != nil, "u")
 	contract.Require(ctx != nil, "ctx")
 
@@ -29,13 +30,13 @@ func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 
 	info, err := newPlanContext(u, "destroy", ctx.ParentSpan)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 	defer info.Close()
 
 	emitter, err := makeEventEmitter(ctx.Events, u)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 	return update(ctx, info, planOptions{
 		UpdateOptions: opts,

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -267,8 +267,10 @@ func (op TestOp) Run(project workspace.Project, target deploy.Target, opts Updat
 	return op.RunWithContext(context.Background(), project, target, opts, dryRun, backendClient, validate)
 }
 
-func (op TestOp) RunWithContext(callerCtx context.Context, project workspace.Project, target deploy.Target,
-	opts UpdateOptions, dryRun bool, backendClient deploy.BackendClient, validate ValidateFunc) (*deploy.Snapshot, *result.Result) {
+func (op TestOp) RunWithContext(
+	callerCtx context.Context, project workspace.Project,
+	target deploy.Target, opts UpdateOptions, dryRun bool,
+	backendClient deploy.BackendClient, validate ValidateFunc) (*deploy.Snapshot, *result.Result) {
 
 	// Create an appropriate update info and context.
 	info := &updateInfo{project: project, target: target}

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -16,6 +16,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"sync"
 
@@ -248,6 +249,12 @@ func printPlan(ctx *Context, result *planResult, dryRun bool) (ResourceChanges, 
 	// Walk the plan's steps and and pretty-print them out.
 	actions := newPlanActions(result.Options)
 	if err := result.Walk(ctx, actions, true); err != nil {
+		fmt.Printf("Got this error: %v\n", err.Error())
+		fmt.Printf("Got this error: %v\n", err.Error())
+		if err.Error() == "A97455BA-8A80-42A5-8639-53CD49E88D75" {
+			return nil, err
+		}
+
 		return nil, errors.New("an error occurred while advancing the preview")
 	}
 

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -18,10 +18,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
-func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (ResourceChanges, error) {
+func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (ResourceChanges, *result.Result) {
 	contract.Require(u != nil, "u")
 	contract.Require(ctx != nil, "ctx")
 
@@ -29,13 +30,13 @@ func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 
 	info, err := newPlanContext(u, "refresh", ctx.ParentSpan)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 	defer info.Close()
 
 	emitter, err := makeEventEmitter(ctx.Events, u)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 
 	// Force opts.Refresh to true.

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/logging"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
@@ -69,7 +70,7 @@ func (changes ResourceChanges) HasChanges() bool {
 	return c > 0
 }
 
-func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (ResourceChanges, error) {
+func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (ResourceChanges, *result.Result) {
 	contract.Require(u != nil, "update")
 	contract.Require(ctx != nil, "ctx")
 
@@ -77,13 +78,13 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resour
 
 	info, err := newPlanContext(u, "update", ctx.ParentSpan)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 	defer info.Close()
 
 	emitter, err := makeEventEmitter(ctx.Events, u)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 	return update(ctx, info, planOptions{
 		UpdateOptions: opts,
@@ -133,35 +134,36 @@ func newUpdateSource(
 	}, defaultProviderVersions, dryRun), nil
 }
 
-func update(ctx *Context, info *planContext, opts planOptions, dryRun bool) (ResourceChanges, error) {
-	result, err := plan(ctx, info, opts, dryRun)
+func update(ctx *Context, info *planContext, opts planOptions, dryRun bool) (ResourceChanges, *result.Result) {
+	planResult, err := plan(ctx, info, opts, dryRun)
 	if err != nil {
-		return nil, err
+		return nil, result.FromError(err)
 	}
 
 	var resourceChanges ResourceChanges
-	if result != nil {
-		defer contract.IgnoreClose(result)
+	var res *result.Result
+	if planResult != nil {
+		defer contract.IgnoreClose(planResult)
 
 		// Make the current working directory the same as the program's, and restore it upon exit.
-		done, chErr := result.Chdir()
+		done, chErr := planResult.Chdir()
 		if chErr != nil {
-			return nil, chErr
+			return nil, result.FromError(chErr)
 		}
 		defer done()
 
 		if dryRun {
 			// If a dry run, just print the plan, don't actually carry out the deployment.
-			resourceChanges, err = printPlan(ctx, result, dryRun)
+			resourceChanges, res = printPlan(ctx, planResult, dryRun)
 		} else {
 			// Otherwise, we will actually deploy the latest bits.
-			opts.Events.preludeEvent(dryRun, result.Ctx.Update.GetTarget().Config)
+			opts.Events.preludeEvent(dryRun, planResult.Ctx.Update.GetTarget().Config)
 
 			// Walk the plan, reporting progress and executing the actual operations as we go.
 			start := time.Now()
 			actions := newUpdateActions(ctx, info.Update, opts)
 
-			err = result.Walk(ctx, actions, false)
+			res = planResult.Walk(ctx, actions, false)
 			resourceChanges = ResourceChanges(actions.Ops)
 
 			if len(resourceChanges) != 0 {
@@ -170,7 +172,7 @@ func update(ctx *Context, info *planContext, opts planOptions, dryRun bool) (Res
 			}
 		}
 	}
-	return resourceChanges, err
+	return resourceChanges, res
 }
 
 // pluginActions listens for plugin events and persists the set of loaded plugins

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // BackendClient provides an interface for retrieving information about other stacks.
@@ -290,7 +291,7 @@ func (p *Plan) generateEventURN(event SourceEvent) resource.URN {
 
 // Execute executes a plan to completion, using the given cancellation context and running a preview
 // or update.
-func (p *Plan) Execute(ctx context.Context, opts Options, preview bool) error {
+func (p *Plan) Execute(ctx context.Context, opts Options, preview bool) *result.Result {
 	planExec := &planExecutor{plan: p}
 	return planExec.Execute(ctx, opts, preview)
 }

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -16,6 +16,7 @@ package deploy
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
@@ -141,6 +142,12 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 				logging.V(4).Infof("planExecutor.Execute(...): incoming event (nil? %v, %v)", event.Event == nil, event.Error)
 
 				if event.Error != nil {
+					fmt.Printf("planeexecuter.Execute got error: %v\n", event.Error)
+					if event.Error.Error() == "A97455BA-8A80-42A5-8639-53CD49E88D75" {
+						cancel()
+						return false, event.Error
+					}
+
 					pe.reportError("", event.Error)
 					cancel()
 					return false, event.Error
@@ -188,6 +195,10 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 
 	pe.stepExec.WaitForCompletion()
 	logging.V(4).Infof("planExecutor.Execute(...): step executor has completed")
+
+	if err != nil && err.Error() == "A97455BA-8A80-42A5-8639-53CD49E88D75" {
+		return err
+	}
 
 	// Figure out if execution failed and why. Step generation and execution errors trump cancellation.
 	if err != nil || pe.stepExec.Errored() {

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -16,7 +16,6 @@ package deploy
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
@@ -54,7 +53,7 @@ func (pe *planExecutor) reportError(urn resource.URN, err error) {
 
 // Execute executes a plan to completion, using the given cancellation context and running a preview
 // or update.
-func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview bool) error {
+func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview bool) *result.Result {
 	// Set up a goroutine that will signal cancellation to the plan's plugins if the caller context is cancelled. We do
 	// not hang this off of the context we create below because we do not want the failure of a single step to cause
 	// other steps to fail.
@@ -76,7 +75,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	// Before doing anything else, optionally refresh each resource in the base checkpoint.
 	if opts.Refresh {
 		if err := pe.refresh(callerCtx, opts, preview); err != nil {
-			return err
+			return result.FromError(err)
 		}
 		if opts.RefreshOnly {
 			return nil
@@ -84,17 +83,17 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	}
 
 	// Begin iterating the source.
-	src, err := pe.plan.source.Iterate(callerCtx, opts, pe.plan)
-	if err != nil {
-		return err
+	src, res := pe.plan.source.Iterate(callerCtx, opts, pe.plan)
+	if res != nil {
+		return res
 	}
 
 	// Set up a step generator for this plan.
 	pe.stepGen = newStepGenerator(pe.plan, opts)
 
 	// Retire any pending deletes that are currently present in this plan.
-	if err = pe.retirePendingDeletes(callerCtx, opts, preview); err != nil {
-		return err
+	if err := pe.retirePendingDeletes(callerCtx, opts, preview); err != nil {
+		return result.FromError(err)
 	}
 
 	// Derive a cancellable context for this plan. We will only cancel this context if some piece of the plan's
@@ -107,8 +106,8 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	// We iterate the source in its own goroutine because iteration is blocking and we want the main loop to be able to
 	// respond to cancellation requests promptly.
 	type nextEvent struct {
-		Event SourceEvent
-		Error error
+		Event  SourceEvent
+		Result *result.Result
 	}
 	incomingEvents := make(chan nextEvent)
 	go func() {
@@ -134,23 +133,19 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	//     should bail.
 	//  3. The stepExecCancel cancel context gets canceled. This means some error occurred in the step executor
 	//     and we need to bail. This can also happen if the user hits Ctrl-C.
-	canceled, err := func() (bool, error) {
+	canceled, res := func() (bool, *result.Result) {
 		logging.V(4).Infof("planExecutor.Execute(...): waiting for incoming events")
 		for {
 			select {
 			case event := <-incomingEvents:
-				logging.V(4).Infof("planExecutor.Execute(...): incoming event (nil? %v, %v)", event.Event == nil, event.Error)
+				logging.V(4).Infof("planExecutor.Execute(...): incoming event (nil? %v, %v)", event.Event == nil, event.Result)
 
-				if event.Error != nil {
-					fmt.Printf("planeexecuter.Execute got error: %v\n", event.Error)
-					if event.Error.Error() == "A97455BA-8A80-42A5-8639-53CD49E88D75" {
-						cancel()
-						return false, event.Error
-					}
-
-					pe.reportError("", event.Error)
+				if event.Result != nil {
 					cancel()
-					return false, event.Error
+					if event.Result.Error() != nil {
+						pe.reportError("", event.Result.Error())
+					}
+					return false, event.Result
 				}
 
 				if event.Event == nil {
@@ -181,7 +176,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 						pe.reportError(pe.plan.generateEventURN(event.Event), resErr)
 					}
 					cancel()
-					return false, result.TODO()
+					return false, result.FromError(result.TODO())
 				}
 			case <-ctx.Done():
 				logging.V(4).Infof("planExecutor.Execute(...): context finished: %v", ctx.Err())
@@ -196,8 +191,13 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	pe.stepExec.WaitForCompletion()
 	logging.V(4).Infof("planExecutor.Execute(...): step executor has completed")
 
-	if err != nil && err.Error() == "A97455BA-8A80-42A5-8639-53CD49E88D75" {
-		return err
+	if res != nil && res.Error() == nil {
+		return res
+	}
+
+	var err error
+	if res != nil {
+		err = res.Error()
 	}
 
 	// Figure out if execution failed and why. Step generation and execution errors trump cancellation.
@@ -206,7 +206,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	} else if canceled {
 		err = execError("canceled", preview)
 	}
-	return err
+	return result.WrapIfNonNil(err)
 }
 
 // handleSingleEvent handles a single source event. For all incoming events, it produces a chain that needs

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -141,10 +141,10 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 				logging.V(4).Infof("planExecutor.Execute(...): incoming event (nil? %v, %v)", event.Event == nil, event.Result)
 
 				if event.Result != nil {
-					cancel()
 					if event.Result.Error() != nil {
 						pe.reportError("", event.Result.Error())
 					}
+					cancel()
 					return false, event.Result
 				}
 

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // A ProviderSource allows a Source to lookup provider plugins.
@@ -40,7 +41,7 @@ type Source interface {
 	Info() interface{}
 
 	// Iterate begins iterating the source. Error is non-nil upon failure; otherwise, a valid iterator is returned.
-	Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error)
+	Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result)
 }
 
 // A SourceIterator enumerates the list of resources that a source has to offer and tracks associated state.
@@ -48,7 +49,7 @@ type SourceIterator interface {
 	io.Closer
 
 	// Next returns the next event from the source.
-	Next() (SourceEvent, error)
+	Next() (SourceEvent, *result.Result)
 }
 
 // SourceEvent is an event associated with the enumeration of a plan.  It is an intent expressed by the source

--- a/pkg/resource/deploy/source_error.go
+++ b/pkg/resource/deploy/source_error.go
@@ -37,6 +37,8 @@ func (src *errorSource) Close() error                { return nil }
 func (src *errorSource) Project() tokens.PackageName { return src.project }
 func (src *errorSource) Info() interface{}           { return nil }
 
-func (src *errorSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
+func (src *errorSource) Iterate(
+	ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
+
 	panic("internal error: unexpected call to errorSource.Iterate")
 }

--- a/pkg/resource/deploy/source_error.go
+++ b/pkg/resource/deploy/source_error.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // NewErrorSource creates a source that panics if it is iterated. This is used by the engine to guard against unexpected
@@ -36,6 +37,6 @@ func (src *errorSource) Close() error                { return nil }
 func (src *errorSource) Project() tokens.PackageName { return src.project }
 func (src *errorSource) Info() interface{}           { return nil }
 
-func (src *errorSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error) {
+func (src *errorSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
 	panic("internal error: unexpected call to errorSource.Iterate")
 }

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -154,6 +154,7 @@ func (iter *evalSourceIterator) Next() (SourceEvent, error) {
 	case err := <-iter.finChan:
 		// If we are finished, we can safely exit.  The contract with the language provider is that this implies
 		// that the language runtime has exited and so calling Close on the plugin is fine.
+		fmt.Printf("evalSourceIterator.next.  got error and returned it: %v\n", err)
 		iter.done = true
 		if err != nil {
 			logging.V(5).Infof("EvalSourceIterator ended with an error: %v", err)
@@ -198,6 +199,12 @@ func (iter *evalSourceIterator) forkRun(opts Options) {
 				DryRun:         iter.src.dryRun,
 				Parallel:       opts.Parallel,
 			})
+
+			if err == nil && progerr == "A97455BA-8A80-42A5-8639-53CD49E88D75" {
+				fmt.Printf("source_eval.forkRun: saw cancel and returned it\n")
+				return errors.Errorf(progerr)
+			}
+
 			if err == nil && progerr != "" {
 				// If the program had an unhandled error; propagate it to the caller.
 				err = errors.Errorf("an unhandled error occurred: %v", progerr)

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/logging"
+	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/util/rpcutil"
 	"github.com/pulumi/pulumi/pkg/util/rpcutil/rpcerror"
 	"github.com/pulumi/pulumi/pkg/workspace"
@@ -83,7 +84,7 @@ func (src *evalSource) Stack() tokens.QName {
 func (src *evalSource) Info() interface{} { return src.runinfo }
 
 // Iterate will spawn an evaluator coroutine and prepare to interact with it on subsequent calls to Next.
-func (src *evalSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error) {
+func (src *evalSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
 	contract.Ignore(ctx) // TODO[pulumi/pulumi#1714]
 
 	// First, fire up a resource monitor that will watch for and record resource creation.
@@ -92,7 +93,7 @@ func (src *evalSource) Iterate(ctx context.Context, opts Options, providers Prov
 	regReadChan := make(chan *readResourceEvent)
 	mon, err := newResourceMonitor(src, providers, regChan, regOutChan, regReadChan)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start resource monitor")
+		return nil, result.FromError(errors.Wrap(err, "failed to start resource monitor"))
 	}
 
 	// Create a new iterator with appropriate channels, and gear up to go!
@@ -102,7 +103,7 @@ func (src *evalSource) Iterate(ctx context.Context, opts Options, providers Prov
 		regChan:     regChan,
 		regOutChan:  regOutChan,
 		regReadChan: regReadChan,
-		finChan:     make(chan error),
+		finChan:     make(chan *result.Result),
 	}
 
 	// Now invoke Run in a goroutine.  All subsequent resource creation events will come in over the gRPC channel,
@@ -119,7 +120,7 @@ type evalSourceIterator struct {
 	regChan     chan *registerResourceEvent        // the channel that contains resource registrations.
 	regOutChan  chan *registerResourceOutputsEvent // the channel that contains resource completions.
 	regReadChan chan *readResourceEvent            // the channel that contains read resource requests.
-	finChan     chan error                         // the channel that communicates completion.
+	finChan     chan *result.Result                // the channel that communicates completion.
 	done        bool                               // set to true when the evaluation is done.
 }
 
@@ -128,7 +129,7 @@ func (iter *evalSourceIterator) Close() error {
 	return iter.mon.Cancel()
 }
 
-func (iter *evalSourceIterator) Next() (SourceEvent, error) {
+func (iter *evalSourceIterator) Next() (SourceEvent, *result.Result) {
 	// If we are done, quit.
 	if iter.done {
 		return nil, nil
@@ -151,15 +152,15 @@ func (iter *evalSourceIterator) Next() (SourceEvent, error) {
 		contract.Assert(read != nil)
 		logging.V(5).Infoln("EvalSourceIterator produced a read")
 		return read, nil
-	case err := <-iter.finChan:
+	case res := <-iter.finChan:
 		// If we are finished, we can safely exit.  The contract with the language provider is that this implies
 		// that the language runtime has exited and so calling Close on the plugin is fine.
-		fmt.Printf("evalSourceIterator.next.  got error and returned it: %v\n", err)
+		// fmt.Printf("evalSourceIterator.next.  got error and returned it: %v\n", err)
 		iter.done = true
-		if err != nil {
-			logging.V(5).Infof("EvalSourceIterator ended with an error: %v", err)
+		if res.Error() != nil {
+			logging.V(5).Infof("EvalSourceIterator ended with an error: %v", res.Error())
 		}
-		return nil, err
+		return nil, res
 	}
 }
 
@@ -169,11 +170,11 @@ func (iter *evalSourceIterator) forkRun(opts Options) {
 	// to queue things up in the resource channel will occur, and we will serve them concurrently.
 	go func() {
 		// Next, launch the language plugin.
-		run := func() error {
+		run := func() *result.Result {
 			rt := iter.src.runinfo.Proj.Runtime.Name()
 			langhost, err := iter.src.plugctx.Host.LanguageRuntime(rt)
 			if err != nil {
-				return errors.Wrapf(err, "failed to launch language host %s", rt)
+				return result.FromError(errors.Wrapf(err, "failed to launch language host %s", rt))
 			}
 			contract.Assertf(langhost != nil, "expected non-nil language host %s", rt)
 
@@ -183,7 +184,7 @@ func (iter *evalSourceIterator) forkRun(opts Options) {
 			// Decrypt the configuration.
 			config, err := iter.src.runinfo.Target.Config.Decrypt(iter.src.runinfo.Target.Decrypter)
 			if err != nil {
-				return err
+				return result.FromError(err)
 			}
 
 			// Now run the actual program.
@@ -201,15 +202,14 @@ func (iter *evalSourceIterator) forkRun(opts Options) {
 			})
 
 			if err == nil && progerr == "A97455BA-8A80-42A5-8639-53CD49E88D75" {
-				fmt.Printf("source_eval.forkRun: saw cancel and returned it\n")
-				return errors.Errorf(progerr)
+				return result.Bail()
 			}
 
 			if err == nil && progerr != "" {
 				// If the program had an unhandled error; propagate it to the caller.
 				err = errors.Errorf("an unhandled error occurred: %v", progerr)
 			}
-			return err
+			return result.WrapIfNonNil(err)
 		}
 
 		// Communicate the error, if it exists, or nil if the program exited cleanly.

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -159,7 +159,7 @@ func (iter *evalSourceIterator) Next() (SourceEvent, *result.Result) {
 		// that the language runtime has exited and so calling Close on the plugin is fine.
 		// fmt.Printf("evalSourceIterator.next.  got error and returned it: %v\n", err)
 		iter.done = true
-		if res.Error() != nil {
+		if res != nil && res.Error() != nil {
 			logging.V(5).Infof("EvalSourceIterator ended with an error: %v", res.Error())
 		}
 		return nil, res

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -84,7 +84,9 @@ func (src *evalSource) Stack() tokens.QName {
 func (src *evalSource) Info() interface{} { return src.runinfo }
 
 // Iterate will spawn an evaluator coroutine and prepare to interact with it on subsequent calls to Next.
-func (src *evalSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
+func (src *evalSource) Iterate(
+	ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
+
 	contract.Ignore(ctx) // TODO[pulumi/pulumi#1714]
 
 	// First, fire up a resource monitor that will watch for and record resource creation.

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -172,13 +172,13 @@ func TestRegisterNoDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(fixedProgram(steps))
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
-	assert.NoError(t, err)
+	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
+	assert.Nil(t, res)
 
 	processed := 0
 	for {
-		event, err := iter.Next()
-		assert.NoError(t, err)
+		event, res := iter.Next()
+		assert.Nil(t, res)
 
 		if event == nil {
 			break
@@ -253,13 +253,13 @@ func TestRegisterDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(fixedProgram(steps))
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
-	assert.NoError(t, err)
+	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, &testProviderSource{})
+	assert.Nil(t, res)
 
 	processed, defaults := 0, make(map[string]struct{})
 	for {
-		event, err := iter.Next()
-		assert.NoError(t, err)
+		event, res := iter.Next()
+		assert.Nil(t, res)
 
 		if event == nil {
 			break
@@ -364,13 +364,13 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 	ctx, err := newTestPluginContext(program)
 	assert.NoError(t, err)
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
-	assert.NoError(t, err)
+	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
+	assert.Nil(t, res)
 
 	reads := 0
 	for {
-		event, err := iter.Next()
-		assert.NoError(t, err)
+		event, res := iter.Next()
+		assert.Nil(t, res)
 		if event == nil {
 			break
 		}
@@ -437,13 +437,13 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 
 	providerSource := &testProviderSource{providers: make(map[providers.Reference]plugin.Provider)}
 
-	iter, err := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
-	assert.NoError(t, err)
+	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
+	assert.Nil(t, res)
 
 	reads, registers := 0, 0
 	for {
-		event, err := iter.Next()
-		assert.NoError(t, err)
+		event, res := iter.Next()
+		assert.Nil(t, res)
 
 		if event == nil {
 			break

--- a/pkg/resource/deploy/source_fixed.go
+++ b/pkg/resource/deploy/source_fixed.go
@@ -37,7 +37,9 @@ func (src *fixedSource) Close() error                { return nil }
 func (src *fixedSource) Project() tokens.PackageName { return src.ctx }
 func (src *fixedSource) Info() interface{}           { return nil }
 
-func (src *fixedSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
+func (src *fixedSource) Iterate(
+	ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
+
 	contract.Ignore(ctx) // TODO[pulumi/pulumi#1714]
 	return &fixedSourceIterator{
 		src:     src,

--- a/pkg/resource/deploy/source_fixed.go
+++ b/pkg/resource/deploy/source_fixed.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // NewFixedSource returns a valid planning source that is comprised of a list of pre-computed steps.
@@ -36,7 +37,7 @@ func (src *fixedSource) Close() error                { return nil }
 func (src *fixedSource) Project() tokens.PackageName { return src.ctx }
 func (src *fixedSource) Info() interface{}           { return nil }
 
-func (src *fixedSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error) {
+func (src *fixedSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
 	contract.Ignore(ctx) // TODO[pulumi/pulumi#1714]
 	return &fixedSourceIterator{
 		src:     src,
@@ -54,7 +55,7 @@ func (iter *fixedSourceIterator) Close() error {
 	return nil // nothing to do.
 }
 
-func (iter *fixedSourceIterator) Next() (SourceEvent, error) {
+func (iter *fixedSourceIterator) Next() (SourceEvent, *result.Result) {
 	iter.current++
 	if iter.current >= len(iter.src.steps) {
 		return nil, nil

--- a/pkg/resource/deploy/source_null.go
+++ b/pkg/resource/deploy/source_null.go
@@ -34,7 +34,9 @@ func (src *nullSource) Close() error                { return nil }
 func (src *nullSource) Project() tokens.PackageName { return "" }
 func (src *nullSource) Info() interface{}           { return nil }
 
-func (src *nullSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
+func (src *nullSource) Iterate(
+	ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
+
 	contract.Ignore(ctx)
 	return &nullSourceIterator{}, nil
 }

--- a/pkg/resource/deploy/source_null.go
+++ b/pkg/resource/deploy/source_null.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
 // NullSource is a singleton source that never returns any resources.  This may be used in scenarios where the "new"
@@ -33,7 +34,7 @@ func (src *nullSource) Close() error                { return nil }
 func (src *nullSource) Project() tokens.PackageName { return "" }
 func (src *nullSource) Info() interface{}           { return nil }
 
-func (src *nullSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, error) {
+func (src *nullSource) Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, *result.Result) {
 	contract.Ignore(ctx)
 	return &nullSourceIterator{}, nil
 }
@@ -46,6 +47,6 @@ func (iter *nullSourceIterator) Close() error {
 	return nil // nothing to do.
 }
 
-func (iter *nullSourceIterator) Next() (SourceEvent, error) {
+func (iter *nullSourceIterator) Next() (SourceEvent, *result.Result) {
 	return nil, nil // means "done"
 }

--- a/pkg/util/result/result.go
+++ b/pkg/util/result/result.go
@@ -71,9 +71,18 @@ func FromError(err error) *Result {
 	return &Result{err: err}
 }
 
+// WrapIfNonNil returns a non-nil Result if [err] is non-nil.  Otherwise it returns nil.
+func WrapIfNonNil(err error) *Result {
+	if err == nil {
+		return nil
+	}
+
+	return FromError(err)
+}
+
 // TODO returns an error that can be used in places that have not yet been
 // adapted to use Results.  Their use is intended to be temporary until Results
 // are plumbed throughout the Pulumi codebase.
 func TODO() error {
-	return errors.New("bailng due to error")
+	return errors.New("bailing due to error")
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -367,9 +367,16 @@ func (host *nodeLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest
 		contract.IgnoreError(os.Stdout.Sync())
 		contract.IgnoreError(os.Stderr.Sync())
 		if exiterr, ok := err.(*exec.ExitError); ok {
-			// If the program ran, but exited with a non-zero error code.  This will happen often, since user
-			// errors will trigger this.  So, the error message should look as nice as possible.
+			// If the program ran, but exited with a non-zero error code.  This will happen often,
+			// since user errors will trigger this.  So, the error message should look as nice as
+			// possible.
 			if status, stok := exiterr.Sys().(syscall.WaitStatus); stok {
+				// 32 is the special exit code that means "we already logged all messages with the
+				// user, no need to report anything else.
+				if status.ExitStatus() == 32 {
+					return &pulumirpc.RunResponse{Error: "A97455BA-8A80-42A5-8639-53CD49E88D75"}, nil
+				}
+
 				err = errors.Errorf("Program exited with non-zero exit code: %d", status.ExitStatus())
 			} else {
 				err = errors.Wrapf(exiterr, "Program exited unexpectedly")

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -13,23 +13,32 @@
 // limitations under the License.
 
 // The very first thing we do is set up unhandled exception and rejection hooks to ensure that these events cause us to
-// exit with a non-zero code. It is criticially important that we do this early: if we do not, unhandled rejections in
+// exit with a non-zero code. It is critically important that we do this early: if we do not, unhandled rejections in
 // particular may cause us to exit with a 0 exit code, which will trick the engine into thinking that the program ran
 // successfully. This can cause the engine to decide to delete all of a stack's resources.
 let uncaught: Error | undefined;
 let programRunning = false;
+let allErrorsAreRunErrors = true;
 const uncaughtHandler = (err: Error) => {
     uncaught = err;
     if (!programRunning) {
         console.error(err.stack || err.message);
     }
+
+    allErrorsAreRunErrors = allErrorsAreRunErrors && (<any>err).__pulumiRunError === true;
 };
 process.on("uncaughtException", uncaughtHandler);
 process.on("unhandledRejection", uncaughtHandler);
 process.on("exit", (code: number) => {
-    // If we don't already have an exit code, and we had an unhandled error, exit with a non-success.
+    // If we don't already have an exit code, and we had an unhandled error, exit with a
+    // non-success.  Also keep track if all we heard about were RunErrors.  If so, we end with a
+    // different error code so that we can avoid printing extra messages to the user about the
+    // process exiting.
+    //
+    // 32 was picked so as to be very unlikely to collide with any of the error codes documented by
+    // nodejs here: https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
     if (code === 0 && uncaught) {
-        process.exitCode = 1;
+        process.exitCode = allErrorsAreRunErrors ? 32 : 1;
     }
 });
 

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -25,6 +25,9 @@ const uncaughtHandler = (err: Error) => {
         console.error(err.stack || err.message);
     }
 
+    // Don't actually reference RunError.isInstance here.  We don't want to actually end up doing
+    // any sort of module either prior to the creation, or during the execution, of this error
+    // handler.
     allErrorsAreRunErrors = allErrorsAreRunErrors && (<any>err).__pulumiRunError === true;
 };
 process.on("uncaughtException", uncaughtHandler);

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -111,8 +111,9 @@ function main(args: string[]): void {
     v8Hooks.isInitializedAsync().then(() => {
         require("./run").run(argv, () => {
             programRunning = true;
+        }).then(() =>  {
+            programRunning = false;
         });
-        programRunning = false;
     });
 }
 

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -117,7 +117,7 @@ function reportModuleLoadFailure(program: string, error: Error): never {
     return process.exit(1);
 }
 
-export function run(argv: minimist.ParsedArgs, programStarted: () => void): void {
+export function run(argv: minimist.ParsedArgs, programStarted: () => void) {
     // If there is a --pwd directive, switch directories.
     const pwd: string | undefined = argv["pwd"];
     if (pwd) {
@@ -198,7 +198,7 @@ export function run(argv: minimist.ParsedArgs, programStarted: () => void): void
     programStarted();
 
     // Construct a `Stack` resource to represent the outputs of the program.
-    runtime.runInPulumiStack(() => {
+    return runtime.runInPulumiStack(() => {
         // We run the program inside this context so that it adopts all resources.
         //
         // IDEA: This will miss any resources created on other turns of the event loop.  I think that's a fundamental

--- a/sdk/nodejs/errors.ts
+++ b/sdk/nodejs/errors.ts
@@ -33,6 +33,7 @@ export class RunError extends Error {
      * multiple copies of the Pulumi SDK have been loaded into the same process.
      */
     public static isInstance(obj: any): obj is RunError {
+        // NOTE: keep this in sync with the check in cmd\run\index.ts
         return utils.isInstance<RunError>(obj, "__pulumiRunError");
     }
 

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -122,6 +122,10 @@ export abstract class Resource {
      * @param opts A bag of options that control this resource's behavior.
      */
     constructor(t: string, name: string, custom: boolean, props: Inputs = {}, opts: ResourceOptions = {}) {
+        if (opts.parent && !Resource.isInstance(opts.parent)) {
+            throw new Error(`Resource parent is not a valid Resource: ${opts.parent}`);
+        }
+
         if (!t) {
             throw new ResourceError("Missing resource type argument", opts.parent);
         }
@@ -132,10 +136,6 @@ export abstract class Resource {
         // Check the parent type if one exists and fill in any default options.
         this.__providers = {};
         if (opts.parent) {
-            if (!Resource.isInstance(opts.parent)) {
-                throw new RunError(`Resource parent is not a valid Resource: ${opts.parent}`);
-            }
-
             this.__parentResource = opts.parent;
             this.__parentResource.__childResources = this.__parentResource.__childResources || new Set();
             this.__parentResource.__childResources.add(this);

--- a/sdk/nodejs/tests/runtime/langhost/cases/040.run_error/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/040.run_error/index.js
@@ -1,0 +1,3 @@
+let errors = require("../../../../../errors");
+
+throw new errors.RunError("💥 goes the dynamite");

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -727,10 +727,17 @@ describe("rpc", () => {
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
             },
         },
+        "run_error": {
+            program: path.join(base, "040.run_error"),
+            expectResourceCount: 0,
+            // We should get the error message saying that a message was reported and the
+            // host should bail.
+            expectError: "A97455BA-8A80-42A5-8639-53CD49E88D75",
+        },
     };
 
     for (const casename of Object.keys(cases)) {
-        // if (casename.indexOf("parent_child_dependencies") < 0) {
+        // if (casename.indexOf("run_error") < 0) {
         //     continue;
         // }
 

--- a/sdk/proto/language.proto
+++ b/sdk/proto/language.proto
@@ -58,6 +58,8 @@ message RunResponse {
     // An unhandled error if any occurred.
     string error = 1;
 
-    // An error happened.  And it was reported to the user.  Work should stop 
-    bool doNotContinue = 2;
+    // An error happened.  And it was reported to the user.  Work should stop immediately
+    // with nothing further to print to the user.  This corresponds to a "result.Bail()"
+    // value in the 'go' layer.
+    bool bail = 2;
 }

--- a/sdk/proto/language.proto
+++ b/sdk/proto/language.proto
@@ -55,5 +55,9 @@ message RunRequest {
 
 // RunResponse is the response back from the interpreter/source back to the monitor.
 message RunResponse {
-    string error = 1; // an unhandled error if any occurred.
+    // An unhandled error if any occurred.
+    string error = 1;
+
+    // An error happened.  And it was reported to the user.  Work should stop 
+    bool doNotContinue = 2;
 }


### PR DESCRIPTION
The primary purpose of this is to get a better experience around nodejs reporting issues to the user (especially around config).  The current experience is somewhat poor, with the user getting the following errors:

![image](https://user-images.githubusercontent.com/4564579/54236199-49968b80-44d0-11e9-9102-16503a667ec0.png)

Only the first message is relevant, with the subsequent messages just being noise.

This PR takes the work around the "result.Bail" type that @swgillespie added a while back, and expands it to be used in more cases.  Specifically:

1. We allow the nodejs process to exit with a special error code saying: I errored, but i gave the user the appropriate information that they could use to handle the issue.
2. on the 'go' side, if we see that exit code, we now 'Bail()' instead of returning an error.  This 'Bail()' travels up the stack *not* printing further messages.

The result of this is that we now see:

![image](https://user-images.githubusercontent.com/4564579/54236479-d7727680-44d0-11e9-9b10-e378c364a9ed.png)

This is much cleaner and much more in line with the experience we want.