### PR TITLE
Fix number of args expected for `policy disable`

### DIFF
--- a/pkg/cmd/pulumi/policy_disable.go
+++ b/pkg/cmd/pulumi/policy_disable.go
@@ -30,7 +30,7 @@ func newPolicyDisableCmd() *cobra.Command {
 
 	var cmd = &cobra.Command{
 		Use:   "disable <org-name>/<policy-pack-name>",
-		Args:  cmdutil.MaximumNArgs(1),
+		Args:  cmdutil.ExactArgs(1),
 		Short: "Disable a Policy Pack for a Pulumi organization",
 		Long:  "Disable a Policy Pack for a Pulumi organization",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, cliArgs []string) error {


### PR DESCRIPTION
It expects one arg. Currently, we panic if no arg is specified. This fixes that.

Fixes https://github.com/pulumi/pulumi/issues/4413