### PR TITLE
Mention mocks in the missing project error

### DIFF
--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -139,7 +139,7 @@ export function getProject(): string {
     requireTestModeEnabled();
 
     // And now an error if test mode is enabled, instructing how to manually configure the project:
-    throw new Error("Missing project name; for test mode, please set PULUMI_NODEJS_PROJECT");
+    throw new Error("Missing project name; for test mode, please call `pulumi.runtime.setMocks`");
 }
 
 /** @internal Used only for testing purposes. */

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -129,7 +129,7 @@ def get_project() -> str:
     project = SETTINGS.project
     if not project:
         require_test_mode_enabled()
-        raise RunError('Missing project name; for test mode, please set PULUMI_NODEJS_PROJECT')
+        raise RunError('Missing project name; for test mode, please call `pulumi.runtime.set_mocks`')
     return project
 
 


### PR DESCRIPTION
Fixes #4039 in a very direct and minimal way. We'll see what else we need to do while writing the testing guides.