### PR TITLE
Fix Node.js SxS checks for 1.x and 1.y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
-_(none)_
+- Fix error related to side-by-side versions of `@pulumi/pulumi`.
+  [#4235](https://github.com/pulumi/pulumi/pull/4235)
 
 ## 1.13.1 (2020-03-27)
 - Move to a multi-module repo to enable modules for the Go SDK

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -170,17 +170,17 @@ func compatibleVersions(a, b semver.Version) (bool, string) {
 			return false, "Differing major or minor versions are not supported."
 		}
 
-	case a.Major >= 2 && b.Major >= 2:
-		// If both major versions are post-2.0, we require that the major versions match.
+	case a.Major >= 1 && a.Major <= 2 && b.Major >= 1 && b.Major <= 2:
+		// If both versions are 1.0<=v<=2.0, they are compatible.
+
+	case a.Major > 2 || b.Major > 2:
+		// If either version is post-2.0, we require that the major versions match.
 		if a.Major != b.Major {
 			return false, "Differing major versions are not supported."
 		}
 
 	case a.Major == 1 && b.Major == 0 && b.Minor == 17 || b.Major == 1 && a.Major == 0 && a.Minor == 17:
 		// If one version is pre-1.0 and the other is post-1.0, we unify 1.x.y and 0.17.z. This combination is legal.
-
-	case (a.Major == 1 && b.Major == 2) || (a.Major == 2 && b.Major == 1):
-		// If one version is 1.0 and the other is 2.0, we unify 1.x and 2.x.  This combination is legal.
 
 	default:
 		// All other combinations of versions are illegal.

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main_test.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blang/semver"
 	pulumirpc "github.com/pulumi/pulumi/sdk/proto/go"
 	"github.com/stretchr/testify/assert"
 )
@@ -71,4 +72,34 @@ func TestConfig(t *testing.T) {
 		assert.NoError(tt, err)
 		assert.JSONEq(tt, "{}", str)
 	})
+}
+
+func TestCompatibleVersions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a          string
+		b          string
+		compatible bool
+		errmsg     string
+	}{
+		{"0.17.1", "0.16.2", false, "Differing major or minor versions are not supported."},
+		{"0.17.1", "1.0.0", true, ""},
+		{"1.0.0", "0.17.1", true, ""},
+		{"1.13.0", "1.13.0", true, ""},
+		{"1.1.1", "1.13.0", true, ""},
+		{"1.13.0", "1.1.1", true, ""},
+		{"1.1.0", "2.1.0", true, ""},
+		{"2.1.0", "1.1.0", true, ""},
+		{"1.1.0", "2.0.0-beta1", true, ""},
+		{"2.0.0-beta1", "1.1.0", true, ""},
+		{"2.1.0", "3.1.0", false, "Differing major versions are not supported."},
+		{"0.16.1", "1.0.0", false, "Differing major or minor versions are not supported."},
+	}
+
+	for _, c := range cases {
+		compatible, errmsg := compatibleVersions(semver.MustParse(c.a), semver.MustParse(c.b))
+		assert.Equal(t, c.errmsg, errmsg)
+		assert.Equal(t, c.compatible, compatible)
+	}
 }


### PR DESCRIPTION
Addresses a regression introduced in https://github.com/pulumi/pulumi/pull/4161 and adds test coverage.

Fixes #4234