### PR TITLE
Send GitHub Actions CLI output to a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,13 @@ CHANGELOG
 
 ## Unreleased
 
-- Do not propagate input properties to missing output properties during preview. The old behavior can case issues that
+- Do not propagate input properties to missing output properties during preview. The old behavior can cause issues that
   are difficult to diagnose in cases where the actual value of the output property differs from the value of the input
   property, and can cause `apply`s to run at unexpected times. If this change causes issues in a Pulumi program, the
   original behavior can be enabled by setting the `PULUMI_ENABLE_LEGACY_APPLY` environment variable to `true`.
+
+- Fix a bug in the GitHub Actions program preventing errors from being rendered in the Actions log on github.com.
+  [#3036](https://github.com/pulumi/pulumi/pull/3036)
 
 ## 0.17.28 (2019-08-05)
 

--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -86,7 +86,7 @@ fi
 # later use. Note that we exit immediately on failure (under set -e), so we `tee` stdout, but
 # allow errors to be surfaced in the Actions log.
 PULUMI_COMMAND="pulumi $*"
-OUTPUT_FILE="/tmp/out.txt"
+OUTPUT_FILE=$(mktemp)
 echo "#### :tropical_drink: \`$PULUMI_COMMAND\`"
 bash -c "$PULUMI_COMMAND" | tee $OUTPUT_FILE
 EXIT_CODE=${PIPESTATUS[0]}

--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -89,7 +89,7 @@ PULUMI_COMMAND="pulumi $*"
 OUTPUT_FILE="/tmp/out.txt"
 echo "#### :tropical_drink: \`$PULUMI_COMMAND\`"
 bash -c "$PULUMI_COMMAND" | tee $OUTPUT_FILE
-EXIT_CODE=$?
+EXIT_CODE=${PIPESTATUS[0]}
 
 # If the GitHub action stems from a Pull Request event, we may optionally leave a comment if the
 # COMMENT_ON_PR is set.


### PR DESCRIPTION
During a GitHub Actions run, because we currently capture CLI output in a variable and exit immediately on failure, we prevent the details of the failure from being rendered in the Actions log. This change has us `tee` stdout instead (as the intent is to use it to post a PR comment later), allowing errors to be rendered properly in the log.

Fixes https://github.com/pulumi/actions/issues/11.
