### PR TITLE
Fix panic on failed stack policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 CHANGELOG
 =========
 
-- Fix a regression for CustomTimeouts in Python SDK
+## HEAD (unreleased)
+- Fix a regression for CustomTimeouts in Python SDK.
   [#3964](https://github.com/pulumi/pulumi/pull/3964)
+
+- Avoid panic when displaying failed stack policies.
+  [#3960](https://github.com/pulumi/pulumi/pull/3960)
 
 ## 1.11.0 (2020-02-19)
 - Allow oversize protocol buffers for Python SDK.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -812,18 +812,12 @@ func (display *ProgressDisplay) printPolicyViolations() bool {
 			c = colors.SpecError
 		}
 
-		urn := policyEvent.ResourceURN
-		if urn == "" {
-			// An empty URN is associated with the stack itself.
-			urn = resource.DefaultRootStackURN(display.stack, display.proj)
-		}
-
 		policyNameLine := fmt.Sprintf("    %s[%s]  %s v%s %s %s (%s)",
 			c, policyEvent.EnforcementLevel,
 			policyEvent.PolicyPackName,
 			policyEvent.PolicyPackVersion, colors.Reset,
 			policyEvent.PolicyName,
-			urn.Name())
+			policyEvent.ResourceURN.Name())
 		display.writeSimpleMessage(policyNameLine)
 
 		// The message may span multiple lines, so we massage it so it will be indented properly.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -812,12 +812,18 @@ func (display *ProgressDisplay) printPolicyViolations() bool {
 			c = colors.SpecError
 		}
 
+		urn := policyEvent.ResourceURN
+		if urn == "" {
+			// An empty URN is associated with the stack itself.
+			urn = resource.DefaultRootStackURN(display.stack, display.proj)
+		}
+
 		policyNameLine := fmt.Sprintf("    %s[%s]  %s v%s %s %s (%s)",
 			c, policyEvent.EnforcementLevel,
 			policyEvent.PolicyPackName,
 			policyEvent.PolicyPackVersion, colors.Reset,
 			policyEvent.PolicyName,
-			policyEvent.ResourceURN.Name())
+			urn.Name())
 		display.writeSimpleMessage(policyNameLine)
 
 		// The message may span multiple lines, so we massage it so it will be indented properly.

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -1321,12 +1321,16 @@ func (sg *stepGenerator) AnalyzeResources() result.Result {
 		for _, d := range diagnostics {
 			sg.sawError = sg.sawError || (d.EnforcementLevel == apitype.Mandatory)
 			// If a URN was provided and it is a URN associated with a resource in the stack, use it.
-			// Otherwise, use the default URN value ("") to not associate the violation with any particular URN.
+			// Otherwise, if the URN is empty or is not associated with a resource in the stack, use
+			// the default root stack URN.
 			var urn resource.URN
 			if d.URN != "" {
 				if _, ok := resourcesSeen[d.URN]; ok {
 					urn = d.URN
 				}
+			}
+			if urn == "" {
+				urn = resource.DefaultRootStackURN(sg.plan.Target().Name, sg.plan.source.Project())
 			}
 			sg.opts.Events.OnPolicyViolation(urn, d)
 		}


### PR DESCRIPTION
Avoid panic during stack validations. This regressed recently with https://github.com/pulumi/pulumi/pull/3881/files#diff-1484cdf02b75d8b12012f9474273ec54R815 when the PAC error output was modified.

Fixes https://github.com/pulumi/pulumi-policy/issues/200