### PR TITLE
Add support for a PULUMI_CONSOLE_DOMAIN env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ CHANGELOG
 - Avoid unexpected replace on resource with `import` applied on second update.
   [#4403](https://github.com/pulumi/pulumi/pull/4403)
 
+- Add support for a `PULUMI_CONSOLE_DOMAIN` environment variable to override the
+  behavior for how URLs to the Pulumi Console are generated.
+  [#4410](https://github.com/pulumi/pulumi/pull/4410)
+
 ## 1.14.1 (2020-04-13)
 - Propagate `additionalSecretOutputs` opt to Read in NodeJS.
   [#4307](https://github.com/pulumi/pulumi/pull/4307)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -57,13 +57,6 @@ import (
 )
 
 const (
-	// PulumiCloudURL is the Cloud URL used if no environment or explicit cloud is chosen.
-	PulumiCloudURL = "https://" + defaultAPIDomainPrefix + "pulumi.com"
-	// defaultAPIDomainPrefix is the assumed Cloud URL prefix for typical Pulumi Cloud API endpoints.
-	defaultAPIDomainPrefix = "api."
-	// defaultConsoleDomainPrefix is the assumed Cloud URL prefix typically used for the Pulumi Console.
-	defaultConsoleDomainPrefix = "app."
-
 	// defaultAPIEnvVar can be set to override the default cloud chosen, if `--cloud` is not present.
 	defaultURLEnvVar = "PULUMI_API"
 	// AccessTokenEnvVar is the environment variable used to bypass a prompt on login.

--- a/pkg/backend/httpstate/console_test.go
+++ b/pkg/backend/httpstate/console_test.go
@@ -14,25 +14,51 @@
 package httpstate
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConsoleURL(t *testing.T) {
-	assert.Equal(t,
-		"https://app.pulumi.com/pulumi-bot/my-stack",
-		cloudConsoleURL("https://api.pulumi.com", "pulumi-bot", "my-stack"))
+	t.Run("HonorEnvVar", func(t *testing.T) {
+		initial := os.Getenv("PULUMI_CONSOLE_DOMAIN")
+		defer func() {
+			os.Setenv("PULUMI_CONSOLE_DOMAIN", initial)
+		}()
 
-	assert.Equal(t,
-		"http://app.pulumi.example.com/pulumi-bot/my-stack",
-		cloudConsoleURL("http://api.pulumi.example.com", "pulumi-bot", "my-stack"))
+		// Honor the PULUMI_CONSOLE_DOMAIN environment variable.
+		os.Setenv("PULUMI_CONSOLE_DOMAIN", "https://pulumi-console.contoso.com")
+		assert.Equal(t,
+			"https://pulumi-console.contoso.com/alpha/beta",
+			cloudConsoleURL("https://api.pulumi.contoso.com", "1", "2"))
 
-	assert.Equal(t,
-		"http://localhost:3000/pulumi-bot/my-stack",
-		cloudConsoleURL("http://localhost:8080", "pulumi-bot", "my-stack"))
+		// Unset the variable, confirm the "standard behavior" where we
+		// replace "api." with "app.".
+		os.Unsetenv("PULUMI_CONSOLE_DOMAIN")
+		assert.Equal(t,
+			"https://app.pulumi.contoso.com/1/2",
+			cloudConsoleURL("https://api.pulumi.contoso.com", "1", "2"))
+	})
 
-	assert.Equal(t, "", cloudConsoleURL("https://example.com", "pulumi-bot", "my-stack"))
+	t.Run("CloudURLUsingStandardPattern", func(t *testing.T) {
+		assert.Equal(t,
+			"https://app.pulumi.com/pulumi-bot/my-stack",
+			cloudConsoleURL("https://api.pulumi.com", "pulumi-bot", "my-stack"))
 
-	assert.Equal(t, "", cloudConsoleURL("not-even-a-rea-url", "pulumi-bot", "my-stack"))
+		assert.Equal(t,
+			"http://app.pulumi.example.com/pulumi-bot/my-stack",
+			cloudConsoleURL("http://api.pulumi.example.com", "pulumi-bot", "my-stack"))
+	})
+
+	t.Run("LocalDevelopment", func(t *testing.T) {
+		assert.Equal(t,
+			"http://localhost:3000/pulumi-bot/my-stack",
+			cloudConsoleURL("http://localhost:8080", "pulumi-bot", "my-stack"))
+	})
+
+	t.Run("ConsoleDomainUnknown", func(t *testing.T) {
+		assert.Equal(t, "/pulumi-bot/my-stack", cloudConsoleURL("https://example.com", "pulumi-bot", "my-stack"))
+		assert.Equal(t, "/pulumi-bot/my-stack", cloudConsoleURL("not-even-a-rea-url", "pulumi-bot", "my-stack"))
+	})
 }

--- a/pkg/backend/httpstate/console_test.go
+++ b/pkg/backend/httpstate/console_test.go
@@ -28,9 +28,9 @@ func TestConsoleURL(t *testing.T) {
 		}()
 
 		// Honor the PULUMI_CONSOLE_DOMAIN environment variable.
-		os.Setenv("PULUMI_CONSOLE_DOMAIN", "https://pulumi-console.contoso.com")
+		os.Setenv("PULUMI_CONSOLE_DOMAIN", "pulumi-console.contoso.com")
 		assert.Equal(t,
-			"https://pulumi-console.contoso.com/alpha/beta",
+			"https://pulumi-console.contoso.com/1/2",
 			cloudConsoleURL("https://api.pulumi.contoso.com", "1", "2"))
 
 		// Unset the variable, confirm the "standard behavior" where we
@@ -58,7 +58,7 @@ func TestConsoleURL(t *testing.T) {
 	})
 
 	t.Run("ConsoleDomainUnknown", func(t *testing.T) {
-		assert.Equal(t, "/pulumi-bot/my-stack", cloudConsoleURL("https://example.com", "pulumi-bot", "my-stack"))
-		assert.Equal(t, "/pulumi-bot/my-stack", cloudConsoleURL("not-even-a-real-url", "pulumi-bot", "my-stack"))
+		assert.Equal(t, "pulumi-bot/my-stack", cloudConsoleURL("https://example.com", "pulumi-bot", "my-stack"))
+		assert.Equal(t, "pulumi-bot/my-stack", cloudConsoleURL("not-even-a-real-url", "pulumi-bot", "my-stack"))
 	})
 }

--- a/pkg/backend/httpstate/console_test.go
+++ b/pkg/backend/httpstate/console_test.go
@@ -59,6 +59,6 @@ func TestConsoleURL(t *testing.T) {
 
 	t.Run("ConsoleDomainUnknown", func(t *testing.T) {
 		assert.Equal(t, "/pulumi-bot/my-stack", cloudConsoleURL("https://example.com", "pulumi-bot", "my-stack"))
-		assert.Equal(t, "/pulumi-bot/my-stack", cloudConsoleURL("not-even-a-rea-url", "pulumi-bot", "my-stack"))
+		assert.Equal(t, "/pulumi-bot/my-stack", cloudConsoleURL("not-even-a-real-url", "pulumi-bot", "my-stack"))
 	})
 }

--- a/pkg/backend/httpstate/console_test.go
+++ b/pkg/backend/httpstate/console_test.go
@@ -58,7 +58,7 @@ func TestConsoleURL(t *testing.T) {
 	})
 
 	t.Run("ConsoleDomainUnknown", func(t *testing.T) {
-		assert.Equal(t, "pulumi-bot/my-stack", cloudConsoleURL("https://example.com", "pulumi-bot", "my-stack"))
-		assert.Equal(t, "pulumi-bot/my-stack", cloudConsoleURL("not-even-a-real-url", "pulumi-bot", "my-stack"))
+		assert.Equal(t, "", cloudConsoleURL("https://pulumi.example.com", "pulumi-bot", "my-stack"))
+		assert.Equal(t, "", cloudConsoleURL("not-even-a-real-url", "pulumi-bot", "my-stack"))
 	})
 }


### PR DESCRIPTION
A Pulumi "backend" is identified by a URL, such as `https://api.pulumi.com`, `file:///Users/chris/pulumi-checkpoints`, or `s3://my-pulumi-stacks/`. And `filestate.IsFileStateBackendURL` is used to determine which backend to use ("file state" or "http state") based on the URL's scheme.

This has served us well, however it poses a problem when you try to couple the Pulumi CLI with the Pulumi Console. The Pulumi Service is served from two different domains: api.pulumi.com (REST API) and app.pulumi.com (web frontend).

The CLI is currently wired so that `pulumi login` is the same as if you had written `pulumi login --cloud-url https://api.pulumi.com`. (Meaning you specify the REST API's domain as the "cloud backend URL".) And so whenever we go to generate a URL to the Pulumi Console, we have a simple heuristic for guessing at what the Pulumi Console domain should be.

The problem is that when you are using an on-prem version of the Pulumi Service, and not using the same `api.*` and `app.*` convention for the domains, we end up generating incorrect URLs. (e.g. if you have `api.pulumi.contoso.com` and `console.pulumi.contoso.com`, at the end of every update we will link you to https://app.pulumi.contoso.com which would be wrong.)

This PR adds a small hack, which is to honor a `PULUMI_CONSOLE_DOMAIN` environment variable that would allow you to set the domain we use for links to the Pulumi Console.

A better solution would be to somehow couple the "backend URL" with its "console URL". (e.g. when you login, we pass around something like `type HTTPBackendURLs struct { RESTAPIDomain string; ConsoleDomain string }`. However, that would be a big undertaking for how we persist credentials and accounts in the `workspace` package.

Another approach would be to have you "log in" using the Pulumi Console domain, and then figure out how to have app.pulumi.com serve both API and web traffic. (That's a reasonable idea, but would require a bunch of work server-side.)

So that leads us to just honoring a new environment variable for now.

Fixes [#4888](https://github.com/pulumi/pulumi-service/issues/4888)