### PR TITLE
Use Go's file handling libs for integration test framework

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1737,18 +1737,15 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 		}
 
 		for _, pkg := range pt.opts.Dependencies {
-			err = pt.runCommand("vendor-rm-dep",
-				[]string{"/bin/rm", "-rf", filepath.Join(".", "vendor", pkg)}, cwd)
+			err = os.RemoveAll(filepath.Join(cwd, "vendor", pkg))
 			if err != nil {
 				return fmt.Errorf("error installing go dependencies: %w", err)
 			}
-			err = pt.runCommand("vendor-cp-dep",
-				[]string{"/bin/cp", "-r", filepath.Join(gopath, "src", pkg), filepath.Join(".", "vendor", pkg)}, cwd)
+			err = CopyDir(filepath.Join(gopath, "src", pkg), filepath.Join(cwd, "vendor", pkg))
 			if err != nil {
 				return fmt.Errorf("error installing go dependencies: %w", err)
 			}
-			err = pt.runCommand("vendor-rm-dep-vendor",
-				[]string{"/bin/rm", "-rf", filepath.Join(".", "vendor", pkg, "vendor")}, cwd)
+			err = os.RemoveAll(filepath.Join(cwd, "vendor", pkg, "vendor"))
 			if err != nil {
 				return fmt.Errorf("error installing go dependencies: %w", err)
 			}

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -16,10 +16,12 @@ package integration
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -133,4 +135,66 @@ func (prefixer *prefixer) Write(p []byte) (int, error) {
 		}
 	}
 	return n, nil
+}
+
+// CopyFile copies a single file from src to dst
+// From https://blog.depado.eu/post/copy-files-and-directories-in-go
+func CopyFile(src, dst string) error {
+	var err error
+	var srcfd *os.File
+	var dstfd *os.File
+	var srcinfo os.FileInfo
+
+	if srcfd, err = os.Open(src); err != nil {
+		return err
+	}
+	defer srcfd.Close()
+
+	if dstfd, err = os.Create(dst); err != nil {
+		return err
+	}
+	defer dstfd.Close()
+
+	if _, err = io.Copy(dstfd, srcfd); err != nil {
+		return err
+	}
+	if srcinfo, err = os.Stat(src); err != nil {
+		return err
+	}
+	return os.Chmod(dst, srcinfo.Mode())
+}
+
+// CopyDir copies a whole directory recursively
+// From https://blog.depado.eu/post/copy-files-and-directories-in-go
+func CopyDir(src, dst string) error {
+	var err error
+	var fds []os.FileInfo
+	var srcinfo os.FileInfo
+
+	if srcinfo, err = os.Stat(src); err != nil {
+		return err
+	}
+
+	if err = os.MkdirAll(dst, srcinfo.Mode()); err != nil {
+		return err
+	}
+
+	if fds, err = ioutil.ReadDir(src); err != nil {
+		return err
+	}
+	for _, fd := range fds {
+		srcfp := path.Join(src, fd.Name())
+		dstfp := path.Join(dst, fd.Name())
+
+		if fd.IsDir() {
+			if err = CopyDir(srcfp, dstfp); err != nil {
+				fmt.Println(err)
+			}
+		} else {
+			if err = CopyFile(srcfp, dstfp); err != nil {
+				fmt.Println(err)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Rather than shelling out to the `rm` and `cp` commands,
use Go's os utils to perform these operations. This will
work on any platform rather than just Linux.