### PR TITLE
fix: logging out with filestate when url is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
-_(none)_
+- Fix logout with file backend when state is deleted
+  [#4218](https://github.com/pulumi/pulumi/pull/4218)
 
 ## 1.13.1 (2020-03-27)
 - Move to a multi-module repo to enable modules for the Go SDK

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -68,7 +68,7 @@ func newLogoutCmd() *cobra.Command {
 			var be backend.Backend
 			var err error
 			if filestate.IsFileStateBackendURL(cloudURL) {
-				be, err = filestate.New(cmdutil.Diag(), cloudURL)
+				return workspace.DeleteAccount(cloudURL)
 			} else {
 				be, err = httpstate.New(cmdutil.Diag(), cloudURL)
 			}


### PR DESCRIPTION
I'm not 100% sure if this is the best solution or not, but it makes sense to me. If the directory doesn't exist anymore, I don't see the reason the user couldn't be logged out. If it was due to a network issue, they should be able to login easily without any repercussions.

Fixes #4054 