### PR TITLE
Run dotnet test with version parameters

### DIFF
--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -51,7 +51,8 @@ lint::
 	golangci-lint run
 
 dotnet_test::
-	dotnet test
+	# include the version prefix/suffix to avoid generating a separate nupkg file
+	dotnet test /p:VersionPrefix=${VERSION_PREFIX} /p:VersionSuffix=${VERSION_SUFFIX}
 	# work around a bug where running `dotnet test` disables console stdinput display
 	stty echo
 


### PR DESCRIPTION
Run dotnet test with version parameters so that it doesn't generate a differently versioned .nupkg file from the actual build. This ensures that on a developer machine that runs make twice, differently versioned .nupkg files won't be copied from the build directory to /opt/pulumi/nuget