### PR TITLE
Make `async:true` the default for `invoke` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- All data-source invocations are now asynchronous (Promise-returning) by default.
+
 - Lock dep ts-node to v8.5.4 [#3733](https://github.com/pulumi/pulumi/pull/3733)
 
 - Improvements to `pulumi policy` functionality. Add ability to remove & disable Policy Packs.
@@ -34,7 +36,7 @@ CHANGELOG
 - Add `pulumi preview` support for `--refresh`, `--target`, `--replace`, `--target-replace` and
   `--target-dependents` to align with `pulumi up`.
   [#3675](https://github.com/pulumi/pulumi/pull/3675)
-  
+
 - `ComponentResource`s now have built-in support for asynchronously constructing their children. [#3676](https://github.com/pulumi/pulumi/pull/3676)
 
 - `Output.apply` (for the JS, Python and .Net sdks) has updated semantics, and will lift dependencies from inner Outputs to the returned Output.
@@ -53,7 +55,7 @@ CHANGELOG
 
 ## 1.7.0 (2019-12-11)
 
-- A Pulumi JavaScript/TypeScript program can now consist of a single exported top level function. This 
+- A Pulumi JavaScript/TypeScript program can now consist of a single exported top level function. This
   allows for an easy approach to create a Pulumi program that needs to perform `async`/`await`
   operations at the top-level. [#3321](https://github.com/pulumi/pulumi/pull/3321)
 

--- a/sdk/nodejs/invoke.ts
+++ b/sdk/nodejs/invoke.ts
@@ -36,8 +36,12 @@ export interface InvokeOptions {
     version?: string;
 
     /**
-     * Invoke this function asynchronously.  If 'true' is passed in here, then an invoked function
-     * will only supply the `Promise<>` side of its result.
+     * Invoke this data source function asynchronously.  Defaults to `true` if unspecified.
+     *
+     * When `true`, only the `Promise<>` side of the invoke result is present.  Explicitly pass in
+     * `false` to get the non-Promise side of the result.  Invoking data source functions
+     * synchronously is deprecated.  The ability to do this will be removed at a later point in
+     * time.
      */
     async?: boolean;
 }

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -68,11 +68,11 @@ const providerproto = require("../proto/provider_pb.js");
  * synchronously.
  */
 export function invoke(tok: string, props: Inputs, opts: InvokeOptions = {}): Promise<any> {
-    if (opts.async) {
-        // User specifically requested async invoking.  Respect that.
+    if (opts.async !== false) {
         return invokeAsync(tok, props, opts);
     }
 
+    // User specifically requested sync invoking.  Respect that.
     const config = new Config("pulumi");
     const noSyncCalls = config.getBoolean("noSyncCalls");
     if (noSyncCalls) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/009.invoke/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/009.invoke/index.js
@@ -11,7 +11,7 @@ let args = {
     urn: "some-urn",
 };
 
-let result1 = pulumi.runtime.invoke("invoke:index:echo", args);
+let result1 = pulumi.runtime.invoke("invoke:index:echo", args, { async: false });
 
 // When invoking synchronously: Ensure the properties come back synchronously and are present on the
 // result.
@@ -25,7 +25,7 @@ result1.then(v => {
     assert.deepEqual(v, args);
 });
 
-let result2 = pulumi.runtime.invoke("invoke:index:echo", args, { async: true });
+let result2 = pulumi.runtime.invoke("invoke:index:echo", args);
 
 // When invoking asynchronously: Ensure the properties are *not* present on the result.
 for (const key in args) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/044.versions/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/044.versions/index.js
@@ -10,13 +10,13 @@ new MyResource("testResource", "0.19.1");
 new MyResource("testResource2", "0.19.2");
 new MyResource("testResource3");
 
+pulumi.runtime.invoke("invoke:index:doit", {}, { version: "0.19.1" }, { async: false });
+pulumi.runtime.invoke("invoke:index:doit_v2", {}, { version: "0.19.2" }, { async: false });
+pulumi.runtime.invoke("invoke:index:doit_noversion", {}, { async: false });
+
 pulumi.runtime.invoke("invoke:index:doit", {}, { version: "0.19.1" });
 pulumi.runtime.invoke("invoke:index:doit_v2", {}, { version: "0.19.2" });
 pulumi.runtime.invoke("invoke:index:doit_noversion", {});
-
-pulumi.runtime.invoke("invoke:index:doit", {}, { version: "0.19.1" }, { async: true });
-pulumi.runtime.invoke("invoke:index:doit_v2", {}, { version: "0.19.2" }, { async: true });
-pulumi.runtime.invoke("invoke:index:doit_noversion", {}, { async: true });
 
 new pulumi.CustomResource("test:index:ReadResource", "foo", {}, { id: "readme", version: "0.20.0" });
 new pulumi.CustomResource("test:index:ReadResource", "foo_noversion", {}, { id: "readme" });

--- a/sdk/nodejs/tests/runtime/langhost/cases/060.provider_invokes/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/060.provider_invokes/index.js
@@ -23,18 +23,18 @@ let args = {
 if (semver.lt(process.version, "12.11.0")) {
 	// These tests hang on runtimes later than 12.10.x due to their use of deasync.
 
-	let result1 = pulumi.runtime.invoke("test:index:echo", args, { provider });
+	let result1 = pulumi.runtime.invoke("test:index:echo", args, { provider, async: false });
 	for (const key in args) {
 		assert.deepEqual(result1[key], args[key]);
 	}
 
-	let result2 = pulumi.runtime.invoke("test:index:echo", args, { provider });
+	let result2 = pulumi.runtime.invoke("test:index:echo", args, { provider, async: false });
 	result2.then((v) => {
 		assert.deepEqual(v, args);
 	});
 }
 
-let result3 = pulumi.runtime.invoke("test:index:echo", args, { provider, async: true });
+let result3 = pulumi.runtime.invoke("test:index:echo", args, { provider });
 result3.then((v) => {
     assert.deepEqual(v, args);
 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/061.provider_in_parent_invokes/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/061.provider_in_parent_invokes/index.js
@@ -30,18 +30,18 @@ let args = {
 if (semver.lt(process.version, "12.11.0")) {
 	// These tests hang on runtimes later than 12.10.x due to their use of deasync.
 
-	let result1 = pulumi.runtime.invoke("test:index:echo", args, { parent });
+	let result1 = pulumi.runtime.invoke("test:index:echo", args, { parent, async: false });
 	for (const key in args) {
 		assert.deepEqual(result1[key], args[key]);
 	}
 
-	let result2 = pulumi.runtime.invoke("test:index:echo", args, { parent });
+	let result2 = pulumi.runtime.invoke("test:index:echo", args, { parent, async: false });
 	result2.then((v) => {
 		assert.deepEqual(v, args);
 	});
 }
 
-let result3 = pulumi.runtime.invoke("test:index:echo", args, { parent, async: true });
+let result3 = pulumi.runtime.invoke("test:index:echo", args, { parent });
 result3.then((v) => {
     assert.deepEqual(v, args);
 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/062.providerref_invokes/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/062.providerref_invokes/index.js
@@ -21,17 +21,17 @@ let pulumi = require("../../../../../");
         urn: "some-urn",
     };
 
-    let result1 = pulumi.runtime.invoke("test:index:echo", args, { provider });
+    let result1 = pulumi.runtime.invoke("test:index:echo", args, { provider, async: false });
     for (const key in args) {
         assert.deepEqual(result1[key], args[key]);
     }
 
-    let result2 = pulumi.runtime.invoke("test:index:echo", args, { provider });
+    let result2 = pulumi.runtime.invoke("test:index:echo", args, { provider, async: false });
     result2.then((v) => {
         assert.deepEqual(v, args);
     });
 
-    let result3 = pulumi.runtime.invoke("test:index:echo", args, { provider, async: true });
+    let result3 = pulumi.runtime.invoke("test:index:echo", args, { provider });
     result3.then((v) => {
         assert.deepEqual(v, args);
     });

--- a/sdk/nodejs/tests/runtime/langhost/cases/063.providerref_in_parent_invokes/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/063.providerref_in_parent_invokes/index.js
@@ -29,17 +29,17 @@ let pulumi = require("../../../../../");
         urn: "some-urn",
     };
 
-    let result1 = pulumi.runtime.invoke("test:index:echo", args, { parent });
+    let result1 = pulumi.runtime.invoke("test:index:echo", args, { parent, async: false });
     for (const key in args) {
         assert.deepEqual(result1[key], args[key]);
     }
 
-    let result2 = pulumi.runtime.invoke("test:index:echo", args, { parent });
+    let result2 = pulumi.runtime.invoke("test:index:echo", args, { parent, async: false });
     result2.then((v) => {
         assert.deepEqual(v, args);
     });
 
-    let result3 = pulumi.runtime.invoke("test:index:echo", args, { parent, async: true });
+    let result3 = pulumi.runtime.invoke("test:index:echo", args, { parent });
     result3.then((v) => {
         assert.deepEqual(v, args);
     });


### PR DESCRIPTION
Note: this is going into the 2.0 branch.  This is part of https://github.com/pulumi/pulumi/issues/3693