### PR TITLE
Remove input props from output properties list

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -964,6 +964,21 @@ func (mod *modContext) genLookupParams(r *schema.Resource, stateParam string) ma
 	return lookupParams
 }
 
+// filterOutputProperties removes the input properties from the properties list, returning only output props. 
+func filterOutputProperties(inputProps []property, props []property) []property {
+	var outputProps []property
+	inputMap := make(map[string]bool, len(inputProps))
+	for _, prop := range inputProps {
+		inputMap[prop.Name] = true
+	}
+	for _, p := range props {
+		if _, found := inputMap[p.Name]; !found {
+			outputProps = append(outputProps, p)
+		}
+	}
+	return outputProps
+}
+
 // genResource is the entrypoint for generating a doc for a resource
 // from its Pulumi schema.
 func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
@@ -985,6 +1000,7 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 		if r.StateInputs != nil {
 			stateInputs[lang] = mod.getProperties(r.StateInputs.Properties, lang, true, false)
 		}
+		outputProps[lang] = filterOutputProperties(inputProps[lang], outputProps[lang])
 	}
 
 	allOptionalInputs := true

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -966,8 +966,8 @@ func (mod *modContext) genLookupParams(r *schema.Resource, stateParam string) ma
 
 // filterOutputProperties removes the input properties from the properties list
 // (since input props are implicitly output props), returning only "output" props.
-func filterOutputProperties(inputProps []property, props []property) []property {
-	var outputProps []property
+func filterOutputProperties(inputProps []*schema.Property, props []*schema.Property) []*schema.Property {
+	var outputProps []*schema.Property
 	inputMap := make(map[string]bool, len(inputProps))
 	for _, p := range inputProps {
 		inputMap[p.Name] = true
@@ -997,11 +997,11 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 		if r.IsProvider {
 			continue
 		}
-		outputProps[lang] = mod.getProperties(r.Properties, lang, false, false)
+		filteredOutputProps := filterOutputProperties(r.InputProperties, r.Properties)
+		outputProps[lang] = mod.getProperties(filteredOutputProps, lang, false, false)
 		if r.StateInputs != nil {
 			stateInputs[lang] = mod.getProperties(r.StateInputs.Properties, lang, true, false)
 		}
-		outputProps[lang] = filterOutputProperties(inputProps[lang], outputProps[lang])
 	}
 
 	allOptionalInputs := true

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -964,12 +964,13 @@ func (mod *modContext) genLookupParams(r *schema.Resource, stateParam string) ma
 	return lookupParams
 }
 
-// filterOutputProperties removes the input properties from the properties list, returning only output props. 
+// filterOutputProperties removes the input properties from the properties list
+// (since input props are implicitly output props), returning only "output" props.
 func filterOutputProperties(inputProps []property, props []property) []property {
 	var outputProps []property
 	inputMap := make(map[string]bool, len(inputProps))
-	for _, prop := range inputProps {
-		inputMap[prop.Name] = true
+	for _, p := range inputProps {
+		inputMap[p.Name] = true
 	}
 	for _, p := range props {
 		if _, found := inputMap[p.Name]; !found {


### PR DESCRIPTION
Issue: https://github.com/pulumi/docs/issues/2872

In the resource docs we show the input props (resource arguments) as output props as well because they are implicitly output props as well. This is kind of redundant so we are removing the input props from the output props list output.