### PR TITLE
Add permalink to policy publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ CHANGELOG
 
 - Breaking change for Policy which is in Public Preview: Change `pulumi policy apply` to `pulumi policy enable`, and allow users to specify the Policy Group.
 
+- Add Permalink to output when publishing a Policy Pack.
+
 ## 1.8.1 (2019-12-20)
 
 - Fix a panic in `pulumi stack select`. [#3687](https://github.com/pulumi/pulumi/pull/3687)

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -497,7 +497,7 @@ func (pc *Client) StartUpdate(ctx context.Context, update UpdateIdentifier,
 	return resp.Version, resp.Token, nil
 }
 
-// PublishPolicyPack publishes a `PolicyPack` to the Pulumi service. If its successful, it returns
+// PublishPolicyPack publishes a `PolicyPack` to the Pulumi service. If it's successful, it returns
 // the version that was published.
 func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 	analyzerInfo plugin.AnalyzerInfo, dirArchive io.Reader) (int, error) {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -497,9 +497,10 @@ func (pc *Client) StartUpdate(ctx context.Context, update UpdateIdentifier,
 	return resp.Version, resp.Token, nil
 }
 
-// PublishPolicyPack publishes a `PolicyPack` to the Pulumi service.
+// PublishPolicyPack publishes a `PolicyPack` to the Pulumi service. If its successful, it returns
+// the version that was published.
 func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
-	analyzerInfo plugin.AnalyzerInfo, dirArchive io.Reader) error {
+	analyzerInfo plugin.AnalyzerInfo, dirArchive io.Reader) (int, error) {
 
 	//
 	// Step 1: Send POST containing policy metadata to service. This begins process of creating
@@ -517,7 +518,7 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 	var resp apitype.CreatePolicyPackResponse
 	err := pc.restCall(ctx, "POST", publishPolicyPackPath(orgName), nil, req, &resp)
 	if err != nil {
-		return errors.Wrapf(err, "Publish policy pack failed")
+		return 0, errors.Wrapf(err, "Publish policy pack failed")
 	}
 
 	fmt.Printf("Published as version %d\n", resp.Version)
@@ -529,12 +530,12 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 
 	putS3Req, err := http.NewRequest(http.MethodPut, resp.UploadURI, dirArchive)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to upload compressed PolicyPack")
+		return 0, errors.Wrapf(err, "Failed to upload compressed PolicyPack")
 	}
 
 	_, err = http.DefaultClient.Do(putS3Req)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to upload compressed PolicyPack")
+		return 0, errors.Wrapf(err, "Failed to upload compressed PolicyPack")
 	}
 
 	//
@@ -544,10 +545,10 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 	err = pc.restCall(ctx, "POST",
 		publishPolicyPackPublishComplete(orgName, analyzerInfo.Name, resp.Version), nil, nil, nil)
 	if err != nil {
-		return errors.Wrapf(err, "Request to signal completion of the publish operation failed")
+		return 0, errors.Wrapf(err, "Request to signal completion of the publish operation failed")
 	}
 
-	return nil
+	return resp.Version, nil
 }
 
 // ApplyPolicyPack enables a `PolicyPack` to the Pulumi organization. If policyGroup is not empty,

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -158,10 +158,12 @@ func (pack *cloudPolicyPack) Publish(
 
 	fmt.Println("Uploading policy pack to Pulumi service")
 
-	err = pack.cl.PublishPolicyPack(ctx, pack.ref.orgName, analyzerInfo, bytes.NewReader(packTarball))
+	version, err := pack.cl.PublishPolicyPack(ctx, pack.ref.orgName, analyzerInfo, bytes.NewReader(packTarball))
 	if err != nil {
 		return result.FromError(err)
 	}
+
+	fmt.Printf("\nPermalink: %s/policypacks/%s/%d\n", pack.Backend().URL(), pack.ref.Name(), version)
 
 	return nil
 }


### PR DESCRIPTION
This isnt super pretty but theres an issue to fix that: https://github.com/pulumi/pulumi-policy/issues/58

```
➜  test_policy_pack (eck/link-to-policy-pack) ✗ pulumi policy publish
Obtaining policy metadata from policy plugin
Compressing policy pack
Uploading policy pack to Pulumi service
Publishing test-url to ekrengel
Published as version 4

Permalink: http://localhost:3000/ekrengel/policypacks/test-url/4
```

Fixes https://github.com/pulumi/pulumi-policy/issues/79
