### PR TITLE
WIP: Simple `EnumerablePromise` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.17.7 (Unreleased)
 
+### Improvements
+
+- Add ability to enumerate resource outputs from state snapshot of arbitrary stacks.
+
 ## 0.17.6 (Released April 11, 2019)
 
 ### Improvements

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1255,3 +1255,8 @@ func (c httpstateBackendClient) GetStackOutputs(ctx context.Context, name string
 func (c httpstateBackendClient) DownloadPlugin(ctx context.Context, plug workspace.PluginInfo) (io.ReadCloser, error) {
 	return c.backend.DownloadPlugin(ctx, plug, false, display.Options{})
 }
+
+func (c httpstateBackendClient) GetStackResourceOutputs(
+	ctx context.Context, name string) (resource.PropertyMap, error) {
+	return backend.NewBackendClient(c.backend).GetStackResourceOutputs(ctx, name)
+}

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -142,10 +142,20 @@ func (p *builtinProvider) Read(urn resource.URN, id resource.ID,
 	}, resource.StatusOK, nil
 }
 
+const readStackResourceOutputs = "pulumi:pulumi:readStackResourceOutputs"
+
 func (p *builtinProvider) Invoke(tok tokens.ModuleMember,
 	args resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+	if tok != readStackResourceOutputs {
+		return nil, nil, errors.Errorf("unrecognized function name: '%v'", tok)
+	}
 
-	return nil, nil, errors.Errorf("unrecognized function name: '%v'", tok)
+	outs, err := p.readStackResourceOutputs(args)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return outs, nil, nil
 }
 
 func (p *builtinProvider) GetPluginInfo() (workspace.PluginInfo, error) {
@@ -168,6 +178,26 @@ func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resou
 	}
 
 	outputs, err := p.backendClient.GetStackOutputs(p.context, name.StringValue())
+	if err != nil {
+		return nil, err
+	}
+
+	return resource.PropertyMap{
+		"name":    name,
+		"outputs": resource.NewObjectProperty(outputs),
+	}, nil
+}
+
+func (p *builtinProvider) readStackResourceOutputs(inputs resource.PropertyMap) (resource.PropertyMap, error) {
+	name, ok := inputs["stackName"]
+	contract.Assert(ok)
+	contract.Assert(name.IsString())
+
+	if p.backendClient == nil {
+		return nil, errors.New("no backend client is available")
+	}
+
+	outputs, err := p.backendClient.GetStackResourceOutputs(p.context, name.StringValue())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/deploytest/backendclient.go
+++ b/pkg/resource/deploy/deploytest/backendclient.go
@@ -26,7 +26,8 @@ import (
 
 // BackendClient provides a simple implementation of deploy.BackendClient that defers to a function value.
 type BackendClient struct {
-	GetStackOutputsF func(ctx context.Context, name string) (resource.PropertyMap, error)
+	GetStackOutputsF         func(ctx context.Context, name string) (resource.PropertyMap, error)
+	GetStackResourceOutputsF func(ctx context.Context, name, typ string) (resource.PropertyMap, error)
 }
 
 // GetStackOutputs returns the outputs (if any) for the named stack or an error if the stack cannot be found.
@@ -37,4 +38,13 @@ func (b *BackendClient) GetStackOutputs(ctx context.Context, name string) (resou
 // DownloadPlugin optionally downloads a plugin corresponding to the requested plugin info.
 func (b *BackendClient) DownloadPlugin(ctx context.Context, plugin workspace.PluginInfo) (io.ReadCloser, error) {
 	return nil, errors.New("don't download plugins during unit tests")
+}
+
+// GetStackResourceOutputs returns the resource outputs of type (if any) for a stack, or an error if
+// the stack cannot be found. Resources are retrieved from the latest stack snapshot, which may
+// include ongoing updates. `typ` optionally specifies the type of resource to retrieve, formatted
+// using the Pulumi URN format (e.g., `kubernetes:core/v1:Service`).
+func (b *BackendClient) GetStackResourceOutputs(
+	ctx context.Context, name, typ string) (resource.PropertyMap, error) {
+	return b.GetStackResourceOutputsF(ctx, name, typ)
 }

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -19,8 +19,6 @@ import (
 	"io"
 	"math"
 
-	"github.com/pulumi/pulumi/pkg/workspace"
-
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -33,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/result"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 // BackendClient provides an interface for retrieving information about other stacks.
@@ -41,6 +40,11 @@ type BackendClient interface {
 	GetStackOutputs(ctx context.Context, name string) (resource.PropertyMap, error)
 
 	DownloadPlugin(ctx context.Context, plug workspace.PluginInfo) (io.ReadCloser, error)
+
+	// GetStackResourceOutputs returns the resource outputs (if any) for a stack, or an
+	// error if the stack cannot be found. Resources are retrieved from the latest stack snapshot,
+	// which may include ongoing updates.
+	GetStackResourceOutputs(ctx context.Context, stackName string) (resource.PropertyMap, error)
 }
 
 // Options controls the planning and deployment process.

--- a/sdk/nodejs/index.ts
+++ b/sdk/nodejs/index.ts
@@ -29,8 +29,9 @@ import * as asset from "./asset";
 import * as dynamic from "./dynamic";
 import * as iterable from "./iterable";
 import * as log from "./log";
+import * as query from "./query";
 import * as runtime from "./runtime";
-export { asset, dynamic, iterable, log, runtime };
+export { asset, dynamic, iterable, log, query, runtime };
 
 // @pulumi is a deployment-only module.  If someone tries to capture it, and we fail for some reason
 // we want to give a good message about what the problem likely is.  Note that capturing a

--- a/sdk/nodejs/query/enumerablePromise.ts
+++ b/sdk/nodejs/query/enumerablePromise.ts
@@ -1,0 +1,72 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { EnumerablePromise, Enumerator } from "./interfaces";
+import { Filter, FlatMap, Map, Take } from "./operators";
+import { ListEnumerator, RangeEnumerator } from "./sources";
+
+export class EnumerablePromiseImpl<T> extends Promise<Enumerator<T>>
+    implements EnumerablePromise<T> {
+    public static from<T>(source: T[] | Promise<T[]>): EnumerablePromiseImpl<T> {
+        if (Array.isArray(source)) {
+            return new EnumerablePromiseImpl(resolve => resolve(ListEnumerator.from(source)));
+        } else {
+            return new EnumerablePromiseImpl(resolve =>
+                source.then(ts => resolve(ListEnumerator.from(ts))),
+            );
+        }
+    }
+
+    public static range(start: number, stop?: number): EnumerablePromise<number> {
+        return new EnumerablePromiseImpl(resolve => resolve(new RangeEnumerator(start, stop)));
+    }
+
+    private constructor(executor: (resolve: (value?: Enumerator<T>) => void) => void) {
+        super(executor);
+    }
+
+    public filter(f: (t: T) => boolean): EnumerablePromise<T> {
+        return new EnumerablePromiseImpl(resolve => this.then(ts => resolve(new Filter(ts, f))));
+    }
+
+    public flatMap<U>(f: (t: T) => U[]): EnumerablePromise<U> {
+        return new EnumerablePromiseImpl(resolve => this.then(ts => resolve(new FlatMap(ts, f))));
+    }
+
+    public map<U>(f: (t: T) => U): EnumerablePromise<U> {
+        return new EnumerablePromiseImpl(resolve => this.then(ts => resolve(new Map(ts, f))));
+    }
+
+    public take(n: number): EnumerablePromise<T> {
+        return new EnumerablePromiseImpl(resolve => this.then(ts => resolve(new Take(ts, n))));
+    }
+
+    public toArray(): Promise<T[]> {
+        return this.then(ts => {
+            const tss: T[] = [];
+            while (ts.moveNext()) {
+                tss.push(ts.current());
+            }
+            return tss;
+        });
+    }
+
+    public forEach(f: (t: T) => void): void {
+        this.then(ts => {
+            while (ts.moveNext()) {
+                f(ts.current());
+            }
+        });
+    }
+}

--- a/sdk/nodejs/query/index.ts
+++ b/sdk/nodejs/query/index.ts
@@ -1,0 +1,32 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// NOTE: We choose to be purposefully conservative about what details are exposed through these
+// interfaces in case we decide to change the implementation drastically later.
+//
+
+import { EnumerablePromiseImpl } from "./enumerablePromise";
+import { EnumerablePromise } from "./interfaces";
+
+export { Enumerable, EnumerablePromise } from "./interfaces";
+export { Queryable, QueryableCustomResource } from "./queryable";
+
+export function from<T>(source: T[] | Promise<T[]>): EnumerablePromise<T> {
+    return EnumerablePromiseImpl.from(source);
+}
+
+export function range(start: number, stop?: number): EnumerablePromise<number> {
+    return EnumerablePromiseImpl.range(start, stop);
+}

--- a/sdk/nodejs/query/interfaces.ts
+++ b/sdk/nodejs/query/interfaces.ts
@@ -1,0 +1,44 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//
+// NOTE: We don't need `Disposable` or `Enumerator#reset()` yet, but it's worth noting here that we
+// didn't include them, and this causes us to diverge slightly from the "canonical" `Enumerable`
+// model.
+//
+
+export interface Enumerable<T> {
+    filter(f: (t: T) => boolean): Enumerable<T>;
+    flatMap(f: (t: T, index?: number) => T[]): Enumerable<T>;
+    map<U>(f: (t: T) => U): Enumerable<U>;
+    take(n: number): Enumerable<T>;
+
+    toArray(): Promise<T[]>;
+    forEach(f: (t: T) => void): void;
+}
+
+export interface Enumerator<T> {
+    current(): T;
+    moveNext(): boolean;
+}
+
+export interface EnumerablePromise<T> extends Enumerable<T>, Promise<Enumerator<T>> {
+    filter(f: (t: T) => boolean): EnumerablePromise<T>;
+    flatMap(f: (t: T, index?: number) => T[]): EnumerablePromise<T>;
+    map<U>(f: (t: T) => U): EnumerablePromise<U>;
+    take(n: number): EnumerablePromise<T>;
+
+    toArray(): Promise<T[]>;
+    forEach(f: (t: T) => void): void;
+}

--- a/sdk/nodejs/query/operators.ts
+++ b/sdk/nodejs/query/operators.ts
@@ -1,0 +1,92 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Enumerator } from "./interfaces";
+import { ListEnumerator } from "./sources";
+
+export class Filter<T> implements Enumerator<T> {
+    constructor(private readonly source: Enumerator<T>, private readonly f: (t: T) => boolean) {}
+
+    public current(): T {
+        return this.source.current();
+    }
+
+    public moveNext(): boolean {
+        while (this.source.moveNext()) {
+            if (this.f(this.source.current())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+export class FlatMap<T, U> implements Enumerator<U> {
+    private inner: Enumerator<U> = ListEnumerator.from([]);
+
+    constructor(private readonly source: Enumerator<T>, private readonly f: (t: T) => U[]) {}
+
+    public current(): U {
+        return this.inner.current();
+    }
+
+    public moveNext(): boolean {
+        while (true) {
+            if (this.inner.moveNext()) {
+                return true;
+            }
+
+            if (!this.source.moveNext()) {
+                return false;
+            }
+            const inner = this.f(this.source.current());
+            if (Array.isArray(inner)) {
+                this.inner = ListEnumerator.from(inner);
+            } else {
+                this.inner = inner;
+            }
+        }
+    }
+}
+
+export class Map<T, U> implements Enumerator<U> {
+    constructor(private readonly source: Enumerator<T>, private readonly f: (t: T) => U) {}
+
+    public current(): U {
+        return this.f(this.source.current());
+    }
+
+    public moveNext(): boolean {
+        return this.source.moveNext();
+    }
+}
+
+export class Take<T> implements Enumerator<T> {
+    private index: number = 0;
+
+    constructor(private readonly source: Enumerator<T>, private readonly n: number) {}
+
+    public current(): T {
+        return this.source.current();
+    }
+
+    public moveNext(): boolean {
+        this.index++;
+        if (this.index <= this.n && this.source.moveNext()) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}

--- a/sdk/nodejs/query/queryable.ts
+++ b/sdk/nodejs/query/queryable.ts
@@ -1,0 +1,54 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { OutputInstance } from "../index";
+import { CustomResource } from "../resource";
+
+type KeyOf = string | number | symbol;
+type Diff<T extends KeyOf, U extends KeyOf> = ({ [P in T]: P } &
+    { [P in U]: never } & { [x: string]: never })[T];
+type Omit<T, K extends KeyOf> = Pick<T, Diff<keyof T, K>>;
+
+export type QueryableCustomResource<T extends CustomResource> = Omit<
+    Queryable<T>,
+    "urn" | "getProvider"
+>;
+
+export type Queryable<T> = T extends Promise<infer U1>
+    ? QueryableSimple<U1>
+    : T extends OutputInstance<infer U2>
+    ? QueryableSimple<U2>
+    : QueryableSimple<T>;
+
+type primitive = string | number | boolean | undefined | null;
+
+type QueryableSimple<T> = T extends primitive
+    ? T
+    : T extends Array<infer U>
+    ? QueryableArray<T>
+    : T extends Function
+    ? never
+    : T extends object
+    ? QueryableObject<T>
+    : never;
+
+interface QueryableArray<T> extends Array<Queryable<T>> {}
+
+type QueryableObject<T> = ModifyOptionalProperties<{ [P in keyof T]: Queryable<T[P]> }>;
+
+type RequiredKeys<T> = { [P in keyof T]: undefined extends T[P] ? never : P }[keyof T];
+type OptionalKeys<T> = { [P in keyof T]: undefined extends T[P] ? P : never }[keyof T];
+
+type ModifyOptionalProperties<T> = { [P in RequiredKeys<T>]: T[P] } &
+    { [P in OptionalKeys<T>]?: T[P] };

--- a/sdk/nodejs/query/sources.ts
+++ b/sdk/nodejs/query/sources.ts
@@ -1,0 +1,60 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Enumerator } from "./interfaces";
+
+export class RangeEnumerator implements Enumerator<number> {
+    private curr: number;
+
+    constructor(private readonly start: number, private readonly stop?: number) {
+        this.curr = start - 1;
+    }
+
+    public current(): number {
+        return this.curr;
+    }
+
+    public moveNext(): boolean {
+        this.curr++;
+        if (this.stop === undefined || this.curr < this.stop) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
+
+export class ListEnumerator<T> implements Enumerator<T> {
+    private index: number = -1;
+    public static from<T>(ts: T[]): ListEnumerator<T> {
+        return new ListEnumerator<T>(ts);
+    }
+
+    private constructor(private readonly ts: T[]) {}
+
+    public current(): T {
+        if (this.index < 0) {
+            throw Error("`moveNext` must be called before `current`");
+        } else if (this.index >= this.ts.length) {
+            throw Error("`current` called after the last element in the sequence");
+        }
+
+        return this.ts[this.index];
+    }
+
+    public moveNext(): boolean {
+        this.index++;
+        return this.index < this.ts.length;
+    }
+}

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -252,6 +252,13 @@ export abstract class CustomResource extends Resource {
     /* @internal */ public readonly __pulumiCustomResource: boolean;
 
     /**
+     * Private field containing the type ID for this object. Useful for implementing `isInstance` on
+     * classes that inherit from `CustomResource`.
+     */
+    // tslint:disable-next-line:variable-name
+    /* @internal */ public readonly __pulumiType: string;
+
+    /**
      * id is the provider-assigned unique ID for this managed resource.  It is set during
      * deployments and may be missing (undefined) during planning phases.
      */
@@ -285,6 +292,7 @@ export abstract class CustomResource extends Resource {
 
         super(t, name, true, props, opts);
         this.__pulumiCustomResource = true;
+        this.__pulumiType = t;
     }
 }
 

--- a/sdk/nodejs/tests/query/enumerablePromise.spec.ts
+++ b/sdk/nodejs/tests/query/enumerablePromise.spec.ts
@@ -1,0 +1,124 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+
+import { EnumerablePromiseImpl } from "../../query/enumerablePromise";
+
+describe("EnumerablePromise", () => {
+    describe("range", () => {
+        it("produces an empty array for overlapping ranges", async () => {
+            let xs = await EnumerablePromiseImpl.range(0, 0).toArray();
+            assert.deepEqual(xs, []);
+
+            xs = await EnumerablePromiseImpl.range(0, -1).toArray();
+            assert.deepEqual(xs, []);
+        });
+
+        it("produces an array of one for boundary case", async () => {
+            const xs = await EnumerablePromiseImpl.range(0, 1).toArray();
+            assert.deepEqual(xs, [0]);
+        });
+
+        it("can produce a range including negative numbers", async () => {
+            const xs = await EnumerablePromiseImpl.range(-3, 2).toArray();
+            assert.deepEqual(xs, [-3, -2, -1, 0, 1]);
+        });
+
+        it("is lazily evaluated by take when range is infinite", async () => {
+            const xs = await EnumerablePromiseImpl.range(0)
+                .take(5)
+                .toArray();
+            assert.deepEqual(xs, [0, 1, 2, 3, 4]);
+        });
+
+        it("is lazily transformed and filtered when range is infinite", async () => {
+            const xs = await EnumerablePromiseImpl.range(0)
+                .map(x => x + 2)
+                // If filter is bigger than the take window, we enumerate all numbers and hang
+                // forever.
+                .filter(x => x <= 10)
+                .take(7)
+                .map(x => x - 2)
+                .filter(x => x > 3)
+                .toArray();
+            assert.deepEqual(xs, [4, 5, 6]);
+        });
+
+        it("is lazily flatMap'd when range is infinite", async () => {
+            const xs = await EnumerablePromiseImpl.range(0)
+                // If filter is bigger than the take window, we enumerate all numbers and hang
+                // forever.
+                .flatMap(x => (x <= 10 ? [x, x] : []))
+                .take(5)
+                .toArray();
+            assert.deepEqual(xs, [0, 0, 1, 1, 2]);
+        });
+    });
+
+    describe("filter", () => {
+        it("produces [] when all elements are filtered out", async () => {
+            const xs = await EnumerablePromiseImpl.from([1, 2, 3, 4])
+                .filter(x => x < 0)
+                .toArray();
+            assert.deepEqual(xs, []);
+        });
+
+        it("produces an non-empty array when some elements are filtered out", async () => {
+            const xs = await EnumerablePromiseImpl.from([1, 2, 3, 4])
+                .filter(x => x >= 3)
+                .toArray();
+            assert.deepEqual(xs, [3, 4]);
+        });
+    });
+
+    describe("flatMap", () => {
+        it("produces [] when all elements are filtered out", async () => {
+            const xs = await EnumerablePromiseImpl.from([1, 2, 3, 4])
+                .flatMap(x => [])
+                .toArray();
+            assert.deepEqual(xs, []);
+        });
+
+        it("can add elements to an enumerable", async () => {
+            const xs = await EnumerablePromiseImpl.from([1, 2, 3, 4])
+                .flatMap(x => [x, x])
+                .toArray();
+            assert.deepEqual(xs, [1, 1, 2, 2, 3, 3, 4, 4]);
+        });
+    });
+
+    describe("map", () => {
+        it("x => x does identity transformation", async () => {
+            const xs = await EnumerablePromiseImpl.from([1, 2, 3, 4])
+                .map(x => x)
+                .toArray();
+            assert.deepEqual(xs, [1, 2, 3, 4]);
+        });
+
+        it("x => x+1 adds one to every element", async () => {
+            const xs = await EnumerablePromiseImpl.from([1, 2, 3, 4])
+                .map(x => x + 1)
+                .toArray();
+            assert.deepEqual(xs, [2, 3, 4, 5]);
+        });
+    });
+
+    describe("toArray", () => {
+        it("returns empty array for empty enumerable", async () => {
+            const xs = await EnumerablePromiseImpl.from([]).toArray();
+            assert.deepEqual(xs, []);
+        });
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -36,6 +36,13 @@
 
         "log/index.ts",
 
+        "query/enumerablePromise.ts",
+        "query/index.ts",
+        "query/interfaces.ts",
+        "query/operators.ts",
+        "query/sources.ts",
+        "query/queryable.ts",
+
         "runtime/index.ts",
         "runtime/closure/v8.ts",
         "runtime/closure/createClosure.ts",
@@ -63,7 +70,8 @@
         "tests/runtime/closureLoader.spec.ts",
         "tests/runtime/tsClosureCases.ts",
         "tests/runtime/props.spec.ts",
-        "tests/runtime/langhost/run.spec.ts"
+        "tests/runtime/langhost/run.spec.ts",
+        "tests/query/enumerablePromise.spec.ts"
     ]
 }
 


### PR DESCRIPTION
NOTE: This PR contains #2630, which it depends on. You probably want to start by looking at the new TS tests to get a flavor for what's happening.

This WIP PR shows how we're starting to think about `list`-style queries in Pulumi.

Unfortunately, the state of the LINQ-style query libraries in the JS ecosystem is quite bad. Particularly for our use case:

* These libraries tend to either diverge from the "canonical" `Enumerable` model in ways that are subtle, surprising, or bad
* None of these libraries play well with `Promise<T>`, which is a big deal in JS because concurrency can't be "hidden" in the way it can with C#.
* The mature model in this space that _does_ deal with `Promise<T>` and has a reasonable enumeration model is rxjs. But it actually an `Observable` model, which provides a fully stream query algebra. This _dramatically_ increases the complexity writing queries in a way that is probably unacceptable for many of the comparatively "boring" use cases we have in mind.
* Less critically, rxjs also uses the `pipe` API instead of methods, which diverges quite a bit from the rest of the Pulumi API.

To this end, we present a very simple `EnumerablePromise<T>` API, which is essentially a `Promise<T[]>`, but with some query primitives hanging off of it. For example:

```typescript
// Take the first 5 elements of an infinite range. `EnumerablePromise` takes `Promise`s,
// but also has a couple handy primitives building queries out of ranges, arrays, etc.
const xs = await EnumerablePromise.range(0)
    .take(5)
    .toArray(); // Converts `EnumerablePromise<T>` -> `Promise<T[]>`

// Add 1 to every element in an array.
const xs = await EnumerablePromise.from([1, 2, 3, 4])
    .map(x => x + 1)
    .toArray();

// Find Kubernetes Service objects in the statefile. (There will be more sugar around this soon.)
const svcs = await EnumerablePromise.from(getResourceOutputs())
    .filter(k8s.core.v1.isService)
    .toArray()
```

This PR includes a bunch of tests, but I'll be coming back and rounding off edges, making sure the API is what we want, _etc_.