### PR TITLE
Error instead of panic when different resources use the same alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Gracefully handle errors when resources use duplicate aliases.
 - Use the update token for renew_lease calls and update the API version to 5.
   [#3348](https://github.com/pulumi/pulumi/pull/3348)
 

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -562,7 +562,9 @@ func (sm *SnapshotManager) snap() *deploy.Snapshot {
 // saveSnapshot persists the current snapshot and optionally verifies it afterwards.
 func (sm *SnapshotManager) saveSnapshot() error {
 	snap := sm.snap()
-	snap.NormalizeURNReferences()
+	if err := snap.NormalizeURNReferences(); err != nil {
+		return errors.Wrap(err, "failed to normalize URN references")
+	}
 	if err := sm.persister.Save(snap); err != nil {
 		return errors.Wrap(err, "failed to save snapshot")
 	}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -75,7 +75,7 @@ func NewSnapshot(manifest Manifest, secretsManager secrets.Manager,
 // of a resource in the resources map.
 //
 // Note: This method modifies the snapshot (and resource.States in the snapshot) in-place.
-func (snap *Snapshot) NormalizeURNReferences() {
+func (snap *Snapshot) NormalizeURNReferences() error {
 	if snap != nil {
 		aliased := make(map[resource.URN]resource.URN)
 		fixUrn := func(urn resource.URN) resource.URN {
@@ -109,12 +109,14 @@ func (snap *Snapshot) NormalizeURNReferences() {
 				// same resource multiple times.  That's fine, only error if we see the same alias,
 				// but it maps to *different* resources.
 				if otherUrn, has := aliased[alias]; has && otherUrn != state.URN {
-					contract.Assertf(!has, "Two resources ('%s' and '%s') aliased to the same: '%s'", otherUrn, state.URN, alias)
+					return errors.Errorf("Two resources ('%s' and '%s') aliased to the same: '%s'", otherUrn, state.URN, alias)
 				}
 				aliased[alias] = state.URN
 			}
 		}
 	}
+
+	return nil
 }
 
 // VerifyIntegrity checks a snapshot to ensure it is well-formed.  Because of the cost of this operation,


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/3445

repro: 

```ts
import * as pulumi from "@pulumi/pulumi";
import * as aws from "@pulumi/aws";
import * as awsx from "@pulumi/awsx";

// Create an AWS resource (S3 Bucket)
const bucket1 = new aws.s3.Bucket("bucket1", {}, { aliases: ["foo1"]});
const bucket2 = new aws.s3.Bucket("bucket2", {}, { aliases: ["foo1"]});

// Export the name of the bucket
export const bucketName1 = bucket1.id;
export const bucketName2 = bucket2.id;
```

Output after fix:

```
Do you want to perform this update? yes
Updating (evanDupeAliasRepro):

     Type                 Name                               Status         Info
     pulumi:pulumi:Stack  dupeAliasRepro-evanDupeAliasRepro  **failed**     2 errors

Diagnostics:
  pulumi:pulumi:Stack (dupeAliasRepro-evanDupeAliasRepro):
    error: post-step event returned an error: failed to normalize URN references: Two resources ('urn:pulumi:evanDupeAliasRepro::dupeAliasRepro::aws:s3/bucket:Bucket::bucket2' and 'urn:pulumi:evanDupeAliasRepro::dupeAliasRepro::aws:s3/bucket:Bucket::bucket1') aliased to the same: 'foo1'
    error: update failed

Outputs:
  - bucketName1: "bucket1-69896e1"
  - bucketName2: "bucket2-08a7428"

Resources:
    1 unchanged

Duration: 1s
```