### PR TITLE
Revert back to ts-node ^7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ CHANGELOG
   [#3983](https://github.com/pulumi/pulumi/pull/3983)
 
 - Add support for mocking the resource monitor to the NodeJS and Python SDKs.
-  [#3738](https://github.com/pulumi/pulumi/pull/3738/files)
+  [#3738](https://github.com/pulumi/pulumi/pull/3738)
+
+- Reinstate caching of TypeScript compilation.
+  [#4007](https://github.com/pulumi/pulumi/pull/4007)
 
 ## 1.11.1 (2020-02-26)
 - Fix a regression for CustomTimeouts in Python SDK.

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -20,7 +20,7 @@
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",
         "source-map-support": "^0.4.16",
-        "ts-node": "8.5.4",
+        "ts-node": "^7.0.1",
         "typescript": "~3.7.3",
         "upath": "^1.1.0"
     },


### PR DESCRIPTION
We upgraded to `ts-node@^8.0.0`  2.5 months ago as part of https://github.com/pulumi/pulumi/pull/3627, though it seems it wasn't really necessary to make that update for the purposes of the PR - updating the default TypeScript version.

The `8.0.0` series of `ts-node` unfortunately dropped all of it's caching support, due to what appear to be some corner-case correctness issues with the cache.  We have not seen reports of those issues for Pulumi, and have much more experience with the `7.0.0` series overall (2 years vs. 2 months).  The performance difference between `7.0.0` and `8.0.0` of ts-node for Pulumi is massive - it adds 4-4.5s to each of `pulumi preview` and `pulumi up` even on a trivial program.

As a result, for now we will revert back to `ts-node@^7.0.0`.  In the future, we may want to look into our own caching layer or alternative to `ts-node` to ensure we get the behaviour and performance we expect.

See https://github.com/pulumi/pulumi/issues/3671#issuecomment-592810579 for more details.

Part of #3671.