### PR TITLE
Add EngineEventsBatch type

### DIFF
--- a/pkg/apitype/events.go
+++ b/pkg/apitype/events.go
@@ -173,3 +173,8 @@ type EngineEvent struct {
 	ResOpFailedEvent *ResOpFailedEvent  `json:"resOpFailedEvent,omitempty"`
 	PolicyEvent      *PolicyEvent       `json:"policyEvent,omitempty"`
 }
+
+// EngineEventBatch is a group of engine events.
+type EngineEventBatch struct {
+	Events []EngineEvent `json:"events"`
+}


### PR DESCRIPTION
Add a new `apitype.EngineEventsBatch` type, which is just a collection of individual engine events.

This will allow us to update the Service to accept batches of engine events at a time, which will allow us to improve the performance of updates with many engine events.

Part of #2856