### PR TITLE
Persist engine events in batches

### DIFF
--- a/pkg/apitype/events.go
+++ b/pkg/apitype/events.go
@@ -173,3 +173,8 @@ type EngineEvent struct {
 	ResOpFailedEvent *ResOpFailedEvent  `json:"resOpFailedEvent,omitempty"`
 	PolicyEvent      *PolicyEvent       `json:"policyEvent,omitempty"`
 }
+
+// EngineEventBatch is a group of engine events.
+type EngineEventBatch struct {
+	Events []EngineEvent `json:"events"`
+}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -504,16 +504,16 @@ func (pc *Client) CompleteUpdate(ctx context.Context, update UpdateIdentifier, s
 		updateAccessToken(token), httpCallOptions{RetryAllMethods: true})
 }
 
-// RecordEngineEvent posts an engine event to the Pulumi service.
-func (pc *Client) RecordEngineEvent(
-	ctx context.Context, update UpdateIdentifier, event apitype.EngineEvent, token string) error {
+// RecordEngineEvents posts a batch of engine events to the Pulumi service.
+func (pc *Client) RecordEngineEvents(
+	ctx context.Context, update UpdateIdentifier, batch apitype.EngineEventBatch, token string) error {
 	callOpts := httpCallOptions{
 		GzipCompress:    true,
 		RetryAllMethods: true,
 	}
 	return pc.updateRESTCall(
-		ctx, "POST", getUpdatePath(update, "events"),
-		nil, event, nil,
+		ctx, "POST", getUpdatePath(update, "event-batch"),
+		nil, batch, nil,
 		updateAccessToken(token), callOpts)
 }
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -512,7 +512,7 @@ func (pc *Client) RecordEngineEvents(
 		RetryAllMethods: true,
 	}
 	return pc.updateRESTCall(
-		ctx, "POST", getUpdatePath(update, "event-batch"),
+		ctx, "POST", getUpdatePath(update, "events/batch"),
 		nil, batch, nil,
 		updateAccessToken(token), callOpts)
 }

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -193,7 +193,7 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	// We take the channel of engine events and pass them to separate components that will display
 	// them to the console or persist them on the Pulumi Service. Both should terminate as soon as
 	// they see a CancelEvent, and when finished, close the "done" channel.
-	displayEvents := make(chan engine.Event, 100)
+	displayEvents := make(chan engine.Event) // Note: unbuffered, but we assume it won't matter in practice.
 	displayEventsDone := make(chan bool)
 
 	persistEvents := make(chan engine.Event, 100)

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -153,6 +153,9 @@ type ProgramTestOptions struct {
 	ExpectRefreshChanges bool
 	// SkipRefresh indicates that the refresh step should be skipped entirely.
 	SkipRefresh bool
+	// SkipStackRemoval indicates that the stack should not be removed. (And so the test's results could be inspected
+	// in the Pulumi Service after the test has completed.)
+	SkipStackRemoval bool
 	// Quick can be set to true to run a "quick" test that skips any non-essential steps (e.g., empty updates).
 	Quick bool
 	// PreviewCommandlineFlags specifies flags to add to the `pulumi preview` command line (e.g. "--color=raw")
@@ -330,6 +333,9 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 	}
 	if overrides.SkipRefresh {
 		opts.SkipRefresh = overrides.SkipRefresh
+	}
+	if overrides.SkipStackRemoval {
+		opts.SkipStackRemoval = overrides.SkipStackRemoval
 	}
 	if overrides.AllowEmptyPreviewChanges {
 		opts.AllowEmptyPreviewChanges = overrides.AllowEmptyPreviewChanges
@@ -832,7 +838,10 @@ func (pt *programTester) testLifeCycleDestroy(dir string) error {
 		return nil
 	}
 
-	return pt.runPulumiCommand("pulumi-stack-rm", []string{"stack", "rm", "--yes"}, dir)
+	if !pt.opts.SkipStackRemoval {
+		return pt.runPulumiCommand("pulumi-stack-rm", []string{"stack", "rm", "--yes"}, dir)
+	}
+	return nil
 }
 
 func (pt *programTester) testPreviewUpdateAndEdits(dir string) error {

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -172,7 +172,7 @@ type ProgramTestOptions struct {
 	// environment during tests.
 	StackName string
 
-	// Tracing specifies the Zipkin endpoint if any to use for tracing Pulumi invocatoions.
+	// Tracing specifies the Zipkin endpoint if any to use for tracing Pulumi invocations.
 	Tracing string
 	// NoParallel will opt the test out of being ran in parallel.
 	NoParallel bool
@@ -208,7 +208,7 @@ type ProgramTestOptions struct {
 	// PipenvBin is a location of a `pipenv` executable to run.  Taken from the $PATH if missing.
 	PipenvBin string
 
-	// Additional environment variaibles to pass for each command we run.
+	// Additional environment variables to pass for each command we run.
 	Env []string
 }
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 	// "time"
 
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -28,33 +29,33 @@ import (
 
 // assertPerfBenchmark implements the integration.TestStatsReporter interface, and reports test
 // failures when a scenario exceeds the provided threshold.
-// type assertPerfBenchmark struct {
-// 	T                  *testing.T
-// 	MaxPreviewDuration time.Duration
-// 	MaxUpdateDuration  time.Duration
-// }
+type assertPerfBenchmark struct {
+	T                  *testing.T
+	MaxPreviewDuration time.Duration
+	MaxUpdateDuration  time.Duration
+}
 
-// func (t assertPerfBenchmark) ReportCommand(stats integration.TestCommandStats) {
-// 	var maxDuration *time.Duration
-// 	if strings.HasPrefix(stats.StepName, "pulumi-preview") {
-// 		maxDuration = &t.MaxPreviewDuration
-// 	}
-// 	if strings.HasPrefix(stats.StepName, "pulumi-update") {
-// 		maxDuration = &t.MaxUpdateDuration
-// 	}
+func (t assertPerfBenchmark) ReportCommand(stats integration.TestCommandStats) {
+	var maxDuration *time.Duration
+	if strings.HasPrefix(stats.StepName, "pulumi-preview") {
+		maxDuration = &t.MaxPreviewDuration
+	}
+	if strings.HasPrefix(stats.StepName, "pulumi-update") {
+		maxDuration = &t.MaxUpdateDuration
+	}
 
-// 	if maxDuration != nil && *maxDuration != 0 {
-// 		if stats.ElapsedSeconds < maxDuration.Seconds() {
-// 			t.T.Logf(
-// 				"Test step %q was under threshold. %.2f (max %.2fs)",
-// 				stats.StepName, stats.ElapsedSeconds, maxDuration.Seconds())
-// 		} else {
-// 			t.T.Errorf(
-// 				"Test step %q took longer than expected. %.2f vs. max %.2fs",
-// 				stats.StepName, stats.ElapsedSeconds, maxDuration.Seconds())
-// 		}
-// 	}
-// }
+	if maxDuration != nil && *maxDuration != 0 {
+		if stats.ElapsedSeconds < maxDuration.Seconds() {
+			t.T.Logf(
+				"Test step %q was under threshold. %.2fs (max %.2fs)",
+				stats.StepName, stats.ElapsedSeconds, maxDuration.Seconds())
+		} else {
+			t.T.Errorf(
+				"Test step %q took longer than expected. %.2fs vs. max %.2fs",
+				stats.StepName, stats.ElapsedSeconds, maxDuration.Seconds())
+		}
+	}
+}
 
 // TestEmptyNodeJS simply tests that we can run an empty NodeJS project.
 func TestEmptyNodeJS(t *testing.T) {
@@ -85,26 +86,26 @@ func TestEmptyGo(t *testing.T) {
 }
 
 // Tests emitting many engine events doesn't result in a performance problem.
-// func TestEngineEventPerf(t *testing.T) {
-// 	// Prior to pulumi/pulumi#2303, a preview or update would take ~40s.
-// 	// Since then, it should now be down to ~4s, with additional padding,
-// 	// since some travis machines (especially the OSX ones) seem quite slow
-// 	// to begin with.
-// 	benchmarkEnforcer := &assertPerfBenchmark{
-// 		T:                  t,
-// 		MaxPreviewDuration: 8 * time.Second,
-// 		MaxUpdateDuration:  8 * time.Second,
-// 	}
+func TestEngineEventPerf(t *testing.T) {
+	// Prior to pulumi/pulumi#2303, a preview or update would take ~40s.
+	// Since then, it should now be down to ~4s, with additional padding,
+	// since some Travis machines (especially the macOS ones) seem quite slow
+	// to begin with.
+	benchmarkEnforcer := &assertPerfBenchmark{
+		T:                  t,
+		MaxPreviewDuration: 8 * time.Second,
+		MaxUpdateDuration:  8 * time.Second,
+	}
 
-// 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-// 		Dir:          "ee_perf",
-// 		Dependencies: []string{"@pulumi/pulumi"},
-// 		Quick:        true,
-// 		ReportStats:  benchmarkEnforcer,
-// 		// Don't run in parallel since it is sensitive to system resources.
-// 		NoParallel: true,
-// 	})
-// }
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          "ee_perf",
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        true,
+		ReportStats:  benchmarkEnforcer,
+		// Don't run in parallel since it is sensitive to system resources.
+		NoParallel: true,
+	})
+}
 
 // TestProjectMain tests out the ability to override the main entrypoint.
 func TestProjectMain(t *testing.T) {


### PR DESCRIPTION
Update: The required service-side changes have been rolled out. This is ready to review now.

---

When persisting engine events, send them in large batches rather than individually. This not only leads to a noticeable increase in "throughput", but also can reduce the variability in response time.

Currently, we persist engine events one-by-one, concurrently. Spawning a new go-routine to make the HTTP request to the Pulumi Service every time an event is encountered. When we first landed, https://github.com/pulumi/pulumi/pull/2314, it was clear this approach would lead to problems elsewhere but it actually worked surprisingly well the past six months.

However, over time this has has lead to some problems. For overly chatty updates, e.g. those spawning tens of thousands or hundreds of thousands of engine events, this would lead to several types of errors:

- I haven't tried to prove it just yet, but I'm pretty sure that it's possible for an update to fail because the go-routine that updates the lease token gets starved (because the system is busy dealing with all of the concurrent API requests).
- The Pulumi Service's response latency for engine events is very low, except occasionally some requests from clients will take 1-2 minutes. It seems that the problem is for whatever reason the HTTP request is started on the machine, and just gets starved -- despite other engine events being sent from the same machine. I haven't tried to prove this either, but I would guess it is possible that if the NIC or OS is overwhelmed with HTTP requests, it's possible to get into this state.

Sending engine events in batches addresses this by dramatically cutting down on concurrent network requests. The tradeoff is that the "payloads" of these requests can be 50x larger, but the majority of engine events are actually pretty small. (Since they are JSON serialized and then gzip-compressed before being sent.)

There are two key changes with this PR:

- First we buffer the channel sending engine events off for persistence (and to be displayed in the terminal). So if persistence "gets backed up" for some reason, there is a little wiggle room for it to catch up.
- We use a second, unbuffered channel specifically for persisting engine events. This way we can cap the number of concurrent HTTP requests to the Pulumi Service, so that sending many engine events wouldn't overwhelm the threadpool and/or network bandwidth. (It does mean however that if the CLI cannot transmit engine events fast enough, it would eventually cause the update to be blocked until they could be sent off.)

---

I won't have perf numbers for what to expect until I can deploy the service-side changes to production. But here are some stats from running the current `ee_perf` test against my devstack (now located in Mumbai (AWS `ap-southeast-1`)

The `ee_perf` test just sends 1,000 `DiagEvents` in a tight for loop. In December, that took ~4s, and has gotten on average a little slower and more unpredictable when ran from Travis CI jobs. (Sometimes almost taking a minute to complete!)

**Current, unlimited go-routines approach**
Times to run the test on my laptop, connecting to a devstack halfway-across the world. (So I would expect US-US traffic to be much faster.)

12.32s
11.56s
11.40s
10.20s
9.32s
16.24s

4x attempts didn't even complete, because my dev stack was overwhelmed and returned a 500 or 502.

**With the batched approach**
With the patch applied, we are back under that 8s limit, even though the devstack is in Mumbai. When rolled out to production (with its much larger database capacity), and larger number of service workers, I would think these numbers would be slightly better.

5.68s
5.33s
5.22s
6.37s

When connecting to the production instance on the west-coast, the numbers are even better:

2.22s
1.79s
1.79s
2.09s