### PR TITLE
Fix problem with divergent project names

### DIFF
--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/spf13/cobra"

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -60,11 +60,11 @@ type StackReference interface {
 	fmt.Stringer
 	// Name is the name that will be passed to the Pulumi engine when preforming operations on this stack. This
 	// name may not uniquely identify the stack (e.g. the cloud backend embeds owner information in the StackReference
-	// but that informaion is not part of the StackName() we pass to the engine.
+	// but that information is not part of the StackName() we pass to the engine.
 	Name() tokens.QName
 }
 
-// PolicyPackReference is an opaque type that refers to a PolicyPack managedby a backend. The CLI
+// PolicyPackReference is an opaque type that refers to a PolicyPack managed by a backend. The CLI
 // uses the ParsePolicyPackReference method to turn a string like "myOrg/mySecurityRules" into a
 // PolicyPackReference that can be used to interact with the PolicyPack via the backend.
 // PolicyPackReferences are specific to a given backend and different back ends may interpret the

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -552,6 +552,16 @@ func (b *cloudBackend) CreateStack(
 		return nil, errors.Wrap(err, "error determining initial tags")
 	}
 
+	// Confirm the stack identity matches the environment. e.g. stack init foo/bar/baz shouldn't work
+	// if the project name in Pulumi.yaml is anything other than "bar".
+	projNameTag, ok := tags[apitype.ProjectNameTag]
+	if !ok {
+		return nil, errors.Wrap(err, "workspace file did not contain project name")
+	}
+	if stackID.Project != projNameTag {
+		return nil, errors.Errorf("provided project name %q doesn't match Pulumi.yaml", stackID.Project)
+	}
+
 	apistack, err := b.client.CreateStack(ctx, stackID, tags)
 	if err != nil {
 		// If the status is 409 Conflict (stack already exists), return StackAlreadyExistsError.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -555,10 +555,7 @@ func (b *cloudBackend) CreateStack(
 	// Confirm the stack identity matches the environment. e.g. stack init foo/bar/baz shouldn't work
 	// if the project name in Pulumi.yaml is anything other than "bar".
 	projNameTag, ok := tags[apitype.ProjectNameTag]
-	if !ok {
-		return nil, errors.Wrap(err, "workspace file did not contain project name")
-	}
-	if stackID.Project != projNameTag {
+	if ok && stackID.Project != projNameTag {
 		return nil, errors.Errorf("provided project name %q doesn't match Pulumi.yaml", stackID.Project)
 	}
 


### PR DESCRIPTION
A stack is uniquely identified in the Pulumi Service by its organization, project name, and stack name. e.g. `pulumi/www.pulumi.com/production`. When referring to a stack from the command-line we accept several forms of stack identifiers. Defaulting the organization to the user that is currently logged in, and the project to the current workspace (`Pulumi.yaml`).

For example the following are all valid when using `pulumi stack select`:
`production` -> `chrsmith/foo/production`
`pulumi/production` -> `pulumi/foo/production`
`robot-co/other-project/dev` -> `robot-co/other-project/dev`

Now this setup causes problems when a new stack is created, because if we don't verify that the qualified stack identifier ("robot-co/other-project/dev") matches what is in `Pulumi.yaml` ("actual-project"), then bad things happen.

- The stack doesn't show up in `pulumi stack ls`, because the default filter is using the project name from `Pulumi.yaml` but the stack has a _different_ project name.
- The stack isn't grouped properly in the Pulumi Service, since it's project name is different than all of the other ones using the same `Pulumi.yaml` file.
- etc.

We had a recent customer contact us with a `pulumi preview` showing that every resource in the stack was going to be deleted and recreated. Which was rooted in this same issue.

Fixes #3268 