### PR TITLE
Breaking out individual testing knobs.

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -378,6 +378,12 @@ func (opts ProgramTestOptions) With(overrides ProgramTestOptions) ProgramTestOpt
 	if overrides.SkipUpdate {
 		opts.SkipUpdate = overrides.SkipUpdate
 	}
+	if overrides.SkipExportImport {
+		opts.SkipExportImport = overrides.SkipExportImport
+	}
+	if overrides.SkipEmptyPreviewUpdate {
+		opts.SkipEmptyPreviewUpdate = overrides.SkipEmptyPreviewUpdate
+	}
 	if overrides.SkipStackRemoval {
 		opts.SkipStackRemoval = overrides.SkipStackRemoval
 	}

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -178,13 +178,13 @@ type ProgramTestOptions struct {
 	RetryFailedSteps bool
 	// SkipRefresh indicates that the refresh step should be skipped entirely.
 	SkipRefresh bool
-	// SkipRefresh indicates that the preview step should be skipped entirely.
+	// SkipPreview indicates that the preview step should be skipped entirely.
 	SkipPreview bool
-	// SkipUpdate indicates that the preview step should be skipped entirely.
+	// SkipUpdate indicates that the update step should be skipped entirely.
 	SkipUpdate bool
 	// SkipExportImport skips testing that exporting and importing the stack works properly.
 	SkipExportImport bool
-	// SkipEmptyPreviewUpdate skips a no-change preview/update that is performed that validates
+	// SkipEmptyPreviewUpdate skips the no-change preview/update that is performed that validates
 	// that no changes happen.
 	SkipEmptyPreviewUpdate bool
 	// SkipStackRemoval indicates that the stack should not be removed. (And so the test's results could be inspected


### PR DESCRIPTION
This is needed downstream where i'm validating that something fails during *preview*.  This is hard to test today because we always run an update.  So even if we pass that we expect failure, we cannot tell if it was the update that failed or hte preview.