### PR TITLE
Show errors when analyzing the stack

### DIFF
--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -269,7 +269,11 @@ func (pe *planExecutor) Execute(callerCtx context.Context, opts Options, preview
 	if res == nil && !pe.stepExec.Errored() {
 		res := pe.stepGen.AnalyzeResources()
 		if res != nil {
-			return res
+			if resErr := res.Error(); resErr != nil {
+				logging.V(4).Infof("planExecutor.Execute(...): error analyzing resources: %v", resErr)
+				pe.reportError("", resErr)
+			}
+			return result.Bail()
 		}
 	}
 


### PR DESCRIPTION
Actually show the error that occurred while analyzing the stack. This is consistent with what we show when there is an error analyzing individual resources.

Using the repro code in https://github.com/pulumi/pulumi-policy/issues/157:

### Before

```
$ pulumi preview --policy-pack ~/Desktop/2019/12/09/pp
Previewing update (dev):

     Type                 Name          Plan       Info
 +   pulumi:pulumi:Stack  progdec9-dev  create     1 message
 +   └─ aws:s3:Bucket     my-bucket     create     
 
Diagnostics:
  pulumi:pulumi:Stack (progdec9-dev):
    aws:s3/bucket:Bucket
 
Permalink: https://app.pulumi.com/justinvp/progdec9/dev/previews/35559094-b18f-4a7f-9432-c73991af82e2
error: an error occurred while advancing the preview
```

### After

```
$ pulumi preview --policy-pack ~/Desktop/2019/12/09/pp
Previewing update (dev):

     Type                 Name          Plan       Info
 +   pulumi:pulumi:Stack  progdec9-dev  create     1 error; 1 message
 +   └─ aws:s3:Bucket     my-bucket     create     
 
Diagnostics:
  pulumi:pulumi:Stack (progdec9-dev):
    pulumi:pulumi:Stack
 
    error: Error validating stack with policy s3-test:
    TypeError: Cannot read property 'asdf' of undefined
        at Object.validateStack (/Users/justin/Desktop/2019/12/09/pp/index.ts:15:29)
        at Object.<anonymous> (/Users/justin/Desktop/2019/12/09/pp/node_modules/@pulumi/policy/server.js:204:49)
        at Generator.next (<anonymous>)
        at /Users/justin/Desktop/2019/12/09/pp/node_modules/@pulumi/policy/server.js:21:71
        at new Promise (<anonymous>)
        at __awaiter (/Users/justin/Desktop/2019/12/09/pp/node_modules/@pulumi/policy/server.js:17:12)
        at Object.analyzeStack (/Users/justin/Desktop/2019/12/09/pp/node_modules/@pulumi/policy/server.js:173:16)
        at /Users/justin/Desktop/2019/12/09/pp/node_modules/grpc/src/server.js:593:13
 
Permalink: https://app.pulumi.com/justinvp/progdec9/dev/previews/83299e92-0923-424b-8337-407bfa682ae9
```

Fixes https://github.com/pulumi/pulumi-policy/issues/157