### PR TITLE
Allow resource IDs to change on reresh steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 - When using StackReference to fetch output values from another stack, do not mark a value as secret if it was not
   secret in the stack you referenced. (fixes [#2744](https://github.com/pulumi/pulumi/issues/2744)).
 
+- Allow resource IDs to be changed during `pulumi refresh` operations
+
 ## 1.0.0-beta.2 (2019-08-13)
 
 - Fix the package version compatibility checks in the NodeJS language host.

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -711,7 +711,7 @@ func (s *RefreshStep) Apply(preview bool) (resource.Status, StepCompleteFunc, er
 		// There is a chance that the ID has changed. We want to allow this change to happen
 		// it will have changed already in the outputs, but we need to persist this change
 		// at a state level because the Id
-		if refreshed.ID.String() != "" && refreshed.ID != resourceID {
+		if refreshed.ID != "" && refreshed.ID != resourceID {
 			logging.V(7).Infof("Refreshing ID; oldId=%s, newId=%s", resourceID, refreshed.ID)
 			resourceID = refreshed.ID
 		}

--- a/pkg/resource/plugin/provider.go
+++ b/pkg/resource/plugin/provider.go
@@ -190,6 +190,9 @@ func (e DiffUnavailableError) Error() string {
 
 // ReadResult is the result of a call to Read.
 type ReadResult struct {
+	// This is the ID for the resource. This ID will always be populated and will ensure we get the most up-to-date
+	// resource ID.
+	ID resource.ID
 	// Inputs contains the new inputs for the resource, if any. If this field is nil, the provider does not support
 	// returning inputs from a call to Read and the old inputs (if any) should be preserved.
 	Inputs resource.PropertyMap

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -734,9 +734,6 @@ func (p *provider) Read(urn resource.URN, id resource.ID,
 	// If the resource was missing, simply return a nil property map.
 	if string(readID) == "" {
 		return ReadResult{}, resourceStatus, nil
-	} else if readID != id {
-		return ReadResult{}, resourceStatus, errors.Errorf(
-			"reading resource %s yielded an unexpected ID; expected %s, got %s", urn, id, readID)
 	}
 
 	// Finally, unmarshal the resulting state properties and return them.
@@ -771,6 +768,7 @@ func (p *provider) Read(urn resource.URN, id resource.ID,
 
 	logging.V(7).Infof("%s success; #outs=%d, #inputs=%d", label, len(newState), len(newInputs))
 	return ReadResult{
+		ID:      readID,
 		Outputs: newState,
 		Inputs:  newInputs,
 	}, resourceStatus, resourceError


### PR DESCRIPTION
This is a requirement for us to be able to move forward with
versions of the Terraform Azurerm provider. In v1.32.1, there was
a state migration that changed the ID format of the azure table
storage resource

We used to have a check in place for old ID being equal to new ID.
This has been changed now and we allow the change of ID to happen
in the RefreshStep

<img width="1207" alt="Screenshot 2019-08-14 at 17 08 42" src="https://user-images.githubusercontent.com/227823/63035761-62163200-bec4-11e9-935a-a22b0cc9dd3a.png">

From my debugging

```
[14:08:58 deploy/step.go:717 github.com/pulumi/pulumi/pkg/resource/deploy.(*RefreshStep).Apply]
0.003s Refreshed the ID
0.007s from
       s.old.ID=https://storage2a983676.table.core.windows.net/values087ce62b
0.009s to
       refreshedID=https://storage2a983676.table.core.windows.net/Tables('values087ce62b')
```