### PR TITLE
Correctly handle FileArchives when the filename contains a dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## 0.17.5 (Unreleased)
 
-## Improvements
+### Improvements
+
+- Correctly handle the case where we would fail to detect an archive type if the filename included a dot in it. (fixes [pulumi/pulumi#2589](https://github.com/pulumi/pulumi/issues/2589))
 
 ## 0.17.4 (Released March 26, 2019)
 
-## Improvements
+### Improvements
 
 - Don't print the `error:` prefix when Pulumi exists because of a declined confirmation prompt (fixes [pulumi/pulumi#458](https://github.com/pulumi/pulumi/issues/2070))
 - Fix issue where `Outputs` produced by `pulumi.interpolate` might have values which could

--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -1101,15 +1101,13 @@ var ArchiveExts = map[string]ArchiveFormat{
 
 // detectArchiveFormat takes a path and infers its archive format based on the file extension.
 func detectArchiveFormat(path string) ArchiveFormat {
-	ext := filepath.Ext(path)
-	if moreext := filepath.Ext(strings.TrimRight(path, ext)); moreext != "" {
-		ext = moreext + ext // this ensures we detect ".tar.gz" correctly.
+	for ext, typ := range ArchiveExts {
+		if strings.HasSuffix(path, ext) {
+			return typ
+		}
 	}
-	format, has := ArchiveExts[ext]
-	if !has {
-		return NotArchive
-	}
-	return format
+
+	return NotArchive
 }
 
 // readArchive takes a stream to an existing archive and returns a map of names to readers for the inner assets.

--- a/pkg/resource/asset_test.go
+++ b/pkg/resource/asset_test.go
@@ -456,6 +456,22 @@ func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	assert.Equal(t, "foo/bar/b.txt", files[0].Name)
 }
 
+func TestFileExtentionSniffing(t *testing.T) {
+	assert.Equal(t, ArchiveFormat(ZIPArchive), detectArchiveFormat("./some/path/my.zip"))
+	assert.Equal(t, ArchiveFormat(TarArchive), detectArchiveFormat("./some/path/my.tar"))
+	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.tar.gz"))
+	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.tgz"))
+	assert.Equal(t, ArchiveFormat(NotArchive), detectArchiveFormat("./some/path/who.knows"))
+
+	// In #2589 we had cases where a file would look like it had an longer extension, because the suffix would include
+	// some stuff after a dot. i.e. we failed to treat "my.file.zip" as a ZIPArchive.
+	assert.Equal(t, ArchiveFormat(ZIPArchive), detectArchiveFormat("./some/path/my.file.zip"))
+	assert.Equal(t, ArchiveFormat(TarArchive), detectArchiveFormat("./some/path/my.file.tar"))
+	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.file.tar.gz"))
+	assert.Equal(t, ArchiveFormat(TarGZIPArchive), detectArchiveFormat("./some/path/my.file.tgz"))
+	assert.Equal(t, ArchiveFormat(NotArchive), detectArchiveFormat("./some/path/who.even.knows"))
+}
+
 func TestInvalidPathArchive(t *testing.T) {
 	// Create a temp file that is not an asset.
 	tmpFile, err := ioutil.TempFile("", "")


### PR DESCRIPTION
Our logic for how we handled `.tar.gz` archives meant that any other
type of file that had a dot in the filename would not be detected
correctly.

Fixes #2589