### PR TITLE
Align defaults with OpenAPI

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1037,10 +1037,15 @@ func nestedStructure(typ schema.Type) []*nestedVariable {
 // pyType returns the expected runtime type for the given variable.  Of course, being a dynamic language, this
 // check is not exhaustive, but it should be good enough to catch 80% of the cases early on.
 func pyType(typ schema.Type) string {
-	switch typ.(type) {
+	switch typ := typ.(type) {
 	case *schema.ArrayType:
 		return "list"
-	case *schema.MapType, *schema.ObjectType, *schema.TokenType, *schema.UnionType:
+	case *schema.MapType, *schema.ObjectType, *schema.UnionType:
+		return "dict"
+	case *schema.TokenType:
+		if typ.UnderlyingType != nil {
+			return pyType(typ.UnderlyingType)
+		}
 		return "dict"
 	default:
 		switch typ {


### PR DESCRIPTION
Replace the various `defaults` maps in the schema with per-property
`default` and `defaultInfo` fields. The former holds the static default
value; the latter holds the envvars and language-specific info.

Also, fix a minor bug in the Python codegen that caused diffs in
property docstrings.