### PR TITLE
fix propagation of secrets for resource inputs/outputs in go sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (unreleased)
-_(none)_
+- Fix Go SDK secret propagation for Resource inputs/outputs.
+  [#4387](https://github.com/pulumi/pulumi/pull/4387)
 
 ## 1.14.1 (2020-04-13)
 - Propagate `additionalSecretOutputs` opt to Read in NodeJS.

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -157,12 +157,12 @@ func marshalInput(v interface{}, destType reflect.Type, await bool) (resource.Pr
 func marshalInputAndDetermineSecret(v interface{},
 	destType reflect.Type,
 	await bool) (resource.PropertyValue, []Resource, bool, error) {
+	secret := false
 	for {
 		valueType := reflect.TypeOf(v)
 
 		// If this is an Input, make sure it is of the proper type and await it if it is an output/
 		var deps []Resource
-		secret := false
 		if input, ok := v.(Input); ok {
 			valueType = input.ElementType()
 


### PR DESCRIPTION
This is a very subtle bug. This for loop can run multiple times to deal with things like pointers and previously we were losing the secret information that could've been captured on previous iterations. 