### PR TITLE
ignore internal properties when unmarshaling

### DIFF
--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"golang.org/x/net/context"
 
@@ -523,6 +524,10 @@ func unmarshalOutput(v resource.PropertyValue, dest reflect.Value) (bool, error)
 		result := reflect.MakeMap(dest.Type())
 		secret := false
 		for k, e := range v.ObjectValue() {
+			// ignore properties internal to the pulumi engine
+			if strings.HasPrefix(string(k), "__") {
+				continue
+			}
 			elem := reflect.New(elemType).Elem()
 			esecret, err := unmarshalOutput(e, elem)
 			if err != nil {

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -396,6 +396,22 @@ func TestUnmarshalSecret(t *testing.T) {
 	assert.True(t, isSecret)
 }
 
+func TestUnmarshalInternalMapValue(t *testing.T) {
+	m := make(map[string]interface{})
+	m["foo"] = "bar"
+	m["__default"] = "buzz"
+	pmap := resource.NewObjectProperty(resource.NewPropertyMapFromMap(m))
+
+	var mv map[string]string
+	_, err := unmarshalOutput(pmap, reflect.ValueOf(&mv).Elem())
+	assert.Nil(t, err)
+	val, ok := mv["foo"]
+	assert.True(t, ok)
+	assert.Equal(t, "bar", val)
+	_, ok = mv["__default"]
+	assert.False(t, ok)
+}
+
 // TestMarshalRoundtripNestedSecret ensures that marshaling a complex structure to and from
 // its on-the-wire gRPC format succeeds including a nested secret property.
 func TestMarshalRoundtripNestedSecret(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-azure/issues/460

We are supposed to ignore unmarshaling any properties that begin with a double underscore `__`.

We have similar behavior in dotnet, node, etc. Not quite sure if this fix is in the right place. Will need @pgavlin to confirm. 