### PR TITLE
Replace IDeployment with a sealed class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ CHANGELOG
 
 - C# code generation switched to schema.
 
+- .NET API: replace `IDeployment` interface with `DeploymentInstance` class.
+
 ## 1.13.1 (2020-03-27)
 - Move to a multi-module repo to enable modules for the Go SDK
   [#4109](https://github.com/pulumi/pulumi/pull/4109)

--- a/sdk/dotnet/Pulumi.Tests/PulumiTest.cs
+++ b/sdk/dotnet/Pulumi.Tests/PulumiTest.cs
@@ -20,7 +20,7 @@ namespace Pulumi.Tests
             var mock = new Mock<IDeployment>(MockBehavior.Strict);
             mock.Setup(d => d.IsDryRun).Returns(dryRun);
 
-            Deployment.Instance = mock.Object;
+            Deployment.Instance = new DeploymentInstance(mock.Object);
             await func().ConfigureAwait(false);
             Deployment.Instance = null!;
         }

--- a/sdk/dotnet/Pulumi.Tests/StackTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/StackTests.cs
@@ -98,7 +98,7 @@ namespace Pulumi.Tests
             mock.Setup(d => d.RegisterResourceOutputs(It.IsAny<Stack>(), It.IsAny<Output<IDictionary<string, object?>>>()))
                 .Callback((Resource _, Output<IDictionary<string, object?>> o) => outputs = o);
 
-            Deployment.Instance = mock.Object;
+            Deployment.Instance = new DeploymentInstance(mock.Object);
 
             // Act
             var stack = new T();

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.cs
@@ -32,21 +32,21 @@ namespace Pulumi
     /// </summary>
     public sealed partial class Deployment : IDeploymentInternal
     {
-        private static IDeployment? _instance;
+        private static DeploymentInstance? _instance;
         private static readonly object _instanceLock = new object();
 
         /// <summary>
         /// The current running deployment instance. This is only available from inside the function
         /// passed to <see cref="Deployment.RunAsync(Action)"/> (or its overloads).
         /// </summary>
-        public static IDeployment Instance
+        public static DeploymentInstance Instance
         {
             get => _instance ?? throw new InvalidOperationException("Trying to acquire Deployment.Instance before 'Run' was called.");
             internal set => _instance = value;
         }
 
         internal static IDeploymentInternal InternalInstance
-            => (IDeploymentInternal)Instance;
+            => Instance.Internal;
 
         private readonly string _projectName;
         private readonly string _stackName;

--- a/sdk/dotnet/Pulumi/Deployment/DeploymentInstance.cs
+++ b/sdk/dotnet/Pulumi/Deployment/DeploymentInstance.cs
@@ -7,7 +7,7 @@ namespace Pulumi
     /// </summary>
     public sealed class DeploymentInstance : IDeployment
     {
-        private IDeployment _deployment;
+        private readonly IDeployment _deployment;
         
         internal DeploymentInstance(IDeployment deployment)
         {

--- a/sdk/dotnet/Pulumi/Deployment/DeploymentInstance.cs
+++ b/sdk/dotnet/Pulumi/Deployment/DeploymentInstance.cs
@@ -1,25 +1,33 @@
-﻿// Copyright 2016-2019, Pulumi Corporation
-
 using System.Threading.Tasks;
 
 namespace Pulumi
 {
-    internal interface IDeployment
+    /// <summary>
+    /// Metadata of the deployment that is currently running. Accessible via <see cref="Deployment.Instance"/>.
+    /// </summary>
+    public sealed class DeploymentInstance : IDeployment
     {
+        private IDeployment _deployment;
+        
+        internal DeploymentInstance(IDeployment deployment)
+        {
+            _deployment = deployment;
+        }
+
         /// <summary>
         /// Returns the current stack name.
         /// </summary>
-        string StackName { get; }
+        public string StackName => _deployment.StackName;
 
         /// <summary>
         /// Returns the current project name.
         /// </summary>
-        string ProjectName { get; }
+        public string ProjectName => _deployment.ProjectName;
 
         /// <summary>
         /// Whether or not the application is currently being previewed or actually applied.
         /// </summary>
-        bool IsDryRun { get; }
+        public bool IsDryRun => _deployment.IsDryRun;
 
         /// <summary>
         /// Dynamically invokes the function '<paramref name="token"/>', which is offered by a
@@ -31,12 +39,16 @@ namespace Pulumi
         /// The <paramref name="args"/> inputs can be a bag of computed values(including, `T`s,
         /// <see cref="Task{TResult}"/>s, <see cref="Output{T}"/>s etc.).
         /// </summary>
-        Task<T> InvokeAsync<T>(string token, InvokeArgs args, InvokeOptions? options = null);
+        public Task<T> InvokeAsync<T>(string token, InvokeArgs args, InvokeOptions? options = null)
+            => _deployment.InvokeAsync<T>(token, args, options);
 
         /// <summary>
         /// Same as <see cref="InvokeAsync{T}(string, InvokeArgs, InvokeOptions)"/>, however the
         /// return value is ignored.
         /// </summary>
-        Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options = null);
+        public Task InvokeAsync(string token, InvokeArgs args, InvokeOptions? options = null)
+            => _deployment.InvokeAsync(token, args, options);
+
+        internal IDeploymentInternal Internal => (IDeploymentInternal)_deployment;
     }
 }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs
@@ -111,7 +111,7 @@ namespace Pulumi
                     throw new NotSupportedException($"Mulitple executions of {nameof(TestAsync)} must run serially. Please configure your unit test suite to run tests one-by-one.");
 
                 deployment = new Deployment(engine, monitor, options);
-                Instance = deployment;
+                Instance = new DeploymentInstance(deployment);
             }
 
             try
@@ -145,7 +145,7 @@ namespace Pulumi
 
                 Serilog.Log.Debug("Creating new Deployment.");
                 var deployment = new Deployment();
-                Instance = deployment;
+                Instance = new DeploymentInstance(deployment);
                 return deployment._runner;
             }
         }

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -71,16 +71,16 @@ Pulumi.CustomTimeouts.Update.set -> void
 Pulumi.DictionaryResourceArgs
 Pulumi.DictionaryResourceArgs.DictionaryResourceArgs(System.Collections.Immutable.ImmutableDictionary<string, object> dictionary) -> void
 Pulumi.Deployment
+Pulumi.DeploymentInstance
+Pulumi.DeploymentInstance.InvokeAsync(string token, Pulumi.InvokeArgs args, Pulumi.InvokeOptions options = null) -> System.Threading.Tasks.Task
+Pulumi.DeploymentInstance.InvokeAsync<T>(string token, Pulumi.InvokeArgs args, Pulumi.InvokeOptions options = null) -> System.Threading.Tasks.Task<T>
+Pulumi.DeploymentInstance.IsDryRun.get -> bool
+Pulumi.DeploymentInstance.ProjectName.get -> string
+Pulumi.DeploymentInstance.StackName.get -> string
 Pulumi.FileArchive
 Pulumi.FileArchive.FileArchive(string path) -> void
 Pulumi.FileAsset
 Pulumi.FileAsset.FileAsset(string path) -> void
-Pulumi.IDeployment
-Pulumi.IDeployment.InvokeAsync(string token, Pulumi.InvokeArgs args, Pulumi.InvokeOptions options = null) -> System.Threading.Tasks.Task
-Pulumi.IDeployment.InvokeAsync<T>(string token, Pulumi.InvokeArgs args, Pulumi.InvokeOptions options = null) -> System.Threading.Tasks.Task<T>
-Pulumi.IDeployment.IsDryRun.get -> bool
-Pulumi.IDeployment.ProjectName.get -> string
-Pulumi.IDeployment.StackName.get -> string
 Pulumi.Input<T>
 Pulumi.InputArgs
 Pulumi.InputArgs.InputArgs() -> void
@@ -224,7 +224,7 @@ override Pulumi.Union<T0, T1>.GetHashCode() -> int
 override Pulumi.Union<T0, T1>.ToString() -> string
 static Pulumi.ComponentResourceOptions.Merge(Pulumi.ComponentResourceOptions options1, Pulumi.ComponentResourceOptions options2) -> Pulumi.ComponentResourceOptions
 static Pulumi.CustomResourceOptions.Merge(Pulumi.CustomResourceOptions options1, Pulumi.CustomResourceOptions options2) -> Pulumi.CustomResourceOptions
-static Pulumi.Deployment.Instance.get -> Pulumi.IDeployment
+static Pulumi.Deployment.Instance.get -> Pulumi.DeploymentInstance
 static Pulumi.Deployment.RunAsync(System.Action action) -> System.Threading.Tasks.Task<int>
 static Pulumi.Deployment.RunAsync(System.Func<System.Collections.Generic.IDictionary<string, object>> func) -> System.Threading.Tasks.Task<int>
 static Pulumi.Deployment.RunAsync(System.Func<System.Threading.Tasks.Task<System.Collections.Generic.IDictionary<string, object>>> func) -> System.Threading.Tasks.Task<int>


### PR DESCRIPTION
Wrap our previously public `IDeployment` interface into the sealed class `DeploymentInstance`. This way we can avoid breaking changes in case we want to extend the instance with an extra member. `IDeployment` used to be the only public interface except `IMocks`.

Resolves #4241