### PR TITLE
Update apitype.StackRenameRequest // Support project renames

### DIFF
--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -215,6 +215,9 @@ type AppendUpdateLogEntryRequest struct {
 }
 
 // StackRenameRequest is the shape of the request to change an existing stack's name.
+// If either NewName or NewProject is the empty string, the current project/name will
+// be preserved. (But at least one should be set.)
 type StackRenameRequest struct {
-	NewName string `json:"newName"`
+	NewName    string `json:"newName"`
+	NewProject string `json:"newProject"`
 }

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -328,7 +328,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stackRef backend.StackRe
 
 	// If we have a snapshot, we need to rename the URNs inside it to use the new stack name.
 	if snap != nil {
-		if err = edit.RenameStack(snap, newName, nil /*new project*/); err != nil {
+		if err = edit.RenameStack(snap, newName, ""); err != nil {
 			return err
 		}
 	}

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -328,7 +328,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stackRef backend.StackRe
 
 	// If we have a snapshot, we need to rename the URNs inside it to use the new stack name.
 	if snap != nil {
-		if err = edit.RenameStack(snap, newName); err != nil {
+		if err = edit.RenameStack(snap, newName, nil /*new project*/); err != nil {
 			return err
 		}
 	}

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -95,13 +95,13 @@ func LocateResource(snap *deploy.Snapshot, urn resource.URN) []*resource.State {
 
 // RenameStack changes the `stackName` component of every URN in a snapshot. In addition, it rewrites the name of
 // the root Stack resource itself. May optionally change the project/package name as well.
-func RenameStack(snap *deploy.Snapshot, newName tokens.QName, newProject *tokens.PackageName) error {
+func RenameStack(snap *deploy.Snapshot, newName tokens.QName, newProject tokens.PackageName) error {
 	contract.Require(snap != nil, "snap")
 
 	rewriteUrn := func(u resource.URN) resource.URN {
 		project := u.Project()
-		if newProject != nil {
-			project = *newProject
+		if newProject != "" {
+			project = newProject
 		}
 
 		// The pulumi:pulumi:Stack resource's name component is of the form `<project>-<stack>` so we want

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -94,18 +94,23 @@ func LocateResource(snap *deploy.Snapshot, urn resource.URN) []*resource.State {
 }
 
 // RenameStack changes the `stackName` component of every URN in a snapshot. In addition, it rewrites the name of
-// the root Stack resource itself.
-func RenameStack(snap *deploy.Snapshot, newName tokens.QName) error {
+// the root Stack resource itself. May optionally change the project/package name as well.
+func RenameStack(snap *deploy.Snapshot, newName tokens.QName, newProject *tokens.PackageName) error {
 	contract.Require(snap != nil, "snap")
 
 	rewriteUrn := func(u resource.URN) resource.URN {
+		project := u.Project()
+		if newProject != nil {
+			project = *newProject
+		}
+
 		// The pulumi:pulumi:Stack resource's name component is of the form `<project>-<stack>` so we want
 		// to rename the name portion as well.
 		if u.QualifiedType() == "pulumi:pulumi:Stack" {
-			return resource.NewURN(newName, u.Project(), "", u.QualifiedType(), tokens.QName(u.Project())+"-"+newName)
+			return resource.NewURN(newName, project, "", u.QualifiedType(), tokens.QName(project)+"-"+newName)
 		}
 
-		return resource.NewURN(newName, u.Project(), "", u.QualifiedType(), u.Name())
+		return resource.NewURN(newName, project, "", u.QualifiedType(), u.Name())
 	}
 
 	rewriteState := func(res *resource.State) {

--- a/pkg/resource/edit/operations_test.go
+++ b/pkg/resource/edit/operations_test.go
@@ -288,7 +288,7 @@ func TestRenameStack(t *testing.T) {
 
 	// Rename just the stack.
 	t.Run("JustTheStack", func(t *testing.T) {
-		err := RenameStack(snap, tokens.QName("new-stack"), nil)
+		err := RenameStack(snap, tokens.QName("new-stack"), tokens.PackageName(""))
 		if err != nil {
 			t.Fatalf("Error renaming stack: %v", err)
 		}
@@ -307,8 +307,7 @@ func TestRenameStack(t *testing.T) {
 
 	// Rename the stack and project.
 	t.Run("StackAndProject", func(t *testing.T) {
-		newProject := tokens.PackageName("new-project")
-		err := RenameStack(snap, tokens.QName("new-stack2"), &newProject)
+		err := RenameStack(snap, tokens.QName("new-stack2"), tokens.PackageName("new-project"))
 		if err != nil {
 			t.Fatalf("Error renaming stack: %v", err)
 		}


### PR DESCRIPTION
Today, there is no way to safely rename a stack's project name. (If you edit `Pulumi.yaml` and update the `name` property, trying to run `pulumi up` on an existing stack will fail.)

As part of cleaning up some of the corner cases around the stack identity model, this PR updates `apitype.StackRenameRequest` to also provide a `NewProject` field. The Pulumi Service can then use this type to support renaming a stack's project as well.

It also adds support for renaming the Stack's project in `edit.RenameStack` too. (I'm assuming this is a safe operation -- that it is not possible to have resources from multiple projects in the same snapshot.)


A subsequent PR after the Pulumi Service gets updated will support operations like:

`pulumi stack rename chrsmith/new-project/new-stack`

It will _not_ however allow `pulumi stack rename new-project/new-stack`. Because the "x/y" qualification in Pulumi commands will infer that to be "x/<current Pulumi.yaml project>/y". So `pulumi stack rename new-project/new-stack` would fail because it would look like you are trying to rename a stack and change its _owner_ to `new-project`.

That is confusing in this particular situation, but it is consistent with how we parse stack references elsewhere in the CLI.