### PR TITLE
Extension methods to navigate Output<Array>

### DIFF
--- a/sdk/dotnet/Pulumi/Core/OutputExtensions.cs
+++ b/sdk/dotnet/Pulumi/Core/OutputExtensions.cs
@@ -17,8 +17,11 @@ namespace Pulumi
         /// <param name="array">An array wrapped into <see cref="Output{T}"/>.</param>
         /// <param name="index">An index to get an element at.</param>
         /// <returns>An <see cref="Output{T}"/> containing an array element.</returns>
-        public static Output<T> GetAt<T>(this Output<ImmutableArray<T>> array, int index)
-            => array.Apply(xs => xs[index]);
+        public static Output<T> GetAt<T>(this Output<ImmutableArray<T>> array, Input<int> index)
+        {
+            var inputArray = (Input<ImmutableArray<T>>)array;
+            return Output.Tuple(inputArray, index).Apply(v => v.Item1[v.Item2]);
+        }
 
         /// <summary>
         /// Convert an output containing an array to an output containing its first element.
@@ -27,5 +30,14 @@ namespace Pulumi
         /// <param name="array">An array wrapped into <see cref="Output{T}"/>.</param>
         /// <returns>An <see cref="Output{T}"/> containing the first array element.</returns>
         public static Output<T> First<T>(this Output<ImmutableArray<T>> array) => array.GetAt(0);
+
+        /// <summary>
+        /// Convert an output containing an array to an output containing the length of the array.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the array.</typeparam>
+        /// <param name="array">An array wrapped into <see cref="Output{T}"/>.</param>
+        /// <returns>An <see cref="Output{T}"/> containing the array length.</returns>
+        public static Output<int> Length<T>(this Output<ImmutableArray<T>> array)
+            => array.Apply(xs => xs.Length);
     } 
 }

--- a/sdk/dotnet/Pulumi/Core/OutputExtensions.cs
+++ b/sdk/dotnet/Pulumi/Core/OutputExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright 2016-2019, Pulumi Corporation
+
+using System.Collections.Immutable;
+
+namespace Pulumi
+{
+    /// <summary>
+    /// Extension methods for <see cref="Output{T}"/>.
+    /// </summary>
+    public static class OutputExtensions
+    {
+        /// <summary>
+        /// Convert an output containing an array to an output containing the array element
+        /// at the specified index.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the array.</typeparam>
+        /// <param name="array">An array wrapped into <see cref="Output{T}"/>.</param>
+        /// <param name="index">An index to get an element at.</param>
+        /// <returns>An <see cref="Output{T}"/> containing an array element.</returns>
+        public static Output<T> GetAt<T>(this Output<ImmutableArray<T>> array, int index)
+            => array.Apply(xs => xs[index]);
+
+        /// <summary>
+        /// Convert an output containing an array to an output containing its first element.
+        /// </summary>
+        /// <typeparam name="T">The type of elements in the array.</typeparam>
+        /// <param name="array">An array wrapped into <see cref="Output{T}"/>.</param>
+        /// <returns>An <see cref="Output{T}"/> containing the first array element.</returns>
+        public static Output<T> First<T>(this Output<ImmutableArray<T>> array) => array.GetAt(0);
+    } 
+}

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -105,6 +105,7 @@ Pulumi.Output<T>
 Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Output<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, U> func) -> Pulumi.Output<U>
+Pulumi.OutputExtensions
 Pulumi.ProviderResource
 Pulumi.ProviderResource.ProviderResource(string package, string name, Pulumi.ResourceArgs args, Pulumi.ResourceOptions options = null) -> void
 Pulumi.RemoteArchive
@@ -218,5 +219,7 @@ static Pulumi.Output.Tuple<T1, T2, T3>(Pulumi.Output<T1> item1, Pulumi.Output<T2
 static Pulumi.Output.Tuple<T1, T2>(Pulumi.Input<T1> item1, Pulumi.Input<T2> item2) -> Pulumi.Output<(T1, T2)>
 static Pulumi.Output.Tuple<T1, T2>(Pulumi.Output<T1> item1, Pulumi.Output<T2> item2) -> Pulumi.Output<(T1, T2)>
 static Pulumi.Output<T>.Create(System.Threading.Tasks.Task<T> value) -> Pulumi.Output<T>
+static Pulumi.OutputExtensions.First<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array) -> Pulumi.Output<T>
+static Pulumi.OutputExtensions.GetAt<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array, int index) -> Pulumi.Output<T>
 static Pulumi.ResourceOptions.Merge(Pulumi.ResourceOptions options1, Pulumi.ResourceOptions options2) -> Pulumi.ResourceOptions
 static readonly Pulumi.ResourceArgs.Empty -> Pulumi.ResourceArgs

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -220,6 +220,7 @@ static Pulumi.Output.Tuple<T1, T2>(Pulumi.Input<T1> item1, Pulumi.Input<T2> item
 static Pulumi.Output.Tuple<T1, T2>(Pulumi.Output<T1> item1, Pulumi.Output<T2> item2) -> Pulumi.Output<(T1, T2)>
 static Pulumi.Output<T>.Create(System.Threading.Tasks.Task<T> value) -> Pulumi.Output<T>
 static Pulumi.OutputExtensions.First<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array) -> Pulumi.Output<T>
-static Pulumi.OutputExtensions.GetAt<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array, int index) -> Pulumi.Output<T>
+static Pulumi.OutputExtensions.GetAt<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array, Pulumi.Input<int> index) -> Pulumi.Output<T>
+static Pulumi.OutputExtensions.Length<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array) -> Pulumi.Output<int>
 static Pulumi.ResourceOptions.Merge(Pulumi.ResourceOptions options1, Pulumi.ResourceOptions options2) -> Pulumi.ResourceOptions
 static readonly Pulumi.ResourceArgs.Empty -> Pulumi.ResourceArgs


### PR DESCRIPTION
An extension method seems like a less intrusive way to provide some help here. I thought of making a `OutputList` class but our `Output` is currently sealed.