### PR TITLE
[codegen/docs] Add an exclusion to manually render the k8s overlay resource constructor params for Python

### DIFF
--- a/pkg/codegen/docs/gen_kubernetes.go
+++ b/pkg/codegen/docs/gen_kubernetes.go
@@ -44,7 +44,7 @@ func getKubernetesOverlayPythonFormalParams(modName string) []formalParam {
 	case "helm/v2", "helm/v3":
 		params = []formalParam{
 			{
-				Name:         "config",
+				Name: "config",
 			},
 			{
 				Name:         "opts",
@@ -54,7 +54,7 @@ func getKubernetesOverlayPythonFormalParams(modName string) []formalParam {
 	case "yaml":
 		params = []formalParam{
 			{
-				Name:         "file",
+				Name: "file",
 			},
 			{
 				Name:         "opts",
@@ -72,10 +72,10 @@ func getKubernetesOverlayPythonFormalParams(modName string) []formalParam {
 	case "apiextensions":
 		params = []formalParam{
 			{
-				Name:         "api_version",
+				Name: "api_version",
 			},
 			{
-				Name:         "kind",
+				Name: "kind",
 			},
 			{
 				Name:         "metadata",

--- a/pkg/codegen/docs/gen_kubernetes.go
+++ b/pkg/codegen/docs/gen_kubernetes.go
@@ -35,6 +35,61 @@ func (mod *modContext) isKubernetesOverlayModule() bool {
 	return mod.mod == "helm/v2" || mod.mod == "yaml"
 }
 
+// getKubernetesOverlayPythonFormalParams returns the formal params to render
+// for a Kubernetes overlay resource. These resources do not follow convention
+// that other resources do, so it is best to manually set these.
+func getKubernetesOverlayPythonFormalParams(modName string) []formalParam {
+	var params []formalParam
+	switch modName {
+	case "helm/v2", "helm/v3":
+		params = []formalParam{
+			{
+				Name:         "config",
+			},
+			{
+				Name:         "opts",
+				DefaultValue: "=None",
+			},
+		}
+	case "yaml":
+		params = []formalParam{
+			{
+				Name:         "file",
+			},
+			{
+				Name:         "opts",
+				DefaultValue: "=None",
+			},
+			{
+				Name:         "transformations",
+				DefaultValue: "=None",
+			},
+			{
+				Name:         "resource_prefix",
+				DefaultValue: "=None",
+			},
+		}
+	case "apiextensions":
+		params = []formalParam{
+			{
+				Name:         "api_version",
+			},
+			{
+				Name:         "kind",
+			},
+			{
+				Name:         "metadata",
+				DefaultValue: "=None",
+			},
+			{
+				Name:         "opts",
+				DefaultValue: "=None",
+			},
+		}
+	}
+	return params
+}
+
 func getKubernetesMod(pkg *schema.Package, token string, modules map[string]*modContext, tool string) *modContext {
 	modName := pkg.TokenToModule(token)
 	// Kubernetes' moduleFormat in the schema will match everything

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -28,7 +28,7 @@
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language python %}}" }}
-<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span><span class="nf">{{ .Header.Title }}</span><span class="p">(resource_name, opts=None, </span>{{ htmlSafe .ConstructorParams.python }}<span class="p">, __props__=None);</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span><span class="nf">{{ .Header.Title }}</span><span class="p">(resource_name, </span>{{ htmlSafe .ConstructorParams.python }}<span class="p">);</span></code></pre></div>
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language go %}}" }}


### PR DESCRIPTION
Fixes #4464.

* Update the docs generator to exclude the `__props__` param from the constructor signature for a k8s resource.
* Render the constructor params for k8s overlay resources according to what is actually in our Python SDK today.