### PR TITLE
Emit stderr of `npm install`

### DIFF
--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -218,9 +218,12 @@ func installRequiredPolicy(finalDir string, tarball []byte) error {
 	fmt.Println()
 
 	// TODO[pulumi/pulumi#1307]: move to the language plugins so we don't have to hard code here.
-	err = npm.Install(finalDir, nil, nil)
+	err = npm.Install(finalDir, nil, os.Stderr)
 	if err != nil {
-		return err
+		return errors.Wrapf(
+			err,
+			"failed to install dependencies of policy pack; you may need to re-run `npm install` "+
+				"in %q before this policy pack works", finalDir)
 	}
 
 	fmt.Println("Finished installing dependencies")

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -92,10 +92,8 @@ func NewPolicyAnalyzer(
 	plug, err := newPlugin(ctx, pluginPath, fmt.Sprintf("%v (analyzer)", name),
 		[]string{host.ServerAddr(), policyPackPath})
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not start policy pack %s because the built-in "+
-			"analyzer plugin that runs policy plugins is missing. This might occur when the "+
-			"plugin directory is not on your $PATH, or when the installed version of the Pulumi "+
-			"SDK does not support resource policies", string(name))
+		return nil, errors.Wrapf(err,
+			"policy pack %s failed to start because of an internal error", string(name))
 	}
 	contract.Assertf(plug != nil, "unexpected nil analyzer plugin for %s", name)
 


### PR DESCRIPTION
If we don't process and report the stderr of `npm install`, the output
is "orphaned" during error condition, and only something like "exit code
1" is reported.