### PR TITLE
Close test language runtime connections.

### DIFF
--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/pkg/resource/plugin"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/workspace"
 	pulumirpc "github.com/pulumi/pulumi/sdk/proto/go"
 )
@@ -51,6 +52,7 @@ func (p *languageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
 	if err != nil {
 		return "", false, errors.Wrapf(err, "could not connect to resource monitor")
 	}
+	defer contract.IgnoreClose(conn)
 
 	// Fire up a resource monitor client
 	resmon := pulumirpc.NewResourceMonitorClient(conn)

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -249,8 +249,7 @@ func execPlugin(bin string, pluginArgs []string, pwd string) (*plugin, error) {
 
 func (p *plugin) Close() error {
 	if p.Conn != nil {
-		closerr := p.Conn.Close()
-		contract.IgnoreError(closerr)
+		contract.IgnoreClose(p.Conn)
 	}
 
 	var result error


### PR DESCRIPTION
This should help address the issues we've begun seeing with too many
open files when running tests on OS X.