### PR TITLE
Properly propagate unknowns in go SDK marshaling operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ CHANGELOG
 - Fix error when setting config without value in non-interactive mode
   [#4358](https://github.com/pulumi/pulumi/pull/4358)
 
+- Propagate unknowns in Go SDK during marshal operations
+  [#4369](https://github.com/pulumi/pulumi/pull/4369/files)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)


### PR DESCRIPTION
We weren't handling this properly. It was resulting in a panic during preview with a secret that was the result of wrapping multiple apply/all calls:

```
    error: an unhandled error occurred: program exited with non-zero exit code: 1
 
    error: program failed: resolving options: malformed RPC secret: missing value
    exit status 1
```