### PR TITLE
Add schema support for constant values

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -171,6 +171,15 @@ func (t *TokenType) String() string {
 
 func (*TokenType) isType() {}
 
+// ConstValue describes a constant value for a property.
+type ConstValue struct {
+	// Value specifies a static constant value, if any. This value must be representable in the Pulumi schema type
+	// system, and its type must be assignable to that of the property to which the constant applies.
+	Value interface{}
+
+	// TODO: Add Language if needed
+}
+
 // DefaultValue describes a default value for a property.
 type DefaultValue struct {
 	// Value specifies a static default value, if any. This value must be representable in the Pulumi schema type
@@ -190,6 +199,8 @@ type Property struct {
 	Comment string
 	// Type is the type of the property.
 	Type Type
+	// ConstValue is the constant value for the property, if any.
+	ConstValue *ConstValue
 	// DefaultValue is the default value for the property, if any.
 	DefaultValue *DefaultValue
 	// IsRequired is true if the property must always be populated.
@@ -319,6 +330,13 @@ type TypeSpec struct {
 	Language map[string]json.RawMessage `json:"language,omitempty"`
 }
 
+// ConstSpec is the serializable form of extra information about the constant value for a property.
+type ConstSpec struct {
+	// TODO: add Language if needed
+	//// Language specifies additional language-specific data about the default value.
+	//Language map[string]json.RawMessage `json:"language,omitempty"`
+}
+
 // DefaultSpec is the serializable form of extra information about the default value for a property.
 type DefaultSpec struct {
 	// Environment specifies a set of environment variables to probe for a default value.
@@ -333,10 +351,15 @@ type PropertySpec struct {
 
 	// Description is the description of the property, if any.
 	Description string `json:"description,omitempty"`
+	// Const is the constant value for the property, if any. The type of the value must be assignable to the type of
+	// the property.
+	Const interface{} `json:"const,omitempty"`
+	// ConstInfo contains additional information about the property's constant value, if any.
+	ConstInfo *ConstSpec `json:"constInfo,omitempty"`
 	// Default is the default value for the property, if any. The type of the value must be assignable to the type of
 	// the property.
 	Default interface{} `json:"default,omitempty"`
-	// DefautSpec contains additional information aboout the property's default value, if any.
+	// DefaultInfo contains additional information about the property's default value, if any.
 	DefaultInfo *DefaultSpec `json:"defaultInfo,omitempty"`
 	// DeprecationMessage indicates whether or not the property is deprecated.
 	DeprecationMessage string `json:"deprecationMessage,omitempty"`
@@ -656,6 +679,47 @@ func (t *types) bindType(spec TypeSpec) (Type, error) {
 	}
 }
 
+func bindConstValue(value interface{}, spec *ConstSpec, typ Type) (*ConstValue, error) {
+	if value == nil && spec == nil {
+		return nil, nil
+	}
+
+	if value != nil {
+		switch typ {
+		case BoolType:
+			if _, ok := value.(bool); !ok {
+				return nil, errors.Errorf("invalid constant of type %T for boolean property", value)
+			}
+		case IntType:
+			v, ok := value.(float64)
+			if !ok {
+				return nil, errors.Errorf("invalid constant of type %T for integer property", value)
+			}
+			if math.Trunc(v) != v || v < math.MinInt32 || v > math.MaxInt32 {
+				return nil, errors.Errorf("invalid constant of type number for integer property")
+			}
+			value = int32(v)
+		case NumberType:
+			if _, ok := value.(float64); !ok {
+				return nil, errors.Errorf("invalid constant of type %T for number property", value)
+			}
+		case StringType:
+			if _, ok := value.(string); !ok {
+				return nil, errors.Errorf("invalid constant of type %T for string property", value)
+			}
+		default:
+			return nil, errors.Errorf("constant values may only be provided for boolean, integer, number, and string properties")
+		}
+	}
+
+	cv := &ConstValue{Value: value}
+	if spec != nil {
+		// TODO: add if needed
+		//cv.Language = spec.Language
+	}
+	return cv, nil
+}
+
 func bindDefaultValue(value interface{}, spec *DefaultSpec, typ Type) (*DefaultValue, error) {
 	if value == nil && spec == nil {
 		return nil, nil
@@ -697,13 +761,18 @@ func bindDefaultValue(value interface{}, spec *DefaultSpec, typ Type) (*DefaultV
 }
 
 func (t *types) bindProperties(properties map[string]PropertySpec, required []string) ([]*Property, error) {
-	// Bind property types and default values.
+	// Bind property types and constant or default values.
 	propertyMap := map[string]*Property{}
 	var result []*Property
 	for name, spec := range properties {
 		typ, err := t.bindType(spec.TypeSpec)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error binding type for property %s", name)
+		}
+
+		cv, err := bindConstValue(spec.Const, spec.ConstInfo, typ)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error binding constant value for property %s", name)
 		}
 
 		dv, err := bindDefaultValue(spec.Default, spec.DefaultInfo, typ)
@@ -715,6 +784,7 @@ func (t *types) bindProperties(properties map[string]PropertySpec, required []st
 			Name:               name,
 			Comment:            spec.Description,
 			Type:               typ,
+			ConstValue:         cv,
 			DefaultValue:       dv,
 			DeprecationMessage: spec.DeprecationMessage,
 			Language:           spec.Language,


### PR DESCRIPTION
Some properties have constant values, such as the
apiVersion and kind for the Kubernetes provider. Add
a Const field to the Property schema to support this.

Here's what this looks like in the generated schema:
```json
"properties": {
  "apiVersion": {
    "type": "string",
    "description": "...",
    "const": "apps/v1"
  },
  "kind": {
    "type": "string",
    "description": "...",
    "const": "Deployment"
  }
}
```