### PR TITLE
Normalize Windows paths for directory archive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fix an issue where a file archive created on Windows would contain back-slashes
+  [#2784](https://github.com/pulumi/pulumi/issues/2784))
+
 ## 0.17.21 (2019-06-26)
 
 - Python SDK fix for a crash resulting from a KeyError if secrets were used in configuration.

--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -754,6 +754,11 @@ func (r *directoryArchiveReader) Next() (string, *Blob, error) {
 	}
 	name = filepath.Clean(name)
 
+	// Replace Windows-style separators with Linux ones (if we are on Windows)
+	if os.PathSeparator == '\\' {
+		name = filepath.ToSlash(name)
+	}
+
 	// Open and return the blob.
 	blob, err := (&Asset{Path: assetPath}).Read()
 	if err != nil {

--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -754,10 +754,8 @@ func (r *directoryArchiveReader) Next() (string, *Blob, error) {
 	}
 	name = filepath.Clean(name)
 
-	// Replace Windows-style separators with Linux ones (if we are on Windows)
-	if os.PathSeparator == '\\' {
-		name = filepath.ToSlash(name)
-	}
+	// Replace Windows separators with Linux ones (ToSlash is a no-op on Linux)
+	name = filepath.ToSlash(name)
 
 	// Open and return the blob.
 	blob, err := (&Asset{Path: assetPath}).Read()


### PR DESCRIPTION
Fixes #2784 (the original issue is fixed once `pulumi-terraform` updates to the new version of `pulumi`, and then `pulumi-azure` updates to the new version of `pulumi-terraform`).

Tested by referencing the modified version of the package from `pulumi-azure` and running the original repro: deploying an Azure Function python app from Windows. Confirmed by inspecting the resulting binary

![image](https://user-images.githubusercontent.com/1454008/60330171-25cd5780-9992-11e9-8f2d-2c1856ec2df3.png)

and running the Azure Function

```
> curl https://http-python.azurewebsites.net/api/HelloPython?name=yes
Hello from Python, yes!
```

I'm struggling to think of a test for this change, because it has no effect on Linux. Ideally, just the same test suite would be runnable on Windows, however, A LOT of tests fail on Windows currently. Let me know you opinion on that.