### PR TITLE
Suppress output correctly in git-diff

### DIFF
--- a/scripts/get-version
+++ b/scripts/get-version
@@ -14,7 +14,7 @@ EXACT=0
 # as we've seen cases in Travis where not doing so causes git to
 # treat the worktree as dirty when it is not.
 git update-index -q --refresh
-if ! git diff-files -- . ':!**/go.mod' ':!**/go.sum' --quiet; then
+if ! git diff-files --quiet -- . ':!**/go.mod' ':!**/go.sum'; then
     DIRTY_TAG="dirty"
 fi
 

--- a/scripts/get-version.ps1
+++ b/scripts/get-version.ps1
@@ -2,7 +2,7 @@
 $ErrorActionPreference="Stop"
 
 git update-index -q --refresh
-git diff-files -- . ':!**/go.mod' ':!**/go.sum' --quiet | Out-Null
+git diff-files --quiet -- . ':!**/go.mod' ':!**/go.sum' | Out-Null
 
 $dirty=($LASTEXITCODE -ne 0)
 


### PR DESCRIPTION
Correctly suppresses the modified files in git diff when checking the version