### PR TITLE
Allow arguments to Invokes to be non-inputs.

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/Core/ResourceArgsTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/ResourceArgsTests.cs
@@ -51,7 +51,7 @@ namespace Pulumi.Tests.Core
             Assert.NotNull(sValue);
             Assert.Null(arrayValue);
 
-            var output = sValue!.ToOutput();
+            var output = ((IInput)sValue!).ToOutput();
             var data = await output.GetDataAsync();
             Assert.Equal("val", data.Value);
         }
@@ -74,7 +74,7 @@ namespace Pulumi.Tests.Core
                 Assert.Null(sValue);
                 Assert.NotNull(arrayValue);
 
-                var output = arrayValue!.ToOutput();
+                var output = ((IInput)arrayValue!).ToOutput();
                 var data = await output.GetDataAsync();
                 AssertEx.SequenceEqual(
                     ImmutableArray<bool>.Empty.Add(true), (ImmutableArray<bool>)data.Value!);
@@ -122,11 +122,8 @@ namespace Pulumi.Tests.Core
             Assert.NotNull(arrayValue);
             Assert.NotNull(mapValue);
 
-            var arrayVal = (await arrayValue!.ToOutput().GetDataAsync()).Value;
-            Assert.Equal("[ true, false ]", arrayVal);
-
-            var mapVal = (await mapValue!.ToOutput().GetDataAsync()).Value;
-            Assert.Equal("{ \"k1\": 1, \"k2\": 2 }", mapVal);
+            Assert.Equal("[ true, false ]", arrayValue);
+            Assert.Equal("{ \"k1\": 1, \"k2\": 2 }", mapValue);
         }
 
         #endregion

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
@@ -15,7 +15,7 @@ namespace Pulumi
             public Runner(IDeploymentInternal deployment)
                 => _deployment = deployment;
 
-            public Task<int> RunAsync(Func<Task<IDictionary<string, object>>> func)
+            public Task<int> RunAsync(Func<Task<IDictionary<string, object?>>> func)
             {
                 var stack = new Stack(func);
                 RegisterTask("User program code.", stack.Outputs.DataTask);

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Invoke.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Invoke.cs
@@ -10,20 +10,20 @@ namespace Pulumi
 {
     public sealed partial class Deployment
     {
-        Task IDeployment.InvokeAsync(string token, ResourceArgs args, InvokeOptions? options)
+        Task IDeployment.InvokeAsync(string token, InvokeArgs args, InvokeOptions? options)
             => InvokeAsync<object>(token, args, options, convertResult: false);
 
-        Task<T> IDeployment.InvokeAsync<T>(string token, ResourceArgs args, InvokeOptions? options)
+        Task<T> IDeployment.InvokeAsync<T>(string token, InvokeArgs args, InvokeOptions? options)
             => InvokeAsync<T>(token, args, options, convertResult: true);
 
         private async Task<T> InvokeAsync<T>(
-            string token, ResourceArgs args, InvokeOptions? options, bool convertResult)
+            string token, InvokeArgs args, InvokeOptions? options, bool convertResult)
         {
             var label = $"Invoking function: token={token} asynchronously";
             Log.Debug(label);
 
             // Be resilient to misbehaving callers.
-            args ??= ResourceArgs.Empty;
+            args ??= InvokeArgs.Empty;
 
             // Wait for all values to be available, and then perform the RPC.
             var argsDict = await args.ToDictionaryAsync().ConfigureAwait(false);

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResourceOutputs.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResourceOutputs.cs
@@ -10,7 +10,7 @@ namespace Pulumi
 {
     public partial class Deployment
     {
-        void IDeploymentInternal.RegisterResourceOutputs(Resource resource, Output<IDictionary<string, object>> outputs)
+        void IDeploymentInternal.RegisterResourceOutputs(Resource resource, Output<IDictionary<string, object?>> outputs)
         {
             // RegisterResourceOutputs is called in a fire-and-forget manner.  Make sure we keep track of
             // this task so that the application will not quit until this async work completes.
@@ -20,7 +20,7 @@ namespace Pulumi
         }
 
         private async Task RegisterResourceOutputsAsync(
-            Resource resource, Output<IDictionary<string, object>> outputs)
+            Resource resource, Output<IDictionary<string, object?>> outputs)
         {
             var opLabel = $"monitor.registerResourceOutputs(...)";
 
@@ -28,9 +28,8 @@ namespace Pulumi
             // Additionally, the output properties might have come from other resources, so we must await those too.
             var urn = await resource.Urn.GetValueAsync().ConfigureAwait(false);
             var props = await outputs.GetValueAsync().ConfigureAwait(false);
-            var propInputs = props.ToDictionary(kvp => kvp.Key, kvp => (IInput?)(Input<object?>)kvp.Value.ToObjectOutput());
 
-            var serialized = await SerializeAllPropertiesAsync(opLabel, propInputs).ConfigureAwait(false);
+            var serialized = await SerializeAllPropertiesAsync(opLabel, props).ConfigureAwait(false);
             Log.Debug($"RegisterResourceOutputs RPC prepared: urn={urn}" +
                 (_excessiveDebugOutput ? $", outputs ={JsonFormatter.Default.Format(serialized)}" : ""));
 

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs
@@ -16,7 +16,7 @@ namespace Pulumi
             => RunAsync(() =>
             {
                 action();
-                return ImmutableDictionary<string, object>.Empty;
+                return ImmutableDictionary<string, object?>.Empty;
             });
 
         /// <summary>
@@ -24,7 +24,7 @@ namespace Pulumi
         /// </summary>
         /// <param name="func"></param>
         /// <returns></returns>
-        public static Task<int> RunAsync(Func<IDictionary<string, object>> func)
+        public static Task<int> RunAsync(Func<IDictionary<string, object?>> func)
             => RunAsync(() => Task.FromResult(func()));
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Pulumi
         /// can optionally return an <see cref="IDictionary{TKey, TValue}"/>.  The keys and values
         /// in this dictionary will become the outputs for the Pulumi Stack that is created.
         /// </summary>
-        public static Task<int> RunAsync(Func<Task<IDictionary<string, object>>> func)
+        public static Task<int> RunAsync(Func<Task<IDictionary<string, object?>>> func)
         {
             // Serilog.Log.Logger = new LoggerConfiguration().MinimumLevel.Debug().WriteTo.Console().CreateLogger();
 

--- a/sdk/dotnet/Pulumi/Deployment/IDeployment.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IDeployment.cs
@@ -31,12 +31,12 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        Task<T> InvokeAsync<T>(string token, ResourceArgs args, InvokeOptions? options = null);
+        Task<T> InvokeAsync<T>(string token, InvokeArgs args, InvokeOptions? options = null);
 
         /// <summary>
-        /// Same as <see cref="InvokeAsync{T}(string, ResourceArgs, InvokeOptions)"/>, however the
+        /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions)"/>, however the
         /// return value is ignored.
         /// </summary>
-        Task InvokeAsync(string token, ResourceArgs args, InvokeOptions? options = null);
+        Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options = null);
     }
 }

--- a/sdk/dotnet/Pulumi/Deployment/IDeploymentInternal.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IDeploymentInternal.cs
@@ -19,6 +19,6 @@ namespace Pulumi
         Task SetRootResourceAsync(Stack stack);
 
         void ReadOrRegisterResource(Resource resource, ResourceArgs args, ResourceOptions opts);
-        void RegisterResourceOutputs(Resource resource, Output<IDictionary<string, object>> outputs);
+        void RegisterResourceOutputs(Resource resource, Output<IDictionary<string, object?>> outputs);
     }
 }

--- a/sdk/dotnet/Pulumi/Deployment/IRunner.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IRunner.cs
@@ -9,6 +9,6 @@ namespace Pulumi
     internal interface IRunner
     {
         void RegisterTask(string description, Task task);
-        Task<int> RunAsync(Func<Task<IDictionary<string, object>>> func);
+        Task<int> RunAsync(Func<Task<IDictionary<string, object?>>> func);
     }
 }

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -80,6 +80,8 @@ Pulumi.IDeployment.IsDryRun.get -> bool
 Pulumi.IDeployment.ProjectName.get -> string
 Pulumi.IDeployment.StackName.get -> string
 Pulumi.Input<T>
+Pulumi.InputArgs
+Pulumi.InputArgs.InputArgs() -> void
 Pulumi.InputExtensions
 Pulumi.InputList<T>
 Pulumi.InputList<T>.Add(params Pulumi.Input<T>[] inputs) -> void
@@ -91,6 +93,8 @@ Pulumi.InputMap<V>.Add(string key, Pulumi.Input<V> value) -> void
 Pulumi.InputMap<V>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerator<Pulumi.Input<System.Collections.Generic.KeyValuePair<string, V>>>
 Pulumi.InputMap<V>.InputMap() -> void
 Pulumi.InputMap<V>.this[string key].set -> void
+Pulumi.InvokeArgs
+Pulumi.InvokeArgs.InvokeArgs() -> void
 Pulumi.InvokeOptions
 Pulumi.InvokeOptions.InvokeOptions() -> void
 Pulumi.InvokeOptions.Parent.get -> Pulumi.Resource
@@ -232,4 +236,5 @@ static Pulumi.OutputExtensions.GetAt<T>(this Pulumi.Output<System.Collections.Im
 static Pulumi.OutputExtensions.Length<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array) -> Pulumi.Output<int>
 static Pulumi.ResourceOptions.Merge(Pulumi.ResourceOptions options1, Pulumi.ResourceOptions options2) -> Pulumi.ResourceOptions
 static Pulumi.Urn.Create(Pulumi.Input<string> name, Pulumi.Input<string> type, Pulumi.Resource parent = null, Pulumi.Input<string> parentUrn = null, Pulumi.Input<string> project = null, Pulumi.Input<string> stack = null) -> Pulumi.Output<string>
+static readonly Pulumi.InvokeArgs.Empty -> Pulumi.InvokeArgs
 static readonly Pulumi.ResourceArgs.Empty -> Pulumi.ResourceArgs

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -74,8 +74,8 @@ Pulumi.FileArchive.FileArchive(string path) -> void
 Pulumi.FileAsset
 Pulumi.FileAsset.FileAsset(string path) -> void
 Pulumi.IDeployment
-Pulumi.IDeployment.InvokeAsync(string token, Pulumi.ResourceArgs args, Pulumi.InvokeOptions options = null) -> System.Threading.Tasks.Task
-Pulumi.IDeployment.InvokeAsync<T>(string token, Pulumi.ResourceArgs args, Pulumi.InvokeOptions options = null) -> System.Threading.Tasks.Task<T>
+Pulumi.IDeployment.InvokeAsync(string token, Pulumi.InvokeArgs args, Pulumi.InvokeOptions options = null) -> System.Threading.Tasks.Task
+Pulumi.IDeployment.InvokeAsync<T>(string token, Pulumi.InvokeArgs args, Pulumi.InvokeOptions options = null) -> System.Threading.Tasks.Task<T>
 Pulumi.IDeployment.IsDryRun.get -> bool
 Pulumi.IDeployment.ProjectName.get -> string
 Pulumi.IDeployment.StackName.get -> string

--- a/sdk/dotnet/Pulumi/Resources/ComponentResource.cs
+++ b/sdk/dotnet/Pulumi/Resources/ComponentResource.cs
@@ -39,15 +39,15 @@ namespace Pulumi
         /// state as quickly as possible (instead of waiting until the entire application completes).
         /// </summary>
         protected void RegisterOutputs()
-            => RegisterOutputs(ImmutableDictionary<string, object>.Empty);
+            => RegisterOutputs(ImmutableDictionary<string, object?>.Empty);
 
-        protected void RegisterOutputs(IDictionary<string, object> outputs)
+        protected void RegisterOutputs(IDictionary<string, object?> outputs)
             => RegisterOutputs(Task.FromResult(outputs ?? throw new ArgumentNullException(nameof(outputs))));
 
-        protected void RegisterOutputs(Task<IDictionary<string, object>> outputs)
+        protected void RegisterOutputs(Task<IDictionary<string, object?>> outputs)
             => RegisterOutputs(Output.Create(outputs ?? throw new ArgumentNullException(nameof(outputs))));
 
-        protected void RegisterOutputs(Output<IDictionary<string, object>> outputs)
+        protected void RegisterOutputs(Output<IDictionary<string, object?>> outputs)
             => Deployment.InternalInstance.RegisterResourceOutputs(this, outputs ?? throw new ArgumentNullException(nameof(outputs)));
     }
 }

--- a/sdk/dotnet/Pulumi/Resources/InputArgs.cs
+++ b/sdk/dotnet/Pulumi/Resources/InputArgs.cs
@@ -1,0 +1,99 @@
+﻿// Copyright 2016-2019, Pulumi Corporation
+
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Google.Protobuf;
+using Pulumi.Serialization;
+
+namespace Pulumi
+{
+    /// <summary>
+    /// Base type for all input argument classes.
+    /// </summary>
+    public abstract class InputArgs
+    {
+        private readonly ImmutableArray<InputInfo> _inputInfos;
+
+        private protected abstract void ValidateMember(Type memberType, string fullName);
+
+        protected InputArgs()
+        {
+            var fieldQuery =
+                from field in this.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+                let attr = field.GetCustomAttribute<InputAttribute>()
+                where attr != null
+                select (attr, memberName: field.Name, memberType: field.FieldType, getValue: (Func<object, object?>)field.GetValue);
+
+            var propQuery =
+                from prop in this.GetType().GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
+                let attr = prop.GetCustomAttribute<InputAttribute>()
+                where attr != null
+                select (attr, memberName: prop.Name, memberType: prop.PropertyType, getValue: (Func<object, object?>)prop.GetValue);
+
+            var all = fieldQuery.Concat(propQuery).ToList();
+
+            foreach (var (attr, memberName, memberType, getValue) in all)
+            {
+                var fullName = $"[Input] {this.GetType().FullName}.{memberName}";
+                ValidateMember(memberType, fullName);
+            }
+
+            _inputInfos = all.Select(t =>
+                new InputInfo(t.attr, t.memberName, t.memberType, t.getValue)).ToImmutableArray();
+        }
+
+        internal async Task<ImmutableDictionary<string, object?>> ToDictionaryAsync()
+        {
+            var builder = ImmutableDictionary.CreateBuilder<string, object?>();
+            foreach (var info in _inputInfos)
+            {
+                var fullName = $"[Input] {this.GetType().FullName}.{info.MemberName}";
+
+                var value = info.GetValue(this);
+                if (info.Attribute.IsRequired && value == null)
+                {
+                    throw new ArgumentNullException(info.MemberName, $"{fullName} is required but was not given a value");
+                }
+
+                if (info.Attribute.Json)
+                {
+                    value = await ConvertToJsonAsync(fullName, value).ConfigureAwait(false);
+                }
+
+                builder.Add(info.Attribute.Name, value);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private async Task<object?> ConvertToJsonAsync(string context, object? input)
+        {
+            if (input == null)
+                return null;
+
+            var serializer = new Serializer(excessiveDebugOutput: false);
+            var obj = await serializer.SerializeAsync(context, input).ConfigureAwait(false);
+            var value = Serializer.CreateValue(obj);
+            return JsonFormatter.Default.Format(value);
+        }
+
+        private struct InputInfo
+        {
+            public readonly InputAttribute Attribute;
+            public readonly Type MemberType;
+            public readonly string MemberName;
+            public Func<object, object?> GetValue;
+
+            public InputInfo(InputAttribute attribute, string memberName, Type memberType, Func<object, object> getValue) : this()
+            {
+                Attribute = attribute;
+                MemberName = memberName;
+                MemberType = memberType;
+                GetValue = getValue;
+            }
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Resources/InvokeArgs.cs
+++ b/sdk/dotnet/Pulumi/Resources/InvokeArgs.cs
@@ -1,0 +1,30 @@
+﻿// Copyright 2016-2019, Pulumi Corporation
+
+using System;
+
+namespace Pulumi
+{
+    /// <summary>
+    /// Base type for all invoke argument classes.
+    /// </summary>
+    public abstract class InvokeArgs : InputArgs
+    {
+        public static readonly InvokeArgs Empty = new EmptyInvokeArgs();
+
+        protected InvokeArgs()
+        {
+        }
+
+        private protected override void ValidateMember(Type memberType, string fullName)
+        {
+            if (typeof(IInput).IsAssignableFrom(memberType))
+            {
+                throw new InvalidOperationException($"{fullName} must not be an Input<T>");
+            }
+        }
+
+        private class EmptyInvokeArgs : InvokeArgs
+        {
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Resources/ResourceArgs.cs
+++ b/sdk/dotnet/Pulumi/Resources/ResourceArgs.cs
@@ -1,108 +1,30 @@
 ﻿// Copyright 2016-2019, Pulumi Corporation
 
 using System;
-using System.Collections.Immutable;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
-using Google.Protobuf;
-using Pulumi.Serialization;
 
 namespace Pulumi
 {
     /// <summary>
     /// Base type for all resource argument classes.
     /// </summary>
-    public abstract class ResourceArgs
+    public abstract class ResourceArgs : InputArgs
     {
         public static readonly ResourceArgs Empty = new EmptyResourceArgs();
 
-        private readonly ImmutableArray<InputInfo> _inputInfos;
-
         protected ResourceArgs()
         {
-            var fieldQuery =
-                from field in this.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
-                let attr = field.GetCustomAttribute<InputAttribute>()
-                where attr != null
-                select (attr, memberName: field.Name, memberType: field.FieldType, getValue: (Func<object, object?>)field.GetValue);
-
-            var propQuery =
-                from prop in this.GetType().GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
-                let attr = prop.GetCustomAttribute<InputAttribute>()
-                where attr != null
-                select (attr, memberName: prop.Name, memberType: prop.PropertyType, getValue: (Func<object, object?>)prop.GetValue);
-
-            var all = fieldQuery.Concat(propQuery).ToList();
-
-            foreach (var (attr, memberName, memberType, getValue) in all)
-            {
-                var fullName = $"[Input] {this.GetType().FullName}.{memberName}";
-
-                if (!typeof(IInput).IsAssignableFrom(memberType))
-                {
-                    throw new InvalidOperationException($"{fullName} was not an Input<T>");
-                }
-            }
-
-            _inputInfos = all.Select(t =>
-                new InputInfo(t.attr, t.memberName, t.memberType, t.getValue)).ToImmutableArray();
         }
 
-        internal async Task<ImmutableDictionary<string, IInput?>> ToDictionaryAsync()
+        private protected override void ValidateMember(Type memberType, string fullName)
         {
-            var builder = ImmutableDictionary.CreateBuilder<string, IInput?>();
-            foreach (var info in _inputInfos)
+            if (!typeof(IInput).IsAssignableFrom(memberType))
             {
-                var fullName = $"[Input] {this.GetType().FullName}.{info.MemberName}";
-
-                var value = (IInput?)info.GetValue(this);
-                if (info.Attribute.IsRequired && value == null)
-                {
-                    throw new ArgumentNullException(info.MemberName, $"{fullName} is required but was not given a value");
-                }
-
-                if (info.Attribute.Json)
-                {
-                    value = await ConvertToJsonAsync(fullName, value).ConfigureAwait(false);
-                }
-
-                builder.Add(info.Attribute.Name, value);
+                throw new InvalidOperationException($"{fullName} must be an Input<T>");
             }
-
-            return builder.ToImmutable();
-        }
-
-        private async Task<IInput?> ConvertToJsonAsync(string context, IInput? input)
-        {
-            if (input == null)
-                return null;
-
-            var serializer = new Serializer(excessiveDebugOutput: false);
-            var obj = await serializer.SerializeAsync(context, input).ConfigureAwait(false);
-            var value = Serializer.CreateValue(obj);
-            var valueString = JsonFormatter.Default.Format(value);
-            return (Input<string>)valueString;
         }
 
         private class EmptyResourceArgs : ResourceArgs
         {
-        }
-
-        private struct InputInfo
-        {
-            public readonly InputAttribute Attribute;
-            public readonly Type MemberType;
-            public readonly string MemberName;
-            public Func<object, object?> GetValue;
-
-            public InputInfo(InputAttribute attribute, string memberName, Type memberType, Func<object, object> getValue) : this()
-            {
-                Attribute = attribute;
-                MemberName = memberName;
-                MemberType = memberType;
-                GetValue = getValue;
-            }
         }
     }
 }

--- a/sdk/dotnet/Pulumi/Stack.cs
+++ b/sdk/dotnet/Pulumi/Stack.cs
@@ -44,10 +44,10 @@ namespace Pulumi
         /// <summary>
         /// The outputs of this stack, if the <c>init</c> callback exited normally.
         /// </summary>
-        public readonly Output<IDictionary<string, object>> Outputs =
-            Output.Create<IDictionary<string, object>>(ImmutableDictionary<string, object>.Empty);
+        public readonly Output<IDictionary<string, object?>> Outputs =
+            Output.Create<IDictionary<string, object?>>(ImmutableDictionary<string, object?>.Empty);
 
-        internal Stack(Func<Task<IDictionary<string, object>>> init)
+        internal Stack(Func<Task<IDictionary<string, object?>>> init)
             : base(_rootPulumiStackTypeName, $"{Deployment.Instance.ProjectName}-{Deployment.Instance.StackName}")
         {
             Deployment.InternalInstance.Stack = this;
@@ -62,7 +62,7 @@ namespace Pulumi
             }
         }
 
-        private async Task<IDictionary<string, object>> RunInitAsync(Func<Task<IDictionary<string, object>>> init)
+        private async Task<IDictionary<string, object?>> RunInitAsync(Func<Task<IDictionary<string, object?>>> init)
         {
             // Ensure we are known as the root resource.  This is needed before we execute any user
             // code as many codepaths will request the root resource.
@@ -70,7 +70,7 @@ namespace Pulumi
 
             var dictionary = await init().ConfigureAwait(false);
             return dictionary == null
-                ? ImmutableDictionary<string, object>.Empty
+                ? ImmutableDictionary<string, object?>.Empty
                 : dictionary.ToImmutableDictionary();
         }
     }


### PR DESCRIPTION
Part of the fix for https://github.com/pulumi/pulumi-aws/issues/800.  @mikhailshilkov is doing the rest in the codegen layer.

Specifically, our design around 'data source invokes' is that their arguments are *realized* POCO data.  i.e. they should not be inputs/async data at all.  To that end, we are changing the codegen for the auto-generated `invoke` arguments to just spit out POCO data, including `List<T>` and `Dictionary<string, T>` for collection types.  

