### PR TITLE
Remove `expanded_url` from the command that generate docs

### DIFF
--- a/cmd/gen_markdown.go
+++ b/cmd/gen_markdown.go
@@ -54,7 +54,6 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 				buf := new(bytes.Buffer)
 				buf.WriteString("---\n")
 				buf.WriteString(fmt.Sprintf("title: %q\n", title))
-				buf.WriteString("expanded_url: /docs/reference/commands/\n")
 				buf.WriteString("---\n\n")
 				return buf.String()
 			}


### PR DESCRIPTION
As of the [new TOC](https://github.com/pulumi/docs/pull/1563), `expanded_url` isn't a thing anymore, so no need to emit it when generating command docs.