### PR TITLE
Print destroyed outputs when a stack is destroyed.

### DIFF
--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -329,9 +329,10 @@ func renderDiffResourceOutputsEvent(
 		if !opts.SuppressOutputs {
 			// We want to hide same outputs if we're doing a read and the user didn't ask to see
 			// things that are the same.
-			hideSames := payload.Metadata.Op == deploy.OpRead && !opts.ShowSameResources
-			if text := engine.GetResourceOutputsPropertiesString(
-				payload.Metadata, indent+1, payload.Planning, payload.Debug, refresh, !hideSames); text != "" {
+			text := engine.GetResourceOutputsPropertiesString(
+				payload.Metadata, indent+1, payload.Planning,
+				payload.Debug, refresh, opts.ShowSameResources)
+			if text != "" {
 
 				header := fmt.Sprintf("%v%v--outputs:--%v\n",
 					payload.Metadata.Op.Color(), engine.GetIndentationString(indent+1), colors.Reset)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -739,7 +739,7 @@ func (display *ProgressDisplay) processEndSteps() {
 
 	// If we get stack outputs, display them at the end.
 	var wroteOutputs bool
-	if display.stackUrn != "" && display.seenStackOutputs && !display.opts.SuppressOutputs {
+	if display.stackUrn != "" && !display.opts.SuppressOutputs {
 		stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
 
 		// We want to hide same outputs if we're doing a read and the user didn't ask to see

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -742,11 +742,9 @@ func (display *ProgressDisplay) processEndSteps() {
 	if display.stackUrn != "" && !display.opts.SuppressOutputs {
 		stackStep := display.eventUrnToResourceRow[display.stackUrn].Step()
 
-		// We want to hide same outputs if we're doing a read and the user didn't ask to see
-		// things that are the same.
-		hideSames := stackStep.Op == deploy.OpRead && !display.opts.ShowSameResources
 		props := engine.GetResourceOutputsPropertiesString(
-			stackStep, 1, display.isPreview, display.opts.Debug, false /* refresh */, !hideSames)
+			stackStep, 1, display.isPreview, display.opts.Debug,
+			false /* refresh */, display.opts.ShowSameResources)
 		if props != "" {
 			if !wroteDiagnosticHeader {
 				display.writeBlankLine()

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -243,12 +243,9 @@ func PrintObject(
 func GetResourceOutputsPropertiesString(
 	step StepEventMetadata, indent int, planning, debug, refresh, showSames bool) string {
 
-	if !showSames {
-		if step.URN.Type() == resource.RootStackType && !planning {
-			// For the actual update we always show all the outputs for the stack, even if they are
-			// unchanged.
-			showSames = true
-		}
+	// During the actual update we always show all the outputs for the stack, even if they are unchanged.
+	if !showSames && !planning && step.URN.Type() == resource.RootStackType {
+		showSames = true
 	}
 
 	// We should only print outputs for normal resources if the outputs are known to be complete.

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -243,6 +243,14 @@ func PrintObject(
 func GetResourceOutputsPropertiesString(
 	step StepEventMetadata, indent int, planning, debug, refresh, showSames bool) string {
 
+	if !showSames {
+		if step.URN.Type() == resource.RootStackType && !planning {
+			// For the actual update we always show all the outputs for the stack, even if they are
+			// unchanged.
+			showSames = true
+		}
+	}
+
 	// We should only print outputs for normal resources if the outputs are known to be complete.
 	// This will be the case if we are:
 	//

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -271,15 +271,16 @@ func GetResourceOutputsPropertiesString(
 	b := &bytes.Buffer{}
 
 	// Only certain kinds of steps have output properties associated with them.
-	new := step.New
-	if new == nil || new.Outputs == nil {
-		return ""
+	var ins resource.PropertyMap
+	var outs resource.PropertyMap
+	if step.New == nil || step.New.Outputs == nil {
+		ins = make(resource.PropertyMap)
+		outs = make(resource.PropertyMap)
+	} else {
+		ins = step.New.Inputs
+		outs = step.New.Outputs
 	}
 	op := step.Op
-
-	// First fetch all the relevant property maps that we may consult.
-	ins := new.Inputs
-	outs := new.Outputs
 
 	// If there was an old state associated with this step, we may have old outputs. If we do, and if they differ from
 	// the new outputs, we want to print the diffs.


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/1227

Looks like this:

![image](https://user-images.githubusercontent.com/4564579/65553521-e30d1400-dedb-11e9-9a3d-647218984ec5.png)

Also, show updates to stack outputs during preview if they have changed.  This looks like:

![image](https://user-images.githubusercontent.com/4564579/65555373-5b2a0880-dee1-11e9-9117-6ab12429df10.png)
