### PR TITLE
Add py.typed to Python package for PEP 561 compliance

### DIFF
--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -28,6 +28,11 @@ setup(name='pulumi',
       url='https://github.com/pulumi/pulumi',
       license='Apache 2.0',
       packages=find_packages(exclude=("test*",)),
+      package_data={
+          'pulumi': [
+              'py.typed'
+          ]
+      },
       install_requires=[
           'protobuf>=3.6.0',
           'dill>=0.3.0',


### PR DESCRIPTION
PEP 561 specifies that packages which contain either inline type hints
or type stubs should indicate their support for type hints via
including a file named `py.typed` in the root of the package. Since
Pulumi already includes inline type hints, adding `py.typed` to the
Python SDK simply allows these hints to be used by mypy.