### PR TITLE
cmd: `stack select`: error msg with full stack-reference

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -709,7 +709,7 @@ func (b *cloudBackend) CreateStack(
 			// A 409 error response is returned when per-stack organizations are over their limit,
 			// so we need to look at the message to differentiate.
 			if strings.Contains(errResp.Message, "already exists") {
-				return nil, &backend.StackAlreadyExistsError{StackName: stackID.Stack}
+				return nil, &backend.StackAlreadyExistsError{StackName: stackID.String()}
 			}
 			if strings.Contains(errResp.Message, "you are using") {
 				return nil, &backend.OverStackLimitError{Message: errResp.Message}

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -53,6 +53,10 @@ type StackIdentifier struct {
 	Stack   string
 }
 
+func (s StackIdentifier) String() string {
+	return fmt.Sprintf("%s/%s/%s", s.Owner, s.Project, s.Stack)
+}
+
 // UpdateIdentifier is the set of data needed to identify an update to a Pulumi Cloud stack.
 type UpdateIdentifier struct {
 	StackIdentifier


### PR DESCRIPTION
If I run `pulumi stack select --create ghi`, it implicitly assumes an `organisation` and `project` (see related #3269). If there's sth. wrong, the error message only shows the stack name, i.e. without `organisation/project/` before it. E.g.:

    error: stack 'ghi' already exists

This PR fixes the error message that it reveals the whole stack reference to the Pulumi Cloud. That eases finding the misconfiguration.