### PR TITLE
Remove vestigial field from apitype

### DIFF
--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -361,7 +361,6 @@ type Stack struct {
 	StackName   tokens.QName `json:"stackName"`
 
 	ActiveUpdate string                  `json:"activeUpdate"`
-	Resources    []ResourceV1            `json:"resources,omitempty"`
 	Tags         map[StackTagName]string `json:"tags,omitempty"`
 
 	Version int `json:"version"`


### PR DESCRIPTION
The Pulumi Service no longer accepts requests from CLI versions older than v0.16.2 (~January, 2019). As we a result, we can start cleaning up some apitypes and fields that only exist for backwards compatibility for CLIs older than that. (Which aren't in use anymore.)

I couldn't find a specific commit for when we stopped reading from this field, but this was the comment on the server-side code that populated it:

```
// This field is soft-deprecated in that it is not currently used by the CLI.
// Originally, this field was used to populate a stack's snapshot before an update
// begin. However, it was discovered that this was basically useless because the CLI
// did an Export immediately before starting an update, which re-constructed a new snapshot
// anyway. Noting that this is useless, we stopped reading this field around mid-April 2018.
//
// To preserve compatibility with really old CLIs, we can still project the existing deployment
// to V1 and return that deployment's resources, but newer CLIs will ignore this field.
```