### PR TITLE
Verify statefile integrity during import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ CHANGELOG
 - Fix another colorizer issue that could cause garbled output for messages that did not end in colorization tags.
   [#3417](https://github.com/pulumi/pulumi/pull/3417)
 
+- Verify deployment integrity during import and issue an error if verification fails. The state file can still be
+  imported by passing the `--force` flag.
+  [#3422](https://github.com/pulumi/pulumi/pull/3422)
+
 ## 1.4.0 (2019-10-24)
 
 - `FileAsset` in the Python SDK now accepts anything implementing `os.PathLike` in addition to `str`.

--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -106,6 +106,15 @@ func newStackImportCmd() *cobra.Command {
 					}
 				}
 			}
+			// Validate the stack. If --force was passed, issue an error if validation fails. Otherwise, issue a warning.
+			if err := snapshot.VerifyIntegrity(); err != nil {
+				msg := fmt.Sprintf("deployment file contains errors: %v", err)
+				if force {
+					cmdutil.Diag().Warningf(diag.Message("", msg))
+				} else {
+					result = multierror.Append(result, errors.New(msg))
+				}
+			}
 			if result != nil {
 				return multierror.Append(result,
 					errors.New("importing this file could be dangerous; rerun with --force to proceed anyway"))

--- a/cmd/stack_import.go
+++ b/cmd/stack_import.go
@@ -108,7 +108,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 			// Validate the stack. If --force was passed, issue an error if validation fails. Otherwise, issue a warning.
 			if err := snapshot.VerifyIntegrity(); err != nil {
-				msg := fmt.Sprintf("deployment file contains errors: %v", err)
+				msg := fmt.Sprintf("state file contains errors: %v", err)
 				if force {
 					cmdutil.Diag().Warningf(diag.Message("", msg))
 				} else {


### PR DESCRIPTION
Issue an error if the statefile fails to verify unless the `--force`
flag was passed.

Fixes #3222.