### PR TITLE
Store information about a CustomResource's provider in __providers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   stacks.
 - Fix a crash that would happen if you ran `pulumi stack output` against an empty stack (fixes
   [pulumi/pulumi#2792](https://github.com/pulumi/pulumi/issues/2792)).
+- Unparented Pulumi `CustomResource`s now support calling `.getProvider(...)` on them.
 
 ## 0.17.16 (Released June 6, 2019)
 

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -226,24 +226,27 @@ export abstract class Resource {
             }
 
             this.__providers = opts.parent.__providers;
+        }
 
-            if (custom) {
-                const provider = (<CustomResourceOptions>opts).provider;
-                if (provider === undefined) {
+        if (custom) {
+            const provider = (<CustomResourceOptions>opts).provider;
+            if (provider === undefined) {
+                if (opts.parent) {
+                    // If no provider was given, but we have a parent, then inherit the
+                    // provider from our parent.
                     (<CustomResourceOptions>opts).provider = opts.parent.getProvider(t);
-                } else {
-                    // If a provider was specified, add it to the providers map under this type's package so that
-                    // any children of this resource inherit its provider.
-                    const typeComponents = t.split(":");
-                    if (typeComponents.length === 3) {
-                        const pkg = typeComponents[0];
-                        this.__providers = { ...this.__providers, [pkg]: provider };
-                    }
+                }
+            } else {
+                // If a provider was specified, add it to the providers map under this type's package so that
+                // any children of this resource inherit its provider.
+                const typeComponents = t.split(":");
+                if (typeComponents.length === 3) {
+                    const pkg = typeComponents[0];
+                    this.__providers = { ...this.__providers, [pkg]: provider };
                 }
             }
         }
-
-        if (!custom) {
+        else {
             // Note: we checked above that at most one of opts.provider or opts.providers is set.
 
             // If opts.provider is set, treat that as if we were given a array of provider with that

--- a/sdk/nodejs/tests/runtime/langhost/cases/017.parent_defaults/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/017.parent_defaults/index.js
@@ -38,7 +38,9 @@ function createResources(name, createChildren, parent) {
 	new Resource(`${name}/r2`, createChildren, { parent: parent, protect: true });
 
 	// Override provider
-	new Resource(`${name}/r3`, createChildren, { parent: parent, provider: new Provider(`${name}-p`, { parent: parent }) });
+	const provider = new Provider(`${name}-p`, { parent });
+	const r3 = new Resource(`${name}/r3`, createChildren, { parent, provider });
+	assert.equal(r3.getProvider("test:index:Resource"), provider);
 }
 
 function createComponents(name, createChildren, parent) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/041.component_opt_single_provider/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/041.component_opt_single_provider/index.js
@@ -38,7 +38,9 @@ function createResources(name, createChildren, parent) {
 	new Resource(`${name}/r2`, createChildren, { parent: parent, protect: true });
 
 	// Override provider
-	new Resource(`${name}/r3`, createChildren, { parent: parent, provider: new Provider(`${name}-p`, { parent: parent }) });
+	const provider = new Provider(`${name}-p`, { parent });
+	const r3 = new Resource(`${name}/r3`, createChildren, { parent, provider });
+	assert.equal(r3.getProvider("test:index:Resource"), provider);
 }
 
 function createComponents(name, createChildren, parent) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/042.component_opt_providers_array/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/042.component_opt_providers_array/index.js
@@ -38,7 +38,9 @@ function createResources(name, createChildren, parent) {
 	new Resource(`${name}/r2`, createChildren, { parent: parent, protect: true });
 
 	// Override provider
-	new Resource(`${name}/r3`, createChildren, { parent: parent, provider: new Provider(`${name}-p`, { parent: parent }) });
+	const provider = new Provider(`${name}-p`, { parent });
+	const r3 = new Resource(`${name}/r3`, createChildren, { parent, provider });
+	assert.equal(r3.getProvider("test:index:Resource"), provider);
 }
 
 function createComponents(name, createChildren, parent) {

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -189,19 +189,22 @@ class Resource:
 
             # Infer providers and provider maps from parent, if one was provided.
             self._providers = opts.parent._providers
-            if custom:
-                provider = opts.provider
-                if provider is None:
-                    opts.provider = opts.parent.get_provider(t)
-                else:
-                    # If a provider was specified, add it to the providers map under this type's package so that
-                    # any children of this resource inherit its provider.
-                    type_components = t.split(":")
-                    if len(type_components) == 3:
-                        [pkg, _, _] = type_components
-                        self._providers = {**self._providers, pkg: provider}
 
-        if not custom:
+        if custom:
+            provider = opts.provider
+            if provider is None:
+                if not opts.parent is None:
+                    # If no provider was given, but we have a parent, then inherit the
+                    # provider from our parent.
+                    opts.provider = opts.parent.get_provider(t)
+            else:
+                # If a provider was specified, add it to the providers map under this type's package so that
+                # any children of this resource inherit its provider.
+                type_components = t.split(":")
+                if len(type_components) == 3:
+                    [pkg, _, _] = type_components
+                    self._providers = {**self._providers, pkg: provider}
+        else:
             providers = self._convert_providers(opts.provider, opts.providers)
             self._providers = {**self._providers, **providers}
 

--- a/sdk/python/lib/test/langhost/first_class_provider/__main__.py
+++ b/sdk/python/lib/test/langhost/first_class_provider/__main__.py
@@ -27,3 +27,5 @@ prov = Provider("testprov")
 
 # Use this Provider to create a resource.
 res = Resource("testres", ResourceOptions(provider=prov))
+
+assert prov == res.get_provider("test:index:Resource")


### PR DESCRIPTION
Should be reviewed with whitespace diffing off