### PR TITLE
Do not ask for a passphrase in non-interactive sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
   [#3197](https://github.com/pulumi/pulumi/pull/3197)
 - Increase the MaxCallRecvMsgSize for interacting with the gRPC server. 
   [#3201](https://github.com/pulumi/pulumi/pull/3201)
+- Do not ask for a passphrase in non-interactive sessions (fix [#2758](https://github.com/pulumi/pulumi/issues/2758)).
+  [#3204](https://github.com/pulumi/pulumi/pull/3204)
 
 ## 1.0.0 (2019-09-03)
 

--- a/cmd/crypto_local.go
+++ b/cmd/crypto_local.go
@@ -16,6 +16,7 @@ package cmd
 import (
 	cryptorand "crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"os"
 
@@ -32,6 +33,9 @@ import (
 func readPassphrase(prompt string) (string, error) {
 	if phrase, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE"); ok {
 		return phrase, nil
+	}
+	if !cmdutil.Interactive() {
+		return "", errors.New("passphrase must be set with PULUMI_CONFIG_PASSPHRASE environment variable")
 	}
 	return cmdutil.ReadConsoleNoEcho(prompt)
 }


### PR DESCRIPTION
Fail with a hint to set the PULUMI_CONFIG_PASSPHRASE environment variable.
Fixes #2758.