### PR TITLE
Fetch CLI verisons from Homebrew where applicable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,34 @@ CHANGELOG
   using defaults calculated by the provider.
   [#3245](https://github.com/pulumi/pulumi/pull/3245)
 
+- Fetch version information from the Homebrew JSON API for CLIs installed using `brew`.
+  [#3290](https://github.com/pulumi/pulumi/pull/3290)
+
 ## 1.2.0 (2019-09-26)
 
 - Support emitting high-level execution trace data to a file and add a debug-only command to view trace data.
   [#3238](https://github.com/pulumi/pulumi/pull/3238)
+
 - Fix parsing of GitLab urls with subgroups.
   [#3239](https://github.com/pulumi/pulumi/pull/3239)
+
 - `pulumi refresh` can now be scoped to refresh a subset of resources by adding a `--target urn` or
   `-t urn` argument.  Multiple resources can be specified using `-t urn1 -t urn2`.
+
 - `pulumi destroy` can now be scoped to delete a single resource (and its dependents) by adding a
   `--target urn` or `-t urn` argument.  Multiple resources can be specified using `-t urn1 -t urn2`.
+
 - `pulumi update` can now be scoped to update a single resource by adding a `--target urn` or `-t urn`
   argument.  Multiple resources can be specified using `-t urn1 -t urn2`.
+
 - Avoid re-encrypting secret values on each checkpoint write. These changes should improve update times for stacks
   that contain secret values.
   [#3183](https://github.com/pulumi/pulumi/pull/3183)
+
 - Add Codefresh CI detection.
+
 - Add `-c` (config array) flag to the `preview` command.
+
 - Adds the ability to provide transformations to modify the properties and resource options that
   will be used for any child resource of a component or stack.
   [#3174](https://github.com/pulumi/pulumi/pull/3174)
@@ -33,17 +44,23 @@ CHANGELOG
 
 - Fix a bug that caused the Python runtime to ignore unhandled exceptions and erroneously report that a Pulumi program executed successfully.
   [#3170](https://github.com/pulumi/pulumi/pull/3170)
+
 - Read operations are no longer considered changes for the purposes of `--expect-no-changes`.
   [#3197](https://github.com/pulumi/pulumi/pull/3197)
+
 - Increase the MaxCallRecvMsgSize for interacting with the gRPC server.
   [#3201](https://github.com/pulumi/pulumi/pull/3201)
+
 - Do not ask for a passphrase in non-interactive sessions (fix [#2758](https://github.com/pulumi/pulumi/issues/2758)).
   [#3204](https://github.com/pulumi/pulumi/pull/3204)
+
 - Support combining the filestate backend (local or remote storage) with the cloud-backed secrets providers (KMS, etc.).
   [#3198](https://github.com/pulumi/pulumi/pull/3198)
+
 - Moved `@pulumi/pulumi` to target `es2016` instead of `es6`.  As `@pulumi/pulumi` programs run
   inside Nodejs, this should not change anything externally as Nodejs already provides es2016
   support. Internally, this makes more APIs available for `@pulumi/pulumi` to use in its implementation.
+
 - Fix the --stack option of the `pulumi new` command.
   ([#3131](https://github.com/pulumi/pulumi/pull/3131) fixes [#2880](https://github.com/pulumi/pulumi/issues/2880))
 

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -229,18 +229,19 @@ func getCLIVersionInfo() (semver.Version, semver.Version, error) {
 		return latest, oldest, err
 	}
 
+	client := client.NewClient(httpstate.DefaultURL(), "", cmdutil.Diag())
+	latest, oldest, err = client.GetCLIVersionInfo(commandContext())
+	if err != nil {
+		return semver.Version{}, semver.Version{}, err
+	}
+
 	brewLatest, isBrew, err := getLatestBrewFormulaVersion()
 	if err != nil {
 		return semver.Version{}, semver.Version{}, err
 	}
 	if isBrew {
-		return brewLatest, brewLatest, nil
-	}
-
-	client := client.NewClient(httpstate.DefaultURL(), "", cmdutil.Diag())
-	latest, oldest, err = client.GetCLIVersionInfo(commandContext())
-	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		// When consulting Homebrew for version info, we just use the latest version as the oldest allowed.
+		latest, oldest = brewLatest, brewLatest
 	}
 
 	err = cacheVersionInfo(latest, oldest)

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -428,7 +428,7 @@ func getLatestBrewFormulaVersion() (semver.Version, bool, error) {
 	}
 
 	url, err := url.Parse("https://formulae.brew.sh/api/formula/pulumi.json")
-	contract.Assert(err == nil)
+	contract.AssertNoError(err)
 
 	resp, err := httputil.DoWithRetry(&http.Request{
 		Method: http.MethodGet,


### PR DESCRIPTION
If the CLI seems to have been installed using Homebrew, do not consult
the service for the latest version. Instead, consult the Homebrew JSON
API.

Fixes #3230.