### PR TITLE
Add DisplayName to Package

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -233,6 +233,14 @@ func (mod *modContext) details(t *schema.ObjectType) *typeDetails {
 	return details
 }
 
+func (mod *modContext) getPackageDisplayName() string {
+	displayName := mod.pkg.DisplayName
+	if displayName != "" {
+		return displayName
+	}
+	return mod.pkg.Name
+}
+
 type propertyCharacteristics struct {
 	// input is a flag indicating if the property is an input type.
 	input bool

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -254,6 +254,8 @@ type Package struct {
 
 	// Name is the unqualified name of the package (e.g. "aws", "azure", "gcp", "kubernetes". "random")
 	Name string
+	// DisplayName is the ready-to-display name of the package (e.g. "Microsoft Azure", "Google Cloud").
+	DisplayName string
 	// Version is the version of the package.
 	Version *semver.Version
 	// Description is the description of the package.
@@ -421,6 +423,8 @@ type MetadataSpec struct {
 type PackageSpec struct {
 	// Name is the unqualified name of the package (e.g. "aws", "azure", "gcp", "kubernetes". "random")
 	Name string `json:"name"`
+	// DisplayName is the ready-to-display name of the package (e.g. "Microsoft Azure", "Google Cloud").
+	DisplayName string
 	// Version is the version of the package. The version must be valid semver.
 	Version string `json:"version,omitempty"`
 	// Description is the description of the package.
@@ -525,6 +529,7 @@ func ImportSpec(spec PackageSpec) (*Package, error) {
 	return &Package{
 		moduleFormat: moduleFormatRegexp,
 		Name:         spec.Name,
+		DisplayName:  spec.DisplayName,
 		Version:      version,
 		Description:  spec.Description,
 		Keywords:     spec.Keywords,


### PR DESCRIPTION
CAUTION: Due to time constraints, I haven't thoroughly tested this. You would still need to go into each provider manually to add in the proper display name, but this PR at least provides the ability to extract the display name from the package.