### PR TITLE
Fixes for resource docs generator

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -516,7 +516,7 @@ func (mod *modContext) genConstructors(r *schema.Resource, allOptionalInputs boo
 			paramTemplate = "csharp_formal_param"
 		case "python":
 			paramTemplate = "py_formal_param"
-			// The Pulumi Python SDK does not yet have types for constructor args.
+			// The Pulumi Python SDK does not have types for constructor args.
 			// The input properties for a resource needs to be exploded as
 			// individual constructor params.
 			params = make([]formalParam, 0, len(r.InputProperties))

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -485,6 +485,18 @@ func (mod *modContext) genConstructors(r *schema.Resource, allOptionalInputs boo
 		case "csharp":
 			params = mod.genConstructorCS(r, allOptionalInputs)
 			paramTemplate = "csharp_constructor_param"
+		case "python":
+			paramTemplate = "py_constructor_param"
+			// The Pulumi Python SDK does not yet have types for constructor args.
+			// The input properties for a resource needs to be exploded as
+			// individual constructor params.
+			params = make([]constructorParam, 0, len(r.InputProperties))
+			for _, p := range r.InputProperties {
+				params = append(params, constructorParam{
+					Name:         python.PyName(p.Name),
+					DefaultValue: "=None",
+				})
+			}
 		}
 
 		n := len(params)

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -123,7 +123,7 @@ func (mod *modContext) genFunctionTS(f *schema.Function, resourceName string) []
 }
 
 func (mod *modContext) genFunctionGo(f *schema.Function, resourceName string) []formalParam {
-	argsType := resourceName + "Args"
+	argsType := "Get" + resourceName + "Args"
 
 	docLangHelper := getLanguageDocHelper("go")
 	params := []formalParam{

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -123,7 +123,12 @@ func (mod *modContext) genFunctionTS(f *schema.Function, resourceName string) []
 }
 
 func (mod *modContext) genFunctionGo(f *schema.Function, resourceName string) []formalParam {
-	argsType := "Lookup" + resourceName + "Args"
+	argsType := resourceName + "Args"
+	if mod.mod == "" {
+		argsType = "Get" + argsType
+	} else {
+		argsType = "Lookup" + argsType
+	}
 
 	docLangHelper := getLanguageDocHelper("go")
 	params := []formalParam{

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -123,7 +123,7 @@ func (mod *modContext) genFunctionTS(f *schema.Function, resourceName string) []
 }
 
 func (mod *modContext) genFunctionGo(f *schema.Function, resourceName string) []formalParam {
-	argsType := "Get" + resourceName + "Args"
+	argsType := "Lookup" + resourceName + "Args"
 
 	docLangHelper := getLanguageDocHelper("go")
 	params := []formalParam{

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -94,9 +94,8 @@ func (mod *modContext) getFunctionResourceInfo(resourceTypeName string) map[stri
 	return resourceMap
 }
 
-func (mod *modContext) genFunctionTS(f *schema.Function) []formalParam {
-	resourceName := tokenToName(f.Token)
-	argsType := resourceName + "Args"
+func (mod *modContext) genFunctionTS(f *schema.Function, resourceName string) []formalParam {
+	argsType := "Get" + resourceName + "Args"
 
 	docLangHelper := getLanguageDocHelper("nodejs")
 	var params []formalParam
@@ -123,8 +122,7 @@ func (mod *modContext) genFunctionTS(f *schema.Function) []formalParam {
 	return params
 }
 
-func (mod *modContext) genFunctionGo(f *schema.Function) []formalParam {
-	resourceName := tokenToName(f.Token)
+func (mod *modContext) genFunctionGo(f *schema.Function, resourceName string) []formalParam {
 	argsType := resourceName + "Args"
 
 	docLangHelper := getLanguageDocHelper("go")
@@ -161,9 +159,8 @@ func (mod *modContext) genFunctionGo(f *schema.Function) []formalParam {
 	return params
 }
 
-func (mod *modContext) genFunctionCS(f *schema.Function) []formalParam {
-	resourceName := tokenToName(f.Token)
-	argsType := resourceName + "Args"
+func (mod *modContext) genFunctionCS(f *schema.Function, resourceName string) []formalParam {
+	argsType := "Get" + resourceName + "Args"
 	argsSchemaType := &schema.ObjectType{
 		Token: f.Token,
 	}
@@ -200,7 +197,7 @@ func (mod *modContext) genFunctionCS(f *schema.Function) []formalParam {
 	return params
 }
 
-func (mod *modContext) genFunctionPython(f *schema.Function) []formalParam {
+func (mod *modContext) genFunctionPython(f *schema.Function, resourceName string) []formalParam {
 	var params []formalParam
 
 	// Some functions don't have any inputs other than the InvokeOptions.
@@ -228,7 +225,7 @@ func (mod *modContext) genFunctionPython(f *schema.Function) []formalParam {
 
 // genFunctionArgs generates the arguments string for a given Function that can be
 // rendered directly into a template.
-func (mod *modContext) genFunctionArgs(f *schema.Function) map[string]string {
+func (mod *modContext) genFunctionArgs(f *schema.Function, resourceName string) map[string]string {
 	functionParams := make(map[string]string)
 
 	for _, lang := range supportedLanguages {
@@ -240,16 +237,16 @@ func (mod *modContext) genFunctionArgs(f *schema.Function) map[string]string {
 
 		switch lang {
 		case "nodejs":
-			params = mod.genFunctionTS(f)
+			params = mod.genFunctionTS(f, resourceName)
 			paramTemplate = "ts_formal_param"
 		case "go":
-			params = mod.genFunctionGo(f)
+			params = mod.genFunctionGo(f, resourceName)
 			paramTemplate = "go_formal_param"
 		case "csharp":
-			params = mod.genFunctionCS(f)
+			params = mod.genFunctionCS(f, resourceName)
 			paramTemplate = "csharp_formal_param"
 		case "python":
-			params = mod.genFunctionPython(f)
+			params = mod.genFunctionPython(f, resourceName)
 			paramTemplate = "py_formal_param"
 		}
 
@@ -298,7 +295,7 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		},
 
 		ResourceName:   resourceName,
-		FunctionArgs:   mod.genFunctionArgs(f),
+		FunctionArgs:   mod.genFunctionArgs(f, resourceName),
 		FunctionResult: mod.getFunctionResourceInfo(resourceName),
 
 		Comment:            f.Comment,

--- a/pkg/codegen/docs/templates/constructor_params.tmpl
+++ b/pkg/codegen/docs/templates/constructor_params.tmpl
@@ -1,11 +1,9 @@
 {{ define "param_separator" }}<span class="p">, </span>{{ end }}
 
-{{ define "go_constructor_param" }}<span class="nx">{{ .Name }}</span> {{ .OptionalFlag }}{{ template "linkify_param" .Type }}{{ end }}
+{{ define "go_formal_param" }}<span class="nx">{{ .Name }}</span> {{ .OptionalFlag }}{{ template "linkify_param" .Type }}{{ end }}
 
-{{ define "ts_constructor_param" }}<span class="nx">{{ .Name }}</span>{{ .OptionalFlag }}: {{ template "linkify_param" .Type }}{{ end }}
+{{ define "ts_formal_param" }}<span class="nx">{{ .Name }}</span>{{ .OptionalFlag }}: {{ template "linkify_param" .Type }}{{ end }}
 
-{{ define "csharp_constructor_param" }}{{ template "linkify_param" .Type }}{{ .OptionalFlag }} <span class="nx">{{ .Name }}{{ .DefaultValue }}{{ end }}
+{{ define "csharp_formal_param" }}{{ template "linkify_param" .Type }}{{ .OptionalFlag }} <span class="nx">{{ .Name }}{{ .DefaultValue }}{{ end }}
 
-{{ define "py_constructor_param" }}{{ .Name }}{{ .DefaultValue }}{{ end }}
-
-{{ define "py_function_param" }}{{ htmlSafe .Name }}{{ .DefaultValue }}{{ end }}
+{{ define "py_formal_param" }}{{ .Name }}{{ .DefaultValue }}{{ end }}

--- a/pkg/codegen/docs/templates/constructor_params.tmpl
+++ b/pkg/codegen/docs/templates/constructor_params.tmpl
@@ -6,6 +6,6 @@
 
 {{ define "csharp_constructor_param" }}{{ template "linkify_param" .Type }}{{ .OptionalFlag }} <span class="nx">{{ .Name }}{{ .DefaultValue }}{{ end }}
 
-{{ define "py_param" }}{{ range . }}, {{ htmlSafe .Name }}=None{{ end }}{{ end }}
+{{ define "py_constructor_param" }}{{ .Name }}{{ .DefaultValue }}{{ end }}
 
 {{ define "py_function_param" }}{{ htmlSafe .Name }}{{ .DefaultValue }}{{ end }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -9,9 +9,7 @@
 
 <div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">new </span>{{ template "linkify_param" .ConstructorResource.nodejs }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.nodejs }}<span class="p">);</span></code></pre></div>
 
-```python
-def {{ .Header.Title }}(resource_name, id, opts=None{{ template "py_param" .InputProperties.python }}, __props__=None)
-```
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span><span class="nf">{{ .Header.Title }}</span><span class="p">(resource_name, id, opts=None, </span>{{ htmlSafe .ConstructorParams.python }}<span class="p">, __props__=None);</span></code></pre></div>
 
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>New{{ .Header.Title }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.go }}<span class="p">) (*{{ template "linkify_param" .ConstructorResource.go }}, error)</span></code></pre></div>
 
@@ -54,7 +52,7 @@ public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: {{ .StatePa
 ```
 
 ```python
-def get(resource_name, id, opts=None{{ template "py_param" .StateInputs.python }})
+def get(resource_name, id, opts=None{{ range .StateInputs.python }}, {{ htmlSafe .Name }}=None{{ end }})
 ```
 
 ```go

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -9,7 +9,7 @@
 
 <div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">new </span>{{ template "linkify_param" .ConstructorResource.nodejs }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.nodejs }}<span class="p">);</span></code></pre></div>
 
-<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span><span class="nf">{{ .Header.Title }}</span><span class="p">(resource_name, id, opts=None, </span>{{ htmlSafe .ConstructorParams.python }}<span class="p">, __props__=None);</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span><span class="nf">{{ .Header.Title }}</span><span class="p">(resource_name, opts=None, </span>{{ htmlSafe .ConstructorParams.python }}<span class="p">, __props__=None);</span></code></pre></div>
 
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>New{{ .Header.Title }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.go }}<span class="p">) (*{{ template "linkify_param" .ConstructorResource.go }}, error)</span></code></pre></div>
 
@@ -47,21 +47,13 @@ The following output properties are available:
 
 {{ htmlSafe "{{< langchoose csharp nojavascript >}}" }}
 
-```typescript
-public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: {{ .StateParam }}, opts?: pulumi.CustomResourceOptions): {{ .Header.Title }};
-```
+<div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">public static </span><span class="nf">get</span><span class="p">(</span>{{ htmlSafe .LookupParams.nodejs }}<span class="p">): </span>{{ template "linkify_param" .ConstructorResource.nodejs }}</code></pre></div>
 
-```python
-def get(resource_name, id, opts=None{{ range .StateInputs.python }}, {{ htmlSafe .Name }}=None{{ end }})
-```
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">static </span><span class="nf">get</span><span class="p">(resource_name, id, opts=None, </span>{{ htmlSafe .LookupParams.python }}<span class="p">, __props__=None);</span></code></pre></div>
 
-```go
-func Get{{.Header.Title}}(ctx *pulumi.Context, name string, id pulumi.IDInput, state *{{ .StateParam }}, opts ...pulumi.ResourceOption) (*Bucket, error)
-```
+<div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>Get{{ .Header.Title }}<span class="p">(</span>{{ htmlSafe .LookupParams.go }}<span class="p">) (*{{ template "linkify_param" .ConstructorResource.go }}, error)</span></code></pre></div>
 
-```csharp
-public static {{ .Header.Title }} Get(string name, Input<string> id, {{ .StateParam }}? state = null, CustomResourceOptions? options = null);
-```
+<div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static </span>{{ template "linkify_param" .ConstructorResource.csharp }}<span class="nf"> Get</span><span class="p">(</span>{{ htmlSafe .LookupParams.csharp }}<span class="p">)</span></code></pre></div>
 
 Get an existing {{.Header.Title}} resource's state with the given name, ID, and optional extra properties used to qualify the lookup.
 

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -33,11 +33,20 @@ var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 
 // GetDocLinkForResourceType returns the godoc URL for a type belonging to a resource provider.
 func (d DocLanguageHelper) GetDocLinkForResourceType(packageName string, moduleName string, typeName string) string {
-	path := fmt.Sprintf("%s/%s", packageName, moduleName)
+	var path string
+	if packageName != "" {
+		path = fmt.Sprintf("%s/%s", packageName, moduleName)
+	} else {
+		path = moduleName
+	}
 	typeNameParts := strings.Split(typeName, ".")
 	typeName = typeNameParts[len(typeNameParts)-1]
 	typeName = strings.TrimPrefix(typeName, "*")
-	return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi-%s/sdk/go/%s?tab=doc#%s", packageName, path, typeName)
+
+	if packageName != "" {
+		return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi-%s/sdk/go/%s?tab=doc#%s", packageName, path, typeName)
+	}
+	return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/%s?tab=doc#%s", path, typeName)
 }
 
 // GetDocLinkForResourceInputOrOutputType returns the godoc URL for an input or output type.

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -33,7 +33,12 @@ var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 
 // GetDocLinkForResourceType returns the NodeJS API doc for a type belonging to a resource provider.
 func (d DocLanguageHelper) GetDocLinkForResourceType(packageName, modName, typeName string) string {
-	path := fmt.Sprintf("%s/%s", packageName, modName)
+	var path string
+	if packageName != "" {
+		path = fmt.Sprintf("%s/%s", packageName, modName)
+	} else {
+		path = modName
+	}
 	typeName = strings.ReplaceAll(typeName, "?", "")
 	return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/%s/#%s", path, typeName)
 }

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -66,7 +66,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 		case *schema.ObjectType:
 			return getDictWithTypeName(tokenToName(dictionaryTy.Token))
 		default:
-			return "Dict[Any, Any]"
+			return "Dict[str, Any]"
 		}
 	}
 	return name
@@ -106,14 +106,14 @@ func getDictWithTypeName(t string) string {
 }
 
 // getMapWithTypeName returns the Python representation of a dictionary
-// with a key of type `t` and a value of Any.
+// with a string keu and a value of type `t`.
 func getMapWithTypeName(t string) string {
 	switch t {
 	case "string":
-		return "Dict[str, Any]"
+		return "Dict[str, str]"
 	case "any":
-		return "Dict[Any, Any]"
+		return "Dict[str, Any]"
 	default:
-		return fmt.Sprintf("Dict[%s, Any]", t)
+		return fmt.Sprintf("Dict[str, %s]", PyName(t))
 	}
 }

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -63,7 +63,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 		switch dictionaryTy := t.(type) {
 		case *schema.MapType:
 			elType := dictionaryTy.ElementType.String()
-			return getDictWithTypeName(elementTypeToName(elType))
+			return getMapWithTypeName(elementTypeToName(elType))
 		case *schema.ObjectType:
 			return getDictWithTypeName(tokenToName(dictionaryTy.Token))
 		}
@@ -91,11 +91,24 @@ func elementTypeToName(el string) string {
 // getListWithTypeName returns a Python representation of a list containing
 // items of `t`.
 func getListWithTypeName(t string) string {
-	return fmt.Sprintf("list[%s]", PyName(t))
+	if t == "string" {
+		return "List[str]"
+	}
+
+	return fmt.Sprintf("List[%s]", PyName(t))
 }
 
 // getDictWithTypeName returns the Python representation of a dictionary
 // where each item is of type `t`.
 func getDictWithTypeName(t string) string {
-	return fmt.Sprintf("dict{%s}", PyName(t))
+	return fmt.Sprintf("Dict[%s]", PyName(t))
+}
+
+// getMapWithTypeName returns the Python representation of a dictionary
+// with a key of type `t` and a value of Any.
+func getMapWithTypeName(t string) string {
+	if t == "string" {
+		return "Dict[str, Any]"
+	}
+	return fmt.Sprintf("Dict[%s, Any]", PyName(t))
 }

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -41,7 +41,7 @@ func (d DocLanguageHelper) GetDocLinkForResourceInputOrOutputType(packageName, m
 	return ""
 }
 
-// GetDocLinkForResourceInputOrOutputType is not implemented at this time for Python.
+// GetDocLinkForFunctionInputOrOutputType is not implemented at this time for Python.
 func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(packageName, modName, typeName string, input bool) string {
 	return ""
 }


### PR DESCRIPTION
This PR contains the following changes/fixes:
* Fix the generation of formal parameters of the function shown in the "Lookup a resource" section by individually generating the formal parameters string.
* "Linkify" the formal parameters in the code snippet of the "Lookup a resource" section.
* Generate the constructor params for Python in code and render the string in the template, so we can control the insertion of word-break tags in the names. This essentially brings it in-sync with how the rest of the constructors were being generated.
* Fix issue with the Go-based Function argument not having the right prefix based on whether or not it was a resource or package-level Function.

The result of these changes can be previewed using the [preview link](http://content-bucket-de682d9.s3-website-us-east-1.amazonaws.com/) provided by Pulumify [here](https://github.com/pulumi/docs/pull/2641#issuecomment-599140931).