### PR TITLE
Various codegen updates.

### DIFF
--- a/pkg/codegen/hcl2/functions.go
+++ b/pkg/codegen/hcl2/functions.go
@@ -40,6 +40,41 @@ func getEntriesSignature(args []model.Expression) (model.StaticFunctionSignature
 }
 
 var pulumiBuiltins = map[string]*model.Function{
+	"element": model.NewFunction(model.GenericFunctionSignature(
+		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+			var diagnostics hcl.Diagnostics
+
+			listType, returnType := model.Type(model.DynamicType), model.Type(model.DynamicType)
+			if len(args) > 0 {
+				switch t := model.ResolveOutputs(args[0].Type()).(type) {
+				case *model.ListType:
+					listType, returnType = args[0].Type(), t.ElementType
+				case *model.TupleType:
+					_, elementType := model.UnifyTypes(t.ElementTypes...)
+					listType, returnType = args[0].Type(), elementType
+				default:
+					rng := args[0].SyntaxNode().Range()
+					diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "the first argument to 'element' must be a list or tuple",
+						Subject:  &rng,
+					}}
+				}
+			}
+			return model.StaticFunctionSignature{
+				Parameters: []model.Parameter{
+					{
+						Name: "list",
+						Type: listType,
+					},
+					{
+						Name: "index",
+						Type: model.NumberType,
+					},
+				},
+				ReturnType: returnType,
+			}, diagnostics
+		})),
 	"entries": model.NewFunction(model.GenericFunctionSignature(getEntriesSignature)),
 	"fileAsset": model.NewFunction(model.StaticFunctionSignature{
 		Parameters: []model.Parameter{{
@@ -48,6 +83,77 @@ var pulumiBuiltins = map[string]*model.Function{
 		}},
 		ReturnType: AssetType,
 	}),
+	"length": model.NewFunction(model.GenericFunctionSignature(
+		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+			var diagnostics hcl.Diagnostics
+
+			valueType := model.Type(model.DynamicType)
+			if len(args) > 0 {
+				valueType = args[0].Type()
+				switch valueType := model.ResolveOutputs(valueType).(type) {
+				case *model.ListType, *model.MapType, *model.ObjectType, *model.TupleType:
+					// OK
+				default:
+					if model.StringType.ConversionFrom(valueType) == model.NoConversion {
+						rng := args[0].SyntaxNode().Range()
+						diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
+							Severity: hcl.DiagError,
+							Summary:  "the first argument to 'length' must be a list, map, object, tuple, or string",
+							Subject:  &rng,
+						}}
+					}
+				}
+			}
+			return model.StaticFunctionSignature{
+				Parameters: []model.Parameter{{
+					Name: "value",
+					Type: valueType,
+				}},
+				ReturnType: model.IntType,
+			}, diagnostics
+		})),
+	"lookup": model.NewFunction(model.GenericFunctionSignature(
+		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+			var diagnostics hcl.Diagnostics
+
+			mapType, elementType := model.Type(model.DynamicType), model.Type(model.DynamicType)
+			if len(args) > 0 {
+				switch t := model.ResolveOutputs(args[0].Type()).(type) {
+				case *model.MapType:
+					mapType, elementType = args[0].Type(), t.ElementType
+				case *model.ObjectType:
+					var unifiedType model.Type
+					for _, t := range t.Properties {
+						_, unifiedType = model.UnifyTypes(unifiedType, t)
+					}
+					mapType, elementType = args[0].Type(), unifiedType
+				default:
+					rng := args[0].SyntaxNode().Range()
+					diagnostics = hcl.Diagnostics{&hcl.Diagnostic{
+						Severity: hcl.DiagError,
+						Summary:  "the first argument to 'lookup' must be a map",
+						Subject:  &rng,
+					}}
+				}
+			}
+			return model.StaticFunctionSignature{
+				Parameters: []model.Parameter{
+					{
+						Name: "map",
+						Type: mapType,
+					},
+					{
+						Name: "key",
+						Type: model.StringType,
+					},
+					{
+						Name: "default",
+						Type: model.NewOptionalType(elementType),
+					},
+				},
+				ReturnType: elementType,
+			}, diagnostics
+		})),
 	"mimeType": model.NewFunction(model.StaticFunctionSignature{
 		Parameters: []model.Parameter{{
 			Name: "path",
@@ -73,6 +179,26 @@ var pulumiBuiltins = map[string]*model.Function{
 			Name: "path",
 			Type: model.StringType,
 		}},
+		ReturnType: model.NewListType(model.StringType),
+	}),
+	"readFile": model.NewFunction(model.StaticFunctionSignature{
+		Parameters: []model.Parameter{{
+			Name: "path",
+			Type: model.StringType,
+		}},
+		ReturnType: model.StringType,
+	}),
+	"split": model.NewFunction(model.StaticFunctionSignature{
+		Parameters: []model.Parameter{
+			{
+				Name: "separator",
+				Type: model.StringType,
+			},
+			{
+				Name: "string",
+				Type: model.StringType,
+			},
+		},
 		ReturnType: model.NewListType(model.StringType),
 	}),
 	"toJSON": model.NewFunction(model.StaticFunctionSignature{

--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -30,7 +30,6 @@ func diagf(severity hcl.DiagnosticSeverity, subject hcl.Range, f string, args ..
 	return &hcl.Diagnostic{
 		Severity: severity,
 		Summary:  message,
-		Detail:   message,
 		Subject:  &subject,
 	}
 }
@@ -111,4 +110,11 @@ func cannotTraverseKeyword(name string, rng hcl.Range) *hcl.Diagnostic {
 
 func cannotTraverseFunction(rng hcl.Range) *hcl.Diagnostic {
 	return errorf(rng, "functions cannot be traversed")
+}
+
+func cannotEvaluateAnonymousFunctionExpressions() *hcl.Diagnostic {
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  "cannot evaluate anonymous function expressions",
+	}
 }

--- a/pkg/codegen/hcl2/model/format/gen.go
+++ b/pkg/codegen/hcl2/model/format/gen.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"math"
 
-	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 )

--- a/pkg/codegen/hcl2/model/format/gen.go
+++ b/pkg/codegen/hcl2/model/format/gen.go
@@ -17,6 +17,7 @@ package format
 import (
 	"fmt"
 	"io"
+	"math"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
@@ -26,6 +27,10 @@ import (
 // ExpressionGenerator is an interface that can be implemented in order to generate code for semantically-analyzed HCL2
 // expressions using a Formatter.
 type ExpressionGenerator interface {
+	// GetPrecedence returns the precedence for the indicated expression. Lower numbers bind more tightly than higher
+	// numbers.
+	GetPrecedence(expr model.Expression) int
+
 	// GenAnonymousFunctionExpression generates code for an AnonymousFunctionExpression.
 	GenAnonymousFunctionExpression(w io.Writer, expr *model.AnonymousFunctionExpression)
 	// GenBinaryOpExpression generates code for a BinaryOpExpression.
@@ -100,50 +105,66 @@ func (e *Formatter) Fprintf(w io.Writer, format string, a ...interface{}) {
 	contract.IgnoreError(err)
 }
 
+func (e *Formatter) gen(w io.Writer, parentPrecedence int, rhs bool, x model.Expression) {
+	precedence := e.g.GetPrecedence(x)
+	switch {
+	case precedence > parentPrecedence:
+		// OK
+	case precedence < parentPrecedence || rhs:
+		_, err := fmt.Fprint(w, "(")
+		contract.AssertNoError(err)
+
+		defer func() {
+			_, err = fmt.Fprint(w, ")")
+			contract.AssertNoError(err)
+		}()
+	}
+
+	switch x := x.(type) {
+	case *model.AnonymousFunctionExpression:
+		e.g.GenAnonymousFunctionExpression(w, x)
+	case *model.BinaryOpExpression:
+		e.g.GenBinaryOpExpression(w, x)
+	case *model.ConditionalExpression:
+		e.g.GenConditionalExpression(w, x)
+	case *model.ForExpression:
+		e.g.GenForExpression(w, x)
+	case *model.FunctionCallExpression:
+		e.g.GenFunctionCallExpression(w, x)
+	case *model.IndexExpression:
+		e.g.GenIndexExpression(w, x)
+	case *model.LiteralValueExpression:
+		e.g.GenLiteralValueExpression(w, x)
+	case *model.ObjectConsExpression:
+		e.g.GenObjectConsExpression(w, x)
+	case *model.RelativeTraversalExpression:
+		e.g.GenRelativeTraversalExpression(w, x)
+	case *model.ScopeTraversalExpression:
+		e.g.GenScopeTraversalExpression(w, x)
+	case *model.SplatExpression:
+		e.g.GenSplatExpression(w, x)
+	case *model.TemplateExpression:
+		e.g.GenTemplateExpression(w, x)
+	case *model.TemplateJoinExpression:
+		e.g.GenTemplateJoinExpression(w, x)
+	case *model.TupleConsExpression:
+		e.g.GenTupleConsExpression(w, x)
+	case *model.UnaryOpExpression:
+		e.g.GenUnaryOpExpression(w, x)
+	default:
+		contract.Failf("unexpected expression node of type %T (%v)", x, x.SyntaxNode().Range())
+	}
+}
+
 // Fgen generates code for a list of strings and expression trees. The former are written directly to the destination;
 // the latter are recursively generated using the appropriate gen* functions.
 func (e *Formatter) Fgen(w io.Writer, vs ...interface{}) {
 	for _, v := range vs {
-		switch v := v.(type) {
-		case string:
+		if x, ok := v.(model.Expression); ok {
+			e.gen(w, math.MaxInt32, false, x)
+		} else {
 			_, err := fmt.Fprint(w, v)
-			contract.IgnoreError(err)
-		case *model.AnonymousFunctionExpression:
-			e.g.GenAnonymousFunctionExpression(w, v)
-		case *model.BinaryOpExpression:
-			e.g.GenBinaryOpExpression(w, v)
-		case *model.ConditionalExpression:
-			e.g.GenConditionalExpression(w, v)
-		case *model.ForExpression:
-			e.g.GenForExpression(w, v)
-		case *model.FunctionCallExpression:
-			e.g.GenFunctionCallExpression(w, v)
-		case *model.IndexExpression:
-			e.g.GenIndexExpression(w, v)
-		case *model.LiteralValueExpression:
-			e.g.GenLiteralValueExpression(w, v)
-		case *model.ObjectConsExpression:
-			e.g.GenObjectConsExpression(w, v)
-		case *model.RelativeTraversalExpression:
-			e.g.GenRelativeTraversalExpression(w, v)
-		case *model.ScopeTraversalExpression:
-			e.g.GenScopeTraversalExpression(w, v)
-		case *model.SplatExpression:
-			e.g.GenSplatExpression(w, v)
-		case *model.TemplateExpression:
-			e.g.GenTemplateExpression(w, v)
-		case *model.TemplateJoinExpression:
-			e.g.GenTemplateJoinExpression(w, v)
-		case *model.TupleConsExpression:
-			e.g.GenTupleConsExpression(w, v)
-		case *model.UnaryOpExpression:
-			e.g.GenUnaryOpExpression(w, v)
-		default:
-			var rng hcl.Range
-			if v, isExpr := v.(model.Expression); isExpr {
-				rng = v.SyntaxNode().Range()
-			}
-			contract.Failf("unexpected expression node of type %T (%v)", v, rng)
+			contract.AssertNoError(err)
 		}
 	}
 }
@@ -155,7 +176,11 @@ func (e *Formatter) Fgen(w io.Writer, vs ...interface{}) {
 func (e *Formatter) Fgenf(w io.Writer, format string, args ...interface{}) {
 	for i := range args {
 		if node, ok := args[i].(model.Expression); ok {
-			args[i] = Func(func(f fmt.State, c rune) { e.Fgen(f, node) })
+			args[i] = Func(func(f fmt.State, c rune) {
+				parentPrecedence, _ := f.Precision()
+				rhs := c == 'o'
+				e.gen(f, parentPrecedence, rhs, node)
+			})
 		}
 	}
 	fmt.Fprintf(w, format, args...)

--- a/pkg/codegen/hcl2/model/traversable.go
+++ b/pkg/codegen/hcl2/model/traversable.go
@@ -33,6 +33,13 @@ type TypedTraversable interface {
 	Type() Type
 }
 
+// ValueTraversable is a Traversable that has an associated value.
+type ValueTraversable interface {
+	Traversable
+
+	Value(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics)
+}
+
 // GetTraversableType returns the type of the given Traversable:
 // - If the Traversable is a TypedTraversable, this returns t.Type()
 // - If the Traversable is a Type, this returns t

--- a/pkg/codegen/hcl2/program.go
+++ b/pkg/codegen/hcl2/program.go
@@ -32,6 +32,11 @@ type Node interface {
 	// Type returns the type of the node.
 	Type() model.Type
 
+	markBinding()
+	markBound()
+	isBinding() bool
+	isBound() bool
+
 	getDependencies() []Node
 	setDependencies(nodes []Node)
 
@@ -39,7 +44,25 @@ type Node interface {
 }
 
 type node struct {
-	deps []Node
+	binding bool
+	bound   bool
+	deps    []Node
+}
+
+func (r *node) markBinding() {
+	r.binding = true
+}
+
+func (r *node) markBound() {
+	r.bound = true
+}
+
+func (r *node) isBinding() bool {
+	return r.binding && !r.bound
+}
+
+func (r *node) isBound() bool {
+	return r.bound
 }
 
 func (r *node) getDependencies() []Node {

--- a/pkg/codegen/hcl2/resource.go
+++ b/pkg/codegen/hcl2/resource.go
@@ -68,9 +68,6 @@ type Resource struct {
 
 	// The resource's options, if any.
 	Options *ResourceOptions
-
-	// range tracks the syntax node for the range option, if any.
-	rangeNode hclsyntax.Node
 }
 
 // SyntaxNode returns the syntax node associated with the resource.
@@ -80,7 +77,7 @@ func (r *Resource) SyntaxNode() hclsyntax.Node {
 
 // Type returns the type of the resource.
 func (r *Resource) Type() model.Type {
-	return ResourceType
+	return r.VariableType
 }
 
 func (r *Resource) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {

--- a/pkg/codegen/hcl2/syntax/comments.go
+++ b/pkg/codegen/hcl2/syntax/comments.go
@@ -63,6 +63,11 @@ func (l tokenList) atPos(p hcl.Pos) Token {
 // inRange returns a slice of the tokens that cover the given range or nil if either the start or end position is
 // uncovered by a token.
 func (l tokenList) inRange(r hcl.Range) []Token {
+	// If the range is empty, ignore it.
+	if r.Empty() {
+		return nil
+	}
+
 	// Find the index of the start and end tokens for this range.
 	start, end := l.offsetIndex(r.Start.Byte), l.offsetIndex(r.End.Byte-1)
 	if start == -1 || end == -1 {

--- a/pkg/codegen/hcl2/syntax/tokens.go
+++ b/pkg/codegen/hcl2/syntax/tokens.go
@@ -67,6 +67,34 @@ type Trivia interface {
 // TriviaList is a list of trivia.
 type TriviaList []Trivia
 
+func (trivia TriviaList) LeadingWhitespace() TriviaList {
+	end := 0
+	for i, t := range trivia {
+		if _, ok := t.(Whitespace); !ok {
+			break
+		}
+		end = i
+	}
+	if end == 0 {
+		return nil
+	}
+	return append(TriviaList(nil), trivia[0:end]...)
+}
+
+func (trivia TriviaList) TrailingWhitespace() TriviaList {
+	start := len(trivia)
+	for i := len(trivia) - 1; i >= 0; i-- {
+		if _, ok := trivia[i].(Whitespace); !ok {
+			break
+		}
+		start = i
+	}
+	if start == len(trivia) {
+		return nil
+	}
+	return append(TriviaList(nil), trivia[start:]...)
+}
+
 func (trivia TriviaList) CollapseWhitespace() TriviaList {
 	result := make(TriviaList, 0, len(trivia))
 	for _, t := range trivia {
@@ -456,8 +484,9 @@ func (t *BlockTokens) GetLabels(labels []string) []Token {
 func (t *BlockTokens) GetOpenBrace() Token {
 	if t == nil {
 		return Token{
-			Raw:           newRawToken(hclsyntax.TokenOBrace),
-			LeadingTrivia: TriviaList{NewWhitespace(' ')},
+			Raw:            newRawToken(hclsyntax.TokenOBrace),
+			LeadingTrivia:  TriviaList{NewWhitespace(' ')},
+			TrailingTrivia: TriviaList{NewWhitespace('\n')},
 		}
 	}
 	return t.OpenBrace
@@ -466,8 +495,9 @@ func (t *BlockTokens) GetOpenBrace() Token {
 func (t *BlockTokens) GetCloseBrace() Token {
 	if t == nil {
 		return Token{
-			Raw:           newRawToken(hclsyntax.TokenCBrace),
-			LeadingTrivia: TriviaList{NewWhitespace('\n')},
+			Raw:            newRawToken(hclsyntax.TokenCBrace),
+			LeadingTrivia:  TriviaList{NewWhitespace('\n')},
+			TrailingTrivia: TriviaList{NewWhitespace('\n')},
 		}
 	}
 	return t.CloseBrace

--- a/pkg/codegen/hcl2/type.go
+++ b/pkg/codegen/hcl2/type.go
@@ -23,8 +23,6 @@ var (
 	ArchiveType model.Type = model.MustNewOpaqueType("Archive")
 	// AssetType represents the set of Pulumi Asset values.
 	AssetType model.Type = model.MustNewOpaqueType("Asset")
-	// ResourceType represents a Pulumi resource instance.
-	ResourceType model.Type = model.MustNewOpaqueType("Resource")
 	// ResourcePropertyType represents a resource property reference.
 	ResourcePropertyType model.Type = model.MustNewOpaqueType("Property")
 )

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.py
@@ -6,13 +6,15 @@ import pulumi_aws as aws
 site_bucket = aws.s3.Bucket("site_bucket", website={
     "indexDocument": "index.html",
 })
-siteDir = "www"
+site_dir = "www"
 # For each file in the directory, create an S3 object stored in `siteBucket`
-files = aws.s3.BucketObject("files",
-    bucket=site_bucket.id,
-    key=range.value,
-    source=pulumi.FileAsset(f"{site_dir}/{range.value}"),
-    content_type=(lambda: raise Exception("FunctionCallExpression: mimeType (aws-s3-folder.pp:19,16-37)"))())
+files = []
+for range in [{"key": k, "value": v} for [k, v] in enumerate(os.listdir(site_dir))]:
+    files.append(aws.s3.BucketObject(f"files-${range.key}",
+        bucket=site_bucket.id,
+        key=range.value,
+        source=pulumi.FileAsset(f"{site_dir}/{range.value}"),
+        content_type=(lambda: raise Exception("FunctionCallExpression: mimeType (aws-s3-folder.pp:19,16-37)"))()))
 # set the MIME type of the file
 # Set the access policy for the bucket so all objects are readable
 bucket_policy = aws.s3.BucketPolicy("bucket_policy",

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.ts
@@ -8,7 +8,7 @@ const siteBucket = new aws.s3.Bucket("siteBucket", {website: {
 const siteDir = "www";
 // For each file in the directory, create an S3 object stored in `siteBucket`
 const files: aws.s3.BucketObject[];
-for (const [__key, __value] of (() => throw new Error("FunctionCallExpression: readDir (aws-s3-folder.pp:12,11-27)"))()) {
+for (const [__key, __value] of fs.readDirSync(siteDir)) {
     const range = {key: __key, value: __value};
     files.push(new aws.s3.BucketObject(`files-${range.key}`, {
         bucket: siteBucket.id,

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"log"
 	"math/big"
 	"strings"
 
@@ -23,15 +22,58 @@ func (nameInfo) IsReservedWord(word string) bool {
 	return isReservedWord(word)
 }
 
-func (g *generator) genExpression(expr model.Expression) string {
+func (g *generator) lowerExpression(expr model.Expression) model.Expression {
 	// TODO(pdg): diagnostics
-
 	expr, _ = hcl2.RewriteApplies(expr, nameInfo(0), true)
 	expr, _ = g.lowerProxyApplies(expr)
+	return expr
+}
 
-	var buf bytes.Buffer
-	g.Fgen(&buf, expr)
-	return buf.String()
+func (g *generator) GetPrecedence(expr model.Expression) int {
+	// Precedence is derived from
+	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence.
+	switch expr := expr.(type) {
+	case *model.ConditionalExpression:
+		return 4
+	case *model.BinaryOpExpression:
+		switch expr.Operation {
+		case hclsyntax.OpLogicalOr:
+			return 5
+		case hclsyntax.OpLogicalAnd:
+			return 6
+		case hclsyntax.OpEqual, hclsyntax.OpNotEqual:
+			return 11
+		case hclsyntax.OpGreaterThan, hclsyntax.OpGreaterThanOrEqual, hclsyntax.OpLessThan,
+			hclsyntax.OpLessThanOrEqual:
+			return 12
+		case hclsyntax.OpAdd, hclsyntax.OpSubtract:
+			return 14
+		case hclsyntax.OpMultiply, hclsyntax.OpDivide, hclsyntax.OpModulo:
+			return 15
+		default:
+			contract.Failf("unexpected binary expression %v", expr)
+		}
+	case *model.UnaryOpExpression:
+		return 17
+	case *model.FunctionCallExpression:
+		switch expr.Name {
+		case intrinsicAwait:
+			return 17
+		case intrinsicInterpolate:
+			return 22
+		default:
+			return 20
+		}
+	case *model.ForExpression, *model.IndexExpression, *model.RelativeTraversalExpression, *model.SplatExpression,
+		*model.TemplateJoinExpression:
+		return 20
+	case *model.AnonymousFunctionExpression, *model.LiteralValueExpression, *model.ObjectConsExpression,
+		*model.ScopeTraversalExpression, *model.TemplateExpression, *model.TupleConsExpression:
+		return 22
+	default:
+		contract.Failf("unexpected expression %v of type %T", expr, expr)
+	}
+	return 0
 }
 
 func (g *generator) GenAnonymousFunctionExpression(w io.Writer, expr *model.AnonymousFunctionExpression) {
@@ -51,11 +93,11 @@ func (g *generator) GenAnonymousFunctionExpression(w io.Writer, expr *model.Anon
 		g.Fgen(w, "])")
 	}
 
-	g.Fgenf(w, " => %v", expr.Body)
+	g.Fgenf(w, " => %.v", expr.Body)
 }
 
 func (g *generator) GenBinaryOpExpression(w io.Writer, expr *model.BinaryOpExpression) {
-	opstr := ","
+	opstr, precedence := "", g.GetPrecedence(expr)
 	switch expr.Operation {
 	case hclsyntax.OpAdd:
 		opstr = "+"
@@ -83,46 +125,48 @@ func (g *generator) GenBinaryOpExpression(w io.Writer, expr *model.BinaryOpExpre
 		opstr = "!="
 	case hclsyntax.OpSubtract:
 		opstr = "-"
+	default:
+		opstr, precedence = ",", 1
 	}
 
-	g.Fgenf(w, "%v %v %v", expr.LeftOperand, opstr, expr.RightOperand)
+	g.Fgenf(w, "%.[1]*[2]v %[3]v %.[1]*[4]o", precedence, expr.LeftOperand, opstr, expr.RightOperand)
 }
 
 func (g *generator) GenConditionalExpression(w io.Writer, expr *model.ConditionalExpression) {
-	g.Fgenf(w, "%v ? %v : %v", expr.Condition, expr.TrueResult, expr.FalseResult)
+	g.Fgenf(w, "%.4v ? %.4v : %.4v", expr.Condition, expr.TrueResult, expr.FalseResult)
 }
 
 func (g *generator) GenForExpression(w io.Writer, expr *model.ForExpression) {
 	switch expr.Collection.Type().(type) {
 	case *model.ListType, *model.TupleType:
 		if expr.KeyVariable == nil {
-			g.Fgenf(w, "%v", expr.Collection)
+			g.Fgenf(w, "%.20v", expr.Collection)
 		} else {
-			g.Fgenf(w, "%v.map((v, k) => [k, v])", expr.Collection)
+			g.Fgenf(w, "%.20v.map((v, k) => [k, v])", expr.Collection)
 		}
 	case *model.MapType, *model.ObjectType:
 		if expr.KeyVariable == nil {
-			g.Fgenf(w, "Object.values(%v)", expr.Collection)
+			g.Fgenf(w, "Object.values(%.v)", expr.Collection)
 		} else {
-			g.Fgenf(w, "Object.entries(%v)", expr.Collection)
+			g.Fgenf(w, "Object.entries(%.v)", expr.Collection)
 		}
 	}
 
 	fnParams, reduceParams := expr.ValueVariable.Name, expr.ValueVariable.Name
 	if expr.KeyVariable != nil {
-		reduceParams = fmt.Sprintf("[%v, %v]", expr.KeyVariable.Name, expr.ValueVariable.Name)
+		reduceParams = fmt.Sprintf("[%.v, %.v]", expr.KeyVariable.Name, expr.ValueVariable.Name)
 		fnParams = fmt.Sprintf("(%v)", reduceParams)
 	}
 
 	if expr.Condition != nil {
-		g.Fgenf(w, ".filter(%s => %v)", fnParams, expr.Condition)
+		g.Fgenf(w, ".filter(%s => %.v)", fnParams, expr.Condition)
 	}
 
 	if expr.Key != nil {
 		// TODO(pdg): grouping
-		g.Fgenf(w, ".reduce((__obj, %s) => { ...__obj, [%v]: %v })", reduceParams, expr.Key, expr.Value)
+		g.Fgenf(w, ".reduce((__obj, %s) => { ...__obj, [%.v]: %.v })", reduceParams, expr.Key, expr.Value)
 	} else {
-		g.Fgenf(w, ".map(%s => %v)", fnParams, expr.Value)
+		g.Fgenf(w, ".map(%s => %.v)", fnParams, expr.Value)
 	}
 }
 
@@ -146,7 +190,7 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 
 	if len(applyArgs) == 1 {
 		// If we only have a single output, just generate a normal `.apply` or `.then`.
-		g.Fgenf(w, "%v.%v(%v)", applyArgs[0], apply, then)
+		g.Fgenf(w, "%.20v.%v(%.v)", applyArgs[0], apply, then)
 	} else {
 		// Otherwise, generate a call to `pulumi.all([]).apply()`.
 		g.Fgen(w, "%v([", all)
@@ -155,12 +199,12 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 				g.Fgen(w, ", ")
 			}
 			if anyOutputs && !isOutput[i] {
-				g.Fgenf(w, "pulumi.output(%v)", o)
+				g.Fgenf(w, "pulumi.output(%.v)", o)
 			} else {
 				g.Fgenf(w, "%v", o)
 			}
 		}
-		g.Fgenf(w, "]).%v(%v)", apply, then)
+		g.Fgenf(w, "]).%v(%.v)", apply, then)
 	}
 }
 
@@ -175,8 +219,6 @@ func functionName(tokenArg model.Expression) (string, string, string, hcl.Diagno
 }
 
 func (g *generator) genRange(w io.Writer, call *model.FunctionCallExpression, entries bool) {
-	log.Printf("generating range() %v", call)
-
 	var from, to model.Expression
 	switch len(call.Args) {
 	case 1:
@@ -189,7 +231,7 @@ func (g *generator) genRange(w io.Writer, call *model.FunctionCallExpression, en
 
 	genPrefix := func() { g.Fprint(w, "((from, to) => (new Array(to - from))") }
 	mapValue := "from + i"
-	genSuffix := func() { g.Fgenf(w, ")(%v, %v)", from, to) }
+	genSuffix := func() { g.Fgenf(w, ")(%.v, %.v)", from, to) }
 
 	if litFrom, ok := from.(*model.LiteralValueExpression); ok {
 		fromV, err := convert.Convert(litFrom.Value, cty.Number)
@@ -209,7 +251,7 @@ func (g *generator) genRange(w io.Writer, call *model.FunctionCallExpression, en
 			genPrefix = func() { g.Fprintf(w, "(new Array(%d))", to-from) }
 			genSuffix = func() {}
 		} else if from == 0 {
-			genPrefix = func() { g.Fgenf(w, "(new Array(%v))", to) }
+			genPrefix = func() { g.Fgenf(w, "(new Array(%.v))", to) }
 			mapValue = "i"
 			genSuffix = func() {}
 		}
@@ -234,10 +276,12 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 			if lit, ok := part.(*model.LiteralValueExpression); ok && lit.Type() == model.StringType {
 				g.Fgen(w, lit.Value.AsString())
 			} else {
-				g.Fgenf(w, "${%v}", part)
+				g.Fgenf(w, "${%.v}", part)
 			}
 		}
 		g.Fgen(w, "`")
+	case "element":
+		g.Fgenf(w, "%.20v[%.v]", expr.Args[0], expr.Args[1])
 	case "entries":
 		switch expr.Args[0].Type().(type) {
 		case *model.ListType, *model.TupleType:
@@ -245,15 +289,15 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 				g.genRange(w, call, true)
 				return
 			}
-			g.Fgenf(w, "%v.map((k, v)", expr.Args[0])
+			g.Fgenf(w, "%.20v.map((k, v)", expr.Args[0])
 		case *model.MapType, *model.ObjectType:
-			g.Fgenf(w, "Object.entries(%v).map(([k, v])", expr.Args[0])
+			g.Fgenf(w, "Object.entries(%.v).map(([k, v])", expr.Args[0])
 		}
 		g.Fgenf(w, " => {key: k, value: v})")
 	case "fileArchive":
-		g.Fgenf(w, "new pulumi.asset.FileArchive(%v)", expr.Args[0])
+		g.Fgenf(w, "new pulumi.asset.FileArchive(%.v)", expr.Args[0])
 	case "fileAsset":
-		g.Fgenf(w, "new pulumi.asset.FileAsset(%v)", expr.Args[0])
+		g.Fgenf(w, "new pulumi.asset.FileAsset(%.v)", expr.Args[0])
 	case "invoke":
 		pkg, module, fn, diags := functionName(expr.Args[0])
 		contract.Assert(len(diags) == 0)
@@ -265,13 +309,26 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		optionsBag := ""
 		if len(expr.Args) == 3 {
 			var buf bytes.Buffer
-			g.Fgenf(&buf, ", %v", expr.Args[2])
+			g.Fgenf(&buf, ", %.v", expr.Args[2])
 			optionsBag = buf.String()
 		}
 
-		g.Fgenf(w, "%s(%v%v)", name, expr.Args[1], optionsBag)
+		g.Fgenf(w, "%s(%.v%v)", name, expr.Args[1], optionsBag)
+	case "length":
+		g.Fgenf(w, "%.20v.length", expr.Args[0])
+	case "lookup":
+		g.Fgenf(w, "%v[%v]", expr.Args[0], expr.Args[1])
+		if len(expr.Args) == 3 {
+			g.Fgenf(w, " || %v", expr.Args[2])
+		}
 	case "range":
 		g.genRange(w, expr, false)
+	case "readFile":
+		g.Fgenf(w, "fs.readFileSync(%v)", expr.Args[0])
+	case "readDir":
+		g.Fgenf(w, "fs.readDirSync(%v)", expr.Args[0])
+	case "split":
+		g.Fgenf(w, "%.20v.split(%v)", expr.Args[1], expr.Args[0])
 	case "toJSON":
 		g.Fgenf(w, "JSON.stringify(%v)", expr.Args[0])
 	default:
@@ -284,7 +341,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 }
 
 func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) {
-	g.Fgenf(w, "%v[%v]", expr.Collection, expr.Key)
+	g.Fgenf(w, "%.20v[%.v]", expr.Collection, expr.Key)
 }
 
 func (g *generator) genStringLiteral(w io.Writer, v string) {
@@ -356,18 +413,16 @@ func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsE
 		g.Indented(func() {
 			for _, item := range expr.Items {
 				g.Fgenf(w, "\n%s", g.Indent)
-				if lit, isLit := item.Key.(*model.LiteralValueExpression); isLit && lit.Type() == model.StringType {
-					key := lit.Value.AsString()
-					if isLegalIdentifier(key) {
-						g.Fprint(w, key)
+				if lit, isLit := item.Key.(*model.LiteralValueExpression); isLit {
+					if lit.Type() == model.StringType && isLegalIdentifier(lit.Value.AsString()) {
+						g.Fprint(w, lit.Value.AsString())
 					} else {
-						g.Fgen(w, lit)
+						g.Fgenf(w, "%.v", lit)
 					}
 				} else {
-					g.Fgen(w, item.Key)
+					g.Fgenf(w, "[%.v]", item.Key)
 				}
-
-				g.Fgenf(w, ": %v,", item.Value)
+				g.Fgenf(w, ": %.v,", item.Value)
 			}
 		})
 		g.Fgenf(w, "\n%s}", g.Indent)
@@ -387,7 +442,7 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, p
 		}
 
 		if model.IsOptionalType(model.GetTraversableType(parts[i])) {
-			g.Fgen(w, "!")
+			g.Fgen(w, "?")
 		}
 
 		switch key.Type() {
@@ -408,13 +463,13 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, p
 }
 
 func (g *generator) GenRelativeTraversalExpression(w io.Writer, expr *model.RelativeTraversalExpression) {
-	g.Fgen(w, expr.Source)
+	g.Fgenf(w, "%.20v", expr.Source)
 	g.genRelativeTraversal(w, expr.Traversal, expr.Parts)
 }
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
 	rootName := expr.RootName
-	if v, ok := expr.Parts[0].(*model.Variable); ok && g.anonymousVariables.Has(v) {
+	if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
 		rootName = "__item"
 	}
 
@@ -423,8 +478,7 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 }
 
 func (g *generator) GenSplatExpression(w io.Writer, expr *model.SplatExpression) {
-	g.anonymousVariables.Add(expr.Item)
-	g.Fgenf(w, "%v.map(__item => %v)", expr.Source, expr.Each)
+	g.Fgenf(w, "%.20v.map(__item => %.v)", expr.Source, expr.Each)
 }
 
 func (g *generator) GenTemplateExpression(w io.Writer, expr *model.TemplateExpression) {
@@ -440,7 +494,7 @@ func (g *generator) GenTemplateExpression(w io.Writer, expr *model.TemplateExpre
 		if lit, ok := expr.(*model.LiteralValueExpression); ok && lit.Type() == model.StringType {
 			g.Fgen(w, lit.Value.AsString())
 		} else {
-			g.Fgenf(w, "${%v}", expr)
+			g.Fgenf(w, "${%.v}", expr)
 		}
 	}
 	g.Fgen(w, "`")
@@ -455,12 +509,12 @@ func (g *generator) GenTupleConsExpression(w io.Writer, expr *model.TupleConsExp
 	case 0:
 		g.Fgen(w, "[]")
 	case 1:
-		g.Fgenf(w, "[%v]", expr.Expressions[0])
+		g.Fgenf(w, "[%.v]", expr.Expressions[0])
 	default:
 		g.Fgen(w, "[")
 		g.Indented(func() {
 			for _, v := range expr.Expressions {
-				g.Fgenf(w, "\n%s%v,", g.Indent, v)
+				g.Fgenf(w, "\n%s%.v,", g.Indent, v)
 			}
 		})
 		g.Fgen(w, "\n", g.Indent, "]")
@@ -468,12 +522,12 @@ func (g *generator) GenTupleConsExpression(w io.Writer, expr *model.TupleConsExp
 }
 
 func (g *generator) GenUnaryOpExpression(w io.Writer, expr *model.UnaryOpExpression) {
-	opstr := ""
+	opstr, precedence := "", g.GetPrecedence(expr)
 	switch expr.Operation {
 	case hclsyntax.OpLogicalNot:
 		opstr = "!"
 	case hclsyntax.OpNegate:
 		opstr = "-"
 	}
-	g.Fgenf(w, "%v%v", opstr, expr.Operand)
+	g.Fgenf(w, "%[2]v%.[1]*[3]v", precedence, opstr, expr.Operand)
 }

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -195,6 +195,7 @@ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4er
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/mock v1.4.0 h1:Rd1kQnQu0Hq3qvJppYSG0HtP+f5LPPUiDswTLiEegLg=
 github.com/golang/mock v1.4.0/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
- Define `null` in Pulumi HCL2
- Bind Pulumi HCL2 in topological order s.t. variable types can be
  properly computed
- Fix resources that range over bools and numbers
- Add element, length, lookup, readFile, and split functions
- Do not rewrite function signatures with input types during binding
- Fix splat expression binding for non-lists
- Add support for evaluating expressions
- Add support for operator precedence to code generators
- Add support for constants to the HCL2 IR
- Add support for generating ranged resources in Python
- Add support for generating conditional resource in Node and Python
- Fix various naming issues in Python