### PR TITLE
Add flag to `pulumi stack` to output only the stack name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGELOG
   
 - Protect against panic when unprotecting non-existant resources
   [#4441](https://github.com/pulumi/pulumi/pull/4441)
+  
+- Add flag to `pulumi stack` to output only the stack name
+  [#4450](https://github.com/pulumi/pulumi/pull/4450)
 
 ## 2.0.0 (2020-04-16)
 =======

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -36,6 +36,7 @@ func newStackCmd() *cobra.Command {
 	var showSecrets bool
 	var stackName string
 	var startTime string
+	var showStackName bool
 
 	cmd := &cobra.Command{
 		Use:   "stack",
@@ -58,6 +59,11 @@ func newStackCmd() *cobra.Command {
 			snap, err := s.Snapshot(commandContext())
 			if err != nil {
 				return err
+			}
+
+			if showStackName {
+				fmt.Printf("%s\n", s.Ref().Name())
+				return nil
 			}
 
 			// First print general info about the current stack.
@@ -160,6 +166,8 @@ func newStackCmd() *cobra.Command {
 		&showURNs, "show-urns", "u", false, "Display each resource's Pulumi-assigned globally unique URN")
 	cmd.Flags().BoolVar(
 		&showSecrets, "show-secrets", false, "Display stack outputs which are marked as secret in plaintext")
+	cmd.Flags().BoolVar(
+		&showStackName, "show-name", false, "Display only the stack name")
 
 	cmd.AddCommand(newStackExportCmd())
 	cmd.AddCommand(newStackGraphCmd())


### PR DESCRIPTION
Fixes: #4444

Before:
```
$ pulumi stack
Current stack is 47BE2956-D665-4EC3-9AE6-4D4A1C417074:
    Managed by demo-mbp
    No updates yet; run 'pulumi up'
Current stack resources (0):
    No resources currently in this stack

Use `pulumi stack select` to change stack; `pulumi stack ls` lists known ones
```

After:
```
$ pulumi stack --show-name
47BE2956-D665-4EC3-9AE6-4D4A1C417074
```