### PR TITLE
Color 'reads' as cyan so they don't look like 'creates'.

### DIFF
--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -40,6 +40,7 @@ func newPreviewCmd() *cobra.Command {
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
+	var showReads bool
 	var suppressOutputs bool
 
 	var cmd = &cobra.Command{
@@ -77,6 +78,7 @@ func newPreviewCmd() *cobra.Command {
 					ShowConfig:           showConfig,
 					ShowReplacementSteps: showReplacementSteps,
 					ShowSameResources:    showSames,
+					ShowReads:            showReads,
 					SuppressOutputs:      suppressOutputs,
 					IsInteractive:        cmdutil.Interactive(),
 					Type:                 displayType,
@@ -170,9 +172,14 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&showReplacementSteps, "show-replacement-steps", false,
 		"Show detailed resource replacement creates and deletes instead of a single step")
+
 	cmd.PersistentFlags().BoolVar(
 		&showSames, "show-sames", false,
 		"Show resources that needn't be updated because they haven't changed, alongside those that do")
+	cmd.PersistentFlags().BoolVar(
+		&showReads, "show-reads", false,
+		"Show resources that are being read in, alongside those being managed directly in the stack")
+
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -60,6 +60,7 @@ func newUpCmd() *cobra.Command {
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
+	var showReads bool
 	var skipPreview bool
 	var suppressOutputs bool
 	var yes bool
@@ -333,6 +334,7 @@ func newUpCmd() *cobra.Command {
 				ShowConfig:           showConfig,
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
+				ShowReads:            showReads,
 				SuppressOutputs:      suppressOutputs,
 				IsInteractive:        interactive,
 				Type:                 displayType,
@@ -393,9 +395,14 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&showReplacementSteps, "show-replacement-steps", false,
 		"Show detailed resource replacement creates and deletes instead of a single step")
+
 	cmd.PersistentFlags().BoolVar(
 		&showSames, "show-sames", false,
 		"Show resources that don't need be updated because they haven't changed, alongside those that do")
+	cmd.PersistentFlags().BoolVar(
+		&showReads, "show-reads", false,
+		"Show resources that are being read in, alongside those being managed directly in the stack")
+
 	cmd.PersistentFlags().BoolVar(
 		&skipPreview, "skip-preview", false,
 		"Do not perform a preview before performing the update")

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -327,8 +327,11 @@ func renderDiffResourceOutputsEvent(
 		}
 
 		if !opts.SuppressOutputs {
+			// We want to hide same outputs if we're doing a read and the user didn't ask to see
+			// things that are the same.
+			hideSames := payload.Metadata.Op == deploy.OpRead && !opts.ShowSameResources
 			if text := engine.GetResourceOutputsPropertiesString(
-				payload.Metadata, indent+1, payload.Planning, payload.Debug, refresh); text != "" {
+				payload.Metadata, indent+1, payload.Planning, payload.Debug, refresh, !hideSames); text != "" {
 
 				header := fmt.Sprintf("%v%v--outputs:--%v\n",
 					payload.Metadata.Op.Color(), engine.GetIndentationString(indent+1), colors.Reset)

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -34,6 +34,7 @@ type Options struct {
 	ShowConfig           bool                // true if we should show configuration information.
 	ShowReplacementSteps bool                // true to show the replacement steps in the plan.
 	ShowSameResources    bool                // true to show the resources that aren't updated in addition to updates.
+	ShowReads            bool                // true to show resources that are being read in
 	SuppressOutputs      bool                // true to suppress output summarization, e.g. if contains sensitive info.
 	SummaryDiff          bool                // true if diff display should be summarized.
 	IsInteractive        bool                // true if we should display things interactively.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -890,7 +890,10 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 
 	// At this point, all events should relate to resources.
 	eventUrn, metadata := getEventUrnAndMetadata(event)
-	if metadata != nil {
+
+	// If we're suppressing reads from the tree-view, then convert notifications about reads into
+	// ephemeral messages that will go into the info column.
+	if metadata != nil && !display.opts.ShowReads {
 		if metadata.Op == deploy.OpReadDiscard || metadata.Op == deploy.OpReadReplacement {
 			// just flat out ignore read discards/replace.  They're only relevant in the context of
 			// 'reads', and we only present reads as an ephemeral diagnostic anyways.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -741,8 +741,12 @@ func (display *ProgressDisplay) processEndSteps() {
 	var wroteOutputs bool
 	if display.stackUrn != "" && display.seenStackOutputs && !display.opts.SuppressOutputs {
 		stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
+
+		// We want to hide same outputs if we're doing a read and the user didn't ask to see
+		// things that are the same.
+		hideSames := stackStep.Op == deploy.OpRead && !display.opts.ShowSameResources
 		props := engine.GetResourceOutputsPropertiesString(
-			stackStep, 1, display.isPreview, display.opts.Debug, false /* refresh */)
+			stackStep, 1, display.isPreview, display.opts.Debug, false /* refresh */, !hideSames)
 		if props != "" {
 			if !wroteDiagnosticHeader {
 				display.writeBlankLine()

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -487,11 +487,10 @@ func getDiffInfo(step engine.StepEventMetadata) string {
 			writePropertyKeys(changesBuf, filteredKeys(diff.Adds), deploy.OpCreate)
 			writePropertyKeys(changesBuf, filteredKeys(diff.Deletes), deploy.OpDelete)
 			writePropertyKeys(changesBuf, filteredKeys(updates), deploy.OpUpdate)
-
-			fprintIgnoreError(changesBuf, colors.Reset)
 		}
 	}
 
+	fprintIgnoreError(changesBuf, colors.Reset)
 	return changesBuf.String()
 }
 

--- a/pkg/diag/colors/colors.go
+++ b/pkg/diag/colors/colors.go
@@ -159,7 +159,5 @@ var (
 	SpecDelete            = Red           // for deletes (in the diff sense).
 	SpecCreateReplacement = BrightGreen   // for replacement creates (in the diff sense).
 	SpecDeleteReplaced    = BrightRed     // for replacement deletes (in the diff sense).
-
-	// for reads (relatively unimportant).  Just use the standard terminal text color.
-	SpecRead = Reset
+	SpecRead              = BrightCyan    // for reads
 )

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -310,9 +310,10 @@ func GetResourceOutputsPropertiesString(
 		// - the property that is present in the inputs is different
 		// - we are doing a refresh, in which case we always want to show state differences
 		if outputDiff != nil || (!IsInternalPropertyKey(k) && shouldPrintPropertyValue(out, true)) {
-			print := true
 			if in, has := ins[k]; has && !refresh {
-				print = (out.Diff(in, IsInternalPropertyKey) != nil)
+				if out.Diff(in, IsInternalPropertyKey) == nil {
+					continue
+				}
 			}
 
 			// If we asked to not show-sames, and this is a same output, then filter it out of what
@@ -321,13 +322,11 @@ func GetResourceOutputsPropertiesString(
 				continue
 			}
 
-			if print {
-				if outputDiff != nil {
-					printObjectPropertyDiff(b, k, maxkey, *outputDiff, planning, indent, false, debug)
-				} else {
-					printPropertyTitle(b, string(k), maxkey, indent, op, false)
-					printPropertyValue(b, out, planning, indent, op, false, debug)
-				}
+			if outputDiff != nil {
+				printObjectPropertyDiff(b, k, maxkey, *outputDiff, planning, indent, false, debug)
+			} else {
+				printPropertyTitle(b, string(k), maxkey, indent, op, false)
+				printPropertyValue(b, out, planning, indent, op, false, debug)
 			}
 		}
 	}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -933,7 +933,7 @@ func (op StepOp) Color() string {
 	case OpDeleteReplaced:
 		return colors.SpecDeleteReplaced
 	case OpRead:
-		return colors.SpecCreate
+		return colors.SpecRead
 	case OpReadReplacement, OpImportReplacement:
 		return colors.SpecReplace
 	case OpRefresh:

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -887,11 +887,12 @@ type dependentReplace struct {
 }
 
 func (sg *stepGenerator) calculateDependentReplacements(root *resource.State) ([]dependentReplace, result.Result) {
-	// We need to compute the set of resources that may be replaced by a change to the resource under consideration.
-	// We do this by taking the complete set of transitive dependents on the resource under consideration and
-	// removing any resources that would not be replaced by changes to their dependencies. We determine whether or not
-	// a resource may be replaced by substituting unknowns for input properties that may change due to deletion of the
-	// resources their value depends on and calling the resource provider's `Diff` method.
+	// We need to compute the set of resources that may be replaced by a change to the resource
+	// under consideration. We do this by taking the complete set of transitive dependents on the
+	// resource under consideration and removing any resources that would not be replaced by changes
+	// to their dependencies. We determine whether or not a resource may be replaced by substituting
+	// unknowns for input properties that may change due to deletion of the resources their value
+	// depends on and calling the resource provider's `Diff` method.
 	//
 	// This is perhaps clearer when described by example. Consider the following dependency graph:
 	//
@@ -901,12 +902,14 @@ func (sg *stepGenerator) calculateDependentReplacements(root *resource.State) ([
 	//     |  _|_
 	//     D  E F
 	//
-	// In this graph, all of B, C, D, E, and F transitively depend on A. It may be the case, however, that changes to
-	// the specific properties of any of those resources R that would occur if a resource on the path to A were deleted
-	// and recreated may not cause R to be replaced. For example, the edge from B to A may be a simple `dependsOn` edge
-	// such that a change to B does not actually influence any of B's input properties.  More commonly, the edge from B
-	// to A may be due to a property from A being used as the input to a property of B that does not require B to be
-	// replaced upon a change. In these cases, neither B nor D would need to be deleted before A could be deleted.
+	// In this graph, all of B, C, D, E, and F transitively depend on A. It may be the case,
+	// however, that changes to the specific properties of any of those resources R that would occur
+	// if a resource on the path to A were deleted and recreated may not cause R to be replaced. For
+	// example, the edge from B to A may be a simple `dependsOn` edge such that a change to B does
+	// not actually influence any of B's input properties.  More commonly, the edge from B to A may
+	// be due to a property from A being used as the input to a property of B that does not require
+	// B to be replaced upon a change. In these cases, neither B nor D would need to be deleted
+	// before A could be deleted.
 	var toReplace []dependentReplace
 	replaceSet := map[resource.URN]bool{root.URN: true}
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/2817

Trying out coloring 'reads' in cyan.  It's a color we don't use in diff.  We could also not color things.  However, i think it's somewhat helpful to understand why we have these values in the diff, so having it be a distinct color seems nice to me. 

Looks like this:

![image](https://user-images.githubusercontent.com/4564579/64979097-d4838480-d86b-11e9-84d4-90933274af92.png)
