### PR TITLE
Do not fail previews for protected deletes.

### DIFF
--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -943,6 +943,7 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 	// And now any properties that failed verification.
 	var failures []CheckFailure
 	for _, failure := range resp.GetFailures() {
+		logging.V(7).Infof("failure %v %v\n", failure.Property, failure.Reason)
 		failures = append(failures, CheckFailure{resource.PropertyKey(failure.Property), failure.Reason})
 	}
 

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -83,7 +83,8 @@ export async function invoke(tok: string, props: Inputs, opts?: InvokeOptions): 
         // If there were failures, propagate them.
         const failures: any = resp.getFailuresList();
         if (failures && failures.length) {
-            throw new Error(`Invoke of '${tok}' failed: ${failures[0].reason} (${failures[0].property})`);
+            const failure = failures[0];
+            throw new Error(`Invoke of '${tok}' failed: ${failure.getReason()} (${failure.getProperty()})`);
         }
 
         // Finally propagate any other properties that were given to us as outputs.


### PR DESCRIPTION
If the deletion of a protected resource is proposed during a preview, do
not fail the preview:
- The deletion of the protected resource may not actually occur
- If there are multiple deletions of such resources planned, letting the
  user see and address all of them as a batch is generally a better
  experience than fixing them one at a time

These changes also fix the Node SDK's implementation of `invoke` to
properly report failures.