### PR TITLE
Fix a bug in the Brew version check.

### DIFF
--- a/cmd/pulumi.go
+++ b/cmd/pulumi.go
@@ -237,7 +237,7 @@ func getCLIVersionInfo() (semver.Version, semver.Version, error) {
 
 	brewLatest, isBrew, err := getLatestBrewFormulaVersion()
 	if err != nil {
-		return semver.Version{}, semver.Version{}, err
+		logging.V(3).Infof("error determining if the running executable was installed with brew: %s", err)
 	}
 	if isBrew {
 		// When consulting Homebrew for version info, we just use the latest version as the oldest allowed.


### PR DESCRIPTION
It is not a fatal error for the brew version check to fail. In this
case, just use the values returned by the service.