### PR TITLE
Update the JSON representation of customTimeouts in state

### DIFF
--- a/pkg/resource/custom_timeouts.go
+++ b/pkg/resource/custom_timeouts.go
@@ -1,7 +1,11 @@
 package resource
 
 type CustomTimeouts struct {
-	Create float64
-	Update float64
-	Delete float64
+	Create float64 `json:"create,omitempty" yaml:"create,omitempty"`
+	Update float64 `json:"update,omitempty" yaml:"update,omitempty"`
+	Delete float64 `json:"delete,omitempty" yaml:"delete,omitempty"`
+}
+
+func (c *CustomTimeouts) IsNotEmpty() bool {
+	return c.Delete != 0 || c.Update != 0 || c.Create != 0
 }

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -262,7 +262,7 @@ func SerializeResource(res *resource.State, enc config.Encrypter) (apitype.Resou
 		outputs = soutp
 	}
 
-	return apitype.ResourceV3{
+	v3Resource := apitype.ResourceV3{
 		URN:                     res.URN,
 		Custom:                  res.Custom,
 		Delete:                  res.Delete,
@@ -280,8 +280,13 @@ func SerializeResource(res *resource.State, enc config.Encrypter) (apitype.Resou
 		PendingReplacement:      res.PendingReplacement,
 		AdditionalSecretOutputs: res.AdditionalSecretOutputs,
 		Aliases:                 res.Aliases,
-		CustomTimeouts:          &res.CustomTimeouts,
-	}, nil
+	}
+
+	if res.CustomTimeouts.IsNotEmpty() {
+		v3Resource.CustomTimeouts = &res.CustomTimeouts
+	}
+
+	return v3Resource, nil
 }
 
 func SerializeOperation(op resource.Operation, enc config.Encrypter) (apitype.OperationV2, error) {


### PR DESCRIPTION
Fixes: #3082 	

Omit them when empty and change the casing of Create, Update and
Delete

When I changed the logic, I was able to test that neither a refresh nor an update had any issues as the state was changing from 1 representation to another

New binary with `pulumi refresh`:
https://asciinema.org/a/2HATak5HsPRi3SPrdKUHWlyxF

New binary with up `pulumi up`:
https://asciinema.org/a/gnQQHUMnbxt5zwRn8bRVlq3U8

This video shows that even with state created by a new binary version (without the bad JSON) that installing an older CLI version and running `pulumi up --yes` the bad JSON will be restored and we will be back to the original state without any user problems
https://asciinema.org/a/pOGwNTKfEFvF26szqdDpcyraI