### PR TITLE
Move stack name validation to the Backend interface

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -516,7 +516,7 @@ func promptAndCreateStack(prompt promptForValueFunc,
 	}
 
 	for {
-		stackName, err := prompt(yes, "stack name", "dev", false, workspace.ValidateStackName, opts)
+		stackName, err := prompt(yes, "stack name", "dev", false, b.ValidateStackName, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/backend/display"
@@ -87,7 +86,7 @@ func newStackInitCmd() *cobra.Command {
 						"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).\n")
 				}
 
-				name, nameErr := promptForValue(false, "stack name", "dev", false, workspace.ValidateStackName, opts)
+				name, nameErr := promptForValue(false, "stack name", "dev", false, b.ValidateStackName, opts)
 				if nameErr != nil {
 					return nameErr
 				}
@@ -98,7 +97,7 @@ func newStackInitCmd() *cobra.Command {
 				return errors.New("missing stack name")
 			}
 
-			if err := workspace.ValidateStackName(stackName); err != nil {
+			if err := b.ValidateStackName(stackName); err != nil {
 				return err
 			}
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -67,7 +67,7 @@ func (e OverStackLimitError) Error() string {
 // StackReference is an opaque type that refers to a stack managed by a backend.  The CLI uses the ParseStackReference
 // method to turn a string like "my-great-stack" or "pulumi/my-great-stack" into a stack reference that can be used to
 // interact with the stack via the backend. Stack references are specific to a given backend and different back ends
-// may interpret the string passed to ParseStackReference differently
+// may interpret the string passed to ParseStackReference differently.
 type StackReference interface {
 	// fmt.Stringer's String() method returns a string of the stack identity, suitable for display in the CLI
 	fmt.Stringer
@@ -125,6 +125,9 @@ type Backend interface {
 	// ParseStackReference takes a string representation and parses it to a reference which may be used for other
 	// methods in this backend.
 	ParseStackReference(s string) (StackReference, error)
+	// ValidateStackName verifies that the string is a legal identifier for a (potentially qualified) stack.
+	// Will check for any backend-specific naming restrictions.
+	ValidateStackName(s string) error
 
 	// DoesProjectExist returns true if a project with the given name exists in this backend, or false otherwise.
 	DoesProjectExist(ctx context.Context, projectName string) (bool, error)

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -238,7 +238,7 @@ func (b *localBackend) ParseStackReference(stackRefName string) (backend.StackRe
 // ValidateStackName verifies the stack name is valid for the local backend. We use the same rules as the
 // httpstate backend.
 func (b *localBackend) ValidateStackName(stackName string) error {
-	if strings.Index(stackName, "/") != -1 {
+	if strings.Contains(stackName, "/") {
 		return errors.New("stack names may not contain slashes")
 	}
 

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -23,6 +23,7 @@ import (
 	"os/user"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -232,6 +233,21 @@ func (b *localBackend) SupportsOrganizations() bool {
 
 func (b *localBackend) ParseStackReference(stackRefName string) (backend.StackReference, error) {
 	return localBackendReference{name: tokens.QName(stackRefName)}, nil
+}
+
+// ValidateStackName verifies the stack name is valid for the local backend. We use the same rules as the
+// httpstate backend.
+func (b *localBackend) ValidateStackName(stackName string) error {
+	if strings.Index(stackName, "/") != -1 {
+		return errors.New("stack names may not contain slashes")
+	}
+
+	validNameRegex := regexp.MustCompile("^[A-Za-z0-9_.-]{1,100}$")
+	if !validNameRegex.MatchString(stackName) {
+		return errors.New("stack names may only contain alphanumeric, hyphens, underscores, or periods")
+	}
+
+	return nil
 }
 
 func (b *localBackend) DoesProjectExist(ctx context.Context, projectName string) (bool, error) {

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -37,6 +37,7 @@ type MockBackend struct {
 	GetPolicyPackF          func(ctx context.Context, policyPack string, d diag.Sink) (PolicyPack, error)
 	SupportsOrganizationsF  func() bool
 	ParseStackReferenceF    func(s string) (StackReference, error)
+	ValidateStackNameF      func(s string) error
 	DoesProjectExistF       func(context.Context, string) (bool, error)
 	GetStackF               func(context.Context, StackReference) (Stack, error)
 	CreateStackF            func(context.Context, StackReference, interface{}) (Stack, error)
@@ -102,6 +103,13 @@ func (be *MockBackend) SupportsOrganizations() bool {
 func (be *MockBackend) ParseStackReference(s string) (StackReference, error) {
 	if be.ParseStackReferenceF != nil {
 		return be.ParseStackReferenceF(s)
+	}
+	panic("not implemented")
+}
+
+func (be *MockBackend) ValidateStackName(s string) error {
+	if be.ValidateStackNameF != nil {
+		return be.ValidateStackNameF(s)
 	}
 	panic("not implemented")
 }

--- a/pkg/workspace/templates.go
+++ b/pkg/workspace/templates.go
@@ -504,13 +504,11 @@ func GetTemplateDir(templateKind TemplateKind) (string, error) {
 	return GetPulumiPath(TemplateDir)
 }
 
-// We are moving towards a world where these restrictions will be enforced by all our backends. When we get there,
-// we can consider removing this code in favor of exported functions in the backend package. For now, these are more
-// restrictive that what the backend enforces, but we want to "stop the bleeding" for new projects created via
-// `pulumi new`.
+// Naming rules are backend-specific. However, we provide baseline sanitization for project names
+// in this file. Though the backend may enforce stronger restrictions for a project name or description
+// further down the line.
 var (
-	stackOwnerRegexp          = regexp.MustCompile("^[a-zA-Z0-9][a-zA-Z0-9-_]{1,38}[a-zA-Z0-9]$")
-	stackNameAndProjectRegexp = regexp.MustCompile("^[A-Za-z0-9_.-]{1,100}$")
+	validProjectNameRegexp = regexp.MustCompile("^[A-Za-z0-9_.-]{1,100}$")
 )
 
 // ValidateProjectName ensures a project name is valid, if it is not it returns an error with a message suitable
@@ -520,7 +518,7 @@ func ValidateProjectName(s string) error {
 		return errors.New("A project name must be 100 characters or less")
 	}
 
-	if !stackNameAndProjectRegexp.MatchString(s) {
+	if !validProjectNameRegexp.MatchString(s) {
 		return errors.New("A project name may only contain alphanumeric, hyphens, underscores, and periods")
 	}
 
@@ -534,51 +532,6 @@ func ValidateProjectDescription(s string) error {
 
 	if len(s) > maxTagValueLength {
 		return errors.New("A project description must be 256 characters or less")
-	}
-
-	return nil
-}
-
-// ValidateStackName ensures a -- potentially qualified -- stack name is valid, if it is not it
-// returns an error with a message suitable for display to an end user.
-func ValidateStackName(s string) error {
-	// First, see if the stack name is qualified or not. It may be of the form "owner/name", when
-	// you have access to multiple organizations.
-	parts := strings.Split(s, "/")
-	switch len(parts) {
-	case 1:
-		return validateStackName(parts[0])
-	case 2:
-		if err := validateStackOwner(parts[0]); err != nil {
-			return err
-		}
-		return validateStackName(parts[1])
-	default:
-		return errors.New("A stack name may not contain slashes")
-	}
-}
-
-// validateStackOwner checks if a stack owner name is valid. An "owner" is simply the namespace
-// a stack may exist within, which for the Pulumi Service is the user account or organization.
-func validateStackOwner(s string) error {
-	// The error message takes a different from here, since stack names are created via the CLI,
-	// Pulumi organizations are created on the Pulumi Service. And so
-	if !stackOwnerRegexp.MatchString(s) {
-		return errors.New("Invalid stack owner")
-	}
-
-	return nil
-}
-
-// validateStackName checks if a stack name is valid, returning a user-suitable error if needed. May
-// need to be paired with validateOwnerName when checking a qualified stack reference.
-func validateStackName(s string) error {
-	if len(s) > 100 {
-		return errors.New("A stack name must be 100 characters or less")
-	}
-
-	if !stackNameAndProjectRegexp.MatchString(s) {
-		return errors.New("A stack name may only contain alphanumeric, hyphens, underscores, and periods")
 	}
 
 	return nil

--- a/pkg/workspace/templates_test.go
+++ b/pkg/workspace/templates_test.go
@@ -62,17 +62,6 @@ func TestGetValidDefaultProjectName(t *testing.T) {
 	assert.Equal(t, "project", getValidProjectName("!@#$%^&*()"))
 }
 
-func TestValidateStackName(t *testing.T) {
-	assert.NoError(t, ValidateStackName("alpha-beta-gamma"))
-	assert.NoError(t, ValidateStackName("owner-name/alpha-beta-gamma"))
-
-	err := ValidateStackName("alpha/beta/gamma")
-	assert.Equal(t, err.Error(), "A stack name may not contain slashes")
-
-	err = ValidateStackName("mooo looo mi/alpha-beta-gamma")
-	assert.Equal(t, err.Error(), "Invalid stack owner")
-}
-
 func getValidProjectNamePrefixes() []string {
 	var results []string
 	for ch := 'A'; ch <= 'Z'; ch++ {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -228,7 +228,7 @@ func TestStackTagValidation(t *testing.T) {
 
 		stdout, stderr := e.RunCommandExpectError("pulumi", "stack", "init", "invalid name (spaces, parens, etc.)")
 		assert.Equal(t, "", stdout)
-		assert.Contains(t, stderr, "stack name may only contain alphanumeric, hyphens, underscores, and periods")
+		assert.Contains(t, stderr, "stack names may only contain alphanumeric, hyphens, underscores, or periods")
 	})
 
 	t.Run("Error_DescriptionLength", func(t *testing.T) {


### PR DESCRIPTION
This PR refactors how stack names are validated within the CLI.

Currently when creating new stacks we call `workspace.ValidateStackName(s string) error` to confirm the stack name is valid. However, that's not quite right as the local and HTTP backends each have different rules for what constitutes a legal stack name.

Also, the HTTP backend has a much more robust notion of stack names by supporting qualified stack references like `"pulumi/www.pulumi.com/production"`. That is, an owner name, project name, and stack name.

Fortunately things more or less "just work" today. You can run `pulumi up -s alpha/beta/gamma` and it do what you expect. (Since `Backend::ParseStackReference` will know how to interpret whatever string you passed.)

This PR however improves the accuracy and errors provided when we try and validate new stack names. (When using `pulumi new` and `pulumi stack init`.) Rather than assuming there is a single ruleset for valid stack names by calling `workspace.ValidateStackName`, we instead add a new method `ValidateStackName(s string) error` to the `Backend` interface. 

Now the file state and HTTP state backends implement their own versions of the function, which allows us to surface validation errors much sooner than before, as well as support some cases we did not.

### Things that Changed

We were previously allowing qualified stack names for the local backend, which would fail later when we tried to validate the stack's properties. So we can provide a better error, sooner.

```bash
# Local backend, before
pulumi stack init alpha/beta
error: could not create stack: validating stack properties: invalid stack name: a stack name may only contain alphanumeric, hyphens, underscores, or periods

# Local backend, now
/Users/chris/pulumi-root/bin/pulumi stack init alpha/beta
error: stack names may not contain slashes
```

Because `workspace.ValidateStackName` didn't support fully-qualified stack names, containing the project name too, we were emitting confusing errors. (We were treating "alpha/beta/gamma" as owner "alpha" and stack name "beta/gamma".)

```bash
# HTTP backend, before
pulumi stack init moolumi/beta/gamma
error: A stack name may not contain slashes

# HTTP backend, after. We accept "moolumi/beta/gamma", but
# (correctly) block you from creating the stack because the project name
# doesn't match the Pulumi.yaml file.
/Users/chris/pulumi-root/bin/pulumi stack init moolumi/project-test/alpha
error: could not create stack: provided project name "project-test" doesn't match Pulumi.yaml


# HTTP backend, after. It now works, although we print the
# stack name at the end as "moolumi/alpha" without the project name because
# that's how cloudBackendReference::String is implemented.
/Users/chris/pulumi-root/bin/pulumi stack init moolumi/resources/alpha    
warning: you are now using 3070 of 0 stacks - manage stack limits for your organization at https://app.pulumi.com/moolumi/settings/billing
Created stack 'moolumi/alpha' 
```

Fixes #3585 .