### PR TITLE
Update go codegen to include usage hints on Input types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 ## HEAD (unreleased)
 - Fix handling of `nil` values in Outputs in Go.
   [#4268](https://github.com/pulumi/pulumi/pull/4268)
+- Include usage hints for Input types in Go SDK
+  [#4279](https://github.com/pulumi/pulumi/pull/4279)
 
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -311,11 +311,31 @@ func printComment(w io.Writer, comment string, indent bool) {
 }
 
 func genInputInterface(w io.Writer, name string) {
+	printComment(w, getInputUsage(name), false)
 	fmt.Fprintf(w, "type %sInput interface {\n", name)
 	fmt.Fprintf(w, "\tpulumi.Input\n\n")
 	fmt.Fprintf(w, "\tTo%sOutput() %sOutput\n", title(name), name)
 	fmt.Fprintf(w, "\tTo%sOutputWithContext(context.Context) %sOutput\n", title(name), name)
 	fmt.Fprintf(w, "}\n\n")
+}
+
+func getInputUsage(name string) string {
+	if strings.HasSuffix(name, "Array") {
+		baseTypeName := name[:strings.LastIndex(name, "Array")]
+		return fmt.Sprintf("Construct a concrete instance of %sInput via:\n\t%s{ %sArgs{...} }", name, name, baseTypeName)
+	}
+
+	if strings.HasSuffix(name, "Map") {
+		baseTypeName := name[:strings.LastIndex(name, "Map")]
+		return fmt.Sprintf("Construct a concrete instance of %sInput via:\n\t%s{ \"key\": %sArgs{...} }", name, name, baseTypeName)
+	}
+
+	if strings.HasSuffix(name, "Ptr") {
+		baseTypeName := name[:strings.LastIndex(name, "Ptr")]
+		return fmt.Sprintf("Construct a concrete instance of %sInput via:\n\t%sArgs{...}.To%sOutput()", name, baseTypeName, name)
+	}
+
+	return fmt.Sprintf("Construct a concrete instance of %sInput via:\n\t%sArgs{...}", name, name)
 }
 
 func genInputMethods(w io.Writer, name, receiverType, elementType string, ptrMethods bool) {

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -322,20 +322,49 @@ func genInputInterface(w io.Writer, name string) {
 func getInputUsage(name string) string {
 	if strings.HasSuffix(name, "Array") {
 		baseTypeName := name[:strings.LastIndex(name, "Array")]
-		return fmt.Sprintf("Construct a concrete instance of %sInput via:\n\t%s{ %sArgs{...} }", name, name, baseTypeName)
+		return strings.Join([]string{
+			fmt.Sprintf("%sInput is an input type that accepts %s and %sOutput values.", name, name, name),
+			fmt.Sprintf("You can construct a concrete instance of `%sInput` via:", name),
+			"",
+			fmt.Sprintf("\t\t %s{ %sArgs{...} }", name, baseTypeName),
+			" ",
+		}, "\n")
+
 	}
 
 	if strings.HasSuffix(name, "Map") {
 		baseTypeName := name[:strings.LastIndex(name, "Map")]
-		return fmt.Sprintf("Construct a concrete instance of %sInput via:\n\t%s{ \"key\": %sArgs{...} }", name, name, baseTypeName)
+		return strings.Join([]string{
+			fmt.Sprintf("%sInput is an input type that accepts %s and %sOutput values.", name, name, name),
+			fmt.Sprintf("You can construct a concrete instance of `%sInput` via:", name),
+			"",
+			fmt.Sprintf("\t\t %s{ \"key\": %sArgs{...} }", name, baseTypeName),
+			" ",
+		}, "\n")
 	}
 
 	if strings.HasSuffix(name, "Ptr") {
 		baseTypeName := name[:strings.LastIndex(name, "Ptr")]
-		return fmt.Sprintf("Construct a concrete instance of %sInput via:\n\t%sArgs{...}.To%sOutput()", name, baseTypeName, name)
+		return strings.Join([]string{
+			fmt.Sprintf("%sInput is an input type that accepts %sArgs, %s and %sOutput values.", name, baseTypeName, name, name),
+			fmt.Sprintf("You can construct a concrete instance of `%sInput` via:", name),
+			"",
+			fmt.Sprintf("\t\t %sArgs{...}", baseTypeName),
+			"",
+			" or:",
+			"",
+			"\t\t nil",
+			" ",
+		}, "\n")
 	}
 
-	return fmt.Sprintf("Construct a concrete instance of %sInput via:\n\t%sArgs{...}", name, name)
+	return strings.Join([]string{
+		fmt.Sprintf("%sInput is an input type that accepts %sArgs and %sOutput values.", name, name, name),
+		fmt.Sprintf("You can construct a concrete instance of `%sInput` via:", name),
+		"",
+		fmt.Sprintf("\t\t %sArgs{...}", name),
+		" ",
+	}, "\n")
 }
 
 func genInputMethods(w io.Writer, name, receiverType, elementType string, ptrMethods bool) {

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -8,14 +8,14 @@ import (
 
 func TestInputUsage(t *testing.T) {
 	arrayUsage := getInputUsage("FooArray")
-	assert.Equal(t, "Construct a concrete instance of FooArrayInput via:\n\tFooArray{ FooArgs{...} }", arrayUsage)
+	assert.Equal(t, "FooArrayInput is an input type that accepts FooArray and FooArrayOutput values.\nYou can construct a concrete instance of `FooArrayInput` via:\n\n\t\t FooArray{ FooArgs{...} }\n ", arrayUsage)
 
 	mapUsage := getInputUsage("FooMap")
-	assert.Equal(t, "Construct a concrete instance of FooMapInput via:\n\tFooMap{ \"key\": FooArgs{...} }", mapUsage)
+	assert.Equal(t, "FooMapInput is an input type that accepts FooMap and FooMapOutput values.\nYou can construct a concrete instance of `FooMapInput` via:\n\n\t\t FooMap{ \"key\": FooArgs{...} }\n ", mapUsage)
 
 	ptrUsage := getInputUsage("FooPtr")
-	assert.Equal(t, "Construct a concrete instance of FooPtrInput via:\n\tFooArgs{...}.ToFooPtrOutput()", ptrUsage)
+	assert.Equal(t, "FooPtrInput is an input type that accepts FooArgs, FooPtr and FooPtrOutput values.\nYou can construct a concrete instance of `FooPtrInput` via:\n\n\t\t FooArgs{...}\n\n or:\n\n\t\t nil\n ", ptrUsage)
 
 	usage := getInputUsage("Foo")
-	assert.Equal(t, "Construct a concrete instance of FooInput via:\n\tFooArgs{...}", usage)
+	assert.Equal(t, "FooInput is an input type that accepts FooArgs and FooOutput values.\nYou can construct a concrete instance of `FooInput` via:\n\n\t\t FooArgs{...}\n ", usage)
 }

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -1,0 +1,21 @@
+package gen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInputUsage(t *testing.T) {
+	arrayUsage := getInputUsage("FooArray")
+	assert.Equal(t, "Construct a concrete instance of FooArrayInput via:\n\tFooArray{ FooArgs{...} }", arrayUsage)
+
+	mapUsage := getInputUsage("FooMap")
+	assert.Equal(t, "Construct a concrete instance of FooMapInput via:\n\tFooMap{ \"key\": FooArgs{...} }", mapUsage)
+
+	ptrUsage := getInputUsage("FooPtr")
+	assert.Equal(t, "Construct a concrete instance of FooPtrInput via:\n\tFooArgs{...}.ToFooPtrOutput()", ptrUsage)
+
+	usage := getInputUsage("Foo")
+	assert.Equal(t, "Construct a concrete instance of FooInput via:\n\tFooArgs{...}", usage)
+}

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -8,14 +8,30 @@ import (
 
 func TestInputUsage(t *testing.T) {
 	arrayUsage := getInputUsage("FooArray")
-	assert.Equal(t, "FooArrayInput is an input type that accepts FooArray and FooArrayOutput values.\nYou can construct a concrete instance of `FooArrayInput` via:\n\n\t\t FooArray{ FooArgs{...} }\n ", arrayUsage)
+	assert.Equal(
+		t,
+		"FooArrayInput is an input type that accepts FooArray and FooArrayOutput values.\nYou can construct a "+
+			"concrete instance of `FooArrayInput` via:\n\n\t\t FooArray{ FooArgs{...} }\n ",
+		arrayUsage)
 
 	mapUsage := getInputUsage("FooMap")
-	assert.Equal(t, "FooMapInput is an input type that accepts FooMap and FooMapOutput values.\nYou can construct a concrete instance of `FooMapInput` via:\n\n\t\t FooMap{ \"key\": FooArgs{...} }\n ", mapUsage)
+	assert.Equal(
+		t,
+		"FooMapInput is an input type that accepts FooMap and FooMapOutput values.\nYou can construct a concrete"+
+			" instance of `FooMapInput` via:\n\n\t\t FooMap{ \"key\": FooArgs{...} }\n ",
+		mapUsage)
 
 	ptrUsage := getInputUsage("FooPtr")
-	assert.Equal(t, "FooPtrInput is an input type that accepts FooArgs, FooPtr and FooPtrOutput values.\nYou can construct a concrete instance of `FooPtrInput` via:\n\n\t\t FooArgs{...}\n\n or:\n\n\t\t nil\n ", ptrUsage)
+	assert.Equal(
+		t,
+		"FooPtrInput is an input type that accepts FooArgs, FooPtr and FooPtrOutput values.\nYou can construct a "+
+			"concrete instance of `FooPtrInput` via:\n\n\t\t FooArgs{...}\n\n or:\n\n\t\t nil\n ",
+		ptrUsage)
 
 	usage := getInputUsage("Foo")
-	assert.Equal(t, "FooInput is an input type that accepts FooArgs and FooOutput values.\nYou can construct a concrete instance of `FooInput` via:\n\n\t\t FooArgs{...}\n ", usage)
+	assert.Equal(
+		t,
+		"FooInput is an input type that accepts FooArgs and FooOutput values.\nYou can construct a concrete instance"+
+			" of `FooInput` via:\n\n\t\t FooArgs{...}\n ",
+		usage)
 }

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -437,6 +437,7 @@ github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/4071

This change adds some very basic usage comments on Input types. It gives users a hint on construction of concrete instances. The tests are illustrative, but here's an example in context for pulumi-aws: 

https://github.com/pulumi/pulumi-aws/compare/evan/goCodeGenUsage?expand=1