### PR TITLE
Add --rm to docker run

### DIFF
--- a/tests/containers/containers_test.go
+++ b/tests/containers/containers_test.go
@@ -143,6 +143,8 @@ func testRuntimeWorksInContainer(t *testing.T, runtime, container string) {
 		"--volume", fmt.Sprintf("%s:/src", e.CWD),
 		// Set working directory when running the container.
 		"--workdir", "/src",
+		// Cleanup the container on shutdown.
+		"--rm",
 		// Container to run.
 		container,
 		// Flags to the container's entry point (`pulumi`).


### PR DESCRIPTION
The tests for the `pulumi/actions` container failed on Travis because of an unexpected file permissions issue:

```
--- FAIL: TestPulumiActionsImage (53.49s)
8812    environment.go:67: Created new test environment:  /tmp/test-env463339487
8813    containers_test.go:98: Running command docker images pulumi/actions:latest --quiet
8814    --- FAIL: TestPulumiActionsImage/dotnet (23.18s)
8815        environment.go:67: Created new test environment:  /tmp/test-env694629298
8816        containers_test.go:133: Running command pulumi stack init moolumi/container-dotnet-15f09f675ad09a9d
8817        containers_test.go:134: Running command pulumi config set runtime dotnet
8818        containers_test.go:137: Running command docker run --env PULUMI_ACCESS_TOKEN=[secure] --volume /tmp/test-env694629298:/src --workdir /src pulumi/actions:latest up --stack moolumi/container-dotnet-15f09f675ad09a9d
8819        containers_test.go:127: Running command pulumi stack rm --force --yes
8820        containers_test.go:128: 
8821            	Error Trace:	environment.go:87
8822            	            				containers_test.go:128
8823            	            				containers_test.go:153
8824            	            				containers_test.go:105
8825            	Error:      	Received unexpected error:
8826            	            	unlinkat /tmp/test-env694629298/bin/Debug/netcoreapp3.0/Grpc.Core.Api.dll: permission denied
8827            	Test:       	TestPulumiActionsImage/dotnet
8828            	Messages:   	cleaning up the test directory
8829    --- FAIL: TestPulumiActionsImage/nodejs (22.47s)
8830        environment.go:67: Created new test environment:  /tmp/test-env383772521
8831        containers_test.go:133: Running command pulumi stack init moolumi/container-nodejs-15f09f6cc09a9854
8832        containers_test.go:134: Running command pulumi config set runtime nodejs
8833        containers_test.go:137: Running command docker run --env PULUMI_ACCESS_TOKEN=[secure] --volume /tmp/test-env383772521:/src --workdir /src pulumi/actions:latest up --stack moolumi/container-nodejs-15f09f6cc09a9854
8834        containers_test.go:127: Running command pulumi stack rm --force --yes
8835        containers_test.go:128: 
8836            	Error Trace:	environment.go:87
8837            	            				containers_test.go:128
8838            	            				containers_test.go:153
8839            	            				containers_test.go:109
8840            	Error:      	Received unexpected error:
8841            	            	unlinkat /tmp/test-env383772521/node_modules/upath/upath.d.ts: permission denied
8842            	Test:       	TestPulumiActionsImage/nodejs
8843            	Messages:   	cleaning up the test directory
8844    --- FAIL: TestPulumiActionsImage/python (7.76s)
8845        environment.go:67: Created new test environment:  /tmp/test-env102087604
8846        containers_test.go:133: Running command pulumi stack init moolumi/container-python-15f09f71fc19efa7
8847        containers_test.go:134: Running command pulumi config set runtime python
8848        containers_test.go:137: Running command docker run --env PULUMI_ACCESS_TOKEN=[secure] --volume /tmp/test-env102087604:/src --workdir /src pulumi/actions:latest up --stack moolumi/container-python-15f09f71fc19efa7
8849        containers_test.go:127: Running command pulumi stack rm --force --yes
8850        containers_test.go:128: 
8851            	Error Trace:	environment.go:87
8852            	            				containers_test.go:128
8853            	            				containers_test.go:153
8854            	            				containers_test.go:113
8855            	Error:      	Received unexpected error:
8856            	            	unlinkat /tmp/test-env102087604/__pycache__/__main__.cpython-37.pyc: permission denied
8857            	Test:       	TestPulumiActionsImage/python
8858            	Messages:   	cleaning up the test directory
8859FAIL
8860FAIL	github.com/pulumi/pulumi/tests/containers	53.506s
8861
```

I suspect this has to do with files created during the execution of the container not being able to be deleted by the host OS after the container shuts down. From [the documentation](https://docs.docker.com/engine/reference/run/#clean-up---rm) the `--rm` flag should do what we want here, although it explicitly says it doesn't clean up any named volumes. (Which is what we do, since we map `~/temp/.../foo:/src`.

Anyways, I wasn't able to reproduce the failure on my machine. But I did confirm that adding this flag doesn't break anything. So 🤞 this will improve our reliability?

... though we won't be able to know for sure until we rerun the v1.10.0 release or start running these container tests more often than just when we are publishing new releases.