### PR TITLE
Use '.finally'

### DIFF
--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -111,7 +111,7 @@ function main(args: string[]): void {
     v8Hooks.isInitializedAsync().then(() => {
         require("./run").run(argv, () => {
             programRunning = true;
-        }).then(() =>  {
+        }).finally(() =>  {
             programRunning = false;
         });
     });

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -113,9 +113,13 @@ function main(args: string[]): void {
             programRunning = true;
         });
 
-        // .finally is not available.  So we call into .then with the same value for both
-        // resolved and rejected.
-        promise.then(() => { programRunning = false; }, () => { programRunning = false; });
+        // when the user's program completes successfully, set programRunning back to false.  That way, if the Pulumi
+        // scaffolding code ends up throwing an exception during teardown, it will get printed directly to the console.
+        //
+        // Note: we only do this in the 'resolved' arg of '.then' (not the 'rejected' arg).  If the users code throws
+        // an exception, this promise will get rejected, and we don't want touch or otherwise intercept the exception
+        // or change the programRunning state here at all.
+        promise.then(() => { programRunning = false; });
     });
 }
 

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -109,11 +109,13 @@ function main(args: string[]): void {
 
     // Ensure that our v8 hooks have been initialized.  Then actually load and run the user program.
     v8Hooks.isInitializedAsync().then(() => {
-        require("./run").run(argv, () => {
+        const promise: Promise<void> = require("./run").run(argv, () => {
             programRunning = true;
-        }).finally(() =>  {
-            programRunning = false;
         });
+
+        // .finally is not available.  So we call into .then with the same value for both
+        // resolved and rejected.
+        promise.then(() => { programRunning = false; }, () => { programRunning = false; });
     });
 }
 


### PR DESCRIPTION
As pointed out by @lukehoban, `.finally` is likely more correct as we want to unilaterally set this value after running the user code.