### PR TITLE
Fix Python package versions.

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -1,6 +1,6 @@
 PROJECT_NAME     := Pulumi Python SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python
-VERSION          := $(shell ../../scripts/get-py-version)
+VERSION          := $(shell ../../scripts/get-py-version HEAD)
 
 PYENV := ./env
 PYENVSRC := $(PYENV)/src


### PR DESCRIPTION
Earlier changes to the get-version script were not adopted by the Python
SDK Makefile. This caused package publishing to skip uploads due to
missing versions.