### PR TITLE
Improve error message when using PAC on out-of-date SDK

### DIFF
--- a/cmd/crypto.go
+++ b/cmd/crypto.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/crypto_cloud.go
+++ b/cmd/crypto_cloud.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/crypto_http.go
+++ b/cmd/crypto_http.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/crypto_local.go
+++ b/cmd/crypto_local.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package cmd
 
 import (

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -95,7 +95,7 @@ func NewPolicyAnalyzer(
 	if err != nil {
 		if err == errRunPolicyModuleNotFound {
 			return nil, fmt.Errorf("the Pulumi SDK used with this stack does not appear to support policy as code.\n" +
-				"Upgrading the a newer version of the Pulumi SDK may fix this problem.")
+				"Upgrading to a newer version of the Pulumi SDK may fix this problem.")
 		}
 		return nil, errors.Wrapf(err, "policy pack %q failed to start", string(name))
 	}

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/resource"
 	"github.com/pulumi/pulumi/pkg/tokens"
@@ -83,7 +84,7 @@ func NewPolicyAnalyzer(
 	if err != nil {
 		return nil, rpcerror.Convert(err)
 	} else if pluginPath == "" {
-		return nil, fmt.Errorf("could not start policy pack %s because the built-in analyzer "+
+		return nil, fmt.Errorf("could not start policy pack %q because the built-in analyzer "+
 			"plugin that runs policy plugins is missing. This might occur when the plugin "+
 			"directory is not on your $PATH, or when the installed version of the Pulumi SDK "+
 			"does not support resource policies", string(name))
@@ -92,8 +93,11 @@ func NewPolicyAnalyzer(
 	plug, err := newPlugin(ctx, pluginPath, fmt.Sprintf("%v (analyzer)", name),
 		[]string{host.ServerAddr(), policyPackPath})
 	if err != nil {
-		return nil, errors.Wrapf(err,
-			"policy pack %s failed to start because of an internal error", string(name))
+		if err == errRunPolicyModuleNotFound {
+			return nil, fmt.Errorf("the Pulumi SDK used with this stack does not appear to support policy as code.\n" +
+				"Upgrading the a newer version of the Pulumi SDK may fix this problem.")
+		}
+		return nil, errors.Wrapf(err, "policy pack %q failed to start", string(name))
 	}
 	contract.Assertf(plug != nil, "unexpected nil analyzer plugin for %s", name)
 

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -63,6 +63,10 @@ var pluginRPCMaxMessageSize = 1024 * 1024 * 400
 // time.
 var nextStreamID int32
 
+// errRunPolicyModuleNotFound is returned when we determine that the plugin failed to load because
+// the stack's Pulumi SDK did not have the required modules. i.e. is too old.
+var errRunPolicyModuleNotFound = errors.New("pulumi SDK does not support policy as code")
+
 func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin, error) {
 	if logging.V(9) {
 		var argstr string
@@ -93,6 +97,7 @@ func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin,
 	errStreamID := atomic.AddInt32(&nextStreamID, 1)
 
 	// For now, we will spawn goroutines that will spew STDOUT/STDERR to the relevant diag streams.
+	var sawPolicyModuleNotFoundErr bool
 	runtrace := func(t io.Reader, stderr bool, done chan<- bool) {
 		reader := bufio.NewReader(t)
 
@@ -100,6 +105,15 @@ func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin,
 			msg, readerr := reader.ReadString('\n')
 			if readerr != nil {
 				break
+			}
+
+			// We may be trying to run a plugin that isn't present in the SDK installed with the stack.
+			// e.g. the stack's package.json does not contain a recent enough @pulumi/pulumi.
+			//
+			// Rather than fail with an opaque error because we didn't get the gRPC port, inspect if it
+			// is a well-known problem and return a better error as appropriate.
+			if strings.Contains(msg, "Cannot find module '@pulumi/pulumi/cmd/run-policy-pack'") {
+				sawPolicyModuleNotFoundErr = true
 			}
 
 			if strings.TrimSpace(msg) != "" {
@@ -127,7 +141,14 @@ func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin,
 		n, readerr := plug.Stdout.Read(b)
 		if readerr != nil {
 			killerr := plug.Proc.Kill()
-			contract.IgnoreError(killerr) // we are ignoring because the readerr trumps it.
+			contract.IgnoreError(killerr) // We are ignoring because the readerr trumps it.
+
+			// If from the output we have seen, return a specific error if possible.
+			if sawPolicyModuleNotFoundErr {
+				return nil, errRunPolicyModuleNotFound
+			}
+
+			// Fall back to a generic, opaque error.
 			if port == "" {
 				return nil, errors.Wrapf(readerr, "could not read plugin [%v] stdout", bin)
 			}


### PR DESCRIPTION
If you try to run PAC on a stack that is using an older version of the Pulumi SDK, e.g. `0.16.0`, then you get a pretty confusing error message:

```
Previewing update (pac-testing):

     Type                 Name                   Plan     Info
     pulumi:pulumi:Stack  resources-pac-testing           1 error; 1 message
 
Diagnostics:
  pulumi:pulumi:Stack (resources-pac-testing):
    Cannot find module '@pulumi/pulumi/cmd/run-policy-pack'
 
    error: policy pack /Users/chris/go/src/github.com/pulumi/pulumi-awsguard/chrsmith-dev failed to start because of an internal error: could not read plugin [/Users/chris/.pulumi/bin/pulumi-analyzer-policy] stdout: EOF
```

The problem stems from the Pulumi CLI trying to run a Node module relative to the current stack's working directory. So the problem is that ./node_modules/@pulumi/pulumi/cmd/run-policy-pack/index.js isn't found.

However, it doesn't look like we can easily just check if that file exists, because the way things work -- assuming I understand things correctly -- is that we run `pulumi-analyzer-policy` (a script that is installed with the CLI) ([source](https://github.com/pulumi/pulumi/blob/master/sdk/nodejs/dist/pulumi-analyzer-policy)).

So as an admitted hack of sorts, we check if we've seen "Cannot find module '@pulumi/pulumi/cmd/run-policy-pack' and if not, return a specific error value. Though alternatively, it seems like we could instead update the `pulumi-analyzer-policy` and `pulumi-analyzer-policy.cmd` scripts to check if `./node_modules/@pulumi/pulumi/cmd/run-policy-pack/index.js` exists instead? And if not return not the PID of the gRPC process, but some well-known exit code like "-93" instead? What do you think @hausdorff ?

Anyways, with this PR, the error is now a much more reasonable IMHO:

```
Previewing update (pac-testing):

     Type                 Name                   Plan     Info
     pulumi:pulumi:Stack  resources-pac-testing           1 error; 1 message
 
Diagnostics:
  pulumi:pulumi:Stack (resources-pac-testing):
    Cannot find module '@pulumi/pulumi/cmd/run-policy-pack'
 
    error: the Pulumi SDK used with this stack does not appear to support policy as code.
    Upgrading the a newer version of the Pulumi SDK may fix this problem.
 ```

Fixes #2968 