### PR TITLE
Standardize on Stack for backend methods.

### DIFF
--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -493,7 +493,9 @@ func removeStack(t *testing.T, name string) {
 	assert.NoError(t, err)
 	ref, err := b.ParseStackReference(name)
 	assert.NoError(t, err)
-	_, err = b.RemoveStack(context.Background(), ref, false)
+	stack, err := b.GetStack(context.Background(), ref)
+	assert.NoError(t, err)
+	_, err = b.RemoveStack(context.Background(), stack, false)
 	assert.NoError(t, err)
 }
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -123,42 +123,42 @@ type Backend interface {
 	// RemoveStack removes a stack with the given name.  If force is true, the stack will be removed even if it
 	// still contains resources.  Otherwise, if the stack contains resources, a non-nil error is returned, and the
 	// first boolean return value will be set to true.
-	RemoveStack(ctx context.Context, stackRef StackReference, force bool) (bool, error)
+	RemoveStack(ctx context.Context, stack Stack, force bool) (bool, error)
 	// ListStacks returns a list of stack summaries for all known stacks in the target backend.
 	ListStacks(ctx context.Context, filter ListStacksFilter) ([]StackSummary, error)
 
-	RenameStack(ctx context.Context, stackRef StackReference, newName tokens.QName) error
+	RenameStack(ctx context.Context, stack Stack, newName tokens.QName) error
 
 	// Preview shows what would be updated given the current workspace's contents.
-	Preview(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, result.Result)
+	Preview(ctx context.Context, stack Stack, op UpdateOperation) (engine.ResourceChanges, result.Result)
 	// Update updates the target stack with the current workspace's contents (config and code).
-	Update(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, result.Result)
+	Update(ctx context.Context, stack Stack, op UpdateOperation) (engine.ResourceChanges, result.Result)
 	// Refresh refreshes the stack's state from the cloud provider.
-	Refresh(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, result.Result)
+	Refresh(ctx context.Context, stack Stack, op UpdateOperation) (engine.ResourceChanges, result.Result)
 	// Destroy destroys all of this stack's resources.
-	Destroy(ctx context.Context, stackRef StackReference, op UpdateOperation) (engine.ResourceChanges, result.Result)
+	Destroy(ctx context.Context, stack Stack, op UpdateOperation) (engine.ResourceChanges, result.Result)
 
 	// Query against the resource outputs in a stack's state checkpoint.
-	Query(ctx context.Context, stackRef StackReference, op UpdateOperation) result.Result
+	Query(ctx context.Context, stack Stack, op UpdateOperation) result.Result
 
 	// GetHistory returns all updates for the stack. The returned UpdateInfo slice will be in
 	// descending order (newest first).
 	GetHistory(ctx context.Context, stackRef StackReference) ([]UpdateInfo, error)
 	// GetLogs fetches a list of log entries for the given stack, with optional filtering/querying.
-	GetLogs(ctx context.Context, stackRef StackReference, cfg StackConfiguration,
+	GetLogs(ctx context.Context, stack Stack, cfg StackConfiguration,
 		query operations.LogQuery) ([]operations.LogEntry, error)
 	// Get the configuration from the most recent deployment of the stack.
-	GetLatestConfiguration(ctx context.Context, stackRef StackReference) (config.Map, error)
+	GetLatestConfiguration(ctx context.Context, stack Stack) (config.Map, error)
 
 	// GetStackTags fetches the stack's existing tags.
-	GetStackTags(ctx context.Context, stackRef StackReference) (map[apitype.StackTagName]string, error)
+	GetStackTags(ctx context.Context, stack Stack) (map[apitype.StackTagName]string, error)
 	// UpdateStackTags updates the stacks's tags, replacing all existing tags.
-	UpdateStackTags(ctx context.Context, stackRef StackReference, tags map[apitype.StackTagName]string) error
+	UpdateStackTags(ctx context.Context, stack Stack, tags map[apitype.StackTagName]string) error
 
 	// ExportDeployment exports the deployment for the given stack as an opaque JSON message.
-	ExportDeployment(ctx context.Context, stackRef StackReference) (*apitype.UntypedDeployment, error)
+	ExportDeployment(ctx context.Context, stack Stack) (*apitype.UntypedDeployment, error)
 	// ImportDeployment imports the given deployment into the indicated stack.
-	ImportDeployment(ctx context.Context, stackRef StackReference, deployment *apitype.UntypedDeployment) error
+	ImportDeployment(ctx context.Context, stack Stack, deployment *apitype.UntypedDeployment) error
 	// Logout logs you out of the backend and removes any stored credentials.
 	Logout() error
 	// Returns the identity of the current user for the backend.

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -610,17 +610,17 @@ func (b *cloudBackend) ListStacks(
 	return backendSummaries, nil
 }
 
-func (b *cloudBackend) RemoveStack(ctx context.Context, stackRef backend.StackReference, force bool) (bool, error) {
-	stack, err := b.getCloudStackIdentifier(stackRef)
+func (b *cloudBackend) RemoveStack(ctx context.Context, stack backend.Stack, force bool) (bool, error) {
+	stackID, err := b.getCloudStackIdentifier(stack.Ref())
 	if err != nil {
 		return false, err
 	}
 
-	return b.client.DeleteStack(ctx, stack, force)
+	return b.client.DeleteStack(ctx, stackID, force)
 }
 
-func (b *cloudBackend) RenameStack(ctx context.Context, stackRef backend.StackReference, newName tokens.QName) error {
-	stack, err := b.getCloudStackIdentifier(stackRef)
+func (b *cloudBackend) RenameStack(ctx context.Context, stack backend.Stack, newName tokens.QName) error {
+	stackID, err := b.getCloudStackIdentifier(stack.Ref())
 	if err != nil {
 		return err
 	}
@@ -639,13 +639,13 @@ func (b *cloudBackend) RenameStack(ctx context.Context, stackRef backend.StackRe
 
 	// Transferring stack ownership is available to Pulumi admins, but isn't quite ready
 	// for general use yet.
-	if stack.Owner != newIdentity.Owner {
+	if stackID.Owner != newIdentity.Owner {
 		errMsg := "You cannot transfer stack ownership via a rename. If you wish to transfer ownership\n" +
 			"of a stack to another organization, please contact support@pulumi.com."
 		return errors.Errorf(errMsg)
 	}
 
-	return b.client.RenameStack(ctx, stack, newIdentity)
+	return b.client.RenameStack(ctx, stackID, newIdentity)
 }
 
 func getStack(ctx context.Context, b *cloudBackend, stackRef backend.StackReference) (backend.Stack, error) {
@@ -659,13 +659,8 @@ func getStack(ctx context.Context, b *cloudBackend, stackRef backend.StackRefere
 	return stack, nil
 }
 
-func (b *cloudBackend) Preview(ctx context.Context, stackRef backend.StackReference,
+func (b *cloudBackend) Preview(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
-	stack, err := getStack(ctx, b, stackRef)
-	if err != nil {
-		return nil, result.FromError(err)
-	}
-
 	// We can skip PreviewtThenPromptThenExecute, and just go straight to Execute.
 	opts := backend.ApplierOptions{
 		DryRun:   true,
@@ -675,41 +670,23 @@ func (b *cloudBackend) Preview(ctx context.Context, stackRef backend.StackRefere
 		ctx, apitype.PreviewUpdate, stack, op, opts, nil /*events*/)
 }
 
-func (b *cloudBackend) Update(ctx context.Context, stackRef backend.StackReference,
+func (b *cloudBackend) Update(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
-	stack, err := getStack(ctx, b, stackRef)
-	if err != nil {
-		return nil, result.FromError(err)
-	}
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply)
 }
 
-func (b *cloudBackend) Refresh(ctx context.Context, stackRef backend.StackReference,
+func (b *cloudBackend) Refresh(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
-	stack, err := getStack(ctx, b, stackRef)
-	if err != nil {
-		return nil, result.FromError(err)
-	}
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply)
 }
 
-func (b *cloudBackend) Destroy(ctx context.Context, stackRef backend.StackReference,
+func (b *cloudBackend) Destroy(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
-	stack, err := getStack(ctx, b, stackRef)
-	if err != nil {
-		return nil, result.FromError(err)
-	}
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.DestroyUpdate, stack, op, b.apply)
 }
 
-func (b *cloudBackend) Query(ctx context.Context, stackRef backend.StackReference,
+func (b *cloudBackend) Query(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) result.Result {
-
-	stack, err := b.GetStack(ctx, stackRef)
-	if err != nil {
-		return result.FromError(err)
-	}
-
 	return b.query(ctx, stack, op, nil /*events*/)
 }
 
@@ -1031,9 +1008,9 @@ func (b *cloudBackend) GetHistory(ctx context.Context, stackRef backend.StackRef
 }
 
 func (b *cloudBackend) GetLatestConfiguration(ctx context.Context,
-	stackRef backend.StackReference) (config.Map, error) {
+	stack backend.Stack) (config.Map, error) {
 
-	stackID, err := b.getCloudStackIdentifier(stackRef)
+	stackID, err := b.getCloudStackIdentifier(stack.Ref())
 	if err != nil {
 		return nil, err
 	}
@@ -1075,18 +1052,10 @@ func convertConfig(apiConfig map[string]apitype.ConfigValue) (config.Map, error)
 	return c, nil
 }
 
-func (b *cloudBackend) GetLogs(ctx context.Context, stackRef backend.StackReference, cfg backend.StackConfiguration,
+func (b *cloudBackend) GetLogs(ctx context.Context, stack backend.Stack, cfg backend.StackConfiguration,
 	logQuery operations.LogQuery) ([]operations.LogEntry, error) {
 
-	stack, err := b.GetStack(ctx, stackRef)
-	if err != nil {
-		return nil, err
-	}
-	if stack == nil {
-		return nil, errors.New("stack not found")
-	}
-
-	target, targetErr := b.getTarget(ctx, stackRef, cfg.Config, cfg.Decrypter)
+	target, targetErr := b.getTarget(ctx, stack.Ref(), cfg.Config, cfg.Decrypter)
 	if targetErr != nil {
 		return nil, targetErr
 	}
@@ -1094,8 +1063,12 @@ func (b *cloudBackend) GetLogs(ctx context.Context, stackRef backend.StackRefere
 }
 
 func (b *cloudBackend) ExportDeployment(ctx context.Context,
-	stackRef backend.StackReference) (*apitype.UntypedDeployment, error) {
+	stack backend.Stack) (*apitype.UntypedDeployment, error) {
+	return b.exportDeployment(ctx, stack.Ref())
+}
 
+func (b *cloudBackend) exportDeployment(ctx context.Context,
+	stackRef backend.StackReference) (*apitype.UntypedDeployment, error) {
 	stack, err := b.getCloudStackIdentifier(stackRef)
 	if err != nil {
 		return nil, err
@@ -1109,15 +1082,15 @@ func (b *cloudBackend) ExportDeployment(ctx context.Context,
 	return &deployment, nil
 }
 
-func (b *cloudBackend) ImportDeployment(ctx context.Context, stackRef backend.StackReference,
+func (b *cloudBackend) ImportDeployment(ctx context.Context, stack backend.Stack,
 	deployment *apitype.UntypedDeployment) error {
 
-	stack, err := b.getCloudStackIdentifier(stackRef)
+	stackID, err := b.getCloudStackIdentifier(stack.Ref())
 	if err != nil {
 		return err
 	}
 
-	update, err := b.client.ImportStackDeployment(ctx, stack, deployment)
+	update, err := b.client.ImportStackDeployment(ctx, stackID, deployment)
 	if err != nil {
 		return err
 	}
@@ -1326,29 +1299,20 @@ func IsValidAccessToken(ctx context.Context, cloudURL, accessToken string) (bool
 
 // GetStackTags fetches the stack's existing tags.
 func (b *cloudBackend) GetStackTags(ctx context.Context,
-	stackRef backend.StackReference) (map[apitype.StackTagName]string, error) {
-
-	stack, err := b.GetStack(ctx, stackRef)
-	if err != nil {
-		return nil, err
-	}
-	if stack == nil {
-		return nil, errors.New("stack not found")
-	}
-
+	stack backend.Stack) (map[apitype.StackTagName]string, error) {
 	return stack.(Stack).Tags(), nil
 }
 
 // UpdateStackTags updates the stacks's tags, replacing all existing tags.
 func (b *cloudBackend) UpdateStackTags(ctx context.Context,
-	stackRef backend.StackReference, tags map[apitype.StackTagName]string) error {
+	stack backend.Stack, tags map[apitype.StackTagName]string) error {
 
-	stack, err := b.getCloudStackIdentifier(stackRef)
+	stackID, err := b.getCloudStackIdentifier(stack.Ref())
 	if err != nil {
 		return err
 	}
 
-	return b.client.UpdateStackTags(ctx, stack, tags)
+	return b.client.UpdateStackTags(ctx, stackID, tags)
 }
 
 type httpstateBackendClient struct {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -648,17 +648,6 @@ func (b *cloudBackend) RenameStack(ctx context.Context, stack backend.Stack, new
 	return b.client.RenameStack(ctx, stackID, newIdentity)
 }
 
-func getStack(ctx context.Context, b *cloudBackend, stackRef backend.StackReference) (backend.Stack, error) {
-	stack, err := b.GetStack(ctx, stackRef)
-	if err != nil {
-		return nil, err
-	} else if stack == nil {
-		return nil, errors.New("stack not found")
-	}
-
-	return stack, nil
-}
-
 func (b *cloudBackend) Preview(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
 	// We can skip PreviewtThenPromptThenExecute, and just go straight to Execute.

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -272,7 +272,7 @@ func (b *cloudBackend) newUpdate(ctx context.Context, stackRef backend.StackRefe
 }
 
 func (b *cloudBackend) getSnapshot(ctx context.Context, stackRef backend.StackReference) (*deploy.Snapshot, error) {
-	untypedDeployment, err := b.ExportDeployment(ctx, stackRef)
+	untypedDeployment, err := b.exportDeployment(ctx, stackRef)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -40,28 +40,28 @@ type MockBackend struct {
 	DoesProjectExistF       func(context.Context, string) (bool, error)
 	GetStackF               func(context.Context, StackReference) (Stack, error)
 	CreateStackF            func(context.Context, StackReference, interface{}) (Stack, error)
-	RemoveStackF            func(context.Context, StackReference, bool) (bool, error)
+	RemoveStackF            func(context.Context, Stack, bool) (bool, error)
 	ListStacksF             func(context.Context, ListStacksFilter) ([]StackSummary, error)
-	RenameStackF            func(context.Context, StackReference, tokens.QName) error
+	RenameStackF            func(context.Context, Stack, tokens.QName) error
 	GetStackCrypterF        func(StackReference) (config.Crypter, error)
-	QueryF                  func(context.Context, StackReference, UpdateOperation) result.Result
-	GetLatestConfigurationF func(context.Context, StackReference) (config.Map, error)
+	QueryF                  func(context.Context, Stack, UpdateOperation) result.Result
+	GetLatestConfigurationF func(context.Context, Stack) (config.Map, error)
 	GetHistoryF             func(context.Context, StackReference) ([]UpdateInfo, error)
-	GetStackTagsF           func(context.Context, StackReference) (map[apitype.StackTagName]string, error)
-	UpdateStackTagsF        func(context.Context, StackReference, map[apitype.StackTagName]string) error
-	ExportDeploymentF       func(context.Context, StackReference) (*apitype.UntypedDeployment, error)
-	ImportDeploymentF       func(context.Context, StackReference, *apitype.UntypedDeployment) error
+	GetStackTagsF           func(context.Context, Stack) (map[apitype.StackTagName]string, error)
+	UpdateStackTagsF        func(context.Context, Stack, map[apitype.StackTagName]string) error
+	ExportDeploymentF       func(context.Context, Stack) (*apitype.UntypedDeployment, error)
+	ImportDeploymentF       func(context.Context, Stack, *apitype.UntypedDeployment) error
 	LogoutF                 func() error
 	CurrentUserF            func() (string, error)
-	PreviewF                func(context.Context, StackReference,
+	PreviewF                func(context.Context, Stack,
 		UpdateOperation) (engine.ResourceChanges, result.Result)
-	UpdateF func(context.Context, StackReference,
+	UpdateF func(context.Context, Stack,
 		UpdateOperation) (engine.ResourceChanges, result.Result)
-	RefreshF func(context.Context, StackReference,
+	RefreshF func(context.Context, Stack,
 		UpdateOperation) (engine.ResourceChanges, result.Result)
-	DestroyF func(context.Context, StackReference,
+	DestroyF func(context.Context, Stack,
 		UpdateOperation) (engine.ResourceChanges, result.Result)
-	GetLogsF func(context.Context, StackReference, StackConfiguration,
+	GetLogsF func(context.Context, Stack, StackConfiguration,
 		operations.LogQuery) ([]operations.LogEntry, error)
 }
 
@@ -125,9 +125,9 @@ func (be *MockBackend) CreateStack(ctx context.Context, stackRef StackReference,
 	panic("not implemented")
 }
 
-func (be *MockBackend) RemoveStack(ctx context.Context, stackRef StackReference, force bool) (bool, error) {
+func (be *MockBackend) RemoveStack(ctx context.Context, stack Stack, force bool) (bool, error) {
 	if be.RemoveStackF != nil {
-		return be.RemoveStackF(ctx, stackRef, force)
+		return be.RemoveStackF(ctx, stack, force)
 	}
 	panic("not implemented")
 }
@@ -139,9 +139,9 @@ func (be *MockBackend) ListStacks(ctx context.Context, filter ListStacksFilter) 
 	panic("not implemented")
 }
 
-func (be *MockBackend) RenameStack(ctx context.Context, stackRef StackReference, newName tokens.QName) error {
+func (be *MockBackend) RenameStack(ctx context.Context, stack Stack, newName tokens.QName) error {
 	if be.RenameStackF != nil {
-		return be.RenameStackF(ctx, stackRef, newName)
+		return be.RenameStackF(ctx, stack, newName)
 	}
 	panic("not implemented")
 }
@@ -153,47 +153,47 @@ func (be *MockBackend) GetStackCrypter(stackRef StackReference) (config.Crypter,
 	panic("not implemented")
 }
 
-func (be *MockBackend) Preview(ctx context.Context, stackRef StackReference,
+func (be *MockBackend) Preview(ctx context.Context, stack Stack,
 	op UpdateOperation) (engine.ResourceChanges, result.Result) {
 
 	if be.PreviewF != nil {
-		return be.PreviewF(ctx, stackRef, op)
+		return be.PreviewF(ctx, stack, op)
 	}
 	panic("not implemented")
 }
 
-func (be *MockBackend) Update(ctx context.Context, stackRef StackReference,
+func (be *MockBackend) Update(ctx context.Context, stack Stack,
 	op UpdateOperation) (engine.ResourceChanges, result.Result) {
 
 	if be.UpdateF != nil {
-		return be.UpdateF(ctx, stackRef, op)
+		return be.UpdateF(ctx, stack, op)
 	}
 	panic("not implemented")
 }
 
-func (be *MockBackend) Refresh(ctx context.Context, stackRef StackReference,
+func (be *MockBackend) Refresh(ctx context.Context, stack Stack,
 	op UpdateOperation) (engine.ResourceChanges, result.Result) {
 
 	if be.RefreshF != nil {
-		return be.RefreshF(ctx, stackRef, op)
+		return be.RefreshF(ctx, stack, op)
 	}
 	panic("not implemented")
 }
 
-func (be *MockBackend) Destroy(ctx context.Context, stackRef StackReference,
+func (be *MockBackend) Destroy(ctx context.Context, stack Stack,
 	op UpdateOperation) (engine.ResourceChanges, result.Result) {
 
 	if be.DestroyF != nil {
-		return be.DestroyF(ctx, stackRef, op)
+		return be.DestroyF(ctx, stack, op)
 	}
 	panic("not implemented")
 }
 
-func (be *MockBackend) Query(ctx context.Context, stackRef StackReference,
+func (be *MockBackend) Query(ctx context.Context, stack Stack,
 	op UpdateOperation) result.Result {
 
 	if be.QueryF != nil {
-		return be.QueryF(ctx, stackRef, op)
+		return be.QueryF(ctx, stack, op)
 	}
 	panic("not implemented")
 }
@@ -205,56 +205,56 @@ func (be *MockBackend) GetHistory(ctx context.Context, stackRef StackReference) 
 	panic("not implemented")
 }
 
-func (be *MockBackend) GetLogs(ctx context.Context, stackRef StackReference, cfg StackConfiguration,
+func (be *MockBackend) GetLogs(ctx context.Context, stack Stack, cfg StackConfiguration,
 	query operations.LogQuery) ([]operations.LogEntry, error) {
 
 	if be.GetLogsF != nil {
-		return be.GetLogsF(ctx, stackRef, cfg, query)
+		return be.GetLogsF(ctx, stack, cfg, query)
 	}
 	panic("not implemented")
 }
 
 func (be *MockBackend) GetLatestConfiguration(ctx context.Context,
-	stackRef StackReference) (config.Map, error) {
+	stack Stack) (config.Map, error) {
 
 	if be.GetLatestConfigurationF != nil {
-		return be.GetLatestConfigurationF(ctx, stackRef)
+		return be.GetLatestConfigurationF(ctx, stack)
 	}
 	panic("not implemented")
 }
 
 func (be *MockBackend) GetStackTags(ctx context.Context,
-	stackRef StackReference) (map[apitype.StackTagName]string, error) {
+	stack Stack) (map[apitype.StackTagName]string, error) {
 
 	if be.GetStackTagsF != nil {
-		return be.GetStackTagsF(ctx, stackRef)
+		return be.GetStackTagsF(ctx, stack)
 	}
 	panic("not implemented")
 }
 
-func (be *MockBackend) UpdateStackTags(ctx context.Context, stackRef StackReference,
+func (be *MockBackend) UpdateStackTags(ctx context.Context, stack Stack,
 	tags map[apitype.StackTagName]string) error {
 
 	if be.UpdateStackTagsF != nil {
-		return be.UpdateStackTagsF(ctx, stackRef, tags)
+		return be.UpdateStackTagsF(ctx, stack, tags)
 	}
 	panic("not implemented")
 }
 
 func (be *MockBackend) ExportDeployment(ctx context.Context,
-	stackRef StackReference) (*apitype.UntypedDeployment, error) {
+	stack Stack) (*apitype.UntypedDeployment, error) {
 
 	if be.ExportDeploymentF != nil {
-		return be.ExportDeploymentF(ctx, stackRef)
+		return be.ExportDeploymentF(ctx, stack)
 	}
 	panic("not implemented")
 }
 
-func (be *MockBackend) ImportDeployment(ctx context.Context, stackRef StackReference,
+func (be *MockBackend) ImportDeployment(ctx context.Context, stack Stack,
 	deployment *apitype.UntypedDeployment) error {
 
 	if be.ImportDeploymentF != nil {
-		return be.ImportDeploymentF(ctx, stackRef, deployment)
+		return be.ImportDeploymentF(ctx, stack, deployment)
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -64,67 +64,67 @@ type Stack interface {
 
 // Query executes a query program against a stack's resource outputs.
 func Query(ctx context.Context, s Stack, op UpdateOperation) result.Result {
-	return s.Backend().Query(ctx, s.Ref(), op)
+	return s.Backend().Query(ctx, s, op)
 }
 
 // RemoveStack returns the stack, or returns an error if it cannot.
 func RemoveStack(ctx context.Context, s Stack, force bool) (bool, error) {
-	return s.Backend().RemoveStack(ctx, s.Ref(), force)
+	return s.Backend().RemoveStack(ctx, s, force)
 }
 
 func RenameStack(ctx context.Context, s Stack, newName tokens.QName) error {
-	return s.Backend().RenameStack(ctx, s.Ref(), newName)
+	return s.Backend().RenameStack(ctx, s, newName)
 }
 
 // PreviewStack previews changes to this stack.
 func PreviewStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, result.Result) {
-	return s.Backend().Preview(ctx, s.Ref(), op)
+	return s.Backend().Preview(ctx, s, op)
 }
 
 // UpdateStack updates the target stack with the current workspace's contents (config and code).
 func UpdateStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, result.Result) {
-	return s.Backend().Update(ctx, s.Ref(), op)
+	return s.Backend().Update(ctx, s, op)
 }
 
 // RefreshStack refresh's the stack's state from the cloud provider.
 func RefreshStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, result.Result) {
-	return s.Backend().Refresh(ctx, s.Ref(), op)
+	return s.Backend().Refresh(ctx, s, op)
 }
 
 // DestroyStack destroys all of this stack's resources.
 func DestroyStack(ctx context.Context, s Stack, op UpdateOperation) (engine.ResourceChanges, result.Result) {
-	return s.Backend().Destroy(ctx, s.Ref(), op)
+	return s.Backend().Destroy(ctx, s, op)
 }
 
 // GetLatestConfiguration returns the configuration for the most recent deployment of the stack.
 func GetLatestConfiguration(ctx context.Context, s Stack) (config.Map, error) {
-	return s.Backend().GetLatestConfiguration(ctx, s.Ref())
+	return s.Backend().GetLatestConfiguration(ctx, s)
 }
 
 // GetStackLogs fetches a list of log entries for the current stack in the current backend.
 func GetStackLogs(ctx context.Context, s Stack, cfg StackConfiguration,
 	query operations.LogQuery) ([]operations.LogEntry, error) {
-	return s.Backend().GetLogs(ctx, s.Ref(), cfg, query)
+	return s.Backend().GetLogs(ctx, s, cfg, query)
 }
 
 // ExportStackDeployment exports the given stack's deployment as an opaque JSON message.
 func ExportStackDeployment(ctx context.Context, s Stack) (*apitype.UntypedDeployment, error) {
-	return s.Backend().ExportDeployment(ctx, s.Ref())
+	return s.Backend().ExportDeployment(ctx, s)
 }
 
 // ImportStackDeployment imports the given deployment into the indicated stack.
 func ImportStackDeployment(ctx context.Context, s Stack, deployment *apitype.UntypedDeployment) error {
-	return s.Backend().ImportDeployment(ctx, s.Ref(), deployment)
+	return s.Backend().ImportDeployment(ctx, s, deployment)
 }
 
 // GetStackTags fetches the stack's existing tags.
 func GetStackTags(ctx context.Context, s Stack) (map[apitype.StackTagName]string, error) {
-	return s.Backend().GetStackTags(ctx, s.Ref())
+	return s.Backend().GetStackTags(ctx, s)
 }
 
 // UpdateStackTags updates the stacks's tags, replacing all existing tags.
 func UpdateStackTags(ctx context.Context, s Stack, tags map[apitype.StackTagName]string) error {
-	return s.Backend().UpdateStackTags(ctx, s.Ref(), tags)
+	return s.Backend().UpdateStackTags(ctx, s, tags)
 }
 
 // GetMergedStackTags returns the stack's existing tags merged with fresh tags from the environment


### PR DESCRIPTION
The current pattern of using backend.Stack values in the CLI but
accepting backend.StackReference values in backend methods leads to
frequent transitions between these types. In the case of the HTTP
backend, the transition from a StackReference to a Stack requires an API
call. These changes refactor the backend.Backend API such that most of
its methods accept backend.Stack values in place of
backend.StackReference values, which avoids these transitions.

This removes two calls to the getStack API on the startup path of a
`pulumi preview`.