### PR TITLE
Throw proper error

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -122,6 +122,10 @@ export abstract class Resource {
      * @param opts A bag of options that control this resource's behavior.
      */
     constructor(t: string, name: string, custom: boolean, props: Inputs = {}, opts: ResourceOptions = {}) {
+        if (opts.parent && !Resource.isInstance(opts.parent)) {
+            throw new Error(`Resource parent is not a valid Resource: ${opts.parent}`);
+        }
+
         if (!t) {
             throw new ResourceError("Missing resource type argument", opts.parent);
         }
@@ -132,10 +136,6 @@ export abstract class Resource {
         // Check the parent type if one exists and fill in any default options.
         this.__providers = {};
         if (opts.parent) {
-            if (!Resource.isInstance(opts.parent)) {
-                throw new RunError(`Resource parent is not a valid Resource: ${opts.parent}`);
-            }
-
             this.__parentResource = opts.parent;
             this.__parentResource.__childResources = this.__parentResource.__childResources || new Set();
             this.__parentResource.__childResources.add(this);


### PR DESCRIPTION
Note that this changes into an Error. This should not have been a 'RunError'. "RunError" means "do not print the stack, it's noisy". In this case, we def do want to print the stack so the user can go and find the problem here.