### PR TITLE
PULUMI_CONFIG_PASSPHRASE now supports an empty passphrase

### DIFF
--- a/cmd/crypto_local.go
+++ b/cmd/crypto_local.go
@@ -30,7 +30,7 @@ import (
 )
 
 func readPassphrase(prompt string) (string, error) {
-	if phrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE"); phrase != "" {
+	if phrase, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); ok {
 		return phrase, nil
 	}
 	return cmdutil.ReadConsoleNoEcho(prompt)


### PR DESCRIPTION
This should provide a solution (perhaps not the final solution) for #2758

This change allows you to run pulumi in non-interactive environments without a state passphrase.

e.g. the following will now work.

```
export PULUMI_CONFIG_PASSPHRASE=""
pulumi up --yes
```

before this change pulumi would still prompt for an empty passphrase and block the non-interactive (usually CI) environment from completing.

this is a non-breaking change.
