### PR TITLE
Do not prompt for passphrase multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- Pulumi no longer prompts for your passphrase twice during operations when you
+  are using the passphrase based secrets provider. (fixes [pulumi/pulumi#2729](https://github.com/pulumi/pulumi/issues/2729)).
+
 ## 0.17.11 (Released May 13, 2019)
 
 ### Major Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- Pulumi now tells you much earlier when the `--secrets-provider` argument to
+  `up` `init` or `new` has the wrong value. In addition, supported values are
+  now listed in the help text. (fixes [pulumi/pulumi#2727](https://github.com/pulumi/pulumi/issues/2727)).
 - Pulumi no longer prompts for your passphrase twice during operations when you
   are using the passphrase based secrets provider. (fixes [pulumi/pulumi#2729](https://github.com/pulumi/pulumi/issues/2729)).
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend"
 	"github.com/pulumi/pulumi/pkg/backend/display"
 	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/secrets"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/workspace"
@@ -533,7 +534,7 @@ func looksLikeSecret(k config.Key, v string) bool {
 
 // getStackConfiguration loads configuration information for a given stack. If stackConfigFile is non empty,
 // it is uses instead of the default configuration file for the stack
-func getStackConfiguration(stack backend.Stack) (backend.StackConfiguration, error) {
+func getStackConfiguration(stack backend.Stack, sm secrets.Manager) (backend.StackConfiguration, error) {
 	workspaceStack, err := loadProjectStack(stack)
 	if err != nil {
 		return backend.StackConfiguration{}, errors.Wrap(err, "loading stack configuration")
@@ -549,7 +550,7 @@ func getStackConfiguration(stack backend.Stack) (backend.StackConfiguration, err
 		}, nil
 	}
 
-	crypter, err := getStackDencrypter(stack)
+	crypter, err := sm.Decrypter()
 	if err != nil {
 		return backend.StackConfiguration{}, errors.Wrap(err, "getting configuration decrypter")
 	}

--- a/cmd/crypto.go
+++ b/cmd/crypto.go
@@ -61,3 +61,11 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 
 	return nil, errors.Errorf("unknown stack type %s", reflect.TypeOf(s))
 }
+
+func validateSecretsProvider(typ string) error {
+	if typ != "default" && typ != "passphrase" {
+		return errors.Errorf("unknown secrets provider type '%s' (supported values: default, passphrase)", typ)
+	}
+
+	return nil
+}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -98,14 +98,14 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
 
-			cfg, err := getStackConfiguration(s)
-			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
-			}
-
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+			}
+
+			cfg, err := getStackConfiguration(s, sm)
+			if err != nil {
+				return result.FromError(errors.Wrap(err, "getting stack configuration"))
 			}
 
 			opts.Engine = engine.UpdateOptions{

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -55,7 +55,12 @@ func newLogsCmd() *cobra.Command {
 				return err
 			}
 
-			cfg, err := getStackConfiguration(s)
+			sm, err := getStackSecretsManager(s)
+			if err != nil {
+				return errors.Wrap(err, "getting secrets manager")
+			}
+
+			cfg, err := getStackConfiguration(s, sm)
 			if err != nil {
 				return errors.Wrap(err, "getting stack configuration")
 			}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -47,7 +47,8 @@ import (
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 )
 
-// nolint: vetshadow, intentionally disabling here for cleaner err declaration/assignment.
+// intentionally disabling here for cleaner err declaration/assignment.
+// nolint: vetshadow
 func newNewCmd() *cobra.Command {
 	var configArray []string
 	var description string
@@ -262,7 +263,7 @@ func newNewCmd() *cobra.Command {
 
 			// Ensure the stack is selected.
 			if !generateOnly && s != nil {
-				state.SetCurrentStack(s.Ref().String())
+				contract.IgnoreError(state.SetCurrentStack(s.Ref().String()))
 			}
 
 			// Install dependencies.

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -82,6 +82,11 @@ func newNewCmd() *cobra.Command {
 				return errors.Errorf("'%s' is not a valid project name. %s.", name, workspace.ValidateProjectName(name))
 			}
 
+			// Validate secrets provider type
+			if err := validateSecretsProvider(secretsProvider); err != nil {
+				return err
+			}
+
 			// Get the current working directory.
 			cwd, err := os.Getwd()
 			if err != nil {
@@ -343,8 +348,8 @@ func newNewCmd() *cobra.Command {
 		&yes, "yes", "y", false,
 		"Skip prompts and proceed with default values")
 	cmd.PersistentFlags().StringVar(
-		&secretsProvider, "secrets-provider", "", "The name of the provider that should be used to encrypt and "+
-			"decrypt secrets.")
+		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
+			"decrypt secrets (possible choices: default, passpharse)")
 
 	return cmd
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -350,7 +350,7 @@ func newNewCmd() *cobra.Command {
 		"Skip prompts and proceed with default values")
 	cmd.PersistentFlags().StringVar(
 		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
-			"decrypt secrets (possible choices: default, passpharse)")
+			"decrypt secrets (possible choices: default, passphrase)")
 
 	return cmd
 }

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -98,14 +98,14 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
 
-			cfg, err := getStackConfiguration(s)
-			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
-			}
-
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+			}
+
+			cfg, err := getStackConfiguration(s, sm)
+			if err != nil {
+				return result.FromError(errors.Wrap(err, "getting stack configuration"))
 			}
 
 			changes, res := s.Preview(commandContext(), backend.UpdateOperation{

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -64,7 +64,12 @@ func newQueryCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			cfg, err := getStackConfiguration(s)
+			sm, err := getStackSecretsManager(s)
+			if err != nil {
+				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+			}
+
+			cfg, err := getStackConfiguration(s, sm)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "getting stack configuration"))
 			}
@@ -76,6 +81,7 @@ func newQueryCmd() *cobra.Command {
 				Root:               root,
 				Opts:               opts,
 				StackConfiguration: cfg,
+				SecretsManager:     sm,
 				Scopes:             cancellationScopes,
 			})
 			switch {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -27,7 +27,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/result"
 )
 
-// nolint: vetshadow, intentionally disabling here for cleaner err declaration/assignment.
+// intentionally disabling here for cleaner err declaration/assignment.
+// nolint: vetshadow
 func newQueryCmd() *cobra.Command {
 	var stack string
 

--- a/cmd/refresh.go
+++ b/cmd/refresh.go
@@ -99,14 +99,14 @@ func newRefreshCmd() *cobra.Command {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
 
-			cfg, err := getStackConfiguration(s)
-			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
-			}
-
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+			}
+
+			cfg, err := getStackConfiguration(s, sm)
+			if err != nil {
+				return result.FromError(errors.Wrap(err, "getting stack configuration"))
 			}
 
 			opts.Engine = engine.UpdateOptions{

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -55,6 +55,11 @@ func newStackInitCmd() *cobra.Command {
 				stackName = args[0]
 			}
 
+			// Validate secrets provider type
+			if err := validateSecretsProvider(secretsProvider); err != nil {
+				return err
+			}
+
 			if stackName == "" && cmdutil.Interactive() {
 				name, nameErr := cmdutil.ReadConsole("Please enter your desired stack name.\n" +
 					"To create a stack in an organization, " +
@@ -82,7 +87,7 @@ func newStackInitCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "", "The name of the stack to create")
 	cmd.PersistentFlags().StringVar(
-		&secretsProvider, "secrets-provider", "", "The name of the provider that should be used to encrypt and "+
-			"decrypt secrets.")
+		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
+			"decrypt secrets (possible choices: default, passpharse)")
 	return cmd
 }

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -88,6 +88,6 @@ func newStackInitCmd() *cobra.Command {
 		&stackName, "stack", "s", "", "The name of the stack to create")
 	cmd.PersistentFlags().StringVar(
 		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
-			"decrypt secrets (possible choices: default, passpharse)")
+			"decrypt secrets (possible choices: default, passphrase)")
 	return cmd
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -42,7 +42,8 @@ const (
 	defaultParallel = math.MaxInt32
 )
 
-// nolint: vetshadow, intentionally disabling here for cleaner err declaration/assignment.
+// intentionally disabling here for cleaner err declaration/assignment.
+// nolint: vetshadow
 func newUpCmd() *cobra.Command {
 	var debug bool
 	var expectNop bool

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -362,7 +362,7 @@ func newUpCmd() *cobra.Command {
 		"Config to use during the update")
 	cmd.PersistentFlags().StringVar(
 		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
-			"decrypt secrets (possible choices: default, passpharse). Only used when creating a new stack from "+
+			"decrypt secrets (possible choices: default, passphrase). Only used when creating a new stack from "+
 			"an existing template")
 
 	cmd.PersistentFlags().StringVarP(

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -158,6 +158,11 @@ func newUpCmd() *cobra.Command {
 			}
 		}
 
+		// Validate secrets provider type
+		if err := validateSecretsProvider(secretsProvider); err != nil {
+			return result.FromError(err)
+		}
+
 		// Create temp directory for the "virtual workspace".
 		temp, err := ioutil.TempDir("", "pulumi-up-")
 		if err != nil {
@@ -355,8 +360,9 @@ func newUpCmd() *cobra.Command {
 		&configArray, "config", "c", []string{},
 		"Config to use during the update")
 	cmd.PersistentFlags().StringVar(
-		&secretsProvider, "secrets-provider", "", "The name of the provider that should be used to encrypt and "+
-			"decrypt secrets. Only used when creating a new stack from an existing template.")
+		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
+			"decrypt secrets (possible choices: default, passpharse). Only used when creating a new stack from "+
+			"an existing template")
 
 	cmd.PersistentFlags().StringVarP(
 		&message, "message", "m", "",

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -92,14 +92,14 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 		}
 
-		cfg, err := getStackConfiguration(s)
-		if err != nil {
-			return result.FromError(errors.Wrap(err, "getting stack configuration"))
-		}
-
 		sm, err := getStackSecretsManager(s)
 		if err != nil {
 			return result.FromError(errors.Wrap(err, "getting secrets manager"))
+		}
+
+		cfg, err := getStackConfiguration(s, sm)
+		if err != nil {
+			return result.FromError(errors.Wrap(err, "getting stack configuration"))
 		}
 
 		opts.Engine = engine.UpdateOptions{
@@ -244,16 +244,14 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 		}
 
-		cfg, err := getStackConfiguration(s)
-		if err != nil {
-			return result.FromError(errors.Wrap(err, "getting stack configuration"))
-		}
-
-		// TODO(ellismg): Is there UX here what we want?  Do we end up double prompting for a passphrase
-		// when using passphrase based secrets management?
 		sm, err := getStackSecretsManager(s)
 		if err != nil {
 			return result.FromError(errors.Wrap(err, "getting secrets manager"))
+		}
+
+		cfg, err := getStackConfiguration(s, sm)
+		if err != nil {
+			return result.FromError(errors.Wrap(err, "getting stack configuration"))
 		}
 
 		opts.Engine = engine.UpdateOptions{

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -90,10 +90,6 @@ func createStack(
 	b backend.Backend, stackRef backend.StackReference, opts interface{}, setCurrent bool,
 	secretsProvider string) (backend.Stack, error) {
 
-	if secretsProvider != "" && secretsProvider != "passphrase" {
-		return nil, errors.Errorf("unknown secrets provider type '%s'", secretsProvider)
-	}
-
 	// As part of creating the stack, we also need to configure the secrets provider for the stack. Today, we only
 	// have to do this configuration step when you are using the passpharse provider (which is used for all filestate,
 	// stacks and well as httpstate stacks that opted into this by passing --secrets-provider passphrase

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -91,7 +91,7 @@ func createStack(
 	secretsProvider string) (backend.Stack, error) {
 
 	// As part of creating the stack, we also need to configure the secrets provider for the stack. Today, we only
-	// have to do this configuration step when you are using the passpharse provider (which is used for all filestate,
+	// have to do this configuration step when you are using the passphrase provider (which is used for all filestate,
 	// stacks and well as httpstate stacks that opted into this by passing --secrets-provider passphrase
 	// while initialing a stack).  The only other supported provider today (the provider that uses the pulumi service
 	// does not need to be initialized explicitly, as creating the stack inside the Pulumi service does this).

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -108,7 +108,7 @@ var lock sync.Mutex
 var cache map[string]secrets.Manager
 
 func NewPassphaseSecretsManager(phrase string, state string) (secrets.Manager, error) {
-	// check the cache first, if we have an already seen this state before, return a cached value
+	// check the cache first, if we have already seen this state before, return a cached value.
 	lock.Lock()
 	if cache == nil {
 		cache = make(map[string]secrets.Manager)

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/pkg/errors"
 
@@ -103,18 +104,38 @@ func (sm *localSecretsManager) Encrypter() (config.Encrypter, error) {
 	return sm.crypter, nil
 }
 
+var lock sync.Mutex
+var cache map[string]secrets.Manager
+
 func NewPassphaseSecretsManager(phrase string, state string) (secrets.Manager, error) {
+	// check the cache first, if we have an already seen this state before, return a cached value
+	lock.Lock()
+	if cache == nil {
+		cache = make(map[string]secrets.Manager)
+	}
+	cachedValue := cache[state]
+	lock.Unlock()
+
+	if cachedValue != nil {
+		return cachedValue, nil
+	}
+
+	// wasn't in the cache so try to construct it and add it if there's no error.
 	crypter, err := symmetricCrypterFromPhraseAndState(phrase, state)
 	if err != nil {
 		return nil, err
 	}
 
-	return &localSecretsManager{
+	lock.Lock()
+	defer lock.Unlock()
+	sm := &localSecretsManager{
 		crypter: crypter,
 		state: localSecretsManagerState{
 			Salt: state,
 		},
-	}, nil
+	}
+	cache[state] = sm
+	return sm, nil
 }
 
 type provider struct{}
@@ -162,11 +183,11 @@ func newLockedPasspharseSecretsManager(state localSecretsManagerState) secrets.M
 type errorCrypter struct{}
 
 func (ec *errorCrypter) EncryptValue(v string) (string, error) {
-	return "", errors.New("failed to encrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the" +
+	return "", errors.New("failed to encrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase")
 }
 
 func (ec *errorCrypter) DecryptValue(v string) (string, error) {
-	return "", errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the" +
+	return "", errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase")
 }


### PR DESCRIPTION
The change does two things:

- Reorders some calls in the CLI to prevent trying to create a secrets
  manager twice (which would end up prompting twice).

- Adds a cache inside the passphrase secrets manager such that when
  decrypting a deployment, we can re-use the one created earlier in
  the update. This is sort of a hack, but is needed because otherwise
  we would fail to decrypt the deployment, meaning that if you had a
  secret value in your deployment *and* you were using local
  passphrase encryption *and* you had not set PULUMI_CONFIG_PASSPHRASE
  you would get an error asking you to do so.

Fixes #2729