### PR TITLE
Validate stack tag names

### DIFF
--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -28,7 +28,7 @@ func validateStackName(s string) error {
 	if stackNameRE.MatchString(s) {
 		return nil
 	}
-	return errors.New("a stack name may only contain alphanumeric, hyphens, underscores, or periods")
+	return errors.New("stack names may only contain alphanumeric, hyphens, underscores, or periods")
 }
 
 // validateStackTagName checks if s is a valid stack tag name, otherwise returns a descriptive error.
@@ -38,7 +38,7 @@ func validateStackTagName(s string) error {
 	if tagNameRE.MatchString(s) {
 		return nil
 	}
-	return errors.New("a stack tag name may only contain alphanumerics, hyphens, underscores, periods, or colons")
+	return errors.New("stack tag names may only contain alphanumerics, hyphens, underscores, periods, or colons")
 }
 
 // ValidateStackTags validates the tag names and values.
@@ -48,13 +48,13 @@ func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 
 	for t, v := range tags {
 		if len(t) > maxTagName {
-			return errors.Errorf("stack tag name %q is too long (max length %d characters)", t, maxTagName)
+			return errors.Errorf("the stack tag name is too long (max length %d characters)", maxTagName)
 		}
 		if err := validateStackTagName(t); err != nil {
-			return errors.Wrapf(err, "invalid stack tag name")
+			return err
 		}
 		if len(v) > maxTagValue {
-			return errors.Errorf("stack tag value %q is too long (max length %d characters)", v, maxTagValue)
+			return errors.Errorf("the stack tag value is too long (max length %d characters)", maxTagValue)
 		}
 	}
 
@@ -66,10 +66,10 @@ func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 func ValidateStackProperties(stack string, tags map[apitype.StackTagName]string) error {
 	const maxStackName = 100 // Derived from the regex in validateStackName.
 	if len(stack) > maxStackName {
-		return errors.Errorf("stack name too long (max length %d characters)", maxStackName)
+		return errors.Errorf("the stack name is too long (max length %d characters)", maxStackName)
 	}
 	if err := validateStackName(stack); err != nil {
-		return errors.Wrapf(err, "invalid stack name")
+		return err
 	}
 
 	// Ensure tag values won't be rejected by the Pulumi Service. We do not validate that their

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -40,7 +40,7 @@ func validateStackTagName(s string) error {
 		return errors.Errorf("invalid stack tag %q", s)
 	}
 	if len(s) > maxTagName {
-		return errors.Errorf("the stack tag name is too long (max length %d characters)", maxTagName)
+		return errors.Errorf("stack tag %q is too long (max length %d characters)", s, maxTagName)
 	}
 
 	var tagNameRE = regexp.MustCompile("^[a-zA-Z0-9-_.:]{1,40}$")
@@ -59,7 +59,7 @@ func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 			return err
 		}
 		if len(v) > maxTagValue {
-			return errors.Errorf("the stack tag value is too long (max length %d characters)", maxTagValue)
+			return errors.Errorf("stack tag %q value is too long (max length %d characters)", t, maxTagValue)
 		}
 	}
 
@@ -71,7 +71,7 @@ func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 func ValidateStackProperties(stack string, tags map[apitype.StackTagName]string) error {
 	const maxStackName = 100 // Derived from the regex in validateStackName.
 	if len(stack) > maxStackName {
-		return errors.Errorf("the stack name is too long (max length %d characters)", maxStackName)
+		return errors.Errorf("stack name too long (max length %d characters)", maxStackName)
 	}
 	if err := validateStackName(stack); err != nil {
 		return err

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -36,6 +36,14 @@ func validateStackName(s string) error {
 // validateStackTagName checks if s is a valid stack tag name, otherwise returns a descriptive error.
 // This should match the stack naming rules enforced by the Pulumi Service.
 func validateStackTagName(s string) error {
+	const maxTagName = 40
+
+	if len(s) == 0 {
+		return errors.Errorf("invalid stack tag %q", s)
+	}
+	if len(s) > maxTagName {
+		return errors.Errorf("the stack tag name is too long (max length %d characters)", maxTagName)
+	}
 	if tagNameRE.MatchString(s) {
 		return nil
 	}
@@ -44,16 +52,9 @@ func validateStackTagName(s string) error {
 
 // ValidateStackTags validates the tag names and values.
 func ValidateStackTags(tags map[apitype.StackTagName]string) error {
-	const maxTagName = 40
 	const maxTagValue = 256
 
 	for t, v := range tags {
-		if len(t) == 0 {
-			return errors.Errorf("invalid stack tag %q", t)
-		}
-		if len(t) > maxTagName {
-			return errors.Errorf("the stack tag name is too long (max length %d characters)", maxTagName)
-		}
 		if err := validateStackTagName(t); err != nil {
 			return err
 		}

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -31,20 +31,30 @@ func validateStackName(s string) error {
 	return errors.New("a stack name may only contain alphanumeric, hyphens, underscores, or periods")
 }
 
+// validateStackTagName checks if s is a valid stack tag name, otherwise returns a descriptive error.
+// This should match the stack naming rules enforced by the Pulumi Service.
+func validateStackTagName(s string) error {
+	tagNameRE := regexp.MustCompile("^[a-zA-Z0-9-_.:]{1,40}$")
+	if tagNameRE.MatchString(s) {
+		return nil
+	}
+	return errors.New("a stack tag name may only contain alphanumerics, hyphens, underscores, or periods")
+}
+
 // ValidateStackTags validates the tag names and values.
 func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 	const maxTagName = 40
 	const maxTagValue = 256
 
 	for t, v := range tags {
-		if len(t) == 0 {
-			return errors.Errorf("invalid stack tag %q", t)
-		}
 		if len(t) > maxTagName {
-			return errors.Errorf("stack tag %q is too long (max length %d characters)", t, maxTagName)
+			return errors.Errorf("stack tag name %q is too long (max length %d characters)", t, maxTagName)
+		}
+		if err := validateStackTagName(t); err != nil {
+			return errors.Wrapf(err, "invalid stack tag name")
 		}
 		if len(v) > maxTagValue {
-			return errors.Errorf("stack tag %q value is too long (max length %d characters)", t, maxTagValue)
+			return errors.Errorf("stack tag value %q is too long (max length %d characters)", v, maxTagValue)
 		}
 	}
 

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -21,6 +21,8 @@ import (
 	"github.com/pulumi/pulumi/pkg/apitype"
 )
 
+var tagNameRE = regexp.MustCompile("^[a-zA-Z0-9-_.:]{1,40}$")
+
 // validateStackName checks if s is a valid stack name, otherwise returns a descriptive error.
 // This should match the stack naming rules enforced by the Pulumi Service.
 func validateStackName(s string) error {
@@ -28,13 +30,12 @@ func validateStackName(s string) error {
 	if stackNameRE.MatchString(s) {
 		return nil
 	}
-	return errors.New("stack names may only contain alphanumeric, hyphens, underscores, or periods")
+	return errors.New("a stack name may only contain alphanumeric, hyphens, underscores, or periods")
 }
 
 // validateStackTagName checks if s is a valid stack tag name, otherwise returns a descriptive error.
 // This should match the stack naming rules enforced by the Pulumi Service.
 func validateStackTagName(s string) error {
-	tagNameRE := regexp.MustCompile("^[a-zA-Z0-9-_.:]{1,40}$")
 	if tagNameRE.MatchString(s) {
 		return nil
 	}
@@ -47,6 +48,9 @@ func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 	const maxTagValue = 256
 
 	for t, v := range tags {
+		if len(t) == 0 {
+			return errors.Errorf("invalid stack tag %q", t)
+		}
 		if len(t) > maxTagName {
 			return errors.Errorf("the stack tag name is too long (max length %d characters)", maxTagName)
 		}

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -38,7 +38,7 @@ func validateStackTagName(s string) error {
 	if tagNameRE.MatchString(s) {
 		return nil
 	}
-	return errors.New("a stack tag name may only contain alphanumerics, hyphens, underscores, or periods")
+	return errors.New("a stack tag name may only contain alphanumerics, hyphens, underscores, periods, or colons")
 }
 
 // ValidateStackTags validates the tag names and values.

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -21,8 +21,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/apitype"
 )
 
-var tagNameRE = regexp.MustCompile("^[a-zA-Z0-9-_.:]{1,40}$")
-
 // validateStackName checks if s is a valid stack name, otherwise returns a descriptive error.
 // This should match the stack naming rules enforced by the Pulumi Service.
 func validateStackName(s string) error {
@@ -44,6 +42,8 @@ func validateStackTagName(s string) error {
 	if len(s) > maxTagName {
 		return errors.Errorf("the stack tag name is too long (max length %d characters)", maxTagName)
 	}
+
+	var tagNameRE = regexp.MustCompile("^[a-zA-Z0-9-_.:]{1,40}$")
 	if tagNameRE.MatchString(s) {
 		return nil
 	}

--- a/pkg/util/validation/stack_test.go
+++ b/pkg/util/validation/stack_test.go
@@ -62,7 +62,7 @@ func TestValidateStackTag(t *testing.T) {
 
 		err := ValidateStackTags(tags)
 		assert.Error(t, err)
-		msg := fmt.Sprintf("the stack tag name is too long (max length %d characters)", 40)
+		msg := fmt.Sprintf("stack tag %q is too long (max length %d characters)", strings.Repeat("v", 41), 40)
 		assert.Equal(t, err.Error(), msg)
 	})
 
@@ -73,7 +73,7 @@ func TestValidateStackTag(t *testing.T) {
 
 		err := ValidateStackTags(tags)
 		assert.Error(t, err)
-		msg := fmt.Sprintf("the stack tag value is too long (max length %d characters)", 256)
+		msg := fmt.Sprintf("stack tag %q value is too long (max length %d characters)", "tag-name", 256)
 		assert.Equal(t, err.Error(), msg)
 	})
 }

--- a/pkg/util/validation/stack_test.go
+++ b/pkg/util/validation/stack_test.go
@@ -26,8 +26,7 @@ func TestValidateStackTag(t *testing.T) {
 
 		err := ValidateStackTags(tags)
 		assert.Error(t, err)
-		msg := "invalid stack tag name: " +
-			"a stack tag name may only contain alphanumerics, hyphens, underscores, or periods"
+		msg := "stack tag names may only contain alphanumerics, hyphens, underscores, periods, or colons"
 		assert.Equal(t, err.Error(), msg)
 	})
 
@@ -38,7 +37,7 @@ func TestValidateStackTag(t *testing.T) {
 
 		err := ValidateStackTags(tags)
 		assert.Error(t, err)
-		msg := fmt.Sprintf("stack tag name %q is too long (max length %d characters)", strings.Repeat("v", 41), 40)
+		msg := fmt.Sprintf("the stack tag name is too long (max length %d characters)", 40)
 		assert.Equal(t, err.Error(), msg)
 	})
 
@@ -49,7 +48,7 @@ func TestValidateStackTag(t *testing.T) {
 
 		err := ValidateStackTags(tags)
 		assert.Error(t, err)
-		msg := fmt.Sprintf("stack tag value %q is too long (max length %d characters)", strings.Repeat("v", 257), 256)
+		msg := fmt.Sprintf("the stack tag value is too long (max length %d characters)", 256)
 		assert.Equal(t, err.Error(), msg)
 	})
 }

--- a/pkg/util/validation/stack_test.go
+++ b/pkg/util/validation/stack_test.go
@@ -10,24 +10,49 @@ import (
 )
 
 func TestValidateStackTag(t *testing.T) {
-	t.Run("valid tag", func(t *testing.T) {
-		tags := map[apitype.StackTagName]string{
-			"tag-name": "tag-value",
+	t.Run("valid tags", func(t *testing.T) {
+		names := []string{
+			"tag-name",
+			"-",
+			"..",
+			"foo:bar:baz",
+			"__underscores__",
+			"AaBb123",
 		}
 
-		err := ValidateStackTags(tags)
-		assert.NoError(t, err)
+		for _, name := range names {
+			t.Run(name, func(t *testing.T) {
+				tags := map[apitype.StackTagName]string{
+					name: "tag-value",
+				}
+
+				err := ValidateStackTags(tags)
+				assert.NoError(t, err)
+			})
+		}
 	})
 
-	t.Run("invalid stack tag name", func(t *testing.T) {
-		tags := map[apitype.StackTagName]string{
-			"hello!": "tag-value",
+	t.Run("invalid stack tag names", func(t *testing.T) {
+		var names = []string{
+			"tag!",
+			"something with spaces",
+			"escape\nsequences\there",
+			"😄",
+			"foo***bar",
 		}
 
-		err := ValidateStackTags(tags)
-		assert.Error(t, err)
-		msg := "stack tag names may only contain alphanumerics, hyphens, underscores, periods, or colons"
-		assert.Equal(t, err.Error(), msg)
+		for _, name := range names {
+			t.Run(name, func(t *testing.T) {
+				tags := map[apitype.StackTagName]string{
+					name: "tag-value",
+				}
+
+				err := ValidateStackTags(tags)
+				assert.Error(t, err)
+				msg := "stack tag names may only contain alphanumerics, hyphens, underscores, periods, or colons"
+				assert.Equal(t, err.Error(), msg)
+			})
+		}
 	})
 
 	t.Run("too long tag name", func(t *testing.T) {

--- a/pkg/util/validation/stack_test.go
+++ b/pkg/util/validation/stack_test.go
@@ -1,0 +1,55 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/apitype"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateStackTag(t *testing.T) {
+	t.Run("valid tag", func(t *testing.T) {
+		tags := map[apitype.StackTagName]string{
+			"tag-name": "tag-value",
+		}
+
+		err := ValidateStackTags(tags)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid stack tag name", func(t *testing.T) {
+		tags := map[apitype.StackTagName]string{
+			"hello!": "tag-value",
+		}
+
+		err := ValidateStackTags(tags)
+		assert.Error(t, err)
+		msg := "invalid stack tag name: " +
+			"a stack tag name may only contain alphanumerics, hyphens, underscores, or periods"
+		assert.Equal(t, err.Error(), msg)
+	})
+
+	t.Run("too long tag name", func(t *testing.T) {
+		tags := map[apitype.StackTagName]string{
+			strings.Repeat("v", 41): "tag-value",
+		}
+
+		err := ValidateStackTags(tags)
+		assert.Error(t, err)
+		msg := fmt.Sprintf("stack tag name %q is too long (max length %d characters)", strings.Repeat("v", 41), 40)
+		assert.Equal(t, err.Error(), msg)
+	})
+
+	t.Run("too long tag value", func(t *testing.T) {
+		tags := map[apitype.StackTagName]string{
+			"tag-name": strings.Repeat("v", 257),
+		}
+
+		err := ValidateStackTags(tags)
+		assert.Error(t, err)
+		msg := fmt.Sprintf("stack tag value %q is too long (max length %d characters)", strings.Repeat("v", 257), 256)
+		assert.Equal(t, err.Error(), msg)
+	})
+}


### PR DESCRIPTION
We now validate stack tag names for [#3942](https://github.com/pulumi/pulumi-service/issues/3942), similar to how we validate stack names. Because this is in `pulumi/pulumi` this only validates stack tags that go through the CLI:

<img width="797" alt="Screen Shot 2020-01-24 at 1 49 41 PM" src="https://user-images.githubusercontent.com/22062995/73106489-63567c80-3eb0-11ea-84f4-54f6c849a448.png">

I also updated the stack error messages to match those in the `pulumi/pulumi-service` counterpart PR [#4566](https://github.com/pulumi/pulumi-service/pull/4566).

The regex I ended up using (`^[a-zA-Z0-9-_.:]{1,40}$`) is a little simpler than what I previously suggested on that PR to closer match the restrictions for [stack names](https://github.com/pulumi/pulumi/blob/fad1292b7b8502910ecf63e2ea23dd7da8c53f2e/pkg/util/validation/stack.go#L27). The next step for #3942 would be to merge [#4566](https://github.com/pulumi/pulumi-service/pull/4566).

I tested the regex against the `tags` table in https://metabase.corp.pulumi.com, and it matched 100% of the tag names selected. To hopefully save reviewers some time, I've attached the results of my query `SELECT distinct name, count(name) FROM tags GROUP BY name ORDER BY name DESC;`: [tag_name_query.xlsx](https://github.com/pulumi/pulumi/files/4110833/tag_name_query.xlsx)
