### PR TITLE
Fix bug in computing whether checkpoint write is necessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
+- Avoid writing checkpoints to backend storage in common case where no changes are being made.
+  [#3860](https://github.com/pulumi/pulumi/pull/3860)
+
 - Add information about an in-flight operation to the stack command output, if applicable.
   [#3822](https://github.com/pulumi/pulumi/pull/3822)
 

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -233,7 +233,9 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 	// reflect.DeepEqual does not treat `nil` and `[]URN{}` as equal, so we must check for both 
 	// lists being empty ourselves.
 	if len(old.Dependencies) != 0 || len(new.Dependencies) != 0 {
-		return !reflect.DeepEqual(old.Dependencies, new.Dependencies)
+		if !reflect.DeepEqual(old.Dependencies, new.Dependencies) {
+			return true
+		}
 	}
 
 	// Init errors are strictly advisory, so we do not consider them when deciding whether or not to write the

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -230,7 +230,7 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 	}
 	sortDeps(old.Dependencies)
 	sortDeps(new.Dependencies)
-	// reflect.DeepEqual does not treat `nil` and `[]URN{}` as equal, so we must check for both 
+	// reflect.DeepEqual does not treat `nil` and `[]URN{}` as equal, so we must check for both
 	// lists being empty ourselves.
 	if len(old.Dependencies) != 0 || len(new.Dependencies) != 0 {
 		if !reflect.DeepEqual(old.Dependencies, new.Dependencies) {
@@ -240,7 +240,7 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 
 	// Init errors are strictly advisory, so we do not consider them when deciding whether or not to write the
 	// checkpoint.
-	
+
 	return false
 }
 

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -225,15 +225,21 @@ func (ssm *sameSnapshotMutation) mustWrite(step *deploy.SameStep) bool {
 	}
 
 	// Sort dependencies before comparing them. If the dependencies have changed, we must write the checkpoint.
-	//
-	// Init errors are strictly advisory, so we do not consider them when deciding whether or not to write the
-	// checkpoint.
 	sortDeps := func(deps []resource.URN) {
 		sort.Slice(deps, func(i, j int) bool { return deps[i] < deps[j] })
 	}
 	sortDeps(old.Dependencies)
 	sortDeps(new.Dependencies)
-	return !reflect.DeepEqual(old.Dependencies, new.Dependencies)
+	// reflect.DeepEqual does not treat `nil` and `[]URN{}` as equal, so we must check for both 
+	// lists being empty ourselves.
+	if len(old.Dependencies) != 0 || len(new.Dependencies) != 0 {
+		return !reflect.DeepEqual(old.Dependencies, new.Dependencies)
+	}
+
+	// Init errors are strictly advisory, so we do not consider them when deciding whether or not to write the
+	// checkpoint.
+	
+	return false
 }
 
 func (ssm *sameSnapshotMutation) End(step deploy.Step, successful bool) error {


### PR DESCRIPTION
We were seeing that ~all same steps were requiring checkpoint writes due to percieving a difference between `Dependencies` being `nil` and `[]URN{}` - which should be considered the same for this purpose.