### PR TITLE
Ensure python overlays work as expected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ CHANGELOG
   [#4013](https://github.com/pulumi/pulumi/pull/4013)
 - Ensure we can locate Go created application binaries on Windows
   [#4030](https://github.com/pulumi/pulumi/pull/4030)
+- Ensure Python overlays work as part of our SDK generation
+  [#4043](https://github.com/pulumi/pulumi/pull/4043)
 
 ## 1.12.0 (2020-03-04)
 - Avoid Configuring providers which are not used during preview.

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -136,7 +136,7 @@ func (mod *modContext) gen(fs fs) error {
 			d = ""
 		}
 		if d == dir {
-			exports = append(exports, p[:len(p)-len(".py")])
+			exports = append(exports, strings.TrimSuffix(path.Base(p), ".py"))
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-terraform-bridge/issues/119

This allows us to specify an overlays block e.g.

```
Overlay: &tfbridge.OverlayInfo{
	DestFiles: []string{
		"pulumi_docker/docker.py",
		"pulumi_docker/image.py",
	},
},
```

The overlays files are treated differently to normal module files
as they are not generated. This structure means that we will emit
the correct entries in the __init__.py file

Without this structure (ie. pulumi_pkgname), the generator actually
copies the file (i.e. docker.py) to the root of the Python SDK. This
is because the structure of the Python SDK has a sub-folder than that
of the NodeJS SDK

I tested this using PR https://github.com/pulumi/pulumi-docker/pull/141
and this now works as expected and we can take advantage of the new
Python overlays for Docker