### PR TITLE
Load PulumiPolicy.yaml instead of Pulumi.yaml during installation

### DIFF
--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -204,7 +204,7 @@ func installRequiredPolicy(finalDir string, tarball []byte) error {
 		return errors.Wrap(err, "moving plugin")
 	}
 
-	proj, err := workspace.LoadProject(path.Join(finalDir, "Pulumi.yaml"))
+	proj, err := workspace.LoadPolicyPack(path.Join(finalDir, "PulumiPolicy.yaml"))
 	if err != nil {
 		return errors.Wrapf(err, "failed to load policy project at %s", finalDir)
 	}


### PR DESCRIPTION
We renamed the policy pack project file from `Pulumi.yaml` to `PulumiPolicy.yaml`, but we were still looking for `Pulumi.yaml` when installing required policy packs.

Fixes https://github.com/pulumi/pulumi-policy/issues/128