### PR TITLE
Fix crash in `pulumi stack output` when stack is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
   logging in to the s3 backend with a path after the bucket name, you will need to either move the .pulumi
   folder in the bucket to the correct location or log in again without the path prefix to see your previous
   stacks.
-
+- Fix a crash that would happen if you ran `pulumi stack output` against an empty stack (fixes
+  [pulumi/pulumi#2792](https://github.com/pulumi/pulumi/issues/2792)).
 
 ## 0.17.16 (Released June 6, 2019)
 

--- a/cmd/stack_output.go
+++ b/cmd/stack_output.go
@@ -105,6 +105,10 @@ func getStackOutputs(snap *deploy.Snapshot, showSecrets bool) (map[string]interf
 		return nil, err
 	}
 
+	if state == nil {
+		return map[string]interface{}{}, nil
+	}
+
 	// massageSecrets will remove all the secrets from the property map, so it should be safe to pass a panic
 	// crypter. This also ensure that if for some reason we didn't remove everything, we don't accidentally disclose
 	// secret values!


### PR DESCRIPTION
Fixes #2792 