### PR TITLE
`pulumi new`: Suppress npm warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
   `PULUMI_SKIP_UPDATE_CHECK` to `1` or `true`.
 - Fix an issue where the stack would not be selected when an existing stack is specified when running
   `pulumi new <template> -s <existing-stack>`.
+- Warnings from `npm` about missing description, repository, and license fields in package.json are
+  now suppressed when `npm install` is run from `pulumi new` (via `npm install --loglevel=error`).
 
 ## 0.17.8 (Released April 23, 2019)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- Warnings from `npm` about missing description, repository, and license fields in package.json are
+  now suppressed when `npm install` is run from `pulumi new` (via `npm install --loglevel=error`).
+
 ## 0.17.9 (Released April 30, 2019)
 
 ### Improvements
@@ -16,8 +19,6 @@
   `PULUMI_SKIP_UPDATE_CHECK` to `1` or `true`.
 - Fix an issue where the stack would not be selected when an existing stack is specified when running
   `pulumi new <template> -s <existing-stack>`.
-- Warnings from `npm` about missing description, repository, and license fields in package.json are
-  now suppressed when `npm install` is run from `pulumi new` (via `npm install --loglevel=error`).
 
 ## 0.17.8 (Released April 23, 2019)
 

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -459,7 +459,9 @@ func installDependencies() error {
 	var c *exec.Cmd
 	if strings.EqualFold(proj.Runtime.Name(), "nodejs") {
 		command = "npm install"
-		c = exec.Command("npm", "install")
+		// We pass `--loglevel=error` to prevent `npm` from printing warnings about missing
+		// `description`, `repository`, and `license` fields in the package.json file.
+		c = exec.Command("npm", "install", "--loglevel=error")
 	} else {
 		return nil
 	}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -477,6 +477,12 @@ func installDependencies() error {
 			"then run 'pulumi up' to perform an initial deployment", command)
 	}
 
+	// Ensure the "node_modules" directory exists.
+	if _, err := os.Stat("node_modules"); os.IsNotExist(err) {
+		return errors.Errorf("installing dependencies; rerun '%s' manually to try again, "+
+			"then run 'pulumi up' to perform an initial deployment", command)
+	}
+
 	fmt.Println("Finished installing dependencies")
 	fmt.Println()
 


### PR DESCRIPTION
Right now, when we run `npm install` as part of `pulumi new`, the
following warnings are emitted:

```
...

node-pre-gyp WARN Using needle for node-pre-gyp https download

...

npm WARN aws-typescript@ No description
npm WARN aws-typescript@ No repository field.
npm WARN aws-typescript@ No license field.

...
```

We can suppress these warnings by specifying [`--loglevel=error`](https://docs.npmjs.com/misc/config#loglevel) to the
`npm install` command.

---

The only downside to doing this: we know of at least one case where `npm` will report an error as a warning, when the `name` field in package.json has an invalid character (#1979). In such cases, the `node_modules` directory isn't created and no dependencies are installed, yet `npm` exits with a `0` status code. This is one of the reasons we decided to go back to always showing `npm`'s output, because we couldn't accurately detect when `npm` fails.

However, we no longer replace the `name` field in package.json (https://github.com/pulumi/templates/pull/40), so the only known issue we've seen is no longer possible in practice and the benefit is we'll no longer show several unnecessary warnings to users (during a flow that almost all new Pulumi users will see).

@ellismg, @lukehoban, what do you think?

Alternatively:

- `node-pre-gyp WARN Using needle for node-pre-gyp https download`: This is emitted while downloading `grpc@1.20.2`. Switching over to `@grpc/grpc-js` (pure JavaScript gRPC client) would address (#2218).

 - `npm WARN aws-typescript@ No description`: We could add bogus `description` fields to `package.json` for all of our templates, or go back to emitting the Pulumi project's description in `package.json`.

- `npm WARN aws-typescript@ No repository field.`: This can be worked around by adding a `"repository": {},` to package.json for all of our templates.

- `npm WARN aws-typescript@ No license field.`: No way around this. We'd have to specify _something_. Maybe `"UNLICENSED"` for our templates and `"Apache-2.0"` for all of our examples? The downside is then all new Pulumi projects created using the standard templates will be `"UNLICENSED"`, which probably isn't what most folks want.