### PR TITLE
Do not pass arguments as secrets to CheckConfig/Configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- Fix an issue where creating a first class provider would fail if any of the
+  configuration values for the providers were secrets. (fixes [pulumi/pulumi#2741](https://github.com/pulumi/pulumi/issues/2741)).
+
 ## 0.17.12 (Released May 15, 2019)
 
 ### Improvements

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -758,3 +758,12 @@ func TestPython3NotInstalled(t *testing.T) {
 		},
 	})
 }
+
+// TestProviderSecretConfig that a first class provider can be created when it has secrets as part of its config.
+func TestProviderSecretConfig(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "provider_secret_config",
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        true,
+	})
+}

--- a/tests/integration/provider_secret_config/Pulumi.yaml
+++ b/tests/integration/provider_secret_config/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: provider-secret-config
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/tests/integration/provider_secret_config/index.ts
+++ b/tests/integration/provider_secret_config/index.ts
@@ -1,0 +1,11 @@
+import * as pulumi from "@pulumi/pulumi";
+
+// Regression test for [pulumi/pulumi#2741], you should be able to create an instance of a first class provider
+// with secret configuration values, so long as these values are themselves strings.
+class DynamicProvider extends pulumi.ProviderResource {
+    constructor(name: string, opts?: pulumi.ResourceOptions) {
+        super("pulumi-nodejs", name,  { secretProperty: pulumi.secret("it's a secret to everybody") }, opts);
+    }
+}
+
+const p = new DynamicProvider("p");

--- a/tests/integration/provider_secret_config/package.json
+++ b/tests/integration/provider_secret_config/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/provider_secret_config/tsconfig.json
+++ b/tests/integration/provider_secret_config/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Providers from plugins require that configuration value be
strings. This means if we are passing a secret string to a
provider (for example, trying to configure a kubernetes provider based
on some secret kubeconfig) we need to be careful to remove the
"secretness" before actually making the calls into the provider.

Failure to do this resulted in errors saying that the provider
configuration values had to be strings, and of course, the values
logically where, they were just marked as secret strings

Fixes #2741