### PR TITLE
Retry failed update steps in integration tests.

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -724,6 +724,7 @@ func (pt *programTester) runPulumiCommand(name string, args []string, wd string,
 					return false, nil, errors.Errorf("%v did not succeed after %v tries", cmd, try+1)
 				}
 
+				pt.t.Logf("%v failed: %v; retrying...", cmd, runerr)
 				return false, nil, nil
 			}
 


### PR DESCRIPTION
Add support for a test option that indicates that failed update steps
should be retried. Currently the maximum number of retries (3) is not
configurable.