### PR TITLE
Suppress JSON outputs in preview correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Improvements
 
-- `pulumi whoami` now outputs the URL of the currently connected backend
+- `pulumi whoami` now outputs the URL of the currently connected backend.
+- Correctly suppress stack outputs when serializing previews to JSON, i.e. `pulumi preview --json --suppress-outputs`.
+  Fixes [pulumi/pulumi#2765](https://github.com/pulumi/pulumi/issues/2765).
 
 ## 0.17.13 (Released May 21, 2019)
 

--- a/tests/integration/single_resource/index.ts
+++ b/tests/integration/single_resource/index.ts
@@ -5,3 +5,5 @@ import { Resource } from "./resource";
 // Allocate a new resource. When this exists, we should not allow
 // the stack holding it to be `rm`'d without `--force`.
 let a = new Resource("res", { state: 1 });
+
+export let o = a.state;

--- a/tests/integration/single_resource/resource.ts
+++ b/tests/integration/single_resource/resource.ts
@@ -20,8 +20,11 @@ export class Provider implements pulumi.dynamic.ResourceProvider {
 }
 
 export class Resource extends pulumi.dynamic.Resource {
+    public readonly state?: any;
+
     constructor(name: string, props: ResourceProps, opts?: pulumi.ResourceOptions) {
         super(Provider.instance, name, props, opts);
+        this.state = props.state;
     }
 }
 


### PR DESCRIPTION
If --suppress-outputs is passed to `pulumi preview --json`, we
should not emit the stack outputs. This change fixes pulumi/pulumi#2765.

Also adds a test case for this plus some variants of updates.