### PR TITLE
Add support for "go run" style execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Support for a `go run` style workflow. Building or installing a pulumi program written in go is
+  now optional. [3503](https://github.com/pulumi/pulumi/pull/3503)
 - `pulumi policy publish` now determines the Policy Pack name from the Policy Pack, and the
   the `org-name` CLI argument is now optional. If not specified; the current user account is
   used.

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -237,9 +237,6 @@ type ProgramTestOptions struct {
 	// DotNetBin is a location of a `dotnet` executable to be run.  Taken from the $PATH if missing.
 	DotNetBin string
 
-	// If true, we skip the build step producing a named go binary and will fallback to invocation via 'go run'
-	GoRunInvoke bool
-
 	// Additional environment variables to pass for each command we run.
 	Env []string
 }
@@ -1613,7 +1610,7 @@ func (pt *programTester) prepareGoProject(projinfo *engine.Projinfo) error {
 	}
 
 	// skip building if the 'go run' invocation path is requested.
-	if pt.opts.GoRunInvoke {
+	if !pt.opts.RunBuild {
 		return nil
 	}
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -237,6 +237,9 @@ type ProgramTestOptions struct {
 	// DotNetBin is a location of a `dotnet` executable to be run.  Taken from the $PATH if missing.
 	DotNetBin string
 
+	// If true, we skip the build step producing a named go binary and will fallback to invocation via 'go run'
+	GoRunInvoke bool
+
 	// Additional environment variables to pass for each command we run.
 	Env []string
 }
@@ -1608,6 +1611,12 @@ func (pt *programTester) prepareGoProject(projinfo *engine.Projinfo) error {
 	if err != nil {
 		return err
 	}
+
+	// skip building if the 'go run' invocation path is requested.
+	if pt.opts.GoRunInvoke {
+		return nil
+	}
+
 	outBin := filepath.Join(gopath, "bin", string(projinfo.Proj.Name))
 	return pt.runCommand("go-build", []string{goBin, "build", "-o", outBin, "."}, cwd)
 }

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -142,6 +142,7 @@ func (host *goLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) 
 
 	// The program to execute is simply the name of the project.  This ensures good Go toolability, whereby
 	// you can simply run `go install .` to build a Pulumi program prior to running it, among other benefits.
+	// For ease of use, if we don't find a pre-built program, we attempt to invoke via 'go run' on behalf of the user.
 	program, err := findProgram(req.GetProject())
 	if err != nil {
 		const message = "problem executing program (could not run language executor)"
@@ -169,7 +170,7 @@ func (host *goLanguageHost) Run(ctx context.Context, req *pulumirpc.RunRequest) 
 			return nil, errors.Wrap(err, "unable to get current working directory")
 		}
 
-		goFileSearchPattern := fmt.Sprintf("%s/*.go", cwd)
+		goFileSearchPattern := filepath.Join(cwd, "*.go")
 		if matches, err := filepath.Glob(goFileSearchPattern); err != nil || len(matches) == 0 {
 			return nil, errors.Errorf("Failed to find go files for 'go run' matching %s", goFileSearchPattern)
 		}

--- a/tests/integration/empty/gorun/Pulumi.yaml
+++ b/tests/integration/empty/gorun/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: emptygorun
+description: An empty Go Pulumi program.
+runtime: go

--- a/tests/integration/empty/gorun/main.go
+++ b/tests/integration/empty/gorun/main.go
@@ -1,0 +1,13 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		return nil
+	})
+}

--- a/tests/integration/empty/gorun_main/Pulumi.yaml
+++ b/tests/integration/empty/gorun_main/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: emptygorunmain
+description: An empty Go Pulumi program.
+runtime: go
+main: ../gorun_main_src/

--- a/tests/integration/empty/gorun_main_src/main.go
+++ b/tests/integration/empty/gorun_main_src/main.go
@@ -1,0 +1,13 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		return nil
+	})
+}

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -76,29 +76,28 @@ func TestEmptyPython(t *testing.T) {
 	})
 }
 
-// TestEmptyGo simply tests that we can run an empty Go project.
+// TestEmptyGo simply tests that we can build and run an empty Go project.
 func TestEmptyGo(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:   filepath.Join("empty", "go"),
-		Quick: true,
+		Dir:      filepath.Join("empty", "go"),
+		Quick:    true,
+		RunBuild: true,
 	})
 }
 
 // TestEmptyGoRun exercises the 'go run' invocation path that doesn't require an explicit build step.
 func TestEmptyGoRun(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:         filepath.Join("empty", "gorun"),
-		Quick:       true,
-		GoRunInvoke: true,
+		Dir:   filepath.Join("empty", "gorun"),
+		Quick: true,
 	})
 }
 
 // TestEmptyGoRunMain exercises the 'go run' invocation path with a 'main' entrypoint specified in Pulumi.yml
 func TestEmptyGoRunMain(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
-		Dir:         filepath.Join("empty", "gorun_main"),
-		Quick:       true,
-		GoRunInvoke: true,
+		Dir:   filepath.Join("empty", "gorun_main"),
+		Quick: true,
 	})
 }
 
@@ -977,6 +976,7 @@ func TestConfigBasicGo(t *testing.T) {
 			{Key: "tokens[0]", Value: "shh", Path: true, Secret: true},
 			{Key: "foo.bar", Value: "don't tell", Path: true, Secret: true},
 		},
+		RunBuild: true,
 	})
 }
 

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -84,6 +84,15 @@ func TestEmptyGo(t *testing.T) {
 	})
 }
 
+// TestEmptyGoRun exercises the 'go run' invocation path that doesn't require an explicit build step.
+func TestEmptyGoRun(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:         filepath.Join("empty", "gorun"),
+		Quick:       true,
+		GoRunInvoke: true,
+	})
+}
+
 // TestEmptyDotNet simply tests that we can run an empty .NET project.
 func TestEmptyDotNet(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -93,6 +93,15 @@ func TestEmptyGoRun(t *testing.T) {
 	})
 }
 
+// TestEmptyGoRunMain exercises the 'go run' invocation path with a 'main' entrypoint specified in Pulumi.yml
+func TestEmptyGoRunMain(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:         filepath.Join("empty", "gorun_main"),
+		Quick:       true,
+		GoRunInvoke: true,
+	})
+}
+
 // TestEmptyDotNet simply tests that we can run an empty .NET project.
 func TestEmptyDotNet(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{


### PR DESCRIPTION
Addresses https://github.com/pulumi/pulumi/issues/3486

We first look for a named binary, and fall back to "go run" execution if none is found. Passes the `cwd` to the run command, respecting the `-C/--cwd` flag if specified to pulumi. 