### PR TITLE
Fix make generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-proto::
 generate::
 	$(call STEP_MESSAGE)
 	echo "Generate static assets bundle for docs generator"
-	go generate ./pkg/codegen/docs/
+	go generate ./pkg/codegen/docs/gen.go
 
 build::
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v2/version.Version=${VERSION}" ${PROJECT}

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-proto::
 generate::
 	$(call STEP_MESSAGE)
 	echo "Generate static assets bundle for docs generator"
-	go generate ./pkg/codegen/docs/gen.go
+	cd pkg && go generate ./codegen/docs/gen.go
 
 build::
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v2/version.Version=${VERSION}" ${PROJECT}


### PR DESCRIPTION
I noticed that I was getting an error locally when I ran `make generate` and it was fixed by running the specific file that contains the `go:generate ..` build instruction.