### PR TITLE
Automate execution of `go mod download` for `pulumi new` Go templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ CHANGELOG
 - Add additional overloads to Deployment.RunAsync in .NET API.
   [#4286](https://github.com/pulumi/pulumi/pull/4286)
 
+- Automate execution of `go mod download` for `pulumi new` Go templates
+  [#4353](https://github.com/pulumi/pulumi/pull/4353)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -42,6 +43,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/go/common/util/executable"
 	"github.com/pulumi/pulumi/sdk/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/go/common/workspace"
 )
@@ -567,6 +569,11 @@ func installDependencies(proj *workspace.Project, root string) error {
 		}
 	} else if strings.EqualFold(proj.Runtime.Name(), "dotnet") {
 		return dotnetInstallDependenciesAndBuild(proj, root)
+	} else if strings.EqualFold(proj.Runtime.Name(), "go") {
+		if err := goInstallDependencies(); err != nil {
+			return errors.Wrapf(err, "`go mod download` failed to install dependencies; rerun manually to try again, "+
+				"then run 'pulumi up' to perform an initial deployment")
+		}
 	}
 
 	return nil
@@ -607,6 +614,30 @@ func dotnetInstallDependenciesAndBuild(proj *workspace.Project, root string) err
 	// restore dependencies, install any plugins, and build the project so it will be
 	// prepped and ready to go for a faster initial `pulumi up`.
 	if err = engine.RunInstallPlugins(proj, pwd, main, nil, plugctx); err != nil {
+		return err
+	}
+
+	fmt.Println("Finished installing dependencies")
+	fmt.Println()
+
+	return nil
+}
+
+// goInstallDependencies will install dependencies for the project by running `go mod download`
+func goInstallDependencies() error {
+	fmt.Println("Installing dependencies...")
+	fmt.Println()
+
+	gobin, err := executable.FindExecutable("go")
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(gobin, "mod", "download")
+	cmd.Env = os.Environ()
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+
+	if err := cmd.Run(); err != nil {
 		return err
 	}
 

--- a/sdk/go/common/util/executable/executable.go
+++ b/sdk/go/common/util/executable/executable.go
@@ -1,0 +1,50 @@
+package executable
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/sdk/go/common/util/logging"
+)
+
+const unableToFindProgramTemplate = "unable to find program: %s"
+
+// FindExecutable attempts to find the needed executable in various locations on the
+// filesystem, eventually resorting to searching in $PATH.
+func FindExecutable(program string) (string, error) {
+	if runtime.GOOS == "windows" {
+		program = fmt.Sprintf("%s.exe", program)
+	}
+	// look in the same directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", errors.Wrap(err, "unable to get current working directory")
+	}
+
+	cwdProgram := filepath.Join(cwd, program)
+	if fileInfo, err := os.Stat(cwdProgram); !os.IsNotExist(err) && !fileInfo.Mode().IsDir() {
+		logging.V(5).Infof("program %s found in CWD", program)
+		return cwdProgram, nil
+	}
+
+	// look in $GOPATH/bin
+	if goPath := os.Getenv("GOPATH"); len(goPath) > 0 {
+		goPathProgram := filepath.Join(goPath, "bin", program)
+		if fileInfo, err := os.Stat(goPathProgram); !os.IsNotExist(err) && !fileInfo.Mode().IsDir() {
+			logging.V(5).Infof("program %s found in $GOPATH/bin", program)
+			return goPathProgram, nil
+		}
+	}
+
+	// look in the $PATH somewhere
+	if fullPath, err := exec.LookPath(program); err == nil {
+		logging.V(5).Infof("program %s found in $PATH", program)
+		return fullPath, nil
+	}
+
+	return "", errors.Errorf(unableToFindProgramTemplate, program)
+}

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 
@@ -35,6 +34,7 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/go/common/util/buildutil"
 	"github.com/pulumi/pulumi/sdk/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/go/common/util/executable"
 	"github.com/pulumi/pulumi/sdk/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/go/common/version"
@@ -44,47 +44,11 @@ import (
 
 const unableToFindProgramTemplate = "unable to find program: %s"
 
-// findExecutable attempts to find the needed executable in various locations on the
-// filesystem, eventually resorting to searching in $PATH.
-func findExecutable(program string) (string, error) {
-	if runtime.GOOS == "windows" {
-		program = fmt.Sprintf("%s.exe", program)
-	}
-	// look in the same directory
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", errors.Wrap(err, "unable to get current working directory")
-	}
-
-	cwdProgram := filepath.Join(cwd, program)
-	if fileInfo, err := os.Stat(cwdProgram); !os.IsNotExist(err) && !fileInfo.Mode().IsDir() {
-		logging.V(5).Infof("program %s found in CWD", program)
-		return cwdProgram, nil
-	}
-
-	// look in $GOPATH/bin
-	if goPath := os.Getenv("GOPATH"); len(goPath) > 0 {
-		goPathProgram := filepath.Join(goPath, "bin", program)
-		if fileInfo, err := os.Stat(goPathProgram); !os.IsNotExist(err) && !fileInfo.Mode().IsDir() {
-			logging.V(5).Infof("program %s found in $GOPATH/bin", program)
-			return goPathProgram, nil
-		}
-	}
-
-	// look in the $PATH somewhere
-	if fullPath, err := exec.LookPath(program); err == nil {
-		logging.V(5).Infof("program %s found in $PATH", program)
-		return fullPath, nil
-	}
-
-	return "", errors.Errorf(unableToFindProgramTemplate, program)
-}
-
 func findProgram(project string) (*exec.Cmd, error) {
 	// The program to execute is simply the name of the project. This ensures good Go toolability, whereby
 	// you can simply run `go install .` to build a Pulumi program prior to running it, among other benefits.
 	// For ease of use, if we don't find a pre-built program, we attempt to invoke via 'go run' on behalf of the user.
-	program, err := findExecutable(project)
+	program, err := executable.FindExecutable(project)
 	if err == nil {
 		return exec.Command(program), nil
 	}
@@ -92,7 +56,7 @@ func findProgram(project string) (*exec.Cmd, error) {
 	const message = "problem executing program (could not run language executor)"
 	if err.Error() == fmt.Sprintf(unableToFindProgramTemplate, project) {
 		logging.V(5).Infof("Unable to find program %s in $PATH, attempting invocation via 'go run'", program)
-		program, err = findExecutable("go")
+		program, err = executable.FindExecutable("go")
 	}
 	if err != nil {
 		return nil, errors.Wrap(err, message)
@@ -219,7 +183,7 @@ func (host *goLanguageHost) GetRequiredPlugins(ctx context.Context,
 
 	logging.V(5).Infof("GetRequiredPlugins: Determining pulumi packages")
 
-	gobin, err := findExecutable("go")
+	gobin, err := executable.FindExecutable("go")
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't find go binary")
 	}


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi/issues/4236

```
Evans-MBP:newtest evanboyle$ pulumi new
Please choose a template: Show additional templates
Please choose a template: go                         A minimal Go Pulumi program
This command will walk you through creating a new Pulumi project.

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.

project name: abc
project description: (A minimal Go Pulumi program) def
Created project 'abc'

Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
stack name: (dev) 
Created stack 'dev'

Installing dependencies...

go: finding cloud.google.com/go v0.26.0
go: finding github.com/BurntSushi/toml v0.3.1
go: finding github.com/Microsoft/go-winio v0.4.14
go: finding github.com/OneOfOne/xxhash v1.2.2
go: finding github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7
go: finding github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
go: finding github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
go: finding github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239
go: finding github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6
go: finding github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
go: finding github.com/beorn7/perks v1.0.0
go: finding github.com/blang/semver v3.5.1+incompatible
go: finding github.com/census-instrumentation/opencensus-proto v0.2.1
go: finding github.com/cespare/xxhash v1.1.0
go: finding github.com/cheggaaa/pb v1.0.18
go: finding github.com/client9/misspell v0.3.4
go: finding github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f
go: finding github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd
go: finding github.com/coreos/bbolt v1.3.2
go: finding github.com/coreos/etcd v3.3.10+incompatible
go: finding github.com/coreos/go-semver v0.2.0
go: finding github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
go: finding github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
go: finding github.com/cpuguy83/go-md2man/v2 v2.0.0
go: finding github.com/creack/pty v1.1.7
go: finding github.com/davecgh/go-spew v1.1.1
go: finding github.com/dgrijalva/jwt-go v3.2.0+incompatible
go: finding github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954
go: finding github.com/djherbis/times v1.2.0
go: finding github.com/emirpasic/gods v1.12.0
go: finding github.com/envoyproxy/go-control-plane v0.9.4
go: finding github.com/envoyproxy/protoc-gen-validate v0.1.0
go: finding github.com/fatih/color v1.9.0
go: finding github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568
go: finding github.com/fsnotify/fsnotify v1.4.7
go: finding github.com/ghodss/yaml v1.0.0
go: finding github.com/gliderlabs/ssh v0.2.2
go: finding github.com/go-kit/kit v0.8.0
go: finding github.com/go-logfmt/logfmt v0.4.0
go: finding github.com/go-stack/stack v1.8.0
go: finding github.com/gofrs/flock v0.7.1
go: finding github.com/gogo/protobuf v1.2.1
go: finding github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: finding github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef
go: finding github.com/golang/mock v1.1.1
go: finding github.com/golang/protobuf v1.3.5
go: finding github.com/google/btree v1.0.0
go: finding github.com/google/go-cmp v0.3.0
go: finding github.com/gorilla/websocket v1.4.0
go: finding github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
go: finding github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
go: finding github.com/grpc-ecosystem/grpc-gateway v1.9.0
go: finding github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
go: finding github.com/hashicorp/errwrap v1.0.0
go: finding github.com/hashicorp/go-multierror v1.0.0
go: finding github.com/hashicorp/hcl v1.0.0
go: finding github.com/inconshreveable/mousetrap v1.0.0
go: finding github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99
go: finding github.com/jessevdk/go-flags v1.4.0
go: finding github.com/jonboulle/clockwork v0.1.0
go: finding github.com/julienschmidt/httprouter v1.2.0
go: finding github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd
go: finding github.com/kisielk/errcheck v1.1.0
go: finding github.com/kisielk/gotool v1.0.0
go: finding github.com/konsorten/go-windows-terminal-sequences v1.0.1
go: finding github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
go: finding github.com/kr/pretty v0.1.0
go: finding github.com/kr/pty v1.1.8
go: finding github.com/kr/text v0.1.0
go: finding github.com/magiconair/properties v1.8.0
go: finding github.com/mattn/go-colorable v0.1.6
go: finding github.com/mattn/go-isatty v0.0.12
go: finding github.com/mattn/go-runewidth v0.0.8
go: finding github.com/matttproud/golang_protobuf_extensions v1.0.1
go: finding github.com/mitchellh/go-homedir v1.1.0
go: finding github.com/mitchellh/go-ps v1.0.0
go: finding github.com/mitchellh/mapstructure v1.1.2
go: finding github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
go: finding github.com/oklog/ulid v1.3.1
go: finding github.com/opentracing/basictracer-go v1.0.0
go: finding github.com/opentracing/opentracing-go v1.1.0
go: finding github.com/pelletier/go-buffruneio v0.2.0
go: finding github.com/pelletier/go-toml v1.2.0
go: finding github.com/pkg/errors v0.9.1
go: finding github.com/pmezard/go-difflib v1.0.0
go: finding github.com/prometheus/client_golang v0.9.3
go: finding github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
go: finding github.com/prometheus/common v0.4.0
go: finding github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084
go: finding github.com/prometheus/tsdb v0.7.1
go: finding github.com/pulumi/pulumi/sdk v1.13.1
go: finding github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
go: finding github.com/russross/blackfriday/v2 v2.0.1
go: finding github.com/sergi/go-diff v1.0.0
go: finding github.com/shurcooL/sanitized_anchor_name v1.0.0
go: finding github.com/sirupsen/logrus v1.4.1
go: finding github.com/soheilhy/cmux v0.1.4
go: finding github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72
go: finding github.com/spf13/afero v1.1.2
go: finding github.com/spf13/cast v1.3.1
go: finding github.com/spf13/cobra v0.0.6
go: finding github.com/spf13/jwalterweatherman v1.0.0
go: finding github.com/spf13/pflag v1.0.3
go: finding github.com/spf13/viper v1.4.0
go: finding github.com/src-d/gcfg v1.4.0
go: finding github.com/stretchr/objx v0.2.0
go: finding github.com/stretchr/testify v1.5.1
go: finding github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6
go: finding github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5
go: finding github.com/uber/jaeger-client-go v2.22.1+incompatible
go: finding github.com/uber/jaeger-lib v2.2.0+incompatible
go: finding github.com/ugorji/go v1.1.4
go: finding github.com/xanzy/ssh-agent v0.2.1
go: finding github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2
go: finding github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77
go: finding go.etcd.io/bbolt v1.3.2
go: finding go.uber.org/atomic v1.4.0
go: finding go.uber.org/multierr v1.1.0
go: finding go.uber.org/zap v1.10.0
go: finding golang.org/x/crypto v0.0.0-20200317142112-1b76d66859c6
go: finding golang.org/x/exp v0.0.0-20190121172915-509febef88a4
go: finding golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
go: finding golang.org/x/net v0.0.0-20200301022130-244492dfa37a
go: finding golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
go: finding golang.org/x/sync v0.0.0-20190423024810-112230192c58
go: finding golang.org/x/sys v0.0.0-20200317113312-5766fd39f98d
go: finding golang.org/x/text v0.3.2
go: finding golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
go: finding golang.org/x/tools v0.0.0-20190729092621-ff9f1409240a
go: finding google.golang.org/appengine v1.4.0
go: finding google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
go: finding google.golang.org/grpc v1.28.0
go: finding gopkg.in/alecthomas/kingpin.v2 v2.2.6
go: finding gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
go: finding gopkg.in/cheggaaa/pb.v1 v1.0.28
go: finding gopkg.in/resty.v1 v1.12.0
go: finding gopkg.in/src-d/go-billy.v4 v4.3.2
go: finding gopkg.in/src-d/go-git-fixtures.v3 v3.5.0
go: finding gopkg.in/src-d/go-git.v4 v4.13.1
go: finding gopkg.in/warnings.v0 v0.1.2
go: finding gopkg.in/yaml.v2 v2.2.8
go: finding honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc
go: finding sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
Finished installing dependencies

Your new project is ready to go! ✨

To perform an initial deployment, run 'pulumi up'

```

E2E automated setup including plugin acquisition:

```
Evans-MBP:newtest evanboyle$ pulumi new
Please choose a template: Show additional templates
Please choose a template: aws-go                     A minimal AWS Go Pulumi program
This command will walk you through creating a new Pulumi project.

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.

project name: abfdf
project description: (A minimal AWS Go Pulumi program) sds
Created project 'abfdf'

Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
stack name: (dev) 
Created stack 'dev'

aws:region: The AWS region to deploy into: (us-east-1) 
Saved config

Installing dependencies...

go: finding github.com/pulumi/pulumi-aws/sdk v1.28.0
Finished installing dependencies

Your new project is ready to go! ✨

To perform an initial deployment, run 'pulumi up'

Evans-MBP:newtest evanboyle$ pulumi up
Previewing update (dev):
[resource plugin aws-1.28.0] installing
Downloading plugin: 64.58 MiB / 64.58 MiB [=========================] 100.00% 7s
Moving plugin... done.
     Type                 Name       Plan       
 +   pulumi:pulumi:Stack  abfdf-dev  create     
 +   └─ aws:s3:Bucket     my-bucket  create     
 
Resources:
    + 2 to create

Do you want to perform this update? yes
Updating (dev):
     Type                 Name       Status      
 +   pulumi:pulumi:Stack  abfdf-dev  created     
 +   └─ aws:s3:Bucket     my-bucket  created     
 
Outputs:
    bucketName: "my-bucket-5627649"

Resources:
    + 2 created

Duration: 12s

Permalink: https://app.pulumi.com/EvanBoyle/abfdf/dev/updates/1
Evans-MBP:newtest evanboyle$ 

```