### PR TITLE
Add stack output helpers for String and ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ CHANGELOG
 - Add overloads to Output.All in .NET
   [#4321](https://github.com/pulumi/pulumi/pull/4321)
 
+- Add helper methods for stack outputs in the Go SDK
+  [#4341](https://github.com/pulumi/pulumi/pull/4341)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/sdk/go/pulumi/stack_reference.go
+++ b/sdk/go/pulumi/stack_reference.go
@@ -12,12 +12,27 @@ type StackReference struct {
 	Outputs MapOutput `pulumi:"outputs"`
 }
 
+// GetOutput returns a stack output keyed by the given name as an AnyOutput
 func (s *StackReference) GetOutput(name StringInput) AnyOutput {
 	return All(name, s.Outputs).
 		ApplyT(func(args []interface{}) interface{} {
 			n, outs := args[0].(string), args[1].(map[string]interface{})
 			return outs[n]
 		}).(AnyOutput)
+}
+
+// GetStringOutput returns a stack output keyed by the given name as an StringOutput
+func (s *StackReference) GetStringOutput(name StringInput) StringOutput {
+	return s.GetOutput(name).ApplyString(func(v interface{}) string {
+		return v.(string)
+	})
+}
+
+// GetIDOutput returns a stack output keyed by the given name as an IDOutput
+func (s *StackReference) GetIDOutput(name StringInput) IDOutput {
+	return s.GetOutput(name).ApplyID(func(v interface{}) ID {
+		return ID(v.(string))
+	})
 }
 
 type stackReferenceArgs struct {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/4335

This was a feature request to unblock a customer until we have the time to codegen these methods for all built-ins. 

The method signatures are compatible with what we will generate in the future. 

Usage:

```go
package main

import (
	"fmt"

	"github.com/pulumi/pulumi/sdk/go/pulumi"
)

func main() {
	pulumi.Run(func(ctx *pulumi.Context) error {
		slug := fmt.Sprintf("evanboyle/%v/%v", ctx.Project(), ctx.Stack())
		stackRef, _ := pulumi.NewStackReference(ctx, slug, nil)
		s := stackRef.GetStringOutput(pulumi.String("str"))
		i := stackRef.GetIDOutput(pulumi.String("str"))
		ctx.Export("str", pulumi.String("foo"))
		ctx.Export("strOut", s)
		ctx.Export("idOut", i)
		return nil
	})
}

```

```sh
Evans-MBP:stackrefhelpers evanboyle$ pulumi up
Previewing update (dev):
     Type                 Name         Plan     
     pulumi:pulumi:Stack  abcdefs-dev           
 
Outputs:
  + idOut : "foo"

Resources:
    1 unchanged

Do you want to perform this update? yes
Updating (dev):
     Type                 Name         Status     
     pulumi:pulumi:Stack  abcdefs-dev             
 
Outputs:
  + idOut : "foo"
    str   : "foo"
    strOut: "foo"

Resources:
    1 unchanged

Duration: 3s

Permalink: https://app.pulumi.com/EvanBoyle/abcdefs/dev/updates/3

```