### PR TITLE
Use a stack name other than 'dev' to work around service failures

### DIFF
--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -154,6 +154,7 @@ func TestCreatingProjectWithDefaultName(t *testing.T) {
 		interactive:       true,
 		prompt:            promptForValue,
 		secretsProvider:   "default",
+		stack:             stackName,
 		templateNameOrURL: "typescript",
 		yes:               true,
 	}
@@ -161,7 +162,7 @@ func TestCreatingProjectWithDefaultName(t *testing.T) {
 	err := runNew(args)
 	assert.NoError(t, err)
 
-	removeStack(t, "dev")
+	removeStack(t, stackName)
 
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, defaultProjectName, proj.Name.String())
@@ -180,13 +181,14 @@ func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 		name:              uniqueProjectName,
 		prompt:            promptForValue,
 		secretsProvider:   "default",
+		stack:             stackName,
 		templateNameOrURL: "typescript",
 	}
 
 	err := runNew(args)
 	assert.NoError(t, err)
 
-	removeStack(t, "dev")
+	removeStack(t, stackName)
 
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, uniqueProjectName, proj.Name.String())

--- a/tests/templates/templates_test.go
+++ b/tests/templates/templates_test.go
@@ -85,7 +85,7 @@ func TestTemplates(t *testing.T) {
 			e := ptesting.NewEnvironment(t)
 			defer deleteIfNotFailed(e)
 
-			e.RunCommand("pulumi", "new", template.Name, "-f")
+			e.RunCommand("pulumi", "new", template.Name, "-f", "-s", "template-test")
 
 			path, err := workspace.DetectProjectPathFrom(e.RootPath)
 			assert.NoError(t, err)


### PR DESCRIPTION
Workaround #3250