### PR TITLE
Don't print prelude in terminal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+## HEAD (unreleased)
+- Avoid duplicated messages in preview/update progress display.
+  [#3890](https://github.com/pulumi/pulumi/pull/3890)
+
 ## 1.10.1 (2020-02-06)
 - Support stack references in the Go SDK.
   [#3829](https://github.com/pulumi/pulumi/pull/3829)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -856,8 +856,16 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 		// Note: we should probably make sure we don't get any prelude events
 		// once we start hearing about actual resource events.
 
-		payload := event.Payload.(engine.PreludeEventPayload)
-		display.writeSimpleMessage(renderPreludeEvent(payload, display.opts))
+		if !display.isTerminal {
+			// If we are in a terminal, then we may have already rendered progress events, and so we
+			// cannot write a "simple message" at this point (doing so would reset the progress
+			// display). As a result, we don't really have any place to render the configuration
+			// associated witht prelude event (in case `ShowConfig` is true), so we skip it.  If we
+			// aren't in a terminal, we go ahead and render a simple message in between the progress
+			// events.
+			payload := event.Payload.(engine.PreludeEventPayload)
+			display.writeSimpleMessage(renderPreludeEvent(payload, display.opts))
+		}
 		return
 	case engine.SummaryEvent:
 		// keep track of the summar event so that we can display it after all other

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -860,7 +860,7 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 			// If we are in a terminal, then we may have already rendered progress events, and so we
 			// cannot write a "simple message" at this point (doing so would reset the progress
 			// display). As a result, we don't really have any place to render the configuration
-			// associated witht prelude event (in case `ShowConfig` is true), so we skip it.  If we
+			// associated with prelude event (in case `ShowConfig` is true), so we skip it.  If we
 			// aren't in a terminal, we go ahead and render a simple message in between the progress
 			// events.
 			payload := event.Payload.(engine.PreludeEventPayload)


### PR DESCRIPTION
We can't correctly print simple messages for prelude events when doing progress based display in a terminal, as it would lead to resetting the display of the table rendering.

This does mean that `--show-config` no longer works in the default terminal display mode - but it's not clear it *can* work correctly (at least as currently implemented) since it doesn't cleanly participate in the table rendering.

For cases where `--show-config` is not set (the norm) - nothing would have been printed anyway, so the changes here just avoid resetting the table rendering unnecessarily.

Fixes #3469.