### PR TITLE
Move required PP out of start update

### DIFF
--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -100,7 +100,7 @@ type ApplyPolicyPackRequest struct {
 }
 
 // GetStackPolicyPacksResponse is the response to getting the applicable Policy Packs
-// for a particular stack. This allows the CLI to download the packs prior to 
+// for a particular stack. This allows the CLI to download the packs prior to
 // starting an update.
 type GetStackPolicyPacksResponse struct {
 	// RequiredPolicies is a list of required Policy Packs to run during the update.

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -53,7 +53,7 @@ type RequiredPolicy struct {
 	DisplayName string `json:"displayName"`
 
 	// Where the Policy Pack can be downloaded from.
-	PackLocation string `json:"packLocation"`
+	PackLocation string `json:"packLocation,omitempty"`
 }
 
 // Policy defines the metadata for an individual Policy within a Policy Pack.
@@ -97,4 +97,12 @@ type GetPolicyPackResponse struct {
 type ApplyPolicyPackRequest struct {
 	Name    string `json:"name"`
 	Version int    `json:"version"`
+}
+
+// GetStackPolicyPacksResponse is the response to getting the applicable Policy Packs
+// for a particular stack. This allows the CLI to download the packs prior to 
+// starting an update.
+type GetStackPolicyPacksResponse struct {
+	// RequiredPolicies is a list of required Policy Packs to run during the update.
+	RequiredPolicies []RequiredPolicy `json:"requiredPolicies,omitempty"`
 }


### PR DESCRIPTION
I also added the `omitempty` to `PackLocation` so I can reuse this for the UI. I dont think this should cause any problems for the CLI since when you unmarshal it should just make `PackLocation` an empty string if it was omitted (but the service not sending the `PackLocation` would a bigger issue anyhow).

This is the first step in fixing issues: #3810 (from svc repo)

Also I realize the naming here isnt great `RequiredPolicies` would ideally be `RequiredPolicyPacks` but I want to be consistent with whats already implemented in the `UpdateProgramResponse`