### PR TITLE
Do a `dotnet build` after installing a template

### DIFF
--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -128,6 +128,13 @@ func Update(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resour
 	}, dryRun)
 }
 
+// RunInstallPlugins calls installPlugins and just returns the error (avoids having to export pluginSet).
+func RunInstallPlugins(
+	proj *workspace.Project, pwd, main string, target *deploy.Target, plugctx *plugin.Context) error {
+	_, _, err := installPlugins(proj, pwd, main, target, plugctx)
+	return err
+}
+
 func installPlugins(
 	proj *workspace.Project, pwd, main string, target *deploy.Target,
 	plugctx *plugin.Context) (pluginSet, map[tokens.Package]*semver.Version, error) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/templates/issues/70

Example output:

```
$ pulumi new aws-csharp
This command will walk you through creating a new Pulumi project.

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.

project name: (dnr) 
project description: (A minimal AWS C# Pulumi program) 
Created project 'dnr'

Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
stack name: (dev) 
Created stack 'dev'

aws:region: The AWS region to deploy into: (us-east-1) 
Saved config

Installing dependencies...

running 'dotnet build .'
Microsoft (R) Build Engine version 16.3.0+0f4c62fea for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.


  Restore completed in 1.03 sec for /Users/justin/Desktop/2019/11/08/dnr/Infra.csproj.

  Infra -> /Users/justin/Desktop/2019/11/08/dnr/bin/Debug/netcoreapp3.0/Infra.dll


Build succeeded.

    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:02.85

'dotnet build .' completed successfully
[resource plugin aws-1.8.0] installing
Downloading plugin: 62.14 MiB / 62.14 MiB [=========================] 100.00% 6s
Moving plugin... done.
Finished installing dependencies

Your new project is ready to go! ✨

To perform an initial deployment, run 'pulumi up'
```

A subsequent `pulumi up` is then pretty quick, but it still shows the duplicate output from #3469:

```
$ pulumi up
Previewing update (dev):
     Type                 Name     Plan     Info
     pulumi:pulumi:Stack  dnr-dev           'dotnet build .' completed successfully

     Type                 Name       Plan       
 +   pulumi:pulumi:Stack  dnr-dev    create     
 +   └─ aws:s3:Bucket     my-bucket  create     
 
Resources:
    + 2 to create

Do you want to perform this update?
```