### PR TITLE
Fix issue when logging out of local backend

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -112,6 +112,11 @@
 
     <!-- Ignore the exit code (but retain it) so we can kill all the lingering node processes even when go test
          fails. Otherwise, the AppVeyor job would hang until it reached the timeout -->
+    <Exec Command="go test -count=1 -timeout 10m -cover -parallel $(TestParallelism) .\pkg\..."
+          IgnoreExitCode="true"
+          WorkingDirectory="$(RepoRootDirectory)">
+      <Output TaskParameter="ExitCode" PropertyName="GoTestExitCode" />
+    </Exec>
     <Exec Command="go test -count=1 -timeout 10m -cover -parallel $(TestParallelism) .\examples"
           IgnoreExitCode="true"
           WorkingDirectory="$(RepoRootDirectory)">

--- a/build.proj
+++ b/build.proj
@@ -112,11 +112,6 @@
 
     <!-- Ignore the exit code (but retain it) so we can kill all the lingering node processes even when go test
          fails. Otherwise, the AppVeyor job would hang until it reached the timeout -->
-    <Exec Command="go test -count=1 -timeout 10m -cover -parallel $(TestParallelism) .\pkg\..."
-          IgnoreExitCode="true"
-          WorkingDirectory="$(RepoRootDirectory)">
-      <Output TaskParameter="ExitCode" PropertyName="GoTestExitCode" />
-    </Exec>
     <Exec Command="go test -count=1 -timeout 10m -cover -parallel $(TestParallelism) .\examples"
           IgnoreExitCode="true"
           WorkingDirectory="$(RepoRootDirectory)">

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -38,7 +38,7 @@ func newLogoutCmd() *cobra.Command {
 			"\n" +
 			"Because you may be logged into multiple backends simultaneously, you can optionally pass\n" +
 			"a specific URL argument, formatted just as you logged in, to log out of a specific one.\n" +
-			"If none is supplied, you will be logged out of the default cloud.",
+			"If no URL is provided, you will be logged out of the current backend.",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			// If a <cloud> was specified as an argument, use it.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -131,11 +131,11 @@ func New(d diag.Sink, u string) (Backend, error) {
 // file:// paths which have a few oddities around them that we want to ensure work properly.
 func massageBlobPath(path string) (string, error) {
 	if !strings.HasPrefix(path, FilePathPrefix) {
-		// not a file:// path.  Keep this untouched and pass directly to gocloud.
+		// Not a file:// path.  Keep this untouched and pass directly to gocloud.
 		return path, nil
 	}
 
-	// Strip off the "file://"" portion so we can examine and determine what to do with the rest.
+	// Strip off the "file://" portion so we can examine and determine what to do with the rest.
 	path = strings.TrimPrefix(path, FilePathPrefix)
 
 	// We need to specially handle ~.  The shell doesn't take care of this for us, and later
@@ -162,7 +162,7 @@ func massageBlobPath(path string) (string, error) {
 	}
 
 	// Using example from https://godoc.org/gocloud.dev/blob/fileblob#example-package--OpenBucket
-	// On Windows, convert "\" to "/" and add a leading "/":
+	// On Windows, convert "\" to "/" and add a leading "/". (See https://gocloud.dev/howto/blob/#local)
 	path = filepath.ToSlash(path)
 	if os.PathSeparator != '/' && !strings.HasPrefix(path, "/") {
 		path = "/" + path

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -176,7 +176,7 @@ func Login(d diag.Sink, url string) (Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	return be, workspace.StoreAccessToken(url, "", true)
+	return be, workspace.StoreAccessToken(be.URL(), "", true)
 }
 
 func (b *localBackend) local() {}

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -60,8 +60,14 @@ type Backend interface {
 }
 
 type localBackend struct {
-	d      diag.Sink
-	url    string
+	d diag.Sink
+
+	// originalURL is the URL provided when the localBackend was initialized, for example
+	// "file://~". url is a canonicalized version that should be used when persisting data.
+	// (For example, replacing ~ with the home directory, making an absolute path, etc.)
+	originalURL string
+	url         string
+
 	bucket Bucket
 }
 
@@ -88,13 +94,13 @@ func IsFileStateBackendURL(urlstr string) bool {
 
 const FilePathPrefix = "file://"
 
-func New(d diag.Sink, u string) (Backend, error) {
-	if !IsFileStateBackendURL(u) {
+func New(d diag.Sink, originalURL string) (Backend, error) {
+	if !IsFileStateBackendURL(originalURL) {
 		return nil, errors.Errorf("local URL %s has an illegal prefix; expected one of: %s",
-			u, strings.Join(blob.DefaultURLMux().BucketSchemes(), ", "))
+			originalURL, strings.Join(blob.DefaultURLMux().BucketSchemes(), ", "))
 	}
 
-	u, err := massageBlobPath(u)
+	u, err := massageBlobPath(originalURL)
 	if err != nil {
 		return nil, err
 	}
@@ -120,9 +126,10 @@ func New(d diag.Sink, u string) (Backend, error) {
 	}
 
 	return &localBackend{
-		d:      d,
-		url:    u,
-		bucket: &wrappedBucket{bucket: bucket},
+		d:           d,
+		originalURL: originalURL,
+		url:         u,
+		bucket:      &wrappedBucket{bucket: bucket},
 	}, nil
 }
 
@@ -191,7 +198,7 @@ func (b *localBackend) Name() string {
 }
 
 func (b *localBackend) URL() string {
-	return b.url
+	return b.originalURL
 }
 
 func (b *localBackend) StateDir() string {
@@ -648,7 +655,7 @@ func (b *localBackend) ImportDeployment(ctx context.Context, stackRef backend.St
 }
 
 func (b *localBackend) Logout() error {
-	return workspace.DeleteAccessToken(b.url)
+	return workspace.DeleteAccessToken(b.originalURL)
 }
 
 func (b *localBackend) CurrentUser() (string, error) {

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -1,0 +1,64 @@
+package filestate
+
+import (
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMassageBlobPath(t *testing.T) {
+	testMassagePath := func(t *testing.T, s string, want string) {
+		massaged, err := massageBlobPath(s)
+		assert.NoError(t, err)
+		assert.Equal(t, want, massaged,
+			"massageBlobPath(%s) didn't return expected result.\nWant: %q\nGot:  %q", s, want, massaged)
+	}
+
+	// URLs not prefixed with "file://" are kept as-is. Also why we add FilePathPrefix as a prefix for other tests.
+	t.Run("NonFilePrefixed", func(t *testing.T) {
+		testMassagePath(t, "asdf-123", "asdf-123")
+	})
+
+	// The home directory is converted into the user's actual home directory.
+	// Which requires even more tweaks to work on Windows.
+	t.Run("PrefixedWithTilde", func(t *testing.T) {
+		usr, err := user.Current()
+		if err != nil {
+			t.Fatalf("Unable to get current user: %v", err)
+		}
+
+		homeDir := usr.HomeDir
+
+		// When running on Windows, the "home directory" takes on a different meaning.
+		if runtime.GOOS == "windows" {
+			t.Logf("Running on %v", runtime.GOOS)
+
+			t.Run("NormalizeDirSeparator", func(t *testing.T) {
+				testMassagePath(t, FilePathPrefix+`C:\Users\steve\`, FilePathPrefix+"/C:/Users/steve")
+			})
+
+			newHomeDir := "/" + filepath.ToSlash(homeDir)
+			t.Logf("Changed homeDir to expect from %q to %q", homeDir, newHomeDir)
+		}
+
+		testMassagePath(t, FilePathPrefix+"~", FilePathPrefix+homeDir)
+		testMassagePath(t, FilePathPrefix+"~/alpha/beta", FilePathPrefix+homeDir+"/alpha/beta")
+	})
+
+	t.Run("MakeAbsolute", func(t *testing.T) {
+		// Run the expected result through filepath.Abs, since on Windows we expect "C:\1\2".
+		expected := "/1/2"
+		abs, err := filepath.Abs(expected)
+		assert.NoError(t, err)
+
+		expected = filepath.ToSlash(abs)
+		if expected[0] != '/' {
+			expected = "/" + expected // A leading slash is added on Windows.
+		}
+
+		testMassagePath(t, FilePathPrefix+"/1/2/3/../4/..", FilePathPrefix+expected)
+	})
+}

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -42,6 +42,7 @@ func TestMassageBlobPath(t *testing.T) {
 
 			newHomeDir := "/" + filepath.ToSlash(homeDir)
 			t.Logf("Changed homeDir to expect from %q to %q", homeDir, newHomeDir)
+			homeDir = newHomeDir
 		}
 
 		testMassagePath(t, FilePathPrefix+"~", FilePathPrefix+homeDir)


### PR DESCRIPTION
The issue and its fix are kinda hard to explain, so sorry for the long explanation.

There was a regression recently, where logging out of the local backend didn't actually work.

```
pulumi login --local
pulumi logout

# BUG: Should default to the Pulumi Service, but instead behaved as if
# --local were passed. In fact, running `pulumi whoami` indicates that
# you were never actually logged out.
pulumi login
```

The root problem was that we weren't using the right URL to identify the local backend when running `pulumi logout`. As a result, the `credentials.json` file wasn't being modified to reflect logging out of the current backend.

## Background

Logging in and logging out are handled is by updating `~/.pulumi/credentials.json`. It contains a "current cloud URL", and the credentials for all of the known cloud URLs. Something like:

```
{
    "current": "https://api.pulumi.com",
    "accessTokens": {
        "file://~": "",
        "http://localhost:8080": "pul-xxxx",
        "https://api.pulumi.com": "pul-xxxx"
    }
}
```

When you run `pulumi stack ls`, we determine which cloud to use by dereferencing the "current" cloud URL, and then looking up the corresponding access token to use. (Or just "" if using a `file://` or other file state provider protocol, like `s3://`, `gc://`, etc.)

When you "logout", we simply remove the `current` field from the `Credentials` object, so the next time you login (or we determine the current cloud to use) we'd default to the Pulumi Service. (Or `PULUMI_API` env var, etc.)

- [filestate.IsFileStateBackendURL](https://github.com/pulumi/pulumi/blob/master/pkg/backend/filestate/backend.go#L80-L87)
- [workspace.GetCurrentCloudURL](https://github.com/pulumi/pulumi/blob/master/pkg/workspace/creds.go#L106-L132)
- [workspace.DeleteAccessToken](https://github.com/pulumi/pulumi/blob/master/pkg/workspace/creds.go#L46-L59)

## The Problem

It looks like this bug was introduced when we added support for `s3://` and other cloud-hosted file providers. Since we were no longer supporting only the local file system, we needed to localize the URL mappings to account for `file://~` being something like `file:///users/ned`.

The culprit is this function: [massageBlobPath](https://github.com/pulumi/pulumi/blob/master/pkg/backend/filestate/backend.go#L132). This is called as part of `file state.New(...)`.

So the bug was as follows:

- When you run `pulumi login --local`, we would store a new entry into `credentials.json` with the `file://~` URL, and set the current URL to `file://~`.
- When you run `pulumi logout`, we would try to delete the access token for the _current_ cloud URL. Which would be the _massaged_ URL, `file:///Users/chris`. This would lead to not removing the "current" cloud URL, and logout being a no-op.

The fix is to simply keep track of the original URL passed to `localBackend` and, and then look for _that_ when logging out. (i.e. store `file://~` in `credentials.json`, even if `localBackend.url` is canonicalized to `file:///Users/chris/`.)

## The Fix

The PR adds some tests and does some minor cleanups, but the relevant change is as follows:

- `localBackend.URL()` returns the `originalURL` instead of the massaged URL. This way outside of the local backend clients get a consistent view of the URL. (i.e. it matches the one passed when it was constructed.)
- `Login` now stores the `originalURL` and not the canonical one. (Via `workspace.StoreAccessToken(be.URL(), "", true)`)
- `localBackend.Logout` now removes the `originalURL` as well. (Via `return workspace.DeleteAccessToken(b.originalURL)`.)

The asymmetry between accessing the `originalURL` field and calling `backend.URL()` has to do with `Login` being a method found in the `filestate` package, and not a method on the `backend.Backend` interface.

Fixes #2926