### PR TITLE
Update baselines to react to TypeScript 3.6.2

### DIFF
--- a/sdk/nodejs/tests/runtime/tsClosureCases.ts
+++ b/sdk/nodejs/tests/runtime/tsClosureCases.ts
@@ -199,14 +199,17 @@ return () => __awaiter(void 0, void 0, void 0, function* () { });
     cases.push({
         title: "Async lambda that does capture this",
         func: async () => { console.log(this); },
-        expectText: undefined,
-        error: `Error serializing function 'func': tsClosureCases.js(0,0)
+        expectText: `exports.handler = __f0;
+${awaiterCode}
+function __f0() {
+  return (function() {
+    with({ __awaiter: __f1 }) {
 
-function 'func': tsClosureCases.js(0,0): which could not be serialized because
-  arrow function captured 'this'. Assign 'this' to another name outside function and capture that.
+return () => __awaiter(void 0, void 0, void 0, function* () { console.log(this); });
 
-Function code:
-  () => __awaiter(this, void 0, void 0, function* () { console.log(this); })
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
 `,
     });
 


### PR DESCRIPTION
Some code generation in the typescript compiler changed as part of 3.6.2, so I've updated our baselines so PRs and builds go green again.

I will open a bug to track getting better coverage on the behavior on capturing this in an arrow function (ref: https://github.com/pulumi/pulumi/commit/67f6d4d7e5cbeb8446c60038d972041ea66591e3 which had us adjust a test because the typescript compiler no longer generates problematic code)