### PR TITLE
Support private npm dependencies in github action

### DIFF
--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -79,6 +79,10 @@ fi
 
 # Next, lazily install packages if required.
 if [ -e package.json ] && [ ! -d node_modules ]; then
+    # Set npm auth token if one is provided.
+    if [ ! -z "$NPM_AUTH_TOKEN" ]; then
+        npm config set "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN"
+    fi
     npm install
 fi
 


### PR DESCRIPTION
If the pulumi stack depends on a private NPM package, the github action fails when running `npm install`. This change sets the npm auth token if one is provided with the `NPM_AUTH_TOKEN` environment variable before calling `npm install`.
