### PR TITLE
Small fixes in schema codegen.

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -177,6 +177,14 @@ func (mod *modContext) typeString(t schema.Type, input, wrapInput, optional bool
 	return typ
 }
 
+func isStringType(t schema.Type) bool {
+	for tt, ok := t.(*schema.TokenType); ok; tt, ok = t.(*schema.TokenType) {
+		t = tt.UnderlyingType
+	}
+
+	return t == schema.StringType
+}
+
 func sanitizeComment(str string) string {
 	return strings.Replace(str, "*/", "*&#47;", -1)
 }
@@ -472,7 +480,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		}
 
 		// provider properties must be marshaled as JSON strings.
-		if r.IsProvider && prop.Type != schema.StringType {
+		if r.IsProvider && !isStringType(prop.Type) {
 			arg = fmt.Sprintf("pulumi.output(%s).apply(JSON.stringify)\n", arg)
 		}
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -448,7 +448,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		//
 		// Note the use of the `json` package here - we must import it at the top of the file so
 		// that we can use it.
-		if res.IsProvider && prop.Type != schema.StringType {
+		if res.IsProvider && !isStringType(prop.Type) {
 			arg = fmt.Sprintf("pulumi.Output.from_input(%s).apply(json.dumps) if %s is not None else None", arg, arg)
 		}
 		fmt.Fprintf(w, "            __props__['%s'] = %s\n", pname, arg)
@@ -721,6 +721,13 @@ func genPackageMetadata(tool string, pkg *schema.Package, requires map[string]st
 		fmt.Fprintf(w, "      license='%s',\n", pkg.License)
 	}
 	fmt.Fprintf(w, "      packages=find_packages(),\n")
+
+	// Publish type metadata: PEP 561
+	fmt.Fprintf(w, "      package_data={\n")
+	fmt.Fprintf(w, "          '%s': [\n", pyPack(pkg.Name))
+	fmt.Fprintf(w, "              'py.typed'\n")
+	fmt.Fprintf(w, "          ]\n")
+	fmt.Fprintf(w, "      },\n")
 
 	// Ensure that the Pulumi SDK has an entry if not specified. If the SDK _is_ specified, ensure
 	// that it specifies an acceptable version range.
@@ -1063,6 +1070,14 @@ func pyType(typ schema.Type) string {
 			return "dict"
 		}
 	}
+}
+
+func isStringType(t schema.Type) bool {
+	for tt, ok := t.(*schema.TokenType); ok; tt, ok = t.(*schema.TokenType) {
+		t = tt.UnderlyingType
+	}
+
+	return t == schema.StringType
 }
 
 // pyPack returns the suggested package name for the given string.


### PR DESCRIPTION
- Do not JSON-encode provider properties that are token types with an
  underlying string type
- Emit PEP 561 type metadata in setup.py