### PR TITLE
Add a new BuildNumber property to the backend metadata bag and CI vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
 
 - Add `pulumi policy ls` and `pulumi policy group ls` to list Policy related resources.
 
-- Update GitLab CI detection code for setting an update's `BuildID` and `PRNumber` metadata properties. [#3763](https://github.com/pulumi/pulumi/pull/3763)
+- Add `BuildNumber` to CI vars and backend metadata property bag for CI systems that have separate ID and a user-friendly number.
 
 ## 1.8.1 (2019-12-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ CHANGELOG
 
 - Add `pulumi policy ls` and `pulumi policy group ls` to list Policy related resources.
 
-- Add `BuildNumber` to CI vars and backend metadata property bag for CI systems that have separate ID and a user-friendly number.
+- Add `BuildNumber` to CI vars and backend metadata property bag for CI systems that have separate ID and a user-friendly number. [#3766](https://github.com/pulumi/pulumi/pull/3766)
 
 ## 1.8.1 (2019-12-20)
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -602,6 +602,7 @@ func addCIMetadataToEnvironment(env map[string]string) {
 	}
 	env[backend.CISystem] = string(vars.Name)
 	addIfSet(backend.CIBuildID, vars.BuildID)
+	addIfSet(backend.CIBuildNumer, vars.BuildNumber)
 	addIfSet(backend.CIBuildType, vars.BuildType)
 	addIfSet(backend.CIBuildURL, vars.BuildURL)
 	addIfSet(backend.CIPRHeadSHA, vars.SHA)

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -70,6 +70,10 @@ const (
 	CISystem = "ci.system"
 	// CIBuildID is an opaque ID of the build in the CI system.
 	CIBuildID = "ci.build.id"
+	// CIBuildNumber is a sequentially incrementing number specific for a project/repo.
+	// This value is only set for CI systems that have separate Build ID and a Build Number.
+	// If this value is blank, use `CIBuildID` always.
+	CIBuildNumer = "ci.build.number"
 	// CIBuildType is the type of build of the CI system, e.g. "push", "pull_request", "test_only".
 	CIBuildType = "ci.build.type"
 	// CIBuildURL is a URL to get more information about the particular CI build.

--- a/pkg/util/ciutil/codefresh.go
+++ b/pkg/util/ciutil/codefresh.go
@@ -24,6 +24,7 @@ type codefreshCI struct {
 }
 
 // DetectVars detects the env vars for a Codefresh CI system.
+// See: https://codefresh.io/docs/docs/codefresh-yaml/variables/
 func (c codefreshCI) DetectVars() Vars {
 	v := Vars{Name: c.Name}
 	v.BuildID = os.Getenv("CF_BUILD_ID")

--- a/pkg/util/ciutil/gitlab.go
+++ b/pkg/util/ciutil/gitlab.go
@@ -27,7 +27,8 @@ type gitlabCI struct {
 // See https://docs.gitlab.com/ee/ci/variables/.
 func (gl gitlabCI) DetectVars() Vars {
 	v := Vars{Name: gl.Name}
-	v.BuildID = os.Getenv("CI_PIPELINE_IID")
+	v.BuildID = os.Getenv("CI_PIPELINE_ID")
+	v.BuildNumber = os.Getenv("CI_PIPELINE_IID")
 	v.BuildType = os.Getenv("CI_PIPELINE_SOURCE")
 	v.BuildURL = os.Getenv("CI_JOB_URL")
 	v.SHA = os.Getenv("CI_COMMIT_SHA")

--- a/pkg/util/ciutil/systems.go
+++ b/pkg/util/ciutil/systems.go
@@ -67,7 +67,13 @@ type Vars struct {
 	// Name is a required friendly name of the CI system.
 	Name SystemName
 	// BuildID is an optional unique identifier for the current build/job.
+	// In some CI systems the build ID is a system-wide unique internal ID
+	// and the `BuildNumber` is the repo/project-specific unique ID.
 	BuildID string
+	// BuildNumber is the unique identifier of a build within a project/repository.
+	// This is only set for CI systems that expose both the internal ID, as well as
+	// a project/repo-specific ID.
+	BuildNumber string
 	// BuildType is an optional friendly type name of the build/job type.
 	BuildType string
 	// BuildURL is an optional URL for this build/job's webpage.

--- a/pkg/util/ciutil/travis.go
+++ b/pkg/util/ciutil/travis.go
@@ -28,6 +28,7 @@ type travisCI struct {
 func (t travisCI) DetectVars() Vars {
 	v := Vars{Name: Travis}
 	v.BuildID = os.Getenv("TRAVIS_JOB_ID")
+	v.BuildNumber = os.Getenv("TRAVIS_JOB_NUMBER")
 	v.BuildType = os.Getenv("TRAVIS_EVENT_TYPE")
 	v.BuildURL = os.Getenv("TRAVIS_BUILD_WEB_URL")
 	v.SHA = os.Getenv("TRAVIS_PULL_REQUEST_SHA")

--- a/pkg/util/ciutil/vars_test.go
+++ b/pkg/util/ciutil/vars_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 func TestDetectVars(t *testing.T) {
-	buildID := "123"
+	buildNumber := "123"
+	buildID := "87638724"
 	systemAndEnvVars := map[SystemName]map[string]string{
 		// Since the `pulumi/pulumi` repo runs on Travis,
 		// we set the TRAVIS env var to an empty string for all test cases
@@ -31,31 +32,33 @@ func TestDetectVars(t *testing.T) {
 		AzurePipelines: {
 			"TRAVIS":        "",
 			"TF_BUILD":      "true",
-			"BUILD_BUILDID": buildID,
+			"BUILD_BUILDID": buildNumber,
 		},
 		CircleCI: {
 			"TRAVIS":           "",
 			"CIRCLECI":         "true",
-			"CIRCLE_BUILD_NUM": buildID,
+			"CIRCLE_BUILD_NUM": buildNumber,
 		},
 		Codefresh: {
 			"TRAVIS":       "",
 			"CF_BUILD_URL": "https://g.codefresh.io/build/99f5d825577e23c56f8c6b2a",
-			"CF_BUILD_ID":  buildID,
+			"CF_BUILD_ID":  buildNumber,
 		},
 		GenericCI: {
 			"TRAVIS":             "",
 			"PULUMI_CI_SYSTEM":   "generic-ci-system",
-			"PULUMI_CI_BUILD_ID": buildID,
+			"PULUMI_CI_BUILD_ID": buildNumber,
 		},
 		GitLab: {
 			"TRAVIS":          "",
 			"GITLAB_CI":       "true",
-			"CI_PIPELINE_IID": buildID,
+			"CI_PIPELINE_ID":  buildID,
+			"CI_PIPELINE_IID": buildNumber,
 		},
 		Travis: {
-			"TRAVIS":        "true",
-			"TRAVIS_JOB_ID": buildID,
+			"TRAVIS":            "true",
+			"TRAVIS_JOB_ID":     buildID,
+			"TRAVIS_JOB_NUMBER": buildNumber,
 		},
 	}
 
@@ -72,9 +75,20 @@ func TestDetectVars(t *testing.T) {
 				os.Setenv(envVar, envVars[envVar])
 			}
 			vars := DetectVars()
-			assert.Equal(t,
-				buildID, vars.BuildID,
-				"%v did not set the expected build ID %v in the Vars struct.", system, buildID)
+			// For CI systems where the build number and the ID are the same,
+			// only the BuildID is set and is considered to be the build "number".
+			if vars.BuildNumber == "" {
+				assert.Equal(t,
+					buildNumber, vars.BuildID,
+					"%v did not set the expected build ID %v in the Vars struct.", system, buildNumber)
+			} else {
+				assert.Equal(t,
+					buildID, vars.BuildID,
+					"%v did not set the expected build ID %v in the Vars struct.", system, buildNumber)
+				assert.Equal(t,
+					buildNumber, vars.BuildNumber,
+					"%v did not set the expected build number %v in the Vars struct.", system, buildNumber)
+			}
 
 			// Restore any modified env vars back to their original value
 			// if we previously saved it. Otherwise, just unset it.


### PR DESCRIPTION
Some CI systems use two versions of a build "ID". One is an internal "ID" that is used for API calls and in URLs. We need to also distinguish them as such so that the right value is used later. For example, systems like Travis CI use the internal "ID" value in their URLs, but always use the "number" as the user-friendly display value. This is why when you click on the build # URL on travis-ci.com or travis-ci.org, the URL has a big int instead of the value that you see, even though the build URL is scoped to your repository. The same applies to the GitLab as well.