### PR TITLE
Fix policy integration test dependencies

### DIFF
--- a/tests/integration/policy/policy_pack_w_config/PulumiPolicy.yaml
+++ b/tests/integration/policy/policy_pack_w_config/PulumiPolicy.yaml
@@ -1,3 +1,1 @@
-name: aws-policy
-description: Example policies for AWS
 runtime: nodejs

--- a/tests/integration/policy/policy_pack_w_config/package.json
+++ b/tests/integration/policy/policy_pack_w_config/package.json
@@ -2,7 +2,6 @@
     "name": "test-policy-w-config",
     "version": "0.0.1",
     "dependencies": {
-        "@pulumi/pulumi": "^1.13.0",
         "@pulumi/policy": "0.4.1-dev.1584625475"
     },
     "devDependencies": {

--- a/tests/integration/policy/policy_pack_w_config/package.json.tmpl
+++ b/tests/integration/policy/policy_pack_w_config/package.json.tmpl
@@ -1,14 +1,10 @@
 {
-    "name": "aws-policy",
+    "name": "test-policy-w-config",
     "version": { policyVersion },
     "dependencies": {
-        "@pulumi/pulumi": "^1.13.0",
-        "@pulumi/aws": "^1.0.0",
         "@pulumi/policy": "0.4.1-dev.1584625475"
     },
     "devDependencies": {
-        "@types/mocha": "^2.2.42",
-        "@types/node": "^10.12.7",
-        "tslint": "^5.11.0"
+        "@types/node": "^10.12.7"
     }
 }

--- a/tests/integration/policy/policy_pack_wo_config/PulumiPolicy.yaml
+++ b/tests/integration/policy/policy_pack_wo_config/PulumiPolicy.yaml
@@ -1,3 +1,1 @@
-name: aws-policy
-description: Example policies for AWS
 runtime: nodejs

--- a/tests/integration/policy/policy_pack_wo_config/package.json
+++ b/tests/integration/policy/policy_pack_wo_config/package.json
@@ -2,12 +2,9 @@
     "name": "test-policy-wo-config",
     "version": "0.0.1",
     "dependencies": {
-        "@pulumi/pulumi": "^1.0.0",
-        "@pulumi/policy": "^0.2.0"
+        "@pulumi/policy": "^0.4.0"
     },
     "devDependencies": {
-        "@types/mocha": "^2.2.42",
-        "@types/node": "^10.12.7",
-        "tslint": "^5.11.0"
+        "@types/node": "^10.12.7"
     }
 }

--- a/tests/integration/policy/policy_test.go
+++ b/tests/integration/policy/policy_test.go
@@ -87,7 +87,7 @@ func TestPolicyWithConfig(t *testing.T) {
 }
 
 // TestPolicyWithoutConfig runs integration tests against the policy pack in the policy_pack_w_config
-// directory. This tests against version 0.2.0 of the pulumi/policy sdk, prior to policy config being supported.
+// directory. This tests against version 0.4.0 of the pulumi/policy sdk, prior to policy config being supported.
 func TestPolicyWithoutConfig(t *testing.T) {
 	e := ptesting.NewEnvironment(t)
 	defer func() {


### PR DESCRIPTION
The failure on the node 13.11.3 build is due to `tests/integration/policy/policy_pack_wo_config/package.json` having a dependency on a much older version of the policy library, `"@pulumi/policy": "^0.2.0"` which has an explicit dependency on an old version of `@pulumi/pulumi` (`"@pulumi/pulumi": "1.4.1"`) which doesn't have pre-built grpc binaries (`Pre-built binaries not found for grpc@1.21.1 and node@13.11.0`).

The fix is to depend on the latest released version of `@pulumi/policy`, which will use the latest `@pulumi/pulumi`.

Also removed some other unnecessary cruft in these policy packs, while cleaning things up here.

Fixes #4226