### PR TITLE
Do not require setters on stack output properties in .NET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ CHANGELOG
 - Automate execution of `go mod download` for `pulumi new` Go templates
   [#4353](https://github.com/pulumi/pulumi/pull/4353)
 
+- Do not require setters on stack output properties in .NET 
+  [#4356](https://github.com/pulumi/pulumi/pull/4356)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/sdk/dotnet/Pulumi.Tests/StackTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/StackTests.cs
@@ -15,10 +15,10 @@ namespace Pulumi.Tests
         private class ValidStack : Stack
         {
             [Output("foo")]
-            public Output<string> ExplicitName { get; set; }
+            public Output<string> ExplicitName { get; }
 
             [Output]
-            public Output<string> ImplicitName { get; set; }
+            public Output<string> ImplicitName { get; }
 
             public ValidStack()
             {
@@ -61,7 +61,7 @@ namespace Pulumi.Tests
         private class InvalidOutputTypeStack : Stack
         {
             [Output("foo")]
-            public string Foo { get; set; }
+            public string Foo { get; }
 
             public InvalidOutputTypeStack()
             {

--- a/sdk/dotnet/Pulumi/Serialization/OutputCompletionSource.cs
+++ b/sdk/dotnet/Pulumi/Serialization/OutputCompletionSource.cs
@@ -59,6 +59,12 @@ namespace Pulumi.Serialization
     {
         public static ImmutableDictionary<string, IOutputCompletionSource> InitializeOutputs(Resource resource)
         {
+            var result = ImmutableDictionary.CreateBuilder<string, IOutputCompletionSource>();
+
+            // Stack outputs are registered and checked separately in Deployment.RegisterPropertyOutputs.
+            if (resource is Stack)
+                return result.ToImmutableDictionary();
+
             var name = resource.GetResourceName();
             var type = resource.GetResourceType();
 
@@ -67,7 +73,6 @@ namespace Pulumi.Serialization
                         where attr != null
                         select (property, attrName: attr?.Name);
 
-            var result = ImmutableDictionary.CreateBuilder<string, IOutputCompletionSource>();
             foreach (var (prop, attrName) in query.ToList())
             {
                 var propType = prop.PropertyType;

--- a/sdk/dotnet/Pulumi/Serialization/OutputCompletionSource.cs
+++ b/sdk/dotnet/Pulumi/Serialization/OutputCompletionSource.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Serialization
         {
             var result = ImmutableDictionary.CreateBuilder<string, IOutputCompletionSource>();
 
-            // Stack outputs are registered and checked separately in Deployment.RegisterPropertyOutputs.
+            // Stack outputs are registered and checked separately in Stack.RegisterPropertyOutputs.
             if (resource is Stack)
                 return result.ToImmutableDictionary();
 

--- a/tests/integration/stack_component/dotnet/Program.cs
+++ b/tests/integration/stack_component/dotnet/Program.cs
@@ -7,13 +7,13 @@ using Pulumi;
 class MyStack : Stack
 {
     [Output("abc")]
-    public Output<string> Abc { get; private set; }
+    public Output<string> Abc { get; }
 
     [Output]
-    public Output<int> Foo { get; private set; }
+    public Output<int> Foo { get; }
 
     // This should NOT be exported as stack output due to the missing attribute
-    public Output<string> Bar { get; private set; }
+    public Output<string> Bar { get; }
 
     public MyStack()
     {


### PR DESCRIPTION
Resolves #4077