### PR TITLE
Cache account information.

### DIFF
--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -184,7 +184,7 @@ func Login(d diag.Sink, url string) (Backend, error) {
 	if err != nil {
 		return nil, err
 	}
-	return be, workspace.StoreAccessToken(be.URL(), "", true)
+	return be, workspace.StoreAccount(be.URL(), workspace.Account{}, true)
 }
 
 func (b *localBackend) local() {}
@@ -645,7 +645,7 @@ func (b *localBackend) ImportDeployment(ctx context.Context, stk backend.Stack,
 }
 
 func (b *localBackend) Logout() error {
-	return workspace.DeleteAccessToken(b.originalURL)
+	return workspace.DeleteAccount(b.originalURL)
 }
 
 func (b *localBackend) CurrentUser() (string, error) {

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -216,7 +216,7 @@ func loginWithBrowser(ctx context.Context, d diag.Sink, cloudURL string, opts di
 	}
 
 	// Save the token and return the backend
-	account := workspace.Account{AccessToken: accessToken, Username: username}
+	account := workspace.Account{AccessToken: accessToken, Username: username, LastValidatedAt: time.Now()}
 	if err = workspace.StoreAccount(cloudURL, account, true); err != nil {
 		return nil, err
 	}
@@ -236,12 +236,12 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	if err == nil && existingAccount.AccessToken != "" {
 		// If the account was last verified less than an hour ago, assume the token is valid.
 		valid, username := true, existingAccount.Username
-		if username == "" || existingAccount.LastUse.Add(1*time.Hour).Before(time.Now()) {
+		if username == "" || existingAccount.LastValidatedAt.Add(1*time.Hour).Before(time.Now()) {
 			valid, username, err = IsValidAccessToken(ctx, cloudURL, existingAccount.AccessToken)
 			if err != nil {
 				return nil, err
 			}
-			existingAccount.LastUse = time.Now()
+			existingAccount.LastValidatedAt = time.Now()
 		}
 
 		if valid {
@@ -335,7 +335,7 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	}
 
 	// Save them.
-	account := workspace.Account{AccessToken: accessToken, Username: username}
+	account := workspace.Account{AccessToken: accessToken, Username: username, LastValidatedAt: time.Now()}
 	if err = workspace.StoreAccount(cloudURL, account, true); err != nil {
 		return nil, err
 	}

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -101,10 +101,11 @@ func NewServiceSecretsManagerFromState(state json.RawMessage) (secrets.Manager, 
 		return nil, errors.Wrap(err, "unmarshalling state")
 	}
 
-	token, err := workspace.GetAccessToken(s.URL)
+	account, err := workspace.GetAccount(s.URL)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting access token")
 	}
+	token := account.AccessToken
 
 	if token == "" {
 		return nil, errors.Errorf("could not find access token for %s, have you logged in?", s.URL)

--- a/pkg/workspace/creds.go
+++ b/pkg/workspace/creds.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -30,20 +31,24 @@ import (
 // credentials or tests interacting with one another
 const PulumiCredentialsPathEnvVar = "PULUMI_CREDENTIALS_PATH"
 
-// GetAccessToken returns an access token underneath a given key.
-func GetAccessToken(key string) (string, error) {
+// GetAccount returns an account underneath a given key.
+func GetAccount(key string) (Account, error) {
 	creds, err := GetStoredCredentials()
 	if err != nil && !os.IsNotExist(err) {
-		return "", err
+		return Account{}, err
 	}
-	if creds.AccessTokens == nil {
-		return "", nil
+	if creds.Accounts == nil {
+		token, ok := creds.AccessTokens[key]
+		if !ok {
+			return Account{}, nil
+		}
+		return Account{AccessToken: token}, nil
 	}
-	return creds.AccessTokens[key], nil
+	return creds.Accounts[key], nil
 }
 
-// DeleteAccessToken deletes an access token underneath the given key.
-func DeleteAccessToken(key string) error {
+// DeleteAccount deletes an account underneath the given key.
+func DeleteAccount(key string) error {
 	creds, err := GetStoredCredentials()
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -51,14 +56,17 @@ func DeleteAccessToken(key string) error {
 	if creds.AccessTokens != nil {
 		delete(creds.AccessTokens, key)
 	}
+	if creds.Accounts != nil {
+		delete(creds.Accounts, key)
+	}
 	if creds.Current == key {
 		creds.Current = ""
 	}
 	return StoreCredentials(creds)
 }
 
-// StoreAccessToken saves the given access token underneath the given key.
-func StoreAccessToken(key string, token string, current bool) error {
+// StoreAccount saves the given account underneath the given key.
+func StoreAccount(key string, account Account, current bool) error {
 	creds, err := GetStoredCredentials()
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -66,18 +74,29 @@ func StoreAccessToken(key string, token string, current bool) error {
 	if creds.AccessTokens == nil {
 		creds.AccessTokens = make(map[string]string)
 	}
-	creds.AccessTokens[key] = token
+	if creds.Accounts == nil {
+		creds.Accounts = make(map[string]Account)
+	}
+	creds.AccessTokens[key], creds.Accounts[key] = account.AccessToken, account
 	if current {
 		creds.Current = key
 	}
 	return StoreCredentials(creds)
 }
 
+// Account holds the information associated with a Pulumi account.
+type Account struct {
+	AccessToken string    `json:"accessToken,omitempty"` // The access token for this account.
+	Username    string    `json:"username,omitempty"`    // The username for this account.
+	LastUse     time.Time `json:"lastUse,omitempty"`     // The last time this token was used.
+}
+
 // Credentials hold the information necessary for authenticating Pulumi Cloud API requests.  It contains
 // a map from the cloud API URL to the associated access token.
 type Credentials struct {
-	Current      string            `json:"current,omitempty"`      // the currently selected key.
-	AccessTokens map[string]string `json:"accessTokens,omitempty"` // a map of arbitrary key strings to tokens.
+	Current      string             `json:"current,omitempty"`      // the currently selected key.
+	AccessTokens map[string]string  `json:"accessTokens,omitempty"` // a map of arbitrary key strings to tokens.
+	Accounts     map[string]Account `json:"accounts,omitempty"`     // a map of arbitrary keys to account info.
 }
 
 // getCredsFilePath returns the path to the Pulumi credentials file on disk, regardless of


### PR DESCRIPTION
- Cache the username and last verified time associated with each logged-in
  backend
- In the HTTP backend, verify the access token explicitly at most once
  per hour

This trades off a little bit of usability for improved inner-loop
latency: if a user's API token becomes invalid less than an hour after
it was last verified, the user will see 4xx errors when attempting stack
operations rather than seeing the login prompt.