### PR TITLE
only run release builds on tags that start with "vX"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,7 +68,7 @@ build_script:
 
       pushd . && cd tests && go mod tidy && go mod download && popd
 
-      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1
+      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1;
       if %errorlevel% == 0 (
       dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj
       ) else (

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,10 +68,5 @@ build_script:
 
       pushd . && cd tests && go mod tidy && go mod download && popd
 
-      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1;
-      if %errorlevel% == 0 (
-      dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj
-      ) else (
-      exit 0
-      )
+      .\scripts\release.cmd
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,5 +68,5 @@ build_script:
 
       pushd . && cd tests && go mod tidy && go mod download && popd
 
-      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || rem
+      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || exit 0
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,5 +68,5 @@ build_script:
 
       pushd . && cd tests && go mod tidy && go mod download && popd
 
-      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || exit 0
+      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj )
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,5 +68,5 @@ build_script:
 
       pushd . && cd tests && go mod tidy && go mod download && popd
 
-      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || (echo "skipping release")
+      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || rem
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,5 +68,10 @@ build_script:
 
       pushd . && cd tests && go mod tidy && go mod download && popd
 
-      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj )
+      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1
+      if %errorlevel% == 0 (
+      dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj
+      ) else (
+      exit 0
+      )
 test: off

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -68,5 +68,5 @@ build_script:
 
       pushd . && cd tests && go mod tidy && go mod download && popd
 
-      if defined APPVEYOR_REPO_TAG_NAME ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj )
+      echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || (echo "skipping release")
 test: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-if: branch = master OR branch =~ ^features/ OR branch =~ ^feature- OR tag IS present
+if: branch = master OR branch =~ ^features/ OR branch =~ ^feature- OR tag =~ ^v\d+.*
 matrix:
   include:
   - os: linux

--- a/scripts/release.cmd
+++ b/scripts/release.cmd
@@ -1,0 +1,6 @@
+echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1
+if %errorlevel% == 0 ( 
+dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj
+) else (
+exit 0
+)


### PR DESCRIPTION
We need to begin publishing tags for each submodule to enable using facing consumption:

`go get github.com/pulumi/pulumi/sdk@v1.13.1`


We don't want anything to change with our current release and publish process. When we publish a `v1.13.2` tag, we should kick off the release job that publishes all SDK artifacts and pulumi binaries. Publishing of the sub-module tags should not kick off a release. These tags are only consumed by Go users (the only artifact being the tagged remote on github.com). 

This change alters our release builds to check the form of a tag (starts with `v0`, `v1`, etc) rather than just it's existence. I updated the appveyor script, and travis. As far as I can tell, the GHA windows build is not tag aware. 

I tested the CMD updates by running that line on CMD shell in a windows VM:

```cmd
C:\Users\Administrator>set APPVEYOR_REPO_TAG_NAME=v1.1.1

C:\Users\Administrator> echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || (echo "skipping release")
'dotnet' is not recognized as an internal or external command,
operable program or batch file.
"skipping release"

C:\Users\Administrator>set APPVEYOR_REPO_TAG_NAME=sdk/v1.1.1

C:\Users\Administrator> echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || (echo "skipping release")
"skipping release"

C:\Users\Administrator>set APPVEYOR_REPO_TAG_NAME=vpkg/v1.1.1

C:\Users\Administrator> echo %APPVEYOR_REPO_TAG_NAME%|findstr "^v[0-9]" >Nul 2>&1 && ( dotnet msbuild /t:ReleaseProcess /v:Detailed build.proj ) || (echo "skipping release")
"skipping release"
```

With this new release process, we'll start by tagging the top level module `vX.X.X` and push causing a release build. Then we'll tag each submodule `submod/vX.X.X` and push, but these won't cause release builds. 

