### PR TITLE
Stabilize Python codegen.

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -173,21 +173,6 @@ func (mod *modContext) gen(fs fs) error {
 		}
 	}
 
-	// Calculate casing tables. We do this up front because our docstring generator (which is run during
-	// genResource) requires them.
-	for _, r := range mod.resources {
-		for _, prop := range r.Properties {
-			if err := mod.recordProperty(prop); err != nil {
-				return err
-			}
-		}
-		for _, prop := range r.InputProperties {
-			if err := mod.recordProperty(prop); err != nil {
-				return err
-			}
-		}
-	}
-
 	// Resources
 	for _, r := range mod.resources {
 		res, err := mod.genResource(r)
@@ -836,19 +821,20 @@ type propertyInfo struct {
 // Once all resources have been emitted, the table is written out to a format usable for implementations of
 // translate_input_property and translate_output_property.
 func (mod *modContext) recordProperty(prop *schema.Property) error {
+	mapCase := true
 	if python, ok := prop.Language["python"]; ok {
 		var info propertyInfo
 		if err := json.Unmarshal([]byte(python), &info); err != nil {
 			return errors.Wrap(err, "decoding python property info")
 		}
-		if !info.MapCase {
-			return nil
-		}
+		mapCase = info.MapCase
 	}
 
-	snakeCaseName := PyName(prop.Name)
-	mod.snakeCaseToCamelCase[snakeCaseName] = prop.Name
-	mod.camelCaseToSnakeCase[prop.Name] = snakeCaseName
+	if mapCase {
+		snakeCaseName := PyName(prop.Name)
+		mod.snakeCaseToCamelCase[snakeCaseName] = prop.Name
+		mod.camelCaseToSnakeCase[prop.Name] = snakeCaseName
+	}
 
 	if obj, ok := prop.Type.(*schema.ObjectType); ok {
 		for _, p := range obj.Properties {
@@ -1199,14 +1185,32 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 		_ = getMod(":config/config:")
 	}
 
-	scanResource := func(r *schema.Resource) {
+	scanResource := func(r *schema.Resource) error {
 		mod := getMod(r.Token)
 		mod.resources = append(mod.resources, r)
+
+		// Calculate casing tables. We do this up front because our docstring generator (which is run during
+		// genResource) requires them.
+		for _, prop := range r.Properties {
+			if err := mod.recordProperty(prop); err != nil {
+				return err
+			}
+		}
+		for _, prop := range r.InputProperties {
+			if err := mod.recordProperty(prop); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
-	scanResource(pkg.Provider)
+	if err := scanResource(pkg.Provider); err != nil {
+		return nil, err
+	}
 	for _, r := range pkg.Resources {
-		scanResource(r)
+		if err := scanResource(r); err != nil {
+			return nil, err
+		}
 	}
 
 	for _, f := range pkg.Functions {


### PR DESCRIPTION
Make sure all property casing conversions are computed prior to codegen.