### PR TITLE
Inject `id` resource output property in docs

### DIFF
--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -86,15 +86,10 @@ The {{ .Header.Title }} resource accepts the following [input]({{ htmlSafe "{{< 
 
 <!-- Output properties -->
 ### Outputs
-{{ if ne (len .OutputProperties) 0 }}
-All [input](#inputs) properties are implicitly available as output properties. Additionally, the {{ .Header.Title }} resource produces the following computed outputs.
 
-The following output properties are available:
+All [input](#inputs) properties are implicitly available as output properties. Additionally, the {{ .Header.Title }} resource produces the following output properties:
 
 {{ template "properties" .OutputProperties }}
-{{ else }}
-All [input](#inputs) properties are implicitly available as output properties. The {{ .Header.Title }} resource does not produce any additional output properties.
-{{ end }}
 
 <!-- Read resource -->
 {{ if ne (len .StateInputs) 0 }}


### PR DESCRIPTION
All resources have an implicit `id` output property that must be injected in docs (per https://github.com/pulumi/docs/issues/2975#issuecomment-615411715). (We don't need to do this for TF data sources, as they already have an id).

Here's how this change looks in the docs for AWS and Kubernetes:
- AWS: https://github.com/pulumi/docs/commit/4c45a5828c2575337f319c0347168b124fc94064
- Kubernetes: https://github.com/pulumi/docs/commit/6c8fccdbbfab02694f866d3c04f7b8b976ef738b

Fixes https://github.com/pulumi/docs/issues/2884
Fixes https://github.com/pulumi/docs/issues/2975