### PR TITLE
Enable mypy

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -23,7 +23,7 @@ build_plugin::
 build:: build_package build_plugin
 
 lint::
-	pipenv run mypy ./lib/pulumi
+	pipenv run mypy ./lib/pulumi --config-file=mypy.ini
 	pipenv run pylint ./lib/pulumi --rcfile=.pylintrc
 	golangci-lint run
 

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -23,6 +23,7 @@ build_plugin::
 build:: build_package build_plugin
 
 lint::
+	pipenv run mypy ./lib/pulumi
 	pipenv run pylint ./lib/pulumi --rcfile=.pylintrc
 	golangci-lint run
 

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -11,3 +11,4 @@ six = ">=1.12.0"
 
 [dev-packages]
 pylint = ">=2.1"
+mypy = ">=0.761"

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -11,4 +11,4 @@ six = ">=1.12.0"
 
 [dev-packages]
 pylint = ">=2.1"
-mypy = ">=0.761"
+mypy = ">=0.77"

--- a/sdk/python/Pipfile.lock
+++ b/sdk/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b51d443cfdc6681b0f87cca71b6fa6a930ca951c3e86e082e70d307133b36381"
+            "sha256": "ed38041c004113f7fb2ec797ce11c64679e00ccd7a85449e8cb34b01ec6b5864"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,88 +16,100 @@
     "default": {
         "dill": {
             "hashes": [
-                "sha256:993409439ebf7f7902d9de93eaa2a395e0446ff773d29f13dc46646482f76906"
+                "sha256:42d8ef819367516592a825746a18073ced42ca169ab1f5f4044134703e7a049c"
             ],
             "index": "pypi",
-            "version": "==0.3.0"
+            "version": "==0.3.1.1"
         },
         "grpcio": {
             "hashes": [
-                "sha256:03b78b4e7dcdfe3e257bb528cc93923f9cbbab6d5babf15a60d21e9a4a70b1a2",
-                "sha256:1ce0ccfbdfe84387dbcbf44adb4ae16ec7ae70e166ffab478993eb1ea1cba3ce",
-                "sha256:22e167a9406d73dd19ffe8ed6a485f17e6eac82505be8c108897f15e68badcbb",
-                "sha256:31d0aeca8d8ee2301c62c5c340e0889d653b1280d68f9fa203982cb6337b050e",
-                "sha256:44c7f99ca17ebbcc96fc54ed00b454d8313f1eac28c563098d8b901025aff941",
-                "sha256:5471444f53f9db6a1f1f11f5dbc173228881df8446380b6b98f90afb8fd8348e",
-                "sha256:561bca3b1bde6d6564306eb05848fd155136e9c3a25d2961129b1e2edba22fce",
-                "sha256:5bf58e1d2c2f55365c06e8cb5abe067b88ca2e5550fb62009c41df4b54505acf",
-                "sha256:6b7163d1e85d76b0815df63fcc310daec02b44532bb433f743142d4febcb181f",
-                "sha256:766d79cddad95f5f6020037fe60ea8b98578afdf0c59d5a60c106c1bdd886303",
-                "sha256:770b7372d5ca68308ff66d7baee53369fa5ce985f84bcb6aa1948c1f2f7b02f2",
-                "sha256:7ab178da777fc0f55b6aef5a755f99726e8e4b75e3903954df07b27059b54fcf",
-                "sha256:8078305e77c2f6649d36b24d8778096413e474d9d7892c6f92cfb589c9d71b2e",
-                "sha256:85600b63a386d860eeaa955e9335e18dd0d7e5477e9214825abf2c2884488369",
-                "sha256:857d9b939ae128be1c0c792eb885c7ff6a386b9dea899ac4b06f4d90a31f9d87",
-                "sha256:87a41630c90c179fa5c593400f30a467c498972c702f348d41e19dafeb1d319e",
-                "sha256:8805d486c6128cc0fcc8ecf16c4095d99a8693a541ef851429ab334e028a4a97",
-                "sha256:8d71b7a89c306a41ccc7741fc9409b14f5b86727455c2a1c0c7cfcb0f784e1f2",
-                "sha256:9e1b80bd65f8f160880cb4dad7f55697f6d37b2d7f251fc0c2128e811928f369",
-                "sha256:9e290c84a145ae2411ee0ec9913c41cd7500e2e7485fe93632434d84ef4fda67",
-                "sha256:9ec9f88b5bc94bd99372f27cdd53af1c92ba06717380b127733b953cfb181174",
-                "sha256:a0a02a8b4ba6deadf706d5f849539b3685b72b186a3c9ef5d43e8972ed60fb6f",
-                "sha256:a4059c59519f5940e01a071f74ae2a60ea8f6185b03d22a09d40c7959a36b16b",
-                "sha256:a6e028c2a6da2ebfa2365a5b32531d311fbfec0e3600fc27e901b64f0ff7e54e",
-                "sha256:adcdebf9f8463df4120c427cf6c9aed39258bccd03ed37b6939e7a145d64d6e0",
-                "sha256:bdec982610259d07156a58f80b8c3e69be7751a9208bc577b059c5193d087fad",
-                "sha256:cefc4d4251ffb73feb303d4b7e9d6c367cb60f2db16d259ea28b114045f965aa",
-                "sha256:d4145c8aa6afbac10ad27e408f7ce15992fe89ba5d0b4abca31c0c2729864c03",
-                "sha256:da76dc5ad719ee99de5ea28a5629ff92172cbb4a70d8a6ae3a5b7a53c7382ce1",
-                "sha256:dde2452c08ef8b6426ccab6b5b6de9f06d836d9937d6870e68153cbf8cb49348",
-                "sha256:e3d88091d2539a4868750914a6fe7b9ec50e42b913851fc1b77423b5bd918530",
-                "sha256:f9c67cfe6278499d7f83559dc6322a8bbb108e307817a3d7acbfea807b3603cc"
+                "sha256:066630f6b62bffa291dacbee56994279a6a3682b8a11967e9ccaf3cc770fc11e",
+                "sha256:07e95762ca6b18afbeb3aa2793e827c841152d5e507089b1db0b18304edda105",
+                "sha256:0a0fb2f8e3a13537106bc77e4c63005bc60124a6203034304d9101921afa4e90",
+                "sha256:0c61b74dcfb302613926e785cb3542a0905b9a3a86e9410d8cf5d25e25e10104",
+                "sha256:13383bd70618da03684a8aafbdd9e3d9a6720bf8c07b85d0bc697afed599d8f0",
+                "sha256:1c6e0f6b9d091e3717e9a58d631c8bb4898be3b261c2a01fe46371fdc271052f",
+                "sha256:1cf710c04689daa5cc1e598efba00b028215700dcc1bf66fcb7b4f64f2ea5d5f",
+                "sha256:2da5cee9faf17bb8daf500cd0d28a17ae881ab5500f070a6aace457f4c08cac4",
+                "sha256:2f78ebf340eaf28fa09aba0f836a8b869af1716078dfe8f3b3f6ff785d8f2b0f",
+                "sha256:33a07a1a8e817d733588dbd18e567caad1a6fe0d440c165619866cd490c7911a",
+                "sha256:3d090c66af9c065b7228b07c3416f93173e9839b1d40bb0ce3dd2aa783645026",
+                "sha256:42b903a3596a10e2a3727bae2a76f8aefd324d498424b843cfa9606847faea7b",
+                "sha256:4fffbb58134c4f23e5a8312ac3412db6f5e39e961dc0eb5e3115ce5aa16bf927",
+                "sha256:57be5a6c509a406fe0ffa6f8b86904314c77b5e2791be8123368ad2ebccec874",
+                "sha256:5b0fa09efb33e2af4e8822b4eb8b2cbc201d562e3e185c439be7eaeee2e8b8aa",
+                "sha256:5ef42dfc18f9a63a06aca938770b69470bb322e4c137cf08cf21703d1ef4ae5c",
+                "sha256:6a43d2f2ff8250f200fdf7aa31fa191a997922aa9ea1182453acd705ad83ab72",
+                "sha256:6d8ab28559be98b02f8b3a154b53239df1aa5b0d28ff865ae5be4f30e7ed4d3f",
+                "sha256:6e47866b7dc14ca3a12d40c1d6082e7bea964670f1c5315ea0fb8b0550244d64",
+                "sha256:6edda1b96541187f73aab11800d25f18ee87e53d5f96bb74473873072bf28a0e",
+                "sha256:7109c8738a8a3c98cfb5dda1c45642a8d6d35dc00d257ab7a175099b2b4daecd",
+                "sha256:8d866aafb08657c456a18c4a31c8526ea62de42427c242b58210b9eae6c64559",
+                "sha256:9939727d9ae01690b24a2b159ac9dbca7b7e8e6edd5af6a6eb709243cae7b52b",
+                "sha256:99fd873699df17cb11c542553270ae2b32c169986e475df0d68a8629b8ef4df7",
+                "sha256:b6fda5674f990e15e1bcaacf026428cf50bce36e708ddcbd1de9673b14aab760",
+                "sha256:bdb2f3dcb664f0c39ef1312cd6acf6bc6375252e4420cf8f36fff4cb4fa55c71",
+                "sha256:bfd7d3130683a1a0a50c456273c21ec8a604f2d043b241a55235a78a0090ee06",
+                "sha256:c6c2db348ac73d73afe14e0833b18abbbe920969bf2c5c03c0922719f8020d06",
+                "sha256:cb7a4b41b5e2611f85c3402ac364f1d689f5d7ecbc24a55ef010eedcd6cf460f",
+                "sha256:cd3d3e328f20f7c807a862620c6ee748e8d57ba2a8fc960d48337ed71c6d9d32",
+                "sha256:d1a481777952e4f99b8a6956581f3ee866d7614100d70ae6d7e07327570b85ce",
+                "sha256:d1d49720ed636920bb3d74cedf549382caa9ad55aea89d1de99d817068d896b2",
+                "sha256:d42433f0086cccd192114343473d7dbd4aae9141794f939e2b7b83efc57543db",
+                "sha256:d44c34463a7c481e076f691d8fa25d080c3486978c2c41dca09a8dd75296c2d7",
+                "sha256:d7e5b7af1350e9c8c17a7baf99d575fbd2de69f7f0b0e6ebd47b57506de6493a",
+                "sha256:d9542366a0917b9b48bab1fee481ac01f56bdffc52437b598c09e7840148a6a9",
+                "sha256:df7cdfb40179acc9790a462c049e0b8e109481164dd7ad1a388dd67ff1528759",
+                "sha256:e1a9d9d2e7224d981aea8da79260c7f6932bf31ce1f99b7ccfa5eceeb30dc5d0",
+                "sha256:ed10e5fad105ecb0b12822f924e62d0deb07f46683a0b64416b17fd143daba1d",
+                "sha256:f0ec5371ce2363b03531ed522bfbe691ec940f51f0e111f0500fc0f44518c69d",
+                "sha256:f6580a8a4f5e701289b45fd62a8f6cb5ec41e4d77082424f8b676806dcd22564",
+                "sha256:f7b83e4b2842d44fce3cdc0d54db7a7e0d169a598751bf393601efaa401c83e0",
+                "sha256:ffec45b0db18a555fdfe0c6fa2d0a3fceb751b22b31e8fcd14ceed7bde05481e"
             ],
             "index": "pypi",
-            "version": "==1.22.0"
+            "version": "==1.26.0"
         },
         "protobuf": {
             "hashes": [
-                "sha256:00a1b0b352dc7c809749526d1688a64b62ea400c5b05416f93cfb1b11a036295",
-                "sha256:01acbca2d2c8c3f7f235f1842440adbe01bbc379fa1cbdd80753801432b3fae9",
-                "sha256:0a795bca65987b62d6b8a2d934aa317fd1a4d06a6dd4df36312f5b0ade44a8d9",
-                "sha256:0ec035114213b6d6e7713987a759d762dd94e9f82284515b3b7331f34bfaec7f",
-                "sha256:31b18e1434b4907cb0113e7a372cd4d92c047ce7ba0fa7ea66a404d6388ed2c1",
-                "sha256:32a3abf79b0bef073c70656e86d5bd68a28a1fbb138429912c4fc07b9d426b07",
-                "sha256:55f85b7808766e5e3f526818f5e2aeb5ba2edcc45bcccede46a3ccc19b569cb0",
-                "sha256:64ab9bc971989cbdd648c102a96253fdf0202b0c38f15bd34759a8707bdd5f64",
-                "sha256:64cf847e843a465b6c1ba90fb6c7f7844d54dbe9eb731e86a60981d03f5b2e6e",
-                "sha256:917c8662b585470e8fd42f052661fc66d59fccaae450a60044307dcbf82a3335",
-                "sha256:afed9003d7f2be2c3df20f64220c30faec441073731511728a2cb4cab4cd46a6",
-                "sha256:b883d7eb129b1b57c5128146bc7c2d1f15de457e96a549827fbee6f26eeedc46",
-                "sha256:bf8e05d638b585d1752c5a84247134a0350d3a8b73d3632489a014a9f6f1e758",
-                "sha256:d831b047bd69becaf64019a47179eb22118a50dd008340655266a906c69c6417",
-                "sha256:de2760583ed28749ff885789c1cbc6c9c06d6de92fc825740ab99deb2f25ea4d",
-                "sha256:eabc4cf1bc19689af8022ba52fd668564a8d96e0d08f3b4732d26a64255216a4",
-                "sha256:fcff6086c86fb1628d94ea455c7b9de898afc50378042927a59df8065a79a549"
+                "sha256:0329e86a397db2a83f9dcbe21d9be55a47f963cdabc893c3a24f4d3a8f117c37",
+                "sha256:0a7219254afec0d488211f3d482d8ed57e80ae735394e584a98d8f30a8c88a36",
+                "sha256:14d6ac53df9cb5bb87c4f91b677c1bc5cec9c0fd44327f367a3c9562de2877c4",
+                "sha256:180fc364b42907a1d2afa183ccbeffafe659378c236b1ec3daca524950bb918d",
+                "sha256:3d7a7d8d20b4e7a8f63f62de2d192cfd8b7a53c56caba7ece95367ca2b80c574",
+                "sha256:3f509f7e50d806a434fe4a5fbf602516002a0f092889209fff7db82060efffc0",
+                "sha256:4571da974019849201fc1ec6626b9cea54bd11b6bed140f8f737c0a33ea37de5",
+                "sha256:56bd1d84fbf4505c7b73f04de987eef5682e5752c811141b0186a3809bfb396f",
+                "sha256:680c668d00b5eff08b86aef9e5ba9a705e621ea05d39071cfea8e28cb2400946",
+                "sha256:6b5b947dc8b3f2aec0eaad65b0b5113fcd642c358c31357c647da6281ee31104",
+                "sha256:6e96dffaf4d0a9a329e528b353ba62fd9ef13599688723d96bc9c165d0b6871e",
+                "sha256:919f0d6f6addc836d08658eba3b52be2e92fd3e76da3ce00c325d8e9826d17c7",
+                "sha256:9c7b19c30cf0644afd0e4218b13f637ce54382fdcb1c8f75bf3e84e49a5f6d0a",
+                "sha256:a2e6f57114933882ec701807f217df2fb4588d47f71f227c0a163446b930d507",
+                "sha256:a6b970a2eccfcbabe1acf230fbf112face1c4700036c95e195f3554d7bcb04c1",
+                "sha256:bc45641cbcdea068b67438244c926f9fd3e5cbdd824448a4a64370610df7c593",
+                "sha256:d61b14a9090da77fe87e38ba4c6c43d3533dcbeb5d84f5474e7ac63c532dcc9c",
+                "sha256:d6faf5dbefb593e127463f58076b62fcfe0784187be8fe1aa9167388f24a22a1"
             ],
             "index": "pypi",
-            "version": "==3.9.1"
+            "version": "==3.11.2"
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
             "index": "pypi",
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         }
     },
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
-                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
+                "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a",
+                "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"
             ],
-            "version": "==2.2.5"
+            "version": "==2.3.3"
         },
         "isort": {
             "hashes": [
@@ -108,26 +120,29 @@
         },
         "lazy-object-proxy": {
             "hashes": [
-                "sha256:159a745e61422217881c4de71f9eafd9d703b93af95618635849fe469a283661",
-                "sha256:23f63c0821cc96a23332e45dfaa83266feff8adc72b9bcaef86c202af765244f",
-                "sha256:3b11be575475db2e8a6e11215f5aa95b9ec14de658628776e10d96fa0b4dac13",
-                "sha256:3f447aff8bc61ca8b42b73304f6a44fa0d915487de144652816f950a3f1ab821",
-                "sha256:4ba73f6089cd9b9478bc0a4fa807b47dbdb8fad1d8f31a0f0a5dbf26a4527a71",
-                "sha256:4f53eadd9932055eac465bd3ca1bd610e4d7141e1278012bd1f28646aebc1d0e",
-                "sha256:64483bd7154580158ea90de5b8e5e6fc29a16a9b4db24f10193f0c1ae3f9d1ea",
-                "sha256:6f72d42b0d04bfee2397aa1862262654b56922c20a9bb66bb76b6f0e5e4f9229",
-                "sha256:7c7f1ec07b227bdc561299fa2328e85000f90179a2f44ea30579d38e037cb3d4",
-                "sha256:7c8b1ba1e15c10b13cad4171cfa77f5bb5ec2580abc5a353907780805ebe158e",
-                "sha256:8559b94b823f85342e10d3d9ca4ba5478168e1ac5658a8a2f18c991ba9c52c20",
-                "sha256:a262c7dfb046f00e12a2bdd1bafaed2408114a89ac414b0af8755c696eb3fc16",
-                "sha256:acce4e3267610c4fdb6632b3886fe3f2f7dd641158a843cf6b6a68e4ce81477b",
-                "sha256:be089bb6b83fac7f29d357b2dc4cf2b8eb8d98fe9d9ff89f9ea6012970a853c7",
-                "sha256:bfab710d859c779f273cc48fb86af38d6e9210f38287df0069a63e40b45a2f5c",
-                "sha256:c10d29019927301d524a22ced72706380de7cfc50f767217485a912b4c8bd82a",
-                "sha256:dd6e2b598849b3d7aee2295ac765a578879830fb8966f70be8cd472e6069932e",
-                "sha256:e408f1eacc0a68fed0c08da45f31d0ebb38079f043328dce69ff133b95c29dc1"
+                "sha256:0c4b206227a8097f05c4dbdd323c50edf81f15db3b8dc064d08c62d37e1a504d",
+                "sha256:194d092e6f246b906e8f70884e620e459fc54db3259e60cf69a4d66c3fda3449",
+                "sha256:1be7e4c9f96948003609aa6c974ae59830a6baecc5376c25c92d7d697e684c08",
+                "sha256:4677f594e474c91da97f489fea5b7daa17b5517190899cf213697e48d3902f5a",
+                "sha256:48dab84ebd4831077b150572aec802f303117c8cc5c871e182447281ebf3ac50",
+                "sha256:5541cada25cd173702dbd99f8e22434105456314462326f06dba3e180f203dfd",
+                "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239",
+                "sha256:8d859b89baf8ef7f8bc6b00aa20316483d67f0b1cbf422f5b4dc56701c8f2ffb",
+                "sha256:9254f4358b9b541e3441b007a0ea0764b9d056afdeafc1a5569eee1cc6c1b9ea",
+                "sha256:9651375199045a358eb6741df3e02a651e0330be090b3bc79f6d0de31a80ec3e",
+                "sha256:97bb5884f6f1cdce0099f86b907aa41c970c3c672ac8b9c8352789e103cf3156",
+                "sha256:9b15f3f4c0f35727d3a0fba4b770b3c4ebbb1fa907dbcc046a1d2799f3edd142",
+                "sha256:a2238e9d1bb71a56cd710611a1614d1194dc10a175c1e08d75e1a7bcc250d442",
+                "sha256:a6ae12d08c0bf9909ce12385803a543bfe99b95fe01e752536a60af2b7797c62",
+                "sha256:ca0a928a3ddbc5725be2dd1cf895ec0a254798915fb3a36af0964a0a4149e3db",
+                "sha256:cb2c7c57005a6804ab66f106ceb8482da55f5314b7fcb06551db1edae4ad1531",
+                "sha256:d74bb8693bf9cf75ac3b47a54d716bbb1a92648d5f781fc799347cfc95952383",
+                "sha256:d945239a5639b3ff35b70a88c5f2f491913eb94871780ebfabb2568bd58afc5a",
+                "sha256:eba7011090323c1dadf18b3b689845fd96a61ba0a1dfbd7f24b921398affc357",
+                "sha256:efa1909120ce98bbb3777e8b6f92237f5d5c8ea6758efea36a473e1d38f7d3e4",
+                "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"
             ],
-            "version": "==1.4.1"
+            "version": "==1.4.3"
         },
         "mccabe": {
             "hashes": [
@@ -136,45 +151,87 @@
             ],
             "version": "==0.6.1"
         },
-        "pylint": {
+        "mypy": {
             "hashes": [
-                "sha256:5d77031694a5fb97ea95e828c8d10fc770a1df6eb3906067aaed42201a8a6a09",
-                "sha256:723e3db49555abaf9bf79dc474c6b9e2935ad82230b10c1138a71ea41ac0fff1"
+                "sha256:0a9a45157e532da06fe56adcfef8a74629566b607fa2c1ac0122d1ff995c748a",
+                "sha256:2c35cae79ceb20d47facfad51f952df16c2ae9f45db6cb38405a3da1cf8fc0a7",
+                "sha256:4b9365ade157794cef9685791032521233729cb00ce76b0ddc78749abea463d2",
+                "sha256:53ea810ae3f83f9c9b452582261ea859828a9ed666f2e1ca840300b69322c474",
+                "sha256:634aef60b4ff0f650d3e59d4374626ca6153fcaff96ec075b215b568e6ee3cb0",
+                "sha256:7e396ce53cacd5596ff6d191b47ab0ea18f8e0ec04e15d69728d530e86d4c217",
+                "sha256:7eadc91af8270455e0d73565b8964da1642fe226665dd5c9560067cd64d56749",
+                "sha256:7f672d02fffcbace4db2b05369142e0506cdcde20cea0e07c7c2171c4fd11dd6",
+                "sha256:85baab8d74ec601e86134afe2bcccd87820f79d2f8d5798c889507d1088287bf",
+                "sha256:87c556fb85d709dacd4b4cb6167eecc5bbb4f0a9864b69136a0d4640fdc76a36",
+                "sha256:a6bd44efee4dc8c3324c13785a9dc3519b3ee3a92cada42d2b57762b7053b49b",
+                "sha256:c6d27bd20c3ba60d5b02f20bd28e20091d6286a699174dfad515636cb09b5a72",
+                "sha256:e2bb577d10d09a2d8822a042a23b8d62bc3b269667c9eb8e60a6edfa000211b1",
+                "sha256:f97a605d7c8bc2c6d1172c2f0d5a65b24142e11a58de689046e62c2d632ca8c1"
             ],
             "index": "pypi",
-            "version": "==2.3.1"
+            "version": "==0.761"
+        },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
+        "pylint": {
+            "hashes": [
+                "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd",
+                "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"
+            ],
+            "index": "pypi",
+            "version": "==2.4.4"
         },
         "six": {
             "hashes": [
-                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
-                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
             ],
             "index": "pypi",
-            "version": "==1.12.0"
+            "version": "==1.13.0"
         },
         "typed-ast": {
             "hashes": [
-                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
-                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
-                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
-                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
-                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
-                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
-                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
-                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
-                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
-                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
-                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
-                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
-                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
-                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
-                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
-            "markers": "implementation_name == 'cpython'",
-            "version": "==1.4.0"
+            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
+            "version": "==1.4.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:091ecc894d5e908ac75209f10d5b4f118fbdb2eb1ede6a63544054bb1edb41f2",
+                "sha256:910f4656f54de5993ad9304959ce9bb903f90aadc7c67a0bef07e678014e892d",
+                "sha256:cf8b63fedea4d89bab840ecbb93e75578af28f76f66c35889bd7065f5af88575"
+            ],
+            "version": "==3.7.4.1"
         },
         "wrapt": {
             "hashes": [
+                "sha256:079fe01d237900044bfc0caea79c47b28fe43a20ca43ca9f02d6c4684e97ce21",
                 "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
             "version": "==1.11.2"

--- a/sdk/python/Pipfile.lock
+++ b/sdk/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ed38041c004113f7fb2ec797ce11c64679e00ccd7a85449e8cb34b01ec6b5864"
+            "sha256": "77e790c89dcee1cbb8a37996cc6b5c21f51b49bdff58879c946b2098bae7d98e"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -231,7 +231,6 @@
         },
         "wrapt": {
             "hashes": [
-                "sha256:079fe01d237900044bfc0caea79c47b28fe43a20ca43ca9f02d6c4684e97ce21",
                 "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"
             ],
             "version": "==1.11.2"

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -169,7 +169,7 @@ class Config:
         :rtype: Optional[float]
         :raises ConfigTypeError: The configuration value existed but couldn't be coerced to float.
         """
-        v = self.get(key)
+        v = self.get_float(key)
         if v is None:
             return None
 
@@ -299,7 +299,7 @@ class Config:
             raise ConfigMissingError(self.full_key(key))
         return v
 
-    def require_secret_float(self, key: str) -> float:
+    def require_secret_float(self, key: str) -> Output[float]:
         """
         Returns a configuration value, as a float, marked as a secret by its given key.  If it doesn't exist, or the
         configuration value is not a legal number, an error is thrown.

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -15,7 +15,7 @@
 import asyncio
 import base64
 import pickle
-from typing import Any, Optional, List, TYPE_CHECKING
+from typing import Any, Optional, List, TYPE_CHECKING, no_type_check, cast
 
 import dill
 from .. import CustomResource, ResourceOptions
@@ -202,6 +202,8 @@ class ResourceProvider:
     def __init__(self) -> None:
         pass
 
+#https://github.com/python/mypy/issues/1102
+@no_type_check
 def serialize_provider(provider: ResourceProvider) -> str:
         # We need to customize our Pickler to ensure we sort dictionaries before serializing to try to
     # ensure we get a deterministic result.  Without this we would see changes to our serialized
@@ -247,6 +249,7 @@ class Resource(CustomResource):
         if PROVIDER_KEY in props:
             raise  Exception("A dynamic resource must not define the __provider key")
 
+        props = cast(dict, props)
         props[PROVIDER_KEY] = serialize_provider(provider)
 
         super(Resource, self).__init__("pulumi-python:dynamic:Resource", name, props, opts)

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -202,7 +202,8 @@ class ResourceProvider:
     def __init__(self) -> None:
         pass
 
-#https://github.com/python/mypy/issues/1102
+# TODO[python/mypy#1102]: mypy doesn't currently support multiline comments
+# multiple errors related to the type assignment we're doing in this method eg 'Picker = _Pickler'
 @no_type_check
 def serialize_provider(provider: ResourceProvider) -> str:
         # We need to customize our Pickler to ensure we sort dictionaries before serializing to try to

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 from typing import Optional
 
+if TYPE_CHECKING:
+    from .resource import Resource, ProviderResource
+
 class InvokeOptions:
     """
     InvokeOptions is a bag of options that control the behavior of a call to runtime.invoke.

--- a/sdk/python/lib/pulumi/invoke.py
+++ b/sdk/python/lib/pulumi/invoke.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .resource import Resource, ProviderResource

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -278,7 +278,7 @@ class Output(Generic[T]):
             return promise_output.apply(Output.from_input, True)
 
         # Is it a prompt value? Set up a new resolved future and use that as the value future.
-        value_fut: asyncio.Future = asyncio.Future()
+        value_fut: asyncio.Future[Any] = asyncio.Future()
         value_fut.set_result(val)
         return Output(set(), value_fut, is_known_fut, is_secret_fut)
 

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -107,10 +107,10 @@ class Output(Generic[T]):
     def resources(self) -> Awaitable[Set['Resource']]:
         return self._resources
 
-    def future(self, with_unknowns: Optional[bool] = None) -> Awaitable[T]:
+    def future(self, with_unknowns: Optional[bool] = None) -> Awaitable[Optional[T]]:
         # If the caller did not explicitly ask to see unknown values and the value of this output contains unnkowns,
         # return None. This preserves compatibility with earlier versios of the Pulumi SDK.
-        async def get_value() -> T:
+        async def get_value() -> Optional[T]:
             val = await self._future
             return None if not with_unknowns and contains_unknowns(val) else val
         return asyncio.ensure_future(get_value())

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -141,9 +141,9 @@ class Output(Generic[T]):
         :return: A transformed Output obtained from running the transformation function on this Output's value.
         :rtype: Output[U]
         """
-        result_resources: asyncio.Future = asyncio.Future()
-        result_is_known: asyncio.Future = asyncio.Future()
-        result_is_secret: asyncio.Future = asyncio.Future()
+        result_resources: asyncio.Future[Set['Resource']] = asyncio.Future()
+        result_is_known: asyncio.Future[bool] = asyncio.Future()
+        result_is_secret: asyncio.Future[bool] = asyncio.Future()
 
         # The "run" coroutine actually runs the apply.
         async def run() -> U:
@@ -265,8 +265,8 @@ class Output(Generic[T]):
             return output
 
         # If it's not an output, list, or dict, it must be known and not secret
-        is_known_fut: asyncio.Future = asyncio.Future()
-        is_secret_fut: asyncio.Future = asyncio.Future()
+        is_known_fut: asyncio.Future[bool] = asyncio.Future()
+        is_secret_fut: asyncio.Future[bool] = asyncio.Future()
         is_known_fut.set_result(True)
         is_secret_fut.set_result(False)
 
@@ -295,7 +295,7 @@ class Output(Generic[T]):
         """
 
         o = Output.from_input(val)
-        is_secret: asyncio.Future = asyncio.Future()
+        is_secret: asyncio.Future[bool] = asyncio.Future()
         is_secret.set_result(True)
         return Output(o._resources, o._future, o._is_known, is_secret)
 

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -366,7 +366,7 @@ class Output(Generic[T]):
         :rtype: Output[str]
         """
 
-        transformed_items: List[Union[Any, Awaitable[Any], Output[Any]]] = [Output.from_input(v) for v in args]
+        transformed_items: List[Input[Any]] = [Output.from_input(v) for v in args]
         # invariant http://mypy.readthedocs.io/en/latest/common_issues.html#variance
         return Output.all(*transformed_items).apply("".join) # type: ignore
 

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -255,7 +255,7 @@ class Output(Generic[T]):
             # Once we have a output of the list of properties, we can use an apply to re-hydrate it back into a dict.
             dict_items = [[k, Output.from_input(v)] for k, v in val.items()]
             # type checker doesn't like returing a Dict in the apply callback
-            fn = cast(Callable[[List[Any]], T], lambda props: {k: v for k, v in props})
+            fn = cast(Callable[[List[Any]], T], lambda props: {k: v for k, v in props}) # pylint: disable=unnecessary-comprehension
             return Output.all(*dict_items).apply(fn, True)
 
         if isinstance(val, list):

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -410,7 +410,7 @@ class ResourceOptions:
         """
 
         # Expose 'merge' again this this object, but this time as an instance method.
-        # https://github.com/python/mypy/issues/2427
+        # TODO[python/mypy#2427]: mypy disallows method assignment
         self.merge = self._merge_instance # type: ignore
         self.merge.__func__.__doc__ = ResourceOptions.merge.__doc__ # type: ignore
 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -691,7 +691,7 @@ class Resource:
         # Collapse any `Alias`es down to URNs. We have to wait until this point to do so because we
         # do not know the default `name` and `type` to apply until we are inside the resource
         # constructor.
-        self._aliases: List[Input[str]] = [] # pylint: disable=used-before-assignment
+        self._aliases: 'List[Input[str]]' = []
         if opts.aliases is not None:
             for alias in opts.aliases:
                 self._aliases.append(collapse_alias_to_urn(

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """The Resource module, containing all resource-related definitions."""
-from typing import Optional, List, Any, Mapping, Union, Callable, TYPE_CHECKING
+from typing import Optional, List, Any, Mapping, Union, Callable, TYPE_CHECKING, cast
 
 import copy
 
@@ -568,7 +568,7 @@ class Resource:
     A collection of transformations to apply as part of resource registration.
     """
 
-    _aliases: 'Input[str]'
+    _aliases: 'List[Input[str]]'
     """
     A list of aliases applied to this resource.
     """
@@ -683,7 +683,7 @@ class Resource:
         # Collapse any `Alias`es down to URNs. We have to wait until this point to do so because we
         # do not know the default `name` and `type` to apply until we are inside the resource
         # constructor.
-        self._aliases = []
+        self._aliases: List[Input[str]] = []
         if opts.aliases is not None:
             for alias in opts.aliases:
                 self._aliases.append(collapse_alias_to_urn(

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -702,7 +702,8 @@ class Resource:
             if not custom:
                 raise Exception(
                     "Cannot read an existing resource unless it has a custom provider")
-            read_resource(self, t, name, props, opts)
+            res = cast('CustomResource', self)
+            read_resource(res, t, name, props, opts)
         else:
             register_resource(self, t, name, custom, props, opts)
 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -202,7 +202,8 @@ def collapse_alias_to_urn(
 
         return create_urn(name, type_, parent, project, stack)
 
-    return Output.from_input(alias).apply(collapse_alias_to_urn_worker) # type: ignore
+    inputAlias: Output[Union[Alias, str]] = Output.from_input(alias)
+    return inputAlias.apply(collapse_alias_to_urn_worker)
 
 class ResourceTransformationArgs:
     """

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -523,7 +523,7 @@ def _expand_providers(options: 'ResourceOptions'):
 
 def _collapse_providers(opts: 'ResourceOptions'):
     # If we have only 0-1 providers, then merge that back down to the .provider field.
-    providers: Union[Mapping[str, ProviderResource], List[ProviderResource], None] = opts.providers
+    providers: Optional[Union[Mapping[str, ProviderResource], List[ProviderResource]]] = opts.providers
     if providers is not None:
         provider_length = len(providers)
         if provider_length == 0:
@@ -705,8 +705,7 @@ class Resource:
             if not custom:
                 raise Exception(
                     "Cannot read an existing resource unless it has a custom provider")
-            res = cast('CustomResource', self)
-            read_resource(res, t, name, props, opts)
+            read_resource(cast('CustomResource', self), t, name, props, opts)
         else:
             register_resource(self, t, name, custom, props, opts)
 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -161,7 +161,9 @@ class Alias:
     The previous project of the resource. If not provided, defaults to `pulumi.getProject()`.
     """
 
-    #ignoring ... types as this value is used as a sentinal marker
+    # Ignoring type errors associated with the ellipsis constant being assigned to a string value.
+    # We use it as a internal sentinal value, and don't need to expose this in the user facing type system.
+    # https://docs.python.org/3/library/constants.html#Ellipsis
     def __init__(self,
                  name: Optional[str] = ..., # type: ignore
                  type_: Optional[str] = ..., # type: ignore

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -873,7 +873,8 @@ def export(name: str, value: Any):
     :param str name: The name to assign to this output.
     :param Any value: The value of this output.
     """
-    stack = cast(Stack, get_root_resource()) # pylint: disable=used-before-assignment
+    stack = cast('Stack', get_root_resource())
+
     if stack is not None:
         stack.output(name, value)
 
@@ -907,6 +908,7 @@ def create_urn(
             project = get_project()
 
         parent_prefix = Output.from_input("urn:pulumi:" + stack + "::" + project + "::")
+
     all_args = [parent_prefix, type_, name]
-    return Output.all(all_args).apply(
-        lambda arr: arr[0] + arr[1] + "::" + arr[2])
+    # invariant http://mypy.readthedocs.io/en/latest/common_issues.html#variance
+    return Output.all(*all_args).apply(lambda arr: arr[0] + arr[1] + "::" + arr[2]) # type: ignore

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from .runtime.stack import Stack
 
 
+
 class CustomTimeouts:
     create: Optional[str]
     """
@@ -874,10 +875,11 @@ def export(name: str, value: Any):
     :param str name: The name to assign to this output.
     :param Any value: The value of this output.
     """
-    stack = cast('Stack', get_root_resource())
-
-    if stack is not None:
-        stack.output(name, value)
+    res = cast('Stack', get_root_resource())
+    if known_types.is_stack(res):
+        res.output(name, value)
+    else:
+        raise Exception("Failed to export output. Root resource is not an instance of 'Stack'")
 
 
 def create_urn(

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -39,8 +39,8 @@ if sys.version_info[0] == 3 and sys.version_info[1] < 7:
     _enter_task = enter_task
     _leave_task = leave_task
 else:
-    _enter_task = asyncio.tasks._enter_task
-    _leave_task = asyncio.tasks._leave_task
+    _enter_task = asyncio.tasks._enter_task # type: ignore
+    _leave_task = asyncio.tasks._leave_task # type: ignore
 
 
 def _sync_await(awaitable: Awaitable[Any]) -> Any:
@@ -72,17 +72,17 @@ def _sync_await(awaitable: Awaitable[Any]) -> Any:
     #
     # See https://github.com/python/cpython/blob/3.6/Lib/asyncio/base_events.py#L1428-L1452 for the details of the
     # _run_once kernel with which we need to cooperate.
-    ntodo = len(loop._ready)
+    ntodo = len(loop._ready) # type: ignore
     while not fut.done() and not fut.cancelled():
-        loop._run_once()
-        if loop._stopping:
+        loop._run_once() # type: ignore
+        if loop._stopping: # type: ignore
             break
     # If we drained the ready list past what a calling _run_once would have expected, fix things up by pushing
     # cancelled handles onto the list.
-    while len(loop._ready) < ntodo:
-        handle = asyncio.Handle(None, None, loop)
+    while len(loop._ready) < ntodo: # type: ignore
+        handle = asyncio.Handle(lambda: None, [], loop)
         handle._cancelled = True
-        loop._ready.append(handle)
+        loop._ready.append(handle) # type: ignore
 
     # If we were executing inside a task, restore its context and continue on.
     if task is not None:

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -15,7 +15,7 @@
 The known_types module contains state for keeping track of types that
 are known to be special in the Pulumi type system.
 
-Python strictly disallows circular references between imported packages.    
+Python strictly disallows circular references between imported packages.
 Because the Pulumi top-level module depends on the `pulumi.runtime` submodule,
 it is not allowed for `pulumi.runtime` to reach back to the `pulumi` top-level
 to reference types that are defined there.
@@ -38,7 +38,7 @@ _custom_resource_type: Optional[type] = None
 _asset_resource_type: Optional[type] = None
 """The type of Asset. Filled-in as the Pulumi package is initializing."""
 
-_file_asset_resource_type: Optional[type] = None 
+_file_asset_resource_type: Optional[type] = None
 """The type of FileAsset. Filled-in as the Pulumi package is initializing."""
 
 _string_asset_resource_type: Optional[type] = None

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -59,6 +59,9 @@ _file_archive_resource_type: Optional[type] = None
 _remote_archive_resource_type: Optional[type] = None
 """The type of RemoteArchive. Filled-in as the Pulumi package is initializing."""
 
+_stack_resource_type: Optional[type] = None
+"""The type of Stack. Filled-in as the Pulumi package is initializing."""
+
 _output_type: Optional[type] = None
 """The type of Output. Filled-in as the Pulumi package is initializing."""
 
@@ -163,6 +166,16 @@ def custom_resource(class_obj: type) -> type:
     _custom_resource_type = class_obj
     return class_obj
 
+def stack(class_obj: type) -> type:
+    """
+    Decorator to annotate the Stack class. Registers the decorated class
+    as the Stack known type.
+    """
+    assert isinstance(class_obj, type), "class_obj is not a Class"
+    global _stack_resource_type
+    _stack_resource_type = class_obj
+    return class_obj
+
 
 def output(class_obj: type) -> type:
     assert isinstance(class_obj, type), "class_obj is not a Class"
@@ -254,6 +267,11 @@ def is_custom_resource(obj: Any) -> bool:
     """
     return _custom_resource_type is not None and isinstance(obj, _custom_resource_type)
 
+def is_stack(obj: Any) -> bool:
+    """
+    Returns true if the given type is an Output, false otherwise.
+    """
+    return _stack_resource_type is not None and isinstance(obj, _stack_resource_type)
 
 def is_output(obj: Any) -> bool:
     """

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -15,7 +15,7 @@
 The known_types module contains state for keeping track of types that
 are known to be special in the Pulumi type system.
 
-Python strictly disallows circular references between imported packages.
+Python strictly disallows circular references between imported packages.    
 Because the Pulumi top-level module depends on the `pulumi.runtime` submodule,
 it is not allowed for `pulumi.runtime` to reach back to the `pulumi` top-level
 to reference types that are defined there.
@@ -38,7 +38,7 @@ _custom_resource_type: Optional[type] = None
 _asset_resource_type: Optional[type] = None
 """The type of Asset. Filled-in as the Pulumi package is initializing."""
 
-_file_asset_resource_type: Optional[type] = None
+_file_asset_resource_type: Optional[type] = None 
 """The type of FileAsset. Filled-in as the Pulumi package is initializing."""
 
 _string_asset_resource_type: Optional[type] = None
@@ -182,56 +182,56 @@ def new_file_asset(*args: Any) -> Any:
     """
     Instantiates a new FileAsset, passing the given arguments to the constructor.
     """
-    return _file_asset_resource_type(*args)
+    return _file_asset_resource_type(*args) # type: ignore
 
 
 def new_string_asset(*args: Any) -> Any:
     """
     Instantiates a new StringAsset, passing the given arguments to the constructor.
     """
-    return _string_asset_resource_type(*args)
+    return _string_asset_resource_type(*args) # type: ignore
 
 
 def new_remote_asset(*args: Any) -> Any:
     """
     Instantiates a new StringAsset, passing the given arguments to the constructor.
     """
-    return _remote_asset_resource_type(*args)
+    return _remote_asset_resource_type(*args) # type: ignore
 
 
 def new_asset_archive(*args: Any) -> Any:
     """
     Instantiates a new AssetArchive, passing the given arguments to the constructor.
     """
-    return _asset_archive_resource_type(*args)
+    return _asset_archive_resource_type(*args) # type: ignore
 
 
 def new_file_archive(*args: Any) -> Any:
     """
     Instantiates a new FileArchive, passing the given arguments to the constructor.
     """
-    return _file_archive_resource_type(*args)
+    return _file_archive_resource_type(*args) # type: ignore
 
 
 def new_remote_archive(*args: Any) -> Any:
     """
     Instantiates a new StringArchive, passing the given arguments to the constructor.
     """
-    return _remote_archive_resource_type(*args)
+    return _remote_archive_resource_type(*args) # type: ignore
 
 
 def new_output(*args: Any) -> Any:
     """
     Instantiates a new Output, passing the given arguments to the constructor.
     """
-    return _output_type(*args)
+    return _output_type(*args) # type: ignore
 
 
 def new_unknown(*args: Any) -> Any:
     """
     Instantiates a new Unknown, passing the given arguments to the constructor.
     """
-    return _unknown_type(*args)
+    return _unknown_type(*args) # type: ignore
 
 
 def is_asset(obj: Any) -> bool:

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -15,7 +15,7 @@ import asyncio
 import sys
 import traceback
 
-from typing import Optional, Any, Callable, List, NamedTuple, Dict, Set, Union, TYPE_CHECKING
+from typing import Optional, Any, Callable, List, NamedTuple, Dict, Set, Union, TYPE_CHECKING, cast
 from google.protobuf import struct_pb2
 import grpc
 
@@ -28,7 +28,7 @@ from ..metadata import get_project, get_stack
 from ..output import Output
 
 if TYPE_CHECKING:
-    from .. import Resource, ResourceOptions
+    from .. import Resource, ResourceOptions, CustomResource
     from ..output import Inputs
 
 
@@ -57,12 +57,12 @@ class ResourceResolverOperations(NamedTuple):
     An optional reference to a provider that should be used for this resource's CRUD operations.
     """
 
-    property_dependencies: Dict[str, List[str]]
+    property_dependencies: Dict[str, List[Optional[str]]]
     """
     A map from property name to the URNs of the resources the property depends on.
     """
 
-    aliases: List[str]
+    aliases: List[Optional[str]]
     """
     A list of aliases applied to this resource.
     """
@@ -88,7 +88,7 @@ async def prepare_resource(res: 'Resource',
     serialized_props = await rpc.serialize_properties(props, property_dependencies_resources, res.translate_input_property)
 
     # Wait for our parent to resolve
-    parent_urn = ""
+    parent_urn: Optional[str] = ""
     if opts is not None and opts.parent is not None:
         parent_urn = await opts.parent.urn.future()
     # TODO(sean) is it necessary to check the type here?
@@ -100,7 +100,7 @@ async def prepare_resource(res: 'Resource',
 
     # Construct the provider reference, if we were given a provider to use.
     provider_ref = None
-    if custom and opts.provider is not None:
+    if custom and opts is not None and opts.provider is not None:
         provider = opts.provider
 
         # If we were given a provider, wait for it to resolve and construct a provider reference from it.
@@ -110,7 +110,7 @@ async def prepare_resource(res: 'Resource',
         provider_ref = f"{provider_urn}::{provider_id}"
 
     dependencies = set(explicit_urn_dependencies)
-    property_dependencies: Dict[str, List[str]] = {}
+    property_dependencies: Dict[str, List[Optional[str]]] = {}
     for key, deps in property_dependencies_resources.items():
         urns = set()
         for dep in deps:
@@ -123,7 +123,7 @@ async def prepare_resource(res: 'Resource',
     # former has been processed in the Resource constructor prior to calling
     # `register_resource` - both adding new inherited aliases and simplifying aliases down
     # to URNs.
-    aliases = []
+    aliases: List[Optional[str]] = []
     for alias in res._aliases:
         alias_val = await Output.from_input(alias).future()
         if not alias_val in aliases:
@@ -132,7 +132,7 @@ async def prepare_resource(res: 'Resource',
     log.debug(f"resource {props} prepared")
     return ResourceResolverOperations(
         parent_urn,
-        serialized_props,
+        cast(Dict[str, Any], serialized_props),
         dependencies,
         provider_ref,
         property_dependencies,
@@ -142,7 +142,7 @@ async def prepare_resource(res: 'Resource',
 # pylint: disable=too-many-locals,too-many-statements
 
 
-def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: Optional['ResourceOptions']):
+def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: 'ResourceOptions'):
     if opts.id is None:
         raise Exception(
             "Cannot read resource whose options are lacking an ID value")
@@ -155,9 +155,9 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: Op
     #
     # Same as below, we initialize the URN property on the resource, which will always be resolved.
     log.debug(f"preparing read resource for RPC")
-    urn_future = asyncio.Future()
-    urn_known = asyncio.Future()
-    urn_secret = asyncio.Future()
+    urn_future: asyncio.Future = asyncio.Future()
+    urn_known: asyncio.Future = asyncio.Future()
+    urn_secret: asyncio.Future = asyncio.Future()
     urn_known.set_result(True)
     urn_secret.set_result(False)
     resolve_urn = urn_future.set_result
@@ -170,9 +170,11 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: Op
     #
     # Note that we technically already have the ID (opts.id), but it's more consistent with the rest
     # of the model to resolve it asynchronously along with all of the other resources.
-    resolve_value = asyncio.Future()
-    resolve_perform_apply = asyncio.Future()
-    resolve_secret = asyncio.Future()
+    res = cast(CustomResource, res)
+
+    resolve_value: asyncio.Future = asyncio.Future()
+    resolve_perform_apply: asyncio.Future = asyncio.Future()
+    resolve_secret: asyncio.Future = asyncio.Future()
     res.id = known_types.new_output(
         {res}, resolve_value, resolve_perform_apply, resolve_secret)
 
@@ -281,9 +283,9 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
     # Note: a resource urn will always get a value, and thus the output property
     # for it can always run .apply calls.
     log.debug(f"preparing resource for RPC")
-    urn_future = asyncio.Future()
-    urn_known = asyncio.Future()
-    urn_secret = asyncio.Future()
+    urn_future: asyncio.Future = asyncio.Future()
+    urn_known: asyncio.Future = asyncio.Future()
+    urn_secret: asyncio.Future = asyncio.Future()
     urn_known.set_result(True)
     urn_secret.set_result(False)
     resolve_urn = urn_future.set_result
@@ -292,11 +294,12 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
 
     # If a custom resource, make room for the ID property.
     resolve_id: Optional[Callable[[
-        Any, str, Optional[Exception]], None]] = None
+        Any, bool, Optional[Exception]], None]] = None
     if custom:
-        resolve_value = asyncio.Future()
-        resolve_perform_apply = asyncio.Future()
-        resolve_secret = asyncio.Future()
+        res = cast(CustomResource, res)
+        resolve_value: asyncio.Future = asyncio.Future()
+        resolve_perform_apply: asyncio.Future = asyncio.Future()
+        resolve_secret: asyncio.Future = asyncio.Future()
         res.id = known_types.new_output(
             {res}, resolve_value, resolve_perform_apply, resolve_secret)
 
@@ -409,7 +412,7 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
         "register resource", do_register)())
 
 
-def register_resource_outputs(res: 'Resource', outputs: 'Union[Inputs, Awaitable[Inputs], Output[Inputs]]'):
+def register_resource_outputs(res: 'Resource', outputs: 'Union[Inputs, Output[Inputs]]'):
     async def do_register_resource_outputs():
         urn = await res.urn.future()
         serialized_props = await rpc.serialize_properties(outputs, {})

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -171,7 +171,7 @@ def read_resource(res: 'CustomResource', ty: str, name: str, props: 'Inputs', op
     # Note that we technically already have the ID (opts.id), but it's more consistent with the rest
     # of the model to resolve it asynchronously along with all of the other resources.
 
-    resolve_value: asyncio.Future = asyncio.Future()
+    resolve_value: asyncio.Future[Any] = asyncio.Future()
     resolve_perform_apply: asyncio.Future[bool] = asyncio.Future()
     resolve_secret: asyncio.Future[bool] = asyncio.Future()
     res.id = known_types.new_output(
@@ -296,7 +296,7 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
         Any, bool, Optional[Exception]], None]] = None
     if custom:
         res = cast('CustomResource', res)
-        resolve_value: asyncio.Future = asyncio.Future()
+        resolve_value: asyncio.Future[Any] = asyncio.Future()
         resolve_perform_apply: asyncio.Future[bool] = asyncio.Future()
         resolve_secret: asyncio.Future[bool] = asyncio.Future()
         res.id = known_types.new_output(

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -155,7 +155,7 @@ def read_resource(res: 'CustomResource', ty: str, name: str, props: 'Inputs', op
     #
     # Same as below, we initialize the URN property on the resource, which will always be resolved.
     log.debug(f"preparing read resource for RPC")
-    urn_future: asyncio.Future[Output[str]] = asyncio.Future()
+    urn_future: asyncio.Future[Any] = asyncio.Future()
     urn_known: asyncio.Future[bool] = asyncio.Future()
     urn_secret: asyncio.Future[bool] = asyncio.Future()
     urn_known.set_result(True)
@@ -282,7 +282,7 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
     # Note: a resource urn will always get a value, and thus the output property
     # for it can always run .apply calls.
     log.debug(f"preparing resource for RPC")
-    urn_future: asyncio.Future[Output[str]] = asyncio.Future()
+    urn_future: asyncio.Future[Any] = asyncio.Future()
     urn_known: asyncio.Future[bool] = asyncio.Future()
     urn_secret: asyncio.Future[bool] = asyncio.Future()
     urn_known.set_result(True)

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -142,7 +142,7 @@ async def prepare_resource(res: 'Resource',
 # pylint: disable=too-many-locals,too-many-statements
 
 
-def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: 'ResourceOptions'):
+def read_resource(res: 'CustomResource', ty: str, name: str, props: 'Inputs', opts: 'ResourceOptions'):
     if opts.id is None:
         raise Exception(
             "Cannot read resource whose options are lacking an ID value")
@@ -170,7 +170,6 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: 'R
     #
     # Note that we technically already have the ID (opts.id), but it's more consistent with the rest
     # of the model to resolve it asynchronously along with all of the other resources.
-    res = cast('CustomResource', res)
 
     resolve_value: asyncio.Future = asyncio.Future()
     resolve_perform_apply: asyncio.Future[bool] = asyncio.Future()

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -170,7 +170,7 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: 'R
     #
     # Note that we technically already have the ID (opts.id), but it's more consistent with the rest
     # of the model to resolve it asynchronously along with all of the other resources.
-    res = cast(CustomResource, res) # pylint: disable=used-before-assignment
+    res = cast('CustomResource', res)
 
     resolve_value: asyncio.Future = asyncio.Future()
     resolve_perform_apply: asyncio.Future = asyncio.Future()
@@ -296,7 +296,7 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
     resolve_id: Optional[Callable[[
         Any, bool, Optional[Exception]], None]] = None
     if custom:
-        res = cast(CustomResource, res)
+        res = cast('CustomResource', res)
         resolve_value: asyncio.Future = asyncio.Future()
         resolve_perform_apply: asyncio.Future = asyncio.Future()
         resolve_secret: asyncio.Future = asyncio.Future()

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -155,9 +155,9 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: 'R
     #
     # Same as below, we initialize the URN property on the resource, which will always be resolved.
     log.debug(f"preparing read resource for RPC")
-    urn_future: asyncio.Future = asyncio.Future()
-    urn_known: asyncio.Future = asyncio.Future()
-    urn_secret: asyncio.Future = asyncio.Future()
+    urn_future: asyncio.Future[Output[str]] = asyncio.Future()
+    urn_known: asyncio.Future[bool] = asyncio.Future()
+    urn_secret: asyncio.Future[bool] = asyncio.Future()
     urn_known.set_result(True)
     urn_secret.set_result(False)
     resolve_urn = urn_future.set_result
@@ -173,8 +173,8 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: 'R
     res = cast('CustomResource', res)
 
     resolve_value: asyncio.Future = asyncio.Future()
-    resolve_perform_apply: asyncio.Future = asyncio.Future()
-    resolve_secret: asyncio.Future = asyncio.Future()
+    resolve_perform_apply: asyncio.Future[bool] = asyncio.Future()
+    resolve_secret: asyncio.Future[bool] = asyncio.Future()
     res.id = known_types.new_output(
         {res}, resolve_value, resolve_perform_apply, resolve_secret)
 
@@ -283,9 +283,9 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
     # Note: a resource urn will always get a value, and thus the output property
     # for it can always run .apply calls.
     log.debug(f"preparing resource for RPC")
-    urn_future: asyncio.Future = asyncio.Future()
-    urn_known: asyncio.Future = asyncio.Future()
-    urn_secret: asyncio.Future = asyncio.Future()
+    urn_future: asyncio.Future[Output[str]] = asyncio.Future()
+    urn_known: asyncio.Future[bool] = asyncio.Future()
+    urn_secret: asyncio.Future[bool] = asyncio.Future()
     urn_known.set_result(True)
     urn_secret.set_result(False)
     resolve_urn = urn_future.set_result
@@ -298,8 +298,8 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
     if custom:
         res = cast('CustomResource', res)
         resolve_value: asyncio.Future = asyncio.Future()
-        resolve_perform_apply: asyncio.Future = asyncio.Future()
-        resolve_secret: asyncio.Future = asyncio.Future()
+        resolve_perform_apply: asyncio.Future[bool] = asyncio.Future()
+        resolve_secret: asyncio.Future[bool] = asyncio.Future()
         res.id = known_types.new_output(
             {res}, resolve_value, resolve_perform_apply, resolve_secret)
 

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -170,7 +170,7 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: 'R
     #
     # Note that we technically already have the ID (opts.id), but it's more consistent with the rest
     # of the model to resolve it asynchronously along with all of the other resources.
-    res = cast(CustomResource, res)
+    res = cast(CustomResource, res) # pylint: disable=used-before-assignment
 
     resolve_value: asyncio.Future = asyncio.Future()
     resolve_perform_apply: asyncio.Future = asyncio.Future()
@@ -226,7 +226,7 @@ def read_resource(res: 'Resource', ty: str, name: str, props: 'Inputs', opts: 'R
                 additionalSecretOutputs=additional_secret_outputs,
             )
 
-            from ..resource import create_urn
+            from ..resource import create_urn # pylint: disable=import-outside-toplevel
             mock_urn = await create_urn(name, ty, resolver.parent_urn).future()
 
             def do_rpc_call():
@@ -366,7 +366,7 @@ def register_resource(res: 'Resource', ty: str, name: str, custom: bool, props: 
                 supportsPartialValues=True,
             )
 
-            from ..resource import create_urn
+            from ..resource import create_urn # pylint: disable=import-outside-toplevel
             mock_urn = await create_urn(name, ty, resolver.parent_urn).future()
 
             def do_rpc_call():

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -42,7 +42,7 @@ class ResourceResolverOperations(NamedTuple):
     This resource's parent URN.
     """
 
-    serialized_props: Dict[str, Any]
+    serialized_props: struct_pb2.Struct
     """
     This resource's input properties, serialized into protobuf structures.
     """
@@ -132,7 +132,7 @@ async def prepare_resource(res: 'Resource',
     log.debug(f"resource {props} prepared")
     return ResourceResolverOperations(
         parent_urn,
-        cast(Dict[str, Any], serialized_props),
+        serialized_props,
         dependencies,
         provider_ref,
         property_dependencies,

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -18,7 +18,7 @@ out of RPC calls.
 import asyncio
 import functools
 import inspect
-from typing import List, Any, Callable, Dict, Optional, TYPE_CHECKING
+from typing import List, Any, Callable, Dict, Optional, TYPE_CHECKING, cast
 
 from google.protobuf import struct_pb2
 import six
@@ -27,7 +27,8 @@ from .. import log
 
 if TYPE_CHECKING:
     from ..output import Inputs, Input
-    from ..resource import Resource
+    from ..resource import Resource, CustomResource
+    from ..asset import FileAsset, RemoteAsset, StringAsset, FileArchive, RemoteArchive, AssetArchive
 
 UNKNOWN = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
 """If a value is None, we serialize as UNKNOWN, which tells the engine that it may be computed later."""
@@ -63,7 +64,7 @@ async def serialize_properties(inputs: 'Inputs',
     """
     struct = struct_pb2.Struct()
     for k, v in inputs.items():
-        deps = []
+        deps: List['Resource'] = []
         result = await serialize_property(v, deps, input_transformer)
         # We treat properties that serialize to None as if they don't exist.
         if result is not None:
@@ -99,8 +100,9 @@ async def serialize_property(value: 'Input[Any]',
         return UNKNOWN
 
     if known_types.is_custom_resource(value):
-        deps.append(value)
-        return await serialize_property(value.id, deps, input_transformer)
+        resource = cast('CustomResource', value)
+        deps.append(resource)
+        return await serialize_property(resource.id, deps, input_transformer)
 
     if known_types.is_asset(value):
         # Serializing an asset requires the use of a magical signature key, since otherwise it would
@@ -111,11 +113,14 @@ async def serialize_property(value: 'Input[Any]',
         }
 
         if hasattr(value, "path"):
-            obj["path"] = await serialize_property(value.path, deps, input_transformer)
+            file_asset = cast('FileAsset', value)
+            obj["path"] = await serialize_property(file_asset.path, deps, input_transformer)
         elif hasattr(value, "text"):
-            obj["text"] = await serialize_property(value.text, deps, input_transformer)
+            str_asset = cast('StringAsset', value)
+            obj["text"] = await serialize_property(str_asset.text, deps, input_transformer)
         elif hasattr(value, "uri"):
-            obj["uri"] = await serialize_property(value.uri, deps, input_transformer)
+            remote_asset = cast('RemoteAsset', value)
+            obj["uri"] = await serialize_property(remote_asset.uri, deps, input_transformer)
         else:
             raise AssertionError(f"unknown asset type: {value}")
 
@@ -130,11 +135,14 @@ async def serialize_property(value: 'Input[Any]',
         }
 
         if hasattr(value, "assets"):
-            obj["assets"] = await serialize_property(value.assets, deps, input_transformer)
+            asset_archive = cast('AssetArchive', value)
+            obj["assets"] = await serialize_property(asset_archive.assets, deps, input_transformer)
         elif hasattr(value, "path"):
-            obj["path"] = await serialize_property(value.path, deps, input_transformer)
+            file_archive = cast('FileArchive', value)
+            obj["path"] = await serialize_property(file_archive.path, deps, input_transformer)
         elif hasattr(value, "uri"):
-            obj["uri"] = await serialize_property(value.uri, deps, input_transformer)
+            remote_archive = cast('RemoteArchive', value)
+            obj["uri"] = await serialize_property(remote_archive.uri, deps, input_transformer)
         else:
             raise AssertionError(f"unknown archive type: {value}")
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -331,9 +331,9 @@ def transfer_properties(res: 'Resource', props: 'Inputs') -> Dict[str, Resolver]
         resolve_is_known: 'asyncio.Future' = asyncio.Future()
         resolve_is_secret: 'asyncio.Future' = asyncio.Future()
 
-        def do_resolve(value_fut: asyncio.Future,
-                       known_fut: asyncio.Future,
-                       secret_fut: asyncio.Future,
+        def do_resolve(value_fut: 'asyncio.Future',
+                       known_fut: 'asyncio.Future[bool]',
+                       secret_fut: 'asyncio.Future[bool]',
                        value: Any,
                        is_known: bool,
                        is_secret: bool,

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -274,7 +274,8 @@ def deserialize_property(value: Any, keep_unknowns: Optional[bool] = None) -> An
 
     # ListValues are projected to lists
     if isinstance(value, struct_pb2.ListValue):
-        values = [deserialize_property(v, keep_unknowns) for v in value.values]
+        # values has no __iter__ defined but this works.
+        values = [deserialize_property(v, keep_unknowns) for v in value] # type: ignore
         # If there are any secret values in the list, push the secretness "up" a level by returning
         # an array that is marked as a secret with raw values inside.
         if any(is_rpc_secret(v) for v in values):

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -117,7 +117,7 @@ def is_legacy_apply_enabled():
     return bool(SETTINGS.legacy_apply_enabled)
 
 
-def get_project() -> Optional[str]:
+def get_project() -> str:
     """
     Returns the current project name.
     """
@@ -135,7 +135,7 @@ def _set_project(v: Optional[str]):
     SETTINGS.project = v
 
 
-def get_stack() -> Optional[str]:
+def get_stack() -> str:
     """
     Returns the current stack name.
     """

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -24,6 +24,7 @@ from ..resource import ComponentResource, Resource, ResourceTransformation
 from .settings import get_project, get_stack, get_root_resource, is_dry_run, set_root_resource
 from .rpc_manager import RPC_MANAGER
 from .. import log
+from . import known_types
 
 from ..output import Output
 
@@ -71,7 +72,7 @@ async def run_in_stack(func: Callable):
     if RPC_MANAGER.unhandled_exception is not None:
         raise RPC_MANAGER.unhandled_exception.with_traceback(RPC_MANAGER.exception_traceback)
 
-
+@known_types.stack
 class Stack(ComponentResource):
     """
     A synthetic stack component that automatically parents resources as the program runs.

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from asyncio import ensure_future
-from typing import Optional, Any, List
+from typing import Optional, Any, List, Callable
 from copy import deepcopy
 
 from .output import Output, Input
@@ -67,7 +67,7 @@ class StackReference(CustomResource):
 
         :param Input[str] name: The name of the stack output to fetch.
         """
-        value = Output.all(Output.from_input(name), self.outputs).apply(lambda l: l[1].get(l[0]))
+        value: Output[Any] = Output.all([Output.from_input(name), self.outputs]).apply(lambda l: l[1].get(l[0])) # type: ignore
         is_secret = ensure_future(self.__is_secret_name(name))
 
         return Output(value.resources(), value.future(), value.is_known(), is_secret)
@@ -80,7 +80,7 @@ class StackReference(CustomResource):
         :param Input[str] name: The name of the stack output to fetch.
         """
 
-        value = Output.all(Output.from_input(name), self.outputs).apply(lambda l: l[1][l[0]])
+        value = Output.all(Output.from_input(name), self.outputs).apply(lambda l: l[1][l[0]]) # type: ignore
         is_secret = ensure_future(self.__is_secret_name(name))
 
         return Output(value.resources(), value.future(), value.is_known(), is_secret)

--- a/sdk/python/mypy.ini
+++ b/sdk/python/mypy.ini
@@ -4,6 +4,11 @@
 
 # Per-module options:
 
+# grpc python lib is untyped
+[mypy-grpc]
+ignore_missing_imports = True
+
 # grpc generated
- [mypy-pulumi.runtime.proto.*]
- ignore_errors = True
+[mypy-pulumi.runtime.proto.*]
+ignore_errors = True
+

--- a/sdk/python/mypy.ini
+++ b/sdk/python/mypy.ini
@@ -4,8 +4,10 @@
 
 # Per-module options:
 
-# grpc python lib is untyped
 [mypy-grpc]
+ignore_missing_imports = True
+
+[mypy-dill]
 ignore_missing_imports = True
 
 # grpc generated

--- a/sdk/python/mypy.ini
+++ b/sdk/python/mypy.ini
@@ -1,0 +1,9 @@
+# Global options:
+
+[mypy]
+
+# Per-module options:
+
+# grpc generated
+ [mypy-pulumi.runtime.proto.*]
+ ignore_errors = True


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/3710, and enables us to merge https://github.com/pulumi/pulumi/pull/3704 so that we can start distributing Python types as a part of our SDK.

There were ~ 150 errors that I had to work through so my general methodology was to spend ~10 minutes per error and then move on (by using `# type: ignore`) if there wasn't an obvious solution. I'm not a python or type system expert by any means, so if anyone has some suggestions to tighten things up here I'm all ears. 

Regardless this is a good starting point, stops the bleeding, and opens up the opportunity to make incremental improvements as we continue to work on the Python SDK. The most painful part was probably the type confusion that comes along with using `all` and `apply` when using multiple output types simultaneously.

There were ~30 instances where I used `ignore` and another 20 where I had to cast. I definitely found a few legitimate bugs along the way, but nothing serious. 