### PR TITLE
Build version tags in AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,6 +7,7 @@ branches:
     only:
         - master
         - /release\/.*/
+        - /v\d*\.\d*\.\d*/
 init:
 - ps: Install-Product node 8.10 x64
 environment:


### PR DESCRIPTION
From the AppVeyor docs (https://www.appveyor.com/docs/branches/):

> Despite the option name, `only` and `except` is applied to tag names
> too, so the above example using only would cause tags not trigger
> the build. For example to enable builds for a tag version scheme
> like v1.0.0 you would need...

We had previously been getting lucky here since our workflow for
releasing was more or less always push master and the tag at the same
time, so the fact that the tag did not also kick off a build was not a
problem.

When releasing 0.17.22, we just pushed a tag for an older commit and
we had to do some gymnastics to get AppVeyor to build it.