### PR TITLE
Expose engine logging to Go SDK

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,7 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/go.sum
+++ b/go.sum
@@ -135,7 +135,6 @@ github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -50,6 +50,7 @@ type Context struct {
 	rpcsDone    *sync.Cond  // an event signaling completion of RPCs.
 	rpcsLock    *sync.Mutex // a lock protecting the RPC count and event.
 	rpcError    error       // the first error (if any) encountered during an RPC.
+	Log         Log
 }
 
 // NewContext creates a fresh run context out of the given metadata.
@@ -83,6 +84,10 @@ func NewContext(ctx context.Context, info RunInfo) (*Context, error) {
 	}
 
 	mutex := &sync.Mutex{}
+	log := &logState{
+		engine: engine,
+		ctx:    ctx,
+	}
 	return &Context{
 		ctx:         ctx,
 		info:        info,
@@ -94,6 +99,7 @@ func NewContext(ctx context.Context, info RunInfo) (*Context, error) {
 		rpcs:        0,
 		rpcsLock:    mutex,
 		rpcsDone:    sync.NewCond(mutex),
+		Log:         log,
 	}, nil
 }
 

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -50,7 +50,8 @@ type Context struct {
 	rpcsDone    *sync.Cond  // an event signaling completion of RPCs.
 	rpcsLock    *sync.Mutex // a lock protecting the RPC count and event.
 	rpcError    error       // the first error (if any) encountered during an RPC.
-	Log         Log
+
+	Log Log // the logging interface for the Pulumi log stream.
 }
 
 // NewContext creates a fresh run context out of the given metadata.

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -1,0 +1,76 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The log module logs messages in a way that tightly integrates with the resource engine's interface.
+
+package pulumi
+
+import (
+	pulumirpc "github.com/pulumi/pulumi/sdk/proto/go"
+	"golang.org/x/net/context"
+)
+
+// Log is a group of logging functions that can be called from a Go application that will be logged to the
+// Pulumi log stream.  These events will be printed in the terminal while the Pulumi app
+// runs, and will be available from the Web console afterwards.
+type Log interface {
+	Debug(msg string, resource Resource, streamID int32, ephemeral bool) error
+	Info(msg string, resource Resource, streamID int32, ephemeral bool) error
+	Warn(msg string, resource Resource, streamID int32, ephemeral bool) error
+	Error(msg string, resource Resource, streamID int32, ephemeral bool) error
+}
+
+type logState struct {
+	engine pulumirpc.EngineClient
+	ctx    context.Context
+}
+
+// Debug logs a debug-level message that is generally hidden from end-users.
+func (log *logState) Debug(msg string, resource Resource, streamID int32, ephemeral bool) error {
+	return _log(log.ctx, log.engine, pulumirpc.LogSeverity_DEBUG, msg, resource, streamID, ephemeral)
+}
+
+// Logs an informational message that is generally printed to stdout during resource
+func (log *logState) Info(msg string, resource Resource, streamID int32, ephemeral bool) error {
+	return _log(log.ctx, log.engine, pulumirpc.LogSeverity_INFO, msg, resource, streamID, ephemeral)
+}
+
+// Logs a warning to indicate that something went wrong, but not catastrophically so.
+func (log *logState) Warn(msg string, resource Resource, streamID int32, ephemeral bool) error {
+	return _log(log.ctx, log.engine, pulumirpc.LogSeverity_WARNING, msg, resource, streamID, ephemeral)
+}
+
+// Logs a fatal error to indicate that the tool should stop processing resource
+func (log *logState) Error(msg string, resource Resource, streamID int32, ephemeral bool) error {
+	return _log(log.ctx, log.engine, pulumirpc.LogSeverity_ERROR, msg, resource, streamID, ephemeral)
+}
+
+func _log(ctx context.Context, engine pulumirpc.EngineClient, severity pulumirpc.LogSeverity,
+	message string, resource Resource, streamID int32, ephemeral bool) error {
+
+	resolvedUrn, _, _, err := resource.URN().awaitURN(ctx)
+	if err != nil {
+		return err
+	}
+
+	logRequest := &pulumirpc.LogRequest{
+		Severity:  severity,
+		Message:   message,
+		Urn:       string(resolvedUrn),
+		StreamId:  streamID,
+		Ephemeral: ephemeral,
+	}
+	_, err = engine.Log(ctx, logRequest)
+	return err
+}

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -21,8 +21,8 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Log is a group of logging functions that can be called from a Go application that will be logged to the
-// Pulumi log stream.  These events will be printed in the terminal while the Pulumi app
+// Log is a group of logging functions that can be called from a Go application that will be logged
+// to the Pulumi log stream.  These events will be printed in the terminal while the Pulumi app
 // runs, and will be available from the Web console afterwards.
 type Log interface {
 	Debug(msg string, resource Resource, streamID int32, ephemeral bool) error


### PR DESCRIPTION
Fixes #3801 

To allow users to do something like `ctx.Log.Info("Starting docker build and push...", logResource, 0, false)`, I needed to add another field to `pulumi.Context` as I describe [here](https://github.com/pulumi/pulumi/issues/3801#issuecomment-598328191). The implementation isn't the prettiest, but the end result is pretty similar to the other languages'. An alternative could be to  instead add new functions directly onto `pulumi.Context` like `ctx.Info(...)` and `ctx.Debug(...)`.

After this has been merged we should (1) update the [docs](https://www.pulumi.com/docs/intro/concepts/programming-model/#logging) and (2) update the logging for pulumi/pulumi-docker.