### PR TITLE
Enable policies to run for all languages

### DIFF
--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -57,7 +57,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 		})
 	}
 
-	plug, err := newPlugin(ctx, path, fmt.Sprintf("%v (analyzer)", name),
+	plug, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (analyzer)", name),
 		[]string{host.ServerAddr(), ctx.Pwd})
 	if err != nil {
 		return nil, err
@@ -90,7 +90,13 @@ func NewPolicyAnalyzer(
 			"does not support resource policies", string(name))
 	}
 
-	plug, err := newPlugin(ctx, pluginPath, fmt.Sprintf("%v (analyzer)", name),
+	// The `pulumi-analyzer-policy` plugin is a script that looks for the '@pulumi/pulumi/cmd/run-policy-pack'
+	// node module and runs it with node. To allow non-node Pulumi programs (e.g. Python, .NET, Go, etc.) to
+	// run node policy packs, we must set the plugin's pwd to the policy pack directory instead of the Pulumi
+	// program directory, so that the '@pulumi/pulumi/cmd/run-policy-pack' module from the policy pack's
+	// node_modules is used.
+	pwd := policyPackPath
+	plug, err := newPlugin(ctx, pwd, pluginPath, fmt.Sprintf("%v (analyzer)", name),
 		[]string{host.ServerAddr(), policyPackPath})
 	if err != nil {
 		if err == errRunPolicyModuleNotFound {

--- a/pkg/resource/plugin/langruntime_plugin.go
+++ b/pkg/resource/plugin/langruntime_plugin.go
@@ -61,7 +61,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime string,
 	}
 	args = append(args, host.ServerAddr())
 
-	plug, err := newPlugin(ctx, path, runtime, args)
+	plug, err := newPlugin(ctx, ctx.Pwd, path, runtime, args)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -67,7 +67,7 @@ var nextStreamID int32
 // the stack's Pulumi SDK did not have the required modules. i.e. is too old.
 var errRunPolicyModuleNotFound = errors.New("pulumi SDK does not support policy as code")
 
-func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin, error) {
+func newPlugin(ctx *Context, pwd, bin, prefix string, args []string) (*plugin, error) {
 	if logging.V(9) {
 		var argstr string
 		for i, arg := range args {
@@ -80,7 +80,7 @@ func newPlugin(ctx *Context, bin string, prefix string, args []string) (*plugin,
 	}
 
 	// Try to execute the binary.
-	plug, err := execPlugin(bin, args, ctx.Pwd)
+	plug, err := execPlugin(bin, args, pwd)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load plugin %s", bin)
 	}

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -77,7 +77,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 		})
 	}
 
-	plug, err := newPlugin(ctx, path, fmt.Sprintf("%v (resource)", pkg), []string{host.ServerAddr()})
+	plug, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (resource)", pkg), []string{host.ServerAddr()})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When running a Policy Pack, we were previously looking for and running the `@pulumi/pulumi/cmd/run-policy-pack` Node.js module inside the _program's_ `node_modules`, which prevents the Policy Pack from working when run against Pulumi programs using other runtimes (e.g. Python, .NET, etc.).

Instead, look for `@pulumi/pulumi/cmd/run-policy-pack` in the Policy Pack's `node_modules`. That way, the Policy Pack can run for Pulumi programs written in any language.

I added an integration test here: https://github.com/pulumi/pulumi-policy/pull/149 (which will fail until these changes are available).

Fixes https://github.com/pulumi/pulumi-policy/issues/138