### PR TITLE
Use Outputs instead of merged Inputs+Outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- Fix an engine bug that could lead to incorrect interpretation of the previous state of a resource leading to 
+  unexpected Update, Replace or Delete operations being scheduled. [#2650]https://github.com/pulumi/pulumi/issues/2650)
+
 ## 0.17.7 (Released April 17, 2019)
 
 ### Improvements

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -728,7 +728,6 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	}
 
 	state := result.State
-	props = state.All()
 	stable := result.Stable
 	var stables []string
 	for _, sta := range result.Stables {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -735,11 +735,11 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	}
 	logging.V(5).Infof(
 		"ResourceMonitor.RegisterResource operation finished: t=%v, urn=%v, stable=%v, #stables=%v #outs=%v",
-		state.Type, state.URN, stable, len(stables), len(props))
+		state.Type, state.URN, stable, len(stables), len(state.Outputs))
 
 	// Finally, unpack the response into properties that we can return to the language runtime.  This mostly includes
 	// an ID, URN, and defaults and output properties that will all be blitted back onto the runtime object.
-	obj, err := plugin.MarshalProperties(props, plugin.MarshalOptions{Label: label, KeepUnknowns: true})
+	obj, err := plugin.MarshalProperties(state.Outputs, plugin.MarshalOptions{Label: label, KeepUnknowns: true})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -302,7 +302,7 @@ func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 			if err != nil {
 				return resource.StatusOK, nil, err
 			}
-			if rst, err := prov.Delete(s.URN(), s.old.ID, s.old.All()); err != nil {
+			if rst, err := prov.Delete(s.URN(), s.old.ID, s.old.Outputs); err != nil {
 				return rst, nil, err
 			}
 		}
@@ -403,8 +403,8 @@ func (s *UpdateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 				return resource.StatusOK, nil, err
 			}
 
-			// Update to the combination of the old "all" state (including outputs), but overwritten with new inputs.
-			outs, rst, upderr := prov.Update(s.URN(), s.old.ID, s.old.All(), s.new.Inputs)
+			// Update to the combination of the old "all" state, but overwritten with new inputs.
+			outs, rst, upderr := prov.Update(s.URN(), s.old.ID, s.old.Outputs, s.new.Inputs)
 			if upderr != nil {
 				if rst != resource.StatusPartialFailure {
 					return rst, nil, upderr

--- a/pkg/resource/resource_state.go
+++ b/pkg/resource/resource_state.go
@@ -68,8 +68,3 @@ func NewState(t tokens.Type, urn URN, custom bool, del bool, id ID,
 		PendingReplacement:   pendingReplacement,
 	}
 }
-
-// All returns all resource state, including the inputs and outputs, overlaid in that order.
-func (s *State) All() PropertyMap {
-	return s.Inputs.Merge(s.Outputs)
-}


### PR DESCRIPTION
Fixes #2650.

We have historically relied on merging inputs and outputs in several places in the engine.  This used to be necessary, as discussed in https://github.com/pulumi/pulumi/issues/2650#issuecomment-485171283, but our core engine model has moved away from depending on this.  However, we still have a couple places we do this merge, and those places have triggered several severe issues recently in subtle cases.

We believe that this merging should no longer be needed for a correct interpretation of the current engine model, and indeed that doing the merge actively violates the contract with providers.  In this PR we remove the remaining places where this input + output merge was being done.  In all three cases, we use just the Outputs, which for most providers will already include the same values as the inputs - but correctly as determined by the provider itself.