### PR TITLE
Use `PULUMI_TEST_MODE` to control test mode in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 ## 0.17.18 (Unreleased)
 
 - Allow setting backend URL explicitly in `Pulumi.yaml` file
-
 - `StackReference` now has a `.getOutputSync` function to retrieve exported values from an existing
   stack synchronously.  This can be valuable when creating another stack that wants to base
   flow-control off of the values of an existing stack (i.e. importing the information about all AZs
   and basing logic off of that in a new stack). Note: this only works for importing values from
   Stacks that have not exported `secrets`.
+- When the environment variaible `PULUMI_TEST_MODE` is set to `true`, the
+  Python runtime will now behave as if
+  `pulumi.runtime.settings._set_test_mode_enabled(True)` had been called. This
+  mirrors the behavior for NodeJS programs (fixes [#2818](https://github.com/pulumi/pulumi/issues/2818)). 
 
 ## 0.17.17 (Released June 12, 2019)
 

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -16,6 +16,7 @@
 Runtime settings and configuration.
 """
 import asyncio
+import os
 import sys
 from typing import Optional, Awaitable, TYPE_CHECKING
 
@@ -54,6 +55,9 @@ class Settings:
         self.dry_run = dry_run
         self.test_mode_enabled = test_mode_enabled
 
+        if self.test_mode_enabled is None:
+            self.test_mode_enabled = os.getenv("PULUMI_TEST_MODE", "false") == "true"
+
         # Actually connect to the monitor/engine over gRPC.
         if monitor:
             self.monitor = resource_pb2_grpc.ResourceMonitorStub(grpc.insecure_channel(monitor))
@@ -63,7 +67,6 @@ class Settings:
             self.engine = engine_pb2_grpc.EngineStub(grpc.insecure_channel(engine))
         else:
             self.engine = None
-
 
 # default to "empty" settings.
 SETTINGS = Settings()


### PR DESCRIPTION
This mirrors the UX that we have in node where you can set
`PULUMI_TEST_MODE` to control if test mode is enabled from outside
your program.

Fixes #2818