### PR TITLE
Use literal string "value" in returned dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Python SDK fix for a crash resulting from a KeyError if secrets were used in configuration.
+
 ## 0.17.20 (2019-06-23)
 
 - SDK fix for crash that could occasionally happen if there were multiple identical aliases to the

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -223,7 +223,7 @@ def deserialize_properties(props_struct: struct_pb2.Struct) -> Any:
     if had_secret:
         return {
             _special_sig_key: _special_secret_sig,
-            value: output
+            "value": output
         }
 
     return output


### PR DESCRIPTION
Currently, if a secret was present, the value of variable "value" is used as the key for the dictionary object containing the output. This leads to `KeyError` exceptions in various places, as reported in #2782. This PR changes that to use the literal string "value".

Fixes #2782.