### PR TITLE
Fix spurious warnings when using dynamic provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Improvements
 
 - A new command, `pulumi stack rename` was added. This allows you to change the name of an existing stack in a project. Note: When a stack is renamed, the `pulumi.getStack` function in the SDK will now return a new value. If a stack name is used as part of a resource name, the next `pulumi update` will not understand that the old and new resources are logically the same. We plan to support adding aliases to individual resources so you can handle these cases. See [pulumi/pulumi#458](https://github.com/pulumi/pulumi/issues/458) for discussion on this new feature. For now, if you are unwilling to have `pulumi update` create and destroy these resources, you can rename your stack back to the old name. (fixes [pulumi/pulumi#2402](https://github.com/pulumi/pulumi/issues/2402))
+- Fix two warnings that were printed when using a dynamic provider about missing method handlers.
 
 ## 0.17.2 (Released March 15, 2019)
 

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -108,6 +108,10 @@ async function checkRPC(call: any, callback: any): Promise<void> {
     }
 }
 
+function checkConfigRPC(call: any, callback: any): void {
+    callback(undefined, new emptyproto.Empty());
+}
+
 async function diffRPC(call: any, callback: any): Promise<void> {
     try {
         const req: any = call.request;
@@ -148,6 +152,10 @@ async function diffRPC(call: any, callback: any): Promise<void> {
         console.error(`${e}: ${e.stack}`);
         callback(e, undefined);
     }
+}
+
+function diffConfigRPC(call: any, callback: any): void {
+    callback(undefined, new emptyproto.Empty());
 }
 
 async function createRPC(call: any, callback: any): Promise<void> {
@@ -302,7 +310,9 @@ export function main(args: string[]): void {
         configure: configureRPC,
         invoke: invokeRPC,
         check: checkRPC,
+        checkConfig: checkConfigRPC,
         diff: diffRPC,
+        diffConfig: diffConfigRPC,
         create: createRPC,
         read: readRPC,
         update: updateRPC,


### PR DESCRIPTION
When using a dynamic provider, the following messages are printed,
because we did not update the dynamic provider when we added these new
RPCs:

```
Method handler checkConfig for /pulumirpc.ResourceProvider/CheckConfig expected but not provided
Method handler diffConfig for /pulumirpc.ResourceProvider/DiffConfig expected but not provided
```

Given that we don't do anything for the `configure` RPC today, we can
also just no-op these RPCs as well.