### PR TITLE
Validate stack name on stack init with non default secrets provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ CHANGELOG
   better estimate the state of a resource after an update, including property values that were populated using defaults
   calculated by the provider.
   [#3327](https://github.com/pulumi/pulumi/pull/3327)
+  
+- Validate StackName when passing a non-default secrets provider to `pulumi stack init`
 
 ## 1.5.2 (2019-11-13)
 

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -98,6 +98,10 @@ func newStackInitCmd() *cobra.Command {
 				return errors.New("missing stack name")
 			}
 
+			if err := workspace.ValidateStackName(stackName); err != nil {
+				return err
+			}
+
 			stackRef, err := b.ParseStackReference(stackName)
 			if err != nil {
 				return err

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -227,9 +227,7 @@ func TestStackTagValidation(t *testing.T) {
 
 		stdout, stderr := e.RunCommandExpectError("pulumi", "stack", "init", "invalid name (spaces, parens, etc.)")
 		assert.Equal(t, "", stdout)
-		assert.Contains(t, stderr, "error: could not create stack:")
-		assert.Contains(t, stderr, "validating stack properties:")
-		assert.Contains(t, stderr, "stack name may only contain alphanumeric, hyphens, underscores, or periods")
+		assert.Contains(t, stderr, "stack name may only contain alphanumeric, hyphens, underscores, and periods")
 	})
 
 	t.Run("Error_DescriptionLength", func(t *testing.T) {


### PR DESCRIPTION
Fixes: #3248

Before, we got a panic. in the createStack, when we had a non-default
secrets provider, we were assuming the name of the stack was correct
if we were in non-interactive mode

This commit adds a guard against this by doing a final validation of
the stack name *before* we even get into the createStack func

This means, that we get the following (and not the panic)

```
▶ pulumi stack init -s "org/" --secrets-provider="gcpkms://"
error: A stack name may only contain alphanumeric, hyphens, underscores, and periods
```