### PR TITLE
Support json values in the .net sdk

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/Serialization/JsonConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/JsonConverterTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright 2016-2019, Pulumi Corporation
+
+using System.Text.Json;
+using System.Threading.Tasks;
+using Pulumi.Serialization;
+using Xunit;
+
+namespace Pulumi.Tests.Serialization
+{
+    public class JsonConverterTests : ConverterTests
+    {
+        private async Task Test(string json, string expected)
+        {
+            var element = JsonDocument.Parse(json).RootElement;
+            var serialized = await SerializeToValueAsync(element);
+            var converted = Converter.ConvertValue<JsonElement>("", serialized);
+
+            Assert.Equal(expected, converted.Value.ToString());
+        }
+
+        [Fact]
+        public async Task TestString()
+        {
+            await Test("\"x\"", "x");
+        }
+
+        [Fact]
+        public async Task TestNumber()
+        {
+            await Test("1.1", "1.1");
+        }
+
+        [Fact]
+        public async Task TestBoolean()
+        {
+            await Test("true", "True");
+        }
+
+        [Fact]
+        public async Task TestNull()
+        {
+            await Test("null", "");
+        }
+
+        [Fact]
+        public async Task TestArray()
+        {
+            await Test("[1, true, null]", "[1,true,null]");
+        }
+
+        [Fact]
+        public async Task TestObject()
+        {
+            await Test("{ \"n\": 1 }", "{\"n\":1}");
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Core/InputJson.cs
+++ b/sdk/dotnet/Pulumi/Core/InputJson.cs
@@ -1,0 +1,43 @@
+﻿// Copyright 2016-2019, Pulumi Corporation
+
+using System.Text.Json;
+
+namespace Pulumi
+{
+    /// <summary>
+    /// Represents an <see cref="Input{T}"/> value that wraps a <see cref="JsonElement"/>.
+    /// </summary>
+    public sealed class InputJson : Input<JsonElement>
+    {
+        public InputJson() : this(Output.Create(default(JsonElement)))
+        {
+        }
+
+        private InputJson(Output<JsonElement> output)
+            : base(output)
+        {
+        }
+
+        #region common 
+
+        public static implicit operator InputJson(string json)
+            => JsonDocument.Parse(json);
+
+        public static implicit operator InputJson(JsonDocument document)
+            => document.RootElement;
+
+        public static implicit operator InputJson(JsonElement element)
+            => Output.Create(element);
+
+        public static implicit operator InputJson(Output<string> json)
+            => json.Apply(j => JsonDocument.Parse(j));
+
+        public static implicit operator InputJson(Output<JsonDocument> document)
+            => document.Apply(d => d.RootElement);
+
+        public static implicit operator InputJson(Output<JsonElement> element)
+            => new InputJson(element);
+
+        #endregion
+    }
+}

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -83,6 +83,8 @@ Pulumi.Input<T>
 Pulumi.InputArgs
 Pulumi.InputArgs.InputArgs() -> void
 Pulumi.InputExtensions
+Pulumi.InputJson
+Pulumi.InputJson.InputJson() -> void
 Pulumi.InputList<T>
 Pulumi.InputList<T>.Add(params Pulumi.Input<T>[] inputs) -> void
 Pulumi.InputList<T>.Concat(Pulumi.InputList<T> other) -> Pulumi.InputList<T>
@@ -201,6 +203,12 @@ static Pulumi.InputExtensions.Apply<T, U>(this Pulumi.Input<T> input, System.Fun
 static Pulumi.InputExtensions.Apply<T, U>(this Pulumi.Input<T> input, System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
 static Pulumi.InputExtensions.Apply<T, U>(this Pulumi.Input<T> input, System.Func<T, U> func) -> Pulumi.Output<U>
 static Pulumi.InputExtensions.ToOutput<T>(this Pulumi.Input<T> input) -> Pulumi.Output<T>
+static Pulumi.InputJson.implicit operator Pulumi.InputJson(Pulumi.Output<System.Text.Json.JsonDocument> document) -> Pulumi.InputJson
+static Pulumi.InputJson.implicit operator Pulumi.InputJson(Pulumi.Output<System.Text.Json.JsonElement> element) -> Pulumi.InputJson
+static Pulumi.InputJson.implicit operator Pulumi.InputJson(Pulumi.Output<string> json) -> Pulumi.InputJson
+static Pulumi.InputJson.implicit operator Pulumi.InputJson(System.Text.Json.JsonDocument document) -> Pulumi.InputJson
+static Pulumi.InputJson.implicit operator Pulumi.InputJson(System.Text.Json.JsonElement element) -> Pulumi.InputJson
+static Pulumi.InputJson.implicit operator Pulumi.InputJson(string json) -> Pulumi.InputJson
 static Pulumi.InputList<T>.implicit operator Pulumi.InputList<T>(Pulumi.Input<T> value) -> Pulumi.InputList<T>
 static Pulumi.InputList<T>.implicit operator Pulumi.InputList<T>(Pulumi.Input<T>[] values) -> Pulumi.InputList<T>
 static Pulumi.InputList<T>.implicit operator Pulumi.InputList<T>(Pulumi.Output<System.Collections.Generic.IEnumerable<T>> values) -> Pulumi.InputList<T>

--- a/sdk/dotnet/Pulumi/Serialization/Attributes.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Attributes.cs
@@ -26,7 +26,7 @@ namespace Pulumi.Serialization
     /// Note: for simple inputs (i.e. <see cref="Input{T}"/> this should just be placed on the
     /// property itself.  i.e. <c>[Input] Input&lt;string&gt; Acl</c>.
     /// 
-    /// For collection inputs (i.e. <see cref="InputList{T}"/> this shuld be placed on the
+    /// For collection inputs (i.e. <see cref="InputList{T}"/> this should be placed on the
     /// backing field for the property.  i.e.
     /// 
     /// <code>

--- a/sdk/dotnet/Pulumi/Serialization/Converter.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Converter.cs
@@ -153,7 +153,7 @@ namespace Pulumi.Serialization
             {
                 using (var writer = new Utf8JsonWriter(stream))
                 {
-                    var exception = WriteJson(context, writer, val);
+                    var exception = TryWriteJson(context, writer, val);
                     if (exception != null)
                         return (null, exception);
                 }
@@ -165,7 +165,7 @@ namespace Pulumi.Serialization
             }
         }
 
-        private static InvalidOperationException? WriteJson(string context, Utf8JsonWriter writer, object? val)
+        private static InvalidOperationException? TryWriteJson(string context, Utf8JsonWriter writer, object? val)
         {
             switch (val)
             {
@@ -185,7 +185,7 @@ namespace Pulumi.Serialization
                     writer.WriteStartArray();
                     foreach (var element in v)
                     {
-                        var exception = WriteJson(context, writer, element);
+                        var exception = TryWriteJson(context, writer, element);
                         if (exception != null)
                             return exception;
                     }
@@ -196,7 +196,7 @@ namespace Pulumi.Serialization
                     foreach (var (key, element) in v)
                     {
                         writer.WritePropertyName(key);
-                        var exception = WriteJson(context, writer, element);
+                        var exception = TryWriteJson(context, writer, element);
                         if (exception != null)
                             return exception;
                     }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-kubernetes/issues/889

On the input side, this can be used like so:

```c#
        [Input("whatever")]
        public InputJson Whatever { get; set; } = null!;
```

On the output side this will be:

```c#
[Output]
public Output<System.Text.JsonElement> Whatever = null!;
```

JsonElement is the .net core way to represent json data in an efficient manner.  It is doc'ed here: https://docs.microsoft.com/en-us/dotnet/api/system.text.json.jsonelement?view=netcore-3.0

Producing Json on the .net side can be done through the JsonDocument type.  For convenience, we also allow passing alon strings that we will parse.  i.e.:

```c#
new SomeArgs
{
    Whatever = "[1, 2, 3]"
}
```