### PR TITLE
Better present interpolated strings during preview.

### DIFF
--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -710,5 +710,8 @@ export function interpolate(literals: TemplateStringsArray, ...placeholders: Inp
         return result;
     });
 
-    return new Output<string>(allResources, val, Promise.resolve(true));
+    // We mark the resultant Output we return as 'isKnown=true', regardless of what the component
+    // Output values are.  We consider this value known-enough because we have the information from
+    // the actual literal sections that we want to still be able to show the user during preview.
+    return new Output(allResources, val, Promise.resolve(true));
 }

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -677,17 +677,38 @@ export function concat(...params: Input<any>[]): Output<string> {
  * [Promise]s, [Output]s, or just plain JavaScript values.
  */
 export function interpolate(literals: TemplateStringsArray, ...placeholders: Input<any>[]): Output<string> {
-    return output(placeholders).apply(unwrapped => {
+    const outputs = placeholders.map(i => output(i));
+    const allResources = new Set<Resource>();
+
+    for (const op of outputs) {
+        for (const res of op.resources()) {
+            allResources.add(res);
+        }
+    }
+
+    const valuesAndIsKnowns = outputs.map(o => Promise.all([o.promise(), o.isKnown]));
+
+    const val = Promise.all(valuesAndIsKnowns).then(unwrapped => {
         let result = "";
 
         // interleave the literals with the placeholders
         for (let i = 0; i < unwrapped.length; i++) {
+            const value = unwrapped[i][0];
+            const isKnown = unwrapped[i][1];
+
             result += literals[i];
-            result += unwrapped[i];
+
+            // If the value is known, just concat into the string.  If it isn't known,
+            // then just add "<computed>".  This helps ensure we build a string that
+            // contains a lot of helpful structure for the user, while still indicating
+            // the sections that aren't known during preview.
+            result += value !== undefined || isKnown ? value : "<computed>";
         }
 
         // add the last literal
         result += literals[literals.length - 1];
         return result;
     });
+
+    return new Output<string>(allResources, val, Promise.resolve(true));
 }

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -146,6 +146,16 @@ describe("output", () => {
             const result = interpolate `http://${output("a")}:${80}/`;
             assert.equal(await result.promise(), "http://a:80/");
         }));
+
+        it ("places <computed> for unknown outputs", asyncTest(async () => {
+            const result = interpolate `http://${new Output([], Promise.resolve(undefined), Promise.resolve(false))}:${80}/`;
+            assert.equal(await result.promise(), "http://<computed>:80/");
+        }));
+
+        it ("places 'undefined' for undefined outputs", asyncTest(async () => {
+            const result = interpolate `http://${new Output([], Promise.resolve(undefined), Promise.resolve(true))}:${80}/`;
+            assert.equal(await result.promise(), "http://undefined:80/");
+        }));
     });
 
     describe("lifted operations", () => {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/871

Our current implementation of 'pulumi.interpolate' is correct, but will often produce `<computed>` during preview for the entire string.  This is unfortunate given that the original interpolation expression contained a useful amount of information (like ``pulumi.interpolate`http://${ep.hostname}:${ep.port}/${stage}``).  

We can do better here, and instead produce: `http://<computed>:<computed>/<computed`.  This helps provide a bit of useful information to the user, while still making it clear what the holes are.  