### PR TITLE
Transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ CHANGELOG
   [#3183](https://github.com/pulumi/pulumi/pull/3183)
 - Add Codefresh CI detection.
 - Add `-c` (config array) flag to the `preview` command.
+- Adds the ability to provide transformations to modify the properties and resource options that
+  will be used for any child resource of a component or stack.
+  [#3174](https://github.com/pulumi/pulumi/pull/3174)
 
 ## 1.1.0 (2019-09-11)
 
@@ -46,6 +49,7 @@ CHANGELOG
 
 - Filter the list of templates shown by default during `pulumi new`.
   [#3147](https://github.com/pulumi/pulumi/pull/3147)
+
 ## 1.0.0-beta.4 (2019-08-22)
 
 - Fix a crash when using StackReference from the `1.0.0-beta.3` version of

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -341,15 +341,13 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, res
 	if hasOld {
 		contract.Assert(old != nil)
 		diff, err := sg.diff(urn, old, new, oldInputs, oldOutputs, inputs, prov, allowUnknowns, goal.IgnoreChanges)
-		if err != nil {
-			// If the plugin indicated that the diff is unavailable, assume that the resource will be updated and
-			// report the message contained in the error.
-			if _, ok := err.(plugin.DiffUnavailableError); ok {
-				diff = plugin.DiffResult{Changes: plugin.DiffSome}
-				sg.plan.ctx.Diag.Warningf(diag.RawMessage(urn, err.Error()))
-			} else {
-				return nil, result.FromError(err)
-			}
+		// If the plugin indicated that the diff is unavailable, assume that the resource will be updated and
+		// report the message contained in the error.
+		if _, ok := err.(plugin.DiffUnavailableError); ok {
+			diff = plugin.DiffResult{Changes: plugin.DiffSome}
+			sg.plan.ctx.Diag.Warningf(diag.RawMessage(urn, err.Error()))
+		} else if err != nil {
+			return nil, result.FromError(err)
 		}
 
 		// Ensure that we received a sensible response.

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -516,8 +516,33 @@ export interface CustomTimeouts {
  * of the original call to the `Resource` constructor.  If the transformation returns undefined,
  * this indicates that the resource will not be transformed.
  */
-export type ResourceTransformation =
-    (type: string, name: string, props: Inputs, opts: ResourceOptions) => ResourceTransformationResult | undefined;
+export type ResourceTransformation = (args: ResourceTransformationArgs) => ResourceTransformationResult | undefined;
+
+/**
+ * ResourceTransformationArgs is the argument bag passed to a resource transformation.
+ */
+export interface ResourceTransformationArgs {
+    /**
+     * The Resource instance that is being transformed.
+     */
+    resource: Resource;
+    /**
+     * The type of the Resource.
+     */
+    type: string;
+    /**
+     * The name of the Resource.
+     */
+    name: string;
+    /**
+     * The original properties passed to the Resource constructor.
+     */
+    props: Inputs;
+    /**
+     * The original resource options passed to the Resource constructor.
+     */
+    opts: ResourceOptions;
+}
 
 /**
  * ResourceTransformationResult is the result that must be returned by a resource transformation

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -483,7 +483,9 @@ export interface ResourceOptions {
      */
     customTimeouts?: CustomTimeouts;
     /**
-     * Optional list of transformations to apply to this resource during construction.
+     * Optional list of transformations to apply to this resource during construction. The
+     * transformations are applied in order, and transformations applied to parents are applied in
+     * order of specificity prior to transformations on this resources.
      */
     transformations?: ResourceTransformation[];
 
@@ -522,7 +524,16 @@ export type ResourceTransformation =
  * callback.  It includes new values to use for the `props` and `opts` of the `Resource` in place of
  * the originally provided values.
  */
-export type ResourceTransformationResult = { props: Inputs, opts: ResourceOptions };
+export interface ResourceTransformationResult {
+    /**
+     * The new properties to use in place of the original `props`
+     */
+    props: Inputs;
+    /**
+     * The new resource options to use in place of the original `opts`
+     */
+    opts: ResourceOptions;
+}
 
 /**
  * CustomResourceOptions is a bag of optional settings that control a custom resource's behavior.

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -405,10 +405,10 @@ export interface Alias {
 
 // collapseAliasToUrn turns an Alias into a URN given a set of default data
 function collapseAliasToUrn(
-    alias: Input<Alias | string>,
-    defaultName: string,
-    defaultType: string,
-    defaultParent: Resource | undefined): Output<URN> {
+        alias: Input<Alias | string>,
+        defaultName: string,
+        defaultType: string,
+        defaultParent: Resource | undefined): Output<URN> {
 
     return output(alias).apply(a => {
         if (typeof a === "string") {
@@ -506,8 +506,23 @@ export interface CustomTimeouts {
     delete?: string;
 }
 
+/**
+ * ResourceTransformation is the callback signature for the `transformations` resource option.  A
+ * transformation is passed the same set of inputs provided to the `Resource` constructor, and can
+ * optionally return back alternate values for the `props` and/or `opts` prior to the resource
+ * actually being created.  The effect will be as though those props and opts were passed in place
+ * of the original call to the `Resource` constructor.  If the transformation returns undefined,
+ * this indicates that the resource will not be transformed.
+ */
 export type ResourceTransformation =
-    (type: string, name: string, props: Inputs, opts: ResourceOptions) => { props: Inputs, opts: ResourceOptions } | undefined;
+    (type: string, name: string, props: Inputs, opts: ResourceOptions) => ResourceTransformationResult | undefined;
+
+/**
+ * ResourceTransformationResult is the result that must be returned by a resource transformation
+ * callback.  It includes new values to use for the `props` and `opts` of the `Resource` in place of
+ * the originally provided values.
+ */
+export type ResourceTransformationResult = { props: Inputs, opts: ResourceOptions };
 
 /**
  * CustomResourceOptions is a bag of optional settings that control a custom resource's behavior.

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -283,7 +283,7 @@ export abstract class Resource {
 
         // Combine transformations inherited from the parent with transformations provided in opts.
         const parent = opts.parent || getStackResource() || { __transformations: undefined };
-        this.__transformations = [...(parent.__transformations || []), ...(opts.transformations || [])];
+        this.__transformations = [ ...(opts.transformations || []), ...(parent.__transformations || []) ];
 
         this.__protect = !!opts.protect;
 
@@ -484,8 +484,8 @@ export interface ResourceOptions {
     customTimeouts?: CustomTimeouts;
     /**
      * Optional list of transformations to apply to this resource during construction. The
-     * transformations are applied in order, and transformations applied to parents are applied in
-     * order of specificity prior to transformations on this resources.
+     * transformations are applied in order, and are applied prior to transformation applied to
+     * parents walking from the resource up to the stack.
      */
     transformations?: ResourceTransformation[];
 

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -166,7 +166,7 @@ export function registerResource(res: Resource, t: string, name: string, custom:
     // If there are transformations registered, invoke them in order to transform the properties and
     // options assigned to this resource.
     for (const transformation of (res.__transformations || [])) {
-        const tres = transformation(t, name, props, opts);
+        const tres = transformation({ resource: res, type: t, name, props, opts });
         if (tres) {
             props = tres.props;
             opts = tres.opts;

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -163,6 +163,16 @@ export function registerResource(res: Resource, t: string, name: string, custom:
     const label = `resource:${name}[${t}]`;
     log.debug(`Registering resource: t=${t}, name=${name}, custom=${custom}`);
 
+    // If there are transformations registered, invoke them in order to transform the properties and
+    // options assigned to this resource.
+    for (const transformation of (res.__transformations || [])) {
+        const tres = transformation(t, name, props, opts);
+        if (tres) {
+            props = tres.props;
+            opts = tres.opts;
+        }
+    }
+
     const monitor = getMonitor();
     const resopAsync = prepareResource(label, res, custom, props, opts);
 

--- a/sdk/nodejs/tests/options.spec.ts
+++ b/sdk/nodejs/tests/options.spec.ts
@@ -103,6 +103,31 @@ describe("options", () => {
             });
         });
 
+        describe("arrayTransformations", () => {
+            const a = () => undefined;
+            const b = () => undefined;
+            it("keeps value from opts1 if not provided in opts2", asyncTest(async () => {
+                const result = mergeOptions({ transformations: [a] }, {});
+                assert.deepStrictEqual(result.transformations, [a]);
+            }));
+            it("keeps value from opts2 if not provided in opts1", asyncTest(async () => {
+                const result = mergeOptions({ }, { transformations: [a] });
+                assert.deepStrictEqual(result.transformations, [a]);
+            }));
+            it("does nothing to value from opts1 if given null in opts2", asyncTest(async () => {
+                const result = mergeOptions({ transformations: [a] }, { transformations: null! });
+                assert.deepStrictEqual(result.transformations, [a]);
+            }));
+            it("does nothing to value from opts1 if given undefined in opts2", asyncTest(async () => {
+                const result = mergeOptions({ transformations: [a] }, { transformations: undefined });
+                assert.deepStrictEqual(result.transformations, [a]);
+            }));
+            it("merges values from opts1 if given value in opts2", asyncTest(async () => {
+                const result = mergeOptions({ transformations: [a] }, { transformations: [b] });
+                assert.deepStrictEqual(result.transformations, [a, b]);
+            }));
+        });
+
         describe("providers", () => {
             const awsProvider = <ProviderResource>{ getPackage: () => "aws" };
             const azureProvider = <ProviderResource>{ getPackage: () => "azure" };

--- a/tests/integration/transformations/nodejs/simple/Pulumi.yaml
+++ b/tests/integration/transformations/nodejs/simple/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: transformations_simple
+description: 
+runtime: nodejs

--- a/tests/integration/transformations/nodejs/simple/index.ts
+++ b/tests/integration/transformations/nodejs/simple/index.ts
@@ -77,11 +77,11 @@ pulumi.runtime.registerStackTransformation(({ type, props, opts }) => {
 
 const res3 = new SimpleResource("res3", { input: "hello" });
 
-// Scenario #4 - transformations are applied in order of increasing specificity
-// 1. Stack transformation
+// Scenario #4 - transformations are applied in order of decreasing specificity
+// 1. (not in this example) Child transformation
 // 2. First parent transformation
 // 3. Second parent transformation
-// 4. (not in this example) Child transformation
+// 4. Stack transformation
 const res4 = new MyComponent("res4", {
     transformations: [
         ({ type, props, opts }) => {

--- a/tests/integration/transformations/nodejs/simple/index.ts
+++ b/tests/integration/transformations/nodejs/simple/index.ts
@@ -6,7 +6,7 @@ const simpleProvider: pulumi.dynamic.ResourceProvider = {
     async create(inputs: any) {
         return {
             id: "0",
-            outs: { output: "goodbye" },
+            outs: { output: "a", output2: "b" },
         };
     },
 };
@@ -18,8 +18,9 @@ interface SimpleArgs {
 
 class SimpleResource extends pulumi.dynamic.Resource {
     output: pulumi.Output<string>;
+    output2: pulumi.Output<string>;
     constructor(name, args: SimpleArgs, opts?: pulumi.CustomResourceOptions) {
-        super(simpleProvider, name, { ...args, output: undefined }, opts);
+        super(simpleProvider, name, { ...args, output: undefined, output2: undefined }, opts);
     }
 }
 
@@ -27,48 +28,79 @@ class MyComponent extends pulumi.ComponentResource {
     child: SimpleResource;
     constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
         super("my:component:MyComponent", name, {}, opts);
-        this.child = new SimpleResource("child", { input: "hello" }, { parent: this });
+        this.child = new SimpleResource(`${name}-child`, { input: "hello" }, {
+            parent: this,
+            additionalSecretOutputs: ["output2"],
+        });
         this.registerOutputs({});
     }
 }
 
-// Scenario #1 - rename a resource
+// Scenario #1 - apply a transformation to a CustomResource
 const res1 = new SimpleResource("res1", { input: "hello" }, {
     transformations: [
         (t, n, props, opts) => {
             console.log("res1 transformation");
             return {
                 props: props,
-                opts: { ...opts, additionalSecretOutputs: ["output"] },
+                opts: pulumi.mergeOptions(opts, { additionalSecretOutputs: ["output"] }),
             };
         },
     ],
 });
 
+// Scenario #2 - apply a transformation to a Component to transform it's children
 const res2 = new MyComponent("res2", {
     transformations: [
         (t, n, props, opts) => {
             console.log("res2 transformation");
             if (t === "pulumi-nodejs:dynamic:Resource") {
-                const newAso = [...((opts as pulumi.CustomResourceOptions).additionalSecretOutputs || []), "output"];
                 return {
                     props: { optionalInput: "newDefault", ...props },
-                    opts: { ...opts, additionalSecretOutputs: newAso },
+                    opts: pulumi.mergeOptions(opts, { additionalSecretOutputs: ["output"] }),
                 };
             }
         },
     ],
 });
 
+// Scenario #3 - apply a transformation to the Stack to transform all (future) resources in the stack
 pulumi.runtime.registerStackTransformation((t, n, props, opts) => {
     console.log("stack transformation");
     if (t === "pulumi-nodejs:dynamic:Resource") {
-        const newAso = [...((opts as pulumi.CustomResourceOptions).additionalSecretOutputs || []), "output"];
         return {
-            props: { optionalInput: "stackDefault", ...props },
-            opts: { ...opts, additionalSecretOutputs: newAso },
+            props: { ...props, optionalInput: "stackDefault" },
+            opts: pulumi.mergeOptions(opts, { additionalSecretOutputs: ["output"] }),
         };
     }
 });
 
 const res3 = new SimpleResource("res3", { input: "hello" });
+
+// Scenario #4 - transformations are applied in order of increasing specificity
+// 1. Stack transformation
+// 2. First parent transformation
+// 3. Second parent transformation
+// 4. (not in this example) Child transformation
+const res4 = new MyComponent("res4", {
+    transformations: [
+        (t, n, props, opts) => {
+            console.log("res4 transformation");
+            if (t === "pulumi-nodejs:dynamic:Resource") {
+                return {
+                    props: { ...props, optionalInput: "default1" },
+                    opts,
+                };
+            }
+        },
+        (t, n, props, opts) => {
+            console.log("res4 transformation 2");
+            if (t === "pulumi-nodejs:dynamic:Resource") {
+                return {
+                    props: { ...props, optionalInput: "default2" },
+                    opts,
+                };
+            }
+        },
+    ],
+});

--- a/tests/integration/transformations/nodejs/simple/index.ts
+++ b/tests/integration/transformations/nodejs/simple/index.ts
@@ -39,7 +39,7 @@ class MyComponent extends pulumi.ComponentResource {
 // Scenario #1 - apply a transformation to a CustomResource
 const res1 = new SimpleResource("res1", { input: "hello" }, {
     transformations: [
-        (t, n, props, opts) => {
+        ({ props, opts }) => {
             console.log("res1 transformation");
             return {
                 props: props,
@@ -52,9 +52,9 @@ const res1 = new SimpleResource("res1", { input: "hello" }, {
 // Scenario #2 - apply a transformation to a Component to transform it's children
 const res2 = new MyComponent("res2", {
     transformations: [
-        (t, n, props, opts) => {
+        ({ type, props, opts }) => {
             console.log("res2 transformation");
-            if (t === "pulumi-nodejs:dynamic:Resource") {
+            if (type === "pulumi-nodejs:dynamic:Resource") {
                 return {
                     props: { optionalInput: "newDefault", ...props },
                     opts: pulumi.mergeOptions(opts, { additionalSecretOutputs: ["output"] }),
@@ -65,9 +65,9 @@ const res2 = new MyComponent("res2", {
 });
 
 // Scenario #3 - apply a transformation to the Stack to transform all (future) resources in the stack
-pulumi.runtime.registerStackTransformation((t, n, props, opts) => {
+pulumi.runtime.registerStackTransformation(({ type, props, opts }) => {
     console.log("stack transformation");
-    if (t === "pulumi-nodejs:dynamic:Resource") {
+    if (type === "pulumi-nodejs:dynamic:Resource") {
         return {
             props: { ...props, optionalInput: "stackDefault" },
             opts: pulumi.mergeOptions(opts, { additionalSecretOutputs: ["output"] }),
@@ -84,18 +84,18 @@ const res3 = new SimpleResource("res3", { input: "hello" });
 // 4. (not in this example) Child transformation
 const res4 = new MyComponent("res4", {
     transformations: [
-        (t, n, props, opts) => {
+        ({ type, props, opts }) => {
             console.log("res4 transformation");
-            if (t === "pulumi-nodejs:dynamic:Resource") {
+            if (type === "pulumi-nodejs:dynamic:Resource") {
                 return {
                     props: { ...props, optionalInput: "default1" },
                     opts,
                 };
             }
         },
-        (t, n, props, opts) => {
+        ({ type, props, opts }) => {
             console.log("res4 transformation 2");
-            if (t === "pulumi-nodejs:dynamic:Resource") {
+            if (type === "pulumi-nodejs:dynamic:Resource") {
                 return {
                     props: { ...props, optionalInput: "default2" },
                     opts,
@@ -103,4 +103,51 @@ const res4 = new MyComponent("res4", {
             }
         },
     ],
+});
+
+class MyOtherComponent extends pulumi.ComponentResource {
+    child1: SimpleResource;
+    child2: SimpleResource;
+    constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
+        super("my:component:MyComponent", name, {}, opts);
+        this.child1 = new SimpleResource(`${name}-child1`, { input: "hello" }, { parent: this });
+        this.child2 = new SimpleResource(`${name}-child2`, { input: "hello" }, { parent: this });
+        this.registerOutputs({});
+    }
+}
+
+const transformChild1DependsOnChild2: pulumi.ResourceTransformation = (() => {
+    // Create a promise that wil be resolved once we find child2.  This is needed because we do not
+    // know what order we will see the resource registrations of child1 and child2.
+    let child2Found: (res: pulumi.Resource) => void;
+    const child2 = new Promise<pulumi.Resource>((res) => child2Found = res);
+
+    // Return a transformation which will rewrite child1 to depend on the promise for child2, and
+    // will resolve that promise when it finds child2.
+    return (args: pulumi.ResourceTransformationArgs) => {
+        if (args.name.endsWith("-child2")) {
+            // Resolve the child2 promise with the child2 resource.
+            child2Found(args.resource);
+            return undefined;
+        } else if (args.name.endsWith("-child1")) {
+            // Overwrite the `input` to child2 with a dependency on the `output2` from child1.
+            const child2Input = pulumi.output(args.props["input"]).apply(async (input) => {
+                if (input !== "hello") {
+                    // Not strictly necessary - but shows we can confirm invariants we expect to be
+                    // true.
+                    throw new Error("unexpected input value");
+                }
+                return child2.then(c2Res => c2Res["output2"]);
+            });
+            // Finally - overwrite the input of child2.
+            return {
+                props: { ...args.props, input: child2Input },
+                opts: args.opts,
+            };
+        }
+    };
+})();
+
+const res5 = new MyOtherComponent("res5", {
+    transformations: [ transformChild1DependsOnChild2 ],
 });

--- a/tests/integration/transformations/nodejs/simple/index.ts
+++ b/tests/integration/transformations/nodejs/simple/index.ts
@@ -1,0 +1,74 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+const simpleProvider: pulumi.dynamic.ResourceProvider = {
+    async create(inputs: any) {
+        return {
+            id: "0",
+            outs: { output: "goodbye" },
+        };
+    },
+};
+
+interface SimpleArgs {
+    input: pulumi.Input<string>;
+    optionalInput?: pulumi.Input<string>;
+}
+
+class SimpleResource extends pulumi.dynamic.Resource {
+    output: pulumi.Output<string>;
+    constructor(name, args: SimpleArgs, opts?: pulumi.CustomResourceOptions) {
+        super(simpleProvider, name, { ...args, output: undefined }, opts);
+    }
+}
+
+class MyComponent extends pulumi.ComponentResource {
+    child: SimpleResource;
+    constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
+        super("my:component:MyComponent", name, {}, opts);
+        this.child = new SimpleResource("child", { input: "hello" }, { parent: this });
+        this.registerOutputs({});
+    }
+}
+
+// Scenario #1 - rename a resource
+const res1 = new SimpleResource("res1", { input: "hello" }, {
+    transformations: [
+        (t, n, props, opts) => {
+            console.log("res1 transformation");
+            return {
+                props: props,
+                opts: { ...opts, additionalSecretOutputs: ["output"] },
+            };
+        },
+    ],
+});
+
+const res2 = new MyComponent("res2", {
+    transformations: [
+        (t, n, props, opts) => {
+            console.log("res2 transformation");
+            if (t === "pulumi-nodejs:dynamic:Resource") {
+                const newAso = [...((opts as pulumi.CustomResourceOptions).additionalSecretOutputs || []), "output"];
+                return {
+                    props: { optionalInput: "newDefault", ...props },
+                    opts: { ...opts, additionalSecretOutputs: newAso },
+                };
+            }
+        },
+    ],
+});
+
+pulumi.runtime.registerStackTransformation((t, n, props, opts) => {
+    console.log("stack transformation");
+    if (t === "pulumi-nodejs:dynamic:Resource") {
+        const newAso = [...((opts as pulumi.CustomResourceOptions).additionalSecretOutputs || []), "output"];
+        return {
+            props: { optionalInput: "stackDefault", ...props },
+            opts: { ...opts, additionalSecretOutputs: newAso },
+        };
+    }
+});
+
+const res3 = new SimpleResource("res3", { input: "hello" });

--- a/tests/integration/transformations/nodejs/simple/package.json
+++ b/tests/integration/transformations/nodejs/simple/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "aliases",
+    "license": "Apache-2.0",
+    "main": "bin/index.js",
+    "typings": "bin/index.d.ts",
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/transformations/transformations_test.go
+++ b/tests/integration/transformations/transformations_test.go
@@ -1,0 +1,57 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package ints
+
+import (
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/resource"
+	"github.com/pulumi/pulumi/pkg/testing/integration"
+	"github.com/pulumi/pulumi/pkg/tokens"
+)
+
+var dirs = []string{
+	"simple",
+}
+
+// TestNodejsAliases tests a case where a resource's name changes but it provides an `alias`
+// pointing to the old URN to ensure the resource is preserved across the update.
+func TestNodejsAliases(t *testing.T) {
+	for _, dir := range dirs {
+		d := path.Join("nodejs", dir)
+		t.Run(d, func(t *testing.T) {
+			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Dir:          d,
+				Dependencies: []string{"@pulumi/pulumi"},
+				Quick:        true,
+				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+					for _, res := range stack.Deployment.Resources {
+						// "res1" has a transformation which adds additionalSecretOutputs
+						if res.URN.Name() == "res1" {
+							assert.Equal(t, res.Type, tokens.Type("pulumi-nodejs:dynamic:Resource"))
+							assert.Contains(t, res.AdditionalSecretOutputs, resource.PropertyKey("output"))
+						}
+						// "res2" has a transformation which adds additionalSecretOutputs to it's
+						// "child"
+						if res.URN.Name() == "child" {
+							assert.Equal(t, res.Type, tokens.Type("pulumi-nodejs:dynamic:Resource"))
+							assert.Equal(t, res.Parent.Type(), tokens.Type("my:component:MyComponent"))
+							assert.Contains(t, res.AdditionalSecretOutputs, resource.PropertyKey("output"))
+						}
+						// "res3" is impacted by a global stack transformation which sets
+						// optionalDefault to "stackDefault"
+						if res.URN.Name() == "res3" {
+							assert.Equal(t, res.Type, tokens.Type("pulumi-nodejs:dynamic:Resource"))
+							optionalInput := res.Inputs["optionalInput"]
+							assert.NotNil(t, optionalInput)
+							assert.Equal(t, optionalInput.(string), "stackDefault")
+						}
+					}
+				},
+			})
+		})
+	}
+}

--- a/tests/integration/transformations/transformations_test.go
+++ b/tests/integration/transformations/transformations_test.go
@@ -58,17 +58,17 @@ func TestNodejsAliases(t *testing.T) {
 							assert.NotNil(t, optionalInput)
 							assert.Equal(t, "stackDefault", optionalInput.(string))
 						}
-						// "res4" is impacted by both a global stack transformation which sets
-						// optionalDefault to "stackDefault" and then two component parent
-						// transformations which set optionalDefault to "default1" and then finally
-						// "default2".  The end result should be "default2".
+						// "res4" is impacted by two component parent transformations which set
+						// optionalDefault to "default1" and then "default2" and also a global stack
+						// transformation which sets optionalDefault to "stackDefault".  The end
+						// result should be "stackDefault".
 						if res.URN.Name() == "res4-child" {
 							foundRes4Child = true
 							assert.Equal(t, res.Type, tokens.Type("pulumi-nodejs:dynamic:Resource"))
 							assert.Equal(t, res.Parent.Type(), tokens.Type("my:component:MyComponent"))
 							optionalInput := res.Inputs["optionalInput"]
 							assert.NotNil(t, optionalInput)
-							assert.Equal(t, "default2", optionalInput.(string))
+							assert.Equal(t, "stackDefault", optionalInput.(string))
 						}
 						// "res5" modifies one of its children to depend on another of its children.
 						if res.URN.Name() == "res5-child1" {


### PR DESCRIPTION
Adds the ability to provide `transformations` to modify the properties and resource options that will be used for any child resource of a component or stack.

This offers an "escape hatch" to modify the behaviour of a component by peeking behind it's abstraction.  For example, it can be used to add a resource option (`additionalSecretOutputs`, `aliases`, `protect`, etc.) to a specific known child of a component, or to modify some input property to a child resource if the component does not (yet) expose the ability to control that input directly.  It could also be used for more interesting scenarios - such as:
1. Automatically applying tags to all resources that support them in a stack (or component)
2. Injecting real dependencies between stringly-referenced  resources in a Helm Chart 
3. Injecting explicit names using a preferred naming convention across all resources in a stack
4. Injecting `import` onto all resources by doing a lookup into a name=>id mapping

Because this feature makes it possible to peek behind a component abstraction, it must be used with care in cases where the component is versioned independently of the use of transformations.  Also, this can result in "spooky action at a distance", so should be used judiciously.  That said - this can be used as an escape hatch to unblock a wide variety of common use cases without waiting on changes to be made in a component implementation, as well 

Each transformation is passed the `name`, `type`, `props` and `opts` that are passed into the `Resource` constructor for any resource descended from the resource that has the transformation applied.  The transformation callback can optionally return alternate versions of the `props` and `opts` to be used in place of the originally provided values.

Transformations are applied iteratively in order of specificity - so stack transformations are applied first, then parent transformations (in order), then child transformations (in order).  The `props` and `opts` are passed through each layer of these transformations.

Questions for reviewers:
1. I'm actually not sure order of specificity is correct here - somewhat counterintuitively - this feature is actually about allow less specific code to override more specific code.  Should the order of application of transformations actually be inverted so that the last added Stack transformation gets final say?
2. Is there really value in using `transformations` instead of just `transformation`?  It seems exceedingly rare to provide multiple at one callsite - and in the case this is necessary, it seems the user could compose them functionally themselves.
3. `transformations` vs. `transforms` (vs. something else)?
4. The stack level version of this is dependent on the global context, which is not shared in SxS scenarios.  That means it could be possible for the transformation to not apply to all children.  I'm not sure what to do about that.  The stack level version of this is likely to be the most common use case for casual usage ("apply tags to everything", "adding import to everything").  

Fixes #2068.