### PR TITLE
Provide a more helpful PaC error

### DIFF
--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -100,8 +100,8 @@ func NewPolicyAnalyzer(
 		[]string{host.ServerAddr(), policyPackPath})
 	if err != nil {
 		if err == errRunPolicyModuleNotFound {
-			return nil, fmt.Errorf("the Pulumi SDK used with this stack does not appear to support policy as code.\n" +
-				"Upgrading to a newer version of the Pulumi SDK may fix this problem.")
+			return nil, fmt.Errorf("it looks like the policy pack's dependencies are not installed; "+
+				"try running npm install or yarn install in %q", policyPackPath)
 		}
 		return nil, errors.Wrapf(err, "policy pack %q failed to start", string(name))
 	}

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -107,7 +107,7 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, args []string) (*plugin, e
 				break
 			}
 
-			// We may be trying to run a plugin that isn't present in the SDK installed with the stack.
+			// We may be trying to run a plugin that isn't present in the SDK installed with the Policy Pack.
 			// e.g. the stack's package.json does not contain a recent enough @pulumi/pulumi.
 			//
 			// Rather than fail with an opaque error because we didn't get the gRPC port, inspect if it


### PR DESCRIPTION
To allow Policy Packs to run against Pulumi programs written in all languages, as of #3524, we now look for the `@pulumi/pulumi/cmd/run-policy-pack` module in the Policy Pack's `node_modules` (instead of in the Pulumi program's `node_modules`; which doesn't exist for non-Node.js programs). The `@pulumi/policy` library that a Policy Pack will depend on should already depend on a recent enough version of `@pulumi/pulumi`, so when we can't find the module, it's more likely it's due to the dependencies for the Policy Pack not being installed. Provide a more helpful error message in this case, similar to the one we show for Pulumi programs:

https://github.com/pulumi/pulumi/blob/022826bac5635e208f0b2e40d15a7e3a997ae0d1/sdk/nodejs/cmd/pulumi-language-nodejs/main.go#L103