### PR TITLE
Do not resolve missing outputs to inputs in preview.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+## Unreleased
+
+- Do not propagate input properties to missing output properties during preview. The old behavior can case issues that
+  are difficult to diagnose in cases where the actual value of the output property differs from the value of the input
+  property, and can cause `apply`s to run at unexpected times. If this change causes issues in a Pulumi program, the
+  original behavior can be enabled by setting the `PULUMI_ENABLE_LEGACY_APPLY` environment variable to `true`.
+
 ## 0.17.28 (2019-08-05)
 
 - Retry renaming a temporary folder during plugin installation
@@ -28,11 +35,6 @@ CHANGELOG
 
 - Fix a bug in the Python SDK that caused input properties that are coroutines to be awaited twice.
   [#3024](https://github.com/pulumi/pulumi/pull/3024)
-
-- Do not propagate input properties to missing output properties during preview. The old behavior can case issues that
-  are difficult to diagnose in cases where the actual value of the output property differs from the value of the input
-  property, and can cause `apply`s to run at unexpected times. If this change causes issues in a Pulumi program, the
-  original behavior can be enabled by setting the `PULUMI_ENABLE_LEGACY_APPLY` environment variable to `true`.
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ CHANGELOG
 - Fix a bug in the Python SDK that caused input properties that are coroutines to be awaited twice.
   [#3024](https://github.com/pulumi/pulumi/pull/3024)
 
+- Do not propagate input properties to missing output properties during preview. The old behavior can case issues that
+  are difficult to diagnose in cases where the actual value of the output property differs from the value of the input
+  property, and can cause `apply`s to run at unexpected times. If this change causes issues in a Pulumi program, the
+  original behavior can be enabled by setting the `PULUMI_ENABLE_LEGACY_APPLY` environment variable to `true`.
+
 ### Compatibility
 
 - Deprecated functions in `@pulumi/pulumi` will now issue warnings if you call them.  Please migrate

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -395,7 +395,7 @@ func (outputs *resourceOutputs) resolve(dryrun bool, err error, inputs map[strin
 		// Now resolve all output properties.
 		for k, s := range outputs.state {
 			v, has := outprops[k]
-			if !has {
+			if !has && !dryrun {
 				// If we did not receive a value for a particular property, resolve it to the corresponding input
 				// if any exists.
 				v = inputs[k]

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -40,6 +40,7 @@ export interface Options {
     readonly dryRun?: boolean; // whether we are performing a preview (true) or a real deployment (false).
     readonly testModeEnabled?: boolean; // true if we're in testing mode (allows execution without the CLI).
     readonly queryMode?: boolean; // true if we're in query mode (does not allow resource registration).
+    readonly legacyApply?: boolean; // true if we will resolve missing outputs to inputs during preview.
 }
 
 /**
@@ -93,6 +94,13 @@ export function _setQueryMode(val: boolean) {
  */
 export function isQueryMode(): boolean {
     return options.queryMode === true;
+}
+
+/**
+ * Returns true if we will resolve missing outputs to inputs during preview (PULUMI_ENABLE_LEGACY_APPLY).
+ */
+export function isLegacyApplyEnabled(): boolean {
+    return options.legacyApply === true;
 }
 
 /**
@@ -218,6 +226,7 @@ function loadOptions(): Options {
         monitorAddr: process.env["PULUMI_NODEJS_MONITOR"],
         engineAddr: process.env["PULUMI_NODEJS_ENGINE"],
         testModeEnabled: (process.env["PULUMI_TEST_MODE"] === "true"),
+        legacyApply: (process.env["PULUMI_ENABLE_LEGACY_APPLY"] === "true"),
     };
 }
 

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -218,12 +218,9 @@ describe("rpc", () => {
                         assert.deepEqual(dependencies, ["test:index:ResourceA::resourceA"]);
 
                         if (dryrun) {
-                            // If this is a dry-run, we will have the values of the original
-                            // resource copied over as outputs.  Note: this should really
-                            // only be done for values known to be stable.  This is tracked
-                            // by: https://github.com/pulumi/pulumi/issues/1055
+                            // If this is a dry-run, we will have no known values.
                             assert.deepEqual(res, {
-                                otherIn: 777,
+                                otherIn: runtime.unknownValue,
                                 otherOut: runtime.unknownValue,
                             });
                         }

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -364,12 +364,13 @@ async def resolve_outputs(res: 'Resource',
         log.debug(f"incoming output value translated: {value} -> {translated_value}")
         all_properties[translated_key] = translated_value
 
-    for key, value in list(serialized_props.items()):
-        translated_key = res.translate_output_property(key)
-        if translated_key not in all_properties:
-            # input prop the engine didn't give us a final value for.Just use the value passed into the resource by
-            # the user.
-            all_properties[translated_key] = translate_output_properties(res, deserialize_property(value))
+    if not settings.is_dry_run() or settings.is_legacy_apply_enabled():
+        for key, value in list(serialized_props.items()):
+            translated_key = res.translate_output_property(key)
+            if translated_key not in all_properties:
+                # input prop the engine didn't give us a final value for.Just use the value passed into the resource by
+                # the user.
+                all_properties[translated_key] = translate_output_properties(res, deserialize_property(value))
 
     for key, value in all_properties.items():
         # Skip "id" and "urn", since we handle those specially.

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -36,6 +36,7 @@ class Settings:
     parallel: Optional[str]
     dry_run: Optional[bool]
     test_mode_enabled: Optional[bool]
+    legacy_apply_enabled: Optional[bool]
 
     """
     A bag of properties for configuring the Pulumi Python language runtime.
@@ -47,16 +48,21 @@ class Settings:
                  stack: Optional[str] = None,
                  parallel: Optional[str] = None,
                  dry_run: Optional[bool] = None,
-                 test_mode_enabled: Optional[bool] = None):
+                 test_mode_enabled: Optional[bool] = None,
+                 legacy_apply_enabled: Optional[bool] = None):
         # Save the metadata information.
         self.project = project
         self.stack = stack
         self.parallel = parallel
         self.dry_run = dry_run
         self.test_mode_enabled = test_mode_enabled
+        self.legacy_apply_enabled = legacy_apply_enabled
 
         if self.test_mode_enabled is None:
             self.test_mode_enabled = os.getenv("PULUMI_TEST_MODE", "false") == "true"
+
+        if self.legacy_apply_enabled is None:
+            self.legacy_apply_enabled = os.getenv("PULUMI_ENABLE_LEGACY_APPLY", "false") == "true"
 
         # Actually connect to the monitor/engine over gRPC.
         if monitor:
@@ -107,6 +113,10 @@ def require_test_mode_enabled():
     if not is_test_mode_enabled():
         raise RunError('Program run without the `pulumi` CLI; this may not be what you want '+
                        '(enable PULUMI_TEST_MODE to disable this error)')
+
+
+def is_legacy_apply_enabled():
+    return bool(SETTINGS.legacy_apply_enabled)
 
 
 def get_project() -> Optional[str]:

--- a/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
+++ b/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
@@ -53,7 +53,7 @@ class ResourceThensTest(LanghostTest):
             self.assertListEqual(deps, ["test:index:ResourceA::resourceA"])
             if dry_run:
                 self.assertDictEqual(res, {
-                    "other_in": 777,
+                    # other_in is unknown, so it is not in the dictionary.
                     # other_out is unknown, so it is not in the dictionary.
                     # other_id is also unknown so it is not in the dictionary
                 })


### PR DESCRIPTION
This can cause `apply`s to run on values that may change during an
update, which can lead to unexpected behavior.

Fixes #2433.