### PR TITLE
Generate links for primitive types.

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -48,6 +48,7 @@ type DocLanguageHelper interface {
 	GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string
 	GetDocLinkForResourceInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
 	GetDocLinkForFunctionInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
+	GetDocLinkForBuiltInType(typeName string) string
 	GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string
 	// GetResourceFunctionResultName returns the name of the result type when a static resource function is used to lookup
 	// an existing resource.

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -419,8 +419,10 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 		// Links to anchor tags on the same page must be lower-cased.
 		href = "#" + strings.ToLower(tokenName)
 	default:
-		// Assume primitive/built-in type if no match for cases listed above.
-		href = docLanguageHelper.GetDocLinkForBuiltInType(t.String())
+		// Check if type is primitive/built-in type if no match for cases listed above.
+		if schema.IsPrimitiveType(t) {
+			href = docLanguageHelper.GetDocLinkForBuiltInType(t.String())
+		}
 	}
 
 	// Strip the namespace/module prefix for the type's display name.

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -418,6 +418,9 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 		tokenName := tokenToName(t.Token)
 		// Links to anchor tags on the same page must be lower-cased.
 		href = "#" + strings.ToLower(tokenName)
+	default:
+		// Assume primitive/built-in type if no match for cases listed above.
+		href = docLanguageHelper.GetDocLinkForBuiltInType(t.String())
 	}
 
 	// Strip the namespace/module prefix for the type's display name.
@@ -489,7 +492,7 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: nodejs.GetDocLinkForBuiltInType("string"),
+				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{
@@ -535,7 +538,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: go_gen.GetDocLinkForBuiltInType("string"),
+				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{
@@ -598,7 +601,7 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: "https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types",
+				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{
@@ -891,9 +894,10 @@ func (mod *modContext) getTSLookupParams(r *schema.Resource, stateParam string) 
 	return []formalParam{
 		{
 			Name: "name",
+
 			Type: propertyType{
 				Name: "string",
-				Link: nodejs.GetDocLinkForBuiltInType("string"),
+				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{
@@ -939,7 +943,7 @@ func (mod *modContext) getGoLookupParams(r *schema.Resource, stateParam string) 
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: go_gen.GetDocLinkForBuiltInType("string"),
+				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{
@@ -978,7 +982,7 @@ func (mod *modContext) getCSLookupParams(r *schema.Resource, stateParam string) 
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: "https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types",
+				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -50,11 +50,9 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, _, typ
 	return fmt.Sprintf("/docs/reference/pkg/dotnet/Pulumi%s/%s.html", packageNamespace, typeName)
 }
 
-// GetDocLinkForBuiltInType returns the godoc URL for a built-in type.
-// Currently not using the typeName parameter because the returned link takes to a general page
-// containing info for all built in types. We could link deeper but the routes are
-// not easily decipherable just based on infering type so will need to create a map to map
-// the typeName to the url route. I figure we can do this at a later date if needed.
+// GetDocLinkForBuiltInType returns the C# URL for a built-in type.
+// Currently not using the typeName parameter because the returned link takes to a general
+// top -level page containing info for all built in types.
 func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
 	return "https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types"
 }

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -50,6 +50,15 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, _, typ
 	return fmt.Sprintf("/docs/reference/pkg/dotnet/Pulumi%s/%s.html", packageNamespace, typeName)
 }
 
+// GetDocLinkForBuiltInType returns the godoc URL for a built-in type.
+// Currently not using the typeName parameter because the returned link takes to a general page
+// containing info for all built in types. We could link deeper but the routes are
+// not easily decipherable just based on infering type so will need to create a map to map
+// the typeName to the url route. I figure we can do this at a later date if needed.
+func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
+	return "https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types"
+}
+
 // GetDocLinkForResourceInputOrOutputType returns the doc link for an input or output type of a Resource.
 func (d DocLanguageHelper) GetDocLinkForResourceInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string {
 	return d.GetDocLinkForResourceType(pkg, moduleName, typeName)

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -82,7 +82,7 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetDocLinkForBuiltInType returns the godoc URL for a built-in type.
-func GetDocLinkForBuiltInType(typeName string) string {
+func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
 	return fmt.Sprintf("https://golang.org/pkg/builtin/#%s", typeName)
 }
 

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -69,7 +69,7 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 }
 
 // GetDocLinkForBuiltInType returns the URL for a built-in type.
-func GetDocLinkForBuiltInType(typeName string) string {
+func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
 	return fmt.Sprintf("https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/%s", typeName)
 }
 

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -52,9 +52,11 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 	return ""
 }
 
-// GetDocLinkForBuiltInType returns the godoc URL for a built-in type.
+// GetDocLinkForBuiltInType returns the Python URL for a built-in type.
+// Currently not using the typeName parameter because the returned link takes to a general
+// top-level page containing info for all built in types.
 func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
-	return ""
+	return "https://docs.python.org/3/library/stdtypes.html"
 }
 
 // GetLanguageTypeString returns the Python-specific type given a Pulumi schema type.

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -52,6 +52,11 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 	return ""
 }
 
+// GetDocLinkForBuiltInType returns the godoc URL for a built-in type.
+func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
+	return ""
+}
+
 // GetLanguageTypeString returns the Python-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string {
 	name := pyType(t)


### PR DESCRIPTION
Issue: https://github.com/pulumi/docs/issues/2874

Add links for primitive types. Did a small bit of refactoring to convert `GetDocLinkForBuiltInType` to be part of the DocHelperInterface so that we can just refer to the concrete instance of `DocLanguageHelper` which is already tied to the language needed when it is initially instantiated. The only other way was to create a switch statement and make a different case for each language which felt counter-intuitive to the pattern we were already trying to establish.