### PR TITLE
Output watcher

### DIFF
--- a/sdk/dotnet/Pulumi/Core/OutputUtilities.cs
+++ b/sdk/dotnet/Pulumi/Core/OutputUtilities.cs
@@ -3,13 +3,13 @@
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 
-namespace Pulumi
+namespace Pulumi.Utilities
 {
     /// <summary>
     /// Allows extracting some internal insights about an instance of
     /// <see cref="Output{T}"/>. 
     /// </summary>
-    public static class OutputWatcher
+    public static class OutputUtilities
     {
         /// <summary>
         /// Retrieve the Is Known status of the given output.
@@ -28,6 +28,6 @@ namespace Pulumi
         /// </summary>
         /// <param name="output">The <see cref="Output{T}"/> to get dependencies of.</param>
         public static Task<ImmutableHashSet<Resource>> GetDependenciesAsync<T>(Output<T> output)
-            => (output as IOutput).GetResourcesAsync();
+            => ((IOutput)output).GetResourcesAsync();
     }
 }

--- a/sdk/dotnet/Pulumi/Core/OutputWatcher.cs
+++ b/sdk/dotnet/Pulumi/Core/OutputWatcher.cs
@@ -1,0 +1,68 @@
+// Copyright 2016-2020, Pulumi Corporation
+
+using System;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+
+namespace Pulumi
+{
+    /// <summary>
+    /// Allows extracting some internal insights about an instance of
+    /// <see cref="Output{T}"/>. 
+    /// </summary>
+    public sealed class OutputWatcher<T>
+    {
+        private readonly Output<T> _output;
+
+        public OutputWatcher(Output<T> output)
+        {
+            _output = output;
+            _output.DataTask.ContinueWith(t =>
+            {
+                var data = t.Result;
+                var args = new OutputResolvedArgs<T>(data.Value, data.IsKnown, data.IsSecret);
+                Resolved?.Invoke(this, args);
+            });
+        }
+
+        /// <summary>
+        /// Retrieve a set of resources that the output depends on.
+        /// </summary>
+        /// <returns></returns>
+        public Task<ImmutableHashSet<Resource>> GetDependenciesAsync()
+            => (_output as IOutput).GetResourcesAsync();
+
+        /// <summary>
+        /// Fires when the output value is resolved.
+        /// </summary>
+        public event EventHandler<OutputResolvedArgs<T>>? Resolved;
+    }
+
+    /// <summary>
+    /// Arguments for <see cref="OutputWatcher{T}.Resolved"/> events handler.
+    /// </summary>
+    public sealed class OutputResolvedArgs<T> : EventArgs
+    {
+        internal OutputResolvedArgs(T value, bool isKnown, bool isSecret)
+        {
+            Value = value;
+            IsKnown = isKnown;
+            IsSecret = isSecret;
+        }
+
+        /// <summary>
+        /// Output value, if known.
+        /// </summary>
+        public T Value { get; }
+
+        /// <summary>
+        /// Whether the output value is known.
+        /// </summary>
+        public bool IsKnown { get; }
+
+        /// <summary>
+        /// Whether the output value is a secret.
+        /// </summary>
+        public bool IsSecret { get; }
+    }
+}

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -115,14 +115,7 @@ Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Output<U>> func) -> Pulumi.Outpu
 Pulumi.Output<T>.Apply<U>(System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, U> func) -> Pulumi.Output<U>
 Pulumi.OutputExtensions
-Pulumi.OutputResolvedArgs<T>
-Pulumi.OutputResolvedArgs<T>.IsKnown.get -> bool
-Pulumi.OutputResolvedArgs<T>.IsSecret.get -> bool
-Pulumi.OutputResolvedArgs<T>.Value.get -> T
-Pulumi.OutputWatcher<T>
-Pulumi.OutputWatcher<T>.OutputWatcher(Pulumi.Output<T> output) -> void
-Pulumi.OutputWatcher<T>.GetDependenciesAsync() -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableHashSet<Pulumi.Resource>>
-Pulumi.OutputWatcher<T>.Resolved -> System.EventHandler<Pulumi.OutputResolvedArgs<T>>
+Pulumi.OutputWatcher
 Pulumi.ProviderResource
 Pulumi.ProviderResource.ProviderResource(string package, string name, Pulumi.ResourceArgs args, Pulumi.ResourceOptions options = null) -> void
 Pulumi.RemoteArchive
@@ -294,6 +287,8 @@ static Pulumi.OutputExtensions.IsT0<T0, T1>(this Pulumi.Output<Pulumi.Union<T0, 
 static Pulumi.OutputExtensions.IsT1<T0, T1>(this Pulumi.Output<Pulumi.Union<T0, T1>> output) -> Pulumi.Output<bool>
 static Pulumi.OutputExtensions.Length<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array) -> Pulumi.Output<int>
 static Pulumi.OutputExtensions.Value<T0, T1>(this Pulumi.Output<Pulumi.Union<T0, T1>> output) -> Pulumi.Output<object>
+static Pulumi.OutputWatcher.GetDependenciesAsync<T>(Pulumi.Output<T> output) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableHashSet<Pulumi.Resource>>
+static Pulumi.OutputWatcher.GetIsKnownAsync<T>(Pulumi.Output<T> output) -> System.Threading.Tasks.Task<bool>
 static Pulumi.ResourceOptions.Merge(Pulumi.ResourceOptions options1, Pulumi.ResourceOptions options2) -> Pulumi.ResourceOptions
 static Pulumi.Union<T0, T1>.FromT0(T0 input) -> Pulumi.Union<T0, T1>
 static Pulumi.Union<T0, T1>.FromT1(T1 input) -> Pulumi.Union<T0, T1>

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -115,7 +115,6 @@ Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Output<U>> func) -> Pulumi.Outpu
 Pulumi.Output<T>.Apply<U>(System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, U> func) -> Pulumi.Output<U>
 Pulumi.OutputExtensions
-Pulumi.OutputWatcher
 Pulumi.ProviderResource
 Pulumi.ProviderResource.ProviderResource(string package, string name, Pulumi.ResourceArgs args, Pulumi.ResourceOptions options = null) -> void
 Pulumi.RemoteArchive
@@ -202,6 +201,7 @@ Pulumi.Union<T0, T1>.TryPickT0(out T0 value, out T1 remainder) -> bool
 Pulumi.Union<T0, T1>.TryPickT1(out T1 value, out T0 remainder) -> bool
 Pulumi.Union<T0, T1>.Value.get -> object
 Pulumi.Urn
+Pulumi.Utilities.OutputUtilities
 override Pulumi.Union<T0, T1>.Equals(object obj) -> bool
 override Pulumi.Union<T0, T1>.GetHashCode() -> int
 override Pulumi.Union<T0, T1>.ToString() -> string
@@ -287,8 +287,8 @@ static Pulumi.OutputExtensions.IsT0<T0, T1>(this Pulumi.Output<Pulumi.Union<T0, 
 static Pulumi.OutputExtensions.IsT1<T0, T1>(this Pulumi.Output<Pulumi.Union<T0, T1>> output) -> Pulumi.Output<bool>
 static Pulumi.OutputExtensions.Length<T>(this Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>> array) -> Pulumi.Output<int>
 static Pulumi.OutputExtensions.Value<T0, T1>(this Pulumi.Output<Pulumi.Union<T0, T1>> output) -> Pulumi.Output<object>
-static Pulumi.OutputWatcher.GetDependenciesAsync<T>(Pulumi.Output<T> output) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableHashSet<Pulumi.Resource>>
-static Pulumi.OutputWatcher.GetIsKnownAsync<T>(Pulumi.Output<T> output) -> System.Threading.Tasks.Task<bool>
+static Pulumi.Utilities.OutputUtilities.GetDependenciesAsync<T>(Pulumi.Output<T> output) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableHashSet<Pulumi.Resource>>
+static Pulumi.Utilities.OutputUtilities.GetIsKnownAsync<T>(Pulumi.Output<T> output) -> System.Threading.Tasks.Task<bool>
 static Pulumi.ResourceOptions.Merge(Pulumi.ResourceOptions options1, Pulumi.ResourceOptions options2) -> Pulumi.ResourceOptions
 static Pulumi.Union<T0, T1>.FromT0(T0 input) -> Pulumi.Union<T0, T1>
 static Pulumi.Union<T0, T1>.FromT1(T1 input) -> Pulumi.Union<T0, T1>

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -115,6 +115,14 @@ Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Output<U>> func) -> Pulumi.Outpu
 Pulumi.Output<T>.Apply<U>(System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, U> func) -> Pulumi.Output<U>
 Pulumi.OutputExtensions
+Pulumi.OutputResolvedArgs<T>
+Pulumi.OutputResolvedArgs<T>.IsKnown.get -> bool
+Pulumi.OutputResolvedArgs<T>.IsSecret.get -> bool
+Pulumi.OutputResolvedArgs<T>.Value.get -> T
+Pulumi.OutputWatcher<T>
+Pulumi.OutputWatcher<T>.OutputWatcher(Pulumi.Output<T> output) -> void
+Pulumi.OutputWatcher<T>.GetDependenciesAsync() -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableHashSet<Pulumi.Resource>>
+Pulumi.OutputWatcher<T>.Resolved -> System.EventHandler<Pulumi.OutputResolvedArgs<T>>
 Pulumi.ProviderResource
 Pulumi.ProviderResource.ProviderResource(string package, string name, Pulumi.ResourceArgs args, Pulumi.ResourceOptions options = null) -> void
 Pulumi.RemoteArchive


### PR DESCRIPTION
Introduces an escape hatch to get into the internals of an Output. It is needed for Helm support in the .NET Kubernetes SDK (https://github.com/pulumi/pulumi-kubernetes/issues/957). See [this TS counterpart](https://github.com/pulumi/pulumi-kubernetes/blob/master/sdk/nodejs/helm/v2/helm.ts#L143-L150).