### PR TITLE
Suppress further errors at LangHost level if we know the nodejs process reported the errors to the user.

### DIFF
--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -12,11 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// The very first thing we do is set up unhandled exception and rejection hooks to ensure that these events cause us to
-// exit with a non-zero code. It is critically important that we do this early: if we do not, unhandled rejections in
-// particular may cause us to exit with a 0 exit code, which will trick the engine into thinking that the program ran
-// successfully. This can cause the engine to decide to delete all of a stack's resources.
+// The very first thing we do is set up unhandled exception and rejection hooks to ensure that these
+// events cause us to exit with a non-zero code. It is critically important that we do this early:
+// if we do not, unhandled rejections in particular may cause us to exit with a 0 exit code, which
+// will trick the engine into thinking that the program ran successfully. This can cause the engine
+// to decide to delete all of a stack's resources.
+//
+// We track all uncaught errors here.  If we have any, we will make sure we always have a non-0 exit
+// code.
 const uncaughtErrors = new Set<Error>();
+
+// We also track errors we know were logged to the user using our standard `log.error` call from
+// inside our uncaught-error-handler in run.ts.  If all uncaught-errors above were also known to all
+// be logged properly to the user, then we know the user has the information they need to proceed.
+// We can then report the langhost that it should just stop running immediately and not print any
+// additional superfluous information.
 const loggedErrors = new Set<Error>();
 
 let programRunning = false;

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -37,17 +37,18 @@ const uncaughtHandler = (err: Error) => {
     }
 };
 
+// Keep track if we already logged the information about an unhandled error to the user..  If
+// so, we end with a different exit code.  The language host recognizes this and will not print
+// any further messages to the user since we already took care of it.
+//
+// 32 was picked so as to be very unlikely to collide with any of the error codes documented by
+// nodejs here:
+// https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+export const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
+
 process.on("uncaughtException", uncaughtHandler);
 process.on("unhandledRejection", uncaughtHandler);
 process.on("exit", (code: number) => {
-    // Keep track if we already logged the information about an unhandled error to the user..  If
-    // so, we end with a different exit code.  The language host recognizes this and will not print
-    // any further messages to the user since we already took care of it.
-    //
-    // 32 was picked so as to be very unlikely to collide with any of the error codes documented by
-    // nodejs here:
-    // https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
-    const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
 
     // If there were any uncaught errors at all, we always want to exit with an error code. If we
     // did not, it could be disastrous for the user.  i.e. not all resources may have been created,

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -117,7 +117,9 @@ function reportModuleLoadFailure(program: string, error: Error): never {
     return process.exit(1);
 }
 
-export function run(argv: minimist.ParsedArgs, programStarted: () => void) {
+export function run(argv: minimist.ParsedArgs,
+                    programStarted: () => void,
+                    reportLoggedError: (err: Error) => void) {
     // If there is a --pwd directive, switch directories.
     const pwd: string | undefined = argv["pwd"];
     if (pwd) {
@@ -190,6 +192,8 @@ export function run(argv: minimist.ParsedArgs, programStarted: () => void) {
 `Running program '${program}' failed with an unhandled exception:
 ${defaultMessage}`);
         }
+
+        reportLoggedError(err);
     };
 
     process.on("uncaughtException", uncaughtHandler);

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -20,6 +20,8 @@ import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
 import * as runtime from "../../runtime";
 
+import * as mod from ".";
+
 /**
  * Attempts to provide a detailed error message for module load failure if the
  * module that failed to load is the top-level module.
@@ -27,6 +29,15 @@ import * as runtime from "../../runtime";
  * @param error The error that occured. Must be a module load error.
  */
 function reportModuleLoadFailure(program: string, error: Error): never {
+    throwOrPrintModuleLoadError(program, error);
+
+    // Note: from this point on, we've printed something to the user telling them about the
+    // problem.  So we can let our langhost know it doesn't need to report any further issues.
+    return process.exit(mod.nodeJSProcessExitedAfterLoggingUserActionableMessage);
+}
+
+
+function throwOrPrintModuleLoadError(program: string, error: Error): void {
     // error is guaranteed to be a Node module load error. Node emits a very
     // specific string in its error message for module load errors, which includes
     // the module it was trying to load.
@@ -49,6 +60,8 @@ function reportModuleLoadFailure(program: string, error: Error): never {
         throw error;
     }
 
+    // Note: from this point on, we've printed something to the user telling them about the
+    // problem.  So we can let our langhost know it doesn't need to report any further issues.
     console.error(`We failed to locate the entry point for your program: ${program}`);
 
     // From here on out, we're going to try to inspect the program we're being asked to run
@@ -72,7 +85,7 @@ function reportModuleLoadFailure(program: string, error: Error): never {
     } catch {
         // This is all best-effort so if we can't load the package.json file, that's
         // fine.
-        return process.exit(1);
+        return;
     }
 
     console.error("Here's what we think went wrong:");
@@ -93,14 +106,14 @@ function reportModuleLoadFailure(program: string, error: Error): never {
         console.error(`  * Your program looks like it has a build script associated with it ('${command}').\n`);
         console.error("Pulumi does not run build scripts before running your program. " +
                         `Please run '${command}', 'yarn build', or 'npm run build' and try again.`);
-        return process.exit(1);
+        return;
     }
 
     // Not all typescript programs have build scripts. If we think it's a typescript program,
     // tell the user to run tsc.
     if ("typescript" in deps || "typescript" in devDeps) {
         console.error("  * Your program looks like a TypeScript program. Have you run 'tsc'?");
-        return process.exit(1);
+        return;
     }
 
     // Not all projects are typescript. If there's a main property, check that the file exists.
@@ -108,13 +121,13 @@ function reportModuleLoadFailure(program: string, error: Error): never {
         const mainFile = path.join(projectRoot, mainProperty);
         if (!fs.existsSync(mainFile)) {
             console.error(`  * Your program's 'main' file (${mainFile}) does not exist.`);
-            return process.exit(1);
+            return;
         }
     }
 
     console.error("  * Yowzas, our sincere apologies, we haven't seen this before!");
     console.error(`    Here is the raw exception message we received: ${error.message}`);
-    return process.exit(1);
+    return;
 }
 
 export function run(argv: minimist.ParsedArgs,

--- a/sdk/nodejs/errors.ts
+++ b/sdk/nodejs/errors.ts
@@ -33,7 +33,6 @@ export class RunError extends Error {
      * multiple copies of the Pulumi SDK have been loaded into the same process.
      */
     public static isInstance(obj: any): obj is RunError {
-        // NOTE: keep this in sync with the check in cmd\run\index.ts
         return utils.isInstance<RunError>(obj, "__pulumiRunError");
     }
 

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -337,7 +337,21 @@ describe("rpc", () => {
         "unhandled_error": {
             program: path.join(base, "011.unhandled_error"),
             expectResourceCount: 0,
-            expectError: "Program exited with non-zero exit code: 1",
+            expectError: "",
+            expectBail: true,
+            expectedLogs: {
+                count: 1,
+                ignoreDebug: true,
+            },
+            log: (ctx: any, severity: any, message: string) => {
+                if (severity === engineproto.LogSeverity.ERROR) {
+                    if (message.indexOf("failed with an unhandled exception") < 0 &&
+                        message.indexOf("es the dynamite") < 0) {
+
+                        throw new Error("Unexpected error: message");
+                    }
+                }
+            },
         },
         // A program that creates one resource that contains an assets archive.
         "assets_archive": {
@@ -351,7 +365,21 @@ describe("rpc", () => {
         "unhandled_promise_rejection": {
             program: path.join(base, "013.unhandled_promise_rejection"),
             expectResourceCount: 0,
-            expectError: "Program exited with non-zero exit code: 1",
+            expectError: "",
+            expectBail: true,
+            expectedLogs: {
+                count: 1,
+                ignoreDebug: true,
+            },
+            log: (ctx: any, severity: any, message: string) => {
+                if (severity === engineproto.LogSeverity.ERROR) {
+                    if (message.indexOf("failed with an unhandled exception") < 0 &&
+                        message.indexOf("es the dynamite") < 0) {
+
+                        throw new Error("Unexpected error: message");
+                    }
+                }
+            },
         },
         // A simple test of the read resource behavior.
         "read_resource": {
@@ -738,7 +766,7 @@ describe("rpc", () => {
     };
 
     for (const casename of Object.keys(cases)) {
-        // if (casename.indexOf("run_error") < 0) {
+        // if (casename.indexOf("unhandled_promise_rejection") < 0) {
         //     continue;
         // }
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/1694

Note: importantly, we do not change teh invariant that if there's a problem we exit with a non-zero code.  We're just more permissive about the circumstances when we report the special "we've printed an errror, no need for subsequent errors" message.

Now, instead of seeing:

![image](https://user-images.githubusercontent.com/4564579/55107416-7e890d80-508e-11e9-9d67-0db2e392441c.png)

Users will only see:

![image](https://user-images.githubusercontent.com/4564579/55107438-88ab0c00-508e-11e9-9d83-c96bd778b29d.png)

(which has the last, not helpful, error message stripped).

Similarly: 

![image](https://user-images.githubusercontent.com/4564579/55109815-e8f07c80-5093-11e9-885d-20e598be43c8.png)
