### PR TITLE
Add ArrayMap builtin types to Go SDK

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - govet
     - ineffassign
     - lll
-    - megacheck
     - misspell
     - nakedret
     - structcheck
@@ -18,3 +17,4 @@ linters:
     - varcheck
   disable:
     - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0
+    - megacheck # Disabled due to OOM errors in golangci-lint@v1.18.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+- Add ArrayMap builtin types to Go SDK
+  [#4086](https://github.com/pulumi/pulumi/pull/4086)
+
 - Improve documentation of URL formats for `pulumi login`
   [#4059](https://github.com/pulumi/pulumi/pull/4059)
 

--- a/sdk/go/pulumi/generate.go
+++ b/sdk/go/pulumi/generate.go
@@ -176,6 +176,7 @@ func makeBuiltins(primitives []*builtin) []*builtin {
 		}
 		builtins = append(builtins, &builtin{Name: name + "Array", Type: "[]" + name + "Input", elementType: "[]" + p.Type, Example: fmt.Sprintf("%sArray{%s}", name, p.Example)})
 		builtins = append(builtins, &builtin{Name: name + "Map", Type: "map[string]" + name + "Input", elementType: "map[string]" + p.Type, Example: fmt.Sprintf("%sMap{\"baz\": %s}", name, p.Example)})
+		builtins = append(builtins, &builtin{Name: name + "ArrayMap", Type: "map[string]" + name + "ArrayInput", elementType: "map[string][]" + p.Type, Example: fmt.Sprintf("%sArrayMap{\"baz\": %sArray{%s}}", name, name, p.Example)})
 	}
 
 	nameToBuiltin := map[string]*builtin{}

--- a/sdk/go/pulumi/generate.go
+++ b/sdk/go/pulumi/generate.go
@@ -172,11 +172,31 @@ func makeBuiltins(primitives []*builtin) []*builtin {
 		case "Archive", "Asset", "AssetOrArchive", "":
 			// do nothing
 		default:
-			builtins = append(builtins, &builtin{Name: name + "Ptr", Type: "*" + p.Type, inputType: "*" + unexported(p.Type) + "Ptr", Example: fmt.Sprintf("%sPtr(%s(%s))", name, p.Type, p.Example)})
+			builtins = append(builtins, &builtin{
+				Name:      name + "Ptr",
+				Type:      "*" + p.Type,
+				inputType: "*" + unexported(p.Type) + "Ptr",
+				Example:   fmt.Sprintf("%sPtr(%s(%s))", name, p.Type, p.Example),
+			})
 		}
-		builtins = append(builtins, &builtin{Name: name + "Array", Type: "[]" + name + "Input", elementType: "[]" + p.Type, Example: fmt.Sprintf("%sArray{%s}", name, p.Example)})
-		builtins = append(builtins, &builtin{Name: name + "Map", Type: "map[string]" + name + "Input", elementType: "map[string]" + p.Type, Example: fmt.Sprintf("%sMap{\"baz\": %s}", name, p.Example)})
-		builtins = append(builtins, &builtin{Name: name + "ArrayMap", Type: "map[string]" + name + "ArrayInput", elementType: "map[string][]" + p.Type, Example: fmt.Sprintf("%sArrayMap{\"baz\": %sArray{%s}}", name, name, p.Example)})
+		builtins = append(builtins, &builtin{
+			Name:        name + "Array",
+			Type:        "[]" + name + "Input",
+			elementType: "[]" + p.Type,
+			Example:     fmt.Sprintf("%sArray{%s}", name, p.Example),
+		})
+		builtins = append(builtins, &builtin{
+			Name:        name + "Map",
+			Type:        "map[string]" + name + "Input",
+			elementType: "map[string]" + p.Type,
+			Example:     fmt.Sprintf("%sMap{\"baz\": %s}", name, p.Example),
+		})
+		builtins = append(builtins, &builtin{
+			Name:        name + "ArrayMap",
+			Type:        "map[string]" + name + "ArrayInput",
+			elementType: "map[string][]" + p.Type,
+			Example:     fmt.Sprintf("%sArrayMap{\"baz\": %sArray{%s}}", name, name, p.Example),
+		})
 	}
 
 	nameToBuiltin := map[string]*builtin{}

--- a/sdk/go/pulumi/types_builtins.go
+++ b/sdk/go/pulumi/types_builtins.go
@@ -50,6 +50,16 @@ func (o *OutputState) ApplyArchiveMapWithContext(ctx context.Context, applier in
 	return o.ApplyTWithContext(ctx, applier).(ArchiveMapOutput)
 }
 
+// ApplyArchiveArrayMap is like ApplyT, but returns a ArchiveArrayMapOutput.
+func (o *OutputState) ApplyArchiveArrayMap(applier interface{}) ArchiveArrayMapOutput {
+	return o.ApplyT(applier).(ArchiveArrayMapOutput)
+}
+
+// ApplyArchiveArrayMapWithContext is like ApplyTWithContext, but returns a ArchiveArrayMapOutput.
+func (o *OutputState) ApplyArchiveArrayMapWithContext(ctx context.Context, applier interface{}) ArchiveArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(ArchiveArrayMapOutput)
+}
+
 // ApplyAsset is like ApplyT, but returns a AssetOutput.
 func (o *OutputState) ApplyAsset(applier interface{}) AssetOutput {
 	return o.ApplyT(applier).(AssetOutput)
@@ -80,6 +90,16 @@ func (o *OutputState) ApplyAssetMapWithContext(ctx context.Context, applier inte
 	return o.ApplyTWithContext(ctx, applier).(AssetMapOutput)
 }
 
+// ApplyAssetArrayMap is like ApplyT, but returns a AssetArrayMapOutput.
+func (o *OutputState) ApplyAssetArrayMap(applier interface{}) AssetArrayMapOutput {
+	return o.ApplyT(applier).(AssetArrayMapOutput)
+}
+
+// ApplyAssetArrayMapWithContext is like ApplyTWithContext, but returns a AssetArrayMapOutput.
+func (o *OutputState) ApplyAssetArrayMapWithContext(ctx context.Context, applier interface{}) AssetArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(AssetArrayMapOutput)
+}
+
 // ApplyAssetOrArchive is like ApplyT, but returns a AssetOrArchiveOutput.
 func (o *OutputState) ApplyAssetOrArchive(applier interface{}) AssetOrArchiveOutput {
 	return o.ApplyT(applier).(AssetOrArchiveOutput)
@@ -108,6 +128,16 @@ func (o *OutputState) ApplyAssetOrArchiveMap(applier interface{}) AssetOrArchive
 // ApplyAssetOrArchiveMapWithContext is like ApplyTWithContext, but returns a AssetOrArchiveMapOutput.
 func (o *OutputState) ApplyAssetOrArchiveMapWithContext(ctx context.Context, applier interface{}) AssetOrArchiveMapOutput {
 	return o.ApplyTWithContext(ctx, applier).(AssetOrArchiveMapOutput)
+}
+
+// ApplyAssetOrArchiveArrayMap is like ApplyT, but returns a AssetOrArchiveArrayMapOutput.
+func (o *OutputState) ApplyAssetOrArchiveArrayMap(applier interface{}) AssetOrArchiveArrayMapOutput {
+	return o.ApplyT(applier).(AssetOrArchiveArrayMapOutput)
+}
+
+// ApplyAssetOrArchiveArrayMapWithContext is like ApplyTWithContext, but returns a AssetOrArchiveArrayMapOutput.
+func (o *OutputState) ApplyAssetOrArchiveArrayMapWithContext(ctx context.Context, applier interface{}) AssetOrArchiveArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(AssetOrArchiveArrayMapOutput)
 }
 
 // ApplyBool is like ApplyT, but returns a BoolOutput.
@@ -150,6 +180,16 @@ func (o *OutputState) ApplyBoolMapWithContext(ctx context.Context, applier inter
 	return o.ApplyTWithContext(ctx, applier).(BoolMapOutput)
 }
 
+// ApplyBoolArrayMap is like ApplyT, but returns a BoolArrayMapOutput.
+func (o *OutputState) ApplyBoolArrayMap(applier interface{}) BoolArrayMapOutput {
+	return o.ApplyT(applier).(BoolArrayMapOutput)
+}
+
+// ApplyBoolArrayMapWithContext is like ApplyTWithContext, but returns a BoolArrayMapOutput.
+func (o *OutputState) ApplyBoolArrayMapWithContext(ctx context.Context, applier interface{}) BoolArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(BoolArrayMapOutput)
+}
+
 // ApplyFloat32 is like ApplyT, but returns a Float32Output.
 func (o *OutputState) ApplyFloat32(applier interface{}) Float32Output {
 	return o.ApplyT(applier).(Float32Output)
@@ -188,6 +228,16 @@ func (o *OutputState) ApplyFloat32Map(applier interface{}) Float32MapOutput {
 // ApplyFloat32MapWithContext is like ApplyTWithContext, but returns a Float32MapOutput.
 func (o *OutputState) ApplyFloat32MapWithContext(ctx context.Context, applier interface{}) Float32MapOutput {
 	return o.ApplyTWithContext(ctx, applier).(Float32MapOutput)
+}
+
+// ApplyFloat32ArrayMap is like ApplyT, but returns a Float32ArrayMapOutput.
+func (o *OutputState) ApplyFloat32ArrayMap(applier interface{}) Float32ArrayMapOutput {
+	return o.ApplyT(applier).(Float32ArrayMapOutput)
+}
+
+// ApplyFloat32ArrayMapWithContext is like ApplyTWithContext, but returns a Float32ArrayMapOutput.
+func (o *OutputState) ApplyFloat32ArrayMapWithContext(ctx context.Context, applier interface{}) Float32ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Float32ArrayMapOutput)
 }
 
 // ApplyFloat64 is like ApplyT, but returns a Float64Output.
@@ -230,6 +280,16 @@ func (o *OutputState) ApplyFloat64MapWithContext(ctx context.Context, applier in
 	return o.ApplyTWithContext(ctx, applier).(Float64MapOutput)
 }
 
+// ApplyFloat64ArrayMap is like ApplyT, but returns a Float64ArrayMapOutput.
+func (o *OutputState) ApplyFloat64ArrayMap(applier interface{}) Float64ArrayMapOutput {
+	return o.ApplyT(applier).(Float64ArrayMapOutput)
+}
+
+// ApplyFloat64ArrayMapWithContext is like ApplyTWithContext, but returns a Float64ArrayMapOutput.
+func (o *OutputState) ApplyFloat64ArrayMapWithContext(ctx context.Context, applier interface{}) Float64ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Float64ArrayMapOutput)
+}
+
 // ApplyID is like ApplyT, but returns a IDOutput.
 func (o *OutputState) ApplyID(applier interface{}) IDOutput {
 	return o.ApplyT(applier).(IDOutput)
@@ -270,6 +330,16 @@ func (o *OutputState) ApplyIDMapWithContext(ctx context.Context, applier interfa
 	return o.ApplyTWithContext(ctx, applier).(IDMapOutput)
 }
 
+// ApplyIDArrayMap is like ApplyT, but returns a IDArrayMapOutput.
+func (o *OutputState) ApplyIDArrayMap(applier interface{}) IDArrayMapOutput {
+	return o.ApplyT(applier).(IDArrayMapOutput)
+}
+
+// ApplyIDArrayMapWithContext is like ApplyTWithContext, but returns a IDArrayMapOutput.
+func (o *OutputState) ApplyIDArrayMapWithContext(ctx context.Context, applier interface{}) IDArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(IDArrayMapOutput)
+}
+
 // ApplyArray is like ApplyT, but returns a ArrayOutput.
 func (o *OutputState) ApplyArray(applier interface{}) ArrayOutput {
 	return o.ApplyT(applier).(ArrayOutput)
@@ -288,6 +358,16 @@ func (o *OutputState) ApplyMap(applier interface{}) MapOutput {
 // ApplyMapWithContext is like ApplyTWithContext, but returns a MapOutput.
 func (o *OutputState) ApplyMapWithContext(ctx context.Context, applier interface{}) MapOutput {
 	return o.ApplyTWithContext(ctx, applier).(MapOutput)
+}
+
+// ApplyArrayMap is like ApplyT, but returns a ArrayMapOutput.
+func (o *OutputState) ApplyArrayMap(applier interface{}) ArrayMapOutput {
+	return o.ApplyT(applier).(ArrayMapOutput)
+}
+
+// ApplyArrayMapWithContext is like ApplyTWithContext, but returns a ArrayMapOutput.
+func (o *OutputState) ApplyArrayMapWithContext(ctx context.Context, applier interface{}) ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(ArrayMapOutput)
 }
 
 // ApplyInt is like ApplyT, but returns a IntOutput.
@@ -330,6 +410,16 @@ func (o *OutputState) ApplyIntMapWithContext(ctx context.Context, applier interf
 	return o.ApplyTWithContext(ctx, applier).(IntMapOutput)
 }
 
+// ApplyIntArrayMap is like ApplyT, but returns a IntArrayMapOutput.
+func (o *OutputState) ApplyIntArrayMap(applier interface{}) IntArrayMapOutput {
+	return o.ApplyT(applier).(IntArrayMapOutput)
+}
+
+// ApplyIntArrayMapWithContext is like ApplyTWithContext, but returns a IntArrayMapOutput.
+func (o *OutputState) ApplyIntArrayMapWithContext(ctx context.Context, applier interface{}) IntArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(IntArrayMapOutput)
+}
+
 // ApplyInt16 is like ApplyT, but returns a Int16Output.
 func (o *OutputState) ApplyInt16(applier interface{}) Int16Output {
 	return o.ApplyT(applier).(Int16Output)
@@ -368,6 +458,16 @@ func (o *OutputState) ApplyInt16Map(applier interface{}) Int16MapOutput {
 // ApplyInt16MapWithContext is like ApplyTWithContext, but returns a Int16MapOutput.
 func (o *OutputState) ApplyInt16MapWithContext(ctx context.Context, applier interface{}) Int16MapOutput {
 	return o.ApplyTWithContext(ctx, applier).(Int16MapOutput)
+}
+
+// ApplyInt16ArrayMap is like ApplyT, but returns a Int16ArrayMapOutput.
+func (o *OutputState) ApplyInt16ArrayMap(applier interface{}) Int16ArrayMapOutput {
+	return o.ApplyT(applier).(Int16ArrayMapOutput)
+}
+
+// ApplyInt16ArrayMapWithContext is like ApplyTWithContext, but returns a Int16ArrayMapOutput.
+func (o *OutputState) ApplyInt16ArrayMapWithContext(ctx context.Context, applier interface{}) Int16ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Int16ArrayMapOutput)
 }
 
 // ApplyInt32 is like ApplyT, but returns a Int32Output.
@@ -410,6 +510,16 @@ func (o *OutputState) ApplyInt32MapWithContext(ctx context.Context, applier inte
 	return o.ApplyTWithContext(ctx, applier).(Int32MapOutput)
 }
 
+// ApplyInt32ArrayMap is like ApplyT, but returns a Int32ArrayMapOutput.
+func (o *OutputState) ApplyInt32ArrayMap(applier interface{}) Int32ArrayMapOutput {
+	return o.ApplyT(applier).(Int32ArrayMapOutput)
+}
+
+// ApplyInt32ArrayMapWithContext is like ApplyTWithContext, but returns a Int32ArrayMapOutput.
+func (o *OutputState) ApplyInt32ArrayMapWithContext(ctx context.Context, applier interface{}) Int32ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Int32ArrayMapOutput)
+}
+
 // ApplyInt64 is like ApplyT, but returns a Int64Output.
 func (o *OutputState) ApplyInt64(applier interface{}) Int64Output {
 	return o.ApplyT(applier).(Int64Output)
@@ -448,6 +558,16 @@ func (o *OutputState) ApplyInt64Map(applier interface{}) Int64MapOutput {
 // ApplyInt64MapWithContext is like ApplyTWithContext, but returns a Int64MapOutput.
 func (o *OutputState) ApplyInt64MapWithContext(ctx context.Context, applier interface{}) Int64MapOutput {
 	return o.ApplyTWithContext(ctx, applier).(Int64MapOutput)
+}
+
+// ApplyInt64ArrayMap is like ApplyT, but returns a Int64ArrayMapOutput.
+func (o *OutputState) ApplyInt64ArrayMap(applier interface{}) Int64ArrayMapOutput {
+	return o.ApplyT(applier).(Int64ArrayMapOutput)
+}
+
+// ApplyInt64ArrayMapWithContext is like ApplyTWithContext, but returns a Int64ArrayMapOutput.
+func (o *OutputState) ApplyInt64ArrayMapWithContext(ctx context.Context, applier interface{}) Int64ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Int64ArrayMapOutput)
 }
 
 // ApplyInt8 is like ApplyT, but returns a Int8Output.
@@ -490,6 +610,16 @@ func (o *OutputState) ApplyInt8MapWithContext(ctx context.Context, applier inter
 	return o.ApplyTWithContext(ctx, applier).(Int8MapOutput)
 }
 
+// ApplyInt8ArrayMap is like ApplyT, but returns a Int8ArrayMapOutput.
+func (o *OutputState) ApplyInt8ArrayMap(applier interface{}) Int8ArrayMapOutput {
+	return o.ApplyT(applier).(Int8ArrayMapOutput)
+}
+
+// ApplyInt8ArrayMapWithContext is like ApplyTWithContext, but returns a Int8ArrayMapOutput.
+func (o *OutputState) ApplyInt8ArrayMapWithContext(ctx context.Context, applier interface{}) Int8ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Int8ArrayMapOutput)
+}
+
 // ApplyString is like ApplyT, but returns a StringOutput.
 func (o *OutputState) ApplyString(applier interface{}) StringOutput {
 	return o.ApplyT(applier).(StringOutput)
@@ -528,6 +658,16 @@ func (o *OutputState) ApplyStringMap(applier interface{}) StringMapOutput {
 // ApplyStringMapWithContext is like ApplyTWithContext, but returns a StringMapOutput.
 func (o *OutputState) ApplyStringMapWithContext(ctx context.Context, applier interface{}) StringMapOutput {
 	return o.ApplyTWithContext(ctx, applier).(StringMapOutput)
+}
+
+// ApplyStringArrayMap is like ApplyT, but returns a StringArrayMapOutput.
+func (o *OutputState) ApplyStringArrayMap(applier interface{}) StringArrayMapOutput {
+	return o.ApplyT(applier).(StringArrayMapOutput)
+}
+
+// ApplyStringArrayMapWithContext is like ApplyTWithContext, but returns a StringArrayMapOutput.
+func (o *OutputState) ApplyStringArrayMapWithContext(ctx context.Context, applier interface{}) StringArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(StringArrayMapOutput)
 }
 
 // ApplyURN is like ApplyT, but returns a URNOutput.
@@ -570,6 +710,16 @@ func (o *OutputState) ApplyURNMapWithContext(ctx context.Context, applier interf
 	return o.ApplyTWithContext(ctx, applier).(URNMapOutput)
 }
 
+// ApplyURNArrayMap is like ApplyT, but returns a URNArrayMapOutput.
+func (o *OutputState) ApplyURNArrayMap(applier interface{}) URNArrayMapOutput {
+	return o.ApplyT(applier).(URNArrayMapOutput)
+}
+
+// ApplyURNArrayMapWithContext is like ApplyTWithContext, but returns a URNArrayMapOutput.
+func (o *OutputState) ApplyURNArrayMapWithContext(ctx context.Context, applier interface{}) URNArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(URNArrayMapOutput)
+}
+
 // ApplyUint is like ApplyT, but returns a UintOutput.
 func (o *OutputState) ApplyUint(applier interface{}) UintOutput {
 	return o.ApplyT(applier).(UintOutput)
@@ -608,6 +758,16 @@ func (o *OutputState) ApplyUintMap(applier interface{}) UintMapOutput {
 // ApplyUintMapWithContext is like ApplyTWithContext, but returns a UintMapOutput.
 func (o *OutputState) ApplyUintMapWithContext(ctx context.Context, applier interface{}) UintMapOutput {
 	return o.ApplyTWithContext(ctx, applier).(UintMapOutput)
+}
+
+// ApplyUintArrayMap is like ApplyT, but returns a UintArrayMapOutput.
+func (o *OutputState) ApplyUintArrayMap(applier interface{}) UintArrayMapOutput {
+	return o.ApplyT(applier).(UintArrayMapOutput)
+}
+
+// ApplyUintArrayMapWithContext is like ApplyTWithContext, but returns a UintArrayMapOutput.
+func (o *OutputState) ApplyUintArrayMapWithContext(ctx context.Context, applier interface{}) UintArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(UintArrayMapOutput)
 }
 
 // ApplyUint16 is like ApplyT, but returns a Uint16Output.
@@ -650,6 +810,16 @@ func (o *OutputState) ApplyUint16MapWithContext(ctx context.Context, applier int
 	return o.ApplyTWithContext(ctx, applier).(Uint16MapOutput)
 }
 
+// ApplyUint16ArrayMap is like ApplyT, but returns a Uint16ArrayMapOutput.
+func (o *OutputState) ApplyUint16ArrayMap(applier interface{}) Uint16ArrayMapOutput {
+	return o.ApplyT(applier).(Uint16ArrayMapOutput)
+}
+
+// ApplyUint16ArrayMapWithContext is like ApplyTWithContext, but returns a Uint16ArrayMapOutput.
+func (o *OutputState) ApplyUint16ArrayMapWithContext(ctx context.Context, applier interface{}) Uint16ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Uint16ArrayMapOutput)
+}
+
 // ApplyUint32 is like ApplyT, but returns a Uint32Output.
 func (o *OutputState) ApplyUint32(applier interface{}) Uint32Output {
 	return o.ApplyT(applier).(Uint32Output)
@@ -688,6 +858,16 @@ func (o *OutputState) ApplyUint32Map(applier interface{}) Uint32MapOutput {
 // ApplyUint32MapWithContext is like ApplyTWithContext, but returns a Uint32MapOutput.
 func (o *OutputState) ApplyUint32MapWithContext(ctx context.Context, applier interface{}) Uint32MapOutput {
 	return o.ApplyTWithContext(ctx, applier).(Uint32MapOutput)
+}
+
+// ApplyUint32ArrayMap is like ApplyT, but returns a Uint32ArrayMapOutput.
+func (o *OutputState) ApplyUint32ArrayMap(applier interface{}) Uint32ArrayMapOutput {
+	return o.ApplyT(applier).(Uint32ArrayMapOutput)
+}
+
+// ApplyUint32ArrayMapWithContext is like ApplyTWithContext, but returns a Uint32ArrayMapOutput.
+func (o *OutputState) ApplyUint32ArrayMapWithContext(ctx context.Context, applier interface{}) Uint32ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Uint32ArrayMapOutput)
 }
 
 // ApplyUint64 is like ApplyT, but returns a Uint64Output.
@@ -730,6 +910,16 @@ func (o *OutputState) ApplyUint64MapWithContext(ctx context.Context, applier int
 	return o.ApplyTWithContext(ctx, applier).(Uint64MapOutput)
 }
 
+// ApplyUint64ArrayMap is like ApplyT, but returns a Uint64ArrayMapOutput.
+func (o *OutputState) ApplyUint64ArrayMap(applier interface{}) Uint64ArrayMapOutput {
+	return o.ApplyT(applier).(Uint64ArrayMapOutput)
+}
+
+// ApplyUint64ArrayMapWithContext is like ApplyTWithContext, but returns a Uint64ArrayMapOutput.
+func (o *OutputState) ApplyUint64ArrayMapWithContext(ctx context.Context, applier interface{}) Uint64ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Uint64ArrayMapOutput)
+}
+
 // ApplyUint8 is like ApplyT, but returns a Uint8Output.
 func (o *OutputState) ApplyUint8(applier interface{}) Uint8Output {
 	return o.ApplyT(applier).(Uint8Output)
@@ -768,6 +958,16 @@ func (o *OutputState) ApplyUint8Map(applier interface{}) Uint8MapOutput {
 // ApplyUint8MapWithContext is like ApplyTWithContext, but returns a Uint8MapOutput.
 func (o *OutputState) ApplyUint8MapWithContext(ctx context.Context, applier interface{}) Uint8MapOutput {
 	return o.ApplyTWithContext(ctx, applier).(Uint8MapOutput)
+}
+
+// ApplyUint8ArrayMap is like ApplyT, but returns a Uint8ArrayMapOutput.
+func (o *OutputState) ApplyUint8ArrayMap(applier interface{}) Uint8ArrayMapOutput {
+	return o.ApplyT(applier).(Uint8ArrayMapOutput)
+}
+
+// ApplyUint8ArrayMapWithContext is like ApplyTWithContext, but returns a Uint8ArrayMapOutput.
+func (o *OutputState) ApplyUint8ArrayMapWithContext(ctx context.Context, applier interface{}) Uint8ArrayMapOutput {
+	return o.ApplyTWithContext(ctx, applier).(Uint8ArrayMapOutput)
 }
 
 var archiveType = reflect.TypeOf((*Archive)(nil)).Elem()
@@ -923,6 +1123,54 @@ func (o ArchiveMapOutput) MapIndex(k StringInput) ArchiveOutput {
 	}).(ArchiveOutput)
 }
 
+var archiveArrayMapType = reflect.TypeOf((*map[string][]Archive)(nil)).Elem()
+
+// ArchiveArrayMapInput is an input type that accepts ArchiveArrayMap and ArchiveArrayMapOutput values.
+type ArchiveArrayMapInput interface {
+	Input
+
+	ToArchiveArrayMapOutput() ArchiveArrayMapOutput
+	ToArchiveArrayMapOutputWithContext(ctx context.Context) ArchiveArrayMapOutput
+}
+
+// ArchiveArrayMap is an input type for map[string]ArchiveArrayInput values.
+type ArchiveArrayMap map[string]ArchiveArrayInput
+
+// ElementType returns the element type of this Input (map[string][]Archive).
+func (ArchiveArrayMap) ElementType() reflect.Type {
+	return archiveArrayMapType
+}
+
+func (in ArchiveArrayMap) ToArchiveArrayMapOutput() ArchiveArrayMapOutput {
+	return ToOutput(in).(ArchiveArrayMapOutput)
+}
+
+func (in ArchiveArrayMap) ToArchiveArrayMapOutputWithContext(ctx context.Context) ArchiveArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(ArchiveArrayMapOutput)
+}
+
+// ArchiveArrayMapOutput is an Output that returns map[string][]Archive values.
+type ArchiveArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]Archive).
+func (ArchiveArrayMapOutput) ElementType() reflect.Type {
+	return archiveArrayMapType
+}
+
+func (o ArchiveArrayMapOutput) ToArchiveArrayMapOutput() ArchiveArrayMapOutput {
+	return o
+}
+
+func (o ArchiveArrayMapOutput) ToArchiveArrayMapOutputWithContext(ctx context.Context) ArchiveArrayMapOutput {
+	return o
+}
+
+func (o ArchiveArrayMapOutput) MapIndex(k StringInput) ArchiveArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []Archive {
+		return vs[0].(map[string][]Archive)[vs[1].(string)]
+	}).(ArchiveArrayOutput)
+}
+
 var assetType = reflect.TypeOf((*Asset)(nil)).Elem()
 
 // AssetInput is an input type that accepts Asset and AssetOutput values.
@@ -1076,6 +1324,54 @@ func (o AssetMapOutput) MapIndex(k StringInput) AssetOutput {
 	}).(AssetOutput)
 }
 
+var assetArrayMapType = reflect.TypeOf((*map[string][]Asset)(nil)).Elem()
+
+// AssetArrayMapInput is an input type that accepts AssetArrayMap and AssetArrayMapOutput values.
+type AssetArrayMapInput interface {
+	Input
+
+	ToAssetArrayMapOutput() AssetArrayMapOutput
+	ToAssetArrayMapOutputWithContext(ctx context.Context) AssetArrayMapOutput
+}
+
+// AssetArrayMap is an input type for map[string]AssetArrayInput values.
+type AssetArrayMap map[string]AssetArrayInput
+
+// ElementType returns the element type of this Input (map[string][]Asset).
+func (AssetArrayMap) ElementType() reflect.Type {
+	return assetArrayMapType
+}
+
+func (in AssetArrayMap) ToAssetArrayMapOutput() AssetArrayMapOutput {
+	return ToOutput(in).(AssetArrayMapOutput)
+}
+
+func (in AssetArrayMap) ToAssetArrayMapOutputWithContext(ctx context.Context) AssetArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(AssetArrayMapOutput)
+}
+
+// AssetArrayMapOutput is an Output that returns map[string][]Asset values.
+type AssetArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]Asset).
+func (AssetArrayMapOutput) ElementType() reflect.Type {
+	return assetArrayMapType
+}
+
+func (o AssetArrayMapOutput) ToAssetArrayMapOutput() AssetArrayMapOutput {
+	return o
+}
+
+func (o AssetArrayMapOutput) ToAssetArrayMapOutputWithContext(ctx context.Context) AssetArrayMapOutput {
+	return o
+}
+
+func (o AssetArrayMapOutput) MapIndex(k StringInput) AssetArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []Asset {
+		return vs[0].(map[string][]Asset)[vs[1].(string)]
+	}).(AssetArrayOutput)
+}
+
 var assetOrArchiveType = reflect.TypeOf((*AssetOrArchive)(nil)).Elem()
 
 // AssetOrArchiveInput is an input type that accepts AssetOrArchive and AssetOrArchiveOutput values.
@@ -1196,6 +1492,54 @@ func (o AssetOrArchiveMapOutput) MapIndex(k StringInput) AssetOrArchiveOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) AssetOrArchive {
 		return vs[0].(map[string]AssetOrArchive)[vs[1].(string)]
 	}).(AssetOrArchiveOutput)
+}
+
+var assetOrArchiveArrayMapType = reflect.TypeOf((*map[string][]AssetOrArchive)(nil)).Elem()
+
+// AssetOrArchiveArrayMapInput is an input type that accepts AssetOrArchiveArrayMap and AssetOrArchiveArrayMapOutput values.
+type AssetOrArchiveArrayMapInput interface {
+	Input
+
+	ToAssetOrArchiveArrayMapOutput() AssetOrArchiveArrayMapOutput
+	ToAssetOrArchiveArrayMapOutputWithContext(ctx context.Context) AssetOrArchiveArrayMapOutput
+}
+
+// AssetOrArchiveArrayMap is an input type for map[string]AssetOrArchiveArrayInput values.
+type AssetOrArchiveArrayMap map[string]AssetOrArchiveArrayInput
+
+// ElementType returns the element type of this Input (map[string][]AssetOrArchive).
+func (AssetOrArchiveArrayMap) ElementType() reflect.Type {
+	return assetOrArchiveArrayMapType
+}
+
+func (in AssetOrArchiveArrayMap) ToAssetOrArchiveArrayMapOutput() AssetOrArchiveArrayMapOutput {
+	return ToOutput(in).(AssetOrArchiveArrayMapOutput)
+}
+
+func (in AssetOrArchiveArrayMap) ToAssetOrArchiveArrayMapOutputWithContext(ctx context.Context) AssetOrArchiveArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(AssetOrArchiveArrayMapOutput)
+}
+
+// AssetOrArchiveArrayMapOutput is an Output that returns map[string][]AssetOrArchive values.
+type AssetOrArchiveArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]AssetOrArchive).
+func (AssetOrArchiveArrayMapOutput) ElementType() reflect.Type {
+	return assetOrArchiveArrayMapType
+}
+
+func (o AssetOrArchiveArrayMapOutput) ToAssetOrArchiveArrayMapOutput() AssetOrArchiveArrayMapOutput {
+	return o
+}
+
+func (o AssetOrArchiveArrayMapOutput) ToAssetOrArchiveArrayMapOutputWithContext(ctx context.Context) AssetOrArchiveArrayMapOutput {
+	return o
+}
+
+func (o AssetOrArchiveArrayMapOutput) MapIndex(k StringInput) AssetOrArchiveArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []AssetOrArchive {
+		return vs[0].(map[string][]AssetOrArchive)[vs[1].(string)]
+	}).(AssetOrArchiveArrayOutput)
 }
 
 var boolType = reflect.TypeOf((*bool)(nil)).Elem()
@@ -1406,6 +1750,54 @@ func (o BoolMapOutput) MapIndex(k StringInput) BoolOutput {
 	}).(BoolOutput)
 }
 
+var boolArrayMapType = reflect.TypeOf((*map[string][]bool)(nil)).Elem()
+
+// BoolArrayMapInput is an input type that accepts BoolArrayMap and BoolArrayMapOutput values.
+type BoolArrayMapInput interface {
+	Input
+
+	ToBoolArrayMapOutput() BoolArrayMapOutput
+	ToBoolArrayMapOutputWithContext(ctx context.Context) BoolArrayMapOutput
+}
+
+// BoolArrayMap is an input type for map[string]BoolArrayInput values.
+type BoolArrayMap map[string]BoolArrayInput
+
+// ElementType returns the element type of this Input (map[string][]bool).
+func (BoolArrayMap) ElementType() reflect.Type {
+	return boolArrayMapType
+}
+
+func (in BoolArrayMap) ToBoolArrayMapOutput() BoolArrayMapOutput {
+	return ToOutput(in).(BoolArrayMapOutput)
+}
+
+func (in BoolArrayMap) ToBoolArrayMapOutputWithContext(ctx context.Context) BoolArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(BoolArrayMapOutput)
+}
+
+// BoolArrayMapOutput is an Output that returns map[string][]bool values.
+type BoolArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]bool).
+func (BoolArrayMapOutput) ElementType() reflect.Type {
+	return boolArrayMapType
+}
+
+func (o BoolArrayMapOutput) ToBoolArrayMapOutput() BoolArrayMapOutput {
+	return o
+}
+
+func (o BoolArrayMapOutput) ToBoolArrayMapOutputWithContext(ctx context.Context) BoolArrayMapOutput {
+	return o
+}
+
+func (o BoolArrayMapOutput) MapIndex(k StringInput) BoolArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []bool {
+		return vs[0].(map[string][]bool)[vs[1].(string)]
+	}).(BoolArrayOutput)
+}
+
 var float32Type = reflect.TypeOf((*float32)(nil)).Elem()
 
 // Float32Input is an input type that accepts Float32 and Float32Output values.
@@ -1614,6 +2006,54 @@ func (o Float32MapOutput) MapIndex(k StringInput) Float32Output {
 	}).(Float32Output)
 }
 
+var float32ArrayMapType = reflect.TypeOf((*map[string][]float32)(nil)).Elem()
+
+// Float32ArrayMapInput is an input type that accepts Float32ArrayMap and Float32ArrayMapOutput values.
+type Float32ArrayMapInput interface {
+	Input
+
+	ToFloat32ArrayMapOutput() Float32ArrayMapOutput
+	ToFloat32ArrayMapOutputWithContext(ctx context.Context) Float32ArrayMapOutput
+}
+
+// Float32ArrayMap is an input type for map[string]Float32ArrayInput values.
+type Float32ArrayMap map[string]Float32ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]float32).
+func (Float32ArrayMap) ElementType() reflect.Type {
+	return float32ArrayMapType
+}
+
+func (in Float32ArrayMap) ToFloat32ArrayMapOutput() Float32ArrayMapOutput {
+	return ToOutput(in).(Float32ArrayMapOutput)
+}
+
+func (in Float32ArrayMap) ToFloat32ArrayMapOutputWithContext(ctx context.Context) Float32ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Float32ArrayMapOutput)
+}
+
+// Float32ArrayMapOutput is an Output that returns map[string][]float32 values.
+type Float32ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]float32).
+func (Float32ArrayMapOutput) ElementType() reflect.Type {
+	return float32ArrayMapType
+}
+
+func (o Float32ArrayMapOutput) ToFloat32ArrayMapOutput() Float32ArrayMapOutput {
+	return o
+}
+
+func (o Float32ArrayMapOutput) ToFloat32ArrayMapOutputWithContext(ctx context.Context) Float32ArrayMapOutput {
+	return o
+}
+
+func (o Float32ArrayMapOutput) MapIndex(k StringInput) Float32ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []float32 {
+		return vs[0].(map[string][]float32)[vs[1].(string)]
+	}).(Float32ArrayOutput)
+}
+
 var float64Type = reflect.TypeOf((*float64)(nil)).Elem()
 
 // Float64Input is an input type that accepts Float64 and Float64Output values.
@@ -1820,6 +2260,54 @@ func (o Float64MapOutput) MapIndex(k StringInput) Float64Output {
 	return All(o, k).ApplyT(func(vs []interface{}) float64 {
 		return vs[0].(map[string]float64)[vs[1].(string)]
 	}).(Float64Output)
+}
+
+var float64ArrayMapType = reflect.TypeOf((*map[string][]float64)(nil)).Elem()
+
+// Float64ArrayMapInput is an input type that accepts Float64ArrayMap and Float64ArrayMapOutput values.
+type Float64ArrayMapInput interface {
+	Input
+
+	ToFloat64ArrayMapOutput() Float64ArrayMapOutput
+	ToFloat64ArrayMapOutputWithContext(ctx context.Context) Float64ArrayMapOutput
+}
+
+// Float64ArrayMap is an input type for map[string]Float64ArrayInput values.
+type Float64ArrayMap map[string]Float64ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]float64).
+func (Float64ArrayMap) ElementType() reflect.Type {
+	return float64ArrayMapType
+}
+
+func (in Float64ArrayMap) ToFloat64ArrayMapOutput() Float64ArrayMapOutput {
+	return ToOutput(in).(Float64ArrayMapOutput)
+}
+
+func (in Float64ArrayMap) ToFloat64ArrayMapOutputWithContext(ctx context.Context) Float64ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Float64ArrayMapOutput)
+}
+
+// Float64ArrayMapOutput is an Output that returns map[string][]float64 values.
+type Float64ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]float64).
+func (Float64ArrayMapOutput) ElementType() reflect.Type {
+	return float64ArrayMapType
+}
+
+func (o Float64ArrayMapOutput) ToFloat64ArrayMapOutput() Float64ArrayMapOutput {
+	return o
+}
+
+func (o Float64ArrayMapOutput) ToFloat64ArrayMapOutputWithContext(ctx context.Context) Float64ArrayMapOutput {
+	return o
+}
+
+func (o Float64ArrayMapOutput) MapIndex(k StringInput) Float64ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []float64 {
+		return vs[0].(map[string][]float64)[vs[1].(string)]
+	}).(Float64ArrayOutput)
 }
 
 var idType = reflect.TypeOf((*ID)(nil)).Elem()
@@ -2045,6 +2533,54 @@ func (o IDMapOutput) MapIndex(k StringInput) IDOutput {
 	}).(IDOutput)
 }
 
+var iDArrayMapType = reflect.TypeOf((*map[string][]ID)(nil)).Elem()
+
+// IDArrayMapInput is an input type that accepts IDArrayMap and IDArrayMapOutput values.
+type IDArrayMapInput interface {
+	Input
+
+	ToIDArrayMapOutput() IDArrayMapOutput
+	ToIDArrayMapOutputWithContext(ctx context.Context) IDArrayMapOutput
+}
+
+// IDArrayMap is an input type for map[string]IDArrayInput values.
+type IDArrayMap map[string]IDArrayInput
+
+// ElementType returns the element type of this Input (map[string][]ID).
+func (IDArrayMap) ElementType() reflect.Type {
+	return iDArrayMapType
+}
+
+func (in IDArrayMap) ToIDArrayMapOutput() IDArrayMapOutput {
+	return ToOutput(in).(IDArrayMapOutput)
+}
+
+func (in IDArrayMap) ToIDArrayMapOutputWithContext(ctx context.Context) IDArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(IDArrayMapOutput)
+}
+
+// IDArrayMapOutput is an Output that returns map[string][]ID values.
+type IDArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]ID).
+func (IDArrayMapOutput) ElementType() reflect.Type {
+	return iDArrayMapType
+}
+
+func (o IDArrayMapOutput) ToIDArrayMapOutput() IDArrayMapOutput {
+	return o
+}
+
+func (o IDArrayMapOutput) ToIDArrayMapOutputWithContext(ctx context.Context) IDArrayMapOutput {
+	return o
+}
+
+func (o IDArrayMapOutput) MapIndex(k StringInput) IDArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []ID {
+		return vs[0].(map[string][]ID)[vs[1].(string)]
+	}).(IDArrayOutput)
+}
+
 var arrayType = reflect.TypeOf((*[]interface{})(nil)).Elem()
 
 // ArrayInput is an input type that accepts Array and ArrayOutput values.
@@ -2139,6 +2675,54 @@ func (o MapOutput) MapIndex(k StringInput) Output {
 	return All(o, k).ApplyT(func(vs []interface{}) interface{} {
 		return vs[0].(map[string]interface{})[vs[1].(string)]
 	}).(Output)
+}
+
+var arrayMapType = reflect.TypeOf((*map[string][]interface{})(nil)).Elem()
+
+// ArrayMapInput is an input type that accepts ArrayMap and ArrayMapOutput values.
+type ArrayMapInput interface {
+	Input
+
+	ToArrayMapOutput() ArrayMapOutput
+	ToArrayMapOutputWithContext(ctx context.Context) ArrayMapOutput
+}
+
+// ArrayMap is an input type for map[string]ArrayInput values.
+type ArrayMap map[string]ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]interface{}).
+func (ArrayMap) ElementType() reflect.Type {
+	return arrayMapType
+}
+
+func (in ArrayMap) ToArrayMapOutput() ArrayMapOutput {
+	return ToOutput(in).(ArrayMapOutput)
+}
+
+func (in ArrayMap) ToArrayMapOutputWithContext(ctx context.Context) ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(ArrayMapOutput)
+}
+
+// ArrayMapOutput is an Output that returns map[string][]interface{} values.
+type ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]interface{}).
+func (ArrayMapOutput) ElementType() reflect.Type {
+	return arrayMapType
+}
+
+func (o ArrayMapOutput) ToArrayMapOutput() ArrayMapOutput {
+	return o
+}
+
+func (o ArrayMapOutput) ToArrayMapOutputWithContext(ctx context.Context) ArrayMapOutput {
+	return o
+}
+
+func (o ArrayMapOutput) MapIndex(k StringInput) ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []interface{} {
+		return vs[0].(map[string][]interface{})[vs[1].(string)]
+	}).(ArrayOutput)
 }
 
 var intType = reflect.TypeOf((*int)(nil)).Elem()
@@ -2349,6 +2933,54 @@ func (o IntMapOutput) MapIndex(k StringInput) IntOutput {
 	}).(IntOutput)
 }
 
+var intArrayMapType = reflect.TypeOf((*map[string][]int)(nil)).Elem()
+
+// IntArrayMapInput is an input type that accepts IntArrayMap and IntArrayMapOutput values.
+type IntArrayMapInput interface {
+	Input
+
+	ToIntArrayMapOutput() IntArrayMapOutput
+	ToIntArrayMapOutputWithContext(ctx context.Context) IntArrayMapOutput
+}
+
+// IntArrayMap is an input type for map[string]IntArrayInput values.
+type IntArrayMap map[string]IntArrayInput
+
+// ElementType returns the element type of this Input (map[string][]int).
+func (IntArrayMap) ElementType() reflect.Type {
+	return intArrayMapType
+}
+
+func (in IntArrayMap) ToIntArrayMapOutput() IntArrayMapOutput {
+	return ToOutput(in).(IntArrayMapOutput)
+}
+
+func (in IntArrayMap) ToIntArrayMapOutputWithContext(ctx context.Context) IntArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(IntArrayMapOutput)
+}
+
+// IntArrayMapOutput is an Output that returns map[string][]int values.
+type IntArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]int).
+func (IntArrayMapOutput) ElementType() reflect.Type {
+	return intArrayMapType
+}
+
+func (o IntArrayMapOutput) ToIntArrayMapOutput() IntArrayMapOutput {
+	return o
+}
+
+func (o IntArrayMapOutput) ToIntArrayMapOutputWithContext(ctx context.Context) IntArrayMapOutput {
+	return o
+}
+
+func (o IntArrayMapOutput) MapIndex(k StringInput) IntArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []int {
+		return vs[0].(map[string][]int)[vs[1].(string)]
+	}).(IntArrayOutput)
+}
+
 var int16Type = reflect.TypeOf((*int16)(nil)).Elem()
 
 // Int16Input is an input type that accepts Int16 and Int16Output values.
@@ -2555,6 +3187,54 @@ func (o Int16MapOutput) MapIndex(k StringInput) Int16Output {
 	return All(o, k).ApplyT(func(vs []interface{}) int16 {
 		return vs[0].(map[string]int16)[vs[1].(string)]
 	}).(Int16Output)
+}
+
+var int16ArrayMapType = reflect.TypeOf((*map[string][]int16)(nil)).Elem()
+
+// Int16ArrayMapInput is an input type that accepts Int16ArrayMap and Int16ArrayMapOutput values.
+type Int16ArrayMapInput interface {
+	Input
+
+	ToInt16ArrayMapOutput() Int16ArrayMapOutput
+	ToInt16ArrayMapOutputWithContext(ctx context.Context) Int16ArrayMapOutput
+}
+
+// Int16ArrayMap is an input type for map[string]Int16ArrayInput values.
+type Int16ArrayMap map[string]Int16ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]int16).
+func (Int16ArrayMap) ElementType() reflect.Type {
+	return int16ArrayMapType
+}
+
+func (in Int16ArrayMap) ToInt16ArrayMapOutput() Int16ArrayMapOutput {
+	return ToOutput(in).(Int16ArrayMapOutput)
+}
+
+func (in Int16ArrayMap) ToInt16ArrayMapOutputWithContext(ctx context.Context) Int16ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Int16ArrayMapOutput)
+}
+
+// Int16ArrayMapOutput is an Output that returns map[string][]int16 values.
+type Int16ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]int16).
+func (Int16ArrayMapOutput) ElementType() reflect.Type {
+	return int16ArrayMapType
+}
+
+func (o Int16ArrayMapOutput) ToInt16ArrayMapOutput() Int16ArrayMapOutput {
+	return o
+}
+
+func (o Int16ArrayMapOutput) ToInt16ArrayMapOutputWithContext(ctx context.Context) Int16ArrayMapOutput {
+	return o
+}
+
+func (o Int16ArrayMapOutput) MapIndex(k StringInput) Int16ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []int16 {
+		return vs[0].(map[string][]int16)[vs[1].(string)]
+	}).(Int16ArrayOutput)
 }
 
 var int32Type = reflect.TypeOf((*int32)(nil)).Elem()
@@ -2765,6 +3445,54 @@ func (o Int32MapOutput) MapIndex(k StringInput) Int32Output {
 	}).(Int32Output)
 }
 
+var int32ArrayMapType = reflect.TypeOf((*map[string][]int32)(nil)).Elem()
+
+// Int32ArrayMapInput is an input type that accepts Int32ArrayMap and Int32ArrayMapOutput values.
+type Int32ArrayMapInput interface {
+	Input
+
+	ToInt32ArrayMapOutput() Int32ArrayMapOutput
+	ToInt32ArrayMapOutputWithContext(ctx context.Context) Int32ArrayMapOutput
+}
+
+// Int32ArrayMap is an input type for map[string]Int32ArrayInput values.
+type Int32ArrayMap map[string]Int32ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]int32).
+func (Int32ArrayMap) ElementType() reflect.Type {
+	return int32ArrayMapType
+}
+
+func (in Int32ArrayMap) ToInt32ArrayMapOutput() Int32ArrayMapOutput {
+	return ToOutput(in).(Int32ArrayMapOutput)
+}
+
+func (in Int32ArrayMap) ToInt32ArrayMapOutputWithContext(ctx context.Context) Int32ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Int32ArrayMapOutput)
+}
+
+// Int32ArrayMapOutput is an Output that returns map[string][]int32 values.
+type Int32ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]int32).
+func (Int32ArrayMapOutput) ElementType() reflect.Type {
+	return int32ArrayMapType
+}
+
+func (o Int32ArrayMapOutput) ToInt32ArrayMapOutput() Int32ArrayMapOutput {
+	return o
+}
+
+func (o Int32ArrayMapOutput) ToInt32ArrayMapOutputWithContext(ctx context.Context) Int32ArrayMapOutput {
+	return o
+}
+
+func (o Int32ArrayMapOutput) MapIndex(k StringInput) Int32ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []int32 {
+		return vs[0].(map[string][]int32)[vs[1].(string)]
+	}).(Int32ArrayOutput)
+}
+
 var int64Type = reflect.TypeOf((*int64)(nil)).Elem()
 
 // Int64Input is an input type that accepts Int64 and Int64Output values.
@@ -2971,6 +3699,54 @@ func (o Int64MapOutput) MapIndex(k StringInput) Int64Output {
 	return All(o, k).ApplyT(func(vs []interface{}) int64 {
 		return vs[0].(map[string]int64)[vs[1].(string)]
 	}).(Int64Output)
+}
+
+var int64ArrayMapType = reflect.TypeOf((*map[string][]int64)(nil)).Elem()
+
+// Int64ArrayMapInput is an input type that accepts Int64ArrayMap and Int64ArrayMapOutput values.
+type Int64ArrayMapInput interface {
+	Input
+
+	ToInt64ArrayMapOutput() Int64ArrayMapOutput
+	ToInt64ArrayMapOutputWithContext(ctx context.Context) Int64ArrayMapOutput
+}
+
+// Int64ArrayMap is an input type for map[string]Int64ArrayInput values.
+type Int64ArrayMap map[string]Int64ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]int64).
+func (Int64ArrayMap) ElementType() reflect.Type {
+	return int64ArrayMapType
+}
+
+func (in Int64ArrayMap) ToInt64ArrayMapOutput() Int64ArrayMapOutput {
+	return ToOutput(in).(Int64ArrayMapOutput)
+}
+
+func (in Int64ArrayMap) ToInt64ArrayMapOutputWithContext(ctx context.Context) Int64ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Int64ArrayMapOutput)
+}
+
+// Int64ArrayMapOutput is an Output that returns map[string][]int64 values.
+type Int64ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]int64).
+func (Int64ArrayMapOutput) ElementType() reflect.Type {
+	return int64ArrayMapType
+}
+
+func (o Int64ArrayMapOutput) ToInt64ArrayMapOutput() Int64ArrayMapOutput {
+	return o
+}
+
+func (o Int64ArrayMapOutput) ToInt64ArrayMapOutputWithContext(ctx context.Context) Int64ArrayMapOutput {
+	return o
+}
+
+func (o Int64ArrayMapOutput) MapIndex(k StringInput) Int64ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []int64 {
+		return vs[0].(map[string][]int64)[vs[1].(string)]
+	}).(Int64ArrayOutput)
 }
 
 var int8Type = reflect.TypeOf((*int8)(nil)).Elem()
@@ -3181,6 +3957,54 @@ func (o Int8MapOutput) MapIndex(k StringInput) Int8Output {
 	}).(Int8Output)
 }
 
+var int8ArrayMapType = reflect.TypeOf((*map[string][]int8)(nil)).Elem()
+
+// Int8ArrayMapInput is an input type that accepts Int8ArrayMap and Int8ArrayMapOutput values.
+type Int8ArrayMapInput interface {
+	Input
+
+	ToInt8ArrayMapOutput() Int8ArrayMapOutput
+	ToInt8ArrayMapOutputWithContext(ctx context.Context) Int8ArrayMapOutput
+}
+
+// Int8ArrayMap is an input type for map[string]Int8ArrayInput values.
+type Int8ArrayMap map[string]Int8ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]int8).
+func (Int8ArrayMap) ElementType() reflect.Type {
+	return int8ArrayMapType
+}
+
+func (in Int8ArrayMap) ToInt8ArrayMapOutput() Int8ArrayMapOutput {
+	return ToOutput(in).(Int8ArrayMapOutput)
+}
+
+func (in Int8ArrayMap) ToInt8ArrayMapOutputWithContext(ctx context.Context) Int8ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Int8ArrayMapOutput)
+}
+
+// Int8ArrayMapOutput is an Output that returns map[string][]int8 values.
+type Int8ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]int8).
+func (Int8ArrayMapOutput) ElementType() reflect.Type {
+	return int8ArrayMapType
+}
+
+func (o Int8ArrayMapOutput) ToInt8ArrayMapOutput() Int8ArrayMapOutput {
+	return o
+}
+
+func (o Int8ArrayMapOutput) ToInt8ArrayMapOutputWithContext(ctx context.Context) Int8ArrayMapOutput {
+	return o
+}
+
+func (o Int8ArrayMapOutput) MapIndex(k StringInput) Int8ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []int8 {
+		return vs[0].(map[string][]int8)[vs[1].(string)]
+	}).(Int8ArrayOutput)
+}
+
 var stringType = reflect.TypeOf((*string)(nil)).Elem()
 
 // StringInput is an input type that accepts String and StringOutput values.
@@ -3387,6 +4211,54 @@ func (o StringMapOutput) MapIndex(k StringInput) StringOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) string {
 		return vs[0].(map[string]string)[vs[1].(string)]
 	}).(StringOutput)
+}
+
+var stringArrayMapType = reflect.TypeOf((*map[string][]string)(nil)).Elem()
+
+// StringArrayMapInput is an input type that accepts StringArrayMap and StringArrayMapOutput values.
+type StringArrayMapInput interface {
+	Input
+
+	ToStringArrayMapOutput() StringArrayMapOutput
+	ToStringArrayMapOutputWithContext(ctx context.Context) StringArrayMapOutput
+}
+
+// StringArrayMap is an input type for map[string]StringArrayInput values.
+type StringArrayMap map[string]StringArrayInput
+
+// ElementType returns the element type of this Input (map[string][]string).
+func (StringArrayMap) ElementType() reflect.Type {
+	return stringArrayMapType
+}
+
+func (in StringArrayMap) ToStringArrayMapOutput() StringArrayMapOutput {
+	return ToOutput(in).(StringArrayMapOutput)
+}
+
+func (in StringArrayMap) ToStringArrayMapOutputWithContext(ctx context.Context) StringArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(StringArrayMapOutput)
+}
+
+// StringArrayMapOutput is an Output that returns map[string][]string values.
+type StringArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]string).
+func (StringArrayMapOutput) ElementType() reflect.Type {
+	return stringArrayMapType
+}
+
+func (o StringArrayMapOutput) ToStringArrayMapOutput() StringArrayMapOutput {
+	return o
+}
+
+func (o StringArrayMapOutput) ToStringArrayMapOutputWithContext(ctx context.Context) StringArrayMapOutput {
+	return o
+}
+
+func (o StringArrayMapOutput) MapIndex(k StringInput) StringArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []string {
+		return vs[0].(map[string][]string)[vs[1].(string)]
+	}).(StringArrayOutput)
 }
 
 var urnType = reflect.TypeOf((*URN)(nil)).Elem()
@@ -3612,6 +4484,54 @@ func (o URNMapOutput) MapIndex(k StringInput) URNOutput {
 	}).(URNOutput)
 }
 
+var uRNArrayMapType = reflect.TypeOf((*map[string][]URN)(nil)).Elem()
+
+// URNArrayMapInput is an input type that accepts URNArrayMap and URNArrayMapOutput values.
+type URNArrayMapInput interface {
+	Input
+
+	ToURNArrayMapOutput() URNArrayMapOutput
+	ToURNArrayMapOutputWithContext(ctx context.Context) URNArrayMapOutput
+}
+
+// URNArrayMap is an input type for map[string]URNArrayInput values.
+type URNArrayMap map[string]URNArrayInput
+
+// ElementType returns the element type of this Input (map[string][]URN).
+func (URNArrayMap) ElementType() reflect.Type {
+	return uRNArrayMapType
+}
+
+func (in URNArrayMap) ToURNArrayMapOutput() URNArrayMapOutput {
+	return ToOutput(in).(URNArrayMapOutput)
+}
+
+func (in URNArrayMap) ToURNArrayMapOutputWithContext(ctx context.Context) URNArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(URNArrayMapOutput)
+}
+
+// URNArrayMapOutput is an Output that returns map[string][]URN values.
+type URNArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]URN).
+func (URNArrayMapOutput) ElementType() reflect.Type {
+	return uRNArrayMapType
+}
+
+func (o URNArrayMapOutput) ToURNArrayMapOutput() URNArrayMapOutput {
+	return o
+}
+
+func (o URNArrayMapOutput) ToURNArrayMapOutputWithContext(ctx context.Context) URNArrayMapOutput {
+	return o
+}
+
+func (o URNArrayMapOutput) MapIndex(k StringInput) URNArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []URN {
+		return vs[0].(map[string][]URN)[vs[1].(string)]
+	}).(URNArrayOutput)
+}
+
 var uintType = reflect.TypeOf((*uint)(nil)).Elem()
 
 // UintInput is an input type that accepts Uint and UintOutput values.
@@ -3818,6 +4738,54 @@ func (o UintMapOutput) MapIndex(k StringInput) UintOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) uint {
 		return vs[0].(map[string]uint)[vs[1].(string)]
 	}).(UintOutput)
+}
+
+var uintArrayMapType = reflect.TypeOf((*map[string][]uint)(nil)).Elem()
+
+// UintArrayMapInput is an input type that accepts UintArrayMap and UintArrayMapOutput values.
+type UintArrayMapInput interface {
+	Input
+
+	ToUintArrayMapOutput() UintArrayMapOutput
+	ToUintArrayMapOutputWithContext(ctx context.Context) UintArrayMapOutput
+}
+
+// UintArrayMap is an input type for map[string]UintArrayInput values.
+type UintArrayMap map[string]UintArrayInput
+
+// ElementType returns the element type of this Input (map[string][]uint).
+func (UintArrayMap) ElementType() reflect.Type {
+	return uintArrayMapType
+}
+
+func (in UintArrayMap) ToUintArrayMapOutput() UintArrayMapOutput {
+	return ToOutput(in).(UintArrayMapOutput)
+}
+
+func (in UintArrayMap) ToUintArrayMapOutputWithContext(ctx context.Context) UintArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(UintArrayMapOutput)
+}
+
+// UintArrayMapOutput is an Output that returns map[string][]uint values.
+type UintArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]uint).
+func (UintArrayMapOutput) ElementType() reflect.Type {
+	return uintArrayMapType
+}
+
+func (o UintArrayMapOutput) ToUintArrayMapOutput() UintArrayMapOutput {
+	return o
+}
+
+func (o UintArrayMapOutput) ToUintArrayMapOutputWithContext(ctx context.Context) UintArrayMapOutput {
+	return o
+}
+
+func (o UintArrayMapOutput) MapIndex(k StringInput) UintArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []uint {
+		return vs[0].(map[string][]uint)[vs[1].(string)]
+	}).(UintArrayOutput)
 }
 
 var uint16Type = reflect.TypeOf((*uint16)(nil)).Elem()
@@ -4028,6 +4996,54 @@ func (o Uint16MapOutput) MapIndex(k StringInput) Uint16Output {
 	}).(Uint16Output)
 }
 
+var uint16ArrayMapType = reflect.TypeOf((*map[string][]uint16)(nil)).Elem()
+
+// Uint16ArrayMapInput is an input type that accepts Uint16ArrayMap and Uint16ArrayMapOutput values.
+type Uint16ArrayMapInput interface {
+	Input
+
+	ToUint16ArrayMapOutput() Uint16ArrayMapOutput
+	ToUint16ArrayMapOutputWithContext(ctx context.Context) Uint16ArrayMapOutput
+}
+
+// Uint16ArrayMap is an input type for map[string]Uint16ArrayInput values.
+type Uint16ArrayMap map[string]Uint16ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]uint16).
+func (Uint16ArrayMap) ElementType() reflect.Type {
+	return uint16ArrayMapType
+}
+
+func (in Uint16ArrayMap) ToUint16ArrayMapOutput() Uint16ArrayMapOutput {
+	return ToOutput(in).(Uint16ArrayMapOutput)
+}
+
+func (in Uint16ArrayMap) ToUint16ArrayMapOutputWithContext(ctx context.Context) Uint16ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Uint16ArrayMapOutput)
+}
+
+// Uint16ArrayMapOutput is an Output that returns map[string][]uint16 values.
+type Uint16ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]uint16).
+func (Uint16ArrayMapOutput) ElementType() reflect.Type {
+	return uint16ArrayMapType
+}
+
+func (o Uint16ArrayMapOutput) ToUint16ArrayMapOutput() Uint16ArrayMapOutput {
+	return o
+}
+
+func (o Uint16ArrayMapOutput) ToUint16ArrayMapOutputWithContext(ctx context.Context) Uint16ArrayMapOutput {
+	return o
+}
+
+func (o Uint16ArrayMapOutput) MapIndex(k StringInput) Uint16ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []uint16 {
+		return vs[0].(map[string][]uint16)[vs[1].(string)]
+	}).(Uint16ArrayOutput)
+}
+
 var uint32Type = reflect.TypeOf((*uint32)(nil)).Elem()
 
 // Uint32Input is an input type that accepts Uint32 and Uint32Output values.
@@ -4234,6 +5250,54 @@ func (o Uint32MapOutput) MapIndex(k StringInput) Uint32Output {
 	return All(o, k).ApplyT(func(vs []interface{}) uint32 {
 		return vs[0].(map[string]uint32)[vs[1].(string)]
 	}).(Uint32Output)
+}
+
+var uint32ArrayMapType = reflect.TypeOf((*map[string][]uint32)(nil)).Elem()
+
+// Uint32ArrayMapInput is an input type that accepts Uint32ArrayMap and Uint32ArrayMapOutput values.
+type Uint32ArrayMapInput interface {
+	Input
+
+	ToUint32ArrayMapOutput() Uint32ArrayMapOutput
+	ToUint32ArrayMapOutputWithContext(ctx context.Context) Uint32ArrayMapOutput
+}
+
+// Uint32ArrayMap is an input type for map[string]Uint32ArrayInput values.
+type Uint32ArrayMap map[string]Uint32ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]uint32).
+func (Uint32ArrayMap) ElementType() reflect.Type {
+	return uint32ArrayMapType
+}
+
+func (in Uint32ArrayMap) ToUint32ArrayMapOutput() Uint32ArrayMapOutput {
+	return ToOutput(in).(Uint32ArrayMapOutput)
+}
+
+func (in Uint32ArrayMap) ToUint32ArrayMapOutputWithContext(ctx context.Context) Uint32ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Uint32ArrayMapOutput)
+}
+
+// Uint32ArrayMapOutput is an Output that returns map[string][]uint32 values.
+type Uint32ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]uint32).
+func (Uint32ArrayMapOutput) ElementType() reflect.Type {
+	return uint32ArrayMapType
+}
+
+func (o Uint32ArrayMapOutput) ToUint32ArrayMapOutput() Uint32ArrayMapOutput {
+	return o
+}
+
+func (o Uint32ArrayMapOutput) ToUint32ArrayMapOutputWithContext(ctx context.Context) Uint32ArrayMapOutput {
+	return o
+}
+
+func (o Uint32ArrayMapOutput) MapIndex(k StringInput) Uint32ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []uint32 {
+		return vs[0].(map[string][]uint32)[vs[1].(string)]
+	}).(Uint32ArrayOutput)
 }
 
 var uint64Type = reflect.TypeOf((*uint64)(nil)).Elem()
@@ -4444,6 +5508,54 @@ func (o Uint64MapOutput) MapIndex(k StringInput) Uint64Output {
 	}).(Uint64Output)
 }
 
+var uint64ArrayMapType = reflect.TypeOf((*map[string][]uint64)(nil)).Elem()
+
+// Uint64ArrayMapInput is an input type that accepts Uint64ArrayMap and Uint64ArrayMapOutput values.
+type Uint64ArrayMapInput interface {
+	Input
+
+	ToUint64ArrayMapOutput() Uint64ArrayMapOutput
+	ToUint64ArrayMapOutputWithContext(ctx context.Context) Uint64ArrayMapOutput
+}
+
+// Uint64ArrayMap is an input type for map[string]Uint64ArrayInput values.
+type Uint64ArrayMap map[string]Uint64ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]uint64).
+func (Uint64ArrayMap) ElementType() reflect.Type {
+	return uint64ArrayMapType
+}
+
+func (in Uint64ArrayMap) ToUint64ArrayMapOutput() Uint64ArrayMapOutput {
+	return ToOutput(in).(Uint64ArrayMapOutput)
+}
+
+func (in Uint64ArrayMap) ToUint64ArrayMapOutputWithContext(ctx context.Context) Uint64ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Uint64ArrayMapOutput)
+}
+
+// Uint64ArrayMapOutput is an Output that returns map[string][]uint64 values.
+type Uint64ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]uint64).
+func (Uint64ArrayMapOutput) ElementType() reflect.Type {
+	return uint64ArrayMapType
+}
+
+func (o Uint64ArrayMapOutput) ToUint64ArrayMapOutput() Uint64ArrayMapOutput {
+	return o
+}
+
+func (o Uint64ArrayMapOutput) ToUint64ArrayMapOutputWithContext(ctx context.Context) Uint64ArrayMapOutput {
+	return o
+}
+
+func (o Uint64ArrayMapOutput) MapIndex(k StringInput) Uint64ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []uint64 {
+		return vs[0].(map[string][]uint64)[vs[1].(string)]
+	}).(Uint64ArrayOutput)
+}
+
 var uint8Type = reflect.TypeOf((*uint8)(nil)).Elem()
 
 // Uint8Input is an input type that accepts Uint8 and Uint8Output values.
@@ -4652,6 +5764,54 @@ func (o Uint8MapOutput) MapIndex(k StringInput) Uint8Output {
 	}).(Uint8Output)
 }
 
+var uint8ArrayMapType = reflect.TypeOf((*map[string][]uint8)(nil)).Elem()
+
+// Uint8ArrayMapInput is an input type that accepts Uint8ArrayMap and Uint8ArrayMapOutput values.
+type Uint8ArrayMapInput interface {
+	Input
+
+	ToUint8ArrayMapOutput() Uint8ArrayMapOutput
+	ToUint8ArrayMapOutputWithContext(ctx context.Context) Uint8ArrayMapOutput
+}
+
+// Uint8ArrayMap is an input type for map[string]Uint8ArrayInput values.
+type Uint8ArrayMap map[string]Uint8ArrayInput
+
+// ElementType returns the element type of this Input (map[string][]uint8).
+func (Uint8ArrayMap) ElementType() reflect.Type {
+	return uint8ArrayMapType
+}
+
+func (in Uint8ArrayMap) ToUint8ArrayMapOutput() Uint8ArrayMapOutput {
+	return ToOutput(in).(Uint8ArrayMapOutput)
+}
+
+func (in Uint8ArrayMap) ToUint8ArrayMapOutputWithContext(ctx context.Context) Uint8ArrayMapOutput {
+	return ToOutputWithContext(ctx, in).(Uint8ArrayMapOutput)
+}
+
+// Uint8ArrayMapOutput is an Output that returns map[string][]uint8 values.
+type Uint8ArrayMapOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (map[string][]uint8).
+func (Uint8ArrayMapOutput) ElementType() reflect.Type {
+	return uint8ArrayMapType
+}
+
+func (o Uint8ArrayMapOutput) ToUint8ArrayMapOutput() Uint8ArrayMapOutput {
+	return o
+}
+
+func (o Uint8ArrayMapOutput) ToUint8ArrayMapOutputWithContext(ctx context.Context) Uint8ArrayMapOutput {
+	return o
+}
+
+func (o Uint8ArrayMapOutput) MapIndex(k StringInput) Uint8ArrayOutput {
+	return All(o, k).ApplyT(func(vs []interface{}) []uint8 {
+		return vs[0].(map[string][]uint8)[vs[1].(string)]
+	}).(Uint8ArrayOutput)
+}
+
 func getResolvedValue(input Input) (reflect.Value, bool) {
 	switch input := input.(type) {
 	case *asset, *archive:
@@ -4665,76 +5825,96 @@ func init() {
 	RegisterOutputType(ArchiveOutput{})
 	RegisterOutputType(ArchiveArrayOutput{})
 	RegisterOutputType(ArchiveMapOutput{})
+	RegisterOutputType(ArchiveArrayMapOutput{})
 	RegisterOutputType(AssetOutput{})
 	RegisterOutputType(AssetArrayOutput{})
 	RegisterOutputType(AssetMapOutput{})
+	RegisterOutputType(AssetArrayMapOutput{})
 	RegisterOutputType(AssetOrArchiveOutput{})
 	RegisterOutputType(AssetOrArchiveArrayOutput{})
 	RegisterOutputType(AssetOrArchiveMapOutput{})
+	RegisterOutputType(AssetOrArchiveArrayMapOutput{})
 	RegisterOutputType(BoolOutput{})
 	RegisterOutputType(BoolPtrOutput{})
 	RegisterOutputType(BoolArrayOutput{})
 	RegisterOutputType(BoolMapOutput{})
+	RegisterOutputType(BoolArrayMapOutput{})
 	RegisterOutputType(Float32Output{})
 	RegisterOutputType(Float32PtrOutput{})
 	RegisterOutputType(Float32ArrayOutput{})
 	RegisterOutputType(Float32MapOutput{})
+	RegisterOutputType(Float32ArrayMapOutput{})
 	RegisterOutputType(Float64Output{})
 	RegisterOutputType(Float64PtrOutput{})
 	RegisterOutputType(Float64ArrayOutput{})
 	RegisterOutputType(Float64MapOutput{})
+	RegisterOutputType(Float64ArrayMapOutput{})
 	RegisterOutputType(IDOutput{})
 	RegisterOutputType(IDPtrOutput{})
 	RegisterOutputType(IDArrayOutput{})
 	RegisterOutputType(IDMapOutput{})
+	RegisterOutputType(IDArrayMapOutput{})
 	RegisterOutputType(ArrayOutput{})
 	RegisterOutputType(MapOutput{})
+	RegisterOutputType(ArrayMapOutput{})
 	RegisterOutputType(IntOutput{})
 	RegisterOutputType(IntPtrOutput{})
 	RegisterOutputType(IntArrayOutput{})
 	RegisterOutputType(IntMapOutput{})
+	RegisterOutputType(IntArrayMapOutput{})
 	RegisterOutputType(Int16Output{})
 	RegisterOutputType(Int16PtrOutput{})
 	RegisterOutputType(Int16ArrayOutput{})
 	RegisterOutputType(Int16MapOutput{})
+	RegisterOutputType(Int16ArrayMapOutput{})
 	RegisterOutputType(Int32Output{})
 	RegisterOutputType(Int32PtrOutput{})
 	RegisterOutputType(Int32ArrayOutput{})
 	RegisterOutputType(Int32MapOutput{})
+	RegisterOutputType(Int32ArrayMapOutput{})
 	RegisterOutputType(Int64Output{})
 	RegisterOutputType(Int64PtrOutput{})
 	RegisterOutputType(Int64ArrayOutput{})
 	RegisterOutputType(Int64MapOutput{})
+	RegisterOutputType(Int64ArrayMapOutput{})
 	RegisterOutputType(Int8Output{})
 	RegisterOutputType(Int8PtrOutput{})
 	RegisterOutputType(Int8ArrayOutput{})
 	RegisterOutputType(Int8MapOutput{})
+	RegisterOutputType(Int8ArrayMapOutput{})
 	RegisterOutputType(StringOutput{})
 	RegisterOutputType(StringPtrOutput{})
 	RegisterOutputType(StringArrayOutput{})
 	RegisterOutputType(StringMapOutput{})
+	RegisterOutputType(StringArrayMapOutput{})
 	RegisterOutputType(URNOutput{})
 	RegisterOutputType(URNPtrOutput{})
 	RegisterOutputType(URNArrayOutput{})
 	RegisterOutputType(URNMapOutput{})
+	RegisterOutputType(URNArrayMapOutput{})
 	RegisterOutputType(UintOutput{})
 	RegisterOutputType(UintPtrOutput{})
 	RegisterOutputType(UintArrayOutput{})
 	RegisterOutputType(UintMapOutput{})
+	RegisterOutputType(UintArrayMapOutput{})
 	RegisterOutputType(Uint16Output{})
 	RegisterOutputType(Uint16PtrOutput{})
 	RegisterOutputType(Uint16ArrayOutput{})
 	RegisterOutputType(Uint16MapOutput{})
+	RegisterOutputType(Uint16ArrayMapOutput{})
 	RegisterOutputType(Uint32Output{})
 	RegisterOutputType(Uint32PtrOutput{})
 	RegisterOutputType(Uint32ArrayOutput{})
 	RegisterOutputType(Uint32MapOutput{})
+	RegisterOutputType(Uint32ArrayMapOutput{})
 	RegisterOutputType(Uint64Output{})
 	RegisterOutputType(Uint64PtrOutput{})
 	RegisterOutputType(Uint64ArrayOutput{})
 	RegisterOutputType(Uint64MapOutput{})
+	RegisterOutputType(Uint64ArrayMapOutput{})
 	RegisterOutputType(Uint8Output{})
 	RegisterOutputType(Uint8PtrOutput{})
 	RegisterOutputType(Uint8ArrayOutput{})
 	RegisterOutputType(Uint8MapOutput{})
+	RegisterOutputType(Uint8ArrayMapOutput{})
 }

--- a/sdk/go/pulumi/types_builtins_test.go
+++ b/sdk/go/pulumi/types_builtins_test.go
@@ -167,6 +167,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyArchiveArrayMap", func(t *testing.T) {
+			o2 := out.ApplyArchiveArrayMap(func(v int) map[string][]Archive { return *new(map[string][]Archive) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyArchiveArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]Archive { return *new(map[string][]Archive) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyAsset", func(t *testing.T) {
 			o2 := out.ApplyAsset(func(v int) Asset { return *new(Asset) })
 			_, known, _, err := await(o2)
@@ -203,6 +215,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyAssetArrayMap", func(t *testing.T) {
+			o2 := out.ApplyAssetArrayMap(func(v int) map[string][]Asset { return *new(map[string][]Asset) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyAssetArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]Asset { return *new(map[string][]Asset) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyAssetOrArchive", func(t *testing.T) {
 			o2 := out.ApplyAssetOrArchive(func(v int) AssetOrArchive { return *new(AssetOrArchive) })
 			_, known, _, err := await(o2)
@@ -234,6 +258,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 
 			o2 = out.ApplyAssetOrArchiveMapWithContext(context.Background(), func(_ context.Context, v int) map[string]AssetOrArchive { return *new(map[string]AssetOrArchive) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
+		t.Run("ApplyAssetOrArchiveArrayMap", func(t *testing.T) {
+			o2 := out.ApplyAssetOrArchiveArrayMap(func(v int) map[string][]AssetOrArchive { return *new(map[string][]AssetOrArchive) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyAssetOrArchiveArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]AssetOrArchive { return *new(map[string][]AssetOrArchive) })
 			_, known, _, err = await(o2)
 			assert.True(t, known)
 			assert.NoError(t, err)
@@ -287,6 +323,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyBoolArrayMap", func(t *testing.T) {
+			o2 := out.ApplyBoolArrayMap(func(v int) map[string][]bool { return *new(map[string][]bool) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyBoolArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]bool { return *new(map[string][]bool) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyFloat32", func(t *testing.T) {
 			o2 := out.ApplyFloat32(func(v int) float32 { return *new(float32) })
 			_, known, _, err := await(o2)
@@ -330,6 +378,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 
 			o2 = out.ApplyFloat32MapWithContext(context.Background(), func(_ context.Context, v int) map[string]float32 { return *new(map[string]float32) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
+		t.Run("ApplyFloat32ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyFloat32ArrayMap(func(v int) map[string][]float32 { return *new(map[string][]float32) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyFloat32ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]float32 { return *new(map[string][]float32) })
 			_, known, _, err = await(o2)
 			assert.True(t, known)
 			assert.NoError(t, err)
@@ -383,6 +443,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyFloat64ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyFloat64ArrayMap(func(v int) map[string][]float64 { return *new(map[string][]float64) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyFloat64ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]float64 { return *new(map[string][]float64) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyID", func(t *testing.T) {
 			o2 := out.ApplyID(func(v int) ID { return *new(ID) })
 			_, known, _, err := await(o2)
@@ -431,6 +503,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyIDArrayMap", func(t *testing.T) {
+			o2 := out.ApplyIDArrayMap(func(v int) map[string][]ID { return *new(map[string][]ID) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyIDArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]ID { return *new(map[string][]ID) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyArray", func(t *testing.T) {
 			o2 := out.ApplyArray(func(v int) []interface{} { return *new([]interface{}) })
 			_, known, _, err := await(o2)
@@ -450,6 +534,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 
 			o2 = out.ApplyMapWithContext(context.Background(), func(_ context.Context, v int) map[string]interface{} { return *new(map[string]interface{}) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
+		t.Run("ApplyArrayMap", func(t *testing.T) {
+			o2 := out.ApplyArrayMap(func(v int) map[string][]interface{} { return *new(map[string][]interface{}) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]interface{} { return *new(map[string][]interface{}) })
 			_, known, _, err = await(o2)
 			assert.True(t, known)
 			assert.NoError(t, err)
@@ -503,6 +599,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyIntArrayMap", func(t *testing.T) {
+			o2 := out.ApplyIntArrayMap(func(v int) map[string][]int { return *new(map[string][]int) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyIntArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]int { return *new(map[string][]int) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyInt16", func(t *testing.T) {
 			o2 := out.ApplyInt16(func(v int) int16 { return *new(int16) })
 			_, known, _, err := await(o2)
@@ -546,6 +654,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 
 			o2 = out.ApplyInt16MapWithContext(context.Background(), func(_ context.Context, v int) map[string]int16 { return *new(map[string]int16) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
+		t.Run("ApplyInt16ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyInt16ArrayMap(func(v int) map[string][]int16 { return *new(map[string][]int16) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyInt16ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]int16 { return *new(map[string][]int16) })
 			_, known, _, err = await(o2)
 			assert.True(t, known)
 			assert.NoError(t, err)
@@ -599,6 +719,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyInt32ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyInt32ArrayMap(func(v int) map[string][]int32 { return *new(map[string][]int32) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyInt32ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]int32 { return *new(map[string][]int32) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyInt64", func(t *testing.T) {
 			o2 := out.ApplyInt64(func(v int) int64 { return *new(int64) })
 			_, known, _, err := await(o2)
@@ -642,6 +774,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 
 			o2 = out.ApplyInt64MapWithContext(context.Background(), func(_ context.Context, v int) map[string]int64 { return *new(map[string]int64) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
+		t.Run("ApplyInt64ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyInt64ArrayMap(func(v int) map[string][]int64 { return *new(map[string][]int64) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyInt64ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]int64 { return *new(map[string][]int64) })
 			_, known, _, err = await(o2)
 			assert.True(t, known)
 			assert.NoError(t, err)
@@ -695,6 +839,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyInt8ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyInt8ArrayMap(func(v int) map[string][]int8 { return *new(map[string][]int8) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyInt8ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]int8 { return *new(map[string][]int8) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyString", func(t *testing.T) {
 			o2 := out.ApplyString(func(v int) string { return *new(string) })
 			_, known, _, err := await(o2)
@@ -738,6 +894,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 
 			o2 = out.ApplyStringMapWithContext(context.Background(), func(_ context.Context, v int) map[string]string { return *new(map[string]string) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
+		t.Run("ApplyStringArrayMap", func(t *testing.T) {
+			o2 := out.ApplyStringArrayMap(func(v int) map[string][]string { return *new(map[string][]string) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyStringArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]string { return *new(map[string][]string) })
 			_, known, _, err = await(o2)
 			assert.True(t, known)
 			assert.NoError(t, err)
@@ -791,6 +959,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyURNArrayMap", func(t *testing.T) {
+			o2 := out.ApplyURNArrayMap(func(v int) map[string][]URN { return *new(map[string][]URN) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyURNArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]URN { return *new(map[string][]URN) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyUint", func(t *testing.T) {
 			o2 := out.ApplyUint(func(v int) uint { return *new(uint) })
 			_, known, _, err := await(o2)
@@ -834,6 +1014,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 
 			o2 = out.ApplyUintMapWithContext(context.Background(), func(_ context.Context, v int) map[string]uint { return *new(map[string]uint) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
+		t.Run("ApplyUintArrayMap", func(t *testing.T) {
+			o2 := out.ApplyUintArrayMap(func(v int) map[string][]uint { return *new(map[string][]uint) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyUintArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]uint { return *new(map[string][]uint) })
 			_, known, _, err = await(o2)
 			assert.True(t, known)
 			assert.NoError(t, err)
@@ -887,6 +1079,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyUint16ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyUint16ArrayMap(func(v int) map[string][]uint16 { return *new(map[string][]uint16) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyUint16ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]uint16 { return *new(map[string][]uint16) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyUint32", func(t *testing.T) {
 			o2 := out.ApplyUint32(func(v int) uint32 { return *new(uint32) })
 			_, known, _, err := await(o2)
@@ -930,6 +1134,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 
 			o2 = out.ApplyUint32MapWithContext(context.Background(), func(_ context.Context, v int) map[string]uint32 { return *new(map[string]uint32) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
+		t.Run("ApplyUint32ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyUint32ArrayMap(func(v int) map[string][]uint32 { return *new(map[string][]uint32) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyUint32ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]uint32 { return *new(map[string][]uint32) })
 			_, known, _, err = await(o2)
 			assert.True(t, known)
 			assert.NoError(t, err)
@@ -983,6 +1199,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyUint64ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyUint64ArrayMap(func(v int) map[string][]uint64 { return *new(map[string][]uint64) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyUint64ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]uint64 { return *new(map[string][]uint64) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 		t.Run("ApplyUint8", func(t *testing.T) {
 			o2 := out.ApplyUint8(func(v int) uint8 { return *new(uint8) })
 			_, known, _, err := await(o2)
@@ -1031,6 +1259,18 @@ func TestOutputApply(t *testing.T) {
 			assert.NoError(t, err)
 		})
 
+		t.Run("ApplyUint8ArrayMap", func(t *testing.T) {
+			o2 := out.ApplyUint8ArrayMap(func(v int) map[string][]uint8 { return *new(map[string][]uint8) })
+			_, known, _, err := await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+
+			o2 = out.ApplyUint8ArrayMapWithContext(context.Background(), func(_ context.Context, v int) map[string][]uint8 { return *new(map[string][]uint8) })
+			_, known, _, err = await(o2)
+			assert.True(t, known)
+			assert.NoError(t, err)
+		})
+
 	}
 	// Test that applies return appropriate concrete implementations of Output based on the callback type
 	{
@@ -1052,6 +1292,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::ArchiveArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]Archive { return *new(map[string][]Archive) }).(ArchiveArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::AssetOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) Asset { return *new(Asset) }).(AssetOutput)
 			assert.True(t, ok)
@@ -1067,6 +1312,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::AssetArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]Asset { return *new(map[string][]Asset) }).(AssetArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::AssetOrArchiveOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) AssetOrArchive { return *new(AssetOrArchive) }).(AssetOrArchiveOutput)
 			assert.True(t, ok)
@@ -1079,6 +1329,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::AssetOrArchiveMapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]AssetOrArchive { return *new(map[string]AssetOrArchive) }).(AssetOrArchiveMapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::AssetOrArchiveArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]AssetOrArchive { return *new(map[string][]AssetOrArchive) }).(AssetOrArchiveArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1102,6 +1357,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::BoolArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]bool { return *new(map[string][]bool) }).(BoolArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::Float32Output", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) float32 { return *new(float32) }).(Float32Output)
 			assert.True(t, ok)
@@ -1119,6 +1379,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::Float32MapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]float32 { return *new(map[string]float32) }).(Float32MapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::Float32ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]float32 { return *new(map[string][]float32) }).(Float32ArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1142,6 +1407,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::Float64ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]float64 { return *new(map[string][]float64) }).(Float64ArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::IDOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) ID { return *new(ID) }).(IDOutput)
 			assert.True(t, ok)
@@ -1162,6 +1432,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::IDArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]ID { return *new(map[string][]ID) }).(IDArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::ArrayOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) []interface{} { return *new([]interface{}) }).(ArrayOutput)
 			assert.True(t, ok)
@@ -1169,6 +1444,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::MapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]interface{} { return *new(map[string]interface{}) }).(MapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]interface{} { return *new(map[string][]interface{}) }).(ArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1192,6 +1472,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::IntArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]int { return *new(map[string][]int) }).(IntArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::Int16Output", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) int16 { return *new(int16) }).(Int16Output)
 			assert.True(t, ok)
@@ -1209,6 +1494,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::Int16MapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]int16 { return *new(map[string]int16) }).(Int16MapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::Int16ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]int16 { return *new(map[string][]int16) }).(Int16ArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1232,6 +1522,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::Int32ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]int32 { return *new(map[string][]int32) }).(Int32ArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::Int64Output", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) int64 { return *new(int64) }).(Int64Output)
 			assert.True(t, ok)
@@ -1249,6 +1544,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::Int64MapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]int64 { return *new(map[string]int64) }).(Int64MapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::Int64ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]int64 { return *new(map[string][]int64) }).(Int64ArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1272,6 +1572,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::Int8ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]int8 { return *new(map[string][]int8) }).(Int8ArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::StringOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) string { return *new(string) }).(StringOutput)
 			assert.True(t, ok)
@@ -1289,6 +1594,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::StringMapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]string { return *new(map[string]string) }).(StringMapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::StringArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]string { return *new(map[string][]string) }).(StringArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1312,6 +1622,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::URNArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]URN { return *new(map[string][]URN) }).(URNArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::UintOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) uint { return *new(uint) }).(UintOutput)
 			assert.True(t, ok)
@@ -1329,6 +1644,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::UintMapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]uint { return *new(map[string]uint) }).(UintMapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::UintArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]uint { return *new(map[string][]uint) }).(UintArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1352,6 +1672,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::Uint16ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]uint16 { return *new(map[string][]uint16) }).(Uint16ArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::Uint32Output", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) uint32 { return *new(uint32) }).(Uint32Output)
 			assert.True(t, ok)
@@ -1369,6 +1694,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::Uint32MapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]uint32 { return *new(map[string]uint32) }).(Uint32MapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::Uint32ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]uint32 { return *new(map[string][]uint32) }).(Uint32ArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1392,6 +1722,11 @@ func TestOutputApply(t *testing.T) {
 			assert.True(t, ok)
 		})
 
+		t.Run("ApplyT::Uint64ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]uint64 { return *new(map[string][]uint64) }).(Uint64ArrayMapOutput)
+			assert.True(t, ok)
+		})
+
 		t.Run("ApplyT::Uint8Output", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) uint8 { return *new(uint8) }).(Uint8Output)
 			assert.True(t, ok)
@@ -1409,6 +1744,11 @@ func TestOutputApply(t *testing.T) {
 
 		t.Run("ApplyT::Uint8MapOutput", func(t *testing.T) {
 			_, ok := out.ApplyT(func(v int) map[string]uint8 { return *new(map[string]uint8) }).(Uint8MapOutput)
+			assert.True(t, ok)
+		})
+
+		t.Run("ApplyT::Uint8ArrayMapOutput", func(t *testing.T) {
+			_, ok := out.ApplyT(func(v int) map[string][]uint8 { return *new(map[string][]uint8) }).(Uint8ArrayMapOutput)
 			assert.True(t, ok)
 		})
 
@@ -1578,6 +1918,24 @@ func TestToOutputArchiveMap(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputArchiveArrayMap(t *testing.T) {
+	out := ToOutput(ArchiveArrayMap{"baz": ArchiveArray{NewFileArchive("foo.zip")}})
+	_, ok := out.(ArchiveArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(ArchiveArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputAsset(t *testing.T) {
 	out := ToOutput(NewFileAsset("foo.txt"))
 	_, ok := out.(AssetInput)
@@ -1632,6 +1990,24 @@ func TestToOutputAssetMap(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputAssetArrayMap(t *testing.T) {
+	out := ToOutput(AssetArrayMap{"baz": AssetArray{NewFileAsset("foo.txt")}})
+	_, ok := out.(AssetArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(AssetArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputAssetOrArchive(t *testing.T) {
 	out := ToOutput(NewFileArchive("foo.zip"))
 	_, ok := out.(AssetOrArchiveInput)
@@ -1679,6 +2055,24 @@ func TestToOutputAssetOrArchiveMap(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(AssetOrArchiveMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputAssetOrArchiveArrayMap(t *testing.T) {
+	out := ToOutput(AssetOrArchiveArrayMap{"baz": AssetOrArchiveArray{NewFileArchive("foo.zip")}})
+	_, ok := out.(AssetOrArchiveArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(AssetOrArchiveArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -1758,6 +2152,24 @@ func TestToOutputBoolMap(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputBoolArrayMap(t *testing.T) {
+	out := ToOutput(BoolArrayMap{"baz": BoolArray{Bool(true)}})
+	_, ok := out.(BoolArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(BoolArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputFloat32(t *testing.T) {
 	out := ToOutput(Float32(1.3))
 	_, ok := out.(Float32Input)
@@ -1823,6 +2235,24 @@ func TestToOutputFloat32Map(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(Float32MapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputFloat32ArrayMap(t *testing.T) {
+	out := ToOutput(Float32ArrayMap{"baz": Float32Array{Float32(1.3)}})
+	_, ok := out.(Float32ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Float32ArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -1902,6 +2332,24 @@ func TestToOutputFloat64Map(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputFloat64ArrayMap(t *testing.T) {
+	out := ToOutput(Float64ArrayMap{"baz": Float64Array{Float64(999.9)}})
+	_, ok := out.(Float64ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Float64ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputID(t *testing.T) {
 	out := ToOutput(ID("foo"))
 	_, ok := out.(IDInput)
@@ -1974,6 +2422,24 @@ func TestToOutputIDMap(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputIDArrayMap(t *testing.T) {
+	out := ToOutput(IDArrayMap{"baz": IDArray{ID("foo")}})
+	_, ok := out.(IDArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(IDArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputArray(t *testing.T) {
 	out := ToOutput(Array{String("any")})
 	_, ok := out.(ArrayInput)
@@ -2003,6 +2469,24 @@ func TestToOutputMap(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(MapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputArrayMap(t *testing.T) {
+	out := ToOutput(ArrayMap{"baz": Array{String("any")}})
+	_, ok := out.(ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(ArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -2082,6 +2566,24 @@ func TestToOutputIntMap(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputIntArrayMap(t *testing.T) {
+	out := ToOutput(IntArrayMap{"baz": IntArray{Int(42)}})
+	_, ok := out.(IntArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(IntArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputInt16(t *testing.T) {
 	out := ToOutput(Int16(33))
 	_, ok := out.(Int16Input)
@@ -2147,6 +2649,24 @@ func TestToOutputInt16Map(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(Int16MapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputInt16ArrayMap(t *testing.T) {
+	out := ToOutput(Int16ArrayMap{"baz": Int16Array{Int16(33)}})
+	_, ok := out.(Int16ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Int16ArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -2226,6 +2746,24 @@ func TestToOutputInt32Map(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputInt32ArrayMap(t *testing.T) {
+	out := ToOutput(Int32ArrayMap{"baz": Int32Array{Int32(24)}})
+	_, ok := out.(Int32ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Int32ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputInt64(t *testing.T) {
 	out := ToOutput(Int64(15))
 	_, ok := out.(Int64Input)
@@ -2291,6 +2829,24 @@ func TestToOutputInt64Map(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(Int64MapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputInt64ArrayMap(t *testing.T) {
+	out := ToOutput(Int64ArrayMap{"baz": Int64Array{Int64(15)}})
+	_, ok := out.(Int64ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Int64ArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -2370,6 +2926,24 @@ func TestToOutputInt8Map(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputInt8ArrayMap(t *testing.T) {
+	out := ToOutput(Int8ArrayMap{"baz": Int8Array{Int8(6)}})
+	_, ok := out.(Int8ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Int8ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputString(t *testing.T) {
 	out := ToOutput(String("foo"))
 	_, ok := out.(StringInput)
@@ -2435,6 +3009,24 @@ func TestToOutputStringMap(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(StringMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputStringArrayMap(t *testing.T) {
+	out := ToOutput(StringArrayMap{"baz": StringArray{String("foo")}})
+	_, ok := out.(StringArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(StringArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -2514,6 +3106,24 @@ func TestToOutputURNMap(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputURNArrayMap(t *testing.T) {
+	out := ToOutput(URNArrayMap{"baz": URNArray{URN("foo")}})
+	_, ok := out.(URNArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(URNArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputUint(t *testing.T) {
 	out := ToOutput(Uint(42))
 	_, ok := out.(UintInput)
@@ -2579,6 +3189,24 @@ func TestToOutputUintMap(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(UintMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputUintArrayMap(t *testing.T) {
+	out := ToOutput(UintArrayMap{"baz": UintArray{Uint(42)}})
+	_, ok := out.(UintArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(UintArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -2658,6 +3286,24 @@ func TestToOutputUint16Map(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputUint16ArrayMap(t *testing.T) {
+	out := ToOutput(Uint16ArrayMap{"baz": Uint16Array{Uint16(33)}})
+	_, ok := out.(Uint16ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Uint16ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputUint32(t *testing.T) {
 	out := ToOutput(Uint32(24))
 	_, ok := out.(Uint32Input)
@@ -2723,6 +3369,24 @@ func TestToOutputUint32Map(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(Uint32MapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputUint32ArrayMap(t *testing.T) {
+	out := ToOutput(Uint32ArrayMap{"baz": Uint32Array{Uint32(24)}})
+	_, ok := out.(Uint32ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Uint32ArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -2802,6 +3466,24 @@ func TestToOutputUint64Map(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToOutputUint64ArrayMap(t *testing.T) {
+	out := ToOutput(Uint64ArrayMap{"baz": Uint64Array{Uint64(15)}})
+	_, ok := out.(Uint64ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Uint64ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToOutputUint8(t *testing.T) {
 	out := ToOutput(Uint8(6))
 	_, ok := out.(Uint8Input)
@@ -2867,6 +3549,24 @@ func TestToOutputUint8Map(t *testing.T) {
 
 	out = ToOutput(out)
 	_, ok = out.(Uint8MapInput)
+	assert.True(t, ok)
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToOutputUint8ArrayMap(t *testing.T) {
+	out := ToOutput(Uint8ArrayMap{"baz": Uint8Array{Uint8(6)}})
+	_, ok := out.(Uint8ArrayMapInput)
+	assert.True(t, ok)
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = ToOutput(out)
+	_, ok = out.(Uint8ArrayMapInput)
 	assert.True(t, ok)
 
 	_, known, _, err = await(out)
@@ -2960,6 +3660,34 @@ func TestToArchiveMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToArchiveArrayMapOutput(t *testing.T) {
+	in := ArchiveArrayMapInput(ArchiveArrayMap{"baz": ArchiveArray{NewFileArchive("foo.zip")}})
+
+	out := in.ToArchiveArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToArchiveArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToArchiveArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToArchiveArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToAssetOutput(t *testing.T) {
 	in := AssetInput(NewFileAsset("foo.txt"))
 
@@ -3044,6 +3772,34 @@ func TestToAssetMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToAssetArrayMapOutput(t *testing.T) {
+	in := AssetArrayMapInput(AssetArrayMap{"baz": AssetArray{NewFileAsset("foo.txt")}})
+
+	out := in.ToAssetArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToAssetArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToAssetArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToAssetArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToAssetOrArchiveOutput(t *testing.T) {
 	in := AssetOrArchiveInput(NewFileArchive("foo.zip"))
 
@@ -3122,6 +3878,34 @@ func TestToAssetOrArchiveMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToAssetOrArchiveMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToAssetOrArchiveArrayMapOutput(t *testing.T) {
+	in := AssetOrArchiveArrayMapInput(AssetOrArchiveArrayMap{"baz": AssetOrArchiveArray{NewFileArchive("foo.zip")}})
+
+	out := in.ToAssetOrArchiveArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToAssetOrArchiveArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToAssetOrArchiveArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToAssetOrArchiveArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -3240,6 +4024,34 @@ func TestToBoolMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToBoolArrayMapOutput(t *testing.T) {
+	in := BoolArrayMapInput(BoolArrayMap{"baz": BoolArray{Bool(true)}})
+
+	out := in.ToBoolArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToBoolArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToBoolArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToBoolArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToFloat32Output(t *testing.T) {
 	in := Float32Input(Float32(1.3))
 
@@ -3346,6 +4158,34 @@ func TestToFloat32MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToFloat32MapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToFloat32ArrayMapOutput(t *testing.T) {
+	in := Float32ArrayMapInput(Float32ArrayMap{"baz": Float32Array{Float32(1.3)}})
+
+	out := in.ToFloat32ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToFloat32ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToFloat32ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToFloat32ArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -3464,6 +4304,34 @@ func TestToFloat64MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToFloat64ArrayMapOutput(t *testing.T) {
+	in := Float64ArrayMapInput(Float64ArrayMap{"baz": Float64Array{Float64(999.9)}})
+
+	out := in.ToFloat64ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToFloat64ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToFloat64ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToFloat64ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToIDOutput(t *testing.T) {
 	in := IDInput(ID("foo"))
 
@@ -3576,6 +4444,34 @@ func TestToIDMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToIDArrayMapOutput(t *testing.T) {
+	in := IDArrayMapInput(IDArrayMap{"baz": IDArray{ID("foo")}})
+
+	out := in.ToIDArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToIDArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToIDArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToIDArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToArrayOutput(t *testing.T) {
 	in := ArrayInput(Array{String("any")})
 
@@ -3626,6 +4522,34 @@ func TestToMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToArrayMapOutput(t *testing.T) {
+	in := ArrayMapInput(ArrayMap{"baz": Array{String("any")}})
+
+	out := in.ToArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -3744,6 +4668,34 @@ func TestToIntMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToIntArrayMapOutput(t *testing.T) {
+	in := IntArrayMapInput(IntArrayMap{"baz": IntArray{Int(42)}})
+
+	out := in.ToIntArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToIntArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToIntArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToIntArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToInt16Output(t *testing.T) {
 	in := Int16Input(Int16(33))
 
@@ -3850,6 +4802,34 @@ func TestToInt16MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToInt16MapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToInt16ArrayMapOutput(t *testing.T) {
+	in := Int16ArrayMapInput(Int16ArrayMap{"baz": Int16Array{Int16(33)}})
+
+	out := in.ToInt16ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToInt16ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToInt16ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToInt16ArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -3968,6 +4948,34 @@ func TestToInt32MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToInt32ArrayMapOutput(t *testing.T) {
+	in := Int32ArrayMapInput(Int32ArrayMap{"baz": Int32Array{Int32(24)}})
+
+	out := in.ToInt32ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToInt32ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToInt32ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToInt32ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToInt64Output(t *testing.T) {
 	in := Int64Input(Int64(15))
 
@@ -4074,6 +5082,34 @@ func TestToInt64MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToInt64MapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToInt64ArrayMapOutput(t *testing.T) {
+	in := Int64ArrayMapInput(Int64ArrayMap{"baz": Int64Array{Int64(15)}})
+
+	out := in.ToInt64ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToInt64ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToInt64ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToInt64ArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -4192,6 +5228,34 @@ func TestToInt8MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToInt8ArrayMapOutput(t *testing.T) {
+	in := Int8ArrayMapInput(Int8ArrayMap{"baz": Int8Array{Int8(6)}})
+
+	out := in.ToInt8ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToInt8ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToInt8ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToInt8ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToStringOutput(t *testing.T) {
 	in := StringInput(String("foo"))
 
@@ -4298,6 +5362,34 @@ func TestToStringMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToStringMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToStringArrayMapOutput(t *testing.T) {
+	in := StringArrayMapInput(StringArrayMap{"baz": StringArray{String("foo")}})
+
+	out := in.ToStringArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToStringArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToStringArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToStringArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -4416,6 +5508,34 @@ func TestToURNMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToURNArrayMapOutput(t *testing.T) {
+	in := URNArrayMapInput(URNArrayMap{"baz": URNArray{URN("foo")}})
+
+	out := in.ToURNArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToURNArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToURNArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToURNArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToUintOutput(t *testing.T) {
 	in := UintInput(Uint(42))
 
@@ -4522,6 +5642,34 @@ func TestToUintMapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToUintMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToUintArrayMapOutput(t *testing.T) {
+	in := UintArrayMapInput(UintArrayMap{"baz": UintArray{Uint(42)}})
+
+	out := in.ToUintArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUintArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToUintArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUintArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -4640,6 +5788,34 @@ func TestToUint16MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToUint16ArrayMapOutput(t *testing.T) {
+	in := Uint16ArrayMapInput(Uint16ArrayMap{"baz": Uint16Array{Uint16(33)}})
+
+	out := in.ToUint16ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUint16ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToUint16ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUint16ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToUint32Output(t *testing.T) {
 	in := Uint32Input(Uint32(24))
 
@@ -4746,6 +5922,34 @@ func TestToUint32MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToUint32MapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToUint32ArrayMapOutput(t *testing.T) {
+	in := Uint32ArrayMapInput(Uint32ArrayMap{"baz": Uint32Array{Uint32(24)}})
+
+	out := in.ToUint32ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUint32ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToUint32ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUint32ArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -4864,6 +6068,34 @@ func TestToUint64MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestToUint64ArrayMapOutput(t *testing.T) {
+	in := Uint64ArrayMapInput(Uint64ArrayMap{"baz": Uint64Array{Uint64(15)}})
+
+	out := in.ToUint64ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUint64ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToUint64ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUint64ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
 func TestToUint8Output(t *testing.T) {
 	in := Uint8Input(Uint8(6))
 
@@ -4970,6 +6202,34 @@ func TestToUint8MapOutput(t *testing.T) {
 	assert.NoError(t, err)
 
 	out = out.ToUint8MapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+}
+
+func TestToUint8ArrayMapOutput(t *testing.T) {
+	in := Uint8ArrayMapInput(Uint8ArrayMap{"baz": Uint8Array{Uint8(6)}})
+
+	out := in.ToUint8ArrayMapOutput()
+
+	_, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUint8ArrayMapOutput()
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = in.ToUint8ArrayMapOutputWithContext(context.Background())
+
+	_, known, _, err = await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	out = out.ToUint8ArrayMapOutputWithContext(context.Background())
 
 	_, known, _, err = await(out)
 	assert.True(t, known)
@@ -5559,6 +6819,20 @@ func TestArchiveMapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]Archive)["baz"], iv)
 }
 
+func TestArchiveArrayMapIndex(t *testing.T) {
+	out := (ArchiveArrayMap{"baz": ArchiveArray{NewFileArchive("foo.zip")}}).ToArchiveArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]Archive)["baz"], iv)
+}
+
 func TestAssetMapIndex(t *testing.T) {
 	out := (AssetMap{"baz": NewFileAsset("foo.txt")}).ToAssetMapOutput()
 
@@ -5571,6 +6845,20 @@ func TestAssetMapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]Asset)["baz"], iv)
+}
+
+func TestAssetArrayMapIndex(t *testing.T) {
+	out := (AssetArrayMap{"baz": AssetArray{NewFileAsset("foo.txt")}}).ToAssetArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]Asset)["baz"], iv)
 }
 
 func TestAssetOrArchiveMapIndex(t *testing.T) {
@@ -5587,6 +6875,20 @@ func TestAssetOrArchiveMapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]AssetOrArchive)["baz"], iv)
 }
 
+func TestAssetOrArchiveArrayMapIndex(t *testing.T) {
+	out := (AssetOrArchiveArrayMap{"baz": AssetOrArchiveArray{NewFileArchive("foo.zip")}}).ToAssetOrArchiveArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]AssetOrArchive)["baz"], iv)
+}
+
 func TestBoolMapIndex(t *testing.T) {
 	out := (BoolMap{"baz": Bool(true)}).ToBoolMapOutput()
 
@@ -5599,6 +6901,20 @@ func TestBoolMapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]bool)["baz"], iv)
+}
+
+func TestBoolArrayMapIndex(t *testing.T) {
+	out := (BoolArrayMap{"baz": BoolArray{Bool(true)}}).ToBoolArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]bool)["baz"], iv)
 }
 
 func TestFloat32MapIndex(t *testing.T) {
@@ -5615,6 +6931,20 @@ func TestFloat32MapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]float32)["baz"], iv)
 }
 
+func TestFloat32ArrayMapIndex(t *testing.T) {
+	out := (Float32ArrayMap{"baz": Float32Array{Float32(1.3)}}).ToFloat32ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]float32)["baz"], iv)
+}
+
 func TestFloat64MapIndex(t *testing.T) {
 	out := (Float64Map{"baz": Float64(999.9)}).ToFloat64MapOutput()
 
@@ -5627,6 +6957,20 @@ func TestFloat64MapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]float64)["baz"], iv)
+}
+
+func TestFloat64ArrayMapIndex(t *testing.T) {
+	out := (Float64ArrayMap{"baz": Float64Array{Float64(999.9)}}).ToFloat64ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]float64)["baz"], iv)
 }
 
 func TestIDMapIndex(t *testing.T) {
@@ -5643,6 +6987,20 @@ func TestIDMapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]ID)["baz"], iv)
 }
 
+func TestIDArrayMapIndex(t *testing.T) {
+	out := (IDArrayMap{"baz": IDArray{ID("foo")}}).ToIDArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]ID)["baz"], iv)
+}
+
 func TestMapIndex(t *testing.T) {
 	out := (Map{"baz": String("any")}).ToMapOutput()
 
@@ -5655,6 +7013,20 @@ func TestMapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]interface{})["baz"], iv)
+}
+
+func TestArrayMapIndex(t *testing.T) {
+	out := (ArrayMap{"baz": Array{String("any")}}).ToArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]interface{})["baz"], iv)
 }
 
 func TestIntMapIndex(t *testing.T) {
@@ -5671,6 +7043,20 @@ func TestIntMapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]int)["baz"], iv)
 }
 
+func TestIntArrayMapIndex(t *testing.T) {
+	out := (IntArrayMap{"baz": IntArray{Int(42)}}).ToIntArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]int)["baz"], iv)
+}
+
 func TestInt16MapIndex(t *testing.T) {
 	out := (Int16Map{"baz": Int16(33)}).ToInt16MapOutput()
 
@@ -5683,6 +7069,20 @@ func TestInt16MapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]int16)["baz"], iv)
+}
+
+func TestInt16ArrayMapIndex(t *testing.T) {
+	out := (Int16ArrayMap{"baz": Int16Array{Int16(33)}}).ToInt16ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]int16)["baz"], iv)
 }
 
 func TestInt32MapIndex(t *testing.T) {
@@ -5699,6 +7099,20 @@ func TestInt32MapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]int32)["baz"], iv)
 }
 
+func TestInt32ArrayMapIndex(t *testing.T) {
+	out := (Int32ArrayMap{"baz": Int32Array{Int32(24)}}).ToInt32ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]int32)["baz"], iv)
+}
+
 func TestInt64MapIndex(t *testing.T) {
 	out := (Int64Map{"baz": Int64(15)}).ToInt64MapOutput()
 
@@ -5711,6 +7125,20 @@ func TestInt64MapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]int64)["baz"], iv)
+}
+
+func TestInt64ArrayMapIndex(t *testing.T) {
+	out := (Int64ArrayMap{"baz": Int64Array{Int64(15)}}).ToInt64ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]int64)["baz"], iv)
 }
 
 func TestInt8MapIndex(t *testing.T) {
@@ -5727,6 +7155,20 @@ func TestInt8MapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]int8)["baz"], iv)
 }
 
+func TestInt8ArrayMapIndex(t *testing.T) {
+	out := (Int8ArrayMap{"baz": Int8Array{Int8(6)}}).ToInt8ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]int8)["baz"], iv)
+}
+
 func TestStringMapIndex(t *testing.T) {
 	out := (StringMap{"baz": String("foo")}).ToStringMapOutput()
 
@@ -5739,6 +7181,20 @@ func TestStringMapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]string)["baz"], iv)
+}
+
+func TestStringArrayMapIndex(t *testing.T) {
+	out := (StringArrayMap{"baz": StringArray{String("foo")}}).ToStringArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]string)["baz"], iv)
 }
 
 func TestURNMapIndex(t *testing.T) {
@@ -5755,6 +7211,20 @@ func TestURNMapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]URN)["baz"], iv)
 }
 
+func TestURNArrayMapIndex(t *testing.T) {
+	out := (URNArrayMap{"baz": URNArray{URN("foo")}}).ToURNArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]URN)["baz"], iv)
+}
+
 func TestUintMapIndex(t *testing.T) {
 	out := (UintMap{"baz": Uint(42)}).ToUintMapOutput()
 
@@ -5767,6 +7237,20 @@ func TestUintMapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]uint)["baz"], iv)
+}
+
+func TestUintArrayMapIndex(t *testing.T) {
+	out := (UintArrayMap{"baz": UintArray{Uint(42)}}).ToUintArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]uint)["baz"], iv)
 }
 
 func TestUint16MapIndex(t *testing.T) {
@@ -5783,6 +7267,20 @@ func TestUint16MapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]uint16)["baz"], iv)
 }
 
+func TestUint16ArrayMapIndex(t *testing.T) {
+	out := (Uint16ArrayMap{"baz": Uint16Array{Uint16(33)}}).ToUint16ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]uint16)["baz"], iv)
+}
+
 func TestUint32MapIndex(t *testing.T) {
 	out := (Uint32Map{"baz": Uint32(24)}).ToUint32MapOutput()
 
@@ -5795,6 +7293,20 @@ func TestUint32MapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]uint32)["baz"], iv)
+}
+
+func TestUint32ArrayMapIndex(t *testing.T) {
+	out := (Uint32ArrayMap{"baz": Uint32Array{Uint32(24)}}).ToUint32ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]uint32)["baz"], iv)
 }
 
 func TestUint64MapIndex(t *testing.T) {
@@ -5811,6 +7323,20 @@ func TestUint64MapIndex(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]uint64)["baz"], iv)
 }
 
+func TestUint64ArrayMapIndex(t *testing.T) {
+	out := (Uint64ArrayMap{"baz": Uint64Array{Uint64(15)}}).ToUint64ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]uint64)["baz"], iv)
+}
+
 func TestUint8MapIndex(t *testing.T) {
 	out := (Uint8Map{"baz": Uint8(6)}).ToUint8MapOutput()
 
@@ -5823,4 +7349,18 @@ func TestUint8MapIndex(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, av.(map[string]uint8)["baz"], iv)
+}
+
+func TestUint8ArrayMapIndex(t *testing.T) {
+	out := (Uint8ArrayMap{"baz": Uint8Array{Uint8(6)}}).ToUint8ArrayMapOutput()
+
+	av, known, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]uint8)["baz"], iv)
 }


### PR DESCRIPTION
Add support for maps of arrays of builtin types.
These types are of the form `map[string][]builtin`.