### PR TITLE
Support `object` target type in .NET

### DIFF
--- a/sdk/dotnet/Pulumi/Serialization/Converter.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Converter.cs
@@ -51,6 +51,9 @@ namespace Pulumi.Serialization
             if (targetIsNullable)
                 return ConvertObject(context, val, targetType.GenericTypeArguments.Single());
 
+            if (targetType == typeof(object))
+                return EnsureType<object>(context, val);
+
             if (targetType == typeof(string))
                 return EnsureType<string>(context, val);
 
@@ -182,7 +185,8 @@ namespace Pulumi.Serialization
 
         public static void CheckTargetType(string context, System.Type targetType)
         {
-            if (targetType == typeof(bool) ||
+            if (targetType == typeof(object) ||
+                targetType == typeof(bool) ||
                 targetType == typeof(int) ||
                 targetType == typeof(double) ||
                 targetType == typeof(string) ||


### PR DESCRIPTION
Allow the `object` target type to be used by resources when they need to handle values that could be of a variety of different underlying types.