### PR TITLE
`pulumi new`: Ensure the stack is selected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   environment, or your `.aws/credentials` file, etc.
 - The pulumi version update check can be skipped by setting the environment variable
   `PULUMI_SKIP_UPDATE_CHECK` to `1` or `true`.
+- Fix an issue where the stack would not be selected when an existing stack is specified when running
+  `pulumi new <template> -s <existing-stack>`.
 
 ### Improvements
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/pulumi/pulumi/pkg/backend/state"
+
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/backend/display"
@@ -250,6 +252,11 @@ func newNewCmd() *cobra.Command {
 				if err = handleConfig(s, templateNameOrURL, template, configArray, yes, opts); err != nil {
 					return err
 				}
+			}
+
+			// Ensure the stack is selected.
+			if !generateOnly && s != nil {
+				state.SetCurrentStack(s.Ref().String())
 			}
 
 			// Install dependencies.


### PR DESCRIPTION
Ensure the stack is selected when using `pulumi new` with an existing
stack (e.g. a stack created on app.pulumi.com).

Fixes #2681