### PR TITLE
Allows conditional dependencies and Resources from apply

### DIFF
--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -457,7 +457,7 @@ async function gatherExplicitDependencies(
             const urns = await dos.promise();
             const dosResources = await getAllResources(dos);
             const implicits = await gatherExplicitDependencies([...dosResources]);
-            return urns.concat(implicits);
+            return (urns ?? []).concat(implicits);
         } else {
             if (!Resource.isInstance(dependsOn)) {
                 throw new Error("'dependsOn' was passed a value that was not a Resource.");


### PR DESCRIPTION
When creating a Resource inside an apply the Output might result in `undefined` during previews. This was reported in #3645 I added the use case that got me to this problem there

I edited this directly on the JS on my local `node_modules` just to get the deployment working and then replicated it here from the Github editor. No idea where to add a test for this, but I'll gladly add as soon as I find out :sweat_smile: 