### PR TITLE
Fix invalid bullet points in `stack init` CLI document

### DIFF
--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -47,9 +47,11 @@ func newStackInitCmd() *cobra.Command {
 			"`--secrets-provider` flag.\n" +
 			"\n" +
 			"To use the `passphrase` secrets provider with the pulumi.com backend, use:\n" +
+			"\n" +
 			"* `pulumi stack init --secrets-provider=passphrase`\n" +
 			"\n" +
 			"To use a cloud secrets provider with any backend, use one of the following:\n" +
+			"\n" +
 			"* `pulumi stack init --secrets-provider=\"awskms://alias/ExampleAlias?region=us-east-1\"`\n" +
 			"* `pulumi stack init --secrets-provider=\"awskms://1234abcd-12ab-34cd-56ef-1234567890ab?region=us-east-1\"`\n" +
 			"* `pulumi stack init --secrets-provider=\"azurekeyvault://mykeyvaultname.vault.azure.net/keys/mykeyname\"`\n" +


### PR DESCRIPTION
Related PR: https://github.com/pulumi/docs/pull/1817

Not sure if this if worth a PR but nevertheless, it'll improve the docs' readability.

I've built the CLI in my local env and confirmed that the new lines are added with `pulumi gen-markdown`.