### PR TITLE
Temporarily disable gosec G204 linting rule

### DIFF
--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -485,6 +485,7 @@ func (host *nodeLanguageHost) execNodejs(
 
 		// Now simply spawn a process to execute the requested program, wiring up stdout/stderr directly.
 		var errResult string
+		// #nosec G204
 		cmd := exec.Command(host.nodeBin, args...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr


### PR DESCRIPTION
This is a temporary workaround to https://github.com/pulumi/pulumi/issues/3440. I'll look into a proper solution, but this unblocks folks in the meantime. 

When setting up the repo I ran into the following [linting error](https://github.com/securego/gosec/blob/master/rules/subproc.go#L52): 

``` 
cmd/pulumi-language-nodejs/main.go:488: G204: Subprocess launched with function call as argument or cmd arguments (gosec)
		cmd := exec.Command(host.nodeBin, args...)
make[1]: *** [lint] Error 1
make: *** [sdk/nodejs_default] Error 2
```
[Related gosec PR](https://github.com/securego/gosec/pull/339). Our CI must be using an out of date version which I will look into as a part of the permanent fix. 

