### PR TITLE
Remove use of GENERIC_CI_SYSTEM

### DIFF
--- a/pkg/util/ciutil/detect.go
+++ b/pkg/util/ciutil/detect.go
@@ -74,7 +74,7 @@ var detectors = map[SystemName]system{
 	GenericCI: genericCICI{
 		baseCI: baseCI{
 			Name:            SystemName(os.Getenv("PULUMI_CI_SYSTEM")),
-			EnvVarsToDetect: []string{"GENERIC_CI_SYSTEM"},
+			EnvVarsToDetect: []string{"PULUMI_CI_SYSTEM"},
 		},
 	},
 

--- a/pkg/util/ciutil/generic.go
+++ b/pkg/util/ciutil/generic.go
@@ -28,7 +28,8 @@ type genericCICI struct {
 
 // DetectVars detects the env vars for a Generic CI system.
 func (g genericCICI) DetectVars() Vars {
-	v := Vars{Name: g.Name}
+	v := Vars{}
+	v.Name = SystemName(os.Getenv("PULUMI_CI_SYSTEM"))
 	v.BuildID = os.Getenv("PULUMI_CI_BUILD_ID")
 	v.BuildType = os.Getenv("PULUMI_CI_BUILD_TYPE")
 	v.BuildURL = os.Getenv("PULUMI_CI_BUILD_URL")

--- a/pkg/util/ciutil/vars_test.go
+++ b/pkg/util/ciutil/vars_test.go
@@ -40,7 +40,7 @@ func TestDetectVars(t *testing.T) {
 		},
 		GenericCI: {
 			"TRAVIS":             "",
-			"GENERIC_CI_SYSTEM":  "true",
+			"PULUMI_CI_SYSTEM":   "generic-ci-system",
 			"PULUMI_CI_BUILD_ID": buildID,
 		},
 		GitLab: {


### PR DESCRIPTION
There was an odd environment variable that was required in order to use our "generic" CI/CD setup. But that seems unnecessary, since it would be much clearer if we made `PULUMI_CI_SYSTEM` both necessary and sufficient for us using the generic CI detection logic.

Fixes #3258 