### PR TITLE
Serialize null property values.

### DIFF
--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -321,16 +321,15 @@ func SerializeProperties(props resource.PropertyMap, enc config.Encrypter) (map[
 
 // SerializePropertyValue serializes a resource property value so that it's suitable for serialization.
 func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter) (interface{}, error) {
-	// Skip nulls and "outputs"; the former needn't be serialized, and the latter happens if there is an output
-	// that hasn't materialized (either because we're serializing inputs or the provider didn't give us the value).
-	if !prop.HasValue() {
+	// Serialize nulls as nil.
+	if prop.IsNull() {
 		return nil, nil
 	}
 
 	// A computed value marks something that will be determined at a later time. (e.g. the result of
 	// a computation that we don't perform during a preview operation.) We serialize a magic constant
 	// to record its existence.
-	if prop.IsComputed() {
+	if prop.IsComputed() || prop.IsOutput() {
 		return computedValuePlaceholder, nil
 	}
 

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -314,9 +314,7 @@ func SerializeProperties(props resource.PropertyMap, enc config.Encrypter) (map[
 		if err != nil {
 			return nil, err
 		}
-		if v != nil {
-			dst[string(k)] = v
-		}
+		dst[string(k)] = v
 	}
 	return dst, nil
 }

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -307,6 +307,7 @@ func TestCustomSerialization(t *testing.T) {
 			`"float64":1.5`,
 			`"int32":41`,
 			`"int64":42`,
+			`"nil":null`,
 
 			// Data structures
 			`"array":["a",true,32]`,
@@ -320,6 +321,8 @@ func TestCustomSerialization(t *testing.T) {
 
 			// Computed values are replaced with a magic constant.
 			`"computed":"04da6b54-80e4-46f7-96ec-b56ff0331ba9"`,
+			`"output":"04da6b54-80e4-46f7-96ec-b56ff0331ba9"`,
+
 			// Secrets are serialized with the special sig key, and their underlying cipher text.
 			// Since we passed in a config.BlindingCrypter the cipher text isn't super-useful.
 			`"secret":{"4dabf18193072939515e22adb298388d":"1b47061264138c4ac30d75fd1eb44270","ciphertext":"[secret]"}`,
@@ -327,17 +330,6 @@ func TestCustomSerialization(t *testing.T) {
 		for _, want := range tests {
 			if !strings.Contains(json, want) {
 				t.Errorf("Did not find expected snippet: %v", want)
-			}
-		}
-
-		// Some properties are explicitly _not_ in serialized output.
-		negativeTests := []string{
-			`"nil"`,
-			`"output"`,
-		}
-		for _, doNotWant := range negativeTests {
-			if strings.Contains(json, doNotWant) {
-				t.Errorf("Found unexpected snippet: %v", doNotWant)
 			}
 		}
 


### PR DESCRIPTION
Eliding these values prevents us from properly round-tripping resource
states that include null property values.

This is part of the fix for
https://github.com/pulumi/pulumi-azure/issues/383.