### PR TITLE
Support the binary option for .NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,10 @@ CHANGELOG
 
 - Make prebuilt executables opt-in only for the Go SDK
  [#4338](https://github.com/pulumi/pulumi/pull/4338)
- 
+
+- Support the `binary` option (prebuilt executables) for the .NET SDK
+ [#4355](https://github.com/pulumi/pulumi/pull/4355)
+
 - Add helper methods for stack outputs in the Go SDK
   [#4341](https://github.com/pulumi/pulumi/pull/4341)
 


### PR DESCRIPTION
The `binary` option was added to the Go plugin. Do the same for the .NET plugin.

Pulumi yaml example:

```
name: azure-cs
runtime:
    name: dotnet
    options:
        binary: netcoreapp3.1/Infra.dll
description: A minimal Azure C# Pulumi program
```

Resolves #3509

An error message if the given path is not found:

```
Diagnostics:
  pulumi:pulumi:Stack (azure-cs-dev):
    Could not execute because the specified command or file was not found.
    Possible reasons for this include:
      * You misspelled a built-in dotnet command.
      * You intended to execute a .NET Core program, but dotnet-netcoreapp3.1/Infra2.dll does not exist.
      * You intended to run a global tool, but a dotnet-prefixed executable with this name could not be found on the PATH.
 
    error: an unhandled error occurred: Program exited with non-zero exit code: 1
```

I'm on the fence whether we should check the path ourselves. The standard error does give the name of the DLL and says it's not found, so I decided to keep it simple for now.