### PR TITLE
`pulumi update` => `pulumi up`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 
 ### Improvements
 
-- A new command, `pulumi stack rename` was added. This allows you to change the name of an existing stack in a project. Note: When a stack is renamed, the `pulumi.getStack` function in the SDK will now return a new value. If a stack name is used as part of a resource name, the next `pulumi update` will not understand that the old and new resources are logically the same. We plan to support adding aliases to individual resources so you can handle these cases. See [pulumi/pulumi#458](https://github.com/pulumi/pulumi/issues/458) for discussion on this new feature. For now, if you are unwilling to have `pulumi update` create and destroy these resources, you can rename your stack back to the old name. (fixes [pulumi/pulumi#2402](https://github.com/pulumi/pulumi/issues/2402))
+- A new command, `pulumi stack rename` was added. This allows you to change the name of an existing stack in a project. Note: When a stack is renamed, the `pulumi.getStack` function in the SDK will now return a new value. If a stack name is used as part of a resource name, the next `pulumi up` will not understand that the old and new resources are logically the same. We plan to support adding aliases to individual resources so you can handle these cases. See [pulumi/pulumi#458](https://github.com/pulumi/pulumi/issues/458) for discussion on this new feature. For now, if you are unwilling to have `pulumi up` create and destroy these resources, you can rename your stack back to the old name. (fixes [pulumi/pulumi#2402](https://github.com/pulumi/pulumi/issues/2402))
 - Fix two warnings that were printed when using a dynamic provider about missing method handlers.
 - A bug in the previous version of the Pulumi CLI occasionally caused the Pulumi Engine to load the incorrect resource
   plugin when processing an update. This bug has been fixed in 0.17.3 by performing a deterministic selection of the
@@ -292,7 +292,7 @@ We appologize for the regression.  (fixes [pulumi/pulumi#2414](https://github.co
 
 - During previews and updates, read operations (i.e. calls to `.get` methods) are no longer shown in the output unless they cause any changes.
 
-- Fix a performance regression where `pulumi preview` and `pulumi update` would hang for a few moments at the end of a preview or update, in additon to the overall operation being slower.
+- Fix a performance regression where `pulumi preview` and `pulumi up` would hang for a few moments at the end of a preview or update, in additon to the overall operation being slower.
 
 ## 0.16.8 (Released December 14th, 2018)
 
@@ -382,7 +382,7 @@ We appologize for the regression.  (fixes [pulumi/pulumi#2414](https://github.co
 
 - Add an `iterable` module to `@pulumi/pulumi` with two helpful combinators `toObject` and `groupBy` to help combine multiple `Output<T>`'s into a single object.
 
-- Pulumi no longer prompts you for confirmation when `--skip-preview` is passed to `pulumi update`. Instead, it just preforms the update as requested.
+- Pulumi no longer prompts you for confirmation when `--skip-preview` is passed to `pulumi up`. Instead, it just preforms the update as requested.
 
 - Add the `--json` flag to the `pulumi stack ls` command.
 

--- a/README.md
+++ b/README.md
@@ -110,14 +110,14 @@ Follow these steps to deploy your first Pulumi program, using AWS Serverless Lam
 
 4. **Deploy to the Cloud**:
 
-    Run `pulumi update` to get your code to the cloud:
+    Run `pulumi up` to get your code to the cloud:
 
     ```bash
-    $ pulumi update
+    $ pulumi up
     ```
 
     This makes all cloud resources needed to run your code.  Simply make edits to your project, and subsequent
-    `pulumi update`s will compute the minimal diff to deploy your changes.
+    `pulumi up`s will compute the minimal diff to deploy your changes.
 
 5. **Use Your Program**:
 

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -93,7 +93,7 @@ func newStackCmd() *cobra.Command {
 					fmt.Printf("    Plugin %s [%s] version: %s\n", plugin.Name, plugin.Kind, plugver)
 				}
 			} else {
-				fmt.Printf("    No updates yet; run 'pulumi update'\n")
+				fmt.Printf("    No updates yet; run 'pulumi up'\n")
 			}
 
 			cfg := s.Config()

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -151,7 +151,7 @@ type ProgramTestOptions struct {
 	Quick bool
 	// PreviewCommandlineFlags specifies flags to add to the `pulumi preview` command line (e.g. "--color=raw")
 	PreviewCommandlineFlags []string
-	// UpdateCommandlineFlags specifies flags to add to the `pulumi update` command line (e.g. "--color=raw")
+	// UpdateCommandlineFlags specifies flags to add to the `pulumi up` command line (e.g. "--color=raw")
 	UpdateCommandlineFlags []string
 	// RunBuild indicates that the build step should be run (e.g. run `yarn build` for `nodejs` programs)
 	RunBuild bool
@@ -187,7 +187,7 @@ type ProgramTestOptions struct {
 	// equivalent to `--logtostderr -v=N`, where N is the value of DebugLogLevel.  This may also be enabled by setting
 	// the environment variable PULUMI_TEST_DEBUG_LOG_LEVEL.
 	DebugLogLevel int
-	// DebugUpdates may be set to true to enable debug logging from `pulumi preview`, `pulumi update`, and
+	// DebugUpdates may be set to true to enable debug logging from `pulumi preview`, `pulumi up`, and
 	// `pulumi destroy`.  This may also be enabled by setting the environment variable PULUMI_TEST_DEBUG_UPDATES.
 	DebugUpdates bool
 
@@ -426,11 +426,11 @@ func GetLogs(
 //   pulumi config set <each opts.Config>
 //   pulumi config set --secret <each opts.Secrets>
 //   pulumi preview
-//   pulumi update
+//   pulumi up
 //   pulumi stack export --file stack.json
 //   pulumi stack import --file stack.json
 //   pulumi preview (expected to be empty)
-//   pulumi update (expected to be empty)
+//   pulumi up (expected to be empty)
 //   pulumi destroy --yes
 //   pulumi stack rm --yes integrationtesting
 //

--- a/sdk/go/README.md
+++ b/sdk/go/README.md
@@ -13,4 +13,4 @@ To author a Pulumi program in Go, simply say so in your `Pulumi.yaml`
 and ensure you have `pulumi-language-go` on your path (it is distributed in the Pulumi download automatically).
 
 By default, the language plugin will use your project's name, `<my-project>`, as the executable that it loads.  This too
-must be on your path for the language provider to load it when you run `pulumi preview` or `pulumi update`.
+must be on your path for the language provider to load it when you run `pulumi preview` or `pulumi up`.

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -45,5 +45,5 @@ root).  This will build the code, run tests, and install the package and its sup
 
 At the moment, for local development, we install everything into `/opt/pulumi`.  You will want this on your `$PATH`.
 
-The tests will verify that everything works, but feel free to try running `pulumi preview` and/or `pulumi update` from
+The tests will verify that everything works, but feel free to try running `pulumi preview` and/or `pulumi up` from
 the `examples/minimal/` directory.  Remember to run `tsc` first, since `pulumi` expects JavaScript, not TypeScript.

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -510,7 +510,7 @@ export interface OutputInstance<T> {
      * If you need have multiple Outputs and a single Output is needed that combines both
      * set of resources, then 'pulumi.all' should be used instead.
      *
-     * This function will only be called execution of a 'pulumi update' request.  It will not run
+     * This function will only be called execution of a 'pulumi up' request.  It will not run
      * during 'pulumi preview' (as the values of resources are of course not known then). It is not
      * available for functions that end up executing in the cloud during runtime.  To get the value
      * of the Output during cloud runtime execution, use `get()`.

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -173,7 +173,7 @@ export function resolveProperties(
             // can propagate its final value.  Otherwise, it must be undefined, since we don't know
             // if it's final.
             if (!isDryRun()) {
-                // normal 'pulumi update'.  resolve the output with the value we got back
+                // normal 'pulumi up'.  resolve the output with the value we got back
                 // from the engine.  That output can always run its .apply calls.
                 resolve(allProps[k], true);
             }

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -93,7 +93,7 @@ class Output(Generic[T]):
         'func' can return other Outputs.  This can be handy if you have a Output<SomeVal>
         and you want to get a transitive dependency of it.
 
-        This function will be called during execution of a 'pulumi update' request.  It may not run
+        This function will be called during execution of a 'pulumi up' request.  It may not run
         during 'pulumi preview' (as the values of resources are of course may not be known then).
 
         :param Callable[[T],Input[U]] func: A function that will, given this Output's value, transform the value to

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -344,7 +344,7 @@ async def resolve_outputs(res: 'Resource', props: 'Inputs', outputs: struct_pb2.
         # can propagate its final value.  Otherwise, it must be undefined, since we don't know
         # if it's final.
         if not settings.is_dry_run():
-            # normal 'pulumi update'.  resolve the output with the value we got back
+            # normal 'pulumi up'.  resolve the output with the value we got back
             # from the engine.  That output can always run its .apply calls.
             resolve(value, True, None)
         else:

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -65,7 +65,7 @@ func TestHistoryCommand(t *testing.T) {
 		e.RunCommand("yarn", "install")
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
 		// Update the history-test stack.
-		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview", "-m", "this is an updated stack")
+		e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview", "-m", "this is an updated stack")
 		// Confirm we see the update message in thie history output.
 		out, err := e.RunCommand("pulumi", "history")
 		assert.Equal(t, "", err)

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -207,7 +207,7 @@ func TestStackCommands(t *testing.T) {
 		e.RunCommand("pulumi", "stack", "init", stackName)
 		e.RunCommand("yarn", "install")
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
-		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview")
+		e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 		// We're going to futz with the stack a little so that one of the resources we just created
 		// becomes invalid.
 		stackFile := path.Join(e.RootPath, "stack.json")
@@ -249,7 +249,7 @@ func TestStackCommands(t *testing.T) {
 		_, stderr := e.RunCommand("pulumi", "stack", "import", "--file", "stack.json")
 		assert.Contains(t, stderr, fmt.Sprintf("removing pending operation 'deleting' on '%s'", res.URN))
 		// The engine should be happy now that there are no invalid resources.
-		e.RunCommand("pulumi", "update", "--non-interactive", "--skip-preview")
+		e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 		e.RunCommand("pulumi", "stack", "rm", "--yes", "--force")
 	})
 }
@@ -291,7 +291,7 @@ func TestStackBackups(t *testing.T) {
 		e.RunCommand("yarn", "install")
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
 
-		// Now run pulumi update.
+		// Now run pulumi up.
 		before := time.Now().UnixNano()
 		e.RunCommand("pulumi", "up", "--non-interactive", "--skip-preview")
 		after := time.Now().UnixNano()


### PR DESCRIPTION
We changed the `pulumi update` command to be `pulumi up` a while back
(`update` is an alias of `up`). This change just makes it so we refer to
the actual command, `pulumi up`, instead of the older `pulumi update`.