### PR TITLE
Annotate .ctor args in docs

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -553,6 +553,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 				Name: "Context",
 				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Context"),
 			},
+			Comment: "Context object for the current deployment",
 		},
 		{
 			Name: "name",

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -173,6 +173,9 @@ type formalParam struct {
 	OptionalFlag string
 
 	DefaultValue string
+
+	// Comment is an optional description of the parameter.
+	Comment string
 }
 
 type packageDetails struct {
@@ -188,7 +191,11 @@ type resourceDocArgs struct {
 	Comment            string
 	DeprecationMessage string
 
+	// ConstructorParams is a map from language to the rendered HTML for the constructor's
+	// arguments.
 	ConstructorParams map[string]string
+	// ConstructorParamsTyped is the typed set of parameters for the constructor, in order.
+	ConstructorParamsTyped map[string][]formalParam
 	// ConstructorResource is the resource that is being constructed or
 	// is the result of a constructor-like function.
 	ConstructorResource map[string]propertyType
@@ -467,6 +474,14 @@ func cleanOptionalIdentifier(s, lang string) string {
 	return s
 }
 
+// Resources typically take the same set of parameters to their constructors, and these
+// are the default comments/descriptions for them.
+const (
+	ctorNameArgComment = "The unique name of the resource."
+	ctorArgsArgComment = "The arguments to resource properties."
+	ctorOptsArgComment = "Bag of options to control resource's behavior."
+)
+
 func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) []formalParam {
 	name := resourceName(r)
 	docLangHelper := getLanguageDocHelper("nodejs")
@@ -496,6 +511,7 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 				Name: "string",
 				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
+			Comment: ctorNameArgComment,
 		},
 		{
 			Name:         "args",
@@ -504,6 +520,7 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 				Name: argsType,
 				Link: argsDocLink,
 			},
+			Comment: ctorArgsArgComment,
 		},
 		{
 			Name:         "opts",
@@ -512,6 +529,7 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 				Name: "CustomResourceOptions",
 				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "CustomResourceOptions"),
 			},
+			Comment: ctorOptsArgComment,
 		},
 	}
 }
@@ -542,6 +560,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 				Name: "string",
 				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
+			Comment: ctorNameArgComment,
 		},
 		{
 			Name:         "args",
@@ -550,6 +569,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 				Name: argsType,
 				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg, modName, argsType),
 			},
+			Comment: ctorArgsArgComment,
 		},
 		{
 			Name:         "opts",
@@ -558,6 +578,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 				Name: "ResourceOption",
 				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "ResourceOption"),
 			},
+			Comment: ctorOptsArgComment,
 		},
 	}
 }
@@ -605,6 +626,7 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 				Name: "string",
 				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
+			Comment: ctorNameArgComment,
 		},
 		{
 			Name:         "args",
@@ -614,6 +636,7 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 				Name: name + "Args",
 				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg, "", argLangTypeName),
 			},
+			Comment: ctorArgsArgComment,
 		},
 		{
 			Name:         "opts",
@@ -623,6 +646,7 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 				Name: "CustomResourceOptions",
 				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Pulumi.CustomResourceOptions"),
 			},
+			Comment: ctorOptsArgComment,
 		},
 	}
 }
@@ -786,8 +810,10 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 	return docProperties
 }
 
-func (mod *modContext) genConstructors(r *schema.Resource, allOptionalInputs bool) map[string]string {
-	constructorParams := make(map[string]string)
+// Returns the rendered HTML for the resource's constructor, as well as the specific arguments.
+func (mod *modContext) genConstructors(r *schema.Resource, allOptionalInputs bool) (map[string]string, map[string][]formalParam) {
+	renderedParams := make(map[string]string)
+	formalParams := make(map[string][]formalParam)
 	for _, lang := range supportedLanguages {
 		var (
 			paramTemplate string
@@ -836,9 +862,11 @@ func (mod *modContext) genConstructors(r *schema.Resource, allOptionalInputs boo
 				}
 			}
 		}
-		constructorParams[lang] = b.String()
+		renderedParams[lang] = b.String()
+		formalParams[lang] = params
 	}
-	return constructorParams
+
+	return renderedParams, formalParams
 }
 
 // getConstructorResourceInfo returns a map of per-language information about
@@ -1129,6 +1157,8 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 		Notes:      mod.pkg.Attribution,
 	}
 
+	renderedCtorParams, typedCtorPArams := mod.genConstructors(r, allOptionalInputs)
+
 	stateParam := name + "State"
 	data := resourceDocArgs{
 		Header: header{
@@ -1138,7 +1168,9 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 		Comment:            r.Comment,
 		DeprecationMessage: r.DeprecationMessage,
 
-		ConstructorParams:   mod.genConstructors(r, allOptionalInputs),
+		ConstructorParams:      renderedCtorParams,
+		ConstructorParamsTyped: typedCtorPArams,
+
 		ConstructorResource: mod.getConstructorResourceInfo(name),
 		ArgsRequired:        !allOptionalInputs,
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1157,7 +1157,7 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 		Notes:      mod.pkg.Attribution,
 	}
 
-	renderedCtorParams, typedCtorPArams := mod.genConstructors(r, allOptionalInputs)
+	renderedCtorParams, typedCtorParams := mod.genConstructors(r, allOptionalInputs)
 
 	stateParam := name + "State"
 	data := resourceDocArgs{

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1169,7 +1169,7 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 		DeprecationMessage: r.DeprecationMessage,
 
 		ConstructorParams:      renderedCtorParams,
-		ConstructorParamsTyped: typedCtorPArams,
+		ConstructorParamsTyped: typedCtorParams,
 
 		ConstructorResource: mod.getConstructorResourceInfo(name),
 		ArgsRequired:        !allOptionalInputs,

--- a/pkg/codegen/docs/templates/constructor_args.tmpl
+++ b/pkg/codegen/docs/templates/constructor_args.tmpl
@@ -1,19 +1,15 @@
 {{ define "constructor_args" }}
 <dl class="resources-properties">
-    <dt class="property-required" title="Required">
-        <span>name</span>
+  {{ range $params := . }}
+    <dt class="property-xxx" title="xxx">
+        <span>{{- htmlSafe .Name -}}</span>
         <span class="property-indicator"></span>
+        <span class="property-type">{{- if eq .Type.Link "#" "" -}}{{- htmlSafe .Type.Name -}}{{- else -}}{{ template "linkify" .Type }}{{- end -}}</span>
     </dt>
-    <dd>The unique name of the resource.</dd>
-    <dt class="property-optional" title="Optional">
-        <span>args</span>
-        <span class="property-indicator"></span>
-    </dt>
-    <dd>The arguments to use to populate this resource's properties.</dd>
-    <dt class="property-optional" title="Optional">
-        <span>opts</span>
-        <span class="property-indicator"></span>
-    </dt>
-    <dd>A bag of options that control this resource's behavior.</dd>
+    <dd>
+      {{ .Comment }}
+    </dd>
+  {{ end }}
+
 </dl>
 {{ end }}

--- a/pkg/codegen/docs/templates/constructor_args.tmpl
+++ b/pkg/codegen/docs/templates/constructor_args.tmpl
@@ -1,7 +1,10 @@
 {{ define "constructor_args" }}
 <dl class="resources-properties">
   {{ range $params := . }}
-    <dt class="property-xxx" title="xxx">
+    <dt
+        {{ if .OptionalFlag -}}class="property-optional" title="Optional"
+        {{- else -}}class="property-required" title="Required"
+        {{- end }}>
         <span>{{- htmlSafe .Name -}}</span>
         <span class="property-indicator"></span>
         <span class="property-type">{{- if eq .Type.Link "#" "" -}}{{- htmlSafe .Type.Name -}}{{- else -}}{{ template "linkify" .Type }}{{- end -}}</span>

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -11,6 +11,11 @@
 
 {{ htmlSafe "{{< chooser language \"javascript,typescript,python,go,csharp\" / >}}" }}
 
+{{/*
+    Render the specific snippet to construct the resource, e.g.
+    "new Bucket(name: string, args?: BucketArgs, opts?: pulumi.ResourceOptions);"
+    "def Bucket(resource_name, opts=None, acceleration_status=None, ..."
+*/}}
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
 <div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">new </span>{{ template "linkify_param" .ConstructorResource.nodejs }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.nodejs }}<span class="p">);</span></code></pre></div>
 {{ htmlSafe "{{% /choosable %}}" }}
@@ -28,30 +33,38 @@
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
-{{ template "constructor_args" }}
+{{ template "constructor_args" .ConstructorParamsTyped.nodejs }}
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language python %}}" }}
+{{/*
+    Constructing resources in python uses a different approach, which is why
+    we don't use the "constructor_args" and just hard-code two params here.
+*/}}
 <dl class="resources-properties">
     <dt class="property-required" title="Required">
-        <span>name</span>
+        <span>resource_name</span>
         <span class="property-indicator"></span>
+        <span class="property-type">str</span>
     </dt>
     <dd>The unique name of the resource.</dd>
     <dt class="property-optional" title="Optional">
         <span>opts</span>
         <span class="property-indicator"></span>
+        <span class="property-type">
+            <a href="#resource-arguments">object</a>
+        </span>
     </dt>
     <dd>A bag of options that control this resource's behavior.</dd>
 </dl>
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language go %}}" }}
-{{ template "constructor_args" }}
+{{ template "constructor_args" .ConstructorParamsTyped.go }}
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language csharp %}}" }}
-{{ template "constructor_args" }}
+{{ template "constructor_args" .ConstructorParamsTyped.csharp }}
 {{ htmlSafe "{{% /choosable %}}" }}
 
 #### Resource Arguments

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -52,7 +52,7 @@
         <span>opts</span>
         <span class="property-indicator"></span>
         <span class="property-type">
-            <a href="#resource-arguments">object</a>
+            <a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">ResourceOptions</a>
         </span>
     </dt>
     <dd>A bag of options that control this resource's behavior.</dd>


### PR DESCRIPTION
For the generated resource documentation, we were previously hard-coding the constructor arguments (in `constructor_args.tmpl`). This however isn't all that great.

- Golang needs to add a `ctx` parameter.
- The constructor args were missing their type information (i.e. https://github.com/pulumi/docs/issues/2865)

This PR fixes https://github.com/pulumi/docs/issues/2865 and tries to improve things if only slightly. It does this by:

- Adding a `ConstructorParamsTyped` (type `map[string][]formalParam`) so that we can pass along the actual set of param names and types.
- Add a new `Comment` field to `formalParam` so we can describe each ctor param.

Happy to do any refactoring or cleanup to leave the code a little better than when I found it. e.g. having the pre-rendered `ConstructorParams map[string]string` seems like a code smell. But I would guess that that's simplifying `resource.tmpl` quite a bit. (But if it's been bugging you and seems like something we'd want to merge into this PR, let me know.)

http://localhost:1313/docs/reference/pkg/kafka/acl/ **(new)**

<img width="838" alt="image" src="https://user-images.githubusercontent.com/4029847/79172039-75a5cf80-7da8-11ea-8d9c-3de185d4d4e4.png">
<img width="835" alt="image" src="https://user-images.githubusercontent.com/4029847/79172051-7c344700-7da8-11ea-90dc-3aee79c88d2d.png">
<img width="827" alt="image" src="https://user-images.githubusercontent.com/4029847/79172064-822a2800-7da8-11ea-9faa-9c51f393baaf.png">
<img width="818" alt="image" src="https://user-images.githubusercontent.com/4029847/79172070-87877280-7da8-11ea-927f-76257532ff6b.png">

https://www.pulumi.com/docs/reference/pkg/kafka/acl/ **(current)**

<img width="820" alt="image" src="https://user-images.githubusercontent.com/4029847/79172083-94a46180-7da8-11ea-8051-9394a78adac3.png">
<img width="828" alt="image" src="https://user-images.githubusercontent.com/4029847/79172111-a8e85e80-7da8-11ea-8740-97ce2a053ed8.png">
