### PR TITLE
Annotate preview features

### DIFF
--- a/cmd/history.go
+++ b/cmd/history.go
@@ -40,7 +40,7 @@ func newHistoryCmd() *cobra.Command {
 		Use:        "history",
 		Aliases:    []string{"hist"},
 		SuggestFor: []string{"updates"},
-		Short:      "Update history for a stack",
+		Short:      "[PREVIEW] Update history for a stack",
 		Long: `Update history for a stack
 
 This command lists data about previous updates for a stack.`,

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -55,7 +55,7 @@ func newLoginCmd() *cobra.Command {
 			"to log in to a Pulumi Enterprise server running at the pulumi.acmecorp.com domain.\n" +
 			"\n" +
 			"For `https://` URLs, the CLI will speak REST to a service that manages state and concurrency control.\n" +
-			"If you prefer to operate Pulumi independently of a service, and entirely local to your computer,\n" +
+			"[PREVIEW] If you prefer to operate Pulumi independently of a service, and entirely local to your computer,\n" +
 			"pass `file://<path>`, where `<path>` will be where state checkpoints will be stored. For instance,\n" +
 			"\n" +
 			"    $ pulumi login file://~\n" +
@@ -67,7 +67,7 @@ func newLoginCmd() *cobra.Command {
 			"\n" +
 			"    $ pulumi login --local\n" +
 			"\n" +
-			"Additionally, you may leverage supported object storage backends from one of the cloud providers " +
+			"[PREVIEW] Additionally, you may leverage supported object storage backends from one of the cloud providers " +
 			"to manage the state independent of the service. For instance,\n" +
 			"\n" +
 			"AWS S3:\n" +

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -43,7 +43,7 @@ func newLogsCmd() *cobra.Command {
 
 	logsCmd := &cobra.Command{
 		Use:   "logs",
-		Short: "Show aggregated logs for a stack",
+		Short: "[PREVIEW] Show aggregated logs for a stack",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			opts := display.Options{


### PR DESCRIPTION
The `pulumi logs` and `pulumi history` commands are still in preview, even as `pulumi` itself will reach 1.0.  We now communicate this clearly in CLI help text.

The local and remote state backends are also still in preview, and this is annotated inline in the help text for the `pulumi login` command which is the entrypoint to this functionality.