### PR TITLE
Update the index template for resource docs generator

### DIFF
--- a/pkg/codegen/docs/templates/index.tmpl
+++ b/pkg/codegen/docs/templates/index.tmpl
@@ -12,6 +12,11 @@ menu:
 {{ htmlSafe "<!-- Do not edit by hand unless you're certain you know what you are doing! -->" }}
 
 {{ htmlSafe .PackageDescription }}
+<!--
+    This comment ensures that there is always a new-line between the
+    package description and the start of the headers. This comment
+    will not be included in the generated markdown.
+-->
 
 {{- if ne (len .Modules) 0 -}}
 {{ template "index_modules" .Modules }}


### PR DESCRIPTION
Make sure there is a new-line between the package description and the first header on the index page.

See this [comment](https://github.com/pulumi/docs/pull/2853#issuecomment-610104451) in the docs repo PR for background info.