### PR TITLE
Transform the name of the files when copying a template to a new project

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -152,7 +152,7 @@ func runNew(args newArgs) error {
 
 	// Do a dry run, if we're not forcing files to be overwritten.
 	if !args.force {
-		if err = workspace.CopyTemplateFilesDryRun(template.Dir, cwd); err != nil {
+		if err = workspace.CopyTemplateFilesDryRun(template.Dir, cwd, args.name); err != nil {
 			if os.IsNotExist(err) {
 				return errors.Wrapf(err, "template '%s' not found", args.templateNameOrURL)
 			}

--- a/cmd/policy_new.go
+++ b/cmd/policy_new.go
@@ -143,7 +143,7 @@ func runNewPolicyPack(args newPolicyArgs) error {
 
 	// Do a dry run, if we're not forcing files to be overwritten.
 	if !args.force {
-		if err = workspace.CopyTemplateFilesDryRun(template.Dir, cwd); err != nil {
+		if err = workspace.CopyTemplateFilesDryRun(template.Dir, cwd, ""); err != nil {
 			if os.IsNotExist(err) {
 				return errors.Wrapf(err, "template '%s' not found", args.templateNameOrURL)
 			}


### PR DESCRIPTION
We want to put the project name into the file name of the templated .NET project files. E.g. change `Infra.csproj` in our templates to `${PROJECT}.csproj` and subscritite it with `myproject.csproj` during `pulumi new`.