### PR TITLE
create testing temp dir recursively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ CHANGELOG
 - Filter the list of templates shown by default during `pulumi new`.
   [#3147](https://github.com/pulumi/pulumi/pull/3147)
 
+- Fix a bug in the test-harness which would fail to create temp directories when the stack name was prefixed with `ORG_NAME/`
+  [#3164](https://github.com/pulumi/pulumi/pull/3164)
+
 ## 1.0.0-beta.4 (2019-08-22)
 
 - Fix a crash when using StackReference from the `1.0.0-beta.3` version of

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1060,7 +1060,8 @@ func (pt *programTester) testEdit(dir string, i int, edit EditDir) error {
 		}
 	} else {
 		// Create a new temporary directory
-		newDir, err := ioutil.TempDir("", pt.opts.StackName+"-")
+		newDir := os.TempDir() + pt.opts.StackName + "-"
+		err := os.MkdirAll(newDir, os.ModePerm)
 		if err != nil {
 			return errors.Wrapf(err, "Couldn't create new temporary directory")
 		}
@@ -1263,7 +1264,8 @@ func (pt *programTester) copyTestToTemporaryDirectory() (string, string, error) 
 		projdir = projinfo.Root
 	} else {
 		stackName := string(pt.opts.GetStackName())
-		targetDir, tempErr := ioutil.TempDir("", stackName+"-")
+		targetDir := os.TempDir() + stackName + "-"
+		tempErr := os.MkdirAll(targetDir, os.ModePerm)
 		if tempErr != nil {
 			return "", "", errors.Wrap(tempErr, "Couldn't create temporary directory")
 		}


### PR DESCRIPTION
Ran into this issue when prefixing `stackname` with the organization in the test-harness.

Pulumi would fail to create the temp directory because `ioutil.TempDir` doesn't handle recursive creation.

Current workaround is to run `mkdir /tmp/ORG_NAME` in our makefile before running our tests.

Example:
```
--- FAIL: XXXXXXXXXXXXXXX (0.00s)
    program.go:497: 
        	Error Trace:	program.go:497
        	            				standard_test.go:37
        	Error:      	Received unexpected error:
        	            	mkdir /tmp/ORG_NAME/ec66c20-integration-test-859829154: no such file or directory
        	            	Couldn't create temporary directory
        	            	github.com/pulumi/pulumi/pkg/testing/integration.(*programTester).copyTestToTemporaryDirectory
        	            		/home/azamat/go/pkg/mod/github.com/pulumi/pulumi@v0.17.20/pkg/testing/integration/program.go:1209
        	            	github.com/pulumi/pulumi/pkg/testing/integration.(*programTester).testLifeCycleInitAndDestroy
        	            		/home/azamat/go/pkg/mod/github.com/pulumi/pulumi@v0.17.20/pkg/testing/integration/program.go:705
        	            	github.com/pulumi/pulumi/pkg/testing/integration.ProgramTest
        	            		/home/azamat/go/pkg/mod/github.com/pulumi/pulumi@v0.17.20/pkg/testing/integration/program.go:496

```