### PR TITLE
Install user's Python requirements with pip3

### DIFF
--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -94,6 +94,11 @@ if [ -e package.json ]; then
     fi
 fi
 
+# If the user is running the Python SDK, we will need to install their requirements as well.
+if [ -e requirements.txt ]; then
+    pip3 install -r requirements.txt
+fi
+
 # Now just pass along all arguments to the Pulumi CLI, sending the output to a file for
 # later use. Note that we exit immediately on failure (under set -e), so we `tee` stdout, but
 # allow errors to be surfaced in the Actions log.


### PR DESCRIPTION
Pulumi will fail against the Python SDK if the user has any packages required beyond the absolute minimum.