### PR TITLE
Revert "Fix getting logs in tests for Lambdas"

### DIFF
--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	mobytime "github.com/docker/docker/api/types/time"
@@ -125,8 +126,12 @@ func newLogsCmd() *cobra.Command {
 						eventTime := time.Unix(0, logEntry.Timestamp*1000000)
 
 						if !jsonOut {
-							fmt.Printf("%30.30s[%30.30s] %v\n", eventTime.Format(timeFormat),
-								logEntry.ID, logEntry.Message)
+							fmt.Printf(
+								"%30.30s[%30.30s] %v\n",
+								eventTime.Format(timeFormat),
+								logEntry.ID,
+								strings.TrimRight(logEntry.Message, "\n"),
+							)
 						} else {
 							err = printJSON(logEntryJSON{
 								ID:        logEntry.ID,

--- a/pkg/operations/operations_cloud_aws.go
+++ b/pkg/operations/operations_cloud_aws.go
@@ -194,15 +194,14 @@ var (
 	logRegexp = regexp.MustCompile("^(.{23}Z)\t[a-g0-9\\-]{36}\t((?s).*)\n")
 )
 
-// extractLambdaLogMessage extracts out only the log messages associated with user logs, skipping
-// Lambda-specific metadata.  In particular, only the second line below is extracted, and it is
-// extracted with the recorded timestamp.
+// extractLambdaLogMessage extracts out only the log messages associated with user logs, skipping Lambda-specific
+// metadata.  In particular, only the second line below is extracter, and it is extracted with the recorded timestamp.
 //
 // ```
 //  START RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723 Version: $LATEST
-//  2017-11-17T20:30:27.736Z    25e0d1e0-cbd6-11e7-9808-c7085dfe5723    GET /todo
+//  2017-11-17T20:30:27.736Z	25e0d1e0-cbd6-11e7-9808-c7085dfe5723	GET /todo
 //  END RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723
-//  REPORT RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723  Duration: 222.92 ms Billed Duration: 300 ms     <snip>
+//  REPORT RequestId: 25e0d1e0-cbd6-11e7-9808-c7085dfe5723	Duration: 222.92 ms	Billed Duration: 300 ms 	<snip>
 // ```
 func extractLambdaLogMessage(message string, id string) *LogEntry {
 	innerMatches := logRegexp.FindAllStringSubmatch(message, -1)


### PR DESCRIPTION
Reverts pulumi/pulumi#1977.

As discussed in https://github.com/pulumi/pulumi/pull/1977#issuecomment-426334935, we don't want to do any filtering of the raw logs returned from AWS for normal AWS Lambda Logs.