### PR TITLE
Provide an envvar to skip the update check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   `xxx.checkpoint.json` file) will then be stored in that bucket.  Credentials for accessing the
   bucket operate in the normal manner for each cloud provider.  i.e. for AWS this can come from the
   environment, or your `.aws/credentials` file, etc.
+- The pulumi version update check can be skipped by setting the environment variable
+  `PULUMI_SKIP_UPDATE_CHECK` to `1` or `true`.
 
 ### Improvements
 

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -111,7 +111,11 @@ func NewPulumiCmd() *cobra.Command {
 				}
 			}
 
-			checkForUpdate()
+			if cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_UPDATE_CHECK")) {
+				logging.Infof("skipping update check")
+			} else {
+				checkForUpdate()
+			}
 
 			return nil
 		}),


### PR DESCRIPTION
For users in secure environments without internet access the update
check in pulumi causes a significant hitch on running any pulumi
command, as pulumi tries to access pulumi.com to get the latest version
and after a while times out.

This commit adds an envvar (PULUMI_SKIP_UPDATE_CHECK) that if set to "1"
or "true" will cause pulumi to skip the update check.