### PR TITLE
Correctly flow secretness across POJO serialization for stack outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ CHANGELOG
 
 - Python SDK fix for a crash resulting from a KeyError if secrets were used in configuration.
 
+- Fix an issue where a secret would not be encrypted in the state file if it was
+  a property of a resource which was used as a stack output (fixes
+  [#2862](https://github.com/pulumi/pulumi/issues/2862))
+
 ## 0.17.20 (2019-06-23)
 
 - SDK fix for crash that could occasionally happen if there were multiple identical aliases to the

--- a/tests/integration/secret_outputs/Pulumi.yaml
+++ b/tests/integration/secret_outputs/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: secret-outputs
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/tests/integration/secret_outputs/index.ts
+++ b/tests/integration/secret_outputs/index.ts
@@ -1,0 +1,10 @@
+import * as pulumi from "@pulumi/pulumi";
+import { R } from "./res";
+
+export const withoutSecret = new R("withoutSecret", {
+    prefix: pulumi.output("it's a secret to everybody")
+});
+
+export const withSecret = new R("withSecret", {
+    prefix: pulumi.secret("it's a secret to everybody")
+});

--- a/tests/integration/secret_outputs/package.json
+++ b/tests/integration/secret_outputs/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/secret_outputs/res.ts
+++ b/tests/integration/secret_outputs/res.ts
@@ -1,0 +1,22 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as dynamic from "@pulumi/pulumi/dynamic";
+
+export interface RArgs {
+    prefix: pulumi.Input<string>
+}
+
+const provider: pulumi.dynamic.ResourceProvider = {
+    async create(inputs) {
+        return { id: "1", outs: {
+            prefix: inputs["prefix"]
+        }};
+    }
+}
+
+export class R extends dynamic.Resource {
+    public prefix: pulumi.Output<string>;
+
+    constructor(name: string, props: RArgs, opts?: pulumi.CustomResourceOptions) {
+        super(provider, name, props, opts)
+    }
+}

--- a/tests/integration/secret_outputs/tsconfig.json
+++ b/tests/integration/secret_outputs/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}


### PR DESCRIPTION
Our logic to export a resource as a stack output transforms the
resource into a plain old object by eliding internal fields and then
just serializing the resource as a POJO.

The custom serialization logic we used here unwrapped an Output
without care to see if it held a secret. Now, when it does, we
continue to return an Output as the thing to be serialized and that
output is marked as a secret.

Fixes #2862