### PR TITLE
Specify StringComparison.Ordinal to StartsWith

### DIFF
--- a/sdk/dotnet/Pulumi/Serialization/Deserializer.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Deserializer.cs
@@ -83,7 +83,7 @@ namespace Pulumi.Serialization
                         // These don't actually contribute to the exposed shape of the object, do
                         // not need to be passed back to the engine, and often will not match the
                         // expected type we are deserializing into.
-                        if (key.StartsWith("__"))
+                        if (key.StartsWith("__", StringComparison.Ordinal))
                             continue;
 
                         var elementData = Deserialize(element);


### PR DESCRIPTION
Minor change: `StartsWith` does a culture-sensitive comparison by default, and in this case, we really just want an ordinal comparison.