### PR TITLE
Fix Python module names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ CHANGELOG
 - Ensure Go accessor methods correctly support nested fields of optional outputs
   [#4456](https://github.com/pulumi/pulumi/pull/4456)
 
+- Ensure generated Python module names are keyword-safe.
+  [#4473](https://github.com/pulumi/pulumi/pull/4473)
+
 
 ## 2.0.0 (2020-04-16)
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1152,7 +1152,7 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 
 	var getMod func(token string) *modContext
 	getMod = func(token string) *modContext {
-		modName := pkg.TokenToModule(token)
+		modName := PyName(pkg.TokenToModule(token))
 		mod, ok := modules[modName]
 		if !ok {
 			mod = &modContext{

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -72,7 +72,7 @@ func pyName(pulumiName string, isObjectKey bool) string {
 	if isObjectKey {
 		return fmt.Sprintf("%q", pulumiName)
 	}
-	return PyName(cleanName(pulumiName))
+	return PyName(pulumiName)
 }
 
 // genLeadingTrivia generates the list of leading trivia assicated with a given token.
@@ -167,7 +167,13 @@ func (g *generator) genNode(w io.Writer, n hcl2.Node) {
 func resourceTypeName(r *hcl2.Resource) (string, string, string, hcl.Diagnostics) {
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diagnostics := r.DecomposeToken()
-	return pyName(pkg, false), strings.Replace(module, "/", ".", -1), title(member), diagnostics
+
+	components := strings.Split(module, ".")
+	for i, component := range components {
+		components[i] = PyName(component)
+	}
+
+	return pyName(pkg, false), strings.Join(components, "."), title(member), diagnostics
 }
 
 // makeResourceName returns the expression that should be emitted for a resource's "name" parameter given its base name

--- a/pkg/codegen/python/python.go
+++ b/pkg/codegen/python/python.go
@@ -72,7 +72,7 @@ func PyName(name string) string {
 	var components []string     // The components that will be joined together with underscores
 	var currentComponent []rune // The characters composing the current component being built
 	state := stateFirst
-	for _, char := range name {
+	for _, char := range cleanName(name) {
 		switch state {
 		case stateFirst:
 			if unicode.IsUpper(char) {


### PR DESCRIPTION
In particular, ensure that they are keyword-safe. This affects
`aws:lambda:*` in particular: prior to these changes, we were generating
code into `pulumi_aws.lamdba`, which is not referencable due to its use
of the `lamdba` keyword. With these changes, we generate code into
`pulumi_aws.lambda_`.

There is also a small fix for multi-line non-formatted strings: these
strings do not need escaped braces.