### PR TITLE
Change how we generate dotnet versions while we're in preview.

### DIFF
--- a/scripts/get-version
+++ b/scripts/get-version
@@ -17,15 +17,26 @@ if ! git diff-files --quiet; then
     DIRTY_TAG="dirty"
 fi
 
-# If we have an exact tag, just use it.
-if git describe --tags --exact-match "${COMMITISH}" >/dev/null 2>&1; then
-    echo -n "$(git describe --tags --exact-match "${COMMITISH}")"
-    if [ ! -z "${DIRTY_TAG}" ]; then
-        echo -n "+${DIRTY_TAG}"
+# if we're passed --preview then generate the full version-timestamp+hash value.
+IN_PREVIEW=""
+for arg in "$@"
+do
+    if [[ "$arg" == "--preview" ]]; then
+        IN_PREVIEW="1"
     fi
+done
 
-    echo ""
-    exit 0
+if [ ! -z "${IN_PREVIEW}" ]; then
+    # If we have an exact tag, just use it.
+    if git describe --tags --exact-match "${COMMITISH}" >/dev/null 2>&1; then
+        echo -n "$(git describe --tags --exact-match "${COMMITISH}")"
+        if [ ! -z "${DIRTY_TAG}" ]; then
+            echo -n "+${DIRTY_TAG}"
+        fi
+
+        echo ""
+        exit 0
+    fi
 fi
 
 # Otherwise, increment the minor version version (if the package is 1.X or later) or the
@@ -52,23 +63,11 @@ else
     PATCH=0
 fi
 
-# if we're in a features/xxx branch and caller passed --embed-feature-branch then append `-xxx` to
-# the version as well.
-FEATURE_TAG=""
-for arg in "$@"
-do
-    if [[ "$arg" == "--embed-feature-branch" ]]; then
-        if [[ "${TRAVIS_BRANCH:-}" == features/* ]]; then
-            FEATURE_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|-|g')
-        fi
-    fi
-done
-
 # We want to include some additional information. To the base tag we
 # add a timestamp and commit hash. We use the timestamp of the commit
 # itself, not the date it was authored (so it will change when someone
 # rebases a PR into master, for example).
-echo -n "${MAJOR}.${MINOR}.${PATCH}-alpha${FEATURE_TAG}.$(git show -s --format='%ct+g%h' ${COMMITISH})"
+echo -n "${MAJOR}.${MINOR}.${PATCH}-alpha.$(git show -s --format='%ct+g%h' ${COMMITISH})"
 if [ ! -z "${DIRTY_TAG}" ]; then
     echo -n ".${DIRTY_TAG}"
 fi

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -56,9 +56,13 @@ if [[ "${TRAVIS_PUBLISH_PACKAGES:-}" == "true" ]]; then
         --skip-existing \
         --verbose
 
-    echo "Publishing .nupkgs to nuget.org:"
-    find /opt/pulumi/nuget -name 'Pulumi*.nupkg' \
-        -exec dotnet nuget push -k ${NUGET_PUBLISH_KEY} -s https://api.nuget.org/v3/index.json {} ';'
+    if [[ "${TRAVIS_BRANCH:-}" != features/* ]]; then
+        echo "Publishing .nupkgs to nuget.org:"
+        find /opt/pulumi/nuget -name 'Pulumi*.nupkg' \
+            -exec dotnet nuget push -k ${NUGET_PUBLISH_KEY} -s https://api.nuget.org/v3/index.json {} ';'
+    else
+        echo "Skipping publishin of .nupkgs in feature branch"
+    fi
 
     "${ROOT}/scripts/build-and-publish-docker" "${NPM_VERSION}"
 

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -3,39 +3,34 @@ LANGHOST_PKG         := github.com/pulumi/pulumi/sdk/dotnet/cmd/pulumi-language-
 
 PROJECT_PKGS         := $(shell go list ./cmd...)
 
-VERSION              := $(shell ../../scripts/get-version HEAD --embed-feature-branch)
-VERSION_DOTNET       := ${VERSION:v%=%}                                   # strip v from the beginning
-VERSION_FIRST_WORD   := $(word 1,$(subst -, ,${VERSION_DOTNET})) # e.g. 1.5.0
-VERSION_SECOND_WORD  := $(word 2,$(subst -, ,${VERSION_DOTNET})) # e.g. alpha or alpha.1
-VERSION_THIRD_WORD   := $(word 3,$(subst -, ,${VERSION_DOTNET})) # e.g. featbranch or featbranch.1
+# VERSION will be something like: v1.5.0-timestamp+ghash
+VERSION              := $(shell ../../scripts/get-version HEAD --preview)
 
-VERSION_PREFIX       := $(strip ${VERSION_FIRST_WORD})
+# strip v from the beginning to get: 1.5.0-timestamp+ghash
+VERSION_DOTNET       := ${VERSION:v%=%}
 
-ifeq ($(strip ${VERSION_SECOND_WORD}),)
-	VERSION_SUFFIX   := preview
-else ifeq ($(strip ${VERSION_THIRD_WORD}),)
-	VERSION_SUFFIX   := preview-$(strip ${VERSION_SECOND_WORD})
-else
-	VERSION_SUFFIX   := preview-$(strip ${VERSION_THIRD_WORD})-$(strip ${VERSION_SECOND_WORD})
-endif
+# Grab: 1.5.0
+VERSION_FIRST_WORD   := $(strip $(word 1,$(subst -, ,${VERSION_DOTNET})))
+
+# Grab: timestamp+ghash
+VERSION_SECOND_WORD  := $(strip $(word 2,$(subst -, ,${VERSION_DOTNET})))
+
+VERSION_PREFIX := ${VERSION_FIRST_WORD}
+
+# .NET support is only in Preview currently.  So unilaterally add `-timestamp+ghash` to the version
+# suffix. From the nuget docs:
+#
+# Pre-release versions are then denoted by appending a hyphen and a string after the patch number.
+# Technically speaking, you can use any string after the hyphen and NuGet will treat the package as
+# pre-release. NuGet then displays the full version number in the applicable UI, leaving consumers
+# to interpret the meaning for themselves.
+VERSION_SUFFIX := -${VERSION_SECOND_WORD}
 
 TESTPARALLELISM := 10
 
 include ../../build/common.mk
 
 build::
-	# .NET support is only in Preview currently.  So unilaterally add `-preview` to the version suffix.
-	# From the nuget docs:
-	#
-	# Pre-release versions are then denoted by appending a hyphen and a string after the patch number.
-	# Technically speaking, you can use any string after the hyphen and NuGet will treat the package as
-	# pre-release. NuGet then displays the full version number in the applicable UI, leaving consumers
-	# to interpret the meaning for themselves.
-	#
-	# With this in mind, it's generally good to follow recognized naming conventions such as the
-	# following:
-	#
-	#     -alpha: Alpha release, typically used for work-in-progress and experimentation
 	dotnet build dotnet.sln /p:VersionPrefix=${VERSION_PREFIX} /p:VersionSuffix=${VERSION_SUFFIX}
 	go install -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}
 

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -3,16 +3,16 @@ LANGHOST_PKG         := github.com/pulumi/pulumi/sdk/dotnet/cmd/pulumi-language-
 
 PROJECT_PKGS         := $(shell go list ./cmd...)
 
-# VERSION will be something like: v1.5.0-timestamp+ghash
+# VERSION will be something like: v1.5.0-alpha.1573070062+g76d79be4
 VERSION              := $(shell ../../scripts/get-version HEAD --preview)
 
-# strip v from the beginning to get: 1.5.0-timestamp+ghash
+# strip v from the beginning to get: 1.5.0-alpha.1573070062+g76d79be4
 VERSION_DOTNET       := ${VERSION:v%=%}
 
 # Grab: 1.5.0
 VERSION_FIRST_WORD   := $(strip $(word 1,$(subst -, ,${VERSION_DOTNET})))
 
-# Grab: timestamp+ghash
+# Grab: -alpha.1573070062+g76d79be4
 VERSION_SECOND_WORD  := $(strip $(word 2,$(subst -, ,${VERSION_DOTNET})))
 
 VERSION_PREFIX := ${VERSION_FIRST_WORD}


### PR DESCRIPTION
IMPORTANT: this is not intended ot be taken in for our thursday release. For that release we will simply hardcode in a specific version that we will snap everything to.

This PR is a proposal + proof of concept of what we can do *in the future* to have a reasonable versioning story that avoids the problems we have currently.

--

For potential consideration.  This changes how we generate versions for the .net sdk while we're currently in preview.  Specifically:

1. We pass a flag in stating: always give us a version string containing both the `-alpha` portion and a `commit-timestamp + hash` portion.  We can use this to always generate monotonically increasing prerelease builds to ensure proper ordering.

2.  We no longer publish feature-branches for .net.  There is no clear way to do this and not have the feature-branch package somehow interfere with people that want normal dev builds.

Here are examples of what this approach produces.  For a normal dev build we will produce a version like so:

`1.5.0-alpha.1573070062+g76d79be4`

Importantly:

1. the `-alpha` (which always is included) indicates we're prerelease.  We will always be including this in .NET builds until the actual point in time that we confidently feel we have a non-prerelease product.
2. as we actually rev the package with real releases for our other sdks, this will increment like so:
2.1. `1.5.1-alpha.xxx`
2.2. `1.5.2-alpha.xxx`
2.3. ...
2.4. `1.6.0-alpha.xxx`
2.5. ...
2.6. `2.0.0-alpha.xxx`
3. These are all properly incrementing versions where later releases will beat out earlier releases.
4. Within a single release, we are only incrementing the xxx portion, and we are doing so with the commit timestamp.  This ensures that as more 'dev' builds get produced they do 'win' out over the previous 'dev' build.  However, once a new 'release' happens its 'dev' builds will beat previous 'dev' builds 

--

Once we finally get out of 'preview' we can switch to using the same model as above *except* that we don't include `-alpha` or hte `.xxx` portion for true releases.  so we would actually release a versoin like `1.7.0`.  Because this had no `-alpha`, it would always beat out prerelease versions. 

When we do the above, we should likely delist all our existing versions to ensure they don't conflict with any of these new versions we produce.