### PR TITLE
fix: ensure plugins are available before Pulumi command

### DIFF
--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -77,9 +77,21 @@ if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
     gcloud auth activate-service-account --key-file=$GCLOUD_KEYFILE
 fi
 
-# Next, lazily install packages if required.
-if [ -e package.json ] && [ ! -d node_modules ]; then
-    npm install
+# Next, run npm install. We always call this, as
+# previous calls (stack select, login, preview) will run the
+# npm scripts that install plugins; plugin installation directory
+# is outside of the persisted filesystem (GitHub Actions).
+# So we need to run this everytime to ensure the plugins are
+# always available. This shouldn't cause a performance hit,
+# as the node_modules/lock file will be persisted across runs.
+#
+# Similarly, run yarn install as applicable for the same reasons.
+if [ -e package.json ]; then
+    if [ -f yarn.lock ] || [ ! -z $USE_YARN ]; then
+        yarn install
+    else
+        npm install
+    fi
 fi
 
 # Now just pass along all arguments to the Pulumi CLI, sending the output to a file for


### PR DESCRIPTION
This patch ensures, if `package.json` exists, that `npm install` is
always run prior to any pulumi command. This will trigger any scripts
that install plugins; ensuring most CI systems can build Pulumi projects
without hacky workarounds.