### PR TITLE
Add policy config apitypes

### DIFF
--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -14,6 +14,8 @@
 
 package apitype
 
+import "encoding/json"
+
 // DefaultPolicyGroup is the name of the default Policy Group for organizations.
 const DefaultPolicyGroup = "default-policy-group"
 
@@ -39,7 +41,7 @@ type CreatePolicyPackRequest struct {
 	Policies []Policy `json:"policies"`
 
 	// The JSON schema for the Policy Pack's configuration.
-	ConfigSchema map[string]interface{} `json:"configSchema,omitempty"`
+	ConfigSchema *json.RawMessage `json:"configSchema,omitempty"`
 }
 
 // CreatePolicyPackResponse is the response from creating a Policy Pack. It returns
@@ -70,7 +72,7 @@ type RequiredPolicy struct {
 
 	// The configuration that is to be passed to the Policy Pack. This must be valid
 	// in accordance with the JSON schema for the Policy Pack's configuration.
-	Config map[string]interface{} `json:"config,omitempty"`
+	Config *json.RawMessage `json:"config,omitempty"`
 }
 
 // Policy defines the metadata for an individual Policy within a Policy Pack.
@@ -146,7 +148,7 @@ type PolicyPackMetadata struct {
 	VersionTag  string `json:"versionTag"`
 
 	// The configuration that is to be passed to the Policy Pack.
-	Config map[string]interface{} `json:"config,omitempty"`
+	Config *json.RawMessage `json:"config,omitempty"`
 }
 
 // ListPolicyPacksResponse is the response to list an organization's
@@ -181,5 +183,5 @@ type PolicyGroupSummary struct {
 // of a particular Policy Pack's configuration.
 type GetPolicyPackConfigSchemaResponse struct {
 	// The JSON schema for the Policy Pack's configuration.
-	ConfigSchema map[string]interface{} `json:"configSchema,omitempty"`
+	ConfigSchema *json.RawMessage `json:"configSchema,omitempty"`
 }

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -99,7 +99,17 @@ type PolicyConfigSchema struct {
 	Properties map[string]*json.RawMessage `json:"properties,omitempty"`
 	// Required config properties.
 	Required []string `json:"required,omitempty"`
+
+	Type JSONSchemaType `json:"type"`
 }
+
+// JSONSchemaType in an enum of allowed data types for a schema.
+type JSONSchemaType string
+
+const (
+	// Object is a dictionary.
+	Object JSONSchemaType = "object"
+)
 
 // EnforcementLevel indicates how a policy should be enforced
 type EnforcementLevel string

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -89,7 +89,16 @@ type Policy struct {
 	Message string `json:"message"`
 
 	// The JSON schema for the Policy's configuration.
-	ConfigSchema *json.RawMessage `json:"configSchema,omitempty"`
+	ConfigSchema *PolicyConfigSchema `json:"configSchema,omitempty"`
+}
+
+// PolicyConfigSchema defines the JSON schema of a particular Policies'
+// configuration.
+type PolicyConfigSchema struct {
+    // Config property name to JSON Schema map.
+    Properties: map[string]*json.RawMessage `json:"properties,omitempty"`
+    // Required config properties.
+    Required:   []string                   `json:"required,omitempty"`
 }
 
 // EnforcementLevel indicates how a policy should be enforced
@@ -185,5 +194,5 @@ type PolicyGroupSummary struct {
 // schemas of Policies within a particular Policy Pack.
 type GetPolicyPackConfigSchemaResponse struct {
 	// The JSON schema for each Policy's configuration.
-	ConfigSchema map[string]*json.RawMessage `json:"configSchema,omitempty"`
+	ConfigSchema map[string]*PolicyConfigSchema `json:"configSchema,omitempty"`
 }

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -69,7 +69,7 @@ type RequiredPolicy struct {
 
 	// The configuration that is to be passed to the Policy Pack. This is map a of policies
 	// mapped to their configuration. Each individual configuration must comply with the
-	// JSON schema for the each Policy within the Policy Pack.
+	// JSON schema for each Policy within the Policy Pack.
 	Config map[string]*json.RawMessage `json:"config,omitempty"`
 }
 
@@ -92,7 +92,7 @@ type Policy struct {
 	ConfigSchema *PolicyConfigSchema `json:"configSchema,omitempty"`
 }
 
-// PolicyConfigSchema defines the JSON schema of a particular Policies'
+// PolicyConfigSchema defines the JSON schema of a particular Policy's
 // configuration.
 type PolicyConfigSchema struct {
 	// Config property name to JSON Schema map.
@@ -204,5 +204,5 @@ type PolicyGroupSummary struct {
 // schemas of Policies within a particular Policy Pack.
 type GetPolicyPackConfigSchemaResponse struct {
 	// The JSON schema for each Policy's configuration.
-	ConfigSchema map[string]*PolicyConfigSchema `json:"configSchema,omitempty"`
+	ConfigSchema map[string]PolicyConfigSchema `json:"configSchema,omitempty"`
 }

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -100,6 +100,7 @@ type PolicyConfigSchema struct {
 	// Required config properties.
 	Required []string `json:"required,omitempty"`
 
+	// Type defines the data type allowed for the schema.
 	Type JSONSchemaType `json:"type"`
 }
 

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -39,9 +39,6 @@ type CreatePolicyPackRequest struct {
 	// The Policies outline the specific Policies in the package, and are derived
 	// from the package by the CLI.
 	Policies []Policy `json:"policies"`
-
-	// The JSON schema for the Policy Pack's configuration.
-	ConfigSchema *json.RawMessage `json:"configSchema,omitempty"`
 }
 
 // CreatePolicyPackResponse is the response from creating a Policy Pack. It returns
@@ -70,9 +67,10 @@ type RequiredPolicy struct {
 	// Where the Policy Pack can be downloaded from.
 	PackLocation string `json:"packLocation,omitempty"`
 
-	// The configuration that is to be passed to the Policy Pack. This must be valid
-	// in accordance with the JSON schema for the Policy Pack's configuration.
-	Config *json.RawMessage `json:"config,omitempty"`
+	// The configuration that is to be passed to the Policy Pack. This is map a of policies
+	// mapped to their configuration. Each individual configuration must comply with the
+	// JSON schema for the each Policy within the Policy Pack.
+	Config map[string]*json.RawMessage `json:"config,omitempty"`
 }
 
 // Policy defines the metadata for an individual Policy within a Policy Pack.
@@ -89,6 +87,9 @@ type Policy struct {
 	// Message is the message that will be displayed to end users when they violate
 	// this policy.
 	Message string `json:"message"`
+
+	// The JSON schema for the Policy's configuration.
+	ConfigSchema *json.RawMessage `json:"configSchema,omitempty"`
 }
 
 // EnforcementLevel indicates how a policy should be enforced
@@ -147,8 +148,9 @@ type PolicyPackMetadata struct {
 	Version     int    `json:"version"`
 	VersionTag  string `json:"versionTag"`
 
-	// The configuration that is to be passed to the Policy Pack.
-	Config *json.RawMessage `json:"config,omitempty"`
+	// The configuration that is to be passed to the Policy Pack. This
+	// map ties Policies with their configuration.
+	Config map[string]*json.RawMessage `json:"config,omitempty"`
 }
 
 // ListPolicyPacksResponse is the response to list an organization's
@@ -180,8 +182,8 @@ type PolicyGroupSummary struct {
 }
 
 // GetPolicyPackConfigSchemaResponse is the response that includes the JSON
-// of a particular Policy Pack's configuration.
+// schemas of Policies within a particular Policy Pack.
 type GetPolicyPackConfigSchemaResponse struct {
-	// The JSON schema for the Policy Pack's configuration.
-	ConfigSchema *json.RawMessage `json:"configSchema,omitempty"`
+	// The JSON schema for each Policy's configuration.
+	ConfigSchema map[string]*json.RawMessage `json:"configSchema,omitempty"`
 }

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -95,10 +95,10 @@ type Policy struct {
 // PolicyConfigSchema defines the JSON schema of a particular Policies'
 // configuration.
 type PolicyConfigSchema struct {
-    // Config property name to JSON Schema map.
-    Properties: map[string]*json.RawMessage `json:"properties,omitempty"`
-    // Required config properties.
-    Required:   []string                   `json:"required,omitempty"`
+	// Config property name to JSON Schema map.
+	Properties map[string]*json.RawMessage `json:"properties,omitempty"`
+	// Required config properties.
+	Required []string `json:"required,omitempty"`
 }
 
 // EnforcementLevel indicates how a policy should be enforced

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -37,6 +37,9 @@ type CreatePolicyPackRequest struct {
 	// The Policies outline the specific Policies in the package, and are derived
 	// from the package by the CLI.
 	Policies []Policy `json:"policies"`
+
+	// The Configuration schema that the Policy Pack accepts.
+	ConfigSchema map[string]interface{} `json:"configSchema,omitempty"`
 }
 
 // CreatePolicyPackResponse is the response from creating a Policy Pack. It returns
@@ -64,6 +67,10 @@ type RequiredPolicy struct {
 
 	// Where the Policy Pack can be downloaded from.
 	PackLocation string `json:"packLocation,omitempty"`
+
+	// The configuration to use with the Policy Pack. This is to be validated with
+	// the JSON schema that is the Policy Pack's config schema.
+	Config map[string]interface{} `json:"config,omitempty"`
 }
 
 // Policy defines the metadata for an individual Policy within a Policy Pack.
@@ -120,8 +127,9 @@ type UpdatePolicyGroupRequest struct {
 	AddStack    *PulumiStackReference `json:"addStack,omitempty"`
 	RemoveStack *PulumiStackReference `json:"removeStack,omitempty"`
 
-	AddPolicyPack    *PolicyPackMetadata `json:"addPolicyPack,omitempty"`
-	RemovePolicyPack *PolicyPackMetadata `json:"removePolicyPack,omitempty"`
+	AddPolicyPack          *PolicyPackMetadata `json:"addPolicyPack,omitempty"`
+	RemovePolicyPack       *PolicyPackMetadata `json:"removePolicyPack,omitempty"`
+	UpdatePolicyPackConfig *PolicyPackMetadata `json:"updatePolicyPackConfig,omitempty"`
 }
 
 // PulumiStackReference contains the StackName and ProjectName of the stack.
@@ -136,6 +144,9 @@ type PolicyPackMetadata struct {
 	DisplayName string `json:"displayName"`
 	Version     int    `json:"version"`
 	VersionTag  string `json:"versionTag"`
+
+	// The configuration to use with the Policy Pack.
+	Config map[string]interface{} `json:"config,omitempty"`
 }
 
 // ListPolicyPacksResponse is the response to list an organization's
@@ -164,4 +175,11 @@ type PolicyGroupSummary struct {
 	IsOrgDefault          bool   `json:"isOrgDefault"`
 	NumStacks             int    `json:"numStacks"`
 	NumEnabledPolicyPacks int    `json:"numEnabledPolicyPacks"`
+}
+
+// GetPolicyPackConfigSchemaResponse is the response that includes the JSON configuration
+// schema of a particular Policy Pack.
+type GetPolicyPackConfigSchemaResponse struct {
+	// The Configuration schema that the Policy Pack accepts.
+	ConfigSchema map[string]interface{} `json:"configSchema,omitempty"`
 }

--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -38,7 +38,7 @@ type CreatePolicyPackRequest struct {
 	// from the package by the CLI.
 	Policies []Policy `json:"policies"`
 
-	// The Configuration schema that the Policy Pack accepts.
+	// The JSON schema for the Policy Pack's configuration.
 	ConfigSchema map[string]interface{} `json:"configSchema,omitempty"`
 }
 
@@ -68,8 +68,8 @@ type RequiredPolicy struct {
 	// Where the Policy Pack can be downloaded from.
 	PackLocation string `json:"packLocation,omitempty"`
 
-	// The configuration to use with the Policy Pack. This is to be validated with
-	// the JSON schema that is the Policy Pack's config schema.
+	// The configuration that is to be passed to the Policy Pack. This must be valid
+	// in accordance with the JSON schema for the Policy Pack's configuration.
 	Config map[string]interface{} `json:"config,omitempty"`
 }
 
@@ -145,7 +145,7 @@ type PolicyPackMetadata struct {
 	Version     int    `json:"version"`
 	VersionTag  string `json:"versionTag"`
 
-	// The configuration to use with the Policy Pack.
+	// The configuration that is to be passed to the Policy Pack.
 	Config map[string]interface{} `json:"config,omitempty"`
 }
 
@@ -177,9 +177,9 @@ type PolicyGroupSummary struct {
 	NumEnabledPolicyPacks int    `json:"numEnabledPolicyPacks"`
 }
 
-// GetPolicyPackConfigSchemaResponse is the response that includes the JSON configuration
-// schema of a particular Policy Pack.
+// GetPolicyPackConfigSchemaResponse is the response that includes the JSON
+// of a particular Policy Pack's configuration.
 type GetPolicyPackConfigSchemaResponse struct {
-	// The Configuration schema that the Policy Pack accepts.
+	// The JSON schema for the Policy Pack's configuration.
 	ConfigSchema map[string]interface{} `json:"configSchema,omitempty"`
 }


### PR DESCRIPTION
Using a `map[string]interface{}` we are able to easily transform into JSON Schema or JSON configuration values to be validated for this [JSON schema library](https://github.com/xeipuuv/gojsonschema). I am assuming that if we choose another library we still should be able to convert from a map to whatever struct the library uses since its pretty common.

The CLI as well as frontend will be responsible for running schema validations.

These changes entail:

* Add `ConfigSchema` to `CreatePolicyPackRequest` so the CLI can include the schema when it creates a new Policy Pack
* Add `Config` to `RequiredPolicy` -- this allows us to include the required configuration in response to Creating an Update & for the service's `GetStackPolicyPacksHandler`
* Add `Config` to `PolicyPackMetadata` which is used:
     * when Adding a Policy Pack to a Policy Group via `UpdatePolicyGroupRequest`
     * in `service_apitype.UpdateInfo` used to render Policy Packs used with an update (for the console)
    * will be used when updating the configuration of a Policy Pack via  `UpdatePolicyGroupRequest.UpdatePolicyPackConfig`
*  Add `GetPolicyPackConfigSchemaResponse` which will be used to return the schema of a PP in various situations (e.g. when trying to enable a Policy Pack that requires configuration)

Closes https://github.com/pulumi/pulumi-service/issues/4517