### PR TITLE
Make private field internal

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -498,6 +498,9 @@ export abstract class CustomResource extends Resource {
  * managed similarly to other resources, including the usual diffing and update semantics.
  */
 export abstract class ProviderResource extends CustomResource {
+    /** @internal */
+    private readonly pkg: string;
+
     /**
      * Creates and registers a new provider resource for a particular package.
      *
@@ -506,8 +509,9 @@ export abstract class ProviderResource extends CustomResource {
      * @param props The configuration to use for this provider.
      * @param opts A bag of options that control this provider's behavior.
      */
-    constructor(private readonly pkg: string, name: string, props?: Inputs, opts: ResourceOptions = {}) {
+    constructor(pkg: string, name: string, props?: Inputs, opts: ResourceOptions = {}) {
         super(`pulumi:providers:${pkg}`, name, props, opts);
+        this.pkg = pkg;
     }
 
     /** @internal */


### PR DESCRIPTION
This private field makes TS think that different `ProviderResource` resources are not compatible if they are defined in differen SxS loaded `@pulumi/pulumi` packages.  By making it `internal` it will be stripped from the `.d.ts` and TS will be ok with the types.