### PR TITLE
fix python sdk stack ref regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
+- Fix a stack reference regression in the Python SDK.
+  [#3798](https://github.com/pulumi/pulumi/pull/3798)
 
 - Fix a buggy assertion in the Go SDK.
   [#3794](https://github.com/pulumi/pulumi/pull/3794)

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -67,7 +67,7 @@ class StackReference(CustomResource):
 
         :param Input[str] name: The name of the stack output to fetch.
         """
-        value: Output[Any] = Output.all([Output.from_input(name), self.outputs]).apply(lambda l: l[1].get(l[0])) # type: ignore
+        value: Output[Any] = Output.all(Output.from_input(name), self.outputs).apply(lambda l: l[1].get(l[0])) # type: ignore
         is_secret = ensure_future(self.__is_secret_name(name))
 
         return Output(value.resources(), value.future(), value.is_known(), is_secret)


### PR DESCRIPTION
There was an erroneous change made in the mypy PR: https://github.com/pulumi/pulumi/pull/3758/files#diff-1c4bae904f6f7227aaac700e53ee77edR70

This reverts that change. We still need test coverage in this area, but that will require more work in the test framework. This unblocks our users for now. 