### PR TITLE
update python instructions

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -653,7 +653,12 @@ func printNextSteps(proj *workspace.Project, originalCwd, cwd string, generateOn
 		// environment.
 
 		// Create the virtual environment.
-		commands = append(commands, "virtualenv -p python3 venv")
+		switch runtime.GOOS {
+		case "windows":
+			commands = append(commands, "python -m venv venv")
+		default:
+			commands = append(commands, "python3 -m venv venv")
+		}
 
 		// Activate the virtual environment. Only active in the user's current shell, so we can't
 		// just run it for the user here.


### PR DESCRIPTION
The following instructions after pulumi new python need updating, they do not match the instructions in Getting Started.

The current instructions are:

To perform an initial deployment, run the following commands:
   1. virtualenv -p python3 venv
   2. venv\Scripts\activate
   3. pip3 install -r requirements.txt

for Linux and macOS:

To perform an initial deployment, run the following commands:
   1. python3 -m venv venv
   2. venv\Scripts\activate
   3. pip3 install -r requirements.txt

for Windows:

To perform an initial deployment, run the following commands:
   1. python -m venv venv
   2. venv\Scripts\activate
   3. pip3 install -r requirements.txt