### PR TITLE
Always render PPs even if there are diagnostic events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
 - Fix a buggy assertion in the Go SDK.
   [#3794](https://github.com/pulumi/pulumi/pull/3794)
 
+- Fix rendering of Policy Packs to ensure they are always displayed.
+
 ## 1.9.0 (2020-01-22)
 - Publish python types for PEP 561
   [#3704](https://github.com/pulumi/pulumi/pull/3704)

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -142,7 +142,7 @@ func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayl
 
 	out := &bytes.Buffer{}
 
-	// If it is a Preview & it failed, we just render the Policy Packs ran. This because rendering the summary for a preview that failed may be
+	// If this is a failed preview, we only render the Policy Packs that ran. This is because rendering the summary for a failed preview may be
 	// surprising/misleading, as it does not describe the totality of the proposed changes (as the preview may have aborted when the error occurred).
 	if event.IsPreview && wroteDiagnosticHeader {
 		renderPolicyPacks(out, event.PolicyPacks, opts)

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -98,7 +98,7 @@ func RenderDiffEvent(action apitype.UpdateKind, event engine.Event,
 	case engine.PreludeEvent:
 		return renderPreludeEvent(event.Payload.(engine.PreludeEventPayload), opts)
 	case engine.SummaryEvent:
-		return renderSummaryEvent(action, event.Payload.(engine.SummaryEventPayload), opts)
+		return renderSummaryEvent(action, event.Payload.(engine.SummaryEventPayload), false /* wroteDiagnosticHeader */, opts)
 	case engine.StdoutColorEvent:
 		return renderStdoutColorEvent(event.Payload.(engine.StdoutEventPayload), opts)
 
@@ -137,10 +137,17 @@ func renderStdoutColorEvent(payload engine.StdoutEventPayload, opts Options) str
 	return opts.Color.Colorize(payload.Message)
 }
 
-func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayload, opts Options) string {
+func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayload, wroteDiagnosticHeader bool, opts Options) string {
 	changes := event.ResourceChanges
 
 	out := &bytes.Buffer{}
+
+	// If it is a Preview & it failed, we just render the Policy Packs ran. This because rendering the summary for a preview that failed may be
+	// surprising/misleading, as it does not describe the totality of the proposed changes (as the preview may have aborted when the error occurred).
+	if event.IsPreview && wroteDiagnosticHeader {
+		renderPolicyPacks(out, event.PolicyPacks, opts)
+		return out.String()
+	}
 	fprintIgnoreError(out, opts.Color.Colorize(
 		fmt.Sprintf("%sResources:%s\n", colors.SpecHeadline, colors.Reset)))
 
@@ -183,29 +190,7 @@ func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayl
 	}
 
 	// Print policy packs loaded. Data is rendered as a table of {policy-pack-name, version}.
-	if len(event.PolicyPacks) > 0 {
-		fprintIgnoreError(out, opts.Color.Colorize(fmt.Sprintf("\n%sPolicy Packs run:%s\n",
-			colors.SpecHeadline, colors.Reset)))
-
-		// Calculate column width for the `name` column
-		const nameColHeader = "Name"
-		maxNameLen := len(nameColHeader)
-		for pp := range event.PolicyPacks {
-			if l := len(pp); l > maxNameLen {
-				maxNameLen = l
-			}
-		}
-
-		// Print the column headers and the policy packs.
-		fprintIgnoreError(out, opts.Color.Colorize(
-			fmt.Sprintf("    %s%s%s\n",
-				columnHeader(nameColHeader), messagePadding(nameColHeader, maxNameLen, 2),
-				columnHeader("Version"))))
-		for pp, ver := range event.PolicyPacks {
-			fprintIgnoreError(out, opts.Color.Colorize(
-				fmt.Sprintf("    %s%s%s\n", pp, messagePadding(pp, maxNameLen, 2), ver)))
-		}
-	}
+	renderPolicyPacks(out, event.PolicyPacks, opts)
 
 	summaryPieces := []string{}
 	if changeKindCount >= 2 {
@@ -245,6 +230,33 @@ func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayl
 	}
 
 	return out.String()
+}
+
+func renderPolicyPacks(out io.Writer, policyPacks map[string]string, opts Options) {
+	if len(policyPacks) == 0 {
+		return
+	}
+	fprintIgnoreError(out, opts.Color.Colorize(fmt.Sprintf("\n%sPolicy Packs run:%s\n",
+		colors.SpecHeadline, colors.Reset)))
+
+	// Calculate column width for the `name` column
+	const nameColHeader = "Name"
+	maxNameLen := len(nameColHeader)
+	for pp := range policyPacks {
+		if l := len(pp); l > maxNameLen {
+			maxNameLen = l
+		}
+	}
+
+	// Print the column headers and the policy packs.
+	fprintIgnoreError(out, opts.Color.Colorize(
+		fmt.Sprintf("    %s%s%s\n",
+			columnHeader(nameColHeader), messagePadding(nameColHeader, maxNameLen, 2),
+			columnHeader("Version"))))
+	for pp, ver := range policyPacks {
+		fprintIgnoreError(out, opts.Color.Colorize(
+			fmt.Sprintf("    %s%s%s\n", pp, messagePadding(pp, maxNameLen, 2), ver)))
+	}
 }
 
 func renderPreludeEvent(event engine.PreludeEventPayload, opts Options) string {

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -137,13 +137,16 @@ func renderStdoutColorEvent(payload engine.StdoutEventPayload, opts Options) str
 	return opts.Color.Colorize(payload.Message)
 }
 
-func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayload, wroteDiagnosticHeader bool, opts Options) string {
+func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayload,
+	wroteDiagnosticHeader bool, opts Options) string {
+
 	changes := event.ResourceChanges
 
 	out := &bytes.Buffer{}
 
-	// If this is a failed preview, we only render the Policy Packs that ran. This is because rendering the summary for a failed preview may be
-	// surprising/misleading, as it does not describe the totality of the proposed changes (as the preview may have aborted when the error occurred).
+	// If this is a failed preview, we only render the Policy Packs that ran. This is because rendering the summary
+	// for a failed preview may be surprising/misleading, as it does not describe the totality of the proposed changes
+	// (as the preview may have aborted when the error occurred).
 	if event.IsPreview && wroteDiagnosticHeader {
 		renderPolicyPacks(out, event.PolicyPacks, opts)
 		return out.String()

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -751,7 +751,7 @@ func (display *ProgressDisplay) processEndSteps() {
 			display.writeBlankLine()
 		}
 
-		msg := renderSummaryEvent(display.action, *display.summaryEventPayload, display.opts)
+		msg := renderSummaryEvent(display.action, *display.summaryEventPayload, wroteDiagnosticHeader, display.opts)
 		display.writeSimpleMessage(msg)
 	}
 }

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -227,6 +227,10 @@ func printPlan(ctx *Context, planResult *planResult, dryRun bool, policies map[s
 	actions := newPlanActions(planResult.Options)
 	if res := planResult.Walk(ctx, actions, true); res != nil {
 		if res.IsBail() {
+			// Even if we had to bail, we emit an event with a summary of operation
+			// counts. This is so we can display the Policy Packs ran with the Plan.
+			changes := ResourceChanges(actions.Ops)
+			planResult.Options.Events.previewSummaryEvent(changes, policies)
 			return nil, res
 		}
 

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -226,30 +226,20 @@ func printPlan(ctx *Context, planResult *planResult, dryRun bool, policies map[s
 	// Walk the plan's steps and and pretty-print them out.
 	actions := newPlanActions(planResult.Options)
 	res := planResult.Walk(ctx, actions, true)
-	changes := ResourceChanges(actions.Ops)
-	planResult.Options.Events.previewSummaryEvent(changes, policies)
-	if res != nil {
-		if res.IsBail() {
-			return nil, res
-		}
-		return nil, result.Error("an error occurred while advancing the preview")
-	}
-	
-	return changes, nil
-		if res.IsBail() {
-			// Even if we had to bail, we emit an event with a summary of operation
-			// counts. This is so we can display the Policy Packs ran with the Plan.
-			changes := ResourceChanges(actions.Ops)
-			planResult.Options.Events.previewSummaryEvent(changes, policies)
-			return nil, res
-		}
-
-		return nil, result.Error("an error occurred while advancing the preview")
-	}
 
 	// Emit an event with a summary of operation counts.
 	changes := ResourceChanges(actions.Ops)
 	planResult.Options.Events.previewSummaryEvent(changes, policies)
+
+	if res != nil {
+
+		if res.IsBail() {
+			return nil, res
+		}
+
+		return nil, result.Error("an error occurred while advancing the preview")
+	}
+
 	return changes, nil
 }
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-policy/issues/174

This makes sure PP are always rendered during a Preview, even when there are diagnostic events. This is because during Previews if we'd bailed, we did not send the SummaryEvent. We now send the Summary Event but if its a Preview & we wrote the diagnostic header then we only render the PPs.