### PR TITLE
Fix property serialization in engine events.

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -389,7 +389,7 @@ func listConfig(stack backend.Stack, showSecrets bool, jsonOut bool) error {
 	cfg := ps.Config
 
 	// By default, we will use a blinding decrypter to show "[secret]". If requested, display secrets in plaintext.
-	decrypter := config.NewBlindingDecrypter()
+	decrypter := config.Decrypter(config.BlindingCrypter)
 	if cfg.HasSecureValue() && showSecrets {
 		dec, decerr := getStackDencrypter(stack)
 		if decerr != nil {

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -414,6 +414,11 @@ func (b *localBackend) apply(
 			colors.SpecHeadline+"%s (%s):"+colors.Reset+"\n"), actionLabel, stackRef)
 	}
 
+	encrypter, err := op.SecretsManager.Encrypter()
+	if err != nil {
+		return nil, result.FromError(err)
+	}
+
 	// Start the update.
 	update, err := b.newUpdate(stackName, op)
 	if err != nil {
@@ -425,7 +430,7 @@ func (b *localBackend) apply(
 	displayDone := make(chan bool)
 	go display.ShowEvents(
 		strings.ToLower(actionLabel), kind, stackName, op.Proj.Name,
-		displayEvents, displayDone, op.Opts.Display, opts.DryRun)
+		displayEvents, displayDone, op.Opts.Display, opts.DryRun, encrypter)
 
 	// Create a separate event channel for engine events that we'll pipe to both listening streams.
 	engineEvents := make(chan engine.Event)

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -459,7 +459,7 @@ func (e *eventEmitter) preludeEvent(isPreview bool, cfg config.Map) {
 	configStringMap := make(map[string]string, len(cfg))
 	for k, v := range cfg {
 		keyString := k.String()
-		valueString, err := v.Value(config.NewBlindingDecrypter())
+		valueString, err := v.Value(config.BlindingCrypter)
 		contract.AssertNoError(err)
 		configStringMap[keyString] = valueString
 	}

--- a/pkg/resource/config/crypt.go
+++ b/pkg/resource/config/crypt.go
@@ -58,16 +58,18 @@ func (nopCrypter) EncryptValue(plaintext string) (string, error) {
 	return plaintext, nil
 }
 
-// NewBlindingDecrypter returns a Decrypter that instead of decrypting data, just returns "[secret]", it can
+// BlindingCrypter returns a Crypter that instead of decrypting or encrypting data, just returns "[secret]", it can
 // be used when you want to display configuration information to a user but don't want to prompt for a password
-// so secrets will not be decrypted.
-func NewBlindingDecrypter() Decrypter {
-	return blindingDecrypter{}
+// so secrets will not be decrypted or encrypted.
+var BlindingCrypter = blindingCrypter{}
+
+type blindingCrypter struct{}
+
+func (b blindingCrypter) DecryptValue(ciphertext string) (string, error) {
+	return "[secret]", nil
 }
 
-type blindingDecrypter struct{}
-
-func (b blindingDecrypter) DecryptValue(ciphertext string) (string, error) {
+func (b blindingCrypter) EncryptValue(plaintext string) (string, error) {
 	return "[secret]", nil
 }
 

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -37,6 +37,8 @@ const (
 	// need to be at least one less than the current schema version so that old deployments can
 	// be migrated to the current schema.
 	DeploymentSchemaVersionOldestSupported = 1
+
+	unknownValue = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
 )
 
 var (
@@ -319,8 +321,12 @@ func SerializeProperties(props resource.PropertyMap, enc config.Encrypter) (map[
 func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter) (interface{}, error) {
 	// Skip nulls and "outputs"; the former needn't be serialized, and the latter happens if there is an output
 	// that hasn't materialized (either because we're serializing inputs or the provider didn't give us the value).
-	if prop.IsComputed() || !prop.HasValue() {
+	if !prop.HasValue() {
 		return nil, nil
+	}
+
+	if prop.IsComputed() {
+		return unknownValue, nil
 	}
 
 	// For arrays, make sure to recurse.
@@ -433,6 +439,9 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter) (resource.Pro
 		case float64:
 			return resource.NewNumberProperty(w), nil
 		case string:
+			if w == unknownValue {
+				return resource.MakeComputed(resource.NewStringProperty("")), nil
+			}
 			return resource.NewStringProperty(w), nil
 		case []interface{}:
 			var arr []resource.PropertyValue


### PR DESCRIPTION
The conversion of an engine event to an API event was not properly
serializing the property bags associated with the event, if any. Aside
from issues with the generated structures, the converter was completely
ignoring secrets.