### PR TITLE
Only await input properties once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ CHANGELOG
 
 - Make `pulumi.runtime.invoke` synchronous in the Python SDK [#3019](https://github.com/pulumi/pulumi/pull/3019)
 
+- Fix a bug in the Python SDK that caused input properties that are coroutines to be awaited twice.
+  [#3024](https://github.com/pulumi/pulumi/pull/3024)
+
 ### Compatibility
 
 - Deprecated functions in `@pulumi/pulumi` will now issue warnings if you call them.  Please migrate

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -256,7 +256,7 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: Op
         log.debug(f"resource read successful: ty={ty}, urn={resp.urn}")
         resolve_urn(resp.urn)
         resolve_id(resolved_id, True, None)  # Read IDs are always known.
-        await rpc.resolve_outputs(res, props, resp.properties, resolvers)
+        await rpc.resolve_outputs(res, resolver.serialized_props, resp.properties, resolvers)
 
     asyncio.ensure_future(RPC_MANAGER.do_rpc("read resource", do_read)())
 
@@ -399,7 +399,7 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
             is_known = bool(resp.id)
             resolve_id(resp.id, is_known, None)
 
-        await rpc.resolve_outputs(res, props, resp.object, resolvers)
+        await rpc.resolve_outputs(res, resolver.serialized_props, resp.object, resolvers)
 
     asyncio.ensure_future(RPC_MANAGER.do_rpc(
         "register resource", do_register)())

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -367,9 +367,8 @@ async def resolve_outputs(res: 'Resource',
     for key, value in list(serialized_props.items()):
         translated_key = res.translate_output_property(key)
         if translated_key not in all_properties:
-            # input prop the engine didn't give us a final value for.  Just use the value passed into the resource
-            # after round-tripping it through serialization. We do the round-tripping primarily s.t. we ensure that
-            # Output values are handled properly w.r.t. unknowns.
+            # input prop the engine didn't give us a final value for.Just use the value passed into the resource by
+            # the user.
             all_properties[translated_key] = translate_output_properties(res, deserialize_property(value))
 
     for key, value in all_properties.items():

--- a/sdk/python/lib/test/langhost/resource_thens/__main__.py
+++ b/sdk/python/lib/test/langhost/resource_thens/__main__.py
@@ -11,19 +11,26 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 from functools import partial
 from pulumi import CustomResource, Output
 
 def assert_eq(l, r):
     assert l == r
 
+async def inprop2():
+    await asyncio.sleep(0)
+    return 42
+
 class ResourceA(CustomResource):
     inprop: Output[int]
+    inprop_2: Output[int]
     outprop: Output[str]
 
     def __init__(self, name: str) -> None:
         CustomResource.__init__(self, "test:index:ResourceA", name, {
             "inprop": 777,
+            "inprop_2": inprop2(),
             "outprop": None
         })
 
@@ -41,6 +48,7 @@ class ResourceB(CustomResource):
 a = ResourceA("resourceA")
 a.urn.apply(lambda urn: assert_eq(urn, "test:index:ResourceA::resourceA"))
 a.inprop.apply(lambda v: assert_eq(v, 777))
+a.inprop_2.apply(lambda v: assert_eq(v, 42))
 a.outprop.apply(lambda v: assert_eq(v, "output yeah"))
 
 b = ResourceB("resourceB", a)

--- a/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
+++ b/sdk/python/lib/test/langhost/resource_thens/test_resource_thens.py
@@ -34,7 +34,7 @@ class ResourceThensTest(LanghostTest):
                           _ignore_changes, _version):
         if ty == "test:index:ResourceA":
             self.assertEqual(name, "resourceA")
-            self.assertDictEqual(res, {"inprop": 777})
+            self.assertDictEqual(res, {"inprop": 777, "inprop_2": 42})
             urn = self.make_urn(ty, name)
             res_id = ""
             props = {}


### PR DESCRIPTION
These changes fix a bug in the Python runtime that would cause any
awaitable input properties passed to a resource that are missing
from the resource's output properties to be awaited twice. The fix is
straightforward: rather than roundtripping an input property through
serialize/deserialize, just deserialized the already-serialized input
property.

Fixes #2940.