### PR TITLE
Move a dot for a better prompt in local login

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -275,9 +275,9 @@ func chooseStack(
 	}
 
 	if option == newOption {
-		hint := "Please enter your desired stack name."
+		hint := "Please enter your desired stack name"
 		if b.SupportsOrganizations() {
-			hint += "\nTo create a stack in an organization, " +
+			hint += ".\nTo create a stack in an organization, " +
 				"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`)"
 		}
 		stackName, readErr := cmdutil.ReadConsole(hint)


### PR DESCRIPTION
Currently, with a local login (`pulumi login --local`), the prompt during `pulumi new` includes a dot:
```
Please enter your desired stack name.: dev
```

This PR removes the dot, but keeps it for the cloud login.