### PR TITLE
Consistency when updating/destroying resources and using --target flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ CHANGELOG
 
 - Add support for go1.13.x
 
+- `pulumi update --target` and `pulumi destroy --target` will both error if they determine a
+  dependent resource needs to be updated, destroyed, or created that was not was specified in the
+  `--target` list.  To proceed with an `update/destroy` after this error, either specify all the
+  reported resources as `--target`s, or pass the `--target-dependents` flag to allow necessary
+  changes to unspecified dependent targets.
+
 ## 1.5.2 (2019-11-13)
 
 - `pulumi policy publish` now determines the Policy Pack name from the Policy Pack, and the

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -47,6 +47,7 @@ func newDestroyCmd() *cobra.Command {
 	var suppressOutputs bool
 	var yes bool
 	var targets *[]string
+	var targetDependents bool
 
 	var cmd = &cobra.Command{
 		Use:        "destroy",
@@ -118,11 +119,12 @@ func newDestroyCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				Parallel:       parallel,
-				Debug:          debug,
-				Refresh:        refresh,
-				DestroyTargets: targetUrns,
-				UseLegacyDiff:  useLegacyDiff(),
+				Parallel:         parallel,
+				Debug:            debug,
+				Refresh:          refresh,
+				DestroyTargets:   targetUrns,
+				TargetDependents: targetDependents,
+				UseLegacyDiff:    useLegacyDiff(),
 			}
 
 			_, res := s.Destroy(commandContext(), backend.UpdateOperation{
@@ -163,6 +165,9 @@ func newDestroyCmd() *cobra.Command {
 		"target", "t", []string{},
 		"Specify a single resource URN to destroy. All resources necessary to destroy this target will also be destroyed."+
 			" Multiple resources can be specified using: --target urn1 --target urn2")
+	cmd.PersistentFlags().BoolVar(
+		&targetDependents, "target-dependents", false,
+		"Allows destroying of dependent targets discovered but not specified in --target list")
 
 	// Flags for engine.UpdateOptions.
 	cmd.PersistentFlags().BoolVar(

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -70,6 +70,7 @@ func newUpCmd() *cobra.Command {
 	var targets []string
 	var replaces []string
 	var targetReplaces []string
+	var targetDependents bool
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(opts backend.UpdateOptions) result.Result {
@@ -126,6 +127,7 @@ func newUpCmd() *cobra.Command {
 			ReplaceTargets:       replaceURNs,
 			UseLegacyDiff:        useLegacyDiff(),
 			UpdateTargets:        targetURNs,
+			TargetDependents:     targetDependents,
 		}
 
 		changes, res := s.Update(commandContext(), backend.UpdateOperation{
@@ -403,6 +405,9 @@ func newUpCmd() *cobra.Command {
 		&targetReplaces, "target-replace", []string{},
 		"Specify a single resource URN to replace. Other resources will not be updated."+
 			" Shorthand for --target urn --replace urn.")
+	cmd.PersistentFlags().BoolVar(
+		&targetDependents, "target-dependents", false,
+		"Allows updating of dependent targets discovered but not specified in --target list")
 
 	// Flags for engine.UpdateOptions.
 	if hasDebugCommands() || hasExperimentalCommands() {

--- a/pkg/diag/errors.go
+++ b/pkg/diag/errors.go
@@ -72,6 +72,11 @@ func GetCannotDeleteParentResourceWithoutAlsoDeletingChildError(urn resource.URN
 	return newError(urn, 2012, "Cannot delete parent resource '%v' without also deleting child '%v'.")
 }
 
-func GetResourceIsBeingCreatedButWasNotSpecifiedInTargetList(urn resource.URN) *Diag {
-	return newError(urn, 2013, "Resource '%v' is being created but was not specified in -target list.")
+func GetResourceWillBeCreatedButWasNotSpecifiedInTargetList(urn resource.URN) *Diag {
+	return newError(urn, 2013, `Resource '%v' depends on '%v' which was was not specified in --target list.`)
+}
+
+func GetResourceWillBeDestroyedButWasNotSpecifiedInTargetList(urn resource.URN) *Diag {
+	return newError(urn, 2014, `Resource '%v' will be destroyed but was not specified in --target list.
+Either include resource in --target list or pass --target-dependents to proceed.`)
 }

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -185,6 +185,7 @@ func (planResult *planResult) Walk(cancelCtx *Context, events deploy.Events, pre
 			ReplaceTargets:    planResult.Options.ReplaceTargets,
 			DestroyTargets:    planResult.Options.DestroyTargets,
 			UpdateTargets:     planResult.Options.UpdateTargets,
+			TargetDependents:  planResult.Options.TargetDependents,
 			TrustDependencies: planResult.Options.trustDependencies,
 			UseLegacyDiff:     planResult.Options.UseLegacyDiff,
 		}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -74,6 +74,10 @@ type UpdateOptions struct {
 	// Specific resources to update during an update operation.
 	UpdateTargets []resource.URN
 
+	// true if we're allowing dependent targets to change, even if not specified in one of the above
+	// XXXTargets lists.
+	TargetDependents bool
+
 	// true if the engine should use legacy diffing behavior during an update.
 	UseLegacyDiff bool
 

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -55,6 +55,7 @@ type Options struct {
 	ReplaceTargets    []resource.URN // Specific resources to replace.
 	DestroyTargets    []resource.URN // Specific resources to destroy.
 	UpdateTargets     []resource.URN // Specific resources to update.
+	TargetDependents  bool           // true if we're allowing things to proceed, even with unspecified targets
 	TrustDependencies bool           // whether or not to trust the resource dependency graph.
 	UseLegacyDiff     bool           // whether or not to use legacy diffing behavior.
 }

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -182,7 +182,7 @@ func (se *stepExecutor) ExecuteRegisterResourceOutputs(e RegisterResourceOutputs
 	e.Done()
 }
 
-// Errored returnes whether or not this step executor saw a step whose execution ended in failure.
+// Errored returns whether or not this step executor saw a step whose execution ended in failure.
 func (se *stepExecutor) Errored() bool {
 	return se.sawError.Load().(bool)
 }

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -43,26 +43,37 @@ type stepGenerator struct {
 	updateTargetsOpt  map[resource.URN]bool // the set of resources to update; resources not in this set will be same'd
 	replaceTargetsOpt map[resource.URN]bool // the set of resoures to replace
 
-	// signals that one or more PolicyViolationEvents have been reported to the user, and the plan
-	// should terminate in error. This primarily allows `preview` to aggregate many policy violation
-	// events and report them all at once.
-	hasPolicyViolations bool
+	// signals that one or more errors have been reported to the user, and the plan should terminate
+	// in error. This primarily allows `preview` to aggregate many policy violation events and
+	// report them all at once.
+	sawError bool
 
-	urns           map[resource.URN]bool            // set of URNs discovered for this plan
-	reads          map[resource.URN]bool            // set of URNs read for this plan
-	deletes        map[resource.URN]bool            // set of URNs deleted in this plan
-	replaces       map[resource.URN]bool            // set of URNs replaced in this plan
-	updates        map[resource.URN]bool            // set of URNs updated in this plan
-	creates        map[resource.URN]bool            // set of URNs created in this plan
-	sames          map[resource.URN]bool            // set of URNs that were not changed in this plan
+	urns     map[resource.URN]bool // set of URNs discovered for this plan
+	reads    map[resource.URN]bool // set of URNs read for this plan
+	deletes  map[resource.URN]bool // set of URNs deleted in this plan
+	replaces map[resource.URN]bool // set of URNs replaced in this plan
+	updates  map[resource.URN]bool // set of URNs updated in this plan
+	creates  map[resource.URN]bool // set of URNs created in this plan
+	sames    map[resource.URN]bool // set of URNs that were not changed in this plan
+
+	// set of URNs that would have been created, but were filtered out because the user didn't
+	// specify them with --target
+	skippedCreates map[resource.URN]bool
+
 	pendingDeletes map[*resource.State]bool         // set of resources (not URNs!) that are pending deletion
 	providers      map[resource.URN]*resource.State // URN map of providers that we have seen so far.
 	resourceStates map[resource.URN]*resource.State // URN map of state for ALL resources we have seen so far.
+
 	// a map from URN to a list of property keys that caused the replacement of a dependent resource during a
 	// delete-before-replace.
 	dependentReplaceKeys map[resource.URN][]resource.PropertyKey
+
 	// a map from old names (aliased URNs) to the new URN that aliased to them.
 	aliased map[resource.URN]resource.URN
+}
+
+func (sg *stepGenerator) isTargetedUpdate() bool {
+	return sg.updateTargetsOpt != nil || sg.replaceTargetsOpt != nil
 }
 
 func (sg *stepGenerator) isTargetedForUpdate(urn resource.URN) bool {
@@ -71,6 +82,10 @@ func (sg *stepGenerator) isTargetedForUpdate(urn resource.URN) bool {
 
 func (sg *stepGenerator) isTargetedReplace(urn resource.URN) bool {
 	return sg.replaceTargetsOpt != nil && sg.replaceTargetsOpt[urn]
+}
+
+func (sg *stepGenerator) Errored() bool {
+	return sg.sawError
 }
 
 // GenerateReadSteps is responsible for producing one or more steps required to service
@@ -137,7 +152,55 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, res
 // If the given resource is a custom resource, the step generator will invoke Diff and Check on the
 // provider associated with that resource. If those fail, an error is returned.
 func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, result.Result) {
+	steps, res := sg.generateSteps(event)
+	if res != nil {
+		contract.Assert(len(steps) == 0)
+		return nil, res
+	}
+	if !sg.isTargetedUpdate() {
+		return steps, nil
+	}
 
+	// We got a set of steps to perfom during a targeted update. If any of the steps are not same steps and depend on
+	// creates we skipped because they were not in the --target list, issue an error that that the create was necessary
+	// and that the user must target the resource to create.
+	for _, step := range steps {
+		if step.Op() == OpSame || step.New() == nil {
+			continue
+		}
+
+		for _, urn := range step.New().Dependencies {
+			if sg.skippedCreates[urn] {
+				// Targets were specified, but didn't include this resource to create.  And a
+				// resource we are producing a step for does depend on this created resource.
+				// Give a particular error in that case to let them know.  Also mark that we're
+				// in an error state so that we eventually will error out of the entire
+				// application run.
+				d := diag.GetResourceWillBeCreatedButWasNotSpecifiedInTargetList(step.URN())
+
+				sg.plan.Diag().Errorf(d, step.URN(), urn)
+				sg.sawError = true
+
+				if !sg.plan.preview {
+					// In preview we keep going so that the user will hear about all the problems and can then
+					// fix up their command once (as opposed to adding a target, rerunning, adding a target,
+					// rerunning, etc. etc.).
+					//
+					// Doing a normal run.  We should not proceed here at all.  We don't want to create
+					// something the user didn't ask for.
+					return nil, result.Bail()
+				}
+
+				// Remove the resource from the list of skipped creates so that we do not issue duplicate diagnostics.
+				delete(sg.skippedCreates, urn)
+			}
+		}
+	}
+
+	return steps, nil
+}
+
+func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, result.Result) {
 	var invalid bool // will be set to true if this object fails validation.
 
 	goal := event.Goal()
@@ -274,18 +337,16 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, res
 			Type:       new.Type,
 			Properties: inputs,
 		}
-		diagnostics, aErr := analyzer.Analyze(r)
-		if aErr != nil {
-			return nil, result.FromError(aErr)
+		diagnostics, err := analyzer.Analyze(r)
+		if err != nil {
+			return nil, result.FromError(err)
 		}
 		for _, d := range diagnostics {
-			// TODO(hausdorff): Batch up failures and report them all at once during preview. This code here
-			// will cause them to fail eagerly, and stop the plan immediately.
 			if d.EnforcementLevel == apitype.Mandatory {
 				if !sg.plan.preview {
 					invalid = true
 				}
-				sg.hasPolicyViolations = true
+				sg.sawError = true
 			}
 			sg.opts.Events.OnPolicyViolation(new.URN, d)
 		}
@@ -390,26 +451,38 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, res
 		return []Step{NewSameStep(sg.plan, event, old, new)}, nil
 	}
 
-	if !sg.isTargetedForUpdate(urn) {
-		d := diag.GetResourceIsBeingCreatedButWasNotSpecifiedInTargetList(urn)
-
-		if sg.plan.preview {
-			// During preview we only warn here but let the planning proceed.  This allows the user
-			// to hear about *all* the potential resources they'd need to add a -target arg for.
-			// This prevents the annoying scenario where you get notified about a problem, fix it,
-			// rerun and then get notified about the very next problem.
-			sg.plan.Diag().Warningf(d, urn)
-		} else {
-			// Targets were specified, but didn't include this resource to create.  Give a particular
-			// error in that case and stop immediately.
-			sg.plan.Diag().Errorf(d, urn)
-			return nil, result.Bail()
-		}
-	}
-
 	// Case 4: Not Case 1, 2, or 3
 	//  If a resource isn't being recreated and it's not being updated or replaced,
 	//  it's just being created.
+
+	// We're in the create stage now.  In a normal run just issue a 'create step'. If, however, the
+	// user is doing a run with `--target`s, then we need to operate specially here.
+	//
+	// 1. If the user did include this resource urn in the --target list, then we can proceed
+	// normally and issue a create step for this.
+	//
+	// 2. However, if they did not include the resource in the --target list, then we want to flat
+	// out ignore it (just like we ignore updates to resource not in the --target list).  This has
+	// interesting implications though. Specifically, what to do if a prop from this resource is
+	// then actually needed by a property we *are* doing a targeted create/update for.
+	//
+	// In that case, we want to error to force the user to be explicit about wanting this resource
+	// to be created. However, we can't issue the error until later on when the resource is
+	// referenced. So, to support this we create a special "same" step here for this resource. That
+	// "same" step has a bit on it letting us know that it is for this case. If we then later see a
+	// resource that depends on this resource, we will issue an error letting the user know.
+	//
+	// We will also not record this non-created resource into the checkpoint as it doesn't actually
+	// exist.
+
+	if !sg.isTargetedForUpdate(urn) &&
+		!providers.IsProviderType(goal.Type) {
+
+		sg.sames[urn] = true
+		sg.skippedCreates[urn] = true
+		return []Step{NewSkippedCreateStep(sg.plan, event, new)}, nil
+	}
+
 	sg.creates[urn] = true
 	logging.V(7).Infof("Planner decided to create '%v' (inputs=%v)", urn, new.Inputs)
 	return []Step{NewCreateStep(sg.plan, event, new)}, nil
@@ -642,6 +715,34 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt map[resource.URN]bool) ([]St
 		}
 
 		dels = filtered
+	}
+
+	deletingUnspecifiedTarget := false
+	for _, step := range dels {
+		urn := step.URN()
+		if targetsOpt != nil && !targetsOpt[urn] && !sg.opts.TargetDependents {
+			d := diag.GetResourceWillBeDestroyedButWasNotSpecifiedInTargetList(urn)
+
+			// Targets were specified, but didn't include this resource to create.  Report all the
+			// problematic targets so the user doesn't have to keep adding them one at a time and
+			// re-running the operation.
+			//
+			// Mark that step generation entered an error state so that the entire app run fails.
+			sg.plan.Diag().Errorf(d, urn)
+			sg.sawError = true
+
+			deletingUnspecifiedTarget = true
+		}
+	}
+
+	if deletingUnspecifiedTarget && !sg.plan.preview {
+		// In preview we keep going so that the user will hear about all the problems and can then
+		// fix up their command once (as opposed to adding a target, rerunning, adding a target,
+		// rerunning, etc. etc.).
+		//
+		// Doing a normal run.  We should not proceed here at all.  We don't want to delete
+		// something the user didn't ask for.
+		return nil, result.Bail()
 	}
 
 	return dels, nil
@@ -1153,6 +1254,33 @@ func (sg *stepGenerator) calculateDependentReplacements(root *resource.State) ([
 	return toReplace, nil
 }
 
+func (sg *stepGenerator) AnalyzeResources() result.Result {
+	resourcesSeen := sg.resourceStates
+	resources := make([]plugin.AnalyzerResource, 0, len(resourcesSeen))
+	for _, v := range resourcesSeen {
+		resources = append(resources, plugin.AnalyzerResource{
+			Type: v.Type,
+			// Unlike Analyze, AnalyzeStack is called on the final outputs of each resource,
+			// to verify the final stack is in a compliant state.
+			Properties: v.Outputs,
+		})
+	}
+
+	analyzers := sg.plan.ctx.Host.ListAnalyzers()
+	for _, analyzer := range analyzers {
+		diagnostics, aErr := analyzer.AnalyzeStack(resources)
+		if aErr != nil {
+			return result.FromError(aErr)
+		}
+		for _, d := range diagnostics {
+			sg.sawError = sg.sawError || (d.EnforcementLevel == apitype.Mandatory)
+			sg.opts.Events.OnPolicyViolation("" /* don't associate with any particular URN */, d)
+		}
+	}
+
+	return nil
+}
+
 // newStepGenerator creates a new step generator that operates on the given plan.
 func newStepGenerator(
 	plan *Plan, opts Options, updateTargetsOpt, replaceTargetsOpt map[resource.URN]bool) *stepGenerator {
@@ -1169,6 +1297,7 @@ func newStepGenerator(
 		replaces:             make(map[resource.URN]bool),
 		updates:              make(map[resource.URN]bool),
 		deletes:              make(map[resource.URN]bool),
+		skippedCreates:       make(map[resource.URN]bool),
 		pendingDeletes:       make(map[*resource.State]bool),
 		providers:            make(map[resource.URN]*resource.State),
 		resourceStates:       make(map[resource.URN]*resource.State),


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/3369

Ignore whatever is in the "This PR changes how --target" works section below.  It is based on a plan that we are revising.  

The current plan that @pgavlin and i have discussed is as follows:

1. When the user provides `--target`s we only want to touch those `--target`ed urns and not touch anything else.  Not touching means: do not create those resources, do not update those resource, and do not destroy those resources.
2. For resources not mentioned in a --target list, we can think of them as following into two buckets.  
    1. Bucket A: the resource is not affected by (and does not affect) a resource that is in the --target list.  For example, some unrelated resource that happens to be created, have an update for it, or is no longer in the program and will be destroyed.  In this case, because it was not mentioned, and because it doesn't affect, and is not affected by a --target'ed resource, we just flat out ignore it.
    2. Bucket B: The resource affects, or is affected by, a resource in the --target list.  i.e. if we are destroying some resource, and some other resource needs to be replaced because of this, then it is affected by the targetted resource.  Similarly, if we are updating/creating some --target'ed resource that depends on some other resource being created, then that --target'ed resource depends-on the other resource being created.  In this case, there is a 'dependency' relationship, and we cannot properly perform the action on the --target'ed resource because of these other resource.  In this case, we will error and let the user know about the issue.  The user then has two things they can do to move forward.
        1. Add the dependent resource to the --target list.
        2. Add the --target-dependents flag.  This is basically a globbing version of the above, preventing the user from having to be explicitly reference everything manually.  This can be nice, for example, if they want to destroy one resource, and it will impact another 20 dependencies.

In terms of implementation, this is fairly simple for untargetted "destroy" operations but more complex for untargetted "create" operations.  For untargetted destroy operations, we can just simply ignore destroys with no dependency relationship, and immediately error on ones that do.  This is "easy" in that when we destroy we already have full knowledge of what is affected, so we can just determine this at the destroy  point.

For creates, it's a bit harder.  At the point where we want to create an untargetted resource, we don't know yet if there is some targetted resource later on that will depend on it.  Currently, the plan is as follows.

1. When we encounter an untargetted create, we treat that as a "same-step" of an effectively empty/unknown resource.  i.e. while the resource will have a urn, it will have an unknown id, and effectively no properties.  Such a step can be used to complete the registration of the resource, and return reasonable-ish values to our sdks.
2. We will have to make sure that these same-step resources do not flow into our checkpoint.  This may mean adding a bit to a same-step to indicate this.
3. later steps that do targetted updates/creates need to check the dependency list of the resource they are touching (either the depgraph or PropertyDependencies).  If they depend on one of these 'same' resources we created in '1' then we error, stating that this is a problem.


--

Ignore below for now.

This PR changes how --target works for both the `update` and `destroy` commands.  It is based on the conclusions of the discussions in #3369.

Specifically, our default behavior when you specify --target is now changed so that:

1. if we encounter any resources we would need to update/create/destroy that is not in the specified list of `--target` we report the issue as an error and fail the preview/update.
2. the user always has two options for what they can do here (and it's consistent between`destroy` and `update`).
2.1 They can add the urns they didn't mention to the --target list.
2.2 They can pass a new `--force-targets` flag to the operation.  This tells pulumi that any dependent resources found that need to be touched are ok, even if they're not explicitly specified.

This new behavior has the following benefits.

1. Behavior is consistent between operations.  Previously it was not.
2. By default we opt towards safety and not having us touch a broader set of resources than what the user explicitly specified.
3. We have an escape hatch to make it easy for users to say "yes, damnit, i'm ok with all these dependent resources being affected, go make the change and don't force me to specify **every single urn**".

