### PR TITLE
SDK feature proposal for 'none' value.

### DIFF
--- a/sdk/nodejs/none.ts
+++ b/sdk/nodejs/none.ts
@@ -1,0 +1,49 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as utils from "./utils";
+
+export class None {
+    /** @internal */
+    // tslint:disable-next-line:variable-name
+    public __isPulumiNone = true;
+
+    public static isNone(obj: any): obj is None {
+        return utils.isInstance<None>(obj, "__isPulumiNone");
+    }
+}
+
+/**
+ * Sentinel value allowed by some APIs to indicate that no value should be created.
+ * For example, some APIs want to allow any of these forms:
+ *
+ * ```ts
+ * const r1 = new X({ });                   // 'role' not provided, create a suitable default.
+ * const r1 = new X({ role: undefined });   // same as above, just explicit.
+ * const r3 = new X({ role: new Role() });  // explicit 'role' provided.
+ * const r4 = new X({ role: pulumi.none }); // do not use or create a role here.
+ * ```
+ *
+ * APIs can then be typed like so:
+ *
+ * ```ts
+ * interface XArgs
+ * {
+ *     role: Role | None | undefined;
+ * }
+ * ```
+ *
+ * To indicate the allowable values.
+ */
+export const none = new None();

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -21,6 +21,7 @@
         "errors.ts",
         "metadata.ts",
         "output.ts",
+        "none.ts",
         "resource.ts",
         "stackReference.ts",
         "utils.ts",


### PR DESCRIPTION
https://github.com/pulumi/pulumi-awsx/issues/344 has revealed a problem in some of our SDK design patterns that can impact users.

Specifically, today, we have the ability to say "i want to pass along a value.  but if i don't pass along a value, create a suitable default".  However, there is no way to say "i do not want to pass a value, and in the case, do **NOT** create a default".

This PR demonstrates a proposal for how we might support this.  It does so with an explicit new value in the `@pulumi/pulumi` module called 'none'.  Clients can pass this along to declaratively specify intent for  APIs that opt into supporting it.

`none` is a sentinel value allowed by some APIs to indicate that no value should be created.

For example, some APIs want to allow any of these forms:

```ts
const r1 = new X({ });                   // 'role' not provided, create a suitable default.
const r1 = new X({ role: undefined });   // same as above, just explicit.
const r3 = new X({ role: new Role() });  // explicit 'role' provided.
const r4 = new X({ role: pulumi.none }); // do not use or create a role here.
```

APIs can then be typed like so:

```ts
interface XArgs
{
    role: Role | None | undefined;
}
```

to indicate the allowable values.

--

Alternative options that were considered and rejected:

1. Allow `null` to be the explicit sentinel that says "to not create a default".  This was rejected because it's unclear to me how we woudl represent this in python or other jsii interop layers.  On hte other hand, it would be easy to have these layers  have access to the `none` sentinel they can pass along.

2.  Distinguish between `.hasOwnProperty` or not.  i.e. consider `{ role: undefined }` different from `{ }`.  As with `1`, it's not clear if this will work in interop scenarios.  It's also extremely subtle for a mainline case.  We went with this approach with aliases, but i'm very hesitant to expand this out further.

3. Create explicit `none` instances for individual types.  i.e. `{ role: Role.none }`.  I'm not opposed to this, but it would require a lot of boilerplate that doesn't seem necessary given we have a single 'none' sentinel that works for all these cases.  The major benefit here is that instead of having to type things as `{ role: Role | None | undefined }` it could be typed as `{ role: Role | undefined }`.

Thoughts, concerns, etc. all appreciated!  Thanks!