### PR TITLE
Support renaming stack projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ CHANGELOG
 - Fetch version information from the Homebrew JSON API for CLIs installed using `brew`.
   [#3290](https://github.com/pulumi/pulumi/pull/3290)
 
+- Support renaming stack projects via `pulumi stack rename`.
+  [#3292](https://github.com/pulumi/pulumi/pull/3292)
+
 ## 1.2.0 (2019-09-26)
 
 - Support emitting high-level execution trace data to a file and add a debug-only command to view trace data.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -333,7 +333,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stackRef backend.StackRe
 		}
 	}
 
-	// Now save the snapshot with a new name (we pass nil to re-use the existing secrets manager from the snapshot)
+	// Now save the snapshot with a new name (we pass nil to re-use the existing secrets manager from the snapshot).
 	if _, err = b.saveStack(newName, snap, nil); err != nil {
 		return err
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -638,8 +638,7 @@ func (b *cloudBackend) RenameStack(ctx context.Context, stackRef backend.StackRe
 	}
 
 	// Transferring stack ownership is available to Pulumi admins, but isn't quite ready
-	// for general use yet. Will ship sometime in Q4'2019.
-	// TODO[pulumi-service#2224]: UI support for moving stacks between organizations
+	// for general use yet.
 	if stack.Owner != newIdentity.Owner {
 		errMsg := "You cannot transfer stack ownership via a rename. If you wish to transfer ownership\n" +
 			"of a stack to another organization, please contact support@pulumi.com."

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -625,7 +625,28 @@ func (b *cloudBackend) RenameStack(ctx context.Context, stackRef backend.StackRe
 		return err
 	}
 
-	return b.client.RenameStack(ctx, stack, string(newName))
+	// Support a qualified stack name, which would also rename the stack's project too.
+	// e.g. if you want to change the project name on the Pulumi Console to reflect a
+	// new value in Pulumi.yaml.
+	newRef, err := b.ParseStackReference(string(newName))
+	if err != nil {
+		return err
+	}
+	newIdentity, err := b.getCloudStackIdentifier(newRef)
+	if err != nil {
+		return err
+	}
+
+	// Transferring stack ownership is available to Pulumi admins, but isn't quite ready
+	// for general use yet. Will ship sometime in Q4'2019.
+	// TODO[pulumi-service#2224]: UI support for moving stacks between organizations
+	if stack.Owner != newIdentity.Owner {
+		errMsg := "You cannot transfer stack ownership via a rename. If you wish to transfer ownership\n" +
+			"of a stack to another organization, please contact support@pulumi.com."
+		return errors.Errorf(errMsg)
+	}
+
+	return b.client.RenameStack(ctx, stack, newIdentity)
 }
 
 func getStack(ctx context.Context, b *cloudBackend, stackRef backend.StackReference) (backend.Stack, error) {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -441,13 +441,15 @@ func (pc *Client) CreateUpdate(
 	}, updateResponse.RequiredPolicies, nil
 }
 
-func (pc *Client) RenameStack(ctx context.Context, stack StackIdentifier, newName string) error {
+// RenameStack renames the provided stack to have the new identifier.
+func (pc *Client) RenameStack(ctx context.Context, currentID, newID StackIdentifier) error {
 	req := apitype.StackRenameRequest{
-		NewName: newName,
+		NewName:    newID.Stack,
+		NewProject: newID.Project,
 	}
 	var resp apitype.ImportStackResponse
 
-	return pc.restCall(ctx, "POST", getStackPath(stack, "rename"), nil, &req, &resp)
+	return pc.restCall(ctx, "POST", getStackPath(currentID, "rename"), nil, &req, &resp)
 }
 
 // StartUpdate starts the indicated update. It returns the new version of the update's target stack and the token used


### PR DESCRIPTION
Add CLI support for renaming stack projects.

The first PR, https://github.com/pulumi/pulumi/pull/3273, added the API types. Now that the Pulumi Service has been updated to support the functionality, this commit adds the CLI-side.

`pulumi stack rename`, when using the HTTP backend, will now accept a fully-qualified stack name. This allows you to rename the stack's project on the Pulumi Service safely.

In practice, you will need to pair this with a change to the `Pulumi.yaml` file. So the experience of project renaming will always be a bit clunky. But by adding this support it is at least possible.