### PR TITLE
Ignore events for providers prefixed with 'default'

### DIFF
--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -17,6 +17,7 @@ package engine
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/opentracing/opentracing-go"
@@ -367,5 +368,5 @@ func assertSeen(seen map[resource.URN]deploy.Step, step deploy.Step) {
 
 func isDefaultProviderStep(step deploy.Step) bool {
 	urn := step.URN()
-	return providers.IsProviderType(urn.Type()) && urn.Name() == "default"
+	return providers.IsProviderType(urn.Type()) && strings.HasPrefix(urn.Name().String(), "default")
 }


### PR DESCRIPTION
Starting with https://github.com/pulumi/pulumi/pull/2656, the engine now occasionally produces default providers with a name that's not exactly "default", but instead just begins with "default". This commit makes sure that we still suppress any default providers from the output if their name is prefixed with "default". 