### PR TITLE
.NET: Treat warnings as errors

### DIFF
--- a/sdk/dotnet/Pulumi.FSharp/Pulumi.FSharp.fsproj
+++ b/sdk/dotnet/Pulumi.FSharp/Pulumi.FSharp.fsproj
@@ -10,6 +10,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>pulumi_logo_64x64.png</PackageIcon>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sdk/dotnet/Pulumi.Tests/Pulumi.Tests.csproj
+++ b/sdk/dotnet/Pulumi.Tests/Pulumi.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/dotnet/Pulumi/Deployment/InvokeOptions.cs
+++ b/sdk/dotnet/Pulumi/Deployment/InvokeOptions.cs
@@ -4,7 +4,7 @@ namespace Pulumi
 {
     /// <summary>
     /// Options to help control the behavior of <see cref="IDeployment.InvokeAsync{T}(string,
-    /// ResourceArgs, InvokeOptions)"/>.
+    /// InvokeArgs, InvokeOptions)"/>.
     /// </summary>
     public class InvokeOptions
     {

--- a/sdk/dotnet/Pulumi/Pulumi.csproj
+++ b/sdk/dotnet/Pulumi/Pulumi.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>
@@ -9,9 +11,7 @@
     <RepositoryUrl>https://github.com/pulumi/pulumi</RepositoryUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageIcon>pulumi_logo_64x64.png</PackageIcon>
-
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-    <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Fix the following warning and turn on "treat warnings as errors" for our .NET projects.

```
Deployment/InvokeOptions.cs(6,60): warning CS1574: XML comment has cref attribute 'InvokeAsync{T}(string,
```