### PR TITLE
Support lists and maps in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ CHANGELOG
   change, and users should see https://www.pulumi.com/docs/troubleshooting/#synchronous-call for
   details on adjusting their code if needed.
 
+- Support for lists and maps in config.
+
 ## 1.3.1 (2019-10-09)
 
 - Revert "propagate resource inputs to resource state during preview". These changes had a critical issue that needs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ CHANGELOG
 - `pulumi stack` now renders the stack as a tree view.
   [#3430](https://github.com/pulumi/pulumi/pull/3430)
 
+- Support for lists and maps in config.
+  [#3342](https://github.com/pulumi/pulumi/pull/3342)
+
 ## 1.4.0 (2019-10-24)
 
 - `FileAsset` in the Python SDK now accepts anything implementing `os.PathLike` in addition to `str`.
@@ -51,8 +54,6 @@ CHANGELOG
   Some less common existing styles of using `getResource` calls are also deprecated as part of this
   change, and users should see https://www.pulumi.com/docs/troubleshooting/#synchronous-call for
   details on adjusting their code if needed.
-
-- Support for lists and maps in config.
 
 ## 1.3.1 (2019-10-09)
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -410,10 +410,10 @@ func prettyKeyForProject(k config.Key, proj *workspace.Project) string {
 // structure in the future, we should not change existing fields.
 type configValueJSON struct {
 	// When the value is encrypted and --show-secrets was not passed, the value will not be set.
+	// If the value is an object, ObjectValue will be set.
 	Value       *string     `json:"value,omitempty"`
-	Secret      bool        `json:"secret"`
-	Object      bool        `json:"object"`
 	ObjectValue interface{} `json:"objectValue,omitempty"`
+	Secret      bool        `json:"secret"`
 }
 
 func listConfig(stack backend.Stack, showSecrets bool, jsonOut bool) error {
@@ -447,7 +447,6 @@ func listConfig(stack backend.Stack, showSecrets bool, jsonOut bool) error {
 		for _, key := range keys {
 			entry := configValueJSON{
 				Secret: cfg[key].Secure(),
-				Object: cfg[key].Object(),
 			}
 
 			decrypted, err := cfg[key].Value(decrypter)
@@ -530,7 +529,6 @@ func getConfig(stack backend.Stack, key config.Key, path, jsonOut bool) error {
 			value := configValueJSON{
 				Value:  &raw,
 				Secret: v.Secure(),
-				Object: v.Object(),
 			}
 
 			if v.Object() {

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -118,11 +119,20 @@ func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter
 		for k, v := range update.Config {
 			configValue := configValueJSON{
 				Secret: v.Secure(),
+				Object: v.Object(),
 			}
 			if !v.Secure() || (v.Secure() && decrypter != nil) {
 				value, err := v.Value(decrypter)
 				contract.AssertNoError(err)
 				configValue.Value = makeStringRef(value)
+
+				if v.Object() {
+					var obj interface{}
+					if err := json.Unmarshal([]byte(value), &obj); err != nil {
+						return err
+					}
+					configValue.ObjectValue = obj
+				}
 			}
 
 			info.Config[k.String()] = configValue

--- a/cmd/history.go
+++ b/cmd/history.go
@@ -119,7 +119,6 @@ func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter
 		for k, v := range update.Config {
 			configValue := configValueJSON{
 				Secret: v.Secure(),
-				Object: v.Object(),
 			}
 			if !v.Secure() || (v.Secure() && decrypter != nil) {
 				value, err := v.Value(decrypter)

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -61,6 +61,7 @@ type newArgs struct {
 	stack             string
 	templateNameOrURL string
 	yes               bool
+	path              bool
 }
 
 func runNew(args newArgs) error {
@@ -253,7 +254,8 @@ func runNew(args newArgs) error {
 
 	// Prompt for config values (if needed) and save.
 	if !args.generateOnly {
-		if err = handleConfig(s, args.templateNameOrURL, template, args.configArray, args.yes, opts); err != nil {
+		err = handleConfig(s, args.templateNameOrURL, template, args.configArray, args.yes, args.path, opts)
+		if err != nil {
 			return err
 		}
 	}
@@ -384,6 +386,9 @@ func newNewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVarP(
 		&args.configArray, "config", "c", []string{},
 		"Config to save")
+	cmd.PersistentFlags().BoolVar(
+		&args.path, "path", false,
+		"Config keys contain a path to a property in a map or list to set")
 	cmd.PersistentFlags().StringVarP(
 		&args.description, "description", "d", "",
 		"The project description; if not specified, a prompt will request it")
@@ -724,7 +729,7 @@ func chooseTemplate(templates []workspace.Template, opts display.Options) (works
 // These are passed as `-c aws:region=us-east-1 -c foo:bar=blah` and end up
 // in configArray as ["aws:region=us-east-1", "foo:bar=blah"].
 // This function converts the array into a config.Map.
-func parseConfig(configArray []string) (config.Map, error) {
+func parseConfig(configArray []string, path bool) (config.Map, error) {
 	configMap := make(config.Map)
 	for _, c := range configArray {
 		kvp := strings.SplitN(c, "=", 2)
@@ -739,7 +744,9 @@ func parseConfig(configArray []string) (config.Map, error) {
 			value = config.NewValue(kvp[1])
 		}
 
-		configMap[key] = value
+		if err = configMap.Set(key, value, path); err != nil {
+			return nil, err
+		}
 	}
 	return configMap, nil
 }

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -49,6 +49,7 @@ type promptForValueFunc func(yes bool, valueType string, defaultValue string, se
 
 type newArgs struct {
 	configArray       []string
+	configPath        bool
 	description       string
 	dir               string
 	force             bool
@@ -61,7 +62,6 @@ type newArgs struct {
 	stack             string
 	templateNameOrURL string
 	yes               bool
-	path              bool
 }
 
 func runNew(args newArgs) error {
@@ -254,7 +254,7 @@ func runNew(args newArgs) error {
 
 	// Prompt for config values (if needed) and save.
 	if !args.generateOnly {
-		err = handleConfig(s, args.templateNameOrURL, template, args.configArray, args.yes, args.path, opts)
+		err = handleConfig(s, args.templateNameOrURL, template, args.configArray, args.yes, args.configPath, opts)
 		if err != nil {
 			return err
 		}
@@ -387,7 +387,7 @@ func newNewCmd() *cobra.Command {
 		&args.configArray, "config", "c", []string{},
 		"Config to save")
 	cmd.PersistentFlags().BoolVar(
-		&args.path, "path", false,
+		&args.configPath, "config-path", false,
 		"Config keys contain a path to a property in a map or list to set")
 	cmd.PersistentFlags().StringVarP(
 		&args.description, "description", "d", "",

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -31,6 +31,7 @@ func newPreviewCmd() *cobra.Command {
 	var message string
 	var stack string
 	var configArray []string
+	var path bool
 
 	// Flags for engine.UpdateOptions.
 	var policyPackPaths []string
@@ -95,7 +96,7 @@ func newPreviewCmd() *cobra.Command {
 			}
 
 			// Save any config values passed via flags.
-			if err := parseAndSaveConfigArray(s, configArray); err != nil {
+			if err := parseAndSaveConfigArray(s, configArray, path); err != nil {
 				return result.FromError(err)
 			}
 
@@ -155,6 +156,9 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the preview")
+	cmd.PersistentFlags().BoolVar(
+		&path, "path", false,
+		"Config keys contain a path to a property in a map or list to set")
 
 	cmd.PersistentFlags().StringVarP(
 		&message, "message", "m", "",

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -31,7 +31,7 @@ func newPreviewCmd() *cobra.Command {
 	var message string
 	var stack string
 	var configArray []string
-	var path bool
+	var configPath bool
 
 	// Flags for engine.UpdateOptions.
 	var policyPackPaths []string
@@ -96,7 +96,7 @@ func newPreviewCmd() *cobra.Command {
 			}
 
 			// Save any config values passed via flags.
-			if err := parseAndSaveConfigArray(s, configArray, path); err != nil {
+			if err := parseAndSaveConfigArray(s, configArray, configPath); err != nil {
 				return result.FromError(err)
 			}
 
@@ -157,7 +157,7 @@ func newPreviewCmd() *cobra.Command {
 		&configArray, "config", "c", []string{},
 		"Config to use during the preview")
 	cmd.PersistentFlags().BoolVar(
-		&path, "path", false,
+		&configPath, "config-path", false,
 		"Config keys contain a path to a property in a map or list to set")
 
 	cmd.PersistentFlags().StringVarP(

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -381,7 +381,7 @@ func newUpCmd() *cobra.Command {
 		&configArray, "config", "c", []string{},
 		"Config to use during the update")
 	cmd.PersistentFlags().BoolVar(
-		&path, "path", false,
+		&path, "config-path", false,
 		"Config keys contain a path to a property in a map or list to set")
 	cmd.PersistentFlags().StringVar(
 		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -51,6 +51,7 @@ func newUpCmd() *cobra.Command {
 	var message string
 	var stack string
 	var configArray []string
+	var path bool
 
 	// Flags for engine.UpdateOptions.
 	var policyPackPaths []string
@@ -78,7 +79,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// Save any config values passed via flags.
-		if err := parseAndSaveConfigArray(s, configArray); err != nil {
+		if err := parseAndSaveConfigArray(s, configArray, path); err != nil {
 			return result.FromError(err)
 		}
 
@@ -253,7 +254,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// Prompt for config values (if needed) and save.
-		if err = handleConfig(s, templateNameOrURL, template, configArray, yes, opts.Display); err != nil {
+		if err = handleConfig(s, templateNameOrURL, template, configArray, yes, path, opts.Display); err != nil {
 			return result.FromError(err)
 		}
 
@@ -379,6 +380,9 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVarP(
 		&configArray, "config", "c", []string{},
 		"Config to use during the update")
+	cmd.PersistentFlags().BoolVar(
+		&path, "path", false,
+		"Config keys contain a path to a property in a map or list to set")
 	cmd.PersistentFlags().StringVar(
 		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
 			"decrypt secrets (possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault). Only"+
@@ -454,6 +458,7 @@ func handleConfig(
 	template workspace.Template,
 	configArray []string,
 	yes bool,
+	path bool,
 	opts display.Options) error {
 
 	// Get the existing config. stackConfig will be nil if there wasn't a previous deployment.
@@ -480,7 +485,7 @@ func handleConfig(
 		// the stack's `pulumi:template` config value.
 	} else {
 		// Get config values passed on the command line.
-		commandLineConfig, parseErr := parseConfig(configArray)
+		commandLineConfig, parseErr := parseConfig(configArray, path)
 		if parseErr != nil {
 			return parseErr
 		}

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -315,11 +315,11 @@ func chooseStack(
 
 // parseAndSaveConfigArray parses the config array and saves it as a config for
 // the provided stack.
-func parseAndSaveConfigArray(s backend.Stack, configArray []string) error {
+func parseAndSaveConfigArray(s backend.Stack, configArray []string, path bool) error {
 	if len(configArray) == 0 {
 		return nil
 	}
-	commandLineConfig, err := parseConfig(configArray)
+	commandLineConfig, err := parseConfig(configArray, path)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1007,10 +1007,18 @@ func convertConfig(apiConfig map[string]apitype.ConfigValue) (config.Map, error)
 		if err != nil {
 			return nil, err
 		}
-		if rawV.Secret {
-			c[k] = config.NewSecureValue(rawV.String)
+		if rawV.Object {
+			if rawV.Secret {
+				c[k] = config.NewSecureObjectValue(rawV.String)
+			} else {
+				c[k] = config.NewObjectValue(rawV.String)
+			}
 		} else {
-			c[k] = config.NewValue(rawV.String)
+			if rawV.Secret {
+				c[k] = config.NewSecureValue(rawV.String)
+			} else {
+				c[k] = config.NewValue(rawV.String)
+			}
 		}
 	}
 	return c, nil

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -224,10 +224,18 @@ func (pc *Client) GetLatestConfiguration(ctx context.Context, stackID StackIdent
 		if err != nil {
 			return nil, err
 		}
-		if v.Secret {
-			cfg[newKey] = config.NewSecureValue(v.String)
+		if v.Object {
+			if v.Secret {
+				cfg[newKey] = config.NewSecureObjectValue(v.String)
+			} else {
+				cfg[newKey] = config.NewObjectValue(v.String)
+			}
 		} else {
-			cfg[newKey] = config.NewValue(v.String)
+			if v.Secret {
+				cfg[newKey] = config.NewSecureValue(v.String)
+			} else {
+				cfg[newKey] = config.NewValue(v.String)
+			}
 		}
 	}
 
@@ -387,6 +395,7 @@ func (pc *Client) CreateUpdate(
 		wireConfig[k.String()] = apitype.ConfigValue{
 			String: v,
 			Secret: cv.Secure(),
+			Object: cv.Object(),
 		}
 	}
 

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -175,14 +175,14 @@ func makeEventEmitter(events chan<- Event, update UpdateInfo) (eventEmitter, err
 				continue
 			}
 
-			secret, err := v.Value(target.Decrypter)
+			secureValues, err := v.SecureValues(target.Decrypter)
 			if err != nil {
 				return eventEmitter{}, DecryptError{
 					Key: k,
 					Err: err,
 				}
 			}
-			secrets = append(secrets, secret)
+			secrets = append(secrets, secureValues...)
 		}
 	}
 

--- a/pkg/resource/asset.go
+++ b/pkg/resource/asset.go
@@ -38,7 +38,12 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/util/contract"
 	"github.com/pulumi/pulumi/pkg/util/httputil"
-	"github.com/pulumi/pulumi/pkg/workspace"
+)
+
+const (
+	// BookkeepingDir is the name of our bookkeeping folder, we store state here (like .git for git).
+	// Copied from workspace.BookkeepingDir to break import cycle.
+	BookkeepingDir = ".pulumi"
 )
 
 // Asset is a serialized asset reference.  It is a union: thus, only one of its fields will be non-nil.  Several helper
@@ -828,7 +833,7 @@ func (a *Archive) readPath() (ArchiveReader, error) {
 
 			// If this is a .pulumi directory, we will skip this by default.
 			// TODO[pulumi/pulumi#122]: when we support .pulumiignore, this will be customizable.
-			if f.Name() == workspace.BookkeepingDir {
+			if f.Name() == BookkeepingDir {
 				if f.IsDir() {
 					return filepath.SkipDir
 				}

--- a/pkg/resource/config/map.go
+++ b/pkg/resource/config/map.go
@@ -16,9 +16,17 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
 
 	"github.com/pkg/errors"
+
+	"github.com/pulumi/pulumi/pkg/resource"
 )
+
+var errSecureKeyReserved = errors.New(`"secure" key in maps of length 1 are reserved`)
 
 // Map is a bag of config stored in the settings file.
 type Map map[Key]Value
@@ -45,6 +53,253 @@ func (m Map) HasSecureValue() bool {
 	}
 
 	return false
+}
+
+// Get gets the value for a given key. If path is true, the key's name portion is treated as a path.
+func (m Map) Get(k Key, path bool) (Value, bool, error) {
+	// If the key isn't a path, go ahead and lookup the value.
+	if !path {
+		v, ok := m[k]
+		return v, ok, nil
+	}
+
+	// Otherwise, parse the path and get the new config key.
+	p, configKey, err := parseKeyPath(k)
+	if err != nil {
+		return Value{}, false, err
+	}
+
+	// If we only have a single path segment, go ahead and lookup the value.
+	if len(p) == 1 {
+		v, ok := m[configKey]
+		return v, ok, nil
+	}
+
+	// Otherwise, lookup the current root value and save it into a temporary map.
+	root := make(map[string]interface{})
+	if val, ok := m[configKey]; ok {
+		obj, err := val.ToObject()
+		if err != nil {
+			return Value{}, false, err
+		}
+		root[configKey.Name()] = obj
+	}
+
+	// Get the value within the object.
+	_, v, ok := getValueForPath(root, p)
+	if !ok {
+		return Value{}, false, nil
+	}
+
+	// If the value is a secure value, return it as one.
+	if is, s := isSecureValue(v); is {
+		return NewSecureValue(s), true, nil
+	}
+
+	// If it's a simple type, return it as a regular value.
+	switch t := v.(type) {
+	case string:
+		return NewValue(t), true, nil
+	case bool, int, uint, int32, uint32, int64, uint64, float32, float64:
+		return NewValue(fmt.Sprintf("%v", v)), true, nil
+	}
+
+	// Otherwise, return it as an object value.
+	json, err := json.Marshal(v)
+	if err != nil {
+		return Value{}, false, err
+	}
+	if hasSecureValue(v) {
+		return NewSecureObjectValue(string(json)), true, nil
+	}
+	return NewObjectValue(string(json)), true, nil
+}
+
+// Remove removes the value for a given key. If path is true, the key's name portion is treated as a path.
+func (m Map) Remove(k Key, path bool) error {
+	// If the key isn't a path, go ahead and delete it and return.
+	if !path {
+		delete(m, k)
+		return nil
+	}
+
+	// Parse the path.
+	p, err := resource.ParsePropertyPath(k.Name())
+	if err != nil {
+		return errors.Wrap(err, "invalid config key path")
+	}
+	if len(p) == 0 {
+		return nil
+	}
+	firstKey, ok := p[0].(string)
+	if !ok || firstKey == "" {
+		return nil
+	}
+	configKey := MustMakeKey(k.Namespace(), firstKey)
+
+	// If we only have a single path segment, delete the key and return.
+	if len(p) == 1 {
+		delete(m, configKey)
+		return nil
+	}
+
+	// Otherwise, lookup the current root value and save it into a temporary map.
+	root := make(map[string]interface{})
+	if val, ok := m[configKey]; ok {
+		obj, err := val.ToObject()
+		if err != nil {
+			return err
+		}
+		root[configKey.Name()] = obj
+	}
+
+	// Get the value within the object up to the second-to-last path segment.
+	// If not found, exit early.
+	parent, dest, ok := getValueForPath(root, p[:len(p)-1])
+	if !ok {
+		return nil
+	}
+
+	// Remove the last path segment.
+	key := p[len(p)-1]
+	switch t := dest.(type) {
+	case []interface{}:
+		index, ok := key.(int)
+		if !ok || index < 0 || index >= len(t) {
+			return nil
+		}
+		t = append(t[:index], t[index+1:]...)
+		// Since we changed the array, we need to update the parent.
+		if parent != nil {
+			pkey := p[len(p)-2]
+			if _, err := setValue(parent, pkey, t, nil, nil); err != nil {
+				return err
+			}
+		}
+	case map[string]interface{}:
+		k, ok := key.(string)
+		if !ok {
+			return nil
+		}
+		delete(t, k)
+
+		// Secure values are reserved, so return an error when attempting to add one.
+		if isSecure, _ := isSecureValue(t); isSecure {
+			return errSecureKeyReserved
+		}
+	}
+
+	// Now, marshal then unmarshal the value, which will handle detecting
+	// whether it's a secure object or not.
+	jsonBytes, err := json.Marshal(root[configKey.Name()])
+	if err != nil {
+		return err
+	}
+	var v Value
+	if err = json.Unmarshal(jsonBytes, &v); err != nil {
+		return err
+	}
+
+	m[configKey] = v
+	return nil
+}
+
+// Set sets the value for a given key. If path is true, the key's name portion is treated as a path.
+func (m Map) Set(k Key, v Value, path bool) error {
+	// If the key isn't a path, go ahead and set the value and return.
+	if !path {
+		m[k] = v
+		return nil
+	}
+
+	// Otherwise, parse the path and get the new config key.
+	p, configKey, err := parseKeyPath(k)
+	if err != nil {
+		return err
+	}
+
+	// If we only have a single path segment, set the value and return.
+	if len(p) == 1 {
+		m[configKey] = v
+		return nil
+	}
+
+	// Otherwise, lookup the current value and save it into a temporary map.
+	root := make(map[string]interface{})
+	if val, ok := m[configKey]; ok {
+		obj, err := val.ToObject()
+		if err != nil {
+			return err
+		}
+		root[configKey.Name()] = obj
+	}
+
+	// Now, loop through the path segments, and walk the object tree.
+	// If the value for a given segment is nil or isn't the expected type, create a new array/map.
+	// The root map is the initial cursor value, and parent is nil.
+	var parent interface{}
+	var parentKey interface{}
+	var cursor interface{}
+	var cursorKey interface{}
+	cursor = root
+	cursorKey = p[0]
+	for _, pkey := range p[1:] {
+		pvalue, err := getValue(cursor, cursorKey)
+		if err != nil {
+			return err
+		}
+
+		// If the value is nil or isn't the expected type for the path segment key, create a new array/map.
+		var newValue interface{}
+		switch pkey.(type) {
+		case int:
+			if _, ok := pvalue.([]interface{}); !ok {
+				newValue = make([]interface{}, 0)
+			}
+		case string:
+			if _, ok := pvalue.(map[string]interface{}); !ok {
+				newValue = make(map[string]interface{})
+			}
+		default:
+			contract.Failf("unexpected path type")
+		}
+		if newValue != nil {
+			pvalue = newValue
+			cursor, err = setValue(cursor, cursorKey, pvalue, parent, parentKey)
+			if err != nil {
+				return err
+			}
+		}
+
+		parent = cursor
+		parentKey = cursorKey
+		cursor = pvalue
+		cursorKey = pkey
+	}
+
+	// Adjust the value (e.g. convert "true"/"false" to booleans and integers to ints) and set it.
+	adjustedValue := adjustObjectValue(v, path)
+	if _, err = setValue(cursor, cursorKey, adjustedValue, parent, parentKey); err != nil {
+		return err
+	}
+
+	// Secure values are reserved, so return an error when attempting to add one.
+	if isSecure, _ := isSecureValue(cursor); isSecure {
+		return errSecureKeyReserved
+	}
+
+	// Serialize the updated object as JSON, and save it in the config map.
+	json, err := json.Marshal(root[configKey.Name()])
+	if err != nil {
+		return err
+	}
+	if v.Secure() {
+		m[configKey] = NewSecureObjectValue(string(json))
+	} else {
+		m[configKey] = NewObjectValue(string(json))
+	}
+
+	return nil
 }
 
 func (m Map) MarshalJSON() ([]byte, error) {
@@ -103,4 +358,154 @@ func (m *Map) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	*m = newMap
 	return nil
+}
+
+// parseKeyPath returns the property paths in the key and a new config key with the first
+// path segment as the name.
+func parseKeyPath(k Key) (resource.PropertyPath, Key, error) {
+	// Parse the path, which will be in the name portion of the key.
+	p, err := resource.ParsePropertyPath(k.Name())
+	if err != nil {
+		return nil, Key{}, errors.Wrap(err, "invalid config key path")
+	}
+	if len(p) == 0 {
+		return nil, Key{}, errors.New("empty config key path")
+	}
+
+	// Create a new key that has the first path segment as the name.
+	firstKey, ok := p[0].(string)
+	if !ok {
+		return nil, Key{}, errors.New("first path segement of config key must be a string")
+	}
+	if firstKey == "" {
+		return nil, Key{}, errors.New("config key is empty")
+	}
+
+	configKey := MustMakeKey(k.Namespace(), firstKey)
+
+	return p, configKey, nil
+}
+
+// getValueForPath returns the parent, value, and true if the value is found in source given the path segments in p.
+func getValueForPath(source interface{}, p resource.PropertyPath) (interface{}, interface{}, bool) {
+	// If the source is nil, exit early.
+	if source == nil {
+		return nil, nil, false
+	}
+
+	// Lookup the value by each path segment.
+	var parent interface{}
+	v := source
+	for _, key := range p {
+		parent = v
+		switch t := v.(type) {
+		case []interface{}:
+			index, ok := key.(int)
+			if !ok || index < 0 || index >= len(t) {
+				return nil, nil, false
+			}
+			v = t[index]
+		case map[string]interface{}:
+			k, ok := key.(string)
+			if !ok {
+				return nil, nil, false
+			}
+			v, ok = t[k]
+			if !ok {
+				return nil, nil, false
+			}
+		default:
+			return nil, nil, false
+		}
+	}
+	return parent, v, true
+}
+
+// getValue returns the value in the container for the given key.
+func getValue(container, key interface{}) (interface{}, error) {
+	switch t := container.(type) {
+	case []interface{}:
+		i, ok := key.(int)
+		contract.Assertf(ok, "key for an array must be an int")
+		// We explicitly allow i == len(t) here, which indicates a
+		// value that will be appended to the end of the array.
+		if i < 0 || i > len(t) {
+			return nil, errors.New("array index out of range")
+		}
+		if i == len(t) {
+			return nil, nil
+		}
+		return t[i], nil
+	case map[string]interface{}:
+		k, ok := key.(string)
+		contract.Assertf(ok, "key for a map must be a string")
+		return t[k], nil
+	}
+
+	contract.Failf("should not reach here")
+	return nil, nil
+}
+
+// Set value sets the value in the container for the given key, and returns the container.
+// If the container is an array, and a value is being appended, containerParent and containerParentKey must
+// not be nil since a new slice will be created to append the value, which needs to be saved in the parent.
+// In this case, the new slice will be returned.
+func setValue(container, key, value, containerParent, containerParentKey interface{}) (interface{}, error) {
+	switch t := container.(type) {
+	case []interface{}:
+		i, ok := key.(int)
+		contract.Assertf(ok, "key for an array must be an int")
+		// We allow i == len(t), which indicates the value should be appended to the end of the array.
+		if i < 0 || i > len(t) {
+			return nil, errors.New("array index out of range")
+		}
+		// If i == len(t), we need to append to the end of the array, which involves creating a new slice
+		// and saving it in the parent container.
+		if i == len(t) {
+			t = append(t, value)
+			contract.Assertf(containerParent != nil, "parent must not be nil")
+			contract.Assertf(containerParentKey != nil, "parentKey must not be nil")
+			if _, err := setValue(containerParent, containerParentKey, t, nil, nil); err != nil {
+				return nil, err
+			}
+			return t, nil
+		}
+		t[i] = value
+	case map[string]interface{}:
+		k, ok := key.(string)
+		contract.Assertf(ok, "key for a map must be a string")
+		t[k] = value
+	}
+	return container, nil
+}
+
+// adjustObjectValue returns a more suitable value for objects:
+func adjustObjectValue(v Value, path bool) interface{} {
+	contract.Assertf(!v.Object(), "v must not be an Object")
+
+	// If the path flag isn't set, just return the value as-is.
+	if !path {
+		return v
+	}
+
+	// If it's a secure value, return as-is.
+	if v.Secure() {
+		return v
+	}
+
+	// If "false" or "true", return the boolean value.
+	if v.value == "false" {
+		return false
+	} else if v.value == "true" {
+		return true
+	}
+
+	// If it's convertible to an int, return the int.
+	i, err := strconv.Atoi(v.value)
+	if err == nil {
+		return i
+	}
+
+	// Otherwise, just return the string value.
+	return v.value
 }

--- a/pkg/resource/config/map_test.go
+++ b/pkg/resource/config/map_test.go
@@ -635,6 +635,20 @@ func TestSetSuccess(t *testing.T) {
 			},
 		},
 		{
+			Key:   "my:0",
+			Value: NewValue("testValue"),
+			Expected: Map{
+				MustMakeKey("my", "0"): NewValue("testValue"),
+			},
+		},
+		{
+			Key:   "my:true",
+			Value: NewValue("testValue"),
+			Expected: Map{
+				MustMakeKey("my", "true"): NewValue("testValue"),
+			},
+		},
+		{
 			Key:   "my:test.Key",
 			Value: NewValue("testValue"),
 			Expected: Map{
@@ -659,6 +673,22 @@ func TestSetSuccess(t *testing.T) {
 		},
 		{
 			Key:   "my:true",
+			Path:  true,
+			Value: NewValue("testValue"),
+			Expected: Map{
+				MustMakeKey("my", "true"): NewValue("testValue"),
+			},
+		},
+		{
+			Key:   `my:["0"]`,
+			Path:  true,
+			Value: NewValue("testValue"),
+			Expected: Map{
+				MustMakeKey("my", "0"): NewValue("testValue"),
+			},
+		},
+		{
+			Key:   `my:["true"]`,
 			Path:  true,
 			Value: NewValue("testValue"),
 			Expected: Map{
@@ -705,10 +735,32 @@ func TestSetSuccess(t *testing.T) {
 			Path:  true,
 			Value: NewValue("value"),
 			Config: Map{
-				MustMakeKey("my", "outer"): NewObjectValue("[1,2,3]"),
+				MustMakeKey("my", "outer"): NewSecureValue("securevalue"),
 			},
 			Expected: Map{
 				MustMakeKey("my", "outer"): NewObjectValue(`{"inner":"value"}`),
+			},
+		},
+		{
+			Key:   `my:array[0]`,
+			Path:  true,
+			Value: NewValue("value"),
+			Config: Map{
+				MustMakeKey("my", "array"): NewValue("value"),
+			},
+			Expected: Map{
+				MustMakeKey("my", "array"): NewObjectValue(`["value"]`),
+			},
+		},
+		{
+			Key:   `my:array[0]`,
+			Path:  true,
+			Value: NewValue("value"),
+			Config: Map{
+				MustMakeKey("my", "array"): NewSecureValue("value"),
+			},
+			Expected: Map{
+				MustMakeKey("my", "array"): NewObjectValue(`["value"]`),
 			},
 		},
 		{
@@ -979,6 +1031,32 @@ func TestSetFail(t *testing.T) {
 		// A "secure" key that is a map with a single string value is reserved by the system.
 		{Key: `my:key.secure`},
 		{Key: `my:super.nested.map.secure`},
+
+		// Type mismatches.
+		{
+			Key: `my:outer.inner`,
+			Config: Map{
+				MustMakeKey("my", "outer"): NewObjectValue("[1,2,3]"),
+			},
+		},
+		{
+			Key: `my:array[0]`,
+			Config: Map{
+				MustMakeKey("my", "array"): NewObjectValue(`{"inner":"value"}`),
+			},
+		},
+		{
+			Key: `my:outer.inner.nested`,
+			Config: Map{
+				MustMakeKey("my", "outer"): NewObjectValue(`{"inner":"value"}`),
+			},
+		},
+		{
+			Key: `my:outer.inner[0]`,
+			Config: Map{
+				MustMakeKey("my", "outer"): NewObjectValue(`{"inner":"value"}`),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/pkg/workspace/paths.go
+++ b/pkg/workspace/paths.go
@@ -31,7 +31,7 @@ import (
 const (
 	// BackupDir is the name of the folder where backup stack information is stored.
 	BackupDir = "backups"
-	// BookkeepingDir is the name of our bookeeping folder, we store state here (like .git for git).
+	// BookkeepingDir is the name of our bookkeeping folder, we store state here (like .git for git).
 	BookkeepingDir = ".pulumi"
 	// ConfigDir is the name of the folder that holds local configuration information.
 	ConfigDir = "config"

--- a/tests/integration/config_basic/dotnet/Program.cs
+++ b/tests/integration/config_basic/dotnet/Program.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright 2016-2019, Pulumi Corporation.  All rights reserved.
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Pulumi;
 
@@ -8,23 +10,136 @@ class Program
 {
     static Task<int> Main(string[] args)
     {
-        return Deployment.RunAsync(() => 
+        return Deployment.RunAsync(() =>
         {
             var config = new Config("config_basic_dotnet");
 
-            // This value is plaintext and doesn't require encryption.
-            var value = config.Require("aConfigValue");
-            if (value != "this value is a value")
+            var tests = new[]
             {
-                throw new Exception($"aConfigValue not the expected value; got {value}");
-            }
+                new Test
+                {
+                    Key = "aConfigValue",
+                    Expected = "this value is a value"
+                },
+                new Test
+                {
+                    Key = "bEncryptedSecret",
+                    Expected = "this super secret is encrypted"
+                },
+                new Test
+                {
+                    Key = "outer",
+                    Expected = "{\"inner\":\"value\"}",
+                    AdditionalValidation = () =>
+                    {
+                        var outer = config.RequireObject<Dictionary<string, string>>("outer");
+                        if (outer.Count != 1 || outer["inner"] != "value")
+                        {
+                            throw new Exception("'outer' not the expected object value");
+                        }
+                    }
+                },
+                new Test
+                {
+                    Key = "names",
+                    Expected = "[\"a\",\"b\",\"c\",\"super secret name\"]",
+                    AdditionalValidation = () =>
+                    {
+                        var expected = new[] { "a", "b", "c", "super secret name" };
+                        var names = config.RequireObject<string[]>("names");
+                        if (!Enumerable.SequenceEqual(expected, names))
+                        {
+                            throw new Exception("'names' not the expected object value");
+                        }
+                    }
+                },
+                new Test
+                {
+                    Key = "servers",
+                    Expected = "[{\"host\":\"example\",\"port\":80}]",
+                    AdditionalValidation = () =>
+                    {
+                        var servers = config.RequireObject<Server[]>("servers");
+                        if (servers.Length != 1 || servers[0].host != "example" || servers[0].port != 80)
+                        {
+                            throw new Exception("'servers' not the expected object value");
+                        }
+                    }
+                },
+                new Test
+                {
+                    Key = "a",
+                    Expected = "{\"b\":[{\"c\":true},{\"c\":false}]}",
+                    AdditionalValidation = () =>
+                    {
+                        var a = config.RequireObject<A>("a");
+                        if (a.b.Length != 2 || a.b[0].c != true || a.b[1].c != false)
+                        {
+                            throw new Exception("'a' not the expected object value");
+                        }
+                    }
+                },
+                new Test
+                {
+                    Key = "tokens",
+                    Expected = "[\"shh\"]",
+                    AdditionalValidation = () =>
+                    {
+                        var expected = new[] { "shh" };
+                        var tokens = config.RequireObject<string[]>("tokens");
+                        if (!Enumerable.SequenceEqual(expected, tokens))
+                        {
+                            throw new Exception("'tokens' not the expected object value");
+                        }
+                    }
+                },
+                new Test
+                {
+                    Key = "foo",
+                    Expected = "{\"bar\":\"don't tell\"}",
+                    AdditionalValidation = () =>
+                    {
+                        var foo = config.RequireObject<Dictionary<string, string>>("foo");
+                        if (foo.Count != 1 || foo["bar"] != "don't tell")
+                        {
+                            throw new Exception("'foo' not the expected object value");
+                        }
+                    }
+                },
+            };
 
-            // This value is a secret
-            var secret = config.Require("bEncryptedSecret");
-            if (secret != "this super secret is encrypted")
+            foreach (var test in tests)
             {
-                throw new Exception($"bEncryptedSecret not the expected value; got {secret}");
+                var value = config.Require(test.Key);
+                if (value != test.Expected)
+                {
+                    throw new Exception($"'{test.Key}' not the expected value; got {value}");
+                }
+                test.AdditionalValidation?.Invoke();
             }
         });
     }
+}
+
+class Test
+{
+    public string Key;
+    public string Expected;
+    public Action AdditionalValidation;
+}
+
+class Server
+{
+    public string host { get; set; }
+    public int port { get; set; }
+}
+
+class A
+{
+    public B[] b { get; set; }
+}
+
+class B
+{
+    public bool c { get; set; }
 }

--- a/tests/integration/config_basic/go/main.go
+++ b/tests/integration/config_basic/go/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/go/pulumi/config"
 )
@@ -13,16 +14,49 @@ func main() {
 		// Just test that basic config works.
 		cfg := config.New(ctx, "config_basic_go")
 
-		// This value is plaintext and doesn't require encryption.
-		value := cfg.Require("aConfigValue")
-		if value != "this value is a value" {
-			return fmt.Errorf("aConfigValue not the expected value; got %s", value)
+		tests := []struct {
+			Key      string
+			Expected string
+		}{
+			{
+				Key:      "aConfigValue",
+				Expected: `this value is a value`,
+			},
+			{
+				Key:      "bEncryptedSecret",
+				Expected: `this super secret is encrypted`,
+			},
+			{
+				Key:      "outer",
+				Expected: `{"inner":"value"}`,
+			},
+			{
+				Key:      "names",
+				Expected: `["a","b","c","super secret name"]`,
+			},
+			{
+				Key:      "servers",
+				Expected: `[{"host":"example","port":80}]`,
+			},
+			{
+				Key:      "a",
+				Expected: `{"b":[{"c":true},{"c":false}]}`,
+			},
+			{
+				Key:      "tokens",
+				Expected: `["shh"]`,
+			},
+			{
+				Key:      "foo",
+				Expected: `{"bar":"don't tell"}`,
+			},
 		}
 
-		// This value is a secret and is encrypted using the passphrase `supersecret`.
-		secret := cfg.Require("bEncryptedSecret")
-		if secret != "this super secret is encrypted" {
-			return fmt.Errorf("bEncryptedSecret not the expected value; got %s", secret)
+		for _, test := range tests {
+			value := cfg.Require(test.Key)
+			if value != test.Expected {
+				return fmt.Errorf("%q not the expected value; got %q", test.Key, value)
+			}
 		}
 
 		return nil

--- a/tests/integration/config_basic/nodejs/index.ts
+++ b/tests/integration/config_basic/nodejs/index.ts
@@ -8,8 +8,52 @@ const config = new Config("config_basic_js");
 
 // This value is plaintext and doesn't require encryption.
 const value = config.require("aConfigValue");
-assert.equal(value, "this value is a value", "aConfigValue not the expected value");
+assert.strictEqual(value, "this value is a value", "'aConfigValue' not the expected value");
 
 // This value is a secret and is encrypted using the passphrase `supersecret`.
 const secret = config.require("bEncryptedSecret");
-assert.equal(secret, "this super secret is encrypted", "bEncryptedSecret not the expected value");
+assert.strictEqual(secret, "this super secret is encrypted", "'bEncryptedSecret' not the expected value");
+
+const testData: {
+    key: string;
+    expectedJSON: string;
+    expectedObject: any;
+}[] = [
+    {
+        key: "outer",
+        expectedJSON: `{"inner":"value"}`,
+        expectedObject: { inner: "value" },
+    },
+    {
+        key: "names",
+        expectedJSON: `["a","b","c","super secret name"]`,
+        expectedObject: ["a", "b", "c", "super secret name"],
+    },
+    {
+        key: "servers",
+        expectedJSON: `[{"host":"example","port":80}]`,
+        expectedObject: [{ host: "example", port: 80 }],
+    },
+    {
+        key: "a",
+        expectedJSON: `{"b":[{"c":true},{"c":false}]}`,
+        expectedObject: { b: [{ c: true }, { c: false }] },
+    },
+    {
+        key: "tokens",
+        expectedJSON: `["shh"]`,
+        expectedObject: ["shh"],
+    },
+    {
+        key: "foo",
+        expectedJSON: `{"bar":"don't tell"}`,
+        expectedObject: { bar: "don't tell" },
+    },
+];
+
+for (const test of testData) {
+    const json = config.require(test.key);
+    const obj = config.requireObject(test.key);
+    assert.strictEqual(json, test.expectedJSON, `'${test.key}' not the expected JSON`);
+    assert.deepStrictEqual(obj, test.expectedObject, `'${test.key}' not the expected object`);
+}

--- a/tests/integration/config_basic/python/__main__.py
+++ b/tests/integration/config_basic/python/__main__.py
@@ -12,3 +12,42 @@ assert value == 'this value is a Pythonic value'
 # This value is a secret and is encrypted using the passphrase `supersecret`.
 secret = config.require('bEncryptedSecret')
 assert secret == 'this super Pythonic secret is encrypted'
+
+test_data = [
+    {
+        'key': 'outer',
+        'expected_json': '{"inner":"value"}',
+        'expected_object': { 'inner': 'value' }
+    },
+    {
+        'key': 'names',
+        'expected_json': '["a","b","c","super secret name"]',
+        'expected_object': ['a', 'b', 'c', 'super secret name']
+    },
+    {
+        'key': 'servers',
+        'expected_json': '[{"host":"example","port":80}]',
+        'expected_object': [{ 'host': 'example', 'port': 80 }]
+    },
+    {
+        'key': 'a',
+        'expected_json': '{"b":[{"c":true},{"c":false}]}',
+        'expected_object': { 'b': [{ 'c': True }, { 'c': False }] }
+    },
+    {
+        'key': 'tokens',
+        'expected_json': '["shh"]',
+        'expected_object': ['shh']
+    },
+    {
+        'key': 'foo',
+        'expected_json': '{"bar":"don\'t tell"}',
+        'expected_object': { 'bar': "don't tell" }
+    }
+]
+
+for test in test_data:
+    json = config.require(test['key'])
+    obj = config.require_object(test['key'])
+    assert json == test['expected_json']
+    assert obj == test['expected_object']

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -598,11 +598,24 @@ func TestConfigPaths(t *testing.T) {
 			TopLevelExpectedValue: "this value is a value",
 		},
 		{
+			Key:                   "anotherConfigValue",
+			Value:                 "this value is another value",
+			TopLevelKey:           "anotherConfigValue",
+			TopLevelExpectedValue: "this value is another value",
+		},
+		{
 			Key:                   "bEncryptedSecret",
 			Value:                 "this super secret is encrypted",
 			Secret:                true,
 			TopLevelKey:           "bEncryptedSecret",
 			TopLevelExpectedValue: "this super secret is encrypted",
+		},
+		{
+			Key:                   "anotherEncryptedSecret",
+			Value:                 "another encrypted secret",
+			Secret:                true,
+			TopLevelKey:           "anotherEncryptedSecret",
+			TopLevelExpectedValue: "another encrypted secret",
 		},
 		{
 			Key:                   "[]",
@@ -738,6 +751,36 @@ func TestConfigPaths(t *testing.T) {
 			TopLevelKey:           "wayInner",
 			TopLevelExpectedValue: `{"a":{"b":{"c":{"d":{"e":{"f":{"g":{"h":{"i":{"j":{"k":false}}}}}}}}}}}`,
 		},
+
+		// Overwriting a top-level string value is allowed.
+		{
+			Key:                   "aConfigValue.inner",
+			Value:                 "new value",
+			Path:                  true,
+			TopLevelKey:           "aConfigValue",
+			TopLevelExpectedValue: `{"inner":"new value"}`,
+		},
+		{
+			Key:                   "anotherConfigValue[0]",
+			Value:                 "new value",
+			Path:                  true,
+			TopLevelKey:           "anotherConfigValue",
+			TopLevelExpectedValue: `["new value"]`,
+		},
+		{
+			Key:                   "bEncryptedSecret.inner",
+			Value:                 "new value",
+			Path:                  true,
+			TopLevelKey:           "bEncryptedSecret",
+			TopLevelExpectedValue: `{"inner":"new value"}`,
+		},
+		{
+			Key:                   "anotherEncryptedSecret[0]",
+			Value:                 "new value",
+			Path:                  true,
+			TopLevelKey:           "anotherEncryptedSecret",
+			TopLevelExpectedValue: `["new value"]`,
+		},
 	}
 
 	validateConfigGet := func(key string, value string, path bool) {
@@ -794,6 +837,12 @@ func TestConfigPaths(t *testing.T) {
 		// A "secure" key that is a map with a single string value is reserved by the system.
 		"key.secure",
 		"super.nested.map.secure",
+
+		// Type mismatch.
+		"outer[0]",
+		"names.nested",
+		"outer.inner.nested",
+		"outer.inner[0]",
 	}
 
 	for _, ns := range namespaces {


### PR DESCRIPTION
This change adds support for lists and maps in config. We now allow lists/maps (and nested structures) in `Pulumi.<stack>.yaml` (or `Pulumi.<stack>.json`; yes, we currently support that).

For example:

```yaml
config:
  proj:blah:
  - a
  - b
  - c
  proj:hello: world
  proj:outer:
    inner: value
  proj:servers:
  - port: 80
```

While such structures could be specified in the `.yaml` file manually, we support setting values in maps/lists from the command line.

As always, you can specify single values with:

```shell
$ pulumi config set hello world
```

Which results in the following YAML:

```yaml
proj:hello world
```

And single value secrets via:

```shell
$ pulumi config set --secret token shhh
```

Which results in the following YAML:

```yaml
proj:token:
  secure: v1:VZAhuroR69FkEPTk:isKafsoZVMWA9pQayGzbWNynww==
```

Values in a list can be set from the command line using the new `--path` flag, which indicates the config key contains a path to a property in a map or list:

```shell
$ pulumi config set --path names[0] a
$ pulumi config set --path names[1] b
$ pulumi config set --path names[2] c
```

Which results in:

```yaml
proj:names
- a
- b
- c
```

Values can be obtained similarly:

```shell
$ pulumi config get --path names[1]
b
```

Or setting values in a map:

```shell
$ pulumi config set --path outer.inner value
```

Which results in:

```yaml
proj:outer:
  inner: value
```

Of course, setting values in nested structures is supported:

```shell
$ pulumi config set --path servers[0].port 80
```

Which results in:

```yaml
proj:servers:
- port: 80
```

If you want to include a period in the name of a property, it can be specified as:

```
$ pulumi config set --path 'nested["foo.bar"]' baz
```

Which results in:

```yaml
proj:nested:
  foo.bar: baz
```

Examples of valid paths:

- root
- root.nested
- 'root["nested"]'
- root.double.nest
- 'root["double"].nest'
- 'root["double"]["nest"]'
- root.array[0]
- root.array[100]
- root.array[0].nested
- root.array[0][1].nested
- root.nested.array[0].double[1]
- 'root["key with \"escaped\" quotes"]'
- 'root["key with a ."]'
- '["root key with \"escaped\" quotes"].nested'
- '["root key with a ."][100]'

Note: paths that contain quotes can be surrounded by single quotes when set from the command line.

When setting values with `--path`, if the value is `"false"` or `"true"`, it will be saved as the boolean value, and if it is convertible to an integer, it will be saved as an integer. (Unless it is a secret, in which case it will always be stored as an encrypted string).

Secure values are supported in lists/maps as well:

```shell
$ pulumi config set --path --secret tokens[0] shh
```

Will result in:

```yaml
proj:tokens:
- secure: v1:wpZRCe36sFg1RxwG:WzPeQrCn4n+m4Ks8ps15MxvFXg==
```

Note: maps of length 1 with a key of “secure” and string value are reserved for storing secret values. Attempting to create such a value manually will result in an error:

```shell
$ pulumi config set --path parent.secure foo
error: "secure" key in maps of length 1 are reserved
```

## Accessing config values from the command line with JSON

```shell
$ pulumi config --json
```

Will output:

```json
{
  "proj:hello": {
    "value": "world",
    "secret": false,
  },
  "proj:names": {
    "value": "[\"a\",\"b\",\"c\"]",
    "secret": false,
    "objectValue": [
      "a",
      "b",
      "c"
    ]
  },
  "proj:nested": {
    "value": "{\"foo.bar\":\"baz\"}",
    "secret": false,
    "objectValue": {
      "foo.bar": "baz"
    }
  },
  "proj:outer": {
    "value": "{\"inner\":\"value\"}",
    "secret": false,
    "objectValue": {
      "inner": "value"
    }
  },
  "proj:servers": {
    "value": "[{\"port\":80}]",
    "secret": false,
    "objectValue": [
      {
        "port": 80
      }
    ]
  },
  "proj:token": {
    "secret": true,
  },
  "proj:tokens": {
    "secret": true,
  }
}
```

If the value is a map or list, `"value"` will contain the object as serialized JSON and a new `"objectValue"` property will be available containing the value of the object.

If the object contains any secret values, `"secret"` will be `true`, and just like with scalar values, the value will not be outputted unless `--show-secrets` is specified.

## Accessing config values from Pulumi programs

Map/list values are available to Pulumi programs as serialized JSON, so the existing `getObject`/`requireObject`/`getSecretObject`/`requireSecretObject` functions can be used to retrieve such values, e.g.:

```typescript
import * as pulumi from "@pulumi/pulumi";

interface Server {
    port: number;
}

const config = new pulumi.Config();

const names = config.requireObject<string[]>("names");
for (const n of names) {
    console.log(n);
}

const servers = config.requireObject<Server[]>("servers");
for (const s of servers) {
    console.log(s.port);
}
```

Fixes #2306