### PR TITLE
fix panic when dest is struct and input is ptr

### DIFF
--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -572,6 +572,15 @@ func awaitInputs(ctx context.Context, v, resolved reflect.Value) (bool, bool, er
 
 		v, isInput = reflect.ValueOf(input), true
 
+		// We require that the kind of an `Input`'s `ElementType` agrees with the kind of the `Input`'s underlying value.
+		// This requirement is trivially (and unintentionally) violated by `*T` if `*T` does not define `ElementType`,
+		// but `T` does (https://golang.org/ref/spec#Method_sets).
+		// In this case, dereference the pointer to get at its actual value.
+		if v.Kind() == reflect.Ptr && valueType.Kind() != reflect.Ptr {
+			v = v.Elem()
+			contract.Assert(v.Interface().(Input).ElementType() == valueType)
+		}
+
 		// If we are assigning the input value itself, update the value type.
 		if assignInput {
 			valueType = v.Type()


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-azure/issues/459

Minimal repro:

```go
package main

import (
	"github.com/pulumi/pulumi-aws/sdk/go/aws/kms"
	"github.com/pulumi/pulumi-aws/sdk/go/aws/s3"
	"github.com/pulumi/pulumi/sdk/go/pulumi"
)

func main() {
	pulumi.Run(func(ctx *pulumi.Context) error {
		// Create a KMS Key for S3 server-side encryption
		key, err := kms.NewKey(ctx, "my-key", nil)
		if err != nil {
			return err
		}

		// Create an AWS resource (S3 Bucket)
		bucket, err := s3.NewBucket(ctx, "my-bucket", &s3.BucketArgs{
			ServerSideEncryptionConfiguration: s3.BucketServerSideEncryptionConfigurationArgs{
				Rule: &s3.BucketServerSideEncryptionConfigurationRuleArgs{
					ApplyServerSideEncryptionByDefault: s3.BucketServerSideEncryptionConfigurationRuleApplyServerSideEncryptionByDefaultArgs{
						SseAlgorithm:   pulumi.StringInput(pulumi.String("aws:kms")),
						KmsMasterKeyId: key.ID(),
					},
				},
			},
		})
		if err != nil {
			return err
		}

		// Export the name of the bucket
		ctx.Export("bucketName", bucket.ID())
		return nil
```

This update works without changes if you pass `Rule: s3.BucketServerSideEncryptionConfigurationRuleArgs{` instead of the pointer. 

This change properly handles awaiting inputs when resolved is a concrete struct and the value is a pointer. 

There may be a cleaner way to achieve this (I'm not very familiar with the reflection library) but this works. 