### PR TITLE
Reduce the output of dotnet build

### DIFF
--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -332,7 +332,7 @@ func (host *dotnetLanguageHost) DeterminePluginDependency(
 func (host *dotnetLanguageHost) DotnetBuild(
 	ctx context.Context, req *pulumirpc.GetRequiredPluginsRequest, engineClient pulumirpc.EngineClient) error {
 
-	args := []string{"build"}
+	args := []string{"build", "-nologo"}
 
 	if req.GetProgram() != "" {
 		args = append(args, req.GetProgram())


### PR DESCRIPTION
Use [nologo](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/nologo-compiler-option) option to remove Microsoft copyright lines from the output

Thanks @clstokes!