### PR TITLE
Fix conversion of empty array properties.

### DIFF
--- a/pkg/resource/properties.go
+++ b/pkg/resource/properties.go
@@ -257,7 +257,7 @@ func NewPropertyValueRepl(v interface{},
 	switch rk := rv.Type().Kind(); rk {
 	case reflect.Array, reflect.Slice:
 		// If an array or slice, just create an array out of it.
-		var arr []PropertyValue
+		arr := []PropertyValue{}
 		for i := 0; i < rv.Len(); i++ {
 			elem := rv.Index(i)
 			arr = append(arr, NewPropertyValueRepl(elem.Interface(), replk, replv))
@@ -492,7 +492,7 @@ func (v PropertyValue) MapRepl(replk func(string) (string, bool),
 	} else if v.IsString() {
 		return v.StringValue()
 	} else if v.IsArray() {
-		var arr []interface{}
+		arr := []interface{}{}
 		for _, e := range v.ArrayValue() {
 			arr = append(arr, e.MapRepl(replk, replv))
 		}

--- a/pkg/resource/properties_test.go
+++ b/pkg/resource/properties_test.go
@@ -34,6 +34,7 @@ func TestMappable(t *testing.T) {
 			"e.n": float64(676.767),
 			"e.^": []interface{}{"bbb"},
 		},
+		"f": []interface{}{},
 	}
 	ma1p := NewPropertyMapFromMap(ma1)
 	assert.Equal(t, len(ma1), len(ma1p))


### PR DESCRIPTION
Empty `[]interface{}` values were being converted to array property
values with a `nil` element, and empty array property values were being
coverted to `nil` `[]interface{}` values. These changes fix the
converters to return empty but non-nil values in both cases.

This is part of the fix for
https://github.com/pulumi/pulumi-kubernetes/issues/693.