### PR TITLE
Fix syntax error in script

### DIFF
--- a/scripts/build-and-publish-docker
+++ b/scripts/build-and-publish-docker
@@ -33,7 +33,7 @@ fi
 docker login -u "${DOCKER_HUB_USER}" -p "${DOCKER_HUB_PASSWORD}"
 
 echo "Building containers..."
-for container in [pulumi actions]; do
+for container in pulumi actions; do
     echo "- pulumi/${container}"
     docker build --build-arg PULUMI_VERSION="${CLI_VERSION}" \
         -t "pulumi/${container}:${CLI_VERSION}" \
@@ -45,7 +45,7 @@ echo "Running container runtime tests..."
 RUN_CONTAINER_TESTS=true go test tests/containers/...
 
 echo "Publishing containers..."
-for container in [pulumi actions]; do
+for container in pulumi actions; do
     echo "- pulumi/${container}"
     docker push "pulumi/${container}:${CLI_VERSION}"
     docker push "pulumi/${container}:latest"


### PR DESCRIPTION
Fix typo in script. Sorry about that!

Tested on both `bash` and `zsh`. Though I'm not 100% certain this will unblock the v1.8.0 release, since the next step is to run the new "container runtime tests" for the first time under CI.