### PR TITLE
Reset patch to 0 when generating a version for a minor update

### DIFF
--- a/scripts/get-version
+++ b/scripts/get-version
@@ -44,6 +44,7 @@ if [ "${MAJOR}" = "v0" ]; then
     PATCH=$((${PATCH}+1))
 else
     MINOR=$((${MINOR}+1))
+    PATCH=0
 fi
 
 # We want to include some additional information. To the base tag we


### PR DESCRIPTION
This fixes an issue we didn't forsee. If we do a patch release by
tagging a commit as `v1.1.1`, the next version we generate will be
`v1.2.1-alpha.....` which is not what we want. When bumping the minor
version, we should reset the patch version to zero, regardless of what
it is.