### PR TITLE
Update python FileAsset to accept os.PathLike in addition to str.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- `FileAsset` in the Python SDK now accepts anything implementing `os.PathLike` in addition to `str`.
+  [#3368](https://github.com/pulumi/pulumi/pull/3368)
+
 ## 1.3.3 (2019-10-17)
 
 - Fix an issue with first-class providers introduced in 1.3.2.

--- a/sdk/python/lib/pulumi/asset.py
+++ b/sdk/python/lib/pulumi/asset.py
@@ -15,6 +15,7 @@
 """
 Assets are the Pulumi notion of data blobs that can be passed to resources.
 """
+from os import PathLike, fspath
 from typing import Dict, Union
 
 from .runtime import known_types
@@ -36,10 +37,11 @@ class FileAsset(Asset):
     A FileAsset is a kind of asset produced from a given path to a file on
     the local filesysetm.
     """
-    def __init__(self, path: str) -> None:
-        if not isinstance(path, str):
-            raise TypeError("FileAsset path must be a string")
-        self.path = path
+
+    def __init__(self, path: Union[str, PathLike]) -> None:
+        if not isinstance(path, (str, PathLike)):
+            raise TypeError("FileAsset path must be a string or os.PathLike")
+        self.path = fspath(path)
 
 
 @known_types.string_asset

--- a/sdk/python/lib/test/langhost/asset/__main__.py
+++ b/sdk/python/lib/test/langhost/asset/__main__.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pathlib import Path
+
 from pulumi import CustomResource
 from pulumi.asset import FileAsset, StringAsset, RemoteAsset
 
@@ -23,5 +25,6 @@ class MyResource(CustomResource):
         })
 
 MyResource("file", FileAsset("./testfile.txt"))
+MyResource("file", FileAsset(Path(".") / "testfile.txt"))
 MyResource("string", StringAsset("its a string"))
 MyResource("remote", RemoteAsset("https://pulumi.com"))

--- a/sdk/python/lib/test/langhost/asset/test_asset.py
+++ b/sdk/python/lib/test/langhost/asset/test_asset.py
@@ -21,7 +21,7 @@ class AssetTest(LanghostTest):
     def test_asset(self):
         self.run_test(
             program=path.join(self.base_path(), "asset"),
-            expected_resource_count=3)
+            expected_resource_count=4)
 
     def register_resource(self, _ctx, _dry_run, ty, name, resource,
                           _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
@@ -29,7 +29,7 @@ class AssetTest(LanghostTest):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "file":
             self.assertIsInstance(resource["asset"], FileAsset)
-            self.assertEqual(resource["asset"].path, "./testfile.txt")
+            self.assertEqual(path.normpath(resource["asset"].path), "testfile.txt")
         elif name == "string":
             self.assertIsInstance(resource["asset"], StringAsset)
             self.assertEqual(resource["asset"].text, "its a string")


### PR DESCRIPTION
This should fix #2896.

For the record I'm not very familiar with the codebase and it wasn't entirely clear to me what the tests are actually *doing*, so if the test changes I made are insufficient I'd be happy to fix them.

