### PR TITLE
Revert "Revert "Use result.Result pattern in more places. (#2573)" (#2575)"

### DIFF
--- a/pkg/diag/errors.go
+++ b/pkg/diag/errors.go
@@ -52,3 +52,11 @@ func GetAnalyzeResourceFailureError(urn resource.URN) *Diag {
 func GetPreviewFailedError(urn resource.URN) *Diag {
 	return newError(urn, 2005, "Preview failed: %v")
 }
+
+func GetBadProviderError(urn resource.URN) *Diag {
+	return newError(urn, 2006, "bad provider reference '%v' for resource '%v': %v")
+}
+
+func GetUnknownProviderError(urn resource.URN) *Diag {
+	return newError(urn, 2007, "unknown provider '%v' for resource '%v'")
+}

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -37,7 +37,7 @@ type planExecutor struct {
 	stepExec *stepExecutor  // step executor owned by this plan
 }
 
-// execError creates an error appropriate for returning from planExecutor.Execute.
+// reportExecResult issues an appropriate diagnostic depending on went wrong.
 func (pe *planExecutor) reportExecResult(message string, preview bool) {
 	kind := "update"
 	if preview {


### PR DESCRIPTION
This reverts commit 4abdc88c2e63f95f08fcf6c28219a4e61312c95a.

I originally reverted this thinking it might be the cause of an issue being seen in CI.  It turned out not to be, so im un-reverting it.