### PR TITLE
bump api version number to indicate PaC support

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -165,7 +165,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 	userAgent := fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)
 	req.Header.Set("User-Agent", userAgent)
 	// Specify the specific API version we accept.
-	req.Header.Set("Accept", "application/vnd.pulumi+3")
+	req.Header.Set("Accept", "application/vnd.pulumi+4")
 
 	// Apply credentials if provided.
 	if tok.String() != "" {


### PR DESCRIPTION
We are bumping the CLI version so the service can confirm PaC is supported by the CLI being used. (Note: not adding this to the changelog since we have not been including PaC updates there)