### PR TITLE
Enable unit testing for Pulumi programs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `refresh` will now warn instead of returning an error when it notices a resource is in an
   unhealthy state. This is in service of https://github.com/pulumi/pulumi/issues/2633.
+- A new "test mode" can be enabled by setting the `PULUMI_TEST_MODE` environment variable to
+  `true` in either the Node.js or Python SDK. This new mode allows you to unit test your Pulumi programs
+  using standard test harnesses, without needing to run the program using the Pulumi CLI. In this mode, limited
+  functionality is available, however basic resource creation with input properties will work.
 
 ## 0.17.5 (Released April 8, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@
 - A new "test mode" can be enabled by setting the `PULUMI_TEST_MODE` environment variable to
   `true` in either the Node.js or Python SDK. This new mode allows you to unit test your Pulumi programs
   using standard test harnesses, without needing to run the program using the Pulumi CLI. In this mode, limited
-  functionality is available, however basic resource creation with input properties will work.
+  functionality is available, however basic resource object allocation with input properties will work.
+  Note that no actual engine operations will occur in this mode, and that you'll need to use the
+  `PULUMI_CONFIG`, `PULUMI_NODEJS_PROJECT`, and `PULUMI_NODEJS_STACK` environment variables to control settings
+  the CLI would have otherwise managed for you.
 
 ## 0.17.5 (Released April 8, 2019)
 

--- a/sdk/nodejs/metadata.ts
+++ b/sdk/nodejs/metadata.ts
@@ -20,19 +20,11 @@ import * as runtime from "./runtime";
  * getProject returns the current project name.  It throws an exception if none is registered.
  */
 export function getProject(): string {
-    const project = runtime.getProject();
-    if (project) {
-        return project;
-    }
-    throw new Error("Project unknown; are you using the Pulumi CLI?");
+    return runtime.getProject();
 }
 /**
  * getStack returns the current stack name.  It throws an exception if none is registered.
  */
 export function getStack(): string {
-    const stack = runtime.getStack();
-    if (stack) {
-        return stack;
-    }
-    throw new Error("Stack unknown; are you using the Pulumi CLI?");
+    return runtime.getStack();
 }

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -72,7 +72,10 @@ interface ResourceResolverOperation {
     propertyToDirectDependencyURNs: Map<string, Set<URN>>;
 }
 
-function createUrn(t: string, name: string): string {
+/**
+ * Creates a test URN in the case where the engine isn't available to give us one.
+ */
+function createTestUrn(t: string, name: string): string {
     return `urn:pulumi:${getStack()}::${getProject()}::${t}::${name}`;
 }
 
@@ -127,9 +130,9 @@ export function readResource(res: Resource, t: string, name: string, props: Inpu
                         }
                     })), opLabel);
             } else {
-                // If we aren't attached to the engine, mock up a fake response for testing purposes.
+                // If we aren't attached to the engine, in test mode, mock up a fake response for testing purposes.
                 resp = {
-                    getUrn: () => createUrn(t, name),
+                    getUrn: () => createTestUrn(t, name),
                     getProperties: () => req.getProperties(),
                 };
             }
@@ -208,9 +211,9 @@ export function registerResource(res: Resource, t: string, name: string, custom:
                         }
                     })), opLabel);
             } else {
-                // If we aren't attached to the engine, mock up a fake response for testing purposes.
+                // If we aren't attached to the engine, in test mode, mock up a fake response for testing purposes.
                 resp = {
-                    getUrn: () => createUrn(t, name),
+                    getUrn: () => createTestUrn(t, name),
                     getId: () => undefined,
                     getObject: () => req.getObject(),
                 };

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -15,7 +15,15 @@
 import * as grpc from "grpc";
 import * as log from "../log";
 import { Input, Inputs, Output } from "../output";
-import { ComponentResource, CustomResource, CustomResourceOptions, ID, Resource, ResourceOptions, URN } from "../resource";
+import {
+    ComponentResource,
+    CustomResource,
+    CustomResourceOptions,
+    ID,
+    Resource,
+    ResourceOptions,
+    URN,
+} from "../resource";
 import { debuggablePromise } from "./debuggable";
 
 import {
@@ -29,7 +37,15 @@ import {
     transferProperties,
     unknownValue,
 } from "./rpc";
-import { excessiveDebugOutput, getMonitor, getRootResource, rpcKeepAlive, serialize } from "./settings";
+import {
+    excessiveDebugOutput,
+    getMonitor,
+    getProject,
+    getRootResource,
+    getStack,
+    rpcKeepAlive,
+    serialize,
+} from "./settings";
 
 const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
 const resproto = require("../proto/resource_pb.js");
@@ -56,6 +72,10 @@ interface ResourceResolverOperation {
     propertyToDirectDependencyURNs: Map<string, Set<URN>>;
 }
 
+function createUrn(t: string, name: string): string {
+    return `urn:pulumi:${getStack()}::${getProject()}::${t}::${name}`;
+}
+
 /**
  * Reads an existing custom resource's state from the resource monitor.  Note that resources read in this way
  * will not be part of the resulting stack's state, as they are presumed to belong to another.
@@ -69,7 +89,7 @@ export function readResource(res: Resource, t: string, name: string, props: Inpu
     const label = `resource:${name}[${t}]#...`;
     log.debug(`Reading resource: id=${Output.isInstance(id) ? "Output<T>" : id}, t=${t}, name=${name}`);
 
-    const monitor: any = getMonitor();
+    const monitor = getMonitor();
     const resopAsync = prepareResource(label, res, true, props, opts);
 
     const preallocError = new Error();
@@ -91,18 +111,28 @@ export function readResource(res: Resource, t: string, name: string, props: Inpu
         // Now run the operation, serializing the invocation if necessary.
         const opLabel = `monitor.readResource(${label})`;
         runAsyncResourceOp(opLabel, async () => {
-            const resp: any = await debuggablePromise(new Promise((resolve, reject) =>
-                monitor.readResource(req, (err: Error, innerResponse: any) => {
-                    log.debug(`ReadResource RPC finished: ${label}; err: ${err}, resp: ${innerResponse}`);
-                    if (err) {
-                        preallocError.message =
-                            `failed to read resource #${resolvedID} '${name}' [${t}]: ${err.message}`;
-                        reject(preallocError);
-                    }
-                    else {
-                        resolve(innerResponse);
-                    }
-                })), opLabel);
+            let resp: any;
+            if (monitor) {
+                // If we're attached to the engine, make an RPC call and wait for it to resolve.
+                resp = await debuggablePromise(new Promise((resolve, reject) =>
+                    (monitor as any).readResource(req, (err: Error, innerResponse: any) => {
+                        log.debug(`ReadResource RPC finished: ${label}; err: ${err}, resp: ${innerResponse}`);
+                        if (err) {
+                            preallocError.message =
+                                `failed to read resource #${resolvedID} '${name}' [${t}]: ${err.message}`;
+                            reject(preallocError);
+                        }
+                        else {
+                            resolve(innerResponse);
+                        }
+                    })), opLabel);
+            } else {
+                // If we aren't attached to the engine, mock up a fake response for testing purposes.
+                resp = {
+                    getUrn: () => createUrn(t, name),
+                    getProperties: () => req.getProperties(),
+                };
+            }
 
             // Now resolve everything: the URN, the ID (supplied as input), and the output properties.
             resop.resolveURN(resp.getUrn());
@@ -122,7 +152,7 @@ export function registerResource(res: Resource, t: string, name: string, custom:
     const label = `resource:${name}[${t}]`;
     log.debug(`Registering resource: t=${t}, name=${name}, custom=${custom}`);
 
-    const monitor: any = getMonitor();
+    const monitor = getMonitor();
     const resopAsync = prepareResource(label, res, custom, props, opts);
 
     // In order to present a useful stack trace if an error does occur, we preallocate potential
@@ -155,25 +185,36 @@ export function registerResource(res: Resource, t: string, name: string, custom:
         // Now run the operation, serializing the invocation if necessary.
         const opLabel = `monitor.registerResource(${label})`;
         runAsyncResourceOp(opLabel, async () => {
-            const resp: any = await debuggablePromise(new Promise((resolve, reject) =>
-                monitor.registerResource(req, (err: grpc.ServiceError, innerResponse: any) => {
-                    log.debug(`RegisterResource RPC finished: ${label}; err: ${err}, resp: ${innerResponse}`);
-                    if (err) {
-                        // If the monitor is unavailable, it is in the process of shutting down or has already
-                        // shut down. Don't emit an error and don't do any more RPCs, just exit.
-                        if (err.code === grpc.status.UNAVAILABLE) {
-                            log.debug("Resource monitor is terminating");
-                            process.exit(0);
-                        }
+            let resp: any;
+            if (monitor) {
+                // If we're running with an attachment to the engine, perform the operation.
+                resp = await debuggablePromise(new Promise((resolve, reject) =>
+                    (monitor as any).registerResource(req, (err: grpc.ServiceError, innerResponse: any) => {
+                        log.debug(`RegisterResource RPC finished: ${label}; err: ${err}, resp: ${innerResponse}`);
+                        if (err) {
+                            // If the monitor is unavailable, it is in the process of shutting down or has already
+                            // shut down. Don't emit an error and don't do any more RPCs, just exit.
+                            if (err.code === grpc.status.UNAVAILABLE) {
+                                log.debug("Resource monitor is terminating");
+                                process.exit(0);
+                            }
 
-                        // Node lets us hack the message as long as we do it before accessing the `stack` property.
-                        preallocError.message = `failed to register new resource ${name} [${t}]: ${err.message}`;
-                        reject(preallocError);
-                    }
-                    else {
-                        resolve(innerResponse);
-                    }
-                })), opLabel);
+                            // Node lets us hack the message as long as we do it before accessing the `stack` property.
+                            preallocError.message = `failed to register new resource ${name} [${t}]: ${err.message}`;
+                            reject(preallocError);
+                        }
+                        else {
+                            resolve(innerResponse);
+                        }
+                    })), opLabel);
+            } else {
+                // If we aren't attached to the engine, mock up a fake response for testing purposes.
+                resp = {
+                    getUrn: () => createUrn(t, name),
+                    getId: () => undefined,
+                    getObject: () => req.getObject(),
+                };
+            }
 
             resop.resolveURN(resp.getUrn());
 
@@ -424,32 +465,33 @@ export function registerResourceOutputs(res: Resource, outputs: Inputs | Promise
             (excessiveDebugOutput ? `, outputs=${JSON.stringify(outputsObj)}` : ``));
 
         // Fetch the monitor and make an RPC request.
-        const monitor: any = getMonitor();
+        const monitor = getMonitor();
+        if (monitor) {
+            const req = new resproto.RegisterResourceOutputsRequest();
+            req.setUrn(urn);
+            req.setOutputs(outputsObj);
 
-        const req = new resproto.RegisterResourceOutputsRequest();
-        req.setUrn(urn);
-        req.setOutputs(outputsObj);
+            const label = `monitor.registerResourceOutputs(${urn}, ...)`;
+            await debuggablePromise(new Promise((resolve, reject) =>
+                (monitor as any).registerResourceOutputs(req, (err: grpc.ServiceError, innerResponse: any) => {
+                    log.debug(`RegisterResourceOutputs RPC finished: urn=${urn}; `+
+                        `err: ${err}, resp: ${innerResponse}`);
+                    if (err) {
+                        // If the monitor is unavailable, it is in the process of shutting down or has already
+                        // shut down. Don't emit an error and don't do any more RPCs, just exit.
+                        if (err.code === grpc.status.UNAVAILABLE) {
+                            log.debug("Resource monitor is terminating");
+                            process.exit(0);
+                        }
 
-        const label = `monitor.registerResourceOutputs(${urn}, ...)`;
-        await debuggablePromise(new Promise((resolve, reject) =>
-            monitor.registerResourceOutputs(req, (err: grpc.ServiceError, innerResponse: any) => {
-                log.debug(`RegisterResourceOutputs RPC finished: urn=${urn}; `+
-                    `err: ${err}, resp: ${innerResponse}`);
-                if (err) {
-                    // If the monitor is unavailable, it is in the process of shutting down or has already
-                    // shut down. Don't emit an error and don't do any more RPCs, just exit.
-                    if (err.code === grpc.status.UNAVAILABLE) {
-                        log.debug("Resource monitor is terminating");
-                        process.exit(0);
+                        log.error(`Failed to end new resource registration '${urn}': ${err.stack}`);
+                        reject(err);
                     }
-
-                    log.error(`Failed to end new resource registration '${urn}': ${err.stack}`);
-                    reject(err);
-                }
-                else {
-                    resolve();
-                }
-            })), label);
+                    else {
+                        resolve();
+                    }
+                })), label);
+            }
     }, false);
 }
 

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -51,10 +51,12 @@ export function _setIsDryRun(val: boolean) {
 }
 
 /**
- * Returns true if we're currently performing a dry-run, or false if this is a true update.
+ * Returns true if we're currently performing a dry-run, or false if this is a true update. Note that we
+ * always consider executions in test mode to be "dry-runs", since we will never actually carry out an update,
+ * and therefore certain output properties will never be resolved.
  */
 export function isDryRun(): boolean {
-    return options.dryRun === true;
+    return options.dryRun === true || isTestModeEnabled();
 }
 
 /* @internal Used only for testing purposes */

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -40,7 +40,7 @@ function mustCompile(): Output<Widget> {
 
 describe("output", () => {
     it("propagates true isKnown bit from inner Output", asyncTest(async () => {
-        runtime.setIsDryRun(true);
+        runtime._setIsDryRun(true);
 
         const output1 = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
         const output2 = output1.apply(v => new Output(new Set(), Promise.resolve("inner"), Promise.resolve(true)));
@@ -53,7 +53,7 @@ describe("output", () => {
     }));
 
     it("propagates false isKnown bit from inner Output", asyncTest(async () => {
-        runtime.setIsDryRun(true);
+        runtime._setIsDryRun(true);
 
         const output1 = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
         const output2 = output1.apply(v => new Output(new Set(), Promise.resolve("inner"), Promise.resolve(false)));
@@ -66,7 +66,7 @@ describe("output", () => {
     }));
 
     it("can await even when isKnown is a rejected promise.", asyncTest(async () => {
-        runtime.setIsDryRun(true);
+        runtime._setIsDryRun(true);
 
         const output1 = new Output(new Set(), Promise.resolve("outer"), Promise.resolve(true));
         const output2 = output1.apply(v => new Output(new Set(), Promise.resolve("inner"), Promise.reject(new Error())));

--- a/sdk/nodejs/tests/testmode.spec.ts
+++ b/sdk/nodejs/tests/testmode.spec.ts
@@ -24,9 +24,9 @@ class FakeResource extends CustomResource {
     }
 }
 
-const testModeDisabledError = {
-    message: "Program run without the `pulumi` CLI; this may not be what you want " +
-        "(enable PULUMI_TEST_MODE to disable this error)",
+const testModeDisabledError = (err: Error) => {
+    return err.message === "Program run without the `pulumi` CLI; this may not be what you want " +
+        "(enable PULUMI_TEST_MODE to disable this error)";
 };
 
 describe("testMode", () => {

--- a/sdk/nodejs/tests/testmode.spec.ts
+++ b/sdk/nodejs/tests/testmode.spec.ts
@@ -1,0 +1,70 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import { Output } from "../output";
+import { CustomResource } from "../resource";
+import * as runtime from "../runtime";
+
+class FakeResource extends CustomResource {
+    public x?: Output<number>;
+    constructor(name: string, props?: { x: number }) {
+        super("nodejs:test:FakeResource", name, props);
+    }
+}
+
+const testModeDisabledError = {
+    message: "Program run without the `pulumi` CLI; this may not be what you want " +
+        "(enable PULUMI_TEST_MODE to disable this error)",
+};
+
+describe("testMode", () => {
+    it("rejects non-test mode", () => {
+        // Allocating a resource directly while not in test mode errors out.
+        assert.throws(() => { const _ = new FakeResource("fake"); }, testModeDisabledError);
+        // Fetching the project name while not in test mode errors out.
+        assert.throws(() => { const _ = runtime.getProject(); }, testModeDisabledError);
+        // Fetching the stack name while not in test mode errors out.
+        assert.throws(() => { const _ = runtime.getStack(); }, testModeDisabledError);
+    });
+    it("accepts test mode", () => {
+        (async () => {
+            // Set up all the test mode envvars, so that the test will pass.
+            runtime._setTestModeEnabled(true);
+            const testProject = "TestProject";
+            runtime._setProject(testProject);
+            const testStack = "TestStack";
+            runtime._setStack(testStack);
+            try {
+                // Allocating a resource directly while in test mode succeeds.
+                let res: FakeResource | undefined;
+                assert.doesNotThrow(() => { res = new FakeResource("fake", { x: 42 }); });
+                const x = await new Promise((resolve) => res!.x!.apply(resolve));
+                assert.equal(x, 42);
+                // Fetching the project name while in test mode succeeds.
+                let project: string | undefined;
+                assert.doesNotThrow(() => { project = runtime.getProject(); });
+                assert.equal(project, testProject);
+                // Fetching the stack name while in test mode succeeds.
+                let stack: string | undefined;
+                assert.doesNotThrow(() => { stack = runtime.getStack(); });
+                assert.equal(stack, testStack);
+            } finally {
+                runtime._setTestModeEnabled(false);
+                runtime._setProject("");
+                runtime._setStack("");
+            }
+        })();
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -58,6 +58,7 @@
         "tests/init.spec.ts",
         "tests/iterable.spec.ts",
         "tests/output.spec.ts",
+        "tests/testmode.spec.ts",
         "tests/unwrap.spec.ts",
         "tests/util.ts",
         "tests/runtime/closureLoader.spec.ts",

--- a/sdk/python/lib/test/test_test_mode.py
+++ b/sdk/python/lib/test/test_test_mode.py
@@ -1,0 +1,76 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import unittest
+
+from pulumi import Output
+from pulumi.errors import RunError
+from pulumi.resource import CustomResource
+from pulumi.runtime.settings import _set_project, _set_stack, _set_test_mode_enabled, get_project, get_stack
+
+
+class FakeResource(CustomResource):
+    x: Output[float]
+
+    def __init__(__self__, name, x=None):
+        __props__ = dict()
+        __props__['x'] = x
+        super(FakeResource, __self__).__init__('python:test:FakeResource', name, __props__, None)
+
+
+def async_test(coro):
+    def wrapper(*args, **kwargs):
+        loop = asyncio.new_event_loop()
+        loop.run_until_complete(coro(*args, **kwargs))
+        loop.close()
+    return wrapper
+
+
+class TestModeTests(unittest.TestCase):
+    def test_reject_non_test_resource(self):
+        self.assertRaises(RunError, lambda: FakeResource("fake"))
+
+    def test_reject_non_test_project(self):
+        self.assertRaises(RunError, lambda: get_project())
+
+    def test_reject_non_test_stack(self):
+        self.assertRaises(RunError, lambda: get_stack())
+
+    @async_test
+    async def test_test_mode_values(self):
+        # Swap in temporary values.
+        _set_test_mode_enabled(True)
+        test_project = "TestProject"
+        _set_project(test_project)
+        test_stack = "TestStack"
+        _set_stack(test_stack)
+        try:
+            # Now access the settings -- in test mode, this will work.
+            p = get_project()
+            self.assertEqual(test_project, p)
+            s = get_stack()
+            self.assertEqual(test_stack, s)
+
+            # Allocate a resource and make sure its output property is set as expected.
+            x_fut = asyncio.Future()
+            res = FakeResource("fake", x=42)
+            res.x.apply(lambda x: x_fut.set_result(x))
+            x_val = await x_fut
+            self.assertEqual(42, x_val)
+        finally:
+            # Reset global state back to its previous settings.
+            _set_test_mode_enabled(False)
+            _set_project(None)
+            _set_stack(None)


### PR DESCRIPTION
This change enables rudimentary unit testing of your Pulumi programs, by introducing a `PULUMI_TEST_MODE` envvar that, when set, allows programs to run without a CLI. That includes

* Just being able to import your Pulumi modules, and test ordinary functions -- which otherwise would have often accidentally triggered the "Not Running in a CLI" error message
* Being able to verify a subset of resource properties and shapes, with the caveat that outputs are not included, due to the fact that this is a perpetual "dry run" without any engine operations occurring

In principle, this also means you can attach a debugger and step through your code.