### PR TITLE
make usage of prebuilt go binaries opt-in only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ CHANGELOG
 - Add overloads to Output.All in .NET
   [#4321](https://github.com/pulumi/pulumi/pull/4321)
 
+- Make prebuilt executables opt-in only for the Go SDK
+ [#4338](https://github.com/pulumi/pulumi/pull/4338)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -57,7 +57,12 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime string,
 
 	var args []string
 	for k, v := range options {
-		args = append(args, fmt.Sprintf("-%s=%t", k, v))
+		fmtstr := "-%s=%t"
+		// the prebuilt option specifies a string with an executable name
+		if k == "prebuilt" {
+			fmtstr = "-%s=%s"
+		}
+		args = append(args, fmt.Sprintf(fmtstr, k, v))
 	}
 	args = append(args, host.ServerAddr())
 

--- a/sdk/go/common/resource/plugin/langruntime_plugin.go
+++ b/sdk/go/common/resource/plugin/langruntime_plugin.go
@@ -57,12 +57,7 @@ func NewLanguageRuntime(host Host, ctx *Context, runtime string,
 
 	var args []string
 	for k, v := range options {
-		fmtstr := "-%s=%t"
-		// the prebuilt option specifies a string with an executable name
-		if k == "prebuilt" {
-			fmtstr = "-%s=%s"
-		}
-		args = append(args, fmt.Sprintf(fmtstr, k, v))
+		args = append(args, fmt.Sprintf("-%s=%v", k, v))
 	}
 	args = append(args, host.ServerAddr())
 

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -45,7 +45,7 @@ import (
 // findExecutable attempts to find the needed executable in various locations on the
 // filesystem, eventually resorting to searching in $PATH.
 func findExecutable(program string) (string, error) {
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == "windows" && !strings.HasSuffix(program, ".exe") {
 		program = fmt.Sprintf("%s.exe", program)
 	}
 	// look in the same directory


### PR DESCRIPTION
This change forces the specification of a `runtime.options.prebuilt` property in order for the go language host to use a prebuilt executable.

Fixes https://github.com/pulumi/pulumi/issues/4123

```yaml
name: ls
runtime:
    name: go
    options: 
        prebuilt: myprebuilt
description: A minimal Go Pulumi program
```
```sh
$pulumi up
Previewing update (dev):
     Type                 Name    Plan     Info
     pulumi:pulumi:Stack  ls-dev           1 error
 
Diagnostics:
  pulumi:pulumi:Stack (ls-dev):
    error: expected to find prebuilt executable: unable to find program: myprebuilt
```

```sh

$go build -o myprebuilt
$pulumi up 
Previewing update (dev):
     Type                 Name    Plan       
 +   pulumi:pulumi:Stack  ls-dev  create     
 
Resources:
    + 1 to create

Do you want to perform this update? yes
Updating (dev):
     Type                 Name    Status      
 +   pulumi:pulumi:Stack  ls-dev  created     
 
Resources:
    + 1 created

Duration: 1s

Permalink: https://app.pulumi.com/EvanBoyle/ls/dev/updates/1
```

@mikhailshilkov can you provide input here for consistency with dotnet? I figure that this property could be used in dotnet in the future to execute a prebuilt dll via `dotnet myprebuilt.dll`. Does that sound right to you? I understand that this doesn't solve for specification of a csproj file to build from, but that can be a separate property. 