### PR TITLE
Remove non-relevant examples and empty examples section from docs comments

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -30,3 +30,12 @@ type DocLanguageHelper interface {
 	// an existing resource.
 	GetResourceFunctionResultName(resourceName string) string
 }
+
+// StripNonRelevantExamples strips the non-relevant language snippets from a resource's description.
+func StripNonRelevantExamples(resourceDescription string, lang string) string {
+	// Initialize a new string builder with the initial value set to the resourceDescription.
+	// Strip the outer examples short code.
+	// For each example short code, only keep the code snippet for the language that was passed-in.
+	// Return the String() from the string builder.
+	return ""
+}

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -176,12 +176,19 @@ func StripNonRelevantExamples(description string, lang string) string {
 	// Within the examples section, identify each example.
 	builder := strings.Builder{}
 	examples := getExamplesForLang(*examplesContent, lang)
-	if len(examples) > 0 {
-		builder.WriteString("## Example Usage\n")
+	numExamples := len(examples)
+	if numExamples > 0 {
+		builder.WriteString("## Example Usage\n\n")
 	}
-	for _, ex := range examples {
-		builder.WriteString(ex.Title + "\n")
+	for i, ex := range examples {
+		builder.WriteString(ex.Title + "\n\n")
 		builder.WriteString(ex.Snippet + "\n")
+
+		// Print an extra new-line character as long as this is not
+		// the last example.
+		if i != numExamples-1 {
+			builder.WriteString("\n")
+		}
 	}
 
 	return strings.ReplaceAll(newDescription, "{{ .Examples }}", builder.String())

--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -68,12 +68,16 @@ func fakeFunc() {
 }
 ` + codeFence
 
+	leadingDescription := "This is a leading description for this resource."
 	exampleShortCode := `{{% example %}}` + tsCodeSnippet + "\n" + goCodeSnippet + `{{% /example %}}`
-	description := `{{% examples %}}` + exampleShortCode + `{{% /examples %}}`
+	description := leadingDescription + `
+{{% examples %}}` + exampleShortCode + `
+{{% /examples %}}`
 
 	t.Run("ContainsRelevantCodeSnippet", func(t *testing.T) {
 		strippedDescription := StripNonRelevantExamples(description, "typescript")
 		assert.NotEmpty(t, strippedDescription, "content could not be extracted")
+		assert.Contains(t, strippedDescription, leadingDescription, "expected to at least find the leading description")
 	})
 
 	// The above description does not contain a Python code snippet and because
@@ -81,7 +85,9 @@ func fakeFunc() {
 	// we should expect an empty string in this test.
 	t.Run("DoesNotContainRelevantSnippet", func(t *testing.T) {
 		strippedDescription := StripNonRelevantExamples(description, "python")
-		assert.Empty(t, strippedDescription, "expected empty description")
+		assert.Contains(t, strippedDescription, leadingDescription, "expected to at least find the leading description")
+		// Should not contain any examples sections.
+		assert.NotContains(t, strippedDescription, "### ", "expected to not have any examples but found at least one")
 	})
 }
 

--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -1,0 +1,130 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package codegen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractExamplesSection(t *testing.T) {
+	t.Run("NonEmptyContent", func(t *testing.T) {
+		expectedContent := `
+something here
+
+and here
+
+.... and there
+
+..some..more here..
+`
+		description := `{{% examples %}}` + expectedContent + `{{% /examples %}}`
+
+		actualContent := extractExamplesSection(description)
+		assert.NotNil(t, actualContent, "content could not be extracted")
+		assert.Equal(t, expectedContent, *actualContent, "strings don't match")
+	})
+
+	t.Run("EmptyContent", func(t *testing.T) {
+		description := `{{% examples %}}
+{{% /examples %}}`
+
+		actualContent := extractExamplesSection(description)
+		assert.Nil(t, actualContent, "expected content to be nil")
+	})
+}
+
+var codeFence = "```"
+
+func TestStripNonRelevantExamples(t *testing.T) {
+	tsCodeSnippet := `### Example 1
+` + codeFence + `typescript
+import * as path from path;
+
+console.log("I am a console log statement in ts.");
+` + codeFence
+
+	goCodeSnippet := `\n` + codeFence + `go
+import (
+	"fmt"
+	"strings"
+)
+
+func fakeFunc() {
+	fmt.Print("Hi, I am a fake func!")
+}
+` + codeFence
+
+	exampleShortCode := `{{% example %}}` + tsCodeSnippet + "\n" + goCodeSnippet + `{{% /example %}}`
+	description := `{{% examples %}}` + exampleShortCode + `{{% /examples %}}`
+
+	t.Run("ContainsRelevantCodeSnippet", func(t *testing.T) {
+		strippedDescription := StripNonRelevantExamples(description, "typescript")
+		assert.NotEmpty(t, strippedDescription, "content could not be extracted")
+	})
+
+	// The above description does not contain a Python code snippet and because
+	// the description contains only one Example without any Python code snippet,
+	// we should expect an empty string in this test.
+	t.Run("DoesNotContainRelevantSnippet", func(t *testing.T) {
+		strippedDescription := StripNonRelevantExamples(description, "python")
+		assert.Empty(t, strippedDescription, "expected empty description")
+	})
+}
+
+func TestTestStripNonRelevantExamplesFromMultipleExampleSections(t *testing.T) {
+	tsCodeSnippet := codeFence + `typescript
+import * as path from path;
+
+console.log("I am a console log statement in ts.");
+` + codeFence
+
+	goCodeSnippet := codeFence + `go
+import (
+	"fmt"
+	"strings"
+)
+
+func fakeFunc() {
+	fmt.Print("Hi, I am a fake func!")
+}
+` + codeFence
+
+	example1 := `### Example 1
+	` + tsCodeSnippet + "\n" + goCodeSnippet
+
+	example2 := `### Example 2
+	` + tsCodeSnippet
+
+	example1ShortCode := `{{% example %}}` + "\n" + example1 + "\n" + `{{% /example %}}`
+	example2ShortCode := `{{% example %}}` + "\n" + example2 + "\n" + `{{% /example %}}`
+	description := `{{% examples %}}` + "\n" + example1ShortCode + "\n" + example2ShortCode + "\n" + `{{% /examples %}}`
+
+	t.Run("EveryExampleHasRelevantCodeSnippet", func(t *testing.T) {
+		strippedDescription := StripNonRelevantExamples(description, "typescript")
+		assert.NotEmpty(t, strippedDescription, "content could not be extracted")
+		assert.Contains(t, strippedDescription, "Example 1", "expected Example 1 section")
+		assert.Contains(t, strippedDescription, "Example 2", "expected Example 2 section")
+	})
+
+	t.Run("SomeExamplesHaveRelevantCodeSnippet", func(t *testing.T) {
+		strippedDescription := StripNonRelevantExamples(description, "go")
+		assert.NotEmpty(t, strippedDescription, "content could not be extracted")
+		assert.Contains(t, strippedDescription, "Example 1", "expected Example 1 section")
+		assert.NotContains(t, strippedDescription, "Example 2",
+			"unexpected Example 2 section. section should have been excluded")
+	})
+}

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -33,6 +33,7 @@ import (
 	"unicode"
 
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/codegen"
 	"github.com/pulumi/pulumi/pkg/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
 )
@@ -554,7 +555,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	fmt.Fprintf(w, "{\n")
 
 	// Write the TypeDoc/JSDoc for the resource class
-	printComment(w, r.Comment, "    ")
+	printComment(w, codegen.StripNonRelevantExamples(r.Comment, "csharp"), "    ")
 
 	// Open the class.
 	className := name

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -772,7 +772,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 	}
 
 	// Emit the doc comment, if any.
-	printComment(w, fun.Comment, "        ")
+	printComment(w, codegen.StripNonRelevantExamples(fun.Comment, "csharp"), "        ")
 
 	// Emit the datasource method.
 	fmt.Fprintf(w, "        public static Task%s %s(%sInvokeOptions? options = null)\n", typeParameter, methodName, argsParamDef)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -696,7 +696,7 @@ func (pkg *pkgContext) genFunction(w io.Writer, f *schema.Function) {
 	// If the function starts with New or Get, it will conflict; so rename them.
 	name := pkg.functionNames[f]
 
-	printComment(w, f.Comment, false)
+	printComment(w, codegen.StripNonRelevantExamples(f.Comment, "go"), false)
 
 	// Now, emit the function signature.
 	argsig := "ctx *pulumi.Context"

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/pulumi/pulumi/pkg/codegen"
 	"github.com/pulumi/pulumi/pkg/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
 )
@@ -553,7 +554,7 @@ func (pkg *pkgContext) getDefaultValue(dv *schema.DefaultValue, t schema.Type) (
 func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource) error {
 	name := resourceName(r)
 
-	printComment(w, r.Comment, false)
+	printComment(w, codegen.StripNonRelevantExamples(r.Comment, "go"), false)
 	fmt.Fprintf(w, "type %s struct {\n", name)
 
 	if r.IsProvider {

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -544,7 +544,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) {
 	name := camel(tokenToName(fun.Token))
 
 	// Write the TypeDoc/JSDoc for the data source function.
-	printComment(w, fun.Comment, "", "")
+	printComment(w, codegen.StripNonRelevantExamples(fun.Comment, "typescript"), "", "")
 
 	if fun.DeprecationMessage != "" {
 		fmt.Fprintf(w, "/** @deprecated %s */\n", fun.DeprecationMessage)

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -32,6 +32,7 @@ import (
 	"unicode"
 
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/codegen"
 	"github.com/pulumi/pulumi/pkg/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
 )
@@ -334,7 +335,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	name := resourceName(r)
 
 	// Write the TypeDoc/JSDoc for the resource class
-	printComment(w, r.Comment, "", "")
+	printComment(w, codegen.StripNonRelevantExamples(r.Comment, "typescript"), "", "")
 
 	baseType := "CustomResource"
 	if r.IsProvider {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/codegen"
 	"github.com/pulumi/pulumi/pkg/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
 )
@@ -879,7 +880,7 @@ func (mod *modContext) genInitDocstring(w io.Writer, res *schema.Resource) {
 
 	// If this resource has documentation, write it at the top of the docstring, otherwise use a generic comment.
 	if res.Comment != "" {
-		fmt.Fprintln(b, res.Comment)
+		fmt.Fprintln(b, codegen.StripNonRelevantExamples(res.Comment, "python"))
 	} else {
 		fmt.Fprintf(b, "Create a %s resource with the given unique name, props, and options.\n", tokenToName(res.Token))
 	}

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -571,7 +571,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	// If this func has documentation, write it at the top of the docstring, otherwise use a generic comment.
 	docs := &bytes.Buffer{}
 	if fun.Comment != "" {
-		fmt.Fprintln(docs, fun.Comment)
+		fmt.Fprintln(docs, codegen.StripNonRelevantExamples(fun.Comment, "python"))
 	} else {
 		fmt.Fprintln(docs, "Use this data source to access information about an existing resource.")
 	}


### PR DESCRIPTION
Part of #4158.

This PR introduces a package-level function in `codegen` for the language generators to use in order to strip out the examples short code and also any examples that are in languages not relevant to a specific language. For example, for a TS SDK, the Python and the C# examples are unnecessary and irrelevant and so on...

There is a companion PR for this in the pulumi-terraform-bridge to be opened. I have the changes there that re-introduce the examples short code (as well as updates to the old language code generators), but will open that PR once this is merged.