### PR TITLE
Implement DiffConfig/CheckConfig for plugin based providers

### DIFF
--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -715,7 +715,7 @@ func TestSingleResourceDefaultProviderReplace(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffConfigF: func(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 					// Always require replacement.
 					keys := []resource.PropertyKey{}
 					for k := range news {
@@ -793,7 +793,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffConfigF: func(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 					// Always require replacement.
 					keys := []resource.PropertyKey{}
 					for k := range news {
@@ -882,7 +882,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffConfigF: func(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 					// Always require replacement.
 					keys := []resource.PropertyKey{}
 					for k := range news {
@@ -2598,7 +2598,7 @@ func TestDeleteBeforeReplace(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffConfigF: func(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 					if !olds["A"].DeepEquals(news["A"]) {
 						return plugin.DiffResult{
 							ReplaceKeys:         []resource.PropertyKey{"A"},

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -715,7 +715,8 @@ func TestSingleResourceDefaultProviderReplace(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap,
+					allowUnknowns bool) (plugin.DiffResult, error) {
 					// Always require replacement.
 					keys := []resource.PropertyKey{}
 					for k := range news {
@@ -793,7 +794,8 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap,
+					allowUnknowns bool) (plugin.DiffResult, error) {
 					// Always require replacement.
 					keys := []resource.PropertyKey{}
 					for k := range news {
@@ -882,7 +884,8 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap,
+					allowUnknowns bool) (plugin.DiffResult, error) {
 					// Always require replacement.
 					keys := []resource.PropertyKey{}
 					for k := range news {
@@ -2598,7 +2601,8 @@ func TestDeleteBeforeReplace(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
-				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap,
+					allowUnknowns bool) (plugin.DiffResult, error) {
 					if !olds["A"].DeepEquals(news["A"]) {
 						return plugin.DiffResult{
 							ReplaceKeys:         []resource.PropertyKey{"A"},

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -38,15 +38,14 @@ func (p *builtinProvider) Pkg() tokens.Package {
 }
 
 // CheckConfig validates the configuration for this resource provider.
-func (p *builtinProvider) CheckConfig(olds,
+func (p *builtinProvider) CheckConfig(urn resource.URN, olds,
 	news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
 
 	return nil, nil, nil
 }
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-func (p *builtinProvider) DiffConfig(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
-
+func (p *builtinProvider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 	return plugin.DiffResult{Changes: plugin.DiffNone}, nil
 }
 

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -39,13 +39,14 @@ func (p *builtinProvider) Pkg() tokens.Package {
 
 // CheckConfig validates the configuration for this resource provider.
 func (p *builtinProvider) CheckConfig(urn resource.URN, olds,
-	news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+	news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
 
 	return nil, nil, nil
 }
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-func (p *builtinProvider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+func (p *builtinProvider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap,
+	allowUnknowns bool) (plugin.DiffResult, error) {
 	return plugin.DiffResult{Changes: plugin.DiffNone}, nil
 }
 

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -33,8 +33,8 @@ type Provider struct {
 	configured bool
 
 	CheckConfigF func(urn resource.URN, olds,
-		news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
-	DiffConfigF func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error)
+		news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error)
+	DiffConfigF func(urn resource.URN, olds, news resource.PropertyMap, allowUnknowns bool) (plugin.DiffResult, error)
 	ConfigureF  func(news resource.PropertyMap) error
 
 	CheckF func(urn resource.URN,
@@ -77,17 +77,18 @@ func (prov *Provider) GetPluginInfo() (workspace.PluginInfo, error) {
 }
 
 func (prov *Provider) CheckConfig(urn resource.URN, olds,
-	news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+	news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
 	if prov.CheckConfigF == nil {
 		return news, nil, nil
 	}
-	return prov.CheckConfigF(urn, olds, news)
+	return prov.CheckConfigF(urn, olds, news, allowUnknowns)
 }
-func (prov *Provider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+func (prov *Provider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap,
+	allowUnknowns bool) (plugin.DiffResult, error) {
 	if prov.DiffConfigF == nil {
 		return plugin.DiffResult{}, nil
 	}
-	return prov.DiffConfigF(urn, olds, news)
+	return prov.DiffConfigF(urn, olds, news, allowUnknowns)
 }
 func (prov *Provider) Configure(inputs resource.PropertyMap) error {
 	contract.Assert(!prov.configured)

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -32,9 +32,10 @@ type Provider struct {
 
 	configured bool
 
-	CheckConfigF func(olds, news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
-	DiffConfigF  func(olds, news resource.PropertyMap) (plugin.DiffResult, error)
-	ConfigureF   func(news resource.PropertyMap) error
+	CheckConfigF func(urn resource.URN, olds,
+		news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
+	DiffConfigF func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error)
+	ConfigureF  func(news resource.PropertyMap) error
 
 	CheckF func(urn resource.URN,
 		olds, news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
@@ -75,18 +76,18 @@ func (prov *Provider) GetPluginInfo() (workspace.PluginInfo, error) {
 	}, nil
 }
 
-func (prov *Provider) CheckConfig(olds,
+func (prov *Provider) CheckConfig(urn resource.URN, olds,
 	news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
 	if prov.CheckConfigF == nil {
 		return news, nil, nil
 	}
-	return prov.CheckConfigF(olds, news)
+	return prov.CheckConfigF(urn, olds, news)
 }
-func (prov *Provider) DiffConfig(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+func (prov *Provider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 	if prov.DiffConfigF == nil {
 		return plugin.DiffResult{}, nil
 	}
-	return prov.DiffConfigF(olds, news)
+	return prov.DiffConfigF(urn, olds, news)
 }
 func (prov *Provider) Configure(inputs resource.PropertyMap) error {
 	contract.Assert(!prov.configured)

--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -185,13 +185,15 @@ func (r *Registry) label() string {
 }
 
 // CheckConfig validates the configuration for this resource provider.
-func (r *Registry) CheckConfig(olds, news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+func (r *Registry) CheckConfig(urn resource.URN, olds,
+	news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+
 	contract.Fail()
 	return nil, nil, errors.New("the provider registry is not configurable")
 }
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-func (r *Registry) DiffConfig(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+func (r *Registry) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 	contract.Fail()
 	return plugin.DiffResult{}, errors.New("the provider registry is not configurable")
 }
@@ -231,7 +233,7 @@ func (r *Registry) Check(urn resource.URN, olds, news resource.PropertyMap,
 	}
 
 	// Check the provider's config. If the check fails, unload the provider.
-	inputs, failures, err := provider.CheckConfig(olds, news)
+	inputs, failures, err := provider.CheckConfig(urn, olds, news)
 	if len(failures) != 0 || err != nil {
 		closeErr := r.host.CloseProvider(provider)
 		contract.IgnoreError(closeErr)
@@ -274,7 +276,7 @@ func (r *Registry) Diff(urn resource.URN, id resource.ID, olds, news resource.Pr
 		provider, ok = r.GetProvider(mustNewReference(urn, id))
 		contract.Assertf(ok, "Provider must have been registered by NewRegistry for DBR Diff (%v::%v)", urn, id)
 
-		diff, err := provider.DiffConfig(olds, news)
+		diff, err := provider.DiffConfig(urn, olds, news)
 		if err != nil {
 			return plugin.DiffResult{Changes: plugin.DiffUnknown}, err
 		}
@@ -282,7 +284,7 @@ func (r *Registry) Diff(urn resource.URN, id resource.ID, olds, news resource.Pr
 	}
 
 	// Diff the properties.
-	diff, err := provider.DiffConfig(olds, news)
+	diff, err := provider.DiffConfig(urn, olds, news)
 	if err != nil {
 		return plugin.DiffResult{Changes: plugin.DiffUnknown}, err
 	}

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -77,9 +77,10 @@ type testProvider struct {
 	pkg         tokens.Package
 	version     semver.Version
 	configured  bool
-	checkConfig func(resource.PropertyMap, resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
-	diffConfig  func(resource.PropertyMap, resource.PropertyMap) (plugin.DiffResult, error)
-	config      func(resource.PropertyMap) error
+	checkConfig func(resource.URN, resource.PropertyMap,
+		resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
+	diffConfig func(resource.URN, resource.PropertyMap, resource.PropertyMap) (plugin.DiffResult, error)
+	config     func(resource.PropertyMap) error
 }
 
 func (prov *testProvider) SignalCancellation() error {
@@ -91,12 +92,12 @@ func (prov *testProvider) Close() error {
 func (prov *testProvider) Pkg() tokens.Package {
 	return prov.pkg
 }
-func (prov *testProvider) CheckConfig(olds,
+func (prov *testProvider) CheckConfig(urn resource.URN, olds,
 	news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	return prov.checkConfig(olds, news)
+	return prov.checkConfig(urn, olds, news)
 }
-func (prov *testProvider) DiffConfig(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
-	return prov.diffConfig(olds, news)
+func (prov *testProvider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+	return prov.diffConfig(urn, olds, news)
 }
 func (prov *testProvider) Configure(inputs resource.PropertyMap) error {
 	if err := prov.config(inputs); err != nil {
@@ -202,10 +203,11 @@ func newSimpleLoader(t *testing.T, pkg, version string, config func(resource.Pro
 		return &testProvider{
 			pkg:     pkg,
 			version: ver,
-			checkConfig: func(olds, news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+			checkConfig: func(urn resource.URN, olds,
+				news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
 				return news, nil, nil
 			},
-			diffConfig: func(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+			diffConfig: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 				return plugin.DiffResult{}, nil
 			},
 			config: config,
@@ -512,10 +514,11 @@ func TestCRUDPreview(t *testing.T) {
 			return &testProvider{
 				pkg:     pkg,
 				version: ver,
-				checkConfig: func(olds, news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+				checkConfig: func(urn resource.URN, olds,
+					news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
 					return news, nil, nil
 				},
-				diffConfig: func(olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				diffConfig: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
 					// Always reuquire replacement.
 					return plugin.DiffResult{ReplaceKeys: []resource.PropertyKey{"id"}}, nil
 				},

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -78,8 +78,8 @@ type testProvider struct {
 	version     semver.Version
 	configured  bool
 	checkConfig func(resource.URN, resource.PropertyMap,
-		resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error)
-	diffConfig func(resource.URN, resource.PropertyMap, resource.PropertyMap) (plugin.DiffResult, error)
+		resource.PropertyMap, bool) (resource.PropertyMap, []plugin.CheckFailure, error)
+	diffConfig func(resource.URN, resource.PropertyMap, resource.PropertyMap, bool) (plugin.DiffResult, error)
 	config     func(resource.PropertyMap) error
 }
 
@@ -93,11 +93,12 @@ func (prov *testProvider) Pkg() tokens.Package {
 	return prov.pkg
 }
 func (prov *testProvider) CheckConfig(urn resource.URN, olds,
-	news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	return prov.checkConfig(urn, olds, news)
+	news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
+	return prov.checkConfig(urn, olds, news, allowUnknowns)
 }
-func (prov *testProvider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
-	return prov.diffConfig(urn, olds, news)
+func (prov *testProvider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap,
+	allowUnknowns bool) (plugin.DiffResult, error) {
+	return prov.diffConfig(urn, olds, news, allowUnknowns)
 }
 func (prov *testProvider) Configure(inputs resource.PropertyMap) error {
 	if err := prov.config(inputs); err != nil {
@@ -204,10 +205,11 @@ func newSimpleLoader(t *testing.T, pkg, version string, config func(resource.Pro
 			pkg:     pkg,
 			version: ver,
 			checkConfig: func(urn resource.URN, olds,
-				news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+				news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
 				return news, nil, nil
 			},
-			diffConfig: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+			diffConfig: func(urn resource.URN, olds, news resource.PropertyMap,
+				allowUnknowns bool) (plugin.DiffResult, error) {
 				return plugin.DiffResult{}, nil
 			},
 			config: config,
@@ -515,10 +517,11 @@ func TestCRUDPreview(t *testing.T) {
 				pkg:     pkg,
 				version: ver,
 				checkConfig: func(urn resource.URN, olds,
-					news resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
+					news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error) {
 					return news, nil, nil
 				},
-				diffConfig: func(urn resource.URN, olds, news resource.PropertyMap) (plugin.DiffResult, error) {
+				diffConfig: func(urn resource.URN, olds, news resource.PropertyMap,
+					allowUnknowns bool) (plugin.DiffResult, error) {
 					// Always reuquire replacement.
 					return plugin.DiffResult{ReplaceKeys: []resource.PropertyKey{"id"}}, nil
 				},

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -39,9 +39,9 @@ type Provider interface {
 	Pkg() tokens.Package
 
 	// CheckConfig validates the configuration for this resource provider.
-	CheckConfig(olds, news resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error)
+	CheckConfig(urn resource.URN, olds, news resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error)
 	// DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-	DiffConfig(olds, news resource.PropertyMap) (DiffResult, error)
+	DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (DiffResult, error)
 	// Configure configures the resource provider with "globals" that control its behavior.
 	Configure(inputs resource.PropertyMap) error
 

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -39,9 +39,10 @@ type Provider interface {
 	Pkg() tokens.Package
 
 	// CheckConfig validates the configuration for this resource provider.
-	CheckConfig(urn resource.URN, olds, news resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error)
+	CheckConfig(urn resource.URN, olds, news resource.PropertyMap,
+		allowUnknowns bool) (resource.PropertyMap, []CheckFailure, error)
 	// DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-	DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (DiffResult, error)
+	DiffConfig(urn resource.URN, olds, news resource.PropertyMap, allowUnknowns bool) (DiffResult, error)
 	// Configure configures the resource provider with "globals" that control its behavior.
 	Configure(inputs resource.PropertyMap) error
 

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -85,7 +85,8 @@ func (p *provider) label() string {
 }
 
 // CheckConfig validates the configuration for this resource provider.
-func (p *provider) CheckConfig(olds, news resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error) {
+func (p *provider) CheckConfig(urn resource.URN, olds,
+	news resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error) {
 	// Ensure that all config values are strings or unknowns.
 	var failures []CheckFailure
 	for k, v := range news {
@@ -111,7 +112,7 @@ func (p *provider) CheckConfig(olds, news resource.PropertyMap) (resource.Proper
 }
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-func (p *provider) DiffConfig(olds, news resource.PropertyMap) (DiffResult, error) {
+func (p *provider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (DiffResult, error) {
 	// There are two interesting scenarios with the present gRPC interface:
 	// 1. Configuration differences in which all properties are known
 	// 2. Configuration differences in which some new property is unknown.

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -86,7 +86,7 @@ func (p *provider) label() string {
 
 // CheckConfig validates the configuration for this resource provider.
 func (p *provider) CheckConfig(urn resource.URN, olds,
-	news resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error) {
+	news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []CheckFailure, error) {
 	// Ensure that all config values are strings or unknowns.
 	var failures []CheckFailure
 	for k, v := range news {
@@ -112,7 +112,8 @@ func (p *provider) CheckConfig(urn resource.URN, olds,
 }
 
 // DiffConfig checks what impacts a hypothetical change to this provider's configuration will have on the provider.
-func (p *provider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap) (DiffResult, error) {
+func (p *provider) DiffConfig(urn resource.URN, olds, news resource.PropertyMap,
+	allowUnknowns bool) (DiffResult, error) {
 	// There are two interesting scenarios with the present gRPC interface:
 	// 1. Configuration differences in which all properties are known
 	// 2. Configuration differences in which some new property is unknown.

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -111,7 +111,10 @@ async function checkRPC(call: any, callback: any): Promise<void> {
 }
 
 function checkConfigRPC(call: any, callback: any): void {
-    callback(undefined, new emptyproto.Empty());
+    callback({
+        code: grpc.status.UNIMPLEMENTED,
+        details: "CheckConfig is not implemented by the dynamic provider",
+    }, undefined);
 }
 
 async function diffRPC(call: any, callback: any): Promise<void> {
@@ -157,7 +160,10 @@ async function diffRPC(call: any, callback: any): Promise<void> {
 }
 
 function diffConfigRPC(call: any, callback: any): void {
-    callback(undefined, new emptyproto.Empty());
+    callback({
+        code: grpc.status.UNIMPLEMENTED,
+        details: "DiffConfig is not implemented by the dynamic provider",
+    }, undefined);
 }
 
 async function createRPC(call: any, callback: any): Promise<void> {


### PR DESCRIPTION
This set of changes implements DiffConfig/CheckConfig for providers that are managed by plugins.  At a high level:

1. Adjust the Provider interface (in golang) to pass a URN and if unknowns are allowed during these operations. This mimics the shape of the existing Check/Diff methods.
2. Implement DiffConfig and CheckConfig in `provider_plugin.go`, which behave more or less the same as Diff and Check.
3. Fix an issue in the dynamic provider, which I introduced, where it was not actually correctly implementing Diff and Check, leading to errors when actually trying to use a CLI with these fixes but an older version of the dynamic provider.