### PR TITLE
Don't encourage PULUMI_TEST_MODE

### DIFF
--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -79,8 +79,7 @@ export function isTestModeEnabled(): boolean {
  */
 function requireTestModeEnabled(): void {
     if (!isTestModeEnabled()) {
-        throw new Error("Program run without the `pulumi` CLI; this may not be what you want " +
-            "(enable PULUMI_TEST_MODE to disable this error)");
+        throw new Error("Program run without the Pulumi engine available; re-run using the `pulumi` CLI");
     }
 }
 

--- a/sdk/nodejs/tests/testmode.spec.ts
+++ b/sdk/nodejs/tests/testmode.spec.ts
@@ -25,8 +25,7 @@ class FakeResource extends CustomResource {
 }
 
 const testModeDisabledError = (err: Error) => {
-    return err.message === "Program run without the `pulumi` CLI; this may not be what you want " +
-        "(enable PULUMI_TEST_MODE to disable this error)";
+    return err.message === "Program run without the Pulumi engine available; re-run using the `pulumi` CLI";
 };
 
 describe("testMode", () => {

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -111,9 +111,7 @@ def _set_test_mode_enabled(v: Optional[bool]):
 
 def require_test_mode_enabled():
     if not is_test_mode_enabled():
-        raise RunError('Program run without the `pulumi` CLI; this may not be what you want '+
-                       '(enable PULUMI_TEST_MODE to disable this error)')
-
+        raise RunError('Program run without the Pulumi engine available; re-run using the `pulumi` CLI')
 
 def is_legacy_apply_enabled():
     return bool(SETTINGS.legacy_apply_enabled)


### PR DESCRIPTION
We intend to replace PULUMI_TEST_MODE with better testing support
that doesn't suffer from all the pitfalls of our current approach.
Unfortunately, we don't yet have complete guidance or validation
that the new approaches will work for all existing end users. So,
until we do, we'll take a lighter touch approach here, and simply
not encourage new usage of PULUMI_TEST_MODE.

Issue #3045 will remain open to track a mroe permanent fix.