### PR TITLE
add golangci-lint to brew install in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ To hack on Pulumi, you'll need to get a development environment set up. You'll w
 You can easily get all required dependencies with brew
 
 ```bash
-brew install node pipenv python@3 typescript yarn pandoc go
+brew install node pipenv python@3 typescript yarn pandoc go golangci/tap/golangci-lint
 ```
 
 ## Make build system


### PR DESCRIPTION

`make` (not `make ensure`...) errors without this installed:

```LINT:
golangci-lint run
/bin/bash: golangci-lint: command not found
```

so add `golangci/tap/golangci-lint` to the brew install
