### PR TITLE
Don't print `error` prefix when a confirmation prompt is declined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 0.17.4 (Unreleased)
 
-## 0.17.3 (Released March 26, 2019)
+## Improvements
 
-- Add support for serializing JavaScript function that capture [BigInts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt).
-- Support serializing arrow-functions with deconstructed parameters.
+- Don't print the `error:` prefix when Pulumi exists because of a declined confirmation prompt (fixes [pulumi/pulumi#458](https://github.com/pulumi/pulumi/issues/2070))
+
+## 0.17.3 (Released March 26, 2019)
 
 ### Improvements
 
@@ -12,7 +13,8 @@
 - A bug in the previous version of the Pulumi CLI occasionally caused the Pulumi Engine to load the incorrect resource
   plugin when processing an update. This bug has been fixed in 0.17.3 by performing a deterministic selection of the
   best set of plugins available to the engine before starting up. See
-  [pulumi/pulumi#2579](https://github.com/pulumi/pulumi/issues/2579) for discussion on this issue.
+- Add support for serializing JavaScript function that capture [BigInts](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt).
+- Support serializing arrow-functions with deconstructed parameters.
 
 ## 0.17.2 (Released March 15, 2019)
 

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -123,14 +123,14 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	}
 
 	// Otherwise, ensure the user wants to proceed.
-	err := confirmBeforeUpdating(kind, stack, events, op.Opts)
+	res = confirmBeforeUpdating(kind, stack, events, op.Opts)
 	close(eventsChannel)
-	return changes, result.WrapIfNonNil(err)
+	return changes, res
 }
 
 // confirmBeforeUpdating asks the user whether to proceed. A nil error means yes.
 func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
-	events []engine.Event, opts UpdateOptions) error {
+	events []engine.Event, opts UpdateOptions) result.Result {
 	for {
 		var response string
 
@@ -167,11 +167,12 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 			Options: choices,
 			Default: string(no),
 		}, &response, nil); err != nil {
-			return errors.Wrapf(err, "confirmation cancelled, not proceeding with the %s", kind)
+			return result.FromError(errors.Wrapf(err, "confirmation cancelled, not proceeding with the %s", kind))
 		}
 
 		if response == string(no) {
-			return errors.Errorf("confirmation declined, not proceeding with the %s", kind)
+			fmt.Printf("confirmation declined, not proceeding with the %s\n", kind)
+			return result.Bail()
 		}
 
 		if response == string(yes) {


### PR DESCRIPTION
Use `result.Result` in more places, so when a confirmation prompt is
declined, we just return `result.Bail()` after printing a message
without the `error: ` prefix.

Fixes #2070