### PR TITLE
Bring `pulumi preview` in-line with `pulumi up`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ CHANGELOG
 
 - Add the .NET Core 3.0 runtime to the pulumi/pulumi container. [#3616](https://github.com/pulumi/pulumi/pull/3616).
 
+- Add `pulumi preview` support for `--refresh`, `--target`, `--replace`, `--target-replace` and
+  `--target-dependents` to align with `pulumi up`.
+  [#3675](https://github.com/pulumi/pulumi/pull/3675).
+
 ## 1.7.1 (2019-12-13)
 
 - Fix [SxS issue](https://github.com/pulumi/pulumi/issues/3652) introduced in 1.7.0 when assigning


### PR DESCRIPTION
Adds support to `pulumi preview` to match `pulumi up` for:
* `refresh`
* `target`
* `replace`
* `target-replace`
* `target-dependents`

Fixes #3674.