### PR TITLE
Fix doc comment to filter internal API

### DIFF
--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -88,12 +88,12 @@ function requireTestModeEnabled(): void {
     }
 }
 
-/* @internal Used only for testing purposes */
+/** @internal Used only for testing purposes. */
 export function _setQueryMode(val: boolean) {
     (options as any).queryMode = val;
 }
 
- /**
+/**
  * Returns true if query mode is enabled.
  */
 export function isQueryMode(): boolean {


### PR DESCRIPTION
I noticed `_setQueryMode` wasn't being filtered out of API docs, and it was due to the comment not being a _doc_ comment.