### PR TITLE
Add API types for the v4 checkpoint

### DIFF
--- a/sdk/go/common/apitype/migrate/checkpoint.go
+++ b/sdk/go/common/apitype/migrate/checkpoint.go
@@ -51,3 +51,18 @@ func UpToCheckpointV3(v2 apitype.CheckpointV2) apitype.CheckpointV3 {
 	v3.Latest = v3deploy
 	return v3
 }
+
+// UpToCheckpointV4 migrates a CheckpointV3 to a CheckpointV4.
+func UpToCheckpointV4(v3 apitype.CheckpointV3) apitype.CheckpointV4 {
+	var v4 apitype.CheckpointV4
+	v4.Stack = v3.Stack
+	v4.Config = v3.Config
+
+	var v4deploy *apitype.DeploymentV4
+	if v3.Latest != nil {
+		deploy := UpToDeploymentV4(*v3.Latest)
+		v4deploy = &deploy
+	}
+	v4.Latest = v4deploy
+	return v4
+}

--- a/sdk/go/common/apitype/migrate/deployment.go
+++ b/sdk/go/common/apitype/migrate/deployment.go
@@ -42,3 +42,18 @@ func UpToDeploymentV3(v2 apitype.DeploymentV2) apitype.DeploymentV3 {
 
 	return v3
 }
+
+// UpToDeploymentV4 migrates a deployment from DeploymentV3 to UpToDeploymentV4.
+func UpToDeploymentV4(v3 apitype.DeploymentV3) apitype.DeploymentV4 {
+	var v4 apitype.DeploymentV4
+	// The manifest format did not change between V3 and V4.
+	v4.Manifest = v3.Manifest
+	for _, res := range v3.Resources {
+		v4.Resources = append(v4.Resources, UpToResourceV4(res))
+	}
+	for _, op := range v3.PendingOperations {
+		v4.PendingOperations = append(v4.PendingOperations, UpToOperationV3(op))
+	}
+
+	return v4
+}

--- a/sdk/go/common/apitype/migrate/operation.go
+++ b/sdk/go/common/apitype/migrate/operation.go
@@ -23,3 +23,11 @@ func UpToOperationV2(v1 apitype.OperationV1) apitype.OperationV2 {
 		Type:     v1.Type,
 	}
 }
+
+// UpToOperationV3 migrates a resource from OperationV2 to OperationV3.
+func UpToOperationV3(v2 apitype.OperationV2) apitype.OperationV3 {
+	return apitype.OperationV3{
+		Resource: UpToResourceV4(v2.Resource),
+		Type:     v2.Type,
+	}
+}

--- a/sdk/go/common/apitype/migrate/resource.go
+++ b/sdk/go/common/apitype/migrate/resource.go
@@ -76,3 +76,30 @@ func UpToResourceV3(v2 apitype.ResourceV2) apitype.ResourceV3 {
 
 	return v3
 }
+
+// UpToResourceV4 migrates a resource from ResourceV3 to ResourceV4.
+func UpToResourceV4(v3 apitype.ResourceV3) apitype.ResourceV4 {
+	var v4 apitype.ResourceV4
+	v4.URN = v3.URN
+	v4.Custom = v3.Custom
+	v4.Delete = v3.Delete
+	v4.ID = v3.ID
+	v4.Type = v3.Type
+	v4.Inputs = v3.Inputs
+	v4.Outputs = v3.Outputs
+	v4.Parent = v3.Parent
+	v4.Protect = v3.Protect
+	v4.External = v3.External
+	v4.Dependencies = v3.Dependencies
+	v4.InitErrors = v3.InitErrors
+	v4.Provider = v3.Provider
+	v4.PropertyDependencies = v3.PropertyDependencies
+	v4.PendingReplacement = v3.PendingReplacement
+	v4.AdditionalSecretOutputs = v3.AdditionalSecretOutputs
+	v4.Aliases = v3.Aliases
+	v4.CustomTimeouts = v3.CustomTimeouts
+
+	v4.ImportID = ""
+
+	return v4
+}


### PR DESCRIPTION
Resource gains a new `ImportID` field, which will be used to avoid
unexpected replaces on some resources with `import` applied on second
updates.