### PR TITLE
Fix header anchor ids in resource docs

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -148,6 +148,7 @@ type apiTypeDocLinks struct {
 // docNestedType represents a complex type.
 type docNestedType struct {
 	Name        string
+	AnchorID    string
 	APIDocLinks map[string]apiTypeDocLinks
 	Properties  map[string][]property
 }
@@ -733,8 +734,10 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 				props[lang] = mod.getProperties(obj.Properties, lang, true, true)
 			}
 
+			name := tokenToName(obj.Token)
 			objs = append(objs, docNestedType{
-				Name:        wbr(tokenToName(obj.Token)),
+				Name:        wbr(name),
+				AnchorID:    strings.ToLower(name),
 				APIDocLinks: apiDocLinks,
 				Properties:  props,
 			})

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -51,8 +51,7 @@ The following output properties are available:
 ## Supporting Types
 
 {{ range .NestedTypes }}
-#### {{ htmlSafe .Name }}
-
+<h4 id="{{ .AnchorID }}">{{ htmlSafe .Name }}</h4>
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
 > See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -49,8 +49,10 @@ The following output properties are available:
 {{ if ne (len .NestedTypes) 0 }}
 
 ## Supporting Types
+
 {{ range .NestedTypes }}
-<h4>{{ htmlSafe .Name }}</h4>
+#### {{ htmlSafe .Name }}
+
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
 > See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -5,7 +5,7 @@
 {{ .DeprecationMessage }}
 
 <!-- Input properties -->
-## Using {{ .Header.Title }}
+## Using {{ .Header.Title }} {#using}
 
 {{ htmlSafe "{{< chooser language \"javascript,typescript,python,go,csharp\" / >}}" }}
 
@@ -39,7 +39,7 @@ The following arguments are supported:
 {{ end }}
 
 <!-- Output properties -->
-## {{.Header.Title}} Result
+## {{.Header.Title}} Result {#result}
 
 The following output properties are available:
 

--- a/pkg/codegen/docs/templates/index_categories.tmpl
+++ b/pkg/codegen/docs/templates/index_categories.tmpl
@@ -1,5 +1,5 @@
 {{- define "index_modules" }}
-<h3>Modules</h3>
+<h3 id="modules">Modules</h3>
 <ul class="api">
 {{- range . }}
     <li><a href="{{ .Link }}" title="{{ .DisplayName }}"><span class="symbol module"></span>{{ .DisplayName }}</a></li>
@@ -8,7 +8,7 @@
 {{- end }}
 
 {{- define "index_resources" }}
-<h3>Resources</h3>
+<h3 id="resources">Resources</h3>
 <ul class="api">
 {{- range . }}
     <li><a href="{{ .Link }}" title="{{ .DisplayName }}"><span class="symbol resource"></span>{{ .DisplayName }}</a></li>
@@ -17,7 +17,7 @@
 {{- end }}
 
 {{- define "index_functions" }}
-<h3>Functions</h3>
+<h3 id="functions">Functions</h3>
 <ul class="api">
 {{- range . }}
     <li><a href="{{ .Link }}" title="{{ .DisplayName }}"><span class="symbol function"></span>{{ .DisplayName }}</a></li>

--- a/pkg/codegen/docs/templates/index_categories.tmpl
+++ b/pkg/codegen/docs/templates/index_categories.tmpl
@@ -1,5 +1,5 @@
 {{- define "index_modules" }}
-<h3 id="modules">Modules</h3>
+<h2 id="modules">Modules</h2>
 <ul class="api">
 {{- range . }}
     <li><a href="{{ .Link }}" title="{{ .DisplayName }}"><span class="symbol module"></span>{{ .DisplayName }}</a></li>
@@ -8,7 +8,7 @@
 {{- end }}
 
 {{- define "index_resources" }}
-<h3 id="resources">Resources</h3>
+<h2 id="resources">Resources</h2>
 <ul class="api">
 {{- range . }}
     <li><a href="{{ .Link }}" title="{{ .DisplayName }}"><span class="symbol resource"></span>{{ .DisplayName }}</a></li>
@@ -17,7 +17,7 @@
 {{- end }}
 
 {{- define "index_functions" }}
-<h3 id="functions">Functions</h3>
+<h2 id="functions">Functions</h2>
 <ul class="api">
 {{- range . }}
     <li><a href="{{ .Link }}" title="{{ .DisplayName }}"><span class="symbol function"></span>{{ .DisplayName }}</a></li>

--- a/pkg/codegen/docs/templates/package_details.tmpl
+++ b/pkg/codegen/docs/templates/package_details.tmpl
@@ -1,5 +1,5 @@
 {{ define "package_details" }}
-<h3>Package Details</h3>
+<h3 id="package-details">Package Details</h3>
 <dl class="package-details">
 	<dt>Repository</dt>
 	<dd><a href="{{ htmlSafe .Repository }}">{{ htmlSafe .Repository }}</a></dd>

--- a/pkg/codegen/docs/templates/package_details.tmpl
+++ b/pkg/codegen/docs/templates/package_details.tmpl
@@ -1,5 +1,5 @@
 {{ define "package_details" }}
-<h3 id="package-details">Package Details</h3>
+<h2 id="package-details">Package Details</h2>
 <dl class="package-details">
 	<dt>Repository</dt>
 	<dd><a href="{{ htmlSafe .Repository }}">{{ htmlSafe .Repository }}</a></dd>

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -162,8 +162,7 @@ The following state arguments are supported:
 ## Supporting Types
 
 {{ range .NestedTypes }}
-#### {{ htmlSafe .Name }}
-
+<h4 id="{{ .AnchorID }}">{{ htmlSafe .Name }}</h4>
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
 > See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -10,7 +10,7 @@
 {{- end }}
 
 <!-- Create resource -->
-## Create a {{ .Header.Title }} Resource
+## Create a {{ .Header.Title }} Resource {#create}
 
 {{- if eq .LangChooserLanguages "" }}
 {{ htmlSafe "{{< chooser language \"javascript,typescript,python,go,csharp\" / >}}" }}
@@ -74,7 +74,7 @@
 {{ template "constructor_args" .ConstructorParamsTyped.csharp }}
 {{ htmlSafe "{{% /choosable %}}" }}
 
-## {{ .Header.Title }} Resource Properties
+## {{ .Header.Title }} Resource Properties {#properties}
 
 To learn more about resource properties and how to use them, see [Inputs and Outputs]({{ htmlSafe "{{< relref \"/docs/intro/concepts/programming-model#outputs\" >}}" }}) in the Programming Model docs.
 
@@ -98,7 +98,7 @@ All [input](#inputs) properties are implicitly available as output properties. T
 
 <!-- Read resource -->
 {{ if ne (len .StateInputs) 0 }}
-## Look up an Existing {{.Header.Title}} Resource
+## Look up an Existing {{.Header.Title}} Resource {#look-up}
 
 Get an existing {{.Header.Title}} resource's state with the given name, ID, and optional extra properties used to qualify the lookup.
 

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -160,8 +160,10 @@ The following state arguments are supported:
 {{ if ne (len .NestedTypes) 0 }}
 
 ## Supporting Types
+
 {{ range .NestedTypes }}
-<h4>{{ htmlSafe .Name }}</h4>
+#### {{ htmlSafe .Name }}
+
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
 > See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}


### PR DESCRIPTION
1. Add ids to headers so they can be linked to
2. Make header ids more general
    - Rather than including the identifier in the name of the id, use a simpler more generic id.

@praneetloke, @cnunciato, what do you think about (2)?

Fixes https://github.com/pulumi/docs/issues/2987