### PR TITLE
Correctly flow secretness across structured values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.17.12
+## 0.17.13
+
+### Improvements
+
+## 0.17.12 (Released May 15, 2019)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   now listed in the help text. (fixes [pulumi/pulumi#2727](https://github.com/pulumi/pulumi/issues/2727)).
 - Pulumi no longer prompts for your passphrase twice during operations when you
   are using the passphrase based secrets provider. (fixes [pulumi/pulumi#2729](https://github.com/pulumi/pulumi/issues/2729)).
+- Fix an issue where complex inputs to a resource which contained secret values
+  would not be stored correctly.
 
 ## 0.17.11 (Released May 13, 2019)
 

--- a/examples/secrets/index.ts
+++ b/examples/secrets/index.ts
@@ -32,6 +32,14 @@ export const plaintextApply = new ReflectResource("pApply", message.length).valu
 export const combinedMessage = new ReflectResource("cValue", combined).value;
 export const combinedApply = new ReflectResource("cApply", combined.apply(x => x.length)).value;
 
+// With a rich structure like this, we expect that the actual reasource properties in the state file will be stored
+// as a mixture of plaintext and secrets, but the outputed stack property will be a secret (because part of the value
+// property  contains a secret, and that means the entire Output object must be marked as a secret.
+export const richStructure = new ReflectResource("rValue", {
+    plain: pulumi.output("plaintext"),
+    secret: pulumi.secret("secret value"),
+}).value;
+
 // The dummy resource just provides a single output named "value" with a simple message.  But we can use
 // `additionalSecretOutputs` as a way to enforce that it is treated as a secret.
 export const dummyValue = new DummyResource("pDummy").value;

--- a/examples/secrets/provider.ts
+++ b/examples/secrets/provider.ts
@@ -9,10 +9,10 @@ class ReflectProvider implements dynamic.ResourceProvider {
     public update(id: string, olds: any, news: any) { return Promise.resolve({ outs: news }); }
 }
 
-export class ReflectResource extends dynamic.Resource {
-    public readonly value: pulumi.Output<string>;
+export class ReflectResource<T> extends dynamic.Resource {
+    public readonly value: pulumi.Output<T>;
 
-    constructor(name: string, value: pulumi.Input<any>, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, value: pulumi.Input<T>, opts?: pulumi.CustomResourceOptions) {
         super(new ReflectProvider(), name, {value: value }, opts);
     }
 }

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -136,44 +136,35 @@ func (p *provider) ensureConfigured() error {
 	return p.cfgerr
 }
 
-// annotateSecrets copies the "secretness" of any properties from one PropertyMap to another. For any property with a
-// secret value in "from", if there is a coresponding property in "to", it is marked as secret.
-func annotateSecrets(to, from resource.PropertyMap) {
-	if to == nil || from == nil {
+// annotateSecrets copies the "secretness" from the ins to the outs. If there are values with the same keys for the
+// outs and the ins, if they are both objects, they are transformed recursively. Otherwise, if the value in the ins
+// contains a secret, the entire out value is marked as a secret.  This is very close to how we project secrets
+// in the programming model, with one small difference, which is how we treat the case where both are objects. In the
+// programming model, we would say the entire output object is a secret. Here, we actually recur in. We do this because
+// we don't want a single secret value in a rich structure to taint the entire object. Doing so would mean things like
+// the entire value in the deployment would be encrypted instead of a small chunk. It also means the entire property
+// would be displayed as `[secret]` in the CLI instead of a small part.
+//
+// NOTE: This means that for an array, if any value in the input version is a secret, the entire output array is
+// marked as a secret. This is actually a very nice result, because often arrays are treated like sets by providers
+// and the order may not be preserved across an operation. This means we do end up encrypting the entire array
+// but that's better than accidentally leaking a value which just moved to a different location.
+func annotateSecrets(outs, ins resource.PropertyMap) {
+	if outs == nil || ins == nil {
 		return
 	}
 
-	for toKey, toValue := range to {
-		fromValue, has := from[toKey]
+	for key, inValue := range ins {
+		outValue, has := outs[key]
 		if !has {
 			continue
 		}
-		to[toKey] = annotateSecretValue(toValue, fromValue)
-	}
-}
-
-func annotateSecretValue(to, from resource.PropertyValue) resource.PropertyValue {
-	if from.IsSecret() && !to.IsSecret() {
-		return resource.MakeSecret(to)
-	}
-	if from.IsComputed() && to.IsComputed() {
-		return resource.MakeComputed(annotateSecretValue(to.Input().Element, to.Input().Element))
-	}
-	if from.IsOutput() && to.IsOutput() {
-		return resource.MakeOutput(annotateSecretValue(to.OutputValue().Element, to.OutputValue().Element))
-	}
-	if from.IsObject() && to.IsObject() {
-		annotateSecrets(to.ObjectValue(), from.ObjectValue())
-	}
-	if from.IsArray() && to.IsArray() && len(from.ArrayValue()) == len(to.ArrayValue()) {
-		fromArr := from.ArrayValue()
-		toArr := to.ArrayValue()
-		for idx, v := range toArr {
-			toArr[idx] = annotateSecretValue(v, fromArr[idx])
+		if outValue.IsObject() && inValue.IsObject() {
+			annotateSecrets(outValue.ObjectValue(), inValue.ObjectValue())
+		} else if !outValue.IsSecret() && inValue.ContainsSecrets() {
+			outs[key] = resource.MakeSecret(outValue)
 		}
 	}
-
-	return to
 }
 
 // Configure configures the resource provider with "globals" that control its behavior.

--- a/pkg/resource/plugin/provider_plugin_test.go
+++ b/pkg/resource/plugin/provider_plugin_test.go
@@ -1,0 +1,144 @@
+package plugin
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+)
+
+func TestAnnotateSecrets(t *testing.T) {
+	from := resource.PropertyMap{
+		"stringValue": resource.MakeSecret(resource.NewStringProperty("hello")),
+		"numberValue": resource.MakeSecret(resource.NewNumberProperty(1.00)),
+		"boolValue":   resource.MakeSecret(resource.NewBoolProperty(true)),
+		"secretArrayValue": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		})),
+		"arrayWithSecretsValue": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.MakeSecret(resource.NewStringProperty("b")),
+			resource.NewStringProperty("c"),
+		}),
+		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("aValue"),
+			"b": resource.NewStringProperty("bValue"),
+			"c": resource.NewStringProperty("cValue"),
+		})),
+		"objectWithSecretValue": resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("aValue"),
+			"b": resource.MakeSecret(resource.NewStringProperty("bValue")),
+			"c": resource.NewStringProperty("cValue"),
+		}),
+	}
+
+	to := resource.PropertyMap{
+		"stringValue": resource.NewStringProperty("hello"),
+		"numberValue": resource.NewNumberProperty(1.00),
+		"boolValue":   resource.NewBoolProperty(true),
+		"secretArrayValue": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		}),
+		"arrayWithSecretsValue": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		}),
+		"secretObjectValue": resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("aValue"),
+			"b": resource.NewStringProperty("bValue"),
+			"c": resource.NewStringProperty("cValue"),
+		}),
+		"objectWithSecretValue": resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("aValue"),
+			"b": resource.NewStringProperty("bValue"),
+			"c": resource.NewStringProperty("cValue"),
+		}),
+	}
+
+	annotateSecrets(to, from)
+
+	assert.Truef(t, reflect.DeepEqual(to, from), "objects should be deeply equal")
+}
+
+func TestAnnotateSecretsDifferentProperties(t *testing.T) {
+	// ensure that if from and and to have different shapes, values on from are not put into to, values on to which
+	// are not present in from stay in to, but any secretness is propigated for shared keys.
+
+	from := resource.PropertyMap{
+		"stringValue": resource.MakeSecret(resource.NewStringProperty("hello")),
+		"numberValue": resource.MakeSecret(resource.NewNumberProperty(1.00)),
+		"boolValue":   resource.MakeSecret(resource.NewBoolProperty(true)),
+		"secretArrayValue": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		})),
+		"arrayWithSecretsValue": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.MakeSecret(resource.NewStringProperty("b")),
+			resource.NewStringProperty("c"),
+		}),
+		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("aValue"),
+			"b": resource.NewStringProperty("bValue"),
+			"c": resource.NewStringProperty("cValue"),
+		})),
+		"objectWithSecretValue": resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("aValue"),
+			"b": resource.MakeSecret(resource.NewStringProperty("bValue")),
+			"c": resource.NewStringProperty("cValue"),
+		}),
+		"extraFromValue": resource.NewStringProperty("extraFromValue"),
+	}
+
+	to := resource.PropertyMap{
+		"stringValue": resource.NewStringProperty("hello"),
+		"numberValue": resource.NewNumberProperty(1.00),
+		"boolValue":   resource.NewBoolProperty(true),
+		"secretArrayValue": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		}),
+		"arrayWithSecretsValue": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		}),
+		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("aValue"),
+			"b": resource.NewStringProperty("bValue"),
+			"c": resource.NewStringProperty("cValue"),
+		})),
+		"objectWithSecretValue": resource.NewObjectProperty(resource.PropertyMap{
+			"a": resource.NewStringProperty("aValue"),
+			"b": resource.NewStringProperty("bValue"),
+			"c": resource.NewStringProperty("cValue"),
+		}),
+		"extraToValue": resource.NewStringProperty("extraToValue"),
+	}
+
+	annotateSecrets(to, from)
+
+	for key, val := range to {
+		fromVal, fromHas := from[key]
+		if !fromHas {
+			continue
+		}
+
+		assert.Truef(t, reflect.DeepEqual(fromVal, val), "expected properites %s to be deeply equal", key)
+	}
+
+	_, has := to["extraFromValue"]
+	assert.Falsef(t, has, "to should not have a key named extraFromValue, it was not present before annotating secrets")
+
+	_, has = to["extraToValue"]
+	assert.True(t, has, "to should have a key named extraToValue, even though it was not in the from value")
+}

--- a/pkg/resource/plugin/provider_plugin_test.go
+++ b/pkg/resource/plugin/provider_plugin_test.go
@@ -19,11 +19,6 @@ func TestAnnotateSecrets(t *testing.T) {
 			resource.NewStringProperty("b"),
 			resource.NewStringProperty("c"),
 		})),
-		"arrayWithSecretsValue": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.MakeSecret(resource.NewStringProperty("b")),
-			resource.NewStringProperty("c"),
-		}),
 		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
 			"a": resource.NewStringProperty("aValue"),
 			"b": resource.NewStringProperty("bValue"),
@@ -41,11 +36,6 @@ func TestAnnotateSecrets(t *testing.T) {
 		"numberValue": resource.NewNumberProperty(1.00),
 		"boolValue":   resource.NewBoolProperty(true),
 		"secretArrayValue": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
-		}),
-		"arrayWithSecretsValue": resource.NewArrayProperty([]resource.PropertyValue{
 			resource.NewStringProperty("a"),
 			resource.NewStringProperty("b"),
 			resource.NewStringProperty("c"),
@@ -75,16 +65,6 @@ func TestAnnotateSecretsDifferentProperties(t *testing.T) {
 		"stringValue": resource.MakeSecret(resource.NewStringProperty("hello")),
 		"numberValue": resource.MakeSecret(resource.NewNumberProperty(1.00)),
 		"boolValue":   resource.MakeSecret(resource.NewBoolProperty(true)),
-		"secretArrayValue": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
-		})),
-		"arrayWithSecretsValue": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.MakeSecret(resource.NewStringProperty("b")),
-			resource.NewStringProperty("c"),
-		}),
 		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
 			"a": resource.NewStringProperty("aValue"),
 			"b": resource.NewStringProperty("bValue"),
@@ -102,16 +82,6 @@ func TestAnnotateSecretsDifferentProperties(t *testing.T) {
 		"stringValue": resource.NewStringProperty("hello"),
 		"numberValue": resource.NewNumberProperty(1.00),
 		"boolValue":   resource.NewBoolProperty(true),
-		"secretArrayValue": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
-		}),
-		"arrayWithSecretsValue": resource.NewArrayProperty([]resource.PropertyValue{
-			resource.NewStringProperty("a"),
-			resource.NewStringProperty("b"),
-			resource.NewStringProperty("c"),
-		}),
 		"secretObjectValue": resource.MakeSecret(resource.NewObjectProperty(resource.PropertyMap{
 			"a": resource.NewStringProperty("aValue"),
 			"b": resource.NewStringProperty("bValue"),
@@ -141,4 +111,49 @@ func TestAnnotateSecretsDifferentProperties(t *testing.T) {
 
 	_, has = to["extraToValue"]
 	assert.True(t, has, "to should have a key named extraToValue, even though it was not in the from value")
+}
+
+func TestAnnotateSecretsArrays(t *testing.T) {
+	from := resource.PropertyMap{
+		"secretArray": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		})),
+		"arrayWithSecrets": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.MakeSecret(resource.NewStringProperty("b")),
+			resource.NewStringProperty("c"),
+		}),
+	}
+
+	to := resource.PropertyMap{
+		"secretArray": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		}),
+		"arrayWithSecrets": resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("c"),
+			resource.NewStringProperty("b"),
+		}),
+	}
+
+	expected := resource.PropertyMap{
+		"secretArray": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("b"),
+			resource.NewStringProperty("c"),
+		})),
+		"arrayWithSecrets": resource.MakeSecret(resource.NewArrayProperty([]resource.PropertyValue{
+			resource.NewStringProperty("a"),
+			resource.NewStringProperty("c"),
+			resource.NewStringProperty("b"),
+		})),
+	}
+
+	annotateSecrets(to, from)
+
+	assert.Truef(t, reflect.DeepEqual(to, expected), "did not match expected after annotation")
 }

--- a/pkg/resource/properties.go
+++ b/pkg/resource/properties.go
@@ -122,6 +122,16 @@ func (m PropertyMap) ContainsUnknowns() bool {
 	return false
 }
 
+// ContainsSecrets returns true if the property map contains at least one secret value.
+func (m PropertyMap) ContainsSecrets() bool {
+	for _, v := range m {
+		if v.ContainsSecrets() {
+			return true
+		}
+	}
+	return false
+}
+
 // Mappable returns a mapper-compatible object map, suitable for deserialization into structures.
 func (m PropertyMap) Mappable() map[string]interface{} {
 	return m.MapRepl(nil, nil)
@@ -311,6 +321,26 @@ func (v PropertyValue) ContainsUnknowns() bool {
 		}
 	} else if v.IsObject() {
 		return v.ObjectValue().ContainsUnknowns()
+	}
+	return false
+}
+
+// ContainsSecrets returns true if the property value contains at least one secret (deeply).
+func (v PropertyValue) ContainsSecrets() bool {
+	if v.IsSecret() {
+		return true
+	} else if v.IsComputed() {
+		return v.Input().Element.ContainsSecrets()
+	} else if v.IsOutput() {
+		return v.OutputValue().Element.ContainsSecrets()
+	} else if v.IsArray() {
+		for _, e := range v.ArrayValue() {
+			if e.ContainsSecrets() {
+				return true
+			}
+		}
+	} else if v.IsObject() {
+		return v.ObjectValue().ContainsSecrets()
 	}
 	return false
 }


### PR DESCRIPTION
For providers which do not natively support secrets (which is all of
them today), we annotate output values coming back from the provider
if there is a coresponding secret input in the inputs we passed in.

This logic was not tearing into rich objects, so if you passed a
secret as a member of an array or object into a resource provider, we
would lose the secretness on the way back.

Because of the interaction with Check (where we call Check and then
take the values returned by the provider as inputs for all calls to
Diff/Update), this would apply not only to the Output values of a
resource but also the Inputs (because the secret metadata would not
flow from the inputs of check to the outputs).

This change augments our logic which transfers secrets metadata from
one property map to another to handle these additional cases.