### PR TITLE
Indicate local policy packs ran

### DIFF
--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -43,11 +43,11 @@ type RequiredPolicy interface {
 
 // UpdateOptions contains all the settings for customizing how an update (deploy, preview, or destroy) is performed.
 //
-// This structre is embedded in another which uses some of the unexported fields, which trips up the `structcheck`
+// This structure is embedded in another which uses some of the unexported fields, which trips up the `structcheck`
 // linter.
 // nolint: structcheck
 type UpdateOptions struct {
-	// an optional set of paths of policy packs to run as part of this deployment.
+	// LocalPolicyPackPaths contains an optional set of paths to policy packs to run as part of this deployment.
 	LocalPolicyPackPaths []string
 
 	// RequiredPolicies is the set of policies that are required to run as part of the update.
@@ -233,6 +233,9 @@ func update(ctx *Context, info *planContext, opts planOptions, dryRun bool) (Res
 	policies := map[string]string{}
 	for _, p := range opts.RequiredPolicies {
 		policies[p.Name()] = p.Version()
+	}
+	for _, path := range opts.LocalPolicyPackPaths {
+		policies[path] = "(local)"
 	}
 
 	var resourceChanges ResourceChanges

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -250,7 +250,7 @@ func (sg *stepGenerator) GenerateSteps(
 		if err != nil {
 			return nil, result.FromError(err)
 		} else if analyzer == nil {
-			return nil, result.Errorf("analyzer could not be loaded from path '%s'", path)
+			return nil, result.Errorf("analyzer could not be loaded from path %q", path)
 		}
 	}
 


### PR DESCRIPTION
We include the list of required policy packs (as sent from the Pulumi Service) in the `engine.SummaryEvent` that gets emitted at the end of a preview or update. However, that doesn't include any reference to the policy packs that are specified via the `--policy-pack` command-line flag.

This PR also adds those policy packs as well. So the end result looks something like:

```
Previewing update (pac-testing):

     Type                 Name                   Plan       
 +   pulumi:pulumi:Stack  resources-pac-testing  create     
 
Resources:
    + 1 to create

Policy Packs run:
    Name                                                                Version
    /Users/chris/go/src/github.com/pulumi/pulumi-awsguard/chrsmith-dev  (local)

Permalink: https://app.pulumi.com/chrsmith/resources/pac-testing/previews/b6c84414-5411-47f1-8636-8ff5216e0ca7
```

I'll admit "Name: <path name>" and "Version: (local)" isn't ideal. But it's certainly a better developer experience than having no indication that the policy pack(s) were run at all.