### PR TITLE
Updates to resource doc generator for generating docs for Functions

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -24,4 +24,7 @@ type DocLanguageHelper interface {
 	GetDocLinkForResourceType(packageName, moduleName, typeName string) string
 	GetDocLinkForInputType(packageName, moduleName, typeName string) string
 	GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string
+	// GetResourceFunctionResultName returns the name of the result type when a static resource function is used to lookup
+	// an existing resource.
+	GetResourceFunctionResultName(resourceName string) string
 }

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -22,7 +22,8 @@ import (
 // See the implementation for this interface under each of the language code generators.
 type DocLanguageHelper interface {
 	GetDocLinkForResourceType(packageName, moduleName, typeName string) string
-	GetDocLinkForInputType(packageName, moduleName, typeName string) string
+	GetDocLinkForResourceInputOrOutputType(packageName, moduleName, typeName string, input bool) string
+	GetDocLinkForFunctionInputOrOutputType(packageName, moduleName, typeName string, input bool) string
 	GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string
 	// GetResourceFunctionResultName returns the name of the result type when a static resource function is used to lookup
 	// an existing resource.

--- a/pkg/codegen/docs/bundler.go
+++ b/pkg/codegen/docs/bundler.go
@@ -96,14 +96,14 @@ func main() {
 	contents := make(map[string][]byte)
 	for _, f := range files {
 		if f.IsDir() {
-			fmt.Println(fmt.Sprintf("%q is a dir. Skipping...", f.Name()))
+			fmt.Printf("%q is a dir. Skipping...\n", f.Name())
 		}
 		b, err := ioutil.ReadFile(docsTemplatesPath + "/" + f.Name())
 		if err != nil {
 			log.Fatalf("Error reading file %s: %v", f.Name(), err)
 		}
 		if len(b) == 0 {
-			fmt.Println(fmt.Sprintf("%q is empty. Skipping...", f.Name()))
+			fmt.Printf("%q is empty. Skipping...\n", f.Name())
 			continue
 		}
 		contents[f.Name()] = b

--- a/pkg/codegen/docs/bundler.go
+++ b/pkg/codegen/docs/bundler.go
@@ -96,11 +96,15 @@ func main() {
 	contents := make(map[string][]byte)
 	for _, f := range files {
 		if f.IsDir() {
-			fmt.Printf("%q is a dir. Skipping...", f.Name())
+			fmt.Println(fmt.Sprintf("%q is a dir. Skipping...", f.Name()))
 		}
 		b, err := ioutil.ReadFile(docsTemplatesPath + "/" + f.Name())
 		if err != nil {
 			log.Fatalf("Error reading file %s: %v", f.Name(), err)
+		}
+		if len(b) == 0 {
+			fmt.Println(fmt.Sprintf("%q is empty. Skipping...", f.Name()))
+			continue
 		}
 		contents[f.Name()] = b
 	}

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -70,6 +70,7 @@ type header struct {
 }
 
 type exampleUsage struct {
+	// Heading is the title of an example.
 	Heading string
 	Code    string
 }
@@ -82,9 +83,7 @@ type property struct {
 	DeprecationMessage string
 
 	IsRequired bool
-	// IsInput is a flag to indicate if a property is an input
-	// property.
-	IsInput bool
+	IsInput    bool
 }
 
 // apiTypeDocLinks represents the links for a type's input and output API doc.
@@ -125,6 +124,7 @@ type constructorParam struct {
 type resourceDocArgs struct {
 	Header header
 
+	// Comment represents the introductory resource comment.
 	Comment  string
 	Examples []exampleUsage
 
@@ -132,13 +132,26 @@ type resourceDocArgs struct {
 	// ConstructorResource is the resource that is being constructed or
 	// is the result of a constructor-like function.
 	ConstructorResource map[string]propertyType
-	ArgsRequired        bool
+	// ArgsRequired is a flag indicating if the args param is required
+	// when creating a new resource.
+	ArgsRequired bool
 
-	InputProperties  map[string][]property
+	// InputProperties is a map per language and a corresponding slice of
+	// input properties accepted as args while creating a new resource.
+	InputProperties map[string][]property
+	// InputProperties is a map per language and a corresponding slice of
+	// output properties returned when a new instance of the resource is
+	// created.
 	OutputProperties map[string][]property
-	StateInputs      map[string][]property
-	StateParam       string
 
+	// StateInputs is a map per language and the corresponding slice of
+	// state input properties required while looking-up an existing resource.
+	StateInputs map[string][]property
+	// StateParam is the type name of the state param, if any.
+	StateParam string
+
+	// NestedTypes is a slice of the nested types used in the input and
+	// output properties.
 	NestedTypes []docNestedType
 }
 
@@ -147,6 +160,9 @@ type appearsIn struct {
 	Output bool
 }
 
+// stringSet is a type-alias for a map of type tokens
+// and whether or not the type appears in input as well
+// as output properties.
 type stringSet map[string]appearsIn
 
 func (ss stringSet) add(s string, input bool) {

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -94,10 +94,9 @@ type apiTypeDocLinks struct {
 
 // docNestedType represents a complex type.
 type docNestedType struct {
-	Name         string
-	IsOutputType bool
-	APIDocLinks  map[string]apiTypeDocLinks
-	Properties   map[string][]property
+	Name        string
+	APIDocLinks map[string]apiTypeDocLinks
+	Properties  map[string][]property
 }
 
 // propertyType represents the type of a property.
@@ -139,7 +138,7 @@ type resourceDocArgs struct {
 	// InputProperties is a map per language and a corresponding slice of
 	// input properties accepted as args while creating a new resource.
 	InputProperties map[string][]property
-	// InputProperties is a map per language and a corresponding slice of
+	// OutputProperties is a map per language and a corresponding slice of
 	// output properties returned when a new instance of the resource is
 	// created.
 	OutputProperties map[string][]property
@@ -160,12 +159,12 @@ type appearsIn struct {
 	Output bool
 }
 
-// stringSet is a type-alias for a map of type tokens
-// and whether or not the type appears in input as well
-// as output properties.
-type stringSet map[string]appearsIn
+// nestedTypeUsageInfo is a type-alias for a map of Pulumi type-tokens
+// and whether or not the type appears in input and/or output
+// properties.
+type nestedTypeUsageInfo map[string]appearsIn
 
-func (ss stringSet) add(s string, input bool) {
+func (ss nestedTypeUsageInfo) add(s string, input bool) {
 	if v, ok := ss[s]; ok {
 		if input {
 			v.Input = true
@@ -386,7 +385,7 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 }
 
 func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []docNestedType {
-	tokens := stringSet{}
+	tokens := nestedTypeUsageInfo{}
 	// Collect all of the types for this "member" as a map of resource names
 	// and if it appears in an input object and/or output object.
 	mod.getTypes(member, tokens)
@@ -616,7 +615,7 @@ func visitObjectTypes(t schema.Type, visitor func(*schema.ObjectType)) {
 	}
 }
 
-func (mod *modContext) getNestedTypes(t schema.Type, types stringSet, input bool) {
+func (mod *modContext) getNestedTypes(t schema.Type, types nestedTypeUsageInfo, input bool) {
 	switch t := t.(type) {
 	case *schema.ArrayType:
 		mod.getNestedTypes(t.ElementType, types, input)
@@ -634,7 +633,7 @@ func (mod *modContext) getNestedTypes(t schema.Type, types stringSet, input bool
 	}
 }
 
-func (mod *modContext) getTypes(member interface{}, types stringSet) {
+func (mod *modContext) getTypes(member interface{}, types nestedTypeUsageInfo) {
 	switch t := member.(type) {
 	case *schema.ObjectType:
 		for _, p := range t.Properties {

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/codegen/schema"
 )
 
+// functionDocArgs represents the args that a Function doc template needs.
 type functionDocArgs struct {
 	Header header
 
@@ -37,12 +38,22 @@ type functionDocArgs struct {
 	DeprecationMessage string
 	Comment            string
 
-	FunctionArgs   map[string]string
+	// FunctionArgs is map per language view of the parameters
+	// in the Function.
+	FunctionArgs map[string]string
+	// FunctionResult is a map per language property types
+	// that is returned as a result of calling a Function.
 	FunctionResult map[string]propertyType
 
-	InputProperties  map[string][]property
+	// InputProperties is a map per language and the corresponding slice
+	// of input properties accepted by the Function.
+	InputProperties map[string][]property
+	// InputProperties is a map per language and the corresponding slice
+	// of output properties, which are properties of the FunctionResult type.
 	OutputProperties map[string][]property
 
+	// NestedTypes is a slice of the nested types used in the input and
+	// output properties.
 	NestedTypes []docNestedType
 }
 

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -1,0 +1,282 @@
+//go:generate go run bundler.go
+
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pulling out some of the repeated strings tokens into constants would harm readability, so we just ignore the
+// goconst linter's warning.
+//
+// nolint: lll, goconst
+package docs
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/codegen"
+	"github.com/pulumi/pulumi/pkg/codegen/dotnet"
+	go_gen "github.com/pulumi/pulumi/pkg/codegen/go"
+	"github.com/pulumi/pulumi/pkg/codegen/nodejs"
+	"github.com/pulumi/pulumi/pkg/codegen/python"
+	"github.com/pulumi/pulumi/pkg/codegen/schema"
+)
+
+type functionDocArgs struct {
+	Header
+
+	ResourceName       string
+	DeprecationMessage string
+	Comment            string
+
+	FunctionArgs   map[string]string
+	FunctionResult map[string]PropertyType
+
+	InputProperties  map[string][]Property
+	OutputProperties map[string][]Property
+}
+
+// getFunctionResourceInfo returns a map of per-language information about
+// the resource being looked-up using a static "getter" function.
+func (mod *modContext) getFunctionResourceInfo(resourceTypeName string) map[string]PropertyType {
+	resourceMap := make(map[string]PropertyType)
+
+	var resultTypeName string
+	for _, lang := range supportedLanguages {
+		var docLangHelper codegen.DocLanguageHelper
+		switch lang {
+		case "nodejs":
+			docLangHelper = nodejs.DocLanguageHelper{}
+			resultTypeName = docLangHelper.GetResourceFunctionResultName(resourceTypeName)
+		case "go":
+			docLangHelper = go_gen.DocLanguageHelper{}
+			resultTypeName = docLangHelper.GetResourceFunctionResultName(resourceTypeName)
+		case "csharp":
+			docLangHelper = dotnet.DocLanguageHelper{}
+			resultTypeName = docLangHelper.GetResourceFunctionResultName(resourceTypeName)
+			resultTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", strings.Title(mod.pkg.Name), strings.Title(mod.mod), resultTypeName)
+		case "python":
+			// Pulumi's Python language SDK does not have "types" yet, so we will skip it for now.
+			continue
+		default:
+			panic(errors.Errorf("cannot generate function resource info for unhandled language %q", lang))
+		}
+
+		resourceMap[lang] = PropertyType{
+			Name: resultTypeName,
+			Link: docLangHelper.GetDocLinkForResourceType(mod.pkg.Name, mod.mod, resultTypeName),
+		}
+	}
+
+	return resourceMap
+}
+
+func (mod *modContext) genFunctionTS(f *schema.Function) []ConstructorParam {
+	resourceName := tokenToName(f.Token)
+	argsType := resourceName + "Args"
+
+	docLangHelper := nodejs.DocLanguageHelper{}
+	return []ConstructorParam{
+		{
+			Name:         "args",
+			OptionalFlag: "",
+			Type: PropertyType{
+				Name: argsType,
+				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg.Name, mod.mod, argsType),
+			},
+		},
+		{
+			Name:         "opts",
+			OptionalFlag: "?",
+			Type: PropertyType{
+				Name: "pulumi.InvokeOptions",
+				Link: docLangHelper.GetDocLinkForResourceType("pulumi", "pulumi", "InvokeOptions"),
+			},
+		},
+	}
+}
+
+func (mod *modContext) genFunctionGo(f *schema.Function) []ConstructorParam {
+	resourceName := tokenToName(f.Token)
+	argsType := resourceName + "Args"
+
+	docLangHelper := go_gen.DocLanguageHelper{}
+	return []ConstructorParam{
+		{
+			Name:         "ctx",
+			OptionalFlag: "*",
+			Type: PropertyType{
+				Name: "pulumi.Context",
+				Link: "https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#Context",
+			},
+		},
+		{
+			Name:         "args",
+			OptionalFlag: "",
+			Type: PropertyType{
+				Name: argsType,
+				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg.Name, mod.mod, argsType),
+			},
+		},
+		{
+			Name:         "opts",
+			OptionalFlag: "...",
+			Type: PropertyType{
+				Name: "pulumi.InvokeOption",
+				Link: "https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#InvokeOption",
+			},
+		},
+	}
+}
+
+func (mod *modContext) genFunctionCS(f *schema.Function) []ConstructorParam {
+	resourceName := tokenToName(f.Token)
+	argsType := resourceName + "Args"
+	argsSchemaType := &schema.ObjectType{
+		Token: f.Token,
+	}
+	argLangType := mod.typeString(argsSchemaType, "csharp", true /* input */, false /* optional */, false /* insertWordBreaks */)
+
+	docLangHelper := dotnet.DocLanguageHelper{}
+	return []ConstructorParam{
+		{
+			Name:         "args",
+			OptionalFlag: "",
+			DefaultValue: "",
+			Type: PropertyType{
+				Name: argsType,
+				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg.Name, "", argLangType.Name),
+			},
+		},
+		{
+			Name:         "opts",
+			OptionalFlag: "?",
+			DefaultValue: " = null",
+			Type: PropertyType{
+				Name: "InvokeOptions",
+				Link: docLangHelper.GetDocLinkForResourceType("", "", "InvokeOptions"),
+			},
+		},
+	}
+}
+
+func (mod *modContext) genFunctionPython(f *schema.Function) []ConstructorParam {
+	var params []ConstructorParam
+
+	// Some functions don't have any inputs other than the InvokeOptions.
+	// For example, the `get_billing_service_account` function.
+	if f.Inputs != nil {
+		params = make([]ConstructorParam, 0, len(f.Inputs.Properties))
+		for _, prop := range f.Inputs.Properties {
+			fArg := ConstructorParam{
+				Name:         python.PyName(prop.Name),
+				DefaultValue: "=None",
+			}
+			params = append(params, fArg)
+		}
+	} else {
+		params = make([]ConstructorParam, 0, 1)
+	}
+
+	params = append(params, ConstructorParam{
+		Name:         "opts",
+		DefaultValue: "=None",
+	})
+
+	return params
+}
+
+// genFunctionArgs generates the arguments string for a given Function that can be
+// rendered directly into a template.
+func (mod *modContext) genFunctionArgs(f *schema.Function) map[string]string {
+	functionParams := make(map[string]string)
+
+	for _, lang := range supportedLanguages {
+		var (
+			paramTemplate string
+			params        []ConstructorParam
+		)
+		b := &bytes.Buffer{}
+
+		switch lang {
+		case "nodejs":
+			params = mod.genFunctionTS(f)
+			paramTemplate = "ts_constructor_param"
+		case "go":
+			params = mod.genFunctionGo(f)
+			paramTemplate = "go_constructor_param"
+		case "csharp":
+			params = mod.genFunctionCS(f)
+			paramTemplate = "csharp_constructor_param"
+		case "python":
+			params = mod.genFunctionPython(f)
+			paramTemplate = "py_function_param"
+		}
+
+		n := len(params)
+		if n == 0 {
+			continue
+		}
+
+		for i, p := range params {
+			if err := templates.ExecuteTemplate(b, paramTemplate, p); err != nil {
+				panic(err)
+			}
+			if i != n-1 {
+				if err := templates.ExecuteTemplate(b, "param_separator", nil); err != nil {
+					panic(err)
+				}
+			}
+		}
+		functionParams[lang] = b.String()
+	}
+	return functionParams
+}
+
+// genFunction is the main entrypoint for generating docs for a Function.
+// Returns args type that can be used to execute the `function.tmpl` doc template.
+func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
+	name := tokenToName(f.Token)
+	resourceName := strings.ReplaceAll(name, "Get", "")
+
+	inputProps := make(map[string][]Property)
+	outputProps := make(map[string][]Property)
+	for _, lang := range supportedLanguages {
+		if f.Inputs != nil {
+			inputProps[lang] = mod.getProperties(f.Inputs.Properties, lang, true)
+		}
+		if f.Outputs != nil {
+			outputProps[lang] = mod.getProperties(f.Outputs.Properties, lang, false)
+		}
+	}
+
+	args := functionDocArgs{
+		Header: Header{
+			Title: name,
+		},
+
+		ResourceName:   resourceName,
+		FunctionArgs:   mod.genFunctionArgs(f),
+		FunctionResult: mod.getFunctionResourceInfo(resourceName),
+
+		Comment:            f.Comment,
+		DeprecationMessage: f.DeprecationMessage,
+
+		InputProperties:  inputProps,
+		OutputProperties: outputProps,
+	}
+
+	return args
+}

--- a/pkg/codegen/docs/templates/constructor_params.tmpl
+++ b/pkg/codegen/docs/templates/constructor_params.tmpl
@@ -7,3 +7,5 @@
 {{ define "csharp_constructor_param" }}{{ template "linkify_param" .Type }}{{ .OptionalFlag }} <span class="nx">{{ .Name }}{{ .DefaultValue }}{{ end }}
 
 {{ define "py_param" }}{{ range . }}, {{ htmlSafe .Name }}=None{{ end }}{{ end }}
+
+{{ define "py_function_param" }}{{ htmlSafe .Name }}{{ .DefaultValue }}{{ end }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -29,7 +29,7 @@ The following arguments are supported:
 {{ end }}
 
 <!-- Output properties -->
-## {{.Header.Title}} Output Properties
+## {{.Header.Title}} Result
 
 The following output properties are available:
 

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -1,0 +1,32 @@
+{{ template "header" .Header }}
+
+{{ htmlSafe .Comment }}
+
+{{ .DeprecationMessage }}
+
+<!-- Input properties -->
+## {{ .Header.Title }} Input Arguments
+
+{{ htmlSafe "{{< langchoose csharp nojavascript >}}" }}
+
+<!-- TS/JS -->
+<div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">function </span>get{{ .ResourceName }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.nodejs }}<span class="p">): Promise<{{ template "linkify_param" .FunctionResult.nodejs }}></span></code></pre></div>
+
+<!-- Python -->
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">function </span> get_{{ .ResourceName }}(</span>{{ htmlSafe .FunctionArgs.python }}<span class="p">)</span></code></pre></div>
+
+<!-- Go -->
+<div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>Lookup{{ .ResourceName }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.go }}<span class="p">) (*{{ template "linkify_param" .FunctionResult.go }}, error)</span></code></pre></div>
+
+<!-- C# -->
+<div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static </span>Task<{{ template "linkify_param" .FunctionResult.csharp }}> <span class="p">Get{{ .ResourceName }}(</span>{{ htmlSafe .FunctionArgs.csharp }}<span class="p">)</span></code></pre></div>
+
+The following arguments are supported:
+{{ template "properties" .InputProperties }}
+
+<!-- Output properties -->
+## {{.Header.Title}} Output Properties
+
+The following output properties are available:
+
+{{ template "properties" .OutputProperties }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -13,7 +13,7 @@
 <div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">function </span>get{{ .ResourceName }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.nodejs }}<span class="p">): Promise<{{ template "linkify_param" .FunctionResult.nodejs }}></span></code></pre></div>
 
 <!-- Python -->
-<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">function </span> get_{{ .ResourceName }}(</span>{{ htmlSafe .FunctionArgs.python }}<span class="p">)</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">function </span> get_{{ pyName .ResourceName }}(</span>{{ htmlSafe .FunctionArgs.python }}<span class="p">)</span></code></pre></div>
 
 <!-- Go -->
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>Lookup{{ .ResourceName }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.go }}<span class="p">) (*{{ template "linkify_param" .FunctionResult.go }}, error)</span></code></pre></div>
@@ -30,3 +30,26 @@ The following arguments are supported:
 The following output properties are available:
 
 {{ template "properties" .OutputProperties }}
+
+<!-- Supporting types -->
+{{ if ne (len .NestedTypes) 0 }}
+
+## Supporting Types
+{{ range .NestedTypes }}
+#### {{ .Name }}
+{{ htmlSafe "{{% lang nodejs %}}" }}
+> See the <a href="{{ .APIDocLinks.nodejs }}">API doc</a> for this type.
+{{ htmlSafe "{{% /lang %}}" }}
+
+{{ htmlSafe "{{% lang go %}}" }}
+> See the <a href="{{ .APIDocLinks.go }}">API doc</a> for this type.
+{{ htmlSafe "{{% /lang %}}" }}
+
+{{ htmlSafe "{{% lang csharp %}}" }}
+> See the <a href="{{ .APIDocLinks.csharp }}">API doc</a> for this type.
+{{ htmlSafe "{{% /lang %}}" }}
+
+{{ template "properties" .Properties }}
+{{ end }}
+
+{{ end }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -42,15 +42,15 @@ The following output properties are available:
 {{ range .NestedTypes }}
 #### {{ .Name }}
 {{ htmlSafe "{{% lang nodejs %}}" }}
-> See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} for this type.
+> See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ htmlSafe "{{% lang go %}}" }}
-> See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} for this type.
+> See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.go.InputType "") (ne .APIDocLinks.go.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ htmlSafe "{{% lang csharp %}}" }}
-> See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} for this type.
+> See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.csharp.InputType "") (ne .APIDocLinks.csharp.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ template "properties" .Properties }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -5,7 +5,7 @@
 {{ .DeprecationMessage }}
 
 <!-- Input properties -->
-## {{ .Header.Title }} Input Arguments
+## Using {{ .Header.Title }}
 
 {{ htmlSafe "{{< langchoose csharp nojavascript >}}" }}
 
@@ -21,8 +21,12 @@
 <!-- C# -->
 <div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static </span>Task<{{ template "linkify_param" .FunctionResult.csharp }}> <span class="p">Get{{ .ResourceName }}(</span>{{ htmlSafe .FunctionArgs.csharp }}<span class="p">)</span></code></pre></div>
 
+{{ if ne (len .InputProperties) 0 }}
+
 The following arguments are supported:
 {{ template "properties" .InputProperties }}
+
+{{ end }}
 
 <!-- Output properties -->
 ## {{.Header.Title}} Output Properties
@@ -38,15 +42,15 @@ The following output properties are available:
 {{ range .NestedTypes }}
 #### {{ .Name }}
 {{ htmlSafe "{{% lang nodejs %}}" }}
-> See the <a href="{{ .APIDocLinks.nodejs }}">API doc</a> for this type.
+> See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ htmlSafe "{{% lang go %}}" }}
-> See the <a href="{{ .APIDocLinks.go }}">API doc</a> for this type.
+> See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ htmlSafe "{{% lang csharp %}}" }}
-> See the <a href="{{ .APIDocLinks.csharp }}">API doc</a> for this type.
+> See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ template "properties" .Properties }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -94,15 +94,15 @@ The following state arguments are supported:
 {{ range .NestedTypes }}
 #### {{ .Name }}
 {{ htmlSafe "{{% lang nodejs %}}" }}
-> See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} for this type.
+> See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ htmlSafe "{{% lang go %}}" }}
-> See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} for this type.
+> See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.go.InputType "") (ne .APIDocLinks.go.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ htmlSafe "{{% lang csharp %}}" }}
-> See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} for this type.
+> See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.csharp.InputType "") (ne .APIDocLinks.csharp.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ template "properties" .Properties }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -13,7 +13,7 @@
 <div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">new </span>{{ template "linkify_param" .ConstructorResource.nodejs }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.nodejs }}<span class="p">);</span></code></pre></div>
 
 ```python
-def {{ .Header.Title}}(resource_name, id, opts=None{{ template "py_param" .InputProperties.python }}, __props__=None)
+def {{ .Header.Title }}(resource_name, id, opts=None{{ template "py_param" .InputProperties.python }}, __props__=None)
 ```
 
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>New{{ .Header.Title }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.go }}<span class="p">) (*{{ template "linkify_param" .ConstructorResource.go }}, error)</span></code></pre></div>

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -94,15 +94,15 @@ The following state arguments are supported:
 {{ range .NestedTypes }}
 #### {{ .Name }}
 {{ htmlSafe "{{% lang nodejs %}}" }}
-> See the <a href="{{ .APIDocLinks.nodejs }}">input</a> API doc.
+> See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ htmlSafe "{{% lang go %}}" }}
-> See the <a href="{{ .APIDocLinks.go }}">input</a> API doc.
+> See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ htmlSafe "{{% lang csharp %}}" }}
-> See the <a href="{{ .APIDocLinks.csharp }}">input</a> API doc.
+> See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a> and {{- end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} for this type.
 {{ htmlSafe "{{% /lang %}}" }}
 
 {{ template "properties" .Properties }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -89,6 +89,7 @@ The following state arguments are supported:
 
 <!-- Supporting types -->
 {{ if ne (len .NestedTypes) 0 }}
+
 ## Supporting Types
 {{ range .NestedTypes }}
 #### {{ .Name }}

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -52,3 +52,9 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 	}
 	return mod.typeString(t, "", input, false /*state*/, false /*wrapInput*/, true /*requireInitializers*/, optional)
 }
+
+// GetResourceFunctionResultName returns the name of the result type when a function is used to lookup
+// an existing resource.
+func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) string {
+	return "Get" + resourceName + "Result"
+}

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -38,8 +38,13 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(packageName, _, typeName st
 	return fmt.Sprintf("/docs/reference/pkg/dotnet/Pulumi%s/%s.html", packageNamespace, typeName)
 }
 
-// GetDocLinkForInputType is not implemented at this time for Python.
-func (d DocLanguageHelper) GetDocLinkForInputType(packageName, moduleName, typeName string) string {
+// GetDocLinkForResourceInputOrOutputType returns the doc link for an input or output type of a Resource.
+func (d DocLanguageHelper) GetDocLinkForResourceInputOrOutputType(packageName, moduleName, typeName string, input bool) string {
+	return d.GetDocLinkForResourceType(packageName, moduleName, typeName)
+}
+
+// GetDocLinkForFunctionInputOrOutputType returns the doc link for an input or output type of a Function.
+func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(packageName, moduleName, typeName string, input bool) string {
 	return d.GetDocLinkForResourceType(packageName, moduleName, typeName)
 }
 

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -57,3 +57,9 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 	}
 	return mod.plainType(t, optional)
 }
+
+// GetResourceFunctionResultName returns the name of the result type when a function is used to lookup
+// an existing resource.
+func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) string {
+	return "Lookup" + resourceName + "Result"
+}

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -36,13 +36,26 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(packageName string, moduleN
 	path := fmt.Sprintf("%s/%s", packageName, moduleName)
 	typeNameParts := strings.Split(typeName, ".")
 	typeName = typeNameParts[len(typeNameParts)-1]
+	typeName = strings.TrimPrefix(typeName, "*")
 	return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi-%s/sdk/go/%s?tab=doc#%s", packageName, path, typeName)
 }
 
-// GetDocLinkForInputType returns the godoc URL for an input type.
-func (d DocLanguageHelper) GetDocLinkForInputType(packageName, moduleName, typeName string) string {
-	name := d.GetDocLinkForResourceType(packageName, moduleName, typeName)
-	return name + "Args"
+// GetDocLinkForResourceInputOrOutputType returns the godoc URL for an input or output type.
+func (d DocLanguageHelper) GetDocLinkForResourceInputOrOutputType(packageName, moduleName, typeName string, input bool) string {
+	link := d.GetDocLinkForResourceType(packageName, moduleName, typeName)
+	if !input {
+		return link + "Output"
+	}
+	return link + "Args"
+}
+
+// GetDocLinkForFunctionInputOrOutputType returns the doc link for an input or output type of a Function.
+func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(packageName, moduleName, typeName string, input bool) string {
+	link := d.GetDocLinkForResourceType(packageName, moduleName, typeName)
+	if !input {
+		return link
+	}
+	return link + "Args"
 }
 
 // GetDocLinkForBuiltInType returns the godoc URL for a built-in type.

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -41,6 +41,7 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(packageName, modName, typeN
 // GetDocLinkForResourceInputOrOutputType returns the doc link for an input or output type of a Resource.
 func (d DocLanguageHelper) GetDocLinkForResourceInputOrOutputType(packageName, modName, typeName string, input bool) string {
 	typeName = strings.ReplaceAll(typeName, "?", "")
+	typeName = strings.ReplaceAll(typeName, modName+".", "")
 	if input {
 		return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/%s/types/input/#%s", packageName, typeName)
 	}

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -38,10 +38,18 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(packageName, modName, typeN
 	return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/%s/#%s", path, typeName)
 }
 
-// GetDocLinkForInputType returns the doc link for an input type.
-func (d DocLanguageHelper) GetDocLinkForInputType(packageName, modName, typeName string) string {
+// GetDocLinkForResourceInputOrOutputType returns the doc link for an input or output type of a Resource.
+func (d DocLanguageHelper) GetDocLinkForResourceInputOrOutputType(packageName, modName, typeName string, input bool) string {
 	typeName = strings.ReplaceAll(typeName, "?", "")
-	return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/%s/types/input/#%s", packageName, typeName)
+	if input {
+		return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/%s/types/input/#%s", packageName, typeName)
+	}
+	return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/%s/types/output/#%s", packageName, typeName)
+}
+
+// GetDocLinkForFunctionInputOrOutputType returns the doc link for an input or output type of a Function.
+func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(packageName, modName, typeName string, input bool) string {
+	return d.GetDocLinkForResourceInputOrOutputType(packageName, modName, typeName, input)
 }
 
 // GetDocLinkForBuiltInType returns the URL for a built-in type.

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -71,3 +71,9 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 	}
 	return typeName
 }
+
+// GetResourceFunctionResultName returns the name of the result type when a function is used to lookup
+// an existing resource.
+func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) string {
+	return "Get" + resourceName + "Result"
+}

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -36,8 +36,13 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(packageName, modName, typeN
 	return ""
 }
 
-// GetDocLinkForInputType is not implemented at this time for Python.
-func (d DocLanguageHelper) GetDocLinkForInputType(packageName, modName, typeName string) string {
+// GetDocLinkForResourceInputOrOutputType is not implemented at this time for Python.
+func (d DocLanguageHelper) GetDocLinkForResourceInputOrOutputType(packageName, modName, typeName string, input bool) string {
+	return ""
+}
+
+// GetDocLinkForResourceInputOrOutputType is not implemented at this time for Python.
+func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(packageName, modName, typeName string, input bool) string {
 	return ""
 }
 

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -66,6 +66,11 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 	return name
 }
 
+// GetResourceFunctionResultName is not implemented for Python and returns an empty string.
+func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) string {
+	return ""
+}
+
 // elementTypeToName returns the type name from an element type of the form
 // package:module:_type, with its leading "_" stripped.
 func elementTypeToName(el string) string {


### PR DESCRIPTION
Closes #4024.

This PR does the following:
* Implement the `genFunction` method to process the relevant doc template for generating a doc for Functions using the new resource-based doc generator
* Generate links for a nested type for its input and output type variants.

Example screenshots:
#### GetAmi
> An example of a "index"-level function.

TS:
https://user-images.githubusercontent.com/1466314/76449047-9c777d00-6388-11ea-8d16-e3a58f4e8a58.png

Python:
https://user-images.githubusercontent.com/1466314/76449052-9f726d80-6388-11ea-860a-680568e8f11e.png

Go:
https://user-images.githubusercontent.com/1466314/76449062-a26d5e00-6388-11ea-9ff9-321bbd700c0c.png

C#:
https://user-images.githubusercontent.com/1466314/76449076-a6997b80-6388-11ea-996b-71613e971547.png

#### s3.GetBucket
> An example of a "module"-level function.

TS:
https://user-images.githubusercontent.com/1466314/76449106-b6b15b00-6388-11ea-9282-e8f466d71d58.png

Python:
https://user-images.githubusercontent.com/1466314/76449115-ba44e200-6388-11ea-82ca-273db73cb1ec.png

Go:
https://user-images.githubusercontent.com/1466314/76449121-be70ff80-6388-11ea-8e9d-228c240b52bd.png

C#:
https://user-images.githubusercontent.com/1466314/76449125-c0d35980-6388-11ea-9288-b75871a56bc8.png