### PR TITLE
Use a bag for misc. resource options in deploytest

### DIFF
--- a/pkg/resource/deploy/source_eval_test.go
+++ b/pkg/resource/deploy/source_eval_test.go
@@ -54,8 +54,14 @@ func fixedProgram(steps []RegisterResourceEvent) deploytest.ProgramFunc {
 	return func(_ plugin.RunInfo, resmon *deploytest.ResourceMonitor) error {
 		for _, s := range steps {
 			g := s.Goal()
-			urn, id, outs, err := resmon.RegisterResource(g.Type, string(g.Name), g.Custom, g.Parent, g.Protect,
-				g.Dependencies, g.Provider, g.Properties, g.PropertyDependencies, false, "", nil, nil, "", nil)
+			urn, id, outs, err := resmon.RegisterResource(g.Type, string(g.Name), g.Custom, deploytest.ResourceOptions{
+				Parent:       g.Parent,
+				Protect:      g.Protect,
+				Dependencies: g.Dependencies,
+				Provider:     g.Provider,
+				Inputs:       g.Properties,
+				PropertyDeps: g.PropertyDependencies,
+			})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Most of these options are typically left unset. In order to make it
easier to update the lifecycle test when adding new options, collect
them in a bag s.t. most callsites can go without being updated.