### PR TITLE
Stop using loreley.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.0.2
 	github.com/pkg/errors v0.8.1
-	github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54
+	github.com/reconquest/loreley v0.0.0-20160708080500-2ab6b7470a54 // indirect
 	github.com/russross/blackfriday v1.5.2 // indirect
 	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 // indirect
 	github.com/satori/go.uuid v1.2.0

--- a/pkg/diag/colors/colors.go
+++ b/pkg/diag/colors/colors.go
@@ -15,10 +15,9 @@
 package colors
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
-
-	"github.com/reconquest/loreley"
 
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
@@ -26,19 +25,15 @@ import (
 const colorLeft = "<{%"
 const colorRight = "%}>"
 
-func init() {
-	// Change the Loreley delimiters from { and }, to something more complex, to avoid accidental collisions.
-	loreley.DelimLeft = colorLeft
-	loreley.DelimRight = colorRight
-}
+var disableColorization bool
 
-func Command(s string) string {
+func command(s string) string {
 	return colorLeft + s + colorRight
 }
 
-// TrimPartialCommand returns the input string with any partial colorization command trimmed off of the right end of
+// TrimPartialcommand returns the input string with any partial colorization command trimmed off of the right end of
 // the string.
-func TrimPartialCommand(s string) string {
+func TrimPartialcommand(s string) string {
 	// First check for a partial left delimiter at the end of the string.
 	partialDelimLeft := colorLeft
 	if len(partialDelimLeft) > len(s) {
@@ -69,26 +64,117 @@ func TrimPartialCommand(s string) string {
 }
 
 func Colorize(s fmt.Stringer) string {
-	txt := s.String()
-	return colorizeText(txt)
+	return colorizeText(s.String(), Always, -1)
 }
 
-func colorizeText(s string) string {
-	style, err := loreley.Compile(s, nil /*extensions*/)
-	contract.Assertf(err == nil, "Expected no errors during string colorization; str=%v, err=%v", s, err)
+func writeCodes(buf *bytes.Buffer, codes ...string) {
+	buf.WriteString("\x1b[")
+	buf.WriteString(strings.Join(codes, ";"))
+	buf.WriteString("m")
+}
 
-	// Note: we only get into this codepath if we determined colors should be on.  This was either
-	// because we were in color=auto mode and our env detection determined colors were reasonable to
-	// have, or because we're in color=always mode.
-	//
-	// However, Loreley does its own tty detection and disables colors if there is no tty.  We don't
-	// want that behavior if we've determined colors should be on.  So we explicitly override their
-	// automatic detection.
-	style.NoColors = false
-	result, err := style.ExecuteToString(nil /*data*/)
-	contract.Assertf(err == nil, "Expected no errors during string colorization; str=%v, err=%v", s, err)
+func writeDirective(buf *bytes.Buffer, c Colorization, directive string) {
+	if disableColorization || c == Never {
+		return
+	}
+	if c == Raw {
+		buf.WriteString(directive)
+		return
+	}
 
-	return result
+	switch directive {
+	case Reset: // command("reset")
+		writeCodes(buf, "0")
+	case Bold: // command("bold")
+		writeCodes(buf, "1")
+	case Underline: // command("underline")
+		writeCodes(buf, "4")
+	case Red: // command("fg 1")
+		writeCodes(buf, "38", "5", "1")
+	case Green: // command("fg 2")
+		writeCodes(buf, "38", "5", "2")
+	case Yellow: // command("fg 3")
+		writeCodes(buf, "38", "5", "3")
+	case Blue: // command("fg 4")
+		writeCodes(buf, "38", "5", "4")
+	case Magenta: // command("fg 5")
+		writeCodes(buf, "38", "5", "5")
+	case Cyan: // command("fg 6")
+		writeCodes(buf, "38", "5", "6")
+	case BrightRed: // command("fg 9")
+		writeCodes(buf, "38", "5", "9")
+	case BrightGreen: // command("fg 10")
+		writeCodes(buf, "38", "5", "10")
+	case BrightBlue: // command("fg 12")
+		writeCodes(buf, "38", "5", "12")
+	case BrightMagenta: // command("fg 13")
+		writeCodes(buf, "38", "5", "13")
+	case BrightCyan: // command("fg 14")
+		writeCodes(buf, "38", "5", "14")
+	case RedBackground: // command("bg 1")
+		writeCodes(buf, "48", "5", "1")
+	case GreenBackground: // command("bg 2")
+		writeCodes(buf, "48", "5", "2")
+	case YellowBackground: // command("bg 3")
+		writeCodes(buf, "48", "5", "3")
+	case BlueBackground: // command("bg 4")
+		writeCodes(buf, "48", "5", "4")
+	case Black: // command("fg 0") // Only use with background colors.
+		writeCodes(buf, "38", "5", "0")
+	}
+}
+
+func colorizeText(s string, c Colorization, maxLen int) string {
+	var buf bytes.Buffer
+
+	textLen := 0
+	for input := s; len(input) > 0; {
+		// Do we have another directive to process?
+		nextDirectiveStart := strings.Index(input, colorLeft)
+		if nextDirectiveStart == -1 {
+			// If there are no more directives and we still have the entire original string, return it as-is: there
+			// must not have been any directives.
+			if len(input) == len(s) {
+				if maxLen >= 0 && len(input) > maxLen {
+					return input[:maxLen]
+				}
+				return input
+			}
+
+			// Otherwise, write the remaining input into the buffer and terminate.
+			_, err := buf.WriteString(input)
+			contract.IgnoreError(err)
+			break
+		}
+		if buf.Cap() < len(input) {
+			buf.Grow(len(input))
+		}
+
+		// Copy the text up to but not including the delimiter into the buffer.
+		text := input[:nextDirectiveStart]
+		if maxLen >= 0 && textLen+len(text) > maxLen {
+			_, err := buf.WriteString(text[:maxLen])
+			contract.IgnoreError(err)
+			writeDirective(&buf, c, Reset)
+			break
+		}
+		_, err := buf.WriteString(input[:nextDirectiveStart])
+		contract.IgnoreError(err)
+		input = input[nextDirectiveStart+len(colorLeft):]
+
+		// If we have a start delimiter but no end delimiter, terminate. The partial command will not be present in the
+		// output.
+		nextDirectiveEnd := strings.Index(input, colorRight)
+		if nextDirectiveEnd == -1 {
+			break
+		}
+
+		directive := command(input[:nextDirectiveEnd])
+		writeDirective(&buf, c, directive)
+		input = input[nextDirectiveEnd+len(colorRight):]
+	}
+
+	return buf.String()
 }
 
 // Highlight takes an input string, a sequence of commands, and replaces all occurrences of that string with
@@ -98,38 +184,38 @@ func Highlight(s, text, commands string) string {
 }
 
 var (
-	Reset     = Command("reset")
-	Bold      = Command("bold")
-	Underline = Command("underline")
+	Reset     = command("reset")
+	Bold      = command("bold")
+	Underline = command("underline")
 )
 
 // Basic colors.
 var (
-	Red           = Command("fg 1")
-	Green         = Command("fg 2")
-	Yellow        = Command("fg 3")
-	Blue          = Command("fg 4")
-	Magenta       = Command("fg 5")
-	Cyan          = Command("fg 6")
-	BrightRed     = Command("fg 9")
-	BrightGreen   = Command("fg 10")
-	BrightBlue    = Command("fg 12")
-	BrightMagenta = Command("fg 13")
-	BrightCyan    = Command("fg 14")
+	Red           = command("fg 1")
+	Green         = command("fg 2")
+	Yellow        = command("fg 3")
+	Blue          = command("fg 4")
+	Magenta       = command("fg 5")
+	Cyan          = command("fg 6")
+	BrightRed     = command("fg 9")
+	BrightGreen   = command("fg 10")
+	BrightBlue    = command("fg 12")
+	BrightMagenta = command("fg 13")
+	BrightCyan    = command("fg 14")
 
-	RedBackground    = Command("bg 1")
-	GreenBackground  = Command("bg 2")
-	YellowBackground = Command("bg 3")
-	BlueBackground   = Command("bg 4")
+	RedBackground    = command("bg 1")
+	GreenBackground  = command("bg 2")
+	YellowBackground = command("bg 3")
+	BlueBackground   = command("bg 4")
 
 	// We explicitly do not expose blacks/whites.  They're problematic given that we don't know what
 	// terminal settings the user has.  Best to avoid them and not run into contrast problems.
 
-	Black = Command("fg 0") // Only use with background colors.
-	// White         = Command("fg 7")
-	// BrightBlack   = Command("fg 8")
-	// BrightYellow  = Command("fg 11")
-	// BrightWhite   = Command("fg 15")
+	Black = command("fg 0") // Only use with background colors.
+	// White         = command("fg 7")
+	// BrightBlack   = command("fg 8")
+	// BrightYellow  = command("fg 11")
+	// BrightWhite   = command("fg 15")
 )
 
 // Special predefined colors for logical conditions.

--- a/pkg/diag/colors/colors.go
+++ b/pkg/diag/colors/colors.go
@@ -17,6 +17,7 @@ package colors
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -67,60 +68,64 @@ func Colorize(s fmt.Stringer) string {
 	return colorizeText(s.String(), Always, -1)
 }
 
-func writeCodes(buf *bytes.Buffer, codes ...string) {
-	buf.WriteString("\x1b[")
-	buf.WriteString(strings.Join(codes, ";"))
-	buf.WriteString("m")
+func writeCodes(w io.StringWriter, codes ...string) {
+	_, err := w.WriteString("\x1b[")
+	contract.IgnoreError(err)
+	_, err = w.WriteString(strings.Join(codes, ";"))
+	contract.IgnoreError(err)
+	_, err = w.WriteString("m")
+	contract.IgnoreError(err)
 }
 
-func writeDirective(buf *bytes.Buffer, c Colorization, directive string) {
+func writeDirective(w io.StringWriter, c Colorization, directive string) {
 	if disableColorization || c == Never {
 		return
 	}
 	if c == Raw {
-		buf.WriteString(directive)
+		_, err := w.WriteString(directive)
+		contract.IgnoreError(err)
 		return
 	}
 
 	switch directive {
 	case Reset: // command("reset")
-		writeCodes(buf, "0")
+		writeCodes(w, "0")
 	case Bold: // command("bold")
-		writeCodes(buf, "1")
+		writeCodes(w, "1")
 	case Underline: // command("underline")
-		writeCodes(buf, "4")
+		writeCodes(w, "4")
 	case Red: // command("fg 1")
-		writeCodes(buf, "38", "5", "1")
+		writeCodes(w, "38", "5", "1")
 	case Green: // command("fg 2")
-		writeCodes(buf, "38", "5", "2")
+		writeCodes(w, "38", "5", "2")
 	case Yellow: // command("fg 3")
-		writeCodes(buf, "38", "5", "3")
+		writeCodes(w, "38", "5", "3")
 	case Blue: // command("fg 4")
-		writeCodes(buf, "38", "5", "4")
+		writeCodes(w, "38", "5", "4")
 	case Magenta: // command("fg 5")
-		writeCodes(buf, "38", "5", "5")
+		writeCodes(w, "38", "5", "5")
 	case Cyan: // command("fg 6")
-		writeCodes(buf, "38", "5", "6")
+		writeCodes(w, "38", "5", "6")
 	case BrightRed: // command("fg 9")
-		writeCodes(buf, "38", "5", "9")
+		writeCodes(w, "38", "5", "9")
 	case BrightGreen: // command("fg 10")
-		writeCodes(buf, "38", "5", "10")
+		writeCodes(w, "38", "5", "10")
 	case BrightBlue: // command("fg 12")
-		writeCodes(buf, "38", "5", "12")
+		writeCodes(w, "38", "5", "12")
 	case BrightMagenta: // command("fg 13")
-		writeCodes(buf, "38", "5", "13")
+		writeCodes(w, "38", "5", "13")
 	case BrightCyan: // command("fg 14")
-		writeCodes(buf, "38", "5", "14")
+		writeCodes(w, "38", "5", "14")
 	case RedBackground: // command("bg 1")
-		writeCodes(buf, "48", "5", "1")
+		writeCodes(w, "48", "5", "1")
 	case GreenBackground: // command("bg 2")
-		writeCodes(buf, "48", "5", "2")
+		writeCodes(w, "48", "5", "2")
 	case YellowBackground: // command("bg 3")
-		writeCodes(buf, "48", "5", "3")
+		writeCodes(w, "48", "5", "3")
 	case BlueBackground: // command("bg 4")
-		writeCodes(buf, "48", "5", "4")
+		writeCodes(w, "48", "5", "4")
 	case Black: // command("fg 0") // Only use with background colors.
-		writeCodes(buf, "38", "5", "0")
+		writeCodes(w, "38", "5", "0")
 	}
 }
 

--- a/pkg/diag/colors/colors.go
+++ b/pkg/diag/colors/colors.go
@@ -31,9 +31,9 @@ func command(s string) string {
 	return colorLeft + s + colorRight
 }
 
-// TrimPartialcommand returns the input string with any partial colorization command trimmed off of the right end of
+// TrimPartialCommand returns the input string with any partial colorization command trimmed off of the right end of
 // the string.
-func TrimPartialcommand(s string) string {
+func TrimPartialCommand(s string) string {
 	// First check for a partial left delimiter at the end of the string.
 	partialDelimLeft := colorLeft
 	if len(partialDelimLeft) > len(s) {

--- a/pkg/diag/colors/colors_test.go
+++ b/pkg/diag/colors/colors_test.go
@@ -15,6 +15,8 @@
 package colors
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,5 +29,54 @@ func TestTrimPartialCommand(t *testing.T) {
 	expected := Red + "foo" + Green + "bar"
 	for partial := noPartial[:len(noPartial)-1]; partial[len(partial)-3:] != "bar"; partial = partial[:len(partial)-1] {
 		assert.Equal(t, expected, TrimPartialCommand(partial))
+	}
+}
+
+func codes(codes ...string) string {
+	return fmt.Sprintf("\x1b[%sm", strings.Join(codes, ";"))
+}
+
+func TestColorizer(t *testing.T) {
+	cases := []struct {
+		command, codes string
+	}{
+		{Bold, codes("1")},
+		{Underline, codes("4")},
+		{Red, codes("38", "5", "1")},
+		{Green, codes("38", "5", "2")},
+		{Yellow, codes("38", "5", "3")},
+		{Blue, codes("38", "5", "4")},
+		{Magenta, codes("38", "5", "5")},
+		{Cyan, codes("38", "5", "6")},
+		{BrightRed, codes("38", "5", "9")},
+		{BrightGreen, codes("38", "5", "10")},
+		{BrightBlue, codes("38", "5", "12")},
+		{BrightMagenta, codes("38", "5", "13")},
+		{BrightCyan, codes("38", "5", "14")},
+		{RedBackground, codes("48", "5", "1")},
+		{GreenBackground, codes("48", "5", "2")},
+		{YellowBackground, codes("48", "5", "3")},
+		{BlueBackground, codes("48", "5", "4")},
+		{Black, codes("38", "5", "0")},
+	}
+
+	for _, c := range cases {
+		t.Run(c.command, func(t *testing.T) {
+			const content = "hello"
+			str := c.command + content + Reset + "\n"
+
+			actualRaw := colorizeText(str, Raw, -1)
+			assert.Equal(t, str, actualRaw)
+
+			actualAlways := Always.Colorize(str)
+			assert.Equal(t, c.codes+content+codes("0")+"\n", actualAlways)
+
+			actualNever := Never.Colorize(str)
+			assert.Equal(t, content+"\n", actualNever)
+
+			trimmedContent := content[:3]
+			actualTrimmed := TrimColorizedString(str, len(trimmedContent))
+			assert.Equal(t, c.command+trimmedContent+Reset, actualTrimmed)
+		})
 	}
 }

--- a/pkg/diag/colors/diag.go
+++ b/pkg/diag/colors/diag.go
@@ -15,14 +15,9 @@
 package colors
 
 import (
-	"regexp"
-
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
-var tagRegexp = regexp.MustCompile(`<\{%(.*?)%\}>`)
-
-// Colorization is an instruction to perform a certain kind of colorization.
 type Colorization string
 
 const (
@@ -44,36 +39,13 @@ func (c Colorization) Colorize(v string) string {
 		return v
 	case Always:
 		// Convert the constrol sequences into appropriate console escapes for the platform we're on.
-		return colorizeText(v)
+		return colorizeText(v, Always, -1)
 	case Never:
-		// Remove all the colors that any other layers added.
-		return tagRegexp.ReplaceAllString(v, "")
+		return colorizeText(v, Never, -1)
 	default:
 		contract.Failf("Unexpected colorization value: %v", c)
 		return ""
 	}
-}
-
-// SplitIntoTextAndTags breaks up a colorized string into alternating sections of a raw-text-chunk
-// and then a color-tag.  The returned array will always be non empty, with the first and last
-// elements in the array being (possibly empty) raw-text-chunks.  For example, if you started with
-// "<%fg 8>hello<%fg 7>", this would return:  ["", "<%fg 8>", "hello", "<%fg 7>", ""]
-func SplitIntoTextAndTags(v string) []string {
-	tagIndices := tagRegexp.FindAllStringIndex(v, -1)
-
-	currentIndex := 0
-	textAndTags := []string{}
-	for _, tagPair := range tagIndices {
-		tagStart := tagPair[0]
-		tagEnd := tagPair[1]
-		textAndTags = append(textAndTags, v[currentIndex:tagStart])
-		textAndTags = append(textAndTags, v[tagStart:tagEnd])
-		currentIndex = tagEnd
-	}
-
-	textAndTags = append(textAndTags, v[currentIndex:])
-
-	return textAndTags
 }
 
 // TrimColorizedString takes a string with embedded color tags and returns a new string (still with
@@ -83,41 +55,5 @@ func SplitIntoTextAndTags(v string) []string {
 // string as the embedded color tags would count against it, even though they end up with no length
 // when actually interpretted by the console.
 func TrimColorizedString(v string, maxRuneLength int) string {
-	textAndTags := SplitIntoTextAndTags(v)
-
-	currentRuneLength := 0
-	trimmed := ""
-
-	for i := 0; i < len(textAndTags); i++ {
-		textOrTag := textAndTags[i]
-
-		if i%2 == 0 {
-			contract.Assertf(!tagRegexp.MatchString(textOrTag), "Got a tag when we did not expect it")
-
-			chunk := textOrTag
-			chunkRunes := []rune(chunk)
-			chunkRunesLen := len(chunkRunes)
-
-			if currentRuneLength+chunkRunesLen > maxRuneLength {
-				// adding this text chunk will cause us to go past the max length we allow.
-				// just take whatever subportion we can and stop what we're doing.
-				trimmed += string(chunkRunes[0 : maxRuneLength-currentRuneLength])
-				break
-			} else {
-				// can safely add this text chunk
-				trimmed += chunk
-				currentRuneLength += chunkRunesLen
-			}
-		} else {
-			contract.Assertf(tagRegexp.MatchString(textOrTag), "Should have gotten a tag")
-
-			// can safely add the tag to the trimmed string.  tags don't contribute any actual length.
-			trimmed += textOrTag
-		}
-	}
-
-	// add a trailing reset, so that any unclosed tags will be closed.
-	trimmed += Reset
-
-	return trimmed
+	return colorizeText(v, Raw, maxRuneLength)
 }

--- a/pkg/diag/colors/windows.go
+++ b/pkg/diag/colors/windows.go
@@ -16,10 +16,6 @@
 
 package colors
 
-import (
-	"github.com/reconquest/loreley"
-)
-
 func init() {
-	loreley.Colorize = loreley.ColorizeNever
+	disableColorization = true
 }


### PR DESCRIPTION
Loreley's approach to colorization via Go templates has significant
overhead when colorization is used extensively.

Also, stop parsing colorized text with regexes and use the actual
parser.

This saves over a second of execution time when running the
initial preview of the k8s Istio test locally, which is about a 25%
improvement.