### PR TITLE
Move CHANGELOG entry for `pulumi preview --json`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
   `PULUMI_SKIP_UPDATE_CHECK` to `1` or `true`.
 - Fix an issue where the stack would not be selected when an existing stack is specified when running
   `pulumi new <template> -s <existing-stack>`.
+- Add a `--json` flag (`-j` for short) to the `preview` command. This allows basic serialization of a plan,
+  including the anticipated set of deployment steps, list of diagnostics messages, and summary information.
+  Each step includes deeply serialized information about the resource state and step metadata itself. This
+  is part of ongoing work tracked in [pulumi/pulumi#2390](https://github.com/pulumi/pulumi/issues/2390).
 
 ## 0.17.8 (Released April 23, 2019)
 
@@ -29,10 +33,6 @@
 - Fix an engine bug that could lead to incorrect interpretation of the previous state of a resource leading to
   unexpected Update, Replace or Delete operations being scheduled. [#2650]https://github.com/pulumi/pulumi/issues/2650)
 - Build/push `pulumi/actions` container to [DockerHub](https://hub.docker.com/r/pulumi/actions) with new SDK releases [#2646](https://github.com/pulumi/pulumi/pull/2646)
-- Add a `--json` flag (`-j` for short) to the `preview` command. This allows basic serialization of a plan,
-  including the anticipated set of deployment steps, list of diagnostics messages, and summary information.
-  Each step includes deeply serialized information about the resource state and step metadata itself. This
-  is part of ongoing work tracked in [pulumi/pulumi#2390](https://github.com/pulumi/pulumi/issues/2390).
 
 ## 0.17.7 (Released April 17, 2019)
 


### PR DESCRIPTION
This was first released in `0.17.9` not `0.17.8`.