### PR TITLE
update remote path for policy pack template tests

### DIFF
--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -153,9 +153,9 @@ func TestRetrieveHttpsTemplate(t *testing.T) {
 		{
 			testName:        "TemplateKindPolicyPack",
 			templateKind:    TemplateKindPolicyPack,
-			templateURL:     "https://github.com/pulumi/examples/tree/master/policy-packs/aws-advanced",
+			templateURL:     "https://github.com/pulumi/examples/tree/master/policy-packs/aws-ts-advanced",
 			yamlFile:        "PulumiPolicy.yaml",
-			expectedSubPath: []string{"policy-packs", "aws-advanced"},
+			expectedSubPath: []string{"policy-packs", "aws-ts-advanced"},
 		},
 	}
 
@@ -202,7 +202,7 @@ func TestRetrieveHttpsTemplateOffline(t *testing.T) {
 		{
 			testName:     "TemplateKindPolicyPack",
 			templateKind: TemplateKindPolicyPack,
-			templateURL:  "https://github.com/pulumi/examples/tree/master/policy-packs/aws-advanced",
+			templateURL:  "https://github.com/pulumi/examples/tree/master/policy-packs/aws-ts-advanced",
 		},
 	}
 


### PR DESCRIPTION
This broke in https://github.com/pulumi/examples/pull/639/files

We have an issue open to remove the examples dependency from out unit tests https://github.com/pulumi/pulumi/issues/4380

This unblocks us in the meantime. 