### PR TITLE
Add a link to docs for the 409 Conflict error message

### DIFF
--- a/pkg/backend/errors.go
+++ b/pkg/backend/errors.go
@@ -11,6 +11,6 @@ type ConflictingUpdateError struct {
 }
 
 func (c ConflictingUpdateError) Error() string {
-	return fmt.Sprintf("%s\nTo learn more about possible reasons and resolution, visit " +
+	return fmt.Sprintf("%s\nTo learn more about possible reasons and resolution, visit "+
 		"https://www.pulumi.com/docs/troubleshooting/#conflict", c.Err.Error())
 }

--- a/pkg/backend/errors.go
+++ b/pkg/backend/errors.go
@@ -1,0 +1,16 @@
+package backend
+
+import (
+	"fmt"
+)
+
+// ConflictingUpdateError represents an error which occurred while starting an update/destroy operation.
+// Another update of the same stack was in progress, so the operation got cancelled due to this conflict.
+type ConflictingUpdateError struct {
+	Err error // The error that occurred while starting the operation.
+}
+
+func (c ConflictingUpdateError) Error() string {
+	return fmt.Sprintf("%s\nTo learn more about possible reasons and resolution, visit " +
+		"https://www.pulumi.com/docs/troubleshooting/#conflict", c.Err.Error())
+}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -725,6 +725,10 @@ func (b *cloudBackend) createAndStartUpdate(
 	}
 	version, token, err := b.client.StartUpdate(ctx, update, tags)
 	if err != nil {
+		if err, ok := err.(*apitype.ErrorResponse); ok && err.Code == 409 {
+			conflict := backend.ConflictingUpdateError{Err: err}
+			return client.UpdateIdentifier{}, 0, "", conflict
+		}
 		return client.UpdateIdentifier{}, 0, "", err
 	}
 	// Any non-preview update will be considered part of the stack's update history.


### PR DESCRIPTION
If the cloud backend 's client returns a 409 while starting an update operation, wrap the HTTP error into a special error type. The error should print a link to the docs to help users troubleshoot it:

```
$ pulumi up --skip-preview
Updating (dev):
error: [409] Conflict: Another update is currently in progress.
To learn more about possible reasons and resolution, visit https://www.pulumi.com/docs/troubleshooting/#conflict
```

Part of #2073 but this PR doesn't add workflow improvements, just the error message. Let's either keep #2073 open or create a new issue detailing the further steps.