### PR TITLE
Add a URN validation method.

### DIFF
--- a/pkg/resource/deploy/providers/reference.go
+++ b/pkg/resource/deploy/providers/reference.go
@@ -58,6 +58,9 @@ func GetProviderPackage(typ tokens.Type) tokens.Package {
 }
 
 func validateURN(urn resource.URN) error {
+	if !urn.IsValid() {
+		return errors.Errorf("%s is not a valid URN", urn)
+	}
 	typ := urn.Type()
 	if typ.Module() != "pulumi:providers" {
 		return errors.Errorf("invalid module in type: expected 'pulumi:providers', got '%v'", typ.Module())

--- a/pkg/resource/deploy/providers/reference_test.go
+++ b/pkg/resource/deploy/providers/reference_test.go
@@ -31,7 +31,8 @@ func TestRoundTripProviderType(t *testing.T) {
 
 func TestParseReferenceInvalidURN(t *testing.T) {
 	str := "not::a:valid:urn::id"
-	assert.Panics(t, func() { _, _ = ParseReference(str) })
+	_, err := ParseReference(str)
+	assert.Error(t, err)
 }
 
 func TestParseReferenceInvalidModule(t *testing.T) {

--- a/pkg/resource/urn.go
+++ b/pkg/resource/urn.go
@@ -68,6 +68,14 @@ func NewURN(stack tokens.QName, proj tokens.PackageName, parentType, baseType to
 	)
 }
 
+// IsValid returns true if the URN is well-formed.
+func (urn URN) IsValid() bool {
+	if !strings.HasPrefix(string(urn), URNPrefix) {
+		return false
+	}
+	return len(strings.Split(string(urn), URNNameDelimiter)) == 4
+}
+
 // URNName returns the URN name part of a URN (i.e., strips off the prefix).
 func (urn URN) URNName() string {
 	s := string(urn)


### PR DESCRIPTION
This method can be used to check whether or not a URN is well-formed.
This is used by the provider reference parser to avoid panicking on
malformed URNs.