### PR TITLE
Fix 'pulumi stack ls' on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ CHANGELOG
   [#4059](https://github.com/pulumi/pulumi/pull/4059)
 
 - Add support for stack transformations in the .NET SDK.
-  [4008](https://github.com/pulumi/pulumi/pull/4008)
+  [#4008](https://github.com/pulumi/pulumi/pull/4008)
+
+- Fix `pulumi stack ls` on Windows
+  [#4094](https://github.com/pulumi/pulumi/pull/4094)
   
 ## 1.12.1 (2020-03-11)
 - Fix Kubernetes YAML parsing error in .NET.

--- a/build.proj
+++ b/build.proj
@@ -278,6 +278,15 @@
 
   <!-- Tests -->
   <Target Name="Tests">
+    <Exec Command="go test -v -timeout 5m -parallel $(TestParallelism) .\pkg\backend\..."
+          IgnoreExitCode="true"
+          WorkingDirectory="$(RepoRootDirectory)">
+      <Output TaskParameter="ExitCode" PropertyName="BackendTestsExitCode" />
+    </Exec>
+
+    <Error Text="backend tests (.\pkg\backend) failed"
+           Condition="$(BackendTestsExitCode) != 0"/>
+
     <Exec Command="go test -v -timeout 40m -cover -parallel $(TestParallelism) .\examples"
           IgnoreExitCode="true"
           WorkingDirectory="$(RepoRootDirectory)">

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -40,7 +40,9 @@ func (b *wrappedBucket) Delete(ctx context.Context, key string) (err error) {
 }
 
 func (b *wrappedBucket) List(opts *blob.ListOptions) *blob.ListIterator {
-	return b.bucket.List(opts)
+	optsCopy := *opts
+	optsCopy.Prefix = filepath.ToSlash(opts.Prefix)
+	return b.bucket.List(&optsCopy)
 }
 
 func (b *wrappedBucket) SignedURL(ctx context.Context, key string, opts *blob.SignedURLOptions) (string, error) {
@@ -83,7 +85,7 @@ func listBucket(bucket Bucket, dir string) ([]*blob.ListObject, error) {
 	return files, nil
 }
 
-// objectName returns the filename of a ListObject (an object from a bucket)
+// objectName returns the filename of a ListObject (an object from a bucket).
 func objectName(obj *blob.ListObject) string {
 	_, filename := path.Split(obj.Key)
 	return filename

--- a/pkg/backend/filestate/bucket_test.go
+++ b/pkg/backend/filestate/bucket_test.go
@@ -1,0 +1,94 @@
+package filestate
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"gocloud.dev/blob"
+)
+
+func mustNotHaveError(t *testing.T, context string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("Error in testcase %q, aborting: %v", context, err)
+	}
+}
+
+// The wrappedBucket type exists so that when we use the blob.Bucket type we can present a consistent
+// view of file paths. Since it will assume that backslashes (file separators on Windows) are part of
+// file names, and this causes "problems".
+func TestWrappedBucket(t *testing.T) {
+	// wrappedBucket will only massage file paths IFF it is needed, as filepath.ToSlash is a noop.
+	if filepath.Separator == '/' {
+		assert.Equal(t, `foo\bar\baz`, filepath.ToSlash(`foo\bar\baz`))
+		t.Skip("Skipping wrappedBucket tests because file paths won't be modified.")
+	}
+
+	// Initialize a filestate backend, using the default Pulumi directory.
+	cloudURL := FilePathPrefix + "~"
+	b, err := New(nil, cloudURL)
+	if err != nil {
+		t.Fatalf("Initializing new filestate backend: %v", err)
+	}
+	localBackend, ok := b.(*localBackend)
+	if !ok {
+		t.Fatalf("backend wasn't of type localBackend?")
+	}
+
+	wrappedBucket, ok := localBackend.bucket.(*wrappedBucket)
+	if !ok {
+		t.Fatalf("localBackend.bucket wasn't of type wrappedBucket?")
+	}
+
+	ctx := context.Background()
+	// Perform basic file operations using wrappedBucket and verify that it will
+	// successfully handle both "/" and "\" as file separators. (And probably fail in
+	// exciting ways if you try to give it a file on a system that supports "\" or "/" as
+	// a valid character in a filename.)
+	t.Run("SanityCheck", func(t *testing.T) {
+		randomData := []byte("Just some random data")
+
+		err := wrappedBucket.WriteAll(ctx, ".pulumi/bucket-test/foo", randomData, &blob.WriterOptions{})
+		mustNotHaveError(t, "WriteAll", err)
+
+		readData, err := wrappedBucket.ReadAll(ctx, `.pulumi\bucket-test\foo`)
+		mustNotHaveError(t, "ReadAll", err)
+		assert.EqualValues(t, randomData, readData, "data read from bucket doesn't match what was written")
+
+		// Verify the leading slash isn't necessary.
+		err = wrappedBucket.Delete(ctx, ".pulumi/bucket-test/foo")
+		mustNotHaveError(t, "Delete", err)
+
+		exists, err := wrappedBucket.Exists(ctx, ".pulumi/bucket-test/foo")
+		mustNotHaveError(t, "Exists", err)
+		assert.False(t, exists, "Deleted file still found?")
+	})
+
+	// Verify ListObjects / listBucket works with regard to differeing file separators too.
+	t.Run("ListObjects", func(t *testing.T) {
+		randomData := []byte("Just some random data")
+		filenames := []string{"a.json", "b.json", "c.json"}
+
+		// Write some data.
+		for _, filename := range filenames {
+			key := fmt.Sprintf(`.pulumi\bucket-test\%s`, filename)
+			err := wrappedBucket.WriteAll(ctx, key, randomData, &blob.WriterOptions{})
+			mustNotHaveError(t, "WriteAll", err)
+		}
+
+		// Verify it is found. NOTE: This requires that any files created
+		// during other tests have successfully been cleaned up too.
+		objects, err := listBucket(wrappedBucket, `.pulumi\bucket-test`)
+		mustNotHaveError(t, "listBucket", err)
+		if len(objects) != len(filenames) {
+			assert.Equal(t, 3, len(objects), "listBucket returned unexpected number of objects.")
+			for _, object := range objects {
+				t.Logf("Got object: %+v", object)
+			}
+		}
+	})
+}


### PR DESCRIPTION
The command `pulumi stack ls` didn't work on Windows when using the local file backend. The reason boils down to the [`blob.Bucket` type](https://godoc.org/gocloud.dev/blob#Bucket) we use, to abstract file IO for the { local disk, Azure, GCP, S3, etc. }

By design, it only supports forward slashes as directory separator characters. So we canonicalize file paths using `file path.ToSlash` before we call its methods, using the `wrappedBucket` interface.

However, we missed the canonicalization for the data we pass to `ListObjects(...)`. Which was why `pulumi stack ls` didn't work on Windows. (But `pulumi stack` did, because we use a different method, which does the path canonicalization.)

This PR also runs the `pkg/backend/` unit tests on Appveyor too, since previously we didn't have any Windows-coverage for these file bucket methods.

Fixes #3504 