### PR TITLE
Fix path for nodejs sdk

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -3,7 +3,7 @@
     "version": "${VERSION}",
     "description": "Pulumi's Node.js SDK",
     "license": "Apache-2.0",
-    "repository": "https://github.com/pulumi/pulumi/sdk/nodejs",
+    "repository": "https://github.com/pulumi/pulumi/tree/master/sdk/nodejs",
     "dependencies": {
         "google-protobuf": "^3.5.0",
         "grpc": "^1.12.2",


### PR DESCRIPTION
Found a broken link to the github repository on this [page](https://www.npmjs.com/package/@pulumi/pulumi)

Updated this [line](https://github.com/pulumi/pulumi/blob/b774917e57ed877b0e1d5df6505cbd72677386a7/sdk/nodejs/package.json#L6) specifically with the right path.



