### PR TITLE
Enable features in mock monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 ## HEAD (unreleased)
 - Fix handling of `nil` values in Outputs in Go.
   [#4268](https://github.com/pulumi/pulumi/pull/4268)
+  
 - Include usage hints for Input types in Go SDK
   [#4279](https://github.com/pulumi/pulumi/pull/4279)
 
@@ -12,6 +13,9 @@ CHANGELOG
 
 - Fix the `call` mock in Python.
   [#4274](https://github.com/pulumi/pulumi/pull/4274)
+  
+- Fix handling of secret values in mock-based tests.
+  [#4272](https://github.com/pulumi/pulumi/pull/4272)
 
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -112,6 +112,12 @@ export class MockMonitor {
     public registerResourceOutputs(req: any, callback: (err: any, innerResponse: any) => void) {
         callback(null, {});
     }
+
+    public supportsFeature(req: any, callback: (err: any, innerResponse: any) => void) {
+        callback(null, {
+            getHassupport: () => true,
+        });
+    }
 }
 
 /**

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -118,6 +118,10 @@ class MockMonitor:
         #pylint: disable=unused-argument
         return empty_pb2.Empty()
 
+    def SupportsFeature(self, request):
+        #pylint: disable=unused-argument
+        return type('SupportsFeatureResponse', (object,), {'hasSupport' : True})
+
 
 class MockEngine:
     logger: logging.Logger

--- a/sdk/python/lib/test/langhost/testing_with_mocks/resources.py
+++ b/sdk/python/lib/test/langhost/testing_with_mocks/resources.py
@@ -11,12 +11,13 @@ class MyComponent(pulumi.ComponentResource):
 
 class Instance(pulumi.CustomResource):
     public_ip: pulumi.Output[str]
-    def __init__(self, resource_name, name: pulumi.Input[str] = None, opts = None):
+    def __init__(self, resource_name, name: pulumi.Input[str] = None, value: pulumi.Input[str] = None, opts = None):
         if name is None:
                 raise TypeError("Missing required property 'name'")
         __props__: dict = dict()
         __props__["public_ip"] = None
         __props__["name"] = name
+        __props__["value"] = value
         super(Instance, self).__init__('aws:ec2/instance:Instance', resource_name, __props__, opts)
 
 def do_invoke():
@@ -24,5 +25,7 @@ def do_invoke():
     return value["out_value"]
 
 mycomponent = MyComponent("mycomponent", inprop="hello")
-myinstance = Instance("instance", name="myvm")
+myinstance = Instance("instance",
+                      name="myvm",
+                      value=pulumi.Output.secret("secret_value"))
 invoke_result = do_invoke()


### PR DESCRIPTION
Enables secret support in mock-based tests. Go and C# seem to be fine as-is.

Fixes #4145