### PR TITLE
Bump accept header to 6 for pac config

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -165,7 +165,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 	userAgent := fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)
 	req.Header.Set("User-Agent", userAgent)
 	// Specify the specific API version we accept.
-	req.Header.Set("Accept", "application/vnd.pulumi+5")
+	req.Header.Set("Accept", "application/vnd.pulumi+6")
 
 	// Apply credentials if provided.
 	if tok.String() != "" {


### PR DESCRIPTION
I am bumping the accept header version to 6, which will be used to indicate PaC configuration is supported by the CLI.

Related to https://github.com/pulumi/pulumi-service/issues/4810