### PR TITLE
Remove references to pulumi/glog.

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -31,7 +31,6 @@ import (
 	"github.com/djherbis/times"
 	"github.com/docker/docker/pkg/term"
 	"github.com/pkg/errors"
-	"github.com/pulumi/glog"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/backend/display"
@@ -199,7 +198,7 @@ func NewPulumiCmd() *cobra.Command {
 func checkForUpdate() {
 	curVer, err := semver.ParseTolerant(version.Version)
 	if err != nil {
-		glog.V(3).Infof("error parsing current version: %s", err)
+		logging.V(3).Infof("error parsing current version: %s", err)
 	}
 
 	// We don't care about warning for you to update if you have installed a developer version
@@ -209,7 +208,7 @@ func checkForUpdate() {
 
 	latestVer, oldestAllowedVer, err := getCLIVersionInfo()
 	if err != nil {
-		glog.V(3).Infof("error fetching latest version information: %s", err)
+		logging.V(3).Infof("error fetching latest version information: %s", err)
 	}
 
 	if oldestAllowedVer.GT(curVer) {
@@ -233,7 +232,7 @@ func getCLIVersionInfo() (semver.Version, semver.Version, error) {
 
 	err = cacheVersionInfo(latest, oldest)
 	if err != nil {
-		glog.V(3).Infof("failed to cache version info: %s", err)
+		logging.V(3).Infof("failed to cache version info: %s", err)
 	}
 
 	return latest, oldest, err
@@ -334,7 +333,7 @@ func getUpgradeCommand() string {
 
 	isBrew, err := isBrewInstall(exe)
 	if err != nil {
-		glog.V(3).Infof("error determining if the running executable was installed with brew: %s", err)
+		logging.V(3).Infof("error determining if the running executable was installed with brew: %s", err)
 	}
 	if isBrew {
 		return "$ brew upgrade pulumi"

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -28,9 +28,8 @@ import (
 	"strings"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/opentracing/opentracing-go"
+	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
-	"github.com/pulumi/glog"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 	git "gopkg.in/src-d/go-git.v4"
@@ -47,6 +46,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/gitutil"
+	"github.com/pulumi/pulumi/pkg/util/logging"
 	"github.com/pulumi/pulumi/pkg/util/tracing"
 	"github.com/pulumi/pulumi/pkg/workspace"
 )
@@ -362,7 +362,7 @@ func getUpdateMetadata(msg, root string) (*backend.UpdateMetadata, error) {
 	}
 
 	if err := addGitMetadata(root, m); err != nil {
-		glog.V(3).Infof("errors detecting git metadata: %s", err)
+		logging.V(3).Infof("errors detecting git metadata: %s", err)
 	}
 
 	addCIMetadataToEnvironment(m.Environment)

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/gofrs/flock v0.7.0
 	github.com/gogo/protobuf v1.2.0 // indirect
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.1
 	github.com/google/go-querystring v1.0.0
 	github.com/gorilla/context v1.1.1 // indirect
@@ -34,7 +35,6 @@ require (
 	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/pkg/errors v0.8.1
-	github.com/pulumi/glog v0.0.0-20180820174630-7eaa6ffb71e4
 	github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0 h1:xU6/SpYbvkNYiptHJYEDRseDLvYE7wSqhYYNy0QSUzI=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pulumi/glog"
-
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
@@ -30,6 +28,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/resource/stack"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/logging"
 )
 
 // massagePropertyValue takes a property value and strips out the secrets annotations from it.  If showSecrets is
@@ -160,7 +159,7 @@ func ShowJSONEvents(op string, action apitype.UpdateKind, events <-chan engine.E
 					if err == nil {
 						step.OldState = &res
 					} else {
-						glog.V(7).Infof("not adding old state as there was an error serialzing: %s", err)
+						logging.V(7).Infof("not adding old state as there was an error serialzing: %s", err)
 					}
 				}
 				if m.New != nil {
@@ -169,7 +168,7 @@ func ShowJSONEvents(op string, action apitype.UpdateKind, events <-chan engine.E
 					if err == nil {
 						step.NewState = &res
 					} else {
-						glog.V(7).Infof("not adding new state as there was an error serialzing: %s", err)
+						logging.V(7).Infof("not adding new state as there was an error serialzing: %s", err)
 					}
 				}
 

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -20,9 +20,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pulumi/glog"
 	"github.com/pulumi/pulumi/pkg/diag"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/logging"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/apitype"
@@ -572,7 +572,7 @@ func persistEngineEvents(
 		for eventBatch := range batchesToTransmit {
 			err := update.recordEngineEvents(eventBatch.sequenceStart, eventBatch.events)
 			if err != nil {
-				glog.V(3).Infof("error recording engine events: %s", err)
+				logging.V(3).Infof("error recording engine events: %s", err)
 			}
 		}
 	}

--- a/pkg/util/logging/log.go
+++ b/pkg/util/logging/log.go
@@ -30,7 +30,7 @@ import (
 	"strconv"
 	"sync"
 
-	"github.com/pulumi/glog"
+	"github.com/golang/glog"
 )
 
 type Filter interface {
@@ -72,13 +72,16 @@ func InitLogging(logToStderr bool, verbose int, logFlow bool) {
 	LogFlow = logFlow
 
 	// glog uses golang's built in flags package to set configuration values, which is incompatible with how
-	// we use cobra. So we explicitly set the flags we care about here, and don't call flag.Parse()
+	// we use cobra. In order to accommodate this, we call flag.CommandLine.Parse() with an empty array and
+	// explicitly set the flags we care about here.
+	err := flag.CommandLine.Parse([]string{})
+	assertNoError(err)
 	if logToStderr {
-		err := flag.Lookup("logtostderr").Value.Set("true")
+		err = flag.Lookup("logtostderr").Value.Set("true")
 		assertNoError(err)
 	}
 	if verbose > 0 {
-		err := flag.Lookup("v").Value.Set(strconv.Itoa(verbose))
+		err = flag.Lookup("v").Value.Set(strconv.Itoa(verbose))
 		assertNoError(err)
 	}
 }

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -43,7 +43,6 @@ import (
 
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
-	"github.com/pulumi/glog"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -199,7 +198,7 @@ func (host *nodeLanguageHost) GetRequiredPlugins(ctx context.Context,
 	}
 
 	if err != nil {
-		glog.V(3).Infof("one or more errors while discovering plugins: %s", err)
+		logging.V(3).Infof("one or more errors while discovering plugins: %s", err)
 	}
 	return &pulumirpc.GetRequiredPluginsResponse{
 		Plugins: plugins,


### PR DESCRIPTION
This package's flags conflict with those in google/glog. Replace all
references to this package with references to
pulumi/pulumi/pkg/util/logging, and change that package to explicitly
call `flag.CommandLine.Parse` with an empty slice.

This should make it much easier to consume these packages in downstream
repos that have direct or indirect dependencies on google/glog.