### PR TITLE
Handle const values in Go codegen

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -668,7 +668,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource) error {
 				t = "pulumi.Any"
 			}
 
-			fmt.Fprintf(w, "\targs.%s = %s(%s)\n", title(p.Name), t, v)
+			fmt.Fprintf(w, "\targs.%s = %s(%s)\n", Title(p.Name), t, v)
 		}
 		if p.DefaultValue != nil {
 			v, err := pkg.getDefaultValue(p.DefaultValue, p.Type)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -571,6 +571,19 @@ func goPrimitiveValue(value interface{}) (string, error) {
 	}
 }
 
+func (pkg *pkgContext) getConstValue(cv interface{}) (string, error) {
+	var val string
+	if cv != nil {
+		v, err := goPrimitiveValue(cv)
+		if err != nil {
+			return "", err
+		}
+		val = v
+	}
+
+	return val, nil
+}
+
 func (pkg *pkgContext) getDefaultValue(dv *schema.DefaultValue, t schema.Type) (string, error) {
 	var val string
 	if dv.Value != nil {
@@ -644,6 +657,19 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource) error {
 	fmt.Fprintf(w, "\t\targs = &%sArgs{}\n", name)
 	fmt.Fprintf(w, "\t}\n")
 	for _, p := range r.InputProperties {
+		if p.ConstValue != nil {
+			v, err := pkg.getConstValue(p.ConstValue)
+			if err != nil {
+				return err
+			}
+
+			t := strings.TrimSuffix(pkg.inputType(p.Type, !p.IsRequired), "Input")
+			if t == "pulumi." {
+				t = "pulumi.Any"
+			}
+
+			fmt.Fprintf(w, "\targs.%s = %s(%s)\n", title(p.Name), t, v)
+		}
 		if p.DefaultValue != nil {
 			v, err := pkg.getDefaultValue(p.DefaultValue, p.Type)
 			if err != nil {


### PR DESCRIPTION
Here's what that change looks like in the k8s SDK (note `ApiVersion` and `Kind`):
```go
func NewDeployment(ctx *pulumi.Context,
	name string, args *DeploymentArgs, opts ...pulumi.ResourceOption) (*Deployment, error) {
	if args == nil {
		args = &DeploymentArgs{}
	}
	args.ApiVersion = pulumi.StringPtr("apps/v1")
	args.Kind = pulumi.StringPtr("Deployment")
	aliases := pulumi.Aliases([]pulumi.Alias{
		{
			Type: pulumi.String("kubernetes:apps/v1beta1:Deployment"),
		},
		{
			Type: pulumi.String("kubernetes:apps/v1beta2:Deployment"),
		},
		{
			Type: pulumi.String("kubernetes:extensions/v1beta1:Deployment"),
		},
	})
	opts = append(opts, aliases)
	var resource Deployment
	err := ctx.RegisterResource("kubernetes:apps/v1:Deployment", name, args, &resource, opts...)
	if err != nil {
		return nil, err
	}
	return &resource, nil
}
```