### PR TITLE
Produce appropriate diagnostic when asked to refresh a resource that we cannot find.

### DIFF
--- a/pkg/diag/errors.go
+++ b/pkg/diag/errors.go
@@ -64,5 +64,6 @@ func GetResourceToRefreshCouldNotBeFoundError() *Diag {
 }
 
 func GetResourceToRefreshCouldNotBeFoundDidYouForgetError() *Diag {
-	return newError("", 2011, "Resource to refresh '%v' could not be found in the stack. Did you forget to escape $ in your shell?")
+	return newError("", 2011, "Resource to refresh '%v' could not be found in the stack. "+
+		"Did you forget to escape $ in your shell?")
 }

--- a/pkg/diag/errors.go
+++ b/pkg/diag/errors.go
@@ -58,3 +58,7 @@ func GetDuplicateResourceAliasError(urn resource.URN) *Diag {
 		"Duplicate resource alias '%v' applied to resource with URN '%v' conflicting with resource with URN '%v'",
 	)
 }
+
+func GetResourceToRefreshCouldNotBeFoundError() *Diag {
+	return newError("", 2010, "Resource to refresh (%v) could not be found in the stack.")
+}

--- a/pkg/diag/errors.go
+++ b/pkg/diag/errors.go
@@ -60,5 +60,9 @@ func GetDuplicateResourceAliasError(urn resource.URN) *Diag {
 }
 
 func GetResourceToRefreshCouldNotBeFoundError() *Diag {
-	return newError("", 2010, "Resource to refresh (%v) could not be found in the stack.")
+	return newError("", 2010, "Resource to refresh '%v' could not be found in the stack.")
+}
+
+func GetResourceToRefreshCouldNotBeFoundDidYouForgetError() *Diag {
+	return newError("", 2011, "Resource to refresh '%v' could not be found in the stack. Did you forget to escape $ in your shell?")
 }

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -16,6 +16,7 @@ package deploy
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/diag"
@@ -294,7 +295,11 @@ func (pe *planExecutor) refresh(callerCtx context.Context, opts Options, preview
 		for _, target := range opts.RefreshTargets {
 			res := pe.plan.prev.TryGetResource(target)
 			if res == nil {
-				pe.plan.Diag().Errorf(diag.GetResourceToRefreshCouldNotBeFoundError(), target)
+				if strings.Contains(string(target), "$") {
+					pe.plan.Diag().Errorf(diag.GetResourceToRefreshCouldNotBeFoundError(), target)
+				} else {
+					pe.plan.Diag().Errorf(diag.GetResourceToRefreshCouldNotBeFoundDidYouForgetError(), target)
+				}
 				return result.Bail()
 			}
 		}

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -290,6 +290,16 @@ func (pe *planExecutor) refresh(callerCtx context.Context, opts Options, preview
 		return nil
 	}
 
+	if len(opts.RefreshTargets) > 0 {
+		for _, target := range opts.RefreshTargets {
+			res := pe.plan.prev.TryGetResource(target)
+			if res == nil {
+				pe.plan.Diag().Errorf(diag.GetResourceToRefreshCouldNotBeFoundError(), target)
+				return result.Bail()
+			}
+		}
+	}
+
 	// If the user did not provide any --target's, create a refresh step for each resource in the
 	// old snapshot.  If they did provider --target's then only create refresh steps for those
 	// specific targets.

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -293,8 +293,7 @@ func (pe *planExecutor) refresh(callerCtx context.Context, opts Options, preview
 
 	if len(opts.RefreshTargets) > 0 {
 		for _, target := range opts.RefreshTargets {
-			res := pe.plan.prev.TryGetResource(target)
-			if res == nil {
+			if _, has := pe.plan.olds[target]; !has {
 				if strings.Contains(string(target), "$") {
 					pe.plan.Diag().Errorf(diag.GetResourceToRefreshCouldNotBeFoundError(), target)
 				} else {

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -195,3 +195,13 @@ func (snap *Snapshot) VerifyIntegrity() error {
 
 	return nil
 }
+
+func (snap *Snapshot) TryGetResource(urn resource.URN) *resource.State {
+	for _, res := range snap.Resources {
+		if res.URN == urn {
+			return res
+		}
+	}
+
+	return nil
+}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -195,13 +195,3 @@ func (snap *Snapshot) VerifyIntegrity() error {
 
 	return nil
 }
-
-func (snap *Snapshot) TryGetResource(urn resource.URN) *resource.State {
-	for _, res := range snap.Resources {
-		if res.URN == urn {
-			return res
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
Looks like:

![image](https://user-images.githubusercontent.com/4564579/65182194-a2158b00-da15-11e9-80b9-2b86342a2db4.png)

![image](https://user-images.githubusercontent.com/4564579/65182201-aa6dc600-da15-11e9-8680-922ed9820574.png)


Extracted from https://github.com/pulumi/pulumi/pull/3244/files
