### PR TITLE
Fix two colorization issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ CHANGELOG
 - `FileAsset` in the Python SDK now accepts anything implementing `os.PathLike` in addition to `str`.
   [#3368](https://github.com/pulumi/pulumi/pull/3368)
 
+- Fix colorization on Windows 10, and fix a colorizer bug that could cause garbled output for resources with long
+  status messages.
+  [#3385](https://github.com/pulumi/pulumi/pull/3385)
+
 ## 1.3.4 (2019-10-18)
 
 - Remove unintentional console outupt introduced in 1.3.3.

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd
 	golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
+	golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b
 	google.golang.org/api v0.5.0
 	google.golang.org/genproto v0.0.0-20190508193815-b515fa19cec8
 	google.golang.org/grpc v1.20.1

--- a/pkg/diag/colors/colors.go
+++ b/pkg/diag/colors/colors.go
@@ -158,14 +158,15 @@ func colorizeText(s string, c Colorization, maxLen int) string {
 		// Copy the text up to but not including the delimiter into the buffer.
 		text := input[:nextDirectiveStart]
 		if maxLen >= 0 && textLen+len(text) > maxLen {
-			_, err := buf.WriteString(text[:maxLen])
+			_, err := buf.WriteString(text[:maxLen-textLen])
 			contract.IgnoreError(err)
 			writeDirective(&buf, c, Reset)
 			break
 		}
-		_, err := buf.WriteString(input[:nextDirectiveStart])
+		_, err := buf.WriteString(text)
 		contract.IgnoreError(err)
 		input = input[nextDirectiveStart+len(colorLeft):]
+		textLen += len(text)
 
 		// If we have a start delimiter but no end delimiter, terminate. The partial command will not be present in the
 		// output.

--- a/pkg/diag/colors/windows.go
+++ b/pkg/diag/colors/windows.go
@@ -16,6 +16,20 @@
 
 package colors
 
+import "golang.org/x/sys/windows/registry"
+
+func hasVTSupport() bool {
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, `SOFTWARE\Microsoft\Windows NT\CurrentVersion`, registry.QUERY_VALUE)
+	if err != nil {
+		return false
+	}
+	maj, _, err := k.GetIntegerValue("CurrentMajorVersionNumber")
+	if err != nil {
+		return false
+	}
+	return maj >= 10
+}
+
 func init() {
-	disableColorization = true
+	disableColorization = !hasVTSupport()
 }


### PR DESCRIPTION
- The length of the text content (i.e. the content of a colorized string
  that is not control sequences) was not being correctly tracked. This
  caused the "status" column of the progress display to overflow.
- Colorization was unconditionally disabled on Windows. When we were
  using loreley, we had set the global colorization flag s.t.
  colorization on Windows _should_ have been disabled, but we overrode
  this flag each time we actually colorized anything.

Fixes #3378.