### PR TITLE
cmd/whoami: Move the changelog entry to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- `pulumi whoami` now outputs the URL of the currently connected backend
+
 ## 0.17.13 (Released May 21, 2019)
 
 ### Improvements
@@ -108,8 +110,6 @@ Fixes #397
   including the anticipated set of deployment steps, list of diagnostics messages, and summary information.
   Each step includes deeply serialized information about the resource state and step metadata itself. This
   is part of ongoing work tracked in [pulumi/pulumi#2390](https://github.com/pulumi/pulumi/issues/2390).
-
-- `pulumi whoami` now outputs the URL of the currently connected backend
 
 ## 0.17.8 (Released April 23, 2019)
 


### PR DESCRIPTION
This was originally part of an older release but it has since been
moved to unreleased as it was only recently merged