### PR TITLE
Dedupe aliases in the sdk as well

### DIFF
--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -329,8 +329,14 @@ async function prepareResource(label: string, res: Resource, custom: boolean,
     // in the Resource constructor prior to calling `registerResource` - both adding new inherited aliases and
     // simplifying aliases down to URNs.
     const aliases = [];
+    const uniqueAliases = new Set<string>();
     for (const alias of res.__aliases) {
-        aliases.push(await output(alias).promise());
+        console.log("Deduping aliases.");
+        const aliasVal = await output(alias).promise();
+        if (!uniqueAliases.has(aliasVal)) {
+            uniqueAliases.add(aliasVal);
+            aliases.push(aliasVal);
+        }
     }
 
     return {

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -331,7 +331,6 @@ async function prepareResource(label: string, res: Resource, custom: boolean,
     const aliases = [];
     const uniqueAliases = new Set<string>();
     for (const alias of res.__aliases) {
-        console.log("Deduping aliases.");
         const aliasVal = await output(alias).promise();
         if (!uniqueAliases.has(aliasVal)) {
             uniqueAliases.add(aliasVal);

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -28,8 +28,7 @@ build_package::
 		echo "warning: pandoc not found, generating empty README.rst"; \
 		echo "" > "$(PYENVSRC)/README.rst"; \
 	fi
-	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal --bdist-dir /tmp/bdisttmp
-#	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal
+	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal
 
 build_plugin::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -28,7 +28,8 @@ build_package::
 		echo "warning: pandoc not found, generating empty README.rst"; \
 		echo "" > "$(PYENVSRC)/README.rst"; \
 	fi
-	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal
+	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal --bdist-dir /tmp/bdisttmp
+#	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal
 
 build_plugin::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}


### PR DESCRIPTION
Recent changes in awsx are failing in master (due to failures in the 'long' tests).  The primary issue here are errors like the following:

```
panic: fatal: An assertion has failed: two resources (
'urn:pulumi:p-it-travis-job-ec2-a6ee4772::alb::awsx:x:elasticloadbalancingv2:ApplicationListener::nginx' and
'urn:pulumi:p-it-travis-job-ec2-a6ee4772::alb::awsx:x:elasticloadbalancingv2:ApplicationListener::nginx')

aliased to the same: 

'urn:pulumi:p-it-travis-job-ec2-a6ee4772::alb::awsx:x:elasticloadbalancingv2:ApplicationLoadBalancer$awsx:x:elasticloadbalancingv2:ApplicationTargetGroup$awsx:x:elasticloadbalancingv2:ApplicationListener::nginx'
```

This is happening because creating an AppListener goes through a path that has two locations that changes wrt aliases.  `targetGroup.createListener` adds an alias since it now tries to parent to the TG if no parent was provided.  This follows our desired rules around instance methods.  Then, when we go into the constructor for AppListener, it attempts to also create an alias since it now tries to parent to the LB if no parent was provided.

In both cases, the alias says "alias from the original urn (without a parent) to our current urn".

However, both of these aliases are the same (which is expected).  Unfortunately, having multiple equivalent aliases ends up blowing things up deeper when processing.  

We fix this here by deduping aliases here.  