### PR TITLE
Add helper function for aliases.

### DIFF
--- a/sdk/nodejs/utils.ts
+++ b/sdk/nodejs/utils.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as pulumi from ".";
+
 import * as deasync from "deasync";
 
 import { InvokeOptions } from "./invoke";
@@ -111,4 +113,37 @@ export function liftProperties<T>(promise: Promise<T>, opts: InvokeOptions = {})
     // return the combined set of each.
     const value = promiseResult(promise);
     return Object.assign(promise, value);
+}
+
+/**
+ * Returns a full copy of `opts` except with `alias` added to it's list of
+ * `ResourceOptions.aliases`.
+ *
+ * This is an advanced compat function for libraries and should not generally be used by normal
+ * Pulumi application.
+ */
+export function withAlias<T extends pulumi.ResourceOptions>(opts: T | undefined, alias: pulumi.Input<pulumi.URN | pulumi.Alias>): T {
+    return withAliases(opts, [alias]);
+}
+
+/**
+ * Returns a full copy of `opts` except with `aliases` added to it's list of
+ * `ResourceOptions.aliases`.
+ *
+ * This is an advanced compat function for libraries and should not generally be used by normal
+ * Pulumi application.
+ */
+export function withAliases<T extends pulumi.ResourceOptions>(opts: T | undefined, aliases: pulumi.Input<pulumi.URN | pulumi.Alias>[]): T {
+    const allAliases: pulumi.Input<pulumi.URN | pulumi.Alias>[] = [];
+    if (opts && opts.aliases) {
+        for (const alias of opts.aliases) {
+            allAliases.push(alias);
+        }
+    }
+
+    for (const alias of aliases) {
+        allAliases.push(alias);
+    }
+
+    return <T>{ ...opts, aliases };
 }

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -62,6 +62,8 @@ from .resource import (
     create_urn,
     export,
     ROOT_STACK_RESOURCE,
+    with_alias,
+    with_aliases,
 )
 
 from .output import (

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -662,3 +662,39 @@ def create_urn(
 
     return Output.all(parent_prefix, type_, name).apply(
         lambda arr: arr[0] + arr[1] + "::" + arr[2])
+
+
+def with_alias(opts: Optional[ResourceOptions], alias: Input[Union[str, Alias]]) -> ResourceOptions:
+    """
+    Returns a full copy of `opts` except with `alias` added to it's list of
+    `ResourceOptions.aliases`.
+
+    This is an advanced compat function for libraries and should not generally be used by normal
+    Pulumi application.
+    """
+    return with_aliases(opts, [alias])
+
+
+def with_aliases(opts: Optional[ResourceOptions], aliases: List[Input[Union[str, Alias]]]) -> ResourceOptions:
+    """
+    Returns a full copy of `opts` except with `aliases` added to it's list of
+    `ResourceOptions.aliases`.
+
+    This is an advanced compat function for libraries and should not generally be used by normal
+    Pulumi application.
+    """
+
+    if opts is None:
+        opts = ResourceOptions()
+
+    all_aliases: List[Input[Union[str, Alias]]] = []
+    if opts.aliases is not None:
+        for alias in opts.aliases:
+            all_aliases.append(alias)
+
+    for alias in aliases:
+        all_aliases.append(alias)
+
+    opts_copy = copy.copy(opts)
+    opts_copy.aliases = all_aliases
+    return opts_copy


### PR DESCRIPTION
This is a function we already have and use downstream in pulumi-aws and pulumi-awsx.  This moves it up to pulumi/pulumi so that we can depend on it downstream from all our libs.  We'll also be using it specifically in pulumi/aws and pulumi/azure so that we can rename a few things and easily add aliases for the things we've renamed.