### PR TITLE
Updates grpc package to 1.24.2 for js sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ CHANGELOG
   reported resources as `--target`s, or pass the `--target-dependents` flag to allow necessary
   changes to unspecified dependent targets.
 
+- Support for node 13.x, building with gcc 8 and newer. [#3512] (https://github.com/pulumi/pulumi/pull/3512)
+
 ## 1.5.2 (2019-11-13)
 
 - `pulumi policy publish` now determines the Policy Pack name from the Policy Pack, and the

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -12,7 +12,7 @@
         "@pulumi/query": "^0.3.0",
         "deasync": "^0.1.15",
         "google-protobuf": "^3.5.0",
-        "grpc": "1.21.1",
+        "grpc": "1.24.2",
         "minimist": "^1.2.0",
         "normalize-package-data": "^2.4.0",
         "protobufjs": "^6.8.6",


### PR DESCRIPTION
Fixes building grpc package with gcc8 and newer
Fixes building grpc package for node 13.x
Matches minor grpc release (1.24.x) to version used by dotnet sdk