### PR TITLE
Only skip publishing docker images for `-alpha` builds.

### DIFF
--- a/scripts/build-and-publish-docker
+++ b/scripts/build-and-publish-docker
@@ -23,9 +23,9 @@ fi
 
 CLI_VERSION="${1}"
 
-# We only want to push docker images for released versions of Pulumi. So if there are pre-release tags,
-# just skip publishing
-if [[ "${CLI_VERSION}" == *-* ]]; then
+# We only want to push docker images for stable versions of Pulumi. So if there is a -alpha
+# pre-release tag, skip publishing.
+if [[ "${CLI_VERSION}" == *-alpha* ]]; then
     >&2 echo "Skipping docker publishing for ${CLI_VERSION} since it is a pre-release"
     exit 0    
 fi


### PR DESCRIPTION
Previously, we only published docker images for non-prerelease
builds. However, on our move to 1.0.0, we will be publishing a few
`-beta` (and perhaps one or more `-rc`) builds. These are high quality
builds we want folks to use. So, we will publish them to DockerHub and
update the `latest` tag, similar to what we do for NPM and PyPI.

I will manually publish 1.0.0-beta.2, but landing these changes means
that future releases will be published automatically

Fixes #3092