### PR TITLE
Reword step failure message prefix during an `update`

### DIFF
--- a/pkg/diag/errors.go
+++ b/pkg/diag/errors.go
@@ -26,7 +26,7 @@ func newError(urn resource.URN, id ID, message string) *Diag {
 // Plan and apply errors are in the [2000,3000) range.
 
 func GetResourceOperationFailedError(urn resource.URN) *Diag {
-	return newError(urn, 2000, "Resource operation failed: %v")
+	return newError(urn, 2000, "%v")
 }
 
 func GetDuplicateResourceURNError(urn resource.URN) *Diag {

--- a/pkg/diag/errors.go
+++ b/pkg/diag/errors.go
@@ -25,8 +25,8 @@ func newError(urn resource.URN, id ID, message string) *Diag {
 
 // Plan and apply errors are in the [2000,3000) range.
 
-func GetPlanApplyFailedError(urn resource.URN) *Diag {
-	return newError(urn, 2000, "Plan apply failed: %v")
+func GetResourceOperationFailedError(urn resource.URN) *Diag {
+	return newError(urn, 2000, "Resource operation failed: %v")
 }
 
 func GetDuplicateResourceURNError(urn resource.URN) *Diag {

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -356,7 +356,7 @@ func (acts *updateActions) OnResourceStepPost(
 		}
 
 		// Issue a true, bonafide error.
-		acts.Opts.Diag.Errorf(diag.GetPlanApplyFailedError(errorURN), err)
+		acts.Opts.Diag.Errorf(diag.GetResourceOperationFailedError(errorURN), err)
 		if reportStep {
 			acts.Opts.Events.resourceOperationFailedEvent(step, status, acts.Steps, acts.Opts.Debug)
 		}


### PR DESCRIPTION
The text "Plan applied failed: " is pretty inscrutable given our
current system. While both "plan" and "apply" are concepts inside the
the implementation of the CLI, we usually talk in terms of `preview`
and `update`. I suspect there are some cases where this prefix is not
100% technically correct, and if there's a better short way of saying
something more correct, I would love to adopt that instead, but as is,
I would really love to get rid of the "Plan apply failed" text in our
system, it pains me every time I read it.