### PR TITLE
Improve PP naming for local PPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ CHANGELOG
 - Add information about an in-flight operation to the stack command output, if applicable.
   [#3822](https://github.com/pulumi/pulumi/pull/3822)
 
-=======
+- Update SummaryEvent to use the actual name plus path for Local Policy Packs
+
 ## 1.9.1 (2020-01-27)
 - Fix a stack reference regression in the Python SDK.
   [#3798](https://github.com/pulumi/pulumi/pull/3798)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ CHANGELOG
 - Add information about an in-flight operation to the stack command output, if applicable.
   [#3822](https://github.com/pulumi/pulumi/pull/3822)
 
-- Update SummaryEvent to use the actual name plus path for Local Policy Packs
+- Update `SummaryEvent` to include the actual name and local file path for locally-executed policy packs.
 
 ## 1.9.1 (2020-01-27)
 - Fix a stack reference regression in the Python SDK.

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -135,7 +135,7 @@ func newPreviewCmd() *cobra.Command {
 
 			opts := backend.UpdateOptions{
 				Engine: engine.UpdateOptions{
-					LocalPolicyPackPaths: policyPackPaths,
+					LocalPolicyPacks: engine.ConvertPathsToLocalPolicyPacks(policyPackPaths),
 					Parallel:             parallel,
 					Debug:                debug,
 					Refresh:              refresh,

--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -135,14 +135,14 @@ func newPreviewCmd() *cobra.Command {
 
 			opts := backend.UpdateOptions{
 				Engine: engine.UpdateOptions{
-					LocalPolicyPacks: engine.ConvertPathsToLocalPolicyPacks(policyPackPaths),
-					Parallel:             parallel,
-					Debug:                debug,
-					Refresh:              refresh,
-					ReplaceTargets:       replaceURNs,
-					UseLegacyDiff:        useLegacyDiff(),
-					UpdateTargets:        targetURNs,
-					TargetDependents:     targetDependents,
+					LocalPolicyPacks: engine.MakeLocalPolicyPacks(policyPackPaths),
+					Parallel:         parallel,
+					Debug:            debug,
+					Refresh:          refresh,
+					ReplaceTargets:   replaceURNs,
+					UseLegacyDiff:    useLegacyDiff(),
+					UpdateTargets:    targetURNs,
+					TargetDependents: targetDependents,
 				},
 				Display: displayOpts,
 			}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -120,14 +120,14 @@ func newUpCmd() *cobra.Command {
 		}
 
 		opts.Engine = engine.UpdateOptions{
-			LocalPolicyPackPaths: policyPackPaths,
-			Parallel:             parallel,
-			Debug:                debug,
-			Refresh:              refresh,
-			ReplaceTargets:       replaceURNs,
-			UseLegacyDiff:        useLegacyDiff(),
-			UpdateTargets:        targetURNs,
-			TargetDependents:     targetDependents,
+			LocalPolicyPacks: engine.ConvertPathsToLocalPolicyPacks(policyPackPaths),
+			Parallel:         parallel,
+			Debug:            debug,
+			Refresh:          refresh,
+			ReplaceTargets:   replaceURNs,
+			UseLegacyDiff:    useLegacyDiff(),
+			UpdateTargets:    targetURNs,
+			TargetDependents: targetDependents,
 		}
 
 		changes, res := s.Update(commandContext(), backend.UpdateOperation{
@@ -281,10 +281,10 @@ func newUpCmd() *cobra.Command {
 		}
 
 		opts.Engine = engine.UpdateOptions{
-			LocalPolicyPackPaths: policyPackPaths,
-			Parallel:             parallel,
-			Debug:                debug,
-			Refresh:              refresh,
+			LocalPolicyPacks: engine.ConvertPathsToLocalPolicyPacks(policyPackPaths),
+			Parallel:         parallel,
+			Debug:            debug,
+			Refresh:          refresh,
 		}
 
 		// TODO for the URL case:

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -120,7 +120,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		opts.Engine = engine.UpdateOptions{
-			LocalPolicyPacks: engine.ConvertPathsToLocalPolicyPacks(policyPackPaths),
+			LocalPolicyPacks: engine.MakeLocalPolicyPacks(policyPackPaths),
 			Parallel:         parallel,
 			Debug:            debug,
 			Refresh:          refresh,
@@ -281,7 +281,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		opts.Engine = engine.UpdateOptions{
-			LocalPolicyPacks: engine.ConvertPathsToLocalPolicyPacks(policyPackPaths),
+			LocalPolicyPacks: engine.MakeLocalPolicyPacks(policyPackPaths),
 			Parallel:         parallel,
 			Debug:            debug,
 			Refresh:          refresh,

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -107,7 +107,7 @@ func newWatchCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				LocalPolicyPacks: engine.ConvertPathsToLocalPolicyPacks(policyPackPaths),
+				LocalPolicyPacks: engine.MakeLocalPolicyPacks(policyPackPaths),
 				Parallel:         parallel,
 				Debug:            debug,
 				Refresh:          refresh,

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -107,11 +107,11 @@ func newWatchCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				LocalPolicyPackPaths: policyPackPaths,
-				Parallel:             parallel,
-				Debug:                debug,
-				Refresh:              refresh,
-				UseLegacyDiff:        useLegacyDiff(),
+				LocalPolicyPacks: engine.ConvertPathsToLocalPolicyPacks(policyPackPaths),
+				Parallel:         parallel,
+				Debug:            debug,
+				Refresh:          refresh,
+				UseLegacyDiff:    useLegacyDiff(),
 			}
 
 			res := s.Watch(commandContext(), backend.UpdateOperation{

--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -70,12 +70,6 @@ type UpdateMetadata struct {
 	Environment map[string]string `json:"environment"`
 }
 
-// LocalPolicyPack contains information about the locally specified Policy Packs ran with
-// an update.
-type LocalPolicyPack struct {
-	Path string `json:"path"`
-}
-
 // UpdateProgramResponse is the result of an update program request.
 type UpdateProgramResponse struct {
 	// UpdateID is the opaque identifier of the requested update. This value is needed to begin an update, as

--- a/pkg/apitype/updates.go
+++ b/pkg/apitype/updates.go
@@ -70,6 +70,12 @@ type UpdateMetadata struct {
 	Environment map[string]string `json:"environment"`
 }
 
+// LocalPolicyPack contains information about the locally specified Policy Packs ran with
+// an update.
+type LocalPolicyPack struct {
+	Path string `json:"path"`
+}
+
 // UpdateProgramResponse is the result of an update program request.
 type UpdateProgramResponse struct {
 	// UpdateID is the opaque identifier of the requested update. This value is needed to begin an update, as

--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -192,9 +192,6 @@ func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayl
 		}
 	}
 
-	// Print policy packs loaded. Data is rendered as a table of {policy-pack-name, version}.
-	renderPolicyPacks(out, event.PolicyPacks, opts)
-
 	summaryPieces := []string{}
 	if changeKindCount >= 2 {
 		// Only if we made multiple types of changes do we need to print out the total number of
@@ -220,6 +217,9 @@ func renderSummaryEvent(action apitype.UpdateKind, event engine.SummaryEventPayl
 
 		fprintfIgnoreError(out, "\n")
 	}
+
+	// Print policy packs loaded. Data is rendered as a table of {policy-pack-name, version}.
+	renderPolicyPacks(out, event.PolicyPacks, opts)
 
 	// For actual deploys, we print some additional summary information
 	if !event.IsPreview {

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -436,7 +436,7 @@ func (pc *Client) CreateUpdate(
 		Description: description,
 		Config:      wireConfig,
 		Options: apitype.UpdateOptions{
-			LocalPolicyPackPaths: opts.LocalPolicyPackPaths,
+			LocalPolicyPackPaths: engine.ConvertLocalPolicyPacksToPaths(opts.LocalPolicyPacks),
 			Color:                colors.Raw, // force raw colorization, we handle colorization in the CLI
 			DryRun:               dryRun,
 			Parallel:             opts.Parallel,

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -135,8 +135,9 @@ func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*plan
 	}
 
 	// Generate a plan; this API handles all interesting cases (create, update, delete).
+	localPolicyPackPaths := ConvertLocalPolicyPacksToPaths(opts.LocalPolicyPacks)
 	plan, err := deploy.NewPlan(
-		plugctx, target, target.Snapshot, source, opts.LocalPolicyPackPaths, dryRun, ctx.BackendClient)
+		plugctx, target, target.Snapshot, source, localPolicyPackPaths, dryRun, ctx.BackendClient)
 	if err != nil {
 		contract.IgnoreClose(plugctx)
 		return nil, err

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -1,0 +1,40 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShortenPolicyPackPath(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{
+			path:     "/Users/username/test-policy",
+			expected: "/Users/username/test-policy",
+		},
+		{
+			path:     "./..//test-policy",
+			expected: "../test-policy",
+		},
+		{
+			path:     "/Users/username/averylongpath/one/two/three/four/five/six/seven/eight/nine/ten/eleven/twelve/test-policy",
+			expected: "/Users/.../twelve/test-policy",
+		},
+		{
+			path:     "nonrootdir/username/averylongpath/one/two/three/four/five/six/seven/eight/nine/ten/eleven/twelve/test-policy",
+			expected: "nonrootdir/username/.../twelve/test-policy",
+		},
+		{
+			path:     "C:Documents and Settings/username/My Documents/averylongpath/one/two/three/four/five/six/seven/eight/test-policy",
+			expected: "C:Documents and Settings/username/.../eight/test-policy",
+		},
+	}
+
+	for _, tt := range tests {
+		actual := shortenPolicyPackPath(tt.path)
+		assert.Equal(t, tt.expected, actual)
+	}
+}

--- a/pkg/engine/update_test.go
+++ b/pkg/engine/update_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestShortenPolicyPackPath(t *testing.T) {
+func TestAbbreviateFilePath(t *testing.T) {
 	tests := []struct {
 		path     string
 		expected string
@@ -20,21 +20,29 @@ func TestShortenPolicyPackPath(t *testing.T) {
 			expected: "../test-policy",
 		},
 		{
-			path:     "/Users/username/averylongpath/one/two/three/four/five/six/seven/eight/nine/ten/eleven/twelve/test-policy",
+			path: `/Users/username/averylongpath/one/two/three/four/` +
+				`five/six/seven/eight/nine/ten/eleven/twelve/test-policy`,
 			expected: "/Users/.../twelve/test-policy",
 		},
 		{
-			path:     "nonrootdir/username/averylongpath/one/two/three/four/five/six/seven/eight/nine/ten/eleven/twelve/test-policy",
+			path: `nonrootdir/username/averylongpath/one/two/three/four/` +
+				`five/six/seven/eight/nine/ten/eleven/twelve/test-policy`,
 			expected: "nonrootdir/username/.../twelve/test-policy",
 		},
 		{
-			path:     "C:Documents and Settings/username/My Documents/averylongpath/one/two/three/four/five/six/seven/eight/test-policy",
-			expected: "C:Documents and Settings/username/.../eight/test-policy",
+			path: `C:/Documents and Settings/username/My Documents/averylongpath/` +
+				`one/two/three/four/five/six/seven/eight/test-policy`,
+			expected: "C:/Documents and Settings/.../eight/test-policy",
+		},
+		{
+			path: `C:\Documents and Settings\username\My Documents\averylongpath\` +
+				`one\two\three\four\five\six\seven\eight\test-policy`,
+			expected: `C:\Documents and Settings\...\eight\test-policy`,
 		},
 	}
 
 	for _, tt := range tests {
-		actual := shortenPolicyPackPath(tt.path)
+		actual := abbreviateFilePath(tt.path)
 		assert.Equal(t, tt.expected, actual)
 	}
 }


### PR DESCRIPTION
There are two commits
1 - Change the name of Policy Packs to include the actual name from the PP. Includes a shortening function with tests in the case the path is v long.
2 - move were "Policy Packs run:" is rendered to after the Resources instead of the middle

This is in support of https://github.com/pulumi/pulumi-service/issues/4350 -- which we are already doing but needed a way to better consolidate naming of local PPs between the service and CLI.

Old output:
```

Resources:

Policy Packs run:
    Name                            Version
    /Users/erinkrengel/test-policy  (local)
    2 unchanged

Duration: 4s

Permalink: ...
```

New output:
```bash
Resources:
    2 unchanged

Policy Packs run:
    Name                                             Version
    aws-typescript (/Users/erinkrengel/test-policy)  (local)

Duration: 3s

Permalink: ....
```