### PR TITLE
[codegen/go] Handle recursive types when marking optional properties to use Ptr types in Go

### DIFF
--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -97,6 +97,13 @@ func initTestPackageSpec(t *testing.T) {
 							Type: "boolean",
 						},
 					},
+					"recursiveType": {
+						Description: "I am a recursive type.",
+						Language:    pythonMapCase,
+						TypeSpec: schema.TypeSpec{
+							Ref: "#/types/prov:module/ResourceOptions:ResourceOptions",
+						},
+					},
 				},
 			},
 			"prov:module/ResourceOptions2:ResourceOptions2": {
@@ -145,6 +152,12 @@ func initTestPackageSpec(t *testing.T) {
 					"options2Prop": {
 						TypeSpec: schema.TypeSpec{
 							Ref: "#/types/prov:module/ResourceOptions2:ResourceOptions2",
+						},
+					},
+					"recursiveType": {
+						Description: "I am a recursive type.",
+						TypeSpec: schema.TypeSpec{
+							Ref: "#/types/prov:module/ResourceOptions:ResourceOptions",
 						},
 					},
 				},

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1083,8 +1083,8 @@ func generatePackageContextMap(tool string, pkg *schema.Package, goInfo GoPackag
 	markOptionalPropertyTypesAsRequiringPtr = func(parent *schema.ObjectType, props []*schema.Property, parentOptional bool) {
 		for _, p := range props {
 			if obj, ok := p.Type.(*schema.ObjectType); ok && (!p.IsRequired || parentOptional) {
-				// Skip recursive recursive types. For example, at the time of this writing
-				// JSONSchemaProps in the package can have properties with a type of JSONSchemaProps.
+				// Skip recursive recursive types. For example, JSONSchemaProps in the Kubernetes
+				// package can have properties with a type of JSONSchemaProps.
 				if parent != nil && parent.Token == obj.Token {
 					continue
 				}


### PR DESCRIPTION
An issue was introduced with https://github.com/pulumi/pulumi/pull/4456 that specifically affects the Kubernetes package due to the recursive nature of the `JSONSchemaProps` nested type. I have updated the test in the docs codegen to cover this scenario.