### PR TITLE
Exclude stack owner from stackname when using CloudStorage

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -836,8 +836,8 @@ func (pt *programTester) testLifeCycleInitialize(dir string) error {
 		loginArgs := []string{"login"}
 		loginArgs = addFlagIfNonNil(loginArgs, "--cloud-url", pt.opts.CloudURL)
 
-		// If this is a local login, then don't attach the owner to the stack-name.
-		if strings.HasPrefix(pt.opts.CloudURL, "file://") {
+		// If this is a local OR cloud login, then don't attach the owner to the stack-name.
+		if pt.opts.CloudURL != "" {
 			stackInitName = string(pt.opts.GetStackName())
 		}
 


### PR DESCRIPTION
This was causing an error as follows:

```
error: could not create stack: validating stack properties: invalid stack name: a stack name may only contain alphanumeric, hyphens, underscores, or periods
```

This will need to be changed when #2522 is merged

Without this, we cannot add tests for storing state in S3 / GCP etc