### PR TITLE
Compute nested diffs in translateDetailedDiff.

### DIFF
--- a/pkg/backend/display/detailedDiff.go
+++ b/pkg/backend/display/detailedDiff.go
@@ -143,7 +143,11 @@ func addDiff(path []interface{}, kind plugin.DiffKind, parent *resource.ValueDif
 			case plugin.DiffDelete, plugin.DiffDeleteReplace:
 				parent.Array.Deletes[element] = old
 			case plugin.DiffUpdate, plugin.DiffUpdateReplace:
-				parent.Array.Updates[element] = resource.ValueDiff{Old: old, New: new}
+				valueDiff := resource.ValueDiff{Old: old, New: new}
+				if d := old.Diff(new); d != nil {
+					valueDiff = *d
+				}
+				parent.Array.Updates[element] = valueDiff
 			default:
 				contract.Failf("unexpected diff kind %v", kind)
 			}
@@ -177,7 +181,11 @@ func addDiff(path []interface{}, kind plugin.DiffKind, parent *resource.ValueDif
 			case plugin.DiffDelete, plugin.DiffDeleteReplace:
 				parent.Object.Deletes[e] = old
 			case plugin.DiffUpdate, plugin.DiffUpdateReplace:
-				parent.Object.Updates[e] = resource.ValueDiff{Old: old, New: new}
+				valueDiff := resource.ValueDiff{Old: old, New: new}
+				if d := old.Diff(new); d != nil {
+					valueDiff = *d
+				}
+				parent.Object.Updates[e] = valueDiff
 			default:
 				contract.Failf("unexpected diff kind %v", kind)
 			}

--- a/pkg/backend/display/detailedDiff_test.go
+++ b/pkg/backend/display/detailedDiff_test.go
@@ -287,6 +287,54 @@ func TestTranslateDetailedDiff(t *testing.T) {
 			state: map[string]interface{}{
 				"foo": []interface{}{
 					"bar",
+					"baz",
+				},
+			},
+			inputs: map[string]interface{}{
+				"foo": []interface{}{
+					"bar",
+					"qux",
+				},
+			},
+			detailedDiff: map[string]plugin.PropertyDiff{
+				"foo": U,
+			},
+			expected: &resource.ObjectDiff{
+				Adds:    resource.PropertyMap{},
+				Deletes: resource.PropertyMap{},
+				Sames:   resource.PropertyMap{},
+				Updates: map[resource.PropertyKey]resource.ValueDiff{
+					"foo": {
+						Old: resource.NewPropertyValue([]interface{}{
+							"bar",
+							"baz",
+						}),
+						New: resource.NewPropertyValue([]interface{}{
+							"bar",
+							"qux",
+						}),
+						Array: &resource.ArrayDiff{
+							Adds:    map[int]resource.PropertyValue{},
+							Deletes: map[int]resource.PropertyValue{},
+							Sames: map[int]resource.PropertyValue{
+								0: resource.NewPropertyValue("bar"),
+							},
+							Updates: map[int]resource.ValueDiff{
+								1: {
+									Old: resource.NewStringProperty("baz"),
+									New: resource.NewStringProperty("qux"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		{
+			state: map[string]interface{}{
+				"foo": []interface{}{
+					"bar",
 				},
 			},
 			inputs: map[string]interface{}{
@@ -492,6 +540,53 @@ func TestTranslateDetailedDiff(t *testing.T) {
 							Adds:    resource.PropertyMap{},
 							Deletes: resource.PropertyMap{},
 							Sames:   resource.PropertyMap{},
+							Updates: map[resource.PropertyKey]resource.ValueDiff{
+								"qux": {
+									Old: resource.NewStringProperty("zed"),
+									New: resource.NewStringProperty("alpha"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			state: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+					"qux": "zed",
+				},
+			},
+			inputs: map[string]interface{}{
+				"foo": map[string]interface{}{
+					"bar": "baz",
+					"qux": "alpha",
+				},
+			},
+			detailedDiff: map[string]plugin.PropertyDiff{
+				"foo": U,
+			},
+			expected: &resource.ObjectDiff{
+				Adds:    resource.PropertyMap{},
+				Deletes: resource.PropertyMap{},
+				Sames:   resource.PropertyMap{},
+				Updates: map[resource.PropertyKey]resource.ValueDiff{
+					"foo": {
+						Old: resource.NewPropertyValue(map[string]interface{}{
+							"bar": "baz",
+							"qux": "zed",
+						}),
+						New: resource.NewPropertyValue(map[string]interface{}{
+							"bar": "baz",
+							"qux": "alpha",
+						}),
+						Object: &resource.ObjectDiff{
+							Adds:    resource.PropertyMap{},
+							Deletes: resource.PropertyMap{},
+							Sames: resource.PropertyMap{
+								"bar": resource.NewPropertyValue("baz"),
+							},
 							Updates: map[resource.PropertyKey]resource.ValueDiff{
 								"qux": {
 									Old: resource.NewStringProperty("zed"),


### PR DESCRIPTION
Instead of simply converting a detailed diff entry that indicates an
update to an entire composite value as a simple old/new value diff,
compute the nested diff. This alllows us to render a per-element diff
for the nested object rather than simply displaying the new and the old
composite values.

This is necessary in order to improve diff rendering once
pulumi/pulumi-terraform#403 has been rolled out.