### PR TITLE
Update references to pulumi.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,4 +61,7 @@ For contributors we use the standard fork based workflow. Fork this repository, 
 
 ## Getting Help
 
-We're sure there are rough edges and we appreciate you helping out. If you want to talk with other folks hacking on Pulumi (or members of the Pulumi team!) come hang out `#contribute` channel in the [Pulumi Community Slack](https://slack.pulumi.io/).
+We're sure there are rough edges and we appreciate you helping out. If you want
+to talk with other folks hacking on Pulumi (or members of the Pulumi team!)
+come hang out `#contribute` channel in the
+[Pulumi Community Slack](https://slack.pulumi.com/).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-<a href="https://pulumi.io" title="Pulumi - Modern Infrastructure as Code - AWS Azure Kubernetes Containers Serverless"><img src="https://pulumi.io/images/logo/logo.svg" width="350"></a>
+<a href="https://www.pulumi.com" title="Pulumi - Modern Infrastructure as Code - AWS Azure Kubernetes Containers Serverless">
+    <img src="https://www.pulumi.com/images/logo/logo-inv.svg" width="350">
+</a>
 
-[![Slack](https://pulumi.io/images/badges/slack.svg)](https://slack.pulumi.io)
+[![Slack](http://www.pulumi.com/images/docs/badges/slack.svg)](https://slack.pulumi.com)
 [![NPM version](https://badge.fury.io/js/%40pulumi%2Fpulumi.svg)](https://npmjs.com/package/@pulumi/pulumi)
 [![Python version](https://badge.fury.io/py/pulumi.svg)](https://pypi.org/project/pulumi)
 [![GoDoc](https://godoc.org/github.com/pulumi/pulumi?status.svg)](https://godoc.org/github.com/pulumi/pulumi)
@@ -10,11 +12,13 @@
 containers, serverless functions, hosted services, and infrastructure, on any cloud.
 
 Simply write code in your favorite language and Pulumi automatically provisions and manages your
-[AWS](https://pulumi.io/reference/aws.html), [Azure](https://pulumi.io/reference/azure.html),
-[Google Cloud Platform](https://pulumi.io/reference/gcp.html), and/or
-[Kubernetes](https://pulumi.io/reference/kubernetes.html) resources, using an
-[infrastructure-as-code](https://en.wikipedia.org/wiki/Infrastructure_as_Code) approach.  Skip the YAML, and
-use standard language features like loops, functions, classes, and package management that you already know and love.
+[AWS](https://www.pulumi.com/docs/reference/clouds/aws/),
+[Azure](https://www.pulumi.com/docs/reference/clouds/azure/),
+[Google Cloud Platform](https://www.pulumi.com/docs/reference/clouds/gcp/), and/or
+[Kubernetes](https://www.pulumi.com/docs/reference/clouds/kubernetes/) resources, using an
+[infrastructure-as-code](https://en.wikipedia.org/wiki/Infrastructure_as_Code) approach.
+Skip the YAML, and use standard language features like loops, functions, classes,
+and package management that you already know and love.
 
 For example, create three web servers:
 
@@ -59,23 +63,20 @@ repo contains the `pulumi` CLI, language SDKs, and core Pulumi engine, and indiv
 
 ## Welcome
 
-<img align="right" width="400" src="https://pulumi.io/images/quickstart/console.png" />
+<img align="right" width="400" src="https://www.pulumi.com/images/docs/quickstart/console.png" />
 
 * **[Getting Started](#getting-started)**: get up and running quickly.
 
-* **[Tutorials](https://pulumi.io/quickstart)**: walk through end-to-end workflows for creating containers, serverless
+* **[Tutorials](https://www.pulumi.com/docs/quickstart/)**: walk through end-to-end workflows for creating containers, serverless
   functions, and other cloud services and infrastructure.
 
 * **[Examples](https://github.com/pulumi/examples)**: browse a number of useful examples across many languages,
   clouds, and scenarios including containers, serverless, and infrastructure.
 
-* **[A Tour of Pulumi](https://pulumi.io/tour)**: interactively walk through the core Pulumi concepts, one at a time,
-  covering the entire CLI and programming model surface area in a handful of bite-sized chunks.
-
-* **[Reference Docs](https://pulumi.io/reference)**: read conceptual documentation, in addition to details on how
+* **[Reference Docs](https://www.pulumi.com/docs/reference/)**: read conceptual documentation, in addition to details on how
   to configure Pulumi to deploy into your AWS, Azure, or Google Cloud accounts, and/or Kubernetes cluster.
 
-* **[Community Slack](https://slack.pulumi.io)**: join us over at our community Slack channel.  Any and all
+* **[Community Slack](https://slack.pulumi.com)**: join us over at our community Slack channel.  Any and all
   discussion or questions are welcome.
 
 * **[Roadmap](https://github.com/pulumi/pulumi/wiki/Roadmap)**: check out what's on the roadmap for the Pulumi 
@@ -87,13 +88,15 @@ Follow these steps to deploy your first Pulumi program, using AWS Serverless Lam
 
 1. **Install**:
 
-    To install the latest Pulumi release, run the following (see full [installation instructions](https://pulumi.io/install) for additional installation options):
+    To install the latest Pulumi release, run the following (see full
+    [installation instructions](https://www.pulumi.com/docs/reference/install/) for additional installation options):
 
     ```bash
     $ curl -fsSL https://get.pulumi.com/ | sh
     ```
 
-2. **[Configure your Cloud Provider](https://pulumi.io/install#cloud-configuration)** so that Pulumi can deploy into it.
+2. **[Configure your Cloud Provider](https://www.pulumi.com/docs/reference/install/#cloud-configuration)**
+    so that Pulumi can deploy into it.
 
 3. **Create a Project**:
 
@@ -141,9 +144,9 @@ Follow these steps to deploy your first Pulumi program, using AWS Serverless Lam
     $ pulumi destroy -y
     ```
 
-Please head on over to [the project website](https://pulumi.io) for much more information, including
-[tutorials](https://pulumi.io/quickstart), [examples](https://github.com/pulumi/examples), and
-[an interactive tour](https://pulumi.io/tour) of the core Pulumi CLI and programming model concepts.
+To learn more, head over to <pulumi.com> for much more information, including
+[tutorials](https://www.pulumi.com/docs/quickstart/), [examples](https://github.com/pulumi/examples), and
+details of the core Pulumi CLI and [programming model concepts](https://www.pulumi.com/docs/reference/concepts/).
 
 ## <a name="platform"></a>Platform
 
@@ -151,32 +154,24 @@ Please head on over to [the project website](https://pulumi.io) for much more in
 
 | Architecture | Build Status |
 | ------------ | ------------ |
-| Linux/macOS x64 | [![Linux x64 Build Status](https://travis-ci.com/pulumi/pulumi.svg?token=cTUUEgrxaTEGyecqJpDn&branch=master)](https://travis-ci.com/pulumi/pulumi) |
-| Windows x64  | [![Windows x64 Build Status](https://ci.appveyor.com/api/projects/status/uqrduw6qnoss7g4i?svg=true&branch=master)](https://ci.appveyor.com/project/pulumi/pulumi) |
+| Linux/macOS x64 | [![Linux x64 Build Status](https://travis-ci.com/pulumi/pulumi.svg?token=cTUUEgrxaTEGyecqJpDn&branch=master)](https://travis-ci.com/pulumi/pulumi)                |
+| Windows x64     | [![Windows x64 Build Status](https://ci.appveyor.com/api/projects/status/uqrduw6qnoss7g4i?svg=true&branch=master)](https://ci.appveyor.com/project/pulumi/pulumi) |
 
 ### Languages
 
 |    | Language | Status | Runtime |
 | -- | -------- | ------ | ------- |
-| <img src="https://www.pulumi.com/assets/logos/tech/logo-js.png" height=38 /> | [JavaScript](./sdk/nodejs) | Stable | Node.js 8+ |
-| <img src="https://www.pulumi.com/assets/logos/tech/logo-ts.png" height=38 /> | [TypeScript](./sdk/nodejs) | Stable | Node.js 8+ |
-| <img src="https://www.pulumi.com/assets/logos/tech/logo-python.png" height=38 /> | [Python](./sdk/python) | Stable | Python 3.6+ |
-| <img src="https://www.pulumi.com/assets/logos/tech/logo-golang.png" height=38 /> | [Go](./sdk/go) | Preview | Go 1.x |
+| <img src="https://www.pulumi.com/assets/logos/tech/logo-js.png" height=38 />     | [JavaScript](./sdk/nodejs) | Stable  | Node.js 8+  |
+| <img src="https://www.pulumi.com/assets/logos/tech/logo-ts.png" height=38 />     | [TypeScript](./sdk/nodejs) | Stable  | Node.js 8+  |
+| <img src="https://www.pulumi.com/assets/logos/tech/logo-python.png" height=38 /> | [Python](./sdk/python)     | Stable  | Python 3.6+ |
+| <img src="https://www.pulumi.com/assets/logos/tech/logo-golang.png" height=38 /> | [Go](./sdk/go)             | Preview | Go 1.x      |
 
 ### Clouds
 
-See [Supported Clouds](https://pulumi.io/reference/clouds.html) for the full list of supported cloud and infrastructure providers.
-
-### Libraries
-
-There are several libraries that encapsulate best practices and common patterns:
-
-| Library | Status | Docs | Repo |
-| ------- | ------ | ---- | ---- |
-| AWS Serverless | Preview | [Docs](https://pulumi.io/reference/pkg/nodejs/@pulumi/aws-serverless/) | [pulumi/pulumi-aws-serverless](https://github.com/pulumi/pulumi-aws-serverless) |
-| AWS Infrastructure | Preview | [Docs](https://pulumi.io/reference/pkg/nodejs/@pulumi/aws-infra/) | [pulumi/pulumi-aws-infra](https://github.com/pulumi/pulumi-aws-infra) |
-| Pulumi Multi-Cloud Framework | Preview | [Docs](https://pulumi.io/reference/pkg/nodejs/@pulumi/cloud/) | [pulumi/pulumi-cloud](https://github.com/pulumi/pulumi-cloud) |
+See [Supported Clouds](https://www.pulumi.com/docs/reference/clouds/) for the
+full list of supported cloud and infrastructure providers.
 
 ## Contributing
 
-Please See [CONTRIBUTING.md](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) for information on building Pulumi from source or contributing improvments.
+Please See [CONTRIBUTING.md](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md)
+for information on building Pulumi from source or contributing improvements.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://www.pulumi.com" title="Pulumi - Modern Infrastructure as Code - AWS Azure Kubernetes Containers Serverless">
-    <img src="https://www.pulumi.com/images/logo/logo-inv.svg" width="350">
+    <img src="https://www.pulumi.com/images/logo/logo.svg" width="350">
 </a>
 
 [![Slack](http://www.pulumi.com/images/docs/badges/slack.svg)](https://slack.pulumi.com)

--- a/dist/actions/Dockerfile
+++ b/dist/actions/Dockerfile
@@ -12,7 +12,7 @@ LABEL "com.github.actions.color"="purple"
 # pulumi/actions contains documentation, examples. The actual container image is at
 # https://github.com/pulumi/pulumi.
 LABEL "repository"="https://github.com/pulumi/actions"
-LABEL "homepage"="http://pulumi.io/reference/gh-actions.html"
+LABEL "homepage"="https://pulumi.com/docs/reference/cd-github-actions/"
 
 # Install deps not already included in base container image.
 RUN apt-get update -y && \

--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim-stretch
 # TODO[pulumi/pulumi#1986]: consider switching to, or supporting, Alpine Linux for smaller image sizes.
 
 LABEL "repository"="https://github.com/pulumi/pulumi"
-LABEL "homepage"="http://pulumi.io/"
+LABEL "homepage"="https://pulumi.com/"
 LABEL "maintainer"="Pulumi Team <team@pulumi.com>"
 
 # Install deps all in one step

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -16,8 +16,8 @@ Using yarn:
 $ yarn add @pulumi/pulumi
 ```
 
-This SDK is meant for use with the Pulumi CLI.  Please visit [pulumi.io](https://pulumi.io) for
-installation instructions.
+This SDK is meant for use with the Pulumi CLI.  Please visit
+[pulumi.com](https://pulumi.com) for installation instructions.
 
 ## Building and Testing
 

--- a/sdk/python/lib/test/langhost/asset/__main__.py
+++ b/sdk/python/lib/test/langhost/asset/__main__.py
@@ -24,4 +24,4 @@ class MyResource(CustomResource):
 
 MyResource("file", FileAsset("./testfile.txt"))
 MyResource("string", StringAsset("its a string"))
-MyResource("remote", RemoteAsset("https://pulumi.io"))
+MyResource("remote", RemoteAsset("https://pulumi.com"))

--- a/sdk/python/lib/test/langhost/asset/test_asset.py
+++ b/sdk/python/lib/test/langhost/asset/test_asset.py
@@ -35,7 +35,7 @@ class AssetTest(LanghostTest):
             self.assertEqual(resource["asset"].text, "its a string")
         elif name == "remote":
             self.assertIsInstance(resource["asset"], RemoteAsset)
-            self.assertEqual(resource["asset"].uri, "https://pulumi.io")
+            self.assertEqual(resource["asset"].uri, "https://pulumi.com")
         else:
             self.fail("unexpected resource name: " + name)
         return {

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -106,10 +106,10 @@ class NextSerializationTests(unittest.TestCase):
 
     @async_test
     async def test_remote_asset(self):
-        asset = RemoteAsset("https://pulumi.io")
+        asset = RemoteAsset("https://pulumi.com")
         prop = await rpc.serialize_property(asset, [])
         self.assertEqual(rpc._special_asset_sig, prop[rpc._special_sig_key])
-        self.assertEqual("https://pulumi.io", prop["uri"])
+        self.assertEqual("https://pulumi.com", prop["uri"])
 
     @async_test
     async def test_output(self):
@@ -223,10 +223,10 @@ class NextSerializationTests(unittest.TestCase):
 
     @async_test
     async def test_remote_archive(self):
-        asset = RemoteArchive("https://pulumi.io")
+        asset = RemoteArchive("https://pulumi.com")
         prop = await rpc.serialize_property(asset, [])
         self.assertEqual(rpc._special_archive_sig, prop[rpc._special_sig_key])
-        self.assertEqual("https://pulumi.io", prop["uri"])
+        self.assertEqual("https://pulumi.com", prop["uri"])
 
     @async_test
     async def test_file_archive(self):


### PR DESCRIPTION
With TGWMO2019 complete, this PR updates all references to pulumi.io in this repository. We bake the URL into README.md files, some tests, and `Dockerfile`s.

I made a few minor edits outside of just updating the links:

- I removed references to things no longer available, such as the `@pulumi/aws-serverless` package. I think we need to go back and update the `README.md` file to mention Crosswalk for AWS and/or `awsx`.
- When appropriate, I edited Markdown files to line break around 80 chars just to make things more readable.
- For tables within Markdown files, I vertically aligned cell separators.

Also, note that _some_ references to pulumi.io are still around (and should remain so). There are a few places where we use pulumi.io for short links to specific help topics or documentation. For example, https://pulumi.io/help/stack-reference. We'll keep those links working (and add more as needed), since the alternative isn't nearly as elegant.

Part of https://github.com/pulumi/docs/issues/1311.