### PR TITLE
Build feature-xxx branches as well as features/xxx branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-if: branch = master OR branch =~ ^features/ OR tag IS present
+if: branch = master OR branch =~ ^features/ OR branch =~ ^feature- OR tag IS present
 matrix:
   include:
   - os: linux

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -61,6 +61,9 @@ do
         if [[ "${TRAVIS_BRANCH:-}" == features/* ]]; then
             FEATURE_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|-|g')
         fi
+        if [[ "${TRAVIS_BRANCH:-}" == feature-* ]]; then
+            FEATURE_TAG=$(echo "${TRAVIS_BRANCH}")
+        fi
     fi
 done
 

--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -16,6 +16,10 @@ if [[ "${TRAVIS_PUBLISH_PACKAGES:-}" == "true" ]]; then
         NPM_TAG=$(echo "${TRAVIS_BRANCH}" | sed -e 's|^features/|feature-|g')
     fi
 
+    if [[ "${TRAVIS_BRANCH:-}" == feature-* ]]; then
+        NPM_TAG=$(echo "${TRAVIS_BRANCH}")
+    fi
+
     PKG_NAME=$(jq -r .name < "${ROOT}/sdk/nodejs/bin/package.json")
     PKG_VERSION=$(jq -r .version < "${ROOT}/sdk/nodejs/bin/package.json")
 


### PR DESCRIPTION
This is necessary so we can effectively use `go` modules.  `go` modules don't allow referencing branches with slashes in them.  So we instead unify on the form `feature-xxx` to make us compatible with them.