### PR TITLE
Mark internal APIs `@internal` to filter from API docs

### DIFF
--- a/sdk/nodejs/asset/archive.ts
+++ b/sdk/nodejs/asset/archive.ts
@@ -20,8 +20,8 @@ import { Asset } from "./asset";
  */
 export abstract class Archive {
     /**
-     * @internal
      * A private field to help with RTTI that works in SxS scenarios.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiArchive: boolean = true;

--- a/sdk/nodejs/asset/asset.ts
+++ b/sdk/nodejs/asset/asset.ts
@@ -19,8 +19,8 @@ import * as utils from "../utils";
  */
 export abstract class Asset {
     /**
-     * @internal
      * A private field to help with RTTI that works in SxS scenarios.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiAsset: boolean = true;

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -308,6 +308,7 @@ function grpcResponseFromError(e: {id: string, properties: any, message: string,
     };
 }
 
+/** @internal */
 export function main(args: string[]): void {
     // The program requires a single argument: the address of the RPC endpoint for the engine.  It
     // optionally also takes a second argument, a reference back to the engine, but this may be missing.

--- a/sdk/nodejs/cmd/run-policy-pack/run.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/run.ts
@@ -137,6 +137,7 @@ function throwOrPrintModuleLoadError(program: string, error: Error): void {
     return;
 }
 
+/** @internal */
 export interface RunOpts {
     // TODO: Explicitly pass `main` in here instead of just argv.
 
@@ -147,6 +148,7 @@ export interface RunOpts {
     typeScript: boolean;
 }
 
+/** @internal */
 export function run(opts: RunOpts): Promise<Record<string, any> | undefined> | Promise<void> {
     // If there is a --pwd directive, switch directories.
     const pwd: string | undefined = opts.argv["pwd"];

--- a/sdk/nodejs/cmd/run/index.ts
+++ b/sdk/nodejs/cmd/run/index.ts
@@ -44,6 +44,7 @@ const uncaughtHandler = (err: Error) => {
 // 32 was picked so as to be very unlikely to collide with any of the error codes documented by
 // nodejs here:
 // https://github.com/nodejs/node-v0.x-archive/blob/master/doc/api/process.markdown#exit-codes
+/** @internal */
 export const nodeJSProcessExitedAfterLoggingUserActionableMessage = 32;
 
 process.on("uncaughtException", uncaughtHandler);

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -130,6 +130,7 @@ function throwOrPrintModuleLoadError(program: string, error: Error): void {
     return;
 }
 
+/** @internal */
 export function run(argv: minimist.ParsedArgs,
                     programStarted: () => void,
                     reportLoggedError: (err: Error) => void) {

--- a/sdk/nodejs/config.ts
+++ b/sdk/nodejs/config.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as util from "util";
 import { RunError } from "./errors";
 import { getProject } from "./metadata";
 import { Output } from "./output";

--- a/sdk/nodejs/errors.ts
+++ b/sdk/nodejs/errors.ts
@@ -23,8 +23,8 @@ import * as utils from "./utils";
  */
 export class RunError extends Error {
     /**
-     * @internal
      * A private field to help with RTTI that works in SxS scenarios.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiRunError: boolean = true;
@@ -50,8 +50,8 @@ export class RunError extends Error {
  */
 export class ResourceError extends Error {
     /**
-     * @internal
      * A private field to help with RTTI that works in SxS scenarios.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumResourceError: boolean = true;

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -14,7 +14,6 @@
 
 // The log module logs messages in a way that tightly integrates with the resource engine's interface.
 
-import * as util from "util";
 import * as resourceTypes from "../resource";
 import { getEngine, rpcKeepAlive } from "../runtime/settings";
 const engproto = require("../proto/engine_pb.js");

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import * as log from "./log";
 import { Resource } from "./resource";
 import * as runtime from "./runtime";
 import * as utils from "./utils";
@@ -26,46 +25,45 @@ import * as utils from "./utils";
  */
 class OutputImpl<T> implements OutputInstance<T> {
     /**
-     * @internal
      * A private field to help with RTTI that works in SxS scenarios.
      *
      * This is internal instead of being truly private, to support mixins and our serialization model.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiOutput: boolean = true;
 
     /**
-     * @internal
-     * Wheter or not this 'Output' wraps a secret value. Values which are marked as secret are stored in an
+     * Whether or not this 'Output' wraps a secret value. Values which are marked as secret are stored in an
      * encrypted format when they are persisted as part of a state file. When`true` this "taints" any
      * additional resources created from it via an [all] or [apply], such that they are also treated as
      * secrets.
+     * @internal
      */
     public readonly isSecret: Promise<boolean>;
 
     /**
-     * @internal
      * Whether or not this 'Output' should actually perform .apply calls.  During a preview,
      * an Output value may not be known (because it would have to actually be computed by doing an
      * 'update').  In that case, we don't want to perform any .apply calls as the callbacks
      * may not expect an undefined value.  So, instead, we just transition to another Output
      * value that itself knows it should not perform .apply calls.
+     * @internal
      */
     public readonly isKnown: Promise<boolean>;
 
     /**
-     * @internal
      * Method that actually produces the concrete value of this output, as well as the total
      * deployment-time set of resources this output depends on. If the value of the output is not
      * known (i.e. isKnown resolves to false), this promise should resolve to undefined unless the
      * `withUnknowns` flag is passed, in which case it will resolve to `unknown`.
      *
      * Only callable on the outside.
+     * @internal
      */
     public readonly promise: (withUnknowns?: boolean) => Promise<T>;
 
     /**
-     * @internal
      * The list of resources that this output value depends on.
      *
      * Only callable on the outside.
@@ -73,11 +71,11 @@ class OutputImpl<T> implements OutputInstance<T> {
      * This only returns the set of dependent resources that were known at Output construction time.
      * It represents the `@pulumi/pulumi` api prior to the addition of 'async resource'
      * dependencies.  Code inside @pulumi/pulumi should use `.allResources` instead.
+     * @internal
      */
     public readonly resources: () => Set<Resource>;
 
     /**
-     * @internal
      * The entire list of resources that this output depends on.
      *
      * This includes both the dependent resources that were known when the Output was explicitly
@@ -89,6 +87,7 @@ class OutputImpl<T> implements OutputInstance<T> {
      *
      * Note: it is fine to use this property if it is guaranteed that it is on an output produced by
      * this SDK (and not another sxs version).
+     * @internal
      */
     // Marked as optional for sxs scenarios.
     public readonly allResources?: () => Promise<Set<Resource>>;
@@ -106,8 +105,9 @@ class OutputImpl<T> implements OutputInstance<T> {
      *
      * This will return an Output with the inner computed value and all resources still tracked. See
      * https://pulumi.io/help/outputs for more details
+     * @internal
      */
-    /** @internal */ public toString: () => string;
+    public toString: () => string;
 
     /**
      * [toJSON] on an [Output<T>] is not supported.  This is because the value an [Output] points
@@ -122,8 +122,9 @@ class OutputImpl<T> implements OutputInstance<T> {
      *
      * This will return an Output with the inner computed value and all resources still tracked.
      * See https://pulumi.io/help/outputs for more details
+     * @internal
      */
-    /** @internal */ public toJSON: () => any;
+    public toJSON: () => any;
 
     // Statics
 
@@ -579,11 +580,11 @@ function getResourcesAndDetails<T>(allOutputs: Output<Unwrap<T>>[]): [Set<Resour
  * if other properties of the containing object are unknown.
  */
 class Unknown {
-     /**
-     * @internal
+    /**
      * A private field to help with RTTI that works in SxS scenarios.
      *
      * This is internal instead of being truly private, to support mixins and our serialization model.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiUnknown: boolean = true;
@@ -598,8 +599,8 @@ class Unknown {
 }
 
 /**
- * @internal
  * unknown is the singleton unknown value.
+ * @internal
  */
 export const unknown = new Unknown();
 

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { util } from "protobufjs";
 import { ResourceError } from "./errors";
 import { Input, Inputs, interpolate, Output, output } from "./output";
 import { getStackResource, unknownValue } from "./runtime";
@@ -74,21 +73,20 @@ function inheritedChildAlias(childName: string, parentName: string, parentAlias:
  */
 export abstract class Resource {
     /**
-     * @internal
      * A private field to help with RTTI that works in SxS scenarios.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiResource: boolean = true;
 
     /**
-     * @internal
      * The optional parent of this resource.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __parentResource: Resource | undefined;
 
     /**
-     * @internal
      * The child resources of this resource.  We use these (only from a ComponentResource) to allow
      * code to dependOn a ComponentResource and have that effectively mean that it is depending on
      * all the CustomResource children of that component.
@@ -124,6 +122,8 @@ export abstract class Resource {
      * However, this would be pretty nonsensical as there is zero need for a custom resource to ever
      * need to reference the urn of a component resource.  So it's acceptable if that sort of
      * pattern failed in practice.
+     *
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public __childResources: Set<Resource> | undefined;
@@ -135,48 +135,48 @@ export abstract class Resource {
     public readonly urn!: Output<URN>;
 
     /**
-     * @internal
      * When set to true, protect ensures this resource cannot be deleted.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     private readonly __protect: boolean;
 
     /**
-     * @internal
      * A collection of transformations to apply as part of resource registration.
      *
      * Note: This is marked optional only because older versions of this library may not have had
      * this property, and marking optional forces consumers of the property to defensively handle
      * cases where they are passed "old" resources.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     __transformations?: ResourceTransformation[];
 
     /**
-     * @internal
      * A list of aliases applied to this resource.
      *
      * Note: This is marked optional only because older versions of this library may not have had
      * this property, and marking optional forces consumers of the property to defensively handle
      * cases where they are passed "old" resources.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     readonly __aliases?: Input<URN>[];
 
     /**
-     * @internal
      * The name assigned to the resource at construction.
      *
      * Note: This is marked optional only because older versions of this library may not have had
      * this property, and marking optional forces consumers of the property to defensively handle
      * cases where they are passed "old" resources.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     private readonly __name?: string;
 
     /**
-     * @internal
      * The set of providers to use for child resources. Keyed by package name (e.g. "aws").
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     private readonly __providers: Record<string, ProviderResource>;
@@ -639,16 +639,16 @@ export interface ComponentResourceOptions extends ResourceOptions {
  */
 export abstract class CustomResource extends Resource {
     /**
-     * @internal
      * A private field to help with RTTI that works in SxS scenarios.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiCustomResource: boolean;
 
     /**
-     * @internal
      * Private field containing the type ID for this object. Useful for implementing `isInstance` on
      * classes that inherit from `CustomResource`.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiType: string;
@@ -745,8 +745,8 @@ export abstract class ProviderResource extends CustomResource {
  */
 export class ComponentResource<TData = any> extends Resource {
     /**
-     * @internal
      * A private field to help with RTTI that works in SxS scenarios.
+     * @internal
      */
     // tslint:disable-next-line:variable-name
     public readonly __pulumiComponentResource = true;

--- a/sdk/nodejs/runtime/asyncIterableUtil.ts
+++ b/sdk/nodejs/runtime/asyncIterableUtil.ts
@@ -33,6 +33,7 @@ const closeValue: CloseValue = "7473659d-924c-414d-84e5-b1640b2a6296";
 // the user can call `complete` at any time. `AsyncIteratable` would normally know when an element
 // is the last, but in this case it can't. Or, another way to look at it is, the last element is
 // guaranteed to be `undefined`.
+/** @internal */
 export class PushableAsyncIterable<T> implements AsyncIterable<T | undefined> {
     private bufferedData: T[] = [];
     private nextQueue: ((payload: T | CloseValue) => void)[] = [];

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -24,6 +24,7 @@ import { rewriteSuperReferences } from "./rewriteSuper";
 import * as utils from "./utils";
 import * as v8 from "./v8";
 
+/** @internal */
 export interface ObjectInfo {
     // information about the prototype of this object/function.  If this is an object, we only store
     // this if the object's prototype is not Object.prototype.  If this is a function, we only store
@@ -37,6 +38,7 @@ export interface ObjectInfo {
 
 // Information about a javascript function.  Note that this derives from ObjectInfo as all functions
 // are objects in JS, and thus can have their own proto and properties.
+/** @internal */
 export interface FunctionInfo extends ObjectInfo {
     // a serialization of the function's source code as text.
     code: string;
@@ -60,6 +62,7 @@ export interface FunctionInfo extends ObjectInfo {
 
 // Similar to PropertyDescriptor.  Helps describe an Entry in the case where it is not
 // simple.
+/** @internal */
 export interface PropertyInfo {
     // If the property has a value we should directly provide when calling .defineProperty
     hasValue: boolean;
@@ -77,6 +80,7 @@ export interface PropertyInfo {
 
 // Information about a property.  Specifically the actual entry containing the data about it and
 // then an optional PropertyInfo in the case that this isn't just a common property.
+/** @internal */
 export interface PropertyInfoAndValue {
     info?: PropertyInfo;
     entry: Entry;
@@ -84,12 +88,14 @@ export interface PropertyInfoAndValue {
 
 // A mapping between the name of a property (symbolic or string) to information about the
 // value for that property.
+/** @internal */
 export interface PropertyMap extends Map<Entry, PropertyInfoAndValue> {
 }
 
 /**
  * Entry is the environment slot for a named lexically captured variable.
  */
+/** @internal */
 export interface Entry {
     // a value which can be safely json serialized.
     json?: any;
@@ -215,6 +221,8 @@ class SerializedOutput<T> {
  * amenable to persistence as simple JSON.  Like toString, it includes the full text of the
  * function's source code, suitable for execution. Unlike toString, it actually includes information
  * about the captured environment.
+ *
+ * @internal
  */
 export async function createFunctionInfoAsync(
     func: Function, serialize: (o: any) => boolean, logResource: resource.Resource | undefined): Promise<FunctionInfo> {

--- a/sdk/nodejs/runtime/closure/parseFunction.ts
+++ b/sdk/nodejs/runtime/closure/parseFunction.ts
@@ -14,9 +14,9 @@
 
 import * as ts from "typescript";
 import * as log from "../../log";
-import * as closure from "./createClosure";
 import * as utils from "./utils";
 
+/** @internal */
 export interface ParsedFunctionCode {
     // The serialized code for the function, usable as an expression. Valid for all functions forms
     // (functions, lambdas, methods, etc.).
@@ -36,6 +36,7 @@ export interface ParsedFunctionCode {
     isArrowFunction: boolean;
 }
 
+/** @internal */
 export interface ParsedFunction extends ParsedFunctionCode {
     // The set of variables the function attempts to capture.
     capturedVariables: CapturedVariables;
@@ -46,6 +47,7 @@ export interface ParsedFunction extends ParsedFunctionCode {
 
 // Information about a captured property.  Both the name and whether or not the property was
 // invoked.
+/** @internal */
 export interface CapturedPropertyInfo {
     name: string;
     invoked: boolean;
@@ -54,6 +56,7 @@ export interface CapturedPropertyInfo {
 // Information about a chain of captured properties.  i.e. if you have "foo.bar.baz.quux()", we'll
 // say that 'foo' was captured, but that "[bar, baz, quux]" was accessed off of it.  We'll also note
 // that 'quux' was invoked.
+/** @internal */
 export interface CapturedPropertyChain {
     infos: CapturedPropertyInfo[];
 }
@@ -66,12 +69,14 @@ export interface CapturedPropertyChain {
 //
 // Note: if we want to capture everything, we just use an empty array for 'CapturedPropertyChain[]'.
 // Otherwise, we'll use the chains to determine what portions of the object to serialize.
+/** @internal */
 export type CapturedVariableMap = Map<string, CapturedPropertyChain[]>;
 
 // The set of variables the function attempts to capture.  There is a required set an an optional
 // set. The optional set will not block closure-serialization if we cannot find them, while the
 // required set will.  For each variable that is captured we also specify the list of properties of
 // that variable we need to serialize.  An empty-list means 'serialize all properties'.
+/** @internal */
 export interface CapturedVariables {
     required: CapturedVariableMap;
     optional: CapturedVariableMap;
@@ -94,6 +99,7 @@ const nodeModuleGlobals: {[key: string]: boolean} = {
 // function declaration.  Note: this ties us heavily to V8 and its representation for functions.  In
 // particular, it has expectations around how functions/lambdas/methods/generators/constructors etc.
 // are represented.  If these change, this will likely break us.
+/** @internal */
 export function parseFunction(funcString: string): [string, ParsedFunction] {
     const [error, functionCode] = parseFunctionCode(funcString);
     if (error) {

--- a/sdk/nodejs/runtime/closure/rewriteSuper.ts
+++ b/sdk/nodejs/runtime/closure/rewriteSuper.ts
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 import * as ts from "typescript";
-import * as closure from "./createClosure";
 import * as utils from "./utils";
 
+/** @internal */
 export function rewriteSuperReferences(code: string, isStatic: boolean): string {
     const sourceFile = ts.createSourceFile(
         "", code, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);

--- a/sdk/nodejs/runtime/closure/utils.ts
+++ b/sdk/nodejs/runtime/closure/utils.ts
@@ -15,10 +15,13 @@
 import * as ts from "typescript";
 
 const legalNameRegex = /^[a-zA-Z_][0-9a-zA-Z_]*$/;
+
+/** @internal */
 export function isLegalMemberName(n: string) {
     return legalNameRegex.test(n);
 }
 
+/** @internal */
 export function isLegalFunctionName(n: string) {
     if (!isLegalMemberName(n)) {
         return false;

--- a/sdk/nodejs/runtime/closure/v8.ts
+++ b/sdk/nodejs/runtime/closure/v8.ts
@@ -19,7 +19,6 @@
 //
 // As a side-effect of importing this file, we must enable the --allow-natives-syntax V8 flag. This
 // is because we are using V8 intrinsics in order to implement this module.
-import * as semver from "semver";
 import * as v8 from "v8";
 v8.setFlagsFromString("--allow-natives-syntax");
 
@@ -41,11 +40,13 @@ const versionSpecificV8Module =  v8Hooks.isNodeAtLeastV11 ? v8_v11andHigher : v8
  * @param freeVariable The name of the free variable to inspect
  * @param throwOnFailure If true, throws if the free variable can't be found.
  * @returns The value of the free variable. If `throwOnFailure` is false, returns `undefined` if not found.
+ * @internal
  */
 export const lookupCapturedVariableValueAsync = versionSpecificV8Module.lookupCapturedVariableValueAsync;
 
 /**
  * Given a function, returns the file, line and column number in the file where this function was
  * defined. Returns { "", 0, 0 } if the location cannot be found or if the given function has no Script.
+ * @internal
  */
 export const getFunctionLocationAsync = versionSpecificV8Module.getFunctionLocationAsync;

--- a/sdk/nodejs/runtime/closure/v8Hooks.ts
+++ b/sdk/nodejs/runtime/closure/v8Hooks.ts
@@ -24,6 +24,7 @@ import * as semver from "semver";
 
 // On node11 and above, create an 'inspector session' that can be used to keep track of what is
 // happening through a supported API.  Pre-11 we can just call into % intrinsics for the same data.
+/** @internal */
 export const isNodeAtLeastV11 = semver.gte(process.version, "11.0.0");
 
 const session = isNodeAtLeastV11
@@ -56,6 +57,7 @@ async function createInspectorSessionAsync(): Promise<import("inspector").Sessio
 /**
  * Returns the inspector session that can be used to query the state of this running Node instance.
  * Must only be called on Node11 and above. On Node10 and below, this will throw.
+ * @internal
  */
 export async function getSessionAsync() {
     if (!isNodeAtLeastV11) {
@@ -68,6 +70,7 @@ export async function getSessionAsync() {
 /**
  * Returns a promise that can be used to determine when the v8hooks have been injected properly and
  * code that depends on them can continue executing.
+ * @internal
  */
 export async function isInitializedAsync() {
     await session;
@@ -75,6 +78,7 @@ export async function isInitializedAsync() {
 
 /**
  * Maps from a script-id to the local file url it corresponds to.
+ * @internal
  */
 export function getScriptUrl(id: import("inspector").Runtime.ScriptId) {
     return scriptIdToUrlMap.get(id);

--- a/sdk/nodejs/runtime/closure/v8_v10andLower.ts
+++ b/sdk/nodejs/runtime/closure/v8_v10andLower.ts
@@ -53,6 +53,7 @@ interface V8ScopeDetails {
     readonly scopeObject: Record<string, any>;
 }
 
+/** @internal */
 export async function getFunctionLocationAsync(func: Function) {
     const script = getScript(func);
     const { line, column } = getLineColumn();
@@ -113,6 +114,7 @@ function scriptPositionInfo(script: V8Script, pos: V8SourcePosition): {line: num
     return <any>undefined;
 }
 
+/** @internal */
 export async function lookupCapturedVariableValueAsync(
     func: Function, freeVariable: string, throwOnFailure: boolean): Promise<any> {
 

--- a/sdk/nodejs/runtime/closure/v8_v11andHigher.ts
+++ b/sdk/nodejs/runtime/closure/v8_v11andHigher.ts
@@ -18,6 +18,7 @@ import * as inspector from "inspector";
 import * as util from "util";
 import * as v8Hooks from "./v8Hooks";
 
+/** @internal */
 export async function getFunctionLocationAsync(func: Function) {
     // First, find the runtime's internal id for this function.
     const functionId = await getRuntimeIdForFunctionAsync(func);
@@ -42,6 +43,7 @@ export async function getFunctionLocationAsync(func: Function) {
     return { file, line, column };
 }
 
+/** @internal */
 export async function lookupCapturedVariableValueAsync(
     func: Function, freeVariable: string, throwOnFailure: boolean): Promise<any> {
 

--- a/sdk/nodejs/runtime/debuggable.ts
+++ b/sdk/nodejs/runtime/debuggable.ts
@@ -36,6 +36,7 @@ function promiseDebugString(p: Promise<any>): string {
 
 /**
  * debuggablePromise optionally wraps a promise with some goo to make it easier to debug common problems.
+ * @internal
  */
 export function debuggablePromise<T>(p: Promise<T>, ctx: any): Promise<T> {
     // Whack some stack onto the promise.  Leave them non-enumerable to avoid awkward rendering.
@@ -98,6 +99,7 @@ export function debuggablePromise<T>(p: Promise<T>, ctx: any): Promise<T> {
 
 /**
  * errorString produces a string from an error, conditionally including additional diagnostics.
+ * @internal
  */
 export function errorString(err: Error): string {
     if (err.stack) {

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -42,7 +42,6 @@ import {
     serializeProperty,
     serializeResourceProperties,
     transferProperties,
-    unknownValue,
 } from "./rpc";
 import {
     excessiveDebugOutput,

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -15,8 +15,6 @@
 import * as fs from "fs";
 import * as grpc from "grpc";
 import * as path from "path";
-import { RunError } from "../errors";
-import * as log from "../log";
 import { ComponentResource, URN } from "../resource";
 import { debuggablePromise } from "./debuggable";
 
@@ -55,7 +53,7 @@ export interface Options {
  */
 const options = loadOptions();
 
-/** @internal Used only for testing purposes */
+/** @internal Used only for testing purposes. */
 export function _setIsDryRun(val: boolean) {
     (options as any).dryRun = val;
 }

--- a/sdk/nodejs/tests/runtime/tsClosureCases.ts
+++ b/sdk/nodejs/tests/runtime/tsClosureCases.ts
@@ -35,6 +35,7 @@ interface ClosureCase {
     afters?: ClosureCase[];         // an optional list of test cases to run afterwards.
 }
 
+/** @internal */
 export const exportedValue = 42;
 
 // This group of tests ensure that we serialize closures properly.

--- a/sdk/nodejs/tests/util.ts
+++ b/sdk/nodejs/tests/util.ts
@@ -14,10 +14,12 @@
 
 import * as assert from "assert";
 
+/** @internal */
 export type MochaFunc = (err: Error) => void;
 
 // A helper function for wrapping some of the boilerplate goo necessary to interface between Mocha's asynchronous
 // testing and our TypeScript async tests.
+/** @internal */
 export function asyncTest(test: () => Promise<void>): (func: MochaFunc) => void {
     return (done: (err: any) => void) => {
         const go = async () => {
@@ -37,6 +39,7 @@ export function asyncTest(test: () => Promise<void>): (func: MochaFunc) => void 
 }
 
 // A helper function for asynchronous tests that throw.
+/** @internal */
 export async function assertAsyncThrows(test: () => Promise<void>): Promise<string> {
     try {
         await test();

--- a/sdk/nodejs/utils.ts
+++ b/sdk/nodejs/utils.ts
@@ -24,8 +24,9 @@ import { InvokeOptions } from "./invoke";
  * that synthesize properties dynamically (like Output).  Checking that the property has the 'true'
  * value isn't strictly necessary, but works to make sure that the impls are following a common
  * pattern.
+ *
+ * @internal
  */
-/** @internal */
 export function isInstance<T>(obj: any, name: keyof T): obj is T {
     return hasTrueBooleanMember(obj, name);
 }
@@ -99,11 +100,11 @@ export function promiseResult<T>(promise: Promise<T>): T {
 }
 
 /**
- * No longer supported. This function is now a no-op and will directly return the promise passed
- * into it.
- *
  * This is an advanced compat function for libraries and should not generally be used by normal
  * Pulumi application.
+ *
+ * @deprecated No longer supported. This function is now a no-op and will directly return the promise
+ * passed into it.
  */
 export function liftProperties<T>(promise: Promise<T>, opts: InvokeOptions = {}): Promise<T> & T {
     return <any>promise;


### PR DESCRIPTION
Also:

 - Cleaned up existing tags so they're consistently at the bottom of doc comments where they should be
 - Cleaned up some unused imports while I was taking a pass over the files
 - Marked one function `@deprecated` that should be deprecated

Docs diff:https://github.com/pulumi/docs/compare/justin/internal