### PR TITLE
Properly handle recursive outputs without penalizing non-recursive ones.

### DIFF
--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -68,16 +68,16 @@ class Stack extends ComponentResource {
         await setRootResource(this);
         let outputs: Inputs | undefined;
         try {
-            outputs = init();
+            outputs = massage(init(), []);
         } finally {
             // We want to expose stack outputs as simple pojo objects (including Resources).  This
             // helps ensure that outputs can point to resources, and that that is stored and
             // presented as something reasonable, and not as just an id/urn in the case of
             // Resources.
-            const massaged = massage(outputs, []);
-            super.registerOutputs(massaged);
-            return massaged;
+            super.registerOutputs(outputs);
         }
+
+        return outputs;
     }
 }
 

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -74,14 +74,14 @@ class Stack extends ComponentResource {
             // helps ensure that outputs can point to resources, and that that is stored and
             // presented as something reasonable, and not as just an id/urn in the case of
             // Resources.
-            super.registerOutputs(massage(outputs, new Set()));
+            const massaged = massage(outputs, []);
+            super.registerOutputs(massaged);
+            return massaged;
         }
-
-        return outputs;
     }
 }
 
-async function massage(prop: any, seenObjects: Set<any>): Promise<any> {
+async function massage(prop: any, seenObjects: any[]): Promise<any> {
     if (prop === undefined ||
         prop === null ||
         typeof prop === "boolean" ||
@@ -101,7 +101,7 @@ async function massage(prop: any, seenObjects: Set<any>): Promise<any> {
 
     // from this point on, we have complex objects.  If we see them again, we don't want to emit
     // them again fully or else we'd loop infinitely.
-    if (seenObjects.has(prop)) {
+    if (seenObjects.indexOf(prop) >= 0) {
         // Note: for Resources we hit again, emit their urn so cycles can be easily understood
         // in the pojo objects.
         if (Resource.isInstance(prop)) {
@@ -111,8 +111,22 @@ async function massage(prop: any, seenObjects: Set<any>): Promise<any> {
         return undefined;
     }
 
-    seenObjects.add(prop);
+    try {
+        // push and pop what we see into a stack.  That way if we see the same object through
+        // different paths, we will still print it out.  We only skip it if it would truly cause
+        // recursion.
+        seenObjects.push(prop);
+        return await massageComplex(prop, seenObjects);
+    }
+    finally {
+        const popped = seenObjects.pop();
+        if (popped !== prop) {
+            throw new Error("Invariant broken when processing stack outputs");
+        }
+    }
+}
 
+async function massageComplex(prop: any, seenObjects: any[]): Promise<any> {
     if (asset.Asset.isInstance(prop)) {
         if ((<asset.FileAsset>prop).path !== undefined) {
             return { path: (<asset.FileAsset>prop).path };

--- a/sdk/nodejs/tests/runtime/langhost/cases/046.recursive_stack_exports/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/046.recursive_stack_exports/index.js
@@ -1,0 +1,19 @@
+function main() {
+    var obj = { a: { b: 1 } };
+    var obj2 = { x: { y: 1 } };
+    obj2.obj2 = obj2;
+    obj2.x.x = obj2.x;
+    obj2.x.y.x = obj2.x;
+
+    return {
+        m: obj,
+        n: obj,
+        o: obj.a,
+        p: obj.a.b,
+        obj2: obj2,
+        obj2_x: obj2.x,
+        obj2_x_y: obj2.x.y,
+    };
+}
+
+module.exports = main();

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -870,10 +870,28 @@ describe("rpc", () => {
                 return { urn: makeUrn(t, name), id: importID, props: {} };
             },
         },
+        // Test stack outputs via exports.
+        "recursive_stack_exports": {
+            program: path.join(base, "046.recursive_stack_exports"),
+            expectResourceCount: 0,
+            registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
+                                      t: string, name: string, res: any, outputs: any | undefined) => {
+                assert.strictEqual(t, "pulumi:pulumi:Stack");
+                assert.strictEqual(outputs, {
+                    m: { a: { b: 1 } },
+                    n: { a: { b: 1 } },
+                    o: { b: 1 },
+                    p: 1,
+                    obj2: { x: { y: 1, x: undefined }, obj2: undefined },
+                    obj2_x: { y: 1, x: undefined },
+                    obj2_x_y: 1,
+                });
+            },
+        },
     };
 
     for (const casename of Object.keys(cases)) {
-        // if (casename.indexOf("depends_on_non_resource") < 0) {
+        // if (casename.indexOf("recursive_stack_exports") < 0) {
         //     continue;
         // }
 

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -90,8 +90,6 @@ describe("runtime", () => {
 
             const result = runtime.deserializeProperties(props);
 
-            console.log(JSON.stringify(result));
-
             // Regular had no secrets in it, so it is returned as is.
             assert.equal(result.regular, "a normal value");
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/3203

Switched from a set to a stack when looking for recursion.  A set meant that we wouldn't print the same vlaue out multiple times, even if seen in non-recursive paths.  An stack means we only stop printing if we have true recursion.
