### PR TITLE
Fix logic to determine PRNumber and BuildURL for Az Pipelines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ CHANGELOG
 - `Output.apply` (for the JS, Python and .Net sdks) has updated semantics, and will lift dependencies from inner Outputs to the returned Output.
   [#3663](https://github.com/pulumi/pulumi/pull/3663)
 
+- Fix bug in determining PRNumber and BuildURL for an Azure Pipelines CI environment. [#3677](https://github.com/pulumi/pulumi/pull/3677)
+
 ## 1.7.1 (2019-12-13)
 
 - Fix [SxS issue](https://github.com/pulumi/pulumi/issues/3652) introduced in 1.7.0 when assigning

--- a/pkg/util/ciutil/az_pipelines.go
+++ b/pkg/util/ciutil/az_pipelines.go
@@ -33,7 +33,6 @@ func (az azurePipelinesCI) DetectVars() Vars {
 	v.BuildID = os.Getenv("BUILD_BUILDID")
 	v.BuildType = os.Getenv("BUILD_REASON")
 	v.SHA = os.Getenv("BUILD_SOURCEVERSION")
-	v.BranchName = os.Getenv("BUILD_SOURCEBRANCHNAME")
 	v.CommitMessage = os.Getenv("BUILD_SOURCEVERSIONMESSAGE")
 
 	orgURI := os.Getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
@@ -55,6 +54,17 @@ func (az azurePipelinesCI) DetectVars() Vars {
 		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
 	default:
 		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
+	}
+
+	// Build.SourceBranchName is the last part of the head.
+	// If the build is running because of a PR, we should use the
+	// PR source branch name, instead of Build.SourceBranchName.
+	// That's because Build.SourceBranchName will always be `merge` --
+	// the last part of `refs/pull/1/merge`.
+	if v.PRNumber != "" {
+		v.BranchName = os.Getenv("SYSTEM_PULLREQUEST_SOURCEBRANCH")
+	} else {
+		v.BranchName = os.Getenv("BUILD_SOURCEBRANCHNAME")
 	}
 
 	return v

--- a/pkg/util/ciutil/az_pipelines.go
+++ b/pkg/util/ciutil/az_pipelines.go
@@ -35,21 +35,24 @@ func (az azurePipelinesCI) DetectVars() Vars {
 	v.SHA = os.Getenv("BUILD_SOURCEVERSION")
 	v.BranchName = os.Getenv("BUILD_SOURCEBRANCHNAME")
 	v.CommitMessage = os.Getenv("BUILD_SOURCEVERSIONMESSAGE")
+
+	orgURI := os.Getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
+	projectName := os.Getenv("SYSTEM_TEAMPROJECT")
+	v.BuildURL = fmt.Sprintf("%v/%v/_build/results?buildId=%v", orgURI, projectName, v.BuildID)
+
 	// Azure Pipelines can be connected to external repos.
 	// So we check if the provider is GitHub, then we use
 	// `SYSTEM_PULLREQUEST_PULLREQUESTNUMBER` instead of `SYSTEM_PULLREQUEST_PULLREQUESTID`.
 	// The PR ID/number only applies to Git repos.
 	vcsProvider := os.Getenv("BUILD_REPOSITORY_PROVIDER")
 	switch vcsProvider {
-	case "TfsGit":
-		orgURI := os.Getenv("SYSTEM_PULLREQUEST_TEAMFOUNDATIONCOLLECTIONURI")
-		projectName := os.Getenv("SYSTEM_TEAMPROJECT")
-		v.BuildURL = fmt.Sprintf("%v/%v/_build/results?buildId=%v", orgURI, projectName, v.BuildID)
-		// TfsGit is a git repo hosted on Azure DevOps.
-		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
 	case "GitHub":
-		// GitHub is a git repo hosted on GitHub.
+		// The number of the pull request that caused this build.
+		// This variable is populated for pull requests from GitHub
+		// which have a different pull request ID and pull request number.
 		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
+	default:
+		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
 	}
 
 	return v

--- a/pkg/util/ciutil/az_pipelines.go
+++ b/pkg/util/ciutil/az_pipelines.go
@@ -40,20 +40,7 @@ func (az azurePipelinesCI) DetectVars() Vars {
 	projectName := os.Getenv("SYSTEM_TEAMPROJECT")
 	v.BuildURL = fmt.Sprintf("%v/%v/_build/results?buildId=%v", orgURI, projectName, v.BuildID)
 
-	// Azure Pipelines can be connected to external repos.
-	// So we check if the provider is GitHub, then we use
-	// `SYSTEM_PULLREQUEST_PULLREQUESTNUMBER` instead of `SYSTEM_PULLREQUEST_PULLREQUESTID`.
-	// The PR ID/number only applies to Git repos.
-	vcsProvider := os.Getenv("BUILD_REPOSITORY_PROVIDER")
-	switch vcsProvider {
-	case "GitHub":
-		// The number of the pull request that caused this build.
-		// This variable is populated for pull requests from GitHub
-		// which have a different pull request ID and pull request number.
-		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
-	default:
-		v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTID")
-	}
+	v.PRNumber = os.Getenv("SYSTEM_PULLREQUEST_PULLREQUESTNUMBER")
 
 	return v
 }


### PR DESCRIPTION
I ran into this bug while using the Pulumi Task Extension for Az Pipelines. Please see my comments inline for details on the changes. Basically, this PR fixes how the `BuildURL` and `PRNumber` properties of the Az Pipelines build are determined -- just as the PR title says.