### PR TITLE
fix: don't hang with invalid --cwd

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -81,7 +81,7 @@ func NewPulumiCmd() *cobra.Command {
 			"    - pulumi destroy  : Tear down your stack's resources entirely\n" +
 			"\n" +
 			"For more information, please visit the project page: https://www.pulumi.com/docs/",
-		PersistentPreRun: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// We run this method for its side-effects. On windows, this will enable the windows terminal
 			// to understand ANSI escape codes.
 			_, _, _ = term.StdStreams()
@@ -128,7 +128,7 @@ func NewPulumiCmd() *cobra.Command {
 			}
 
 			return nil
-		}),
+		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
 			// Before exiting, if there is a new version of the CLI available, print it out.
 			jsonFlag := cmd.Flag("json")


### PR DESCRIPTION
This fixes the problem. I read the docs that say that all Pulumi commands should make use of `cmdutil.RunFunc`, but given that this is executed before any other commands, I'm not sure of the consequences to not having pulumi handle this itself.

To clarify on why this is the fix, Cobra doesn't handle errors in `PersistentPreRun` and Pulumi wasn't handling it either.

Fixes #4002