### PR TITLE
Remove some unused apitype fields

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -356,10 +356,7 @@ const (
 
 // Stack describes a Stack running on a Pulumi Cloud.
 type Stack struct {
-	CloudName string `json:"cloudName"`
-	OrgName   string `json:"orgName"`
-
-	RepoName    string       `json:"repoName"`
+	OrgName     string       `json:"orgName"`
 	ProjectName string       `json:"projectName"`
 	StackName   tokens.QName `json:"stackName"`
 

--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -37,8 +37,9 @@ type ListStacksResponse struct {
 
 // CreateStackRequest defines the request body for creating a new Stack
 type CreateStackRequest struct {
-	// The rest of the StackIdentifier (repo, project) is in the URL.
+	// The rest of the StackIdentifier (e.g. organization, project) is in the URL.
 	StackName string `json:"stackName"`
+
 	// An optional set of tags to apply to the stack.
 	Tags map[StackTagName]string `json:"tags,omitEmpty"`
 }


### PR DESCRIPTION
Remove some long-since unused fields on our `apitype.Stack` struct. We haven't used `CloudName` since <date> when the last PPC was retired. And haven't needed <repo name> since migrating to stack identity model v2 (when it changed to just (org, stack). Stack identity model v3, which was (org, project, stack), was released in January in 0.16.2.

Sending out this PR so it's clearer what code we can cleanup in the service that is used to compute the repo name that is sent in API responses but unused.