### PR TITLE
Remove the need for `pandoc` during the build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ To hack on Pulumi, you'll need to get a development environment set up. You'll w
 You can easily get all required dependencies with brew
 
 ```bash
-brew install node pipenv python@3 typescript yarn pandoc go golangci/tap/golangci-lint
+brew install node pipenv python@3 typescript yarn go golangci/tap/golangci-lint
 ```
 
 ## Make build system

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -22,12 +22,7 @@ ensure::
 build_package::
 	rm -rf $(PYENVSRC) && cp -R ./lib/. $(PYENVSRC)/
 	sed -i.bak "s/\$${VERSION}/$(VERSION)/g" $(PYENVSRC)/setup.py && rm $(PYENVSRC)/setup.py.bak
-	if [ ! -z "$$(command -v pandoc)" ]; then \
-		pandoc --from=markdown --to=rst --output="$(PYENVSRC)/README.rst" ../../README.md; \
-	else \
-		echo "warning: pandoc not found, generating empty README.rst"; \
-		echo "" > "$(PYENVSRC)/README.rst"; \
-	fi
+	cp ../../README.md $(PYENVSRC)
 	cd $(PYENVSRC) && pipenv run python setup.py build bdist_wheel --universal
 
 build_plugin::

--- a/sdk/python/lib/MANIFEST.in
+++ b/sdk/python/lib/MANIFEST.in
@@ -1,1 +1,0 @@
-include README.rst

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -17,13 +17,14 @@
 from setuptools import setup, find_packages
 
 def readme():
-    with open('README.rst') as f:
+    with open('README.md', encoding='utf-8') as f:
         return f.read()
 
 setup(name='pulumi',
       version='${VERSION}',
       description='Pulumi\'s Python SDK',
       long_description=readme(),
+      long_description_content_type='text/markdown',
       url='https://github.com/pulumi/pulumi',
       license='Apache 2.0',
       packages=find_packages(exclude=("test*",)),


### PR DESCRIPTION
We had been using `pandoc` to convert our README.md into a README.rst
for use with `setup.py` and the python package ecosystem. It turns out
that we can use markdown if we set a content type. So let's do that
and make things a little simpler.

While I was in the area, I made the encoding of UTF-8 explicit when
opening README.md.