### PR TITLE
Switch to 'console.log' for our hang warning. Add warning to synchronous StackReference calls.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,8 @@ CHANGELOG
 
 - Support for node 13.x, building with gcc 8 and newer. [#3512] (https://github.com/pulumi/pulumi/pull/3512)
 
-- Codepaths which have a high likelihood of causing a hang will print a message to the console
-  indicating the problem, along with a link to documentation on how to restructure code to best
-  address it.
+- Codepaths which could result in a hang will print a message to the console indicating the problem, along with a link
+  to documentation on how to restructure code to best address it.
 
 ### Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ CHANGELOG
 
 - Support for node 13.x, building with gcc 8 and newer. [#3512] (https://github.com/pulumi/pulumi/pull/3512)
 
+- Codepaths which have a high likelihood of causing a hang will print a message to the console
+  indicating the problem, along with a link to documentation on how to restructure code to best
+  address it.
+
+### Compatibility
+
+- `StackReference.getOutputSync` and `requireOutputSync` are deprecated as they may cause hangs on
+  some combinations of Node and certain OS platforms. `StackReference.getOutput` and `requireOutput`
+  should be used instead.
+
 ## 1.5.2 (2019-11-13)
 
 - `pulumi policy publish` now determines the Policy Pack name from the Policy Pack, and the

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -148,21 +148,20 @@ const readStackResourceOutputs = "pulumi:pulumi:readStackResourceOutputs"
 func (p *builtinProvider) Invoke(tok tokens.ModuleMember,
 	args resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
 
-	if tok == readStackOutputs {
+	switch tok {
+	case readStackOutputs:
 		outs, err := p.readStackReference(args)
 		if err != nil {
 			return nil, nil, err
 		}
-
 		return outs, nil, nil
-	} else if tok == readStackResourceOutputs {
+	case readStackResourceOutputs:
 		outs, err := p.readStackResourceOutputs(args)
 		if err != nil {
 			return nil, nil, err
 		}
-
 		return outs, nil, nil
-	} else {
+	default:
 		return nil, nil, errors.Errorf("unrecognized function name: '%v'", tok)
 	}
 }

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -142,20 +142,29 @@ func (p *builtinProvider) Read(urn resource.URN, id resource.ID,
 	}, resource.StatusOK, nil
 }
 
+const readStackOutputs = "pulumi:pulumi:readStackOutputs"
 const readStackResourceOutputs = "pulumi:pulumi:readStackResourceOutputs"
 
 func (p *builtinProvider) Invoke(tok tokens.ModuleMember,
 	args resource.PropertyMap) (resource.PropertyMap, []plugin.CheckFailure, error) {
-	if tok != readStackResourceOutputs {
+
+	if tok == readStackOutputs {
+		outs, err := p.readStackReference(args)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return outs, nil, nil
+	} else if tok == readStackResourceOutputs {
+		outs, err := p.readStackResourceOutputs(args)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return outs, nil, nil
+	} else {
 		return nil, nil, errors.Errorf("unrecognized function name: '%v'", tok)
 	}
-
-	outs, err := p.readStackResourceOutputs(args)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return outs, nil, nil
 }
 
 func (p *builtinProvider) StreamInvoke(

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -223,8 +223,10 @@ function invokeSync(tok: string, props: any, opts: InvokeOptions, syncInvokes: S
         }
 
         if (provider.__registrationId === undefined) {
-            log.warn(
-`Synchronous call made to "${tok}" with an unregistered provider.
+            // Have to do an explicit console.log here as the call to utils.promiseResult may hang
+            // node, and that may prevent our normal logging calls from making it back to the user.
+            console.log(
+`Synchronous call made to "${tok}" with an unregistered provider. This may cause the program to hang.
 For more details see: https://www.pulumi.com/docs/troubleshooting/#synchronous-call`);
             utils.promiseResult(ProviderResource.register(provider));
         }

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -18,6 +18,7 @@ import * as grpc from "grpc";
 import { AsyncIterable } from "@pulumi/query/interfaces";
 
 import * as asset from "../asset";
+import { Config } from "../config";
 import { InvokeOptions } from "../invoke";
 import * as log from "../log";
 import { Inputs, Output } from "../output";
@@ -68,7 +69,14 @@ const providerproto = require("../proto/provider_pb.js");
  */
 export function invoke(tok: string, props: Inputs, opts: InvokeOptions = {}): Promise<any> {
     if (opts.async) {
-        // Use specifically requested async invoking.  Respect that.
+        // User specifically requested async invoking.  Respect that.
+        return invokeAsync(tok, props, opts);
+    }
+
+    const config = new Config("pulumi");
+    const noSyncInvokes = config.getBoolean("noSyncInvokes");
+    if (noSyncInvokes) {
+        // User globally disabled sync invokes.
         return invokeAsync(tok, props, opts);
     }
 

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -74,8 +74,8 @@ export function invoke(tok: string, props: Inputs, opts: InvokeOptions = {}): Pr
     }
 
     const config = new Config("pulumi");
-    const noSyncInvokes = config.getBoolean("noSyncInvokes");
-    if (noSyncInvokes) {
+    const noSyncCalls = config.getBoolean("noSyncCalls");
+    if (noSyncCalls) {
         // User globally disabled sync invokes.
         return invokeAsync(tok, props, opts);
     }

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -244,7 +244,7 @@ function invokeSyncWorker<T>(tok: string, props: any, opts: InvokeOptions, syncI
             // Have to do an explicit console.log here as the call to utils.promiseResult may hang
             // node, and that may prevent our normal logging calls from making it back to the user.
             console.log(
-`Synchronous call made to "${tok}" with an unregistered provider. This may cause the program to hang.
+`Synchronous call made to "${tok}" with an unregistered provider. This is now deprecated and may cause the program to hang.
 For more details see: https://www.pulumi.com/docs/troubleshooting/#synchronous-call`);
             utils.promiseResult(ProviderResource.register(provider));
         }

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -41,6 +41,8 @@ export class StackReference extends CustomResource {
     // having to go through the async values above.
 
     private readonly stackReferenceName: Input<string>;
+    private syncOutputsSupported: boolean | undefined;
+    private syncName: string | undefined;
     private syncOutputs: Record<string, any> | undefined;
     private syncSecretOutputNames: string[] | undefined;
 
@@ -96,57 +98,64 @@ export class StackReference extends CustomResource {
     }
 
     /**
-     * Fetches the value promptly of the named stack output.  May return undefined if the value is
+     * Fetches the value promptly of the named stack output. May return undefined if the value is
      * not known for some reason.
      *
-     * This operation is not supported (and will throw) if any exported values of the StackReference
-     * are secrets.
+     * This operation is not supported (and will throw) if the named stack output is a secret.
      *
      * @param name The name of the stack output to fetch.
      */
     public getOutputSync(name: string): any {
-        const [outputs, secretNames] = this.readOutputsSync("getOutputSync");
-
-        if (secretNames.indexOf(name) >= 0) {
-            throw new Error("Cannot call 'getOutputSync' if the referenced stack output is a secret. Use 'requireOutput' instead.");
+        const [out, isSecret] = this.readOutputSync("getOutputSync", name, false /*required*/);
+        if (isSecret) {
+            throw new Error("Cannot call 'getOutputSync' if the referenced stack output is a secret. Use 'getOutput' instead.");
         }
-
-        return outputs[name];
+        return out;
     }
 
     /**
-     * Fetches the value promptly of the named stack output.  Throws an error if the stack output is
+     * Fetches the value promptly of the named stack output. Throws an error if the stack output is
      * not found.
      *
-     * This operation is not supported (and will throw) if any exported values of the StackReference
-     * are secrets.
+     * This operation is not supported (and will throw) if the named stack output is a secret.
      *
      * @param name The name of the stack output to fetch.
      */
     public requireOutputSync(name: string): any {
-        const [outputs, secretNames] = this.readOutputsSync("requireOutputSync");
-
-        if (secretNames.indexOf(name) >= 0) {
+        const [out, isSecret] = this.readOutputSync("requireOutputSync", name, true /*required*/);
+        if (isSecret) {
             throw new Error("Cannot call 'requireOutputSync' if the referenced stack output is a secret. Use 'requireOutput' instead.");
         }
-
-        if (!outputs.hasOwnProperty(name)) {
-            throw new Error(`Required output '${name}' does not exist on stack.`);
-        }
-
-        return outputs[name];
+        return out;
     }
 
-    private readOutputsSync(callerName: string): [Record<string, any>, string[]] {
-        // See if we already read in the outputs synchronously.  If so, just use those values.
+    private readOutputSync(callerName: string, outputName: string, required: boolean): [any, boolean] {
+        const [stackName, outputs, secretNames, supported] = this.readOutputsSync("requireOutputSync");
+
+        // If the synchronous readStackOutputs call is supported by the engine, use its results.
+        if (supported) {
+            if (required && !outputs.hasOwnProperty(name)) {
+                throw new Error(`Required output '${name}' does not exist on stack '${stackName}'.`);
+            }
+
+            return [outputs[name], secretNames.includes(name)];
+        }
+
+        // Otherwise, fall back to promiseResult.
+        const out = required ? this.requireOutput(name) : this.getOutput(name);
+        return [promiseResult(out.promise()), promiseResult(out.isSecret)];
+    }
+
+    private readOutputsSync(callerName: string): [string, Record<string, any>, string[], boolean] {
+        // See if we already attempted to read in the outputs synchronously. If so, just use those values.
         if (this.syncOutputs) {
-            return [this.syncOutputs, this.syncSecretOutputNames!];
+            return [this.syncName!, this.syncOutputs, this.syncSecretOutputNames!, this.syncOutputsSupported!];
         }
 
         // We need to pass along our StackReference name to the engine so it knows what results to
         // return.  However, because we're doing this synchronously, we can only do this safely if
         // the stack-reference name is synchronously known (i.e. it's a string and not a
-        // Promise/Output).  If it is only asynchronously known, then warn the user and make an unsafe
+        // Promise/Output). If it is only asynchronously known, then warn the user and make an unsafe
         // call to the deasync lib to get the name.
         let stackName: string;
         if (this.stackReferenceName instanceof Promise) {
@@ -154,14 +163,14 @@ export class StackReference extends CustomResource {
             // node, and that may prevent our normal logging calls from making it back to the user.
             console.log(
                 `Call made to StackReference.${callerName} with a StackReference with a Promise name. This is now deprecated and may cause the program to hang.
-                For more details see: https://www.pulumi.com/docs/troubleshooting/#stackreference-sync`);
+For more details see: https://www.pulumi.com/docs/troubleshooting/#stackreference-sync`);
 
             stackName = promiseResult(this.stackReferenceName);
         }
         else if (Output.isInstance(this.stackReferenceName)) {
             console.log(
                 `Call made to StackReference.${callerName} with a StackReference with an Output name. This is now deprecated and may cause the program to hang.
-                For more details see: https://www.pulumi.com/docs/troubleshooting/#stackreference-sync`);
+For more details see: https://www.pulumi.com/docs/troubleshooting/#stackreference-sync`);
 
             stackName = promiseResult(this.stackReferenceName.promise());
         }
@@ -169,12 +178,19 @@ export class StackReference extends CustomResource {
             stackName = this.stackReferenceName;
         }
 
-        const res = invoke.invokeSync<ReadStackOutputsResult>(
-            "pulumi:pulumi:readStackOutputs", { name: stackName });
-        this.syncOutputs = res.outputs;
-        this.syncSecretOutputNames = res.secretOutputNames;
+        try {
+            const res = invoke.invokeSync<ReadStackOutputsResult>(
+                "pulumi:pulumi:readStackOutputs", { name: stackName });
+            this.syncName = stackName;
+            this.syncOutputs = res.outputs;
+            this.syncSecretOutputNames = res.secretOutputNames;
+            this.syncOutputsSupported = true;
+        } catch {
+            this.syncOutputs = {};
+            this.syncOutputsSupported = false;
+        }
 
-        return [this.syncOutputs, this.syncSecretOutputNames];
+        return [this.syncName!, this.syncOutputs, this.syncSecretOutputNames!, this.syncOutputsSupported];
     }
 }
 

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -134,15 +134,18 @@ export class StackReference extends CustomResource {
 
         // If the synchronous readStackOutputs call is supported by the engine, use its results.
         if (supported) {
-            if (required && !outputs.hasOwnProperty(name)) {
-                throw new Error(`Required output '${name}' does not exist on stack '${stackName}'.`);
+            if (required && !outputs.hasOwnProperty(outputName)) {
+                throw new Error(`Required output '${outputName}' does not exist on stack '${stackName}'.`);
             }
 
-            return [outputs[name], secretNames.includes(name)];
+            return [outputs[outputName], secretNames.includes(outputName)];
         }
 
         // Otherwise, fall back to promiseResult.
-        const out = required ? this.requireOutput(name) : this.getOutput(name);
+        console.log(`StackReference.${callerName} may cause your program to hang. Please update to the latest version of the Pulumi CLI.
+For more details see: https://www.pulumi.com/docs/troubleshooting/#stackreference-sync`);
+
+        const out = required ? this.requireOutput(outputName) : this.getOutput(outputName);
         return [promiseResult(out.promise()), promiseResult(out.isSecret)];
     }
 

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -160,7 +160,7 @@ export class StackReference extends CustomResource {
         }
         else if (Output.isInstance(this.stackReferenceName)) {
             console.log(
-                `Call made to StackReference.${callerName} with a StackReference with an Output name. This may cause the program to hang.
+                `Call made to StackReference.${callerName} with a StackReference with an Output name. This is now deprecated and may cause the program to hang.
                 For more details see: https://www.pulumi.com/docs/troubleshooting/#stackreference-sync`);
 
             stackName = promiseResult(this.stackReferenceName.promise());

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -37,6 +37,9 @@ export class StackReference extends CustomResource {
      */
     public readonly secretOutputNames!: Output<string[]>;
 
+    // Values we stash to support the getOutputSync and requireOutputSync calls without
+    // having to go through the async values above.
+
     private readonly stackReferenceName: Input<string>;
     private syncOutputs: Record<string, any> | undefined;
     private syncSecretOutputNames: string[] | undefined;
@@ -70,7 +73,7 @@ export class StackReference extends CustomResource {
      * @param name The name of the stack output to fetch.
      */
     public getOutput(name: Input<string>): Output<any> {
-        // Note that this is subltly different from "apply" here. A default "apply" will set the secret bit if any
+        // Note that this is subtly different from "apply" here. A default "apply" will set the secret bit if any
         // of the inputs are a secret, and this.outputs is always a secret if it contains any secrets. We do this dance
         // so we can ensure that the Output we return is not needlessly tainted as a secret.
         const value = all([output(name), this.outputs]).apply(([n, os]) => os[n]);

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -91,9 +91,15 @@ export class StackReference extends CustomResource {
      * are secrets.
      *
      * @param name The name of the stack output to fetch.
+     * @deprecated
      */
     public getOutputSync(name: string): any {
         const out = this.getOutput(name);
+
+        // Have to do an explicit console.log here as the call to utils.promiseResult may hang
+        // node, and that may prevent our normal logging calls from making it back to the user.
+        console.log(`"getOutputSync" is deprecated and may cause the program to hang. Please use "getOutput" instead.`);
+
         const isSecret = promiseResult(out.isSecret);
         if (isSecret) {
             throw new Error("Cannot call 'getOutputSync' if the referenced stack has secret outputs. Use 'getOutput' instead.");
@@ -110,8 +116,13 @@ export class StackReference extends CustomResource {
      * are secrets.
      *
      * @param name The name of the stack output to fetch.
+     * @deprecated
      */
     public requireOutputSync(name: string): any {
+        // Have to do an explicit console.log here as the call to utils.promiseResult may hang
+        // node, and that may prevent our normal logging calls from making it back to the user.
+        console.log(`"requireOutputSync" is deprecated and may cause the program to hang. Please use "requireOutput" instead.`);
+
         const out = this.requireOutput(name);
         const isSecret = promiseResult(out.isSecret);
         if (isSecret) {

--- a/sdk/nodejs/stackReference.ts
+++ b/sdk/nodejs/stackReference.ts
@@ -153,7 +153,7 @@ export class StackReference extends CustomResource {
             // Have to do an explicit console.log here as the call to utils.promiseResult may hang
             // node, and that may prevent our normal logging calls from making it back to the user.
             console.log(
-                `Call made to StackReference.${callerName} with a StackReference with a Promise name. This may cause the program to hang.
+                `Call made to StackReference.${callerName} with a StackReference with a Promise name. This is now deprecated and may cause the program to hang.
                 For more details see: https://www.pulumi.com/docs/troubleshooting/#stackreference-sync`);
 
             stackName = promiseResult(this.stackReferenceName);


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-cloudflare/issues/46

Corresponding doc update is here: https://github.com/pulumi/docs/pull/1929