### PR TITLE
Set `Outputs` for providers in the state file.

### DIFF
--- a/pkg/resource/deploy/providers/registry.go
+++ b/pkg/resource/deploy/providers/registry.go
@@ -218,7 +218,7 @@ func (r *Registry) Check(urn resource.URN, olds, news resource.PropertyMap,
 	contract.Require(IsProviderType(urn.Type()), "urn")
 
 	label := fmt.Sprintf("%s.Check(%s)", r.label(), urn)
-	logging.V(7).Infof("%s executing (#olds=%d,#news=%d", label, len(olds), len(news))
+	logging.V(7).Infof("%s executing (#olds=%d,#news=%d)", label, len(olds), len(news))
 
 	// Parse the version from the provider properties and load the provider.
 	version, err := GetProviderVersion(news)
@@ -261,7 +261,6 @@ func (r *Registry) Check(urn resource.URN, olds, news resource.PropertyMap,
 // previously been loaded by a call to Check.
 func (r *Registry) Diff(urn resource.URN, id resource.ID, olds, news resource.PropertyMap,
 	allowUnknowns bool) (plugin.DiffResult, error) {
-
 	contract.Require(id != "", "id")
 
 	label := fmt.Sprintf("%s.Diff(%s,%s)", r.label(), urn, id)
@@ -328,7 +327,7 @@ func (r *Registry) Create(urn resource.URN,
 	contract.Assert(id != UnknownID)
 
 	r.setProvider(mustNewReference(urn, id), provider)
-	return id, resource.PropertyMap{}, resource.StatusOK, nil
+	return id, news, resource.StatusOK, nil
 }
 
 // Update configures the provider with the given URN and ID using the indicated configuration and registers it at the
@@ -353,7 +352,7 @@ func (r *Registry) Update(urn resource.URN, id resource.ID, olds,
 
 	// Publish the configured provider.
 	r.setProvider(mustNewReference(urn, id), provider)
-	return resource.PropertyMap{}, resource.StatusOK, nil
+	return news, resource.StatusOK, nil
 }
 
 // Delete unregisters and unloads the provider with the given URN and ID. The provider must have been loaded when the


### PR DESCRIPTION
We model providers as resources in our state file, but we were
neglecting to set Outputs for these resources.  This was problematic
when we started to try to run DiffConfig, because when diffing a
resource we compare thed new inputs and the old outputs, but the
resource never had any old outputs, so it was impossible for the
provider to see what the old state of the resource was.

To fix this, we now reflect the inputs we use the create the provider
reference as outputs on the resource.