### PR TITLE
Fix the nullability of config type properties in C# codegen

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -94,6 +94,11 @@ func csharpIdentifier(s string) string {
 	}
 }
 
+func isImmutableArrayType(t schema.Type, wrapInput bool) bool {
+	_, isArray := t.(*schema.ArrayType)
+	return isArray && !wrapInput
+}
+
 func isValueType(t schema.Type) bool {
 	switch t {
 	case schema.BoolType, schema.IntType, schema.NumberType:
@@ -959,7 +964,7 @@ func (mod *modContext) genConfig(variables []*schema.Property) (string, error) {
 				typ := mod.typeString(prop.Type, "Types", false, false, false /*wrapInput*/, false, !prop.IsRequired)
 
 				initializer := ""
-				if !prop.IsRequired {
+				if !prop.IsRequired && !isValueType(prop.Type) && !isImmutableArrayType(prop.Type, false) {
 					initializer = " = null!;"
 				}
 


### PR DESCRIPTION
Fix these lines https://github.com/pulumi/pulumi-aws/blob/63a8fd953889844f4d8e3124be3cb84ebe6a6628/sdk/dotnet/Config/Config.cs#L246-L247