### PR TITLE
Propagate secretness correctly in Python `apply`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 - Fix handling of `nil` values in Outputs in Go.
   [#4268](https://github.com/pulumi/pulumi/pull/4268)
 
+- Fix secretness propagation in Python `apply`.
+  [#4273](https://github.com/pulumi/pulumi/pull/4273)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
@@ -27,6 +27,39 @@ namespace Pulumi.Tests.Core
                 });
 
             [Fact]
+            public Task ApplyCanRunOnKnownAwaitableValue()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => Task.FromResult("inner"));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyCanRunOnKnownKnownOutputValue()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyCanRunOnKnownUnknownOutputValue()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
             public Task ApplyProducesUnknownDefaultOnUnknown()
                 => RunInPreview(async () =>
                 {
@@ -35,6 +68,39 @@ namespace Pulumi.Tests.Core
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
                     Assert.Equal(0, data.Value);
+                });
+
+            [Fact]
+            public Task ApplyProducesUnknownDefaultOnUnknownAwaitable()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => Task.FromResult("inner"));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.Null(data.Value);
+                });
+
+            [Fact]
+            public Task ApplyProducesUnknownDefaultOnUnknownKnownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => CreateOutput("", isKnown: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.Null(data.Value);
+                });
+
+            [Fact]
+            public Task ApplyProducesUnknownDefaultOnUnknownUnknownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => CreateOutput("", isKnown: false));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.Null(data.Value);
                 });
 
             [Fact]
@@ -50,6 +116,42 @@ namespace Pulumi.Tests.Core
                 });
 
             [Fact]
+            public Task ApplyPreservesSecretOnKnownAwaitable()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true, isSecret: true);
+                    var o2 = o1.Apply(a => Task.FromResult("inner"));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnKnownKnownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true, isSecret: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnKnownUnknownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true, isSecret: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
             public Task ApplyPreservesSecretOnUnknown()
                 => RunInPreview(async () =>
                 {
@@ -59,6 +161,90 @@ namespace Pulumi.Tests.Core
                     Assert.False(data.IsKnown);
                     Assert.True(data.IsSecret);
                     Assert.Equal(0, data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnUnknownAwaitable()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false, isSecret: true);
+                    var o2 = o1.Apply(a => Task.FromResult("inner"));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Null(data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnUnknownKnownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false, isSecret: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Null(data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnUnknownUnknownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false, isSecret: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Null(data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPropagatesSecretOnKnownKnownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true, isSecret: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPropagatesSecretOnKnownUnknownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false, isSecret: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyDoesNotPropagateSecretOnUnknownKnownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true, isSecret: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.False(data.IsSecret);
+                    Assert.Null(data.Value);
+                });
+
+            [Fact]
+            public Task ApplyDoesNotPropagateSecretOnUnknownUnknownOutput()
+                => RunInPreview(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false, isSecret: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.False(data.IsSecret);
+                    Assert.Null(data.Value);
                 });
         }
 
@@ -76,6 +262,39 @@ namespace Pulumi.Tests.Core
                 });
 
             [Fact]
+            public Task ApplyCanRunOnKnownAwaitableValue()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => Task.FromResult("inner"));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyCanRunOnKnownKnownOutputValue()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyCanRunOnKnownUnknownOutputValue()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
             public Task ApplyProducesKnownOnUnknown()
                 => RunInNormal(async () =>
                 {
@@ -84,6 +303,39 @@ namespace Pulumi.Tests.Core
                     var data = await o2.DataTask.ConfigureAwait(false);
                     Assert.False(data.IsKnown);
                     Assert.Equal(1, data.Value);
+                });
+
+            [Fact]
+            public Task ApplyProducesKnownOnUnknownAwaitable()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => Task.FromResult("inner"));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyProducesKnownOnUnknownKnownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyProducesUnknownOnUnknownUnknownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.Equal("inner", data.Value);
                 });
 
             [Fact]
@@ -99,6 +351,42 @@ namespace Pulumi.Tests.Core
                 });
 
             [Fact]
+            public Task ApplyPreservesSecretOnKnownAwaitable()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true, isSecret: true);
+                    var o2 = o1.Apply(a => Task.FromResult("inner"));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnKnownKnownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true, isSecret: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnKnownUnknownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true, isSecret: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
             public Task ApplyPreservesSecretOnUnknown()
                 => RunInNormal(async () =>
                 {
@@ -108,6 +396,90 @@ namespace Pulumi.Tests.Core
                     Assert.False(data.IsKnown);
                     Assert.True(data.IsSecret);
                     Assert.Equal(1, data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnUnknownAwaitable()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false, isSecret: true);
+                    var o2 = o1.Apply(a => Task.FromResult("inner"));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnUnknownKnownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false, isSecret: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPreservesSecretOnUnknownUnknownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false, isSecret: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPropagatesSecretOnKnownKnownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true, isSecret: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.True(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPropagatesSecretOnKnownUnknownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: true);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false, isSecret: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPropagatesSecretOnUnknownKnownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: true, isSecret: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
+                });
+
+            [Fact]
+            public Task ApplyPropagatesSecretOnUnknownUnknownOutput()
+                => RunInNormal(async () =>
+                {
+                    var o1 = CreateOutput(0, isKnown: false);
+                    var o2 = o1.Apply(a => CreateOutput("inner", isKnown: false, isSecret: true));
+                    var data = await o2.DataTask.ConfigureAwait(false);
+                    Assert.False(data.IsKnown);
+                    Assert.True(data.IsSecret);
+                    Assert.Equal("inner", data.Value);
                 });
         }
     }

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -64,7 +64,7 @@ class Output(Generic[T]):
 
     _is_secret: Awaitable[bool]
     """
-    Where or not this 'Output' should be treated as containing secret data. Secret outputs are tagged when
+    Whether or not this 'Output' should be treated as containing secret data. Secret outputs are tagged when
     flowing across the RPC interface to the resource monitor, such that when they are persisted to disk in
     our state file, they are encrypted instead of being in plaintext.
     """
@@ -155,16 +155,16 @@ class Output(Generic[T]):
                 value = await self._future
 
                 if runtime.is_dry_run():
-                    # During previews only perform the apply if the engine was able togive us an actual value for this
+                    # During previews only perform the apply if the engine was able to give us an actual value for this
                     # Output or if the caller is able to tolerate unknown values.
                     apply_during_preview = is_known or run_with_unknowns
 
                     if not apply_during_preview:
                         # We didn't actually run the function, our new Output is definitely
-                        # **not** known and **not** secret
+                        # **not** known.
                         result_resources.set_result(resources)
                         result_is_known.set_result(False)
-                        result_is_secret.set_result(False)
+                        result_is_secret.set_result(is_secret)
                         return cast(U, None)
 
                     # If we are running with unknown values and the value is explicitly unknown but does not actually
@@ -187,16 +187,16 @@ class Output(Generic[T]):
 
                 #  2. transformed is an Awaitable[U]
                 if isawaitable(transformed):
-                    # Since transformed is not an Output, it is both known and not a secret.
+                    # Since transformed is not an Output, it is known.
                     result_resources.set_result(resources)
                     result_is_known.set_result(True)
-                    result_is_secret.set_result(False)
+                    result_is_secret.set_result(is_secret)
                     return await cast(Awaitable[U], transformed)
 
                 #  3. transformed is U. It is trivially known.
                 result_resources.set_result(resources)
                 result_is_known.set_result(True)
-                result_is_secret.set_result(False)
+                result_is_secret.set_result(is_secret)
                 return cast(U, transformed)
             finally:
                 # Always resolve the future if it hasn't been done already.


### PR DESCRIPTION
Note: I didn't add any new tests for Go -- I'll need to look into that a bit more and see if it could use any additional coverage.

Fixes #4163