### PR TITLE
Resource template fixes

### DIFF
--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -26,7 +26,9 @@
 
 <!-- C# -->
 {{ print "{{% choosable language csharp %}}" }}
-<div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static class </span><span class="nx">Get{{ .ResourceName }} </span><span class="p">{</span><span class="k">public static </span>Task<{{ template "linkify_param" .FunctionResult.csharp }}> <span class="p">InvokeAsync(</span>{{ htmlSafe .FunctionArgs.csharp }}<span class="p">)</span><span class="p">}</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public static class </span><span class="nx">Get{{ .ResourceName }} </span><span class="p">{</span><span class="k">
+    public static </span>Task<{{ template "linkify_param" .FunctionResult.csharp }}> <span class="p">InvokeAsync(</span>{{ htmlSafe .FunctionArgs.csharp }}<span class="p">)</span><span class="p">
+}</span></code></pre></div>
 {{ print "{{% /choosable %}}" }}
 
 {{ if ne (len .InputProperties) 0 }}
@@ -48,7 +50,7 @@ The following output properties are available:
 
 ## Supporting Types
 {{ range .NestedTypes }}
-#### {{ .Name }}
+<h4>{{ htmlSafe .Name }}</h4>
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
 > See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}


### PR DESCRIPTION
This change is intended to fix a couple of formatting issues with the newly shipped resource docs:

**HTML-Escaped Headings**

Before: 
![image](https://user-images.githubusercontent.com/274700/77976861-f9dd5a80-72b2-11ea-9dd2-6855bb928ab5.png)

After:
![image](https://user-images.githubusercontent.com/274700/77976924-209b9100-72b3-11ea-9f0e-dd1e13178ddd.png)

**Missing Indentation**

Before:
![image](https://user-images.githubusercontent.com/274700/77976834-e500c700-72b2-11ea-9cc1-70b6f466b59e.png)

After:
![image](https://user-images.githubusercontent.com/274700/77976807-d4505100-72b2-11ea-8bd0-7e1615c869bc.png)
