### PR TITLE
Load specific provider versions if requested

### DIFF
--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -560,7 +560,7 @@ func TestSingleResourceDefaultProviderLifecycle(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 		return nil
 	})
@@ -582,7 +582,7 @@ func TestSingleResourceExplicitProviderLifecycle(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, "",
-			false, nil, "", resource.PropertyMap{}, nil, false)
+			false, nil, "", resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 
 		if provID == "" {
@@ -593,7 +593,7 @@ func TestSingleResourceExplicitProviderLifecycle(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, provRef.String(),
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 
 		return nil
@@ -616,7 +616,7 @@ func TestSingleResourceDefaultProviderUpgrade(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 		return nil
 	})
@@ -721,7 +721,7 @@ func TestSingleResourceDefaultProviderReplace(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 		return nil
 	})
@@ -802,7 +802,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 	}
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, "",
-			false, nil, "", providerInputs, nil, false)
+			false, nil, "", providerInputs, nil, false, "")
 		assert.NoError(t, err)
 
 		if provID == "" {
@@ -813,7 +813,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, provRef.String(),
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 
 		return nil
@@ -891,7 +891,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 	}
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, "",
-			false, nil, "", providerInputs, nil, false)
+			false, nil, "", providerInputs, nil, false, "")
 		assert.NoError(t, err)
 
 		if provID == "" {
@@ -902,7 +902,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, provRef.String(),
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 
 		return nil
@@ -994,7 +994,8 @@ func TestSingleResourceDiffUnavailable(t *testing.T) {
 
 	inputs := resource.PropertyMap{}
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "", inputs, nil, false)
+		_, _, _, err := monitor.RegisterResource(
+			"pkgA:m:typA", "resA", true, "", false, nil, "", inputs, nil, false, "")
 		assert.NoError(t, err)
 		return nil
 	})
@@ -1193,19 +1194,19 @@ func TestParallelRefresh(t *testing.T) {
 	// it.
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		resA, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 
 		resB, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resB", true, "", false, []resource.URN{resA}, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 
 		resC, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resC", true, "", false, []resource.URN{resB}, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 
 		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resD", true, "", false, []resource.URN{resC}, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 
 		return nil
@@ -1246,7 +1247,7 @@ func TestExternalRefresh(t *testing.T) {
 
 	// Our program reads a resource and exits.
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		_, _, err := monitor.ReadResource("pkgA:m:typA", "resA", "resA-some-id", "", resource.PropertyMap{}, "")
+		_, _, err := monitor.ReadResource("pkgA:m:typA", "resA", "resA-some-id", "", resource.PropertyMap{}, "", "")
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -1319,7 +1320,7 @@ func TestRefreshInitFailure(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 		return nil
 	})
@@ -1407,7 +1408,7 @@ func TestCheckFailureRecord(t *testing.T) {
 	}
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "", nil, nil, false)
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "", nil, nil, false, "")
 		assert.Error(t, err)
 		return err
 	})
@@ -1457,7 +1458,7 @@ func TestCheckFailureInvalidPropertyRecord(t *testing.T) {
 	}
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "", nil, nil, false)
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "", nil, nil, false, "")
 		assert.Error(t, err)
 		return err
 	})
@@ -1514,7 +1515,8 @@ func TestRefreshWithDelete(t *testing.T) {
 			}
 
 			program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-				_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "", nil, nil, false)
+				_, _, _, err := monitor.RegisterResource(
+					"pkgA:m:typA", "resA", true, "", false, nil, "", nil, nil, false, "")
 				assert.NoError(t, err)
 				return err
 			})
@@ -2021,14 +2023,14 @@ func TestBadResourceType(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, mon *deploytest.ResourceMonitor) error {
 		_, _, _, err := mon.RegisterResource(
-			"very:bad", "resA", true, "", false, nil, "", resource.PropertyMap{}, nil, false)
+			"very:bad", "resA", true, "", false, nil, "", resource.PropertyMap{}, nil, false, "")
 		assert.Error(t, err)
 		rpcerr, ok := rpcerror.FromError(err)
 		assert.True(t, ok)
 		assert.Equal(t, codes.InvalidArgument, rpcerr.Code())
 		assert.Contains(t, rpcerr.Message(), "Type 'very:bad' is not a valid type token")
 
-		_, _, err = mon.ReadResource("very:bad", "someResource", "someId", "", resource.PropertyMap{}, "")
+		_, _, err = mon.ReadResource("very:bad", "someResource", "someId", "", resource.PropertyMap{}, "", "")
 		assert.Error(t, err)
 		rpcerr, ok = rpcerror.FromError(err)
 		assert.True(t, ok)
@@ -2037,11 +2039,11 @@ func TestBadResourceType(t *testing.T) {
 
 		// Component resources may have any format type.
 		_, _, _, noErr := mon.RegisterResource(
-			"a:component", "resB", false /* custom */, "", false, nil, "", resource.PropertyMap{}, nil, false)
+			"a:component", "resB", false /* custom */, "", false, nil, "", resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, noErr)
 
 		_, _, _, noErr = mon.RegisterResource(
-			"singlename", "resC", false /* custom */, "", false, nil, "", resource.PropertyMap{}, nil, false)
+			"singlename", "resC", false /* custom */, "", false, nil, "", resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, noErr)
 
 		return err
@@ -2105,7 +2107,7 @@ func TestProviderCancellation(t *testing.T) {
 		for i := 0; i < resourceCount; i++ {
 			go func(idx int) {
 				_, _, _, errors[idx] = monitor.RegisterResource("pkgA:m:typA", fmt.Sprintf("res%d", idx), true, "",
-					false, nil, "", resource.PropertyMap{}, nil, false)
+					false, nil, "", resource.PropertyMap{}, nil, false, "")
 				resources.Done()
 			}(i)
 		}
@@ -2170,7 +2172,7 @@ func TestPreviewWithPendingOperations(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "",
-			resource.PropertyMap{}, nil, false)
+			resource.PropertyMap{}, nil, false, "")
 		assert.NoError(t, err)
 		return nil
 	})
@@ -2216,7 +2218,7 @@ func TestUpdatePartialFailure(t *testing.T) {
 		_, _, _, err := mon.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "",
 			resource.NewPropertyMapFromMap(map[string]interface{}{
 				"input_prop": "new inputs",
-			}), nil, false)
+			}), nil, false, "")
 
 		return err
 	})
@@ -2288,7 +2290,7 @@ func TestStackReference(t *testing.T) {
 		_, _, state, err := mon.RegisterResource("pulumi:pulumi:StackReference", "other", true, "", false, nil, "",
 			resource.NewPropertyMapFromMap(map[string]interface{}{
 				"name": "other",
-			}), nil, false)
+			}), nil, false, "")
 		assert.NoError(t, err)
 		if !info.DryRun {
 			assert.Equal(t, "bar", state["outputs"].ObjectValue()["foo"].StringValue())
@@ -2361,7 +2363,7 @@ func TestStackReference(t *testing.T) {
 		_, _, _, err := mon.RegisterResource("pulumi:pulumi:StackReference", "other", true, "", false, nil, "",
 			resource.NewPropertyMapFromMap(map[string]interface{}{
 				"name": "rehto",
-			}), nil, false)
+			}), nil, false, "")
 		assert.Error(t, err)
 		return err
 	})
@@ -2379,7 +2381,7 @@ func TestStackReference(t *testing.T) {
 			resource.NewPropertyMapFromMap(map[string]interface{}{
 				"name": "other",
 				"foo":  "bar",
-			}), nil, false)
+			}), nil, false, "")
 		assert.Error(t, err)
 		return err
 	})
@@ -2610,7 +2612,7 @@ func TestDeleteBeforeReplace(t *testing.T) {
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		register := func(urn resource.URN, provider string, inputs resource.PropertyMap) resource.ID {
 			_, id, _, err := monitor.RegisterResource(urn.Type(), string(urn.Name()), true, "", false, nil, provider,
-				inputs, nil, false)
+				inputs, nil, false, "")
 			assert.NoError(t, err)
 			return id
 		}
@@ -2685,7 +2687,7 @@ func TestPropertyDependenciesAdapter(t *testing.T) {
 			dependencies []resource.URN) resource.URN {
 
 			urn, _, _, err := monitor.RegisterResource(resType, name, true, "", false, dependencies, "", inputs,
-				inputDeps, false)
+				inputDeps, false, "")
 			assert.NoError(t, err)
 
 			return urn
@@ -2764,7 +2766,7 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 	var err error
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		provURN, provID, _, err = monitor.RegisterResource(
-			providers.MakeProviderType("pkgA"), "provA", true, "", false, nil, "", nil, nil, false)
+			providers.MakeProviderType("pkgA"), "provA", true, "", false, nil, "", nil, nil, false, "")
 		assert.NoError(t, err)
 
 		if provID == "" {
@@ -2774,12 +2776,12 @@ func TestExplicitDeleteBeforeReplace(t *testing.T) {
 		assert.NoError(t, err)
 		provA := provRef.String()
 
-		urnA, _, _, err = monitor.RegisterResource(resType, "resA", true, "", false, nil, provA, inputsA, nil, dbrA)
+		urnA, _, _, err = monitor.RegisterResource(resType, "resA", true, "", false, nil, provA, inputsA, nil, dbrA, "")
 		assert.NoError(t, err)
 
 		inputDepsB := map[resource.PropertyKey][]resource.URN{"A": {urnA}}
 		urnB, _, _, err = monitor.RegisterResource(resType, "resB", true, "", false, []resource.URN{urnA}, provA,
-			inputsB, inputDepsB, false)
+			inputsB, inputDepsB, false, "")
 		assert.NoError(t, err)
 
 		return nil

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -30,7 +30,7 @@ type ResourceMonitor struct {
 func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom bool, parent resource.URN, protect bool,
 	dependencies []resource.URN, provider string, inputs resource.PropertyMap,
 	propertyDeps map[resource.PropertyKey][]resource.URN,
-	deleteBeforeReplace bool) (resource.URN, resource.ID, resource.PropertyMap, error) {
+	deleteBeforeReplace bool, version string) (resource.URN, resource.ID, resource.PropertyMap, error) {
 
 	// marshal inputs
 	ins, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{KeepUnknowns: true})
@@ -67,6 +67,7 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 		Object:               ins,
 		PropertyDependencies: inputDeps,
 		DeleteBeforeReplace:  deleteBeforeReplace,
+		Version:              version,
 	})
 	if err != nil {
 		return "", "", nil, err
@@ -82,7 +83,7 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 }
 
 func (rm *ResourceMonitor) ReadResource(t tokens.Type, name string, id resource.ID, parent resource.URN,
-	inputs resource.PropertyMap, provider string) (resource.URN, resource.PropertyMap, error) {
+	inputs resource.PropertyMap, provider string, version string) (resource.URN, resource.PropertyMap, error) {
 
 	// marshal inputs
 	ins, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{KeepUnknowns: true})
@@ -97,6 +98,7 @@ func (rm *ResourceMonitor) ReadResource(t tokens.Type, name string, id resource.
 		Parent:     string(parent),
 		Provider:   provider,
 		Properties: ins,
+		Version:    version,
 	})
 	if err != nil {
 		return "", nil, err
@@ -111,8 +113,8 @@ func (rm *ResourceMonitor) ReadResource(t tokens.Type, name string, id resource.
 	return resource.URN(resp.Urn), outs, nil
 }
 
-func (rm *ResourceMonitor) Invoke(tok tokens.ModuleMember,
-	inputs resource.PropertyMap, provider string) (resource.PropertyMap, []*pulumirpc.CheckFailure, error) {
+func (rm *ResourceMonitor) Invoke(tok tokens.ModuleMember, inputs resource.PropertyMap,
+	provider string, version string) (resource.PropertyMap, []*pulumirpc.CheckFailure, error) {
 
 	// marshal inputs
 	ins, err := plugin.MarshalProperties(inputs, plugin.MarshalOptions{KeepUnknowns: true})
@@ -125,6 +127,7 @@ func (rm *ResourceMonitor) Invoke(tok tokens.ModuleMember,
 		Tok:      string(tok),
 		Provider: provider,
 		Args:     ins,
+		Version:  version,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -1,0 +1,93 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package providers
+
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+
+	"github.com/pulumi/pulumi/pkg/tokens"
+	"github.com/pulumi/pulumi/pkg/util/contract"
+)
+
+// A ProviderRequest is a tuple of an optional semantic version and a package name. Whenever the engine receives a
+// registration for a resource that doesn't explicitly specify a provider, the engine creates a ProviderRequest for
+// that resource's provider, using the version passed to the engine as part of RegisterResource and the package derived
+// from the resource's token.
+//
+// The source evaluator (source_eval.go) is responsible for servicing provider requests. It does this by interpreting
+// these provider requests and sending resource registrations to the engine for the providers themselves. These are
+// called "default providers".
+//
+// ProviderRequest is useful as a hash key. The engine is free to instantiate any numver of provider requests, but it
+// is free to cache requests for a provider request that is equal to one that has already been serviced.
+type ProviderRequest struct {
+	version *semver.Version
+	pkg     tokens.Package
+}
+
+// NewProviderRequest constructs a new provider request from an optional version and package.
+func NewProviderRequest(version *semver.Version, pkg tokens.Package) ProviderRequest {
+	return ProviderRequest{
+		version: version,
+		pkg:     pkg,
+	}
+}
+
+// Version returns this provider request's version. May be nil if no version was provided.
+func (p ProviderRequest) Version() *semver.Version {
+	return p.version
+}
+
+// Package returns this provider request's package.
+func (p ProviderRequest) Package() tokens.Package {
+	return p.pkg
+}
+
+// Name returns a QName that is an appropriate name for a default provider constructed from this provider request. The
+// name is intended to be unique; as such, the name is derived from the version associated with this request.
+//
+// If a version is not provided, "default" is returned. Otherwise, Name returns a name starting with "default" and
+// followed by a QName-legal representation of the semantic version of the requested provider.
+func (p ProviderRequest) Name() tokens.QName {
+	if p.version == nil {
+		return "default"
+	}
+
+	// QNames are forbidden to contain dashes, so we construct a string here using the semantic version's component
+	// parts.
+	v := p.version
+	base := fmt.Sprintf("default_%d_%d_%d", v.Major, v.Minor, v.Patch)
+	for _, pre := range v.Pre {
+		base += "_" + pre.String()
+	}
+
+	for _, build := range v.Build {
+		base += "_" + build
+	}
+
+	// This thing that we generated must be a QName.
+	contract.Assert(tokens.IsQName(base))
+	return tokens.QName(base)
+}
+
+// String returns a string representation of this request. This string is suitable for use as a hash key.
+func (p ProviderRequest) String() string {
+	if p.version != nil {
+		return fmt.Sprintf("%s-%s", p.pkg, p.version)
+	}
+	return p.pkg.String()
+}

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -32,7 +32,7 @@ import (
 // these provider requests and sending resource registrations to the engine for the providers themselves. These are
 // called "default providers".
 //
-// ProviderRequest is useful as a hash key. The engine is free to instantiate any numver of provider requests, but it
+// ProviderRequest is useful as a hash key. The engine is free to instantiate any number of provider requests, but it
 // is free to cache requests for a provider request that is equal to one that has already been serviced. If you do use
 // ProviderRequest as a hash key, you should call String() to get a usable key for string-based hash maps.
 type ProviderRequest struct {

--- a/pkg/resource/deploy/providers/provider.go
+++ b/pkg/resource/deploy/providers/provider.go
@@ -33,7 +33,8 @@ import (
 // called "default providers".
 //
 // ProviderRequest is useful as a hash key. The engine is free to instantiate any numver of provider requests, but it
-// is free to cache requests for a provider request that is equal to one that has already been serviced.
+// is free to cache requests for a provider request that is equal to one that has already been serviced. If you do use
+// ProviderRequest as a hash key, you should call String() to get a usable key for string-based hash maps.
 type ProviderRequest struct {
 	version *semver.Version
 	pkg     tokens.Package

--- a/pkg/resource/deploy/providers/provider_test.go
+++ b/pkg/resource/deploy/providers/provider_test.go
@@ -1,0 +1,30 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/tokens"
+)
+
+func TestProviderRequestNameNil(t *testing.T) {
+	req := NewProviderRequest(nil, "pkg")
+	assert.Equal(t, tokens.QName("default"), req.Name())
+	assert.Equal(t, "pkg", req.String())
+}
+
+func TestProviderRequestNameNoPre(t *testing.T) {
+	ver := semver.MustParse("0.18.1")
+	req := NewProviderRequest(&ver, "pkg")
+	assert.Equal(t, "default_0_18_1", req.Name().String())
+	assert.Equal(t, "pkg-0.18.1", req.String())
+}
+
+func TestProviderRequestNameDev(t *testing.T) {
+	ver := semver.MustParse("0.17.7-dev.1555435978+gb7030aa4.dirty")
+	req := NewProviderRequest(&ver, "pkg")
+	assert.Equal(t, "default_0_17_7_dev_1555435978_gb7030aa4_dirty", req.Name().String())
+	assert.Equal(t, "pkg-0.17.7-dev.1555435978+gb7030aa4.dirty", req.String())
+}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -227,8 +227,13 @@ func (iter *evalSourceIterator) forkRun(opts Options) {
 // resource that will be used to manage resources that do not explicitly reference a provider. Default providers will
 // only be registered for packages that are used by resources registered by the user's Pulumi program.
 type defaultProviders struct {
-	versions  map[tokens.Package]*semver.Version
-	providers map[tokens.Package]providers.Reference
+	// A map of package identifiers to versions, used to disambiguate which plugin to load if no version is provided
+	// by the language host.
+	defaultVersions map[tokens.Package]*semver.Version
+
+	// A map of ProviderRequest strings to provider references, used to keep track of the set of default providers that
+	// have already been loaded.
+	providers map[string]providers.Reference
 	config    plugin.ConfigSource
 
 	requests chan defaultProviderRequest
@@ -242,17 +247,17 @@ type defaultProviderResponse struct {
 }
 
 type defaultProviderRequest struct {
-	pkg      tokens.Package
+	req      providers.ProviderRequest
 	response chan<- defaultProviderResponse
 }
 
 // newRegisterDefaultProviderEvent creates a RegisterResourceEvent and completion channel that can be sent to the
 // engine to register a default provider resource for the indicated package.
 func (d *defaultProviders) newRegisterDefaultProviderEvent(
-	pkg tokens.Package) (*registerResourceEvent, <-chan *RegisterResult, error) {
+	req providers.ProviderRequest) (*registerResourceEvent, <-chan *RegisterResult, error) {
 
 	// Attempt to get the config for the package.
-	cfg, err := d.config.GetPackageConfig(pkg)
+	cfg, err := d.config.GetPackageConfig(req.Package())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -262,14 +267,38 @@ func (d *defaultProviders) newRegisterDefaultProviderEvent(
 	for k, v := range cfg {
 		inputs[resource.PropertyKey(k.Name())] = resource.NewStringProperty(v)
 	}
-	if version := d.versions[pkg]; version != nil {
-		inputs["version"] = resource.NewStringProperty(version.String())
+
+	// Request that the engine instantiate a specific version of this provider, if one was requested. We'll figure out
+	// what version to request by:
+	//   1. Providing the Version field of the ProviderRequest verbatim, if it was provided, otherwise
+	//   2. Querying the list of default versions provided to us on startup and returning the value associated with
+	//      the given package, if one exists, otherwise
+	//   3. We give nothing to the engine and let the engine figure it out.
+	//
+	// As we tighen up our approach to provider versioning, 2 and 3 will go away and be replaced entirely by 1. 3 is
+	// especially onerous because the engine selects the "newest" plugin available on the machine, which is generally
+	// problematic for a lot of reasons.
+	if req.Version() != nil {
+		logging.V(5).Infof("newRegisterDefaultProviderEvent(%s): using version %s from request", req, req.Version())
+		inputs["version"] = resource.NewStringProperty(req.Version().String())
+	} else {
+		logging.V(5).Infof(
+			"newRegisterDefaultProviderEvent(%s): no version specified, falling back to default version", req)
+		if version := d.defaultVersions[req.Package()]; version != nil {
+			logging.V(5).Infof("newRegisterDefaultProviderEvent(%s): default version hit on version %s", req, version)
+			inputs["version"] = resource.NewStringProperty(version.String())
+		} else {
+			logging.V(5).Infof(
+				"newRegisterDefaultProviderEvent(%s): default provider miss, sending nil version to engine", req)
+		}
 	}
 
 	// Create the result channel and the event.
 	done := make(chan *RegisterResult)
 	event := &registerResourceEvent{
-		goal: resource.NewGoal(providers.MakeProviderType(pkg), "default", true, inputs, "", false, nil, "", nil, nil, false),
+		goal: resource.NewGoal(
+			providers.MakeProviderType(req.Package()),
+			req.Name(), true, inputs, "", false, nil, "", nil, nil, false),
 		done: done,
 	}
 	return event, done, nil
@@ -282,15 +311,21 @@ func (d *defaultProviders) newRegisterDefaultProviderEvent(
 //
 // Note that this function must not be called from two goroutines concurrently; it is the responsibility of d.serve()
 // to ensure this.
-func (d *defaultProviders) handleRequest(pkg tokens.Package) (providers.Reference, error) {
-	logging.V(5).Infof("handling default provider request for package %s", pkg)
+func (d *defaultProviders) handleRequest(req providers.ProviderRequest) (providers.Reference, error) {
+	logging.V(5).Infof("handling default provider request for package %s", req)
 
-	ref, ok := d.providers[pkg]
+	// Have we loaded this provider before? Use the existing reference, if so.
+	//
+	// Note that we are using the request's String as the key for the provider map. Go auto-derives hash and equality
+	// functions for aggregates, but the one auto-derived for ProviderRequest does not have the semantics we want. The
+	// use of a string key here is hacky but gets us the desired semantics - that ProviderRequest is a tuple of
+	// optional value-typed Version and a package.
+	ref, ok := d.providers[req.String()]
 	if ok {
 		return ref, nil
 	}
 
-	event, done, err := d.newRegisterDefaultProviderEvent(pkg)
+	event, done, err := d.newRegisterDefaultProviderEvent(req)
 	if err != nil {
 		return providers.Reference{}, err
 	}
@@ -301,7 +336,7 @@ func (d *defaultProviders) handleRequest(pkg tokens.Package) (providers.Referenc
 		return providers.Reference{}, context.Canceled
 	}
 
-	logging.V(5).Infof("waiting for default provider for package %s", pkg)
+	logging.V(5).Infof("waiting for default provider for package %s", req)
 
 	var result *RegisterResult
 	select {
@@ -310,7 +345,7 @@ func (d *defaultProviders) handleRequest(pkg tokens.Package) (providers.Referenc
 		return providers.Reference{}, context.Canceled
 	}
 
-	logging.V(5).Infof("registered default provider for package %s: %s", pkg, result.State.URN)
+	logging.V(5).Infof("registered default provider for package %s: %s", req, result.State.URN)
 
 	id := result.State.ID
 	if id == "" {
@@ -319,7 +354,7 @@ func (d *defaultProviders) handleRequest(pkg tokens.Package) (providers.Referenc
 
 	ref, err = providers.NewReference(result.State.URN, id)
 	contract.Assert(err == nil)
-	d.providers[pkg] = ref
+	d.providers[req.String()] = ref
 
 	return ref, nil
 }
@@ -331,7 +366,7 @@ func (d *defaultProviders) serve() {
 		case req := <-d.requests:
 			// Note that we do not need to handle cancellation when sending the response: every message we receive is
 			// guaranteed to have something waiting on the other end of the response channel.
-			ref, err := d.handleRequest(req.pkg)
+			ref, err := d.handleRequest(req.req)
 			req.response <- defaultProviderResponse{ref: ref, err: err}
 		case <-d.cancel:
 			return
@@ -340,10 +375,10 @@ func (d *defaultProviders) serve() {
 }
 
 // getDefaultProviderRef fetches the provider reference for the default provider for a particular package.
-func (d *defaultProviders) getDefaultProviderRef(pkg tokens.Package) (providers.Reference, error) {
+func (d *defaultProviders) getDefaultProviderRef(req providers.ProviderRequest) (providers.Reference, error) {
 	response := make(chan defaultProviderResponse)
 	select {
-	case d.requests <- defaultProviderRequest{pkg: pkg, response: response}:
+	case d.requests <- defaultProviderRequest{req: req, response: response}:
 	case <-d.cancel:
 		return providers.Reference{}, context.Canceled
 	}
@@ -374,12 +409,12 @@ func newResourceMonitor(src *evalSource, provs ProviderSource, regChan chan *reg
 
 	// Create a new default provider manager.
 	d := &defaultProviders{
-		versions:  src.defaultProviderVersions,
-		providers: make(map[tokens.Package]providers.Reference),
-		config:    src.runinfo.Target,
-		requests:  make(chan defaultProviderRequest),
-		regChan:   regChan,
-		cancel:    cancel,
+		defaultVersions: src.defaultProviderVersions,
+		providers:       make(map[string]providers.Reference),
+		config:          src.runinfo.Target,
+		requests:        make(chan defaultProviderRequest),
+		regChan:         regChan,
+		cancel:          cancel,
 	}
 
 	// New up an engine RPC server.
@@ -426,7 +461,8 @@ func (rm *resmon) Cancel() error {
 // getProviderReference fetches the provider reference for a resource, read, or invoke from the given package with the
 // given unparsed provider reference. If the unparsed provider reference is empty, this function returns a reference
 // to the default provider for the indicated package.
-func (rm *resmon) getProviderReference(pkg tokens.Package, rawProviderRef string) (providers.Reference, error) {
+func (rm *resmon) getProviderReference(req providers.ProviderRequest,
+	rawProviderRef string) (providers.Reference, error) {
 	if rawProviderRef != "" {
 		ref, err := providers.ParseReference(rawProviderRef)
 		if err != nil {
@@ -435,7 +471,7 @@ func (rm *resmon) getProviderReference(pkg tokens.Package, rawProviderRef string
 		return ref, nil
 	}
 
-	ref, err := rm.defaultProviders.getDefaultProviderRef(pkg)
+	ref, err := rm.defaultProviders.getDefaultProviderRef(req)
 	if err != nil {
 		return providers.Reference{}, err
 	}
@@ -445,8 +481,8 @@ func (rm *resmon) getProviderReference(pkg tokens.Package, rawProviderRef string
 // getProvider fetches the provider plugin for a resource, read, or invoke from the given package with the given
 // unparsed provider reference. If the unparsed provider reference is empty, this function returns the plugin for the
 // indicated package's default provider.
-func (rm *resmon) getProvider(pkg tokens.Package, rawProviderRef string) (plugin.Provider, error) {
-	providerRef, err := rm.getProviderReference(pkg, rawProviderRef)
+func (rm *resmon) getProvider(req providers.ProviderRequest, rawProviderRef string) (plugin.Provider, error) {
+	providerRef, err := rm.getProviderReference(req, rawProviderRef)
 	if err != nil {
 		return nil, err
 	}
@@ -457,12 +493,24 @@ func (rm *resmon) getProvider(pkg tokens.Package, rawProviderRef string) (plugin
 	return provider, nil
 }
 
+func (rm *resmon) parseProviderRequest(pkg tokens.Package, version string) providers.ProviderRequest {
+	var semverVersion *semver.Version
+	parsedVersion, err := semver.Parse(version)
+	if err != nil {
+		logging.V(5).Infof("parseProviderRequest(%s, %s): semver version string is invalid: %v", pkg, version, err)
+	} else {
+		semverVersion = &parsedVersion
+	}
+
+	return providers.NewProviderRequest(semverVersion, pkg)
+}
+
 // Invoke performs an invocation of a member located in a resource provider.
 func (rm *resmon) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
 	// Fetch the token and load up the resource provider if necessary.
 	tok := tokens.ModuleMember(req.GetTok())
-
-	prov, err := rm.getProvider(tok.Package(), req.GetProvider())
+	providerReq := rm.parseProviderRequest(tok.Package(), req.GetVersion())
+	prov, err := rm.getProvider(providerReq, req.GetProvider())
 	if err != nil {
 		return nil, err
 	}
@@ -509,7 +557,8 @@ func (rm *resmon) ReadResource(ctx context.Context,
 
 	provider := req.GetProvider()
 	if !providers.IsProviderType(t) && provider == "" {
-		ref, provErr := rm.defaultProviders.getDefaultProviderRef(t.Package())
+		providerReq := rm.parseProviderRequest(t.Package(), req.GetVersion())
+		ref, provErr := rm.defaultProviders.getDefaultProviderRef(providerReq)
 		if provErr != nil {
 			return nil, provErr
 		}
@@ -601,7 +650,8 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	label := fmt.Sprintf("ResourceMonitor.RegisterResource(%s,%s)", t, name)
 	provider := req.GetProvider()
 	if custom && !providers.IsProviderType(t) && provider == "" {
-		ref, err := rm.defaultProviders.getDefaultProviderRef(t.Package())
+		providerReq := rm.parseProviderRequest(t.Package(), req.GetVersion())
+		ref, err := rm.defaultProviders.getDefaultProviderRef(providerReq)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -55,7 +55,7 @@ func fixedProgram(steps []RegisterResourceEvent) deploytest.ProgramFunc {
 		for _, s := range steps {
 			g := s.Goal()
 			urn, id, outs, err := resmon.RegisterResource(g.Type, string(g.Name), g.Custom, g.Parent, g.Protect,
-				g.Dependencies, g.Provider, g.Properties, g.PropertyDependencies, false)
+				g.Dependencies, g.Provider, g.Properties, g.PropertyDependencies, false, "")
 			if err != nil {
 				return err
 			}
@@ -343,18 +343,18 @@ func TestReadInvokeNoDefaultProviders(t *testing.T) {
 	expectedReads, expectedInvokes := 3, 3
 	program := func(_ plugin.RunInfo, resmon *deploytest.ResourceMonitor) error {
 		// Perform some reads and invokes with explicit provider references.
-		_, _, perr := resmon.ReadResource("pkgA:m:typA", "resA", "id1", "", nil, providerARef.String())
+		_, _, perr := resmon.ReadResource("pkgA:m:typA", "resA", "id1", "", nil, providerARef.String(), "")
 		assert.NoError(t, perr)
-		_, _, perr = resmon.ReadResource("pkgA:m:typB", "resB", "id1", "", nil, providerBRef.String())
+		_, _, perr = resmon.ReadResource("pkgA:m:typB", "resB", "id1", "", nil, providerBRef.String(), "")
 		assert.NoError(t, perr)
-		_, _, perr = resmon.ReadResource("pkgC:m:typC", "resC", "id1", "", nil, providerCRef.String())
+		_, _, perr = resmon.ReadResource("pkgC:m:typC", "resC", "id1", "", nil, providerCRef.String(), "")
 		assert.NoError(t, perr)
 
-		_, _, perr = resmon.Invoke("pkgA:m:funcA", nil, providerARef.String())
+		_, _, perr = resmon.Invoke("pkgA:m:funcA", nil, providerARef.String(), "")
 		assert.NoError(t, perr)
-		_, _, perr = resmon.Invoke("pkgA:m:funcB", nil, providerBRef.String())
+		_, _, perr = resmon.Invoke("pkgA:m:funcB", nil, providerBRef.String(), "")
 		assert.NoError(t, perr)
-		_, _, perr = resmon.Invoke("pkgC:m:funcC", nil, providerCRef.String())
+		_, _, perr = resmon.Invoke("pkgC:m:funcC", nil, providerCRef.String(), "")
 		assert.NoError(t, perr)
 
 		return nil
@@ -414,18 +414,18 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 	expectedReads, expectedInvokes := 3, 3
 	program := func(_ plugin.RunInfo, resmon *deploytest.ResourceMonitor) error {
 		// Perform some reads and invokes with default provider references.
-		_, _, err := resmon.ReadResource("pkgA:m:typA", "resA", "id1", "", nil, "")
+		_, _, err := resmon.ReadResource("pkgA:m:typA", "resA", "id1", "", nil, "", "")
 		assert.NoError(t, err)
-		_, _, err = resmon.ReadResource("pkgA:m:typB", "resB", "id1", "", nil, "")
+		_, _, err = resmon.ReadResource("pkgA:m:typB", "resB", "id1", "", nil, "", "")
 		assert.NoError(t, err)
-		_, _, err = resmon.ReadResource("pkgC:m:typC", "resC", "id1", "", nil, "")
+		_, _, err = resmon.ReadResource("pkgC:m:typC", "resC", "id1", "", nil, "", "")
 		assert.NoError(t, err)
 
-		_, _, err = resmon.Invoke("pkgA:m:funcA", nil, "")
+		_, _, err = resmon.Invoke("pkgA:m:funcA", nil, "", "")
 		assert.NoError(t, err)
-		_, _, err = resmon.Invoke("pkgA:m:funcB", nil, "")
+		_, _, err = resmon.Invoke("pkgA:m:funcB", nil, "", "")
 		assert.NoError(t, err)
-		_, _, err = resmon.Invoke("pkgC:m:funcC", nil, "")
+		_, _, err = resmon.Invoke("pkgC:m:funcC", nil, "", "")
 		assert.NoError(t, err)
 
 		return nil
@@ -482,4 +482,191 @@ func TestReadInvokeDefaultProviders(t *testing.T) {
 	assert.Equal(t, len(providerSource.providers), registers)
 	assert.Equal(t, expectedReads, reads)
 	assert.Equal(t, expectedInvokes, int(invokes))
+}
+
+func TestReadResourceAndInvokeVersion(t *testing.T) {
+	runInfo := &EvalRunInfo{
+		Proj:   &workspace.Project{Name: "test"},
+		Target: &Target{Name: "test"},
+	}
+
+	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
+		var pt tokens.Type
+		if parent != "" {
+			pt = parent.Type()
+		}
+		return resource.NewURN(runInfo.Target.Name, runInfo.Proj.Name, pt, t, tokens.QName(name))
+	}
+
+	invokes := int32(0)
+	noopProvider := &deploytest.Provider{
+		InvokeF: func(tokens.ModuleMember, resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+			atomic.AddInt32(&invokes, 1)
+			return resource.PropertyMap{}, nil, nil
+		},
+	}
+
+	// This program is designed to trigger the instantiation of two default providers:
+	//  1. Provider pkgA, version 0.18.0
+	//  2. Provider pkgC, version 0.18.0
+	program := func(_ plugin.RunInfo, resmon *deploytest.ResourceMonitor) error {
+		// Triggers pkgA, v0.18.0.
+		_, _, err := resmon.ReadResource("pkgA:m:typA", "resA", "id1", "", nil, "", "0.18.0")
+		assert.NoError(t, err)
+		// Uses pkgA's already-instantiated provider.
+		_, _, err = resmon.ReadResource("pkgA:m:typB", "resB", "id1", "", nil, "", "0.18.0")
+		assert.NoError(t, err)
+
+		// Triggers pkgC, v0.18.0.
+		_, _, err = resmon.ReadResource("pkgC:m:typC", "resC", "id1", "", nil, "", "0.18.0")
+		assert.NoError(t, err)
+
+		// Uses pkgA and pkgC's already-instantiated provider.
+		_, _, err = resmon.Invoke("pkgA:m:funcA", nil, "", "0.18.0")
+		assert.NoError(t, err)
+		_, _, err = resmon.Invoke("pkgA:m:funcB", nil, "", "0.18.0")
+		assert.NoError(t, err)
+		_, _, err = resmon.Invoke("pkgC:m:funcC", nil, "", "0.18.0")
+		assert.NoError(t, err)
+
+		return nil
+	}
+
+	ctx, err := newTestPluginContext(program)
+	assert.NoError(t, err)
+
+	providerSource := &testProviderSource{providers: make(map[providers.Reference]plugin.Provider)}
+
+	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
+	assert.Nil(t, res)
+	registrations, reads := 0, 0
+	for {
+		event, res := iter.Next()
+		assert.Nil(t, res)
+
+		if event == nil {
+			break
+		}
+
+		switch e := event.(type) {
+		case RegisterResourceEvent:
+			goal := e.Goal()
+			urn, id := newURN(goal.Type, string(goal.Name), goal.Parent), resource.ID("id")
+
+			assert.True(t, providers.IsProviderType(goal.Type))
+			// The name of the provider resource is derived from the version requested.
+			assert.Equal(t, "default_0_18_0", string(goal.Name))
+			ref, err := providers.NewReference(urn, id)
+			assert.NoError(t, err)
+			_, ok := providerSource.GetProvider(ref)
+			assert.False(t, ok)
+			providerSource.registerProvider(ref, noopProvider)
+
+			e.Done(&RegisterResult{
+				State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
+					goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider, goal.PropertyDependencies,
+					false),
+			})
+			registrations++
+
+		case ReadResourceEvent:
+			urn := newURN(e.Type(), string(e.Name()), e.Parent())
+			e.Done(&ReadResult{
+				State: resource.NewState(e.Type(), urn, true, false, e.ID(), e.Properties(),
+					resource.PropertyMap{}, e.Parent(), false, false, e.Dependencies(), nil, e.Provider(), nil, false),
+			})
+			reads++
+		}
+	}
+
+	assert.Equal(t, 2, registrations)
+	assert.Equal(t, 3, reads)
+	assert.Equal(t, int32(3), invokes)
+}
+
+func TestRegisterResourceWithVersion(t *testing.T) {
+	runInfo := &EvalRunInfo{
+		Proj:   &workspace.Project{Name: "test"},
+		Target: &Target{Name: "test"},
+	}
+
+	newURN := func(t tokens.Type, name string, parent resource.URN) resource.URN {
+		var pt tokens.Type
+		if parent != "" {
+			pt = parent.Type()
+		}
+		return resource.NewURN(runInfo.Target.Name, runInfo.Proj.Name, pt, t, tokens.QName(name))
+	}
+
+	noopProvider := &deploytest.Provider{}
+
+	// This program is designed to trigger the instantiation of two default providers:
+	//  1. Provider pkgA, version 0.18.0
+	//  2. Provider pkgC, version 0.18.0
+	program := func(_ plugin.RunInfo, resmon *deploytest.ResourceMonitor) error {
+		// Triggers pkgA, v0.18.1.
+		_, _, _, err := resmon.RegisterResource("pkgA:m:typA", "resA", true, "", false, nil, "",
+			resource.PropertyMap{}, nil, false, "0.18.1")
+		assert.NoError(t, err)
+
+		// Re-uses pkgA's already-instantiated provider.
+		_, _, _, err = resmon.RegisterResource("pkgA:m:typA", "resB", true, "", false, nil, "",
+			resource.PropertyMap{}, nil, false, "0.18.1")
+		assert.NoError(t, err)
+
+		// Triggers pkgA, v0.18.2
+		_, _, _, err = resmon.RegisterResource("pkgA:m:typA", "resB", true, "", false, nil, "",
+			resource.PropertyMap{}, nil, false, "0.18.2")
+		assert.NoError(t, err)
+		return nil
+	}
+
+	ctx, err := newTestPluginContext(program)
+	assert.NoError(t, err)
+
+	providerSource := &testProviderSource{providers: make(map[providers.Reference]plugin.Provider)}
+
+	iter, res := NewEvalSource(ctx, runInfo, nil, false).Iterate(context.Background(), Options{}, providerSource)
+	assert.Nil(t, res)
+	registered181, registered182 := false, false
+	for {
+		event, res := iter.Next()
+		assert.Nil(t, res)
+
+		if event == nil {
+			break
+		}
+
+		switch e := event.(type) {
+		case RegisterResourceEvent:
+			goal := e.Goal()
+			urn, id := newURN(goal.Type, string(goal.Name), goal.Parent), resource.ID("id")
+
+			if providers.IsProviderType(goal.Type) {
+				switch goal.Name {
+				case "default_0_18_1":
+					assert.False(t, registered181)
+					registered181 = true
+				case "default_0_18_2":
+					assert.False(t, registered182)
+					registered182 = true
+				}
+
+				ref, err := providers.NewReference(urn, id)
+				assert.NoError(t, err)
+				_, ok := providerSource.GetProvider(ref)
+				assert.False(t, ok)
+				providerSource.registerProvider(ref, noopProvider)
+			}
+
+			e.Done(&RegisterResult{
+				State: resource.NewState(goal.Type, urn, goal.Custom, false, id, goal.Properties, resource.PropertyMap{},
+					goal.Parent, goal.Protect, false, goal.Dependencies, nil, goal.Provider, goal.PropertyDependencies,
+					false),
+			})
+		}
+	}
+
+	assert.True(t, registered181)
+	assert.True(t, registered182)
 }


### PR DESCRIPTION
As part of pulumi/pulumi#2389, we need the ability for language hosts to
tell the engine that a particular resource registration, read, or invoke
needs to use a particular version of a resource provider. This was not
previously possible before; the engine prior to this commit loaded
plugins from a default provider map, which was inferred for every
resource provider based on the contents of a user's package.json, and
was itself prone to bugs.

This PR adds the engine support needed for language hosts to request a
particular version of a provider. If this occurs, the source evaluator
specifically records the intent to load a provider with a given version
and produces a "default" provider registration that requests exactly
that version. This allows the source evaluator to produce multiple
default providers for a signle package, which was previously not
possible.

This is accomplished by having the source evaluator deal in the
"ProviderRequest" type, which is a tuple of version and package. A
request to load a provider whose version matches the package of a
previously loaded provider will re-use the existing default provider. If
the version was not previously loaded, a new default provider is
injected.