### PR TITLE
Don't remove tests from locally installed @pulumi/pulumi

### DIFF
--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -2,7 +2,6 @@
 Set-StrictMode -Version 2.0
 $ErrorActionPreference="Stop"
 
-$NodeVersion = "v6.10.2"
 $Root=Join-Path $PSScriptRoot ".."
 $PublishDir=New-Item -ItemType Directory -Path "$env:TEMP\$([System.IO.Path]::GetRandomFileName())"
 $GitHash=$(git rev-parse HEAD)

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -35,8 +35,6 @@ build:: build_package build_plugin
 install_package::
 	cp dist/pulumi-resource-pulumi-nodejs "$(PULUMI_BIN)"
 	cp dist/pulumi-analyzer-policy "$(PULUMI_BIN)"
-	mkdir -p "$(PULUMI_BIN)/v6.10.2"
-	rm -rf "$(PULUMI_NODE_MODULES)/$(NODE_MODULE_NAME)/tests"
 
 install_plugin::
 	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" ${LANGUAGE_HOST}


### PR DESCRIPTION
The test files are currently included in the `@pulumi/pulumi` npm package, and we have packages that depend on them (such as [`@pulumi/policy`](https://github.com/pulumi/pulumi-policy/blob/036b29ac2b0d339842efa50a9fa36dc0e17c4c5c/sdk/nodejs/policy/tests/deserialize.spec.ts#L16)), so when installing the `yarn link`'able `@pulumi/pulumi` package locally in `/opt/pulumi/node_modules/@pulumi`, don't delete the test files.

Some other minor cleanup while making changes here. We were creating an empty `/opt/pulumi/bin/v6.10.2` directory that's no longer used/needed.