### PR TITLE
Rewrite all rows when screen height changes

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -140,7 +140,7 @@ type ProgressDisplay struct {
 	isTerminal bool
 
 	// The width and height of the terminal.  Used so we can trim resource messages that are too long.
-	terminalWidth int
+	terminalWidth  int
 	terminalHeight int
 
 	// If all progress messages are done and we can print out the final display.


### PR DESCRIPTION
Improves things for https://github.com/pulumi/pulumi/issues/2241

Note: it's still easy to get into a state where things are corrupt on screen.  I've done a lot of reading on this problem and it turns out to not be fun (unless you want to write a lot of platform specific code, or accept that it may suck on some platforms).

Two major difficulties:

1. no consistent way to clear the screen (and not the scrollback buffer) across platfoms.  This means it's just hard to try to clear out any stale stuff that might be on screen to ensure the user only sees the latest stuff.
2. no consistent way to know where the caret is across platforms.  This affects things because the window size may not change, but scrolling up/down in a term can lead to staleness/overwritign the wrong stuff.

We can def invest more time here, but we'll have to be careful and will have to do testing across a wide set of platforms.  For example, just from my reading, it appears that several linux terms behave differently here as well.  
