### PR TITLE
Allow pulumi stack export to decrypt secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ CHANGELOG
 - Add ResourceOutput type to Go SDK
   [#4575](https://github.com/pulumi/pulumi/pull/4575)
 
+- Allow secrets to be decrypted when exporting a stack
+  [#4046](https://github.com/pulumi/pulumi/pull/4046)
+
 ## 2.1.0 (2020-04-28)
 
 - Fix infinite recursion bug for Go SDK

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -200,10 +200,10 @@ func convertStepEventStateMetadata(md *engine.StepEventStateMetadata) *apitype.S
 	}
 
 	encrypter := config.BlindingCrypter
-	inputs, err := stack.SerializeProperties(md.Inputs, encrypter)
+	inputs, err := stack.SerializeProperties(md.Inputs, encrypter, false /* showSecrets */)
 	contract.IgnoreError(err)
 
-	outputs, err := stack.SerializeProperties(md.Outputs, encrypter)
+	outputs, err := stack.SerializeProperties(md.Outputs, encrypter, false /* showSecrets */)
 	contract.IgnoreError(err)
 
 	return &apitype.StepEventStateMetadata{

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -156,7 +156,7 @@ func ShowJSONEvents(op string, action apitype.UpdateKind, events <-chan engine.E
 
 				if m.Old != nil {
 					oldState := stateForJSONOutput(m.Old.State, opts)
-					res, err := stack.SerializeResource(oldState, config.NewPanicCrypter())
+					res, err := stack.SerializeResource(oldState, config.NewPanicCrypter(), false /* showSecrets */)
 					if err == nil {
 						step.OldState = &res
 					} else {
@@ -165,7 +165,7 @@ func ShowJSONEvents(op string, action apitype.UpdateKind, events <-chan engine.E
 				}
 				if m.New != nil {
 					newState := stateForJSONOutput(m.New.State, opts)
-					res, err := stack.SerializeResource(newState, config.NewPanicCrypter())
+					res, err := stack.SerializeResource(newState, config.NewPanicCrypter(), false /* showSecrets */)
 					if err == nil {
 						step.NewState = &res
 					} else {

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -657,7 +657,7 @@ func (b *localBackend) ExportDeployment(ctx context.Context,
 		snap = deploy.NewSnapshot(deploy.Manifest{}, nil, nil, nil)
 	}
 
-	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager)
+	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager /* showSecrsts */, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "serializing deployment")
 	}

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -172,7 +172,7 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 	if filepath.Ext(file) == "" {
 		file = file + ext
 	}
-	chk, err := stack.SerializeCheckpoint(name, snap, sm)
+	chk, err := stack.SerializeCheckpoint(name, snap, sm, false /* showSecrets */)
 	if err != nil {
 		return "", errors.Wrap(err, "serializaing checkpoint")
 	}

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -43,7 +43,7 @@ func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 	if err != nil {
 		return err
 	}
-	deployment, err := stack.SerializeDeployment(snapshot, persister.sm)
+	deployment, err := stack.SerializeDeployment(snapshot, persister.sm, false /* showSecrets */)
 	if err != nil {
 		return errors.Wrap(err, "serializing deployment")
 	}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -112,5 +112,6 @@ func getStackOutputs(snap *deploy.Snapshot, showSecrets bool) (map[string]interf
 	// massageSecrets will remove all the secrets from the property map, so it should be safe to pass a panic
 	// crypter. This also ensure that if for some reason we didn't remove everything, we don't accidentally disclose
 	// secret values!
-	return stack.SerializeProperties(display.MassageSecrets(state.Outputs, showSecrets), config.NewPanicCrypter())
+	return stack.SerializeProperties(display.MassageSecrets(state.Outputs, showSecrets),
+		config.NewPanicCrypter(), showSecrets)
 }

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -170,7 +170,7 @@ func runTotalStateEdit(
 		contract.AssertNoErrorf(snap.VerifyIntegrity(), "state edit produced an invalid snapshot")
 	}
 
-	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager)
+	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrets */)
 	if err != nil {
 		return result.FromError(errors.Wrap(err, "serializing deployment"))
 	}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/backend/httpstate"
 	"github.com/pulumi/pulumi/pkg/v2/backend/state"
 	"github.com/pulumi/pulumi/pkg/v2/engine"
+	"github.com/pulumi/pulumi/pkg/v2/resource/stack"
 	"github.com/pulumi/pulumi/pkg/v2/secrets/passphrase"
 	"github.com/pulumi/pulumi/pkg/v2/util/cancel"
 	"github.com/pulumi/pulumi/pkg/v2/util/tracing"
@@ -701,4 +702,16 @@ func updateFlagsToOptions(interactive, skipPreview, yes bool) (backend.UpdateOpt
 		AutoApprove: yes,
 		SkipPreview: skipPreview,
 	}, nil
+}
+
+func checkDeploymentVersionError(err error, stackName string) error {
+	switch err {
+	case stack.ErrDeploymentSchemaVersionTooOld:
+		return fmt.Errorf("the stack '%s' is too old to be used by this version of the Pulumi CLI",
+			stackName)
+	case stack.ErrDeploymentSchemaVersionTooNew:
+		return fmt.Errorf("the stack '%s' is newer than what this version of the Pulumi CLI understands. "+
+			"Please update your version of the Pulumi CLI", stackName)
+	}
+	return errors.Wrap(err, "could not deserialize deployment")
 }

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -81,11 +81,11 @@ func UnmarshalVersionedCheckpointToLatestCheckpoint(bytes []byte) (*apitype.Chec
 
 // SerializeCheckpoint turns a snapshot into a data structure suitable for serialization.
 func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
-	sm secrets.Manager) (*apitype.VersionedCheckpoint, error) {
+	sm secrets.Manager, showSecrets bool) (*apitype.VersionedCheckpoint, error) {
 	// If snap is nil, that's okay, we will just create an empty deployment; otherwise, serialize the whole snapshot.
 	var latest *apitype.DeploymentV3
 	if snap != nil {
-		dep, err := SerializeDeployment(snap, sm)
+		dep, err := SerializeDeployment(snap, sm, showSecrets)
 		if err != nil {
 			return nil, errors.Wrap(err, "serializing deployment")
 		}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -87,7 +87,7 @@ func TestDeploymentSerialization(t *testing.T) {
 		"",
 	)
 
-	dep, err := SerializeResource(res, config.NopEncrypter)
+	dep, err := SerializeResource(res, config.NopEncrypter, false /* showSecrets */)
 	assert.NoError(t, err)
 
 	// assert some things about the deployment record:
@@ -183,7 +183,7 @@ func TestUnsupportedSecret(t *testing.T) {
 	rawProp := map[string]interface{}{
 		resource.SigKey: resource.SecretSig,
 	}
-	_, err := DeserializePropertyValue(rawProp, config.NewPanicCrypter())
+	_, err := DeserializePropertyValue(rawProp, config.NewPanicCrypter(), config.NewPanicCrypter())
 	assert.Error(t, err)
 }
 
@@ -191,7 +191,7 @@ func TestUnknownSig(t *testing.T) {
 	rawProp := map[string]interface{}{
 		resource.SigKey: "foobar",
 	}
-	_, err := DeserializePropertyValue(rawProp, config.NewPanicCrypter())
+	_, err := DeserializePropertyValue(rawProp, config.NewPanicCrypter(), config.NewPanicCrypter())
 	assert.Error(t, err)
 }
 
@@ -289,7 +289,7 @@ func TestCustomSerialization(t *testing.T) {
 	// Using stack.SerializeProperties will get the correct behavior and should be used
 	// whenever persisting resources into some durable form.
 	t.Run("SerializeProperties", func(t *testing.T) {
-		serializedPropMap, err := SerializeProperties(propMap, config.BlindingCrypter)
+		serializedPropMap, err := SerializeProperties(propMap, config.BlindingCrypter, false /* showSecrets */)
 		assert.NoError(t, err)
 
 		// Now JSON encode the results?

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -51,7 +51,7 @@ func deserializeProperty(v interface{}, dec config.Decrypter) (resource.Property
 	if err := json.Unmarshal(b, &v); err != nil {
 		return resource.PropertyValue{}, err
 	}
-	return DeserializePropertyValue(v, dec)
+	return DeserializePropertyValue(v, dec, config.NewPanicCrypter())
 }
 
 func TestCachingCrypter(t *testing.T) {
@@ -66,38 +66,38 @@ func TestCachingCrypter(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Serialize the first copy of "foo". Encrypt should be called once, as this value has not yet been encrypted.
-	foo1Ser, err := SerializePropertyValue(foo1, enc)
+	foo1Ser, err := SerializePropertyValue(foo1, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, sm.encryptCalls)
 
 	// Serialize the second copy of "foo". Because this is a different secret instance, Encrypt should be called
 	// a second time even though the plaintext is the same as the last value we encrypted.
-	foo2Ser, err := SerializePropertyValue(foo2, enc)
+	foo2Ser, err := SerializePropertyValue(foo2, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, sm.encryptCalls)
 	assert.NotEqual(t, foo1Ser, foo2Ser)
 
 	// Serialize "bar". Encrypt should be called once, as this value has not yet been encrypted.
-	barSer, err := SerializePropertyValue(bar, enc)
+	barSer, err := SerializePropertyValue(bar, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 
 	// Serialize the first copy of "foo" again. Encrypt should not be called, as this value has already been
 	// encrypted.
-	foo1Ser2, err := SerializePropertyValue(foo1, enc)
+	foo1Ser2, err := SerializePropertyValue(foo1, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, foo1Ser, foo1Ser2)
 
 	// Serialize the second copy of "foo" again. Encrypt should not be called, as this value has already been
 	// encrypted.
-	foo2Ser2, err := SerializePropertyValue(foo2, enc)
+	foo2Ser2, err := SerializePropertyValue(foo2, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, foo2Ser, foo2Ser2)
 
 	// Serialize "bar" again. Encrypt should not be called, as this value has already been encrypted.
-	barSer2, err := SerializePropertyValue(bar, enc)
+	barSer2, err := SerializePropertyValue(bar, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, barSer, barSer2)
@@ -153,21 +153,21 @@ func TestCachingCrypter(t *testing.T) {
 
 	// Serialize the first copy of "foo" again. Encrypt should not be called, as this value has already been
 	// cached by the earlier calls to Decrypt.
-	foo1Ser2, err = SerializePropertyValue(foo1Dec, enc)
+	foo1Ser2, err = SerializePropertyValue(foo1Dec, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, foo1Ser, foo1Ser2)
 
 	// Serialize the second copy of "foo" again. Encrypt should not be called, as this value has already been
 	// cached by the earlier calls to Decrypt.
-	foo2Ser2, err = SerializePropertyValue(foo2Dec, enc)
+	foo2Ser2, err = SerializePropertyValue(foo2Dec, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, foo2Ser, foo2Ser2)
 
 	// Serialize "bar" again. Encrypt should not be called, as this value has already been cached by the
 	// earlier calls to Decrypt.
-	barSer2, err = SerializePropertyValue(barDec, enc)
+	barSer2, err = SerializePropertyValue(barDec, enc, false /* showSecrets */)
 	assert.NoError(t, err)
 	assert.Equal(t, 3, sm.encryptCalls)
 	assert.Equal(t, barSer, barSer2)

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -316,7 +316,8 @@ type PluginInfoV1 struct {
 // NOTE: nothing produces these values yet. This type is merely a placeholder for future use.
 type SecretV1 struct {
 	Sig        string `json:"4dabf18193072939515e22adb298388d" yaml:"4dabf18193072939515e22adb298388d"`
-	Ciphertext string `json:"ciphertext" yaml:"ciphertext"`
+	Ciphertext string `json:"ciphertext,omitempty" yaml:"ciphertext,omitempty"`
+	Plaintext  string `json:"plaintext,omitempty" yaml:"plaintext,omitempty"`
 }
 
 // ConfigValue describes a single (possibly secret) configuration value.

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -243,7 +243,7 @@ func TestStackCommands(t *testing.T) {
 			Resource: res,
 			Type:     resource.OperationTypeDeleting,
 		})
-		v3deployment, err := stack.SerializeDeployment(snap, nil)
+		v3deployment, err := stack.SerializeDeployment(snap, nil, false /* showSecrets */)
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}


### PR DESCRIPTION
Fixes: #2918

This allows us to run the command `pulumi stack export --show-secrets`
it will also introduce the changes that allows the import to handle
when plain text is included in the import file