### PR TITLE
Plumb provider version through language hosts to engine

### DIFF
--- a/sdk/nodejs/invoke.ts
+++ b/sdk/nodejs/invoke.ts
@@ -28,4 +28,10 @@ export interface InvokeOptions {
      * invoked function's package will be used.
      */
     provider?: ProviderResource;
+
+    /**
+     * An optional version, corresponding to the version of the provider plugin that should be used when performing this
+     * invoke.
+     */
+    version?: string;
 }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -208,10 +208,17 @@ export interface ResourceOptions {
      * When set to true, protect ensures this resource cannot be deleted.
      */
     protect?: boolean;
+
     /**
      * Ignore changes to any of the specified properties.
      */
     ignoreChanges?: string[];
+
+    /**
+     * An optional version, corresponding to the version of the provider plugin that should be used when operating on
+     * this resource.
+     */
+    version?: string;
 }
 
 /**

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -216,7 +216,8 @@ export interface ResourceOptions {
 
     /**
      * An optional version, corresponding to the version of the provider plugin that should be used when operating on
-     * this resource.
+     * this resource. This version overrides the version information inferred from the current package and should
+     * rarely be used.
      */
     version?: string;
 }

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -59,6 +59,7 @@ export async function invoke(tok: string, props: Inputs, opts?: InvokeOptions): 
         req.setTok(tok);
         req.setArgs(obj);
         req.setProvider(providerRef);
+        req.setVersion(opts.version || "");
         const resp: any = await debuggablePromise(new Promise((innerResolve, innerReject) =>
             monitor.invoke(req, (err: grpc.StatusObject, innerResponse: any) => {
                 log.debug(`Invoke RPC finished: tok=${tok}; err: ${err}, resp: ${innerResponse}`);

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -110,6 +110,7 @@ export function readResource(res: Resource, t: string, name: string, props: Inpu
         req.setProvider(resop.providerRef);
         req.setProperties(gstruct.Struct.fromJavaScript(resop.serializedProps));
         req.setDependenciesList(Array.from(resop.allDirectDependencyURNs));
+        req.setVersion(opts.version || "");
 
         // Now run the operation, serializing the invocation if necessary.
         const opLabel = `monitor.readResource(${label})`;
@@ -178,6 +179,7 @@ export function registerResource(res: Resource, t: string, name: string, custom:
         req.setDependenciesList(Array.from(resop.allDirectDependencyURNs));
         req.setDeletebeforereplace((<any>opts).deleteBeforeReplace || false);
         req.setIgnorechangesList(opts.ignoreChanges || []);
+        req.setVersion(opts.version || "");
 
         const propertyDependencies = req.getPropertydependenciesMap();
         for (const [key, resourceURNs] of resop.propertyToDirectDependencyURNs) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/044.versions/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/044.versions/index.js
@@ -1,0 +1,11 @@
+let pulumi = require("../../../../../");
+
+class MyResource extends pulumi.CustomResource {
+    constructor(name, version) {
+        super("test:index:MyResource", name, {}, { version: version });
+    }
+}
+
+new MyResource("testResource", "0.19.1");
+new MyResource("testResource2", "0.19.2");
+new MyResource("testResource3");

--- a/sdk/nodejs/tests/runtime/langhost/cases/044.versions/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/044.versions/index.js
@@ -9,3 +9,8 @@ class MyResource extends pulumi.CustomResource {
 new MyResource("testResource", "0.19.1");
 new MyResource("testResource2", "0.19.2");
 new MyResource("testResource3");
+
+
+pulumi.runtime.invoke("invoke:index:doit", {}, { version: "0.19.1" });
+pulumi.runtime.invoke("invoke:index:doit_v2", {}, { version: "0.19.2" });
+pulumi.runtime.invoke("invoke:index:doit_noversion", {});

--- a/sdk/nodejs/tests/runtime/langhost/cases/044.versions/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/044.versions/index.js
@@ -14,3 +14,7 @@ new MyResource("testResource3");
 pulumi.runtime.invoke("invoke:index:doit", {}, { version: "0.19.1" });
 pulumi.runtime.invoke("invoke:index:doit_v2", {}, { version: "0.19.2" });
 pulumi.runtime.invoke("invoke:index:doit_noversion", {});
+
+
+new pulumi.CustomResource("test:index:ReadResource", "foo", {}, { id: "readme", version: "0.20.0" });
+new pulumi.CustomResource("test:index:ReadResource", "foo_noversion", {}, { id: "readme" });

--- a/sdk/python/.pylintrc
+++ b/sdk/python/.pylintrc
@@ -143,6 +143,7 @@ disable=print-statement,
 
         # Pulumi-specific exclusions begin here
         too-few-public-methods,
+        too-many-instance-attributes,
         wildcard-import,
         global-statement,
         invalid-name,

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -26,13 +26,24 @@ class InvokeOptions:
     An optional provider to use for this invocation. If no provider is supplied, the default provider for the
     invoked function's package will be used.
     """
+    version: Optional[str]
+    """
+    An optional version. If provided, the provider plugin with exactly this version will be used to service
+    the invocation.
+    """
 
-    def __init__(self, parent: Optional['Resource'] = None, provider: Optional['ProviderResource'] = None) -> None:
+    def __init__(self,
+                 parent: Optional['Resource'] = None,
+                 provider: Optional['ProviderResource'] = None,
+                 version: Optional[str] = "") -> None:
         """
         :param Optional[Resource] parent: An optional parent to use for default options for this invoke (e.g. the
                default provider to use).
         :param Optional[ProviderResource] provider: An optional provider to use for this invocation. If no provider is
                supplied, the default provider for the invoked function's package will be used.
+        :param Optional[str] version: An optional version. If provided, the provider plugin with exactly this version
+               will be used to service the invocation.
         """
         self.parent = parent
         self.provider = provider
+        self.version = version

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -65,6 +65,13 @@ class ResourceOptions:
     If provided, ignore changes to any of the specified properties.
     """
 
+    version: Optional[str]
+    """
+    An optional version. If provided, the engine loads a provider with exactly the requested version to operate on this
+    resource.
+    """
+
+
     def __init__(self,
                  parent: Optional['Resource'] = None,
                  depends_on: Optional[List['Resource']] = None,
@@ -72,7 +79,8 @@ class ResourceOptions:
                  provider: Optional['ProviderResource'] = None,
                  providers: Optional[Mapping[str, 'ProviderResource']] = None,
                  delete_before_replace: Optional[bool] = None,
-                 ignore_changes: Optional[List[str]] = None) -> None:
+                 ignore_changes: Optional[List[str]] = None,
+                 version: Optional[str] = None) -> None:
         """
         :param Optional[Resource] parent: If provided, the currently-constructing resource should be the child of
                the provided parent resource.
@@ -95,6 +103,7 @@ class ResourceOptions:
         self.providers = providers
         self.delete_before_replace = delete_before_replace
         self.ignore_changes = ignore_changes
+        self.version = version
 
         if depends_on is not None:
             for dep in depends_on:

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -68,7 +68,8 @@ class ResourceOptions:
     version: Optional[str]
     """
     An optional version. If provided, the engine loads a provider with exactly the requested version to operate on this
-    resource.
+    resource. This version overrides the version information inferred from the current package and should rarely be
+    used.
     """
 
 

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -50,8 +50,9 @@ def invoke(tok: str, props: Inputs, opts: InvokeOptions = None) -> Awaitable[Any
 
         monitor = get_monitor()
         inputs = await rpc.serialize_properties(props, {})
+        version = opts.version or ""
         log.debug(f"Invoking function prepared: tok={tok}")
-        req = provider_pb2.InvokeRequest(tok=tok, args=inputs, provider=provider_ref)
+        req = provider_pb2.InvokeRequest(tok=tok, args=inputs, provider=provider_ref, version=version)
 
         def do_invoke():
             try:

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -189,7 +189,8 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
                 dependencies=resolver.dependencies,
                 propertyDependencies=property_dependencies,
                 deleteBeforeReplace=opts.delete_before_replace,
-                ignoreChanges=ignore_changes
+                ignoreChanges=ignore_changes,
+                version=opts.version or "",
             )
 
             def do_rpc_call():

--- a/sdk/python/lib/test/langhost/asset/test_asset.py
+++ b/sdk/python/lib/test/langhost/asset/test_asset.py
@@ -25,7 +25,7 @@ class AssetTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "file":
             self.assertIsInstance(resource["asset"], FileAsset)

--- a/sdk/python/lib/test/langhost/chained_failure/test_chained_failure.py
+++ b/sdk/python/lib/test/langhost/chained_failure/test_chained_failure.py
@@ -32,7 +32,7 @@ class ChainedFailureTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, res, _deps,
                           _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         if ty == "test:index:ResourceA":
             self.assertEqual(name, "resourceA")
             self.assertDictEqual(res, {"inprop": 777})

--- a/sdk/python/lib/test/langhost/config/test_config.py
+++ b/sdk/python/lib/test/langhost/config/test_config.py
@@ -29,7 +29,7 @@ class ConfigTest(LanghostTest):
 
     def register_resource(self, ctx, dry_run, ty, name, _resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual("test:index:MyResource", ty)
         self.assertEqual("myname", name)
         return {

--- a/sdk/python/lib/test/langhost/delete_before_replace/test_protect.py
+++ b/sdk/python/lib/test/langhost/delete_before_replace/test_protect.py
@@ -26,7 +26,7 @@ class DeleteBeforeReplaceTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual("foo", name)
         self.assertTrue(delete_before_replace)
         return {

--- a/sdk/python/lib/test/langhost/first_class_provider/test_first_class_provider.py
+++ b/sdk/python/lib/test/langhost/first_class_provider/test_first_class_provider.py
@@ -30,7 +30,7 @@ class FirstClassProviderTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource,
                           _dependencies, _parent, _custom, _protect, provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         if name == "testprov":
             # Provider resource.
             self.assertEqual("pulumi:providers:test", ty)

--- a/sdk/python/lib/test/langhost/first_class_provider_invoke/test_first_class_provider_invoke.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_invoke/test_first_class_provider_invoke.py
@@ -54,7 +54,7 @@ class TestFirstClassProviderInvoke(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps,
                           _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         if name == "testprov":
             self.assertEqual("pulumi:providers:test", ty)
             self.prov_urn = self.make_urn(ty, name)

--- a/sdk/python/lib/test/langhost/first_class_provider_invoke/test_first_class_provider_invoke.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_invoke/test_first_class_provider_invoke.py
@@ -30,7 +30,7 @@ class TestFirstClassProviderInvoke(LanghostTest):
             expected_resource_count=4)
 
 
-    def invoke(self, _ctx, token, args, provider):
+    def invoke(self, _ctx, token, args, provider, _version):
         # MyFunction explicitly receives a provider reference.
         if token == "test:index:MyFunction":
             self.assertDictEqual({

--- a/sdk/python/lib/test/langhost/first_class_provider_unknown/test_first_class_provider_unknown.py
+++ b/sdk/python/lib/test/langhost/first_class_provider_unknown/test_first_class_provider_unknown.py
@@ -32,7 +32,7 @@ class FirstClassProviderUnknown(LanghostTest):
 
     def register_resource(self, _ctx, dry_run, ty, name, resource, _deps,
                           _parent, _custom, _protect, provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         if name == "testprov":
             self.assertEqual("pulumi:providers:test", ty)
             # Only provide an ID when doing an update. When doing a preview the ID will be unknown

--- a/sdk/python/lib/test/langhost/future_input/test_future_input.py
+++ b/sdk/python/lib/test/langhost/future_input/test_future_input.py
@@ -27,7 +27,7 @@ class FutureInputTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps,
                           _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual(ty, "test:index:FileResource")
         self.assertEqual(name, "file")
         self.assertDictEqual(resource, {

--- a/sdk/python/lib/test/langhost/ignore_changes/test_ignore_changes.py
+++ b/sdk/python/lib/test/langhost/ignore_changes/test_ignore_changes.py
@@ -26,7 +26,7 @@ class TestIgnoreChanges(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps,
                           _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          ignore_changes):
+                          ignore_changes, _version):
 
         # Note that here we expect to receive `ignoredProperty`, even though the user provided `ignored_property`.
         self.assertListEqual(ignore_changes, ["ignoredProperty", "ignored_property_other"])

--- a/sdk/python/lib/test/langhost/inherit_defaults/test_inherit_defaults.py
+++ b/sdk/python/lib/test/langhost/inherit_defaults/test_inherit_defaults.py
@@ -31,7 +31,7 @@ class InheritDefaultsTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource,
                           _dependencies, _parent, custom, protect, provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         if custom and not ty.startswith("pulumi:providers:"):
             expect_protect = False
             expect_provider_name = ""

--- a/sdk/python/lib/test/langhost/invalid_property_dependency/test_invalid_property_dependency.py
+++ b/sdk/python/lib/test/langhost/invalid_property_dependency/test_invalid_property_dependency.py
@@ -25,7 +25,7 @@ class InvalidPropertyDependencyTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_dependencies, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "resA":
             self.assertListEqual(_dependencies, [])

--- a/sdk/python/lib/test/langhost/invoke/test_invoke.py
+++ b/sdk/python/lib/test/langhost/invoke/test_invoke.py
@@ -21,7 +21,7 @@ class TestInvoke(LanghostTest):
             program=path.join(self.base_path(), "invoke"),
             expected_resource_count=1)
 
-    def invoke(self, _ctx, token, args, provider):
+    def invoke(self, _ctx, token, args, provider, _version):
         self.assertEqual("test:index:MyFunction", token)
         self.assertEqual("", provider)
         self.assertDictEqual({
@@ -53,7 +53,7 @@ class TestInvokeWithFailures(LanghostTest):
             expected_resource_count=0,
             expected_error="Program exited with non-zero exit code: 1")
 
-    def invoke(self, _ctx, token, args, _provider):
+    def invoke(self, _ctx, token, args, _provider, _version):
         self.assertEqual("test:index:MyFunction", token)
         self.assertDictEqual({
             "value": 41,

--- a/sdk/python/lib/test/langhost/invoke/test_invoke.py
+++ b/sdk/python/lib/test/langhost/invoke/test_invoke.py
@@ -34,7 +34,7 @@ class TestInvoke(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps,
                           _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual("test:index:MyResource", ty)
         self.assertEqual("resourceA", name)
         self.assertEqual(resource["value"], 42)

--- a/sdk/python/lib/test/langhost/one_complex_resource/test_one_complex_resource.py
+++ b/sdk/python/lib/test/langhost/one_complex_resource/test_one_complex_resource.py
@@ -24,7 +24,7 @@ class OneComplexResourceTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual(ty, "test:index:MyResource")
         self.assertEqual(name, "testres")
         self.assertEqual(resource["falseprop"], False)

--- a/sdk/python/lib/test/langhost/output_all/test_output_all.py
+++ b/sdk/python/lib/test/langhost/output_all/test_output_all.py
@@ -25,7 +25,7 @@ class OutputAllTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         number = 0
         if name == "testResource1":
             self.assertEqual(ty, "test:index:MyResource")

--- a/sdk/python/lib/test/langhost/output_nested/test_output_nested.py
+++ b/sdk/python/lib/test/langhost/output_nested/test_output_nested.py
@@ -23,7 +23,7 @@ class OutputNestedTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         nested_numbers = None
         if name == "testResource1":
             self.assertEqual(ty, "test:index:MyResource")

--- a/sdk/python/lib/test/langhost/outputs_future/test_outputs_future.py
+++ b/sdk/python/lib/test/langhost/outputs_future/test_outputs_future.py
@@ -21,7 +21,7 @@ class TestOutputsFuture(LanghostTest):
             program=path.join(self.base_path(), "outputs_future"),
             expected_resource_count=0)
 
-    def invoke(self, _ctx, token, args, _provider):
+    def invoke(self, _ctx, token, args, _provider, _version):
         self.assertEqual("test:index:MyFunction", token)
         self.assertDictEqual({
             "value": 41,

--- a/sdk/python/lib/test/langhost/preview/test_preview.py
+++ b/sdk/python/lib/test/langhost/preview/test_preview.py
@@ -26,7 +26,7 @@ class PreviewTest(LanghostTest):
 
     def register_resource(self, _ctx, dry_run, ty, name, resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual(ty, "test:index:MyResource")
         self.assertEqual(name, "foo")
         if dry_run:

--- a/sdk/python/lib/test/langhost/property_dependencies/test_property_dependencies.py
+++ b/sdk/python/lib/test/langhost/property_dependencies/test_property_dependencies.py
@@ -24,7 +24,7 @@ class PropertyDependenciesTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_dependencies, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "resA":
             self.assertListEqual(_dependencies, [])

--- a/sdk/python/lib/test/langhost/property_renaming/test_property_renaming.py
+++ b/sdk/python/lib/test/langhost/property_renaming/test_property_renaming.py
@@ -27,7 +27,7 @@ class PropertyRenamingTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, res, _deps,
                           _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         # Test:
         #  1. Everything that we receive from the running program is in camel-case. The engine never sees
         # the pre-translated names of the input properties.

--- a/sdk/python/lib/test/langhost/protect/test_protect.py
+++ b/sdk/python/lib/test/langhost/protect/test_protect.py
@@ -26,7 +26,7 @@ class ProtectTest(LanghostTest):
 
     def register_resource(self, _ctx, _dry_run, ty, name, _resource,
                           _dependencies, _parent, _custom, protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual("foo", name)
         self.assertTrue(protect)
         return {

--- a/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
+++ b/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
@@ -31,7 +31,7 @@ class ResourceThensTest(LanghostTest):
 
     def register_resource(self, _ctx, dry_run, ty, name, res, deps,
                           _parent, custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         if ty == "test:index:ResourceA":
             self.assertEqual(name, "resourceA")
             self.assertDictEqual(res, {"inprop": 777})

--- a/sdk/python/lib/test/langhost/ten_resources/test_ten_resources.py
+++ b/sdk/python/lib/test/langhost/ten_resources/test_ten_resources.py
@@ -26,7 +26,7 @@ class TenResourcesTest(LanghostTest):
 
     def register_resource(self, ctx, dry_run, ty, name, _resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes):
+                          _ignore_changes, _version):
         self.assertEqual("test:index:MyResource", ty)
         if not dry_run:
             self.assertIsNone(

--- a/sdk/python/lib/test/langhost/util.py
+++ b/sdk/python/lib/test/langhost/util.py
@@ -90,6 +90,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
         provider = request.provider
         delete_before_replace = request.deleteBeforeReplace
         ignore_changes = sorted(list(request.ignoreChanges))
+        version = request.version
 
         property_dependencies = {}
         for key, value in request.propertyDependencies.items():
@@ -99,7 +100,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
         if type_ != "pulumi:pulumi:Stack":
             outs = self.langhost_test.register_resource(
                 context, self.dryrun, type_, name, props, deps, parent, custom, protect, provider, 
-                property_dependencies, delete_before_replace, ignore_changes)
+                property_dependencies, delete_before_replace, ignore_changes, version)
             if outs.get("urn"):
                 urn = outs["urn"]
                 self.registrations[urn] = {

--- a/sdk/python/lib/test/langhost/util.py
+++ b/sdk/python/lib/test/langhost/util.py
@@ -52,7 +52,7 @@ class LanghostMockResourceMonitor(proto.ResourceMonitorServicer):
 
     def Invoke(self, request, context):
         args = rpc.deserialize_properties(request.args)
-        failures, ret = self.langhost_test.invoke(context, request.tok, args, request.provider)
+        failures, ret = self.langhost_test.invoke(context, request.tok, args, request.provider, request.version)
         failures_rpc = list(map(
             lambda fail: provider_pb2.CheckFailure(property=fail["property"], reason=fail["reason"]), failures))
 

--- a/sdk/python/lib/test/langhost/versions/__init__.py
+++ b/sdk/python/lib/test/langhost/versions/__init__.py
@@ -11,17 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from os import path
-from ..util import LanghostTest
-
-
-class UnhandledExceptionTest(LanghostTest):
-    def test_unhandled_exception(self):
-        self.run_test(
-            program=path.join(self.base_path(), "resource_op_fail"),
-            expected_error="Program exited with non-zero exit code: 1")
-
-    def register_resource(self, _ctx, _dry_run, _ty, _name, _resource,
-                          _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes, _version):
-        raise Exception("oh no")

--- a/sdk/python/lib/test/langhost/versions/__main__.py
+++ b/sdk/python/lib/test/langhost/versions/__main__.py
@@ -11,17 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from os import path
-from ..util import LanghostTest
+from pulumi import CustomResource, ResourceOptions
 
 
-class UnhandledExceptionTest(LanghostTest):
-    def test_unhandled_exception(self):
-        self.run_test(
-            program=path.join(self.base_path(), "resource_op_fail"),
-            expected_error="Program exited with non-zero exit code: 1")
+class MyResource(CustomResource):
+    def __init__(self, name, version=None):
+        CustomResource.__init__(self, "test:index:MyResource", name, opts=ResourceOptions(version=version))
 
-    def register_resource(self, _ctx, _dry_run, _ty, _name, _resource,
-                          _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes, _version):
-        raise Exception("oh no")
+
+res = MyResource("testres", version="0.19.1")
+res2 = MyResource("testres2", version="0.19.2")
+res3 = MyResource("testres3")

--- a/sdk/python/lib/test/langhost/versions/__main__.py
+++ b/sdk/python/lib/test/langhost/versions/__main__.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from pulumi import CustomResource, ResourceOptions
+from pulumi import CustomResource, ResourceOptions, InvokeOptions
+from pulumi.runtime import invoke
 
 
 class MyResource(CustomResource):
@@ -22,3 +23,7 @@ class MyResource(CustomResource):
 res = MyResource("testres", version="0.19.1")
 res2 = MyResource("testres2", version="0.19.2")
 res3 = MyResource("testres3")
+
+invoke("test:index:doit", {}, opts=InvokeOptions(version="0.19.1"))
+invoke("test:index:doit_v2", {}, opts=InvokeOptions(version="0.19.2"))
+invoke("test:index:doit_no_version", {})

--- a/sdk/python/lib/test/langhost/versions/test_versions.py
+++ b/sdk/python/lib/test/langhost/versions/test_versions.py
@@ -37,3 +37,12 @@ class TestVersions(LanghostTest):
             "id": name,
             "object": {}
         }
+
+    def invoke(self, _ctx, token, args, _provider, version):
+        if token == "test:index:doit":
+            self.assertEqual("0.19.1", version)
+        elif token == "test:index:doit_v2":
+            self.assertEqual("0.19.2", version)
+        elif token == "test:index:doit_no_version":
+            self.assertEqual("", version)
+        return [], args

--- a/sdk/python/lib/test/langhost/versions/test_versions.py
+++ b/sdk/python/lib/test/langhost/versions/test_versions.py
@@ -15,17 +15,25 @@ from os import path
 from ..util import LanghostTest
 
 
-class OneResourceTest(LanghostTest):
-    def test_one_resource(self):
+class TestVersions(LanghostTest):
+    def test_versions(self):
         self.run_test(
-            program=path.join(self.base_path(), "one_resource"),
-            expected_resource_count=1)
+            program=path.join(self.base_path(), "versions"),
+            expected_resource_count=3)
 
-    def register_resource(self, _ctx, _dry_run, ty, name, _resource,
-                          _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
-                          _ignore_changes, _version):
-        self.assertEqual(ty, "test:index:MyResource")
-        self.assertEqual(name, "testResource1")
+    def register_resource(self, ctx, dry_run, ty, name, _resource,
+                          _dependencies, _parent, _custom, _protect,
+                          _provider, _property_deps, _delete_before_replace, version):
+        if name == "testres":
+            self.assertEqual(version, "0.19.1")
+        elif name == "testres2":
+            self.assertEqual(version, "0.19.2")
+        elif name == "testres3":
+            self.assertEqual(version, "")
+        else:
+            self.fail(f"unknown resource: {name}")
         return {
             "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": {}
         }

--- a/sdk/python/lib/test/langhost/versions/test_versions.py
+++ b/sdk/python/lib/test/langhost/versions/test_versions.py
@@ -23,7 +23,7 @@ class TestVersions(LanghostTest):
 
     def register_resource(self, ctx, dry_run, ty, name, _resource,
                           _dependencies, _parent, _custom, _protect,
-                          _provider, _property_deps, _delete_before_replace, version):
+                          _provider, _property_deps, _delete_before_replace, _ignore_changes, version):
         if name == "testres":
             self.assertEqual(version, "0.19.1")
         elif name == "testres2":


### PR DESCRIPTION
This PR adds a resource option `version` to Python and NodeJS that allows callers to explicitly request a specific version of a provider to use when servicing a resource operation (invoke, read, or register). The idea here is that users won't explicitly use this field but code generated by tfgen and the kubernetes generator will generate code that sets the `version` option if it isn't already set.

Part 2 of https://github.com/pulumi/pulumi/issues/2389.