### PR TITLE
Check for provider changes in mustWrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Improvements
 
+- Fixed a bug that caused an assertion when dealing with unchanged resources across version upgrades.
+
 ## 0.17.15 (Released June 5, 2019)
 
 ### Improvements

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -189,7 +189,12 @@ func (ssm *sameSnapshotMutation) mustWrite(old, new *resource.State) bool {
 	}
 
 	contract.Assert(old.ID == new.ID)
-	contract.Assert(old.Provider == new.Provider)
+
+	// If this resource's provider has changed, we must write the checkpoint. This can happen in scenarios involving
+	// aliased providers or upgrades to default providers.
+	if old.Provider != new.Provider {
+		return true
+	}
 
 	// If this resource's parent has changed, we must write the checkpoint.
 	if old.Parent != new.Parent {

--- a/pkg/backend/snapshot_test.go
+++ b/pkg/backend/snapshot_test.go
@@ -261,7 +261,8 @@ func TestSamesWithOtherMeaningfulChanges(t *testing.T) {
 	provider2 := NewResource("urn:pulumi:foo::bar::pulumi:providers:pkgA::provider2")
 	provider2.Custom, provider2.Type, provider2.ID = true, "pulumi:providers:pkgA", "id2"
 
-	resourceA.Custom, resourceA.ID, resourceA.Provider = true, "id", "urn:pulumi:foo::bar::pulumi:providers:pkgA::provider::id"
+	resourceA.Custom, resourceA.ID, resourceA.Provider =
+		true, "id", "urn:pulumi:foo::bar::pulumi:providers:pkgA::provider::id"
 
 	snap = NewSnapshot([]*resource.State{
 		provider,


### PR DESCRIPTION
Recent changes to default provider semantics and the addition of
resource aliases allow a resource's provider reference to change even if
the resource itself is considered to have no diffs. `mustWrite` did not
expect this scenario, and indeed asserted against it. These changes
update `mustWrite` to detect such changes and require that the
checkpoint be written if and when they occur.

Fixes #2804.