### PR TITLE
Fix hang if PersistentPreRun fails

### DIFF
--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -133,8 +133,15 @@ func NewPulumiCmd() *cobra.Command {
 			// Before exiting, if there is a new version of the CLI available, print it out.
 			jsonFlag := cmd.Flag("json")
 			isJSON := jsonFlag != nil && jsonFlag.Value.String() == "true"
-			if checkVersionMsg := <-updateCheckResult; checkVersionMsg != nil && !isJSON {
-				cmdutil.Diag().Warningf(checkVersionMsg)
+
+			select {
+			case checkVersionMsg := <-updateCheckResult:
+				if checkVersionMsg != nil && !isJSON {
+					cmdutil.Diag().Warningf(checkVersionMsg)
+				}
+			default:
+				// If the channel doesn't have anything in it yet, just ignore it
+				// and continue shutting down.
 			}
 
 			logging.Flush()

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -86,6 +86,15 @@ func NewPulumiCmd() *cobra.Command {
 			// to understand ANSI escape codes.
 			_, _, _ = term.StdStreams()
 
+			// If we fail before we start the async update check, go ahead and close the
+			// channel since we know it will never receive a value.
+			var waitForUpdateCheck bool
+			defer func() {
+				if !waitForUpdateCheck {
+					close(updateCheckResult)
+				}
+			}()
+
 			// For all commands, attempt to grab out the --color value provided so we
 			// can set the GlobalColorization value to be used by any code that doesn't
 			// get DisplayOptions passed in.
@@ -117,10 +126,10 @@ func NewPulumiCmd() *cobra.Command {
 
 			if cmdutil.IsTruthy(os.Getenv("PULUMI_SKIP_UPDATE_CHECK")) {
 				logging.V(5).Infof("skipping update check")
-				close(updateCheckResult)
 			} else {
 				// Run the version check in parallel so that it doesn't block executing the command.
 				// If there is a new version to report, we will do so after the command has finished.
+				waitForUpdateCheck = true
 				go func() {
 					updateCheckResult <- checkForUpdate()
 					close(updateCheckResult)

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -143,14 +143,9 @@ func NewPulumiCmd() *cobra.Command {
 			jsonFlag := cmd.Flag("json")
 			isJSON := jsonFlag != nil && jsonFlag.Value.String() == "true"
 
-			select {
-			case checkVersionMsg := <-updateCheckResult:
-				if checkVersionMsg != nil && !isJSON {
-					cmdutil.Diag().Warningf(checkVersionMsg)
-				}
-			default:
-				// If the channel doesn't have anything in it yet, just ignore it
-				// and continue shutting down.
+			checkVersionMsg, ok := <-updateCheckResult
+			if ok && checkVersionMsg != nil && !isJSON {
+				cmdutil.Diag().Warningf(checkVersionMsg)
 			}
 
 			logging.Flush()


### PR DESCRIPTION
`pulumi` would hang if you gave it a bogus directory for the `--cwd` flag. As it turns out this was because of the update version check.

We create a channel (`updateCheckResult`) and make a request to see if a newer version of the CLI is available. However, if the `PersistentPreRun` callback returns an error early, then we never start the Goroutine that will write a value into `updateCheckResult`... so when we execute the `PersistentPostRun` callback, we block indefinitely trying to read a value from the channel that will never come.

https://github.com/pulumi/pulumi/blob/master/pkg/cmd/pulumi/pulumi.go#L125

With this change, we no longer block until we have received a response to the version check. This might not be what we want, since if the command is super-fast, it's possible we shutdown before the update check is complete. Let me know what you think.

Fixes #4002 