### PR TITLE
Collect logs from Google Cloud Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
-## 0.17.5 (Unreleased)
+## 0.17.6 (Unreleased)
+
+### Improvements
+
+## 0.17.5 (Released April 8, 2019)
 
 ### Improvements
 
 - Correctly handle the case where we would fail to detect an archive type if the filename included a dot in it. (fixes [pulumi/pulumi#2589](https://github.com/pulumi/pulumi/issues/2589))
 - Make `Config`'s constructor's `name` argument optional in Python, for consistency with our Node.js SDK. If it isn't
     supplied, the current project name is used as the default.
+- `pulumi logs` will now display log messages from Google Cloud Functions.
 
 ## 0.17.4 (Released March 26, 2019)
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,17 @@
 
 
 [[projects]]
+  digest = "1:2a9bb06f4bb795b22f4f73e0eeb3aa781c3a2278148ea8e60cc9b61a8cea2a10"
+  name = "cloud.google.com/go"
+  packages = [
+    "compute/metadata",
+    "logging/apiv2",
+  ]
+  pruneopts = ""
+  revision = "458e1f376a2b44413160b5d301183b65debaa3f6"
+  version = "v0.37.2"
+
+[[projects]]
   branch = "master"
   digest = "1:6978a38432a017763a148afbc7ce6491734b54292af7d3e969d84d2e9dd242e2"
   name = "github.com/Azure/go-ansiterm"
@@ -187,6 +198,14 @@
   revision = "53e6ce116135b80d037921a7fdd5138cf32d7a8a"
 
 [[projects]]
+  digest = "1:b2f6f3029f88fb385269d36d2e7ec8c6082ec40b4572f99ced9032b0b166df6e"
+  name = "github.com/googleapis/gax-go"
+  packages = ["v2"]
+  pruneopts = ""
+  revision = "beaecbbdd8af86aa3acf14180d53828ce69400b2"
+  version = "v2.0.4"
+
+[[projects]]
   digest = "1:20ed7daa9b3b38b6d1d39b48ab3fd31122be5419461470d0c28de3e121c93ecf"
   name = "github.com/gorilla/context"
   packages = ["."]
@@ -225,6 +244,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "83588e72410abfbe4df460eeb6f30841ae47d4c4"
+
+[[projects]]
+  digest = "1:85f8f8d390a03287a563e215ea6bd0610c858042731a8b42062435a0dcbc485f"
+  name = "github.com/hashicorp/golang-lru"
+  packages = ["simplelru"]
+  pruneopts = ""
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
 
 [[projects]]
   digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
@@ -509,6 +536,32 @@
   version = "v0.2.0"
 
 [[projects]]
+  digest = "1:01ed7dc01b3f220c715db799d269c7116cd6ac19b0613377800afcb7e36d0929"
+  name = "go.opencensus.io"
+  packages = [
+    ".",
+    "internal",
+    "internal/tagencoding",
+    "metric/metricdata",
+    "metric/metricproducer",
+    "plugin/ocgrpc",
+    "plugin/ochttp",
+    "plugin/ochttp/propagation/b3",
+    "resource",
+    "stats",
+    "stats/internal",
+    "stats/view",
+    "tag",
+    "trace",
+    "trace/internal",
+    "trace/propagation",
+    "trace/tracestate",
+  ]
+  pruneopts = ""
+  revision = "46618d076d80f4eab85adbcb3be9a370be1dc4e0"
+  version = "v0.20.0"
+
+[[projects]]
   branch = "master"
   digest = "1:7ac6c89335cdca86063465acc67ff283d9517a8ceec0da2f893a7a7ff5245e95"
   name = "golang.org/x/crypto"
@@ -538,6 +591,7 @@
   name = "golang.org/x/net"
   packages = [
     "context",
+    "context/ctxhttp",
     "http2",
     "http2/hpack",
     "idna",
@@ -547,6 +601,20 @@
   ]
   pruneopts = ""
   revision = "a337091b0525af65de94df2eb7e98bd9962dcbe2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:348696484a568aa816b0aa29d4924afa1a4e5492e29a003eaf365f650a53c7b4"
+  name = "golang.org/x/oauth2"
+  packages = [
+    ".",
+    "google",
+    "internal",
+    "jws",
+    "jwt",
+  ]
+  pruneopts = ""
+  revision = "9f3314589c9a9136388751d9adae6b0ed400978a"
 
 [[projects]]
   branch = "master"
@@ -591,10 +659,58 @@
   revision = "88f656faf3f37f690df1a32515b479415e1a6769"
 
 [[projects]]
+  digest = "1:07f87f26b7fc5f6a7d42cd64e0acb0106c89d50eaae84665c54a42e3647f5271"
+  name = "google.golang.org/api"
+  packages = [
+    "googleapi/transport",
+    "internal",
+    "iterator",
+    "option",
+    "transport",
+    "transport/grpc",
+    "transport/http",
+    "transport/http/internal/propagation",
+  ]
+  pruneopts = ""
+  revision = "bce707a4d0ea3488942724b3bcc1c8338f38f991"
+  version = "v0.3.0"
+
+[[projects]]
+  digest = "1:0a6cbf5be24f00105d33c9f6d2f40b8149e0316537a92be1b0d4c761b7ae39fb"
+  name = "google.golang.org/appengine"
+  packages = [
+    ".",
+    "internal",
+    "internal/app_identity",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/modules",
+    "internal/remote_api",
+    "internal/socket",
+    "internal/urlfetch",
+    "socket",
+    "urlfetch",
+  ]
+  pruneopts = ""
+  revision = "54a98f90d1c46b7731eb8fb305d2a321c30ef610"
+  version = "v1.5.0"
+
+[[projects]]
   branch = "master"
   digest = "1:b2a56937cae9680d4c1f8cc6d0a80cbbdd61853510509b80af7ffd9d51366a31"
   name = "google.golang.org/genproto"
-  packages = ["googleapis/rpc/status"]
+  packages = [
+    "googleapis/api/annotations",
+    "googleapis/api/distribution",
+    "googleapis/api/label",
+    "googleapis/api/metric",
+    "googleapis/api/monitoredres",
+    "googleapis/logging/type",
+    "googleapis/logging/v2",
+    "googleapis/rpc/status",
+    "protobuf/field_mask",
+  ]
   pruneopts = ""
   revision = "11c7f9e547da6db876260ce49ea7536985904c9b"
 
@@ -609,6 +725,7 @@
     "codes",
     "connectivity",
     "credentials",
+    "credentials/oauth",
     "encoding",
     "encoding/proto",
     "grpclb/grpc_lb_v1/messages",
@@ -727,6 +844,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "cloud.google.com/go/logging/apiv2",
     "github.com/Nvveen/Gotty",
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/credentials",
@@ -770,6 +888,9 @@
     "golang.org/x/net/context",
     "golang.org/x/net/http2",
     "golang.org/x/sync/errgroup",
+    "google.golang.org/api/iterator",
+    "google.golang.org/api/option",
+    "google.golang.org/genproto/googleapis/logging/v2",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",
     "google.golang.org/grpc/connectivity",

--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -20,7 +20,8 @@ import (
 
 // LogEntry is a row in the logs for a running compute service
 type LogEntry struct {
-	ID        string
+	ID string
+	// Timestamp is a Unix timestamp, in milliseconds
 	Timestamp int64
 	Message   string
 }

--- a/pkg/operations/operations_gcp.go
+++ b/pkg/operations/operations_gcp.go
@@ -1,0 +1,156 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package operations
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	gcplogging "cloud.google.com/go/logging/apiv2"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/logging"
+)
+
+// TODO[pulumi/pulumi#54] This should be factored out behind an OperationsProvider RPC interface and versioned with the
+// `pulumi-gcp` repo instead of statically linked into the engine.
+
+// GCPOperationsProvider creates an OperationsProvider capable of answering operational queries based on the
+// underlying resources of the `@pulumi/gcp` implementation.
+func GCPOperationsProvider(
+	config map[config.Key]string,
+	component *Resource) (Provider, error) {
+
+	ctx := context.TODO()
+	client, err := gcplogging.NewClient(ctx, option.WithScopes("https://www.googleapis.com/auth/logging.read"))
+	if err != nil {
+		return nil, err
+	}
+
+	prov := &gcpOpsProvider{
+		ctx:       ctx,
+		client:    client,
+		component: component,
+	}
+	return prov, nil
+}
+
+type gcpOpsProvider struct {
+	ctx       context.Context
+	client    *gcplogging.Client
+	component *Resource
+}
+
+var _ Provider = (*gcpOpsProvider)(nil)
+
+const (
+	// GCP resource types
+	gcpFunctionType = tokens.Type("gcp:cloudfunctions/function:Function")
+)
+
+func (ops *gcpOpsProvider) GetLogs(query LogQuery) (*[]LogEntry, error) {
+	state := ops.component.State
+	logging.V(6).Infof("GetLogs[%v]", state.URN)
+	switch state.Type {
+	case gcpFunctionType:
+		return ops.getFunctionLogs(state, query)
+	default:
+		// Else this resource kind does not produce any logs.
+		logging.V(6).Infof("GetLogs[%v] does not produce logs", state.URN)
+		return nil, nil
+	}
+}
+
+func (ops *gcpOpsProvider) getFunctionLogs(state *resource.State, query LogQuery) (*[]LogEntry, error) {
+	name := state.Outputs["name"].StringValue()
+	project := state.Outputs["project"].StringValue()
+	region := state.Outputs["region"].StringValue()
+
+	// These filters mirror what `gcloud functions logs read [function-name]` does to filter.
+	logFilter := []string{
+		`resource.type="cloud_function"`,
+		`resource.labels.region="` + region + `"`,
+		`logName:"cloud-functions"`,
+		`resource.labels.function_name="` + name + `"`,
+	}
+
+	if query.StartTime != nil {
+		logFilter = append(logFilter, fmt.Sprintf(`timestamp>="%s"`, query.StartTime.Format(time.RFC3339)))
+	}
+
+	if query.EndTime != nil {
+		logFilter = append(logFilter, fmt.Sprintf(`timestamp<="%s"`, query.EndTime.Format(time.RFC3339)))
+	}
+
+	req := &loggingpb.ListLogEntriesRequest{
+		ResourceNames: []string{"projects/" + project},
+		Filter:        strings.Join(logFilter, " "),
+	}
+
+	var logs []LogEntry
+
+	it := ops.client.ListLogEntries(ops.ctx, req)
+	for {
+		entry, err := it.Next()
+		if err == iterator.Done {
+			logging.V(5).Infof("GetLogs[%v] return %d logs", state.URN, len(logs))
+			return &logs, nil
+		}
+		if err != nil {
+			logging.V(5).Infof("GetLogs[%v] error iterating logs: %s", state.URN, err)
+			return nil, err
+		}
+
+		message, err := getLogEntryMessage(entry)
+		if err != nil {
+			logging.V(5).Infof("GetLogs[%v] error getting entry message, ignoring: %s", state.URN, err)
+			continue
+		}
+
+		logs = append(logs, LogEntry{
+			ID:        name,
+			Message:   message,
+			Timestamp: entry.GetTimestamp().Seconds * 1000,
+		})
+	}
+}
+
+// getLogEntryMessage gets the message for a log entry. There are many different underlying types for the message
+// payload. If we don't know how to decode a payload to a string, an error is returned.
+func getLogEntryMessage(e *loggingpb.LogEntry) (string, error) {
+	switch payload := e.GetPayload().(type) {
+	case *loggingpb.LogEntry_TextPayload:
+		return payload.TextPayload, nil
+
+	case *loggingpb.LogEntry_JsonPayload:
+		byts, err := json.Marshal(payload.JsonPayload)
+		if err != nil {
+			return "", errors.Wrap(err, "encoding to JSON")
+		}
+		return string(byts), nil
+	default:
+		return "", errors.Errorf("can't decode entry of type %s", reflect.TypeOf(e))
+	}
+}

--- a/pkg/operations/resources.go
+++ b/pkg/operations/resources.go
@@ -254,6 +254,8 @@ func (ops *resourceOperations) getOperationsProvider() (Provider, error) {
 		return CloudOperationsProvider(ops.config, ops.resource)
 	case "aws":
 		return AWSOperationsProvider(ops.config, ops.resource)
+	case "gcp":
+		return GCPOperationsProvider(ops.config, ops.resource)
 	default:
 		return nil, nil
 	}


### PR DESCRIPTION
This change adds an operations provider for GCP. Right now, it can
just collect logs from google cloud functions, similar to `gcloud
functions logs read`