### PR TITLE
Ignore reads in HasChanges.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 
 - Fix a bug that caused the Python runtime to ignore unhandled exceptions and erroneously report that a Pulumi program executed successfully.
   [#3170](https://github.com/pulumi/pulumi/pull/3170)
+- Read operations are no longer considered changes for the purposes of `--expect-no-changes`.
+  [#3197](https://github.com/pulumi/pulumi/pull/3197)
 
 ## 1.0.0 (2019-09-03)
 

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -79,7 +79,10 @@ type ResourceChanges map[deploy.StepOp]int
 func (changes ResourceChanges) HasChanges() bool {
 	var c int
 	for op, count := range changes {
-		if op != deploy.OpSame {
+		if op != deploy.OpSame &&
+			op != deploy.OpRead &&
+			op != deploy.OpReadDiscard &&
+			op != deploy.OpReadReplacement {
 			c += count
 		}
 	}


### PR DESCRIPTION
This matches the behavior of the display logic, which does not consider
reads to be changes. This also matches the expectation of tests that
pass `--expect-no-changes` (and likely user intuition).