### PR TITLE
Revert "Better present interpolated strings during preview. (#2564)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Improvements
 
 - Don't print the `error:` prefix when Pulumi exists because of a declined confirmation prompt (fixes [pulumi/pulumi#458](https://github.com/pulumi/pulumi/issues/2070))
+- Fix issue where `Outputs` produced by `pulumi.interpolate` might have values which could
+  cause validation errors due to them containing the text `<computed>` during previews.
 
 ## 0.17.3 (Released March 26, 2019)
 

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -677,41 +677,17 @@ export function concat(...params: Input<any>[]): Output<string> {
  * [Promise]s, [Output]s, or just plain JavaScript values.
  */
 export function interpolate(literals: TemplateStringsArray, ...placeholders: Input<any>[]): Output<string> {
-    const outputs = placeholders.map(i => output(i));
-    const allResources = new Set<Resource>();
-
-    for (const op of outputs) {
-        for (const res of op.resources()) {
-            allResources.add(res);
-        }
-    }
-
-    const valuesAndIsKnowns = outputs.map(o => Promise.all([o.promise(), o.isKnown]));
-
-    const val = Promise.all(valuesAndIsKnowns).then(unwrapped => {
+    return output(placeholders).apply(unwrapped => {
         let result = "";
 
         // interleave the literals with the placeholders
         for (let i = 0; i < unwrapped.length; i++) {
-            const value = unwrapped[i][0];
-            const isKnown = unwrapped[i][1];
-
             result += literals[i];
-
-            // If the value is known, just concat into the string.  If it isn't known,
-            // then just add "<computed>".  This helps ensure we build a string that
-            // contains a lot of helpful structure for the user, while still indicating
-            // the sections that aren't known during preview.
-            result += value !== undefined || isKnown ? value : "<computed>";
+            result += unwrapped[i];
         }
 
         // add the last literal
         result += literals[literals.length - 1];
         return result;
     });
-
-    // We mark the resultant Output we return as 'isKnown=true', regardless of what the component
-    // Output values are.  We consider this value known-enough because we have the information from
-    // the actual literal sections that we want to still be able to show the user during preview.
-    return new Output(allResources, val, Promise.resolve(true));
 }

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -146,16 +146,6 @@ describe("output", () => {
             const result = interpolate `http://${output("a")}:${80}/`;
             assert.equal(await result.promise(), "http://a:80/");
         }));
-
-        it ("places <computed> for unknown outputs", asyncTest(async () => {
-            const result = interpolate `http://${new Output([], Promise.resolve(undefined), Promise.resolve(false))}:${80}/`;
-            assert.equal(await result.promise(), "http://<computed>:80/");
-        }));
-
-        it ("places 'undefined' for undefined outputs", asyncTest(async () => {
-            const result = interpolate `http://${new Output([], Promise.resolve(undefined), Promise.resolve(true))}:${80}/`;
-            assert.equal(await result.promise(), "http://undefined:80/");
-        }));
     });
 
     describe("lifted operations", () => {


### PR DESCRIPTION
This reverts commit 718a0c293b3a5985ff65ea03533de35d5b6fb133.

The original change had an unintended downstream effect of now producing *incorrect* values that could then cause things like previews to fail.  While this change is overall a nice one, we need to properly distinguish known/unknown values of Outputs, versus what information we can properly show in the *display* layer.  We cannot conflate the two.  