### PR TITLE
Don't capture secret outputs in closures.

### DIFF
--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -16,7 +16,7 @@
 
 import * as upath from "upath";
 import { ResourceError } from "../../errors";
-import { Input, Output } from "../../output";
+import { Input, isSecretOutput, Output } from "../../output";
 import * as resource from "../../resource";
 import { hasTrueBooleanMember } from "../../utils";
 import { CapturedPropertyChain, CapturedPropertyInfo, CapturedVariableMap, parseFunction } from "./parseFunction";
@@ -881,7 +881,7 @@ async function getOrCreateEntryAsync(
             entry.function = await analyzeFunctionInfoAsync(obj, context, serialize, logInfo);
         }
         else if (Output.isInstance(obj)) {
-            if (await obj.isSecret) {
+            if (await isSecretOutput(obj)) {
                 throw new Error("Secret outputs cannot be captured by a closure.");
             }
             entry.output = await createOutputEntryAsync(obj);

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -880,7 +880,10 @@ async function getOrCreateEntryAsync(
             // Serialize functions recursively, and store them in a closure property.
             entry.function = await analyzeFunctionInfoAsync(obj, context, serialize, logInfo);
         }
-        else if (await isOutputAsync(obj)) {
+        else if (Output.isInstance(obj)) {
+            if (await obj.isSecret) {
+                throw new Error("Secret outputs cannot be captured by a closure.");
+            }
             entry.output = await createOutputEntryAsync(obj);
         }
         else if (obj instanceof Promise) {

--- a/sdk/nodejs/tests/runtime/tsClosureCases.ts
+++ b/sdk/nodejs/tests/runtime/tsClosureCases.ts
@@ -5872,6 +5872,18 @@ return function () { console.log(regex); foo(); };
         });
     }
 
+    {
+        const s = pulumi.secret("can't capture me");
+
+        cases.push({
+            title: "Can't capture secrets",
+            func: function() {
+                console.log(s.get());
+            },
+            error: "Secret outputs cannot be captured by a closure.",
+        });
+    }
+
     // Run a bunch of direct checks on async js functions if we're in node 8 or above.
     // We can't do this inline as node6 doesn't understand 'async functions'.  And we
     // can't do this in TS as TS will convert the async-function to be a normal non-async


### PR DESCRIPTION
Until #2718 is addressed, we will just disallow capturing secret
outputs when we serialize closures.