### PR TITLE
Update `@pulumi/policy` dependency

### DIFF
--- a/tests/integration/policy/policy_pack_w_config/package.json
+++ b/tests/integration/policy/policy_pack_w_config/package.json
@@ -2,7 +2,7 @@
     "name": "test-policy-w-config",
     "version": "0.0.1",
     "dependencies": {
-        "@pulumi/policy": "^1.0.0"
+        "@pulumi/policy": "^1.1.0"
     },
     "devDependencies": {
         "@types/mocha": "^2.2.42",

--- a/tests/integration/policy/policy_pack_w_config/package.json.tmpl
+++ b/tests/integration/policy/policy_pack_w_config/package.json.tmpl
@@ -2,7 +2,7 @@
     "name": "test-policy-w-config",
     "version": { policyVersion },
     "dependencies": {
-        "@pulumi/policy": "^1.0.0"
+        "@pulumi/policy": "^1.1.0"
     },
     "devDependencies": {
         "@types/node": "^10.12.7"


### PR DESCRIPTION
The test that uses these are currently disabled -- but still wanted to make sure we didn't forget to update.