### PR TITLE
Update supported versions list

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Please head on over to [the project website](https://pulumi.io) for much more in
 
 |    | Language | Status | Runtime |
 | -- | -------- | ------ | ------- |
-| <img src="https://www.pulumi.com/assets/logos/tech/logo-js.png" height=38 /> | [JavaScript](./sdk/nodejs) | Stable | Node.js 6.x-10.x |
-| <img src="https://www.pulumi.com/assets/logos/tech/logo-ts.png" height=38 /> | [TypeScript](./sdk/nodejs) | Stable | Node.js 6.x-10.x |
-| <img src="https://www.pulumi.com/assets/logos/tech/logo-python.png" height=38 /> | [Python](./sdk/python) | Preview | Python 3.6 |
+| <img src="https://www.pulumi.com/assets/logos/tech/logo-js.png" height=38 /> | [JavaScript](./sdk/nodejs) | Stable | Node.js 8+ |
+| <img src="https://www.pulumi.com/assets/logos/tech/logo-ts.png" height=38 /> | [TypeScript](./sdk/nodejs) | Stable | Node.js 8+ |
+| <img src="https://www.pulumi.com/assets/logos/tech/logo-python.png" height=38 /> | [Python](./sdk/python) | Preview | Python 3.6+ |
 | <img src="https://www.pulumi.com/assets/logos/tech/logo-golang.png" height=38 /> | [Go](./sdk/go) | Preview | Go 1.x |
 
 ### Clouds

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -38,7 +38,7 @@
     "pulumi": {
         "comment": "Do not remove. Marks this as as a deployment-time-only package"
     },
-    "resolutions": {
-        "grpc/node-pre-gyp": "^0.11.0"
+    "engines": {
+        "node": ">=8.0.0"
     }
 }


### PR DESCRIPTION
We no longer support Node 6.X (it went end of life at the end of
April, we stopped testing on it, and now we use features that are not
in Node 6 like `Object.values`.

Note that we support 8+, and add an `engines` section to our
package.json so folks who try to install on older versions of node see
warnings.