### PR TITLE
Add a period to the end of the Context object comment

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -560,7 +560,7 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 				Name: "Context",
 				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Context"),
 			},
-			Comment: "Context object for the current deployment",
+			Comment: "Context object for the current deployment.",
 		},
 		{
 			Name: "name",


### PR DESCRIPTION
To match the other comments that have periods:

https://github.com/pulumi/pulumi/blob/7f8be330bdb00b74e161e7baa2040a309ca36667/pkg/codegen/docs/gen.go#L487-L489

Quick follow-up from https://github.com/pulumi/pulumi/pull/4385#discussion_r410410781