### PR TITLE
Add StackReference to the Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Pulumi now allows Python programs to "read" existing resources instead of just creating them. This feature enables
   Pulumi Python packages to expose ".get()" methods that allow for reading of resources that already exist.
+- Support for referencing the outputs of other Pulumi stacks has been added to the Pulumi Python libraries via the
+  `StackReference` type.
 
 ## 0.17.14 (Released May 28, 2019)
 

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -73,3 +73,7 @@ from .log import (
     warn,
     error,
 )
+
+from .stack_reference import (
+    StackReference,
+)

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -1,0 +1,62 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from typing import Optional, Any
+from copy import deepcopy
+
+from .output import Output, Input
+from .resource import CustomResource, ResourceOptions
+
+
+class StackReference(CustomResource):
+    """
+    Manages a reference to a Pulumi stack. The referenced stack's outputs are available via its "outputs" property or
+    the "output" method.
+    """
+
+    name: Output[str]
+    """
+    The name of the referenced stack.
+    """
+
+    outputs: Output[dict]
+    """
+    The outputs of the referenced stack.
+    """
+
+    def __init__(self,
+        name: str,
+        stack_name: Optional[str] = None,
+        opts: Optional[ResourceOptions] = None) -> None:
+        """
+        :param str name: The unique name of the stack reference.
+        :param Optional[str] stack_name: The name of the stack to reference. If not provided, defaults to the name of
+               this resource.
+        :param Optional[ResourceOptions] opts: An optional set of resource options for this resource.
+        """
+
+        target_stack = stack_name if stack_name is not None else name
+        opts = deepcopy(opts) if opts is not None else ResourceOptions()
+        opts.id = target_stack
+        super().__init__("pulumi:pulumi:StackReference", name, {
+            "name": target_stack,
+            "outputs": None,
+        }, opts)
+
+    def get_output(name: Input[str]) -> Output[Any]:
+        """
+        Fetches the value of the named stack output.
+
+        :param Input[str] name: The name of the stack output to fetch.
+        """
+        return Output.all(Output.from_input(name), self.outputs).apply(lambda l: l[1][l[0]])

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -35,9 +35,9 @@ class StackReference(CustomResource):
     """
 
     def __init__(self,
-        name: str,
-        stack_name: Optional[str] = None,
-        opts: Optional[ResourceOptions] = None) -> None:
+                 name: str,
+                 stack_name: Optional[str] = None,
+                 opts: Optional[ResourceOptions] = None) -> None:
         """
         :param str name: The unique name of the stack reference.
         :param Optional[str] stack_name: The name of the stack to reference. If not provided, defaults to the name of
@@ -48,12 +48,13 @@ class StackReference(CustomResource):
         target_stack = stack_name if stack_name is not None else name
         opts = deepcopy(opts) if opts is not None else ResourceOptions()
         opts.id = target_stack
+
         super().__init__("pulumi:pulumi:StackReference", name, {
             "name": target_stack,
             "outputs": None,
         }, opts)
 
-    def get_output(name: Input[str]) -> Output[Any]:
+    def get_output(self, name: Input[str]) -> Output[Any]:
         """
         Fetches the value of the named stack output.
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -878,9 +878,9 @@ func TestGetCreated(t *testing.T) {
 	})
 }
 
-// Tests that stack references work.
-func TestStackReference(t *testing.T) {
-	if owner := os.Getenv("PULUMI_TEST_OWNER"); owner != "" {
+// Tests that stack references work in Node.
+func TestStackReferenceNodeJS(t *testing.T) {
+	if owner := os.Getenv("PULUMI_TEST_OWNER"); owner == "" {
 		t.Skipf("Skipping: PULUMI_TEST_OWNER is not set")
 	}
 
@@ -888,6 +888,24 @@ func TestStackReference(t *testing.T) {
 		Dir:          "stack_reference",
 		Dependencies: []string{"@pulumi/pulumi"},
 		Quick:        true,
+		Config: map[string]string{
+			"org": os.Getenv("PULUMI_TEST_OWNER"),
+		},
+	}
+	integration.ProgramTest(t, opts)
+}
+
+func TestStackReferencePython(t *testing.T) {
+	if owner := os.Getenv("PULUMI_TEST_OWNER"); owner == "" {
+		t.Skipf("Skipping: PULUMI_TEST_OWNER is not set")
+	}
+
+	opts := &integration.ProgramTestOptions{
+		Dir: filepath.Join("stack_reference", "python"),
+		Dependencies: []string{
+			filepath.Join("..", "..", "sdk", "python", "env", "src"),
+		},
+		Quick: true,
 		Config: map[string]string{
 			"org": os.Getenv("PULUMI_TEST_OWNER"),
 		},

--- a/tests/integration/stack_reference/python/Pulumi.yaml
+++ b/tests/integration/stack_reference/python/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: stack_reference_py
+description: A simple Python program that has a stack reference.
+runtime: python

--- a/tests/integration/stack_reference/python/__main__.py
+++ b/tests/integration/stack_reference/python/__main__.py
@@ -1,0 +1,19 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pulumi
+
+config = pulumi.Config();
+org = config.require('org');
+slug = f"{org}/{pulumi.get_project()}/{pulumi.get_stack()}"
+a = pulumi.StackReference(slug)


### PR DESCRIPTION
This commit adds StackReference to the Python SDK, which uses
read_resource to read the remote state of a a Pulumi stack.

Contributes to #2344.