### PR TITLE
WIP: rendering init error updates

### DIFF
--- a/pkg/apitype/history.go
+++ b/pkg/apitype/history.go
@@ -65,6 +65,8 @@ const (
 	OpCreate OpType = "create"
 	// OpUpdate indicates an existing resource was updated.
 	OpUpdate OpType = "update"
+	// OpRetryUpdate indicates an existing resource was updated.
+	OpRetryUpdate OpType = "retry-update"
 	// OpDelete indicates an existing resource was deleted.
 	OpDelete OpType = "delete"
 	// OpReplace indicates an existing resource was replaced with a new one.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1075,11 +1075,9 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 			case deploy.OpCreate, deploy.OpCreateReplacement:
 				return "creating failed"
 			case deploy.OpUpdate:
-				if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
-					return "retrying update failed"
-				}
 				return "updating failed"
 			case deploy.OpRetryUpdate:
+				return "retrying update failed"
 			case deploy.OpDelete, deploy.OpDeleteReplaced:
 				return "deleting failed"
 			case deploy.OpReplace:
@@ -1099,10 +1097,7 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 				return ""
 			case deploy.OpCreate:
 				return "created"
-			case deploy.OpUpdate:
-				if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
-					return "updated"
-				}
+			case deploy.OpUpdate, deploy.OpRetryUpdate:
 				return "updated"
 			case deploy.OpDelete:
 				return "deleted"
@@ -1148,10 +1143,9 @@ func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) st
 	case deploy.OpCreate:
 		return "create"
 	case deploy.OpUpdate:
-		if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
-			return "retry update"
-		}
 		return "update"
+	case deploy.OpRetryUpdate:
+		return "retry update"
 	case deploy.OpDelete:
 		return "delete"
 	case deploy.OpReplace:
@@ -1190,10 +1184,9 @@ func (display *ProgressDisplay) getPreviewDoneText(step engine.StepEventMetadata
 	case deploy.OpCreate:
 		return "create"
 	case deploy.OpUpdate:
-		if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
-			return "retry update"
-		}
 		return "update"
+	case deploy.OpRetryUpdate:
+		return "retry update"
 	case deploy.OpDelete:
 		return "delete"
 	case deploy.OpReplace, deploy.OpCreateReplacement, deploy.OpDeleteReplaced, deploy.OpReadReplacement,
@@ -1263,10 +1256,9 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 		case deploy.OpCreate:
 			return "creating"
 		case deploy.OpUpdate:
-			if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
-				return "retrying update"
-			}
 			return "updating"
+		case deploy.OpRetryUpdate:
+			return "retrying update"
 		case deploy.OpDelete:
 			return "deleting"
 		case deploy.OpReplace:

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -1075,7 +1075,11 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 			case deploy.OpCreate, deploy.OpCreateReplacement:
 				return "creating failed"
 			case deploy.OpUpdate:
+				if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
+					return "retrying update failed"
+				}
 				return "updating failed"
+			case deploy.OpRetryUpdate:
 			case deploy.OpDelete, deploy.OpDeleteReplaced:
 				return "deleting failed"
 			case deploy.OpReplace:
@@ -1096,6 +1100,9 @@ func (display *ProgressDisplay) getStepDoneDescription(step engine.StepEventMeta
 			case deploy.OpCreate:
 				return "created"
 			case deploy.OpUpdate:
+				if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
+					return "updated"
+				}
 				return "updated"
 			case deploy.OpDelete:
 				return "deleted"
@@ -1141,6 +1148,9 @@ func (display *ProgressDisplay) getPreviewText(step engine.StepEventMetadata) st
 	case deploy.OpCreate:
 		return "create"
 	case deploy.OpUpdate:
+		if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
+			return "retry update"
+		}
 		return "update"
 	case deploy.OpDelete:
 		return "delete"
@@ -1180,6 +1190,9 @@ func (display *ProgressDisplay) getPreviewDoneText(step engine.StepEventMetadata
 	case deploy.OpCreate:
 		return "create"
 	case deploy.OpUpdate:
+		if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
+			return "retry update"
+		}
 		return "update"
 	case deploy.OpDelete:
 		return "delete"
@@ -1250,6 +1263,9 @@ func (display *ProgressDisplay) getStepInProgressDescription(step engine.StepEve
 		case deploy.OpCreate:
 			return "creating"
 		case deploy.OpUpdate:
+			if len(step.Old.InitErrors) > 0 || len(step.New.InitErrors) > 0 {
+				return "retrying update"
+			}
 			return "updating"
 		case deploy.OpDelete:
 			return "deleting"

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -492,6 +492,7 @@ func (data *resourceRowData) getDiffInfo(step engine.StepEventMetadata) string {
 			writePropertyKeys(changesBuf, filteredKeys(diff.Adds), deploy.OpCreate)
 			writePropertyKeys(changesBuf, filteredKeys(diff.Deletes), deploy.OpDelete)
 			writePropertyKeys(changesBuf, filteredKeys(updates), deploy.OpUpdate)
+			writePropertyKeys(changesBuf, filteredKeys(updates), deploy.OpRetryUpdate)
 		}
 	}
 

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -133,7 +133,7 @@ func (sm *SnapshotManager) BeginMutation(step deploy.Step) (engine.SnapshotMutat
 		return &sameSnapshotMutation{sm}, nil
 	case deploy.OpCreate, deploy.OpCreateReplacement:
 		return sm.doCreate(step)
-	case deploy.OpUpdate:
+	case deploy.OpUpdate, deploy.OpRetryUpdate:
 		return sm.doUpdate(step)
 	case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
 		return sm.doDelete(step)

--- a/pkg/diag/colors/colors.go
+++ b/pkg/diag/colors/colors.go
@@ -154,6 +154,7 @@ var (
 
 	SpecCreate            = Green         // for adds (in the diff sense).
 	SpecUpdate            = Yellow        // for changes (in the diff sense).
+	SpecRetryUpdate       = Yellow        // for changes (in the diff sense).
 	SpecReplace           = BrightMagenta // for replacements (in the diff sense).
 	SpecDelete            = Red           // for deletes (in the diff sense).
 	SpecCreateReplacement = BrightGreen   // for replacement creates (in the diff sense).

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -360,7 +360,7 @@ func (acts *updateActions) OnResourceStepPost(
 	//
 	// This is a little kludgy given that these resources are global state. However, given the way that we have
 	// implemented the snapshot manager and engine today, it's the easiest way to accomplish what we are trying to do.
-	if status == resource.StatusPartialFailure && step.Op() == deploy.OpUpdate {
+	if status == resource.StatusPartialFailure && (step.Op() == deploy.OpUpdate || step.Op() == deploy.OpRetryUpdate) {
 		logging.V(7).Infof(
 			"OnResourceStepPost(%s): Step is partially-failed update, saving old inputs instead of new inputs",
 			step.URN())


### PR DESCRIPTION
Following up from #3091, this PR displays `retry update` (rather than `update`) for operations on resources that have initialization errors. Examples gifs of `preview`, `up`, and `refresh` are included below.

Open questions are:

* What should the diff view be for `retry update`? Right now it's an empty diff, which could be confusing.
* Should we change the error message in the `retry update` case, to make it clearer what's going on? (_e.g._, "this operation will be retried during the next `pulumi up`" or something).

## Preview

Running `pulumi preview` when a resource has failed to initialize will cause Pulumi to display a `refresh error` in the preview. Adding `--diff` could be somewhat confusing under this regiment because it is still empty.

![ie-preview](https://user-images.githubusercontent.com/1409156/63381945-8c497300-c34e-11e9-8e5f-36ff8ed2dcd7.gif)

## Cancelled update

Running `pulumi up` when a resource has failed to initialize will cause Pulumi to explain that the update operation failed, just like any other update operation.

![ie-cancelled-update](https://user-images.githubusercontent.com/1409156/63382569-d2530680-c34f-11e9-920e-2b5444e15b93.gif)

## Refresh

Running `pulumi refresh` when a resource has failed to initialize (but has changed) will cause Pulumi to emit an `update` as normal.

![ie-refresh](https://user-images.githubusercontent.com/1409156/63383270-4fcb4680-c351-11e9-8997-5bb1545e2e7b.gif)
