### PR TITLE
Handle k8s cases in the resource doc generator

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -353,7 +353,7 @@ func (mod *modContext) cleanTypeString(t schema.Type, langTypeString, lang, modN
 				if schema.IsPrimitiveType(e) {
 					continue
 				}
-				return mod.cleanTypeString(e.(*schema.ObjectType), langTypeString, lang, modName, isInput)
+				return mod.cleanTypeString(e, langTypeString, lang, modName, isInput)
 			}
 		case *schema.ObjectType:
 			objTypeModName := mod.pkg.TokenToModule(t.Token)

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -769,7 +769,8 @@ func (mod *modContext) getConstructorResourceInfo(resourceTypeName string) map[s
 		case "nodejs", "go":
 			// Intentionally left blank.
 		case "csharp":
-			resourceTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", title(mod.pkg.Name, "csharp"), title(mod.mod, "csharp"), resourceTypeName)
+			modName := getLanguageModuleName(mod.pkg, mod.mod, lang)
+			resourceTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", title(mod.pkg.Name, lang), title(modName, lang), resourceTypeName)
 		case "python":
 			// Pulumi's Python language SDK does not have "types" yet, so we will skip it for now.
 			continue

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -64,6 +64,7 @@ var (
 	// titleLookup is a map to map module package name to the desired display name
 	// for display in the TOC menu under API Reference.
 	titleLookup = map[string]string{
+		"aiven":        "Aiven",
 		"alicloud":     "AliCloud",
 		"aws":          "AWS",
 		"azure":        "Azure",
@@ -77,9 +78,11 @@ var (
 		"f5bigip":      "f5 BIG-IP",
 		"fastly":       "Fastly",
 		"gcp":          "GCP",
+		"gitlab":       "GitLab",
 		"kafka":        "Kafka",
 		"keycloak":     "Keycloak",
 		"linode":       "Linode",
+		"mailgun":      "Mailgun",
 		"mysql":        "MySQL",
 		"newrelic":     "New Relic",
 		"okta":         "Okta",

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -317,19 +317,22 @@ func getLanguageModuleName(pkg *schema.Package, mod, lang string) string {
 // cleanTypeString removes any namespaces from the generated type string for all languages.
 // The result of this function should be used display purposes only.
 func (mod *modContext) cleanTypeString(t schema.Type, langTypeString, lang, modName string, isInput bool) string {
-	if lang != "csharp" {
+	switch lang {
+	case "go":
 		parts := strings.Split(langTypeString, ".")
 		return parts[len(parts)-1]
-	}
-
-	// C# types can be wrapped in enumerable types such as List<> or Dictionary<>, so we have to
-	// only replace the namespace between the < and the > characters.
-	qualifier := "Inputs"
-	if !isInput {
-		qualifier = "Outputs"
+	case "python":
+		return langTypeString
 	}
 
 	cleanCSharpName := func(pkgName, objModName string) string {
+		// C# types can be wrapped in enumerable types such as List<> or Dictionary<>, so we have to
+		// only replace the namespace between the < and the > characters.
+		qualifier := "Inputs"
+		if !isInput {
+			qualifier = "Outputs"
+		}
+
 		var csharpNS string
 		// This type could be at the package-level, so it won't have a module name.
 		if objModName != "" {
@@ -340,29 +343,37 @@ func (mod *modContext) cleanTypeString(t schema.Type, langTypeString, lang, modN
 		return strings.ReplaceAll(langTypeString, csharpNS, "")
 	}
 
-	if isKubernetesPackage(mod.pkg) {
-		switch t := t.(type) {
-		case *schema.ArrayType:
-			if schema.IsPrimitiveType(t.ElementType) {
-				break
+	cleanNodeJSName := func(objModName string) string {
+		objModName = strings.ReplaceAll(objModName, "/", ".") + "."
+		return strings.ReplaceAll(langTypeString, objModName, "")
+	}
+
+	switch t := t.(type) {
+	case *schema.ArrayType:
+		if schema.IsPrimitiveType(t.ElementType) {
+			break
+		}
+		return mod.cleanTypeString(t.ElementType, langTypeString, lang, modName, isInput)
+	case *schema.UnionType:
+		for _, e := range t.ElementTypes {
+			if schema.IsPrimitiveType(e) {
+				continue
 			}
-			objType := t.ElementType.(*schema.ObjectType)
-			return mod.cleanTypeString(objType, langTypeString, lang, modName, isInput)
-		case *schema.UnionType:
-			for _, e := range t.ElementTypes {
-				if schema.IsPrimitiveType(e) {
-					continue
-				}
-				return mod.cleanTypeString(e, langTypeString, lang, modName, isInput)
-			}
-		case *schema.ObjectType:
-			objTypeModName := mod.pkg.TokenToModule(t.Token)
-			if objTypeModName != mod.mod {
-				modName = getLanguageModuleName(mod.pkg, objTypeModName, lang)
-			}
+			return mod.cleanTypeString(e, langTypeString, lang, modName, isInput)
+		}
+	case *schema.ObjectType:
+		objTypeModName := mod.pkg.TokenToModule(t.Token)
+		if objTypeModName != mod.mod {
+			modName = getLanguageModuleName(mod.pkg, objTypeModName, lang)
 		}
 	}
-	return cleanCSharpName(mod.pkg.Name, modName)
+
+	if lang == "nodejs" {
+		return cleanNodeJSName(modName)
+	} else if lang == "csharp" {
+		return cleanCSharpName(mod.pkg.Name, modName)
+	}
+	return strings.ReplaceAll(langTypeString, modName, "")
 }
 
 // typeString returns a property type suitable for docs with its display name and the anchor link to
@@ -1110,6 +1121,8 @@ func (fs fs) add(path string, contents []byte) {
 	fs[path] = contents
 }
 
+// getModuleFileName returns the normalized package name to use
+// for k8s. Otherwise, returns the current module's name as-is.
 func (mod *modContext) getModuleFileName() string {
 	if !isKubernetesPackage(mod.pkg) {
 		return mod.mod

--- a/pkg/codegen/docs/templates/properties.tmpl
+++ b/pkg/codegen/docs/templates/properties.tmpl
@@ -8,7 +8,7 @@
             title="{{ if .IsInput -}}{{- if .IsRequired -}}Required{{- else -}}Optional{{- end -}}{{- end -}}{{- if .DeprecationMessage -}}, Deprecated{{- end -}}">
         <span>{{- htmlSafe .DisplayName -}}</span>
         <span class="property-indicator"></span>
-        <span class="property-type">{{- if eq .Type.Link "#" "" -}}{{- htmlSafe .Type.Name -}}{{- else -}}{{ template "linkify" .Type }}{{- end -}}</span>
+        <span class="property-type">{{- if eq .Type.Link "#" "" -}}{{- htmlSafe .Type.DisplayName -}}{{- else -}}{{ template "linkify" .Type }}{{- end -}}</span>
     </dt>
     <dd>
         {{- print "{{% md %}}" -}}{{- htmlSafe .Comment -}}{{- print "{{% /md %}}" -}}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -1,8 +1,10 @@
 {{ template "header" .Header }}
 
-{{- htmlSafe .DeprecationMessage }}
-
 {{ htmlSafe .Comment }}
+
+{{- if .DeprecationMessage }}
+<p class="resource-deprecated">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>
+{{- end -}}
 
 <!-- Create resource -->
 ## Create a {{ .Header.Title }} Resource

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -4,7 +4,7 @@
 
 {{- if .DeprecationMessage }}
 <p class="resource-deprecated">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>
-{{- end -}}
+{{- end }}
 
 <!-- Create resource -->
 ## Create a {{ .Header.Title }} Resource


### PR DESCRIPTION
Fixes #4269.

This PR can be previewed using this docs [PR](https://github.com/pulumi/docs/pull/2890).

This PR addresses the following issues:
*  Fix broken customresourcedefinition page in k8s due to html-encoding issue (The fix was to use the html-encoded property `DisplayName)
* Show the resource-level `DeprecationMessage` (The css class is introduced in the associated docs PR)
* Issue with rendering a union type string in Python.

There is still one more thing to add to the generator, which is the generator must pass the `moduleToPackage` from the `nodejs` language info object to the nodejs code gen so that the type strings are properly generated. The codegen support for considering the `moduleToPackage` is actually in-flight in another [PR](https://github.com/pulumi/pulumi/pull/4325). Once that is merged, we will be able to use that.