### PR TITLE
Add targeted replaces to `update`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ CHANGELOG
 - Omit unknowns in resources in stack outputs during preview.
   [#3427](https://github.com/pulumi/pulumi/pull/3427)
 
+- `pulumi update` can now be instructed that a set of resources should be replaced by adding a
+  `--replace urn` argument.  Multiple resources can be specified using `--replace urn1 --replace urn2`. In order to
+  replace exactly one resource, invoke `pulumi update --replace urn --target urn`. In order to treat all resources
+  mentioned by `--replace` as if they were also passed via `--target`, pass the `--target-replaces` flag.
+  [#3418](https://github.com/pulumi/pulumi/pull/3418)
+
 ## 1.4.0 (2019-10-24)
 
 - `FileAsset` in the Python SDK now accepts anything implementing `os.PathLike` in addition to `str`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,8 @@ CHANGELOG
 
 - `pulumi update` can now be instructed that a set of resources should be replaced by adding a
   `--replace urn` argument.  Multiple resources can be specified using `--replace urn1 --replace urn2`. In order to
-  replace exactly one resource, invoke `pulumi update --replace urn --target urn`. In order to treat all resources
-  mentioned by `--replace` as if they were also passed via `--target`, pass the `--target-replaces` flag.
+  replace exactly one resource and leave other resources unchanged, invoke `pulumi update --replace urn --target urn`,
+  or `pulumi update --target-replace urn` for short.
   [#3418](https://github.com/pulumi/pulumi/pull/3418)
 
 ## 1.4.0 (2019-10-24)

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -68,7 +68,7 @@ func newUpCmd() *cobra.Command {
 	var secretsProvider string
 	var targets []string
 	var replaces []string
-	var targetReplaces bool
+	var targetReplaces []string
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(opts backend.UpdateOptions) result.Result {
@@ -112,8 +112,9 @@ func newUpCmd() *cobra.Command {
 			replaceURNs = append(replaceURNs, resource.URN(r))
 		}
 
-		if targetReplaces {
-			targetURNs = append(targetURNs, replaceURNs...)
+		for _, tr := range targetReplaces {
+			targetURNs = append(targetURNs, resource.URN(tr))
+			replaceURNs = append(replaceURNs, resource.URN(tr))
 		}
 
 		opts.Engine = engine.UpdateOptions{
@@ -394,9 +395,10 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVar(
 		&replaces, "replace", []string{},
 		"Specify resources to replace. Multiple resources can be specified using --replace run1 --replace urn2")
-	cmd.PersistentFlags().BoolVar(
-		&targetReplaces, "target-replaces", false,
-		"Add any resources passed to --replace to the set of targets to update. Shorthand for --replace urn --target urn")
+	cmd.PersistentFlags().StringArrayVar(
+		&targetReplaces, "target-replace", []string{},
+		"Specify a single resource URN to replace. Other resources will not be updated."+
+			" Shorthand for --target urn --replace urn.")
 
 	// Flags for engine.UpdateOptions.
 	if hasDebugCommands() {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -68,6 +68,7 @@ func newUpCmd() *cobra.Command {
 	var secretsProvider string
 	var targets []string
 	var replaces []string
+	var targetReplaces bool
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(opts backend.UpdateOptions) result.Result {
@@ -109,6 +110,10 @@ func newUpCmd() *cobra.Command {
 		replaceURNs := []resource.URN{}
 		for _, r := range replaces {
 			replaceURNs = append(replaceURNs, resource.URN(r))
+		}
+
+		if targetReplaces {
+			targetURNs = append(targetURNs, replaceURNs...)
 		}
 
 		opts.Engine = engine.UpdateOptions{
@@ -389,6 +394,9 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().StringArrayVar(
 		&replaces, "replace", []string{},
 		"Specify resources to replace. Multiple resources can be specified using --replace run1 --replace urn2")
+	cmd.PersistentFlags().BoolVar(
+		&targetReplaces, "target-replaces", false,
+		"Add any resources passed to --replace to the set of targets to update. Shorthand for --replace urn --target urn")
 
 	// Flags for engine.UpdateOptions.
 	if hasDebugCommands() {

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// nolint: goconst
 package engine
 
 import (

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -182,6 +182,7 @@ func (planResult *planResult) Walk(cancelCtx *Context, events deploy.Events, pre
 			Refresh:           planResult.Options.Refresh,
 			RefreshOnly:       planResult.Options.isRefresh,
 			RefreshTargets:    planResult.Options.RefreshTargets,
+			ReplaceTargets:    planResult.Options.ReplaceTargets,
 			DestroyTargets:    planResult.Options.DestroyTargets,
 			UpdateTargets:     planResult.Options.UpdateTargets,
 			TrustDependencies: planResult.Options.trustDependencies,

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -65,6 +65,9 @@ type UpdateOptions struct {
 	// Specific resources to refresh during a refresh operation.
 	RefreshTargets []resource.URN
 
+	// Specific resources to replace during an update operation.
+	ReplaceTargets []resource.URN
+
 	// Specific resources to destroy during a destroy operation.
 	DestroyTargets []resource.URN
 

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -52,6 +52,7 @@ type Options struct {
 	Refresh           bool           // whether or not to refresh before executing the plan.
 	RefreshOnly       bool           // whether or not to exit after refreshing.
 	RefreshTargets    []resource.URN // The specific resources to refresh during a refresh op.
+	ReplaceTargets    []resource.URN // Specific resources to replace.
 	DestroyTargets    []resource.URN // Specific resources to destroy.
 	UpdateTargets     []resource.URN // Specific resources to update.
 	TrustDependencies bool           // whether or not to trust the resource dependency graph.

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -60,15 +60,15 @@ func createTargetMap(targets []resource.URN) map[resource.URN]bool {
 // checkTargets validates that all the targets passed in refer to existing resources.  Diagnostics
 // are generated for any target that cannot be found.  The target must either have existed in the stack
 // prior to running the operation, or it must be the urn for a resource that was created.
-func (pe *planExecutor) checkTargets(targets []resource.URN) result.Result {
+func (pe *planExecutor) checkTargets(targets []resource.URN, op StepOp) result.Result {
 	if len(targets) == 0 {
 		return nil
 	}
 
 	olds := pe.plan.olds
 	var news map[resource.URN]bool
-	if pe.stepGen != nil && pe.stepGen.creates != nil {
-		news = pe.stepGen.creates
+	if pe.stepGen != nil {
+		news = pe.stepGen.urns
 	}
 
 	hasUnknownTarget := false
@@ -82,7 +82,7 @@ func (pe *planExecutor) checkTargets(targets []resource.URN) result.Result {
 		if !hasOld && !hasNew {
 			hasUnknownTarget = true
 
-			logging.V(7).Infof("Resource to delete (%v) could not be found in the stack.", target)
+			logging.V(7).Infof("Resource to %v (%v) could not be found in the stack.", op, target)
 			if strings.Contains(string(target), "$") {
 				pe.plan.Diag().Errorf(diag.GetTargetCouldNotBeFoundError(), target)
 			} else {
@@ -149,13 +149,17 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	// during `update` that we don't know about because it might be the urn for a resource they
 	// want to create.
 	updateTargetsOpt := createTargetMap(opts.UpdateTargets)
+	replaceTargetsOpt := createTargetMap(opts.ReplaceTargets)
 	destroyTargetsOpt := createTargetMap(opts.DestroyTargets)
-	if res := pe.checkTargets(opts.DestroyTargets); res != nil {
+	if res := pe.checkTargets(opts.ReplaceTargets, OpReplace); res != nil {
+		return res
+	}
+	if res := pe.checkTargets(opts.DestroyTargets, OpDelete); res != nil {
 		return res
 	}
 
-	if updateTargetsOpt != nil && destroyTargetsOpt != nil {
-		contract.Failf("Should not be possible to have both .DestroyTargets and .UpdateTargets")
+	if (updateTargetsOpt != nil || replaceTargetsOpt != nil) && destroyTargetsOpt != nil {
+		contract.Failf("Should not be possible to have both .DestroyTargets and .UpdateTargets or .ReplaceTargets")
 	}
 
 	// Begin iterating the source.
@@ -165,7 +169,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	}
 
 	// Set up a step generator for this plan.
-	pe.stepGen = newStepGenerator(pe.plan, opts)
+	pe.stepGen = newStepGenerator(pe.plan, opts, updateTargetsOpt, replaceTargetsOpt)
 
 	// Retire any pending deletes that are currently present in this plan.
 	if res := pe.retirePendingDeletes(callerCtx, opts, preview); res != nil {
@@ -230,7 +234,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 					return false, pe.performDeletes(ctx, updateTargetsOpt, destroyTargetsOpt)
 				}
 
-				if res := pe.handleSingleEvent(updateTargetsOpt, event.Event); res != nil {
+				if res := pe.handleSingleEvent(event.Event); res != nil {
 					if resErr := res.Error(); resErr != nil {
 						logging.V(4).Infof("planExecutor.Execute(...): error handling event: %v", resErr)
 						pe.reportError(pe.plan.generateEventURN(event.Event), resErr)
@@ -255,7 +259,7 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	// valid.  We have to do this *after* performing the steps as the target list may have referred
 	// to a resource that was created in one of hte steps.
 	if res == nil {
-		res = pe.checkTargets(opts.UpdateTargets)
+		res = pe.checkTargets(opts.UpdateTargets, OpUpdate)
 	}
 
 	if res != nil && res.IsBail() {
@@ -366,7 +370,7 @@ func (pe *planExecutor) performDeletes(
 
 // handleSingleEvent handles a single source event. For all incoming events, it produces a chain that needs
 // to be executed and schedules the chain for execution.
-func (pe *planExecutor) handleSingleEvent(updateTargetsOpt map[resource.URN]bool, event SourceEvent) result.Result {
+func (pe *planExecutor) handleSingleEvent(event SourceEvent) result.Result {
 	contract.Require(event != nil, "event != nil")
 
 	var steps []Step
@@ -374,7 +378,7 @@ func (pe *planExecutor) handleSingleEvent(updateTargetsOpt map[resource.URN]bool
 	switch e := event.(type) {
 	case RegisterResourceEvent:
 		logging.V(4).Infof("planExecutor.handleSingleEvent(...): received RegisterResourceEvent")
-		steps, res = pe.stepGen.GenerateSteps(updateTargetsOpt, e)
+		steps, res = pe.stepGen.GenerateSteps(e)
 	case ReadResourceEvent:
 		logging.V(4).Infof("planExecutor.handleSingleEvent(...): received ReadResourceEvent")
 		steps, res = pe.stepGen.GenerateReadSteps(e)
@@ -444,7 +448,7 @@ func (pe *planExecutor) refresh(callerCtx context.Context, opts Options, preview
 
 	// Make sure if there were any targets specified, that they all refer to existing resources.
 	targetMapOpt := createTargetMap(opts.RefreshTargets)
-	if res := pe.checkTargets(opts.RefreshTargets); res != nil {
+	if res := pe.checkTargets(opts.RefreshTargets, OpRefresh); res != nil {
 		return res
 	}
 


### PR DESCRIPTION
Allow the user to specify a set of resources to replace via the
`--replace` flag on the CLI. This can be combined with `--target` to
replace a specific set of resources without changing any other
resources.

Fixes #2643.