### PR TITLE
Remove use of `github.com/pkg/errors` from Go SDK

### DIFF
--- a/sdk/go/pulumi/alias.go
+++ b/sdk/go/pulumi/alias.go
@@ -15,9 +15,8 @@
 package pulumi
 
 import (
+	"errors"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 // Alias is a partial description of prior named used for a resource. It can be processed in the

--- a/sdk/go/pulumi/config/config_test.go
+++ b/sdk/go/pulumi/config/config_test.go
@@ -16,10 +16,10 @@ package config
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
@@ -196,7 +196,7 @@ func TestSecretConfig(t *testing.T) {
 			if val == "a string value" {
 				result <- val.(string)
 			} else {
-				errChan <- errors.Errorf("Invalid result: %v", val)
+				errChan <- fmt.Errorf("Invalid result: %v", val)
 
 			}
 		}
@@ -233,7 +233,7 @@ func TestSecretConfig(t *testing.T) {
 			if reflect.DeepEqual(expectedTestStruct, *ts) {
 				objResult <- *ts
 			} else {
-				errChan <- errors.Errorf("Invalid result: %v", val)
+				errChan <- fmt.Errorf("Invalid result: %v", val)
 			}
 		}
 		return v, nil
@@ -263,7 +263,7 @@ func TestSecretConfig(t *testing.T) {
 			if val == true {
 				resultBool <- val.(bool)
 			} else {
-				errChan <- errors.Errorf("Invalid result: %v", val)
+				errChan <- fmt.Errorf("Invalid result: %v", val)
 
 			}
 		}
@@ -294,7 +294,7 @@ func TestSecretConfig(t *testing.T) {
 			if val == 42 {
 				resultInt <- val.(int)
 			} else {
-				errChan <- errors.Errorf("Invalid result: %v", val)
+				errChan <- fmt.Errorf("Invalid result: %v", val)
 
 			}
 		}

--- a/sdk/go/pulumi/config/try.go
+++ b/sdk/go/pulumi/config/try.go
@@ -16,8 +16,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
@@ -27,8 +27,7 @@ import (
 func Try(ctx *pulumi.Context, key string) (string, error) {
 	v, ok := ctx.GetConfig(key)
 	if !ok {
-		return "",
-			errors.Errorf("missing required configuration variable '%s'; run `pulumi config` to set", key)
+		return "", fmt.Errorf("missing required configuration variable '%s'; run `pulumi config` to set", key)
 	}
 	return v, nil
 }

--- a/sdk/go/pulumi/run.go
+++ b/sdk/go/pulumi/run.go
@@ -15,14 +15,14 @@
 package pulumi
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
-	"golang.org/x/net/context"
 
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
@@ -53,7 +53,7 @@ func RunErr(body RunFunc, opts ...RunOption) error {
 
 	// Validate some properties.
 	if info.Project == "" {
-		return errors.Errorf("missing project name")
+		return errors.New("missing project name")
 	} else if info.Stack == "" {
 		return errors.New("missing stack name")
 	} else if info.MonitorAddr == "" && info.Mocks == nil {

--- a/sdk/go/pulumi/templates/config-try.go.template
+++ b/sdk/go/pulumi/templates/config-try.go.template
@@ -16,8 +16,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cast"
 
 	"github.com/pulumi/pulumi/sdk/go/pulumi"
@@ -28,7 +28,7 @@ func Try(ctx *pulumi.Context, key string) (string, error) {
 	v, ok := ctx.GetConfig(key)
 	if !ok {
 		return "",
-			errors.Errorf("missing required configuration variable '%s'; run `pulumi config` to set", key)
+			fmt.Errorf("missing required configuration variable '%s'; run `pulumi config` to set", key)
 	}
 	return v, nil
 }

--- a/sdk/go/pulumi/templates/types_builtins_test.go.template
+++ b/sdk/go/pulumi/templates/types_builtins_test.go.template
@@ -17,12 +17,12 @@ package pulumi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -17,10 +17,11 @@ package pulumi
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
@@ -58,7 +59,7 @@ func RegisterOutputType(output Output) {
 	elementType := output.ElementType()
 	existing, hasExisting := concreteTypeToOutputType.LoadOrStore(elementType, reflect.TypeOf(output))
 	if hasExisting {
-		panic(errors.Errorf("an output type for %v is already registered: %v", elementType, existing))
+		panic(fmt.Errorf("an output type for %v is already registered: %v", elementType, existing))
 	}
 }
 
@@ -242,7 +243,7 @@ func makeContextful(fn interface{}, elementType reflect.Type) interface{} {
 
 	ft := fv.Type()
 	if ft.NumIn() != 1 || !elementType.AssignableTo(ft.In(0)) {
-		panic(errors.Errorf("applier must have 1 input parameter assignable from %v", elementType))
+		panic(fmt.Errorf("applier must have 1 input parameter assignable from %v", elementType))
 	}
 
 	var outs []reflect.Type
@@ -277,7 +278,7 @@ func checkApplier(fn interface{}, elementType reflect.Type) reflect.Value {
 
 	ft := fv.Type()
 	if ft.NumIn() != 2 || !contextType.AssignableTo(ft.In(0)) || !elementType.AssignableTo(ft.In(1)) {
-		panic(errors.Errorf("applier's input parameters must be assignable from %v and %v", contextType, elementType))
+		panic(fmt.Errorf("applier's input parameters must be assignable from %v and %v", contextType, elementType))
 	}
 
 	switch ft.NumOut() {
@@ -541,7 +542,7 @@ func awaitInputs(ctx context.Context, v, resolved reflect.Value) (bool, bool, er
 				// If the value type is not assignable to the destination, see if we can assign the input value itself
 				// to the destination.
 				if !v.Type().AssignableTo(resolved.Type()) {
-					panic(errors.Errorf("cannot convert an input of type %T to a value of type %v",
+					panic(fmt.Errorf("cannot convert an input of type %T to a value of type %v",
 						input, resolved.Type()))
 				} else {
 					assignInput = true
@@ -848,7 +849,7 @@ func (o URNOutput) awaitURN(ctx context.Context) (URN, bool, bool, error) {
 func convert(v interface{}, to reflect.Type) interface{} {
 	rv := reflect.ValueOf(v)
 	if !rv.Type().ConvertibleTo(to) {
-		panic(errors.Errorf("cannot convert output value of type %s to %s", rv.Type(), to))
+		panic(fmt.Errorf("cannot convert output value of type %s to %s", rv.Type(), to))
 	}
 	return rv.Convert(to).Interface()
 }

--- a/sdk/go/pulumi/types_builtins_test.go
+++ b/sdk/go/pulumi/types_builtins_test.go
@@ -17,12 +17,12 @@ package pulumi
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -17,10 +17,11 @@ package pulumi
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -328,7 +329,7 @@ func TestSecrets(t *testing.T) {
 			// validate the value
 			resultChan <- val
 		} else {
-			errChan <- errors.Errorf("Invalid result: %v", val)
+			errChan <- fmt.Errorf("Invalid result: %v", val)
 		}
 		return val, nil
 	})
@@ -372,7 +373,7 @@ func TestSecretApply(t *testing.T) {
 			// validate the value
 			resultChan <- val
 		} else {
-			errChan <- errors.Errorf("Invalid result: %v", val)
+			errChan <- fmt.Errorf("Invalid result: %v", val)
 		}
 		return val, nil
 	})


### PR DESCRIPTION
In preparation for publishing a separate module of the Go SDK for Pulumi on which providers can depend, we should reduce the dependency footprint so as to cause end users as few issues as possible with transitive dependency versioning.

This commit removes all use of `github.com/pkg/errors` from the Go SDK to that end, replacing it with the standard library `errors` package and `fmt` for error formatting where appropriate.