### PR TITLE
Fix a few codegen issues.

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -284,7 +284,11 @@ func printComment(w io.Writer, comment string, indent bool) {
 		if indent {
 			fmt.Fprintf(w, "\t")
 		}
-		fmt.Fprintf(w, "// %s\n", l)
+		if l == "" {
+			fmt.Fprintf(w, "//\n")
+		} else {
+			fmt.Fprintf(w, "// %s\n", l)
+		}
 	}
 }
 

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -200,11 +200,15 @@ func printComment(w io.Writer, comment, deprecationMessage, indent string) {
 	}
 	fmt.Fprintf(w, "%s/**\n", indent)
 	for _, l := range lines {
-		fmt.Fprintf(w, "%s * %s\n", indent, l)
+		if l == "" {
+			fmt.Fprintf(w, "%s *\n", indent)
+		} else {
+			fmt.Fprintf(w, "%s * %s\n", indent, l)
+		}
 	}
 	if deprecationMessage != "" {
 		if len(lines) > 0 {
-			fmt.Fprintf(w, "%s * \n", indent)
+			fmt.Fprintf(w, "%s *\n", indent)
 		}
 		fmt.Fprintf(w, "%s * @deprecated %s\n", indent, deprecationMessage)
 	}
@@ -322,7 +326,7 @@ func (mod *modContext) genAlias(w io.Writer, alias *schema.Alias) {
 		fmt.Fprintf(w, "%s", part)
 	}
 
-	fmt.Fprintf(w, "}")
+	fmt.Fprintf(w, " }")
 }
 
 func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -196,7 +196,7 @@ func (mod *modContext) gen(fs fs) error {
 		}
 		name := PyName(tokenToName(r.Token))
 		if r.IsProvider {
-			name = "Provider"
+			name = "provider"
 		}
 		addFile(name+".py", res)
 	}


### PR DESCRIPTION
- Make go comment generation lint-clean for blank comment lines
- Fix the casing of `Provider.py` in Python to `provider.py`
- Fix a spacing issue in the NodeJS code generator