### PR TITLE
[codegen/docs] Cleanup generating links for Pulumi types

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -45,6 +45,7 @@ var (
 type DocLanguageHelper interface {
 	GetPropertyName(p *schema.Property) (string, error)
 	GetDocLinkForResourceType(pkg *schema.Package, moduleName, typeName string) string
+	GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string
 	GetDocLinkForResourceInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
 	GetDocLinkForFunctionInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
 	GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -505,7 +505,7 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 			OptionalFlag: "?",
 			Type: propertyType{
 				Name: "CustomResourceOptions",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "", "CustomResourceOptions"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "CustomResourceOptions"),
 			},
 		},
 	}
@@ -528,7 +528,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 			OptionalFlag: "*",
 			Type: propertyType{
 				Name: "Context",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "pulumi", "Context"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Context"),
 			},
 		},
 		{
@@ -551,7 +551,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 			OptionalFlag: "...",
 			Type: propertyType{
 				Name: "ResourceOption",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "pulumi", "ResourceOption"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "ResourceOption"),
 			},
 		},
 	}
@@ -616,7 +616,7 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 			DefaultValue: " = null",
 			Type: propertyType{
 				Name: "CustomResourceOptions",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "", "Pulumi.CustomResourceOptions"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Pulumi.CustomResourceOptions"),
 			},
 		},
 	}
@@ -900,7 +900,7 @@ func (mod *modContext) getTSLookupParams(r *schema.Resource, stateParam string) 
 			Name: "id",
 			Type: propertyType{
 				Name: "Input<ID>",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "pulumi", "ID"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "ID"),
 			},
 		},
 		{
@@ -916,7 +916,7 @@ func (mod *modContext) getTSLookupParams(r *schema.Resource, stateParam string) 
 			OptionalFlag: "?",
 			Type: propertyType{
 				Name: "CustomResourceOptions",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "pulumi", "CustomResourceOptions"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "CustomResourceOptions"),
 			},
 		},
 	}
@@ -932,7 +932,7 @@ func (mod *modContext) getGoLookupParams(r *schema.Resource, stateParam string) 
 			OptionalFlag: "*",
 			Type: propertyType{
 				Name: "Context",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "pulumi", "Context"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Context"),
 			},
 		},
 		{
@@ -946,7 +946,7 @@ func (mod *modContext) getGoLookupParams(r *schema.Resource, stateParam string) 
 			Name: "id",
 			Type: propertyType{
 				Name: "IDInput",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "pulumi", "IDInput"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "IDInput"),
 			},
 		},
 		{
@@ -962,7 +962,7 @@ func (mod *modContext) getGoLookupParams(r *schema.Resource, stateParam string) 
 			OptionalFlag: "...",
 			Type: propertyType{
 				Name: "ResourceOption",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "pulumi", "ResourceOption"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "ResourceOption"),
 			},
 		},
 	}
@@ -985,7 +985,7 @@ func (mod *modContext) getCSLookupParams(r *schema.Resource, stateParam string) 
 			Name: "id",
 			Type: propertyType{
 				Name: "Input<string>",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "", "Pulumi.Input"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Pulumi.Input"),
 			},
 		},
 		{
@@ -1002,7 +1002,7 @@ func (mod *modContext) getCSLookupParams(r *schema.Resource, stateParam string) 
 			DefaultValue: " = null",
 			Type: propertyType{
 				Name: "CustomResourceOptions",
-				Link: docLangHelper.GetDocLinkForResourceType(nil, "", "Pulumi.CustomResourceOptions"),
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Pulumi.CustomResourceOptions"),
 			},
 		},
 	}

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -116,7 +116,7 @@ func (mod *modContext) genFunctionTS(f *schema.Function, resourceName string) []
 		OptionalFlag: "?",
 		Type: propertyType{
 			Name: "InvokeOptions",
-			Link: docLangHelper.GetDocLinkForResourceType(nil, "", "InvokeOptions"),
+			Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "InvokeOptions"),
 		},
 	})
 
@@ -200,7 +200,7 @@ func (mod *modContext) genFunctionCS(f *schema.Function, resourceName string) []
 		DefaultValue: " = null",
 		Type: propertyType{
 			Name: "InvokeOptions",
-			Link: docLangHelper.GetDocLinkForResourceType(nil, "", "Pulumi.InvokeOptions"),
+			Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Pulumi.InvokeOptions"),
 		},
 	})
 	return params

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -33,6 +33,11 @@ type DocLanguageHelper struct {
 
 var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 
+// GetDocLinkForPulumiType returns the .Net API doc link for a Pulumi type.
+func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string {
+	return fmt.Sprintf("/docs/reference/pkg/dotnet/Pulumi/%s.html", typeName)
+}
+
 // GetDocLinkForResourceType returns the .NET API doc URL for a type belonging to a resource provider.
 func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, _, typeName string) string {
 	typeName = strings.ReplaceAll(typeName, "?", "")

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -35,14 +35,20 @@ type DocLanguageHelper struct {
 
 var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 
+// GetDocLinkForPulumiType returns the doc link for a Pulumi type.
+func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string {
+	moduleVersion := ""
+	if pkg.Version != nil {
+		if pkg.Version.Major > 1 {
+			moduleVersion = fmt.Sprintf("v%d/", pkg.Version.Major)
+		}
+	}
+	return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi/sdk/%sgo/pulumi?tab=doc#%s", moduleVersion, typeName)
+}
+
 // GetDocLinkForResourceType returns the godoc URL for a type belonging to a resource provider.
 func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, moduleName string, typeName string) string {
-	var path string
-	if pkg != nil && pkg.Name != "" {
-		path = fmt.Sprintf("%s/%s", pkg.Name, moduleName)
-	} else {
-		path = moduleName
-	}
+	path := fmt.Sprintf("%s/%s", pkg.Name, moduleName)
 	typeNameParts := strings.Split(typeName, ".")
 	typeName = typeNameParts[len(typeNameParts)-1]
 	typeName = strings.TrimPrefix(typeName, "*")
@@ -54,10 +60,7 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, module
 		}
 	}
 
-	if pkg.Name != "" {
-		return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi-%s/sdk/%sgo/%s?tab=doc#%s", pkg.Name, path, moduleVersion, typeName)
-	}
-	return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi/sdk/%sgo/%s?tab=doc#%s", moduleVersion, path, typeName)
+	return fmt.Sprintf("https://pkg.go.dev/github.com/pulumi/pulumi-%s/sdk/%sgo/%s?tab=doc#%s", pkg.Name, moduleVersion, path, typeName)
 }
 
 // GetDocLinkForResourceInputOrOutputType returns the godoc URL for an input or output type.

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -16,11 +16,12 @@
 // goconst linter's warning.
 //
 // nolint: lll, goconst
-package nodejs
+package gen
 
 import (
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -66,33 +67,29 @@ func getTestPackage(t *testing.T) *schema.Package {
 	return pkg
 }
 
-func TestDocLinkGenerationForPulumiTypes(t *testing.T) {
+func TestGetDocLinkForPulumiType(t *testing.T) {
 	pkg := getTestPackage(t)
 	d := DocLanguageHelper{}
-	t.Run("GenerateCustomResourceOptionsLink", func(t *testing.T) {
-		expected := "/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions"
-		link := d.GetDocLinkForPulumiType(pkg, "CustomResourceOptions")
+	t.Run("GenerateResourceOptionsLink", func(t *testing.T) {
+		expected := "https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#ResourceOption"
+		link := d.GetDocLinkForPulumiType(pkg, "ResourceOption")
 		assert.Equal(t, expected, link)
 	})
-	t.Run("GenerateInvokeOptionsLink", func(t *testing.T) {
-		expected := "/docs/reference/pkg/nodejs/pulumi/pulumi/#InvokeOptions"
-		link := d.GetDocLinkForPulumiType(pkg, "InvokeOptions")
+	t.Run("Generate_V2_ResourceOptionsLink", func(t *testing.T) {
+		pkg.Version = &semver.Version{
+			Major: 2,
+		}
+		expected := "https://pkg.go.dev/github.com/pulumi/pulumi/sdk/v2/go/pulumi?tab=doc#ResourceOption"
+		link := d.GetDocLinkForPulumiType(pkg, "ResourceOption")
 		assert.Equal(t, expected, link)
+		pkg.Version = nil
 	})
 }
 
 func TestGetDocLinkForResourceType(t *testing.T) {
 	pkg := getTestPackage(t)
 	d := DocLanguageHelper{}
-	expected := "/docs/reference/pkg/nodejs/pulumi/aws/s3/#Bucket"
+	expected := "https://pkg.go.dev/github.com/pulumi/pulumi-aws/sdk/go/aws/s3?tab=doc#Bucket"
 	link := d.GetDocLinkForResourceType(pkg, "s3", "Bucket")
-	assert.Equal(t, expected, link)
-}
-
-func TestGetDocLinkForResourceInputOrOutputType(t *testing.T) {
-	pkg := getTestPackage(t)
-	d := DocLanguageHelper{}
-	expected := "/docs/reference/pkg/nodejs/pulumi/aws/types/input/#BucketCorsRule"
-	link := d.GetDocLinkForResourceInputOrOutputType(pkg, "s3", "BucketCorsRule", true)
 	assert.Equal(t, expected, link)
 }

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -34,7 +34,7 @@ var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 // GetDocLinkForPulumiType returns the NodeJS API doc link for a Pulumi type.
 func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string {
 	typeName = strings.ReplaceAll(typeName, "?", "")
-	return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/pulumi/#%s", path, typeName)
+	return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/pulumi/#%s", typeName)
 }
 
 // GetDocLinkForResourceType returns the NodeJS API doc for a type belonging to a resource provider.

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -31,12 +31,16 @@ type DocLanguageHelper struct{}
 
 var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 
+// GetDocLinkForPulumiType returns the NodeJS API doc link for a Pulumi type.
+func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string {
+	typeName = strings.ReplaceAll(typeName, "?", "")
+	return fmt.Sprintf("/docs/reference/pkg/nodejs/pulumi/pulumi/#%s", path, typeName)
+}
+
 // GetDocLinkForResourceType returns the NodeJS API doc for a type belonging to a resource provider.
 func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, modName, typeName string) string {
 	var path string
 	switch {
-	case pkg == nil:
-		path = "pulumi"
 	case pkg.Name != "" && modName != "":
 		path = fmt.Sprintf("%s/%s", pkg.Name, modName)
 	case pkg.Name == "" && modName != "":

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -32,6 +32,11 @@ type DocLanguageHelper struct{}
 
 var _ codegen.DocLanguageHelper = DocLanguageHelper{}
 
+// GetDocLinkForPulumiType is not implemented at this time for Python.
+func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string {
+	return ""
+}
+
 // GetDocLinkForResourceType is not implemented at this time for Python.
 func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, modName, typeName string) string {
 	return ""


### PR DESCRIPTION
This PR adds a new method to the `DocLangHelper` to generate links Pulumi types in each language. It was getting a bit hairy to use a single method to generate links for both Pulumi types as well as resource types and was starting to feel brittle. Along with that, I also added tests for the Go doc helper.