### PR TITLE
properly check for nil input or nil input pointer

### DIFF
--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -66,7 +66,7 @@ func marshalInputs(props Input) (resource.PropertyMap, map[string][]URN, []URN, 
 	depset := map[URN]bool{}
 	pmap, pdeps := resource.PropertyMap{}, map[string][]URN{}
 
-	if props == nil {
+	if props == nil || (reflect.ValueOf(props).Kind() == reflect.Ptr && reflect.ValueOf(props).IsNil()) {
 		return pmap, pdeps, depURNs, nil
 	}
 

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -66,12 +66,15 @@ func marshalInputs(props Input) (resource.PropertyMap, map[string][]URN, []URN, 
 	depset := map[URN]bool{}
 	pmap, pdeps := resource.PropertyMap{}, map[string][]URN{}
 
-	if props == nil || (reflect.ValueOf(props).Kind() == reflect.Ptr && reflect.ValueOf(props).IsNil()) {
+	if props == nil {
 		return pmap, pdeps, depURNs, nil
 	}
 
 	pv := reflect.ValueOf(props)
 	if pv.Kind() == reflect.Ptr {
+		if pv.IsNil() {
+			return pmap, pdeps, depURNs, nil
+		}
 		pv = pv.Elem()
 	}
 	pt := pv.Type()


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi-azure/issues/470

We check for props being nil, but not a pointer with a nil value. 

A minimal repro is to import any resource. In this case I just imported a `ResourceGroup` from a previously successful `pulumi up`:

```go
package main

import (
	"github.com/pulumi/pulumi-azure/sdk/go/azure/core"
	"github.com/pulumi/pulumi/sdk/go/pulumi"
)

func main() {
	pulumi.Run(func(ctx *pulumi.Context) error {

		_, err := core.GetResourceGroup(ctx, "test,", pulumi.ID("/subscriptions/<subid>/resourceGroups/<rg>"), nil)

		return err
	})
}
```

The original failing line: 

https://github.com/pulumi/pulumi/blob/master/sdk/go/pulumi/rpc.go#L77

I added some logs to rpc.go:

```go
    fmt.Printf("props: %v\n", props)
    fmt.Printf("reflect.TypeOf(props) %v\n", reflect.TypeOf(props))

    pv := reflect.ValueOf(props)
    if pv.Kind() == reflect.Ptr {
        pv = pv.Elem()
    }
    fmt.Printf("pv: %v\n", pv)
    pt := pv.Type() // the error here
```

```
props: <nil>
    reflect.TypeOf(props) *core.ResourceGroupState
    pv: <invalid reflect.Value>
 
    panic: reflect: call of reflect.Value.Type on zero Value
    goroutine 27 [running]:
    reflect.Value.Type(0x0, 0x0, 0x0, 0x7, 0xc000241750)
    	/usr/local/Cellar/go/1.13.8/libexec/src/reflect/value.go:1877 +0x166
    github.com/pulumi/pulumi/sdk/go/pulumi.marshalInputs(0x1c73540, 0x0, 0x26, 0x0, 0xc0000e9a20, 0xc0002ec080, 0x3b, 0x0, 0x0)
    	/Users/evanboyle/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/rpc.go:91 +0x411
    github.com/pulumi/pulumi/sdk/go/pulumi.(*Context).prepareResourceInputs(0xc000210000, 0x1c73540, 0x0, 0x1b867c3, 0x26, 0xc0000e9a20, 0xc0001a2540, 0x0, 0x0, 0x0)
    	/Users/evanboyle/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/context.go:710 +0x23a
    github.com/pulumi/pulumi/sdk/go/pulumi.(*Context).ReadResource.func1(0xc0001a2540, 0xc000210000, 0x1c84be0, 0x1c62d20, 0x1c73540, 0x0, 0x1b867c3, 0x26, 0xc0000e9a20, 0x1b6c0db, ...)
    	/Users/evanboyle/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/context.go:315 +0x1f1
    created by github.com/pulumi/pulumi/sdk/go/pulumi.(*Context).ReadResource
    	/Users/evanboyle/go/src/github.com/pulumi/pulumi/sdk/go/pulumi/context.go:298 +0x3b1
    exit status 2
 
    error: an unhandled error occurred: program exited with non-zero exit code: 1
```