### PR TITLE
PaC: Filter internal resource property keys

### DIFF
--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -32,12 +32,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/util/contract"
 )
 
-// IsInternalPropertyKey returns true if the given property key is an internal key that should not be displayed to
-// users.
-func IsInternalPropertyKey(key resource.PropertyKey) bool {
-	return strings.HasPrefix(string(key), "__")
-}
-
 // GetIndent computes a step's parent indentation.
 func GetIndent(step StepEventMetadata, seen map[resource.URN]StepEventMetadata) int {
 	indent := 0
@@ -231,7 +225,7 @@ func PrintObject(
 
 	// Now print out the values intelligently based on the type.
 	for _, k := range keys {
-		if v := props[k]; !IsInternalPropertyKey(k) && shouldPrintPropertyValue(v, planning) {
+		if v := props[k]; !resource.IsInternalPropertyKey(k) && shouldPrintPropertyValue(v, planning) {
 			printPropertyTitle(b, string(k), maxkey, indent, op, prefix)
 			printPropertyValue(b, v, planning, indent, op, prefix, debug)
 		}
@@ -355,7 +349,7 @@ func GetResourceOutputsPropertiesString(
 	// the new outputs, we want to print the diffs.
 	var outputDiff *resource.ObjectDiff
 	if step.Old != nil && step.Old.Outputs != nil {
-		outputDiff = step.Old.Outputs.Diff(outs, IsInternalPropertyKey)
+		outputDiff = step.Old.Outputs.Diff(outs, resource.IsInternalPropertyKey)
 
 		// If this is the root stack type, we want to strip out any nested resource outputs that are not known if
 		// they have no corresponding output in the old state.
@@ -387,9 +381,9 @@ func GetResourceOutputsPropertiesString(
 		// - a property with the same key is not present in the inputs
 		// - the property that is present in the inputs is different
 		// - we are doing a refresh, in which case we always want to show state differences
-		if outputDiff != nil || (!IsInternalPropertyKey(k) && shouldPrintPropertyValue(out, true)) {
+		if outputDiff != nil || (!resource.IsInternalPropertyKey(k) && shouldPrintPropertyValue(out, true)) {
 			if in, has := ins[k]; has && !refresh {
-				if out.Diff(in, IsInternalPropertyKey) == nil {
+				if out.Diff(in, resource.IsInternalPropertyKey) == nil {
 					continue
 				}
 			}
@@ -551,7 +545,7 @@ func printOldNewDiffs(
 	planning bool, indent int, op deploy.StepOp, summary bool, debug bool) {
 
 	// Get the full diff structure between the two, and print it (recursively).
-	if diff := olds.Diff(news, IsInternalPropertyKey); diff != nil {
+	if diff := olds.Diff(news, resource.IsInternalPropertyKey); diff != nil {
 		PrintObjectDiff(b, *diff, include, planning, indent, summary, debug)
 	} else {
 		// If there's no diff, report the op as Same - there's no diff to render

--- a/pkg/resource/plugin/analyzer_plugin.go
+++ b/pkg/resource/plugin/analyzer_plugin.go
@@ -145,7 +145,8 @@ func (a *analyzer) Analyze(r AnalyzerResource) ([]AnalyzeDiagnostic, error) {
 
 	label := fmt.Sprintf("%s.Analyze(%s)", a.label(), t)
 	logging.V(7).Infof("%s executing (#props=%d)", label, len(props))
-	mprops, err := MarshalProperties(props, MarshalOptions{KeepUnknowns: true, KeepSecrets: true})
+	mprops, err := MarshalProperties(props,
+		MarshalOptions{KeepUnknowns: true, KeepSecrets: true, SkipInternalKeys: true})
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +186,8 @@ func (a *analyzer) AnalyzeStack(resources []AnalyzerStackResource) ([]AnalyzeDia
 
 	protoResources := make([]*pulumirpc.AnalyzerResource, len(resources))
 	for idx, resource := range resources {
-		props, err := MarshalProperties(resource.Properties, MarshalOptions{KeepUnknowns: true, KeepSecrets: true})
+		props, err := MarshalProperties(resource.Properties,
+			MarshalOptions{KeepUnknowns: true, KeepSecrets: true, SkipInternalKeys: true})
 		if err != nil {
 			return nil, errors.Wrap(err, "marshalling properties")
 		}
@@ -406,7 +408,8 @@ func marshalProvider(provider *AnalyzerProviderResource) (*pulumirpc.AnalyzerPro
 		return nil, nil
 	}
 
-	props, err := MarshalProperties(provider.Properties, MarshalOptions{KeepUnknowns: true, KeepSecrets: true})
+	props, err := MarshalProperties(provider.Properties,
+		MarshalOptions{KeepUnknowns: true, KeepSecrets: true, SkipInternalKeys: true})
 	if err != nil {
 		return nil, errors.Wrap(err, "marshalling properties")
 	}

--- a/pkg/resource/plugin/rpc.go
+++ b/pkg/resource/plugin/rpc.go
@@ -36,6 +36,7 @@ type MarshalOptions struct {
 	ComputeAssetHashes bool   // true if we are computing missing asset hashes on the fly.
 	KeepSecrets        bool   // true if we are keeping secrets (otherwise we replace them with their underlying value).
 	RejectAssets       bool   // true if we should return errors on Asset and Archive values.
+	SkipInternalKeys   bool   // true to skip internal property keys (keys that start with "__") in the resulting map.
 }
 
 const (
@@ -72,6 +73,8 @@ func MarshalProperties(props resource.PropertyMap, opts MarshalOptions) (*struct
 			logging.V(9).Infof("Skipping output property for RPC[%s]: %v", opts.Label, key)
 		} else if opts.SkipNulls && v.IsNull() {
 			logging.V(9).Infof("Skipping null property for RPC[%s]: %s (as requested)", opts.Label, key)
+		} else if opts.SkipInternalKeys && resource.IsInternalPropertyKey(key) {
+			logging.V(9).Infof("Skipping internal property for RPC[%s]: %s (as requested)", opts.Label, key)
 		} else {
 			m, err := MarshalPropertyValue(v, opts)
 			if err != nil {
@@ -222,6 +225,8 @@ func UnmarshalProperties(props *structpb.Struct, opts MarshalOptions) (resource.
 			logging.V(9).Infof("Unmarshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
 			if opts.SkipNulls && v.IsNull() {
 				logging.V(9).Infof("Skipping unmarshaling for RPC[%s]: %s is null", opts.Label, key)
+			} else if opts.SkipInternalKeys && resource.IsInternalPropertyKey(pk) {
+				logging.V(9).Infof("Skipping unmarshaling for RPC[%s]: %s is internal", opts.Label, key)
 			} else {
 				result[pk] = *v
 			}

--- a/pkg/resource/plugin/rpc_test.go
+++ b/pkg/resource/plugin/rpc_test.go
@@ -261,3 +261,27 @@ func TestUnknownSig(t *testing.T) {
 	assert.Error(t, err)
 
 }
+
+func TestSkipInternalKeys(t *testing.T) {
+	opts := MarshalOptions{SkipInternalKeys: true}
+	expected := &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"keepers": {
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{},
+					},
+				},
+			},
+		},
+	}
+	props := resource.NewPropertyMapFromMap(map[string]interface{}{
+		"__defaults": []string{},
+		"keepers": map[string]interface{}{
+			"__defaults": []string{},
+		},
+	})
+	actual, err := MarshalProperties(props, opts)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}

--- a/pkg/resource/properties.go
+++ b/pkg/resource/properties.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/pulumi/pulumi/pkg/tokens"
 	"github.com/pulumi/pulumi/pkg/util/contract"
@@ -546,3 +547,9 @@ func HasSig(obj PropertyMap, match string) bool {
 
 // SecretSig is the unique secret signature.
 const SecretSig = "1b47061264138c4ac30d75fd1eb44270"
+
+// IsInternalPropertyKey returns true if the given property key is an internal key that should not be displayed to
+// users.
+func IsInternalPropertyKey(key PropertyKey) bool {
+	return strings.HasPrefix(string(key), "__")
+}


### PR DESCRIPTION
Filter out internal resource properties like `__defaults` before passing to analyzers.

Fixes https://github.com/pulumi/pulumi-policy/issues/213