### PR TITLE
HCL2 updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ dist::
 
 lint::
 	for DIR in "pkg" "sdk" "tests" ; do \
-		pushd $$DIR && golangci-lint run -c ../.golangci.yml --timeout 5m && popd ; \
+		pushd $$DIR ; golangci-lint run -c ../.golangci.yml --timeout 5m ; popd ; \
 	done
 
 test_fast::

--- a/pkg/codegen/hcl2/binder_nodes.go
+++ b/pkg/codegen/hcl2/binder_nodes.go
@@ -91,8 +91,8 @@ func (b *binder) bindConfigVariable(node *ConfigVariable) hcl.Diagnostics {
 	block, diagnostics := model.BindBlock(node.Syntax, model.StaticScope(b.root), b.tokens)
 	if defaultValue, ok := block.Body.Attribute("default"); ok {
 		node.DefaultValue = defaultValue.Value
-		if node.typ.ConversionFrom(node.DefaultValue.Type()) == model.NoConversion {
-			diagnostics = append(diagnostics, model.ExprNotConvertible(node.typ, node.DefaultValue))
+		if model.InputType(node.typ).ConversionFrom(node.DefaultValue.Type()) == model.NoConversion {
+			diagnostics = append(diagnostics, model.ExprNotConvertible(model.InputType(node.typ), node.DefaultValue))
 		}
 	}
 	return diagnostics
@@ -113,8 +113,8 @@ func (b *binder) bindOutputVariable(node *OutputVariable) hcl.Diagnostics {
 	block, diagnostics := model.BindBlock(node.Syntax, model.StaticScope(b.root), b.tokens)
 	if value, ok := block.Body.Attribute("value"); ok {
 		node.Value = value.Value
-		if node.typ.ConversionFrom(node.Value.Type()) == model.NoConversion {
-			diagnostics = append(diagnostics, model.ExprNotConvertible(node.typ, node.Value))
+		if model.InputType(node.typ).ConversionFrom(node.Value.Type()) == model.NoConversion {
+			diagnostics = append(diagnostics, model.ExprNotConvertible(model.InputType(node.typ), node.Value))
 		}
 	}
 	return diagnostics

--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -35,7 +35,7 @@ type packageSchema struct {
 
 // canonicalizeToken converts a Pulumi token into its canonical "pkg:module:member" form.
 func canonicalizeToken(tok string, pkg *schema.Package) string {
-	_, _, member, _ := decomposeToken(tok, hcl.Range{})
+	_, _, member, _ := DecomposeToken(tok, hcl.Range{})
 	return fmt.Sprintf("%s:%s:%s", pkg.Name, pkg.TokenToModule(tok), member)
 }
 
@@ -46,8 +46,10 @@ func (b *binder) loadReferencedPackageSchemas(n Node) error {
 
 	if r, ok := n.(*Resource); ok {
 		token, tokenRange := getResourceToken(r)
-		packageName, _, _, _ := decomposeToken(token, tokenRange)
-		packageNames.Add(packageName)
+		packageName, _, _, _ := DecomposeToken(token, tokenRange)
+		if packageName != "pulumi" {
+			packageNames.Add(packageName)
+		}
 	}
 
 	diags := hclsyntax.VisitAll(n.SyntaxNode(), func(node hclsyntax.Node) hcl.Diagnostics {
@@ -59,8 +61,10 @@ func (b *binder) loadReferencedPackageSchemas(n Node) error {
 		if !ok {
 			return nil
 		}
-		packageName, _, _, _ := decomposeToken(token, tokenRange)
-		packageNames.Add(packageName)
+		packageName, _, _, _ := DecomposeToken(token, tokenRange)
+		if packageName != "pulumi" {
+			packageNames.Add(packageName)
+		}
 		return nil
 	})
 	contract.Assert(len(diags) == 0)

--- a/pkg/codegen/hcl2/binder_test.go
+++ b/pkg/codegen/hcl2/binder_test.go
@@ -1,0 +1,51 @@
+package hcl2
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/codegen/internal/test"
+)
+
+var testdataPath = filepath.Join("..", "internal", "test", "testdata")
+
+func TestBindProgram(t *testing.T) {
+	files, err := ioutil.ReadDir(testdataPath)
+	if err != nil {
+		t.Fatalf("could not read test data: %v", err)
+	}
+
+	for _, f := range files {
+		if filepath.Ext(f.Name()) != ".pp" {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			path := filepath.Join(testdataPath, f.Name())
+			contents, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path, err)
+			}
+
+			parser := syntax.NewParser()
+			err = parser.ParseFile(bytes.NewReader(contents), f.Name())
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path, err)
+			}
+			if parser.Diagnostics.HasErrors() {
+				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
+			}
+
+			_, diags, err := BindProgram(parser.Files, test.NewHost(nil))
+			assert.NoError(t, err)
+			if diags.HasErrors() {
+				t.Fatalf("failed to bind program: %v", diags)
+			}
+		})
+	}
+}

--- a/pkg/codegen/hcl2/binder_test.go
+++ b/pkg/codegen/hcl2/binder_test.go
@@ -41,7 +41,7 @@ func TestBindProgram(t *testing.T) {
 				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 			}
 
-			_, diags, err := BindProgram(parser.Files, test.NewHost(nil))
+			_, diags, err := BindProgram(parser.Files, test.NewHost(testdataPath))
 			assert.NoError(t, err)
 			if diags.HasErrors() {
 				t.Fatalf("failed to bind program: %v", diags)

--- a/pkg/codegen/hcl2/diagnostics.go
+++ b/pkg/codegen/hcl2/diagnostics.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/codegen/hcl2/model"
 )
 
 func errorf(subject hcl.Range, f string, args ...interface{}) *hcl.Diagnostic {
@@ -44,6 +45,10 @@ func unknownResourceType(token string, tokenRange hcl.Range) *hcl.Diagnostic {
 	return errorf(tokenRange, "unknown resource type '%s'", token)
 }
 
+func unknownFunction(token string, tokenRange hcl.Range) *hcl.Diagnostic {
+	return errorf(tokenRange, "unknown function '%s'", token)
+}
+
 func unsupportedBlock(blockType string, typeRange hcl.Range) *hcl.Diagnostic {
 	return errorf(typeRange, "unsupported block of type '%v'", blockType)
 }
@@ -54,4 +59,12 @@ func unsupportedAttribute(attrName string, nameRange hcl.Range) *hcl.Diagnostic 
 
 func missingRequiredAttribute(attrName string, missingRange hcl.Range) *hcl.Diagnostic {
 	return errorf(missingRange, "missing required attribute '%v'", attrName)
+}
+
+func tokenMustBeStringLiteral(tokenExpr model.Expression) *hcl.Diagnostic {
+	return errorf(tokenExpr.SyntaxNode().Range(), "invoke token must be a string literal")
+}
+
+func duplicateBlock(blockType string, typeRange hcl.Range) *hcl.Diagnostic {
+	return errorf(typeRange, "duplicate block of type '%v'", blockType)
 }

--- a/pkg/codegen/hcl2/invoke.go
+++ b/pkg/codegen/hcl2/invoke.go
@@ -17,6 +17,7 @@ package hcl2
 import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/codegen/hcl2/model"
 	"github.com/zclconf/go-cty/cty"
 )
 
@@ -24,7 +25,11 @@ func getInvokeToken(call *hclsyntax.FunctionCallExpr) (string, hcl.Range, bool) 
 	if call.Name != "invoke" || len(call.Args) < 1 {
 		return "", hcl.Range{}, false
 	}
-	literal, ok := call.Args[0].(*hclsyntax.LiteralValueExpr)
+	template, ok := call.Args[0].(*hclsyntax.TemplateExpr)
+	if !ok || len(template.Parts) != 1 {
+		return "", hcl.Range{}, false
+	}
+	literal, ok := template.Parts[0].(*hclsyntax.LiteralValueExpr)
 	if !ok {
 		return "", hcl.Range{}, false
 	}
@@ -32,4 +37,75 @@ func getInvokeToken(call *hclsyntax.FunctionCallExpr) (string, hcl.Range, bool) 
 		return "", hcl.Range{}, false
 	}
 	return literal.Val.AsString(), call.Args[0].Range(), true
+}
+
+func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+	signature := model.StaticFunctionSignature{
+		Parameters: []model.Parameter{
+			{
+				Name: "token",
+				Type: model.StringType,
+			},
+			{
+				Name: "args",
+				Type: model.NewOptionalType(model.DynamicType),
+			},
+			{
+				Name: "provider",
+				Type: model.NewOptionalType(model.StringType),
+			},
+		},
+		ReturnType: model.DynamicType,
+	}
+
+	if len(args) < 1 {
+		return signature, nil
+	}
+
+	template, ok := args[0].(*model.TemplateExpression)
+	if !ok || len(template.Parts) != 1 {
+		return signature, hcl.Diagnostics{tokenMustBeStringLiteral(args[0])}
+	}
+	lit, ok := template.Parts[0].(*model.LiteralValueExpression)
+	if !ok || lit.Type() != model.StringType {
+		return signature, hcl.Diagnostics{tokenMustBeStringLiteral(args[0])}
+	}
+
+	token, tokenRange := lit.Value.AsString(), args[0].SyntaxNode().Range()
+	pkg, _, _, diagnostics := DecomposeToken(token, tokenRange)
+	if diagnostics.HasErrors() {
+		return signature, diagnostics
+	}
+
+	pkgSchema, ok := b.packageSchemas[pkg]
+	if !ok {
+		return signature, hcl.Diagnostics{unknownPackage(pkg, tokenRange)}
+	}
+
+	fn, ok := pkgSchema.functions[token]
+	if !ok {
+		canon := canonicalizeToken(token, pkgSchema.schema)
+		if fn, ok = pkgSchema.functions[canon]; ok {
+			token, lit.Value = canon, cty.StringVal(canon)
+		}
+	}
+	if !ok {
+		return signature, hcl.Diagnostics{unknownFunction(token, tokenRange)}
+	}
+
+	// Create args and result types for the schema.
+	if fn.Inputs == nil {
+		signature.Parameters[1].Type = model.NewOptionalType(model.NewObjectType(map[string]model.Type{}))
+	} else {
+		signature.Parameters[1].Type = schemaTypeToType(fn.Inputs)
+	}
+
+	if fn.Outputs == nil {
+		signature.ReturnType = model.NewObjectType(map[string]model.Type{})
+	} else {
+		signature.ReturnType = schemaTypeToType(fn.Outputs)
+	}
+	signature.ReturnType = model.NewPromiseType(signature.ReturnType)
+
+	return signature, nil
 }

--- a/pkg/codegen/hcl2/model/attribute.go
+++ b/pkg/codegen/hcl2/model/attribute.go
@@ -60,6 +60,10 @@ func (a *Attribute) print(w io.Writer, p *printer) {
 		a.Value)
 }
 
+func (a *Attribute) Type() Type {
+	return a.Value.Type()
+}
+
 func (*Attribute) isBodyItem() {}
 
 // BindAttribute binds an HCL2 attribute using the given scope and token map.

--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -292,37 +292,6 @@ func (b *expressionBinder) bindConditionalExpression(syntax *hclsyntax.Condition
 	}, diagnostics
 }
 
-// unwrapIterableSourceType removes any eventual types that wrap a type intended for iteration.
-func unwrapIterableSourceType(t Type) Type {
-	// TODO(pdg): unions
-	for {
-		switch tt := t.(type) {
-		case *OutputType:
-			t = tt.ElementType
-		case *PromiseType:
-			t = tt.ElementType
-		default:
-			return t
-		}
-	}
-}
-
-// wrapIterableSourceType adds optional or eventual types to a type intended for iteration per the structure of the
-// source type.
-func wrapIterableResultType(sourceType, iterableType Type) Type {
-	// TODO(pdg): unions
-	for {
-		switch t := sourceType.(type) {
-		case *OutputType:
-			sourceType, iterableType = t.ElementType, NewOutputType(iterableType)
-		case *PromiseType:
-			sourceType, iterableType = t.ElementType, NewPromiseType(iterableType)
-		default:
-			return iterableType
-		}
-	}
-}
-
 // bindForExpression binds a for expression. The value being iterated must be an list, map, or object.  The type of
 // the result is an list unless a key expression is present, in which case it is a map. Key types must be strings.
 // The element type of the result is the type of the value expression. If the type of the value being iterated is
@@ -338,31 +307,8 @@ func (b *expressionBinder) bindForExpression(syntax *hclsyntax.ForExpr) (Express
 	collectionType := unwrapIterableSourceType(collection.Type())
 
 	// TODO(pdg): handle union types.
-
-	var keyType, valueType Type
-	switch collectionType := collectionType.(type) {
-	case *ListType:
-		keyType, valueType = NumberType, collectionType.ElementType
-	case *MapType:
-		keyType, valueType = StringType, collectionType.ElementType
-	case *TupleType:
-		keyType = NumberType
-		valueType, _ = UnifyTypes(collectionType.ElementTypes...)
-	case *ObjectType:
-		keyType = StringType
-
-		types := make([]Type, 0, len(collectionType.Properties))
-		for _, t := range collectionType.Properties {
-			types = append(types, t)
-		}
-		valueType, _ = UnifyTypes(types...)
-	default:
-		// If the collection is a dynamic type, treat it as an iterable(dynamic, dynamic). Otherwise, issue an error.
-		if collectionType != DynamicType {
-			diagnostics = append(diagnostics, unsupportedCollectionType(collectionType, syntax.CollExpr.Range()))
-		}
-		keyType, valueType = DynamicType, DynamicType
-	}
+	keyType, valueType, kvDiags := GetCollectionTypes(collectionType, syntax.CollExpr.Range())
+	diagnostics = append(diagnostics, kvDiags...)
 
 	// Push a scope for the key and value variables and define these vars.
 	b.scope = b.scope.Push(syntax)
@@ -669,7 +615,8 @@ func (b *expressionBinder) bindScopeTraversalExpression(
 
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.ScopeTraversalTokens)
 
-	def, ok := b.scope.BindReference(syntax.Traversal.RootName())
+	rootName := syntax.Traversal.RootName()
+	def, ok := b.scope.BindReference(rootName)
 	if !ok {
 		parts := make([]Traversable, len(syntax.Traversal))
 		for i := range parts {
@@ -681,7 +628,7 @@ func (b *expressionBinder) bindScopeTraversalExpression(
 			Parts:     parts,
 			RootName:  syntax.Traversal.RootName(),
 			Traversal: syntax.Traversal,
-		}, hcl.Diagnostics{undefinedVariable(syntax.Traversal.SimpleSplit().Abs.SourceRange())}
+		}, hcl.Diagnostics{undefinedVariable(rootName, syntax.Traversal.SimpleSplit().Abs.SourceRange())}
 	}
 
 	parts, diagnostics := b.bindTraversalParts(def, syntax.Traversal.SimpleSplit().Rel)

--- a/pkg/codegen/hcl2/model/block.go
+++ b/pkg/codegen/hcl2/model/block.go
@@ -74,8 +74,8 @@ func (b *Block) print(w io.Writer, p *printer) {
 		}
 		p.fprintf(w, "% v", t)
 	}
-	if len(b.Labels) < len(b.Tokens.Labels) {
-		for _, l := range b.Tokens.Labels[len(b.Labels):] {
+	if len(b.Labels) < len(labelTokens) {
+		for _, l := range labelTokens[len(b.Labels):] {
 			p.fprintf(w, "%v", syntax.Token{
 				LeadingTrivia:  l.LeadingTrivia,
 				TrailingTrivia: l.TrailingTrivia,
@@ -90,11 +90,14 @@ func (b *Block) print(w io.Writer, p *printer) {
 	p.indented(func() {
 		b.Body.print(w, p)
 	})
+	if !b.Body.hasTrailingTrivia() {
+		p.fprintf(w, "\n")
+	}
 
 	if b.Tokens != nil {
 		p.fprintf(w, "%v", b.Tokens.GetCloseBrace().Or(hclsyntax.TokenCBrace))
 	} else {
-		p.fprintf(w, "\n%s}", p.indent)
+		p.fprintf(w, "%s}", p.indent)
 	}
 }
 

--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -93,8 +93,8 @@ func unsupportedCollectionType(collectionType Type, iteratorRange hcl.Range) *hc
 	return errorf(iteratorRange, "cannot iterator over a value of type %v", collectionType)
 }
 
-func undefinedVariable(variableRange hcl.Range) *hcl.Diagnostic {
-	return errorf(variableRange, "undefined variable")
+func undefinedVariable(variableName string, variableRange hcl.Range) *hcl.Diagnostic {
+	return errorf(variableRange, fmt.Sprintf("undefined variable %v", variableName))
 }
 
 func internalError(rng hcl.Range, fmt string, args ...interface{}) *hcl.Diagnostic {

--- a/pkg/codegen/hcl2/model/scope.go
+++ b/pkg/codegen/hcl2/model/scope.go
@@ -87,13 +87,14 @@ func NewRootScope(syntax hclsyntax.Node) *Scope {
 func (s *Scope) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostics) {
 	name, nameType := GetTraverserKey(traverser)
 	if nameType != StringType {
-		return DynamicType, hcl.Diagnostics{undefinedVariable(traverser.SourceRange())}
+		// TODO(pdg): return a better error here
+		return DynamicType, hcl.Diagnostics{undefinedVariable("", traverser.SourceRange())}
 	}
 
 	memberName := name.AsString()
 	member, hasMember := s.BindReference(memberName)
 	if !hasMember {
-		return DynamicType, hcl.Diagnostics{undefinedVariable(traverser.SourceRange())}
+		return DynamicType, hcl.Diagnostics{undefinedVariable(memberName, traverser.SourceRange())}
 	}
 	return member, nil
 }

--- a/pkg/codegen/hcl2/model/traversable.go
+++ b/pkg/codegen/hcl2/model/traversable.go
@@ -81,8 +81,8 @@ func (b *expressionBinder) bindTraversalParts(receiver Traversable,
 	case TypedTraversable, Type:
 		// OK
 	default:
-		// TODO(pdg): improve this diagnostic?
-		diagnostics = append(diagnostics, undefinedVariable(traversal.SourceRange()))
+		// TODO(pdg): improve this diagnostic
+		diagnostics = append(diagnostics, undefinedVariable("", traversal.SourceRange()))
 	}
 
 	return parts, diagnostics

--- a/pkg/codegen/hcl2/model/type_collection.go
+++ b/pkg/codegen/hcl2/model/type_collection.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package model
+
+import "github.com/hashicorp/hcl/v2"
+
+// unwrapIterableSourceType removes any eventual types that wrap a type intended for iteration.
+func unwrapIterableSourceType(t Type) Type {
+	// TODO(pdg): unions
+	for {
+		switch tt := t.(type) {
+		case *OutputType:
+			t = tt.ElementType
+		case *PromiseType:
+			t = tt.ElementType
+		default:
+			return t
+		}
+	}
+}
+
+// wrapIterableSourceType adds optional or eventual types to a type intended for iteration per the structure of the
+// source type.
+func wrapIterableResultType(sourceType, iterableType Type) Type {
+	// TODO(pdg): unions
+	for {
+		switch t := sourceType.(type) {
+		case *OutputType:
+			sourceType, iterableType = t.ElementType, NewOutputType(iterableType)
+		case *PromiseType:
+			sourceType, iterableType = t.ElementType, NewPromiseType(iterableType)
+		default:
+			return iterableType
+		}
+	}
+}
+
+// GetCollectionTypes returns the key and value types of the given type if it is a collection.
+func GetCollectionTypes(collectionType Type, rng hcl.Range) (Type, Type, hcl.Diagnostics) {
+	var diagnostics hcl.Diagnostics
+	var keyType, valueType Type
+	switch collectionType := collectionType.(type) {
+	case *ListType:
+		keyType, valueType = NumberType, collectionType.ElementType
+	case *MapType:
+		keyType, valueType = StringType, collectionType.ElementType
+	case *TupleType:
+		keyType = NumberType
+		valueType, _ = UnifyTypes(collectionType.ElementTypes...)
+	case *ObjectType:
+		keyType = StringType
+
+		types := make([]Type, 0, len(collectionType.Properties))
+		for _, t := range collectionType.Properties {
+			types = append(types, t)
+		}
+		valueType, _ = UnifyTypes(types...)
+	default:
+		// If the collection is a dynamic type, treat it as an iterable(dynamic, dynamic). Otherwise, issue an error.
+		if collectionType != DynamicType {
+			diagnostics = append(diagnostics, unsupportedCollectionType(collectionType, rng))
+		}
+		keyType, valueType = DynamicType, DynamicType
+	}
+	return keyType, valueType, diagnostics
+}

--- a/pkg/codegen/hcl2/type.go
+++ b/pkg/codegen/hcl2/type.go
@@ -20,7 +20,11 @@ import (
 
 var (
 	// ArchiveType represents the set of Pulumi Archive values.
-	ArchiveType model.Type = model.MustNewOpaqueType("pulumi:pulumi:Archive")
+	ArchiveType model.Type = model.MustNewOpaqueType("Archive")
 	// AssetType represents the set of Pulumi Asset values.
-	AssetType model.Type = model.MustNewOpaqueType("pulumi:pulumi:Asset")
+	AssetType model.Type = model.MustNewOpaqueType("Asset")
+	// ResourceType represents a Pulumi resource instance.
+	ResourceType model.Type = model.MustNewOpaqueType("Resource")
+	// ResourcePropertyType represents a resource property reference.
+	ResourcePropertyType model.Type = model.MustNewOpaqueType("Property")
 )

--- a/pkg/codegen/hcl2/utilities.go
+++ b/pkg/codegen/hcl2/utilities.go
@@ -41,7 +41,7 @@ func SourceOrderNodes(nodes []Node) []Node {
 	return nodes
 }
 
-func decomposeToken(tok string, sourceRange hcl.Range) (string, string, string, hcl.Diagnostics) {
+func DecomposeToken(tok string, sourceRange hcl.Range) (string, string, string, hcl.Diagnostics) {
 	components := strings.Split(tok, ":")
 	if len(components) != 3 {
 		// If we don't have a valid type token, return the invalid token as the type name.

--- a/pkg/codegen/internal/test/host.go
+++ b/pkg/codegen/internal/test/host.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/go/common/resource/plugin"
+
+	"github.com/pulumi/pulumi/pkg/resource/deploy/deploytest"
+)
+
+func NewHost(sink diag.Sink) plugin.Host {
+	return deploytest.NewPluginHost(sink, sink, nil,
+		deploytest.NewProviderLoader("aws", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return AWS, nil
+		}))
+}

--- a/pkg/codegen/internal/test/host.go
+++ b/pkg/codegen/internal/test/host.go
@@ -2,15 +2,13 @@ package test
 
 import (
 	"github.com/blang/semver"
-	"github.com/pulumi/pulumi/sdk/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/go/common/resource/plugin"
-
 	"github.com/pulumi/pulumi/pkg/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/go/common/resource/plugin"
 )
 
-func NewHost(sink diag.Sink) plugin.Host {
-	return deploytest.NewPluginHost(sink, sink, nil,
+func NewHost(schemaDirectoryPath string) plugin.Host {
+	return deploytest.NewPluginHost(nil, nil, nil,
 		deploytest.NewProviderLoader("aws", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			return AWS, nil
+			return AWS(schemaDirectoryPath)
 		}))
 }

--- a/pkg/codegen/internal/test/providers.go
+++ b/pkg/codegen/internal/test/providers.go
@@ -1,9 +1,25 @@
 package test
 
-import "github.com/pulumi/pulumi/pkg/resource/deploy/deploytest"
+import (
+	"io/ioutil"
+	"path/filepath"
 
-var AWS = &deploytest.Provider{
-	GetSchemaF: func(version int) ([]byte, error) {
-		return awsSchema, nil
-	},
+	"github.com/pulumi/pulumi/pkg/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/go/common/resource/plugin"
+)
+
+func GetSchema(schemaDirectoryPath, providerName string) ([]byte, error) {
+	return ioutil.ReadFile(filepath.Join(schemaDirectoryPath, providerName+".json"))
+}
+
+func AWS(schemaDirectoryPath string) (plugin.Provider, error) {
+	schema, err := GetSchema(schemaDirectoryPath, "aws")
+	if err != nil {
+		return nil, err
+	}
+	return &deploytest.Provider{
+		GetSchemaF: func(version int) ([]byte, error) {
+			return schema, nil
+		},
+	}, nil
 }

--- a/pkg/codegen/internal/test/providers.go
+++ b/pkg/codegen/internal/test/providers.go
@@ -1,0 +1,9 @@
+package test
+
+import "github.com/pulumi/pulumi/pkg/resource/deploy/deploytest"
+
+var AWS = &deploytest.Provider{
+	GetSchemaF: func(version int) ([]byte, error) {
+		return awsSchema, nil
+	},
+}

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp
@@ -1,0 +1,108 @@
+// Read the default VPC and public subnets, which we will use.
+vpc = invoke("aws:ec2:getVpc", {
+	default = true
+})
+subnets = invoke("aws:ec2:getSubnetIds", {
+	vpcId = vpc.id
+})
+
+// Create a security group that permits HTTP ingress and unrestricted egress.
+resource webSecurityGroup "aws:ec2:SecurityGroup" {
+	vpcId = vpc.id
+	egress = [{
+		protocol = "-1"
+		fromPort = 0
+		toPort = 0
+		cidrBlocks = ["0.0.0.0/0"]
+	}]
+	ingress = [{
+		protocol = "tcp"
+		fromPort = 80
+		toPort = 80
+		cidrBlocks = ["0.0.0.0/0"]
+	}]
+}
+
+// Create an ECS cluster to run a container-based service.
+resource cluster "aws:ecs:Cluster" {}
+
+// Create an IAM role that can be used by our service's task.
+resource taskExecRole "aws:iam:Role" {
+	assumeRolePolicy = {
+		Version = "2008-10-17"
+		Statement = [{
+			Sid = ""
+			Effect = "Allow"
+			Principal = {
+				Service = "ecs-tasks.amazonaws.com"
+			}
+			Action = "sts:AssumeRole"
+		}]
+	}
+}
+resource taskExecRolePolicyAttachment "aws:iam:RolePolicyAttachment" {
+	role = taskExecRole.name
+	policyArn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+// Create a load balancer to listen for HTTP traffic on port 80.
+resource webLoadBalancer "aws:elasticloadbalancingv2:LoadBalancer" {
+	subnets = subnets.ids
+	securityGroups = [webSecurityGroup.id]
+}
+resource webTargetGroup "aws:elasticloadbalancingv2:TargetGroup" {
+	port = 80
+	protocol = "HTTP"
+	targetType = "ip"
+	vpcId = vpc.id
+}
+resource webListener "aws:elasticloadbalancingv2:Listener" {
+	loadBalancerArn = webLoadBalancer.arn
+	port = 80
+	defaultActions = [{
+		type = "forward"
+		targetGroupArn = webTargetGroup.arn
+	}]
+}
+
+// Spin up a load balanced service running NGINX
+resource appTask "aws:ecs:TaskDefinition" {
+	family = "fargate-task-definition"
+	cpu = "256"
+	memory = "512"
+	networkMode = "awsvpc"
+	requiresCompatibilities = ["FARGATE"]
+	executionRoleArn = taskExecRole.arn
+	containerDefinitions = toJSON([{
+		name = "my-app"
+		image = "nginx"
+		portMappings = [{
+			containerPort = 80
+			hostPort = 80
+			protocol = "tcp"
+		}]
+	}])
+}
+resource appService "aws:ecs:Service" {
+	cluster = cluster.arn
+	desiredCount = 5
+	launchType = "FARGATE"
+	taskDefinition = appTask.arn
+	networkConfiguraiton = {
+		assignPublicIp = true
+		subnets = subnets.ids
+		securityGroups = [webSecurityGroup.id]
+	}
+	loadBalancers = [{
+		targetGroupArn = webTargetGroup.arn
+		containerName = "my-app"
+		containerPort = 80
+	}]
+
+	options {
+		dependsOn = [webListener]
+	}
+}
+
+// Export the resulting web address.
+output url { value = webLoadBalancer.dnsName }

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
@@ -1,0 +1,91 @@
+import pulumi
+import json
+import pulumi_aws as aws
+
+vpc = aws.ec2.get_vpc({
+    "default": True,
+})
+subnets = aws.ec2.get_subnet_ids({
+    "vpcId": vpc.id,
+})
+# Create a security group that permits HTTP ingress and unrestricted egress.
+web_security_group = aws.ec2.SecurityGroup("web_security_group",
+    vpc_id=vpc.id,
+    egress=[{
+        "protocol": "-1",
+        "fromPort": 0,
+        "toPort": 0,
+        "cidrBlocks": ["0.0.0.0/0"],
+    }],
+    ingress=[{
+        "protocol": "tcp",
+        "fromPort": 80,
+        "toPort": 80,
+        "cidrBlocks": ["0.0.0.0/0"],
+    }])
+# Create an ECS cluster to run a container-based service.
+cluster = aws.ecs.Cluster("cluster")
+# Create an IAM role that can be used by our service's task.
+task_exec_role = aws.iam.Role("task_exec_role", assume_role_policy={
+    "Version": "2008-10-17",
+    "Statement": [{
+        "Sid": "",
+        "Effect": "Allow",
+        "Principal": {
+            "Service": "ecs-tasks.amazonaws.com",
+        },
+        "Action": "sts:AssumeRole",
+    }],
+})
+task_exec_role_policy_attachment = aws.iam.RolePolicyAttachment("task_exec_role_policy_attachment",
+    role=task_exec_role.name,
+    policy_arn="arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy")
+# Create a load balancer to listen for HTTP traffic on port 80.
+web_load_balancer = aws.elasticloadbalancingv2.LoadBalancer("web_load_balancer",
+    subnets=subnets.ids,
+    security_groups=[web_security_group.id])
+web_target_group = aws.elasticloadbalancingv2.TargetGroup("web_target_group",
+    port=80,
+    protocol="HTTP",
+    target_type="ip",
+    vpc_id=vpc.id)
+web_listener = aws.elasticloadbalancingv2.Listener("web_listener",
+    load_balancer_arn=web_load_balancer.arn,
+    port=80,
+    default_actions=[{
+        "type": "forward",
+        "targetGroupArn": web_target_group.arn,
+    }])
+# Spin up a load balanced service running NGINX
+app_task = aws.ecs.TaskDefinition("app_task",
+    family="fargate-task-definition",
+    cpu="256",
+    memory="512",
+    network_mode="awsvpc",
+    requires_compatibilities=["FARGATE"],
+    execution_role_arn=task_exec_role.arn,
+    container_definitions=json.dumps([{
+        "name": "my-app",
+        "image": "nginx",
+        "portMappings": [{
+            "containerPort": 80,
+            "hostPort": 80,
+            "protocol": "tcp",
+        }],
+    }]))
+app_service = aws.ecs.Service("app_service",
+    cluster=cluster.arn,
+    desired_count=5,
+    launch_type="FARGATE",
+    task_definition=app_task.arn,
+    network_configuraiton={
+        "assignPublicIp": True,
+        "subnets": subnets.ids,
+        "securityGroups": [web_security_group.id],
+    },
+    load_balancers=[{
+        "targetGroupArn": web_target_group.arn,
+        "containerName": "my-app",
+        "containerPort": 80,
+    }])
+pulumi.export("url", web_load_balancer.dnsName)

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.ts
@@ -1,0 +1,97 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const vpc = aws.ec2.getVpc({
+    "default": true,
+});
+const subnets = vpc.then(vpc => aws.ec2.getSubnetIds({
+    vpcId: vpc.id,
+}));
+// Create a security group that permits HTTP ingress and unrestricted egress.
+const webSecurityGroup = new aws.ec2.SecurityGroup("webSecurityGroup", {
+    vpcId: vpc.id,
+    egress: [{
+        protocol: "-1",
+        fromPort: 0,
+        toPort: 0,
+        cidrBlocks: ["0.0.0.0/0"],
+    }],
+    ingress: [{
+        protocol: "tcp",
+        fromPort: 80,
+        toPort: 80,
+        cidrBlocks: ["0.0.0.0/0"],
+    }],
+});
+// Create an ECS cluster to run a container-based service.
+const cluster = new aws.ecs.Cluster("cluster", {});
+// Create an IAM role that can be used by our service's task.
+const taskExecRole = new aws.iam.Role("taskExecRole", {assumeRolePolicy: {
+    Version: "2008-10-17",
+    Statement: [{
+        Sid: "",
+        Effect: "Allow",
+        Principal: {
+            Service: "ecs-tasks.amazonaws.com",
+        },
+        Action: "sts:AssumeRole",
+    }],
+}});
+const taskExecRolePolicyAttachment = new aws.iam.RolePolicyAttachment("taskExecRolePolicyAttachment", {
+    role: taskExecRole.name,
+    policyArn: "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+});
+// Create a load balancer to listen for HTTP traffic on port 80.
+const webLoadBalancer = new aws.elasticloadbalancingv2.LoadBalancer("webLoadBalancer", {
+    subnets: subnets.ids,
+    securityGroups: [webSecurityGroup.id],
+});
+const webTargetGroup = new aws.elasticloadbalancingv2.TargetGroup("webTargetGroup", {
+    port: 80,
+    protocol: "HTTP",
+    targetType: "ip",
+    vpcId: vpc.id,
+});
+const webListener = new aws.elasticloadbalancingv2.Listener("webListener", {
+    loadBalancerArn: webLoadBalancer.arn,
+    port: 80,
+    defaultActions: [{
+        type: "forward",
+        targetGroupArn: webTargetGroup.arn,
+    }],
+});
+// Spin up a load balanced service running NGINX
+const appTask = new aws.ecs.TaskDefinition("appTask", {
+    family: "fargate-task-definition",
+    cpu: "256",
+    memory: "512",
+    networkMode: "awsvpc",
+    requiresCompatibilities: ["FARGATE"],
+    executionRoleArn: taskExecRole.arn,
+    containerDefinitions: JSON.stringify([{
+        name: "my-app",
+        image: "nginx",
+        portMappings: [{
+            containerPort: 80,
+            hostPort: 80,
+            protocol: "tcp",
+        }],
+    }]),
+});
+const appService = new aws.ecs.Service("appService", {
+    cluster: cluster.arn,
+    desiredCount: 5,
+    launchType: "FARGATE",
+    taskDefinition: appTask.arn,
+    networkConfiguraiton: {
+        assignPublicIp: true,
+        subnets: subnets.ids,
+        securityGroups: [webSecurityGroup.id],
+    },
+    loadBalancers: [{
+        targetGroupArn: webTargetGroup.arn,
+        containerName: "my-app",
+        containerPort: 80,
+    }],
+});
+export const url = webLoadBalancer.dnsName;

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp
@@ -1,0 +1,41 @@
+// Create a bucket and expose a website index document
+resource siteBucket "aws:s3:Bucket" {
+	website = {
+		indexDocument = "index.html"
+	}
+}
+
+siteDir = "www" // directory for content files
+
+// For each file in the directory, create an S3 object stored in `siteBucket`
+resource files "aws:s3:BucketObject" {
+    options {
+		range = readDir(siteDir)
+    }
+
+	bucket = siteBucket.id // Reference the s3.Bucket object
+	key = range.value      // Set the key appropriately
+
+	source = fileAsset("${siteDir}/${range.value}") // use fileAsset to point to a file
+	contentType = mimeType(range.value)             // set the MIME type of the file
+}
+
+// Set the access policy for the bucket so all objects are readable
+resource bucketPolicy "aws:s3:BucketPolicy" {
+	bucket = siteBucket.id // refer to the bucket created earlier
+
+	// The policy is JSON-encoded.
+	policy = toJSON({
+		Version = "2012-10-17"
+		Statement = [{
+			Effect = "Allow"
+			Principal = "*"
+			Action = [ "s3:GetObject" ]
+			Resource = [ "arn:aws:s3:::${siteBucket.id}/*" ]
+		}]
+	})
+}
+
+// Stack outputs
+output bucketName { value = siteBucket.bucket }
+output websiteUrl { value = siteBucket.websiteEndpoint }

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.py
@@ -1,0 +1,30 @@
+import pulumi
+import json
+import pulumi_aws as aws
+
+# Create a bucket and expose a website index document
+site_bucket = aws.s3.Bucket("site_bucket", website={
+    "indexDocument": "index.html",
+})
+siteDir = "www"
+# For each file in the directory, create an S3 object stored in `siteBucket`
+files = aws.s3.BucketObject("files",
+    bucket=site_bucket.id,
+    key=range.value,
+    source=pulumi.FileAsset(f"{site_dir}/{range.value}"),
+    content_type=(lambda: raise Exception("FunctionCallExpression: mimeType (aws-s3-folder.pp:19,16-37)"))())
+# set the MIME type of the file
+# Set the access policy for the bucket so all objects are readable
+bucket_policy = aws.s3.BucketPolicy("bucket_policy",
+    bucket=site_bucket.id,
+    policy=site_bucket.id.apply(lambda id: json.dumps({
+        "Version": "2012-10-17",
+        "Statement": [{
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": ["s3:GetObject"],
+            "Resource": [f"arn:aws:s3:::{id}/*"],
+        }],
+    })))
+pulumi.export("bucketName", site_bucket.bucket)
+pulumi.export("websiteUrl", site_bucket.websiteEndpoint)

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.ts
@@ -1,0 +1,35 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+// Create a bucket and expose a website index document
+const siteBucket = new aws.s3.Bucket("siteBucket", {website: {
+    indexDocument: "index.html",
+}});
+const siteDir = "www";
+// For each file in the directory, create an S3 object stored in `siteBucket`
+const files: aws.s3.BucketObject[];
+for (const [__key, __value] of (() => throw new Error("FunctionCallExpression: readDir (aws-s3-folder.pp:12,11-27)"))()) {
+    const range = {key: __key, value: __value};
+    files.push(new aws.s3.BucketObject(`files-${range.key}`, {
+        bucket: siteBucket.id,
+        key: range.value,
+        source: new pulumi.asset.FileAsset(`${siteDir}/${range.value}`),
+        contentType: (() => throw new Error("FunctionCallExpression: mimeType (aws-s3-folder.pp:19,16-37)"))(),
+    }));
+}
+// set the MIME type of the file
+// Set the access policy for the bucket so all objects are readable
+const bucketPolicy = new aws.s3.BucketPolicy("bucketPolicy", {
+    bucket: siteBucket.id,
+    policy: siteBucket.id.apply(id => JSON.stringify({
+        Version: "2012-10-17",
+        Statement: [{
+            Effect: "Allow",
+            Principal: "*",
+            Action: ["s3:GetObject"],
+            Resource: [`arn:aws:s3:::${id}/*`],
+        }],
+    })),
+});
+export const bucketName = siteBucket.bucket;
+export const websiteUrl = siteBucket.websiteEndpoint;

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp
@@ -1,0 +1,38 @@
+// Create a new security group for port 80.
+resource securityGroup "aws:ec2:SecurityGroup" {
+	ingress = [{
+		protocol = "tcp"
+		fromPort = 0
+		toPort = 0
+		cidrBlocks = ["0.0.0.0/0"]
+	}]
+}
+
+// Get the ID for the latest Amazon Linux AMI.
+ami = invoke("aws:index:getAmi", {
+	filters = [{
+		name = "name"
+		values = ["amzn-ami-hvm-*-x86_64-ebs"]
+	}]
+	owners = ["137112412989"] // Amazon
+	mostRecent = true
+})
+
+// Create a simple web server using the startup script for the instance.
+resource server "aws:ec2:Instance" {
+	tags = {
+		Name = "web-server-www"
+	}
+	instanceType = "t2.micro"
+	securityGroups = [securityGroup.name]
+	ami = ami.id
+	userData = <<-EOF
+		#!/bin/bash
+		echo "Hello, World!" > index.html
+		nohup python -m SimpleHTTPServer 80 &
+	EOF
+}
+
+// Export the resulting server's IP address and DNS name.
+output publicIp { value = server.publicIp }
+output publicHostName { value = server.publicDns }

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.py
@@ -1,0 +1,33 @@
+import pulumi
+import json
+import pulumi_aws as aws
+
+# Create a new security group for port 80.
+security_group = aws.ec2.SecurityGroup("security_group", ingress=[{
+    "protocol": "tcp",
+    "fromPort": 0,
+    "toPort": 0,
+    "cidrBlocks": ["0.0.0.0/0"],
+}])
+ami = aws.get_ami({
+    "filters": [{
+        "name": "name",
+        "values": ["amzn-ami-hvm-*-x86_64-ebs"],
+    }],
+    "owners": ["137112412989"],
+    "mostRecent": True,
+})
+# Create a simple web server using the startup script for the instance.
+server = aws.ec2.Instance("server",
+    tags={
+        "Name": "web-server-www",
+    },
+    instance_type="t2.micro",
+    security_groups=[security_group.name],
+    ami=ami.id,
+    user_data=f"""#!/bin/bash
+echo \"Hello, World!\" > index.html
+nohup python -m SimpleHTTPServer 80 &
+""")
+pulumi.export("publicIp", server.publicIp)
+pulumi.export("publicHostName", server.publicDns)

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.ts
@@ -1,0 +1,33 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+// Create a new security group for port 80.
+const securityGroup = new aws.ec2.SecurityGroup("securityGroup", {ingress: [{
+    protocol: "tcp",
+    fromPort: 0,
+    toPort: 0,
+    cidrBlocks: ["0.0.0.0/0"],
+}]});
+const ami = aws.getAmi({
+    filters: [{
+        name: "name",
+        values: ["amzn-ami-hvm-*-x86_64-ebs"],
+    }],
+    owners: ["137112412989"],
+    mostRecent: true,
+});
+// Create a simple web server using the startup script for the instance.
+const server = new aws.ec2.Instance("server", {
+    tags: {
+        Name: "web-server-www",
+    },
+    instanceType: "t2.micro",
+    securityGroups: [securityGroup.name],
+    ami: ami.id,
+    userData: `#!/bin/bash
+echo "Hello, World!" > index.html
+nohup python -m SimpleHTTPServer 80 &
+`,
+});
+export const publicIp = server.publicIp;
+export const publicHostName = server.publicDns;

--- a/pkg/codegen/nodejs/gen_intrinsics.go
+++ b/pkg/codegen/nodejs/gen_intrinsics.go
@@ -17,44 +17,32 @@ package nodejs
 import "github.com/pulumi/pulumi/pkg/codegen/hcl2/model"
 
 const (
-	// intrinsicDataSource is the name of the data source intrinsic.
-	//	intrinsicDataSource = "__dataSource"
-	// inttrinsicInterpolate is the name of the interpolate intrinsic.
+	// intrinsicAwait is the name of the await intrinsic.
+	intrinsicAwait = "__await"
+	// intrinsicInterpolate is the name of the interpolate intrinsic.
 	intrinsicInterpolate = "__interpolate"
 )
 
-//// newDataSourceCall creates a new call to the data source intrinsic that represents an invocation of the specified
-//// data source function with the given input properties.
-//func newDataSourceCall(functionName string, inputs il.BoundNode, optionsBag string) *il.BoundCall {
-//	return &il.BoundCall{
-//		Func:     intrinsicDataSource,
-//		ExprType: il.TypeMap,
-//		Args: []il.BoundExpr{
-//			&il.BoundLiteral{
-//				ExprType: il.TypeString,
-//				Value:    functionName,
-//			},
-//			&il.BoundPropertyValue{
-//				NodeType: il.TypeMap,
-//				Value:    inputs,
-//			},
-//			&il.BoundLiteral{
-//				ExprType: il.TypeString,
-//				Value:    optionsBag,
-//			},
-//		},
-//	}
-//}
-//
-//// parseDataSourceCall extracts the name of the data source function and the input properties for its invocation from
-//// a call to the data source intrinsic.
-//func parseDataSourceCall(c *il.BoundCall) (function string, inputs il.BoundNode, optionsBag string) {
-//	contract.Assert(c.Func == intrinsicDataSource)
-//	function = c.Args[0].(*il.BoundLiteral).Value.(string)
-//	inputs = c.Args[1].(*il.BoundPropertyValue).Value
-//	optionsBag = c.Args[2].(*il.BoundLiteral).Value.(string)
-//	return
-//}
+// newAwaitCall creates a new call to the await intrinsic.
+func newAwaitCall(promise model.Expression) model.Expression {
+	// TODO(pdg): unions
+	promiseType, ok := promise.Type().(*model.PromiseType)
+	if !ok {
+		return promise
+	}
+
+	return &model.FunctionCallExpression{
+		Name: intrinsicAwait,
+		Signature: model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "promise",
+				Type: promiseType,
+			}},
+			ReturnType: promiseType.ElementType,
+		},
+		Args: []model.Expression{promise},
+	}
+}
 
 // newInterpolateCall creates a new call to the interpolate intrinsic that represents a template literal that uses the
 // pulumi.interpolate function.

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -2,7 +2,9 @@ package nodejs
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"log"
 	"math/big"
 	"strings"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 type nameInfo int
@@ -23,7 +26,7 @@ func (nameInfo) IsReservedWord(word string) bool {
 func (g *generator) genExpression(expr model.Expression) string {
 	// TODO(pdg): diagnostics
 
-	expr, _ = hcl2.RewriteApplies(expr, nameInfo(0))
+	expr, _ = hcl2.RewriteApplies(expr, nameInfo(0), true)
 	expr, _ = g.lowerProxyApplies(expr)
 
 	var buf bytes.Buffer
@@ -92,54 +95,135 @@ func (g *generator) GenConditionalExpression(w io.Writer, expr *model.Conditiona
 func (g *generator) GenForExpression(w io.Writer, expr *model.ForExpression) {
 	switch expr.Collection.Type().(type) {
 	case *model.ListType, *model.TupleType:
-		g.Fgenf(w, "Array.from(%v.entries())", expr.Collection)
+		if expr.KeyVariable == nil {
+			g.Fgenf(w, "%v", expr.Collection)
+		} else {
+			g.Fgenf(w, "%v.map((v, k) => [k, v])", expr.Collection)
+		}
 	case *model.MapType, *model.ObjectType:
-		g.Fgenf(w, "Object.entries(%v)", expr.Collection)
+		if expr.KeyVariable == nil {
+			g.Fgenf(w, "Object.values(%v)", expr.Collection)
+		} else {
+			g.Fgenf(w, "Object.entries(%v)", expr.Collection)
+		}
 	}
 
-	keyVariableName := "_"
+	fnParams, reduceParams := expr.ValueVariable.Name, expr.ValueVariable.Name
 	if expr.KeyVariable != nil {
-		keyVariableName = expr.KeyVariable.Name
+		reduceParams = fmt.Sprintf("[%v, %v]", expr.KeyVariable.Name, expr.ValueVariable.Name)
+		fnParams = fmt.Sprintf("(%v)", reduceParams)
 	}
 
 	if expr.Condition != nil {
-		g.Fgenf(w, ".filter(([%v, %v]) => %v)", keyVariableName, expr.ValueVariable.Name, expr.Condition)
+		g.Fgenf(w, ".filter(%s => %v)", fnParams, expr.Condition)
 	}
 
 	if expr.Key != nil {
 		// TODO(pdg): grouping
-		g.Fgenf(w, ".reduce((__obj, [%v, %v]) => { ...__obj, [%v]: %v })", keyVariableName, expr.ValueVariable.Name,
-			expr.Key, expr.Value)
+		g.Fgenf(w, ".reduce((__obj, %s) => { ...__obj, [%v]: %v })", reduceParams, expr.Key, expr.Value)
 	} else {
-		g.Fgenf(w, ".map(([%v, %v]) => %v)", keyVariableName, expr.ValueVariable.Name, expr.Value)
+		g.Fgenf(w, ".map(%s => %v)", fnParams, expr.Value)
 	}
 }
 
 func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
-	//	g.inApplyCall = true
-	//	defer func() { g.inApplyCall = false }()
-
 	// Extract the list of outputs and the continuation expression from the `__apply` arguments.
 	applyArgs, then := hcl2.ParseApplyCall(expr)
-	//g.applyArgs, g.applyArgNames = applyArgs, g.assignApplyArgNames(applyArgs, then)
-	//defer func() { g.applyArgs = nil }()
+
+	// If all of the arguments are promises, use promise methods. If any argument is an output, convert all other args
+	// to outputs and use output methods.
+	//
+	// TODO(pdg): unions
+	isPromise := make([]bool, len(applyArgs))
+	allPromises := true
+	for i, arg := range applyArgs {
+		_, isPromise[i] = arg.Type().(*model.PromiseType)
+		allPromises = allPromises && isPromise[i]
+	}
+
+	apply, all := "apply", "pulumi.all"
+	if allPromises {
+		apply, all = "then", "Promise.all"
+	}
 
 	if len(applyArgs) == 1 {
-		// If we only have a single output, just generate a normal `.apply`.
-		//g.genApplyOutput(w, g.applyArgs[0])
-		g.Fgenf(w, "%v.apply(%v)", applyArgs[0], then)
+		// If we only have a single output, just generate a normal `.apply` or `.then`.
+		g.Fgenf(w, "%v.%v(%v)", applyArgs[0], apply, then)
 	} else {
 		// Otherwise, generate a call to `pulumi.all([]).apply()`.
-		g.Fgen(w, "pulumi.all([")
+		g.Fgen(w, "%v([", all)
 		for i, o := range applyArgs {
 			if i > 0 {
 				g.Fgen(w, ", ")
 			}
-			//g.genApplyOutput(w, o)
-			g.Fgenf(w, "%v", o)
+			if isPromise[i] {
+				g.Fgenf(w, "pulumi.output(%v)", o)
+			} else {
+				g.Fgenf(w, "%v", o)
+			}
 		}
-		g.Fgenf(w, "]).apply(%v)", then)
+		g.Fgenf(w, "]).%v(%v)", apply, then)
 	}
+}
+
+// functionName computes the NodeJS package, module, and name for the given function token.
+func functionName(tokenArg model.Expression) (string, string, string, hcl.Diagnostics) {
+	token := tokenArg.(*model.TemplateExpression).Parts[0].(*model.LiteralValueExpression).Value.AsString()
+	tokenRange := tokenArg.SyntaxNode().Range()
+
+	// Compute the resource type from the Pulumi type token.
+	pkg, module, member, diagnostics := hcl2.DecomposeToken(token, tokenRange)
+	return cleanName(pkg), strings.Replace(module, "/", ".", -1), member, diagnostics
+}
+
+func (g *generator) genRange(w io.Writer, call *model.FunctionCallExpression, entries bool) {
+	log.Printf("generating range() %v", call)
+
+	var from, to model.Expression
+	switch len(call.Args) {
+	case 1:
+		from, to = &model.LiteralValueExpression{Value: cty.NumberIntVal(0)}, call.Args[0]
+	case 2:
+		from, to = call.Args[0], call.Args[1]
+	default:
+		contract.Failf("expected range() to have exactly 1 or 2 args; got %v", len(call.Args))
+	}
+
+	genPrefix := func() { g.Fprint(w, "((from, to) => (new Array(to - from))") }
+	mapValue := "from + i"
+	genSuffix := func() { g.Fgenf(w, ")(%v, %v)", from, to) }
+
+	if litFrom, ok := from.(*model.LiteralValueExpression); ok {
+		fromV, err := convert.Convert(litFrom.Value, cty.Number)
+		contract.Assert(err == nil)
+
+		from, _ := fromV.AsBigFloat().Int64()
+		if litTo, ok := to.(*model.LiteralValueExpression); ok {
+			toV, err := convert.Convert(litTo.Value, cty.Number)
+			contract.Assert(err == nil)
+
+			to, _ := toV.AsBigFloat().Int64()
+			if from == 0 {
+				mapValue = "i"
+			} else {
+				mapValue = fmt.Sprintf("%d + i", from)
+			}
+			genPrefix = func() { g.Fprintf(w, "(new Array(%d))", to-from) }
+			genSuffix = func() {}
+		} else if from == 0 {
+			genPrefix = func() { g.Fgenf(w, "(new Array(%v))", to) }
+			mapValue = "i"
+			genSuffix = func() {}
+		}
+	}
+
+	if entries {
+		mapValue = fmt.Sprintf("{key: %[1]s, value: %[1]s}", mapValue)
+	}
+
+	genPrefix()
+	g.Fprintf(w, ".map((_, i) => %v)", mapValue)
+	genSuffix()
 }
 
 func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionCallExpression) {
@@ -156,10 +240,40 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			}
 		}
 		g.Fgen(w, "`")
+	case "entries":
+		switch expr.Args[0].Type().(type) {
+		case *model.ListType, *model.TupleType:
+			if call, ok := expr.Args[0].(*model.FunctionCallExpression); ok && call.Name == "range" {
+				g.genRange(w, call, true)
+				return
+			}
+			g.Fgenf(w, "%v.map((k, v)", expr.Args[0])
+		case *model.MapType, *model.ObjectType:
+			g.Fgenf(w, "Object.entries(%v).map(([k, v])", expr.Args[0])
+		}
+		g.Fgenf(w, " => {key: k, value: v})")
 	case "fileArchive":
 		g.Fgenf(w, "new pulumi.asset.FileArchive(%v)", expr.Args[0])
 	case "fileAsset":
 		g.Fgenf(w, "new pulumi.asset.FileAsset(%v)", expr.Args[0])
+	case "invoke":
+		pkg, module, fn, diags := functionName(expr.Args[0])
+		contract.Assert(len(diags) == 0)
+		if module != "" {
+			module = "." + module
+		}
+		name := fmt.Sprintf("%s%s.%s", pkg, module, fn)
+
+		optionsBag := ""
+		if len(expr.Args) == 3 {
+			var buf bytes.Buffer
+			g.Fgenf(&buf, ", %v", expr.Args[2])
+			optionsBag = buf.String()
+		}
+
+		g.Fgenf(w, "%s(%v%v)", name, expr.Args[1], optionsBag)
+	case "range":
+		g.genRange(w, expr, false)
 	case "toJSON":
 		g.Fgenf(w, "JSON.stringify(%v)", expr.Args[0])
 	default:

--- a/pkg/codegen/nodejs/gen_program_lower.go
+++ b/pkg/codegen/nodejs/gen_program_lower.go
@@ -39,7 +39,7 @@ func (g *generator) parseProxyApply(args []*model.ScopeTraversalExpression,
 		return nil, false
 	}
 
-	traversal := hcl.TraversalJoin(args[0].Syntax.Traversal, thenTraversal.Syntax.Traversal[1:])
+	traversal := hcl.TraversalJoin(args[0].Traversal, thenTraversal.Traversal[1:])
 	expr, diags := g.program.BindExpression(&hclsyntax.ScopeTraversalExpr{
 		Traversal: traversal,
 		SrcRange:  traversal.SourceRange(),
@@ -95,7 +95,7 @@ func (g *generator) parseInterpolate(args []*model.ScopeTraversalExpression,
 				return nil, false
 			}
 			arg := args[indices[traversal.Parts[0].(*model.Variable)]]
-			traversal := hcl.TraversalJoin(arg.Syntax.Traversal, traversal.Syntax.Traversal[1:])
+			traversal := hcl.TraversalJoin(arg.Traversal, traversal.Traversal[1:])
 			expr, diags := g.program.BindExpression(&hclsyntax.ScopeTraversalExpr{
 				Traversal: traversal,
 				SrcRange:  traversal.SourceRange(),

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -1,0 +1,65 @@
+package nodejs
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/codegen/hcl2"
+	"github.com/pulumi/pulumi/pkg/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/codegen/internal/test"
+)
+
+var testdataPath = filepath.Join("..", "internal", "test", "testdata")
+
+func TestGenProgram(t *testing.T) {
+	files, err := ioutil.ReadDir(testdataPath)
+	if err != nil {
+		t.Fatalf("could not read test data: %v", err)
+	}
+
+	for _, f := range files {
+		if filepath.Ext(f.Name()) != ".pp" {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			path := filepath.Join(testdataPath, f.Name())
+			contents, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path, err)
+			}
+			expected, err := ioutil.ReadFile(path + ".ts")
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path+".ts", err)
+			}
+
+			parser := syntax.NewParser()
+			err = parser.ParseFile(bytes.NewReader(contents), f.Name())
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path, err)
+			}
+			if parser.Diagnostics.HasErrors() {
+				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
+			}
+
+			program, diags, err := hcl2.BindProgram(parser.Files, test.NewHost(nil))
+			if err != nil {
+				t.Fatalf("could not bind program: %v", err)
+			}
+			if diags.HasErrors() {
+				t.Fatalf("failed to bind program: %v", diags)
+			}
+
+			files, diags, err := GenerateProgram(program)
+			assert.NoError(t, err)
+			if diags.HasErrors() {
+				t.Fatalf("failed to bind program: %v", diags)
+			}
+			assert.Equal(t, string(expected), string(files["index.ts"]))
+		})
+	}
+}

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -46,7 +46,7 @@ func TestGenProgram(t *testing.T) {
 				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 			}
 
-			program, diags, err := hcl2.BindProgram(parser.Files, test.NewHost(nil))
+			program, diags, err := hcl2.BindProgram(parser.Files, test.NewHost(testdataPath))
 			if err != nil {
 				t.Fatalf("could not bind program: %v", err)
 			}

--- a/pkg/codegen/python/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test.go
@@ -1,0 +1,65 @@
+package python
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/codegen/hcl2"
+	"github.com/pulumi/pulumi/pkg/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/codegen/internal/test"
+)
+
+var testdataPath = filepath.Join("..", "internal", "test", "testdata")
+
+func TestGenProgram(t *testing.T) {
+	files, err := ioutil.ReadDir(testdataPath)
+	if err != nil {
+		t.Fatalf("could not read test data: %v", err)
+	}
+
+	for _, f := range files {
+		if filepath.Ext(f.Name()) != ".pp" {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			path := filepath.Join(testdataPath, f.Name())
+			contents, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path, err)
+			}
+			expected, err := ioutil.ReadFile(path + ".py")
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path+".py", err)
+			}
+
+			parser := syntax.NewParser()
+			err = parser.ParseFile(bytes.NewReader(contents), f.Name())
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path, err)
+			}
+			if parser.Diagnostics.HasErrors() {
+				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
+			}
+
+			program, diags, err := hcl2.BindProgram(parser.Files, test.NewHost(nil))
+			if err != nil {
+				t.Fatalf("could not bind program: %v", err)
+			}
+			if diags.HasErrors() {
+				t.Fatalf("failed to bind program: %v", diags)
+			}
+
+			files, diags, err := GenerateProgram(program)
+			assert.NoError(t, err)
+			if diags.HasErrors() {
+				t.Fatalf("failed to bind program: %v", diags)
+			}
+			assert.Equal(t, string(expected), string(files["__main__.py"]))
+		})
+	}
+}

--- a/pkg/codegen/python/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test.go
@@ -46,7 +46,7 @@ func TestGenProgram(t *testing.T) {
 				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 			}
 
-			program, diags, err := hcl2.BindProgram(parser.Files, test.NewHost(nil))
+			program, diags, err := hcl2.BindProgram(parser.Files, test.NewHost(testdataPath))
 			if err != nil {
 				t.Fatalf("could not bind program: %v", err)
 			}

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -35,6 +35,8 @@ type Provider struct {
 	Config     resource.PropertyMap
 	configured bool
 
+	GetSchemaF func(version int) ([]byte, error)
+
 	CheckConfigF func(urn resource.URN, olds,
 		news resource.PropertyMap, allowUnknowns bool) (resource.PropertyMap, []plugin.CheckFailure, error)
 	DiffConfigF func(urn resource.URN, olds, news resource.PropertyMap,
@@ -82,7 +84,10 @@ func (prov *Provider) GetPluginInfo() (workspace.PluginInfo, error) {
 }
 
 func (prov *Provider) GetSchema(version int) ([]byte, error) {
-	return []byte("{}"), nil
+	if prov.GetSchemaF == nil {
+		return []byte("{}"), nil
+	}
+	return prov.GetSchemaF(version)
 }
 
 func (prov *Provider) CheckConfig(urn resource.URN, olds,

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -47,8 +47,8 @@ istanbul_tests::
 	./node_modules/.bin/istanbul report text
 
 sxs_tests::
-	pushd tests/sxs_ts_3.6 && yarn && tsc && popd
-	pushd tests/sxs_ts_latest && yarn && tsc && popd
+	pushd tests/sxs_ts_3.6 && yarn ; tsc ; popd
+	pushd tests/sxs_ts_latest && yarn ; tsc ; popd
 
 test_fast:: sxs_tests istanbul_tests
 	$(GO_TEST_FAST) ${PROJECT_PKGS}


### PR DESCRIPTION
Pulumi HCL2 IR:
- Add support for invokes
- Add support for resource options, incl. ranged resources
- Allow the apply rewriter to ignore promise-typed values
- Add tests for the binder
- Add support functions for TF: entries and range

NodeJS codegen:
- Simplify for expression codegen
- Add support for invoke codegen
- Add support for entries and range functions
- Add tests

Python codegen:
- Implement codegen for most expression types
- Add support for invoke codegen
- Add tests