### PR TITLE
Add --yes params to a couple commands

### DIFF
--- a/cmd/state.go
+++ b/cmd/state.go
@@ -111,8 +111,8 @@ func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resour
 }
 
 // runStateEdit runs the given state edit function on a resource with the given URN in a given stack.
-func runStateEdit(stackName string, urn resource.URN, operation edit.OperationFunc) result.Result {
-	return runTotalStateEdit(stackName, func(opts display.Options, snap *deploy.Snapshot) error {
+func runStateEdit(stackName string, showPrompt bool, urn resource.URN, operation edit.OperationFunc) result.Result {
+	return runTotalStateEdit(stackName, showPrompt, func(opts display.Options, snap *deploy.Snapshot) error {
 		res, err := locateStackResource(opts, snap, urn)
 		if err != nil {
 			return err
@@ -122,9 +122,10 @@ func runStateEdit(stackName string, urn resource.URN, operation edit.OperationFu
 	})
 }
 
-// runTotalStateEdit runs a snapshot-mutating function on the entirity of the given stack's snapshot. Before mutating
-// the snapshot, the user is prompted for confirmation if the current session is interactive.
-func runTotalStateEdit(stackName string,
+// runTotalStateEdit runs a snapshot-mutating function on the entirety of the given stack's snapshot.
+// Before mutating, the user may be prompted to for confirmation if the current session is interactive.
+func runTotalStateEdit(
+	stackName string, showPrompt bool,
 	operation func(opts display.Options, snap *deploy.Snapshot) error) result.Result {
 	opts := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
@@ -138,7 +139,7 @@ func runTotalStateEdit(stackName string,
 		return result.FromError(err)
 	}
 
-	if cmdutil.Interactive() {
+	if showPrompt && cmdutil.Interactive() {
 		confirm := false
 		surveycore.DisableColor = true
 		surveycore.QuestionIcon = ""

--- a/cmd/state_delete.go
+++ b/cmd/state_delete.go
@@ -31,6 +31,7 @@ import (
 func newStateDeleteCommand() *cobra.Command {
 	var force bool // Force deletion of protected resources
 	var stack string
+	var yes bool
 
 	cmd := &cobra.Command{
 		Use:   "delete <resource URN>",
@@ -51,7 +52,10 @@ pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 		Args: cmdutil.ExactArgs(1),
 		Run: cmdutil.RunResultFunc(func(cmd *cobra.Command, args []string) result.Result {
 			urn := resource.URN(args[0])
-			res := runStateEdit(stack, urn, func(snap *deploy.Snapshot, res *resource.State) error {
+			// Show the confirmation prompt if the user didn't pass the --yes parameter to skip it.
+			showPrompt := !yes
+
+			res := runStateEdit(stack, showPrompt, urn, func(snap *deploy.Snapshot, res *resource.State) error {
 				if !force {
 					return edit.DeleteResource(snap, res)
 				}
@@ -91,5 +95,6 @@ pulumi state delete 'urn:pulumi:stage::demo::eks:index:Cluster$pulumi:providers:
 		&stack, "stack", "s", "",
 		"The name of the stack to operate on. Defaults to the current stack")
 	cmd.Flags().BoolVar(&force, "force", false, "Force deletion of protected resources")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
 	return cmd
 }


### PR DESCRIPTION
When trying to tear down a couple of stacks I noticed we didn't have a `--yes` flag for skipping the confirmation prompt on `pulumi state unprotect`. This makes it much more difficult to automate/script this sort of thing.

Fixes #2905