### PR TITLE
Fix lint issue

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -227,7 +227,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stackRef backend.StackRe
 	_, err = os.Stat(b.stackPath(newName))
 	if err == nil {
 		return errors.Errorf("a stack named %s already exists", newName)
-	} else if err != nil && !os.IsNotExist(err) {
+	} else if !os.IsNotExist(err) {
 		return err
 	}
 


### PR DESCRIPTION
A linter was correctly detecting a case where we were we were doing an
unneeded nil check on `err`. The previous clause in the if/else block
ensures that `err` is non nil.