### PR TITLE
Refactor the way secrets managers are provided

### DIFF
--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -75,7 +75,7 @@ func newStackImportCmd() *cobra.Command {
 			// We do, however, now want to unmarshal the json.RawMessage into a real, typed deployment.  We do this so
 			// we can check that the deployment doesn't contain resources from a stack other than the selected one. This
 			// catches errors wherein someone imports the wrong stack's deployment (which can seriously hork things).
-			snapshot, err := stack.DeserializeUntypedDeployment(&deployment)
+			snapshot, err := stack.DeserializeUntypedDeployment(&deployment, stack.DefaultSecretsProvider)
 			if err != nil {
 				switch err {
 				case stack.ErrDeploymentSchemaVersionTooOld:

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -638,7 +638,7 @@ func (b *localBackend) ImportDeployment(ctx context.Context, stackRef backend.St
 		return err
 	}
 
-	snap, err := stack.DeserializeUntypedDeployment(deployment)
+	snap, err := stack.DeserializeUntypedDeployment(deployment, stack.DefaultSecretsProvider)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -278,7 +278,7 @@ func (b *cloudBackend) getSnapshot(ctx context.Context, stackRef backend.StackRe
 		return nil, err
 	}
 
-	snapshot, err := stack.DeserializeUntypedDeployment(untypedDeployment)
+	snapshot, err := stack.DeserializeUntypedDeployment(untypedDeployment, stack.DefaultSecretsProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -111,7 +111,7 @@ func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
 func DeserializeCheckpoint(chkpoint *apitype.CheckpointV3) (*deploy.Snapshot, error) {
 	contract.Require(chkpoint != nil, "chkpoint")
 	if chkpoint.Latest != nil {
-		return DeserializeDeploymentV3(*chkpoint.Latest)
+		return DeserializeDeploymentV3(*chkpoint.Latest, DefaultSecretsProvider)
 	}
 
 	return nil, nil

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/pulumi/pulumi/pkg/secrets/service"
-
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/apitype"
@@ -29,8 +27,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/secrets"
-	"github.com/pulumi/pulumi/pkg/secrets/b64"
-	"github.com/pulumi/pulumi/pkg/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
@@ -136,7 +132,9 @@ func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager) (*apitype.De
 // DeserializeUntypedDeployment deserializes an untyped deployment and produces a `deploy.Snapshot`
 // from it. DeserializeDeployment will return an error if the untyped deployment's version is
 // not within the range `DeploymentSchemaVersionCurrent` and `DeploymentSchemaVersionOldestSupported`.
-func DeserializeUntypedDeployment(deployment *apitype.UntypedDeployment) (*deploy.Snapshot, error) {
+func DeserializeUntypedDeployment(
+	deployment *apitype.UntypedDeployment, secretsProv SecretsProvider) (*deploy.Snapshot, error) {
+
 	contract.Require(deployment != nil, "deployment")
 	switch {
 	case deployment.Version > apitype.DeploymentSchemaVersionCurrent:
@@ -168,11 +166,11 @@ func DeserializeUntypedDeployment(deployment *apitype.UntypedDeployment) (*deplo
 		contract.Failf("unrecognized version: %d", deployment.Version)
 	}
 
-	return DeserializeDeploymentV3(v3deployment)
+	return DeserializeDeploymentV3(v3deployment, secretsProv)
 }
 
 // DeserializeDeploymentV3 deserializes a typed DeploymentV3 into a `deploy.Snapshot`.
-func DeserializeDeploymentV3(deployment apitype.DeploymentV3) (*deploy.Snapshot, error) {
+func DeserializeDeploymentV3(deployment apitype.DeploymentV3, secretsProv SecretsProvider) (*deploy.Snapshot, error) {
 	// Unpack the versions.
 	manifest := deploy.Manifest{
 		Time:    deployment.Manifest.Time,
@@ -197,22 +195,13 @@ func DeserializeDeploymentV3(deployment apitype.DeploymentV3) (*deploy.Snapshot,
 
 	var secretsManager secrets.Manager
 	if deployment.SecretsProviders != nil && deployment.SecretsProviders.Type != "" {
-		var provider secrets.ManagerProvider
-
-		switch deployment.SecretsProviders.Type {
-		case b64.Type:
-			provider = b64.NewProvider()
-		case passphrase.Type:
-			provider = passphrase.NewProvider()
-		case service.Type:
-			provider = service.NewProvider()
-		default:
-			return nil, errors.Errorf("unknown secrets provider type %s", deployment.SecretsProviders.Type)
+		if secretsProv == nil {
+			return nil, errors.New("deployment uses a SecretsProvider but no SecretsProvider was provided")
 		}
 
-		sm, err := provider.FromState(deployment.SecretsProviders.State)
+		sm, err := secretsProv.OfType(deployment.SecretsProviders.Type, deployment.SecretsProviders.State)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating secrets manager from existing state")
+			return nil, err
 		}
 		secretsManager = sm
 	}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -159,7 +159,7 @@ func TestLoadTooNewDeployment(t *testing.T) {
 		Version: apitype.DeploymentSchemaVersionCurrent + 1,
 	}
 
-	deployment, err := DeserializeUntypedDeployment(untypedDeployment)
+	deployment, err := DeserializeUntypedDeployment(untypedDeployment, DefaultSecretsProvider)
 	assert.Nil(t, deployment)
 	assert.Error(t, err)
 	assert.Equal(t, ErrDeploymentSchemaVersionTooNew, err)
@@ -170,7 +170,7 @@ func TestLoadTooOldDeployment(t *testing.T) {
 		Version: DeploymentSchemaVersionOldestSupported - 1,
 	}
 
-	deployment, err := DeserializeUntypedDeployment(untypedDeployment)
+	deployment, err := DeserializeUntypedDeployment(untypedDeployment, DefaultSecretsProvider)
 	assert.Nil(t, deployment)
 	assert.Error(t, err)
 	assert.Equal(t, ErrDeploymentSchemaVersionTooOld, err)

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -1,0 +1,62 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+
+	"github.com/pulumi/pulumi/pkg/secrets"
+	"github.com/pulumi/pulumi/pkg/secrets/b64"
+	"github.com/pulumi/pulumi/pkg/secrets/passphrase"
+	"github.com/pulumi/pulumi/pkg/secrets/service"
+)
+
+// DefaultSecretsProvider is the default SecretsProvider to use when deserializing deployments.
+var DefaultSecretsProvider SecretsProvider = &defaultSecretsProvider{}
+
+// SecretsProvider allows for the creation of secrets managers based on a well-known type name.
+type SecretsProvider interface {
+	// OfType returns a secrets manager for the given type, initialized with its previous state.
+	OfType(ty string, state json.RawMessage) (secrets.Manager, error)
+}
+
+// defaultSecretsProvider implements the secrets.ManagerProviderFactory interface. Essentially
+// it is the global location where new secrets managers can be registered for use when
+// decrypting checkpoints.
+type defaultSecretsProvider struct{}
+
+// OfType returns a secrets manager for the given secrets type. Returns an error
+// if the type is uknown or the state is invalid.
+func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
+	var sm secrets.Manager
+	var err error
+	switch ty {
+	case b64.Type:
+		sm = b64.NewBase64SecretsManager()
+	case passphrase.Type:
+		sm, err = passphrase.NewPassphaseSecretsManagerFromState(state)
+	case service.Type:
+		sm, err = service.NewServiceSecretsManagerFromState(state)
+	default:
+		return nil, errors.Errorf("no known secrets provider for type %q", ty)
+	}
+	if err != nil {
+		return nil, errors.Wrapf(err, "constructing secrets manager of type %q", ty)
+	}
+
+	return sm, nil
+}

--- a/pkg/secrets/b64/manager.go
+++ b/pkg/secrets/b64/manager.go
@@ -16,24 +16,12 @@ package b64
 
 import (
 	"encoding/base64"
-	"encoding/json"
 
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/secrets"
 )
 
 const Type = "b64"
-
-type provider struct{}
-
-func (p *provider) FromState(state json.RawMessage) (secrets.Manager, error) {
-	return &manager{}, nil
-}
-
-// NewProvider returns a new manager provider which hands back Base64SecretsManagers
-func NewProvider() secrets.ManagerProvider {
-	return &provider{}
-}
 
 // NewBase64SecretsManager returns a secrets manager that just base64 encodes instead of encrypting. Useful for testing.
 func NewBase64SecretsManager() secrets.Manager {

--- a/pkg/secrets/manager.go
+++ b/pkg/secrets/manager.go
@@ -14,11 +14,10 @@
 package secrets
 
 import (
-	"encoding/json"
-
 	"github.com/pulumi/pulumi/pkg/resource/config"
 )
 
+// Manager provides the interface for providing stack encryption.
 type Manager interface {
 	// Type retruns a string that reflects the type of this provider. This is serialized along with the state of
 	// the manager into the deployment such that we can re-construct the correct manager when deserializing a
@@ -33,8 +32,4 @@ type Manager interface {
 	// Decrypter returns a `config.Decrypter` that can be used to decrypt values when deserializing a snapshot from a
 	// deployment, or an error if one can not be constructed.
 	Decrypter() (config.Decrypter, error)
-}
-
-type ManagerProvider interface {
-	FromState(state json.RawMessage) (Manager, error)
 }

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -138,15 +138,9 @@ func NewPassphaseSecretsManager(phrase string, state string) (secrets.Manager, e
 	return sm, nil
 }
 
-type provider struct{}
-
-var _ secrets.ManagerProvider = &provider{}
-
-func NewProvider() secrets.ManagerProvider {
-	return &provider{}
-}
-
-func (p *provider) FromState(state json.RawMessage) (secrets.Manager, error) {
+// NewPassphaseSecretsManagerFromState returns a new passphrase-based secrets manager, from the
+// given state. Will use the passphrase found in PULUMI_CONFIG_PASSPHRASE.
+func NewPassphaseSecretsManagerFromState(state json.RawMessage) (secrets.Manager, error) {
 	var s localSecretsManagerState
 	if err := json.Unmarshal(state, &s); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling state")

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -93,15 +93,9 @@ func NewServiceSecretsManager(c *client.Client, id client.StackIdentifier) (secr
 	}, nil
 }
 
-type provider struct{}
-
-var _ secrets.ManagerProvider = &provider{}
-
-func NewProvider() secrets.ManagerProvider {
-	return &provider{}
-}
-
-func (p *provider) FromState(state json.RawMessage) (secrets.Manager, error) {
+// NewServiceSecretsManagerFromState returns a Pulumi service-based secrets manager based on the
+// existing state.
+func NewServiceSecretsManagerFromState(state json.RawMessage) (secrets.Manager, error) {
 	var s serviceSecretsManagerState
 	if err := json.Unmarshal(state, &s); err != nil {
 		return nil, errors.Wrap(err, "unmarshalling state")

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -399,7 +399,7 @@ func GetLogs(
 	stackInfo RuntimeValidationStackInfo,
 	query operations.LogQuery) *[]operations.LogEntry {
 
-	snap, err := stack.DeserializeDeploymentV3(*stackInfo.Deployment)
+	snap, err := stack.DeserializeDeploymentV3(*stackInfo.Deployment, stack.DefaultSecretsProvider)
 	assert.NoError(t, err)
 
 	tree := operations.NewResourceTree(snap.Resources)

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -233,7 +233,7 @@ func TestStackCommands(t *testing.T) {
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		snap, err := stack.DeserializeUntypedDeployment(&deployment)
+		snap, err := stack.DeserializeUntypedDeployment(&deployment, stack.DefaultSecretsProvider)
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}


### PR DESCRIPTION
Refactor the way secrets managers are constructed when deserializing checkpoints.

Currently there is an implicit coupling between the `resource/stack` package and the various "secrets managers" found in the `pkg/secrets` package. When deserializing a deployment, the decrypted resource state is needed, and so the method `DeserializeDeploymentV3` simply created a `secrets.Provider` based on the secrets manager type found in the deployment. (e.g. `secrets/passphrase` or `secrets/service`.)

This dependency however makes it impossible to deserialize deployments outside of the assumptions baked into the secrets managers. For example, the service secrets manager assumes that it can read from a workspace relative to the current working directory. And the passphrase-based one requires a specific environment variable. Neither of those would be the case when referencing this code in another context (e.g. the Pulumi Service).

This PR abstracts the construction of secrets managers into a new `stack.SecretsProvider` interface, which must be passed to `DeserializeDeploymentV3`. This not only makes this dependency between deserialization and secrets managers clearer, but also allows for swapping out alternative secret managers if needed.

The main motivation for this refactoring is #3873. Without going into the details, we need a way to deserialize a "deployment" into a "snapshot" without actually decrypting the snapshot. (Since by construction, the Pulumi Service is unable to do so because of client-side encryption.) With this refactoring, the Pulumi Service could provide a "passthrough secrets manager" that doesn't actually decrypt anything, but just preserves the cipher text. This would allow us to deserialize and operate on a snapshot, albeit without the actual resource data. (Which for limited scenarios, like [un]protecting a single resource, or renaming a stack, is sufficient.)
