### PR TITLE
fix go sdk delete before replace implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fix go SDK DeleteBeforeReplace [#3572](https://github.com/pulumi/pulumi/pull/3572)
+
 - Support for setting the `PULUMI_PREFER_YARN` environment variable to opt-in to using `yarn` instead of `npm` for
   installing Node.js dependencies. [#3556](https://github.com/pulumi/pulumi/pull/3556)
 

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -5296,8 +5296,6 @@ func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
 		}),
 	}
 
-	const resType = "pkgA:index:typ"
-
 	inputsA := map[string]interface{}{"A": "foo"}
 
 	optsA := pulumi.ResourceOpt{}
@@ -5385,5 +5383,5 @@ func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
 			return res
 		},
 	}}
-	snap = p.Run(t, snap)
+	p.Run(t, snap)
 }

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -5267,3 +5267,123 @@ func TestIgnoreChangesGolangLifecycle(t *testing.T) {
 	ignoreChanges = []string{}
 	setupAndRunProgram(ignoreChanges)
 }
+
+func TestExplicitDeleteBeforeReplaceGoSDK(t *testing.T) {
+	p := &TestPlan{}
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				DiffConfigF: func(urn resource.URN, olds, news resource.PropertyMap,
+					ignoreChanges []string) (plugin.DiffResult, error) {
+					if !olds["A"].DeepEquals(news["A"]) {
+						return plugin.DiffResult{
+							ReplaceKeys:         []resource.PropertyKey{"A"},
+							DeleteBeforeReplace: true,
+						}, nil
+					}
+					return plugin.DiffResult{}, nil
+				},
+				DiffF: func(urn resource.URN, id resource.ID,
+					olds, news resource.PropertyMap, ignoreChanges []string) (plugin.DiffResult, error) {
+
+					if !olds["A"].DeepEquals(news["A"]) {
+						return plugin.DiffResult{ReplaceKeys: []resource.PropertyKey{"A"}}, nil
+					}
+					return plugin.DiffResult{}, nil
+				},
+			}, nil
+		}),
+	}
+
+	const resType = "pkgA:index:typ"
+
+	inputsA := map[string]interface{}{"A": "foo"}
+
+	optsA := pulumi.ResourceOpt{}
+
+	dbrValue, dbrA := true, (*bool)(nil)
+	getDbr := func() bool {
+		if dbrA == nil {
+			return false
+		}
+		return *dbrA
+	}
+
+	var stackURN, provURN, urnA resource.URN = "urn:pulumi:test::test::pulumi:pulumi:Stack::test-test",
+		"urn:pulumi:test::test::pulumi:providers:pkgA::provA", "urn:pulumi:test::test::pkgA:m:typA::resA"
+	program := deploytest.NewLanguageRuntime(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		ctx, err := pulumi.NewContext(context.Background(), pulumi.RunInfo{
+			Project:     info.Project,
+			Stack:       info.Stack,
+			Parallel:    info.Parallel,
+			DryRun:      info.DryRun,
+			MonitorAddr: info.MonitorAddress,
+		})
+		assert.NoError(t, err)
+
+		return pulumi.RunWithContext(ctx, func(ctx *pulumi.Context) error {
+			provider, err := ctx.RegisterResource(string(providers.MakeProviderType("pkgA")), "provA", true,
+				map[string]interface{}{})
+			assert.NoError(t, err)
+			optsA.Provider = provider
+			optsA.DeleteBeforeReplace = getDbr()
+			fmt.Println(getDbr())
+			_, err = ctx.RegisterResource("pkgA:m:typA", "resA", true, inputsA, optsA)
+			assert.NoError(t, err)
+
+			return nil
+		})
+
+	})
+
+	p.Options.host = deploytest.NewPluginHost(nil, nil, program, loaders...)
+	p.Steps = []TestStep{{Op: Update}}
+	snap := p.Run(t, nil)
+
+	// Change the value of resA.A. Should create before replace
+	inputsA["A"] = "bar"
+	p.Steps = []TestStep{{
+		Op: Update,
+
+		Validate: func(project workspace.Project, target deploy.Target, j *Journal,
+			evts []Event, res result.Result) result.Result {
+
+			assert.Nil(t, res)
+
+			AssertSameSteps(t, []StepSummary{
+				{Op: deploy.OpSame, URN: stackURN},
+				{Op: deploy.OpSame, URN: provURN},
+				{Op: deploy.OpCreateReplacement, URN: urnA},
+				{Op: deploy.OpReplace, URN: urnA},
+				{Op: deploy.OpDeleteReplaced, URN: urnA},
+			}, j.SuccessfulSteps())
+
+			return res
+		},
+	}}
+	snap = p.Run(t, snap)
+
+	// Change the registration of resA such that it requires delete-before-replace and change the value of resA.A.
+	// replacement should be delete-before-replace.
+	dbrA, inputsA["A"] = &dbrValue, "baz"
+	p.Steps = []TestStep{{
+		Op: Update,
+
+		Validate: func(project workspace.Project, target deploy.Target, j *Journal,
+			evts []Event, res result.Result) result.Result {
+
+			assert.Nil(t, res)
+			AssertSameSteps(t, []StepSummary{
+				{Op: deploy.OpSame, URN: stackURN},
+				{Op: deploy.OpSame, URN: provURN},
+				{Op: deploy.OpDeleteReplaced, URN: urnA},
+				{Op: deploy.OpReplace, URN: urnA},
+				{Op: deploy.OpCreateReplacement, URN: urnA},
+			}, j.SuccessfulSteps())
+
+			return res
+		},
+	}}
+	snap = p.Run(t, snap)
+}

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -540,7 +540,7 @@ func (ctx *Context) getOpts(opts ...ResourceOpt) (URN, []URN, bool, string, bool
 		providerRef = pr
 	}
 
-	return parentURN, depURNs, protect, providerRef, false, importID, ignoreChanges, nil
+	return parentURN, depURNs, protect, providerRef, deleteBeforeReplace, importID, ignoreChanges, nil
 }
 
 func (ctx *Context) resolveProviderReference(provider ProviderResource) (string, error) {


### PR DESCRIPTION
Delete before replace was not properly passed through in the go SDK. Fixes https://github.com/pulumi/pulumi/issues/3513

Was able to verify fail/pass of the new unit test before and after change. 