### PR TITLE
Apply colorization to the `---outputs---` line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - Fix an issue where creating a first class provider would fail if any of the
   configuration values for the providers were secrets. (fixes [pulumi/pulumi#2741](https://github.com/pulumi/pulumi/issues/2741)).
+- Fix an issue where when using `--diff` or looking at details for a proposed
+  updated, the CLI might print text like: `<{%reset%}>
+  --outputs:--<{%reset%}>` instead of just `--outputs:--`.
 
 ## 0.17.12 (Released May 15, 2019)
 

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -279,8 +279,10 @@ func renderDiffResourceOutputsEvent(
 		if !opts.SuppressOutputs {
 			if text := engine.GetResourceOutputsPropertiesString(
 				payload.Metadata, indent+1, payload.Planning, payload.Debug, refresh); text != "" {
-				fprintfIgnoreError(out, "%v%v--outputs:--%v\n",
+
+				header := fmt.Sprintf("%v%v--outputs:--%v\n",
 					payload.Metadata.Op.Color(), engine.GetIndentationString(indent+1), colors.Reset)
+				fprintfIgnoreError(out, opts.Color.Colorize(header))
 				fprintIgnoreError(out, opts.Color.Colorize(text))
 			}
 		}


### PR DESCRIPTION
We were not actually calling our colorization routines, which lead to
printing this very confusing text:

```
<{%reset%}>    --outputs:--<{%reset%}>
```

When running updates with `--diff` or when drilling into details of a
proposed operation, like a refresh.