### PR TITLE
Backend setting in project config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.17.18 (Unreleased)
 
+- Allow setting backend URL explicitly in `Pulumi.yaml` file
 
 ## 0.17.17 (Released June 12, 2019)
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/filestate"
 	"github.com/pulumi/pulumi/pkg/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/workspace"
 )
 
 func newLoginCmd() *cobra.Command {
@@ -107,6 +108,14 @@ func newLoginCmd() *cobra.Command {
 			// what the gocloud blob system requires.
 			if strings.HasPrefix(cloudURL, filestate.FilePathPrefix) && os.PathSeparator != '/' {
 				cloudURL = filepath.ToSlash(cloudURL)
+			}
+
+			if cloudURL == "" {
+				var err error
+				cloudURL, err = workspace.GetCurrentCloudURL()
+				if err != nil {
+					return errors.Wrap(err, "could not determine current cloud")
+				}
 			}
 
 			var be backend.Backend

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -58,12 +58,11 @@ func newLogoutCmd() *cobra.Command {
 			}
 
 			if cloudURL == "" {
-				creds, err := workspace.GetStoredCredentials()
+				var err error
+				cloudURL, err = workspace.GetCurrentCloudURL()
 				if err != nil {
 					return errors.Wrap(err, "could not determine current cloud")
 				}
-
-				cloudURL = creds.Current
 			}
 
 			var be backend.Backend

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -56,14 +56,15 @@ func hasDebugCommands() bool {
 }
 
 func currentBackend(opts display.Options) (backend.Backend, error) {
-	creds, err := workspace.GetStoredCredentials()
+	url, err := workspace.GetCurrentCloudURL()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "could not get cloud url")
 	}
-	if filestate.IsFileStateBackendURL(creds.Current) {
-		return filestate.New(cmdutil.Diag(), creds.Current)
+
+	if filestate.IsFileStateBackendURL(url) {
+		return filestate.New(cmdutil.Diag(), url)
 	}
-	return httpstate.Login(commandContext(), cmdutil.Diag(), creds.Current, opts)
+	return httpstate.Login(commandContext(), cmdutil.Diag(), url, opts)
 }
 
 // This is used to control the contents of the tracing header.

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -106,12 +106,27 @@ func getCredsFilePath() (string, error) {
 // GetCurrentCloudURL returns the URL of the cloud we are currently connected to. This may be empty if we
 // have not logged in.
 func GetCurrentCloudURL() (string, error) {
-	creds, err := GetStoredCredentials()
-	if err != nil {
-		return "", err
+	var url string
+	// Try detecting backend from config
+	projPath, err := DetectProjectPath()
+	if err == nil && projPath != "" {
+		proj, err := LoadProject(projPath)
+		if err != nil {
+			return "", errors.Wrap(err, "could not load current project")
+		}
+
+		url = proj.Backend.URL
 	}
 
-	return creds.Current, nil
+	if url == "" {
+		creds, err := GetStoredCredentials()
+		if err != nil {
+			return "", err
+		}
+		url = creds.Current
+	}
+
+	return url, nil
 }
 
 // GetStoredCredentials returns any credentials stored on the local machine.

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -115,7 +115,9 @@ func GetCurrentCloudURL() (string, error) {
 			return "", errors.Wrap(err, "could not load current project")
 		}
 
-		url = proj.Backend.URL
+		if proj.Backend != nil {
+			url = proj.Backend.URL
+		}
 	}
 
 	if url == "" {

--- a/pkg/workspace/project.go
+++ b/pkg/workspace/project.go
@@ -52,6 +52,12 @@ type ProjectTemplateConfigValue struct {
 	Secret bool `json:"secret,omitempty" yaml:"secret,omitempty"`
 }
 
+// ProjectBackend is a configuration for backend used by project
+type ProjectBackend struct {
+	// URL is optional field to explicitly set backend url
+	URL string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
 // Project is a Pulumi project manifest.
 //
 // We explicitly add yaml tags (instead of using the default behavior from https://github.com/ghodss/yaml which works
@@ -84,6 +90,9 @@ type Project struct {
 
 	// Template is an optional template manifest, if this project is a template.
 	Template *ProjectTemplate `json:"template,omitempty" yaml:"template,omitempty"`
+
+	// Backend is an optional backend configuration
+	Backend *ProjectBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
 }
 
 func (proj *Project) Validate() error {


### PR DESCRIPTION
This change will allow setting backend configuration explicitly in `Pulumi.yaml`, like:
```
backend: https://pulumi.acmecorp.com
```
or
```
backend: s3://some-bucket
```

And it will allow avoiding confusion in scenarios like switching pulumi backends for different installation in different open terminals.