### PR TITLE
Windows requires applications to have exe extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ CHANGELOG
   [#4023](https://github.com/pulumi/pulumi/pull/4023)
 - Avoid projects beginning with `Pulumi` to stop cyclic imports
   [#4013](https://github.com/pulumi/pulumi/pull/4013)
+- Ensure we can locate Go created application binaries on Windows
+  [#4030](https://github.com/pulumi/pulumi/pull/4030)
 
 ## 1.12.0 (2020-03-04)
 - Avoid Configuring providers which are not used during preview.

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"syscall"
 
 	pbempty "github.com/golang/protobuf/ptypes/empty"
@@ -97,6 +98,9 @@ const unableToFindProgramTemplate = "unable to find program: %s"
 // findProgram attempts to find the needed program in various locations on the
 // filesystem, eventually resorting to searching in $PATH.
 func findProgram(program string) (string, error) {
+	if runtime.GOOS == "windows" {
+		program = fmt.Sprintf("%s.exe", program)
+	}
 
 	// look in the same directory
 	cwd, err := os.Getwd()


### PR DESCRIPTION
We need to ensure that if the pulumi application is prebuild on
Windows then it will have the exe extension otherwise it's not
a valid windows program

https://github.com/golang/go/wiki/WindowsCrossCompiling