### PR TITLE
Use \n for provider protocol even on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ CHANGELOG
 
 - Update `SummaryEvent` to include the actual name and local file path for locally-executed policy packs.
 
+- Fix Python Dynamic Providers on Windows. [#3855](https://github.com/pulumi/pulumi/pull/3855)
+
 ## 1.9.1 (2020-01-27)
 - Fix a stack reference regression in the Python SDK.
   [#3798](https://github.com/pulumi/pulumi/pull/3798)

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -28,6 +28,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -1565,7 +1566,14 @@ func (pt *programTester) preparePythonProject(projinfo *engine.Projinfo) error {
 	// Create a new Pipenv environment. This bootstraps a new virtual environment containing the version of Python that
 	// we requested. Note that this version of Python is sourced from the machine, so you must first install the version
 	// of Python that you are requesting on the host machine before building a virtualenv for it.
-	if err = pt.runPipenvCommand("pipenv-new", []string{"--python", "3.7"}, cwd); err != nil {
+	pythonVersion := "3"
+	if runtime.GOOS == "windows" {
+		// Due to https://bugs.python.org/issue34679, Python Dynamic Providers on Windows do not
+		// work on Python 3.8.0 (but are fixed in 3.8.1).  For now we will force Windows to use 3.7
+		// to avoid this bug, until 3.8.1 is available in all our CI systems.
+		pythonVersion = "3.7"
+	}
+	if err = pt.runPipenvCommand("pipenv-new", []string{"--python", pythonVersion}, cwd); err != nil {
 		return err
 	}
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1565,7 +1565,7 @@ func (pt *programTester) preparePythonProject(projinfo *engine.Projinfo) error {
 	// Create a new Pipenv environment. This bootstraps a new virtual environment containing the version of Python that
 	// we requested. Note that this version of Python is sourced from the machine, so you must first install the version
 	// of Python that you are requesting on the host machine before building a virtualenv for it.
-	if err = pt.runPipenvCommand("pipenv-new", []string{"--python", "3"}, cwd); err != nil {
+	if err = pt.runPipenvCommand("pipenv-new", []string{"--python", "3.7"}, cwd); err != nil {
 		return err
 	}
 

--- a/sdk/python/dist/pulumi-resource-pulumi-python.cmd
+++ b/sdk/python/dist/pulumi-resource-pulumi-python.cmd
@@ -1,3 +1,5 @@
 @echo off
 setlocal
-@python3 -u -m pulumi.dynamic %*
+REM We use `python` instead of `python3` because Windows Python installers 
+REM install only `python.exe` by default.
+@python -u -m pulumi.dynamic %*

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -15,6 +15,7 @@
 import asyncio
 import base64
 from concurrent import futures
+import sys
 import time
 
 import dill
@@ -166,7 +167,7 @@ def main():
     provider_pb2_grpc.add_ResourceProviderServicer_to_server(monitor, server)
     port = server.add_insecure_port(address="0.0.0.0:0")
     server.start()
-    print(port)
+    sys.stdout.buffer.write(f"{port}\n".encode())
     try:
         while True:
             time.sleep(_ONE_DAY_IN_SECONDS)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1220,9 +1220,6 @@ func TestProviderSecretConfig(t *testing.T) {
 
 // Tests dynamic provider in Python.
 func TestDynamicPython(t *testing.T) {
-	if runtime.GOOS == WindowsOS {
-		t.Skip("Temporarily skipping test on Windows - pulumi/pulumi#3811")
-	}
 	var randomVal string
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: filepath.Join("dynamic", "python"),


### PR DESCRIPTION
The provider plugin protocol is to write a port number followed by `\n`.  We must guarantee we do that even on Windows, so must avoid Python `print` statements which implicitly rewrite newlines to platform specific character sequences.

Fixes #3807.