### PR TITLE
Make the Python SDK's Config.name argument optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Improvements
 
 - Correctly handle the case where we would fail to detect an archive type if the filename included a dot in it. (fixes [pulumi/pulumi#2589](https://github.com/pulumi/pulumi/issues/2589))
+- Make `Config`'s constructor's `name` argument optional in Python, for consistency with our Node.js SDK. If it isn't
+    supplied, the current project name is used as the default.
 
 ## 0.17.4 (Released March 26, 2019)
 

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -36,10 +36,10 @@ class Config:
     The configuration bag's logical name that uniquely identifies it.  The default is the name of the current project.
     """
 
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: Optional[str] = None) -> None:
         """
-        :param str name: The configuration bag's logical name that uniquely identifies it.  The default is the name of
-               the current project.
+        :param str name: The configuration bag's logical name that uniquely identifies it.  If not provided, the name
+               of the current project is used.
         """
         if not name:
             name = get_project()


### PR DESCRIPTION
This makes the Python SDK's Config constructor name argument
optional, similar to what we do in the Node.js SDK. If not supplied,
the current project name is used as the default.