### PR TITLE
Allow oversize protocol buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
+- Allow oversize protocol buffers for Python SDK.
+  [#3895](https://github.com/pulumi/pulumi/pull/3895)
+
 - Avoid duplicated messages in preview/update progress display.
   [#3890](https://github.com/pulumi/pulumi/pull/3890)
 

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -23,6 +23,10 @@ from .settings import get_monitor
 from ..runtime.proto import provider_pb2
 from . import rpc
 from .rpc_manager import RPC_MANAGER
+from google.protobuf.pyext._message import SetAllowOversizeProtos
+
+# This increases the recursion limit to avoid exceptions on large gRPC payloads.
+SetAllowOversizeProtos(True)
 
 # If we are not running on Python 3.7 or later, we need to swap the Python implementation of Task in for the C
 # implementation in order to support synchronous invokes.

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -15,6 +15,7 @@ import asyncio
 import sys
 from typing import Any, Awaitable
 import grpc
+from google.protobuf.pyext._message import SetAllowOversizeProtos # pylint: disable-msg=E0611
 
 from ..output import Inputs
 from ..invoke import InvokeOptions
@@ -23,7 +24,6 @@ from .settings import get_monitor
 from ..runtime.proto import provider_pb2
 from . import rpc
 from .rpc_manager import RPC_MANAGER
-from google.protobuf.pyext._message import SetAllowOversizeProtos
 
 # This increases the recursion limit to avoid exceptions on large gRPC payloads.
 SetAllowOversizeProtos(True)

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -15,7 +15,7 @@ import asyncio
 import sys
 from typing import Any, Awaitable
 import grpc
-from google.protobuf.pyext._message import SetAllowOversizeProtos # pylint: disable-msg=E0611
+from google.protobuf.pyext._message import SetAllowOversizeProtos  # pylint: disable-msg=E0611
 
 from ..output import Inputs
 from ..invoke import InvokeOptions
@@ -25,7 +25,12 @@ from ..runtime.proto import provider_pb2
 from . import rpc
 from .rpc_manager import RPC_MANAGER
 
-# This increases the recursion limit to avoid exceptions on large gRPC payloads.
+# This setting overrides a hardcoded maximum protobuf size in the python protobuf bindings. This avoids deserialization
+# exceptions on large gRPC payloads, but makes it possible to use enough memory to cause an OOM error instead [1].
+# Note: We hit the default maximum protobuf size in practice when processing Kubernetes CRDs. If this setting ends up
+# causing problems, it should be possible to work around it with more intelligent resource chunking in the k8s provider.
+#
+# [1] https://github.com/protocolbuffers/protobuf/blob/0a59054c30e4f0ba10f10acfc1d7f3814c63e1a7/python/google/protobuf/pyext/message.cc#L2017-L2024
 SetAllowOversizeProtos(True)
 
 # If we are not running on Python 3.7 or later, we need to swap the Python implementation of Task in for the C

--- a/sdk/python/mypy.ini
+++ b/sdk/python/mypy.ini
@@ -10,6 +10,9 @@ ignore_missing_imports = True
 [mypy-dill]
 ignore_missing_imports = True
 
+[mypy-pulumi.runtime.invoke]
+ignore_missing_imports = True
+
 # grpc generated
 [mypy-pulumi.runtime.proto.*]
 ignore_errors = True

--- a/sdk/python/mypy.ini
+++ b/sdk/python/mypy.ini
@@ -10,7 +10,7 @@ ignore_missing_imports = True
 [mypy-dill]
 ignore_missing_imports = True
 
-[mypy-pulumi.runtime.invoke]
+[mypy-google.protobuf.pyext._message]
 ignore_missing_imports = True
 
 # grpc generated


### PR DESCRIPTION
Set an option to increase the recursion limit on protobuf
parsing so that we can handle larger gRPC payloads.

Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/984