### PR TITLE
Relax the pattern to search for local NuGet packages

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1668,7 +1668,7 @@ func (pt *programTester) prepareDotNetProject(projinfo *engine.Projinfo) error {
 	for _, dep := range pt.opts.Dependencies {
 
 		// dotnet add package requires a specific version in case of a pre-release, so we have to look it up.
-		matches, err := filepath.Glob(filepath.Join(localNuget, dep+".?.?.*.nupkg"))
+		matches, err := filepath.Glob(filepath.Join(localNuget, dep+".?.*.nupkg"))
 		if err != nil {
 			return errors.Wrap(err, "failed to find a local Pulumi NuGet package")
 		}


### PR DESCRIPTION
`Pulumi.Aws` is at version 1.12 which fails the pattern matching.
The reason for existence of this match is that we need to distinguish the assembly name `Pulumi` from an assembly name `Pulumi.Providerx` which searching for local NuGet package files.
The relaxed version should still serve the purpose while supporting any version up to `9.*`.