### PR TITLE
Fix panic in stack select

### DIFF
--- a/cmd/stack_select.go
+++ b/cmd/stack_select.go
@@ -56,7 +56,7 @@ func newStackSelectCmd() *cobra.Command {
 
 			if stack != "" {
 				// A stack was given, ask the backend about it
-				stackRef, stackErr := b.ParseStackReference(args[0])
+				stackRef, stackErr := b.ParseStackReference(stack)
 				if stackErr != nil {
 					return stackErr
 				}


### PR DESCRIPTION
Hit a panic while justing the CLI. I scratched my head for a bit, but it is specific to the case where you run `pulumi stack select -s ...`. In that case, the `stack` flag is set, but the Cobra command has no arguments.

So we were panicking when we were trying to parse the stack reference by using `args[0]`, since args had value `[]`. Make sense? If you expand the code above, `args` is never referred to other than being a shorthand for skipping the `-s` or `--stack` flag.

```
pulumi stack select -s moolumi/foo-bar-baz---/1571689334
warning: A new version of Pulumi is available. To upgrade from version '1.3.1' to '1.4.0', run 
   $ curl -sSL https://get.pulumi.com | sh
or visit https://pulumi.com/docs/reference/install/ for manual instructions and release notes.
================================================================================
The Pulumi CLI encountered a fatal error. This is a bug!
We would appreciate a report: https://github.com/pulumi/pulumi/issues/
Please provide all of the below text in your report.
================================================================================
Pulumi Version:   v1.3.1
Go Version:       go1.12.9
Go Compiler:      gc
Architecture:     amd64
Operating System: darwin
Panic:            runtime error: index out of range

goroutine 1 [running]:
runtime/debug.Stack(0xc0007bda90, 0x209f700, 0x33672a0)
        /Users/travis/.gimme/versions/go1.12.9.darwin.amd64/src/runtime/debug/stack.go:24 +0x9d
main.panicHandler()
        /Users/travis/gopath/src/github.com/pulumi/pulumi/main.go:30 +0x6e
panic(0x209f700, 0x33672a0)
        /Users/travis/.gimme/versions/go1.12.9.darwin.amd64/src/runtime/panic.go:522 +0x1b5
github.com/pulumi/pulumi/cmd.newStackSelectCmd.func1(0xc00020d680, 0xc0000d67e0, 0x0, 0x2, 0x10, 0x10)
        /Users/travis/gopath/src/github.com/pulumi/pulumi/cmd/stack_select.go:59 +0x4e9
github.com/pulumi/pulumi/pkg/util/cmdutil.RunFunc.func1(0xc00020d680, 0xc0000d67e0, 0x0, 0x2, 0x0, 0x0)
        /Users/travis/gopath/src/github.com/pulumi/pulumi/pkg/util/cmdutil/exit.go:96 +0x51
github.com/pulumi/pulumi/pkg/util/cmdutil.RunResultFunc.func1(0xc00020d680, 0xc0000d67e0, 0x0, 0x2)
        /Users/travis/gopath/src/github.com/pulumi/pulumi/pkg/util/cmdutil/exit.go:112 +0x6b
github.com/pulumi/pulumi/vendor/github.com/spf13/cobra.(*Command).execute(0xc00020d680, 0xc0000d6760, 0x2, 0x2, 0xc00020d680, 0xc0000d6760)
        /Users/travis/gopath/src/github.com/pulumi/pulumi/vendor/github.com/spf13/cobra/command.go:766 +0x2ae
github.com/pulumi/pulumi/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000170f00, 0x2338ca0, 0x0, 0x0)
        /Users/travis/gopath/src/github.com/pulumi/pulumi/vendor/github.com/spf13/cobra/command.go:852 +0x2ec
github.com/pulumi/pulumi/vendor/github.com/spf13/cobra.(*Command).Execute(...)
        /Users/travis/gopath/src/github.com/pulumi/pulumi/vendor/github.com/spf13/cobra/command.go:800
main.main()
        /Users/travis/gopath/src/github.com/pulumi/pulumi/main.go:49 +0x4c
```