### PR TITLE
Add ability to opt-in to using yarn instead of npm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+## HEAD (Unreleased)
+
+- Support for setting the `PULUMI_PREFER_YARN` environment variable to opt-in to using `yarn` instead of `npm` for
+  installing Node.js dependencies. [#3556](https://github.com/pulumi/pulumi/pull/3556)
+
 ## 1.6.0 (2019-11-20)
 
 - Support for config.GetObject and related variants for Golang. [#3526](https://github.com/pulumi/pulumi/pull/3526)
@@ -8,7 +13,7 @@ CHANGELOG
 - Add support for IgnoreChanges in the go SDK [#3514](https://github.com/pulumi/pulumi/pull/3514)
 
 - Support for a `go run` style workflow. Building or installing a pulumi program written in go is
-  now optional. [3503](https://github.com/pulumi/pulumi/pull/3503)
+  now optional. [#3503](https://github.com/pulumi/pulumi/pull/3503)
 
 - Re-apply "propagate resource inputs to resource state during preview, including first-class unknown values." The new
   set of changes have additional fixes to ensure backwards compatibility with earlier code. This allows the preview to

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -565,10 +565,9 @@ func installDependencies() error {
 
 	// TODO[pulumi/pulumi#1307]: move to the language plugins so we don't have to hard code here.
 	if strings.EqualFold(proj.Runtime.Name(), "nodejs") {
-		err = npmInstallDependencies()
-		if err != nil {
-			return errors.Wrapf(err, "npm install failed; rerun manually to try again, "+
-				"then run 'pulumi up' to perform an initial deployment")
+		if bin, err := nodeInstallDependencies(); err != nil {
+			return errors.Wrapf(err, "%s install failed; rerun manually to try again, "+
+				"then run 'pulumi up' to perform an initial deployment", bin)
 		}
 	} else if strings.EqualFold(proj.Runtime.Name(), "dotnet") {
 		return dotnetInstallDependenciesAndBuild(proj, root)
@@ -577,23 +576,24 @@ func installDependencies() error {
 	return nil
 }
 
-// npmInstallDependencies will install dependencies for the project or Policy Pack by running `npm install`.
-func npmInstallDependencies() error {
+// nodeInstallDependencies will install dependencies for the project or Policy Pack by running `npm install` or
+// `yarn install`.
+func nodeInstallDependencies() (string, error) {
 	fmt.Println("Installing dependencies...")
 	fmt.Println()
 
-	err := npm.Install("", os.Stdout, os.Stderr)
+	bin, err := npm.Install("", os.Stdout, os.Stderr)
 	if err != nil {
-		return err
+		return bin, err
 	}
 
 	fmt.Println("Finished installing dependencies")
 	fmt.Println()
 
-	return nil
+	return bin, nil
 }
 
-// dotnetInstallDependencies will install dependencies and build the project.
+// dotnetInstallDependenciesAndBuild will install dependencies and build the project.
 func dotnetInstallDependenciesAndBuild(proj *workspace.Project, root string) error {
 	contract.Assert(proj != nil)
 

--- a/cmd/policy_new.go
+++ b/cmd/policy_new.go
@@ -163,8 +163,8 @@ func runNewPolicyPack(args newPolicyArgs) error {
 
 	// Install dependencies.
 	if !args.generateOnly {
-		if err := npmInstallDependencies(); err != nil {
-			return errors.Wrapf(err, "npm install failed; rerun manually to try again.")
+		if bin, err := nodeInstallDependencies(); err != nil {
+			return errors.Wrapf(err, "%s install failed; rerun manually to try again.", bin)
 		}
 	}
 

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -224,12 +224,11 @@ func installRequiredPolicy(finalDir string, tarball []byte) error {
 	fmt.Println()
 
 	// TODO[pulumi/pulumi#1307]: move to the language plugins so we don't have to hard code here.
-	err = npm.Install(finalDir, nil, os.Stderr)
-	if err != nil {
+	if bin, err := npm.Install(finalDir, nil, os.Stderr); err != nil {
 		return errors.Wrapf(
 			err,
-			"failed to install dependencies of policy pack; you may need to re-run `npm install` "+
-				"in %q before this policy pack works", finalDir)
+			"failed to install dependencies of policy pack; you may need to re-run `%s install` "+
+				"in %q before this policy pack works", bin, finalDir)
 	}
 
 	fmt.Println("Finished installing dependencies")

--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -9,58 +9,128 @@ import (
 	"os/exec"
 	"strings"
 
+	uuid "github.com/satori/go.uuid"
+
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/util/logging"
 )
 
 // Pack runs `npm pack` in the given directory, packaging the Node.js app located there into a
 // tarball and returning it as `[]byte`. `stdout` is ignored for the command, as it does not
-// generate useful data.
+// generate useful data. If the `PULUMI_PREFER_YARN` environment variable is set, `yarn pack` is run
+// instead of `npm pack`.
 func Pack(dir string, stderr io.Writer) ([]byte, error) {
-	// We pass `--loglevel=error` to prevent `npm` from printing warnings about missing
-	// `description`, `repository`, and `license` fields in the package.json file.
-	c := exec.Command("npm", "pack", "--loglevel=error")
-	c.Dir = dir
-
-	// Run the command. Note that `npm pack` doesn't have the ability to rename the resulting
-	// filename, since it's meant to be uploaded directly to npm, which means that we have to get
-	// that information by parsing the output of the command.
-	var stdout bytes.Buffer
-	c.Stdout = &stdout
-	c.Stderr = os.Stderr
-	if err := c.Run(); err != nil {
+	c, npm, bin, err := getCmd("pack")
+	if err != nil {
 		return nil, err
 	}
-	packfile := strings.TrimSpace(stdout.String())
+	c.Dir = dir
+
+	// Note that `npm pack` doesn't have the ability to specify the resulting filename, since
+	// it's meant to be uploaded directly to npm, which means we have to get that information
+	// by parsing the output of the command. However, if we're using `yarn`, we can specify a
+	// filename.
+	var packfile string
+	if !npm {
+		packfile = fmt.Sprintf("%s.tgz", uuid.NewV4().String())
+		c.Args = append(c.Args, "--filename", packfile)
+	}
+
+	// Run the command.
+	// `stdout` is ignored for the command, as it does not generate useful data.
+	var stdout bytes.Buffer
+	if err = runCmd(c, npm, &stdout, stderr); err != nil {
+		return nil, err
+	}
+
+	// If `npm` was used, parse the filename from the output.
+	if npm {
+		packfile = strings.TrimSpace(stdout.String())
+	}
+
 	defer os.Remove(packfile)
 
 	packTarball, err := ioutil.ReadFile(packfile)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"npm pack completed successfully but the packed .tar.gz file was not generated")
+		return nil, fmt.Errorf("%s pack completed successfully but the packed .tgz file was not generated", bin)
 	}
 
 	return packTarball, nil
 }
 
 // Install runs `npm install` in the given directory, installing the dependencies for the Node.js
-// app located there.
-func Install(dir string, stdout, stderr io.Writer) error {
-	// We pass `--loglevel=error` to prevent `npm` from printing warnings about missing
-	// `description`, `repository`, and `license` fields in the package.json file.
-	c := exec.Command("npm", "install", "--loglevel=error")
+// app located there. If the `PULUMI_PREFER_YARN` environment variable is set, `yarn install` is used
+// instead of `npm install`.
+func Install(dir string, stdout, stderr io.Writer) (string, error) {
+	c, npm, bin, err := getCmd("install")
+	if err != nil {
+		return bin, err
+	}
 	c.Dir = dir
 
 	// Run the command.
-	c.Stdout = stdout
-	c.Stderr = stderr
-	if err := c.Run(); err != nil {
-		return err
+	if err = runCmd(c, npm, stdout, stderr); err != nil {
+		return bin, err
 	}
 
 	// Ensure the "node_modules" directory exists.
 	if _, err := os.Stat("node_modules"); os.IsNotExist(err) {
-		return errors.Errorf("npm install reported success, but node_modules directory is missing")
+		return bin, errors.Errorf("%s install reported success, but node_modules directory is missing", bin)
+	}
+
+	return bin, nil
+}
+
+// getCmd returns the `npm` or `yarn` command depending on whether `PULUMI_PREFER_YARN` is set and yarn can be found
+// on the $PATH. If `npm` is being used, true is returned (false for `yarn`), and the file (either "npm" or "yarn").
+func getCmd(command string) (*exec.Cmd, bool, string, error) {
+	if preferYarn() {
+		const file = "yarn"
+		yarnPath, err := exec.LookPath(file)
+		if err == nil {
+			return exec.Command(yarnPath, command), false, file, nil
+		}
+		logging.Warningf("could not find yarn on the $PATH, trying npm instead: %v", err)
+	}
+
+	const file = "npm"
+	npmPath, err := exec.LookPath(file)
+	if err != nil {
+		return nil, false, file, errors.Wrapf(err, "could not find npm on the $PATH; npm is installed with Node.js "+
+			"available at https://nodejs.org/")
+	}
+	// We pass `--loglevel=error` to prevent `npm` from printing warnings about missing
+	// `description`, `repository`, and `license` fields in the package.json file.
+	return exec.Command(npmPath, command, "--loglevel=error"), true, file, nil
+}
+
+// runCmd handles hooking up `stdout` and `stderr` and then runs the command.
+func runCmd(c *exec.Cmd, npm bool, stdout, stderr io.Writer) error {
+	// Setup `stdout` and `stderr`.
+	// `stderr` is ignored when `yarn` is used because it outputs warnings like "package.json: No license field"
+	// to `stderr` that we don't need to show.
+	c.Stdout = stdout
+	var stderrBuffer bytes.Buffer
+	if npm {
+		c.Stderr = stderr
+	} else {
+		c.Stderr = &stderrBuffer
+	}
+
+	// Run the command.
+	if err := c.Run(); err != nil {
+		// If we failed, and we're using `yarn`, write out any bytes that were written to `stderr`.
+		if !npm {
+			stderr.Write(stderrBuffer.Bytes())
+		}
+		return err
 	}
 
 	return nil
+}
+
+// preferYarn returns true if the `PULUMI_PREFER_YARN` environment variable is set.
+func preferYarn() bool {
+	return cmdutil.IsTruthy(os.Getenv("PULUMI_PREFER_YARN"))
 }

--- a/pkg/npm/npm.go
+++ b/pkg/npm/npm.go
@@ -82,8 +82,9 @@ func Install(dir string, stdout, stderr io.Writer) (string, error) {
 	return bin, nil
 }
 
-// getCmd returns the `npm` or `yarn` command depending on whether `PULUMI_PREFER_YARN` is set and yarn can be found
-// on the $PATH. If `npm` is being used, true is returned (false for `yarn`), and the file (either "npm" or "yarn").
+// getCmd returns the exec.Cmd used to install NPM dependencies. It will either use `npm` or `yarn` depending
+// on what is available on the current path, and if `PULUMI_PREFER_YARN` is truthy.
+// The boolean return parameter indicates if `npm` is chosen or not (instead of `yarn`).
 func getCmd(command string) (*exec.Cmd, bool, string, error) {
 	if preferYarn() {
 		const file = "yarn"


### PR DESCRIPTION
This change adds support for setting `PULUMI_PREFER_YARN` to true to opt-in to preferring yarn over npm. If `PULUMI_PREFER_YARN` is truthy, but yarn cannot be found on `$PATH,` we fallback to using npm. If `npm` can't be found on `$PATH`, we provide a more helpful error message.

Example output:

```bash
$ pulumi new aws-typescript
This command will walk you through creating a new Pulumi project.

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.

project name: (nov21prog) 
project description: (A minimal AWS TypeScript Pulumi program) 
Created project 'nov21prog'

Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
stack name: (dev) 
Created stack 'dev'

aws:region: The AWS region to deploy into: (us-east-1) 
Saved config

Installing dependencies...

yarn install v1.17.3
info No lockfile found.
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[3/4] 🔗  Linking dependencies...
[4/4] 🔨  Building fresh packages...
success Saved lockfile.
✨  Done in 7.33s.
Finished installing dependencies

Your new project is ready to go! ✨

To perform an initial deployment, run 'pulumi up'
```

Fixes https://github.com/pulumi/pulumi-policy/issues/102
Fixes https://github.com/pulumi/pulumi/issues/3520
Fixes https://github.com/pulumi/pulumi/issues/3293