### PR TITLE
Perform synchronous invokes without `deasync` as much as possible.

### DIFF
--- a/sdk/nodejs/tslint.json
+++ b/sdk/nodejs/tslint.json
@@ -53,7 +53,6 @@
         "no-internal-module": true,
         "no-parameter-properties": false,
         "no-require-imports": false,
-        "no-shadowed-variable": true,
         "no-string-literal": false,
         "no-switch-case-fall-through": true,
         "no-trailing-whitespace": true,


### PR DESCRIPTION
This is a draft PR that is part of a larger set of work to more safely perform invokes synchronously in pulumi (i.e. get us off the deasync library). The larger set of work is tracked in: pulumi/pulumi#3299

This PR is built off of many steps.  It also depends on downstream code changes (like https://github.com/pulumi/pulumi-aws/pull/763).  The steps are:

- [ ] Attempt to realize provider inputs to strings as synchronously as possible. Commit: https://github.com/pulumi/pulumi/pull/3306/commits/f20efcac8ef9279ba35aa90c6dd2b2a48ba51d80
- [ ] Provide a synchronous path to the engine to register resources.
- [ ] Provide a synchronous path to the engine to perform invokes.
- [ ] Synchronously register a provider if possible (i.e. if all inputs are synchronous, and all dependent resources are registered).
- [ ] Synchronously issue an invoke (without using `deasync`) if it is given no provider.  Or if it is given a provider that is registered.  Synchronously issue an invoke using `deasync` (possibly with a warning), otherwise.