### PR TITLE
Remove pulumi/aws dep from policy integration tests

### DIFF
--- a/tests/integration/policy/policy_pack_w_config/configs/invalid-config.json
+++ b/tests/integration/policy/policy_pack_w_config/configs/invalid-config.json
@@ -1,5 +1,5 @@
 {
-    "s3-no-public-read": {
+    "test-policy-w-config": {
         "enforcementLevel": "mandatory",
         "message": "this message is invalid because it is way more than 10 characters......"
     }

--- a/tests/integration/policy/policy_pack_w_config/configs/valid-config.json
+++ b/tests/integration/policy/policy_pack_w_config/configs/valid-config.json
@@ -2,7 +2,7 @@
     "all": {
         "enforcementLevel": "advisory"
     },
-    "s3-no-public-read": {
+    "test-policy-w-config": {
         "enforcementLevel": "mandatory",
         "message": "test msg"
     }

--- a/tests/integration/policy/policy_pack_w_config/index.ts
+++ b/tests/integration/policy/policy_pack_w_config/index.ts
@@ -1,6 +1,5 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
 
-import * as aws from "@pulumi/aws";
 import * as policy from "@pulumi/policy";
 
 const packName = process.env.TEST_POLICY_PACK;
@@ -13,8 +12,8 @@ if (!packName) {
     const policies = new policy.PolicyPack(packName, {
         policies: [
             {
-                name: "s3-no-public-read",
-                description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+                name: "test-policy-w-config",
+                description: "Test policy used for tests with policy configuration.",
                 enforcementLevel: "mandatory",
                 configSchema: {
                     properties: {
@@ -25,15 +24,8 @@ if (!packName) {
                         },
                    },
                 },
-                validateResource: policy.validateTypedResource(aws.s3.Bucket, (bucket, args, reportViolation) => {
-                    if (bucket.acl === "public-read" || bucket.acl === "public-read-write") {
-                        reportViolation(
-                            "You cannot set public-read or public-read-write on an S3 bucket. " +
-                            "Read more about ACLs here: " +
-                            "https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");
-                    }
-                }),
-            },
+                validateResource: (args, reportViolation) => {},
+            }
         ],
     });
 }

--- a/tests/integration/policy/policy_pack_w_config/package.json
+++ b/tests/integration/policy/policy_pack_w_config/package.json
@@ -1,9 +1,8 @@
 {
-    "name": "aws-policy",
+    "name": "test-policy-w-config",
     "version": "0.0.1",
     "dependencies": {
         "@pulumi/pulumi": "^1.13.0",
-        "@pulumi/aws": "^1.0.0",
         "@pulumi/policy": "0.4.1-dev.1584625475"
     },
     "devDependencies": {

--- a/tests/integration/policy/policy_pack_wo_config/index.ts
+++ b/tests/integration/policy/policy_pack_wo_config/index.ts
@@ -1,6 +1,5 @@
 // Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
 
-import * as aws from "@pulumi/aws";
 import * as policy from "@pulumi/policy";
 
 const packName = process.env.TEST_POLICY_PACK;
@@ -13,17 +12,10 @@ if (!packName) {
     const policies = new policy.PolicyPack(packName, {
         policies: [
             {
-                name: "s3-no-public-read",
-                description: "Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.",
+                name: "test-policy-wo-config",
+                description: "Test policy used for tests prior to configurable policies being supported.",
                 enforcementLevel: "mandatory",
-                validateResource: policy.validateTypedResource(aws.s3.Bucket, (bucket, args, reportViolation) => {
-                    if (bucket.acl === "public-read" || bucket.acl === "public-read-write") {
-                        reportViolation(
-                            "You cannot set public-read or public-read-write on an S3 bucket. " +
-                            "Read more about ACLs here: " +
-                            "https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html");
-                    }
-                }),
+                validateResource: (args, reportViolation) => {},
             },
         ],
     });

--- a/tests/integration/policy/policy_pack_wo_config/package.json
+++ b/tests/integration/policy/policy_pack_wo_config/package.json
@@ -1,9 +1,8 @@
 {
-    "name": "aws-policy",
+    "name": "test-policy-wo-config",
     "version": "0.0.1",
     "dependencies": {
         "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/aws": "^1.0.0",
         "@pulumi/policy": "^0.2.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Removing dependency on `@pulumi/aws` from the policy integration tests. This is being done in response to https://github.com/pulumi/pulumi/pull/4175, to lessen the likelihood of dependency issues when running tests in the pipeline. 