### PR TITLE
Implement GetSchema in dynamic providers

### DIFF
--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -263,6 +263,13 @@ async function getPluginInfoRPC(call: any, callback: any): Promise<void> {
     callback(undefined, resp);
 }
 
+function getSchemaRPC(call: any, callback: any): void {
+    callback({
+        code: grpc.status.UNIMPLEMENTED,
+        details: "GetSchema is not implemented by the dynamic provider",
+    }, undefined);
+}
+
 function resultIncludingProvider(result: any, props: any): any {
     return Object.assign(result || {}, {
         [providerKey]: props[providerKey],
@@ -335,6 +342,7 @@ export function main(args: string[]): void {
         update: updateRPC,
         delete: deleteRPC,
         getPluginInfo: getPluginInfoRPC,
+        getSchema: getSchemaRPC,
     });
     const port: number = server.bind(`0.0.0.0:0`, grpc.ServerCredentials.createInsecure());
 

--- a/sdk/python/lib/pulumi/dynamic/__main__.py
+++ b/sdk/python/lib/pulumi/dynamic/__main__.py
@@ -143,6 +143,11 @@ class DynamicResourceProviderServicer(ResourceProviderServicer):
         fields = {"version": "0.1.0"}
         return proto.PluginInfo(**fields)
 
+    def GetSchema(self, request, context):
+        context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+        context.set_details("GetSchema is not implemented by the dynamic provider")
+        raise NotImplementedError("GetSchema is not implemented by the dynamic provider")
+
     def Read(self, request, context):
         id_ = request.id
         props = rpc.deserialize_properties(request.properties)


### PR DESCRIPTION
It's not entirely clear why gRPC doesn't already report these cleanly as unimplemented, but for now we'll explicitly implement them to avoid any spurious warnings.

Fixes #4028.