### PR TITLE
[codegen/docs] Fix the anchor link used in resource docs template.

### DIFF
--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -80,7 +80,7 @@ To learn more about resource properties and how to use them, see [Inputs and Out
 
 ### Inputs
 
-The {{ .Header.Title }} resource accepts the following [input]({{ htmlSafe "{{< relref \"/docs/intro/concepts/programming-model#outputs\" >}}" }}) properties:
+The {{ .Header.Title }} resource accepts the following [input]({{ htmlSafe "{{< relref \"/docs/intro/concepts/programming-model#inputs\" >}}" }}) properties:
 
 {{ template "properties" .InputProperties }}
 


### PR DESCRIPTION
The text is talking about inputs, so it should link to the inputs section of the programming model docs.