### PR TITLE
Update to reflect nodejs version constraint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ For larger features, we'd appreciate it if you open a [new issue](https://github
 To hack on Pulumi, you'll need to get a development environment set up. You'll want to install the following on your machine:
 
 - Go 1.12
-- NodeJS 6.10.X or later
+- NodeJS 6.10.X or later (but no later than 12.10.X)
 - Python 3.6 or later
 - [.NET Core](https://dotnet.microsoft.com/download)
 - [pipenv](https://github.com/pypa/pipenv)


### PR DESCRIPTION
Update to reflect nodejs version constraint (since as of 11/15/2019 any nodejs version 12.11 or higher causes a build failure)