### PR TITLE
Updates to the HCL2 syntax helpers.

### DIFF
--- a/pkg/codegen/hcl2/model/attribute.go
+++ b/pkg/codegen/hcl2/model/attribute.go
@@ -25,7 +25,7 @@ type Attribute struct {
 	// The syntax node for the attribute, if any.
 	Syntax *hclsyntax.Attribute
 	// The tokens for the attribute.
-	Tokens syntax.AttributeTokens
+	Tokens *syntax.AttributeTokens
 
 	// The attribute's name.
 	Name string
@@ -43,7 +43,7 @@ func (*Attribute) isBodyItem() {}
 // BindAttribute binds an HCL2 attribute using the given scope and token map.
 func BindAttribute(attribute *hclsyntax.Attribute, scope *Scope, tokens syntax.TokenMap) (*Attribute, hcl.Diagnostics) {
 	value, diagnostics := BindExpression(attribute.Expr, scope, tokens)
-	attributeTokens, _ := tokens.ForNode(attribute).(syntax.AttributeTokens)
+	attributeTokens, _ := tokens.ForNode(attribute).(*syntax.AttributeTokens)
 	return &Attribute{
 		Syntax: attribute,
 		Tokens: attributeTokens,

--- a/pkg/codegen/hcl2/model/block.go
+++ b/pkg/codegen/hcl2/model/block.go
@@ -25,7 +25,7 @@ type Block struct {
 	// The syntax node for the block, if any.
 	Syntax *hclsyntax.Block
 	// The tokens for the block.
-	Tokens syntax.BlockTokens
+	Tokens *syntax.BlockTokens
 
 	// The block's type.
 	Type string
@@ -46,7 +46,7 @@ func (*Block) isBodyItem() {}
 // BindBlock binds an HCL2 block using the given scopes and token map.
 func BindBlock(block *hclsyntax.Block, scopes Scopes, tokens syntax.TokenMap) (*Block, hcl.Diagnostics) {
 	body, diagnostics := BindBody(block.Body, scopes, tokens)
-	blockTokens, _ := tokens.ForNode(block).(syntax.BlockTokens)
+	blockTokens, _ := tokens.ForNode(block).(*syntax.BlockTokens)
 	return &Block{
 		Syntax: block,
 		Tokens: blockTokens,

--- a/pkg/codegen/hcl2/model/body.go
+++ b/pkg/codegen/hcl2/model/body.go
@@ -34,7 +34,7 @@ type Body struct {
 	// The syntax node for the body, if any.
 	Syntax *hclsyntax.Body
 	// The tokens for the body.
-	Tokens syntax.BodyTokens
+	Tokens *syntax.BodyTokens
 
 	// The items that make up the body's contents.
 	Items []BodyItem
@@ -70,7 +70,7 @@ func BindBody(body *hclsyntax.Body, scopes Scopes, tokens syntax.TokenMap) (*Bod
 		diagnostics = append(diagnostics, itemDiags...)
 	}
 
-	bodyTokens, _ := tokens.ForNode(body).(syntax.BodyTokens)
+	bodyTokens, _ := tokens.ForNode(body).(*syntax.BodyTokens)
 	return &Body{
 		Syntax: body,
 		Tokens: bodyTokens,

--- a/pkg/codegen/hcl2/syntax/comments.go
+++ b/pkg/codegen/hcl2/syntax/comments.go
@@ -323,6 +323,7 @@ func (m *tokenMapper) Exit(n hclsyntax.Node) hcl.Diagnostics {
 		nodeTokens = &FunctionCallTokens{
 			Name:       m.tokens.atPos(n.NameRange.Start),
 			OpenParen:  m.tokens.atPos(n.OpenParenRange.Start),
+			Commas:     commas,
 			CloseParen: m.tokens.atPos(n.CloseParenRange.Start),
 		}
 	case *hclsyntax.IndexExpr:
@@ -420,7 +421,9 @@ func (m *tokenMapper) Exit(n hclsyntax.Node) hcl.Diagnostics {
 
 // mapTokens builds a mapping from the syntax nodes in the given source file to their tokens. The mapping is recorded
 // in the map passed in to the function.
-func mapTokens(rawTokens hclsyntax.Tokens, filename string, root hclsyntax.Node, contents []byte, tokenMap tokenMap, initialPos hcl.Pos) {
+func mapTokens(rawTokens hclsyntax.Tokens, filename string, root hclsyntax.Node, contents []byte, tokenMap tokenMap,
+	initialPos hcl.Pos) {
+
 	// Turn the list of raw tokens into a list of trivia-carrying tokens.
 	lastEndPos := initialPos
 	var tokens tokenList

--- a/pkg/codegen/hcl2/syntax/comments.go
+++ b/pkg/codegen/hcl2/syntax/comments.go
@@ -24,249 +24,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
 )
 
-// Trivia represents bytes in a source file that are not syntactically meaningful. This includes whitespace and
-// comments.
-type Trivia interface {
-	// Range returns the range of the trivia in the source file.
-	Range() hcl.Range
-	// Bytes returns the raw bytes that comprise the trivia.
-	Bytes() []byte
-
-	isTrivia()
-}
-
-// Comment is a piece of trivia that represents a line or block comment in a source file.
-type Comment struct {
-	// Lines contains the lines of the comment without leading comment characters or trailing newlines.
-	Lines []string
-
-	rng   hcl.Range
-	bytes []byte
-}
-
-// Range returns the range of the comment in the source file.
-func (c Comment) Range() hcl.Range {
-	return c.rng
-}
-
-// Bytes returns the raw bytes that comprise the comment.
-func (c Comment) Bytes() []byte {
-	return c.bytes
-}
-
-func (Comment) isTrivia() {}
-
-// Whitespace is a piece of trivia that represents a sequence of whitespace characters in a source file.
-type Whitespace struct {
-	rng   hcl.Range
-	bytes []byte
-}
-
-// Range returns the range of the whitespace in the source file.
-func (w Whitespace) Range() hcl.Range {
-	return w.rng
-}
-
-// Bytes returns the raw bytes that comprise the whitespace.
-func (w Whitespace) Bytes() []byte {
-	return w.bytes
-}
-
-func (Whitespace) isTrivia() {}
-
-// Token represents an HCL2 syntax token with attached leading trivia.
-type Token struct {
-	Raw            hclsyntax.Token
-	LeadingTrivia  []Trivia
-	TrailingTrivia []Trivia
-}
-
-// Range returns the total range covered by this token and any leading trivia.
-func (t Token) Range() hcl.Range {
-	start := t.Raw.Range.Start
-	if len(t.LeadingTrivia) > 0 {
-		start = t.LeadingTrivia[0].Range().Start
-	}
-	end := t.Raw.Range.End
-	if len(t.TrailingTrivia) > 0 {
-		end = t.TrailingTrivia[len(t.TrailingTrivia)-1].Range().End
-	}
-	return hcl.Range{Filename: t.Raw.Range.Filename, Start: start, End: end}
-}
-
-// NodeTokens is a closed interface that is used to represent arbitrary *Tokens types in this package.
-type NodeTokens interface {
-	isNodeTokens()
-}
-
-// AttributeTokens records the tokens associated with an *hclsyntax.Attribute.
-type AttributeTokens struct {
-	Name   Token
-	Equals Token
-}
-
-func (AttributeTokens) isNodeTokens() {}
-
-// BinaryOpTokens records the tokens associated with an *hclsyntax.BinaryOpExpr.
-type BinaryOpTokens struct {
-	Operator Token
-}
-
-func (BinaryOpTokens) isNodeTokens() {}
-
-// BlockTokens records the tokens associated with an *hclsyntax.Block.
-type BlockTokens struct {
-	Type       Token
-	Labels     []Token
-	OpenBrace  Token
-	CloseBrace Token
-}
-
-func (BlockTokens) isNodeTokens() {}
-
-// BodyTokens records the tokens associated with an *hclsyntax.Body.
-type BodyTokens struct {
-	EndOfFile Token
-}
-
-func (BodyTokens) isNodeTokens() {}
-
-// ConditionalTokens records the tokens associated with an *hclsyntax.ConditionalExpr.
-type ConditionalTokens struct {
-	QuestionMark Token
-	Colon        Token
-}
-
-func (ConditionalTokens) isNodeTokens() {}
-
-// ForTokens records the tokens associated with an *hclsyntax.ForExpr.
-type ForTokens struct {
-	Open  Token
-	For   Token
-	Key   *Token
-	Comma *Token
-	Value Token
-	In    Token
-	Colon Token
-	Arrow *Token
-	Group *Token
-	If    *Token
-	Close Token
-}
-
-func (ForTokens) isNodeTokens() {}
-
-// FunctionCallTokens records the tokens associated with an *hclsyntax.FunctionCallExpr.
-type FunctionCallTokens struct {
-	Name       Token
-	OpenParen  Token
-	CloseParen Token
-}
-
-func (FunctionCallTokens) isNodeTokens() {}
-
-// IndexTokens records the tokens associated with an *hclsyntax.IndexExpr.
-type IndexTokens struct {
-	OpenBracket  Token
-	CloseBracket Token
-}
-
-func (IndexTokens) isNodeTokens() {}
-
-// LiteralValueTokens records the tokens associated with an *hclsyntax.LiteralValueExpr.
-type LiteralValueTokens struct {
-	Value []Token
-}
-
-func (LiteralValueTokens) isNodeTokens() {}
-
-// ObjectConsItemTokens records the tokens associated with an hclsyntax.ObjectConsItem.
-type ObjectConsItemTokens struct {
-	Equals Token
-	Comma  *Token
-}
-
-// ObjectConsTokens records the tokens associated with an *hclsyntax.ObjectConsExpr.
-type ObjectConsTokens struct {
-	OpenBrace  Token
-	Items      []ObjectConsItemTokens
-	CloseBrace Token
-}
-
-func (ObjectConsTokens) isNodeTokens() {}
-
-// TraverserTokens is a closed interface implemented by DotTraverserTokens and BracketTraverserTokens
-type TraverserTokens interface {
-	isTraverserTokens()
-}
-
-// DotTraverserTokens records the tokens associated with dotted traverser (i.e. '.' <attr>).
-type DotTraverserTokens struct {
-	Dot   Token
-	Index Token
-}
-
-func (DotTraverserTokens) isTraverserTokens() {}
-
-// BracketTraverserTokens records the tokens associated with a bracketed traverser (i.e. '[' <index> ']').
-type BracketTraverserTokens struct {
-	OpenBracket  Token
-	Index        Token
-	CloseBracket Token
-}
-
-func (BracketTraverserTokens) isTraverserTokens() {}
-
-// RelativeTraversalTokens records the tokens associated with an *hclsyntax.RelativeTraversalExpr.
-type RelativeTraversalTokens struct {
-	Traversal []TraverserTokens
-}
-
-func (RelativeTraversalTokens) isNodeTokens() {}
-
-// ScopeTraversalTokens records the tokens associated with an *hclsyntax.ScopeTraversalExpr.
-type ScopeTraversalTokens struct {
-	Root      Token
-	Traversal []TraverserTokens
-}
-
-func (ScopeTraversalTokens) isNodeTokens() {}
-
-// SplatTokens records the tokens associated with an *hclsyntax.SplatExpr.
-type SplatTokens struct {
-	Open  Token
-	Star  Token
-	Close *Token
-}
-
-func (SplatTokens) isNodeTokens() {}
-
-// TemplateTokens records the tokens associated with an *hclsyntax.TemplateExpr.
-type TemplateTokens struct {
-	// TODO(pdg): tokens for template parts
-
-	Open  Token
-	Close Token
-}
-
-func (TemplateTokens) isNodeTokens() {}
-
-// TupleConsTokens records the tokens associated with an *hclsyntax.TupleConsExpr.
-type TupleConsTokens struct {
-	OpenBracket  Token
-	Commas       []Token
-	CloseBracket Token
-}
-
-func (TupleConsTokens) isNodeTokens() {}
-
-// UnaryOpTokens records the tokens associated with an *hclsyntax.UnaryOpExpr.
-type UnaryOpTokens struct {
-	Operator Token
-}
-
-func (UnaryOpTokens) isNodeTokens() {}
-
 // tokenList is a list of Tokens with methods to aid in mapping source positions to tokens.
 type tokenList []Token
 
@@ -341,26 +98,351 @@ func NewTokenMapForFiles(files []*File) TokenMap {
 	return tokens
 }
 
+type tokenMapper struct {
+	tokenMap tokenMap
+	tokens   tokenList
+	stack    []hclsyntax.Node
+}
+
+func (m *tokenMapper) inTemplate() bool {
+	if len(m.stack) < 2 {
+		return false
+	}
+	parent := m.stack[len(m.stack)-2]
+	switch parent.(type) {
+	case *hclsyntax.TemplateExpr, *hclsyntax.TemplateJoinExpr:
+		return true
+	}
+	return false
+}
+
+func (m *tokenMapper) inTemplateControl() bool {
+	if len(m.stack) < 3 {
+		return false
+	}
+	parent, grandparent := m.stack[len(m.stack)-2], m.stack[len(m.stack)-3]
+	switch parent.(type) {
+	case *hclsyntax.ConditionalExpr, *hclsyntax.ForExpr:
+		switch grandparent.(type) {
+		case *hclsyntax.TemplateExpr, *hclsyntax.TemplateJoinExpr:
+			return true
+		}
+	}
+	return false
+}
+
+func (m *tokenMapper) collectLabelTokens(r hcl.Range) Token {
+	tokens := m.tokens.inRange(r)
+	if len(tokens) != 3 {
+		return m.tokens.atPos(r.Start)
+	}
+	open := tokens[0]
+	if open.Raw.Type != hclsyntax.TokenOQuote || len(open.TrailingTrivia) != 0 {
+		return m.tokens.atPos(r.Start)
+	}
+	str := tokens[1]
+	if str.Raw.Type != hclsyntax.TokenQuotedLit || len(str.LeadingTrivia) != 0 || len(str.TrailingTrivia) != 0 {
+		return m.tokens.atPos(r.Start)
+	}
+	close := tokens[2]
+	if close.Raw.Type != hclsyntax.TokenCQuote || len(close.LeadingTrivia) != 0 {
+		return m.tokens.atPos(r.Start)
+	}
+	return Token{
+		Raw: hclsyntax.Token{
+			Type:  hclsyntax.TokenQuotedLit,
+			Bytes: append(append(open.Raw.Bytes, str.Raw.Bytes...), close.Raw.Bytes...),
+			Range: hcl.Range{
+				Filename: open.Raw.Range.Filename,
+				Start:    open.Raw.Range.Start,
+				End:      close.Raw.Range.End,
+			},
+		},
+		LeadingTrivia:  open.LeadingTrivia,
+		TrailingTrivia: close.TrailingTrivia,
+	}
+}
+
+func (m *tokenMapper) Enter(n hclsyntax.Node) hcl.Diagnostics {
+	switch n := n.(type) {
+	case hclsyntax.Attributes, hclsyntax.Blocks, hclsyntax.ChildScope:
+		// Do nothing
+	default:
+		m.stack = append(m.stack, n)
+	}
+	return nil
+}
+
+func (m *tokenMapper) Exit(n hclsyntax.Node) hcl.Diagnostics {
+	var nodeTokens NodeTokens
+	switch n := n.(type) {
+	case *hclsyntax.Attribute:
+		nodeTokens = &AttributeTokens{
+			Name:   m.tokens.atPos(n.NameRange.Start),
+			Equals: m.tokens.atPos(n.EqualsRange.Start),
+		}
+	case *hclsyntax.BinaryOpExpr:
+		nodeTokens = &BinaryOpTokens{
+			Operator: m.tokens.atPos(n.LHS.Range().End),
+		}
+	case *hclsyntax.Block:
+		labels := make([]Token, len(n.Labels))
+		for i, r := range n.LabelRanges {
+			labels[i] = m.collectLabelTokens(r)
+		}
+		nodeTokens = &BlockTokens{
+			Type:       m.tokens.atPos(n.TypeRange.Start),
+			Labels:     labels,
+			OpenBrace:  m.tokens.atPos(n.OpenBraceRange.Start),
+			CloseBrace: m.tokens.atPos(n.CloseBraceRange.Start),
+		}
+	case *hclsyntax.ConditionalExpr:
+		if m.inTemplate() {
+			condition := m.tokens.atPos(n.Condition.Range().Start)
+
+			ift := m.tokens.atOffset(condition.Range().Start.Byte - 1)
+			openIf := m.tokens.atOffset(ift.Range().Start.Byte - 1)
+			closeIf := m.tokens.atPos(n.Condition.Range().End)
+
+			openEndifOrElse := m.tokens.atPos(n.TrueResult.Range().End)
+			endifOrElse := m.tokens.atPos(openEndifOrElse.Range().End)
+			closeEndifOrElse := m.tokens.atPos(endifOrElse.Range().End)
+
+			var openElse, elset, closeElse *Token
+			if endifOrElse.Raw.Type == hclsyntax.TokenIdent && string(endifOrElse.Raw.Bytes) == "else" {
+				open, t, close := openEndifOrElse, endifOrElse, closeEndifOrElse
+				openElse, elset, closeElse = &open, &t, &close
+
+				openEndifOrElse = m.tokens.atPos(n.FalseResult.Range().End)
+				endifOrElse = m.tokens.atPos(openEndifOrElse.Range().End)
+				closeEndifOrElse = m.tokens.atPos(endifOrElse.Range().End)
+			}
+
+			nodeTokens = &TemplateConditionalTokens{
+				OpenIf:     openIf,
+				If:         ift,
+				CloseIf:    closeIf,
+				OpenElse:   openElse,
+				Else:       elset,
+				CloseElse:  closeElse,
+				OpenEndif:  openEndifOrElse,
+				Endif:      endifOrElse,
+				CloseEndif: closeEndifOrElse,
+			}
+		} else {
+			nodeTokens = &ConditionalTokens{
+				QuestionMark: m.tokens.atPos(n.Condition.Range().End),
+				Colon:        m.tokens.atPos(n.TrueResult.Range().End),
+			}
+		}
+	case *hclsyntax.ForExpr:
+		inTemplate := m.inTemplate()
+
+		openToken := m.tokens.atPos(n.OpenRange.Start)
+		forToken := m.tokens.atPos(openToken.Range().End)
+
+		var keyToken, commaToken *Token
+		var valueToken Token
+		if n.KeyVar != "" {
+			key := m.tokens.atPos(forToken.Range().End)
+			comma := m.tokens.atPos(key.Range().End)
+			value := m.tokens.atPos(comma.Range().End)
+
+			keyToken, commaToken, valueToken = &key, &comma, value
+		} else {
+			valueToken = m.tokens.atPos(forToken.Range().End)
+		}
+
+		var arrowToken *Token
+		if n.KeyExpr != nil {
+			arrow := m.tokens.atPos(n.KeyExpr.Range().End)
+			arrowToken = &arrow
+		}
+
+		var groupToken *Token
+		if n.Group {
+			group := m.tokens.atPos(n.ValExpr.Range().End)
+			groupToken = &group
+		}
+
+		var ifToken *Token
+		if n.CondExpr != nil {
+			pos := n.ValExpr.Range().End
+			if groupToken != nil {
+				pos = groupToken.Range().End
+			}
+			ift := m.tokens.atPos(pos)
+			ifToken = &ift
+		}
+
+		if inTemplate {
+			closeFor := m.tokens.atPos(n.CollExpr.Range().End)
+
+			openEndfor := m.tokens.atPos(n.ValExpr.Range().End)
+			endfor := m.tokens.atPos(openEndfor.Range().End)
+			closeEndfor := m.tokens.atPos(endfor.Range().End)
+
+			nodeTokens = &TemplateForTokens{
+				OpenFor:     openToken,
+				For:         forToken,
+				Key:         keyToken,
+				Comma:       commaToken,
+				Value:       valueToken,
+				In:          m.tokens.atPos(valueToken.Range().End),
+				CloseFor:    closeFor,
+				OpenEndfor:  openEndfor,
+				Endfor:      endfor,
+				CloseEndfor: closeEndfor,
+			}
+		} else {
+			nodeTokens = &ForTokens{
+				Open:  openToken,
+				For:   forToken,
+				Key:   keyToken,
+				Comma: commaToken,
+				Value: valueToken,
+				In:    m.tokens.atPos(valueToken.Range().End),
+				Colon: m.tokens.atPos(n.CollExpr.Range().End),
+				Arrow: arrowToken,
+				Group: groupToken,
+				If:    ifToken,
+				Close: m.tokens.atPos(n.CloseRange.Start),
+			}
+		}
+	case *hclsyntax.FunctionCallExpr:
+		args := n.Args
+		commas := make([]Token, 0, len(args))
+		if len(args) > 0 {
+			for _, ex := range args[:len(args)-1] {
+				commas = append(commas, m.tokens.atPos(ex.Range().End))
+			}
+			if trailing := m.tokens.atPos(args[len(args)-1].Range().End); trailing.Raw.Type == hclsyntax.TokenComma {
+				commas = append(commas, trailing)
+			}
+		}
+		nodeTokens = &FunctionCallTokens{
+			Name:       m.tokens.atPos(n.NameRange.Start),
+			OpenParen:  m.tokens.atPos(n.OpenParenRange.Start),
+			CloseParen: m.tokens.atPos(n.CloseParenRange.Start),
+		}
+	case *hclsyntax.IndexExpr:
+		nodeTokens = &IndexTokens{
+			OpenBracket:  m.tokens.atPos(n.OpenRange.Start),
+			CloseBracket: m.tokens.atOffset(n.BracketRange.End.Byte - 1),
+		}
+	case *hclsyntax.LiteralValueExpr:
+		nodeTokens = &LiteralValueTokens{
+			Value: m.tokens.inRange(n.Range()),
+		}
+	case *hclsyntax.ObjectConsKeyExpr:
+		nodeTokens = &LiteralValueTokens{
+			Value: m.tokens.inRange(n.Range()),
+		}
+	case *hclsyntax.ObjectConsExpr:
+		items := make([]ObjectConsItemTokens, len(n.Items))
+		for i, item := range n.Items {
+			var comma *Token
+			if t := m.tokens.atPos(item.ValueExpr.Range().End); t.Raw.Type == hclsyntax.TokenComma {
+				comma = &t
+			}
+			items[i] = ObjectConsItemTokens{
+				Equals: m.tokens.atPos(item.KeyExpr.Range().End),
+				Comma:  comma,
+			}
+		}
+		nodeTokens = &ObjectConsTokens{
+			OpenBrace:  m.tokens.atPos(n.OpenRange.Start),
+			CloseBrace: m.tokens.atOffset(n.SrcRange.End.Byte - 1),
+		}
+	case *hclsyntax.RelativeTraversalExpr:
+		nodeTokens = &RelativeTraversalTokens{
+			Traversal: mapRelativeTraversalTokens(m.tokens, n.Traversal),
+		}
+	case *hclsyntax.ScopeTraversalExpr:
+		nodeTokens = &ScopeTraversalTokens{
+			Root:      m.tokens.atPos(n.Traversal[0].SourceRange().Start),
+			Traversal: mapRelativeTraversalTokens(m.tokens, n.Traversal[1:]),
+		}
+	case *hclsyntax.SplatExpr:
+		openToken := m.tokens.atOffset(n.MarkerRange.Start.Byte - 1)
+		starToken := m.tokens.atPos(n.MarkerRange.Start)
+		var closeToken *Token
+		if openToken.Raw.Type == hclsyntax.TokenOBrack {
+			cbrack := m.tokens.atPos(n.MarkerRange.End)
+			closeToken = &cbrack
+		}
+		nodeTokens = &SplatTokens{
+			Open:  openToken,
+			Star:  starToken,
+			Close: closeToken,
+		}
+	case *hclsyntax.TemplateExpr:
+		// NOTE: the HCL parser lifts control sequences into if or for expressions. This is handled in the correspoding
+		// mappers.
+		if !m.inTemplateControl() {
+			// If we're inside the body of a template if or for, there cannot be any delimiting tokens.
+			nodeTokens = &TemplateTokens{
+				Open:  m.tokens.atPos(n.SrcRange.Start),
+				Close: m.tokens.atOffset(n.SrcRange.End.Byte - 1),
+			}
+		}
+	case *hclsyntax.TupleConsExpr:
+		exprs := n.Exprs
+		commas := make([]Token, 0, len(exprs))
+		if len(exprs) > 0 {
+			for _, ex := range exprs[:len(exprs)-1] {
+				commas = append(commas, m.tokens.atPos(ex.Range().End))
+			}
+			if trailing := m.tokens.atPos(exprs[len(exprs)-1].Range().End); trailing.Raw.Type == hclsyntax.TokenComma {
+				commas = append(commas, trailing)
+			}
+		}
+		nodeTokens = &TupleConsTokens{
+			OpenBracket:  m.tokens.atPos(n.OpenRange.Start),
+			Commas:       commas,
+			CloseBracket: m.tokens.atOffset(n.SrcRange.End.Byte - 1),
+		}
+	case *hclsyntax.UnaryOpExpr:
+		nodeTokens = &UnaryOpTokens{
+			Operator: m.tokens.atPos(n.SymbolRange.Start),
+		}
+	}
+	if nodeTokens != nil {
+		m.tokenMap[n] = nodeTokens
+	}
+
+	if n == m.stack[len(m.stack)-1] {
+		m.stack = m.stack[:len(m.stack)-1]
+	}
+
+	return nil
+}
+
 // mapTokens builds a mapping from the syntax nodes in the given source file to their tokens. The mapping is recorded
 // in the map passed in to the function.
-func mapTokens(rawTokens hclsyntax.Tokens, filename string, root hclsyntax.Node, contents []byte, tokenMap tokenMap) {
+func mapTokens(rawTokens hclsyntax.Tokens, filename string, root hclsyntax.Node, contents []byte, tokenMap tokenMap, initialPos hcl.Pos) {
 	// Turn the list of raw tokens into a list of trivia-carrying tokens.
-	var lastEndPos hcl.Pos
+	lastEndPos := initialPos
 	var tokens tokenList
-	var trivia []Trivia
+	var trivia TriviaList
+	inControlSeq := false
 	for _, raw := range rawTokens {
 		// Snip whitespace out of the body and turn it in to trivia.
 		if startPos := raw.Range.Start; startPos.Byte != lastEndPos.Byte {
-			triviaBytes := contents[lastEndPos.Byte:startPos.Byte]
+			triviaBytes := contents[lastEndPos.Byte-initialPos.Byte : startPos.Byte-initialPos.Byte]
 
 			// If this trivia begins a new line, attach the current trivia to the last processed token, if any.
 			if len(tokens) > 0 {
 				if nl := bytes.IndexByte(triviaBytes, '\n'); nl != -1 {
 					trailingTriviaBytes := triviaBytes[:nl+1]
-					triviaBytes = trailingTriviaBytes[nl+1:]
-					lastEndPos = hcl.Pos{Line: lastEndPos.Line + 1, Column: 0, Byte: lastEndPos.Byte + nl + 1}
+					triviaBytes = triviaBytes[nl+1:]
 
+					endPos := hcl.Pos{Line: lastEndPos.Line + 1, Column: 0, Byte: lastEndPos.Byte + nl + 1}
+					rng := hcl.Range{Filename: filename, Start: lastEndPos, End: endPos}
+					trivia = append(trivia, Whitespace{rng: rng, bytes: trailingTriviaBytes})
 					tokens[len(tokens)-1].TrailingTrivia, trivia = trivia, nil
+
+					lastEndPos = endPos
 				}
 			}
 
@@ -371,17 +453,35 @@ func mapTokens(rawTokens hclsyntax.Tokens, filename string, root hclsyntax.Node,
 		switch raw.Type {
 		case hclsyntax.TokenComment:
 			trivia = append(trivia, Comment{Lines: processComment(raw.Bytes), rng: raw.Range, bytes: raw.Bytes})
-			lastEndPos = raw.Range.End
+		case hclsyntax.TokenTemplateInterp:
+			// Treat these as trailing trivia.
+			trivia = append(trivia, TemplateDelimiter{Type: raw.Type, rng: raw.Range, bytes: raw.Bytes})
+			if len(tokens) > 0 {
+				tokens[len(tokens)-1].TrailingTrivia, trivia = trivia, nil
+			}
+		case hclsyntax.TokenTemplateControl:
+			tokens, trivia = append(tokens, Token{Raw: raw, LeadingTrivia: trivia}), nil
+			inControlSeq = true
+		case hclsyntax.TokenTemplateSeqEnd:
+			// If this terminates a template control sequence, it is a proper token. Otherwise, it is treated as leading
+			// trivia.
+			if !inControlSeq {
+				trivia = append(trivia, TemplateDelimiter{Type: raw.Type, rng: raw.Range, bytes: raw.Bytes})
+			} else {
+				tokens, trivia = append(tokens, Token{Raw: raw, LeadingTrivia: trivia}), nil
+			}
+			inControlSeq = false
 		case hclsyntax.TokenNewline, hclsyntax.TokenBitwiseAnd, hclsyntax.TokenBitwiseOr,
 			hclsyntax.TokenBitwiseNot, hclsyntax.TokenBitwiseXor, hclsyntax.TokenStarStar, hclsyntax.TokenApostrophe,
 			hclsyntax.TokenBacktick, hclsyntax.TokenSemicolon, hclsyntax.TokenTabs, hclsyntax.TokenInvalid,
 			hclsyntax.TokenBadUTF8, hclsyntax.TokenQuotedNewline:
-			// Treat them as whitespace. We cannot omit their bytes from the list entirely, as the algorithm below
+			// Treat these as whitespace. We cannot omit their bytes from the list entirely, as the algorithm below
 			// that maps positions to tokens requires that every byte in the source file is covered by the token list.
+			continue
 		default:
 			tokens, trivia = append(tokens, Token{Raw: raw, LeadingTrivia: trivia}), nil
-			lastEndPos = raw.Range.End
 		}
+		lastEndPos = raw.Range.End
 	}
 
 	// If we had any tokens, we should have attached all trivia to something.
@@ -396,176 +496,16 @@ func mapTokens(rawTokens hclsyntax.Tokens, filename string, root hclsyntax.Node,
 	// expression or a token) is used to find the token.
 	//
 	// TODO(pdg): handle parenthesized expressions
-	diags := hclsyntax.VisitAll(root, func(n hclsyntax.Node) hcl.Diagnostics {
-		var nodeTokens NodeTokens
-		switch n := n.(type) {
-		case *hclsyntax.Attribute:
-			nodeTokens = AttributeTokens{
-				Name:   tokens.atPos(n.NameRange.Start),
-				Equals: tokens.atPos(n.EqualsRange.Start),
-			}
-		case *hclsyntax.BinaryOpExpr:
-			nodeTokens = BinaryOpTokens{
-				Operator: tokens.atPos(n.LHS.Range().End),
-			}
-		case *hclsyntax.Block:
-			labels := make([]Token, len(n.Labels))
-			for i, r := range n.LabelRanges {
-				labels[i] = tokens.atPos(r.Start)
-			}
-			nodeTokens = BlockTokens{
-				Type:       tokens.atPos(n.TypeRange.Start),
-				Labels:     labels,
-				OpenBrace:  tokens.atPos(n.OpenBraceRange.Start),
-				CloseBrace: tokens.atPos(n.CloseBraceRange.Start),
-			}
-		case *hclsyntax.ConditionalExpr:
-			nodeTokens = ConditionalTokens{
-				QuestionMark: tokens.atPos(n.Condition.Range().End),
-				Colon:        tokens.atPos(n.TrueResult.Range().End),
-			}
-		case *hclsyntax.ForExpr:
-			forToken := tokens.atPos(n.OpenRange.End)
-
-			var keyToken, commaToken *Token
-			var valueToken Token
-			if n.KeyVar != "" {
-				key := tokens.atPos(forToken.Range().End)
-				comma := tokens.atPos(key.Range().End)
-				value := tokens.atPos(comma.Range().End)
-
-				keyToken, commaToken, valueToken = &key, &comma, value
-			} else {
-				valueToken = tokens.atPos(forToken.Range().End)
-			}
-
-			var arrowToken *Token
-			if n.KeyExpr != nil {
-				arrow := tokens.atPos(n.KeyExpr.Range().End)
-				arrowToken = &arrow
-			}
-
-			var groupToken *Token
-			if n.Group {
-				group := tokens.atPos(n.ValExpr.Range().End)
-				groupToken = &group
-			}
-
-			var ifToken *Token
-			if n.CondExpr != nil {
-				pos := n.ValExpr.Range().End
-				if groupToken != nil {
-					pos = groupToken.Range().End
-				}
-				ift := tokens.atPos(pos)
-				ifToken = &ift
-			}
-
-			nodeTokens = ForTokens{
-				Open:  tokens.atPos(n.OpenRange.Start),
-				For:   forToken,
-				Key:   keyToken,
-				Comma: commaToken,
-				Value: valueToken,
-				In:    tokens.atPos(valueToken.Range().End),
-				Colon: tokens.atPos(n.CollExpr.Range().End),
-				Arrow: arrowToken,
-				Group: groupToken,
-				If:    ifToken,
-				Close: tokens.atPos(n.CloseRange.Start),
-			}
-		case *hclsyntax.FunctionCallExpr:
-			nodeTokens = FunctionCallTokens{
-				Name:       tokens.atPos(n.NameRange.Start),
-				OpenParen:  tokens.atPos(n.OpenParenRange.Start),
-				CloseParen: tokens.atPos(n.CloseParenRange.Start),
-			}
-		case *hclsyntax.IndexExpr:
-			nodeTokens = IndexTokens{
-				OpenBracket:  tokens.atPos(n.OpenRange.Start),
-				CloseBracket: tokens.atOffset(n.BracketRange.End.Byte - 1),
-			}
-		case *hclsyntax.LiteralValueExpr:
-			nodeTokens = LiteralValueTokens{
-				Value: tokens.inRange(n.Range()),
-			}
-		case *hclsyntax.ObjectConsExpr:
-			items := make([]ObjectConsItemTokens, len(n.Items))
-			for i, item := range n.Items {
-				var comma *Token
-				if t := tokens.atPos(item.ValueExpr.Range().End); t.Raw.Type == hclsyntax.TokenComma {
-					comma = &t
-				}
-				items[i] = ObjectConsItemTokens{
-					Equals: tokens.atPos(item.KeyExpr.Range().End),
-					Comma:  comma,
-				}
-			}
-			nodeTokens = ObjectConsTokens{
-				OpenBrace:  tokens.atPos(n.OpenRange.Start),
-				CloseBrace: tokens.atOffset(n.SrcRange.End.Byte - 1),
-			}
-		case *hclsyntax.RelativeTraversalExpr:
-			nodeTokens = RelativeTraversalTokens{
-				Traversal: mapRelativeTraversalTokens(tokens, n.Traversal),
-			}
-		case *hclsyntax.ScopeTraversalExpr:
-			nodeTokens = ScopeTraversalTokens{
-				Root:      tokens.atPos(n.Traversal[0].SourceRange().Start),
-				Traversal: mapRelativeTraversalTokens(tokens, n.Traversal[1:]),
-			}
-		case *hclsyntax.SplatExpr:
-			openToken := tokens.atOffset(n.MarkerRange.Start.Byte - 1)
-			starToken := tokens.atPos(n.MarkerRange.Start)
-			var closeToken *Token
-			if openToken.Raw.Type == hclsyntax.TokenOBrack {
-				cbrack := tokens.atPos(n.MarkerRange.End)
-				closeToken = &cbrack
-			}
-			nodeTokens = SplatTokens{
-				Open:  openToken,
-				Star:  starToken,
-				Close: closeToken,
-			}
-		case *hclsyntax.TemplateExpr:
-			// TODO(pdg): interpolations, control, etc.
-			nodeTokens = TemplateTokens{
-				Open:  tokens.atPos(n.SrcRange.Start),
-				Close: tokens.atOffset(n.SrcRange.End.Byte - 1),
-			}
-		case *hclsyntax.TupleConsExpr:
-			exprs := n.Exprs
-			commas := make([]Token, 0, len(exprs))
-			if len(exprs) > 0 {
-				for _, ex := range exprs[:len(exprs)-1] {
-					commas = append(commas, tokens.atPos(ex.Range().End))
-				}
-				if trailing := tokens.atPos(exprs[len(exprs)-1].Range().End); trailing.Raw.Type == hclsyntax.TokenComma {
-					commas = append(commas, trailing)
-				}
-			}
-			nodeTokens = TupleConsTokens{
-				OpenBracket:  tokens.atPos(n.OpenRange.Start),
-				Commas:       commas,
-				CloseBracket: tokens.atOffset(n.SrcRange.End.Byte - 1),
-			}
-		case *hclsyntax.UnaryOpExpr:
-			nodeTokens = UnaryOpTokens{
-				Operator: tokens.atPos(n.SymbolRange.Start),
-			}
-		}
-		if nodeTokens != nil {
-			tokenMap[n] = nodeTokens
-		}
-
-		return nil
+	diags := hclsyntax.Walk(root, &tokenMapper{
+		tokenMap: tokenMap,
+		tokens:   tokens,
 	})
 	contract.Assert(diags == nil)
 
 	// If the root was a Body and there is a trailing end-of-file token, attach it to the body.
 	body, isBody := root.(*hclsyntax.Body)
 	if isBody && len(tokens) > 0 && tokens[len(tokens)-1].Raw.Type == hclsyntax.TokenEOF {
-		tokenMap[body] = BodyTokens{EndOfFile: tokens[len(tokens)-1]}
+		tokenMap[body] = &BodyTokens{EndOfFile: &tokens[len(tokens)-1]}
 	}
 }
 
@@ -581,13 +521,13 @@ func mapRelativeTraversalTokens(tokens tokenList, traversal hcl.Traversal) []Tra
 		leadingToken := tokens.atPos(rng.Start)
 		indexToken := tokens.atOffset(rng.Start.Byte + 1)
 		if leadingToken.Raw.Type == hclsyntax.TokenOBrack {
-			items[i] = BracketTraverserTokens{
+			items[i] = &BracketTraverserTokens{
 				OpenBracket:  leadingToken,
 				Index:        indexToken,
 				CloseBracket: tokens.atOffset(rng.End.Byte - 1),
 			}
 		} else {
-			items[i] = DotTraverserTokens{
+			items[i] = &DotTraverserTokens{
 				Dot:   leadingToken,
 				Index: indexToken,
 			}

--- a/pkg/codegen/hcl2/syntax/comments_test.go
+++ b/pkg/codegen/hcl2/syntax/comments_test.go
@@ -57,9 +57,9 @@ func validateTrivia(t *testing.T, tokens ...interface{}) {
 		case []TraverserTokens:
 			for _, tt := range te {
 				switch token := tt.(type) {
-				case DotTraverserTokens:
+				case *DotTraverserTokens:
 					validateTrivia(t, token.Dot, token.Index)
-				case BracketTraverserTokens:
+				case *BracketTraverserTokens:
 					validateTrivia(t, token.OpenBracket, token.Index, token.CloseBracket)
 				}
 			}
@@ -76,53 +76,53 @@ type validator struct {
 func (v *validator) Enter(n hclsyntax.Node) hcl.Diagnostics {
 	switch n := n.(type) {
 	case *hclsyntax.Attribute:
-		tokens := v.tokens.ForNode(n).(AttributeTokens)
+		tokens := v.tokens.ForNode(n).(*AttributeTokens)
 		validateTrivia(v.t, tokens.Name, tokens.Equals)
 	case *hclsyntax.BinaryOpExpr:
-		tokens := v.tokens.ForNode(n).(BinaryOpTokens)
+		tokens := v.tokens.ForNode(n).(*BinaryOpTokens)
 		validateTrivia(v.t, tokens.Operator)
 	case *hclsyntax.Block:
-		tokens := v.tokens.ForNode(n).(BlockTokens)
+		tokens := v.tokens.ForNode(n).(*BlockTokens)
 		validateTrivia(v.t, tokens.Type, tokens.Labels, tokens.OpenBrace, tokens.CloseBrace)
 	case *hclsyntax.ConditionalExpr:
-		tokens := v.tokens.ForNode(n).(ConditionalTokens)
+		tokens := v.tokens.ForNode(n).(*ConditionalTokens)
 		validateTrivia(v.t, tokens.QuestionMark, tokens.Colon)
 	case *hclsyntax.ForExpr:
-		tokens := v.tokens.ForNode(n).(ForTokens)
+		tokens := v.tokens.ForNode(n).(*ForTokens)
 		validateTrivia(v.t, tokens.Open, tokens.For, tokens.Key, tokens.Comma, tokens.Value, tokens.In, tokens.Colon,
 			tokens.Arrow, tokens.Group, tokens.If, tokens.Close)
 	case *hclsyntax.FunctionCallExpr:
-		tokens := v.tokens.ForNode(n).(FunctionCallTokens)
+		tokens := v.tokens.ForNode(n).(*FunctionCallTokens)
 		validateTrivia(v.t, tokens.Name, tokens.OpenParen, tokens.CloseParen)
 	case *hclsyntax.IndexExpr:
-		tokens := v.tokens.ForNode(n).(IndexTokens)
+		tokens := v.tokens.ForNode(n).(*IndexTokens)
 		validateTrivia(v.t, tokens.OpenBracket, tokens.CloseBracket)
 	case *hclsyntax.LiteralValueExpr:
 		// TODO(pdg): validate string literals
 		if !v.inTemplate {
-			tokens := v.tokens.ForNode(n).(LiteralValueTokens)
+			tokens := v.tokens.ForNode(n).(*LiteralValueTokens)
 			validateTrivia(v.t, tokens.Value)
 		}
 	case *hclsyntax.ObjectConsExpr:
-		tokens := v.tokens.ForNode(n).(ObjectConsTokens)
+		tokens := v.tokens.ForNode(n).(*ObjectConsTokens)
 		validateTrivia(v.t, tokens.OpenBrace, tokens.Items, tokens.CloseBrace)
 	case *hclsyntax.RelativeTraversalExpr:
-		tokens := v.tokens.ForNode(n).(RelativeTraversalTokens)
+		tokens := v.tokens.ForNode(n).(*RelativeTraversalTokens)
 		validateTrivia(v.t, tokens.Traversal)
 	case *hclsyntax.ScopeTraversalExpr:
-		tokens := v.tokens.ForNode(n).(ScopeTraversalTokens)
+		tokens := v.tokens.ForNode(n).(*ScopeTraversalTokens)
 		validateTrivia(v.t, tokens.Root, tokens.Traversal)
 	case *hclsyntax.SplatExpr:
-		tokens := v.tokens.ForNode(n).(SplatTokens)
+		tokens := v.tokens.ForNode(n).(*SplatTokens)
 		validateTrivia(v.t, tokens.Open, tokens.Star, tokens.Close)
 	case *hclsyntax.TemplateExpr:
 		// TODO(pdg): validate template tokens.
 		v.inTemplate = true
 	case *hclsyntax.TupleConsExpr:
-		tokens := v.tokens.ForNode(n).(TupleConsTokens)
+		tokens := v.tokens.ForNode(n).(*TupleConsTokens)
 		validateTrivia(v.t, tokens.OpenBracket, tokens.Commas, tokens.CloseBracket)
 	case *hclsyntax.UnaryOpExpr:
-		tokens := v.tokens.ForNode(n).(UnaryOpTokens)
+		tokens := v.tokens.ForNode(n).(*UnaryOpTokens)
 		validateTrivia(v.t, tokens.Operator)
 	}
 	return nil

--- a/pkg/codegen/hcl2/syntax/parser.go
+++ b/pkg/codegen/hcl2/syntax/parser.go
@@ -53,7 +53,7 @@ func (p *Parser) ParseFile(r io.Reader, filename string) error {
 	hclFile, diags := hclsyntax.ParseConfig(src, filename, hcl.Pos{})
 	if !diags.HasErrors() {
 		tokens, _ := hclsyntax.LexConfig(src, filename, hcl.Pos{})
-		mapTokens(tokens, filename, hclFile.Body.(*hclsyntax.Body), hclFile.Bytes, p.tokens)
+		mapTokens(tokens, filename, hclFile.Body.(*hclsyntax.Body), hclFile.Bytes, p.tokens, hcl.Pos{})
 	}
 
 	p.Files = append(p.Files, &File{
@@ -89,6 +89,6 @@ func ParseExpression(expression, filename string, start hcl.Pos) (hclsyntax.Expr
 	}
 	tokens := tokenMap{}
 	hclTokens, _ := hclsyntax.LexExpression(source, filename, start)
-	mapTokens(hclTokens, filename, hclExpression, source, tokens)
+	mapTokens(hclTokens, filename, hclExpression, source, tokens, start)
 	return hclExpression, tokens, diagnostics
 }

--- a/pkg/codegen/hcl2/syntax/tokens.go
+++ b/pkg/codegen/hcl2/syntax/tokens.go
@@ -1,0 +1,1126 @@
+package syntax
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var tokenStrings = map[hclsyntax.TokenType]string{
+	hclsyntax.TokenOBrace: "{",
+	hclsyntax.TokenCBrace: "}",
+	hclsyntax.TokenOBrack: "[",
+	hclsyntax.TokenCBrack: "]",
+	hclsyntax.TokenOParen: "(",
+	hclsyntax.TokenCParen: ")",
+	hclsyntax.TokenOQuote: `"`,
+	hclsyntax.TokenCQuote: `"`,
+
+	hclsyntax.TokenStar:    "*",
+	hclsyntax.TokenSlash:   "/",
+	hclsyntax.TokenPlus:    "+",
+	hclsyntax.TokenMinus:   "-",
+	hclsyntax.TokenPercent: "%",
+
+	hclsyntax.TokenEqual:         "=",
+	hclsyntax.TokenEqualOp:       "==",
+	hclsyntax.TokenNotEqual:      "!=",
+	hclsyntax.TokenLessThan:      "<",
+	hclsyntax.TokenLessThanEq:    "<=",
+	hclsyntax.TokenGreaterThan:   ">",
+	hclsyntax.TokenGreaterThanEq: ">=",
+
+	hclsyntax.TokenAnd:  "&&",
+	hclsyntax.TokenOr:   "||",
+	hclsyntax.TokenBang: "!",
+
+	hclsyntax.TokenDot:   ".",
+	hclsyntax.TokenComma: ",",
+
+	hclsyntax.TokenEllipsis: "...",
+	hclsyntax.TokenFatArrow: "=>",
+
+	hclsyntax.TokenQuestion: "?",
+	hclsyntax.TokenColon:    ":",
+
+	hclsyntax.TokenTemplateInterp:  "${",
+	hclsyntax.TokenTemplateControl: "%{",
+	hclsyntax.TokenTemplateSeqEnd:  "}",
+
+	hclsyntax.TokenNewline: "\n",
+}
+
+// Trivia represents bytes in a source file that are not syntactically meaningful. This includes whitespace and
+// comments.
+type Trivia interface {
+	// Range returns the range of the trivia in the source file.
+	Range() hcl.Range
+	// Bytes returns the raw bytes that comprise the trivia.
+	Bytes() []byte
+
+	isTrivia()
+}
+
+// TriviaList is a list of trivia.
+type TriviaList []Trivia
+
+func (trivia TriviaList) CollapseWhitespace() TriviaList {
+	result := make(TriviaList, 0, len(trivia))
+	for _, t := range trivia {
+		if ws, ok := t.(Whitespace); ok {
+			if len(result) != 0 {
+				ws.bytes = []byte{' '}
+				result = append(result, ws)
+			}
+		} else {
+			result = append(result, t)
+		}
+	}
+	return result
+}
+
+func (trivia TriviaList) Format(f fmt.State, c rune) {
+	for _, trivia := range trivia {
+		_, err := f.Write(trivia.Bytes())
+		if err != nil {
+			panic(err)
+		}
+	}
+}
+
+// Comment is a piece of trivia that represents a line or block comment in a source file.
+type Comment struct {
+	// Lines contains the lines of the comment without leading comment characters or trailing newlines.
+	Lines []string
+
+	rng   hcl.Range
+	bytes []byte
+}
+
+// Range returns the range of the comment in the source file.
+func (c Comment) Range() hcl.Range {
+	return c.rng
+}
+
+// Bytes returns the raw bytes that comprise the comment.
+func (c Comment) Bytes() []byte {
+	return c.bytes
+}
+
+func (Comment) isTrivia() {}
+
+// Whitespace is a piece of trivia that represents a sequence of whitespace characters in a source file.
+type Whitespace struct {
+	rng   hcl.Range
+	bytes []byte
+}
+
+// NewWhitespace returns a new piece of whitespace trivia with the given contents.
+func NewWhitespace(bytes ...byte) Whitespace {
+	return Whitespace{bytes: bytes}
+}
+
+// Range returns the range of the whitespace in the source file.
+func (w Whitespace) Range() hcl.Range {
+	return w.rng
+}
+
+// Bytes returns the raw bytes that comprise the whitespace.
+func (w Whitespace) Bytes() []byte {
+	return w.bytes
+}
+
+func (Whitespace) isTrivia() {}
+
+// TemplateDelimiter is a piece of trivia that represents a token that demarcates an interpolation or control sequence
+// inside of a template.
+type TemplateDelimiter struct {
+	// Type is the type of the delimiter (e.g. hclsyntax.TokenTemplateInterp)
+	Type hclsyntax.TokenType
+
+	rng   hcl.Range
+	bytes []byte
+}
+
+// Range returns the range of the delimiter in the source file.
+func (t TemplateDelimiter) Range() hcl.Range {
+	return t.rng
+}
+
+// Bytes returns the raw bytes that comprise the delimiter.
+func (t TemplateDelimiter) Bytes() []byte {
+	return t.bytes
+}
+
+func (TemplateDelimiter) isTrivia() {}
+
+// Token represents an HCL2 syntax token with attached leading trivia.
+type Token struct {
+	Raw            hclsyntax.Token
+	LeadingTrivia  TriviaList
+	TrailingTrivia TriviaList
+}
+
+func (t Token) Format(f fmt.State, c rune) {
+	if t.LeadingTrivia != nil {
+		t.LeadingTrivia.Format(f, c)
+	} else if f.Flag(' ') {
+		if _, err := f.Write([]byte{' '}); err != nil {
+			panic(err)
+		}
+	}
+	bytes := t.Raw.Bytes
+	if str, ok := tokenStrings[t.Raw.Type]; ok {
+		bytes = []byte(str)
+	}
+	if _, err := f.Write(bytes); err != nil {
+		panic(err)
+	}
+	t.TrailingTrivia.Format(f, c)
+}
+
+func (t Token) AllTrivia() TriviaList {
+	result := make(TriviaList, len(t.LeadingTrivia)+len(t.TrailingTrivia))
+	for i, trivia := range t.LeadingTrivia {
+		result[i] = trivia
+	}
+	for i, trivia := range t.TrailingTrivia {
+		result[len(t.LeadingTrivia)+i] = trivia
+	}
+	return result
+}
+
+// Range returns the total range covered by this token and any leading trivia.
+func (t Token) Range() hcl.Range {
+	start := t.Raw.Range.Start
+	if len(t.LeadingTrivia) > 0 {
+		start = t.LeadingTrivia[0].Range().Start
+	}
+	end := t.Raw.Range.End
+	if len(t.TrailingTrivia) > 0 {
+		end = t.TrailingTrivia[len(t.TrailingTrivia)-1].Range().End
+	}
+	return hcl.Range{Filename: t.Raw.Range.Filename, Start: start, End: end}
+}
+
+func (t Token) Or(typ hclsyntax.TokenType, s ...string) Token {
+	t.Raw.Type = typ
+	if len(s) > 0 {
+		t.Raw.Bytes = []byte(s[0])
+	}
+	return t
+}
+
+func OperationTokenType(operation *hclsyntax.Operation) hclsyntax.TokenType {
+	switch operation {
+	case hclsyntax.OpAdd:
+		return hclsyntax.TokenPlus
+	case hclsyntax.OpDivide:
+		return hclsyntax.TokenSlash
+	case hclsyntax.OpEqual:
+		return hclsyntax.TokenEqualOp
+	case hclsyntax.OpGreaterThan:
+		return hclsyntax.TokenGreaterThan
+	case hclsyntax.OpGreaterThanOrEqual:
+		return hclsyntax.TokenGreaterThanEq
+	case hclsyntax.OpLessThan:
+		return hclsyntax.TokenLessThan
+	case hclsyntax.OpLessThanOrEqual:
+		return hclsyntax.TokenLessThanEq
+	case hclsyntax.OpLogicalAnd:
+		return hclsyntax.TokenAnd
+	case hclsyntax.OpLogicalNot:
+		return hclsyntax.TokenBang
+	case hclsyntax.OpLogicalOr:
+		return hclsyntax.TokenOr
+	case hclsyntax.OpModulo:
+		return hclsyntax.TokenPercent
+	case hclsyntax.OpMultiply:
+		return hclsyntax.TokenStar
+	case hclsyntax.OpNegate:
+		return hclsyntax.TokenMinus
+	case hclsyntax.OpNotEqual:
+		return hclsyntax.TokenNotEqual
+	case hclsyntax.OpSubtract:
+		return hclsyntax.TokenMinus
+	}
+	return hclsyntax.TokenInvalid
+}
+
+func newRawToken(typ hclsyntax.TokenType, text ...string) hclsyntax.Token {
+	bytes := []byte(tokenStrings[typ])
+	if len(text) != 0 {
+		bytes = []byte(text[0])
+	}
+	return hclsyntax.Token{
+		Type:  typ,
+		Bytes: bytes,
+	}
+}
+
+// NodeTokens is a closed interface that is used to represent arbitrary *Tokens types in this package.
+type NodeTokens interface {
+	isNodeTokens()
+}
+
+// AttributeTokens records the tokens associated with an *hclsyntax.Attribute.
+type AttributeTokens struct {
+	Name   Token
+	Equals Token
+}
+
+func NewAttributeTokens(name string) *AttributeTokens {
+	return &AttributeTokens{
+		Name: Token{
+			Raw: newRawToken(hclsyntax.TokenIdent, name),
+		},
+		Equals: Token{
+			Raw:           newRawToken(hclsyntax.TokenEqual),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+	}
+}
+
+func (t *AttributeTokens) GetName() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Name
+}
+
+func (t *AttributeTokens) GetEquals() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Equals
+}
+
+func (*AttributeTokens) isNodeTokens() {}
+
+// BinaryOpTokens records the tokens associated with an *hclsyntax.BinaryOpExpr.
+type BinaryOpTokens struct {
+	Operator Token
+}
+
+func NewBinaryOpTokens(operation *hclsyntax.Operation) *BinaryOpTokens {
+	operatorType := OperationTokenType(operation)
+	return &BinaryOpTokens{
+		Operator: Token{
+			Raw:           newRawToken(operatorType),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+	}
+}
+
+func (t *BinaryOpTokens) GetOperator() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Operator
+}
+
+func (*BinaryOpTokens) isNodeTokens() {}
+
+// BlockTokens records the tokens associated with an *hclsyntax.Block.
+type BlockTokens struct {
+	Type       Token
+	Labels     []Token
+	OpenBrace  Token
+	CloseBrace Token
+}
+
+func NewBlockTokens(typ string, labels ...string) *BlockTokens {
+	labelTokens := make([]Token, len(labels))
+	for i, l := range labels {
+		var raw hclsyntax.Token
+		if hclsyntax.ValidIdentifier(l) {
+			raw = newRawToken(hclsyntax.TokenIdent, l)
+		} else {
+			raw = newRawToken(hclsyntax.TokenQuotedLit, fmt.Sprintf("%q", l))
+		}
+		labelTokens[i] = Token{
+			Raw:           raw,
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		}
+	}
+	return &BlockTokens{
+		Type: Token{
+			Raw: newRawToken(hclsyntax.TokenIdent, typ),
+		},
+		Labels: labelTokens,
+		OpenBrace: Token{
+			Raw:           newRawToken(hclsyntax.TokenOBrace),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+		CloseBrace: Token{
+			Raw:           newRawToken(hclsyntax.TokenCBrace),
+			LeadingTrivia: TriviaList{NewWhitespace('\n')},
+		},
+	}
+}
+
+func (t *BlockTokens) GetType() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Type
+}
+
+func (t *BlockTokens) GetLabels() []Token {
+	if t == nil {
+		return nil
+	}
+	return t.Labels
+}
+
+func (t *BlockTokens) GetOpenBrace() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.OpenBrace
+}
+
+func (t *BlockTokens) GetCloseBrace() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.CloseBrace
+}
+
+func (*BlockTokens) isNodeTokens() {}
+
+// BodyTokens records the tokens associated with an *hclsyntax.Body.
+type BodyTokens struct {
+	EndOfFile *Token
+}
+
+func (t *BodyTokens) GetEndOfFile() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.EndOfFile
+}
+
+func (*BodyTokens) isNodeTokens() {}
+
+// ConditionalTokens records the tokens associated with an *hclsyntax.ConditionalExpr of the form "a ? t : f".
+type ConditionalTokens struct {
+	QuestionMark Token
+	Colon        Token
+}
+
+func NewConditionalTokens() *ConditionalTokens {
+	return &ConditionalTokens{
+		QuestionMark: Token{
+			Raw:           newRawToken(hclsyntax.TokenQuestion),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+		Colon: Token{
+			Raw:           newRawToken(hclsyntax.TokenColon),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+	}
+}
+
+func (t *ConditionalTokens) GetQuestionMark() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.QuestionMark
+}
+
+func (t *ConditionalTokens) GetColon() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Colon
+}
+
+func (*ConditionalTokens) isNodeTokens() {}
+
+// TemplateConditionalTokens records the tokens associated with an *hclsyntax.ConditionalExpr inside a template
+// expression.
+type TemplateConditionalTokens struct {
+	OpenIf     Token
+	If         Token
+	CloseIf    Token
+	OpenElse   *Token
+	Else       *Token
+	CloseElse  *Token
+	OpenEndif  Token
+	Endif      Token
+	CloseEndif Token
+}
+
+func NewTemplateConditionalTokens(hasElse bool) *TemplateConditionalTokens {
+	var openElseT, elseT, closeElseT *Token
+	if hasElse {
+		openElseT = &Token{Raw: newRawToken(hclsyntax.TokenTemplateControl)}
+		elseT = &Token{Raw: newRawToken(hclsyntax.TokenIdent, "else")}
+		closeElseT = &Token{Raw: newRawToken(hclsyntax.TokenTemplateSeqEnd)}
+	}
+	return &TemplateConditionalTokens{
+		OpenIf:     Token{Raw: newRawToken(hclsyntax.TokenTemplateControl)},
+		If:         Token{Raw: newRawToken(hclsyntax.TokenIdent, "if")},
+		CloseIf:    Token{Raw: newRawToken(hclsyntax.TokenTemplateSeqEnd)},
+		OpenElse:   openElseT,
+		Else:       elseT,
+		CloseElse:  closeElseT,
+		OpenEndif:  Token{Raw: newRawToken(hclsyntax.TokenTemplateControl)},
+		Endif:      Token{Raw: newRawToken(hclsyntax.TokenIdent, "endif")},
+		CloseEndif: Token{Raw: newRawToken(hclsyntax.TokenTemplateSeqEnd)},
+	}
+}
+
+func (*TemplateConditionalTokens) isNodeTokens() {}
+
+// ForTokens records the tokens associated with an *hclsyntax.ForExpr.
+type ForTokens struct {
+	Open  Token
+	For   Token
+	Key   *Token
+	Comma *Token
+	Value Token
+	In    Token
+	Colon Token
+	Arrow *Token
+	Group *Token
+	If    *Token
+	Close Token
+}
+
+func NewForTokens(keyVariable, valueVariable string, mapFor, group, conditional bool) *ForTokens {
+	var keyT, commaT, arrowT, groupT, ifT *Token
+	if keyVariable != "" {
+		keyT = &Token{
+			Raw:           newRawToken(hclsyntax.TokenIdent, keyVariable),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		}
+		commaT = &Token{Raw: newRawToken(hclsyntax.TokenComma)}
+	}
+	if mapFor {
+		arrowT = &Token{
+			Raw:           newRawToken(hclsyntax.TokenFatArrow),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		}
+	}
+	if group {
+		groupT = &Token{Raw: newRawToken(hclsyntax.TokenEllipsis)}
+	}
+	if conditional {
+		ifT = &Token{
+			Raw:           newRawToken(hclsyntax.TokenIdent, "if"),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		}
+	}
+
+	return &ForTokens{
+		Open:  Token{Raw: newRawToken(hclsyntax.TokenOBrack)},
+		For:   Token{Raw: newRawToken(hclsyntax.TokenIdent, "for")},
+		Key:   keyT,
+		Comma: commaT,
+		Value: Token{
+			Raw:           newRawToken(hclsyntax.TokenIdent, valueVariable),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+		In: Token{
+			Raw:           newRawToken(hclsyntax.TokenIdent, "in"),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+		Colon: Token{Raw: newRawToken(hclsyntax.TokenColon)},
+		Arrow: arrowT,
+		Group: groupT,
+		If:    ifT,
+		Close: Token{Raw: newRawToken(hclsyntax.TokenCBrack)},
+	}
+}
+
+func (t *ForTokens) GetOpen() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Open
+}
+
+func (t *ForTokens) GetFor() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.For
+}
+
+func (t *ForTokens) GetKey() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.Key
+}
+
+func (t *ForTokens) GetComma() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.Comma
+}
+
+func (t *ForTokens) GetValue() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Value
+}
+
+func (t *ForTokens) GetIn() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.In
+}
+
+func (t *ForTokens) GetColon() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Colon
+}
+
+func (t *ForTokens) GetArrow() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.Arrow
+}
+
+func (t *ForTokens) GetGroup() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.Group
+}
+
+func (t *ForTokens) GetIf() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.If
+}
+
+func (t *ForTokens) GetClose() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Close
+}
+
+func (*ForTokens) isNodeTokens() {}
+
+// TemplateForTokens records the tokens associated with an *hclsyntax.ForExpr inside a template.
+type TemplateForTokens struct {
+	OpenFor     Token
+	For         Token
+	Key         *Token
+	Comma       *Token
+	Value       Token
+	In          Token
+	CloseFor    Token
+	OpenEndfor  Token
+	Endfor      Token
+	CloseEndfor Token
+}
+
+func NewTemplateForTokens(keyVariable, valueVariable string) *TemplateForTokens {
+	var keyT, commaT *Token
+	if keyVariable != "" {
+		keyT = &Token{
+			Raw:           newRawToken(hclsyntax.TokenIdent, keyVariable),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		}
+		commaT = &Token{Raw: newRawToken(hclsyntax.TokenComma)}
+	}
+
+	return &TemplateForTokens{
+		OpenFor: Token{Raw: newRawToken(hclsyntax.TokenTemplateControl)},
+		For:     Token{Raw: newRawToken(hclsyntax.TokenIdent, "for")},
+		Key:     keyT,
+		Comma:   commaT,
+		Value: Token{
+			Raw:           newRawToken(hclsyntax.TokenIdent, valueVariable),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+		In: Token{
+			Raw:           newRawToken(hclsyntax.TokenIdent, "in"),
+			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+		},
+		CloseFor:    Token{Raw: newRawToken(hclsyntax.TokenTemplateSeqEnd)},
+		OpenEndfor:  Token{Raw: newRawToken(hclsyntax.TokenTemplateControl)},
+		Endfor:      Token{Raw: newRawToken(hclsyntax.TokenIdent, "endfor")},
+		CloseEndfor: Token{Raw: newRawToken(hclsyntax.TokenTemplateSeqEnd)},
+	}
+}
+
+func (t *TemplateForTokens) GetFor() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.For
+}
+
+func (t *TemplateForTokens) GetKey() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.Key
+}
+
+func (t *TemplateForTokens) GetComma() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.Comma
+}
+
+func (t *TemplateForTokens) GetValue() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Value
+}
+
+func (t *TemplateForTokens) GetIn() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.In
+}
+
+func (t *TemplateForTokens) GetEndfor() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Endfor
+}
+
+func (*TemplateForTokens) isNodeTokens() {}
+
+// FunctionCallTokens records the tokens associated with an *hclsyntax.FunctionCallExpr.
+type FunctionCallTokens struct {
+	Name       Token
+	OpenParen  Token
+	Commas     []Token
+	CloseParen Token
+}
+
+func NewFunctionCallTokens(name string, argCount int) *FunctionCallTokens {
+	commas := make([]Token, argCount-1)
+	for i := 0; i < len(commas); i++ {
+		commas[i] = Token{Raw: newRawToken(hclsyntax.TokenComma)}
+	}
+	return &FunctionCallTokens{
+		Name:       Token{Raw: newRawToken(hclsyntax.TokenIdent, name)},
+		OpenParen:  Token{Raw: newRawToken(hclsyntax.TokenOParen)},
+		Commas:     commas,
+		CloseParen: Token{Raw: newRawToken(hclsyntax.TokenCParen)},
+	}
+}
+
+func (t *FunctionCallTokens) GetName() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Name
+}
+
+func (t *FunctionCallTokens) GetOpenParen() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.OpenParen
+}
+
+func (t *FunctionCallTokens) GetCommas() []Token {
+	if t == nil {
+		return nil
+	}
+	return t.Commas
+}
+
+func (t *FunctionCallTokens) GetCloseParen() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.CloseParen
+}
+
+func (*FunctionCallTokens) isNodeTokens() {}
+
+// IndexTokens records the tokens associated with an *hclsyntax.IndexExpr.
+type IndexTokens struct {
+	OpenBracket  Token
+	CloseBracket Token
+}
+
+func NewIndexTokens() *IndexTokens {
+	return &IndexTokens{
+		OpenBracket:  Token{Raw: newRawToken(hclsyntax.TokenOBrack)},
+		CloseBracket: Token{Raw: newRawToken(hclsyntax.TokenCBrack)},
+	}
+}
+
+func (t *IndexTokens) GetOpenBracket() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.OpenBracket
+}
+
+func (t *IndexTokens) GetCloseBracket() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.CloseBracket
+}
+
+func (*IndexTokens) isNodeTokens() {}
+
+// LiteralValueTokens records the tokens associated with an *hclsyntax.LiteralValueExpr.
+type LiteralValueTokens struct {
+	Value []Token
+}
+
+func NewLiteralValueTokens(tokens ...Token) *LiteralValueTokens {
+	return &LiteralValueTokens{
+		Value: tokens,
+	}
+}
+
+func (t *LiteralValueTokens) GetValue() []Token {
+	if t == nil {
+		return nil
+	}
+	return t.Value
+}
+
+func (*LiteralValueTokens) isNodeTokens() {}
+
+// ObjectConsItemTokens records the tokens associated with an hclsyntax.ObjectConsItem.
+type ObjectConsItemTokens struct {
+	Equals Token
+	Comma  *Token
+}
+
+// ObjectConsTokens records the tokens associated with an *hclsyntax.ObjectConsExpr.
+type ObjectConsTokens struct {
+	OpenBrace  Token
+	Items      []ObjectConsItemTokens
+	CloseBrace Token
+}
+
+func NewObjectConsTokens(itemCount int) *ObjectConsTokens {
+	items := make([]ObjectConsItemTokens, itemCount)
+	for i := 0; i < len(items); i++ {
+		var comma *Token
+		if i < len(items)-1 {
+			comma = &Token{Raw: newRawToken(hclsyntax.TokenComma)}
+		}
+		items[i] = ObjectConsItemTokens{
+			Equals: Token{Raw: newRawToken(hclsyntax.TokenEqual)},
+			Comma:  comma,
+		}
+	}
+	return &ObjectConsTokens{
+		OpenBrace:  Token{Raw: newRawToken(hclsyntax.TokenOBrace)},
+		Items:      items,
+		CloseBrace: Token{Raw: newRawToken(hclsyntax.TokenCBrace)},
+	}
+}
+
+func (t *ObjectConsTokens) GetOpenBrace() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.OpenBrace
+}
+
+func (t *ObjectConsTokens) GetItems() []ObjectConsItemTokens {
+	if t == nil {
+		return nil
+	}
+	return t.Items
+}
+
+func (t *ObjectConsTokens) GetCloseBrace() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.CloseBrace
+}
+
+func (*ObjectConsTokens) isNodeTokens() {}
+
+// TraverserTokens is a closed interface implemented by DotTraverserTokens and BracketTraverserTokens
+type TraverserTokens interface {
+	GetIndex() Token
+
+	isTraverserTokens()
+}
+
+// DotTraverserTokens records the tokens associated with dotted traverser (i.e. '.' <attr>).
+type DotTraverserTokens struct {
+	Dot   Token
+	Index Token
+}
+
+func NewDotTraverserTokens(index string) *DotTraverserTokens {
+	indexType := hclsyntax.TokenIdent
+	_, err := cty.ParseNumberVal(index)
+	if err == nil {
+		indexType = hclsyntax.TokenNumberLit
+	}
+	return &DotTraverserTokens{
+		Dot:   Token{Raw: newRawToken(hclsyntax.TokenDot)},
+		Index: Token{Raw: newRawToken(indexType, index)},
+	}
+}
+
+func (t *DotTraverserTokens) GetDot() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Dot
+}
+
+func (t *DotTraverserTokens) GetIndex() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Index
+}
+
+func (*DotTraverserTokens) isTraverserTokens() {}
+
+// BracketTraverserTokens records the tokens associated with a bracketed traverser (i.e. '[' <index> ']').
+type BracketTraverserTokens struct {
+	OpenBracket  Token
+	Index        Token
+	CloseBracket Token
+}
+
+func NewBracketTraverserTokens(index string) *BracketTraverserTokens {
+	indexType := hclsyntax.TokenIdent
+	_, err := cty.ParseNumberVal(index)
+	if err == nil {
+		indexType = hclsyntax.TokenNumberLit
+	}
+	return &BracketTraverserTokens{
+		OpenBracket:  Token{Raw: newRawToken(hclsyntax.TokenOBrack)},
+		Index:        Token{Raw: newRawToken(indexType, index)},
+		CloseBracket: Token{Raw: newRawToken(hclsyntax.TokenCBrack)},
+	}
+}
+
+func (t *BracketTraverserTokens) GetOpenBracket() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.OpenBracket
+}
+
+func (t *BracketTraverserTokens) GetIndex() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Index
+}
+
+func (t *BracketTraverserTokens) GetCloseBracket() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.CloseBracket
+}
+
+func (*BracketTraverserTokens) isTraverserTokens() {}
+
+// RelativeTraversalTokens records the tokens associated with an *hclsyntax.RelativeTraversalExpr.
+type RelativeTraversalTokens struct {
+	Traversal []TraverserTokens
+}
+
+func NewRelativeTraversalTokens(traversers ...TraverserTokens) *RelativeTraversalTokens {
+	return &RelativeTraversalTokens{Traversal: traversers}
+}
+
+func (t *RelativeTraversalTokens) GetTraversal() []TraverserTokens {
+	if t == nil {
+		return nil
+	}
+	return t.Traversal
+}
+
+func (*RelativeTraversalTokens) isNodeTokens() {}
+
+// ScopeTraversalTokens records the tokens associated with an *hclsyntax.ScopeTraversalExpr.
+type ScopeTraversalTokens struct {
+	Root      Token
+	Traversal []TraverserTokens
+}
+
+func NewScopeTraversalTokens(root string, traversers ...TraverserTokens) *ScopeTraversalTokens {
+	return &ScopeTraversalTokens{
+		Root:      Token{Raw: newRawToken(hclsyntax.TokenIdent, root)},
+		Traversal: traversers,
+	}
+}
+
+func (t *ScopeTraversalTokens) GetRoot() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Root
+}
+
+func (t *ScopeTraversalTokens) GetTraversal() []TraverserTokens {
+	if t == nil {
+		return nil
+	}
+	return t.Traversal
+}
+
+func (*ScopeTraversalTokens) isNodeTokens() {}
+
+// SplatTokens records the tokens associated with an *hclsyntax.SplatExpr.
+type SplatTokens struct {
+	Open  Token
+	Star  Token
+	Close *Token
+}
+
+func NewSplatTokens(dotted bool) *SplatTokens {
+	openType := hclsyntax.TokenDot
+	var closeT *Token
+	if !dotted {
+		openType = hclsyntax.TokenOBrack
+		closeT = &Token{Raw: newRawToken(hclsyntax.TokenCBrack)}
+	}
+	return &SplatTokens{
+		Open:  Token{Raw: newRawToken(openType)},
+		Star:  Token{Raw: newRawToken(hclsyntax.TokenStar)},
+		Close: closeT,
+	}
+}
+
+func (t *SplatTokens) GetOpen() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Open
+}
+
+func (t *SplatTokens) GetStar() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Star
+}
+
+func (t *SplatTokens) GetClose() *Token {
+	if t == nil {
+		return nil
+	}
+	return t.Close
+}
+
+func (*SplatTokens) isNodeTokens() {}
+
+// TemplateTokens records the tokens associated with an *hclsyntax.TemplateExpr.
+type TemplateTokens struct {
+	Open  Token
+	Close Token
+}
+
+func NewTemplateTokens() *TemplateTokens {
+	return &TemplateTokens{
+		Open:  Token{Raw: newRawToken(hclsyntax.TokenOQuote)},
+		Close: Token{Raw: newRawToken(hclsyntax.TokenCQuote)},
+	}
+}
+
+func (t *TemplateTokens) GetOpen() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Open
+}
+
+func (t *TemplateTokens) GetClose() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Close
+}
+
+func (*TemplateTokens) isNodeTokens() {}
+
+// TupleConsTokens records the tokens associated with an *hclsyntax.TupleConsExpr.
+type TupleConsTokens struct {
+	OpenBracket  Token
+	Commas       []Token
+	CloseBracket Token
+}
+
+func NewTupleConsTokens(elementCount int) *TupleConsTokens {
+	commas := make([]Token, elementCount-1)
+	for i := 0; i < len(commas); i++ {
+		commas[i] = Token{Raw: newRawToken(hclsyntax.TokenComma)}
+	}
+	return &TupleConsTokens{
+		OpenBracket:  Token{Raw: newRawToken(hclsyntax.TokenOBrack)},
+		Commas:       commas,
+		CloseBracket: Token{Raw: newRawToken(hclsyntax.TokenCBrack)},
+	}
+}
+
+func (t *TupleConsTokens) GetOpenBracket() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.OpenBracket
+}
+
+func (t *TupleConsTokens) GetCommas() []Token {
+	if t == nil {
+		return nil
+	}
+	return t.Commas
+}
+
+func (t *TupleConsTokens) GetCloseBracket() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.CloseBracket
+}
+
+func (*TupleConsTokens) isNodeTokens() {}
+
+// UnaryOpTokens records the tokens associated with an *hclsyntax.UnaryOpExpr.
+type UnaryOpTokens struct {
+	Operator Token
+}
+
+func NewUnaryOpTokens(operation *hclsyntax.Operation) *UnaryOpTokens {
+	return &UnaryOpTokens{
+		Operator: Token{Raw: newRawToken(OperationTokenType(operation))},
+	}
+}
+
+func (t *UnaryOpTokens) GetOperator() Token {
+	if t == nil {
+		return Token{}
+	}
+	return t.Operator
+}
+
+func (*UnaryOpTokens) isNodeTokens() {}


### PR DESCRIPTION
- Fix token mapping for template control structures
- Split tokens out into their own file
- Add factory methods for token types