### PR TITLE
Serialize resource states "the right way"

### DIFF
--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/pulumi/pulumi/pkg/apitype"
 	"github.com/pulumi/pulumi/pkg/engine"
@@ -77,12 +78,15 @@ func startEventLogger(events <-chan engine.Event, done chan<- bool, path string)
 			contract.IgnoreError(logFile.Close())
 		}()
 
+		sequence := 0
 		encoder := json.NewEncoder(logFile)
 		logEvent := func(e engine.Event) error {
 			apiEvent, err := ConvertEngineEvent(e)
 			if err != nil {
 				return err
 			}
+			apiEvent.Sequence, sequence = sequence, sequence+1
+			apiEvent.Timestamp = int(time.Now().Unix())
 			return encoder.Encode(apiEvent)
 		}
 


### PR DESCRIPTION
This PR is the spiritual success or of #3377. This PR changes the way we encode/represent resource state information in engine events, when we convert them from the internal format to the `apitype` shape that we send to the Pulumi Service.

There are several reasons for doing this:

- The old way was inconsistent. When persisting resource state information in the checkpoint file, data would be serialized after calling `func SerializeProperties(props resource.PropertyMap, enc config.Encrypter) (map[string]interface{}, error)`. But when persisting the same resource state information via engine events, we were just relying on the default, reflect-based JSON serialization.

  This lead to some weird encodings, where a set of outputs like `{ "foo": "bar" }` would get serialized into JSON as `{ "foo": { "V": "bar" } }`. (That was weird, but we had logic on the Service-side to deal with it.

- The old way was ambiguous in some cases. There are many wrappers around resource values (e.g. `resource.Output` or `resource.Computed` that have the same JSON serialization. So it was impossible to tell them apart.) The newer format doesn't have this problem, or at least works around it for the common case of Output values.

- The old way was insecure. By using the default, reflection-based JSON serialization we would pass `resource.Secret(...)` values in plaintext to the Pulumi Service. (So in theory, even if using customer-supplied encryption keys, the plaintext values would not only be transmitted to the Pulumi Service, but stored in the update's logs!)

  Fortunately that is _not_ the case, and never was the case. But we should call `SerializeProperties` to ensure that secrets are dealt with responsibility, instead of just reflecting over the contents of memory.

- The new format is more concise. Meaning we'll need to transmit smaller engine event payloads, which hopefully will make everything a little faster.

... so subtitles aside, we now call `SerializeProperties` on the inputs/outputs of a resource state when converting an engine event to the public format we send to the service. The returned `map[string]interface{}` will have a different JSON-encoding that is "more correct" and smaller. And also addresses the problems listed above.

Now Pat's original fix for this issue, in #3377, wired the SecretsManager all the way through the "backend". So that when we serialize engine events to send to the service we wouldn't use the `config.BlindingCrypter` (which just returns "[secret]") but instead actually encrypt values. So the code I have in this PR essentially strips out secrets from the resource data.

However, (at least for now and the foreseeable future), we explicitly do _not_ want the secrets in the engine event resource state. The consumers of this data is the Pulumi Service (for rendering logs later) and the Pulumi CLI's `display` package (for rendering CLI output). In neither case will we be showing users the plain-text value of those secrets anyways.

... and, even if we _did_ want to properly flow secrets, it is a moot point anyways. Since the secret values are _already_ stripped when the engine event is first emitted. When constructing the engine event to pass through the engine, we call `makeStepEventStateMetadata` and `filterPropertyMap` which strips out any secret data. (Which I am thankful for, and is why we never had the security problem of accidentally receiving any secret values in plain-text.)

` func makeStepEventStateMetadata`
https://github.com/pulumi/pulumi/blob/master/pkg/engine/events.go#L290
`func filterPropertyMap`
https://github.com/pulumi/pulumi/blob/master/pkg/engine/events.go#L311
https://github.com/pulumi/pulumi/blob/master/pkg/engine/events.go#L371

We shouldn't land this until after we update the Pulumi Service to start rendering engine events in this newer format. That capability is out for review now in https://github.com/pulumi/pulumi-service/pull/4376.