### PR TITLE
fix stack reference helpers to handle nil values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ CHANGELOG
 - Fix error when setting config without value in non-interactive mode
   [#4358](https://github.com/pulumi/pulumi/pull/4358)
 
+- Fix Go SDK stack reference helpers to handle nil values
+  [#4370](https://github.com/pulumi/pulumi/pull/4370)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/sdk/go/pulumi/stack_reference.go
+++ b/sdk/go/pulumi/stack_reference.go
@@ -23,30 +23,20 @@ func (s *StackReference) GetOutput(name StringInput) AnyOutput {
 
 // GetStringOutput returns a stack output keyed by the given name as an StringOutput
 func (s *StackReference) GetStringOutput(name StringInput) StringOutput {
-	return All(name, s.Outputs).
-		ApplyString(func(args []interface{}) string {
-			n, outs := args[0].(string), args[1].(map[string]interface{})
-			out := outs[n]
-			var res string
-			if out != nil {
-				res = out.(string)
-			}
-			return res
-		})
+	return s.GetOutput(name).ApplyString(func(out interface{}) string {
+		var res string
+		if out != nil {
+			res = out.(string)
+		}
+		return res
+	})
 }
 
 // GetIDOutput returns a stack output keyed by the given name as an IDOutput
 func (s *StackReference) GetIDOutput(name StringInput) IDOutput {
-	return All(name, s.Outputs).
-		ApplyID(func(args []interface{}) ID {
-			n, outs := args[0].(string), args[1].(map[string]interface{})
-			out := outs[n]
-			var res string
-			if out != nil {
-				res = out.(string)
-			}
-			return ID(res)
-		})
+	return s.GetStringOutput(name).ApplyID(func(out string) ID {
+		return ID(out)
+	})
 }
 
 type stackReferenceArgs struct {

--- a/sdk/go/pulumi/stack_reference.go
+++ b/sdk/go/pulumi/stack_reference.go
@@ -23,16 +23,30 @@ func (s *StackReference) GetOutput(name StringInput) AnyOutput {
 
 // GetStringOutput returns a stack output keyed by the given name as an StringOutput
 func (s *StackReference) GetStringOutput(name StringInput) StringOutput {
-	return s.GetOutput(name).ApplyString(func(v interface{}) string {
-		return v.(string)
-	})
+	return All(name, s.Outputs).
+		ApplyString(func(args []interface{}) string {
+			n, outs := args[0].(string), args[1].(map[string]interface{})
+			out := outs[n]
+			var res string
+			if out != nil {
+				res = out.(string)
+			}
+			return res
+		})
 }
 
 // GetIDOutput returns a stack output keyed by the given name as an IDOutput
 func (s *StackReference) GetIDOutput(name StringInput) IDOutput {
-	return s.GetOutput(name).ApplyID(func(v interface{}) ID {
-		return ID(v.(string))
-	})
+	return All(name, s.Outputs).
+		ApplyID(func(args []interface{}) ID {
+			n, outs := args[0].(string), args[1].(map[string]interface{})
+			out := outs[n]
+			var res string
+			if out != nil {
+				res = out.(string)
+			}
+			return ID(res)
+		})
 }
 
 type stackReferenceArgs struct {


### PR DESCRIPTION
Stack outputs can be nil and these helper functions need to return a zero value in that instance. 