### PR TITLE
Update Go logging to use LogArgs

### DIFF
--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -25,10 +25,10 @@ import (
 // to the Pulumi log stream.  These events will be printed in the terminal while the Pulumi app
 // runs, and will be available from the Web console afterwards.
 type Log interface {
-	Debug(msg string, resource Resource, streamID int32, ephemeral bool) error
-	Info(msg string, resource Resource, streamID int32, ephemeral bool) error
-	Warn(msg string, resource Resource, streamID int32, ephemeral bool) error
-	Error(msg string, resource Resource, streamID int32, ephemeral bool) error
+	Debug(msg string, args *LogArgs) error
+	Info(msg string, args *LogArgs) error
+	Warn(msg string, args *LogArgs) error
+	Error(msg string, args *LogArgs) error
 }
 
 type logState struct {

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -38,8 +38,17 @@ type logState struct {
 
 // LogArgs may be used to specify arguments to be used for logging.
 type LogArgs struct {
-	Resource  Resource
-	StreamID  int32
+	// Optional resource this log is associated with.
+	Resource Resource
+
+	// Optional stream id that a stream of log messages can be associated with. This allows
+	// clients to not have to buffer a large set of log messages that they all want to be
+	// conceptually connected.  Instead the messages can be sent as chunks (with the same stream id)
+	// and the end display can show the messages as they arrive, while still stitching them together
+	// into one total log message.
+	StreamID int32
+
+	// Optional value indicating whether this is a status message.
 	Ephemeral bool
 }
 


### PR DESCRIPTION
See discussion here https://github.com/pulumi/docs/pull/2643#discussion_r391962960.

Once this has been merged, we should also merge:
- pulumi/docs#2643
- pulumi/pulumi-docker#149 (with updated `go.mod`)
- pulumi/examples#594 (with updated `Gopkg.toml`)