### PR TITLE
Use TypeScript's built-in `Omit`

### DIFF
--- a/sdk/nodejs/queryable/index.ts
+++ b/sdk/nodejs/queryable/index.ts
@@ -20,7 +20,7 @@ import { Resource } from "../resource";
  * is useful primarily when we're querying over resource outputs (e.g., using
  * `pulumi.runtime.listResourceOutputs`), and we expect all values to be present and fully-resolved.
  */
-export type ResolvedResource<T extends Resource> = PulumiOmit<Resolved<T>, "urn" | "getProvider">;
+export type ResolvedResource<T extends Resource> = Omit<Resolved<T>, "urn" | "getProvider">;
 
 export type Resolved<T> = T extends Promise<infer U1>
     ? ResolvedSimple<U1>
@@ -49,6 +49,3 @@ type OptionalKeys<T> = { [P in keyof T]: undefined extends T[P] ? P : never }[ke
 
 type ModifyOptionalProperties<T> = { [P in RequiredKeys<T>]: T[P] } &
     { [P in OptionalKeys<T>]?: T[P] };
-
-type PulumiExclude<T, U> = T extends U ? never : T;
-type PulumiOmit<T, K extends keyof any> = Pick<T, PulumiExclude<keyof T, K>>;


### PR DESCRIPTION
Presumably we needed to define our own variants of `Omit` and `Exclude` because they weren't available in earlier versions of TS that we were using, but I can't think of any reason why we can't move to using TS's built-in definitions going forward.

@CyrusNajmabadi, can you think of any downsides to replacing these with the built-in TS types? I don't believe this is a breaking change. The type definitions are exactly the same (other than the names).

TypeScript's definition of [`Exclude`](https://github.com/microsoft/TypeScript/blob/85ec9bf175da0817254a6ae61a857425d8deee0c/lib/lib.es5.d.ts#L1476) and [`Omit`](https://github.com/microsoft/TypeScript/blob/85ec9bf175da0817254a6ae61a857425d8deee0c/lib/lib.es5.d.ts#L1486):

```typescript
type Exclude<T, U> = T extends U ? never : T;
type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
```

Our previous custom definitions:

```typescript
type PulumiExclude<T, U> = T extends U ? never : T;
type PulumiOmit<T, K extends keyof any> = Pick<T, PulumiExclude<keyof T, K>>;
```