### PR TITLE
Fix a panic during property diffing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   are using the passphrase based secrets provider. (fixes [pulumi/pulumi#2729](https://github.com/pulumi/pulumi/issues/2729)).
 - Fix an issue where complex inputs to a resource which contained secret values
   would not be stored correctly.
+- Fix a panic during property diffing when comparing two secret arrays.
 
 ## 0.17.11 (Released May 13, 2019)
 

--- a/pkg/resource/properties_diff.go
+++ b/pkg/resource/properties_diff.go
@@ -320,7 +320,7 @@ func (v PropertyValue) DeepEquals(other PropertyValue) bool {
 		vs := v.SecretValue()
 		os := other.SecretValue()
 
-		vs.Element.DeepEquals(os.Element)
+		return vs.Element.DeepEquals(os.Element)
 	}
 
 	// For all other cases, primitives are equal if their values are equal.

--- a/pkg/resource/properties_diff_test.go
+++ b/pkg/resource/properties_diff_test.go
@@ -338,3 +338,16 @@ func TestArchivePropertyValueDiffs(t *testing.T) {
 	assert.Equal(t, path, d3.Old.ArchiveValue().Path)
 	assert.True(t, d3.New.IsNull())
 }
+
+func TestMismatchedPropertyValueDiff(t *testing.T) {
+	t.Parallel()
+
+	a1 := NewPropertyValue([]string{"a", "b", "c"})
+	a2 := NewPropertyValue([]string{"a", "b", "c"})
+
+	s1 := MakeSecret(a1)
+	s2 := MakeSecret(a2)
+
+	assert.True(t, s2.DeepEquals(s1))
+	assert.True(t, s1.DeepEquals(s2))
+}


### PR DESCRIPTION
We have to actually return the value we compute instead of just
dropping it on the floor and treating the underlying values as
primitive.

I ran into this during dogfooding, the added test case would
previously panic.