### PR TITLE
[codegen/go] Fix accessors on struct ptr outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ CHANGELOG
 - Protect against panic when unprotecting non-existant resources
   [#4441](https://github.com/pulumi/pulumi/pull/4441)
 
+- Ensure Go accessor methods correctly support nested fields of optional outputs
+  [#4456](https://github.com/pulumi/pulumi/pull/4456)
+
+
 ## 2.0.0 (2020-04-16)
 =======
 - CLI behavior change.  Commands in non-interactive mode (i.e. when `pulumi` has its output piped to


### PR DESCRIPTION
The accesor methods on nestred struct Ptr outputs were previously not accepting pointer typed inputs to their applier callbacks as they should, and would thus always panic if used.

The "simple" fix would be to just accept the pointer type and blindly dereference it.  But this doesn't seem like the right experience - it would make these accessors very unsafe to use in practice.

Instead, this PR implements the accessors on pointer-typed outputs as nil-coaslescing, always lifting the output type into a pointer type and flowing a nil value into the result type.  This ensures the accessor will not nil-deref, and that user code can handle the `nil` value itself (or use `.Apply` directly to implement more specialized behaviour).

Before:

```go
// Name of your S3 bucket.
func (o BuildStorageLocationPtrOutput) Bucket() pulumi.StringOutput {
	return o.ApplyT(func(v BuildStorageLocation) string { return v.Bucket }).(pulumi.StringOutput)
}
```

After:

```go
// Name of your S3 bucket.
func (o BuildStorageLocationPtrOutput) Bucket() pulumi.StringPtrOutput {
	return o.ApplyT(func(v *BuildStorageLocation) *string {
		if v == nil {
			return nil
		}
		return &v.Bucket
	}).(pulumi.StringPtrOutput)
}
```

However, due to the decision to have this more usable behaviour, this is a breaking change, as some/many accessors now return a pointer type when they previously did not.

Fixes pulumi/pulumi-azure#530.