### PR TITLE
Do not drop unhandled exceptions in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fix a bug that caused the Python runtime to ignore unhandled exceptions and erroneously report that a Pulumi program executed successfully.
+  [#3170](https://github.com/pulumi/pulumi/pull/3170)
+
 ## 1.0.0 (2019-09-03)
 
 - No significant changes.

--- a/sdk/python/lib/test/langhost/future_failure/__init__.py
+++ b/sdk/python/lib/test/langhost/future_failure/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/future_failure/__main__.py
+++ b/sdk/python/lib/test/langhost/future_failure/__main__.py
@@ -1,0 +1,39 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import asyncio
+from pulumi import CustomResource, Output, ResourceOptions
+from pulumi.runtime import invoke
+
+class MyResource(CustomResource):
+    value: Output[str]
+
+    def __init__(self, name, value, opts):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={
+            "value": value,
+        }, opts=opts)
+
+# We run this invoke first because of the way in which it interacts with the RPC manager. Prior to #3170, the RPC
+# manager would decide that all outstanding RPCs had finished on any non-zero -> zero transition in the number of
+# outstanding RPCs. Because an invoke is considered an RPC, running any synchronous invokes before any other RPC
+# would confuse this logic, which would cause us to drop exceptions that occurred during subsequent RPCs and
+# incorrectly consider failed programs to have succeeded.
+invoke("test:index:MyFunction", props={})
+
+resA = MyResource("resourceA", "foo", None)
+
+fut = asyncio.Future()
+fut.set_exception(Exception("oh no"))
+resB = MyResource("resourceB", fut, ResourceOptions(depends_on=[resA]))
+
+resC = MyResource("resourceC", "baz", ResourceOptions(depends_on=[resB]))

--- a/sdk/python/lib/test/langhost/future_failure/test_future_failure.py
+++ b/sdk/python/lib/test/langhost/future_failure/test_future_failure.py
@@ -1,0 +1,37 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class TestFutureFailure(LanghostTest):
+    def test_future_failure(self):
+        self.run_test(
+            program=path.join(self.base_path(), "future_failure"),
+            expected_resource_count=1,
+            expected_error="Program exited with non-zero exit code: 1")
+
+    def invoke(self, _ctx, token, args, provider, _version):
+        self.assertEqual("test:index:MyFunction", token)
+        return [], {}
+
+    def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps,
+                          _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
+                          _ignore_changes, _version):
+        self.assertEqual("test:index:MyResource", ty)
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": resource,
+        }

--- a/sdk/python/lib/test/langhost/marshal_failure/__init__.py
+++ b/sdk/python/lib/test/langhost/marshal_failure/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/marshal_failure/__main__.py
+++ b/sdk/python/lib/test/langhost/marshal_failure/__main__.py
@@ -1,0 +1,38 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from pulumi import CustomResource, Output, ResourceOptions
+from pulumi.runtime import invoke
+
+class MyResource(CustomResource):
+    value: Output[str]
+
+    def __init__(self, name, value, opts):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={
+            "value": value,
+        }, opts=opts)
+
+# We run this invoke first because of the way in which it interacts with the RPC manager. Prior to #3170, the RPC
+# manager would decide that all outstanding RPCs had finished on any non-zero -> zero transition in the number of
+# outstanding RPCs. Because an invoke is considered an RPC, running any synchronous invokes before any other RPC
+# would confuse this logic, which would cause us to drop exceptions that occurred during subsequent RPCs and
+# incorrectly consider failed programs to have succeeded.
+invoke("test:index:MyFunction", props={})
+
+resA = MyResource("resourceA", "foo", None)
+
+# The property marshaller does not support values of type `bytes`, so the runtime should fail when preparing this
+# RegisterResource RPC. We use `depends_on` to ensure that resources are registered in a predictable order.
+resB = MyResource("resourceB", "bar".encode("utf8"), ResourceOptions(depends_on=[resA]))
+
+resC = MyResource("resourceC", "baz", ResourceOptions(depends_on=[resB]))

--- a/sdk/python/lib/test/langhost/marshal_failure/test_marshal_failure.py
+++ b/sdk/python/lib/test/langhost/marshal_failure/test_marshal_failure.py
@@ -1,0 +1,37 @@
+# Copyright 2016-2018, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class TestMarshalFailure(LanghostTest):
+    def test_marshal_failure(self):
+        self.run_test(
+            program=path.join(self.base_path(), "marshal_failure"),
+            expected_resource_count=1,
+            expected_error="Program exited with non-zero exit code: 1")
+
+    def invoke(self, _ctx, token, args, provider, _version):
+        self.assertEqual("test:index:MyFunction", token)
+        return [], {}
+
+    def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps,
+                          _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
+                          _ignore_changes, _version):
+        self.assertEqual("test:index:MyResource", ty)
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": resource,
+        }


### PR DESCRIPTION
- Do not use a non-zero-to-zero transition in the number of outstanding
  RPCs to determine the completion of a Python program until after the
  synchronous piece of the program has finished running is complete
- Instead of using a future to indicate that either a) a zero-to-one
  transition in the number of outstanding RPCs has occurred, or b) an
  unhandled exception has occurred, a) observe the transition itself,
  and b) use an optional exception field to track the presence or
  absence of an exception.

Fixes #3162.