### PR TITLE
Add Go support for config.*Object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Support for config.GetObject and related variants for Golang. [#3526](https://github.com/pulumi/pulumi/pull/3526)
+
 - Support for a `go run` style workflow. Building or installing a pulumi program written in go is
   now optional. [3503](https://github.com/pulumi/pulumi/pull/3503)
 

--- a/sdk/go/pulumi/config/config.go
+++ b/sdk/go/pulumi/config/config.go
@@ -85,7 +85,8 @@ func (c *Config) GetInt64(key string) int64 {
 	return GetInt64(c.ctx, c.fullKey(key))
 }
 
-// GetObject loads an optional configuration value into the specified output by its key, or returns an error if unable to do so.
+// GetObject loads an optional configuration value into the specified output by its key,
+// or returns an error if unable to do so.
 func (c *Config) GetObject(key string, output interface{}) error {
 	return GetObject(c.ctx, c.fullKey(key), output)
 }
@@ -160,7 +161,8 @@ func (c *Config) RequireInt64(key string) int64 {
 	return RequireInt64(c.ctx, c.fullKey(key))
 }
 
-// RequireObject loads a required configuration value into the specified output by its key, or panics if unable to do so.
+// RequireObject loads a required configuration value into the specified output by its key,
+// or panics if unable to do so.
 func (c *Config) RequireObject(key string, output interface{}) {
 	RequireObject(c.ctx, c.fullKey(key), output)
 }
@@ -235,7 +237,8 @@ func (c *Config) TryInt64(key string) (int64, error) {
 	return TryInt64(c.ctx, c.fullKey(key))
 }
 
-// TryObject loads an optional configuration value into the specified output by its key, or returns an error if unable to do so.
+// TryObject loads an optional configuration value into the specified output by its key,
+// or returns an error if unable to do so.
 func (c *Config) TryObject(key string, output interface{}) error {
 	return TryObject(c.ctx, c.fullKey(key), output)
 }

--- a/sdk/go/pulumi/config/config.go
+++ b/sdk/go/pulumi/config/config.go
@@ -85,6 +85,11 @@ func (c *Config) GetInt64(key string) int64 {
 	return GetInt64(c.ctx, c.fullKey(key))
 }
 
+// GetObject loads an optional configuration value into the specified output by its key, or returns an error if unable to do so.
+func (c *Config) GetObject(key string, output interface{}) error {
+	return GetObject(c.ctx, c.fullKey(key), output)
+}
+
 // GetUint loads an optional uint configuration value by its key, or returns 0 if it doesn't exist.
 func (c *Config) GetUint(key string) uint {
 	return GetUint(c.ctx, c.fullKey(key))
@@ -155,6 +160,11 @@ func (c *Config) RequireInt64(key string) int64 {
 	return RequireInt64(c.ctx, c.fullKey(key))
 }
 
+// RequireObject loads a required configuration value into the specified output by its key, or panics if unable to do so.
+func (c *Config) RequireObject(key string, output interface{}) {
+	RequireObject(c.ctx, c.fullKey(key), output)
+}
+
 // RequireUint loads a uint configuration value by its key, or panics if it doesn't exist.
 func (c *Config) RequireUint(key string) uint {
 	return RequireUint(c.ctx, c.fullKey(key))
@@ -223,6 +233,11 @@ func (c *Config) TryInt32(key string) (int32, error) {
 // TryInt64 loads an optional int64 configuration value by its key, or returns an error if it doesn't exist.
 func (c *Config) TryInt64(key string) (int64, error) {
 	return TryInt64(c.ctx, c.fullKey(key))
+}
+
+// TryObject loads an optional configuration value into the specified output by its key, or returns an error if unable to do so.
+func (c *Config) TryObject(key string, output interface{}) error {
+	return TryObject(c.ctx, c.fullKey(key), output)
 }
 
 // TryUint loads an optional uint configuration value by its key, or returns an error if it doesn't exist.

--- a/sdk/go/pulumi/config/config_test.go
+++ b/sdk/go/pulumi/config/config_test.go
@@ -62,9 +62,6 @@ func TestConfig(t *testing.T) {
 		Foo: fooMap,
 		Bar: "abc",
 	}
-	clearTestStruct := func(ts *TestStruct) {
-		*ts = TestStruct{}
-	}
 
 	// Test basic keys.
 	assert.Equal(t, "testpkg:sss", cfg.fullKey("sss"))
@@ -79,17 +76,17 @@ func TestConfig(t *testing.T) {
 	err = cfg.GetObject("missing", &testStruct)
 	assert.Equal(t, emptyTestStruct, testStruct)
 	assert.Nil(t, err)
-	clearTestStruct(&testStruct)
+	testStruct = TestStruct{}
 	// malformed key GetObj
 	err = cfg.GetObject("malobj", &testStruct)
 	assert.Equal(t, emptyTestStruct, testStruct)
 	assert.NotNil(t, err)
-	clearTestStruct(&testStruct)
+	testStruct = TestStruct{}
 	// GetObj
 	err = cfg.GetObject("obj", &testStruct)
 	assert.Equal(t, expectedTestStruct, testStruct)
 	assert.Nil(t, err)
-	clearTestStruct(&testStruct)
+	testStruct = TestStruct{}
 
 	// Test Require, which panics for missing entries.
 	assert.Equal(t, "a string value", cfg.Require("sss"))
@@ -98,8 +95,11 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, 99.963, cfg.RequireFloat64("fpfpfp"))
 	cfg.RequireObject("obj", &testStruct)
 	assert.Equal(t, expectedTestStruct, testStruct)
-	clearTestStruct(&testStruct)
+	testStruct = TestStruct{}
 	// GetObj panics if value is malformed
+	willPanic := func() { cfg.RequireObject("malobj", &testStruct) }
+	assert.Panics(t, willPanic)
+	testStruct = TestStruct{}
 	func() {
 		defer func() {
 			if r := recover(); r == nil {
@@ -108,7 +108,7 @@ func TestConfig(t *testing.T) {
 		}()
 		cfg.RequireObject("malobj", &testStruct)
 	}()
-	clearTestStruct(&testStruct)
+	testStruct = TestStruct{}
 	func() {
 		defer func() {
 			if r := recover(); r == nil {
@@ -135,17 +135,17 @@ func TestConfig(t *testing.T) {
 	err = cfg.TryObject("obj", &testStruct)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedTestStruct, testStruct)
-	clearTestStruct(&testStruct)
+	testStruct = TestStruct{}
 	// missing TryObject
 	err = cfg.TryObject("missing", &testStruct)
 	assert.NotNil(t, err)
 	assert.Equal(t, emptyTestStruct, testStruct)
-	clearTestStruct(&testStruct)
+	testStruct = TestStruct{}
 	// malformed TryObject
 	err = cfg.TryObject("malobj", &testStruct)
 	assert.NotNil(t, err)
 	assert.Equal(t, emptyTestStruct, testStruct)
-	clearTestStruct(&testStruct)
+	testStruct = TestStruct{}
 	_, err = cfg.Try("missing")
 	assert.NotNil(t, err)
 }

--- a/sdk/go/pulumi/config/config_test.go
+++ b/sdk/go/pulumi/config/config_test.go
@@ -23,6 +23,11 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
 )
 
+type TestStruct struct {
+	Foo map[string]string
+	Bar string
+}
+
 // TestConfig tests the basic config wrapper.
 func TestConfig(t *testing.T) {
 	ctx, err := pulumi.NewContext(context.Background(), pulumi.RunInfo{
@@ -31,11 +36,35 @@ func TestConfig(t *testing.T) {
 			"testpkg:bbb":    "true",
 			"testpkg:intint": "42",
 			"testpkg:fpfpfp": "99.963",
+			"testpkg:obj": `
+				{
+					"foo": {
+						"a": "1",
+						"b": "2"
+					},
+					"bar": "abc"
+				}
+			`,
+			"testpkg:malobj": "not_a_struct",
 		},
 	})
 	assert.Nil(t, err)
 
 	cfg := New(ctx, "testpkg")
+
+	var testStruct TestStruct
+	var emptyTestStruct TestStruct
+
+	fooMap := make(map[string]string)
+	fooMap["a"] = "1"
+	fooMap["b"] = "2"
+	expectedTestStruct := TestStruct{
+		Foo: fooMap,
+		Bar: "abc",
+	}
+	clearTestStruct := func(ts *TestStruct) {
+		*ts = TestStruct{}
+	}
 
 	// Test basic keys.
 	assert.Equal(t, "testpkg:sss", cfg.fullKey("sss"))
@@ -46,12 +75,40 @@ func TestConfig(t *testing.T) {
 	assert.Equal(t, 42, cfg.GetInt("intint"))
 	assert.Equal(t, 99.963, cfg.GetFloat64("fpfpfp"))
 	assert.Equal(t, "", cfg.Get("missing"))
+	// missing key GetObj
+	err = cfg.GetObject("missing", &testStruct)
+	assert.Equal(t, emptyTestStruct, testStruct)
+	assert.Nil(t, err)
+	clearTestStruct(&testStruct)
+	// malformed key GetObj
+	err = cfg.GetObject("malobj", &testStruct)
+	assert.Equal(t, emptyTestStruct, testStruct)
+	assert.NotNil(t, err)
+	clearTestStruct(&testStruct)
+	// GetObj
+	err = cfg.GetObject("obj", &testStruct)
+	assert.Equal(t, expectedTestStruct, testStruct)
+	assert.Nil(t, err)
+	clearTestStruct(&testStruct)
 
 	// Test Require, which panics for missing entries.
 	assert.Equal(t, "a string value", cfg.Require("sss"))
 	assert.Equal(t, true, cfg.RequireBool("bbb"))
 	assert.Equal(t, 42, cfg.RequireInt("intint"))
 	assert.Equal(t, 99.963, cfg.RequireFloat64("fpfpfp"))
+	cfg.RequireObject("obj", &testStruct)
+	assert.Equal(t, expectedTestStruct, testStruct)
+	clearTestStruct(&testStruct)
+	// GetObj panics if value is malformed
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("expected malformed value for RequireObject to panic")
+			}
+		}()
+		cfg.RequireObject("malobj", &testStruct)
+	}()
+	clearTestStruct(&testStruct)
 	func() {
 		defer func() {
 			if r := recover(); r == nil {
@@ -74,6 +131,21 @@ func TestConfig(t *testing.T) {
 	k4, err := cfg.TryFloat64("fpfpfp")
 	assert.Nil(t, err)
 	assert.Equal(t, 99.963, k4)
+	// happy path TryObject
+	err = cfg.TryObject("obj", &testStruct)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedTestStruct, testStruct)
+	clearTestStruct(&testStruct)
+	// missing TryObject
+	err = cfg.TryObject("missing", &testStruct)
+	assert.NotNil(t, err)
+	assert.Equal(t, emptyTestStruct, testStruct)
+	clearTestStruct(&testStruct)
+	// malformed TryObject
+	err = cfg.TryObject("malobj", &testStruct)
+	assert.NotNil(t, err)
+	assert.Equal(t, emptyTestStruct, testStruct)
+	clearTestStruct(&testStruct)
 	_, err = cfg.Try("missing")
 	assert.NotNil(t, err)
 }

--- a/sdk/go/pulumi/config/get.go
+++ b/sdk/go/pulumi/config/get.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"encoding/json"
+
 	"github.com/spf13/cast"
 
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
@@ -88,6 +90,17 @@ func GetInt64(ctx *pulumi.Context, key string) int64 {
 		return cast.ToInt64(v)
 	}
 	return 0
+}
+
+// GetObject attempts to load an optional configuration value by its key into the specified output variable.
+func GetObject(ctx *pulumi.Context, key string, output interface{}) error {
+	if v, ok := ctx.GetConfig(key); ok {
+		if err := json.Unmarshal([]byte(v), output); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // GetUint loads an optional configuration value by its key, as a uint, or returns 0 if it doesn't exist.

--- a/sdk/go/pulumi/config/require.go
+++ b/sdk/go/pulumi/config/require.go
@@ -80,7 +80,8 @@ func RequireInt64(ctx *pulumi.Context, key string) int64 {
 	return cast.ToInt64(v)
 }
 
-// RequireObject loads an optional configuration value by its key into the output variable, or panics if unable to do so.
+// RequireObject loads an optional configuration value by its key into the output variable,
+// or panics if unable to do so.
 func RequireObject(ctx *pulumi.Context, key string, output interface{}) {
 	v := Require(ctx, key)
 	if err := json.Unmarshal([]byte(v), output); err != nil {

--- a/sdk/go/pulumi/config/require.go
+++ b/sdk/go/pulumi/config/require.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"encoding/json"
+
 	"github.com/spf13/cast"
 
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -76,6 +78,14 @@ func RequireInt32(ctx *pulumi.Context, key string) int32 {
 func RequireInt64(ctx *pulumi.Context, key string) int64 {
 	v := Require(ctx, key)
 	return cast.ToInt64(v)
+}
+
+// RequireObject loads an optional configuration value by its key into the output variable, or panics if unable to do so.
+func RequireObject(ctx *pulumi.Context, key string, output interface{}) {
+	v := Require(ctx, key)
+	if err := json.Unmarshal([]byte(v), output); err != nil {
+		contract.Failf("unable to unmarshall required configuration variable '%s'; %s", key, err.Error())
+	}
 }
 
 // RequireUint loads an optional configuration value by its key, as a uint, or panics if it doesn't exist.

--- a/sdk/go/pulumi/config/try.go
+++ b/sdk/go/pulumi/config/try.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"encoding/json"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 
@@ -101,6 +103,18 @@ func TryInt64(ctx *pulumi.Context, key string) (int64, error) {
 		return 0, err
 	}
 	return cast.ToInt64(v), nil
+}
+
+// TryObject loads an optional configuration value by its key into the specified output variable, or returns an error if unable to do so.
+func TryObject(ctx *pulumi.Context, key string, output interface{}) error {
+	v, err := Try(ctx, key)
+	if err != nil {
+		return err
+	}
+	if err = json.Unmarshal([]byte(v), output); err != nil {
+		return err
+	}
+	return nil
 }
 
 // TryUint loads an optional configuration value by its key, as a uint, or returns an error if it doesn't exist.

--- a/sdk/go/pulumi/config/try.go
+++ b/sdk/go/pulumi/config/try.go
@@ -105,16 +105,14 @@ func TryInt64(ctx *pulumi.Context, key string) (int64, error) {
 	return cast.ToInt64(v), nil
 }
 
-// TryObject loads an optional configuration value by its key into the specified output variable, or returns an error if unable to do so.
+// TryObject loads an optional configuration value by its key into the output variable,
+// or returns an error if unable to do so.
 func TryObject(ctx *pulumi.Context, key string, output interface{}) error {
 	v, err := Try(ctx, key)
 	if err != nil {
 		return err
 	}
-	if err = json.Unmarshal([]byte(v), output); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal([]byte(v), output)
 }
 
 // TryUint loads an optional configuration value by its key, as a uint, or returns an error if it doesn't exist.


### PR DESCRIPTION
Addresses https://github.com/pulumi/pulumi/issues/3493

Usage as follows: 

```go
package main

import "pulumi"

type TestStruct struct {
	Foo map[string]string
	Bar string
}
func main(){
pulumi.Run(func (ctx *pulumi.Context) error {
        var s TestStruct
        if err := config.GetObject("key", &s); err != nil {
            return err
        }
    }
}

```

This implementation doesn't perform any post-unmarshalling checks on the data, and doesn't care about what keys were/weren't populated in the target struct. This seems reasonable for try/get. But may not be quite what the user expects for required. We could potentially do some validation on the result via reflection, or even call a user defined validation function on the result. Curious for some input here. 