### PR TITLE
Wire through OverStackLimitError

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -130,8 +130,11 @@ func createStack(
 
 	stack, err := b.CreateStack(commandContext(), stackRef, opts)
 	if err != nil {
-		// If it's a StackAlreadyExistsError, don't wrap it.
+		// If it's a well-known error, don't wrap it.
 		if _, ok := err.(*backend.StackAlreadyExistsError); ok {
+			return nil, err
+		}
+		if _, ok := err.(*backend.OverStackLimitError); ok {
 			return nil, err
 		}
 		return nil, errors.Wrapf(err, "could not create stack")

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -18,6 +18,7 @@ package backend
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -49,6 +50,18 @@ type StackAlreadyExistsError struct {
 
 func (e StackAlreadyExistsError) Error() string {
 	return fmt.Sprintf("stack '%v' already exists", e.StackName)
+}
+
+// OverStackLimitError is returned from CreateStack when the organization is billed per-stack and
+// is over its stack limit.
+type OverStackLimitError struct {
+	Message string
+}
+
+func (e OverStackLimitError) Error() string {
+	m := e.Message
+	m = strings.Replace(m, "Conflict: ", "over stack limit: ", -1)
+	return m
 }
 
 // StackReference is an opaque type that refers to a stack managed by a backend.  The CLI uses the ParseStackReference


### PR DESCRIPTION
Yesterday the Pulumi Service started enforcing a hard limit for organizations that are billed per-stack. After exceeding their declared stack limit with some wiggle room, a `409 Conflict` response is served preventing new stacks from being created.

The CLI was assuming that all 409 response codes from `CreateStackHandler` were the "stack already exists" error, which was confusing for the few users who ran into this. This PR just wires through a separate `OverStackLimitError` to different the two error responses.

To be honest I don't like the solution here. It seems like we should just cleanup the error messages from the Pulumi Service, and return those to the client unmodified. However, because we automatically include the HTTP status code, definition, and wrap the error, it's cleaner to introduce a new `OverStackLimitError` for now.

If we did the minimal amount of work:
```
$ /Users/chris/pulumi-root/bin/pulumi stack init x
error: could not create stack: [409] Conflict: you are using 47 of 5 stacks - manage stack limits for your organization at https://app.pulumi.com/chrsmith/settings/billing
```

If we return a custom error, and don't wrap with "could not create stack":
```
chris:~/go/src/github.com/pulumi/pulumi-service/examples/resources $ /Users/chris/pulumi-root/bin/pulumi stack init x
error: Conflict: you are using 47 of 5 stacks - manage stack limits for your organization at https://app.pulumi.com/chrsmith/settings/billing
```

Swaping out "Conflict:" with "over stack limit:"
```
$ /Users/chris/pulumi-root/bin/pulumi stack init x
error: over stack limit: you are using 47 of 5 stacks - manage stack limits for your organization at https://app.pulumi.com/chrsmith/settings/billing
```

Fixes #3461