### PR TITLE
Fix the pipeline ID and PR URL for GitLab CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ CHANGELOG
 
 - Add `pulumi policy ls` and `pulumi policy group ls` to list Policy related resources.
 
+- Update GitLab CI detection code for setting an update's `BuildID` and `PRNumber` metadata properties. [#3763](https://github.com/pulumi/pulumi/pull/3763)
+
 ## 1.8.1 (2019-12-20)
 
 - Fix a panic in `pulumi stack select`. [#3687](https://github.com/pulumi/pulumi/pull/3687)

--- a/pkg/util/ciutil/gitlab.go
+++ b/pkg/util/ciutil/gitlab.go
@@ -33,7 +33,7 @@ func (gl gitlabCI) DetectVars() Vars {
 	v.SHA = os.Getenv("CI_COMMIT_SHA")
 	v.BranchName = os.Getenv("CI_COMMIT_REF_NAME")
 	v.CommitMessage = os.Getenv("CI_COMMIT_MESSAGE")
-	v.PRNumber = os.Getenv("CI_MERGE_REQUEST_ID")
+	v.PRNumber = os.Getenv("CI_MERGE_REQUEST_IID")
 
 	return v
 }

--- a/pkg/util/ciutil/gitlab.go
+++ b/pkg/util/ciutil/gitlab.go
@@ -27,7 +27,7 @@ type gitlabCI struct {
 // See https://docs.gitlab.com/ee/ci/variables/.
 func (gl gitlabCI) DetectVars() Vars {
 	v := Vars{Name: gl.Name}
-	v.BuildID = os.Getenv("CI_JOB_ID")
+	v.BuildID = os.Getenv("CI_PIPELINE_IID")
 	v.BuildType = os.Getenv("CI_PIPELINE_SOURCE")
 	v.BuildURL = os.Getenv("CI_JOB_URL")
 	v.SHA = os.Getenv("CI_COMMIT_SHA")

--- a/pkg/util/ciutil/vars_test.go
+++ b/pkg/util/ciutil/vars_test.go
@@ -49,9 +49,9 @@ func TestDetectVars(t *testing.T) {
 			"PULUMI_CI_BUILD_ID": buildID,
 		},
 		GitLab: {
-			"TRAVIS":    "",
-			"GITLAB_CI": "true",
-			"CI_JOB_ID": buildID,
+			"TRAVIS":          "",
+			"GITLAB_CI":       "true",
+			"CI_PIPELINE_IID": buildID,
 		},
 		Travis: {
 			"TRAVIS":        "true",


### PR DESCRIPTION
This PR updates the GitLab env vars, that are used to set the `BuildID` and `PRNumber` in the update environment bag. Details of the changes are inline in the diff.