### PR TITLE
Buffer events.

### DIFF
--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -39,6 +39,8 @@ func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 	if err != nil {
 		return nil, result.FromError(err)
 	}
+	defer emitter.Close()
+
 	return update(ctx, info, planOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newDestroySource,

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -218,17 +218,11 @@ func makeEventEmitter(events chan<- Event, update UpdateInfo) (eventEmitter, err
 						// If the event source has been closed, flush the queue.
 						for _, e := range queue {
 							events <- e
-							if e.Type == CancelEvent {
-								return
-							}
 						}
 						return
 					}
 					queue = append(queue, e)
 				case events <- queue[0]:
-					if queue[0].Type == CancelEvent {
-						return
-					}
 					queue = queue[1:]
 				}
 			}

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -60,6 +60,7 @@ func Query(ctx *Context, u UpdateInfo, opts UpdateOptions) result.Result {
 	if err != nil {
 		return result.FromError(err)
 	}
+	defer emitter.Close()
 
 	// First, load the package metadata and the deployment target in preparation for executing the package's program
 	// and creating resources.  This includes fetching its pwd and main overrides.

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -39,6 +39,7 @@ func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 	if err != nil {
 		return nil, result.FromError(err)
 	}
+	defer emitter.Close()
 
 	// Force opts.Refresh to true.
 	opts.Refresh = true

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -114,6 +114,8 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resour
 	if err != nil {
 		return nil, result.FromError(err)
 	}
+	defer emitter.Close()
+
 	return update(ctx, info, planOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newUpdateSource,


### PR DESCRIPTION
This avoids unnecessary blocking inside pre/post-step callbacks if the
reader on the other side of the event channel is slow.

We do not use a buffered channel in the event pipe because it is
empirically less likely that the goroutine reading from a buffered
channel will be scheduled when new data is placed in the channel. In the
case of our event system in which events will not be delivered to the
service and display until the copying goroutine is scheduled, this can
lead to unacceptable delay between the send of the original event and
its output.