### PR TITLE
Always print out the last diagnostics we got. Unless we had an error and we're in the tree-view.

### DIFF
--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -71,9 +71,9 @@ type DiagInfo struct {
 	// to keep printing out the most significant diagnostic over and over again.
 	LastDiag *engine.DiagEventPayload
 
-	// The last event of each severity kind.  We'll print out the most significant of these (in the
-	// tree-view) next to a resource while it is in progress.
-	LastError, LastWarning, LastInfoError, LastInfo, LastDebug *engine.DiagEventPayload
+	// The last error we received.  If we have an error, and we're in tree-view, we'll prefer to
+	// show this over the last non-error diag so that users know about something bad early on.
+	LastError *engine.DiagEventPayload
 
 	// All the diagnostic events we've heard about this resource.  We'll print the last diagnostic
 	// in the status region while a resource is in progress.  At the end we'll print out all

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -197,17 +197,8 @@ func (data *resourceRowData) recordDiagEventPayload(payload engine.DiagEventPayl
 	diagInfo := data.diagInfo
 	diagInfo.LastDiag = &payload
 
-	switch payload.Severity {
-	case diag.Error:
+	if  payload.Severity == diag.Error {
 		diagInfo.LastError = &payload
-	case diag.Warning:
-		diagInfo.LastWarning = &payload
-	case diag.Infoerr:
-		diagInfo.LastInfoError = &payload
-	case diag.Info:
-		diagInfo.LastInfo = &payload
-	case diag.Debug:
-		diagInfo.LastDebug = &payload
 	}
 
 	if diagInfo.StreamIDToDiagPayloads == nil {
@@ -401,19 +392,18 @@ func (data *resourceRowData) getInfoColumn() string {
 				c, colors.SpecDebug, english.PluralWord(c, "debug", ""), colors.Reset))
 		}
 	} else {
-		// If we're not totally done, and we're in the tree-view, just print out the worst diagnostic next to the
-		// status message. This is helpful for long running tasks to know what's going on. However, once done, we
-		// print the diagnostics at the bottom, so we don't need to show this.
+		// If we're not totally done, and we're in the tree-view, just print out the last error (if
+		// there is one) next to the status message. This is helpful for long running tasks to know
+		// something bad has happened. However, once done, we print the diagnostics at the bottom, so we don't
+		// need to show this.
 		//
-		// if we're not in the tree-view (i.e. non-interactive mode), then we want to print out whatever the last
-		// diagnostics was that we got.  This way, as we're hearing about diagnostic events, we're always printing
-		// out the last one.
+		// if we're not in the tree-view (i.e. non-interactive mode), then we want to print out
+		// whatever the last diagnostics was that we got.  This way, as we're hearing about
+		// diagnostic events, we're always printing out the last one.
 
-		var diagnostic *engine.DiagEventPayload
-		if data.display.isTerminal {
-			diagnostic = data.diagInfo.LastDiag
-		} else {
-			diagnostic = getWorstDiagnostic(data.diagInfo)
+		 diagnostic := data.diagInfo.LastDiag
+		if data.display.isTerminal && data.diagInfo.LastError != nil {
+				diagnostic = data.diagInfo.LastError
 		}
 
 		if diagnostic != nil {
@@ -524,19 +514,4 @@ func writePropertyKeys(b io.StringWriter, keys []string, op deploy.StepOp) {
 
 		writeString(b, colors.Reset)
 	}
-}
-
-// Returns the worst diagnostic we've seen.  Used to produce a diagnostic string to go along with
-// any resource if it has had any issues.
-func getWorstDiagnostic(diagInfo *DiagInfo) *engine.DiagEventPayload {
-	if diagInfo.LastError != nil {
-		return diagInfo.LastError
-	} else if diagInfo.LastWarning != nil {
-		return diagInfo.LastWarning
-	} else if diagInfo.LastInfoError != nil {
-		return diagInfo.LastInfoError
-	} else if diagInfo.LastInfo != nil {
-		return diagInfo.LastInfo
-	}
-	return diagInfo.LastDebug
 }

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -197,7 +197,7 @@ func (data *resourceRowData) recordDiagEventPayload(payload engine.DiagEventPayl
 	diagInfo := data.diagInfo
 	diagInfo.LastDiag = &payload
 
-	if  payload.Severity == diag.Error {
+	if payload.Severity == diag.Error {
 		diagInfo.LastError = &payload
 	}
 
@@ -401,9 +401,9 @@ func (data *resourceRowData) getInfoColumn() string {
 		// whatever the last diagnostics was that we got.  This way, as we're hearing about
 		// diagnostic events, we're always printing out the last one.
 
-		 diagnostic := data.diagInfo.LastDiag
+		diagnostic := data.diagInfo.LastDiag
 		if data.display.isTerminal && data.diagInfo.LastError != nil {
-				diagnostic = data.diagInfo.LastError
+			diagnostic = data.diagInfo.LastError
 		}
 
 		if diagnostic != nil {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/2708

THe general idea here is that in all scenarios (treeview and non-interactive) we want to show the stream of messages as we get it.  However, only in the tree view, we want to override that and just show the last *error* if we have one.  The idea being that an error is significant to override the stream of messages we may get for a resource.  

I've tested this in a fairly wide set of scenarios, and this seems to be what we want.  Importantly, minor warnings (like about docker creds) don't cause us to stop seeing the stream of docker info messages.