### PR TITLE
Fix a dependency graph bug during DBR.

### DIFF
--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -4563,3 +4563,108 @@ func updateSpecificTargets(t *testing.T, targets []string) {
 
 	p.Run(t, old)
 }
+
+func TestDependencyChangeDBR(t *testing.T) {
+	p := &TestPlan{}
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				DiffF: func(urn resource.URN, id resource.ID,
+					olds, news resource.PropertyMap, ignoreChanges []string) (plugin.DiffResult, error) {
+
+					if !olds["A"].DeepEquals(news["A"]) {
+						return plugin.DiffResult{
+							ReplaceKeys:         []resource.PropertyKey{"A"},
+							DeleteBeforeReplace: true,
+						}, nil
+					}
+					if !olds["B"].DeepEquals(news["B"]) {
+						return plugin.DiffResult{
+							Changes: plugin.DiffSome,
+						}, nil
+					}
+					return plugin.DiffResult{}, nil
+				},
+				CreateF: func(urn resource.URN,
+					news resource.PropertyMap, timeout float64) (resource.ID, resource.PropertyMap, resource.Status, error) {
+
+					return "created-id", news, resource.StatusOK, nil
+				},
+			}, nil
+		}),
+	}
+
+	const resType = "pkgA:index:typ"
+
+	inputsA := resource.NewPropertyMapFromMap(map[string]interface{}{"A": "foo"})
+	inputsB := resource.NewPropertyMapFromMap(map[string]interface{}{"A": "foo"})
+
+	var urnA, urnB resource.URN
+	var err error
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		urnA, _, _, err = monitor.RegisterResource(resType, "resA", true, deploytest.ResourceOptions{
+			Inputs: inputsA,
+		})
+		assert.NoError(t, err)
+
+		inputDepsB := map[resource.PropertyKey][]resource.URN{"A": {urnA}}
+		urnB, _, _, err = monitor.RegisterResource(resType, "resB", true, deploytest.ResourceOptions{
+			Inputs:       inputsB,
+			Dependencies: []resource.URN{urnA},
+			PropertyDeps: inputDepsB,
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+
+	p.Options.host = deploytest.NewPluginHost(nil, nil, program, loaders...)
+	p.Steps = []TestStep{{Op: Update}}
+	snap := p.Run(t, nil)
+
+	inputsA["A"] = resource.NewStringProperty("bar")
+	program = deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		urnB, _, _, err = monitor.RegisterResource(resType, "resB", true, deploytest.ResourceOptions{
+			Inputs: inputsB,
+		})
+		assert.NoError(t, err)
+
+		urnA, _, _, err = monitor.RegisterResource(resType, "resA", true, deploytest.ResourceOptions{
+			Inputs: inputsA,
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+
+	p.Options.host = deploytest.NewPluginHost(nil, nil, program, loaders...)
+	p.Steps = []TestStep{
+		{
+			Op: Update,
+			Validate: func(project workspace.Project, target deploy.Target, j *Journal,
+				evts []Event, res result.Result) result.Result {
+
+				assert.Nil(t, res)
+				assert.True(t, len(j.Entries) > 0)
+
+				resBDeleted, resBSame := false, false
+				for _, entry := range j.Entries {
+					if entry.Step.URN() == urnB {
+						switch entry.Step.Op() {
+						case deploy.OpDelete, deploy.OpDeleteReplaced:
+							resBDeleted = true
+						case deploy.OpSame:
+							resBSame = true
+						}
+					}
+				}
+				assert.True(t, resBSame)
+				assert.False(t, resBDeleted)
+
+				return res
+			},
+		},
+	}
+	p.Run(t, snap)
+}

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -41,7 +41,7 @@ func DeleteResource(snapshot *deploy.Snapshot, condemnedRes *resource.State) err
 	}
 
 	dg := graph.NewDependencyGraph(snapshot.Resources)
-	dependencies := dg.DependingOn(condemnedRes)
+	dependencies := dg.DependingOn(condemnedRes, nil)
 	if len(dependencies) != 0 {
 		return ResourceHasDependenciesError{Condemned: condemnedRes, Dependencies: dependencies}
 	}

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -19,7 +19,7 @@ type DependencyGraph struct {
 // order with respect to the snapshot dependency graph.
 //
 // The time complexity of DependingOn is linear with respect to the number of resources.
-func (dg *DependencyGraph) DependingOn(res *resource.State) []*resource.State {
+func (dg *DependencyGraph) DependingOn(res *resource.State, ignore map[resource.URN]bool) []*resource.State {
 	// This implementation relies on the detail that snapshots are stored in a valid
 	// topological order.
 	var dependents []*resource.State
@@ -30,6 +30,9 @@ func (dg *DependencyGraph) DependingOn(res *resource.State) []*resource.State {
 	dependentSet[res.URN] = true
 
 	isDependent := func(candidate *resource.State) bool {
+		if ignore[candidate.URN] {
+			return false
+		}
 		if candidate.Provider != "" {
 			ref, err := providers.ParseReference(candidate.Provider)
 			contract.Assert(err == nil)

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -63,22 +63,22 @@ func TestBasicGraph(t *testing.T) {
 
 	assert.Equal(t, []*resource.State{
 		a, b, pB, c, d,
-	}, dg.DependingOn(pA))
+	}, dg.DependingOn(pA, nil))
 
 	assert.Equal(t, []*resource.State{
 		b, pB, c, d,
-	}, dg.DependingOn(a))
+	}, dg.DependingOn(a, nil))
 
 	assert.Equal(t, []*resource.State{
 		pB, c, d,
-	}, dg.DependingOn(b))
+	}, dg.DependingOn(b, nil))
 
 	assert.Equal(t, []*resource.State{
 		c,
-	}, dg.DependingOn(pB))
+	}, dg.DependingOn(pB, nil))
 
-	assert.Nil(t, dg.DependingOn(c))
-	assert.Nil(t, dg.DependingOn(d))
+	assert.Nil(t, dg.DependingOn(c, nil))
+	assert.Nil(t, dg.DependingOn(d, nil))
 }
 
 // Tests that we don't add the same node to the DependingOn set twice.
@@ -97,7 +97,7 @@ func TestGraphNoDuplicates(t *testing.T) {
 
 	assert.Equal(t, []*resource.State{
 		b, c, d,
-	}, dg.DependingOn(a))
+	}, dg.DependingOn(a, nil))
 }
 
 func TestDependenciesOf(t *testing.T) {

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -79,6 +79,42 @@ func TestBasicGraph(t *testing.T) {
 
 	assert.Nil(t, dg.DependingOn(c, nil))
 	assert.Nil(t, dg.DependingOn(d, nil))
+
+	assert.Nil(t, dg.DependingOn(pA, map[resource.URN]bool{
+		a.URN: true,
+		b.URN: true,
+	}))
+
+	assert.Equal(t, []*resource.State{
+		a, pB, c,
+	}, dg.DependingOn(pA, map[resource.URN]bool{
+		b.URN: true,
+	}))
+
+	assert.Equal(t, []*resource.State{
+		b, pB, c, d,
+	}, dg.DependingOn(pA, map[resource.URN]bool{
+		a.URN: true,
+	}))
+
+	assert.Equal(t, []*resource.State{
+		c,
+	}, dg.DependingOn(a, map[resource.URN]bool{
+		b.URN:  true,
+		pB.URN: true,
+	}))
+
+	assert.Equal(t, []*resource.State{
+		pB, c,
+	}, dg.DependingOn(a, map[resource.URN]bool{
+		b.URN: true,
+	}))
+
+	assert.Equal(t, []*resource.State{
+		d,
+	}, dg.DependingOn(b, map[resource.URN]bool{
+		pB.URN: true,
+	}))
 }
 
 // Tests that we don't add the same node to the DependingOn set twice.


### PR DESCRIPTION
The dependency graph used to determine the set of resources that
depend on a resource being DBR'd is constructured from the list of
resource states present in the old snapshot. However, the dependencies
of resources that are present in both the old snapshot and the current
plan can be different, which in turn can cause the engine to make
incorrect decisions during DBR with respect to which resources need to
be replaced. For example, consider the following program:

```
var resA = new Resource("a", {dbr: "foo"});
var resB = new Resource("b", {dbr: resA.prop});
```

If this program is then changed to:
```
var resB = new Resource("b", {dbr: "<literal value of resA.prop>"});
var resA = new Resource("a", {dbr: "bar"});
```

The engine will first decide to make no changes to "b", as its input
property values have not changed. "b" has changed, however, such that it
no longer has a dependency on "a".

The engine will then decide to DBR "a". In the process, it will
determine that it first needs to delete "b", because the state for "b"
that is used when calculating "a"'s dependents does not reflect the
changes made during the plan.

To fix this issue, we rely on the observation that dependents can only
have been _removed_ from the base dependency graph: for a dependent to
have been added, it would have had to have been registered prior to the
root--a resource it depends on--which is not a valid operation. This
means that any resources that depend on the root must not yet have
been registered, which in turn implies that resources that have already
been registered must not depend on the root. Thus, we ignore these
resources if they are encountered while walking the old dependency graph
to determine the set of dependents.