### PR TITLE
Allow IDs to change during import.

### DIFF
--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -4199,10 +4199,11 @@ func TestImportUpdatedID(t *testing.T) {
 	}
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", false, deploytest.ResourceOptions{
+		_, id, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", false, deploytest.ResourceOptions{
 			ImportID: importID,
 		})
 		assert.NoError(t, err)
+		assert.Equal(t, actualID, id)
 		return nil
 	})
 	p.Options.host = deploytest.NewPluginHost(nil, nil, program, loaders...)

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -827,6 +827,9 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 			"provider does not support importing resources; please try updating the '%v' plugin",
 			s.new.URN.Type().Package())
 	}
+	if read.ID != "" {
+		s.new.ID = read.ID
+	}
 	s.new.Outputs = read.Outputs
 
 	// Magic up an old state so the frontend can display a proper diff. This state is the output of the just-executed


### PR DESCRIPTION
This is necessary for resources like `aws.ec2.RouteTableAssociation`.

Part of https://github.com/pulumi/pulumi-aws/issues/708.