### PR TITLE
Trim tailing slash for Az Pipelines build URL

### DIFF
--- a/pkg/util/ciutil/az_pipelines.go
+++ b/pkg/util/ciutil/az_pipelines.go
@@ -17,6 +17,7 @@ package ciutil
 import (
 	"fmt"
 	"os"
+	"strings"
 )
 
 // azurePipelinesCI represents the Azure Pipelines CI/CD system
@@ -36,6 +37,7 @@ func (az azurePipelinesCI) DetectVars() Vars {
 	v.CommitMessage = os.Getenv("BUILD_SOURCEVERSIONMESSAGE")
 
 	orgURI := os.Getenv("SYSTEM_TEAMFOUNDATIONCOLLECTIONURI")
+	orgURI = strings.TrimSuffix(orgURI, "/")
 	projectName := os.Getenv("SYSTEM_TEAMPROJECT")
 	v.BuildURL = fmt.Sprintf("%v/%v/_build/results?buildId=%v", orgURI, projectName, v.BuildID)
 


### PR DESCRIPTION
The `System.TeamFoundationCollectionUri` contains a trailing slash, which we actually use in a string format to form the Build URL. This PR removes trims the trailing slash from the aforementioned env var before using it.