### PR TITLE
Revert "Simplify signature of `pulumi.all` (#2527)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,6 @@
   --outputs:--<{%reset%}>` instead of just `--outputs:--`.
 - Fixes local login on Windows.  Specifically, windows local paths are properly understood and
   backslashes `\` are not converted to `__5c__` in paths.
-- Signature of `Pulumi.all` has been made more accurate.  Calling `.all` on `Output`s that may
-  be `undefined` will properly encode and pass along that `undefined` information.
 - Fix an issue where some operations would fail with `error: could not deserialize deployment: unknown secrets provider type`.
 - Fix an issue where pulumi might try to replace existing resources when upgrading to the newest version of some resource providers.
 

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -409,11 +409,16 @@ function createSimpleOutput(val: any) {
  * In this example, taking a dependency on d3 means a resource will depend on all the resources of
  * d1 and d2.
  */
-// This overload is effectively the same as the next. However, it handles `tuples` properly, instead
-// of treating them as arrays.  Specifically, if you had `[Output<number>, Output<string>]` it would
-// give you `Output<[number, string]>` instead of `Output<(number | string)[]>`.
-export function all<T extends unknown[]>(xs: T | []): Output<UnwrappedObject<T>>;
-export function all<T extends object>(val: T): Output<UnwrappedObject<T>>;
+// tslint:disable:max-line-length
+export function all<T>(val: Record<string, Input<T>>): Output<Record<string, Unwrap<T>>>;
+export function all<T1, T2, T3, T4, T5, T6, T7, T8>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined, Input<T5> | undefined, Input<T6> | undefined, Input<T7> | undefined, Input<T8> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>, Unwrap<T7>, Unwrap<T8>]>;
+export function all<T1, T2, T3, T4, T5, T6, T7>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined, Input<T5> | undefined, Input<T6> | undefined, Input<T7> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>, Unwrap<T7>]>;
+export function all<T1, T2, T3, T4, T5, T6>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined, Input<T5> | undefined, Input<T6> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>, Unwrap<T6>]>;
+export function all<T1, T2, T3, T4, T5>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined, Input<T5> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>, Unwrap<T5>]>;
+export function all<T1, T2, T3, T4>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined, Input<T4> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>, Unwrap<T4>]>;
+export function all<T1, T2, T3>(values: [Input<T1> | undefined, Input<T2> | undefined, Input<T3> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>, Unwrap<T3>]>;
+export function all<T1, T2>(values: [Input<T1> | undefined, Input<T2> | undefined]): Output<[Unwrap<T1>, Unwrap<T2>]>;
+export function all<T>(ds: (Input<T> | undefined)[]): Output<Unwrap<T>[]>;
 export function all<T>(val: Input<T>[] | Record<string, Input<T>>): Output<any> {
     if (val instanceof Array) {
         const allOutputs = val.map(v => output(v));

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -15,7 +15,7 @@
         "semver": "^6.1.0",
         "source-map-support": "^0.4.16",
         "ts-node": "^7.0.0",
-        "typescript": "^3.4.1",
+        "typescript": "^3.0.0",
         "upath": "^1.1.0"
     },
     "devDependencies": {


### PR DESCRIPTION
This reverts commit b32892e0c1bf9d42795c5aa7b9475132337c2694.

This PR may have potentially caused issues downstream in EKS that were not caught through our other repos.  Rolling back for now until we can investigate and determine the root cause and how impactful this could be for customers.

Looks like pulumi-eks uses typescript 2.6.2, which very likely coudl not handle these more advanced typing scenarios (and it's fairly amazing it's been ok with all the other advanced stuff we do).  However, the gains of this nicer signature aren't sufficient to warrant breaking with that version, so rolling back is sensible now.  If we really need more modern TS features in the future we can decide if we want to force the min-version to the 3.x line.