### PR TITLE
Remove version req for disable; Add --latest to enable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ CHANGELOG
 
 - Breaking changes for the Go SDK. Complete details are in [#3506](https://github.com/pulumi/pulumi/pull/3506).
 
+- Add `--latest` flag to `pulumi policy enable`.
+
+- Breaking change for Policy which removes requirement for version when running `pulumi policy disable`. Add `--version` flag if user wants to specify version of Policy Pack to disable.
+
 ## 1.8.1 (2019-12-20)
 
 - Fix a panic in `pulumi stack select`. [#3687](https://github.com/pulumi/pulumi/pull/3687)

--- a/cmd/policy_disable.go
+++ b/cmd/policy_disable.go
@@ -53,7 +53,8 @@ func newPolicyDisableCmd() *cobra.Command {
 
 	cmd.PersistentFlags().IntVar(
 		&args.version, "version", 0,
-		"The version of the Policy Pack that will be disabled; if not specified, any enabled version of the Policy Pack will be disabled")
+		"The version of the Policy Pack that will be disabled; "+
+			"if not specified, any enabled version of the Policy Pack will be disabled")
 
 	return cmd
 }

--- a/cmd/policy_enable.go
+++ b/cmd/policy_enable.go
@@ -53,11 +53,12 @@ func newPolicyEnableCmd() *cobra.Command {
 
 			// Parse version if it's specified.
 			var version *int
-			if len(cliArgs) == 2 {
-				*version, err = strconv.Atoi(cliArgs[1])
+			if len(cliArgs) > 1 {
+				v, err := strconv.Atoi(cliArgs[1])
 				if err != nil {
 					return errors.Wrapf(err, "Could not parse version (should be an integer)")
 				}
+				version = &v
 			}
 
 			// Attempt to enable the Policy Pack.

--- a/cmd/policy_enable.go
+++ b/cmd/policy_enable.go
@@ -25,16 +25,17 @@ import (
 
 type policyEnableArgs struct {
 	policyGroup string
+	latest      bool
 }
 
 func newPolicyEnableCmd() *cobra.Command {
 	args := policyEnableArgs{}
 
 	var cmd = &cobra.Command{
-		Use:   "enable <org-name>/<policy-pack-name> <version>",
-		Args:  cmdutil.ExactArgs(2),
+		Use:   "enable <org-name>/<policy-pack-name> [version]",
+		Args:  cmdutil.RangeArgs(1, 2),
 		Short: "Enable a Policy Pack for a Pulumi organization",
-		Long:  "Enable a Policy Pack for a Pulumi organization",
+		Long:  "Enable a Policy Pack for a Pulumi organization. Version or latest flag must be specified.",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {
 			// Obtain current PolicyPack, tied to the Pulumi service backend.
 			policyPack, err := requirePolicyPack(cliArgs[0])
@@ -42,13 +43,25 @@ func newPolicyEnableCmd() *cobra.Command {
 				return err
 			}
 
-			version, err := strconv.Atoi(cliArgs[1])
-			if err != nil {
-				return errors.Wrapf(err, "Could not parse version (should be an integer)")
+			// Make sure that a version or latest is specified. Having both or neither
+			// specified would make this an ambiguous request.
+			if len(cliArgs) < 2 && !args.latest {
+				return errors.New("must specify a version or the --latest flag")
+			} else if len(cliArgs) == 2 && args.latest {
+				return errors.New("cannot specify both a version and the --latest flag")
 			}
 
-			// Attempt to enable the PolicyPack.
-			return policyPack.Apply(commandContext(), args.policyGroup, backend.PolicyPackOperation{
+			// Parse version if it's specified.
+			var version *int
+			if len(cliArgs) == 2 {
+				*version, err = strconv.Atoi(cliArgs[1])
+				if err != nil {
+					return errors.Wrapf(err, "Could not parse version (should be an integer)")
+				}
+			}
+
+			// Attempt to enable the Policy Pack.
+			return policyPack.Enable(commandContext(), args.policyGroup, backend.PolicyPackOperation{
 				Version: version, Scopes: cancellationScopes})
 		}),
 	}
@@ -56,6 +69,9 @@ func newPolicyEnableCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVar(
 		&args.policyGroup, "policy-group", "",
 		"The Policy Group for which the Policy Pack will be enabled; if not specified, the default Policy Group is used")
+
+	cmd.PersistentFlags().BoolVarP(
+		&args.latest, "latest", "l", false, "Enable the latest version of the Policy Pack")
 
 	return cmd
 }

--- a/cmd/policy_rm.go
+++ b/cmd/policy_rm.go
@@ -44,7 +44,7 @@ func newPolicyRmCmd() *cobra.Command {
 
 			// Attempt to remove the Policy Pack.
 			return policyPack.Remove(commandContext(), backend.PolicyPackOperation{
-				Version: version, Scopes: cancellationScopes})
+				Version: &version, Scopes: cancellationScopes})
 		}),
 	}
 

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -97,12 +97,6 @@ type GetPolicyPackResponse struct {
 	Applied     bool     `json:"applied"`
 }
 
-// ApplyPolicyPackRequest is the request to apply a Policy Pack to an organization.
-type ApplyPolicyPackRequest struct {
-	Name    string `json:"name"`
-	Version int    `json:"version"`
-}
-
 // GetStackPolicyPacksResponse is the response to getting the applicable Policy Packs
 // for a particular stack. This allows the CLI to download the packs prior to
 // starting an update.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -588,15 +588,9 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 func (pc *Client) ApplyPolicyPack(ctx context.Context, orgName string, policyGroup string,
 	policyPackName string, version int) error {
 
+	// If a Policy Group was not specified, we use the default Policy Group.
 	if policyGroup == "" {
-		req := apitype.ApplyPolicyPackRequest{Name: policyPackName, Version: version}
-
-		err := pc.restCall(
-			ctx, "POST", applyPolicyPackPath(orgName, policyPackName, version), nil, req, nil)
-		if err != nil {
-			return errors.Wrapf(err, "Enable policy pack failed")
-		}
-		return nil
+		policyGroup = apitype.DefaultPolicyGroup
 	}
 
 	// If a Policy Group was specified, enable it for the specific group only.

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -115,13 +115,6 @@ func publishPolicyPackPath(orgName string) string {
 	return fmt.Sprintf("/api/orgs/%s/policypacks", orgName)
 }
 
-// applyPolicyPackPath returns the path for an API call to the Pulumi service to apply a PolicyPack
-// to a Pulumi organization.
-func applyPolicyPackPath(orgName, policyPackName string, version int) string {
-	return fmt.Sprintf(
-		"/api/orgs/%s/policypacks/%s/versions/%d/apply", orgName, policyPackName, version)
-}
-
 // updatePolicyGroupPath returns the path for an API call to the Pulumi service to update a PolicyGroup
 // for a Pulumi organization.
 func updatePolicyGroupPath(orgName, policyGroup string) string {

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -168,16 +168,25 @@ func (pack *cloudPolicyPack) Publish(
 	return nil
 }
 
-func (pack *cloudPolicyPack) Apply(ctx context.Context, policyGroup string, op backend.PolicyPackOperation) error {
-	return pack.cl.ApplyPolicyPack(ctx, pack.ref.orgName, policyGroup, string(pack.ref.name), op.Version)
+func (pack *cloudPolicyPack) Enable(ctx context.Context, policyGroup string, op backend.PolicyPackOperation) error {
+	if op.Version == nil {
+		return pack.cl.ApplyPolicyPack(ctx, pack.ref.orgName, policyGroup, string(pack.ref.name), 0 /* version */)
+	}
+	return pack.cl.ApplyPolicyPack(ctx, pack.ref.orgName, policyGroup, string(pack.ref.name), *op.Version)
 }
 
 func (pack *cloudPolicyPack) Disable(ctx context.Context, policyGroup string, op backend.PolicyPackOperation) error {
-	return pack.cl.DisablePolicyPack(ctx, pack.ref.orgName, policyGroup, string(pack.ref.name), op.Version)
+	if op.Version == nil {
+		return pack.cl.DisablePolicyPack(ctx, pack.ref.orgName, policyGroup, string(pack.ref.name), 0 /* version */)
+	}
+	return pack.cl.DisablePolicyPack(ctx, pack.ref.orgName, policyGroup, string(pack.ref.name), *op.Version)
 }
 
 func (pack *cloudPolicyPack) Remove(ctx context.Context, op backend.PolicyPackOperation) error {
-	return pack.cl.RemovePolicyPack(ctx, pack.ref.orgName, string(pack.ref.name), op.Version)
+	if op.Version == nil {
+		return errors.New("remove requires the version be specified")
+	}
+	return pack.cl.RemovePolicyPack(ctx, pack.ref.orgName, string(pack.ref.name), *op.Version)
 }
 
 const npmPackageDir = "package"

--- a/pkg/backend/policypack.go
+++ b/pkg/backend/policypack.go
@@ -33,7 +33,8 @@ type PublishOperation struct {
 
 // PolicyPackOperation is used to make various operations against a Policy Pack.
 type PolicyPackOperation struct {
-	Version int
+	// If nil, the latest version is assumed.
+	Version *int
 	Scopes  CancellationScopeSource
 }
 
@@ -45,9 +46,9 @@ type PolicyPack interface {
 	Backend() Backend
 	// Publish the PolicyPack to the service.
 	Publish(ctx context.Context, op PublishOperation) result.Result
-	// Apply the PolicyPack to a Policy Group in an organization. If Policy Group is
+	// Enable the PolicyPack to a Policy Group in an organization. If Policy Group is
 	// empty, it enables it for the default Policy Group.
-	Apply(ctx context.Context, policyGroup string, op PolicyPackOperation) error
+	Enable(ctx context.Context, policyGroup string, op PolicyPackOperation) error
 
 	// Disable the PolicyPack for a Policy Group in an organization. If Policy Group is
 	// empty, it disables it for the default Policy Group.

--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -48,7 +48,12 @@ func TestPolicy(t *testing.T) {
 
 	// Enable, Disable and then Delete the Policy Pack.
 	e.RunCommand("pulumi", "policy", "enable", fmt.Sprintf("%s/%s", orgName, policyPackName), "1")
-	e.RunCommand("pulumi", "policy", "disable", fmt.Sprintf("%s/%s", orgName, policyPackName), "1")
+	e.RunCommand("pulumi", "policy", "disable", fmt.Sprintf("%s/%s", orgName, policyPackName), "--version=1")
+
+	// Enable and Disable without specifying the version number.
+	e.RunCommand("pulumi", "policy", "enable", "--latest")
+	e.RunCommand("pulumi", "policy", "disable", fmt.Sprintf("%s/%s", orgName, policyPackName))
+
 	e.RunCommand("pulumi", "policy", "rm", fmt.Sprintf("%s/%s", orgName, policyPackName), "1")
 }
 

--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -51,7 +51,7 @@ func TestPolicy(t *testing.T) {
 	e.RunCommand("pulumi", "policy", "disable", fmt.Sprintf("%s/%s", orgName, policyPackName), "--version=1")
 
 	// Enable and Disable without specifying the version number.
-	e.RunCommand("pulumi", "policy", "enable", "--latest")
+	e.RunCommand("pulumi", "policy", "enable", fmt.Sprintf("%s/%s", orgName, policyPackName), "--latest=true")
 	e.RunCommand("pulumi", "policy", "disable", fmt.Sprintf("%s/%s", orgName, policyPackName))
 
 	e.RunCommand("pulumi", "policy", "rm", fmt.Sprintf("%s/%s", orgName, policyPackName), "1")


### PR DESCRIPTION
This PR does two things:

1. Add latest flag to `pulumi policy enable`. This will enable the latest version of a PP.
1. Remove requirement for version when running `pulumi policy disable`. Add a `--version` flag if user wants to be explicit about the version they are disabling.
