### PR TITLE
add .venv/ to python .gitignore to ignore 

### DIFF
--- a/sdk/python/.gitignore
+++ b/sdk/python/.gitignore
@@ -3,3 +3,4 @@
 *.pyc
 /env/
 /*.egg-info
+.venv/


### PR DESCRIPTION
add .venv/ to python .gitignore to ignore  when using PIPENV_VENV_IN_PROJECT=1 - solves #2843 