### PR TITLE
Python SDK: ephemeral option for log methods

### DIFF
--- a/sdk/python/lib/pulumi/log.py
+++ b/sdk/python/lib/pulumi/log.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from .resource import Resource
 
 
-def debug(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None) -> None:
+def debug(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None, ephemeral: Optional[bool] = None) -> None:
     """
     Logs a message to the Pulumi CLI's debug channel, associating it with a resource
     and stream_id if provided.
@@ -37,12 +37,12 @@ def debug(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[i
     """
     engine = get_engine()
     if engine is not None:
-        _log(engine, engine_pb2.DEBUG, msg, resource, stream_id)
+        _log(engine, engine_pb2.DEBUG, msg, resource, stream_id, ephemeral)
     else:
         print("debug: " + msg, file=sys.stderr)
 
 
-def info(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None) -> None:
+def info(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None, ephemeral: Optional[bool] = None) -> None:
     """
     Logs a message to the Pulumi CLI's info channel, associating it with a resource
     and stream_id if provided.
@@ -53,12 +53,12 @@ def info(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[in
     """
     engine = get_engine()
     if engine is not None:
-        _log(engine, engine_pb2.INFO, msg, resource, stream_id)
+        _log(engine, engine_pb2.INFO, msg, resource, stream_id, ephemeral)
     else:
         print("info: " + msg, file=sys.stderr)
 
 
-def warn(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None) -> None:
+def warn(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None, ephemeral: Optional[bool] = None) -> None:
     """
     Logs a message to the Pulumi CLI's warning channel, associating it with a resource
     and stream_id if provided.
@@ -69,12 +69,12 @@ def warn(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[in
     """
     engine = get_engine()
     if engine is not None:
-        _log(engine, engine_pb2.WARNING, msg, resource, stream_id)
+        _log(engine, engine_pb2.WARNING, msg, resource, stream_id, ephemeral)
     else:
         print("warning: " + msg, file=sys.stderr)
 
 
-def error(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None):
+def error(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None, ephemeral: Optional[bool] = None):
     """
     Logs a message to the Pulumi CLI's error channel, associating it with a resource
     and stream_id if provided.
@@ -85,12 +85,12 @@ def error(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[i
     """
     engine = get_engine()
     if engine is not None:
-        _log(engine, engine_pb2.ERROR, msg, resource, stream_id)
+        _log(engine, engine_pb2.ERROR, msg, resource, stream_id, ephemeral)
     else:
         print("error: " + msg, file=sys.stderr)
 
 
-def _log(engine, severity, message, resource, stream_id):
+def _log(engine, severity, message, resource, stream_id, ephemeral):
     if stream_id is None:
         stream_id = 0
 
@@ -101,11 +101,13 @@ def _log(engine, severity, message, resource, stream_id):
     # we have to asynchronously resolve the URN first.
     async def do_log():
         resolved_urn = await resource.urn.future()
-        req = engine_pb2.LogRequest(severity=severity, message=message, urn=resolved_urn, streamId=stream_id)
+        req = engine_pb2.LogRequest(severity=severity, message=message, urn=resolved_urn,
+                                    streamId=stream_id, ephemeral=ephemeral)
         engine.Log(req)
 
     if resource is not None:
         asyncio.ensure_future(do_log())
     else:
-        req = engine_pb2.LogRequest(severity=severity, message=message, urn="", streamId=stream_id)
+        req = engine_pb2.LogRequest(severity=severity, message=message, urn="",
+                                    streamId=stream_id, ephemeral=ephemeral)
         engine.Log(req)


### PR DESCRIPTION
in pulumi-docker there as the option of sending log lines during Docker images build, to see progress of stuff, but it's not available for the Python SDK. I think it's just adding an `ephemeral` boolean to the LogRequest RPC stuff, but if more is needed please let me know

Fixes #4169.