### PR TITLE
Support filestate backend (local or remote storage) with cloud secrets (S3, etc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - Fix a bug that caused the Python runtime to ignore unhandled exceptions and erroneously report that a Pulumi program executed successfully.
   [#3170](https://github.com/pulumi/pulumi/pull/3170)
 
+- Support combining the filestate backend (local or remote storage) with the cloud-backed secrets providers (KMS, etc.). 
+  [#3198](https://github.com/pulumi/pulumi/pull/3198)
+
 ## 1.0.0 (2019-09-03)
 
 - No significant changes.

--- a/cmd/crypto.go
+++ b/cmd/crypto.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/resource/config"
 	"github.com/pulumi/pulumi/pkg/secrets"
+	"github.com/pulumi/pulumi/pkg/secrets/passphrase"
 )
 
 func getStackEncrypter(s backend.Stack) (config.Encrypter, error) {
@@ -49,7 +50,7 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 		return nil, err
 	}
 
-	if ps.SecretsProvider != "default" && ps.SecretsProvider != "passphrase" && ps.SecretsProvider != "" {
+	if ps.SecretsProvider != passphrase.Type && ps.SecretsProvider != "default" && ps.SecretsProvider != "" {
 		return newCloudSecretsManager(s.Ref().Name(), stackConfigFile, ps.SecretsProvider)
 	}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/state"
 	"github.com/pulumi/pulumi/pkg/diag/colors"
 	"github.com/pulumi/pulumi/pkg/engine"
+	"github.com/pulumi/pulumi/pkg/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/util/cancel"
 	"github.com/pulumi/pulumi/pkg/util/ciutil"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
@@ -109,9 +110,9 @@ func createStack(
 	isDefaultSecretsProvider := secretsProvider == "" || secretsProvider == "default"
 	if _, ok := b.(filestate.Backend); ok && isDefaultSecretsProvider {
 		// The default when using the filestate backend is the passphrase secrets provider
-		secretsProvider = "passphrase"
+		secretsProvider = passphrase.Type
 	}
-	if secretsProvider == "passphrase" {
+	if secretsProvider == passphrase.Type {
 		if _, pharseErr := newPassphraseSecretsManager(stackRef.Name(), stackConfigFile); pharseErr != nil {
 			return nil, pharseErr
 		}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -102,16 +102,14 @@ func createStack(
 	b backend.Backend, stackRef backend.StackReference, opts interface{}, setCurrent bool,
 	secretsProvider string) (backend.Stack, error) {
 
-	// As part of creating the stack, we also need to configure the secrets provider for the stack. Today, we only
-	// have to do this configuration step when you are using the passphrase provider (which is used for all filestate,
-	// stacks and well as httpstate stacks that opted into this by passing --secrets-provider passphrase
-	// while initialing a stack).  The only other supported provider today (the provider that uses the pulumi service
-	// does not need to be initialized explicitly, as creating the stack inside the Pulumi service does this).
-	if _, ok := b.(filestate.Backend); ok || secretsProvider == "passphrase" {
+	// As part of creating the stack, we also need to configure the secrets provider for the stack. We only
+	// have to do this configuration step when you are using the passphrase provider and httpstate stacks that opted
+	// into this by passing --secrets-provider passphrase, or default
+	if secretsProvider == "" || secretsProvider == "default" || secretsProvider == "passphrase" {
 		if _, pharseErr := newPassphraseSecretsManager(stackRef.Name(), stackConfigFile); pharseErr != nil {
 			return nil, pharseErr
 		}
-	} else if secretsProvider != "" && secretsProvider != "default" {
+	} else {
 		// All other non-default secrets providers are handled by the cloud secrets provider which
 		// uses a URL schema to identify the provider
 		if _, secretsErr := newCloudSecretsManager(stackRef.Name(), stackConfigFile, secretsProvider); secretsErr != nil {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -805,7 +805,7 @@ func TestCloudSecretProvider(t *testing.T) {
 		t.Skipf("Skipping: PULUMI_TEST_KMS_KEY_ALIAS is not set")
 	}
 
-	integration.ProgramTest(t, &integration.ProgramTestOptions{
+	testOptions := integration.ProgramTestOptions{
 		Dir:             "cloud_secrets_provider",
 		Dependencies:    []string{"@pulumi/pulumi"},
 		SecretsProvider: fmt.Sprintf("awskms://alias/%s", kmsKeyAlias),
@@ -826,5 +826,15 @@ func TestCloudSecretProvider(t *testing.T) {
 			_, ok = out["ciphertext"]
 			assert.True(t, ok)
 		},
+	}
+
+	localTestOptions := testOptions.With(integration.ProgramTestOptions{
+		CloudURL: "file://~",
 	})
+
+	// Run with default Pulumi service backend
+	t.Run("service", func(t *testing.T) { integration.ProgramTest(t, &testOptions) })
+
+	// Also run with local backend
+	t.Run("local", func(t *testing.T) { integration.ProgramTest(t, &localTestOptions) })
 }


### PR DESCRIPTION
Builds on the work in https://github.com/pulumi/pulumi/pull/3191.

Adds test coverage for cloud-backed secrets combined with filestate backend.  This combination (for example, S3 + KMS) is likely to be common.

Fixes #3189.