### PR TITLE
Fix 'pulumi new' to support creating stacks in an org

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -47,7 +47,7 @@ import (
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 )
 
-// intentionally disabling here for cleaner err declaration/assignment.
+// Intentionally disabling here for cleaner err declaration/assignment.
 // nolint: vetshadow
 func newNewCmd() *cobra.Command {
 	var configArray []string

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/apitype"
 )
 
-// validateStackName checks if s is a valid stack name, otherwise returns a descritive error.
+// validateStackName checks if s is a valid stack name, otherwise returns a descriptive error.
 // This should match the stack naming rules enforced by the Pulumi Service.
 func validateStackName(s string) error {
 	stackNameRE := regexp.MustCompile("^[a-zA-Z0-9-_.]{1,100}$")

--- a/pkg/workspace/templates_test.go
+++ b/pkg/workspace/templates_test.go
@@ -62,6 +62,13 @@ func TestGetValidDefaultProjectName(t *testing.T) {
 	assert.Equal(t, "project", getValidProjectName("!@#$%^&*()"))
 }
 
+func TestValidateStackName(t *testing.T) {
+	assert.NoError(t, ValidateStackName("alpha-beta-gamma"))
+	assert.NoError(t, ValidateStackName("owner-name/alpha-beta-gamma"))
+
+	assert.Error(t, ValidateStackName("alpha/beta/gamma"), "A stack may not contain a slash")
+}
+
 func getValidProjectNamePrefixes() []string {
 	var results []string
 	for ch := 'A'; ch <= 'Z'; ch++ {

--- a/pkg/workspace/templates_test.go
+++ b/pkg/workspace/templates_test.go
@@ -66,7 +66,11 @@ func TestValidateStackName(t *testing.T) {
 	assert.NoError(t, ValidateStackName("alpha-beta-gamma"))
 	assert.NoError(t, ValidateStackName("owner-name/alpha-beta-gamma"))
 
-	assert.Error(t, ValidateStackName("alpha/beta/gamma"), "A stack may not contain a slash")
+	err := ValidateStackName("alpha/beta/gamma")
+	assert.Equal(t, err.Error(), "A stack name may not contain slashes")
+
+	err = ValidateStackName("mooo looo mi/alpha-beta-gamma")
+	assert.Equal(t, err.Error(), "Invalid stack owner")
 }
 
 func getValidProjectNamePrefixes() []string {


### PR DESCRIPTION
@justinvp I had already finished the PR by the time you asked to take it from me :)

I believe this will fix the issue with "qualified" stack names like "pulumi/website-dev" when used in `pulumi new`. I just updated the validation logic we have for the stack name, though if there is something more subtle to do here please let me know. Doing some basic testing, things look like they are working as expected.

Part of #2822