### PR TITLE
Handle mixed versions of Resources in parent hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
    [#2672](https://github.com/pulumi/pulumi/issues/2672))
    
 - Fix an issue where a file archive created on Windows would contain back-slashes
-  [#2784](https://github.com/pulumi/pulumi/issues/2784))
+  [#2784](https://github.com/pulumi/pulumi/issues/2784)
 
 - Fix an issue where output values of a resource would not be present when they
   contained secret values, when using Python.
@@ -23,6 +23,10 @@ CHANGELOG
   
 - Add the ability to pass a customTimeouts object from the providers across the engine
   to resource management. (fixes [#2665](https://github.com/pulumi/pulumi/issues/2665))
+
+- Fix a crash when two different versions of `@pulumi/pulumi` are used in the same Pulumi program
+  [#2942](https://github.com/pulumi/pulumi/issues/2942)
+
 
 ## 0.17.22 (2019-07-11)
 

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -143,16 +143,24 @@ export abstract class Resource {
     /**
      * @internal
      * A list of aliases applied to this resource.
+     *
+     * Note: This is marked optional only because older versions of this library may not have had
+     * this property, and marking optional forces conumers of the property to defensively handle
+     * cases where they are passed "old" resources.
      */
     // tslint:disable-next-line:variable-name
-    readonly __aliases: Input<URN>[];
+    readonly __aliases?: Input<URN>[];
 
     /**
      * @internal
      * The name assigned to the resource at construction.
+     *
+     * Note: This is marked optional only because older versions of this library may not have had
+     * this property, and marking optional forces conumers of the property to defensively handle
+     * cases where they are passed "old" resources.
      */
     // tslint:disable-next-line:variable-name
-    private readonly __name: string;
+    private readonly __name?: string;
 
     /**
      * @internal
@@ -222,8 +230,10 @@ export abstract class Resource {
 
             // Make a copy of the aliases array, and add to it any implicit aliases inherited from its parent
             opts.aliases = [...(opts.aliases || [])];
-            for (const parentAlias of opts.parent.__aliases) {
-                opts.aliases.push(inheritedChildAlias(name, opts.parent.__name, parentAlias, t));
+            if (opts.parent.__name) {
+                for (const parentAlias of (opts.parent.__aliases || [])) {
+                    opts.aliases.push(inheritedChildAlias(name, opts.parent.__name, parentAlias, t));
+                }
             }
 
             this.__providers = opts.parent.__providers;

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -346,7 +346,7 @@ async function prepareResource(label: string, res: Resource, custom: boolean,
     // simplifying aliases down to URNs.
     const aliases = [];
     const uniqueAliases = new Set<string>();
-    for (const alias of res.__aliases) {
+    for (const alias of (res.__aliases || [])) {
         const aliasVal = await output(alias).promise();
         if (!uniqueAliases.has(aliasVal)) {
             uniqueAliases.add(aliasVal);
@@ -563,6 +563,7 @@ export function listResourceOutputs<U extends Resource>(
     if (typeFilter === undefined) {
         typeFilter = isAny;
     }
+
 
     return query
         .from(


### PR DESCRIPTION
For new properties added to `Resource`, we need to make sure to handle cases where these are undefined as they may not be available on versions of `Resource` that come from older SDK versions, which could me side-by-side in a single Pulumi program execution.

Fixes #2938