### PR TITLE
Add Python support to `pulumi policy new`

### DIFF
--- a/pkg/cmd/up.go
+++ b/pkg/cmd/up.go
@@ -262,7 +262,7 @@ func newUpCmd() *cobra.Command {
 		}
 
 		// Install dependencies.
-		if err = installDependencies(); err != nil {
+		if err = installDependencies(proj, root); err != nil {
 			return result.FromError(err)
 		}
 


### PR DESCRIPTION
Instead of always running `npm install`, if the Policy Pack is Python, emit instructions on how to install dependencies. Also minor cleanup/refactoring.

## Node.js

<img width="1052" alt="Screen Shot 2020-04-01 at 10 57 51 AM" src="https://user-images.githubusercontent.com/710598/78170344-ab8da000-7407-11ea-961e-c92162aa976e.png">

## Node.js w/ `-g`

<img width="1053" alt="Screen Shot 2020-04-01 at 10 58 23 AM" src="https://user-images.githubusercontent.com/710598/78170387-b9432580-7407-11ea-8431-0a0ed6a0363c.png">

## Python

<img width="1054" alt="Screen Shot 2020-04-01 at 10 58 54 AM" src="https://user-images.githubusercontent.com/710598/78170434-cc55f580-7407-11ea-8173-7330477da3e0.png">

Fixes https://github.com/pulumi/pulumi/issues/4115
