### PR TITLE
Support Google KMS encryption provider in pulumi github action.

### DIFF
--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -72,9 +72,9 @@ fi
 
 # For Google, we need to authenticate with a service principal for certain authentication operations.
 if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
-    GCLOUD_KEYFILE="$(mktemp).json"
-    echo "$GOOGLE_CREDENTIALS" > $GCLOUD_KEYFILE
-    gcloud auth activate-service-account --key-file=$GCLOUD_KEYFILE
+    export GOOGLE_APPLICATION_CREDENTIALS="$(mktemp).json"
+    echo "$GOOGLE_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+    gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 fi
 
 # Next, lazily install packages if required.


### PR DESCRIPTION
Export GOOGLE_APPLICATION_CREDENTIALS when google credential are given

This avoids the following error when the stack uses Google KMS encryption provider:

```
error: getting secrets manager: open keeper gcpkms://projects/...: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.
```