### PR TITLE
Update us to the same target ES version that Nodejs uses.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,15 @@ CHANGELOG
   [#3170](https://github.com/pulumi/pulumi/pull/3170)
 - Read operations are no longer considered changes for the purposes of `--expect-no-changes`.
   [#3197](https://github.com/pulumi/pulumi/pull/3197)
-- Increase the MaxCallRecvMsgSize for interacting with the gRPC server. 
+- Increase the MaxCallRecvMsgSize for interacting with the gRPC server.
   [#3201](https://github.com/pulumi/pulumi/pull/3201)
 
-- Support combining the filestate backend (local or remote storage) with the cloud-backed secrets providers (KMS, etc.). 
+- Support combining the filestate backend (local or remote storage) with the cloud-backed secrets providers (KMS, etc.).
   [#3198](https://github.com/pulumi/pulumi/pull/3198)
+
+- Moved `@pulumi/pulumi` to target `es2016` instead of `es6`.  As `@pulumi/pulumi` programs run
+  inside Nodejs, this should not change anything externally as Nodejs already provides es2016
+  support. Internally, this makes more APIs available for `@pulumi/pulumi` to use in its implementation.
 
 ## 1.0.0 (2019-09-03)
 

--- a/examples/compat/v0.10.0/minimal/tsconfig.json
+++ b/examples/compat/v0.10.0/minimal/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/examples/minimal/tsconfig.json
+++ b/examples/minimal/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/examples/secrets/tsconfig.json
+++ b/examples/secrets/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "lib": [
             "es6"
         ],

--- a/sdk/nodejs/tests/sxs/tsconfig.json
+++ b/sdk/nodejs/tests/sxs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,
@@ -47,7 +47,7 @@
         "runtime/closure/v8.ts",
         "runtime/closure/v8_v10andLower.ts",
         "runtime/closure/v8_v11andHigher.ts",
-        
+
         "runtime/config.ts",
         "runtime/debuggable.ts",
         "runtime/invoke.ts",

--- a/tests/integration/cloud_secrets_provider/tsconfig.json
+++ b/tests/integration/cloud_secrets_provider/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "lib": [
             "es6"
         ],

--- a/tests/integration/config_capture_e2e/nodejs/tsconfig.json
+++ b/tests/integration/config_capture_e2e/nodejs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/explicit_provider/tsconfig.json
+++ b/tests/integration/explicit_provider/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/get_created/tsconfig.json
+++ b/tests/integration/get_created/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/invalid_package_json/tsconfig.json
+++ b/tests/integration/invalid_package_json/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/provider_secret_config/tsconfig.json
+++ b/tests/integration/provider_secret_config/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "lib": [
             "es6"
         ],

--- a/tests/integration/read/import_acquire/step1/tsconfig.json
+++ b/tests/integration/read/import_acquire/step1/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/read/read_dbr/step1/tsconfig.json
+++ b/tests/integration/read/read_dbr/step1/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/read/read_relinquish/step1/tsconfig.json
+++ b/tests/integration/read/read_relinquish/step1/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/read/read_replace/step1/tsconfig.json
+++ b/tests/integration/read/read_replace/step1/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/secret_outputs/tsconfig.json
+++ b/tests/integration/secret_outputs/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "lib": [
             "es6"
         ],

--- a/tests/integration/stack_reference/tsconfig.json
+++ b/tests/integration/stack_reference/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "module": "commonjs",
         "moduleResolution": "node",
         "declaration": true,

--- a/tests/integration/stack_reference_secrets/step1/tsconfig.json
+++ b/tests/integration/stack_reference_secrets/step1/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "outDir": "bin",
-        "target": "es6",
+        "target": "es2016",
         "lib": [
             "es6"
         ],


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/3148

From talking to TS over here: https://github.com/microsoft/TypeScript/issues/33355

This happens because we pull in node.d.ts which itself pulls in 'es2016' (since it knows it will supply at least that level of support).  Indeed, if we go look at node6, we can see it has had support for `Array.includes` since the 6.x line (the oldest node we've ever supported).  

Note: this will have to be done for all our packages.