### PR TITLE
cli/whoami: Addition of the currently connected backend to whoami

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Improvements
 
+- `pulumi whoami` now outputs the URL of the currently connected backend
+
 ## 0.17.8 (Released April 23, 2019)
 
 ### Improvements

--- a/cmd/whoami.go
+++ b/cmd/whoami.go
@@ -17,11 +17,12 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	"github.com/pulumi/pulumi/pkg/backend/display"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/spf13/cobra"
 )
+
+var verbose bool
 
 func newWhoAmICmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -46,10 +47,20 @@ func newWhoAmICmd() *cobra.Command {
 				return err
 			}
 
-			fmt.Println(name)
+			if verbose {
+				fmt.Printf("User: %s\n", name)
+				fmt.Printf("Backend URL: %s\n", b.URL())
+			} else {
+				fmt.Println(name)
+			}
+
 			return nil
 		}),
 	}
+
+	cmd.PersistentFlags().BoolVarP(
+		&verbose, "verbose", "v", false,
+		"Print detailed whoami information")
 
 	return cmd
 }


### PR DESCRIPTION
This is an attempt towards #2684

I am not sure if this is too simplistic for now OR we need to
consider if this will break anyones automation as they maybe using
the output of that command as plain text

Before:

```
▶ pulumi whoami
stack72
```

After:

```
▶ pulumi whoami
User: stack72
Backend URL: https://app.pulumi.com/stack72
```

@justinvp / @ellismg I am deferring this to you gentlemen to make a decision on :)