### PR TITLE
Support for running Python policy packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ CHANGELOG
 
 - Fix `pulumi stack ls` on Windows
   [#4094](https://github.com/pulumi/pulumi/pull/4094)
-  
+
+- Add support for running Python policy packs.
+  [#4057](https://github.com/pulumi/pulumi/pull/4057)
+
 ## 1.12.1 (2020-03-11)
 - Fix Kubernetes YAML parsing error in .NET.
   [#4023](https://github.com/pulumi/pulumi/pull/4023)

--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -37,6 +37,7 @@ CopyPackage "$Root\sdk\nodejs\bin" "pulumi"
 Copy-Item "$Root\sdk\nodejs\dist\pulumi-resource-pulumi-nodejs.cmd" "$PublishDir\bin"
 Copy-Item "$Root\sdk\python\dist\pulumi-resource-pulumi-python.cmd" "$PublishDir\bin"
 Copy-Item "$Root\sdk\nodejs\dist\pulumi-analyzer-policy.cmd" "$PublishDir\bin"
+Copy-Item "$Root\sdk\python\dist\pulumi-analyzer-policy-python.cmd" "$PublishDir\bin"
 Copy-Item "$Root\sdk\python\cmd\pulumi-language-python-exec" "$PublishDir\bin"
 
 # By default, if the archive already exists, 7zip will just add files to it, so blow away the existing

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -56,6 +56,7 @@ run_go_build "${ROOT}/sdk/go/pulumi-language-go"
 cp "${ROOT}/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs" "${PUBDIR}/bin/"
 cp "${ROOT}/sdk/python/dist/pulumi-resource-pulumi-python" "${PUBDIR}/bin/"
 cp "${ROOT}/sdk/nodejs/dist/pulumi-analyzer-policy" "${PUBDIR}/bin/"
+cp "${ROOT}/sdk/python/dist/pulumi-analyzer-policy-python" "${PUBDIR}/bin/"
 cp "${ROOT}/sdk/python/cmd/pulumi-language-python-exec" "${PUBDIR}/bin/"
 
 # Copy packages

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -30,6 +30,7 @@ lint::
 install_package::
 	cp ./cmd/pulumi-language-python-exec "$(PULUMI_BIN)"
 	cp ./dist/pulumi-resource-pulumi-python "$(PULUMI_BIN)"
+	cp ./dist/pulumi-analyzer-policy-python "$(PULUMI_BIN)"
 
 install_plugin::
 	GOBIN=$(PULUMI_BIN) go install \
@@ -47,3 +48,4 @@ dist::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/python/pkg/version.Version=${VERSION}" ${LANGHOST_PKG}
 	cp ./cmd/pulumi-language-python-exec "$$(go env GOPATH)"/bin/
 	cp ./dist/pulumi-resource-pulumi-python "$$(go env GOPATH)"/bin/
+	cp ./dist/pulumi-analyzer-policy-python "$$(go env GOPATH)"/bin/

--- a/sdk/python/dist/pulumi-analyzer-policy-python
+++ b/sdk/python/dist/pulumi-analyzer-policy-python
@@ -1,0 +1,2 @@
+#!/bin/sh
+python3 -u -m pulumi.policy $@

--- a/sdk/python/dist/pulumi-analyzer-policy-python.cmd
+++ b/sdk/python/dist/pulumi-analyzer-policy-python.cmd
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+REM We use `python` instead of `python3` because Windows Python installers
+REM install only `python.exe` by default.
+@python -u -m pulumi.policy %*

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -19,7 +19,7 @@ resources.
 """
 
 # Make subpackages available.
-__all__ = ['runtime', 'dynamic']
+__all__ = ['runtime', 'dynamic', 'policy']
 
 # Make all module members inside of this package available as package members.
 from .asset import (

--- a/sdk/python/lib/pulumi/policy/__init__.py
+++ b/sdk/python/lib/pulumi/policy/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+The Pulumi SDK's policy module. This is meant for internal use only.
+"""

--- a/sdk/python/lib/pulumi/policy/__main__.py
+++ b/sdk/python/lib/pulumi/policy/__main__.py
@@ -1,4 +1,16 @@
-# Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import os
 import sys
@@ -39,9 +51,7 @@ def main():
     try:
         runpy.run_path(program, run_name="__main__")
         successful = True
-    except pulumi.RunError as e:
-        pulumi.log.error(str(e))
-    except Exception as e:
+    except Exception:
         pulumi.log.error("Program failed with an unhandled exception:")
         pulumi.log.error(traceback.format_exc())
     finally:

--- a/sdk/python/lib/pulumi/policy/__main__.py
+++ b/sdk/python/lib/pulumi/policy/__main__.py
@@ -1,0 +1,55 @@
+# Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import os
+import sys
+import traceback
+import runpy
+
+import pulumi
+import pulumi.runtime
+
+
+def main():
+    if len(sys.argv) != 3:
+        # For whatever reason, sys.stderr.write is not picked up by the engine as a message, but 'print' is. The Python
+        # langhost automatically flushes stdout and stderr on shutdown, so we don't need to do it here - just trust that
+        # Python does the sane thing when printing to stderr.
+        print("usage: python3 -u -m pulumi.policy <engine-address> <program>", file=sys.stderr)
+        sys.exit(1)
+
+    program = sys.argv[2]
+
+    # If any config variables are present, parse and set them, so subsequent accesses are fast.
+    config_env = pulumi.runtime.get_config_env()
+    for k, v in config_env.items():
+        pulumi.runtime.set_config(k, v)
+
+    # Configure the runtime so that the user program hooks up to Pulumi as appropriate.
+    if 'PULUMI_PROJECT' in os.environ and 'PULUMI_STACK' in os.environ and 'PULUMI_DRY_RUN' in os.environ:
+        pulumi.runtime.configure(
+            pulumi.runtime.Settings(
+                project=os.environ["PULUMI_PROJECT"],
+                stack=os.environ["PULUMI_STACK"],
+                dry_run=os.environ["PULUMI_DRY_RUN"] == "true"
+            )
+        )
+
+    successful = False
+
+    try:
+        runpy.run_path(program, run_name="__main__")
+        successful = True
+    except pulumi.RunError as e:
+        pulumi.log.error(str(e))
+    except Exception as e:
+        pulumi.log.error("Program failed with an unhandled exception:")
+        pulumi.log.error(traceback.format_exc())
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+
+    exit_code = 0 if successful else 1
+    sys.exit(exit_code)
+
+
+main()


### PR DESCRIPTION
These changes enable running policy packs written in Python. I'll be opening a subsequent PR in the `pulumi-policy` repo that adds the Python policy SDK.

Part of https://github.com/pulumi/pulumi-policy/issues/208