### PR TITLE
Use new.{URN,Type,Provider} in applicable Steps.

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -73,6 +73,7 @@ func NewSameStep(plan *Plan, reg RegisterResourceEvent, old *resource.State, new
 	contract.Assert(new != nil)
 	contract.Assert(new.URN != "")
 	contract.Assert(new.ID == "")
+	contract.Assert(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type))
 	contract.Assert(!new.Delete)
 	return &SameStep{
 		plan: plan,
@@ -84,17 +85,16 @@ func NewSameStep(plan *Plan, reg RegisterResourceEvent, old *resource.State, new
 
 func (s *SameStep) Op() StepOp           { return OpSame }
 func (s *SameStep) Plan() *Plan          { return s.plan }
-func (s *SameStep) Type() tokens.Type    { return s.old.Type }
-func (s *SameStep) Provider() string     { return s.old.Provider }
-func (s *SameStep) URN() resource.URN    { return s.old.URN }
+func (s *SameStep) Type() tokens.Type    { return s.new.Type }
+func (s *SameStep) Provider() string     { return s.new.Provider }
+func (s *SameStep) URN() resource.URN    { return s.new.URN }
 func (s *SameStep) Old() *resource.State { return s.old }
 func (s *SameStep) New() *resource.State { return s.new }
 func (s *SameStep) Res() *resource.State { return s.new }
 func (s *SameStep) Logical() bool        { return true }
 
 func (s *SameStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error) {
-	// Retain the URN, ID, and outputs:
-	s.new.URN = s.old.URN
+	// Retain the ID, and outputs:
 	s.new.ID = s.old.ID
 	s.new.Outputs = s.old.Outputs
 	complete := func() { s.reg.Done(&RegisterResult{State: s.new, Stable: true}) }
@@ -363,6 +363,7 @@ func NewUpdateStep(plan *Plan, reg RegisterResourceEvent, old *resource.State,
 	contract.Assert(new != nil)
 	contract.Assert(new.URN != "")
 	contract.Assert(new.ID == "")
+	contract.Assert(!new.Custom || new.Provider != "" || providers.IsProviderType(new.Type))
 	contract.Assert(!new.Delete)
 	contract.Assert(old.Type == new.Type)
 	contract.Assert(!new.External)
@@ -379,9 +380,9 @@ func NewUpdateStep(plan *Plan, reg RegisterResourceEvent, old *resource.State,
 
 func (s *UpdateStep) Op() StepOp                    { return OpUpdate }
 func (s *UpdateStep) Plan() *Plan                   { return s.plan }
-func (s *UpdateStep) Type() tokens.Type             { return s.old.Type }
-func (s *UpdateStep) Provider() string              { return s.old.Provider }
-func (s *UpdateStep) URN() resource.URN             { return s.old.URN }
+func (s *UpdateStep) Type() tokens.Type             { return s.new.Type }
+func (s *UpdateStep) Provider() string              { return s.new.Provider }
+func (s *UpdateStep) URN() resource.URN             { return s.new.URN }
 func (s *UpdateStep) Old() *resource.State          { return s.old }
 func (s *UpdateStep) New() *resource.State          { return s.new }
 func (s *UpdateStep) Res() *resource.State          { return s.new }
@@ -389,8 +390,7 @@ func (s *UpdateStep) Logical() bool                 { return true }
 func (s *UpdateStep) Diffs() []resource.PropertyKey { return s.diffs }
 
 func (s *UpdateStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error) {
-	// Always propagate the URN and ID, even in previews and refreshes.
-	s.new.URN = s.old.URN
+	// Always propagate the ID, even in previews and refreshes.
 	s.new.ID = s.old.ID
 
 	var resourceError error
@@ -467,9 +467,9 @@ func NewReplaceStep(plan *Plan, old *resource.State, new *resource.State,
 
 func (s *ReplaceStep) Op() StepOp                    { return OpReplace }
 func (s *ReplaceStep) Plan() *Plan                   { return s.plan }
-func (s *ReplaceStep) Type() tokens.Type             { return s.old.Type }
-func (s *ReplaceStep) Provider() string              { return s.old.Provider }
-func (s *ReplaceStep) URN() resource.URN             { return s.old.URN }
+func (s *ReplaceStep) Type() tokens.Type             { return s.new.Type }
+func (s *ReplaceStep) Provider() string              { return s.new.Provider }
+func (s *ReplaceStep) URN() resource.URN             { return s.new.URN }
 func (s *ReplaceStep) Old() *resource.State          { return s.old }
 func (s *ReplaceStep) New() *resource.State          { return s.new }
 func (s *ReplaceStep) Res() *resource.State          { return s.new }


### PR DESCRIPTION
Just what it says on the tin. These changes are in support of the
aliasing work in #2774.