### PR TITLE
Add create flag to stack select

### DIFF
--- a/cmd/stack_init.go
+++ b/cmd/stack_init.go
@@ -24,6 +24,11 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/cmdutil"
 )
 
+const (
+	possibleSecretsProviderChoices = "The type of the provider that should be used to encrypt and decrypt secrets\n" +
+		"(possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault)"
+)
+
 func newStackInitCmd() *cobra.Command {
 	var secretsProvider string
 	var stackName string
@@ -114,7 +119,6 @@ func newStackInitCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stackName, "stack", "s", "", "The name of the stack to create")
 	cmd.PersistentFlags().StringVar(
-		&secretsProvider, "secrets-provider", "default", "The type of the provider that should be used to encrypt and "+
-			"decrypt secrets (possible choices: default, passphrase, awskms, azurekeyvault, gcpkms, hashivault)")
+		&secretsProvider, "secrets-provider", "default", possibleSecretsProviderChoices)
 	return cmd
 }

--- a/cmd/stack_select.go
+++ b/cmd/stack_select.go
@@ -27,6 +27,8 @@ import (
 // newStackSelectCmd handles both the "local" and "cloud" scenarios in its implementation.
 func newStackSelectCmd() *cobra.Command {
 	var stack string
+	var secretsProvider string
+	var create bool
 	cmd := &cobra.Command{
 		Use:   "select [<stack>]",
 		Short: "Switch the current workspace to the given stack",
@@ -35,7 +37,8 @@ func newStackSelectCmd() *cobra.Command {
 			"Selecting a stack allows you to use commands like `config`, `preview`, and `update`\n" +
 			"without needing to type the stack name each time.\n" +
 			"\n" +
-			"If no <stack> argument is supplied, you will be prompted to select one interactively.",
+			"If no <stack> argument is supplied, you will be prompted to select one interactively.\n" +
+			"If provided stack name is not found you may pass the -create flag to create and select it",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			opts := display.Options{
@@ -62,11 +65,19 @@ func newStackSelectCmd() *cobra.Command {
 					return stackErr
 				}
 
-				stack, stackErr := b.GetStack(commandContext(), stackRef)
+				s, stackErr := b.GetStack(commandContext(), stackRef)
 				if stackErr != nil {
 					return stackErr
-				} else if stack != nil {
+				} else if s != nil {
 					return state.SetCurrentStack(stackRef.String())
+				}
+				//if create flag was passed and stack was not found, create it and select it
+				if create == true && stack != "" {
+					s, err := stackInit(b, stack, false, secretsProvider)
+					if err != nil {
+						return err
+					}
+					return state.SetCurrentStack(s.Ref().String())
 				}
 
 				return errors.Errorf("no stack named '%s' found", stackRef)
@@ -86,5 +97,8 @@ func newStackSelectCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to select")
+	cmd.PersistentFlags().BoolVar(
+		&create, "create", false,
+		"If selected stack does not exist, create it")
 	return cmd
 }

--- a/cmd/stack_select.go
+++ b/cmd/stack_select.go
@@ -38,7 +38,7 @@ func newStackSelectCmd() *cobra.Command {
 			"without needing to type the stack name each time.\n" +
 			"\n" +
 			"If no <stack> argument is supplied, you will be prompted to select one interactively.\n" +
-			"If provided stack name is not found you may pass the -create flag to create and select it",
+			"If provided stack name is not found you may pass the --create flag to create and select it",
 		Args: cmdutil.MaximumNArgs(1),
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			opts := display.Options{
@@ -71,8 +71,8 @@ func newStackSelectCmd() *cobra.Command {
 				} else if s != nil {
 					return state.SetCurrentStack(stackRef.String())
 				}
-				//if create flag was passed and stack was not found, create it and select it
-				if create == true && stack != "" {
+				// If create flag was passed and stack was not found, create it and select it.
+				if create && stack != "" {
 					s, err := stackInit(b, stack, false, secretsProvider)
 					if err != nil {
 						return err
@@ -97,8 +97,11 @@ func newStackSelectCmd() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(
 		&stack, "stack", "s", "",
 		"The name of the stack to select")
-	cmd.PersistentFlags().BoolVar(
-		&create, "create", false,
+	cmd.PersistentFlags().BoolVarP(
+		&create, "create", "c", false,
 		"If selected stack does not exist, create it")
+	cmd.PersistentFlags().StringVar(
+		&secretsProvider, "secrets-provider", "default",
+		"Use with --create flag, "+possibleSecretsProviderChoices)
 	return cmd
 }


### PR DESCRIPTION
This resolves #3535, adding a create flag to the stack select command that will create and select a stack if it doesn't already exist.