### PR TITLE
Disable interactive progress display when no terminal size is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ CHANGELOG
 - Support exporting older stack versions.
   [#3906](https://github.com/pulumi/pulumi/pull/3906)
 
+- Disable interactive progress display when no terminal size is available.
+  [#3936](https://github.com/pulumi/pulumi/pull/3936)
+
 ## 1.10.1 (2020-02-06)
 - Support stack references in the Go SDK.
   [#3829](https://github.com/pulumi/pulumi/pull/3829)

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -272,10 +272,15 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName
 	}
 
 	terminalWidth, terminalHeight, err := terminal.GetSize(int(os.Stdout.Fd()))
-	contract.IgnoreError(err)
-	display.isTerminal = opts.IsInteractive
-	display.terminalWidth = terminalWidth
-	display.terminalHeight = terminalHeight
+	if err == nil {
+		// If the terminal has a size, use it.
+		display.isTerminal = opts.IsInteractive
+		display.terminalWidth = terminalWidth
+		display.terminalHeight = terminalHeight
+	} else {
+		// Else assume we are not displaying in a terminal.
+		display.isTerminal = false
+	}
 
 	go func() {
 		display.processEvents(ticker, events)


### PR DESCRIPTION
It appears there are cases where our `IsInteractive` heuristics return `true`, but `terminal.GetSize` returns an error.  In these cases, we should assume we do not have an interactive terminal and avoid trying to render interactive progress by default.

Fixes #3935.