### PR TITLE
Use an entrypoint script to the pulumi Dockerfile

### DIFF
--- a/dist/docker/Dockerfile
+++ b/dist/docker/Dockerfile
@@ -59,5 +59,12 @@ RUN if [ "$PULUMI_VERSION" = "latest" ]; then \
   fi && \
   mv ~/.pulumi/bin/* /usr/bin
 
-# I think it's safe to say if we're using this mega image, we want pulumi
-ENTRYPOINT ["pulumi"]
+COPY ./entrypoint.sh /usr/bin/pulumi-entrypoint
+
+# The app directory should contain the Pulumi program and is the pwd for the CLI.
+WORKDIR /app
+VOLUME ["/app"]
+
+# This image uses a thin wrapper over the Pulumi CLI as its entrypoint. As a result, you may run commands
+# simply by running `docker run pulumi/pulumi up` to run the program mounted in the `/app` volume location.
+ENTRYPOINT ["/usr/bin/pulumi-entrypoint", "--non-interactive"]

--- a/dist/docker/entrypoint.sh
+++ b/dist/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+# Install Node dependencies if a package.json is present.
+if [ -e package.json ]; then
+    npm install
+fi
+
+# Install Python dependencies if a Pipfile is present.
+if [ -e Pipfile ]; then
+    pip install -r requirements.txt
+fi
+
+# Pass any additional arguments to the pulumi executable.
+pulumi $*


### PR DESCRIPTION
Currently, the UX of the pulumi/pulumi Docker container is hampered by the need to install any framework-specific dependencies before running the `pulumi` executable. This change adds a script to handle installing Node or Python dependencies before running pulumi, passing along any arguments also provided.

It's worth noting that the `pulumi/actions` image is [based on this one](https://github.com/pulumi/pulumi/blob/0bb4e6d70be300c058a8b7564329e2e1c511e3d5/dist/actions/Dockerfile#L2), but since this change modifies only the container's entrypoint (and names it differently from the one created in the pulumi/actions image), it should not interfere with the behavior of that container.  

Signed-off-by: Christian Nunciato <c@nunciato.org>