### PR TITLE
Restore the work to add Publish release builds of Pulumi

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,7 +7,6 @@ branches:
     only:
         - master
         - /v\d*\.\d*\.\d*/
-skip_tags: true
 environment:
   PULUMI_API: https://api.pulumi-staging.io
   PULUMI_ACCESS_TOKEN:
@@ -65,5 +64,5 @@ build_script:
 
     go mod vendor
 
-    dotnet msbuild /t:CIBuild /v:Detailed build.proj
+    if defined APPVEYOR_REPO_TAG_NAME ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) else ( dotnet msbuild /t:CIBuild /v:Detailed build.proj )
 test: off

--- a/build.proj
+++ b/build.proj
@@ -263,6 +263,18 @@
   <Target Name="Build"
           DependsOnTargets="BuildDotNetSDK;BuildGoSDK;BuildNodeJSSDK;BuildPythonSDK;InstallPulumiPlugin">
   </Target>
+  
+  <!-- Release Build
+  This is used to create the dependencies required for shipping the binary to the end user.
+  In the old scripts `BuildNodeJSSDK` was called `BuildNodeSdk` and included tasks for
+  * TypeScriptCompileNodeSdk (now called NodeJSBuild)
+  * GoCompileNodeSdk (now called NodeJSBuild)
+  * BinPlaceNodeSdk (included as part of NodeJSBuild)
+  The old task `BuildGoCmds` has now been renamed to `InstallPulumiPlugin`
+  -->
+  <Target Name="ReleaseBuild"
+          DependsOnTargets="BuildNodeJSSDK;InstallPulumiPlugin">
+  </Target>
 
   <!-- Tests -->
   <Target Name="Tests">
@@ -284,6 +296,13 @@
     <Error Text="integration tests (.\tests\integration) failed"
            Condition="$(IntegrationTestExitCode) != 0"/>
   </Target>
+
+  <Target Name="Publish">
+    <Exec Command="&quot;$(RepoRootDirectory)\scripts\publish.cmd" />
+  </Target>
+  
+  <Target Name="ReleaseProcess"
+          DependsOnTargets="ReleaseBuild;Publish" />
 
   <Target Name="CIBuild"
           DependsOnTargets="Build;Tests" />


### PR DESCRIPTION
Fixes: #3874

As part of #3656, the build.proj was changed around to support
building and running our tests on windows. The work in that PR added
a lot to get Python, Go and DotNet included in our master and PR runs
for those tests

This PR restores the work to allow the original work for non-PRs (i.e.
tagged builds) to work along side this. It adds a `Release` target which
targets the same build targets as before. It is wrapped in a condition that
will mean it can run when AppVeyor is dealing with a tag (i.e a release)

This means that the existing work to allow all of the master and pr builds
to continue running all of our integration tests will still work as
expected