### PR TITLE
Add Applied to GetPolicyPackResponse

### DIFF
--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -91,6 +91,7 @@ type GetPolicyPackResponse struct {
 	DisplayName string   `json:"displayName"`
 	Version     int      `json:"version"`
 	Policies    []Policy `json:"policies"`
+	Applied     bool     `json:"applied"`
 }
 
 // ApplyPolicyPackRequest is the request to apply a Policy Pack to an organization.


### PR DESCRIPTION
`GetPolicyPackResponse` is also used by the UI. `Applied` will allow the UI to determine if the Policy Pack can be deleted.