### PR TITLE
Fix the fully-specified name test for cmd/new

### DIFF
--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -127,7 +127,9 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 	assert.NoError(t, os.Chdir(tempdir))
 
-	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), projectName, stackName)
+	// the project name and the project name in the stack name must match
+	uniqueProjectName := filepath.Base(tempdir)
+	fullStackName := fmt.Sprintf("%s/%s/%s", currentUser(t), uniqueProjectName, stackName)
 
 	var args = newArgs{
 		interactive:       false,
@@ -140,7 +142,8 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 	err := runNew(args)
 	assert.NoError(t, err)
 
-	assert.Equal(t, fullStackName, loadStackName(t))
+	assert.Equal(t, stackName, loadStackName(t))
+	removeStack(t, stackName)
 }
 
 func TestCreatingProjectWithDefaultName(t *testing.T) {


### PR DESCRIPTION
The project name should match the name within the stack name. Previously, this test passed due to state that happened to be lying around, which bypassed the actual stack creation (cmd/new.go:170)