### PR TITLE
Retry renaming a temporary folder during plugin installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ CHANGELOG
 =========
 
 ## Unreleased
+- Retry renaming a temporary folder during plugin installation
+  [#3008](https://github.com/pulumi/pulumi/pull/3008)
 
 ### Compatibility
 

--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -295,12 +295,12 @@ func (info PluginInfo) Install(tarball io.ReadCloser) error {
 		case *os.LinkError:
 			// On Windows, an Access Denied error is sometimes thrown when renaming. Work around by trying the 
 			// second time, which seems to work fine. See https://github.com/pulumi/pulumi/issues/2695
-            if err := os.Rename(tempDir, finalDir); err != nil && !os.IsExist(err) {
+			if err := os.Rename(tempDir, finalDir); err != nil && !os.IsExist(err) {
 				return errors.Wrap(err, "moving plugin")
 			}
-        default:
-            return errors.Wrap(err, "moving plugin")
-        }
+		default:
+			return errors.Wrap(err, "moving plugin")
+		}
 	}
 	fmt.Println(" done.")
 

--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -289,9 +289,20 @@ func (info PluginInfo) Install(tarball io.ReadCloser) error {
 	// If two calls to `plugin install` for the same plugin are racing, the second one will be unable to rename
 	// the directory. That's OK, just ignore the error. The temp directory created as part of the install will be
 	// cleaned up when we exit by the defer above.
+	fmt.Print("Moving plugin...")
 	if err := os.Rename(tempDir, finalDir); err != nil && !os.IsExist(err) {
-		return errors.Wrap(err, "moving plugin")
+		switch err.(type) {
+		case *os.LinkError:
+			// On Windows, an Access Denied error is sometimes thrown when renaming. Work around by trying the 
+			// second time, which seems to work fine. See https://github.com/pulumi/pulumi/issues/2695
+            if err := os.Rename(tempDir, finalDir); err != nil && !os.IsExist(err) {
+				return errors.Wrap(err, "moving plugin")
+			}
+        default:
+            return errors.Wrap(err, "moving plugin")
+        }
 	}
+	fmt.Println(" done.")
 
 	return nil
 }

--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -293,7 +293,7 @@ func (info PluginInfo) Install(tarball io.ReadCloser) error {
 	if err := os.Rename(tempDir, finalDir); err != nil && !os.IsExist(err) {
 		switch err.(type) {
 		case *os.LinkError:
-			// On Windows, an Access Denied error is sometimes thrown when renaming. Work around by trying the 
+			// On Windows, an Access Denied error is sometimes thrown when renaming. Work around by trying the
 			// second time, which seems to work fine. See https://github.com/pulumi/pulumi/issues/2695
 			if err := os.Rename(tempDir, finalDir); err != nil && !os.IsExist(err) {
 				return errors.Wrap(err, "moving plugin")


### PR DESCRIPTION
A workaround for #2695 

During the plugin installation, we create a temporary folder, unzip the binary, and then rename the folder to a permanent name. The rename fails 90% of the time with access denied. An immediate retry of renaming seems to always succeed.

Not exactly the code that I'm proud of, but it should help until we find a root cause.