### PR TITLE
fix link to be lowercase

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1332,7 +1332,7 @@ func (mod *modContext) genIndex() indexData {
 		parts := strings.Split(modName, "/")
 		modName = parts[len(parts)-1]
 		modules = append(modules, indexEntry{
-			Link:        modName + "/",
+			Link:        strings.ToLower(modName) + "/",
 			DisplayName: modName,
 		})
 	}


### PR DESCRIPTION
This makes sure links are lowercase.

Fixes https://github.com/pulumi/docs/issues/2837