### PR TITLE
Minor contributing doc improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Improvements
 
+- Minor contributing document improvement.
 - Warnings from `npm` about missing description, repository, and license fields in package.json are
   now suppressed when `npm install` is run from `pulumi new` (via `npm install --loglevel=error`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ For historical reasons (which we'd [like to address](https://github.com/pulumi/p
 
 Across our projects, we try to use a regular set of make targets. The ones you'll care most about are:
 
+0. `make ensure`, which restores/installs any build dependencies
 1. `make`, which builds Pulumi and runs a quick set of tests
 2. `make all` which builds Pulumi and runs the quick tests and a larger set of tests.
 

--- a/build/common.mk
+++ b/build/common.mk
@@ -5,7 +5,7 @@
 #
 # The default targets we use are:
 #
-#  - ensure: restores and dependencies needed for the build from
+#  - ensure: restores any dependencies needed for the build from
 #            remote sources (e.g dep ensure or yarn install)
 #
 #  - build: builds a project but does not install it. In the case of


### PR DESCRIPTION
The contributing document was missing a step to configure the build dependencies for new users.