### PR TITLE
Build/Push pulumi/actions container with new SDK releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 **/.vscode/
 coverage.cov
 *.coverprofile
-**/dist
 
 /.idea/
 *.iml

--- a/dist/actions/Dockerfile
+++ b/dist/actions/Dockerfile
@@ -1,0 +1,29 @@
+FROM pulumi/pulumi:latest
+# We build the pulumi/actions container at the same time as pulumi/pulumi. So
+# the :latest tag will be relative to when this container was build.
+
+# Label things so it lights up in GitHub Actions!
+LABEL "com.github.actions.name"="Pulumi"
+LABEL "com.github.actions.description"="Deploy apps and infra to your favorite cloud!"
+LABEL "com.github.actions.icon"="cloud-lightning"
+LABEL "com.github.actions.color"="purple"
+
+# pulumi/actions contains documentation, examples. The actual container image is at
+# https://github.com/pulumi/pulumi.
+LABEL "repository"="https://github.com/pulumi/actions"
+LABEL "homepage"="http://pulumi.io/reference/gh-actions.html"
+
+# Install deps not already included in base container image.
+RUN apt-get update -y && \
+  apt-get install -y jq
+
+# Copy the entrypoint script.
+COPY ./entrypoint.sh /usr/bin/pulumi-action
+
+# The app directory should contain the Pulumi program and is the pwd for the CLI.
+WORKDIR /app
+VOLUME ["/app"]
+
+# This image uses a thin wrapper over the Pulumi CLI as its entrypoint. As a result, you may run commands
+# simply by running `docker run pulumi/pulumi up` to run the program mounted in the `/app` volume location.
+ENTRYPOINT ["/usr/bin/pulumi-action", "--non-interactive"]

--- a/dist/actions/Dockerfile
+++ b/dist/actions/Dockerfile
@@ -1,6 +1,7 @@
-FROM pulumi/pulumi:latest
-# We build the pulumi/actions container at the same time as pulumi/pulumi. So
-# the :latest tag will be relative to when this container was build.
+ARG PULUMI_VERSION=latest
+FROM pulumi/pulumi:${PULUMI_VERSION}
+# Extend the base pulumi/pulumi container at a specific version. "latest"
+# will always correspond to the most recently released SDK.
 
 # Label things so it lights up in GitHub Actions!
 LABEL "com.github.actions.name"="Pulumi"

--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# This is an entrypoint for our Docker image that does some minimal bootstrapping before executing.
+
+set -e
+
+# If the PULUMI_CI variable is set, we'll do some extra things to make common tasks easier.
+if [ ! -z "$PULUMI_CI" ]; then
+    # Capture the PWD before we go and potentially change it.
+    ROOT=$(pwd)
+
+    # If the root of the Pulumi project isn't the root of the repo, CD into it.
+    if [ ! -z "$PULUMI_ROOT" ]; then
+        cd $PULUMI_ROOT
+    fi
+
+    # Detect the CI system and configure variables so that we get good Pulumi workflow and GitHub App support.
+    if [ ! -z "$GITHUB_WORKFLOW" ]; then
+        export PULUMI_CI_SYSTEM="GitHub"
+        export PULUMI_CI_BUILD_ID=
+        export PULUMI_CI_BUILD_TYPE=
+        export PULUMI_CI_BUILD_URL=
+        export PULUMI_CI_PULL_REQUEST_SHA="$GITHUB_SHA"
+
+        # For PR events, we want to take the ref of the target branch, not the current. This ensures, for
+        # instance, that a PR for a topic branch merging into `master` will use the `master` branch as the
+        # target for a preview. Note that for push events, we of course want to use the actual branch.
+        if [ "$PULUMI_CI" = "pr" ]; then
+            # Not all PR events warrant running a preview. Many of them pertain to changes in assignments and
+            # ownership, but we only want to run the preview if the action is "opened", "edited", or "synchronize".
+            PR_ACTION=$(jq -r ".action" < $GITHUB_EVENT_PATH)
+            if [ "$PR_ACTION" != "opened" ] && [ "$PR_ACTION" != "edited" ] && [ "$PR_ACTION" != "synchronize" ]; then
+                echo -e "PR event ($PR_ACTION) contains no changes and does not warrant a Pulumi Preview"
+                echo -e "Skipping Pulumi action altogether..."
+                exit 0
+            fi
+
+            BRANCH=$(jq -r ".pull_request.base.ref" < $GITHUB_EVENT_PATH)
+        else
+            BRANCH="$GITHUB_REF"
+        fi
+        BRANCH=$(echo $BRANCH | sed "s/refs\/heads\///g")
+    fi
+
+    # Respect the branch mappings file for stack selection. Note that this is *not* required, but if the file
+    # is missing, the caller of this script will need to pass `-s <stack-name>` to specify the stack explicitly.
+    if [ ! -z "$BRANCH" ]; then
+        if [ -e $ROOT/.pulumi/ci.json ]; then
+            PULUMI_STACK_NAME=$(cat $ROOT/.pulumi/ci.json | jq -r ".\"$BRANCH\"")
+        else
+            # If there's no stack mapping file, we are on master, and there's a single stack, use it.
+            PULUMI_STACK_NAME=$(pulumi stack ls | awk 'FNR == 2 {print $1}' | sed 's/\*//g')
+        fi
+
+        if [ ! -z "$PULUMI_STACK_NAME" ] && [ "$PULUMI_STACK_NAME" != "null" ]; then
+            pulumi stack select $PULUMI_STACK_NAME
+        else
+            echo -e "No stack configured for branch '$BRANCH'"
+            echo -e ""
+            echo -e "To configure this branch, please"
+            echo -e "\t1) Run 'pulumi stack init <stack-name>'"
+            echo -e "\t2) Associated the stack with the branch by adding"
+            echo -e "\t\t{"
+            echo -e "\t\t\t\"$BRANCH\": \"<stack-name>\""
+            echo -e "\t\t}"
+            echo -e "\tto your .pulumi/ci.json file"
+            echo -e ""
+            echo -e "For now, exiting cleanly without doing anything..."
+            exit 0
+        fi
+    fi
+fi
+
+# For Google, we need to authenticate with a service principal for certain authentication operations.
+if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
+    GCLOUD_KEYFILE="$(mktemp).json"
+    echo "$GOOGLE_CREDENTIALS" > $GCLOUD_KEYFILE
+    gcloud auth activate-service-account --key-file=$GCLOUD_KEYFILE
+fi
+
+# Next, lazily install packages if required.
+if [ -e package.json ] && [ ! -d node_modules ]; then
+    npm install
+fi
+
+# Now just pass along all arguments to the Pulumi CLI.
+OUTPUT=$(sh -c "pulumi --non-interactive $*" 2>&1)
+EXIT_CODE=$?
+
+echo "#### :tropical_drink: \`pulumi ${@:2}\`"
+echo "$OUTPUT"
+
+# If the GitHub action stems from a Pull Request event, we may optionally leave a comment if the
+# COMMENT_ON_PR is set.
+COMMENTS_URL=$(cat $GITHUB_EVENT_PATH | jq -r .pull_request.comments_url)
+if [ ! -z $COMMENTS_URL ] && [ ! -z $COMMENT_ON_PR ]; then
+    if [ -z $GITHUB_TOKEN ]; then
+        echo "ERROR: COMMENT_ON_PR was set, but GITHUB_TOKEN is not set."
+    else
+        COMMENT="#### :tropical_drink: \`pulumi ${@:2}\`
+\`\`\`
+$OUTPUT
+\`\`\`"
+        PAYLOAD=$(echo '{}' | jq --arg body "$COMMENT" '.body = $body')
+        echo "Commenting on PR $COMMENTS_URL"
+        curl -s -S -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/json" --data "$PAYLOAD" "$COMMENTS_URL"
+    fi
+fi
+
+exit $EXIT_CODE

--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -1,11 +1,8 @@
 FROM python:3.7-slim
+# TODO[pulumi/pulumi#1986]: consider switching to, or supporting, Alpine Linux for smaller image sizes.
 
-LABEL "com.github.actions.name"="Pulumi"
-LABEL "com.github.actions.description"="Deploy apps and infra to your favorite cloud!"
-LABEL "com.github.actions.icon"="cloud-lightning"
-LABEL "com.github.actions.color"="purple"
 LABEL "repository"="https://github.com/pulumi/pulumi"
-LABEL "homepage"="http://pulumi.io/reference/gh-actions.html"
+LABEL "homepage"="http://pulumi.io/"
 LABEL "maintainer"="Pulumi Team <team@pulumi.com>"
 
 # Install deps all in one step

--- a/scripts/build-and-publish-docker
+++ b/scripts/build-and-publish-docker
@@ -30,10 +30,24 @@ if [[ "${CLI_VERSION}" == *-* ]]; then
     exit 0    
 fi
 
-echo "Building and publishing pulumi/pulumi:${CLI_VERSION}"
-docker build --build-arg PULUMI_VERSION="${CLI_VERSION}" -t "pulumi/pulumi:${CLI_VERSION}" -t "pulumi/pulumi:latest" "${SCRIPT_DIR}/../dist/docker"
-
 docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_PASSWORD}"
+
+echo "Building and publishing pulumi/pulumi:${CLI_VERSION}"
+docker build --build-arg PULUMI_VERSION="${CLI_VERSION}" \
+    -t "pulumi/pulumi:${CLI_VERSION}" \
+    -t "pulumi/pulumi:latest" \
+    "${SCRIPT_DIR}/../dist/docker"
 docker push "pulumi/pulumi:${CLI_VERSION}"
 docker push "pulumi/pulumi:latest"
+
+# Pulumi container optimized for GitHub Actions.
+echo "Building and publishing pulumi/actions:${CLI_VERSION}"
+docker build \
+    -t "pulumi/actions:${CLI_VERSION}" \
+    -t "pulumi/actions:latest" \
+    -t "achrissmith/pulumi-actions-test:latest" \
+    "${SCRIPT_DIR}/../dist/actions"
+docker push "pulumi/actions:${CLI_VERSION}"
+docker push "pulumi/actions:latest"
+
 docker logout

--- a/scripts/build-and-publish-docker
+++ b/scripts/build-and-publish-docker
@@ -42,10 +42,9 @@ docker push "pulumi/pulumi:latest"
 
 # Pulumi container optimized for GitHub Actions.
 echo "Building and publishing pulumi/actions:${CLI_VERSION}"
-docker build \
+docker build --build-arg PULUMI_VERSION="${CLI_VERSION}" \
     -t "pulumi/actions:${CLI_VERSION}" \
     -t "pulumi/actions:latest" \
-    -t "achrissmith/pulumi-actions-test:latest" \
     "${SCRIPT_DIR}/../dist/actions"
 docker push "pulumi/actions:${CLI_VERSION}"
 docker push "pulumi/actions:latest"


### PR DESCRIPTION
Today we build/push the `pulumi/pulumi` image to Dockerhub whenever we release a new version of the Pulumi SDK. Ideally we would do this for the `pulumi/actions` image too, which is a container designed to be used with GitHub Actions workflows.

This PR moves the `Dockerfile` and `entrypoint.sh` from the [pulumi/actions](https://github.com/pulumi/actions) repository into `/dist/actions`, and updates `scripts/build-and-publish-docker` to build/push the `pulumi/actions` container too. The `entrypoint.sh` file is unchanged, but the GitHub Actions `Dockerfile` is mostly trimmed up since it overlapped so much with the `pulumi/pulumi` image's `Dockerfile`.

This should effectively fix https://github.com/pulumi/actions/issues/10. Though I think we should still keep the `pulumi/actions` GitHub repo open/active for providing documentation, examples, and issue tracking specific to using Pulumi as part of GitHub Actions. (Instead of trying to merge that into this repo.)

The one thing that warrants a closer look is removing `**/dist` from the `.gitignore` file. That was added in https://github.com/pulumi/pulumi/pull/1553 to filter out the `dist` folders created when running `pipenv`. However, that also ignores files in the `/dist/` folder too. (And because of the specifics of how [.gitignore files](https://git-scm.com/docs/gitignore#_pattern_format) work, it looks like it isn't possible to carve out an exception for the `/dist` folder.

I can see us either adding a more specific `.gitignore` rules for the pip dist folders, or just renaming `/dist` to `/containers` or something. Let me know what you think would be best.