### PR TITLE
Add some helpers to make the .net Input/Output experience better.

### DIFF
--- a/sdk/dotnet/Pulumi/Core/Input.cs
+++ b/sdk/dotnet/Pulumi/Core/Input.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
 
 namespace Pulumi
 {
@@ -42,10 +43,37 @@ namespace Pulumi
         public static implicit operator Output<T>(Input<T> input)
             => input._outputValue;
 
-        public Output<T> ToOutput()
-            => this;
-
         IOutput IInput.ToOutput()
-            => ToOutput();
+            => this.ToOutput();
+    }
+
+    public static class InputExtensions
+    {
+        /// <summary>
+        /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}?})"/> for more details.
+        /// </summary>
+        public static Output<U> Apply<T, U>(this Input<T>? input, Func<T, U> func)
+            => input.ToOutput().Apply(func);
+
+        /// <summary>
+        /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}?})"/> for more details.
+        /// </summary>
+        public static Output<U> Apply<T, U>(this Input<T>? input, Func<T, Task<U>> func)
+            => input.ToOutput().Apply(func);
+
+        /// <summary>
+        /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}?})"/> for more details.
+        /// </summary>
+        public static Output<U> Apply<T, U>(this Input<T>? input, Func<T, Input<U>?> func)
+            => input.ToOutput().Apply(func);
+
+        /// <summary>
+        /// <see cref="Output{T}.Apply{U}(Func{T, Output{U}?})"/> for more details.
+        /// </summary>
+        public static Output<U> Apply<T, U>(this Input<T>? input, Func<T, Output<U>?> func)
+            => input.ToOutput().Apply(func);
+
+        public static Output<T> ToOutput<T>(this Input<T>? input)
+            => input ?? Output.Create(default(T)!);
     }
 }

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -80,7 +80,7 @@ Pulumi.IDeployment.IsDryRun.get -> bool
 Pulumi.IDeployment.ProjectName.get -> string
 Pulumi.IDeployment.StackName.get -> string
 Pulumi.Input<T>
-Pulumi.Input<T>.ToOutput() -> Pulumi.Output<T>
+Pulumi.InputExtensions
 Pulumi.InputList<T>
 Pulumi.InputList<T>.Add(params Pulumi.Input<T>[] inputs) -> void
 Pulumi.InputList<T>.Concat(Pulumi.InputList<T> other) -> Pulumi.InputList<T>
@@ -88,7 +88,6 @@ Pulumi.InputList<T>.GetAsyncEnumerator(System.Threading.CancellationToken cancel
 Pulumi.InputList<T>.InputList() -> void
 Pulumi.InputMap<V>
 Pulumi.InputMap<V>.Add(string key, Pulumi.Input<V> value) -> void
-Pulumi.InputMap<V>.AddRange(System.Collections.Immutable.ImmutableDictionary<string, V> values) -> void
 Pulumi.InputMap<V>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerator<Pulumi.Input<System.Collections.Generic.KeyValuePair<string, V>>>
 Pulumi.InputMap<V>.InputMap() -> void
 Pulumi.InputMap<V>.this[string key].set -> void
@@ -103,6 +102,7 @@ Pulumi.InvokeOptions.Version.set -> void
 Pulumi.Log
 Pulumi.Output
 Pulumi.Output<T>
+Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Input<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Output<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, U> func) -> Pulumi.Output<U>
@@ -173,6 +173,11 @@ static Pulumi.Deployment.RunAsync(System.Func<System.Threading.Tasks.Task<System
 static Pulumi.Input<T>.implicit operator Pulumi.Input<T>(Pulumi.Output<T> value) -> Pulumi.Input<T>
 static Pulumi.Input<T>.implicit operator Pulumi.Input<T>(T value) -> Pulumi.Input<T>
 static Pulumi.Input<T>.implicit operator Pulumi.Output<T>(Pulumi.Input<T> input) -> Pulumi.Output<T>
+static Pulumi.InputExtensions.Apply<T, U>(this Pulumi.Input<T> input, System.Func<T, Pulumi.Input<U>> func) -> Pulumi.Output<U>
+static Pulumi.InputExtensions.Apply<T, U>(this Pulumi.Input<T> input, System.Func<T, Pulumi.Output<U>> func) -> Pulumi.Output<U>
+static Pulumi.InputExtensions.Apply<T, U>(this Pulumi.Input<T> input, System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
+static Pulumi.InputExtensions.Apply<T, U>(this Pulumi.Input<T> input, System.Func<T, U> func) -> Pulumi.Output<U>
+static Pulumi.InputExtensions.ToOutput<T>(this Pulumi.Input<T> input) -> Pulumi.Output<T>
 static Pulumi.InputList<T>.implicit operator Pulumi.InputList<T>(Pulumi.Input<T> value) -> Pulumi.InputList<T>
 static Pulumi.InputList<T>.implicit operator Pulumi.InputList<T>(Pulumi.Input<T>[] values) -> Pulumi.InputList<T>
 static Pulumi.InputList<T>.implicit operator Pulumi.InputList<T>(Pulumi.Output<System.Collections.Generic.IEnumerable<T>> values) -> Pulumi.InputList<T>


### PR DESCRIPTION
Inspired by slack conversations with @mikhailshilkov about pain points with using the current system.

Note: these are binary breaks, but are not source breaks. Pulumi .NET support is in preview so that's ok.