### PR TITLE
fix unknown status for secrets wrapping unknowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ CHANGELOG
 - Fix Go SDK stack reference helpers to handle nil values
   [#4370](https://github.com/pulumi/pulumi/pull/4370)
 
+- Fix propagation of unknown status for secrets
+  [#4377](https://github.com/pulumi/pulumi/pull/4377)
+
 ## 1.14.0 (2020-04-01)
 - Fix error related to side-by-side versions of `@pulumi/pulumi`.
   [#4235](https://github.com/pulumi/pulumi/pull/4235)

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -326,6 +326,8 @@ func (v PropertyValue) ContainsUnknowns() bool {
 		}
 	} else if v.IsObject() {
 		return v.ObjectValue().ContainsUnknowns()
+	} else if v.IsSecret() {
+		return v.SecretValue().Element.ContainsUnknowns()
 	}
 	return false
 }

--- a/sdk/go/common/resource/properties_test.go
+++ b/sdk/go/common/resource/properties_test.go
@@ -159,3 +159,12 @@ func TestCopy(t *testing.T) {
 	src["c"] = NewNumberProperty(99.99)
 	assert.Equal(t, 2, len(dst))
 }
+
+func TestSecretUnknown(t *testing.T) {
+	o := NewOutputProperty(Output{
+		Element: NewNumberProperty(46),
+	})
+	s := MakeSecret((o))
+	assert.True(t, o.ContainsUnknowns())
+	assert.True(t, s.ContainsUnknowns())
+}

--- a/sdk/go/common/resource/properties_test.go
+++ b/sdk/go/common/resource/properties_test.go
@@ -161,10 +161,12 @@ func TestCopy(t *testing.T) {
 }
 
 func TestSecretUnknown(t *testing.T) {
-	o := NewOutputProperty(Output{
-		Element: NewNumberProperty(46),
-	})
-	s := MakeSecret((o))
+	o := NewOutputProperty(Output{Element: NewNumberProperty(46)})
+	so := MakeSecret(o)
 	assert.True(t, o.ContainsUnknowns())
-	assert.True(t, s.ContainsUnknowns())
+	assert.True(t, so.ContainsUnknowns())
+	c := NewComputedProperty(Computed{Element: NewStringProperty("X")})
+	co := MakeSecret(so)
+	assert.True(t, c.ContainsUnknowns())
+	assert.True(t, co.ContainsUnknowns())
 }


### PR DESCRIPTION
This manifested as a failed preview due to trying to configure a plugin with an unknown value:

https://github.com/pulumi/pulumi/blob/7ff46cb4fac8b4f594d9bb706757be5c191ebd75/sdk/go/common/resource/plugin/provider_plugin.go#L408