### PR TITLE
Update the NodeJS version compat checks.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+## 1.0.0-beta.2 (2019-08-13)
+
+- Fix the package version compatibility checks in the NodeJS language host.
+  [#3083](https://github.com/pulumi/pulumi/pull/3083)
+
 ## 1.0.0-beta.1 (2019-08-13)
 
 - Do not propagate input properties to missing output properties during preview. The old behavior can cause issues that

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -170,11 +170,11 @@ func compatibleVersions(a, b semver.Version) (bool, string) {
 
 	case a.Major >= 1 && b.Major >= 1:
 		// If both major versions are post-1.0, we require that the major versions match.
-		if a.Major != b.Minor {
+		if a.Major != b.Major {
 			return false, "Differing major versions are not supported."
 		}
 
-	case a.Major == 1 && b.Minor == 17 || b.Major == 1 && a.Minor == 17:
+	case a.Major == 1 && b.Major == 0 && b.Minor == 17 || b.Major == 1 && a.Major == 0 && a.Minor == 17:
 		// If one version is pre-1.0 and the other is post-1.0, we unify 1.x.y and 0.17.z. This combination is legal.
 
 	default:


### PR DESCRIPTION
- Unify the 1.x.y series and the 0.17.z series
- Fix the check s.t. post-1.0, only the major versions are required to
  match