### PR TITLE
Prevent poorly formatted strings in fatal error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ CHANGELOG
   by setting the `import` property in the resource options bag when instantiating a resource. In order to
   successfully import a resource, its desired configuration (i.e. its inputs) must not differ from its
   actual configuration (i.e. its state) as calculated by the resource's provider.
+- Better error message for missing npm on `pulumi new` (fixes [#1511](https://github.com/pulumi/pulumi/issues/1511))
 
 ## 0.17.22 (2019-07-11)
 

--- a/pkg/util/cmdutil/exit.go
+++ b/pkg/util/cmdutil/exit.go
@@ -17,6 +17,7 @@ package cmdutil
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
@@ -145,13 +146,15 @@ func Exit(err error) {
 }
 
 // ExitError issues an error and exits with a standard error exit code.
-func ExitError(msg string, args ...interface{}) {
-	exitErrorCode(-1, msg, args...)
+func ExitError(msg string) {
+	// Escape percent sign before passing the message as a format string (e.g., msg could contain %PATH% on Windows).
+	format := strings.Replace(msg, "%", "%%", -1)
+	exitErrorCodef(-1, format)
 }
 
-// exitErrorCode issues an error and exists with the given error exit code.
-func exitErrorCode(code int, msg string, args ...interface{}) {
-	Diag().Errorf(diag.Message("", msg), args...)
+// exitErrorCodef formats the message with arguments, issues an error and exists with the given error exit code.
+func exitErrorCodef(code int, format string, args ...interface{}) {
+	Diag().Errorf(diag.Message("", format), args...)
 	os.Exit(code)
 }
 


### PR DESCRIPTION
Fixes #1511 

The message containing `%PATH%` was passed to a function which treats it as a formatting string.

I changed `exitErrorCodef` to accept a parameter explicitly called `format` to make it clear that formatting will happen.

`ExitError` is a public function but it seems that it was never used to pass arguments. I removed the arguments - let me know if this may break something?

Finally, I added escaping of `%` inside `ExitError`. I wasn't able to find a standard function to do the escaping.