### PR TITLE
dont add PPs to refresh summary event

### DIFF
--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -401,13 +401,17 @@ func update(ctx *Context, info *planContext, opts planOptions, dryRun bool) (Res
 	}
 
 	policies := map[string]string{}
-	for _, p := range opts.RequiredPolicies {
-		policies[p.Name()] = p.Version()
-	}
-	for _, pack := range opts.LocalPolicyPacks {
-		path := abbreviateFilePath(pack.Path)
-		packName := fmt.Sprintf("%s (%s)", pack.Name, path)
-		policies[packName] = "(local)"
+
+	// Refresh does not execute Policy Packs.
+	if !opts.isRefresh {
+		for _, p := range opts.RequiredPolicies {
+			policies[p.Name()] = p.Version()
+		}
+		for _, pack := range opts.LocalPolicyPacks {
+			path := abbreviateFilePath(pack.Path)
+			packName := fmt.Sprintf("%s (%s)", pack.Name, path)
+			policies[packName] = "(local)"
+		}
 	}
 
 	var resourceChanges ResourceChanges


### PR DESCRIPTION
This change does not add PPs to engine summary event for refreshes. Since register resource is not called for resources being refreshed the "Policy Packs ran" is misleading for pure refreshes.

Part of the fix for: https://github.com/pulumi/pulumi/issues/3854


Refresh:
```
➜  deleteme pulumi refresh
Please choose a stack, or create a new one: stackone
Previewing refresh (stackone):
     Type                 Name               Plan
     pulumi:pulumi:Stack  deleteme-stackone
 -   └─ aws:s3:Bucket     my-bucket          delete

Resources:
    - 1 to delete
    1 unchanged

Do you want to perform this refresh?
No resources will be modified as part of this refresh; just your stack's state will be. yes
Refreshing (stackone):
     Type                 Name               Status
     pulumi:pulumi:Stack  deleteme-stackone
 -   └─ aws:s3:Bucket     my-bucket          deleted

Outputs:
    bucket: {
        acl                     : "public-read"
        arn                     : "arn:aws:s3:::my-bucket-a161678"
        bucket                  : "my-bucket-a161678"
        bucketDomainName        : "my-bucket-a161678.s3.amazonaws.com"
        bucketRegionalDomainName: "my-bucket-a161678.s3.amazonaws.com"
        forceDestroy            : false
        hostedZoneId            : "Z3AQBSTGFYJSTF"
        id                      : "my-bucket-a161678"
        region                  : "us-east-1"
        requestPayer            : "BucketOwner"
        urn                     : "urn:pulumi:stackone::deleteme::aws:s3/bucket:Bucket::my-bucket"
        versioning              : {
            enabled  : false
            mfaDelete: false
        }
    }

Resources:
    - 1 deleted
    1 unchanged

Duration: 3s

Permalink: http://localhost:3000/ekrengel/deleteme/stackone/updates/22
```

Preview with refresh still shows PPs:
```
➜  deleteme pulumi preview --refresh
Previewing update (test):
     Type                 Name           Plan       Info
     pulumi:pulumi:Stack  deleteme-test             1 message
 +   └─ aws:s3:Bucket     my-bucket      create

Diagnostics:
  pulumi:pulumi:Stack (deleteme-test):
    Method handler configure for /pulumirpc.Analyzer/Configure expected but not provided

Policy Violations:
    [advisory]  another-fraking-pack v1  s3-no-public-read (my-bucket: aws:s3/bucket:Bucket)
    Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.
    You cannot set public-read or public-read-write on an S3 bucket. Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html

Outputs:
  ~ bucket: {
      + accelerationStatus               : output<string>
        acl                              : "public-read"
      ~ arn                              : "arn:aws:s3:::my-bucket-bf0472c" => output<string>
      ~ bucket                           : "my-bucket-bf0472c" => "my-bucket-d430e3b"
      ~ bucketDomainName                 : "my-bucket-bf0472c.s3.amazonaws.com" => output<string>
      + bucketPrefix                     : output<string>
      ~ bucketRegionalDomainName         : "my-bucket-bf0472c.s3.amazonaws.com" => output<string>
      + corsRules                        : output<string>
        forceDestroy                     : false
      ~ hostedZoneId                     : "Z3AQBSTGFYJSTF" => output<string>
      ~ id                               : "my-bucket-bf0472c" => output<string>
      + lifecycleRules                   : output<string>
      + loggings                         : output<string>
      + objectLockConfiguration          : output<string>
      + policy                           : output<string>
      ~ region                           : "us-east-1" => output<string>
      + replicationConfiguration         : output<string>
      ~ requestPayer                     : "BucketOwner" => output<string>
      + serverSideEncryptionConfiguration: output<string>
      + tags                             : output<string>
        urn                              : "urn:pulumi:test::deleteme::aws:s3/bucket:Bucket::my-bucket"
      - versioning                       : {
          - enabled  : false
          - mfaDelete: false
        }
      + versioning                       : output<string>
      + website                          : output<string>
      + websiteDomain                    : output<string>
      + websiteEndpoint                  : output<string>
    }

Permalink: https://app.pulumi.com/ekrengel/deleteme/test/previews/1e98b4e0-b6b1-4684-83e5-caddcdf8e6ae
```
