### PR TITLE
Allow relative paths to `--policy-pack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - Support for setting the `PULUMI_PREFER_YARN` environment variable to opt-in to using `yarn` instead of `npm` for
   installing Node.js dependencies. [#3556](https://github.com/pulumi/pulumi/pull/3556)
 
+- Fix regression that prevented relative paths passed to `--policy-pack` from working.
+  [#3565](https://github.com/pulumi/pulumi/issues/3564)
+
 ## 1.6.0 (2019-11-20)
 
 - Support for config.GetObject and related variants for Golang. [#3526](https://github.com/pulumi/pulumi/pull/3526)

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -98,7 +98,7 @@ func NewPolicyAnalyzer(
 	// node_modules is used.
 	pwd := policyPackPath
 	plug, err := newPlugin(ctx, pwd, pluginPath, fmt.Sprintf("%v (analyzer)", name),
-		[]string{host.ServerAddr(), policyPackPath})
+		[]string{host.ServerAddr(), "."})
 	if err != nil {
 		if err == errRunPolicyModuleNotFound {
 			return nil, fmt.Errorf("it looks like the policy pack's dependencies are not installed; "+


### PR DESCRIPTION
A regression was introduced when we added support for non-Node.js Pulumi programs to run Policy Packs. With that change, we now pass the Policy Pack's full path as the plugin's pwd (so that it would load the `@pulumi/pulumi/cmd/run-policy-pack` Node module from the Policy Pack's node_modules rather than the program's node_modules), but we also pass the path to the policy pack as well. If the path is a full rooted path, this would work fine, and that's what our tests do. However, if a relative path is specified, then it will be looking to load the Policy Pack relative to the pwd, which doesn't produce a correct path leading to failures trying to load the Policy Pack.

Since the pwd is the policy pack path, we can simply pass the path as `"."` to the analyzer plugin, and it will load the policy pack in its pwd.

Tests: https://github.com/pulumi/pulumi-policy/pull/152

Fixes #3564