### PR TITLE
Add current operation info to stack command output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
+- Add information about an in-flight operation to the stack command output, if applicable.
+  [#3822](https://github.com/pulumi/pulumi/pull/3822)
+
 - Fix a stack reference regression in the Python SDK.
   [#3798](https://github.com/pulumi/pulumi/pull/3798)
 


### PR DESCRIPTION
This will complete the process of wiring through current operation in progress info to the CLI, addressing issue #4468.  If an update is currently in progress a "Last Updated" time won't be displayed.
Example:
![image](https://user-images.githubusercontent.com/41454626/73290421-458c5e80-41b3-11ea-890c-9a3589aa41f5.png)
