### PR TITLE
Add -v option to go test of templates to avoid stalling in TravisCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test_all::
 	$(GO_TEST) -v -p=1 ${EXTRA_TEST_PKGS}
 
 test_templates::
-	$(GO_TEST) ${TEMPLATES_PKGS}
+	$(GO_TEST) -v ${TEMPLATES_PKGS}
 
 .PHONY: publish_tgz
 publish_tgz:


### PR DESCRIPTION
Template tests take about 20 minutes which often leads to stalled tests in CI. As a workaround, add `-v` option to `go test` command - we do that for all other repositories while running integration tests with Pulumi CLI.