### PR TITLE
Simple project support for local backends

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -314,7 +314,7 @@ func (b *localBackend) ListStacks(
 
 	var results []backend.StackSummary
 	for _, stackName := range stacks {
-		backendRef := localBackendReference{}
+		var backendRef localBackendReference
 		if stackName.HasNamespace() {
 			backendRef = localBackendReference{
 				project: stackName.Namespace().String(),

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -85,6 +85,10 @@ func listBucket(bucket Bucket, dir string) ([]*blob.ListObject, error) {
 
 // objectName returns the filename of a ListObject (an object from a bucket)
 func objectName(obj *blob.ListObject) string {
+	if obj.Key[len(obj.Key)-1] == '/' {
+		_, filename := path.Split(obj.Key[:len(obj.Key)-1])
+		return filename
+	}
 	_, filename := path.Split(obj.Key)
 	return filename
 }

--- a/pkg/tokens/names.go
+++ b/pkg/tokens/names.go
@@ -79,6 +79,12 @@ func (nm QName) Name() Name {
 	return Name(nmn)
 }
 
+// HasNamespace returns if the QName has a namespace (dropping the name)
+func (nm QName) HasNamespace() bool {
+	ix := strings.LastIndex(string(nm), QNameDelimiter)
+	return ix != -1
+}
+
 // Namespace extracts the namespace portion of a QName (dropping the name); this may be empty.
 func (nm QName) Namespace() QName {
 	ix := strings.LastIndex(string(nm), QNameDelimiter)


### PR DESCRIPTION
This is probably a bit messy but it gets some basic project support into the local backend. It can still list and load old stacks which aren't associated with a project. Ideally the whole project idea should probably be lifted up so project handling is generalised but that's probably awkward while also keeping back compat with all the current file stacks not under project folders.

There's still some issues, rename isn't working quite right (history files don't move). But want to get some eyes on this early to check the approach is sound before spending time getting it good enough to merge.