### PR TITLE
Fixes python get_secret always returning None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ CHANGELOG
   instances, and the like. Values are treated as "plain old python data" and generally kept as
   simple values (like strings, numbers, etc.) or the simple collections supported by the Pulumi data model (specifically, dictionaries and lists).
 
+- Fix `get_secret` in Python SDK always returning None.
+
 ### Compatibility
 
 - Deprecated functions in `@pulumi/pulumi` will now issue warnings if you call them.  Please migrate

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -66,7 +66,7 @@ class Config:
         :return: The configuration key's value, or None if one does not exist.
         :rtype: Optional[str]
         """
-        c = self.get(self.full_key(key))
+        c = self.get(key)
         if c is None:
             return None
 


### PR DESCRIPTION
get_secret is looking up secrets by the fully resolved key, but should use the simple key.