### PR TITLE
Remove duplicate deprecation notices.

### DIFF
--- a/pkg/codegen/docs/templates/properties.tmpl
+++ b/pkg/codegen/docs/templates/properties.tmpl
@@ -11,8 +11,8 @@
         <span class="property-type">{{- if eq .Type.Link "#" "" -}}{{- htmlSafe .Type.Name -}}{{- else -}}{{ template "linkify" .Type }}{{- end -}}</span>
     </dt>
     <dd>
-        {{- print "{{% md %}}" -}}{{- htmlSafe .Comment -}}{{- print "{{% /md %}}" -}}
-        {{- if .DeprecationMessage -}}<p class="property-message">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>{{- end -}}
+        {{- if .DeprecationMessage -}}<p class="property-message">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>
+        {{- else}}{{- print "{{% md %}}" -}}{{- htmlSafe .Comment -}}{{- print "{{% /md %}}" -}}{{- end -}}
     </dd>
 {{ end }}
 </dl>


### PR DESCRIPTION
This change adds logic that removes the printing of the comment field if a deprecationMessage field is present, to avoid duplication.  This approach is a tradeoff because in some places the comment field correctly adds information, see second example.  See also list of affected files in AWS docs for further reference.

Example 1: https://www.pulumi.com/docs/reference/pkg/aws/glue/job/
before:
![image](https://user-images.githubusercontent.com/41454626/79007810-d4511c00-7b10-11ea-9aa0-8aae18664dcc.png)

after:
![image](https://user-images.githubusercontent.com/41454626/79007762-b08dd600-7b10-11ea-8b3c-c7cfe4addfcd.png)

Example 2: https://www.pulumi.com/docs/reference/pkg/aws/ec2/instance/
before:
![image](https://user-images.githubusercontent.com/41454626/79008176-a7e9cf80-7b11-11ea-9207-a8fedc314cb2.png)


after:
![image](https://user-images.githubusercontent.com/41454626/79007986-445fa200-7b11-11ea-8c2a-171701adf669.png)

List of affected files in AWS docs:
![image](https://user-images.githubusercontent.com/41454626/79008011-52adbe00-7b11-11ea-84a6-4967cef91ee6.png)


refers to https://github.com/pulumi/docs/issues/2867