### PR TITLE
Reads should not cause resources to be displayed in our progress display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,22 @@
 ## 0.17.18 (Unreleased)
 
 - Allow setting backend URL explicitly in `Pulumi.yaml` file
+
 - `StackReference` now has a `.getOutputSync` function to retrieve exported values from an existing
   stack synchronously.  This can be valuable when creating another stack that wants to base
   flow-control off of the values of an existing stack (i.e. importing the information about all AZs
   and basing logic off of that in a new stack). Note: this only works for importing values from
   Stacks that have not exported `secrets`.
+
 - When the environment variaible `PULUMI_TEST_MODE` is set to `true`, the
   Python runtime will now behave as if
   `pulumi.runtime.settings._set_test_mode_enabled(True)` had been called. This
-  mirrors the behavior for NodeJS programs (fixes [#2818](https://github.com/pulumi/pulumi/issues/2818)). 
+  mirrors the behavior for NodeJS programs (fixes [#2818](https://github.com/pulumi/pulumi/issues/2818)).
+
+- Resources that are only 'read' will no longer be displayed in the terminal tree-display anymore.
+  These ended up heavily cluttering the display and often meant that programs without updates still
+  showed a bunch of resources that weren't important.  There will still be a message displayed
+  indicating that a 'read' has happened to help know that these are going on and that the program is making progress.
 
 ## 0.17.17 (Released June 12, 2019)
 

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -153,7 +153,14 @@ func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayl
 
 	// Now summarize all of the changes; we print sames a little differently.
 	for _, op := range deploy.StepOps {
-		if op != deploy.OpSame {
+		// Ignore anything that didn't change, or is related to 'reads'.  'reads' are just an
+		// indication of the operations we were performing, and are not indicative of any sort of
+		// change to the system.
+		if op != deploy.OpSame &&
+			op != deploy.OpRead &&
+			op != deploy.OpReadDiscard &&
+			op != deploy.OpReadReplacement {
+
 			if c := changes[op]; c > 0 {
 				opDescription := string(op)
 				if !event.IsPreview {

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -879,6 +879,32 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 
 	// At this point, all events should relate to resources.
 	eventUrn, metadata := getEventUrnAndMetadata(event)
+	if metadata != nil {
+		if metadata.Op == deploy.OpReadDiscard || metadata.Op == deploy.OpReadReplacement {
+			// just flat out ignore read discards/replace.  They're only relevant in the context of
+			// 'reads', and we filter out all reads from the display anyways.
+			return
+		}
+
+		if metadata.Op == deploy.OpRead {
+			// Don't show reads as operations on a specific resource.  It's an underlying detail
+			// that we don't want to clutter up the display with.  However, to help users know
+			// what's going on, we can show them as ephemeral diagnostic messages that are
+			// associated at the top level with the stack.  That way if things are taking a while,
+			// there's insight in the display as to what's going on.
+			display.processNormalEvent(engine.Event{
+				Type: engine.DiagEvent,
+				Payload: engine.DiagEventPayload{
+					Ephemeral: true,
+					Severity:  diag.Info,
+					Color:     cmdutil.GetGlobalColorization(),
+					Message:   fmt.Sprintf("Reading %v %v", simplifyTypeName(eventUrn.Type()), eventUrn.Name()),
+				},
+			})
+			return
+		}
+	}
+
 	if eventUrn == "" {
 		// If this event has no URN, associate it with the stack. Note that there may not yet be a stack resource, in
 		// which case this is a no-op.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -882,7 +882,7 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 	if metadata != nil {
 		if metadata.Op == deploy.OpReadDiscard || metadata.Op == deploy.OpReadReplacement {
 			// just flat out ignore read discards/replace.  They're only relevant in the context of
-			// 'reads', and we filter out all reads from the display anyways.
+			// 'reads', and we only present reads as an ephemeral diagnostic anyways.
 			return
 		}
 

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -898,7 +898,7 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 					Ephemeral: true,
 					Severity:  diag.Info,
 					Color:     cmdutil.GetGlobalColorization(),
-					Message:   fmt.Sprintf("Reading %v %v", simplifyTypeName(eventUrn.Type()), eventUrn.Name()),
+					Message:   fmt.Sprintf("read %v %v", simplifyTypeName(eventUrn.Type()), eventUrn.Name()),
 				},
 			})
 			return

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -282,6 +282,13 @@ func (data *resourceRowData) IsDone() bool {
 		return true
 	}
 
+	if isRootStack(data.step) {
+		// the root stack only becomes 'done' once the program has completed (i.e. the condition
+		// checked just above this).  If the program is not finished, then always show the root
+		// stack as not done so the user sees "running..." presented for it.
+		return false
+	}
+
 	// We're done if we have the output-step for whatever step operation we're performing
 	return data.ContainsOutputsStep(data.step.Op)
 }


### PR DESCRIPTION
'Reads' are often just an internal step that's being performed (like an 'invoke').  As such, while we want to let users know what's going on, we don't want to clutter up the display by showing the user the read of something that hasn't actually changed.  This PR changes things so that at the CLI display level we filter out these messages.  

With the change, the experience now looks like this:

![image](https://user-images.githubusercontent.com/4564579/59720311-5d3e4600-91d3-11e9-8517-c29f6e72373a.png)

Note: i'm open to different impls here.  For example, i think it's arguable that this might potentially make sense to be done at the engine level.  i.e. have the engine just report these as ephemeral messages, but not as steps to an actual resource (at least for display purposes). 

Also, i'm open to not even having the stack-level message about the reads that are ongoing.  However, i think it's somewhat nice to have the information as it does help give an idea about what's going on.   Note that these messages are 'ephemeral', so they won't be printed at the end of the update.