### PR TITLE
Be resilient to duplicate tasks in our inflight task list.

### DIFF
--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
@@ -15,6 +15,17 @@ namespace Pulumi
         {
             private readonly IDeploymentInternal _deployment;
 
+            /// <summary>
+            /// The list of tasks that we have fired off.  We issue tasks in a Fire-and-Forget
+            /// manner to be able to expose a Synchronous <see cref="Resource"/> model for users.
+            /// i.e. a user just synchronously creates a resource, and we asynchronously kick off
+            /// the work to populate it.  This works well, however we have to make sure the console
+            /// app doesn't exit because it thinks there is no work to do.
+            /// 
+            /// To ensure that doesn't happen, we have the main entrypoint of the app just
+            /// continuously, asynchronously loop, waiting for these tasks in this list to complete,
+            /// and only exiting once the list becomes empty.
+            /// </summary>
             private readonly LinkedList<(Task task, string description)> _inFlightTasks = new LinkedList<(Task, string description)>();
 
             public Runner(IDeploymentInternal deployment)

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
@@ -61,6 +61,11 @@ namespace Pulumi
 
                 lock (_inFlightTasks)
                 {
+                    // We may get several of the same tasks with different descriptions.  That can
+                    // happen when the runtime reuses cached tasks that it knows are value-identical
+                    // (for example Task.CompletedTask).  In that case, we just store all the
+                    // descriptions. We'll print them all out as done once this task actually
+                    // finishes.
                     if (!_inFlightTasks.TryGetValue(task, out var descriptions))
                     {
                         descriptions = new List<string>();

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
@@ -2,9 +2,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Pulumi

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
@@ -93,7 +93,7 @@ namespace Pulumi
 
                     // Now, wait for one of them to finish.
                     var task = await Task.WhenAny(tasks).ConfigureAwait(false);
-                    var description = "";
+                    string description;
                     lock (_inFlightTasks)
                     {
                         // once finished, remove it from the set of tasks that are running.


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/3880

I was able to confirm that .net will cache tasks (or just return the cached .CompletedTask) if thins happen so fast that synchronously the data is already available to the caller of an async method.  This breaks an assumption we had around task uniqueness.

That said, the assumption wasn't really helpful/necessary.  All we're trying to do is keep track of tasks so that we don't shutdown the program prior to actually completing all our work.  This model works fine just adding all tasks and keeping track of them, even if there are duplicates.