### PR TITLE
Disable staticcheck linting to work around OOM errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,3 +16,5 @@ linters:
     - structcheck
     - unconvert
     - varcheck
+  disable:
+    - staticcheck # Disabled due to OOM errors in golangci-lint@v1.18.0


### PR DESCRIPTION
Related: https://github.com/golangci/golangci-lint/issues/483