### PR TITLE
Fix issue where we tore down our sync-rpc channels in expected recoverable scenarios.

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
@@ -109,9 +109,17 @@ func servePipes(ctx context.Context, pipes pipes, target pulumirpc.ResourceMonit
 
 				logging.V(10).Infof("Sync invoke: Invoking: %s", req.GetTok())
 				res, err := target.Invoke(ctx, &req)
-				if err != nil {
+				if err != nil  {
 					logging.V(10).Infof("Sync invoke: Received error invoking: %s\n", err)
-					return err
+					logging.V(10).Infof("Sync invoke: Converting error to response.\n")
+					if res == nil {
+						res = &pulumirpc.InvokeResponse{}
+					}
+
+					res.Failures = append(res.Failures, &pulumirpc.CheckFailure{
+						Property: "",
+						Reason: err.Error(),
+					})
 				}
 
 				// encode the response

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
@@ -109,6 +109,26 @@ func servePipes(ctx context.Context, pipes pipes, target pulumirpc.ResourceMonit
 
 				logging.V(10).Infof("Sync invoke: Invoking: %s", req.GetTok())
 				res, err := target.Invoke(ctx, &req)
+
+				// Unfortunately, `monitor.Invoke` can return `err`s for non-exceptional cases. This
+				// can happen, for example, if the underlying provider call ends up returning an
+				// err.  A common case of this is the aws-provider which will often return errors
+				// for things like
+				//
+				//  aws:ec2/getRouteTable:getRouteTable: Your query returned no results.
+				//
+				// This is not an 'err' in the sense that something has gone terribly wrong and we
+				// need to shutdown.  Rather, it's just a validation issue that needs to be passed
+				// back to the user program to handle.  In the async codepath, this just returns as
+				// a grpc error which is thrown in the sdk code (and can be handled by the user).
+				// Howeve, unfortunately, our sync-rpc pipes have no way to send either an err or a
+				// success result.  It can only send success, and only *terminate* on error.
+				//
+				// So, to workaround this issue, we abuse the 'success result' slightly.
+				// Specifically, we take advantage of the fact that the success-result contains a
+				// list of 'failures' to indicate if 'Check' reported any problems.  We just stash
+				// this error into that array, knowing that the SDK will see it and immediately
+				// throw, just like it would have done for an RPC error in the normal async case.
 				if err != nil  {
 					logging.V(10).Infof("Sync invoke: Received error invoking: %s\n", err)
 					logging.V(10).Infof("Sync invoke: Converting error to response.\n")

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy.go
@@ -110,26 +110,28 @@ func servePipes(ctx context.Context, pipes pipes, target pulumirpc.ResourceMonit
 				logging.V(10).Infof("Sync invoke: Invoking: %s", req.GetTok())
 				res, err := target.Invoke(ctx, &req)
 
-				// Unfortunately, `monitor.Invoke` can return `err`s for non-exceptional cases. This
+				// Unfortunately, `monitor.Invoke` can return errors for non-exceptional cases. This
 				// can happen, for example, if the underlying provider call ends up returning an
-				// err.  A common case of this is the aws-provider which will often return errors
-				// for things like
+				// error itself.  A common case of this is the aws-provider which will often return
+				// errors like:
 				//
 				//  aws:ec2/getRouteTable:getRouteTable: Your query returned no results.
 				//
-				// This is not an 'err' in the sense that something has gone terribly wrong and we
+				// This is not an error in the sense that something has gone terribly wrong and we
 				// need to shutdown.  Rather, it's just a validation issue that needs to be passed
-				// back to the user program to handle.  In the async codepath, this just returns as
-				// a grpc error which is thrown in the sdk code (and can be handled by the user).
-				// Howeve, unfortunately, our sync-rpc pipes have no way to send either an err or a
-				// success result.  It can only send success, and only *terminate* on error.
+				// back to the user program to handle.
+				//
+				// In the async codepath, this just returns as a grpc error which is thrown in the
+				// sdk code (and can be handled by the user). Unfortunately, our sync-rpc pipes have
+				// no way to send either an err or a success result.  They can only send success,
+				// and only *terminate* on error.
 				//
 				// So, to workaround this issue, we abuse the 'success result' slightly.
 				// Specifically, we take advantage of the fact that the success-result contains a
 				// list of 'failures' to indicate if 'Check' reported any problems.  We just stash
 				// this error into that array, knowing that the SDK will see it and immediately
 				// throw, just like it would have done for an RPC error in the normal async case.
-				if err != nil  {
+				if err != nil {
 					logging.V(10).Infof("Sync invoke: Received error invoking: %s\n", err)
 					logging.V(10).Infof("Sync invoke: Converting error to response.\n")
 					if res == nil {
@@ -138,7 +140,7 @@ func servePipes(ctx context.Context, pipes pipes, target pulumirpc.ResourceMonit
 
 					res.Failures = append(res.Failures, &pulumirpc.CheckFailure{
 						Property: "",
-						Reason: err.Error(),
+						Reason:   err.Error(),
 					})
 				}
 

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy_windows.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy_windows.go
@@ -77,7 +77,7 @@ func (p *windowsPipes) writer() io.Writer {
 
 func (p *windowsPipes) connect() error {
 	acceptDone := make(chan error)
-	defer close(acceptDone);
+	defer close(acceptDone)
 
 	go func() {
 		reqConn, err := p.reqListener.Accept()


### PR DESCRIPTION
This affects EKS in the case where they have an older `@pulumi/eks` and a newer `@pulumi/pulumi.

Specifically, the older `@pulumi/eks` makes sync rpc calls, and the newer `@pulumi/pulumi` uses hte new sync-rpc systemto service them.  In particular `@pulumi/eks` makes RPC calls that are expected to fail, and which it has resilient code to handle.  i.e.:

https://github.com/pulumi/pulumi-eks/blob/79907122bd9e44156e8424ca4d469055712e363a/nodejs/eks/nodegroup.ts#L582-L599

This ends up not working with the sync-rpc codepath because that expected failure in translated in the go layer into an `error` object which we use to signal shutting down our rpc-pipes between the sdk and the proxy.  

This happened because i didn't realize that `error`s were used in this layer to represent soft/recoverable issues.  I thought they only represent strict failures in our layer that meant we needed to stop everything and terminate the proxy entirely.  This is not the case.  While errors do sometimes represent strict problems that we must address, in this case it is actually the normal return value for a provider.invoke that fails for any reason the provider cares about.  

--

I have validated locally that this fixes the issue.