### PR TITLE
Support "link" style dependencies in Go tests

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1735,6 +1735,15 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 		if err != nil {
 			return fmt.Errorf("error installing go dependencies: %w", err)
 		}
+
+		for _, pkg := range pt.opts.Dependencies {
+			err = pt.runCommand("vendor-rm-dep",
+				[]string{"/bin/rm", "-rf", filepath.Join(".", "vendor", pkg)}, cwd)
+			err = pt.runCommand("vendor-cp-dep",
+				[]string{"/bin/cp", "-r", filepath.Join(gopath, "src", pkg), filepath.Join(".", "vendor", pkg)}, cwd)
+			err = pt.runCommand("vendor-rm-dep-vendor",
+				[]string{"/bin/rm", "-rf", filepath.Join(".", "vendor", pkg, "vendor")}, cwd)
+		}
 	}
 
 	// In our go tests, there seems to be an issue where we *need* to make a build before we

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1739,10 +1739,19 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 		for _, pkg := range pt.opts.Dependencies {
 			err = pt.runCommand("vendor-rm-dep",
 				[]string{"/bin/rm", "-rf", filepath.Join(".", "vendor", pkg)}, cwd)
+			if err != nil {
+				return fmt.Errorf("error installing go dependencies: %w", err)
+			}
 			err = pt.runCommand("vendor-cp-dep",
 				[]string{"/bin/cp", "-r", filepath.Join(gopath, "src", pkg), filepath.Join(".", "vendor", pkg)}, cwd)
+			if err != nil {
+				return fmt.Errorf("error installing go dependencies: %w", err)
+			}
 			err = pt.runCommand("vendor-rm-dep-vendor",
 				[]string{"/bin/rm", "-rf", filepath.Join(".", "vendor", pkg, "vendor")}, cwd)
+			if err != nil {
+				return fmt.Errorf("error installing go dependencies: %w", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
The intergration test framework currently supports using `dep` for dependency management.

However, `dep` has no native ability to manage "yarn link"-style dependencies on locally available packages.

This is a necessary scenario for testing in most repos though, as (e.g.) examples in the Kubernetes repo need to test against the locally available version of `pulumi-kubernetes`.

The best we can do is a trick of (a) deleting the vendored copy of the locally available dependency (b) copying the locally available dependency into the vendor folder (c) deleting the nested vendor folder in the new copy of the locally available dependency.