### PR TITLE
Stop ignoring HTTP errors at token validation

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -226,7 +226,12 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	// If we have a saved access token, and it is valid, use it.
 	existingToken, err := workspace.GetAccessToken(cloudURL)
 	if err == nil && existingToken != "" {
-		if valid, _ := IsValidAccessToken(ctx, cloudURL, existingToken); valid {
+		valid, err := IsValidAccessToken(ctx, cloudURL, existingToken)
+		if err != nil {
+			return nil, err
+		}
+
+		if valid {
 			// Save the token. While it hasn't changed this will update the current cloud we are logged into, as well.
 			if err = workspace.StoreAccessToken(cloudURL, existingToken, true); err != nil {
 				return nil, err

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -48,7 +48,7 @@ type cloudBackendReference struct {
 }
 
 func (c cloudBackendReference) String() string {
-	curUser, err := c.b.client.GetPulumiAccountName(context.Background())
+	curUser, err := c.b.CurrentUser()
 	if err != nil {
 		curUser = ""
 	}


### PR DESCRIPTION
Resolves #2091.

It doesn't look as bad the issue describes it. The tree of code paths depending on this API call is quite big, but I only found two instances where errors from `/api/user` are discarded:

- After a call to `IsValidAccessToken` while validating a saved token. This caused #1202. `IsValidAccessToken` already checks for `401`, so I think we should pop up all other errors. Changed.
- Several calls to `backend.CurrentUser()` ignore errors and treat them as no user. While some of those could be wrong, I don't see any usage critical for the code path selection - they are all string formattings. Therefore, I prefer not to touch them now and assume they work as designed.

I haven't been able to identify any unit tests that could help me validate the change in `IsValidAccessToken`. Manual testing confirms it works, and if the backend is down it now gives an error instead of a login prompt:

```
error: getting user info from https://api.pulumi.com: [404] 404 page not found
```