### PR TITLE
Harden asset and archive deserialization.

### DIFF
--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -248,19 +248,35 @@ func DeserializeAsset(obj map[string]interface{}) (*Asset, bool, error) {
 	// Else, deserialize the possible fields.
 	var hash string
 	if v, has := obj[AssetHashProperty]; has {
-		hash = v.(string)
+		h, ok := v.(string)
+		if !ok {
+			return &Asset{}, false, errors.Errorf("unexpected asset hash of type %T", v)
+		}
+		hash = h
 	}
 	var text string
 	if v, has := obj[AssetTextProperty]; has {
-		text = v.(string)
+		t, ok := v.(string)
+		if !ok {
+			return &Asset{}, false, errors.Errorf("unexpected asset text of type %T", v)
+		}
+		text = t
 	}
 	var path string
 	if v, has := obj[AssetPathProperty]; has {
-		path = v.(string)
+		p, ok := v.(string)
+		if !ok {
+			return &Asset{}, false, errors.Errorf("unexpected asset path of type %T", v)
+		}
+		path = p
 	}
 	var uri string
 	if v, has := obj[AssetURIProperty]; has {
-		uri = v.(string)
+		u, ok := v.(string)
+		if !ok {
+			return &Asset{}, false, errors.Errorf("unexpected asset URI of type %T", v)
+		}
+		uri = u
 	}
 
 	return &Asset{Hash: hash, Text: text, Path: path, URI: uri}, true, nil
@@ -573,14 +589,23 @@ func DeserializeArchive(obj map[string]interface{}) (*Archive, bool, error) {
 
 	var hash string
 	if v, has := obj[ArchiveHashProperty]; has {
-		hash = v.(string)
+		h, ok := v.(string)
+		if !ok {
+			return &Archive{}, false, errors.Errorf("unexpected archive hash of type %T", v)
+		}
+		hash = h
 	}
 
 	var assets map[string]interface{}
 	if v, has := obj[ArchiveAssetsProperty]; has {
 		assets = make(map[string]interface{})
 		if v != nil {
-			for k, elem := range v.(map[string]interface{}) {
+			m, ok := v.(map[string]interface{})
+			if !ok {
+				return &Archive{}, false, errors.Errorf("unexpected archive contents of type %T", v)
+			}
+
+			for k, elem := range m {
 				switch t := elem.(type) {
 				case *Asset:
 					assets[k] = t
@@ -602,18 +627,26 @@ func DeserializeArchive(obj map[string]interface{}) (*Archive, bool, error) {
 						assets[k] = arch
 					}
 				default:
-					return &Archive{}, false, nil
+					return &Archive{}, false, errors.Errorf("archive member '%v' is not an asset or archive", k)
 				}
 			}
 		}
 	}
 	var path string
 	if v, has := obj[ArchivePathProperty]; has {
-		path = v.(string)
+		p, ok := v.(string)
+		if !ok {
+			return &Archive{}, false, errors.Errorf("unexpected archive path of type %T", v)
+		}
+		path = p
 	}
 	var uri string
 	if v, has := obj[ArchiveURIProperty]; has {
-		uri = v.(string)
+		u, ok := v.(string)
+		if !ok {
+			return &Archive{}, false, errors.Errorf("unexpected archive URI of type %T", v)
+		}
+		uri = u
 	}
 
 	return &Archive{Hash: hash, Assets: assets, Path: path, URI: uri}, true, nil

--- a/pkg/resource/plugin/rpc.go
+++ b/pkg/resource/plugin/rpc.go
@@ -291,6 +291,8 @@ func UnmarshalPropertyValue(v *structpb.Value, opts MarshalOptions) (*resource.P
 			if err != nil {
 				return nil, err
 			}
+			// This can only be false with a non-nil error if there is a signature match. We've already verified the
+			// signature.
 			contract.Assert(isasset)
 			if opts.ComputeAssetHashes {
 				if err = asset.EnsureHash(); err != nil {
@@ -304,6 +306,8 @@ func UnmarshalPropertyValue(v *structpb.Value, opts MarshalOptions) (*resource.P
 			if err != nil {
 				return nil, err
 			}
+			// This can only be false with a non-nil error if there is a signature match. We've already verified the
+			// signature.
 			contract.Assert(isarchive)
 			if opts.ComputeAssetHashes {
 				if err = archive.EnsureHash(); err != nil {

--- a/sdk/nodejs/tests/runtime/langhost/cases/012.assets_archive/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/012.assets_archive/index.js
@@ -8,7 +8,15 @@ class MyResource extends pulumi.CustomResource {
             "asset": new pulumi.asset.StringAsset("foo"),
             "archive": new pulumi.asset.AssetArchive({}),
         });
-        super("test:index:MyResource", name, { "archive": archive });
+        let archiveP = Promise.resolve(new pulumi.asset.AssetArchive({
+            "foo": new pulumi.asset.StringAsset("bar"),
+        }));
+        let assetP = Promise.resolve(new pulumi.asset.StringAsset("baz"));
+        super("test:index:MyResource", name, {
+            "archive": archive,
+            "archiveP": archiveP,
+            "assetP": assetP,
+        });
     }
 }
 

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -356,6 +356,40 @@ describe("rpc", () => {
             program: path.join(base, "012.assets_archive"),
             expectResourceCount: 1,
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any) => {
+                assert.deepEqual(res, {
+                    "archive": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "__pulumiArchive": true,
+                        "assets": {
+                            "archive": {
+                                "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                                "__pulumiArchive": true,
+                                "assets": {},
+                            },
+                            "asset": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "__pulumiAsset": true,
+                                "text": "foo",
+                            },
+                        },
+                    },
+                    "archiveP": {
+                        "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
+                        "__pulumiArchive": true,
+                        "assets": {
+                            "foo": {
+                                "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                                "__pulumiAsset": true,
+                                "text": "bar",
+                            },
+                        },
+                    },
+                    "assetP": {
+                        "4dabf18193072939515e22adb298388d": "c44067f5952c0a294b673a41bacd8c17",
+                        "__pulumiAsset": true,
+                        "text": "baz",
+                    },
+                });
                 return { urn: makeUrn(t, name), id: undefined, props: res };
             },
         },


### PR DESCRIPTION
- Ensure that type assertions are guarded, and that incorrectly-typed
  properties return errors rather than panicking
- Expand the asset/archive tests in the Node SDK to ensure that eventual
  archives and assets serialize and deserialize correctly

Fixes #2836.
Fixes #3016.