### PR TITLE
Lock to an earlier version of gRPC

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -11,7 +11,7 @@
     "dependencies": {
         "@pulumi/query": "^0.3.0",
         "google-protobuf": "^3.5.0",
-        "grpc": "^1.20.2",
+        "grpc": "1.21.1",
         "minimist": "^1.2.0",
         "normalize-package-data": "^2.4.0",
         "protobufjs": "^6.8.6",


### PR DESCRIPTION
The most recently released version of gRPC has a `index.d.ts` file in
it that does not work when complied with noImplicitAny. Until a fix
can be made upstream, lock to an earlier version so that we can build
without turning off noImplicitAny.