### PR TITLE
Add requireOutput to StackReference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 
 - Add `Ouput.concat` to Python SDK [#3006](https://github.com/pulumi/pulumi/pull/3006)
 
+- Add `requireOutput` to `StackReference` [#3007](https://github.com/pulumi/pulumi/pull/3007)
+
 ### Compatibility
 
 - Deprecated functions in `@pulumi/pulumi` will now issue warnings if you call them.  Please migrate

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -66,7 +66,7 @@ export class StackReference extends CustomResource {
     public requireOutput(name: Input<string>): Output<any> {
         return all([output(this.name), output(name), this.outputs]).apply(([stackname, n, os]) => {
             if (!os.hasOwnProperty(n)) {
-                throw new Error(`Required output '${n}' does not exist on stack '${stackname}'."`);
+                throw new Error(`Required output '${n}' does not exist on stack '${stackname}'.`);
             }
             return os[n];
         });
@@ -85,7 +85,7 @@ export class StackReference extends CustomResource {
         const out = this.getOutput(name);
         const isSecret = promiseResult(out.isSecret);
         if (isSecret) {
-            throw new Error("Cannot call [getOutputSync] if the referenced stack has secret outputs. Use [getOutput] instead.");
+            throw new Error("Cannot call 'getOutputSync' if the referenced stack has secret outputs. Use 'getOutput' instead.");
         }
 
         return promiseResult(out.promise());
@@ -104,7 +104,7 @@ export class StackReference extends CustomResource {
         const out = this.requireOutput(name);
         const isSecret = promiseResult(out.isSecret);
         if (isSecret) {
-            throw new Error("Cannot call [getOutputSync] if the referenced stack has secret outputs. Use [getOutput] instead.");
+            throw new Error("Cannot call 'requireOutputSync' if the referenced stack has secret outputs. Use 'requireOutput' instead.");
         }
 
         return promiseResult(out.promise());

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -50,12 +50,26 @@ export class StackReference extends CustomResource {
     }
 
     /**
-     * Fetches the value of the named stack output.
+     * Fetches the value of the named stack output, or undefined if the stack output was not found.
      *
      * @param name The name of the stack output to fetch.
      */
     public getOutput(name: Input<string>): Output<any> {
         return all([output(name), this.outputs]).apply(([n, os]) => os[n]);
+    }
+
+    /**
+     * Fetches the value of the named stack output, or throws an error if the output was not found.
+     *
+     * @param name The name of the stack output to fetch.
+     */
+    public requireOutput(name: Input<string>): Output<any> {
+        return all([output(this.name), output(name), this.outputs]).apply(([stackname, n, os]) => {
+            if (!os.hasOwnProperty(n)) {
+                throw new Error(`Required output '${n}' does not exist on stack '${stackname}'."`);
+            }
+            return os[n];
+        });
     }
 
     /**
@@ -76,6 +90,26 @@ export class StackReference extends CustomResource {
 
         return promiseResult(out.promise());
     }
+
+    /**
+     * Fetches the value promptly of the named stack output.  Throws an error if the stack output is
+     * not found.
+     *
+     * This operation is not supported (and will throw) if any exported values of the StackReference
+     * are secrets.
+     *
+     * @param name The name of the stack output to fetch.
+     */
+    public requireOutputSync(name: string): any {
+        const out = this.requireOutput(name);
+        const isSecret = promiseResult(out.isSecret);
+        if (isSecret) {
+            throw new Error("Cannot call [getOutputSync] if the referenced stack has secret outputs. Use [getOutput] instead.");
+        }
+
+        return promiseResult(out.promise());
+    }
+
 }
 
 /**

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -56,7 +56,16 @@ class StackReference(CustomResource):
 
     def get_output(self, name: Input[str]) -> Output[Any]:
         """
-        Fetches the value of the named stack output.
+        Fetches the value of the named stack output, or None if the stack output was not found.
+
+        :param Input[str] name: The name of the stack output to fetch.
+        """
+        return Output.all(Output.from_input(name), self.outputs).apply(lambda l: l[1].get(l[0]))
+
+    def require_output(self, name: Input[str]) -> Output[Any]:
+        """
+        Fetches the value of the named stack output, or raises a KeyError if the output was not
+        found.
 
         :param Input[str] name: The name of the stack output to fetch.
         """


### PR DESCRIPTION
Provides an additional helper function to read outputs from a stack reference in case it is known that the stack output must be present.  This is similar to the design for config.get and config.require.

Fixes #2343.