### PR TITLE
Speed up the test runs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ include build/common.mk
 
 PROJECT         := github.com/pulumi/pulumi
 PROJECT_PKGS    := $(shell go list ./cmd/... ./pkg/... | grep -v /vendor/)
-EXTRA_TEST_PKGS := $(shell go list ./examples/ ./tests/... | grep -v /vendor/)
+EXTRA_TEST_PKGS := $(shell go list ./examples/ ./tests/... | grep -v tests/templates | grep -v /vendor/)
+TEMPLATES_PKGS  := $(shell go list ./tests/templates)
 VERSION         := $(shell scripts/get-version)
 
 TESTPARALLELISM := 10
@@ -31,6 +32,9 @@ test_all::
 	$(GO_TEST) ${PROJECT_PKGS}
 	$(GO_TEST) -v -p=1 ${EXTRA_TEST_PKGS}
 
+test_templates::
+	$(GO_TEST) ${TEMPLATES_PKGS}
+
 .PHONY: publish_tgz
 publish_tgz:
 	$(call STEP_MESSAGE)
@@ -48,7 +52,7 @@ coverage:
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
-travis_cron: all coverage
+travis_cron: all coverage test_templates
 travis_push: only_build publish_tgz only_test publish_packages
 travis_pull_request: all
 travis_api: all

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -28,6 +28,8 @@ import (
 )
 
 func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -48,6 +50,8 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 }
 
 func TestCreatingStackWithPromptedName(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -68,6 +72,8 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 }
 
 func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -90,6 +96,8 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 }
 
 func TestCreatingStackWithPromptedOrgName(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -112,6 +120,8 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 }
 
 func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -133,6 +143,8 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 }
 
 func TestCreatingProjectWithDefaultName(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -156,6 +168,8 @@ func TestCreatingProjectWithDefaultName(t *testing.T) {
 }
 
 func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -179,6 +193,8 @@ func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 }
 
 func TestCreatingProjectWithPromptedName(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -201,6 +217,8 @@ func TestCreatingProjectWithPromptedName(t *testing.T) {
 }
 
 func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -225,6 +243,8 @@ func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 }
 
 func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -248,6 +268,8 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 }
 
 func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -276,6 +298,8 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 }
 
 func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -303,6 +327,8 @@ func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 }
 
 func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -329,6 +355,8 @@ func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 }
 
 func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
+	skipIfShort(t)
+
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
@@ -354,7 +382,10 @@ func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 }
 
 func TestInvalidTemplateName(t *testing.T) {
+	skipIfShort(t)
+
 	t.Run("NoTemplateSpecified", func(t *testing.T) {
+		t.Parallel()
 		tempdir, _ := ioutil.TempDir("", "test-env")
 		defer os.RemoveAll(tempdir)
 		assert.NoError(t, os.Chdir(tempdir))
@@ -371,6 +402,7 @@ func TestInvalidTemplateName(t *testing.T) {
 	})
 
 	t.Run("RemoteTemplateNotFound", func(t *testing.T) {
+		t.Parallel()
 		tempdir, _ := ioutil.TempDir("", "test-env")
 		defer os.RemoveAll(tempdir)
 		assert.NoError(t, os.Chdir(tempdir))
@@ -390,6 +422,8 @@ func TestInvalidTemplateName(t *testing.T) {
 	})
 
 	t.Run("LocalTemplateNotFound", func(t *testing.T) {
+		t.Parallel()
+
 		tempdir, _ := ioutil.TempDir("", "test-env")
 		defer os.RemoveAll(tempdir)
 		assert.NoError(t, os.Chdir(tempdir))
@@ -459,4 +493,10 @@ func removeStack(t *testing.T, name string) {
 	assert.NoError(t, err)
 	_, err = b.RemoveStack(context.Background(), ref, false)
 	assert.NoError(t, err)
+}
+
+func skipIfShort(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipped in short test run")
+	}
 }

--- a/tests/templates/templates_test.go
+++ b/tests/templates/templates_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tests
+package templates
 
 import (
 	"fmt"
@@ -121,5 +121,13 @@ func TestTemplates(t *testing.T) {
 				integration.ProgramTest(t, &example)
 			}
 		})
+	}
+}
+
+// deleteIfNotFailed deletes the files in the testing environment if the testcase has
+// not failed. (Otherwise they are left to aid debugging.)
+func deleteIfNotFailed(e *ptesting.Environment) {
+	if !e.T.Failed() {
+		e.DeleteEnvironment()
 	}
 }


### PR DESCRIPTION
- Exclude New command tests from the short runs
- Exclude Templates tests from all builds except cron-triggered ones