### PR TITLE
Move .NET serialization attributes to Pulumi namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 coverage.cov
 *.coverprofile
 
-/.idea/
+**/.idea/
 *.iml
 
 # VSCode creates this binary when running tests in the debugger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ CHANGELOG
 - Expose resource options, parent, dependencies, and provider config to policies.
   [#3862](https://github.com/pulumi/pulumi/pull/3862)
 
+- Move .NET SDK attributes to the root namespace.
+  [#3902](https://github.com/pulumi/pulumi/pull/3902)
+
 ## 1.10.1 (2020-02-06)
 - Support stack references in the Go SDK.
   [#3829](https://github.com/pulumi/pulumi/pull/3829)

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -84,6 +84,8 @@ Pulumi.IDeployment.StackName.get -> string
 Pulumi.Input<T>
 Pulumi.InputArgs
 Pulumi.InputArgs.InputArgs() -> void
+Pulumi.InputAttribute
+Pulumi.InputAttribute.InputAttribute(string name, bool required = false, bool json = false) -> void
 Pulumi.InputExtensions
 Pulumi.InputJson
 Pulumi.InputJson.InputJson() -> void
@@ -116,6 +118,13 @@ Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Input<U>> func) -> Pulumi.Output
 Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Output<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, U> func) -> Pulumi.Output<U>
+Pulumi.OutputAttribute
+Pulumi.OutputAttribute.Name.get -> string
+Pulumi.OutputAttribute.OutputAttribute(string name = null) -> void
+Pulumi.OutputConstructorAttribute
+Pulumi.OutputConstructorAttribute.OutputConstructorAttribute() -> void
+Pulumi.OutputTypeAttribute
+Pulumi.OutputTypeAttribute.OutputTypeAttribute() -> void
 Pulumi.OutputExtensions
 Pulumi.ProviderResource
 Pulumi.ProviderResource.ProviderResource(string package, string name, Pulumi.ResourceArgs args, Pulumi.ResourceOptions options = null) -> void

--- a/sdk/dotnet/Pulumi/Resources/InputArgs.cs
+++ b/sdk/dotnet/Pulumi/Resources/InputArgs.cs
@@ -23,14 +23,22 @@ namespace Pulumi
         {
             var fieldQuery =
                 from field in this.GetType().GetFields(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
-                let attr = field.GetCustomAttribute<InputAttribute>()
-                where attr != null
+                let attr1 = field.GetCustomAttribute<Pulumi.InputAttribute>()
+#pragma warning disable 618
+                let attr2 = field.GetCustomAttribute<Pulumi.Serialization.InputAttribute>()
+#pragma warning restore 618
+                where attr1 != null || attr2 != null
+                let attr = attr1 ?? new Pulumi.InputAttribute(attr2.Name, attr2.IsRequired, attr2.Json)
                 select (attr, memberName: field.Name, memberType: field.FieldType, getValue: (Func<object, object?>)field.GetValue);
 
             var propQuery =
                 from prop in this.GetType().GetProperties(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
-                let attr = prop.GetCustomAttribute<InputAttribute>()
-                where attr != null
+                let attr1 = prop.GetCustomAttribute<Pulumi.InputAttribute>()
+#pragma warning disable 618
+                let attr2 = prop.GetCustomAttribute<Pulumi.Serialization.InputAttribute>()
+#pragma warning restore 618
+                where attr1 != null || attr2 != null
+                let attr = attr1 ?? new Pulumi.InputAttribute(attr2.Name, attr2.IsRequired, attr2.Json)
                 select (attr, memberName: prop.Name, memberType: prop.PropertyType, getValue: (Func<object, object?>)prop.GetValue);
 
             var all = fieldQuery.Concat(propQuery).ToList();

--- a/sdk/dotnet/Pulumi/Serialization/Attributes.Legacy.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Attributes.Legacy.cs
@@ -3,12 +3,13 @@
 using System;
 using Google.Protobuf.WellKnownTypes;
 
-namespace Pulumi
+namespace Pulumi.Serialization
 {
     /// <summary>
     /// Attribute used by a Pulumi Cloud Provider Package to mark Resource output properties.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
+    [Obsolete("Use Pulumi.OutputAttribute instead")]
     public sealed class OutputAttribute : Attribute 
     {
         public string? Name { get; }
@@ -39,6 +40,7 @@ namespace Pulumi
     /// </code>
     /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    [Obsolete("Use Pulumi.InputAttribute instead")]
     public sealed class InputAttribute : Attribute
     {
         internal string Name { get; }
@@ -59,6 +61,7 @@ namespace Pulumi
     /// <see cref="OutputConstructorAttribute"/> attribute.
     /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
+    [Obsolete("Use Pulumi.OutputTypeAttribute instead")]
     public sealed class OutputTypeAttribute : Attribute
     {
     }
@@ -71,6 +74,7 @@ namespace Pulumi
     /// cref="Struct.Fields"/> returned by the engine.
     /// </summary>
     [AttributeUsage(AttributeTargets.Constructor)]
+    [Obsolete("Use Pulumi.OutputConstructorAttribute instead")]
     public sealed class OutputConstructorAttribute : Attribute
     {
     }

--- a/sdk/dotnet/Pulumi/Serialization/Attributes.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Attributes.cs
@@ -6,7 +6,9 @@ using Google.Protobuf.WellKnownTypes;
 namespace Pulumi
 {
     /// <summary>
-    /// Attribute used by a Pulumi Cloud Provider Package to mark Resource output properties.
+    /// Attribute used by a mark <see cref="Resource"/> output properties. Use this attribute
+    /// in your Pulumi programs to mark outputs of <see cref="ComponentResource"/> and
+    /// <see cref="Stack"/> resources.
     /// </summary>
     [AttributeUsage(AttributeTargets.Property)]
     public sealed class OutputAttribute : Attribute 
@@ -20,8 +22,8 @@ namespace Pulumi
     }
 
     /// <summary>
-    /// Attribute used by a Pulumi Cloud Provider Package to mark Resource input fields and
-    /// properties.
+    /// Attribute used by a Pulumi Cloud Provider Package to mark <see cref="Resource"/> input
+    /// fields and properties.
     /// <para/>
     /// Note: for simple inputs (i.e. <see cref="Input{T}"/> this should just be placed on the
     /// property itself.  i.e. <c>[Input] Input&lt;string&gt; Acl</c>.

--- a/sdk/dotnet/Pulumi/Stack.cs
+++ b/sdk/dotnet/Pulumi/Stack.cs
@@ -79,9 +79,12 @@ namespace Pulumi
         internal void RegisterPropertyOutputs()
         {
             var outputs = (from property in this.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                           let attr = property.GetCustomAttribute<OutputAttribute>()
-                           where attr != null
-                           let name = attr.Name ?? property.Name
+                           let attr1 = property.GetCustomAttribute<Pulumi.OutputAttribute>()
+#pragma warning disable 618
+                           let attr2 = property.GetCustomAttribute<Pulumi.Serialization.OutputAttribute>()
+#pragma warning restore 618
+                           where attr1 != null || attr2 != null
+                           let name = attr1?.Name ?? attr2?.Name ?? property.Name
                            select new KeyValuePair<string, object?>(name, property.GetValue(this))).ToList();
 
             // Check that none of the values are null: catch unassigned outputs

--- a/tests/integration/stack_component/dotnet/Program.cs
+++ b/tests/integration/stack_component/dotnet/Program.cs
@@ -3,7 +3,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Pulumi;
-using Pulumi.Serialization;
 
 class MyStack : Stack
 {


### PR DESCRIPTION
Resolves #3833

I decided to keep the old attributes but just `Obsolete` them. That should make the transition of providers and side-by-side usage smoother. We'll delete them before 2.0.

This is still a breaking change: any program that referenced `Pulumi` and `Pulumi.Serialization` and used attributes will fail with e.g. `'Output' is an ambiguous reference between 'Pulumi.OutputAttribute' and 'Pulumi.Serialization.OutputAttribute'`.