### PR TITLE
Fix output property names in Python codegen.

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -22,6 +22,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
@@ -32,6 +33,7 @@ type binder struct {
 	host    plugin.Host
 
 	packageSchemas map[string]*packageSchema
+	typeSchemas    map[model.Type]schema.Type
 
 	tokens syntax.TokenMap
 	nodes  []Node
@@ -60,6 +62,7 @@ func BindProgram(files []*syntax.File, host plugin.Host, opts ...model.BindOptio
 		host:           host,
 		tokens:         syntax.NewTokenMapForFiles(files),
 		packageSchemas: map[string]*packageSchema{},
+		typeSchemas:    map[model.Type]schema.Type{},
 		root:           model.NewRootScope(syntax.None),
 	}
 

--- a/pkg/codegen/hcl2/binder_resource.go
+++ b/pkg/codegen/hcl2/binder_resource.go
@@ -81,16 +81,16 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 	node.Token = token
 
 	// Create input and output types for the schema.
-	inputType := model.InputType(schemaTypeToType(&schema.ObjectType{Properties: inputProperties}))
+	inputType := model.InputType(b.schemaTypeToType(&schema.ObjectType{Properties: inputProperties}))
 
 	outputProperties := map[string]model.Type{
 		"id":  model.NewOutputType(model.StringType),
 		"urn": model.NewOutputType(model.StringType),
 	}
 	for _, prop := range properties {
-		outputProperties[prop.Name] = model.NewOutputType(schemaTypeToType(prop.Type))
+		outputProperties[prop.Name] = model.NewOutputType(b.schemaTypeToType(prop.Type))
 	}
-	outputType := model.NewObjectType(outputProperties)
+	outputType := model.NewObjectType(outputProperties, &schema.ObjectType{Properties: properties})
 
 	node.InputType, node.OutputType = inputType, outputType
 	return diagnostics

--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -124,22 +124,26 @@ func (b *binder) loadPackageSchema(name string) error {
 }
 
 // schemaTypeToType converts a schema.Type to a model Type.
-func schemaTypeToType(src schema.Type) model.Type {
+func (b *binder) schemaTypeToType(src schema.Type) (result model.Type) {
+	defer func() {
+		b.typeSchemas[result] = src
+	}()
+
 	switch src := src.(type) {
 	case *schema.ArrayType:
-		return model.NewListType(schemaTypeToType(src.ElementType))
+		return model.NewListType(b.schemaTypeToType(src.ElementType))
 	case *schema.MapType:
-		return model.NewMapType(schemaTypeToType(src.ElementType))
+		return model.NewMapType(b.schemaTypeToType(src.ElementType))
 	case *schema.ObjectType:
 		properties := map[string]model.Type{}
 		for _, prop := range src.Properties {
-			t := schemaTypeToType(prop.Type)
+			t := b.schemaTypeToType(prop.Type)
 			if !prop.IsRequired {
 				t = model.NewOptionalType(t)
 			}
 			properties[prop.Name] = t
 		}
-		return model.NewObjectType(properties)
+		return model.NewObjectType(properties, src)
 	case *schema.TokenType:
 		t, ok := model.GetOpaqueType(src.Token)
 		if !ok {
@@ -149,14 +153,14 @@ func schemaTypeToType(src schema.Type) model.Type {
 		}
 
 		if src.UnderlyingType != nil {
-			underlyingType := schemaTypeToType(src.UnderlyingType)
+			underlyingType := b.schemaTypeToType(src.UnderlyingType)
 			return model.NewUnionType(t, underlyingType)
 		}
 		return t
 	case *schema.UnionType:
 		types := make([]model.Type, len(src.ElementTypes))
 		for i, src := range src.ElementTypes {
-			types[i] = schemaTypeToType(src)
+			types[i] = b.schemaTypeToType(src)
 		}
 		return model.NewUnionType(types...)
 	default:

--- a/pkg/codegen/hcl2/functions.go
+++ b/pkg/codegen/hcl2/functions.go
@@ -76,6 +76,13 @@ var pulumiBuiltins = map[string]*model.Function{
 			}, diagnostics
 		})),
 	"entries": model.NewFunction(model.GenericFunctionSignature(getEntriesSignature)),
+	"fileArchive": model.NewFunction(model.StaticFunctionSignature{
+		Parameters: []model.Parameter{{
+			Name: "path",
+			Type: model.StringType,
+		}},
+		ReturnType: ArchiveType,
+	}),
 	"fileAsset": model.NewFunction(model.StaticFunctionSignature{
 		Parameters: []model.Parameter{{
 			Name: "path",

--- a/pkg/codegen/hcl2/invoke.go
+++ b/pkg/codegen/hcl2/invoke.go
@@ -97,13 +97,13 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 	if fn.Inputs == nil {
 		signature.Parameters[1].Type = model.NewOptionalType(model.NewObjectType(map[string]model.Type{}))
 	} else {
-		signature.Parameters[1].Type = schemaTypeToType(fn.Inputs)
+		signature.Parameters[1].Type = b.schemaTypeToType(fn.Inputs)
 	}
 
 	if fn.Outputs == nil {
 		signature.ReturnType = model.NewObjectType(map[string]model.Type{})
 	} else {
-		signature.ReturnType = schemaTypeToType(fn.Outputs)
+		signature.ReturnType = b.schemaTypeToType(fn.Outputs)
 	}
 	signature.ReturnType = model.NewPromiseType(signature.ReturnType)
 

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -37,6 +37,7 @@ type Type interface {
 
 	AssignableFrom(src Type) bool
 	ConversionFrom(src Type) ConversionKind
+	GetAnnotations() []interface{}
 	String() string
 
 	conversionFrom(src Type, unifying bool) ConversionKind

--- a/pkg/codegen/hcl2/model/type_eventuals.go
+++ b/pkg/codegen/hcl2/model/type_eventuals.go
@@ -76,7 +76,7 @@ func resolveEventuals(t Type, resolveOutputs bool) (Type, typeTransform) {
 			}
 			properties[k] = property
 		}
-		return NewObjectType(properties), transform
+		return NewObjectType(properties, t.Annotations...), transform
 	case *TupleType:
 		transform := makeIdentity
 		elements := make([]Type, len(t.ElementTypes))

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -104,6 +104,10 @@ func (t *ListType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
+func (t *ListType) GetAnnotations() []interface{} {
+	return nil
+}
+
 func (t *ListType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("list(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -103,6 +103,10 @@ func (t *MapType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
+func (t *MapType) GetAnnotations() []interface{} {
+	return nil
+}
+
 func (t *MapType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("map(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -46,6 +46,10 @@ func (noneType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
+func (noneType) GetAnnotations() []interface{} {
+	return nil
+}
+
 func (noneType) String() string {
 	return "none"
 }

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -31,6 +31,8 @@ import (
 type ObjectType struct {
 	// Properties records the types of the object's properties.
 	Properties map[string]Type
+	// Annotations records any annotations associated with the object type.
+	Annotations []interface{}
 
 	propertyUnion Type
 	s             string
@@ -39,9 +41,13 @@ type ObjectType struct {
 // The set of object types, indexed by string representation.
 var objectTypes = map[string]*ObjectType{}
 
-// NewObjectType creates a new object type with the given properties.
-func NewObjectType(properties map[string]Type) *ObjectType {
-	t := &ObjectType{Properties: properties}
+// NewObjectType creates a new object type with the given properties and annotations.
+func NewObjectType(properties map[string]Type, annotations ...interface{}) *ObjectType {
+	t := &ObjectType{Properties: properties, Annotations: annotations}
+	if len(annotations) != 0 {
+		return t
+	}
+
 	if t, ok := objectTypes[t.String()]; ok {
 		return t
 	}
@@ -178,6 +184,10 @@ func (t *ObjectType) conversionFrom(src Type, unifying bool) ConversionKind {
 		}
 		return NoConversion
 	})
+}
+
+func (t *ObjectType) GetAnnotations() []interface{} {
+	return t.Annotations
 }
 
 func (t *ObjectType) String() string {

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -133,6 +133,10 @@ func (t *OpaqueType) ConversionFrom(src Type) ConversionKind {
 	return t.conversionFrom(src, false)
 }
 
+func (t *OpaqueType) GetAnnotations() []interface{} {
+	return nil
+}
+
 func (t *OpaqueType) String() string {
 	if t.s == "" {
 		switch t {

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -88,6 +88,10 @@ func (t *OutputType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
+func (t *OutputType) GetAnnotations() []interface{} {
+	return t.ElementType.GetAnnotations()
+}
+
 func (t *OutputType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("output(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -82,6 +82,10 @@ func (t *PromiseType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
+func (t *PromiseType) GetAnnotations() []interface{} {
+	return t.ElementType.GetAnnotations()
+}
+
 func (t *PromiseType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("promise(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -89,6 +89,10 @@ func (t *SetType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
+func (t *SetType) GetAnnotations() []interface{} {
+	return nil
+}
+
 func (t *SetType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("set(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -189,6 +189,10 @@ func (t *TupleType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
+func (t *TupleType) GetAnnotations() []interface{} {
+	return nil
+}
+
 func (t *TupleType) String() string {
 	if t.s == "" {
 		elements := make([]string, len(t.ElementTypes))

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -180,6 +180,10 @@ func (t *UnionType) conversionTo(dest Type, unifying bool) ConversionKind {
 	return conversionKind
 }
 
+func (t *UnionType) GetAnnotations() []interface{} {
+	return nil
+}
+
 func (t *UnionType) String() string {
 	if t.s == "" {
 		elements := make([]string, len(t.ElementTypes))

--- a/pkg/codegen/hcl2/model/visitor.go
+++ b/pkg/codegen/hcl2/model/visitor.go
@@ -52,21 +52,20 @@ func VisitBodyItem(n BodyItem, pre, post BodyItemVisitor) (BodyItem, hcl.Diagnos
 	if pre == nil {
 		pre = BodyItemIdentityVisitor
 	}
-	if post == nil {
-		post = BodyItemIdentityVisitor
-	}
 
 	nn, preDiags := pre(n)
 
 	var postDiags hcl.Diagnostics
-	switch n := nn.(type) {
-	case *Attribute:
-		nn, postDiags = post(n)
-	case *Block:
-		nn, postDiags = visitBlock(n, pre, post)
-	default:
-		contract.Failf("unexpected node type in visitExpression: %T", n)
-		return nil, nil
+	if post != nil {
+		switch n := nn.(type) {
+		case *Attribute:
+			nn, postDiags = post(n)
+		case *Block:
+			nn, postDiags = visitBlock(n, pre, post)
+		default:
+			contract.Failf("unexpected node type in visitExpression: %T", n)
+			return nil, nil
+		}
 	}
 
 	return nn, append(preDiags, postDiags...)
@@ -303,49 +302,48 @@ func VisitExpression(n Expression, pre, post ExpressionVisitor) (Expression, hcl
 	if pre == nil {
 		pre = IdentityVisitor
 	}
-	if post == nil {
-		post = IdentityVisitor
-	}
 
 	nn, preDiags := pre(n)
 
 	var postDiags hcl.Diagnostics
-	switch n := nn.(type) {
-	case *AnonymousFunctionExpression:
-		nn, postDiags = visitAnonymousFunction(n, pre, post)
-	case *BinaryOpExpression:
-		nn, postDiags = visitBinaryOp(n, pre, post)
-	case *ConditionalExpression:
-		nn, postDiags = visitConditional(n, pre, post)
-	case *ErrorExpression:
-		nn, postDiags = post(n)
-	case *ForExpression:
-		nn, postDiags = visitFor(n, pre, post)
-	case *FunctionCallExpression:
-		nn, postDiags = visitFunctionCall(n, pre, post)
-	case *IndexExpression:
-		nn, postDiags = visitIndex(n, pre, post)
-	case *LiteralValueExpression:
-		nn, postDiags = post(n)
-	case *ObjectConsExpression:
-		nn, postDiags = visitObjectCons(n, pre, post)
-	case *RelativeTraversalExpression:
-		nn, postDiags = visitRelativeTraversal(n, pre, post)
-	case *ScopeTraversalExpression:
-		nn, postDiags = post(n)
-	case *SplatExpression:
-		nn, postDiags = visitSplat(n, pre, post)
-	case *TemplateExpression:
-		nn, postDiags = visitTemplate(n, pre, post)
-	case *TemplateJoinExpression:
-		nn, postDiags = visitTemplateJoin(n, pre, post)
-	case *TupleConsExpression:
-		nn, postDiags = visitTupleCons(n, pre, post)
-	case *UnaryOpExpression:
-		nn, postDiags = visitUnaryOp(n, pre, post)
-	default:
-		contract.Failf("unexpected node type in visitExpression: %T", n)
-		return nil, nil
+	if post != nil {
+		switch n := nn.(type) {
+		case *AnonymousFunctionExpression:
+			nn, postDiags = visitAnonymousFunction(n, pre, post)
+		case *BinaryOpExpression:
+			nn, postDiags = visitBinaryOp(n, pre, post)
+		case *ConditionalExpression:
+			nn, postDiags = visitConditional(n, pre, post)
+		case *ErrorExpression:
+			nn, postDiags = post(n)
+		case *ForExpression:
+			nn, postDiags = visitFor(n, pre, post)
+		case *FunctionCallExpression:
+			nn, postDiags = visitFunctionCall(n, pre, post)
+		case *IndexExpression:
+			nn, postDiags = visitIndex(n, pre, post)
+		case *LiteralValueExpression:
+			nn, postDiags = post(n)
+		case *ObjectConsExpression:
+			nn, postDiags = visitObjectCons(n, pre, post)
+		case *RelativeTraversalExpression:
+			nn, postDiags = visitRelativeTraversal(n, pre, post)
+		case *ScopeTraversalExpression:
+			nn, postDiags = post(n)
+		case *SplatExpression:
+			nn, postDiags = visitSplat(n, pre, post)
+		case *TemplateExpression:
+			nn, postDiags = visitTemplate(n, pre, post)
+		case *TemplateJoinExpression:
+			nn, postDiags = visitTemplateJoin(n, pre, post)
+		case *TupleConsExpression:
+			nn, postDiags = visitTupleCons(n, pre, post)
+		case *UnaryOpExpression:
+			nn, postDiags = visitUnaryOp(n, pre, post)
+		default:
+			contract.Failf("unexpected node type in visitExpression: %T", n)
+			return nil, nil
+		}
 	}
 
 	return nn, append(preDiags, postDiags...)
@@ -370,9 +368,6 @@ func VisitExpressions(n BodyItem, pre, post ExpressionVisitor) hcl.Diagnostics {
 
 	if pre == nil {
 		pre = IdentityVisitor
-	}
-	if post == nil {
-		post = IdentityVisitor
 	}
 
 	switch n := n.(type) {

--- a/pkg/codegen/hcl2/program.go
+++ b/pkg/codegen/hcl2/program.go
@@ -16,11 +16,13 @@ package hcl2
 
 import (
 	"io"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 )
 
 // Node represents a single definition in a program or component. Nodes may be config, locals, resources, or outputs.
@@ -95,4 +97,19 @@ func (p *Program) NewDiagnosticWriter(w io.Writer, width uint, color bool) hcl.D
 // BindExpression binds an HCL2 expression in the top-level context of the program.
 func (p *Program) BindExpression(node hclsyntax.Node) (model.Expression, hcl.Diagnostics) {
 	return p.binder.bindExpression(node)
+}
+
+// Packages returns the list of package schemas used by this program.
+func (p *Program) Packages() []*schema.Package {
+	names := make([]string, 0, len(p.binder.packageSchemas))
+	for name := range p.binder.packageSchemas {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	packages := make([]*schema.Package, len(names))
+	for i, name := range names {
+		packages[i] = p.binder.packageSchemas[name].schema
+	}
+	return packages
 }

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp
@@ -88,7 +88,7 @@ resource appService "aws:ecs:Service" {
 	desiredCount = 5
 	launchType = "FARGATE"
 	taskDefinition = appTask.arn
-	networkConfiguraiton = {
+	networkConfiguration = {
 		assignPublicIp = true
 		subnets = subnets.ids
 		securityGroups = [webSecurityGroup.id]

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
@@ -88,4 +88,4 @@ app_service = aws.ecs.Service("appService",
         "containerName": "my-app",
         "containerPort": 80,
     }])
-pulumi.export("url", web_load_balancer.dnsName)
+pulumi.export("url", web_load_balancer.dns_name)

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
@@ -2,12 +2,8 @@ import pulumi
 import json
 import pulumi_aws as aws
 
-vpc = aws.ec2.get_vpc({
-    "default": True,
-})
-subnets = aws.ec2.get_subnet_ids({
-    "vpcId": vpc.id,
-})
+vpc = aws.ec2.get_vpc(default=True)
+subnets = aws.ec2.get_subnet_ids(vpc_id=vpc.id)
 # Create a security group that permits HTTP ingress and unrestricted egress.
 web_security_group = aws.ec2.SecurityGroup("webSecurityGroup",
     vpc_id=vpc.id,
@@ -78,7 +74,7 @@ app_service = aws.ecs.Service("appService",
     desired_count=5,
     launch_type="FARGATE",
     task_definition=app_task.arn,
-    network_configuraiton={
+    network_configuration={
         "assignPublicIp": True,
         "subnets": subnets.ids,
         "securityGroups": [web_security_group.id],

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.ts
@@ -83,7 +83,7 @@ const appService = new aws.ecs.Service("appService", {
     desiredCount: 5,
     launchType: "FARGATE",
     taskDefinition: appTask.arn,
-    networkConfiguraiton: {
+    networkConfiguration: {
         assignPublicIp: true,
         subnets: subnets.then(subnets => subnets.ids),
         securityGroups: [webSecurityGroup.id],

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.py
@@ -30,4 +30,4 @@ bucket_policy = aws.s3.BucketPolicy("bucketPolicy",
         }],
     })))
 pulumi.export("bucketName", site_bucket.bucket)
-pulumi.export("websiteUrl", site_bucket.websiteEndpoint)
+pulumi.export("websiteUrl", site_bucket.website_endpoint)

--- a/pkg/codegen/internal/test/testdata/aws-s3-logging.pp
+++ b/pkg/codegen/internal/test/testdata/aws-s3-logging.pp
@@ -1,0 +1,11 @@
+resource logs "aws:s3:Bucket" {}
+
+resource bucket "aws:s3:Bucket" {
+	loggings = [{
+		targetBucket = logs.bucket,
+	}]
+}
+
+output targetBucket {
+	value = bucket.loggings[0].targetBucket
+}

--- a/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.py
@@ -1,0 +1,8 @@
+import pulumi
+import pulumi_aws as aws
+
+logs = aws.s3.Bucket("logs")
+bucket = aws.s3.Bucket("bucket", loggings=[{
+    "targetBucket": logs.bucket,
+}])
+pulumi.export("targetBucket", bucket.loggings[0].targetBucket)

--- a/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.ts
@@ -1,0 +1,8 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const logs = new aws.s3.Bucket("logs", {});
+const bucket = new aws.s3.Bucket("bucket", {loggings: [{
+    targetBucket: logs.bucket,
+}]});
+export const targetBucket = bucket.loggings.apply(loggings => loggings[0].targetBucket);

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.py
@@ -24,9 +24,9 @@ server = aws.ec2.Instance("server",
     instance_type="t2.micro",
     security_groups=[security_group.name],
     ami=ami.id,
-    user_data=f"""#!/bin/bash
-echo \"Hello, World!\" > index.html
+    user_data="""#!/bin/bash
+echo "Hello, World!" > index.html
 nohup python -m SimpleHTTPServer 80 &
 """)
-pulumi.export("publicIp", server.publicIp)
-pulumi.export("publicHostName", server.publicDns)
+pulumi.export("publicIp", server.public_ip)
+pulumi.export("publicHostName", server.public_dns)

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.py
@@ -8,14 +8,12 @@ security_group = aws.ec2.SecurityGroup("securityGroup", ingress=[{
     "toPort": 0,
     "cidrBlocks": ["0.0.0.0/0"],
 }])
-ami = aws.get_ami({
-    "filters": [{
+ami = aws.get_ami(filters=[{
         "name": "name",
         "values": ["amzn-ami-hvm-*-x86_64-ebs"],
     }],
-    "owners": ["137112412989"],
-    "mostRecent": True,
-})
+    owners=["137112412989"],
+    most_recent=True)
 # Create a simple web server using the startup script for the instance.
 server = aws.ec2.Instance("server",
     tags={

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -829,7 +829,6 @@ func (mod *modContext) recordProperty(prop *schema.Property) {
 	if python, ok := prop.Language["python"]; ok {
 		mapCase = python.(PropertyInfo).MapCase
 	}
-
 	if mapCase {
 		snakeCaseName := PyName(prop.Name)
 		mod.snakeCaseToCamelCase[snakeCaseName] = prop.Name

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model/format"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 )
 
@@ -40,6 +41,13 @@ type generator struct {
 }
 
 func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics, error) {
+	// Import Python-specific schema info.
+	for _, p := range program.Packages() {
+		if err := p.ImportLanguages(map[string]schema.Language{"python": Importer}); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	// Linearize the nodes into an order appropriate for procedural code generation.
 	nodes := hcl2.Linearize(program)
 

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -208,6 +208,11 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		}
 		indenter(func() {
 			for _, attr := range r.Inputs {
+				attrType, diags := r.InputType.Traverse(hcl.TraverseAttr{Name: attr.Name})
+				contract.Ignore(diags)
+
+				g.lowerObjectKeys(attr.Value, attrType.(model.Type))
+
 				propertyName := pyName(attr.Name, false)
 				if len(r.Inputs) == 1 {
 					g.Fgenf(w, ", %s=%.v", propertyName, g.lowerExpression(attr.Value))

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -274,7 +275,9 @@ func (g *generator) genEscapedString(w runeWriter, v string, escapeNewlines, esc
 				c = 'n'
 			}
 		case '"', '\\':
-			w.WriteRune('\\')
+			if escapeNewlines {
+				w.WriteRune('\\')
+			}
 		case '{', '}':
 			if escapeBraces {
 				w.WriteRune(c)
@@ -344,21 +347,39 @@ func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsE
 	}
 }
 
-func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, types []model.Traversable) {
-	for _, part := range traversal {
+func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, parts []model.Traversable) {
+	for i, traverser := range traversal {
 		var key cty.Value
-		switch part := part.(type) {
+		switch traverser := traverser.(type) {
 		case hcl.TraverseAttr:
-			key = cty.StringVal(part.Name)
+			key = cty.StringVal(traverser.Name)
 		case hcl.TraverseIndex:
-			key = part.Key
+			key = traverser.Key
 		default:
-			contract.Failf("unexpected traversal part of type %T (%v)", part, part.SourceRange())
+			contract.Failf("unexpected traverser of type %T (%v)", traverser, traverser.SourceRange())
 		}
 
 		switch key.Type() {
 		case cty.String:
 			keyVal := key.AsString()
+
+			receiver := parts[i]
+			if receiver, ok := receiver.(model.TypedTraversable); ok {
+				annotations := receiver.Type().GetAnnotations()
+				if len(annotations) == 1 {
+					sch := annotations[0].(*schema.ObjectType)
+					if p, ok := sch.Property(keyVal); ok {
+						mapCase := true
+						if info, ok := p.Language["python"].(PropertyInfo); ok {
+							mapCase = info.MapCase
+						}
+						if mapCase {
+							keyVal = PyName(keyVal)
+						}
+					}
+				}
+			}
+
 			if isLegalIdentifier(keyVal) {
 				g.Fgenf(w, ".%s", keyVal)
 			} else {
@@ -400,27 +421,30 @@ func (g *generator) GenTemplateExpression(w io.Writer, expr *model.TemplateExpre
 		}
 	}
 
-	isMultiLine, quotes := false, `"`
+	prefix, isMultiLine, quotes := "", false, `"`
 	for i, part := range expr.Parts {
-		if lit, ok := part.(*model.LiteralValueExpression); ok && lit.Type() == model.StringType {
-			v := lit.Value.AsString()
-			switch strings.Count(v, "\n") {
-			case 0:
-				continue
-			case 1:
-				if i == 0 && v[0] == '\n' || i == len(expr.Parts)-1 && v[len(v)-1] == '\n' {
+		if lit, ok := part.(*model.LiteralValueExpression); ok {
+			if !isMultiLine && lit.Type() == model.StringType {
+				v := lit.Value.AsString()
+				switch strings.Count(v, "\n") {
+				case 0:
 					continue
+				case 1:
+					if i == 0 && v[0] == '\n' || i == len(expr.Parts)-1 && v[len(v)-1] == '\n' {
+						continue
+					}
 				}
+				isMultiLine, quotes = true, `"""`
 			}
-			isMultiLine, quotes = true, `"""`
-			break
+		} else {
+			prefix = "f"
 		}
 	}
 
 	b := bufio.NewWriter(w)
 	defer b.Flush()
 
-	g.Fprintf(b, `f%s`, quotes)
+	g.Fprintf(b, "%s%s", prefix, quotes)
 	for _, expr := range expr.Parts {
 		if lit, ok := expr.(*model.LiteralValueExpression); ok && lit.Type() == model.StringType {
 			g.genEscapedString(b, lit.Value.AsString(), !isMultiLine, true)

--- a/pkg/codegen/python/gen_program_lower.go
+++ b/pkg/codegen/python/gen_program_lower.go
@@ -5,7 +5,9 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // parseProxyApply attempts to match the given parsed apply against the pattern (call __applyArg 0). If the call
@@ -56,4 +58,78 @@ func (g *generator) lowerProxyApplies(expr model.Expression) (model.Expression, 
 		return expr, nil
 	}
 	return model.VisitExpression(expr, model.IdentityVisitor, rewriter)
+}
+
+func (g *generator) mapObjectKey(key string, obj *schema.ObjectType) string {
+	if obj == nil {
+		return key
+	}
+
+	prop, ok := obj.Property(key)
+	if !ok {
+		return key
+	}
+
+	mapCase := true
+	if info, ok := prop.Language["python"]; ok {
+		mapCase = info.(PropertyInfo).MapCase
+	}
+	if mapCase {
+		return PyName(key)
+	}
+
+	return key
+}
+
+func (g *generator) getObjectSchema(typ model.Type) *schema.ObjectType {
+	typ = model.ResolveOutputs(typ)
+
+	if union, ok := typ.(*model.UnionType); ok {
+		for _, t := range union.ElementTypes {
+			if obj := g.getObjectSchema(t); obj != nil {
+				return obj
+			}
+		}
+		return nil
+	}
+
+	annotations := typ.GetAnnotations()
+	if len(annotations) == 1 {
+		return annotations[0].(*schema.ObjectType)
+	}
+	return nil
+}
+
+func (g *generator) lowerObjectKeys(expr model.Expression, destType model.Type) {
+	rewriter := func(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+		switch expr := expr.(type) {
+		case *model.ObjectConsExpression:
+			obj := g.getObjectSchema(destType)
+			for _, item := range expr.Items {
+				// Ignore non-literal keys
+				valueType := model.Type(model.DynamicType)
+				if key, ok := item.Key.(*model.LiteralValueExpression); ok && key.Value.Type().Equals(cty.String) {
+					k := key.Value.AsString()
+
+					vt, diags := destType.Traverse(hcl.TraverseAttr{Name: k})
+					contract.Ignore(diags)
+
+					valueType = vt.(model.Type)
+					key.Value = cty.StringVal(g.mapObjectKey(k, obj))
+				}
+
+				g.lowerObjectKeys(item.Value, valueType)
+			}
+		case *model.TupleConsExpression:
+			valueType, diags := destType.Traverse(hcl.TraverseIndex{Key: cty.NumberIntVal(0)})
+			contract.Ignore(diags)
+
+			for _, element := range expr.Expressions {
+				g.lowerObjectKeys(element, valueType.(model.Type))
+			}
+		}
+		return expr, nil
+	}
+	_, diags := model.VisitExpression(expr, rewriter, nil)
+	contract.Assert(len(diags) == 0)
 }

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -953,6 +953,8 @@ func bindDefaultValue(value interface{}, spec *DefaultSpec, typ Type) (*DefaultV
 	return dv, nil
 }
 
+// bindProperties binds the map of property specs and list of required properties into a sorted list of peroperties and
+// a lookup table.
 func (t *types) bindProperties(properties map[string]PropertySpec,
 	required []string) ([]*Property, map[string]*Property, error) {
 


### PR DESCRIPTION
Some property names are mapped from their `camelCase` Pulumi name to a
`snake_case` Python name. This mapping is irregular, and only occurs for
resources properties and function calls.

Note that there's still more work to do here: this only fixes names on
the output side; the input side is still broken for nested resource
proprerties and function calls.

The underlying design--annotated types in `hcl2/model`--may need some
additional work in the future, but I _believe_ it's good enough for now.