### PR TITLE
fix reflect panic

### DIFF
--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -267,7 +267,10 @@ func marshalInputAndDetermineSecret(v interface{},
 			if rv.IsNil() {
 				return resource.PropertyValue{}, deps, secret, nil
 			}
-			v, destType = rv.Elem().Interface(), destType.Elem()
+			if destType.Kind() == reflect.Ptr {
+				destType = destType.Elem()
+			}
+			v = rv.Elem().Interface()
 			continue
 		case reflect.String:
 			return resource.NewStringProperty(rv.String()), deps, secret, nil


### PR DESCRIPTION
Closes https://github.com/pulumi/pulumi/issues/4026

We're trying to dereference a struct, assuming the dest is a pointer and getting a panic as a result. Some logs right before this location:

```
 rv.Type(): *eks.ClusterVpcConfigArgs
 rv.Type().kind(): ptr
 destType: eks.ClusterVpcConfig
 destType.kind(): struct

```