### PR TITLE
Fix panic on stack select

### DIFF
--- a/cmd/stack_select.go
+++ b/cmd/stack_select.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/backend/display"
 	"github.com/pulumi/pulumi/pkg/backend/state"
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
+	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
 // newStackSelectCmd handles both the "local" and "cloud" scenarios in its implementation.
@@ -55,7 +56,7 @@ func newStackSelectCmd() *cobra.Command {
 			}
 
 			if stack != "" {
-				// A stack was given, ask the backend about it
+				// A stack was given, ask the backend about it.
 				stackRef, stackErr := b.ParseStackReference(stack)
 				if stackErr != nil {
 					return stackErr
@@ -76,6 +77,8 @@ func newStackSelectCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
+
+			contract.Assert(stack != nil)
 			return state.SetCurrentStack(stack.Ref().String())
 
 		}),


### PR DESCRIPTION
A user was reporting a panic when running `pulumi stack select`. It was odd because the panic only happened when you get prompted and manually type in the stack name, but not when you run `pulumi stack select xxx`.

After more head scratching than I would like to admit, it boiled down to a new class of auth error on the Pulumi Service. (https://github.com/pulumi/pulumi-service/issues/4446) We return a stack `xxx` to the user, so it shows up in the list of available stacks to choose from. But when we actually go and _get_ that stack (`backend::Get`) that returns `(nil, nil)` as is expected when the stack does not exist.

(Because of the specific way we are interpreting a 403 error we are getting from a 3rd party service, we are acting as if the stack doesn't exist at all.) And that's why we had the panic.

The meaningful part of this PR is just adding a new check for the case that `backend::Get` returns `(nil, nil)` and returning an appropriate error. Though until we fix the issue in the Pulumi Service, the user in this state will still see some confusing behavior. (Running `pulumi stack select` will show a stack in the list of stacks to choose from, but if you select it you get a "stack does not exist" error.)

But we'll just properly omit that from the list of stacks returned server-side. The CLI just needs to account for this corner case and not panic.

Fixes #3673