### PR TITLE
Reduce overhead of emitting engine events

### DIFF
--- a/pkg/apitype/events.go
+++ b/pkg/apitype/events.go
@@ -35,14 +35,14 @@ type StdoutEngineEvent struct {
 // DiagnosticEvent is emitted whenever a diagnostic message is provided, for example errors from
 // a cloud resource provider while trying to create or update a resource.
 type DiagnosticEvent struct {
-	URN     string `json:"urn"`
-	Prefix  string `json:"prefix"`
+	URN     string `json:"urn,omitempty"`
+	Prefix  string `json:"prefix,omitempty"`
 	Message string `json:"message"`
 	Color   string `json:"color"`
 	// Severity is one of "info", "info#err", "warning", or "error".
 	Severity  string `json:"severity"`
-	StreamID  int    `json:"streamID"`
-	Ephemeral bool   `json:"ephemeral"`
+	StreamID  int    `json:"streamID,omitempty"`
+	Ephemeral bool   `json:"ephemeral,omitempty"`
 }
 
 // PreludeEvent is emitted at the start of an update.
@@ -75,16 +75,14 @@ type StepEventMetadata struct {
 	Old *StepEventStateMetadata `json:"old"`
 	// New is the state of the resource after performing the step.
 	New *StepEventStateMetadata `json:"new"`
-	// Res is the current state of the resource as known. (e.g. equal to old or new depending on
-	// circumstance.)
-	Res *StepEventStateMetadata `json:"res"`
+	// Omitted from the type sent to the Pulumi Service is "Res", which may be either Old or New.
 
 	// Keys causing a replacement (only applicable for "create" and "replace" Ops).
 	Keys []string `json:"keys,omitempty"`
 	// Keys that changed with this step.
-	Diffs []string `json:"diffs"`
+	Diffs []string `json:"diffs,omitempty"`
 	// Logical is set if the step is a logical operation in the program.
-	Logical bool `json:"logical"`
+	Logical bool `json:"logical,omitempty"`
 	// Provider actually performing the step.
 	Provider string `json:"provider"`
 }
@@ -96,15 +94,15 @@ type StepEventStateMetadata struct {
 	URN  string `json:"urn"`
 
 	// Custom indicates if the resource is managed by a plugin.
-	Custom bool `json:"custom"`
+	Custom bool `json:"custom,omitempty"`
 	// Delete is true when the resource is pending deletion due to a replacement.
-	Delete bool `json:"delete"`
+	Delete bool `json:"delete,omitempty"`
 	// ID is the resource's unique ID, assigned by the resource provider (or blank if none/uncreated).
 	ID string `json:"id"`
 	// Parent is an optional parent URN that this resource belongs to.
 	Parent string `json:"parent"`
 	// Protect is true to "protect" this resource (protected resources cannot be deleted).
-	Protect bool `json:"protect"`
+	Protect bool `json:"protect,omitempty"`
 	// Inputs contains the resource's input properties (as specified by the program). Secrets have
 	// filtered out, and large assets have been replaced by hashes as applicable.
 	Inputs map[string]interface{} `json:"inputs"`
@@ -113,19 +111,19 @@ type StepEventStateMetadata struct {
 	// Provider is the resource's provider reference
 	Provider string `json:"provider"`
 	// InitErrors is the set of errors encountered in the process of initializing resource.
-	InitErrors []string `json:"initErrors"`
+	InitErrors []string `json:"initErrors,omitempty"`
 }
 
 // ResourcePreEvent is emitted before a resource is modified.
 type ResourcePreEvent struct {
 	Metadata StepEventMetadata `json:"metadata"`
-	Planning bool              `json:"planning"`
+	Planning bool              `json:"planning,omitempty"`
 }
 
 // ResOutputsEvent is emitted when a resource is finished being provisioned.
 type ResOutputsEvent struct {
 	Metadata StepEventMetadata `json:"metadata"`
-	Planning bool              `json:"planning"`
+	Planning bool              `json:"planning,omitempty"`
 }
 
 // ResOpFailedEvent is emitted when a resource operation fails. Typically a DiagnosticEvent is

--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -190,7 +190,7 @@ const (
 	UpdateStatusCancelled UpdateStatus = "cancelled"
 )
 
-// CompleteUpdateRequest defines the body of a reqeust to the update completion endpoint of the service API.
+// CompleteUpdateRequest defines the body of a request to the update completion endpoint of the service API.
 type CompleteUpdateRequest struct {
 	Status UpdateStatus `json:"status"`
 }

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -184,7 +184,7 @@ func isDebugDiagEvent(e engine.Event) bool {
 }
 
 // RecordAndDisplayEvents inspects engine events from the given channel, and prints them to the CLI as well as
-// posting them to the Pulumi service. Any failures will post DiaogEvents to be displayed in the CLI.
+// posting them to the Pulumi service.
 func (u *cloudUpdate) RecordAndDisplayEvents(
 	label string, action apitype.UpdateKind, stackRef backend.StackReference, op backend.UpdateOperation,
 	events <-chan engine.Event, done chan<- bool, opts display.Options, isPreview bool) {
@@ -192,7 +192,7 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	// Create a new channel to synchronize with the event renderer.
 	innerDone := make(chan bool)
 	defer func() {
-		// Wait for the display routime to exit, then notify any listeners that this routine is finished.
+		// Wait for the display goroutine to exit, then notify any listeners that this goroutine is finished.
 		<-innerDone
 		close(done)
 	}()
@@ -208,8 +208,8 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	eventIdx := 0
 
 	// We start the requests to record engine events in separate Go routines since they can
-	// all be done independently, and updates with a "chatty" event stream can have serious
-	// perf problems when issuing the requests serially.
+	// all be done independently. Updates with a "chatty" event stream can have serious
+	// perf problems if issued serially.
 	var wg sync.WaitGroup
 	recordEngineEvent := func(event engine.Event, eventIdx int) {
 		defer wg.Done()
@@ -341,7 +341,6 @@ func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMeta
 
 		Old: convertStepEventStateMetadata(md.Old),
 		New: convertStepEventStateMetadata(md.New),
-		Res: convertStepEventStateMetadata(md.Res),
 
 		Keys:     keys,
 		Diffs:    diffs,


### PR DESCRIPTION
Changes the shape and serialization for engine events that get sent to the Pulumi Service as part of #2674. This won't have a big impact, but should at least help.

Specifically, marking fields of the most common types with `omitempty` and removing the `Res` field of `StepEventMetadata`. This should have a minor performance boost for updates, since we would be sending less data as part of an update.

For background, here are some stats for 2,500 random updates from app.pulumi.com. Among those updates, you can see that we average ~20 resources-events and ~40 diagnostic events per update. (Though they actually vary considerably update-to-update, depending on the resource provider, Pulumi program itself, etc.)

| Event Type | Count | Avg Size (bytes) | Max Size (bytes) |
| --- | --- | --- | --- |
| `DiagEvent` | 100,000+ | 758 | 463,539 |
| `ResourcePre` | 50,000+ | 6,267 | 2,086,359 |
| `ResourceOutputs` | 50,000+ | 8,477 | 2,097,715* |
| `CancelEvent` | ~2,500 | 2 | 2 |

- Engine events that are larger than 2MiB get split up, so the maximum size for a `ResourceOutputs` event in that set of updates is even larger.
- Engine events that occurred fewer times than `CancelEvent` aren't listed.

But as far as understanding the opportunity to carve out any sort of perf improvement, if we can find a way to make these things smaller, it would have a minor perf improvement.

## Marking fields with `omitempty`

Looking closely at the `DiagEvents` emitted, the overhead of serializing empty/default fields to JSON actually adds up. At least for the test stacks I was inspecting, every engine event had the default value for the `urn`, `prefix`, `streamID`, and `ephemeral` fields.

So if we mark those as `omitempty`, we can trim `"urn":"","prefix":"","streamID":0,"ephemeral":false,` from the JSON encoding, and save 52 bytes. Or an average of ~7%. That's not too bad for doing nothing. Though in practice, since the HTTP request payload is gzip-encoded, the actual savings for clients is probably much less.

> This is a breaking change, since non-Go clients will see a different type when deserializing the JSON. I confirmed that in the Pulumi Service repo, all of these fields marked as `omitempty` are either not referenced at all, or in such as way that them being `undefined` at runtime wouldn't be a problem.

Looking at the next most frequent engine event types, and their embedded fields of type `StepEventMetadata`, there's room for even more reduction.

The `StepEventMetadata` type has a `New`, `Old` fields with the new and old state of a resource. But it also has a `Res` field which is "the current state as known, equal to old or new depending the circumstance".

Assuming that for the common case the size of `New` is ~= `Old` and ~= `Res`, removing this redundant data is going to reduce the overall size of the JSON-encoding by a third. And in practice we don't actually _use_ this anywhere in the service. So rather than sending the additional information, which is just ignored, we can just not send it in the first place.

## Other Changes

In addition this PR also updates the route definitions in `api_endpoints.go`. These are used to provide an appropriate name for the Zipkin spans we emit for API calls to the Pulumi Service. Since they hadn't been updated since we changed the stack identity model, most of the update-related API calls were printed as "unknown".
