### PR TITLE
Expose `--policy-pack` under PULUMI_EXPERIMENTAL

### DIFF
--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -165,7 +165,7 @@ func newPreviewCmd() *cobra.Command {
 		"Optional message to associate with the preview operation")
 
 	// Flags for engine.UpdateOptions.
-	if hasDebugCommands() {
+	if hasDebugCommands() || hasExperimentalCommands() {
 		cmd.PersistentFlags().StringSliceVar(
 			&policyPackPaths, "policy-pack", []string{},
 			"Run one or more analyzers as part of this update")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -405,7 +405,7 @@ func newUpCmd() *cobra.Command {
 			" Shorthand for --target urn --replace urn.")
 
 	// Flags for engine.UpdateOptions.
-	if hasDebugCommands() {
+	if hasDebugCommands() || hasExperimentalCommands() {
 		cmd.PersistentFlags().StringSliceVar(
 			&policyPackPaths, "policy-pack", []string{},
 			"Run one or more policy packs as part of this update")

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -159,7 +159,7 @@ func newWatchCmd() *cobra.Command {
 		"Optional message to associate with each update operation")
 
 	// Flags for engine.UpdateOptions.
-	if hasDebugCommands() {
+	if hasDebugCommands() || hasExperimentalCommands() {
 		cmd.PersistentFlags().StringSliceVar(
 			&policyPackPaths, "policy-pack", []string{},
 			"Run one or more policy packs as part of each update")


### PR DESCRIPTION
We recently moved `pulumi policy` to be available under `PULUMI_EXPERIMENTAL` along with `pulumi query` and `pulumi watch`.  We missed exposing `--policy-pack`.