### PR TITLE
Order secret outputs in stack references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (unreleased)
 
+- Order secretOutputNames when used in stack references
+  [#4481](https://github.com/pulumi/pulumi/pull/4481)
+
 - Add support for a `PULUMI_CONSOLE_DOMAIN` environment variable to override the
   behavior for how URLs to the Pulumi Console are generated.
   [#4410](https://github.com/pulumi/pulumi/pull/4410)

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -3,6 +3,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
@@ -208,6 +209,11 @@ func (p *builtinProvider) readStackReference(inputs resource.PropertyMap) (resou
 			secretOutputs = append(secretOutputs, resource.NewStringProperty(string(k)))
 		}
 	}
+
+	// Sort the secret outputs
+	sort.Slice(secretOutputs, func(i, j int) bool {
+		return secretOutputs[i].String() < secretOutputs[j].String()
+	})
 
 	return resource.PropertyMap{
 		"name":              name,


### PR DESCRIPTION
When referencing `secretOutputNames` in from another stack, spurious
diffs can often be created because the secret output slice was not
ordered.

This PR orders the slice before it's added to the propertymap, ensuring
the order always remains the same

Fixes #4176 