### PR TITLE
add go to brew install for contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ To hack on Pulumi, you'll need to get a development environment set up. You'll w
 You can easily get all required dependencies with brew
 
 ```bash
-brew install node pipenv python@3 typescript yarn pandoc
+brew install node pipenv python@3 typescript yarn pandoc go
 ```
 
 ## Make build system


### PR DESCRIPTION
golang is required, but isn't called out in the brew install in the CONTRIBUTING.

```
pulumi(master)%% make ensure
/bin/bash: go: command not found
/bin/bash: go: command not found
...
```

updated.