### PR TITLE
Fix stack reference issue when running on a pre `-beta.3` CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+## 1.0.0-beta.4 (2019-08-22)
+
+- Fix a crash when using StackReference from the `1.0.0-beta.3` version of
+  `@pulumi/pulumi` and `1.0.0-beta.2` or earlier of the CLI.
+
 ## 1.0.0-beta.3 (2019-08-21)
 
 - When using StackReference to fetch output values from another stack, do not mark a value as secret if it was not

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -138,7 +138,7 @@ async function isSecretOutputName(sr: StackReference, name: Input<string>): Prom
     // If either the name or set of secret outputs is unknown, we can't do anything smart, so we just copy the
     // secretness from the entire outputs value.
     if (!((await nameOutput.isKnown) && (await sr.secretOutputNames.isKnown))) {
-        return await this.outputs.isSecret;
+        return await sr.outputs.isSecret;
     }
 
     // Otherwise, if we have a list of outputs we know are secret, we can use that list to determine if this


### PR DESCRIPTION
In #3071 we made change to the built in provider for `StackReference`
to return additional data about the names of outputs which were
secrets.  The SDKs uses this information to decide if it should mark a
stack output as secret when returning it's value from `getOutput`.

When using an older CLI which does not report this data, we hit an
error:

```
 TypeError: Cannot read property 'outputs' of undefined
```

This was caused by a refactoring error where we extracted a private
helper out of the StackReference class, but neglected to change one
instance of `this` to `sr`. While we do have tests that exercise this
feature, we would only see this bug when using an older CLI, and we
don't have automated tests here that use the neweset `@pulumi/pulumi`
with an older `pulumi` CLI