### PR TITLE
Attempt to download plugins before doing a `refresh`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.17.14 (Unreleased)
 
+- `pulumi refresh` now tries to install any missing plugins automatically like
+  `pulumi destroy` and `pulumi update` do (fixes [pulumi/pulumi#2669](https://github.com/pulumi/pulumi/issues/2669)).
+
 ### Improvements
 
 ## 0.17.13 (Released May 21, 2019)

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/logging"
 	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
@@ -54,6 +55,19 @@ func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 
 func newRefreshSource(client deploy.BackendClient, opts planOptions, proj *workspace.Project, pwd, main string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool) (deploy.Source, error) {
+
+	// Like Update, we need to gather the set of plugins necessary to refresh everything in the snapshot.
+	// Unlike Update, we don't actually run the user's program so we only need the set of plugins described
+	// in the snapshot.
+	plugins, err := gatherPluginsFromSnapshot(plugctx, target)
+	if err != nil {
+		return nil, err
+	}
+
+	// Like Update, if we're missing plugins, attempt to download the missing plugins.
+	if err := ensurePluginsAreInstalled(client, plugins); err != nil {
+		logging.V(7).Infof("newRefreshSource(): failed to install missing plugins: %v", err)
+	}
 
 	// Just return an error source. Refresh doesn't use its source.
 	return deploy.NewErrorSource(proj.Name), nil


### PR DESCRIPTION
Like `preview`, `update` and `destroy` we should ensure any plugins
that are listed in the snapshot are present.

Fixes #2669