### PR TITLE
Do not taint all stack outputs as secrets if just one is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+## HEAD (Unreleased)
+
+- When using StackReference to fetch output values from another stack, do not mark a value as secret if it was not
+  secret in the stack you referenced. (fixes [#2744](https://github.com/pulumi/pulumi/issues/2744)).
+
 ## 1.0.0-beta.2 (2019-08-13)
 
 - Fix the package version compatibility checks in the NodeJS language host.

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -182,9 +182,17 @@ func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resou
 		return nil, err
 	}
 
+	secretOutputs := make([]resource.PropertyValue, 0)
+	for k, v := range outputs {
+		if v.ContainsSecrets() {
+			secretOutputs = append(secretOutputs, resource.NewStringProperty(string(k)))
+		}
+	}
+
 	return resource.PropertyMap{
-		"name":    name,
-		"outputs": resource.NewObjectProperty(outputs),
+		"name":          name,
+		"outputs":       resource.NewObjectProperty(outputs),
+		"secretOutputs": resource.NewArrayProperty(secretOutputs),
 	}, nil
 }
 

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -97,6 +97,12 @@ class Output(Generic[T]):
 
     def future(self) -> Awaitable[T]:
         return self._future
+
+    def is_known(self) -> Awaitable[bool]:
+        return self._is_known
+
+    def is_secret(self) -> Awaitable[bool]:
+        return self._is_secret
     # End private implementation details.
 
     def apply(self, func: Callable[[T], Input[U]]) -> 'Output[U]':

--- a/tests/integration/stack_reference_secrets/step1/Pulumi.yaml
+++ b/tests/integration/stack_reference_secrets/step1/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: stack_reference_secrets
+description: A program that uses a stack reference with secret outputs
+runtime: nodejs

--- a/tests/integration/stack_reference_secrets/step1/index.ts
+++ b/tests/integration/stack_reference_secrets/step1/index.ts
@@ -1,0 +1,5 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const normal = pulumi.output("normal");
+export const secret = pulumi.secret("secret");
+

--- a/tests/integration/stack_reference_secrets/step1/package.json
+++ b/tests/integration/stack_reference_secrets/step1/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "typescript",
+    "devDependencies": {
+        "@types/node": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/stack_reference_secrets/step1/tsconfig.json
+++ b/tests/integration/stack_reference_secrets/step1/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "outDir": "bin",
+        "target": "es6",
+        "lib": [
+            "es6"
+        ],
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true,
+        "strictNullChecks": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/tests/integration/stack_reference_secrets/step2/index.ts
+++ b/tests/integration/stack_reference_secrets/step2/index.ts
@@ -1,0 +1,14 @@
+import * as pulumi from "@pulumi/pulumi";
+
+export const normal = pulumi.output("normal");
+export const secret = pulumi.secret("secret");
+
+// Kinda strange, but we are getting a stack reference to ourselves, and refercing the result of the /previous/
+// deployment.
+const org = new pulumi.Config().require("org");
+const project = pulumi.getProject();
+const stack = pulumi.getStack();
+const sr = new pulumi.StackReference(`${org}/${project}/${stack}`);
+
+export const refNormal = sr.getOutput("normal");
+export const refSecret = sr.getOutput("secret");


### PR DESCRIPTION
When using StackReference, if the stack you reference contains any
secret outputs, we have to mark the entire `outputs` member as a
secret output. This is because we only track secretness on a per
`Output<T>` basis.

For `getSecret` and friends, however, we know the name of the output
you are looking up and we can be smarter about if the returned
`Output<T>` should be treated as a secret or not.

This change augments the provider for StackReference such that it also
returns a list of top level stack output names who's values contain
secrets. In the language SDKs, we use this information, when present,
to decide if we should return an `Output<T>` that is marked as a
secret or not. Since the SDK and CLI are independent components, care
is taken to ensure that when the CLI does not return this information,
we behave as we did before (i.e. if any output is a secret, we treat
every output as a secret).

Fixes #2744