### PR TITLE
Make 'ResourceOptions.merge' static so downstream clients don't have to manually handle None cases.

### DIFF
--- a/sdk/python/.pylintrc
+++ b/sdk/python/.pylintrc
@@ -159,7 +159,8 @@ disable=print-statement,
         broad-except,
         no-self-use,
         unused-import,
-        unsubscriptable-object
+        unsubscriptable-object,
+        line-too-long
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -354,7 +354,8 @@ class ResourceOptions:
         merge produces a new ResourceOptions object with the respective attributes of the
         `opts1` instance in it with the attributes of `opts2` merged over them.
 
-        Both the `opts1` instance and the `opts2` instance will be unchanged.
+        Both the `opts1` instance and the `opts2` instance will be unchanged.  Both of `opts1` and `opts2` can be 
+        `None`, in which case its attributes are ignored.
 
         Conceptually attributes merging follows these basic rules:
             1. if the attributes is a collection, the final value will be a collection containing

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -343,9 +343,9 @@ class ResourceOptions:
                         "'depends_on' was passed a value that was not a Resource.")
 
     @staticmethod
-    def merge_options(
-            opts1: 'ResourceOptions' = ResourceOptions(),
-            opts2: 'ResourceOptions' = ResourceOptions()) -> 'ResourceOptions':
+    def merge(
+            opts1: 'ResourceOptions',
+            opts2: 'ResourceOptions') -> 'ResourceOptions':
         """
         merge produces a new ResourceOptions object with the respective attributes of the
         `opts` instance in it with the attributes of `opts2` merged over them.
@@ -362,6 +362,9 @@ class ResourceOptions:
                treated as collections, even if only a single value was provided.
             4. Attributes with value 'None' will not be copied over.
         """
+
+        opts1 = ResourceOptions if opts1 is None else opts1
+        opts2 = ResourceOptions if opts2 is None else opts2
 
         dest = copy.copy(opts1)
         source = copy.copy(opts2)
@@ -391,21 +394,6 @@ class ResourceOptions:
         _collapse_providers(dest)
 
         return dest
-
-
-    def merge(self, other: 'ResourceOptions') -> 'ResourceOptions':
-        """
-        merge produces a new ResourceOptions object with the respective attributes of this
-        instance in it with the attributes of `other` merged over them.
-
-        Both this options instance and the `other` options instance will be unchanged.
-
-        Calling `r1.merge(r2)` is equivalent to calling `ResourceOptions.merge_options(r1, r2)`.
-        The latter may be preferable in the case where r1 is not known to be None or not.
-
-        See `merge_options` for more details on how attribute merging behaves.
-        """
-        return ResourceOptions.merge_options(self, other)
 
 
 def _expand_providers(options: 'ResourceOptions'):

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -361,8 +361,8 @@ class ResourceOptions:
             4. Attributes with value 'None' will not be copied over.
         """
 
-        opts1 = ResourceOptions if opts1 is None else opts1
-        opts2 = ResourceOptions if opts2 is None else opts2
+        opts1 = ResourceOptions() if opts1 is None else opts1
+        opts2 = ResourceOptions() if opts2 is None else opts2
 
         dest = copy.copy(opts1)
         source = copy.copy(opts2)

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -400,15 +400,10 @@ class ResourceOptions:
 
         Both this options instance and the `other` options instance will be unchanged.
 
-        Conceptually attributes merging follows these basic rules:
-         1. if the attributes is a collection, the final value will be a collection containing the
-            values from each options object. Both original collections in each options object will
-            be unchanged.
-         2. Simple scaler values from `other` (i.e. strings, numbers, bools) will replace the values
-            from this.
-         3. For the purposes of merging `depends_on`, `provider` and `providers` are always treated
-            as collections, even if only a single value was provided.
-         4. Attributes with value 'None' will not be copied over.
+        Calling `r1.merge(r2)` is equivalent to calling `ResourceOptions.merge_options(r1, r2)`.
+        The latter may be preferable in the case where r1 is not known to be None or not.
+
+        See `merge_options` for more details on how attribute merging behaves.
         """
         return ResourceOptions.merge_options(self, other)
 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -343,9 +343,7 @@ class ResourceOptions:
                         "'depends_on' was passed a value that was not a Resource.")
 
     @staticmethod
-    def merge(
-            opts1: 'ResourceOptions',
-            opts2: 'ResourceOptions') -> 'ResourceOptions':
+    def merge(opts1: 'ResourceOptions', opts2: 'ResourceOptions') -> 'ResourceOptions':
         """
         merge produces a new ResourceOptions object with the respective attributes of the
         `opts` instance in it with the attributes of `opts2` merged over them.

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -322,6 +322,8 @@ class ResourceOptions:
                with the resource's current state. Once a resource has been imported, the import property must be removed from
                the resource's options.
         """
+        self.merge = self._merge_instance
+
         self.parent = parent
         self.depends_on = depends_on
         self.protect = protect
@@ -342,6 +344,10 @@ class ResourceOptions:
                     raise Exception(
                         "'depends_on' was passed a value that was not a Resource.")
 
+    def _merge_instance(self, opts: 'ResourceOptions') -> 'ResourceOptions':
+        return ResourceOptions.merge(self, opts)
+
+    # pylint: disable=method-hidden
     @staticmethod
     def merge(opts1: 'ResourceOptions', opts2: 'ResourceOptions') -> 'ResourceOptions':
         """

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -376,8 +376,7 @@ class ResourceOptions:
         dest.depends_on = _merge_lists(dest.depends_on, source.depends_on)
         dest.ignore_changes = _merge_lists(dest.ignore_changes, source.ignore_changes)
         dest.aliases = _merge_lists(dest.aliases, source.aliases)
-        dest.additional_secret_outputs = _merge_lists(
-            dest.additional_secret_outputs, source.additional_secret_outputs)
+        dest.additional_secret_outputs = _merge_lists(dest.additional_secret_outputs, source.additional_secret_outputs)
 
         dest.parent = dest.parent if source.parent is None else source.parent
         dest.protect = dest.protect if source.protect is None else source.protect

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -365,6 +365,9 @@ class ResourceOptions:
             3. For the purposes of merging `depends_on`, `provider` and `providers` are always
                treated as collections, even if only a single value was provided.
             4. Attributes with value 'None' will not be copied over.
+        This method can be called either as static-method like `ResourceOptions.merge(opts1, opts2)` or as an instance-method
+        like `opts1.merge(opts2)`.  The former is useful for cases where `opts1` may be `None` so the caller does not need
+        to check for this case. 
         """
 
         opts1 = ResourceOptions() if opts1 is None else opts1

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -366,6 +366,7 @@ class ResourceOptions:
             3. For the purposes of merging `depends_on`, `provider` and `providers` are always
                treated as collections, even if only a single value was provided.
             4. Attributes with value 'None' will not be copied over.
+
         This method can be called either as static-method like `ResourceOptions.merge(opts1, opts2)` or as an instance-method
         like `opts1.merge(opts2)`.  The former is useful for cases where `opts1` may be `None` so the caller does not need
         to check for this case. 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -322,7 +322,10 @@ class ResourceOptions:
                with the resource's current state. Once a resource has been imported, the import property must be removed from
                the resource's options.
         """
+
+        # Expose 'merge' again this this object, but this time as an instance method.
         self.merge = self._merge_instance
+        self.merge.__func__.__doc__ = ResourceOptions.merge.__doc__
 
         self.parent = parent
         self.depends_on = depends_on

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -351,25 +351,29 @@ class ResourceOptions:
     @staticmethod
     def merge(opts1: 'ResourceOptions', opts2: 'ResourceOptions') -> 'ResourceOptions':
         """
-        merge produces a new ResourceOptions object with the respective attributes of the
-        `opts1` instance in it with the attributes of `opts2` merged over them.
+        merge produces a new ResourceOptions object with the respective attributes of the `opts1`
+        instance in it with the attributes of `opts2` merged over them.
 
-        Both the `opts1` instance and the `opts2` instance will be unchanged.  Both of `opts1` and `opts2` can be 
-        `None`, in which case its attributes are ignored.
+        Both the `opts1` instance and the `opts2` instance will be unchanged.  Both of `opts1` and
+        `opts2` can be `None`, in which case its attributes are ignored.
 
         Conceptually attributes merging follows these basic rules:
-            1. if the attributes is a collection, the final value will be a collection containing
-               the values from each options object. Both original collections in each options
-               object will be unchanged.
-            2. Simple scaler values from `opts2` (i.e. strings, numbers, bools) will replace the
-               values from `opts1`.
-            3. For the purposes of merging `depends_on`, `provider` and `providers` are always
-               treated as collections, even if only a single value was provided.
-            4. Attributes with value 'None' will not be copied over.
 
-        This method can be called either as static-method like `ResourceOptions.merge(opts1, opts2)` or as an instance-method
-        like `opts1.merge(opts2)`.  The former is useful for cases where `opts1` may be `None` so the caller does not need
-        to check for this case. 
+        1. if the attributes is a collection, the final value will be a collection containing the
+            values from each options object. Both original collections in each options object will
+            be unchanged.
+
+        2. Simple scaler values from `opts2` (i.e. strings, numbers, bools) will replace the values
+            from `opts1`.
+
+        3. For the purposes of merging `depends_on`, `provider` and `providers` are always treated
+            as collections, even if only a single value was provided.
+
+        4. Attributes with value 'None' will not be copied over.
+
+        This method can be called either as static-method like `ResourceOptions.merge(opts1, opts2)`
+        or as an instance-method like `opts1.merge(opts2)`.  The former is useful for cases where
+        `opts1` may be `None` so the caller does not need to check for this case.
         """
 
         opts1 = ResourceOptions() if opts1 is None else opts1

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -352,7 +352,7 @@ class ResourceOptions:
     def merge(opts1: 'ResourceOptions', opts2: 'ResourceOptions') -> 'ResourceOptions':
         """
         merge produces a new ResourceOptions object with the respective attributes of the
-        `opts` instance in it with the attributes of `opts2` merged over them.
+        `opts1` instance in it with the attributes of `opts2` merged over them.
 
         Both the `opts1` instance and the `opts2` instance will be unchanged.
 


### PR DESCRIPTION
I recommend reviewing with whitespace off.