### PR TITLE
Fix up some spelling errors

### DIFF
--- a/pkg/resource/plugin/provider_plugin_test.go
+++ b/pkg/resource/plugin/provider_plugin_test.go
@@ -103,7 +103,7 @@ func TestAnnotateSecretsDifferentProperties(t *testing.T) {
 			continue
 		}
 
-		assert.Truef(t, reflect.DeepEqual(fromVal, val), "expected properites %s to be deeply equal", key)
+		assert.Truef(t, reflect.DeepEqual(fromVal, val), "expected properties %s to be deeply equal", key)
 	}
 
 	_, has := to["extraFromValue"]

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	args := flag.Args()
 	logging.InitLogging(false, 0, false)
-	cmdutil.InitTracing("pulumi-language-nodejs", "pulumi-langauge-nodejs", tracing)
+	cmdutil.InitTracing("pulumi-language-nodejs", "pulumi-language-nodejs", tracing)
 
 	nodePath, err := exec.LookPath("node")
 	if err != nil {

--- a/sdk/proto/generate.sh
+++ b/sdk/proto/generate.sh
@@ -7,7 +7,7 @@
 # hence error prone.
 #
 # This script relies only on Docker. The container holds the installation of gRPC, tools, etc., for
-# different langauges, so nothing is else required to be installed on your machine.
+# different languages, so nothing is else required to be installed on your machine.
 set -e
 
 # First build our Protobuf/gRPC compiler Docker image, so dev machines don't need it.

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -223,7 +223,7 @@ func TestRemoveWithResourcesBlocked(t *testing.T) {
 	}()
 
 	stackName, err := resource.NewUniqueHex("rm-test-", 8, -1)
-	contract.AssertNoErrorf(err, "resource.NewUniqueHex sould not fail with no maximum length is set")
+	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 
 	e.ImportDirectory("single_resource")
 	e.RunCommand("pulumi", "stack", "init", stackName)
@@ -265,7 +265,7 @@ func TestPreviewJSON(t *testing.T) {
 	}
 
 	stackName, err := resource.NewUniqueHex("rm-test-", 8, -1)
-	contract.AssertNoErrorf(err, "resource.NewUniqueHex sould not fail with no maximum length is set")
+	contract.AssertNoErrorf(err, "resource.NewUniqueHex should not fail with no maximum length is set")
 
 	e.ImportDirectory("single_resource")
 	e.RunCommand("pulumi", "stack", "init", stackName)


### PR DESCRIPTION
@keen99 pointed out that newer versions of golangci-lint were failing
due to some spelling errors. This change fixes them up.  We have also
now have a work item to track moving to a newer golangci-lint tool in
the future.

Fixes #2841