### PR TITLE
Reimplement getRequiredPlugins for go sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ CHANGELOG
 - Fix handling of secret values in mock-based tests.
   [#4272](https://github.com/pulumi/pulumi/pull/4272)
 
+- Automatic plugin acquisition for Go
+  [#4297](https://github.com/pulumi/pulumi/pull/4297)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -988,12 +988,6 @@ func (pkg *pkgContext) genConfig(w io.Writer, variables []*schema.Property) erro
 	return nil
 }
 
-func (pkg *pkgContext) genPackageRegistration(w io.Writer) {
-	fmt.Fprintf(w, "func init() {\n")
-	fmt.Fprintf(w, "\tpulumi.RegisterPackage(pulumi.PackageInfo{Name:\"%s\", Version:\"%s\"})\n", pkg.pkg.Name, pkg.pkg.Version.String())
-	fmt.Fprintf(w, "}\n")
-}
-
 func (pkg *pkgContext) getPkg(mod string) *pkgContext {
 	if override, ok := pkg.modToPkg[mod]; ok {
 		mod = override
@@ -1166,7 +1160,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 		files[relPath] = formattedSource
 	}
 
-	name, registerPackage := pkg.Name, pkg.Provider != nil
+	name := pkg.Name
 	for _, mod := range pkgMods {
 		pkg := packages[mod]
 
@@ -1241,16 +1235,6 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 			pkg.genTypeRegistrations(buffer, pkg.types)
 
 			setFile(path.Join(mod, "pulumiTypes.go"), buffer.String())
-		}
-
-		// Package registration
-		if registerPackage {
-			buffer := &bytes.Buffer{}
-
-			pkg.genHeader(buffer, []string{"github.com/pulumi/pulumi/sdk/go/pulumi"}, nil)
-			pkg.genPackageRegistration(buffer)
-
-			setFile(path.Join(mod, "pulumiManifest.go"), buffer.String())
 		}
 
 		// Utilities

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -154,11 +154,14 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -199,6 +202,9 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
 	github.com/uber/jaeger-lib v2.2.0+incompatible // indirect
 	golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6
+	golang.org/x/mod v0.2.0
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d
 	google.golang.org/grpc v1.28.0

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -25,6 +25,7 @@ github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGX
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
+github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -145,7 +145,6 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/pulumi/pulumi v1.14.0 h1:gGQesSkDFwwkXApHBltpZDeMzb4mn7+m9FdA7dwWg+w=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -145,6 +145,7 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/pulumi/pulumi v1.14.0 h1:gGQesSkDFwwkXApHBltpZDeMzb4mn7+m9FdA7dwWg+w=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
@@ -195,12 +196,15 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190219172222-a4c6cb3142f2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6 h1:TjszyFsQsyZNHwdVdZ5m7bjmreu0znc2kRYsEml9/Ww=
 golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -244,6 +248,9 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/sdk/go/common/util/buildutil/semver.go
+++ b/sdk/go/common/util/buildutil/semver.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
+	"golang.org/x/mod/semver"
 )
 
 var (
@@ -35,7 +37,17 @@ var (
 		`^v(?P<version>\d+\.\d+\.\d+)-alpha\.(?P<time>\d+)\+(?P<gitInfo>g[a-z0-9]+)(?P<dirty>.dirty)?$`)
 	devVersionRegex = regexp.MustCompile(
 		`^v(?P<version>\d+\.\d+\.\d+)-dev\.(?P<time>\d+)\+(?P<gitInfo>g[a-z0-9]+)(?P<dirty>.dirty)?$`)
+	// nolint: lll
+	// https://github.com/golang/go/blob/9f40f9f4d3e9e5a08cfd1df5af23a6f61d67d408/src/cmd/go/internal/modfetch/pseudo.go#L49
+	pseudoVersionRegex = regexp.MustCompile(`^v[0-9]+\.(0\.0-|\d+\.\d+-([^+]*\.)?0\.)\d{14}-[A-Za-z0-9]+(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$`)
 )
+
+// IsPseudoVersion reports whether v is a go modules pseudo-version.
+// nolint: lll
+// https://github.com/golang/go/blob/9f40f9f4d3e9e5a08cfd1df5af23a6f61d67d408/src/cmd/go/internal/modfetch/pseudo.go#L118
+func IsPseudoVersion(v string) bool {
+	return strings.Count(v, "-") >= 2 && semver.IsValid(v) && pseudoVersionRegex.MatchString(v)
+}
 
 // PyPiVersionFromNpmVersion returns a PEP-440 compliant version for a given semver version. This method does not
 // support all possible semver strings, but instead just supports versions that we generate for our node packages.

--- a/sdk/go/common/util/buildutil/semver_test.go
+++ b/sdk/go/common/util/buildutil/semver_test.go
@@ -36,3 +36,14 @@ func TestVersions(t *testing.T) {
 		assert.Equal(t, expected, p, "failed parsing '%s'", ver)
 	}
 }
+
+func TestPseduoVersion(t *testing.T) {
+	pseudoVersion := "v1.29.1-0.20200403140640-efb5e2a48a86"
+	assert.True(t, IsPseudoVersion(pseudoVersion))
+
+	tagVersion := "v1.29.0"
+	assert.False(t, IsPseudoVersion(tagVersion))
+
+	betaVersion := "v.1.29.0-beta.1"
+	assert.False(t, IsPseudoVersion(betaVersion))
+}

--- a/sdk/go/common/util/buildutil/semver_test.go
+++ b/sdk/go/common/util/buildutil/semver_test.go
@@ -44,6 +44,6 @@ func TestPseduoVersion(t *testing.T) {
 	tagVersion := "v1.29.0"
 	assert.False(t, IsPseudoVersion(tagVersion))
 
-	betaVersion := "v.1.29.0-beta.1"
+	betaVersion := "v1.29.0-beta.1"
 	assert.False(t, IsPseudoVersion(betaVersion))
 }

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPlugin(t *testing.T) {
+	validPulumiMod := &modInfo{
+		Path:    "github.com/pulumi/pulumi-aws/sdk",
+		Version: "v1.29.0",
+	}
+	validPlugin, err := validPulumiMod.getPlugin()
+	assert.Nil(t, err)
+	assert.Equal(t, validPlugin.Name, "aws")
+	assert.Equal(t, validPlugin.Version, "v1.29.0")
+
+	pulumiPinnedModule := &modInfo{
+		Path:    "github.com/pulumi/pulumi-aws/sdk",
+		Version: "v1.29.1-0.20200403140640-efb5e2a48a86",
+	}
+	pulumiPinnedPlugin, err := pulumiPinnedModule.getPlugin()
+	assert.Nil(t, err)
+	assert.Equal(t, pulumiPinnedPlugin.Name, "aws")
+	assert.Equal(t, pulumiPinnedPlugin.Version, "v1.29.0")
+
+	nonPulumiMod := &modInfo{
+		Path:    "github.com/moolumi/pulumi-aws/sdk",
+		Version: "v1.29.0",
+	}
+	_, err = nonPulumiMod.getPlugin()
+	assert.NotNil(t, err)
+
+	invalidVersionModule := &modInfo{
+		Path:    "github.com/pulumi/pulumi-aws/sdk",
+		Version: "42-42-42",
+	}
+	_, err = invalidVersionModule.getPlugin()
+	assert.NotNil(t, err)
+
+	pulumiPulumiMod := &modInfo{
+		Path:    "github.com/pulumi/pulumi/sdk",
+		Version: "v1.14.0",
+	}
+	_, err = pulumiPulumiMod.getPlugin()
+	assert.NotNil(t, err)
+}

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -16,14 +16,14 @@ func TestGetPlugin(t *testing.T) {
 	assert.Equal(t, validPlugin.Name, "aws")
 	assert.Equal(t, validPlugin.Version, "v1.29.0")
 
-	pulumiPinnedModule := &modInfo{
+	pulumiPseudoVersionModule := &modInfo{
 		Path:    "github.com/pulumi/pulumi-aws/sdk",
 		Version: "v1.29.1-0.20200403140640-efb5e2a48a86",
 	}
-	pulumiPinnedPlugin, err := pulumiPinnedModule.getPlugin()
+	pulumiPseduoVersionPlugin, err := pulumiPseudoVersionModule.getPlugin()
 	assert.Nil(t, err)
-	assert.Equal(t, pulumiPinnedPlugin.Name, "aws")
-	assert.Equal(t, pulumiPinnedPlugin.Version, "v1.29.0")
+	assert.Equal(t, pulumiPseduoVersionPlugin.Name, "aws")
+	assert.Equal(t, pulumiPseduoVersionPlugin.Version, "v1.29.0")
 
 	nonPulumiMod := &modInfo{
 		Path:    "github.com/moolumi/pulumi-aws/sdk",
@@ -45,4 +45,22 @@ func TestGetPlugin(t *testing.T) {
 	}
 	_, err = pulumiPulumiMod.getPlugin()
 	assert.NotNil(t, err)
+
+	betaPulumiModule := &modInfo{
+		Path:    "github.com/pulumi/pulumi-aws/sdk",
+		Version: "v2.0.0-beta.1",
+	}
+	betaPulumiPlugin, err := betaPulumiModule.getPlugin()
+	assert.Nil(t, err)
+	assert.Equal(t, betaPulumiPlugin.Name, "aws")
+	assert.Equal(t, betaPulumiPlugin.Version, "v2.0.0-beta.1")
+
+	nonZeroPatchModule := &modInfo{
+		Path:    "github.com/pulumi/pulumi-kubernetes/sdk",
+		Version: "v1.5.8",
+	}
+	nonZeroPatchPlugin, err := nonZeroPatchModule.getPlugin()
+	assert.Nil(t, err)
+	assert.Equal(t, nonZeroPatchPlugin.Name, "kubernetes")
+	assert.Equal(t, nonZeroPatchPlugin.Version, "v1.5.8")
 }


### PR DESCRIPTION
This uses `go list -m -json all`. We must use -m `module` mode as this is the only way to get the version info as far as I can tell. This means that this approach only works for users using modules, not glide, dep, etc. This is the direction the community is going, and the direction we've moved our docs/examples so this should be fine. But as a result, I've made the implementation lenient. It doesn't fail if we run into errors along the way, just logs some messages saying we failed to acquire plugins. This is strictly better than what we have today, and we can always revisit this decision in the future as the ecosystem evolves. 

```
Evans-MBP:aws-go-webserver evanboyle$ pulumi preview
Previewing update (dcgo):
[resource plugin aws-1.28.0] installing
Downloading plugin: 64.58 MiB / 64.58 MiB [=========================] 100.00% 7s
Moving plugin... done.
     Type                      Name               Plan       
 +   pulumi:pulumi:Stack       go-webserver-dcgo  create     
 +   ├─ aws:ec2:SecurityGroup  web-secgrp         create     
 +   └─ aws:ec2:Instance       web-server-www     create     
 
Resources:
    + 3 to create

Permalink: https://app.pulumi.com/EvanBoyle/go-webserver/dcgo/previews/a761b512-4136-4caa-b504-6843e72c0193

```

Fixes https://github.com/pulumi/pulumi/issues/1549 
Fixes https://github.com/pulumi/pulumi/issues/4211