### PR TITLE
Fix renaming a freshly created stack using the local backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
 
 - Allow resource IDs to be changed during `pulumi refresh` operations
 
+- Do not crash when renaming a stack that has never been updated, when using the local backend. (fixes 
+  [#2654](https://github.com/pulumi/pulumi/issues/2654))
+
 ## 1.0.0-beta.2 (2019-08-13)
 
 - Fix the package version compatibility checks in the NodeJS language host.

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -96,6 +96,8 @@ func LocateResource(snap *deploy.Snapshot, urn resource.URN) []*resource.State {
 // RenameStack changes the `stackName` component of every URN in a snapshot. In addition, it rewrites the name of
 // the root Stack resource itself.
 func RenameStack(snap *deploy.Snapshot, newName tokens.QName) error {
+	contract.Require(snap != nil, "snap")
+
 	rewriteUrn := func(u resource.URN) resource.URN {
 		// The pulumi:pulumi:Stack resource's name component is of the form `<project>-<stack>` so we want
 		// to rename the name portion as well.

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -348,6 +348,22 @@ func TestStackBackups(t *testing.T) {
 	})
 }
 
+func TestStackRenameAfterCreate(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	defer func() {
+		if !t.Failed() {
+			e.DeleteEnvironment()
+		}
+	}()
+	stackName := addRandomSuffix("stack-rename")
+	integration.CreateBasicPulumiRepo(e)
+	e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", stackName)
+
+	newName := addRandomSuffix("renamed-stack")
+	e.RunCommand("pulumi", "stack", "rename", newName)
+}
+
 func getFileNames(infos []os.FileInfo) []string {
 	var result []string
 	for _, i := range infos {


### PR DESCRIPTION
Attempting to `pulumi stack rename` a stack which had been created but
never updated, when using the local backend, was broken because
code-paths were not hardened against the snapshot being `nil` (which
is the case for a stack before the initial deployment had been done).

Fixes #2654