### PR TITLE
[codegen/docs] Use the correct module names for languages.

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -82,6 +82,7 @@ var (
 		"gitlab":       "GitLab",
 		"kafka":        "Kafka",
 		"keycloak":     "Keycloak",
+		"kubernetes":   "Kubernetes",
 		"linode":       "Linode",
 		"mailgun":      "Mailgun",
 		"mysql":        "MySQL",

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1048,7 +1048,9 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 			continue
 		}
 		filteredOutputProps := filterOutputProperties(r.InputProperties, r.Properties)
-		outputProps[lang] = mod.getProperties(filteredOutputProps, lang, false, false)
+		if len(filteredOutputProps) > 0 {
+			outputProps[lang] = mod.getProperties(filteredOutputProps, lang, false, false)
+		}
 		if r.StateInputs != nil {
 			stateInputs[lang] = mod.getProperties(r.StateInputs.Properties, lang, true, false)
 		}


### PR DESCRIPTION
This PR fixes the links generated for Kubernetes resources in the constructor code snippet as well as for the Lookup resource section.

The docs PR https://github.com/pulumi/docs/pull/2890 can be used to preview Kubernetes docs.