### PR TITLE
Clean up the language-specific schema APIs.

### DIFF
--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -198,7 +198,7 @@ func initTestPackageSpec(t *testing.T) {
 func TestResourceNestedPropertyPythonCasing(t *testing.T) {
 	initTestPackageSpec(t)
 
-	schemaPkg, err := schema.ImportSpec(testPackageSpec)
+	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "importing spec")
 
 	modules := generateModulesFromSchemaPackage(unitTestTool, schemaPkg)

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -16,6 +16,7 @@
 package dotnet
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -94,12 +95,17 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) st
 func (d DocLanguageHelper) GetPropertyName(p *schema.Property) (string, error) {
 	propLangName := strings.Title(p.Name)
 
-	names := map[*schema.Property]string{}
-	properties := []*schema.Property{p}
-	if err := computePropertyNames(properties, names); err != nil {
-		return "", err
+	if raw, ok := p.Language["csharp"].(json.RawMessage); ok {
+		val, err := Importer.ImportPropertySpec(p, raw)
+		if err != nil {
+			return "", err
+		}
+		p.Language["csharp"] = val
 	}
 
+	names := map[*schema.Property]string{}
+	properties := []*schema.Property{p}
+	computePropertyNames(properties, names)
 	if name, ok := names[p]; ok {
 		return name, nil
 	}

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -58,7 +58,7 @@ var testPackageSpec = schema.PackageSpec{
 func getTestPackage(t *testing.T) *schema.Package {
 	t.Helper()
 
-	pkg, err := schema.ImportSpec(testPackageSpec)
+	pkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "could not import the test package spec")
 	return pkg
 }

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/dotnet/importer.go
+++ b/pkg/codegen/dotnet/importer.go
@@ -1,0 +1,75 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dotnet
+
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+)
+
+// CSharpPropertyInfo represents the C# language-specific info for a property.
+type CSharpPropertyInfo struct {
+	Name string `json:"name,omitempty"`
+}
+
+// CSharpPackageInfo represents the C# language-specific info for a package.
+type CSharpPackageInfo struct {
+	PackageReferences map[string]string `json:"packageReferences,omitempty"`
+	Namespaces        map[string]string `json:"namespaces,omitempty"`
+}
+
+// Importer implements schema.Language for .NET.
+var Importer schema.Language = importer(0)
+
+type importer int
+
+// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportPropertySpec decodes language-specific metadata associated with a Property.
+func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessage) (interface{}, error) {
+	var info CSharpPropertyInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
+func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportResourceSpec decodes language-specific metadata associated with a Resource.
+func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportFunctionSpec decodes language-specific metadata associated with a Function.
+func (importer) ImportFunctionSpec(function *schema.Function, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportPackageSpec decodes language-specific metadata associated with a Package.
+func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (interface{}, error) {
+	var info CSharpPackageInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}

--- a/pkg/codegen/dotnet/importer.go
+++ b/pkg/codegen/dotnet/importer.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ var Importer schema.Language = importer(0)
 
 type importer int
 
-// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+// ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
 func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -100,7 +100,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 }
 
 // GeneratePackagesMap generates a map of Go packages for resources, functions and types.
-func (d *DocLanguageHelper) GeneratePackagesMap(pkg *schema.Package, tool string, goInfo GoInfo) {
+func (d *DocLanguageHelper) GeneratePackagesMap(pkg *schema.Package, tool string, goInfo GoPackageInfo) {
 	d.packages = generatePackageContextMap(tool, pkg, goInfo)
 }
 

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -62,7 +62,7 @@ var testPackageSpec = schema.PackageSpec{
 func getTestPackage(t *testing.T) *schema.Package {
 	t.Helper()
 
-	pkg, err := schema.ImportSpec(testPackageSpec)
+	pkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "could not import the test package spec")
 	return pkg
 }

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/go/importer.go
+++ b/pkg/codegen/go/importer.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,7 +45,7 @@ var Importer schema.Language = importer(0)
 
 type importer int
 
-// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+// ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
 func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }

--- a/pkg/codegen/go/importer.go
+++ b/pkg/codegen/go/importer.go
@@ -1,0 +1,80 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gen
+
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+)
+
+// GoPackageInfo holds information required to generate the Go SDK from a schema.
+type GoPackageInfo struct {
+	// Base path for package imports
+	//
+	//    github.com/pulumi/pulumi-kubernetes/sdk/go/kubernetes
+	ImportBasePath string `json:"importBasePath,omitempty"`
+
+	// Map from module -> package name
+	//
+	//    { "flowcontrol.apiserver.k8s.io/v1alpha1": "flowcontrol/v1alpha1" }
+	//
+	ModuleToPackage map[string]string `json:"moduleToPackage,omitempty"`
+
+	// Map from package name -> package alias
+	//
+	//    { "github.com/pulumi/pulumi-kubernetes/sdk/go/kubernetes/flowcontrol/v1alpha1": "flowcontrolv1alpha1" }
+	//
+	PackageImportAliases map[string]string `json:"packageImportAliases,omitempty"`
+}
+
+// Importer implements schema.Language for Go.
+var Importer schema.Language = importer(0)
+
+type importer int
+
+// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportPropertySpec decodes language-specific metadata associated with a Property.
+func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
+func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportResourceSpec decodes language-specific metadata associated with a Resource.
+func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportFunctionSpec decodes language-specific metadata associated with a Function.
+func (importer) ImportFunctionSpec(function *schema.Function, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportPackageSpec decodes language-specific metadata associated with a Package.
+func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (interface{}, error) {
+	var info GoPackageInfo
+	if err := json.Unmarshal(raw, &info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}

--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -101,7 +101,7 @@ func (b *binder) loadPackageSchema(name string) error {
 		return err
 	}
 
-	pkg, err := schema.ImportSpec(spec)
+	pkg, err := schema.ImportSpec(spec, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/codegen/nodejs/doc_test.go
+++ b/pkg/codegen/nodejs/doc_test.go
@@ -61,7 +61,7 @@ var testPackageSpec = schema.PackageSpec{
 func getTestPackage(t *testing.T) *schema.Package {
 	t.Helper()
 
-	pkg, err := schema.ImportSpec(testPackageSpec)
+	pkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "could not import the test package spec")
 	return pkg
 }

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1165,25 +1165,12 @@ func genTypeScriptProjectFile(info NodePackageInfo, files fs) string {
 	return w.String()
 }
 
-// NodePackageInfo contains NodeJS specific overrides for a package.
-type NodePackageInfo struct {
-	PackageName        string            `json:"packageName,omitempty"`        // Custom name for the NPM package.
-	PackageDescription string            `json:"packageDescription,omitempty"` // Description for the NPM package.
-	Dependencies       map[string]string `json:"dependencies,omitempty"`       // NPM dependencies to add to package.json.
-	DevDependencies    map[string]string `json:"devDependencies,omitempty"`    // NPM dev-dependencies to add to package.json.
-	PeerDependencies   map[string]string `json:"peerDependencies,omitempty"`   // NPM peer-dependencies to add to package.json.
-	TypeScriptVersion  string            `json:"typescriptVersion,omitempty"`  // A specific version of TypeScript to include in package.json.
-	ModuleToPackage    map[string]string `json:"moduleToPackage,omitempty"`    // A map containing overrides for module names to package names.
-}
-
 func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]byte) (map[string][]byte, error) {
 	// Decode node-specific info
-	var info NodePackageInfo
-	if node, ok := pkg.Language["nodejs"]; ok {
-		if err := json.Unmarshal([]byte(node), &info); err != nil {
-			return nil, errors.Wrap(err, "decoding nodejs package info")
-		}
+	if err := pkg.ImportLanguages(map[string]schema.Language{"nodejs": Importer}); err != nil {
+		return nil, err
 	}
+	info, _ := pkg.Language["nodejs"].(NodePackageInfo)
 
 	// group resources, types, and functions into Go packages
 	modules := map[string]*modContext{}

--- a/pkg/codegen/nodejs/gen_intrinsics.go
+++ b/pkg/codegen/nodejs/gen_intrinsics.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -22,13 +22,20 @@ import (
 
 // NodePackageInfo contains NodeJS specific overrides for a package.
 type NodePackageInfo struct {
-	PackageName        string            `json:"packageName,omitempty"`        // Custom name for the NPM package.
-	PackageDescription string            `json:"packageDescription,omitempty"` // Description for the NPM package.
-	Dependencies       map[string]string `json:"dependencies,omitempty"`       // NPM dependencies to add to package.json.
-	DevDependencies    map[string]string `json:"devDependencies,omitempty"`    // NPM dev-dependencies to add to package.json.
-	PeerDependencies   map[string]string `json:"peerDependencies,omitempty"`   // NPM peer-dependencies to add to package.json.
-	TypeScriptVersion  string            `json:"typescriptVersion,omitempty"`  // A specific version of TypeScript to include in package.json.
-	ModuleToPackage    map[string]string `json:"moduleToPackage,omitempty"`    // A map containing overrides for module names to package names.
+	// Custom name for the NPM package.
+	PackageName string `json:"packageName,omitempty"`
+	// Description for the NPM package.
+	PackageDescription string `json:"packageDescription,omitempty"`
+	// NPM dependencies to add to package.json.
+	Dependencies map[string]string `json:"dependencies,omitempty"`
+	// NPM dev-dependencies to add to package.json.
+	DevDependencies map[string]string `json:"devDependencies,omitempty"`
+	// NPM peer-dependencies to add to package.json.
+	PeerDependencies map[string]string `json:"peerDependencies,omitempty"`
+	// A specific version of TypeScript to include in package.json.
+	TypeScriptVersion string `json:"typescriptVersion,omitempty"`
+	// A map containing overrides for module names to package names.
+	ModuleToPackage map[string]string `json:"moduleToPackage,omitempty"`
 }
 
 // Importer implements schema.Language for NodeJS.

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -1,0 +1,71 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nodejs
+
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+)
+
+// NodePackageInfo contains NodeJS specific overrides for a package.
+type NodePackageInfo struct {
+	PackageName        string            `json:"packageName,omitempty"`        // Custom name for the NPM package.
+	PackageDescription string            `json:"packageDescription,omitempty"` // Description for the NPM package.
+	Dependencies       map[string]string `json:"dependencies,omitempty"`       // NPM dependencies to add to package.json.
+	DevDependencies    map[string]string `json:"devDependencies,omitempty"`    // NPM dev-dependencies to add to package.json.
+	PeerDependencies   map[string]string `json:"peerDependencies,omitempty"`   // NPM peer-dependencies to add to package.json.
+	TypeScriptVersion  string            `json:"typescriptVersion,omitempty"`  // A specific version of TypeScript to include in package.json.
+	ModuleToPackage    map[string]string `json:"moduleToPackage,omitempty"`    // A map containing overrides for module names to package names.
+}
+
+// Importer implements schema.Language for NodeJS.
+var Importer schema.Language = importer(0)
+
+type importer int
+
+// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportPropertySpec decodes language-specific metadata associated with a Property.
+func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
+func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportResourceSpec decodes language-specific metadata associated with a Resource.
+func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportFunctionSpec decodes language-specific metadata associated with a Function.
+func (importer) ImportFunctionSpec(function *schema.Function, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportPackageSpec decodes language-specific metadata associated with a Package.
+func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (interface{}, error) {
+	var info NodePackageInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ var Importer schema.Language = importer(0)
 
 type importer int
 
-// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+// ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
 func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }

--- a/pkg/codegen/nodejs/utilities.go
+++ b/pkg/codegen/nodejs/utilities.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -107,6 +107,11 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(resourceName string) st
 
 // GenPropertyCaseMap generates the case maps for a property.
 func (d DocLanguageHelper) GenPropertyCaseMap(pkg *schema.Package, modName, tool string, prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string) {
+	if err := pkg.ImportLanguages(map[string]schema.Language{"python": Importer}); err != nil {
+		fmt.Printf("error building case map for %q in module %q", prop.Name, modName)
+		return
+	}
+
 	mod := &modContext{
 		pkg:                  pkg,
 		mod:                  modName,
@@ -115,9 +120,7 @@ func (d DocLanguageHelper) GenPropertyCaseMap(pkg *schema.Package, modName, tool
 		camelCaseToSnakeCase: camelCaseToSnakeCase,
 	}
 
-	if err := mod.recordProperty(prop); err != nil {
-		fmt.Printf("error building case map for %q in module %q", prop.Name, modName)
-	}
+	mod.recordProperty(prop)
 }
 
 // GetPropertyName is not implemented for Python because property names in Python must use

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/python/gen_intrinsics.go
+++ b/pkg/codegen/python/gen_intrinsics.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ var Importer schema.Language = importer(0)
 
 type importer int
 
-// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+// ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
 func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
 	return raw, nil
 }

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -1,0 +1,74 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package python
+
+import (
+	"encoding/json"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+)
+
+// PropertyInfo tracks Python-specific information associated with properties in a package.
+type PropertyInfo struct {
+	MapCase bool `json:"mapCase,omitempty"`
+}
+
+// PackageInfo tracks Python-specific information associated with a package.
+type PackageInfo struct {
+	Requires map[string]string `json:"requires,omitempty"`
+}
+
+// Importer implements schema.Language for Python.
+var Importer schema.Language = importer(0)
+
+type importer int
+
+// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+func (importer) ImportDefaultSpec(def *schema.DefaultValue, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportPropertySpec decodes language-specific metadata associated with a Property.
+func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessage) (interface{}, error) {
+	var info PropertyInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+// ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
+func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportResourceSpec decodes language-specific metadata associated with a Resource.
+func (importer) ImportResourceSpec(resource *schema.Resource, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportFunctionSpec decodes language-specific metadata associated with a Function.
+func (importer) ImportFunctionSpec(function *schema.Function, raw json.RawMessage) (interface{}, error) {
+	return raw, nil
+}
+
+// ImportPackageSpec decodes language-specific metadata associated with a Package.
+func (importer) ImportPackageSpec(pkg *schema.Package, raw json.RawMessage) (interface{}, error) {
+	var info PackageInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}

--- a/pkg/codegen/python/python.go
+++ b/pkg/codegen/python/python.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2020, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -289,7 +289,7 @@ type Package struct {
 
 // Language provides hooks for importing language-specific metadata in a package.
 type Language interface {
-	// ImportDefaultSpec decodes language-specific metadata associated with a Default.
+	// ImportDefaultSpec decodes language-specific metadata associated with a DefaultValue.
 	ImportDefaultSpec(def *DefaultValue, bytes json.RawMessage) (interface{}, error)
 	// ImportPropertySpec decodes language-specific metadata associated with a Property.
 	ImportPropertySpec(property *Property, bytes json.RawMessage) (interface{}, error)


### PR DESCRIPTION
Rather than forcing consumers to deal with language-specific data
ad-hoc, add an API that allows all language-specific data to be decoded
up-front.