### PR TITLE
Return a more helpful error when trying to run a Pulumi program using `dotnet run`

### DIFF
--- a/sdk/dotnet/Pulumi/Deployment/Deployment.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.cs
@@ -78,26 +78,16 @@ namespace Pulumi
             var parallel = Environment.GetEnvironmentVariable("PULUMI_PARALLEL");
             var tracing = Environment.GetEnvironmentVariable("PULUMI_TRACING");
 
-            if (string.IsNullOrEmpty(monitor))
-                throw new InvalidOperationException("Environment did not contain: PULUMI_MONITOR");
-
-            if (string.IsNullOrEmpty(engine))
-                throw new InvalidOperationException("Environment did not contain: PULUMI_ENGINE");
-
-            if (string.IsNullOrEmpty(project))
-                throw new InvalidOperationException("Environment did not contain: PULUMI_PROJECT");
-
-            if (string.IsNullOrEmpty(stack))
-                throw new InvalidOperationException("Environment did not contain: PULUMI_STACK");
-
-            if (!bool.TryParse(dryRun, out var dryRunValue))
-                throw new InvalidOperationException("Environment did not contain a valid bool value for: PULUMI_DRY_RUN");
-
-            if (!bool.TryParse(queryMode, out var queryModeValue))
-                throw new InvalidOperationException("Environment did not contain a valid bool value for: PULUMI_QUERY_MODE");
-
-            if (!int.TryParse(parallel, out var parallelValue))
-                throw new InvalidOperationException("Environment did not contain a valid int value for: PULUMI_PARALLEL");
+            if (string.IsNullOrEmpty(monitor) ||
+                string.IsNullOrEmpty(engine) ||
+                string.IsNullOrEmpty(project) ||
+                string.IsNullOrEmpty(stack) ||
+                !bool.TryParse(dryRun, out var dryRunValue) ||
+                !bool.TryParse(queryMode, out var queryModeValue) ||
+                !int.TryParse(parallel, out var parallelValue))
+            {
+                throw new InvalidOperationException("Program run without the Pulumi engine available; re-run using the `pulumi` CLI");
+            }
 
             _isDryRun = dryRunValue;
             _stackName = stack;


### PR DESCRIPTION
After creating an initial Pulumi .NET project, it will be natural for some folks (who are unfamiliar with Pulumi) to try to run it via `dotnet run`, as that's how you'd typically run a .NET Core program. Doing so today fails with:

```
Unhandled exception. System.InvalidOperationException: Environment did not contain: PULUMI_MONITOR
   at Pulumi.Deployment..ctor()
   at Pulumi.Deployment.RunAsync(Func`1 func)
   at Pulumi.Deployment.RunAsync(Func`1 func)
   at Pulumi.Deployment.RunAsync(Action action)
   at Program.Main() in /Users/user/temp/quickstart/Program.cs:line 9
   at Program.<Main>()
```

Instead, provide a more descriptive error message indicating that the `pulumi` CLI should be used to run the program. We return the same error as we do for [Node.js](https://github.com/pulumi/pulumi/blob/b91085431b909d44b87cbf78bfee20c3b3ef5e8a/sdk/nodejs/runtime/settings.ts#L89) and [Python](https://github.com/pulumi/pulumi/blob/b91085431b909d44b87cbf78bfee20c3b3ef5e8a/sdk/python/lib/pulumi/runtime/settings.py#L114).

```
Unhandled exception. System.InvalidOperationException: Program run without the Pulumi engine available; re-run using the `pulumi` CLI
   at Pulumi.Deployment..ctor()
   at Pulumi.Deployment.RunAsync(Func`1 func)
   at Pulumi.Deployment.RunAsync(Func`1 func)
   at Pulumi.Deployment.RunAsync(Action action)
   at Program.Main() in /Users/user/temp/quickstart/Program.cs:line 9
   at Program.<Main>()
```

Part of #3470