### PR TITLE
Tweak to improve reliability and diagnostics under heavy load

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"os"
 
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -39,7 +38,7 @@ import (
 )
 
 const (
-	defaultParallel = math.MaxInt32
+	defaultParallel = 100
 )
 
 // intentionally disabling here for cleaner err declaration/assignment.


### PR DESCRIPTION
This PR has a couple of tweaks intended to make the CLI a little more robust under CPU starvation, as well as add better diagnostics to identify/rule-out the source of an update failing in the future.

The "problem" is that at times an update can fail because the lease token used to authenticate API requests has expired. Under regular conditions, this should never happen unless there is a legitimate problem with the Pulumi Service. However, when the machine is under heavy load, e.g. CPU starvation, or perhaps network throttling, it can lead to problems.

## More aggressive checking for lease tokens

If the OS is over scheduled, then the `ticker` that we use to periodically request new lease tokens in a Go routine won't be scheduled in a timely fashion. e.g. we know the lease token will expire in 5m, so we want to be called back after 2m30s to make a request to refresh it. But if the OS misses that callback by 2m30s, then we have missed our window.

To address that problem, we simply make the ticker more aggressive. This wastes more CPU cycles (and makes the OS scheduling woes worse), but decreases the likelihood that we will miss the tick by such a long amount of time. (If we want to free up a little more CPU time, we can push engine events to the service less aggressively -- we have a ticker firing every 4s for that later in the file...)

## Limit default parallelism

To be clear though, making the request to refresh the lease token more reliably isn't going to fix reliability issues entirely. Because we've seen a different class of problem when `pulumi` is ran under heavy loads as well. It appears that network requests take a _very_ longer time to be sent as well.

I doubt capping the default parallelism to 100 is going to make much of a difference, but it might. And 100 still seems high enough as a default to not impact the common case.

---

Here's a summarized trace of the behavior I've seen from failed CI/CD jobs under heavy load, which explains some of the unexpected behavior with our token source abstraction on a machine under heavy load:

```
[2019-09-07 20:33:05.646867238] Get initial lease token, start ticker.

So we expect the ticker to fire at 20:25:35 to refresh the lease token.

[2019-09-07 20:36:38.524783738] Ticker fires, we start request to get new lease token.

So it's ~a minute late, but the lease token is still valid. This should work.

[2019-09-07 20:38:19.93215518] The CLI receives and processes the response.

Notice this is over a minute later! And at this point the lease token has expired, failing the update.
On the surface it looks like the HTTP request would have taken that full minute to complete. However after looking at the Pulumi Service API logs, the request to renew the lease token was only ~700ms end-to-end. Meaning that there was a long delay on the CLI between when the ticker fired, and we initiated the HTTP request, and when the HTTP request was actually sent and processed by our API.

Read: It appears that the OS isn't starting the HTTP request for some time. I suspect because the machine has too many open network connections, or it is a result of the CPU load and scheduling issues. But either way, it's an important distinction to make. Because the HTTP request (as the Service sees it) is completing very quickly. But for some reason there is a long perceived delay on the CLI side.

[2019-09-07 20:38:19.932171448] Ticker fires again, requesting a new lease token.

The ticker fires again, but this time about on its "regular" schedule. The timer was first created around 20:33:05, so the second tick would be expected at the 20:38:05 mark.

[2019-09-07 20:38:20.000350923] The CLI receives and processes the response.

This second request returns the same response as the first, a 403 that the lease token has expired. But notice that there wasn't a significant delay between when the ticker fired and the HTTP response being sent and received.
```

Fixes #3182, at least for what we know of right now.