### PR TITLE
Fix an assert in the Go SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 CHANGELOG
 =========
 
-## 1.9.0 (2020-01-22)
-- Publish python types for PEP 561 [#3704](https://github.com/pulumi/pulumi/pull/3704)
+## HEAD (unreleased)
 
-- Lock dep ts-node to v8.5.4 [#3733](https://github.com/pulumi/pulumi/pull/3733)
+- Fix a buggy assertion in the Go SDK.
+  [#3794](https://github.com/pulumi/pulumi/pull/3794)
+
+## 1.9.0 (2020-01-22)
+- Publish python types for PEP 561
+  [#3704](https://github.com/pulumi/pulumi/pull/3704)
+
+- Lock dep ts-node to v8.5.4
+  [#3733](https://github.com/pulumi/pulumi/pull/3733)
 
 - Improvements to `pulumi policy` functionality. Add ability to remove & disable Policy Packs.
 
@@ -24,36 +31,44 @@ CHANGELOG
 
 ## 1.8.1 (2019-12-20)
 
-- Fix a panic in `pulumi stack select`. [#3687](https://github.com/pulumi/pulumi/pull/3687)
+- Fix a panic in `pulumi stack select`.
+  [#3687](https://github.com/pulumi/pulumi/pull/3687)
 
 ## 1.8.0 (2019-12-19)
 
-- Update version of TypeScript used by Pulumi to `3.7.3`. [#3627](https://github.com/pulumi/pulumi/pull/3627)
+- Update version of TypeScript used by Pulumi to `3.7.3`.
+  [#3627](https://github.com/pulumi/pulumi/pull/3627)
 
-- Add support for GOOGLE_CREDENTIALS when using Google Cloud Storage backend. [#2906](https://github.com/pulumi/pulumi/pull/2906)
+- Add support for GOOGLE_CREDENTIALS when using Google Cloud Storage backend.
+  [#2906](https://github.com/pulumi/pulumi/pull/2906)
 
   ```sh
    export GOOGLE_CREDENTIALS="$(cat ~/service-account-credentials.json)"
    pulumi login gs://my-bucket
   ```
 
+
 - Support for using `Config`, `getProject()`, `getStack()`, and `isDryRun()` from Policy Packs.
   [#3612](https://github.com/pulumi/pulumi/pull/3612)
+
 - Top-level Stack component in the .NET SDK.
   [#3618](https://github.com/pulumi/pulumi/pull/3618)
 
-- Add the .NET Core 3.0 runtime to the `pulumi/pulumi` container. [#3616](https://github.com/pulumi/pulumi/pull/3616)
+- Add the .NET Core 3.0 runtime to the `pulumi/pulumi` container.
+  [#3616](https://github.com/pulumi/pulumi/pull/3616)
 
 - Add `pulumi preview` support for `--refresh`, `--target`, `--replace`, `--target-replace` and
   `--target-dependents` to align with `pulumi up`.
   [#3675](https://github.com/pulumi/pulumi/pull/3675)
   
-- `ComponentResource`s now have built-in support for asynchronously constructing their children. [#3676](https://github.com/pulumi/pulumi/pull/3676)
+- `ComponentResource`s now have built-in support for asynchronously constructing their children.
+  [#3676](https://github.com/pulumi/pulumi/pull/3676)
 
 - `Output.apply` (for the JS, Python and .Net sdks) has updated semantics, and will lift dependencies from inner Outputs to the returned Output.
   [#3663](https://github.com/pulumi/pulumi/pull/3663)
 
-- Fix bug in determining PRNumber and BuildURL for an Azure Pipelines CI environment. [#3677](https://github.com/pulumi/pulumi/pull/3677)
+- Fix bug in determining PRNumber and BuildURL for an Azure Pipelines CI environment.
+  [#3677](https://github.com/pulumi/pulumi/pull/3677)
 
 - Improvements to `pulumi policy` functionality. Add ability to remove & disable Policy Packs.
 
@@ -62,13 +77,15 @@ CHANGELOG
 ## 1.7.1 (2019-12-13)
 
 - Fix [SxS issue](https://github.com/pulumi/pulumi/issues/3652) introduced in 1.7.0 when assigning
-  `Output`s across different versions of the `@pulumi/pulumi` SDK. [#3658](https://github.com/pulumi/pulumi/pull/3658)
+  `Output`s across different versions of the `@pulumi/pulumi` SDK.
+  [#3658](https://github.com/pulumi/pulumi/pull/3658)
 
 ## 1.7.0 (2019-12-11)
 
 - A Pulumi JavaScript/TypeScript program can now consist of a single exported top level function. This 
   allows for an easy approach to create a Pulumi program that needs to perform `async`/`await`
-  operations at the top-level. [#3321](https://github.com/pulumi/pulumi/pull/3321)
+  operations at the top-level.
+  [#3321](https://github.com/pulumi/pulumi/pull/3321)
 
   ```ts
   // JavaScript
@@ -84,24 +101,30 @@ CHANGELOG
 
 - Support passing a parent and providers for `ReadResource`, `RegisterResource`, and `Invoke` in the go SDK. [#3563](https://github.com/pulumi/pulumi/pull/3563)
 
-- Fix go SDK ReadResource. [#3581](https://github.com/pulumi/pulumi/pull/3581)
+- Fix go SDK ReadResource.
+  [#3581](https://github.com/pulumi/pulumi/pull/3581)
 
-- Fix go SDK DeleteBeforeReplace. [#3572](https://github.com/pulumi/pulumi/pull/3572)
+- Fix go SDK DeleteBeforeReplace.
+  [#3572](https://github.com/pulumi/pulumi/pull/3572)
 
 - Support for setting the `PULUMI_PREFER_YARN` environment variable to opt-in to using `yarn` instead of `npm` for
-  installing Node.js dependencies. [#3556](https://github.com/pulumi/pulumi/pull/3556)
+  installing Node.js dependencies.
+  [#3556](https://github.com/pulumi/pulumi/pull/3556)
 
 - Fix regression that prevented relative paths passed to `--policy-pack` from working.
   [#3565](https://github.com/pulumi/pulumi/issues/3564)
 
 ## 1.6.0 (2019-11-20)
 
-- Support for config.GetObject and related variants for Golang. [#3526](https://github.com/pulumi/pulumi/pull/3526)
+- Support for config.GetObject and related variants for Golang.
+  [#3526](https://github.com/pulumi/pulumi/pull/3526)
 
-- Add support for IgnoreChanges in the go SDK. [#3514](https://github.com/pulumi/pulumi/pull/3514)
+- Add support for IgnoreChanges in the go SDK.
+  [#3514](https://github.com/pulumi/pulumi/pull/3514)
 
 - Support for a `go run` style workflow. Building or installing a pulumi program written in go is
-  now optional. [#3503](https://github.com/pulumi/pulumi/pull/3503)
+  now optional.
+  [#3503](https://github.com/pulumi/pulumi/pull/3503)
 
 - Re-apply "propagate resource inputs to resource state during preview, including first-class unknown values." The new
   set of changes have additional fixes to ensure backwards compatibility with earlier code. This allows the preview to
@@ -119,7 +142,8 @@ CHANGELOG
   reported resources as `--target`s, or pass the `--target-dependents` flag to allow necessary
   changes to unspecified dependent targets.
 
-- Support for node 13.x, building with gcc 8 and newer. [#3512] (https://github.com/pulumi/pulumi/pull/3512)
+- Support for node 13.x, building with gcc 8 and newer.
+  [#3512] (https://github.com/pulumi/pulumi/pull/3512)
 
 - Codepaths which could result in a hang will print a message to the console indicating the problem, along with a link
   to documentation on how to restructure code to best address it.
@@ -154,7 +178,8 @@ CHANGELOG
 - Improve startup time performance by 0.5-1s by checking for a newer CLI release in parallel.
   [#3441](https://github.com/pulumi/pulumi/pull/3441)
 
-- Add an experimental `pulumi watch` command. [#3391](https://github.com/pulumi/pulumi/pull/3391)
+- Add an experimental `pulumi watch` command. 
+  [#3391](https://github.com/pulumi/pulumi/pull/3391)
 
 ## 1.4.1 (2019-11-01)
 
@@ -184,7 +209,8 @@ CHANGELOG
   [#3342](https://github.com/pulumi/pulumi/pull/3342)
 
 - `ResourceProvider#StreamInvoke` implemented, will be the basis for streaming
-  APIs in `pulumi query`. [#3424](https://github.com/pulumi/pulumi/pull/3424)
+  APIs in `pulumi query`.
+  [#3424](https://github.com/pulumi/pulumi/pull/3424)
 
 ## 1.4.0 (2019-10-24)
 

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -216,7 +216,8 @@ func marshalInput(v interface{}, destType reflect.Type, await bool) (resource.Pr
 			return e, append(deps, d...), nil
 		}
 
-		contract.Assertf(valueType.AssignableTo(destType), "%v: cannot assign %v to %v", v, valueType, destType)
+		contract.Assertf(valueType.AssignableTo(destType) || valueType.ConvertibleTo(destType),
+			"%v: cannot assign %v to %v", v, valueType, destType)
 
 		if destType.Kind() == reflect.Interface {
 			destType = valueType


### PR DESCRIPTION
This assert is not correct in the case of pointer input types, in
particular `pulumi.stringPtr`. Though these types are not assignable,
they are convertible.