### PR TITLE
Make property internal

### DIFF
--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -792,6 +792,7 @@ export class ComponentResource<TData = any> extends Resource {
         this.__data = this.initializeAndRegisterOutputs(args);
     }
 
+    /** @internal */
     private async initializeAndRegisterOutputs(args: Inputs) {
         const data = await this.initialize(args);
         this.registerOutputs();
@@ -835,6 +836,8 @@ export class ComponentResource<TData = any> extends Resource {
 
 (<any>ComponentResource).doNotCapture = true;
 (<any>ComponentResource.prototype).registerOutputs.doNotCapture = true;
+(<any>ComponentResource.prototype).initialize.doNotCapture = true;
+(<any>ComponentResource.prototype).initializeAndRegisterOutputs.doNotCapture = true;
 
 /** @internal */
 export const testingOptions = {

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -755,6 +755,7 @@ export class ComponentResource<TData = any> extends Resource {
     // tslint:disable-next-line:variable-name
     public readonly __data: Promise<TData>;
 
+    /** @internal */
     // tslint:disable-next-line:variable-name
     private __registered = false;
 


### PR DESCRIPTION
Minor tweak.  Ths wasn't supposed to have been non-marked.  By not having hte @internal tag, the property is placed in the .d.ts and TS will consider it a necessary part of the shape for structural equivalence.  We def do not want that.