### PR TITLE
NodeJS: add `semver` as dependency 

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -12,6 +12,7 @@
         "protobufjs": "^6.8.6",
         "read-package-tree": "^5.2.1",
         "require-from-string": "^2.0.1",
+        "semver": "^6.1.0",
         "source-map-support": "^0.4.16",
         "ts-node": "^7.0.0",
         "typescript": "^3.4.1",


### PR DESCRIPTION
On using the import `@pulumi/pulumi`, I get the error:

> Error: Cannot find module 'semver'

That's because [`semver` is imported in `runtime/closure/v8Hook.ts`](https://github.com/pulumi/pulumi/blob/master/sdk/nodejs/runtime/closure/v8Hooks.ts#L23), but not declared in `package.json`.

You may wonder why you didn't see this error before. It's because `npm`/`yarn` installs `semver` from the other dependencies into their flat `./node_modules` where you can then import it without explicitly declaring it. That can lead to [spurious bugs from `npm` flattened modules](https://medium.com/pnpm/pnpms-strictness-helps-to-avoid-silly-bugs-9a15fb306308) sometimes later.

To reproduce this error, use [`pnpm`](https://pnpm.js.org) for all `npm` commands.