### PR TITLE
Add tests for serializing PropertyMaps

### DIFF
--- a/pkg/resource/config/crypt.go
+++ b/pkg/resource/config/crypt.go
@@ -88,16 +88,23 @@ func (t *trackingDecrypter) SecureValues() []string {
 	return t.secureValues
 }
 
-// NewBlindingDecrypter returns a Decrypter that instead of decrypting data, just returns "[secret]", it can
+// BlindingCrypter returns a Crypter that instead of decrypting or encrypting data, just returns "[secret]", it can
 // be used when you want to display configuration information to a user but don't want to prompt for a password
-// so secrets will not be decrypted.
+// so secrets will not be decrypted or encrypted.
+var BlindingCrypter Crypter = &blindingCrypter{}
+
+// NewBlindingDecrypter returns a blinding decrypter.
 func NewBlindingDecrypter() Decrypter {
-	return blindingDecrypter{}
+	return &blindingCrypter{}
 }
 
-type blindingDecrypter struct{}
+type blindingCrypter struct{}
 
-func (b blindingDecrypter) DecryptValue(ciphertext string) (string, error) {
+func (b blindingCrypter) DecryptValue(ciphertext string) (string, error) {
+	return "[secret]", nil
+}
+
+func (b blindingCrypter) EncryptValue(plaintext string) (string, error) {
 	return "[secret]", nil
 }
 

--- a/pkg/resource/config/crypt.go
+++ b/pkg/resource/config/crypt.go
@@ -91,11 +91,11 @@ func (t *trackingDecrypter) SecureValues() []string {
 // BlindingCrypter returns a Crypter that instead of decrypting or encrypting data, just returns "[secret]", it can
 // be used when you want to display configuration information to a user but don't want to prompt for a password
 // so secrets will not be decrypted or encrypted.
-var BlindingCrypter Crypter = &blindingCrypter{}
+var BlindingCrypter Crypter = blindingCrypter{}
 
 // NewBlindingDecrypter returns a blinding decrypter.
 func NewBlindingDecrypter() Decrypter {
-	return &blindingCrypter{}
+	return blindingCrypter{}
 }
 
 type blindingCrypter struct{}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -200,11 +200,11 @@ func TestCustomSerialization(t *testing.T) {
 
 	strProp := resource.NewStringProperty("strProp")
 
-	computed := resource.NewComputedProperty(resource.Computed{Element: strProp})
-	output := resource.NewOutputProperty(resource.Output{Element: strProp})
+	computed := resource.Computed{Element: strProp}
+	output := resource.Output{Element: strProp}
 
 	secretElement := resource.Secret{Element: strProp}
-	secret := resource.NewSecretProperty(&secretElement)
+	secret := &resource.Secret{Element: strProp}
 
 	propMap := resource.NewPropertyMapFromMap(map[string]interface{}{
 		// Primitive types


### PR DESCRIPTION
As part of fixing upstream dependencies on the way we currently serialize engine events for rendering in a logs display, this PR adds some tests to pin down the specific way we marshall resources into JSON.

I can use this as a reference when making changes service-side, so that we can then safely merge #3377 and properly serialize engine events in the future.

I'm not super familiar with this part of the code, so I called out some questions in the code itself. (I'm fairly certain I'm not attaching the `resource.Secret` properties correctly.) Also, are there any other "special" types (like `Secret`, `Computed`, `Asset`) that can get serialized as a `resource.PropertyValue`?