### PR TITLE
Use the update access token for renew_lease calls instead of user access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 CHANGELOG
 =========
 
+## HEAD (Unreleased)
+
+- Use the update token for renew_lease calls and update the API version to 5.
+  [#3348](https://github.com/pulumi/pulumi/pull/3348)
+
 ## 1.4.1 (2019-11-01)
 
 - Adds a **preview** of .NET support for Pulumi. This code is an preview state and is subject
   to change at any point.
-
-- Use the update token for renew_lease calls and update the API version to 5.
-  [#3348](https://github.com/pulumi/pulumi/pull/3348)
 
 - Fix another colorizer issue that could cause garbled output for messages that did not end in colorization tags.
   [#3417](https://github.com/pulumi/pulumi/pull/3417)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - Adds a **preview** of .NET support for Pulumi. This code is an preview state and is subject
   to change at any point.
 
+- Use the update token for renew_lease calls and update the API version to 5.
+  [#3348](https://github.com/pulumi/pulumi/pull/3348)
+
 - Fix another colorizer issue that could cause garbled output for messages that did not end in colorization tags.
   [#3417](https://github.com/pulumi/pulumi/pull/3417)
 

--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -172,8 +172,6 @@ type UpdateProgram struct {
 
 // RenewUpdateLeaseRequest defines the body of a request to the update lease renewal endpoint of the service API.
 type RenewUpdateLeaseRequest struct {
-	// The current, valid lease token.
-	Token string `json:"token"`
 	// The duration for which to renew the lease in seconds (maximum 300).
 	Duration int `json:"duration"`
 }

--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -172,6 +172,11 @@ type UpdateProgram struct {
 
 // RenewUpdateLeaseRequest defines the body of a request to the update lease renewal endpoint of the service API.
 type RenewUpdateLeaseRequest struct {
+	// The current, valid lease token.
+	// DEPRECATED as of Pulumi API version 5+. Pulumi API will expect the update token
+	// in the Authorization header instead of this property. This property will be removed
+	// when the minimum supported API version on the service is raised to 5.
+	Token string `json:"token"`
 	// The duration for which to renew the lease in seconds (maximum 300).
 	Duration int `json:"duration"`
 }

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -165,7 +165,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 	userAgent := fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)
 	req.Header.Set("User-Agent", userAgent)
 	// Specify the specific API version we accept.
-	req.Header.Set("Accept", "application/vnd.pulumi+4")
+	req.Header.Set("Accept", "application/vnd.pulumi+5")
 
 	// Apply credentials if provided.
 	if tok.String() != "" {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -596,7 +596,6 @@ func (pc *Client) RenewUpdateLease(ctx context.Context, update UpdateIdentifier,
 	duration time.Duration) (string, error) {
 
 	req := apitype.RenewUpdateLeaseRequest{
-		Token:    token,
 		Duration: int(duration / time.Second),
 	}
 	var resp apitype.RenewUpdateLeaseResponse
@@ -604,8 +603,8 @@ func (pc *Client) RenewUpdateLease(ctx context.Context, update UpdateIdentifier,
 	// While renewing a lease uses POST, it is safe to send multiple requests (consider that we do this multiple times
 	// during a long running update).  Since we would fail our update operation if we can't renew our lease, we'll retry
 	// these POST operations.
-	if err := pc.restCallWithOptions(ctx, "POST", getUpdatePath(update, "renew_lease"), nil,
-		req, &resp, httpCallOptions{RetryAllMethods: true}); err != nil {
+	if err := pc.updateRESTCall(ctx, "POST", getUpdatePath(update, "renew_lease"), nil, req, &resp,
+		updateAccessToken(token), httpCallOptions{RetryAllMethods: true}); err != nil {
 		return "", err
 	}
 	return resp.Token, nil


### PR DESCRIPTION
#### Reason for changing the auth requirement for renew_lease:

- Previously the request to /renew_lease was authenticated using the user's Pulumi access token. The HTTP endpoint also took in the current lease token, to confirm that it was still valid. And then returned a new, extended lease token.

- The change here is to no longer pass the Pulumi access token credential to the /renew_lease endpoint via the Authorization header, but instead the current lease token. This way /renew_lease is authenticated like other Pulumi Service REST APIs dealing with stack updates.

#### Reason for changing the API version number passed to the service:
- In order for the Pulumi Service to differentiate clients that are sending/receiving one type of request vs. another, we are bumping the Accept header version number. Clients with Accept header 4 and lower, are expected to authenticate using a Pulumi access token, and pass a lease token in with the request body. Clients with Accept header 5 and above, are expected to authenticate using a Pulumi lease token, and do not need to pass that same lease token in with the request body.

