### PR TITLE
Write .npmrc if NPM_AUTH_TOKEN is set

### DIFF
--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -90,6 +90,10 @@ if [ -e package.json ]; then
     if [ -f yarn.lock ] || [ ! -z $USE_YARN ]; then
         yarn install
     else
+        # Set npm auth token if one is provided.
+        if [ ! -z "$NPM_AUTH_TOKEN" ]; then
+            echo "//registry.npmjs.org/:_authToken=$NPM_AUTH_TOKEN" > ~/.npmrc
+        fi
         npm install
     fi
 fi


### PR DESCRIPTION
Given the number of merge conflicts and drift, I just recreated the body of https://github.com/pulumi/pulumi/pull/3380 here. Essentially we write the `~/.npmrc` file before `npm install` if `NPM_AUTH_TOKEN` is set.

I don't know if writing `.npmrc` directly is preferred to `npm config set '//reg.example.com/:_authToken' $NPM_AUTH_TOKEN`, but that seemed more common in the handful of searches I did.