### PR TITLE
fix permalink

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -445,7 +445,7 @@ func (b *cloudBackend) parsePolicyPackReference(s string) (backend.PolicyPackRef
 		orgName = currentUser
 	}
 
-	return newCloudBackendPolicyPackReference(orgName, tokens.QName(policyPackName)), nil
+	return newCloudBackendPolicyPackReference(b.CloudConsoleURL(), orgName, tokens.QName(policyPackName)), nil
 }
 
 func (b *cloudBackend) GetPolicyPack(ctx context.Context, policyPack string,
@@ -463,7 +463,7 @@ func (b *cloudBackend) GetPolicyPack(ctx context.Context, policyPack string,
 	apiToken := account.AccessToken
 
 	return &cloudPolicyPack{
-		ref: newCloudBackendPolicyPackReference(
+		ref: newCloudBackendPolicyPackReference(b.CloudConsoleURL(),
 			policyPackRef.OrgName(), policyPackRef.Name()),
 		b:  b,
 		cl: client.NewClient(b.CloudURL(), apiToken, d)}, nil

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -77,9 +77,13 @@ func (rp *cloudRequiredPolicy) Install(ctx context.Context) (string, error) {
 }
 
 func newCloudBackendPolicyPackReference(
-	orgName string, name tokens.QName) *cloudBackendPolicyPackReference {
+	cloudConsoleURL, orgName string, name tokens.QName) *cloudBackendPolicyPackReference {
 
-	return &cloudBackendPolicyPackReference{orgName: orgName, name: name}
+	return &cloudBackendPolicyPackReference{
+		orgName:         orgName,
+		name:            name,
+		cloudConsoleURL: cloudConsoleURL,
+	}
 }
 
 // cloudBackendPolicyPackReference is a reference to a PolicyPack implemented by the Pulumi service.
@@ -92,6 +96,10 @@ type cloudBackendPolicyPackReference struct {
 	// versionTag of the Policy Pack. This is typically the version specified in
 	// a package.json, setup.py, or similar file.
 	versionTag string
+
+	// cloudConsoleURL is the root URL of where the Policy Pack can be found in the console. The
+	// version must be appended to the returned URL.
+	cloudConsoleURL string
 }
 
 var _ backend.PolicyPackReference = (*cloudBackendPolicyPackReference)(nil)
@@ -106,6 +114,10 @@ func (pr *cloudBackendPolicyPackReference) OrgName() string {
 
 func (pr *cloudBackendPolicyPackReference) Name() tokens.QName {
 	return pr.name
+}
+
+func (pr *cloudBackendPolicyPackReference) CloudConsoleURL() string {
+	return fmt.Sprintf("%s/%s/policypacks/%s", pr.cloudConsoleURL, pr.orgName, pr.Name())
 }
 
 // cloudPolicyPack is a the Pulumi service implementation of the PolicyPack interface.
@@ -182,7 +194,8 @@ func (pack *cloudPolicyPack) Publish(
 		return result.FromError(err)
 	}
 
-	fmt.Printf("\nPermalink: %s/policypacks/%s/%s\n", pack.Backend().URL(), pack.ref.Name(), publishedVersion)
+	fmt.Printf("\nPermalink: %s/%s\n", pack.ref.CloudConsoleURL(), publishedVersion)
+
 	return nil
 }
 

--- a/pkg/workspace/plugins.go
+++ b/pkg/workspace/plugins.go
@@ -350,7 +350,7 @@ func HasPluginGTE(plug PluginInfo) (bool, error) {
 	return false, nil
 }
 
-// GetPolicyDir returns the directory in which policies on the current machine are managed.
+// GetPolicyDir returns the directory in which an organization's Policy Packs on the current machine are managed.
 func GetPolicyDir(orgName string) (string, error) {
 	return GetPulumiPath(PolicyDir, orgName)
 }


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/3959

Before - used my default org for the URL.
```bash
➜  test-policy pulumi policy publish eckrengel
Obtaining policy metadata from policy plugin
Compressing policy pack
Uploading policy pack to Pulumi service
Publishing another-fraking-pack to eckrengel
Published as version 10

Permalink: http://localhost:3000/ekrengel/policypacks/another-fraking-pack/10
```

After:
```bash
➜  test-policy pulumi policy publish eckrengel
Obtaining policy metadata from policy plugin
Compressing policy pack
Uploading policy pack to Pulumi service
Publishing another-fraking-pack to eckrengel
Published as version 10

Permalink: http://localhost:3000/eckrengel/policypacks/another-fraking-pack/10
```