### PR TITLE
Temporarily skip test causing unrelated failures in master

### DIFF
--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -15,6 +15,8 @@ import (
 
 // TestPolicy tests policy related commands work.
 func TestPolicy(t *testing.T) {
+	t.Skip("Temporarily skipping test that is causing unrelated tests to fail - pulumi/pulumi#4149")
+
 	e := ptesting.NewEnvironment(t)
 	defer func() {
 		if !t.Failed() {


### PR DESCRIPTION
@ekrengel, I know you generally prefer to not disable tests, but let's temporarily disable this test to get master green, until it's been updated to not use the default policy group.