### PR TITLE
Execute policy against reads

### DIFF
--- a/cmd/preview.go
+++ b/cmd/preview.go
@@ -37,6 +37,7 @@ func newPreviewCmd() *cobra.Command {
 	// Flags for engine.UpdateOptions.
 	var jsonDisplay bool
 	var policyPackPaths []string
+	var policyOnReads bool
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int
@@ -143,6 +144,7 @@ func newPreviewCmd() *cobra.Command {
 					UseLegacyDiff:    useLegacyDiff(),
 					UpdateTargets:    targetURNs,
 					TargetDependents: targetDependents,
+					PolicyOnReads:    policyOnReads,
 				},
 				Display: displayOpts,
 			}
@@ -211,6 +213,9 @@ func newPreviewCmd() *cobra.Command {
 		cmd.PersistentFlags().StringSliceVar(
 			&policyPackPaths, "policy-pack", []string{},
 			"Run one or more analyzers as part of this update")
+		cmd.PersistentFlags().BoolVar(
+			&policyOnReads, "policy-on-reads", false,
+			"Validate read operations with any active policies")
 	}
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -55,6 +55,7 @@ func newUpCmd() *cobra.Command {
 
 	// Flags for engine.UpdateOptions.
 	var policyPackPaths []string
+	var policyOnReads bool
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int
@@ -128,6 +129,7 @@ func newUpCmd() *cobra.Command {
 			UseLegacyDiff:    useLegacyDiff(),
 			UpdateTargets:    targetURNs,
 			TargetDependents: targetDependents,
+			PolicyOnReads:    policyOnReads,
 		}
 
 		changes, res := s.Update(commandContext(), backend.UpdateOperation{
@@ -414,6 +416,9 @@ func newUpCmd() *cobra.Command {
 		cmd.PersistentFlags().StringSliceVar(
 			&policyPackPaths, "policy-pack", []string{},
 			"Run one or more policy packs as part of this update")
+		cmd.PersistentFlags().BoolVar(
+			&policyOnReads, "policy-on-reads", false,
+			"Validate read operations with any active policies")
 	}
 	cmd.PersistentFlags().BoolVar(
 		&diffDisplay, "diff", false,

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -189,6 +189,7 @@ func (planResult *planResult) Walk(cancelCtx *Context, events deploy.Events, pre
 			TargetDependents:  planResult.Options.TargetDependents,
 			TrustDependencies: planResult.Options.trustDependencies,
 			UseLegacyDiff:     planResult.Options.UseLegacyDiff,
+			PolicyOnReads:     planResult.Options.PolicyOnReads,
 		}
 		walkResult = planResult.Plan.Execute(ctx, opts, preview)
 		close(done)

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -116,6 +116,9 @@ type UpdateOptions struct {
 	// true if the engine should use legacy diffing behavior during an update.
 	UseLegacyDiff bool
 
+	// PolicyOnReads enables policy to run against read operations (which it usually does not).
+	PolicyOnReads bool
+
 	// true if we should report events for steps that involve default providers.
 	reportDefaultProviderSteps bool
 

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -58,6 +58,7 @@ type Options struct {
 	TargetDependents  bool           // true if we're allowing things to proceed, even with unspecified targets
 	TrustDependencies bool           // whether or not to trust the resource dependency graph.
 	UseLegacyDiff     bool           // whether or not to use legacy diffing behavior.
+	PolicyOnReads     bool           // verify read operations against any active policies.
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -268,7 +268,7 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 	}
 
 	se.log(workerID, "applying step %v on %v (preview %v)", step.Op(), step.URN(), se.preview)
-	status, stepComplete, err := step.Apply(se.preview)
+	status, stepComplete, err := step.Apply(se.preview, se.opts)
 
 	if err == nil {
 		// If we have a state object, and this is a create or update, remember it, as we may need to update it later.


### PR DESCRIPTION
See my comments here: https://github.com/pulumi/pulumi/issues/3950#issuecomment-589328525.

This is a little hacky -- I wanted to put this check alongside the existing one in the stepper, but unfortunately reads are handled very differently and don't share much of that codepath. So jamming the check right into the read operation itself was the quickest way for me to achieve this. I assume we wouldn't actually want to do it this way.