### PR TITLE
Include `dep ensure` step in `pulumi new` output.

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -666,6 +666,13 @@ func printNextSteps(proj *workspace.Project, originalCwd, cwd string, generateOn
 
 		// Install dependencies within the virtualenv
 		commands = append(commands, "pip3 install -r requirements.txt")
+	} else if strings.EqualFold(proj.Runtime.Name(), "go") {
+		// If we're generating a Go project, we (currently) will be placing a `Gopkg.toml`, and the
+		// user will need to `dep ensure` before running an update.  So we will recommend this to
+		// them explicitly.
+		//
+		// TODO[pulumi/pulumi#3817] When we move to Go modules, we will want to update this.
+		commands = append(commands, "dep ensure")
 	}
 
 	// If we didn't create a stack, show that as a command to run before `pulumi up`.


### PR DESCRIPTION
This change adds the ", run `dep ensure`, then` part to the output below:

<img width="854" alt="Screen Shot 2020-02-20 at 12 27 19 PM" src="https://user-images.githubusercontent.com/223467/74975721-5dcf5200-53dc-11ea-9aac-7101506f593f.png">
