### PR TITLE
PaC: Support Config/getProject/getStack/isDryRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CHANGELOG
    pulumi login gs://my-bucket
   ```
 
+- Support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs.
+  [#3612](https://github.com/pulumi/pulumi/pull/3612)
+
 ## 1.7.1 (2019-12-13)
 
 - Fix [SxS issue](https://github.com/pulumi/pulumi/issues/3652) introduced in 1.7.0 when assigning

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -124,7 +124,7 @@ func (pack *cloudPolicyPack) Publish(
 		return result.FromError(err)
 	}
 
-	analyzer, err := op.PlugCtx.Host.PolicyAnalyzer(tokens.QName(abs), op.PlugCtx.Pwd)
+	analyzer, err := op.PlugCtx.Host.PolicyAnalyzer(tokens.QName(abs), op.PlugCtx.Pwd, nil)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -124,7 +124,7 @@ func (pack *cloudPolicyPack) Publish(
 		return result.FromError(err)
 	}
 
-	analyzer, err := op.PlugCtx.Host.PolicyAnalyzer(tokens.QName(abs), op.PlugCtx.Pwd, nil)
+	analyzer, err := op.PlugCtx.Host.PolicyAnalyzer(tokens.QName(abs), op.PlugCtx.Pwd, nil /*opts*/)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -180,7 +180,8 @@ func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,
 	return nil, nil
 }
 
-func (host *pluginHost) PolicyAnalyzer(name tokens.QName, path string) (plugin.Analyzer, error) {
+func (host *pluginHost) PolicyAnalyzer(name tokens.QName, path string,
+	opts *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
 	return nil, errors.New("unsupported")
 }
 

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -54,7 +54,8 @@ func (host *testPluginHost) LogStatus(sev diag.Severity, urn resource.URN, msg s
 func (host *testPluginHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
 	return nil, errors.New("unsupported")
 }
-func (host *testPluginHost) PolicyAnalyzer(name tokens.QName, path string) (plugin.Analyzer, error) {
+func (host *testPluginHost) PolicyAnalyzer(name tokens.QName, path string,
+	opts *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
 	return nil, errors.New("unsupported")
 }
 func (host *testPluginHost) ListAnalyzers() []plugin.Analyzer {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -15,7 +15,6 @@
 package deploy
 
 import (
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -312,22 +311,6 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 			invalid = true
 		}
 		new.Inputs = inputs
-	}
-
-	// Load all policy packs into the plugin host.
-	for _, path := range sg.plan.localPolicyPackPaths {
-		abs, err := filepath.Abs(path)
-		if err != nil {
-			return nil, result.FromError(err)
-		}
-
-		var analyzer plugin.Analyzer
-		analyzer, err = sg.plan.ctx.Host.PolicyAnalyzer(tokens.QName(abs), path)
-		if err != nil {
-			return nil, result.FromError(err)
-		} else if analyzer == nil {
-			return nil, result.Errorf("analyzer could not be loaded from path %q", path)
-		}
 	}
 
 	// Send the resource off to any Analyzers before being operated on.

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -61,7 +61,7 @@ func NewAnalyzer(host Host, ctx *Context, name tokens.QName) (Analyzer, error) {
 	}
 
 	plug, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (analyzer)", name),
-		[]string{host.ServerAddr(), ctx.Pwd}, nil)
+		[]string{host.ServerAddr(), ctx.Pwd}, nil /*env*/)
 	if err != nil {
 		return nil, err
 	}
@@ -314,6 +314,9 @@ func convertDiagnostics(protoDiagnostics []*pulumirpc.AnalyzeDiagnostic) ([]Anal
 	return diagnostics, nil
 }
 
+// constructEnv creates a slice of key/value pairs to be used as the environment for the policy pack process. Each entry
+// is of the form "key=value". Config is passed as an environment variable (including unecrypted secrets), similar to
+// how config is passed to each language runtime plugin.
 func constructEnv(opts *PolicyAnalyzerOptions) ([]string, error) {
 	env := os.Environ()
 
@@ -338,7 +341,7 @@ func constructEnv(opts *PolicyAnalyzerOptions) ([]string, error) {
 	return env, nil
 }
 
-// constructConfig json-serializes the configuration data.
+// constructConfig JSON-serializes the configuration data.
 func constructConfig(opts *PolicyAnalyzerOptions) (string, error) {
 	if opts == nil || opts.Config == nil {
 		return "", nil

--- a/pkg/resource/plugin/langruntime_plugin.go
+++ b/pkg/resource/plugin/langruntime_plugin.go
@@ -61,7 +61,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime string,
 	}
 	args = append(args, host.ServerAddr())
 
-	plug, err := newPlugin(ctx, ctx.Pwd, path, runtime, args, nil)
+	plug, err := newPlugin(ctx, ctx.Pwd, path, runtime, args, nil /*env*/)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/plugin/langruntime_plugin.go
+++ b/pkg/resource/plugin/langruntime_plugin.go
@@ -61,7 +61,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime string,
 	}
 	args = append(args, host.ServerAddr())
 
-	plug, err := newPlugin(ctx, ctx.Pwd, path, runtime, args)
+	plug, err := newPlugin(ctx, ctx.Pwd, path, runtime, args, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -43,8 +43,10 @@ type plugin struct {
 	stdoutDone <-chan bool
 	stderrDone <-chan bool
 
-	Bin    string
-	Args   []string
+	Bin  string
+	Args []string
+	// Env specifies the environment of the plugin in the same format as go's os/exec.Cmd.Env
+	// https://golang.org/pkg/os/exec/#Cmd (each entry is of the form "key=value").
 	Env    []string
 	Conn   *grpc.ClientConn
 	Proc   *os.Process

--- a/pkg/resource/plugin/plugin.go
+++ b/pkg/resource/plugin/plugin.go
@@ -45,6 +45,7 @@ type plugin struct {
 
 	Bin    string
 	Args   []string
+	Env    []string
 	Conn   *grpc.ClientConn
 	Proc   *os.Process
 	Stdin  io.WriteCloser
@@ -67,7 +68,7 @@ var nextStreamID int32
 // the stack's Pulumi SDK did not have the required modules. i.e. is too old.
 var errRunPolicyModuleNotFound = errors.New("pulumi SDK does not support policy as code")
 
-func newPlugin(ctx *Context, pwd, bin, prefix string, args []string) (*plugin, error) {
+func newPlugin(ctx *Context, pwd, bin, prefix string, args, env []string) (*plugin, error) {
 	if logging.V(9) {
 		var argstr string
 		for i, arg := range args {
@@ -80,7 +81,7 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, args []string) (*plugin, e
 	}
 
 	// Try to execute the binary.
-	plug, err := execPlugin(bin, args, pwd)
+	plug, err := execPlugin(bin, args, pwd, env)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load plugin %s", bin)
 	}
@@ -231,7 +232,7 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, args []string) (*plugin, e
 	return plug, nil
 }
 
-func execPlugin(bin string, pluginArgs []string, pwd string) (*plugin, error) {
+func execPlugin(bin string, pluginArgs []string, pwd string, env []string) (*plugin, error) {
 	var args []string
 	// Flow the logging information if set.
 	if logging.LogFlow {
@@ -251,6 +252,9 @@ func execPlugin(bin string, pluginArgs []string, pwd string) (*plugin, error) {
 	cmd := exec.Command(bin, args...)
 	cmdutil.RegisterProcessGroup(cmd)
 	cmd.Dir = pwd
+	if len(env) > 0 {
+		cmd.Env = env
+	}
 	in, _ := cmd.StdinPipe()
 	out, _ := cmd.StdoutPipe()
 	err, _ := cmd.StderrPipe()
@@ -261,6 +265,7 @@ func execPlugin(bin string, pluginArgs []string, pwd string) (*plugin, error) {
 	return &plugin{
 		Bin:    bin,
 		Args:   args,
+		Env:    env,
 		Proc:   cmd.Process,
 		Stdin:  in,
 		Stdout: out,

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -77,7 +77,7 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 		})
 	}
 
-	plug, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (resource)", pkg), []string{host.ServerAddr()})
+	plug, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (resource)", pkg), []string{host.ServerAddr()}, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/plugin/provider_plugin.go
+++ b/pkg/resource/plugin/provider_plugin.go
@@ -77,7 +77,8 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 		})
 	}
 
-	plug, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (resource)", pkg), []string{host.ServerAddr()}, nil)
+	plug, err := newPlugin(ctx, ctx.Pwd, path, fmt.Sprintf("%v (resource)", pkg),
+		[]string{host.ServerAddr()}, nil /*env*/)
 	if err != nil {
 		return nil, err
 	}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -232,7 +232,7 @@ func (host *goLanguageHost) constructEnv(req *pulumirpc.RunRequest) ([]string, e
 	return env, nil
 }
 
-// constructConfig json-serializes the configuration data given as part of a RunRequest.
+// constructConfig JSON-serializes the configuration data given as part of a RunRequest.
 func (host *goLanguageHost) constructConfig(req *pulumirpc.RunRequest) (string, error) {
 	configMap := req.GetConfig()
 	if configMap == nil {

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -571,7 +571,7 @@ func (host *nodeLanguageHost) constructArguments(req *pulumirpc.RunRequest, addr
 	return args
 }
 
-// constructConfig json-serializes the configuration data given as part of
+// constructConfig JSON-serializes the configuration data given as part of
 // a RunRequest.
 func (host *nodeLanguageHost) constructConfig(req *pulumirpc.RunRequest) (string, error) {
 	configMap := req.GetConfig()

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -18,8 +18,7 @@ import * as path from "path";
 import * as tsnode from "ts-node";
 import { ResourceError, RunError } from "../../errors";
 import * as log from "../../log";
-import { disconnectSync } from "../../runtime/settings";
-import { runInPulumiStack } from "../../runtime/stack";
+import * as runtime from "../../runtime";
 
 // Keep track if we already logged the information about an unhandled error to the user..  If
 // so, we end with a different exit code.  The language host recognizes this and will not print
@@ -226,7 +225,7 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
     // @ts-ignore 'unhandledRejection' will almost always invoke uncaughtHandler with an Error. so
     // just suppress the TS strictness here.
     process.on("unhandledRejection", uncaughtHandler);
-    process.on("exit", disconnectSync);
+    process.on("exit", runtime.disconnectSync);
 
     opts.programStarted();
 
@@ -270,5 +269,5 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
         }
     };
 
-    return opts.runInStack ? runInPulumiStack(runProgram) : runProgram();
+    return opts.runInStack ? runtime.runInPulumiStack(runProgram) : runProgram();
 }


### PR DESCRIPTION
Add support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs.

Integration Tests: https://github.com/pulumi/pulumi-policy/pull/169

Fixes https://github.com/pulumi/pulumi-policy/issues/42
Fixes https://github.com/pulumi/pulumi-policy/issues/78
Fixes https://github.com/pulumi/pulumi-policy/issues/166
Fixes https://github.com/pulumi/pulumi-policy/issues/168