### PR TITLE
Fix python mock's call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 - Fix handling of `nil` values in Outputs in Go.
   [#4268](https://github.com/pulumi/pulumi/pull/4268)
 
+- Fix the `call` mock in Python.
+  [#4274](https://github.com/pulumi/pulumi/pull/4274)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -89,7 +89,7 @@ class MockMonitor:
 
         ret = self.mocks.call(request.tok, args, request.provider)
 
-        ret_proto = _sync_await(asyncio.ensure_future(rpc.serialize_properties(ret, {})))
+        ret_proto = _sync_await(rpc.serialize_properties(ret, {}))
 
         fields = {"failures": None, "return": ret_proto}
         return provider_pb2.InvokeResponse(**fields)
@@ -99,7 +99,7 @@ class MockMonitor:
 
         _, state = self.mocks.new_resource(request.type, request.name, state, request.provider, request.id)
 
-        props_proto = _sync_await(asyncio.ensure_future(rpc.serialize_properties(state, {})))
+        props_proto = _sync_await(rpc.serialize_properties(state, {}))
 
         urn = self.make_urn(request.parent, request.type, request.name)
         return resource_pb2.ReadResourceResponse(urn=urn, properties=props_proto)

--- a/sdk/python/lib/test/langhost/testing_with_mocks/resources.py
+++ b/sdk/python/lib/test/langhost/testing_with_mocks/resources.py
@@ -19,5 +19,10 @@ class Instance(pulumi.CustomResource):
         __props__["name"] = name
         super(Instance, self).__init__('aws:ec2/instance:Instance', resource_name, __props__, opts)
 
+def do_invoke():
+    value = pulumi.runtime.invoke("test:index:MyFunction", props={"value": 41}).value
+    return value["out_value"]
+
 mycomponent = MyComponent("mycomponent", inprop="hello")
 myinstance = Instance("instance", name="myvm")
+invoke_result = do_invoke()

--- a/sdk/python/lib/test/langhost/testing_with_mocks/test_testing_with_mocks.py
+++ b/sdk/python/lib/test/langhost/testing_with_mocks/test_testing_with_mocks.py
@@ -16,7 +16,12 @@ import pulumi
 
 class MyMocks(pulumi.runtime.Mocks):
     def call(self, token, args, provider):
-        return {}
+        if token == 'test:index:MyFunction':
+            return {
+                'out_value': 59,
+            }
+        else:
+            return {}
 
     def new_resource(self, type_, name, inputs, provider, id_):
         if type_ == 'aws:ec2/securityGroup:SecurityGroup':
@@ -55,3 +60,7 @@ class TestingWithMocks(unittest.TestCase):
         def check_ip(ip):
             self.assertEqual(ip, '203.0.113.12')
         return resources.myinstance.public_ip.apply(check_ip)
+
+    @pulumi.runtime.test
+    def test_invoke(self):
+        return self.assertEqual(resources.invoke_result, 59)


### PR DESCRIPTION
I'm not on top of asynchronicity in Python but judging by the `RegisterResource` [implementation](https://github.com/pulumi/pulumi/blob/master/sdk/python/lib/pulumi/runtime/mocks.py#L112), the `ensure_future` seem to be unnecessary. Also, removing them fixes #4101.

Please check that it actually makes sense.