### PR TITLE
Don't require a stack to run `pulumi query`

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/backend"
@@ -55,7 +54,7 @@ func newQueryCmd() *cobra.Command {
 				Type:          display.DisplayQuery,
 			}
 
-			s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
+			b, err := currentBackend(opts.Display)
 			if err != nil {
 				return result.FromError(err)
 			}
@@ -65,25 +64,29 @@ func newQueryCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			sm, err := getStackSecretsManager(s)
-			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting secrets manager"))
-			}
+			//
+			// TODO: Allow secret manager.
+			//
 
-			cfg, err := getStackConfiguration(s, sm)
-			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
-			}
+			// sm, err := getStackSecretsManager(s)
+			// if err != nil {
+			// 	return result.FromError(errors.Wrap(err, "getting secrets manager"))
+			// }
+
+			// cfg, err := getStackConfiguration(s, sm)
+			// if err != nil {
+			// 	return result.FromError(errors.Wrap(err, "getting stack configuration"))
+			// }
 
 			opts.Engine = engine.UpdateOptions{}
 
-			res := s.Query(commandContext(), backend.UpdateOperation{
-				Proj:               proj,
-				Root:               root,
-				Opts:               opts,
-				StackConfiguration: cfg,
-				SecretsManager:     sm,
-				Scopes:             cancellationScopes,
+			res := b.Query(commandContext(), backend.QueryOperation{
+				Proj: proj,
+				Root: root,
+				Opts: opts,
+				// StackConfiguration: cfg,
+				// SecretsManager:     sm,
+				Scopes: cancellationScopes,
 			})
 			switch {
 			case res != nil && res.Error() == context.Canceled:

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -64,28 +64,12 @@ func newQueryCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			//
-			// TODO: Allow secret manager.
-			//
-
-			// sm, err := getStackSecretsManager(s)
-			// if err != nil {
-			// 	return result.FromError(errors.Wrap(err, "getting secrets manager"))
-			// }
-
-			// cfg, err := getStackConfiguration(s, sm)
-			// if err != nil {
-			// 	return result.FromError(errors.Wrap(err, "getting stack configuration"))
-			// }
-
 			opts.Engine = engine.UpdateOptions{}
 
 			res := b.Query(commandContext(), backend.QueryOperation{
-				Proj: proj,
-				Root: root,
-				Opts: opts,
-				// StackConfiguration: cfg,
-				// SecretsManager:     sm,
+				Proj:   proj,
+				Root:   root,
+				Opts:   opts,
 				Scopes: cancellationScopes,
 			})
 			switch {

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -139,7 +139,7 @@ type Backend interface {
 	Destroy(ctx context.Context, stack Stack, op UpdateOperation) (engine.ResourceChanges, result.Result)
 
 	// Query against the resource outputs in a stack's state checkpoint.
-	Query(ctx context.Context, stack Stack, op UpdateOperation) result.Result
+	Query(ctx context.Context, op QueryOperation) result.Result
 
 	// GetHistory returns all updates for the stack. The returned UpdateInfo slice will be in
 	// descending order (newest first).
@@ -176,6 +176,16 @@ type UpdateOperation struct {
 	Scopes             CancellationScopeSource
 }
 
+// QueryOperation configures a query operation.
+type QueryOperation struct {
+	Proj               *workspace.Project
+	Root               string
+	Opts               UpdateOptions
+	SecretsManager     secrets.Manager
+	StackConfiguration StackConfiguration
+	Scopes             CancellationScopeSource
+}
+
 // StackConfiguration holds the configuration for a stack and it's associated decrypter.
 type StackConfiguration struct {
 	Config    config.Map
@@ -193,6 +203,14 @@ type UpdateOptions struct {
 	AutoApprove bool
 	// SkipPreview, when true, causes the preview step to be skipped.
 	SkipPreview bool
+}
+
+// QueryOptions configures a query to operate against a backend and the engine.
+type QueryOptions struct {
+	// Engine contains all of the engine-specific options.
+	Engine engine.UpdateOptions
+	// Display contains all of the backend display options.
+	Display display.Options
 }
 
 // CancellationScope provides a scoped source of cancellation and termination requests.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -393,9 +393,9 @@ func (b *localBackend) Destroy(ctx context.Context, stack backend.Stack,
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply)
 }
 
-func (b *localBackend) Query(ctx context.Context, stack backend.Stack,
-	op backend.UpdateOperation) result.Result {
-	return b.query(ctx, stack, op, nil /*events*/)
+func (b *localBackend) Query(ctx context.Context, op backend.QueryOperation) result.Result {
+
+	return b.query(ctx, op, nil /*events*/)
 }
 
 // apply actually performs the provided type of update on a locally hosted stack.
@@ -549,7 +549,7 @@ func (b *localBackend) apply(
 }
 
 // query executes a query program against the resource outputs of a locally hosted stack.
-func (b *localBackend) query(ctx context.Context, stack backend.Stack, op backend.UpdateOperation,
+func (b *localBackend) query(ctx context.Context, op backend.QueryOperation,
 	events chan<- engine.Event) result.Result {
 
 	// TODO: Consider implementing this for local backend. We left it out for the initial cut

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -56,10 +56,6 @@ func (s *localStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) { r
 func (s *localStack) Backend() backend.Backend                               { return s.b }
 func (s *localStack) Path() string                                           { return s.path }
 
-func (s *localStack) Query(ctx context.Context, op backend.UpdateOperation) result.Result {
-	return backend.Query(ctx, s, op)
-}
-
 func (s *localStack) Remove(ctx context.Context, force bool) (bool, error) {
 	return backend.RemoveStack(ctx, s, force)
 }

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -702,9 +702,8 @@ func (b *cloudBackend) Destroy(ctx context.Context, stack backend.Stack,
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply)
 }
 
-func (b *cloudBackend) Query(ctx context.Context, stack backend.Stack,
-	op backend.UpdateOperation) result.Result {
-	return b.query(ctx, stack, op, nil /*events*/)
+func (b *cloudBackend) Query(ctx context.Context, op backend.QueryOperation) result.Result {
+	return b.query(ctx, op, nil /*events*/)
 }
 
 func (b *cloudBackend) createAndStartUpdate(
@@ -810,13 +809,10 @@ func (b *cloudBackend) apply(
 
 // query executes a query program against the resource outputs of a stack hosted in the Pulumi
 // Cloud.
-func (b *cloudBackend) query(
-	ctx context.Context, stack backend.Stack, op backend.UpdateOperation,
+func (b *cloudBackend) query(ctx context.Context, op backend.QueryOperation,
 	callerEventsOpt chan<- engine.Event) result.Result {
 
-	stackRef := stack.Ref()
-
-	q, err := b.newQuery(ctx, stackRef, op)
+	q, err := b.newQuery(ctx, op)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -107,6 +107,7 @@ func (s *cloudStack) OrgName() string                       { return s.orgName }
 func (s *cloudStack) Tags() map[apitype.StackTagName]string { return s.tags }
 
 func (s *cloudStack) StackIdentifier() client.StackIdentifier {
+
 	si, err := s.b.getCloudStackIdentifier(s.ref)
 	contract.AssertNoError(err) // the above only fails when ref is of the wrong type.
 	return si
@@ -124,10 +125,6 @@ func (s *cloudStack) Snapshot(ctx context.Context) (*deploy.Snapshot, error) {
 
 	s.snapshot = &snap
 	return *s.snapshot, nil
-}
-
-func (s *cloudStack) Query(ctx context.Context, op backend.UpdateOperation) result.Result {
-	return backend.Query(ctx, s, op)
 }
 
 func (s *cloudStack) Remove(ctx context.Context, force bool) (bool, error) {

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -105,9 +105,8 @@ func (ts *tokenSource) GetToken() (string, error) {
 }
 
 type cloudQuery struct {
-	root   string
-	proj   *workspace.Project
-	target *deploy.Target
+	root string
+	proj *workspace.Project
 }
 
 func (q *cloudQuery) GetRoot() string {
@@ -116,10 +115,6 @@ func (q *cloudQuery) GetRoot() string {
 
 func (q *cloudQuery) GetProject() *workspace.Project {
 	return q.proj
-}
-
-func (q *cloudQuery) GetTarget() *deploy.Target {
-	return q.target
 }
 
 // cloudUpdate is an implementation of engine.Update backed by remote state and a local program.
@@ -229,15 +224,10 @@ func (u *cloudUpdate) RecordAndDisplayEvents(
 	// the display and persistence go-routines are finished processing events.
 }
 
-func (b *cloudBackend) newQuery(ctx context.Context, stackRef backend.StackReference,
-	op backend.UpdateOperation) (*cloudQuery, error) {
-	// Construct the query target.
-	target, err := b.getTarget(ctx, stackRef, op.StackConfiguration.Config, op.StackConfiguration.Decrypter)
-	if err != nil {
-		return nil, err
-	}
+func (b *cloudBackend) newQuery(ctx context.Context,
+	op backend.QueryOperation) (*cloudQuery, error) {
 
-	return &cloudQuery{root: op.Root, proj: op.Proj, target: target}, nil
+	return &cloudQuery{root: op.Root, proj: op.Proj}, nil
 }
 
 func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackReference, op backend.UpdateOperation,
@@ -287,6 +277,7 @@ func (b *cloudBackend) getSnapshot(ctx context.Context, stackRef backend.StackRe
 
 func (b *cloudBackend) getTarget(ctx context.Context, stackRef backend.StackReference,
 	cfg config.Map, dec config.Decrypter) (*deploy.Target, error) {
+
 	snapshot, err := b.getSnapshot(ctx, stackRef)
 	if err != nil {
 		switch err {

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -44,7 +44,7 @@ type MockBackend struct {
 	ListStacksF             func(context.Context, ListStacksFilter) ([]StackSummary, error)
 	RenameStackF            func(context.Context, Stack, tokens.QName) error
 	GetStackCrypterF        func(StackReference) (config.Crypter, error)
-	QueryF                  func(context.Context, Stack, UpdateOperation) result.Result
+	QueryF                  func(context.Context, QueryOperation) result.Result
 	GetLatestConfigurationF func(context.Context, Stack) (config.Map, error)
 	GetHistoryF             func(context.Context, StackReference) ([]UpdateInfo, error)
 	GetStackTagsF           func(context.Context, Stack) (map[apitype.StackTagName]string, error)
@@ -189,11 +189,10 @@ func (be *MockBackend) Destroy(ctx context.Context, stack Stack,
 	panic("not implemented")
 }
 
-func (be *MockBackend) Query(ctx context.Context, stack Stack,
-	op UpdateOperation) result.Result {
+func (be *MockBackend) Query(ctx context.Context, op QueryOperation) result.Result {
 
 	if be.QueryF != nil {
-		return be.QueryF(ctx, stack, op)
+		return be.QueryF(ctx, op)
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -48,8 +48,6 @@ type Stack interface {
 	// Destroy this stack's resources.
 	Destroy(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, result.Result)
 
-	// Query this stack's state.
-	Query(ctx context.Context, op UpdateOperation) result.Result
 	// remove this stack.
 	Remove(ctx context.Context, force bool) (bool, error)
 	// rename this stack.
@@ -62,16 +60,12 @@ type Stack interface {
 	ImportDeployment(ctx context.Context, deployment *apitype.UntypedDeployment) error
 }
 
-// Query executes a query program against a stack's resource outputs.
-func Query(ctx context.Context, s Stack, op UpdateOperation) result.Result {
-	return s.Backend().Query(ctx, s, op)
-}
-
 // RemoveStack returns the stack, or returns an error if it cannot.
 func RemoveStack(ctx context.Context, s Stack, force bool) (bool, error) {
 	return s.Backend().RemoveStack(ctx, s, force)
 }
 
+// RenameStack renames the stack, or returns an error if it cannot.
 func RenameStack(ctx context.Context, s Stack, newName tokens.QName) error {
 	return s.Backend().RenameStack(ctx, s, newName)
 }

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -35,6 +35,16 @@ type UpdateInfo interface {
 	GetTarget() *deploy.Target
 }
 
+// QueryInfo abstracts away information about a query operation.
+type QueryInfo interface {
+	// GetRoot returns the root directory for this update. This defines the scope for any filesystem resources
+	// accessed by this update.
+	GetRoot() string
+	// GetProject returns information about the project associated with this update. This includes information such as
+	// the runtime that will be used to execute the Pulumi program and the program's relative working directory.
+	GetProject() *workspace.Project
+}
+
 // Context provides cancellation, termination, and eventing options for an engine operation. It also provides
 // a way for the engine to persist snapshots, using the `SnapshotManager`.
 type Context struct {

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -169,7 +169,7 @@ type StepEventStateMetadata struct {
 func makeEventEmitter(events chan<- Event, update UpdateInfo) (eventEmitter, error) {
 	target := update.GetTarget()
 	var secrets []string
-	if target.Config.HasSecureValue() {
+	if target != nil && target.Config.HasSecureValue() {
 		for k, v := range target.Config {
 			if !v.Secure() {
 				continue
@@ -232,6 +232,12 @@ func makeEventEmitter(events chan<- Event, update UpdateInfo) (eventEmitter, err
 	return eventEmitter{
 		done: done,
 		ch:   buffer,
+	}, nil
+}
+
+func makeQueryEventEmitter(events chan<- Event) (eventEmitter, error) {
+	return eventEmitter{
+		ch: events,
 	}, nil
 }
 

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -91,7 +91,8 @@ func Query(ctx *Context, q QueryInfo, opts UpdateOptions) result.Result {
 func newQuerySource(cancel context.Context, client deploy.BackendClient, q QueryInfo,
 	opts QueryOptions) (deploy.QuerySource, error) {
 
-	allPlugins, _, err := installPlugins(q.GetProject(), opts.pwd, opts.main, nil, opts.plugctx)
+	allPlugins, defaultProviderVersions, err := installPlugins(q.GetProject(), opts.pwd, opts.main,
+		nil, opts.plugctx)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +115,7 @@ func newQuerySource(cancel context.Context, client deploy.BackendClient, q Query
 		Proj:    q.GetProject(),
 		Pwd:     opts.pwd,
 		Program: opts.main,
-	})
+	}, defaultProviderVersions, nil)
 }
 
 func query(ctx *Context, q QueryInfo, opts QueryOptions) result.Result {

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -37,8 +37,8 @@ type QueryOptions struct {
 	tracingSpan opentracing.Span
 }
 
-func Query(ctx *Context, u UpdateInfo, opts UpdateOptions) result.Result {
-	contract.Require(u != nil, "update")
+func Query(ctx *Context, q QueryInfo, opts UpdateOptions) result.Result {
+	contract.Require(q != nil, "update")
 	contract.Require(ctx != nil, "ctx")
 
 	defer func() { ctx.Events <- cancelEvent() }()
@@ -56,7 +56,7 @@ func Query(ctx *Context, u UpdateInfo, opts UpdateOptions) result.Result {
 	}("query", ctx.ParentSpan)
 	defer tracingSpan.Finish()
 
-	emitter, err := makeEventEmitter(ctx.Events, u)
+	emitter, err := makeQueryEventEmitter(ctx.Events)
 	if err != nil {
 		return result.FromError(err)
 	}
@@ -67,17 +67,16 @@ func Query(ctx *Context, u UpdateInfo, opts UpdateOptions) result.Result {
 	diag := newEventSink(emitter, false)
 	statusDiag := newEventSink(emitter, true)
 
-	proj, target := u.GetProject(), u.GetTarget()
+	proj := q.GetProject()
 	contract.Assert(proj != nil)
-	contract.Assert(target != nil)
 
-	pwd, main, plugctx, err := ProjectInfoContext(&Projinfo{Proj: proj, Root: u.GetRoot()}, opts.host,
-		target, diag, statusDiag, tracingSpan)
+	pwd, main, plugctx, err := ProjectInfoContext(&Projinfo{Proj: proj, Root: q.GetRoot()},
+		opts.host, nil, diag, statusDiag, tracingSpan)
 	if err != nil {
 		return result.FromError(err)
 	}
 
-	return query(ctx, u, QueryOptions{
+	return query(ctx, q, QueryOptions{
 		Events:      emitter,
 		Diag:        diag,
 		StatusDiag:  statusDiag,
@@ -89,12 +88,10 @@ func Query(ctx *Context, u UpdateInfo, opts UpdateOptions) result.Result {
 	})
 }
 
-func newQuerySource(ctx context.Context, client deploy.BackendClient, u UpdateInfo,
+func newQuerySource(cancel context.Context, client deploy.BackendClient, q QueryInfo,
 	opts QueryOptions) (deploy.QuerySource, error) {
 
-	allPlugins, _, err := installPlugins(u.GetProject(), opts.pwd,
-		opts.main,
-		u.GetTarget(), opts.plugctx)
+	allPlugins, _, err := installPlugins(q.GetProject(), opts.pwd, opts.main, nil, opts.plugctx)
 	if err != nil {
 		return nil, err
 	}
@@ -108,20 +105,19 @@ func newQuerySource(ctx context.Context, client deploy.BackendClient, u UpdateIn
 	}
 
 	if opts.tracingSpan != nil {
-		ctx = opentracing.ContextWithSpan(ctx, opts.tracingSpan)
+		cancel = opentracing.ContextWithSpan(cancel, opts.tracingSpan)
 	}
 
 	// If that succeeded, create a new source that will perform interpretation of the compiled program.
 	// TODO[pulumi/pulumi#88]: we are passing `nil` as the arguments map; we need to allow a way to pass these.
-	return deploy.NewQuerySource(ctx, opts.plugctx, client, &deploy.EvalRunInfo{
-		Proj:    u.GetProject(),
+	return deploy.NewQuerySource(cancel, opts.plugctx, client, &deploy.EvalRunInfo{
+		Proj:    q.GetProject(),
 		Pwd:     opts.pwd,
 		Program: opts.main,
-		Target:  u.GetTarget(),
 	})
 }
 
-func query(ctx *Context, u UpdateInfo, opts QueryOptions) result.Result {
+func query(ctx *Context, q QueryInfo, opts QueryOptions) result.Result {
 	// Make the current working directory the same as the program's, and restore it upon exit.
 	done, chErr := fsutil.Chdir(opts.plugctx.Pwd)
 	if chErr != nil {
@@ -129,7 +125,7 @@ func query(ctx *Context, u UpdateInfo, opts QueryOptions) result.Result {
 	}
 	defer done()
 
-	if res := runQuery(ctx, u, opts); res != nil {
+	if res := runQuery(ctx, q, opts); res != nil {
 		if res.IsBail() {
 			return res
 		}
@@ -138,11 +134,11 @@ func query(ctx *Context, u UpdateInfo, opts QueryOptions) result.Result {
 	return nil
 }
 
-func runQuery(cancelCtx *Context, u UpdateInfo, opts QueryOptions) result.Result {
+func runQuery(cancelCtx *Context, q QueryInfo, opts QueryOptions) result.Result {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	contract.Ignore(cancelFunc)
 
-	src, err := newQuerySource(ctx, cancelCtx.BackendClient, u, opts)
+	src, err := newQuerySource(ctx, cancelCtx.BackendClient, q, opts)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -464,7 +464,7 @@ func (rm *resmon) Cancel() error {
 // getProviderReference fetches the provider reference for a resource, read, or invoke from the given package with the
 // given unparsed provider reference. If the unparsed provider reference is empty, this function returns a reference
 // to the default provider for the indicated package.
-func (rm *resmon) getProviderReference(req providers.ProviderRequest,
+func getProviderReference(defaultProviders *defaultProviders, req providers.ProviderRequest,
 	rawProviderRef string) (providers.Reference, error) {
 	if rawProviderRef != "" {
 		ref, err := providers.ParseReference(rawProviderRef)
@@ -474,29 +474,32 @@ func (rm *resmon) getProviderReference(req providers.ProviderRequest,
 		return ref, nil
 	}
 
-	ref, err := rm.defaultProviders.getDefaultProviderRef(req)
+	ref, err := defaultProviders.getDefaultProviderRef(req)
 	if err != nil {
 		return providers.Reference{}, err
 	}
 	return ref, nil
 }
 
-// getProvider fetches the provider plugin for a resource, read, or invoke from the given package with the given
-// unparsed provider reference. If the unparsed provider reference is empty, this function returns the plugin for the
-// indicated package's default provider.
-func (rm *resmon) getProvider(req providers.ProviderRequest, rawProviderRef string) (plugin.Provider, error) {
-	providerRef, err := rm.getProviderReference(req, rawProviderRef)
+// getProviderFromSource fetches the provider plugin for a resource, read, or invoke from the given
+// package with the given unparsed provider reference. If the unparsed provider reference is empty,
+// this function returns the plugin for the indicated package's default provider.
+func getProviderFromSource(
+	providers ProviderSource, defaultProviders *defaultProviders,
+	req providers.ProviderRequest, rawProviderRef string) (plugin.Provider, error) {
+
+	providerRef, err := getProviderReference(defaultProviders, req, rawProviderRef)
 	if err != nil {
 		return nil, err
 	}
-	provider, ok := rm.providers.GetProvider(providerRef)
+	provider, ok := providers.GetProvider(providerRef)
 	if !ok {
 		return nil, errors.Errorf("unknown provider '%v'", rawProviderRef)
 	}
 	return provider, nil
 }
 
-func (rm *resmon) parseProviderRequest(pkg tokens.Package, version string) (providers.ProviderRequest, error) {
+func parseProviderRequest(pkg tokens.Package, version string) (providers.ProviderRequest, error) {
 	if version == "" {
 		logging.V(5).Infof("parseProviderRequest(%s): semver version is the empty string", pkg)
 		return providers.NewProviderRequest(nil, pkg), nil
@@ -532,11 +535,11 @@ func (rm *resmon) SupportsFeature(ctx context.Context,
 func (rm *resmon) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
 	// Fetch the token and load up the resource provider if necessary.
 	tok := tokens.ModuleMember(req.GetTok())
-	providerReq, err := rm.parseProviderRequest(tok.Package(), req.GetVersion())
+	providerReq, err := parseProviderRequest(tok.Package(), req.GetVersion())
 	if err != nil {
 		return nil, err
 	}
-	prov, err := rm.getProvider(providerReq, req.GetProvider())
+	prov, err := getProviderFromSource(rm.providers, rm.defaultProviders, providerReq, req.GetProvider())
 	if err != nil {
 		return nil, err
 	}
@@ -590,7 +593,7 @@ func (rm *resmon) ReadResource(ctx context.Context,
 
 	provider := req.GetProvider()
 	if !providers.IsProviderType(t) && provider == "" {
-		providerReq, err := rm.parseProviderRequest(t.Package(), req.GetVersion())
+		providerReq, err := parseProviderRequest(t.Package(), req.GetVersion())
 		if err != nil {
 			return nil, err
 		}
@@ -696,7 +699,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	label := fmt.Sprintf("ResourceMonitor.RegisterResource(%s,%s)", t, name)
 	provider := req.GetProvider()
 	if custom && !providers.IsProviderType(t) && provider == "" {
-		providerReq, err := rm.parseProviderRequest(t.Package(), req.GetVersion())
+		providerReq, err := parseProviderRequest(t.Package(), req.GetVersion())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -238,9 +238,9 @@ type defaultProviders struct {
 	providers map[string]providers.Reference
 	config    plugin.ConfigSource
 
-	requests chan defaultProviderRequest
-	regChan  chan<- *registerResourceEvent
-	cancel   <-chan bool
+	requests        chan defaultProviderRequest
+	providerRegChan chan<- *registerResourceEvent
+	cancel          <-chan bool
 }
 
 type defaultProviderResponse struct {
@@ -333,7 +333,7 @@ func (d *defaultProviders) handleRequest(req providers.ProviderRequest) (provide
 	}
 
 	select {
-	case d.regChan <- event:
+	case d.providerRegChan <- event:
 	case <-d.cancel:
 		return providers.Reference{}, context.Canceled
 	}
@@ -417,7 +417,7 @@ func newResourceMonitor(src *evalSource, provs ProviderSource, regChan chan *reg
 		providers:       make(map[string]providers.Reference),
 		config:          src.runinfo.Target,
 		requests:        make(chan defaultProviderRequest),
-		regChan:         regChan,
+		providerRegChan: regChan,
 		cancel:          cancel,
 	}
 

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -298,12 +298,6 @@ func (rm *queryResmon) SupportsFeature(ctx context.Context,
 	req *pulumirpc.SupportsFeatureRequest) (*pulumirpc.SupportsFeatureResponse, error) {
 
 	hasSupport := false
-
-	switch req.Id {
-	case "secrets":
-		hasSupport = true
-	}
-
 	return &pulumirpc.SupportsFeatureResponse{
 		HasSupport: hasSupport,
 	}, nil

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -19,15 +19,19 @@ import (
 	"fmt"
 	"math"
 
+	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	opentracing "github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
+	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/resource/config"
+	"github.com/pulumi/pulumi/pkg/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
+	"github.com/pulumi/pulumi/pkg/util/logging"
 	"github.com/pulumi/pulumi/pkg/util/result"
 	"github.com/pulumi/pulumi/pkg/util/rpcutil"
 	pulumirpc "github.com/pulumi/pulumi/sdk/proto/go"
@@ -41,30 +45,41 @@ type QuerySource interface {
 
 // NewQuerySource creates a `QuerySource` for some target runtime environment specified by
 // `runinfo`, and supported by language plugins provided in `plugctx`.
-func NewQuerySource(ctx context.Context, plugctx *plugin.Context, client BackendClient,
-	runinfo *EvalRunInfo) (QuerySource, error) {
+func NewQuerySource(cancel context.Context, plugctx *plugin.Context, client BackendClient,
+	runinfo *EvalRunInfo, defaultProviderVersions map[tokens.Package]*semver.Version,
+	provs ProviderSource) (QuerySource, error) {
 
 	// Create a new builtin provider. This provider implements features such as `getStack`.
 	builtins := newBuiltinProvider(client)
+
+	reg, err := providers.NewRegistry(plugctx.Host, nil, false, builtins)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to start resource monitor")
+	}
+
+	// Allows queryResmon to communicate errors loading providers.
+	providerRegErrChan := make(chan result.Result)
 
 	// First, fire up a resource monitor that will disallow all resource operations, as well as
 	// service calls for things like resource ouptuts of state snapshots.
 	//
 	// NOTE: Using the queryResourceMonitor here is *VERY* important, as its job is to disallow
 	// resource operations in query mode!
-	mon, err := newQueryResourceMonitor(builtins, opentracing.SpanFromContext(ctx))
+	mon, err := newQueryResourceMonitor(builtins, defaultProviderVersions, provs, reg, plugctx,
+		providerRegErrChan, opentracing.SpanFromContext(cancel))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start resource monitor")
 	}
 
 	// Create a new iterator with appropriate channels, and gear up to go!
 	src := &querySource{
-		mon:           mon,
-		plugctx:       plugctx,
-		runinfo:       runinfo,
-		runLangPlugin: runLangPlugin,
-		finChan:       make(chan result.Result),
-		cancel:        ctx,
+		mon:                mon,
+		plugctx:            plugctx,
+		runinfo:            runinfo,
+		runLangPlugin:      runLangPlugin,
+		langPluginFinChan:  make(chan result.Result),
+		providerRegErrChan: make(chan result.Result),
+		cancel:             cancel,
 	}
 
 	// Now invoke Run in a goroutine.  All subsequent resource creation events will come in over the gRPC channel,
@@ -76,20 +91,21 @@ func NewQuerySource(ctx context.Context, plugctx *plugin.Context, client Backend
 }
 
 type querySource struct {
-	mon           SourceResourceMonitor            // the resource monitor, per iterator.
-	plugctx       *plugin.Context                  // the plugin context.
-	runinfo       *EvalRunInfo                     // the directives to use when running the program.
-	runLangPlugin func(*querySource) result.Result // runs the language plugin.
-	finChan       chan result.Result               // the channel that communicates completion.
-	done          bool                             // set to true when the evaluation is done.
-	res           result.Result                    // result when the channel is finished.
-	cancel        context.Context
+	mon                SourceResourceMonitor            // the resource monitor, per iterator.
+	plugctx            *plugin.Context                  // the plugin context.
+	runinfo            *EvalRunInfo                     // the directives to use when running the program.
+	runLangPlugin      func(*querySource) result.Result // runs the language plugin.
+	langPluginFinChan  chan result.Result               // communicates language plugin completion.
+	providerRegErrChan chan result.Result               // communicates errors loading providers
+	done               bool                             // set to true when the evaluation is done.
+	res                result.Result                    // result when the channel is finished.
+	cancel             context.Context
 }
 
 func (src *querySource) Close() error {
 	// Cancel the monitor and reclaim any associated resources.
 	src.done = true
-	close(src.finChan)
+	close(src.langPluginFinChan)
 	return src.mon.Cancel()
 }
 
@@ -100,12 +116,15 @@ func (src *querySource) Wait() result.Result {
 	}
 
 	select {
-	case src.res = <-src.finChan:
+	case src.res = <-src.langPluginFinChan:
 		// Language plugin has exited. No need to call `Close`.
 		src.done = true
 		return src.res
+	case src.res = <-src.providerRegErrChan:
+		// Provider registration has failed.
+		src.Close()
+		return src.res
 	case <-src.cancel.Done():
-		src.done = true
 		src.Close()
 		return src.res
 	}
@@ -119,7 +138,7 @@ func (src *querySource) forkRun() {
 	go func() {
 		// Next, launch the language plugin. Communicate the error, if it exists, or nil if the
 		// program exited cleanly.
-		src.finChan <- src.runLangPlugin(src)
+		src.langPluginFinChan <- src.runLangPlugin(src)
 	}()
 }
 
@@ -177,15 +196,57 @@ func runLangPlugin(src *querySource) result.Result {
 
 // newQueryResourceMonitor creates a new resource monitor RPC server intended to be used in Pulumi's
 // "query mode".
-func newQueryResourceMonitor(builtins *builtinProvider, tracingSpan opentracing.Span) (*queryResmon, error) {
+func newQueryResourceMonitor(
+	builtins *builtinProvider, defaultProviderVersions map[tokens.Package]*semver.Version,
+	provs ProviderSource, reg *providers.Registry, plugctx *plugin.Context,
+	providerRegErrChan chan<- result.Result, tracingSpan opentracing.Span) (*queryResmon, error) {
 
 	// Create our cancellation channel.
 	cancel := make(chan bool)
 
+	// Create channel for handling registrations.
+	providerRegChan := make(chan *registerResourceEvent)
+
+	// Create a new default provider manager.
+	var config *Target
+	d := &defaultProviders{
+		defaultVersions: defaultProviderVersions,
+		providers:       make(map[string]providers.Reference),
+		config:          config,
+		requests:        make(chan defaultProviderRequest),
+		providerRegChan: providerRegChan,
+		cancel:          cancel,
+	}
+
+	go func() {
+		for e := range providerRegChan {
+			urn := syntheticProviderURN(e.goal)
+
+			inputs, _, err := reg.Check(urn, resource.PropertyMap{}, e.goal.Properties, false)
+			if err != nil {
+				providerRegErrChan <- result.FromError(err)
+				return
+			}
+			_, _, _, err = reg.Create(urn, inputs, 9999)
+			if err != nil {
+				providerRegErrChan <- result.FromError(err)
+				return
+			}
+
+			e.done <- &RegisterResult{State: &resource.State{
+				Type: e.goal.Type,
+				URN:  urn,
+			}}
+		}
+	}()
+
 	// New up an engine RPC server.
 	queryResmon := &queryResmon{
-		builtins: builtins,
-		cancel:   cancel,
+		builtins:         builtins,
+		providers:        provs,
+		defaultProviders: d,
+		cancel:           cancel,
+		reg:              reg,
 	}
 
 	// Fire up a gRPC server and start listening for incomings.
@@ -202,6 +263,8 @@ func newQueryResourceMonitor(builtins *builtinProvider, tracingSpan opentracing.
 	queryResmon.addr = fmt.Sprintf("127.0.0.1:%d", port)
 	queryResmon.done = done
 
+	go d.serve()
+
 	return queryResmon, nil
 }
 
@@ -213,10 +276,13 @@ func newQueryResourceMonitor(builtins *builtinProvider, tracingSpan opentracing.
 // 2. Services requests for stack snapshots. This is primarily to allow us to allow queries across
 //    stack snapshots.
 type queryResmon struct {
-	builtins *builtinProvider // provides builtins such as `getStack`.
-	addr     string           // the address the host is listening on.
-	cancel   chan bool        // a channel that can cancel the server.
-	done     chan error       // a channel that resolves when the server completes.
+	builtins         *builtinProvider    // provides builtins such as `getStack`.
+	providers        ProviderSource      // the provider source itself.
+	defaultProviders *defaultProviders   // the default provider manager.
+	addr             string              // the address the host is listening on.
+	cancel           chan bool           // a channel that can cancel the server.
+	done             chan error          // a channel that resolves when the server completes.
+	reg              *providers.Registry // registry for resource providers.
 }
 
 var _ SourceResourceMonitor = (*queryResmon)(nil)
@@ -238,9 +304,13 @@ func (rm *queryResmon) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest)
 	tok := tokens.ModuleMember(req.GetTok())
 	label := fmt.Sprintf("QueryResourceMonitor.Invoke(%s)", tok)
 
-	// Fail on all calls to `Invoke` except this one.
-	if tok != readStackResourceOutputs {
-		return nil, fmt.Errorf("Query mode does not support invoke call for operation '%s'", tok)
+	providerReq, err := rm.parseProviderRequest(tok.Package(), req.GetVersion())
+	if err != nil {
+		return nil, err
+	}
+	prov, err := rm.getProvider(providerReq, req.GetProvider())
+	if err != nil {
+		return nil, err
 	}
 
 	args, err := plugin.UnmarshalProperties(
@@ -249,12 +319,12 @@ func (rm *queryResmon) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest)
 		return nil, errors.Wrapf(err, "failed to unmarshal %v args", tok)
 	}
 
-	// Dispatch request for resource outputs to builtin provider.
-	ret, failures, err := rm.builtins.Invoke(tok, args)
+	// Do the invoke and then return the arguments.
+	logging.V(5).Infof("ResourceMonitor.Invoke received: tok=%v #args=%v", tok, len(args))
+	ret, failures, err := prov.Invoke(tok, args)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invoke %s failed", tok)
+		return nil, errors.Wrapf(err, "invocation of %v returned an error", tok)
 	}
-
 	mret, err := plugin.MarshalProperties(ret, plugin.MarshalOptions{Label: label, KeepUnknowns: true})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to marshal return")
@@ -301,4 +371,64 @@ func (rm *queryResmon) SupportsFeature(ctx context.Context,
 	return &pulumirpc.SupportsFeatureResponse{
 		HasSupport: hasSupport,
 	}, nil
+}
+
+func (rm *queryResmon) parseProviderRequest(pkg tokens.Package, version string) (providers.ProviderRequest, error) {
+	if version == "" {
+		logging.V(5).Infof("parseProviderRequest(%s): semver version is the empty string", pkg)
+		return providers.NewProviderRequest(nil, pkg), nil
+	}
+
+	parsedVersion, err := semver.Parse(version)
+	if err != nil {
+		logging.V(5).Infof("parseProviderRequest(%s, %s): semver version string is invalid: %v", pkg, version, err)
+		return providers.ProviderRequest{}, err
+	}
+
+	return providers.NewProviderRequest(&parsedVersion, pkg), nil
+}
+
+// getProviderReference fetches the provider reference for a resource, read, or invoke from the
+// given package with the given unparsed provider reference. If the unparsed provider reference is
+// empty, this function returns a reference to the default provider for the indicated package.
+func (rm *queryResmon) getProviderReference(req providers.ProviderRequest,
+	rawProviderRef string) (providers.Reference, error) {
+	if rawProviderRef != "" {
+		ref, err := providers.ParseReference(rawProviderRef)
+		if err != nil {
+			return providers.Reference{}, errors.Errorf("could not parse provider reference: %v", err)
+		}
+		return ref, nil
+	}
+
+	ref, err := rm.defaultProviders.getDefaultProviderRef(req)
+	if err != nil {
+		return providers.Reference{}, err
+	}
+	return ref, nil
+}
+
+// getProvider fetches the provider plugin for a resource, read, or invoke from the given package
+// with the given unparsed provider reference. If the unparsed provider reference is empty, this
+// function returns the plugin for the indicated package's default provider.
+func (rm *queryResmon) getProvider(
+	req providers.ProviderRequest, rawProviderRef string) (plugin.Provider, error) {
+
+	providerRef, err := rm.getProviderReference(req, rawProviderRef)
+	if err != nil {
+		return nil, err
+	}
+	provider, ok := rm.reg.GetProvider(providerRef)
+	if !ok {
+		return nil, errors.Errorf("unknown provider '%v'", rawProviderRef)
+	}
+	return provider, nil
+}
+
+// syntheticProviderURN will create a "fake" URN for a resource provider in query mode. Query mode
+// has no stack, no project, and no parent, so there is otherwise no way to generate a principled
+// URN.
+func syntheticProviderURN(goal *resource.Goal) resource.URN {
+	return resource.NewURN(
+		"query-stack", "query-project", "parent-type", goal.Type, goal.Name)
 }

--- a/pkg/resource/deploy/source_query_test.go
+++ b/pkg/resource/deploy/source_query_test.go
@@ -129,11 +129,8 @@ func TestQuerySource_Async_Wait(t *testing.T) {
 
 func TestQueryResourceMonitor_UnsupportedOperations(t *testing.T) {
 	rm := &queryResmon{}
-	_, err := rm.Invoke(context.TODO(), &pulumirpc.InvokeRequest{Tok: "foo"})
-	assert.Error(t, err)
-	assert.Equal(t, "Query mode does not support invoke call for operation 'foo'", err.Error())
 
-	_, err = rm.ReadResource(context.TODO(), nil)
+	_, err := rm.ReadResource(context.TODO(), nil)
 	assert.Error(t, err)
 	assert.Equal(t, "Query mode does not support reading resources", err.Error())
 
@@ -156,10 +153,10 @@ func newTestQuerySource(mon SourceResourceMonitor,
 	cancel, cancelFunc := context.WithCancel(context.Background())
 
 	return &querySource{
-		mon:           mon,
-		runLangPlugin: runLangPlugin,
-		finChan:       make(chan result.Result),
-		cancel:        cancel,
+		mon:               mon,
+		runLangPlugin:     runLangPlugin,
+		langPluginFinChan: make(chan result.Result),
+		cancel:            cancel,
 	}, cancelFunc
 }
 

--- a/pkg/resource/deploy/target.go
+++ b/pkg/resource/deploy/target.go
@@ -30,6 +30,10 @@ type Target struct {
 // GetPackageConfig returns the set of configuration parameters for the indicated package, if any.
 func (t *Target) GetPackageConfig(pkg tokens.Package) (map[config.Key]string, error) {
 	var result map[config.Key]string
+	if t == nil {
+		return result, nil
+	}
+
 	for k, c := range t.Config {
 		if tokens.Package(k.Namespace()) != pkg {
 			continue

--- a/tests/integration/query/query_test.go
+++ b/tests/integration/query/query_test.go
@@ -4,31 +4,34 @@ package ints
 
 import (
 	"testing"
-
-	"github.com/pulumi/pulumi/pkg/testing/integration"
 )
 
 // TestQuery creates a stack and runs a query over the stack's resource ouptputs.
 func TestQuery(t *testing.T) {
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		// Create Pulumi resources.
-		Dir:          "step1",
-		Dependencies: []string{"@pulumi/pulumi"},
-		EditDirs: []integration.EditDir{
-			// Try to create resources during `pulumi query`. This should fail.
-			{
-				Dir:           "step2",
-				Additive:      true,
-				QueryMode:     true,
-				ExpectFailure: true,
-			},
-			// Run a query during `pulumi query`. Should succeed.
-			{
-				Dir:           "step3",
-				Additive:      true,
-				QueryMode:     true,
-				ExpectFailure: false,
-			},
-		},
-	})
+	//
+	// TODO[hausdorff, #3396]: Enable once we allow query against local backend stacks.
+	//
+
+	// integration.ProgramTest(t, &integration.ProgramTestOptions{
+	// 	// Create Pulumi resources.
+	// 	Dir:          "step1",
+	// 	StackName:    "query-stack",
+	// 	Dependencies: []string{"@pulumi/pulumi"},
+	// 	EditDirs: []integration.EditDir{
+	// 		// Try to create resources during `pulumi query`. This should fail.
+	// 		{
+	// 			Dir:           "step2",
+	// 			Additive:      true,
+	// 			QueryMode:     true,
+	// 			ExpectFailure: true,
+	// 		},
+	// 		// Run a query during `pulumi query`. Should succeed.
+	// 		{
+	// 			Dir:           "step3",
+	// 			Additive:      true,
+	// 			QueryMode:     true,
+	// 			ExpectFailure: false,
+	// 		},
+	// 	},
+	// })
 }


### PR DESCRIPTION
~Not entirely ready for review, but the basic idea is to remove the requirement that `pulumi query` run inside a Pulumi stack. Now, all that should be necessary is the ability to log into the backend (currently only supporting the cloud backend).~

The reason this is possible is because `pulumi query` doesn't actually need access to a default stack, necessarily—the query primitives are implemented purely inside the SDK, so it needs only to be able to _get_ a snapshot of a stack, feed it into the `query.from`, and query the result.

A outgrowth of this is that `pulumi query` now actually doesn't support running inside a stack at all—this is actually intentional. If you want to use query primitives inside a stack, you should run `pulumi up` or `pulumi preview`. Unfortunately, this is not really enforced yet, so if you do run `pulumi query` in the context of a stack, you'll get some mysterious errors when you run `getStack` because the name will be empty.