### PR TITLE
Fix versions of dependencies in policy tests

### DIFF
--- a/tests/integration/policy/policy_pack_w_config/package.json
+++ b/tests/integration/policy/policy_pack_w_config/package.json
@@ -2,8 +2,8 @@
     "name": "aws-policy",
     "version": "0.0.1",
     "dependencies": {
-        "@pulumi/pulumi": "1.13.0",
-        "@pulumi/aws": "1.27.0",
+        "@pulumi/pulumi": "^1.13.0",
+        "@pulumi/aws": "^1.0.0",
         "@pulumi/policy": "0.4.1-dev.1584625475"
     },
     "devDependencies": {

--- a/tests/integration/policy/policy_pack_w_config/package.json.tmpl
+++ b/tests/integration/policy/policy_pack_w_config/package.json.tmpl
@@ -2,8 +2,8 @@
     "name": "aws-policy",
     "version": { policyVersion },
     "dependencies": {
-        "@pulumi/pulumi": "1.13.0",
-        "@pulumi/aws": "1.27.0",
+        "@pulumi/pulumi": "^1.13.0",
+        "@pulumi/aws": "^1.0.0",
         "@pulumi/policy": "0.4.1-dev.1584625475"
     },
     "devDependencies": {

--- a/tests/integration/policy/policy_pack_wo_config/package.json
+++ b/tests/integration/policy/policy_pack_wo_config/package.json
@@ -2,8 +2,8 @@
     "name": "aws-policy",
     "version": "0.0.1",
     "dependencies": {
-        "@pulumi/pulumi": "^0.17.28",
-        "@pulumi/aws": "0.18.16",
+        "@pulumi/pulumi": "^1.0.0",
+        "@pulumi/aws": "^1.0.0",
         "@pulumi/policy": "^0.2.0"
     },
     "devDependencies": {


### PR DESCRIPTION
These were causing *very* old versions of `@pulumi/pulumi` to get pulled in, and were seeing failures on Node 13 due to missnig gRPC native modules.

Aside - we've tried to not have any dependencies in `@pulumi/pulumi` on `@pulumi/aws` and other higher-level libraries, to avoid layering violation issues.  Would love to see if we can reasonably simplify the testing at this layer to not have this dependency.