### PR TITLE
Make the path to .pulumi folder configurable with an ENV variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGELOG
 
 - Support renaming stack projects via `pulumi stack rename`.
   [#3292](https://github.com/pulumi/pulumi/pull/3292)
+  
+- Make the location of `.pulumi` folder configurable with an environment variable.
+  [#3300](https://github.com/pulumi/pulumi/pull/3300) (Fixes [#2966](https://github.com/pulumi/pulumi/issues/2966))
 
 ## 1.2.0 (2019-09-26)
 

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -334,6 +335,11 @@ func getUpgradeMessage(latest semver.Version, current semver.Version) string {
 // getUpgradeCommand returns a command that will upgrade the CLI to the newest version. If we can not determine how
 // the CLI was installed, the empty string is returned.
 func getUpgradeCommand() string {
+	curUser, err := user.Current()
+	if err != nil {
+		return ""
+	}
+
 	exe, err := os.Executable()
 	if err != nil {
 		return ""
@@ -347,8 +353,7 @@ func getUpgradeCommand() string {
 		return "$ brew upgrade pulumi"
 	}
 
-	path, err := workspace.GetPulumiPath("bin")
-	if filepath.Dir(exe) != path || err != nil {
+	if filepath.Dir(exe) != filepath.Join(curUser.HomeDir, workspace.BookkeepingDir, "bin") {
 		return ""
 	}
 

--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"os/user"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -335,11 +334,6 @@ func getUpgradeMessage(latest semver.Version, current semver.Version) string {
 // getUpgradeCommand returns a command that will upgrade the CLI to the newest version. If we can not determine how
 // the CLI was installed, the empty string is returned.
 func getUpgradeCommand() string {
-	curUser, err := user.Current()
-	if err != nil {
-		return ""
-	}
-
 	exe, err := os.Executable()
 	if err != nil {
 		return ""
@@ -353,7 +347,8 @@ func getUpgradeCommand() string {
 		return "$ brew upgrade pulumi"
 	}
 
-	if filepath.Dir(exe) != filepath.Join(curUser.HomeDir, ".pulumi", "bin") {
+	path, err := workspace.GetPulumiPath("bin")
+	if filepath.Dir(exe) != path || err != nil {
 		return ""
 	}
 

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -84,18 +83,17 @@ type Credentials struct {
 // getCredsFilePath returns the path to the Pulumi credentials file on disk, regardless of
 // whether it exists or not.
 func getCredsFilePath() (string, error) {
-	user, err := user.Current()
-	if user == nil || err != nil {
-		return "", errors.Wrapf(err, "getting creds file path: failed to get current user")
-	}
-
 	// Allow the folder we use to store credentials to be overridden by tests
 	pulumiFolder := os.Getenv(PulumiCredentialsPathEnvVar)
 	if pulumiFolder == "" {
-		pulumiFolder = filepath.Join(user.HomeDir, BookkeepingDir)
+		folder, err := GetPulumiBookkeepingPath()
+		if err != nil {
+			return "", errors.Wrapf(err, "failed to get the bookkeeping path")
+		}
+		pulumiFolder = folder
 	}
 
-	err = os.MkdirAll(pulumiFolder, 0700)
+	err := os.MkdirAll(pulumiFolder, 0700)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to create '%s'", pulumiFolder)
 	}

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -86,7 +86,7 @@ func getCredsFilePath() (string, error) {
 	// Allow the folder we use to store credentials to be overridden by tests
 	pulumiFolder := os.Getenv(PulumiCredentialsPathEnvVar)
 	if pulumiFolder == "" {
-		folder, err := GetPulumiBookkeepingPath()
+		folder, err := GetPulumiHomeDir()
 		if err != nil {
 			return "", errors.Wrapf(err, "failed to get the bookkeeping path")
 		}

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -88,7 +88,7 @@ func getCredsFilePath() (string, error) {
 	if pulumiFolder == "" {
 		folder, err := GetPulumiHomeDir()
 		if err != nil {
-			return "", errors.Wrapf(err, "failed to get the bookkeeping path")
+			return "", errors.Wrapf(err, "failed to get the home path")
 		}
 		pulumiFolder = folder
 	}

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -208,10 +208,10 @@ func GetPulumiHomeDir() (string, error) {
 // GetPulumiPath returns the path to a file or directory under the '.pulumi' folder. It joins the path of
 // the '.pulumi' folder with elements passed as arguments.
 func GetPulumiPath(elem ...string) (string, error) {
-	bookkeepingPath, err := GetPulumiHomeDir()
+	homeDir, err := GetPulumiHomeDir()
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(append([]string{bookkeepingPath}, elem...)...), nil
+	return filepath.Join(append([]string{homeDir}, elem...)...), nil
 }

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -62,9 +62,9 @@ const (
 	// CachedVersionFile is the name of the file we use to store when we last checked if the CLI was out of date
 	CachedVersionFile = ".cachedVersionInfo"
 
-	// PulumiBookkeepingDirEnvVar is a path to the folder where '.pulumi' folder is stored.
+	// PulumiBookkeepingLocationEnvVar is a path to the folder where '.pulumi' folder is stored.
 	// The path should not include '.pulumi' itself. It defaults to the user's home dir if not specified.
-	PulumiBookkeepingDirEnvVar = "PULUMI_BOOKKEEPING_DIR"
+	PulumiBookkeepingLocationEnvVar = "PULUMI_BOOKKEEPING_LOCATION"
 )
 
 // DetectProjectPath locates the closest project from the current working directory, or an error if not found.
@@ -190,7 +190,7 @@ func GetCachedVersionFilePath() (string, error) {
 // GetPulumiBookkeepingPath returns the path of the '.pulumi' folder where Pulumi puts its artifacts.
 func GetPulumiBookkeepingPath() (string, error) {
 	// Allow the folder we use to be overridden by an environment variable
-	dir := os.Getenv(PulumiBookkeepingDirEnvVar)
+	dir := os.Getenv(PulumiBookkeepingLocationEnvVar)
 	if dir == "" {
 		// Otherwise, use the current user's home dir
 		user, err := user.Current()

--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/user"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -353,11 +352,7 @@ func HasPluginGTE(plug PluginInfo) (bool, error) {
 
 // GetPolicyDir returns the directory in which policies on the current machine are managed.
 func GetPolicyDir() (string, error) {
-	u, err := user.Current()
-	if u == nil || err != nil {
-		return "", errors.Wrapf(err, "getting user home directory")
-	}
-	return filepath.Join(u.HomeDir, BookkeepingDir, PolicyDir), nil
+	return GetPulumiPath(PolicyDir)
 }
 
 // GetPolicyPath finds a PolicyPack by its name version, as well as a bool marked true if the path
@@ -385,11 +380,7 @@ func GetPolicyPath(name, version string) (string, bool, error) {
 
 // GetPluginDir returns the directory in which plugins on the current machine are managed.
 func GetPluginDir() (string, error) {
-	u, err := user.Current()
-	if u == nil || err != nil {
-		return "", errors.Wrapf(err, "getting user home directory")
-	}
-	return filepath.Join(u.HomeDir, BookkeepingDir, PluginDir), nil
+	return GetPulumiPath(PluginDir)
 }
 
 // GetPlugins returns a list of installed plugins.

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -18,14 +18,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/texttheater/golang-levenshtein/levenshtein"
-	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 
 	"github.com/pkg/errors"
@@ -382,17 +381,12 @@ func (template Template) CopyTemplateFiles(
 func GetTemplateDir() (string, error) {
 	// Allow the folder we use to store templates to be overridden.
 	dir := os.Getenv(pulumiLocalTemplatePathEnvVar)
-
-	// Use the classic template directory if there is no override.
-	if dir == "" {
-		u, err := user.Current()
-		if u == nil || err != nil {
-			return "", errors.Wrap(err, "getting user home directory")
-		}
-		dir = filepath.Join(u.HomeDir, BookkeepingDir, TemplateDir)
+	if dir != "" {
+		return dir, nil
 	}
 
-	return dir, nil
+	// Use the classic template directory if there is no override.
+	return GetPulumiPath(TemplateDir)
 }
 
 // We are moving towards a world where these restrictions will be enforced by all our backends. When we get there,

--- a/pkg/workspace/workspace.go
+++ b/pkg/workspace/workspace.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"os/user"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -167,11 +166,10 @@ func (pw *projectWorkspace) readSettings() error {
 }
 
 func (pw *projectWorkspace) settingsPath() string {
-	user, err := user.Current()
-	contract.AssertNoErrorf(err, "could not get current user")
-
 	uniqueFileName := string(pw.name) + "-" + sha1HexString(pw.project) + "-" + WorkspaceFile
-	return filepath.Join(user.HomeDir, BookkeepingDir, WorkspaceDir, uniqueFileName)
+	path, err := GetPulumiPath(WorkspaceDir, uniqueFileName)
+	contract.AssertNoErrorf(err, "could not get workspace path")
+	return path
 }
 
 // sha1HexString returns a hex string of the sha1 hash of value.


### PR DESCRIPTION
Introduces `PULUMI_HOME` environment variable which points to a path to the path to `.pulumi` folder. Defaults to `<user's home dir> + ".pulumi"` if not specified.

Fixes #2966. In addition to plugins, it "moves" the credentials file, templates, workspaces.

`bin` folder is intact: to move it, we need to adjust all installation scripts to respect `PULUMI_HOME` and put executables in the proper `bin` folder.