### PR TITLE
GH-2319: Increase the grpc.MaxCallRecvMsgSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
   [#3170](https://github.com/pulumi/pulumi/pull/3170)
 - Read operations are no longer considered changes for the purposes of `--expect-no-changes`.
   [#3197](https://github.com/pulumi/pulumi/pull/3197)
+- Increase the MaxCallRecvMsgSize for interacting with the gRPC server. 
+  [#3201](https://github.com/pulumi/pulumi/pull/3201)
 
 ## 1.0.0 (2019-09-03)
 


### PR DESCRIPTION
Fixes: #2319

In #2319, a user is hitting the gRPC limit on the message size the
server can receive when uploading ec2 user-data

This commit doubles the limit that can be sent from `1024*1024*4` to
`1024*1024*8`