### PR TITLE
remove UpdatePolicyPackConfig from UpdatePolicyGroupRequest

### DIFF
--- a/pkg/apitype/policy.go
+++ b/pkg/apitype/policy.go
@@ -153,9 +153,8 @@ type UpdatePolicyGroupRequest struct {
 	AddStack    *PulumiStackReference `json:"addStack,omitempty"`
 	RemoveStack *PulumiStackReference `json:"removeStack,omitempty"`
 
-	AddPolicyPack          *PolicyPackMetadata `json:"addPolicyPack,omitempty"`
-	RemovePolicyPack       *PolicyPackMetadata `json:"removePolicyPack,omitempty"`
-	UpdatePolicyPackConfig *PolicyPackMetadata `json:"updatePolicyPackConfig,omitempty"`
+	AddPolicyPack    *PolicyPackMetadata `json:"addPolicyPack,omitempty"`
+	RemovePolicyPack *PolicyPackMetadata `json:"removePolicyPack,omitempty"`
 }
 
 // PulumiStackReference contains the StackName and ProjectName of the stack.


### PR DESCRIPTION
No longer using the `UpdatePolicyPackConfig` (we never were). I added it initially bc i thought id need it, but the [implementation](https://github.com/pulumi/pulumi-service/pull/4737/files#diff-dae1829cce9a5bc03e793adc8d7e5c9dR178) just uses`AddPolicyPack`.