### PR TITLE
Gracefully handle the case where secrets_provider is uninitalized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   --outputs:--<{%reset%}>` instead of just `--outputs:--`.
 - Signature of `Pulumi.all` has been made more accurate.  Calling `.all` on `Output`s that may
   be `undefined` will properly encode and pass along that `undefined` information.
+- Fix an issue where some operations would fail with `error: could not deserialize deployment: unknown secrets provider type`.
 
 ## 0.17.12 (Released May 15, 2019)
 

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -111,10 +111,11 @@ func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager) (*apitype.De
 		operations = append(operations, sop)
 	}
 
-	secretsProvider := apitype.SecretsProvidersV1{}
-
+	var secretsProvider *apitype.SecretsProvidersV1
 	if sm != nil {
-		secretsProvider.Type = sm.Type()
+		secretsProvider = &apitype.SecretsProvidersV1{
+			Type: sm.Type(),
+		}
 		if state := sm.State(); state != nil {
 			rm, err := json.Marshal(state)
 			if err != nil {
@@ -127,7 +128,7 @@ func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager) (*apitype.De
 	return &apitype.DeploymentV3{
 		Manifest:          manifest,
 		Resources:         resources,
-		SecretsProviders:  &secretsProvider,
+		SecretsProviders:  secretsProvider,
 		PendingOperations: operations,
 	}, nil
 }
@@ -195,7 +196,7 @@ func DeserializeDeploymentV3(deployment apitype.DeploymentV3) (*deploy.Snapshot,
 	}
 
 	var secretsManager secrets.Manager
-	if deployment.SecretsProviders != nil {
+	if deployment.SecretsProviders != nil && deployment.SecretsProviders.Type != "" {
 		var provider secrets.ManagerProvider
 
 		switch deployment.SecretsProviders.Type {


### PR DESCRIPTION
A customer reported an issue where operations would fail with the
following error:

```
error: could not deserialize deployment: unknown secrets provider type
```

The problem here was the customer's deployment had a
`secrets_provider` section which looked like the following:

```
"secrets_providers": {
    "type": ""
}
```

And so our code to try to construct a secrets manager from this thing
would fail, as our registry does not contain any information about a
provider with an empty type.

We do two things in this change:

1. When serializing a deployment, if there is no secrets manager,
don't even write the `secrets_provider` block. This helps for cases
where we are roundtripping deployments that did not have a provider
configured (i.e. they were older stacks that did not use secrets)

2. When deserializing, if we see an empty secrets provider like the
above, interpret it to mean "this deployment has no secrets". We set
up a decrypter such that if it ends up haiving secrets, we panic
eagerly (since this is a logical bug in our system somewhere).