### PR TITLE
fix go config codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 - Fix Go SDK secret propagation for Resource inputs/outputs.
   [#4387](https://github.com/pulumi/pulumi/pull/4387)
 
+- Fix Go codegen to emit config packages
+  [#4388](https://github.com/pulumi/pulumi/pull/4388)
+
 ## 1.14.1 (2020-04-13)
 - Propagate `additionalSecretOutputs` opt to Read in NodeJS.
   [#4307](https://github.com/pulumi/pulumi/pull/4307)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1081,6 +1081,10 @@ func generatePackageContextMap(tool string, pkg *schema.Package, goInfo GoInfo) 
 		return pack
 	}
 
+	if len(pkg.Config) > 0 {
+		_ = getPkg(":config/config:")
+	}
+
 	for _, t := range pkg.Types {
 		switch t := t.(type) {
 		case *schema.ArrayType:


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi/issues/4363

We were missing the code that creates the config module entry. There is equivalent code in python, dotnet, and nodejs codegens. For example:

https://github.com/pulumi/pulumi/blob/563233d16c0d006839a89cbac96747f8dbc335dc/pkg/codegen/nodejs/gen.go#L1219

Here's a patch from the azuread provider:

```
diff --git a/sdk/go/azuread/config/config.go b/sdk/go/azuread/config/config.go
index b680220..8afb729 100644
--- a/sdk/go/azuread/config/config.go
+++ b/sdk/go/azuread/config/config.go
@@ -4,8 +4,8 @@
 package config
 
 import (
-	"github.com/pulumi/pulumi/sdk/go/pulumi"
-	"github.com/pulumi/pulumi/sdk/go/pulumi/config"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi/config"
 )
 
 func GetClientCertificatePassword(ctx *pulumi.Context) string {
@@ -13,96 +13,61 @@ func GetClientCertificatePassword(ctx *pulumi.Context) string {
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault("", nil, "ARM_CLIENT_CERTIFICATE_PASSWORD").(string); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault("", nil, "ARM_CLIENT_CERTIFICATE_PASSWORD").(string)
 }
-
 func GetClientCertificatePath(ctx *pulumi.Context) string {
 	v, err := config.Try(ctx, "azuread:clientCertificatePath")
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault("", nil, "ARM_CLIENT_CERTIFICATE_PATH").(string); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault("", nil, "ARM_CLIENT_CERTIFICATE_PATH").(string)
 }
-
 func GetClientId(ctx *pulumi.Context) string {
 	v, err := config.Try(ctx, "azuread:clientId")
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault("", nil, "ARM_CLIENT_ID").(string); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault("", nil, "ARM_CLIENT_ID").(string)
 }
-
 func GetClientSecret(ctx *pulumi.Context) string {
 	v, err := config.Try(ctx, "azuread:clientSecret")
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault("", nil, "ARM_CLIENT_SECRET").(string); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault("", nil, "ARM_CLIENT_SECRET").(string)
 }
-
 func GetEnvironment(ctx *pulumi.Context) string {
 	v, err := config.Try(ctx, "azuread:environment")
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault("public", nil, "ARM_ENVIRONMENT").(string); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault("public", nil, "ARM_ENVIRONMENT").(string)
 }
-
 func GetMsiEndpoint(ctx *pulumi.Context) string {
 	v, err := config.Try(ctx, "azuread:msiEndpoint")
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault("", nil, "ARM_MSI_ENDPOINT").(string); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault("", nil, "ARM_MSI_ENDPOINT").(string)
 }
-
 func GetSubscriptionId(ctx *pulumi.Context) string {
 	v, err := config.Try(ctx, "azuread:subscriptionId")
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault("", nil, "ARM_SUBSCRIPTION_ID").(string); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault("", nil, "ARM_SUBSCRIPTION_ID").(string)
 }
-
 func GetTenantId(ctx *pulumi.Context) string {
 	v, err := config.Try(ctx, "azuread:tenantId")
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault("", nil, "ARM_TENANT_ID").(string); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault("", nil, "ARM_TENANT_ID").(string)
 }
-
 func GetUseMsi(ctx *pulumi.Context) bool {
 	v, err := config.TryBool(ctx, "azuread:useMsi")
 	if err == nil {
 		return v
 	}
-	if dv, ok := getEnvOrDefault(false, parseEnvBool, "ARM_USE_MSI").(bool); ok {
-		return dv
-	}
-	return v
+	return getEnvOrDefault(false, parseEnvBool, "ARM_USE_MSI").(bool)
 }

```