### PR TITLE
fix release scripts to be aware of new module structure

### DIFF
--- a/scripts/make_release.ps1
+++ b/scripts/make_release.ps1
@@ -10,10 +10,12 @@ $Version = $( & "$PSScriptRoot\get-version.cmd")
 $Branch = $(if (Test-Path env:APPVEYOR_REPO_BRANCH) { $env:APPVEYOR_REPO_BRANCH } else { $(git rev-parse --abbrev-ref HEAD) })
 $PublishTargets = @($GitHash, $Version, $Branch)
 
-function RunGoBuild($goPackage) {
+function RunGoBuild($goPackage, $dir) {
     $binRoot = New-Item -ItemType Directory -Force -Path "$PublishDir\bin"
     $outputName = Split-Path -Leaf $(go list -f "{{.Target}}" $goPackage)
+    Push-Location $dir
     go build -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=$Version" -o "$binRoot\$outputName" $goPackage
+    Pop-Location
 }
 
 function CopyPackage($pathToModule, $moduleName) {
@@ -27,11 +29,11 @@ function CopyPackage($pathToModule, $moduleName) {
     }
 }
 
-RunGoBuild "github.com/pulumi/pulumi"
-RunGoBuild "github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs"
-RunGoBuild "github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python"
-RunGoBuild "github.com/pulumi/pulumi/sdk/dotnet/cmd/pulumi-language-dotnet"
-RunGoBuild "github.com/pulumi/pulumi/sdk/go/pulumi-language-go"
+RunGoBuild "github.com/pulumi/pulumi/pkg/cmd/pulumi" "pkg"
+RunGoBuild "github.com/pulumi/pulumi/sdk/nodejs/cmd/pulumi-language-nodejs" "sdk"
+RunGoBuild "github.com/pulumi/pulumi/sdk/python/cmd/pulumi-language-python" "sdk"
+RunGoBuild "github.com/pulumi/pulumi/sdk/dotnet/cmd/pulumi-language-dotnet" "sdk"
+RunGoBuild "github.com/pulumi/pulumi/sdk/go/pulumi-language-go" "sdk"
 CopyPackage "$Root\sdk\nodejs\bin" "pulumi"
 
 Copy-Item "$Root\sdk\nodejs\dist\pulumi-resource-pulumi-nodejs.cmd" "$PublishDir\bin"

--- a/scripts/make_release.sh
+++ b/scripts/make_release.sh
@@ -24,10 +24,11 @@ run_go_build() {
     fi
 
     mkdir -p "${PUBDIR}/bin"
-    go build \
+    pushd "$2" && go build \
        -ldflags "-X github.com/pulumi/pulumi/pkg/version.Version=${VERSION}" \
        -o "${PUBDIR}/bin/${output_name}${bin_suffix}" \
        "$1"
+    popd
 }
 
 # usage: copy_package <path-to-module> <module-name>
@@ -44,13 +45,14 @@ copy_package() {
     fi
 }
 
+readonly PULUMI_ROOT=$PWD
 
 # Build binaries
-run_go_build "${ROOT}"
-run_go_build "${ROOT}/sdk/nodejs/cmd/pulumi-language-nodejs"
-run_go_build "${ROOT}/sdk/python/cmd/pulumi-language-python"
-run_go_build "${ROOT}/sdk/dotnet/cmd/pulumi-language-dotnet"
-run_go_build "${ROOT}/sdk/go/pulumi-language-go"
+run_go_build "${PULUMI_ROOT}/pkg/cmd/pulumi" "pkg"
+run_go_build "${PULUMI_ROOT}/sdk/nodejs/cmd/pulumi-language-nodejs" "sdk"
+run_go_build "${PULUMI_ROOT}/sdk/python/cmd/pulumi-language-python" "sdk"
+run_go_build "${PULUMI_ROOT}/sdk/dotnet/cmd/pulumi-language-dotnet" "sdk"
+run_go_build "${PULUMI_ROOT}/sdk/go/pulumi-language-go" "sdk"
 
 # Copy over the language and dynamic resource providers.
 cp "${ROOT}/sdk/nodejs/dist/pulumi-resource-pulumi-nodejs" "${PUBDIR}/bin/"


### PR DESCRIPTION
The new module structure broke the release scripts, these don't get tested in travis_pull builds, just merge builds. 

I don't have access to a windows machine to verify the powershell script. If anyone has a windows machine laying around, or suggestions on a way for me to test it, I'd appreciate it. 

I tested the bash script locally and everything looks right:

```sh
Evans-MBP:pulumi evanboyle$ ./scripts/make_release.sh 
~/go/src/github.com/pulumi/pulumi/pkg ~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi/sdk ~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi/sdk ~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi/sdk ~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi/sdk ~/go/src/github.com/pulumi/pulumi
~/go/src/github.com/pulumi/pulumi
/var/folders/13/q5n976vd6vgc_wysnsmfkrbw0000gn/T/tmp.lGsBiObe) 80f1989600a307d3dee40dcd59504e3d9c43dad4 v1.14.0-alpha.1585177066+g80f19896.dirty master


Evans-MBP:pulumi evanboyle$ ls /var/folders/13/q5n976vd6vgc_wysnsmfkrbw0000gn/T/tmp.lGsBiObe
bin		node_modules
Evans-MBP:pulumi evanboyle$ ls /var/folders/13/q5n976vd6vgc_wysnsmfkrbw0000gn/T/tmp.lGsBiObe/bin
pulumi				pulumi-analyzer-policy		pulumi-analyzer-policy-python	pulumi-language-dotnet		pulumi-language-go		pulumi-language-nodejs		pulumi-language-python		pulumi-language-python-exec	pulumi-resource-pulumi-nodejs	pulumi-resource-pulumi-python

```