### PR TITLE
Check if TRAVIS_PULL_REQUEST is false before setting the ci vars' PRNumber property

### DIFF
--- a/pkg/util/ciutil/travis.go
+++ b/pkg/util/ciutil/travis.go
@@ -38,7 +38,7 @@ func (t travisCI) DetectVars() Vars {
 	// is not a PR build.
 	// See: https://docs.travis-ci.com/user/environment-variables/#convenience-variables
 	if prNumber := os.Getenv("TRAVIS_PULL_REQUEST"); prNumber != "false" {
-		v.PRNumber = prNprNumber
+		v.PRNumber = prNumber
 	}
 
 	return v

--- a/pkg/util/ciutil/travis.go
+++ b/pkg/util/ciutil/travis.go
@@ -34,7 +34,12 @@ func (t travisCI) DetectVars() Vars {
 	v.SHA = os.Getenv("TRAVIS_PULL_REQUEST_SHA")
 	v.BranchName = os.Getenv("TRAVIS_BRANCH")
 	v.CommitMessage = os.Getenv("TRAVIS_COMMIT_MESSAGE")
-	v.PRNumber = os.Getenv("TRAVIS_PULL_REQUEST")
+	// Travis sets the value of TRAVIS_PULL_REQUEST to false if the build
+	// is not a PR build.
+	// See: https://docs.travis-ci.com/user/environment-variables/#convenience-variables
+	if prNumber := os.Getenv("TRAVIS_PULL_REQUEST"); prNumber != "false" {
+		v.PRNumber = prNprNumber
+	}
 
 	return v
 }


### PR DESCRIPTION
As the title says, this PR introduces a fix for the Travis CI env vars detector, so that it doesn't set the `PRNumber` for non-PR builds.

I didn't update the changelog due to this being a small non-user impacting change.