### PR TITLE
Fix `Type` suffix Go codegen for cross-package references

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -124,11 +124,7 @@ func (pkg *pkgContext) tokenToType(tok string) string {
 	}
 
 	if mod == pkg.mod {
-		name := title(name)
-		if pkg.names.has(name) {
-			name += "Type"
-		}
-		return name
+		return title(name)
 	}
 	return strings.Replace(mod, "/", "", -1) + "." + title(name)
 }


### PR DESCRIPTION
Three changes to unblock correct and clean code generation for the Kubernetes Go SDK:

* The Go code generator conditionally adds a `Type` suffix to avoid conflicts between Resources and Types.  This did not correctly handle cross-package references to types which might have needed to add this suffix.

* Fix computation of required imports

* Run Go formatter over code before generating