### PR TITLE
Update the tagline in our CLI

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -60,7 +60,7 @@ func NewPulumiCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "pulumi",
 		Short: "Pulumi command line",
-		Long: "Pulumi - Cloud Native Infrastructure as Code\n" +
+		Long: "Pulumi - Modern Infrastructure as Code\n" +
 			"\n" +
 			"To begin working with Pulumi, run the 'pulumi new' command:\n" +
 			"\n" +


### PR DESCRIPTION
This was bugging me every time I saw it, since we use a different tagline these days.

I considered just removing this altogether, or changing it to be a bit more facts-based and less marketing. However, lacking a brilliant alternative idea, I just updated it to say "modern."

I am 100% open to alternative suggestions.