### PR TITLE
Produce a slightly better error message when a user throws a non-Error object in JS.

### DIFF
--- a/sdk/nodejs/cmd/run-policy-pack/index.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/index.ts
@@ -33,7 +33,7 @@ let programRunning = false;
 const uncaughtHandler = (err: Error) => {
     uncaughtErrors.add(err);
     if (!programRunning) {
-        console.error(err.stack || err.message);
+        console.error(err.stack || err.message || ("" + err));
     }
 };
 

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -201,7 +201,10 @@ export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | P
 
         // Default message should be to include the full stack (which includes the message), or
         // fallback to just the message if we can't get the stack.
-        const defaultMessage = err.stack || err.message;
+        //
+        // If both the stack and message are empty, then just stringify the err object itself. This
+        // is also necessary as users can throw arbitrary things in JS (including non-Errors).
+        const defaultMessage = err.stack || err.message || ("" + err);
 
         // First, log the error.
         if (RunError.isInstance(err)) {

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -33,7 +33,7 @@ let programRunning = false;
 const uncaughtHandler = (err: Error) => {
     uncaughtErrors.add(err);
     if (!programRunning) {
-        console.error(err.stack || err.message);
+        console.error(err.stack || err.message || ("" + err));
     }
 };
 

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -188,7 +188,10 @@ export function run(argv: minimist.ParsedArgs,
 
         // Default message should be to include the full stack (which includes the message), or
         // fallback to just the message if we can't get the stack.
-        const defaultMessage = err.stack || err.message;
+        //
+        // If both the stack and message are empty, then just stringify the err object itself. This
+        // is also necessary as users can throw arbitrary things in JS (including non-Errors).
+        const defaultMessage = err.stack || err.message || ("" + err);
 
         // First, log the error.
         if (RunError.isInstance(err)) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/3668