### PR TITLE
 Disable interactive-terminal spinner when on a CI machine. 

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -259,7 +259,7 @@ func newConfigSetCmd(stack *string) *cobra.Command {
 				if readerr != nil {
 					return readerr
 				}
-				value = cmdutil.RemoveTralingNewline(string(b))
+				value = cmdutil.RemoveTrailingNewline(string(b))
 			case secret:
 				value, err = cmdutil.ReadConsoleNoEcho("value")
 				if err != nil {

--- a/pkg/backend/display/query.go
+++ b/pkg/backend/display/query.go
@@ -112,7 +112,7 @@ func renderQueryDiagEvent(payload engine.DiagEventPayload, opts Options) string 
 
 	// For stdout messages, trim ONLY the last newline character.
 	if payload.Severity == diag.Info {
-		payload.Message = cmdutil.RemoveTralingNewline(payload.Message)
+		payload.Message = cmdutil.RemoveTrailingNewline(payload.Message)
 	}
 
 	return opts.Color.Colorize(payload.Prefix + payload.Message)

--- a/pkg/util/cmdutil/console.go
+++ b/pkg/util/cmdutil/console.go
@@ -75,7 +75,7 @@ func ReadConsole(prompt string) (string, error) {
 		return "", err
 	}
 
-	return RemoveTralingNewline(raw), nil
+	return RemoveTrailingNewline(raw), nil
 }
 
 // IsTruthy returns true if the given string represents a CLI input interpreted as "true".
@@ -83,9 +83,9 @@ func IsTruthy(s string) bool {
 	return s == "1" || strings.EqualFold(s, "true")
 }
 
-// RemoveTralingNewline removes a trailing newline from a string. On windows, we'll remove either \r\n or \n, on other
+// RemoveTrailingNewline removes a trailing newline from a string. On windows, we'll remove either \r\n or \n, on other
 // platforms, we just remove \n.
-func RemoveTralingNewline(s string) string {
+func RemoveTrailingNewline(s string) string {
 	s = strings.TrimSuffix(s, "\n")
 
 	if runtime.GOOS == "windows" {

--- a/pkg/util/cmdutil/spinner.go
+++ b/pkg/util/cmdutil/spinner.go
@@ -35,7 +35,7 @@ func NewSpinnerAndTicker(prefix string, ttyFrames []string, timesPerSecond time.
 		}
 	}
 
-	if InteractiveTerminal() {
+	if Interactive() {
 		return &ttySpinner{
 			prefix: prefix,
 			frames: ttyFrames,


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/2259