### PR TITLE
Fix the signature for C# invokes in the resource docs generator

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -21,6 +21,7 @@ import (
 // DocLanguageHelper is an interface for extracting language-specific information from a Pulumi schema.
 // See the implementation for this interface under each of the language code generators.
 type DocLanguageHelper interface {
+	GetPropertyName(p *schema.Property) (string, error)
 	GetDocLinkForResourceType(packageName, moduleName, typeName string) string
 	GetDocLinkForResourceInputOrOutputType(packageName, moduleName, typeName string, input bool) string
 	GetDocLinkForFunctionInputOrOutputType(packageName, moduleName, typeName string, input bool) string

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -259,13 +259,26 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 		href = "#" + lower(tokenName)
 	}
 
-	parts := strings.Split(langTypeString, ".")
-	displayName := parts[len(parts)-1]
+	// Strip the namespace/module prefix for the type's display name.
+	var parts []string
+	var displayName string
+	if lang == "csharp" {
+		csharpNS := fmt.Sprintf("Pulumi.%s.%s.", strings.Title(mod.pkg.Name), strings.Title(mod.mod))
+		displayName = strings.ReplaceAll(langTypeString, csharpNS, "")
+	} else {
+		parts = strings.Split(langTypeString, ".")
+		displayName = parts[len(parts)-1]
+	}
+
+	// If word-breaks need to be inserted, then the type string
+	// should be html-encoded first if the language is C# in order
+	//  to avoid confusing the Hugo rendering where the word-break
+	// tags are inserted.
 	if insertWordBreaks {
 		if lang == "csharp" {
-			langTypeString = html.EscapeString(langTypeString)
+			displayName = html.EscapeString(displayName)
 		}
-		langTypeString = wbr(langTypeString)
+		displayName = wbr(displayName)
 	}
 	return propertyType{
 		Name:        langTypeString,

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -107,7 +107,8 @@ type docNestedType struct {
 
 // propertyType represents the type of a property.
 type propertyType struct {
-	Name string
+	DisplayName string
+	Name        string
 	// Link can be a link to an anchor tag on the same
 	// page, or to another page/site.
 	Link string
@@ -258,6 +259,8 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 		href = "#" + lower(tokenName)
 	}
 
+	parts := strings.Split(langTypeString, ".")
+	displayName := parts[len(parts)-1]
 	if insertWordBreaks {
 		if lang == "csharp" {
 			langTypeString = html.EscapeString(langTypeString)
@@ -265,8 +268,9 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 		langTypeString = wbr(langTypeString)
 	}
 	return propertyType{
-		Link: href,
-		Name: langTypeString,
+		Name:        langTypeString,
+		DisplayName: displayName,
+		Link:        href,
 	}
 }
 
@@ -607,9 +611,12 @@ func (mod *modContext) getConstructorResourceInfo(resourceTypeName string) map[s
 			panic(errors.Errorf("cannot generate constructor info for unhandled language %q", lang))
 		}
 
+		parts := strings.Split(resourceTypeName, ".")
+		displayName := parts[len(parts)-1]
 		resourceMap[lang] = propertyType{
-			Name: resourceDisplayName,
-			Link: docLangHelper.GetDocLinkForResourceType(mod.pkg.Name, mod.mod, resourceTypeName),
+			Name:        resourceDisplayName,
+			DisplayName: displayName,
+			Link:        docLangHelper.GetDocLinkForResourceType(mod.pkg.Name, mod.mod, resourceTypeName),
 		}
 	}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -491,7 +491,8 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 			optional: !prop.IsRequired,
 		}
 
-		propLangName := prop.Name
+		langDocHelper := getLanguageDocHelper(lang)
+		var propLangName string
 		switch lang {
 		case "python":
 			pyName := python.PyName(prop.Name)
@@ -511,8 +512,13 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 					propLangName = prop.Name
 				}
 			}
-		case "go", "csharp":
-			propLangName = strings.Title(prop.Name)
+		default:
+			name, err := langDocHelper.GetPropertyName(prop)
+			if err != nil {
+				panic(err)
+			}
+
+			propLangName = name
 		}
 
 		docProperties = append(docProperties, property{

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -371,10 +371,6 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 	}
 
 	optionsType := "Pulumi.CustomResourceOptions"
-	if r.IsProvider {
-		optionsType = "Pulumi.ResourceOptions"
-	}
-
 	docLangHelper := getLanguageDocHelper("csharp")
 	return []formalParam{
 		{

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -85,9 +85,12 @@ func (mod *modContext) getFunctionResourceInfo(resourceTypeName string) map[stri
 			panic(errors.Errorf("cannot generate function resource info for unhandled language %q", lang))
 		}
 
+		parts := strings.Split(resultTypeName, ".")
+		displayName := parts[len(parts)-1]
 		resourceMap[lang] = propertyType{
-			Name: resultTypeName,
-			Link: docLangHelper.GetDocLinkForResourceType(mod.pkg.Name, mod.mod, resultTypeName),
+			Name:        resultTypeName,
+			DisplayName: displayName,
+			Link:        docLangHelper.GetDocLinkForResourceType(mod.pkg.Name, mod.mod, resultTypeName),
 		}
 	}
 

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -19,7 +19,12 @@
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>Lookup{{ .ResourceName }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.go }}<span class="p">) (*{{ template "linkify_param" .FunctionResult.go }}, error)</span></code></pre></div>
 
 <!-- C# -->
-<div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static </span>Task<{{ template "linkify_param" .FunctionResult.csharp }}> <span class="p">Get{{ .ResourceName }}(</span>{{ htmlSafe .FunctionArgs.csharp }}<span class="p">)</span></code></pre></div>
+<div class="highlight">
+<pre class="chroma">
+<code class="language-csharp" data-lang="csharp"><span class="k">public static class </span><span class="nx">Get{{ .ResourceName }} </span><span class="p">{</span>
+    <span class="k">public static </span>Task<{{ template "linkify_param" .FunctionResult.csharp }}> <span class="p">InvokeAsync(</span>{{ htmlSafe .FunctionArgs.csharp }}<span class="p">)</span>
+<span class="p">}</span></code></pre>
+</div>
 
 {{ if ne (len .InputProperties) 0 }}
 

--- a/pkg/codegen/docs/templates/utils.tmpl
+++ b/pkg/codegen/docs/templates/utils.tmpl
@@ -1,3 +1,6 @@
-{{ define "linkify_param" }}<span class="nx"><a href="{{ .Link }}">{{ .Name }}</a></span>{{ end }}
+<!-- linkify_param is used to wrap constructor/function params in an anchor tag. -->
+{{ define "linkify_param" }}<span class="nx"><a href="{{ .Link }}">{{ if ne .DisplayName "" }}{{ .DisplayName }}{{ else }}{{ .Name }}{{ end }}</a></span>{{ end }}
 
-{{ define "linkify" }}<a href="{{ .Link }}">{{ htmlSafe .DisplayName }}</a>{{ end }}
+<!-- linkify wraps any propertyType instance in an anchor tag. The display name/name is rendered as-is by passing it through the htmlSafe function
+to avoid double-encoding html characters, which is typical of properties type names. -->
+{{ define "linkify" }}<a href="{{ .Link }}">{{ if ne .DisplayName "" }}{{ htmlSafe .DisplayName }}{{ else }}{{ htmlSafe .Name }}{{ end }}</a>{{ end }}

--- a/pkg/codegen/docs/templates/utils.tmpl
+++ b/pkg/codegen/docs/templates/utils.tmpl
@@ -1,3 +1,3 @@
 {{ define "linkify_param" }}<span class="nx"><a href="{{ .Link }}">{{ .Name }}</a></span>{{ end }}
 
-{{ define "linkify" }}<a href="{{ .Link }}">{{ htmlSafe .Name }}</a>{{ end }}
+{{ define "linkify" }}<a href="{{ .Link }}">{{ htmlSafe .DisplayName }}</a>{{ end }}

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -63,3 +63,20 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) string {
 	return "Get" + resourceName + "Result"
 }
+
+// GetPropertyName uses the property's csharp-specific language info, if available, to generate
+// the property name. Otherwise, returns the PascalCase as the default.
+func (d DocLanguageHelper) GetPropertyName(p *schema.Property) (string, error) {
+	propLangName := strings.Title(p.Name)
+
+	names := map[*schema.Property]string{}
+	properties := []*schema.Property{p}
+	if err := computePropertyNames(properties, names); err != nil {
+		return "", err
+	}
+
+	if name, ok := names[p]; ok {
+		return name, nil
+	}
+	return propLangName, nil
+}

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -85,6 +85,11 @@ func (d *DocLanguageHelper) GeneratePackagesMap(pkg *schema.Package, tool string
 	d.packages = generatePackageContextMap(tool, pkg, goInfo)
 }
 
+// GetPropertyName returns the property name specific to Go.
+func (d DocLanguageHelper) GetPropertyName(p *schema.Property) (string, error) {
+	return strings.Title(p.Name), nil
+}
+
 // GetResourceFunctionResultName returns the name of the result type when a function is used to lookup
 // an existing resource.
 func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) string {

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -91,3 +91,8 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) string {
 	return "Get" + resourceName + "Result"
 }
+
+// GetPropertyName returns the property name specific to NodeJS.
+func (d DocLanguageHelper) GetPropertyName(p *schema.Property) (string, error) {
+	return p.Name, nil
+}

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -19,6 +19,7 @@
 package python
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -90,6 +91,12 @@ func (d DocLanguageHelper) GenPropertyCaseMap(pkg *schema.Package, modName, tool
 	if err := mod.recordProperty(prop); err != nil {
 		fmt.Printf("error building case map for %q in module %q", prop.Name, modName)
 	}
+}
+
+// GetPropertyName is not implemented for Python because property names in Python must use
+// property case maps, which need to be generated at each provider's package-level.
+func (d DocLanguageHelper) GetPropertyName(p *schema.Property) (string, error) {
+	return "", errors.New("this method is not supported for the python language")
 }
 
 // elementTypeToName returns the type name from an element type of the form


### PR DESCRIPTION
Fixes #4075.

This PR fixes two things:
* The `function.tmpl` template has been updated for C# to reflect the new way of using Functions using function classes with a static async invoke function.
* A new interface function has been added to DocLanguageHelper to get the appropriate property name for a language.
  * This was done to enable properties to use any language-level info that may be attached to the property in the schema.

(The above changes are split by commit.)

Here's the docs [PR](https://github.com/pulumi/docs/pull/2687) (also split by commit) to show the effect of these changes.