### PR TITLE
Add Current Operation info to stack command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Add information about in-flight operations to `pulumi stack`.
+
 - Lock dep ts-node to v8.5.4 [#3733](https://github.com/pulumi/pulumi/pull/3733)
 
 - Improvements to `pulumi policy` functionality. Add ability to remove & disable Policy Packs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-- Add information about in-flight operations to `pulumi stack`.
-
 - Lock dep ts-node to v8.5.4 [#3733](https://github.com/pulumi/pulumi/pull/3733)
 
 - Improvements to `pulumi policy` functionality. Add ability to remove & disable Policy Packs.

--- a/pkg/apitype/core.go
+++ b/pkg/apitype/core.go
@@ -364,9 +364,17 @@ type Stack struct {
 	OrgName     string       `json:"orgName"`
 	ProjectName string       `json:"projectName"`
 	StackName   tokens.QName `json:"stackName"`
-
-	ActiveUpdate string                  `json:"activeUpdate"`
-	Tags         map[StackTagName]string `json:"tags,omitempty"`
+	// CurrentOperation provides information about a stack operation in-progress, as applicable.
+	CurrentOperation *OperationStatus        `json:"currentOperation,omitempty"`
+	ActiveUpdate     string                  `json:"activeUpdate"`
+	Tags             map[StackTagName]string `json:"tags,omitempty"`
 
 	Version int `json:"version"`
+}
+
+// OperationStatus describes the state of an operation being performed on a Pulumi stack.
+type OperationStatus struct {
+	Kind    UpdateKind `json:"kind"`
+	Author  string     `json:"author"`
+	Started int64      `json:"started"`
 }

--- a/pkg/apitype/stacks.go
+++ b/pkg/apitype/stacks.go
@@ -23,7 +23,7 @@ type StackSummary struct {
 	// StackName is the name of the stack.
 	StackName string `json:"stackName"`
 
-	// LastUpdate is a Unix timestamp of the stack's last update, as applicable.
+	// LastUpdate is a Unix timestamp of the start time of the stack's last update, as applicable.
 	LastUpdate *int64 `json:"lastUpdate,omitempty"`
 
 	// ResourceCount is the number of resources associated with this stack, as applicable.

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -77,7 +77,7 @@ type cloudStack struct {
 	cloudURL string
 	// orgName is the organization that owns this stack.
 	orgName string
-	// currentOperation contains kind, author, and start time of current operation.
+	// currentOperation contains information about any current operation being performed on the stack, as applicable.
 	currentOperation *apitype.OperationStatus
 	// snapshot contains the latest deployment state, allocated on first use.
 	snapshot **deploy.Snapshot


### PR DESCRIPTION
This partially addresses issue #3535, users would like to see if there is already an update or other operation in progress.  The author, type of operation, and start time will display with the `pulumi stack` command if there is an in-flight operation. 