### PR TITLE
Fixing Istanbul usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,6 @@ To hack on Pulumi, you'll need to get a development environment set up. You'll w
 - [pipenv](https://github.com/pypa/pipenv)
 - [Golangci-lint](https://github.com/golangci/golangci-lint)
 - [Yarn](https://yarnpkg.com/)
-- [Istanbul](https://github.com/gotwarlost/istanbul)
 
 ## Getting dependencies on macOS
 
@@ -24,7 +23,6 @@ You can easily get all required dependencies with brew and npm
 ```bash
 brew install node pipenv python@3 typescript yarn go golangci/tap/golangci-lint
 brew cask install dotnet dotnet-sdk
-npm install -g istanbul
 ```
 
 ## Make build system

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -44,9 +44,9 @@ install_plugin::
 install:: install_package install_plugin
 
 istanbul_tests::
-	istanbul test --print none _mocha -- --timeout 15000 'bin/tests/**/*.spec.js'
-	istanbul report text-summary
-	istanbul report text
+	./node_modules/.bin/istanbul test --print none _mocha -- --timeout 15000 'bin/tests/**/*.spec.js'
+	./node_modules/.bin/istanbul report text-summary
+	./node_modules/.bin/istanbul report text
 
 sxs_tests::
 # Intentionally disabled as PR https://github.com/pulumi/pulumi/pull/2609 breaks SxS


### PR DESCRIPTION
Reference `node_modules/.bin` directly so mac users don't require a new version of `make` or a global Istanbul install. See [discussion](https://github.com/pulumi/pulumi/pull/3447#discussion_r342702015).