### PR TITLE
[codegen/hcl2] Separate binding and typechecking.

### DIFF
--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -22,7 +22,6 @@ import (
 	_syntax "github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
-	"github.com/zclconf/go-cty/cty/convert"
 )
 
 type BindOption func(options *bindOptions)
@@ -264,25 +263,22 @@ func (b *expressionBinder) bindBinaryOpExpression(syntax *hclsyntax.BinaryOpExpr
 	rightOperand, rightDiags := b.bindExpression(syntax.RHS)
 	diagnostics = append(diagnostics, rightDiags...)
 
-	// Compute the signature for the operator and typecheck the arguments.
-	signature := getOperationSignature(syntax.Op)
-	contract.Assert(len(signature.Parameters) == 2)
-
-	typecheckDiags := typecheckArgs(syntax.Range(), signature, leftOperand, rightOperand)
-	diagnostics = append(diagnostics, typecheckDiags...)
-
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.BinaryOpTokens)
 	if tokens == nil {
 		tokens = _syntax.NewBinaryOpTokens(syntax.Op)
 	}
-	return &BinaryOpExpression{
+	expr := &BinaryOpExpression{
 		Syntax:       syntax,
 		Tokens:       tokens,
 		LeftOperand:  leftOperand,
 		Operation:    syntax.Op,
 		RightOperand: rightOperand,
-		exprType:     liftOperationType(signature.ReturnType, leftOperand, rightOperand),
-	}, diagnostics
+	}
+
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindConditionalExpression binds a conditional expression. The condition expression must be of type bool. The type of
@@ -301,22 +297,17 @@ func (b *expressionBinder) bindConditionalExpression(syntax *hclsyntax.Condition
 	falseResult, falseDiags := b.bindExpression(syntax.FalseResult)
 	diagnostics = append(diagnostics, falseDiags...)
 
-	// Compute the type of the result.
-	resultType, _ := UnifyTypes(trueResult.Type(), falseResult.Type())
-
-	// Typecheck the condition expression.
-	if InputType(BoolType).ConversionFrom(condition.Type()) == NoConversion {
-		diagnostics = append(diagnostics, ExprNotConvertible(InputType(BoolType), condition))
-	}
-
-	return &ConditionalExpression{
+	expr := &ConditionalExpression{
 		Syntax:      syntax,
 		Tokens:      b.tokens.ForNode(syntax),
 		Condition:   condition,
 		TrueResult:  trueResult,
 		FalseResult: falseResult,
-		exprType:    liftOperationType(resultType, condition),
-	}, diagnostics
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindForExpression binds a for expression. The value being iterated must be an list, map, or object.  The type of
@@ -356,11 +347,6 @@ func (b *expressionBinder) bindForExpression(syntax *hclsyntax.ForExpr) (Express
 	if syntax.KeyExpr != nil {
 		keyExpr, keyDiags := b.bindExpression(syntax.KeyExpr)
 		key, diagnostics = keyExpr, append(diagnostics, keyDiags...)
-
-		// A key expression is only present when producing a map. Key types must therefore be strings.
-		if !InputType(StringType).ConversionFrom(key.Type()).Exists() {
-			diagnostics = append(diagnostics, ExprNotConvertible(InputType(StringType), key))
-		}
 	}
 
 	value, valueDiags := b.bindExpression(syntax.ValExpr)
@@ -370,33 +356,6 @@ func (b *expressionBinder) bindForExpression(syntax *hclsyntax.ForExpr) (Express
 	if syntax.CondExpr != nil {
 		condExpr, conditionDiags := b.bindExpression(syntax.CondExpr)
 		condition, diagnostics = condExpr, append(diagnostics, conditionDiags...)
-
-		if !InputType(BoolType).ConversionFrom(condition.Type()).Exists() {
-			diagnostics = append(diagnostics, ExprNotConvertible(InputType(BoolType), condition))
-		}
-	}
-
-	// If there is a key expression, we are producing a map. Otherwise, we are producing an list. In either case, wrap
-	// the result type in the same set of eventuals and optionals present in the collection type.
-	var resultType Type
-	if key != nil {
-		valueType := value.Type()
-		if syntax.Group {
-			valueType = NewListType(valueType)
-		}
-		resultType = wrapIterableResultType(collection.Type(), NewMapType(valueType))
-	} else {
-		resultType = wrapIterableResultType(collection.Type(), NewListType(value.Type()))
-	}
-
-	// If either the key expression or the condition expression is eventual, the result is eventual: each of these
-	// values is required to determine which items are present in the result.
-	var liftArgs []Expression
-	if key != nil {
-		liftArgs = append(liftArgs, key)
-	}
-	if condition != nil {
-		liftArgs = append(liftArgs, condition)
 	}
 
 	tokens := b.tokens.ForNode(syntax)
@@ -404,7 +363,7 @@ func (b *expressionBinder) bindForExpression(syntax *hclsyntax.ForExpr) (Express
 		tokens = _syntax.NewForTokens(syntax.KeyVar, syntax.ValVar, syntax.KeyExpr != nil, syntax.Group,
 			syntax.CondExpr != nil)
 	}
-	return &ForExpression{
+	expr := &ForExpression{
 		Syntax:        syntax,
 		Tokens:        tokens,
 		KeyVariable:   keyVariable,
@@ -414,8 +373,11 @@ func (b *expressionBinder) bindForExpression(syntax *hclsyntax.ForExpr) (Express
 		Value:         value,
 		Condition:     condition,
 		Group:         syntax.Group,
-		exprType:      liftOperationType(resultType, liftArgs...),
-	}, diagnostics
+	}
+	typecheckDiags := expr.typecheck(false, false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindFunctionCallExpression binds a function call expression. The name of the function is bound using the current
@@ -460,19 +422,17 @@ func (b *expressionBinder) bindFunctionCallExpression(
 	signature, sigDiags := function.GetSignature(args)
 	diagnostics = append(diagnostics, sigDiags...)
 
-	// Typecheck the function's arguments.
-	typecheckDiags := typecheckArgs(syntax.Range(), signature, args...)
-	diagnostics = append(diagnostics, typecheckDiags...)
-
-	signature.ReturnType = liftOperationType(signature.ReturnType, args...)
-
-	return &FunctionCallExpression{
+	expr := &FunctionCallExpression{
 		Syntax:    syntax,
 		Tokens:    tokens,
 		Name:      syntax.Name,
 		Signature: signature,
 		Args:      args,
-	}, diagnostics
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindIndexExpression binds an index expression. The value being indexed must be an list, map, or object.
@@ -493,24 +453,20 @@ func (b *expressionBinder) bindIndexExpression(syntax *hclsyntax.IndexExpr) (Exp
 	key, keyDiags := b.bindExpression(syntax.Key)
 	diagnostics = append(diagnostics, keyDiags...)
 
-	part, partDiags := collection.Type().Traverse(hcl.TraverseIndex{
-		Key:      encapsulateType(key.Type()),
-		SrcRange: syntax.Key.Range(),
-	})
-
-	diagnostics = append(diagnostics, partDiags...)
-
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.IndexTokens)
 	if tokens == nil {
 		tokens = _syntax.NewIndexTokens()
 	}
-	return &IndexExpression{
+	expr := &IndexExpression{
 		Syntax:     syntax,
 		Tokens:     tokens,
 		Collection: collection,
 		Key:        key,
-		exprType:   liftOperationType(part.(Type), collection, key),
-	}, diagnostics
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindLiteralValueExpression binds a literal value expression. The value must be a boolean, integer, number, or
@@ -518,28 +474,21 @@ func (b *expressionBinder) bindIndexExpression(syntax *hclsyntax.IndexExpr) (Exp
 func (b *expressionBinder) bindLiteralValueExpression(
 	syntax *hclsyntax.LiteralValueExpr) (Expression, hcl.Diagnostics) {
 
-	v, typ, diagnostics := syntax.Val, NoneType, hcl.Diagnostics(nil)
-	if !v.IsNull() {
-		typ = ctyTypeToType(v.Type(), false)
-	}
-
-	switch {
-	case typ == NoneType || typ == StringType || typ == IntType || typ == NumberType || typ == BoolType:
-		// OK
-	default:
-		typ, diagnostics = DynamicType, hcl.Diagnostics{unsupportedLiteralValue(syntax)}
-	}
+	var diagnostics hcl.Diagnostics
 
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.LiteralValueTokens)
 	if tokens == nil {
-		tokens = _syntax.NewLiteralValueTokens(v)
+		tokens = _syntax.NewLiteralValueTokens(syntax.Val)
 	}
-	return &LiteralValueExpression{
-		Syntax:   syntax,
-		Tokens:   tokens,
-		Value:    v,
-		exprType: typ,
-	}, diagnostics
+	expr := &LiteralValueExpression{
+		Syntax: syntax,
+		Tokens: tokens,
+		Value:  syntax.Val,
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindObjectConsExpression binds an object construction expression. The expression's keys must be strings. If any of
@@ -549,16 +498,10 @@ func (b *expressionBinder) bindLiteralValueExpression(
 func (b *expressionBinder) bindObjectConsExpression(syntax *hclsyntax.ObjectConsExpr) (Expression, hcl.Diagnostics) {
 	var diagnostics hcl.Diagnostics
 
-	keys := make([]Expression, len(syntax.Items))
 	items := make([]ObjectConsItem, len(syntax.Items))
 	for i, item := range syntax.Items {
 		keyExpr, keyDiags := b.bindExpression(item.KeyExpr)
 		diagnostics = append(diagnostics, keyDiags...)
-		keys[i] = keyExpr
-
-		if !InputType(StringType).ConversionFrom(keyExpr.Type()).Exists() {
-			diagnostics = append(diagnostics, objectKeysMustBeStrings(keyExpr))
-		}
 
 		valExpr, valDiags := b.bindExpression(item.ValueExpr)
 		diagnostics = append(diagnostics, valDiags...)
@@ -566,45 +509,19 @@ func (b *expressionBinder) bindObjectConsExpression(syntax *hclsyntax.ObjectCons
 		items[i] = ObjectConsItem{Key: keyExpr, Value: valExpr}
 	}
 
-	// Attempt to build an object type out of the result. If there are any attribute names that come from variables,
-	// type the result as map(unify(propertyTypes)).
-	properties, isMapType, types := map[string]Type{}, false, []Type{}
-	for _, item := range items {
-		types = append(types, item.Value.Type())
-
-		key := item.Key
-		if template, ok := key.(*TemplateExpression); ok && len(template.Parts) == 1 {
-			key = template.Parts[0]
-		}
-
-		keyLit, ok := key.(*LiteralValueExpression)
-		if ok {
-			key, err := convert.Convert(keyLit.Value, cty.String)
-			if err == nil {
-				properties[key.AsString()] = item.Value.Type()
-				continue
-			}
-		}
-		isMapType = true
-	}
-	var typ Type
-	if isMapType {
-		elementType, _ := UnifyTypes(types...)
-		typ = NewMapType(elementType)
-	} else {
-		typ = NewObjectType(properties)
-	}
-
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.ObjectConsTokens)
 	if tokens == nil {
 		tokens = _syntax.NewObjectConsTokens(len(syntax.Items))
 	}
-	return &ObjectConsExpression{
-		Syntax:   syntax,
-		Tokens:   tokens,
-		Items:    items,
-		exprType: liftOperationType(typ, keys...),
-	}, diagnostics
+	expr := &ObjectConsExpression{
+		Syntax: syntax,
+		Tokens: tokens,
+		Items:  items,
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindObjectConsKeyExpr binds an object construction key.
@@ -633,9 +550,6 @@ func (b *expressionBinder) bindRelativeTraversalExpression(
 
 	source, diagnostics := b.bindExpression(syntax.Source)
 
-	parts, partDiags := b.bindTraversalParts(source.Type(), syntax.Traversal)
-	diagnostics = append(diagnostics, partDiags...)
-
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.RelativeTraversalTokens)
 	if tokens == nil {
 		tokens = _syntax.NewRelativeTraversalTokens(syntax.Traversal)
@@ -648,17 +562,19 @@ func (b *expressionBinder) bindRelativeTraversalExpression(
 		source.Tokens.Traversal = append(source.Tokens.Traversal, tokens.Traversal...)
 
 		source.Traversal = source.Syntax.Traversal
-		source.Parts = append(source.Parts, parts[1:]...)
-		return source, diagnostics
+		return source, source.Typecheck(false)
 	}
 
-	return &RelativeTraversalExpression{
+	expr := &RelativeTraversalExpression{
 		Syntax:    syntax,
 		Tokens:    tokens,
 		Source:    source,
-		Parts:     parts,
 		Traversal: syntax.Traversal,
-	}, diagnostics
+	}
+	typecheckDiags := expr.typecheck(false, b.options.allowMissingVariables)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindScopeTraversalExpression binds a scope traversal expression. Each step of the traversal must be a legal
@@ -666,6 +582,8 @@ func (b *expressionBinder) bindRelativeTraversalExpression(
 // name.
 func (b *expressionBinder) bindScopeTraversalExpression(
 	syntax *hclsyntax.ScopeTraversalExpr) (Expression, hcl.Diagnostics) {
+
+	var diagnostics hcl.Diagnostics
 
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.ScopeTraversalTokens)
 	if tokens == nil {
@@ -680,7 +598,6 @@ func (b *expressionBinder) bindScopeTraversalExpression(
 			parts[i] = DynamicType
 		}
 
-		var diagnostics hcl.Diagnostics
 		if !b.options.allowMissingVariables {
 			diagnostics = hcl.Diagnostics{
 				undefinedVariable(rootName, syntax.Traversal.SimpleSplit().Abs.SourceRange()),
@@ -695,14 +612,17 @@ func (b *expressionBinder) bindScopeTraversalExpression(
 		}, diagnostics
 	}
 
-	parts, diagnostics := b.bindTraversalParts(def, syntax.Traversal.SimpleSplit().Rel)
-	return &ScopeTraversalExpression{
+	expr := &ScopeTraversalExpression{
 		Syntax:    syntax,
 		Tokens:    tokens,
-		Parts:     parts,
+		Parts:     []Traversable{def},
 		RootName:  syntax.Traversal.RootName(),
 		Traversal: syntax.Traversal,
-	}, diagnostics
+	}
+	typecheckDiags := expr.typecheck(false, b.options.allowMissingVariables)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindSplatExpression binds a splat expression. If the type being splatted is an list or any, the type of the
@@ -716,37 +636,10 @@ func (b *expressionBinder) bindSplatExpression(syntax *hclsyntax.SplatExpr) (Exp
 	source, sourceDiags := b.bindExpression(syntax.Source)
 	diagnostics = append(diagnostics, sourceDiags...)
 
-	sourceType := unwrapIterableSourceType(source.Type())
-	elementType := sourceType
-	switch sourceType := sourceType.(type) {
-	case *ListType:
-		elementType = sourceType.ElementType
-	case *SetType:
-		elementType = sourceType.ElementType
-	case *TupleType:
-		elementType, _ = UnifyTypes(sourceType.ElementTypes...)
-	default:
-		if sourceType != DynamicType {
-			source = &TupleConsExpression{
-				Syntax: &hclsyntax.TupleConsExpr{
-					Exprs:     []hclsyntax.Expression{syntax.Source},
-					SrcRange:  syntax.Source.Range(),
-					OpenRange: syntax.Source.StartRange(),
-				},
-				Tokens:      _syntax.NewTupleConsTokens(1),
-				Expressions: []Expression{source},
-				exprType:    NewListType(source.Type()),
-			}
-		}
-	}
-
-	item := &SplatVariable{
-		Variable: Variable{
-			Name:         "",
-			VariableType: elementType,
-		},
-	}
+	item := &SplatVariable{}
 	b.anonSymbols[syntax.Item] = item
+
+	source, item.VariableType = splatItemType(source, syntax)
 
 	each, eachDiags := b.bindExpression(syntax.Each)
 	diagnostics = append(diagnostics, eachDiags...)
@@ -755,14 +648,17 @@ func (b *expressionBinder) bindSplatExpression(syntax *hclsyntax.SplatExpr) (Exp
 	if tokens == nil {
 		tokens = _syntax.NewSplatTokens(false)
 	}
-	return &SplatExpression{
-		Syntax:   syntax,
-		Tokens:   tokens,
-		Source:   source,
-		Each:     each,
-		Item:     item,
-		exprType: wrapIterableResultType(source.Type(), NewListType(each.Type())),
-	}, diagnostics
+	expr := &SplatExpression{
+		Syntax: syntax,
+		Tokens: tokens,
+		Source: source,
+		Each:   each,
+		Item:   item,
+	}
+	typecheckDiags := expr.typecheck(false, false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindTemplateExpression binds a template expression. The result is always a string. If any of the parts of the
@@ -779,12 +675,15 @@ func (b *expressionBinder) bindTemplateExpression(syntax *hclsyntax.TemplateExpr
 	if tokens == nil {
 		tokens = _syntax.NewTemplateTokens()
 	}
-	return &TemplateExpression{
-		Syntax:   syntax,
-		Tokens:   tokens,
-		Parts:    parts,
-		exprType: liftOperationType(StringType, parts...),
-	}, diagnostics
+	expr := &TemplateExpression{
+		Syntax: syntax,
+		Tokens: tokens,
+		Parts:  parts,
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindTemplateJoinExpression binds a template join expression. If any of the parts of the expression are eventual,
@@ -794,11 +693,14 @@ func (b *expressionBinder) bindTemplateJoinExpression(
 
 	tuple, diagnostics := b.bindExpression(syntax.Tuple)
 
-	return &TemplateJoinExpression{
-		Syntax:   syntax,
-		Tuple:    tuple,
-		exprType: liftOperationType(StringType, tuple),
-	}, diagnostics
+	expr := &TemplateJoinExpression{
+		Syntax: syntax,
+		Tuple:  tuple,
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindTemplateWrapExpression binds a template wrap expression.
@@ -816,27 +718,26 @@ func (b *expressionBinder) bindTemplateWrapExpression(
 // bindTupleConsExpression binds a tuple construction expression. The result is a tuple(T_0, ..., T_N).
 func (b *expressionBinder) bindTupleConsExpression(syntax *hclsyntax.TupleConsExpr) (Expression, hcl.Diagnostics) {
 	var diagnostics hcl.Diagnostics
+
 	exprs := make([]Expression, len(syntax.Exprs))
 	for i, syntax := range syntax.Exprs {
 		expr, exprDiags := b.bindExpression(syntax)
 		exprs[i], diagnostics = expr, append(diagnostics, exprDiags...)
 	}
 
-	elementTypes := make([]Type, len(exprs))
-	for i, expr := range exprs {
-		elementTypes[i] = expr.Type()
-	}
-
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.TupleConsTokens)
 	if tokens == nil {
 		tokens = _syntax.NewTupleConsTokens(len(syntax.Exprs))
 	}
-	return &TupleConsExpression{
+	expr := &TupleConsExpression{
 		Syntax:      syntax,
 		Tokens:      tokens,
 		Expressions: exprs,
-		exprType:    NewTupleType(elementTypes...),
-	}, diagnostics
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }
 
 // bindUnaryOpExpression binds a unary operator expression. If the operand to the unary operator contains eventuals,
@@ -848,22 +749,18 @@ func (b *expressionBinder) bindUnaryOpExpression(syntax *hclsyntax.UnaryOpExpr) 
 	operand, operandDiags := b.bindExpression(syntax.Val)
 	diagnostics = append(diagnostics, operandDiags...)
 
-	// Compute the signature for the operator and typecheck the arguments.
-	signature := getOperationSignature(syntax.Op)
-	contract.Assert(len(signature.Parameters) == 1)
-
-	typecheckDiags := typecheckArgs(syntax.Range(), signature, operand)
-	diagnostics = append(diagnostics, typecheckDiags...)
-
 	tokens, _ := b.tokens.ForNode(syntax).(*_syntax.UnaryOpTokens)
 	if tokens == nil {
 		tokens = _syntax.NewUnaryOpTokens(syntax.Op)
 	}
-	return &UnaryOpExpression{
+	expr := &UnaryOpExpression{
 		Syntax:    syntax,
 		Tokens:    tokens,
 		Operation: syntax.Op,
 		Operand:   operand,
-		exprType:  liftOperationType(signature.ReturnType, operand),
-	}, diagnostics
+	}
+	typecheckDiags := expr.Typecheck(false)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	return expr, diagnostics
 }

--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 )
 
 func errorf(subject hcl.Range, f string, args ...interface{}) *hcl.Diagnostic {
@@ -44,8 +44,8 @@ func objectKeysMustBeStrings(expr Expression) *hcl.Diagnostic {
 		"object keys must be strings: cannot assign expression of type %v to location of type string", expr.Type())
 }
 
-func unsupportedLiteralValue(syntax *hclsyntax.LiteralValueExpr) *hcl.Diagnostic {
-	return errorf(syntax.Range(), "unsupported literal value of type %v", syntax.Val.Type())
+func unsupportedLiteralValue(val cty.Value, valRange hcl.Range) *hcl.Diagnostic {
+	return errorf(valRange, "unsupported literal value of type %v", val.Type())
 }
 
 func unknownFunction(name string, nameRange hcl.Range) *hcl.Diagnostic {

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -1291,6 +1291,7 @@ func (x *LiteralValueExpression) Typecheck(typecheckOperands bool) hcl.Diagnosti
 		typ, diagnostics = DynamicType, hcl.Diagnostics{unsupportedLiteralValue(x.Value, rng)}
 	}
 
+	x.exprType = typ
 	return diagnostics
 }
 

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 )
 
 // Expression represents a semantically-analyzed HCL2 expression.
@@ -46,6 +47,8 @@ type Expression interface {
 
 	// Type returns the type of the expression.
 	Type() Type
+	// Typecheck recomputes the type of the expression, optionally typechecking its operands first.
+	Typecheck(typecheckOperands bool) hcl.Diagnostics
 
 	// Evaluate evaluates the expression.
 	Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics)
@@ -261,6 +264,17 @@ func (x *AnonymousFunctionExpression) Type() Type {
 	return DynamicType
 }
 
+func (x *AnonymousFunctionExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		bodyDiags := x.Body.Typecheck(true)
+		diagnostics = append(diagnostics, bodyDiags...)
+	}
+
+	return diagnostics
+}
+
 func (x *AnonymousFunctionExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	return cty.NilVal, hcl.Diagnostics{cannotEvaluateAnonymousFunctionExpressions()}
 }
@@ -338,6 +352,33 @@ func (x *BinaryOpExpression) NodeTokens() syntax.NodeTokens {
 // Type returns the type of the binary operation.
 func (x *BinaryOpExpression) Type() Type {
 	return x.exprType
+}
+
+func (x *BinaryOpExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	var rng hcl.Range
+	if x.Syntax != nil {
+		rng = x.Syntax.Range()
+	}
+
+	if typecheckOperands {
+		leftDiags := x.LeftOperand.Typecheck(true)
+		diagnostics = append(diagnostics, leftDiags...)
+
+		rightDiags := x.RightOperand.Typecheck(true)
+		diagnostics = append(diagnostics, rightDiags...)
+	}
+
+	// Compute the signature for the operator and typecheck the arguments.
+	signature := getOperationSignature(x.Operation)
+	contract.Assert(len(signature.Parameters) == 2)
+
+	typecheckDiags := typecheckArgs(rng, signature, x.LeftOperand, x.RightOperand)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	x.exprType = liftOperationType(signature.ReturnType, x.LeftOperand, x.RightOperand)
+	return diagnostics
 }
 
 func (x *BinaryOpExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -422,6 +463,32 @@ func (x *ConditionalExpression) NodeTokens() syntax.NodeTokens {
 // Type returns the type of the conditional expression.
 func (x *ConditionalExpression) Type() Type {
 	return x.exprType
+}
+
+func (x *ConditionalExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		conditionDiags := x.Condition.Typecheck(true)
+		diagnostics = append(diagnostics, conditionDiags...)
+
+		trueDiags := x.TrueResult.Typecheck(true)
+		diagnostics = append(diagnostics, trueDiags...)
+
+		falseDiags := x.FalseResult.Typecheck(true)
+		diagnostics = append(diagnostics, falseDiags...)
+	}
+
+	// Compute the type of the result.
+	resultType, _ := UnifyTypes(x.TrueResult.Type(), x.FalseResult.Type())
+
+	// Typecheck the condition expression.
+	if InputType(BoolType).ConversionFrom(x.Condition.Type()) == NoConversion {
+		diagnostics = append(diagnostics, ExprNotConvertible(InputType(BoolType), x.Condition))
+	}
+
+	x.exprType = liftOperationType(resultType, x.Condition)
+	return diagnostics
 }
 
 func (x *ConditionalExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -566,6 +633,10 @@ func (x *ErrorExpression) Type() Type {
 	return x.exprType
 }
 
+func (x *ErrorExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	return nil
+}
+
 func (x *ErrorExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	return cty.DynamicVal, hcl.Diagnostics{{
 		Severity: hcl.DiagError,
@@ -647,6 +718,91 @@ func (x *ForExpression) NodeTokens() syntax.NodeTokens {
 // Type returns the type of the for expression.
 func (x *ForExpression) Type() Type {
 	return x.exprType
+}
+
+func (x *ForExpression) typecheck(typecheckCollection, typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	var rng hcl.Range
+	if x.Syntax != nil {
+		rng = x.Syntax.CollExpr.Range()
+	}
+
+	if typecheckOperands {
+		collectionDiags := x.Collection.Typecheck(true)
+		diagnostics = append(diagnostics, collectionDiags...)
+	}
+
+	if typecheckCollection {
+		// Poke through any eventual and optional types that may wrap the collection type.
+		collectionType := unwrapIterableSourceType(x.Collection.Type())
+
+		keyType, valueType, kvDiags := GetCollectionTypes(collectionType, rng)
+		diagnostics = append(diagnostics, kvDiags...)
+
+		if x.KeyVariable != nil {
+			x.KeyVariable.VariableType = keyType
+		}
+		x.ValueVariable.VariableType = valueType
+	}
+
+	if typecheckOperands {
+		if x.Key != nil {
+			keyDiags := x.Key.Typecheck(true)
+			diagnostics = append(diagnostics, keyDiags...)
+		}
+
+		valueDiags := x.Value.Typecheck(true)
+		diagnostics = append(diagnostics, valueDiags...)
+
+		if x.Condition != nil {
+			conditionDiags := x.Condition.Typecheck(true)
+			diagnostics = append(diagnostics, conditionDiags...)
+		}
+	}
+
+	if x.Key != nil {
+		// A key expression is only present when producing a map. Key types must therefore be strings.
+		if !InputType(StringType).ConversionFrom(x.Key.Type()).Exists() {
+			diagnostics = append(diagnostics, ExprNotConvertible(InputType(StringType), x.Key))
+		}
+	}
+
+	if x.Condition != nil {
+		if !InputType(BoolType).ConversionFrom(x.Condition.Type()).Exists() {
+			diagnostics = append(diagnostics, ExprNotConvertible(InputType(BoolType), x.Condition))
+		}
+	}
+
+	// If there is a key expression, we are producing a map. Otherwise, we are producing an list. In either case, wrap
+	// the result type in the same set of eventuals and optionals present in the collection type.
+	var resultType Type
+	if x.Key != nil {
+		valueType := x.Value.Type()
+		if x.Group {
+			valueType = NewListType(valueType)
+		}
+		resultType = wrapIterableResultType(x.Collection.Type(), NewMapType(valueType))
+	} else {
+		resultType = wrapIterableResultType(x.Collection.Type(), NewListType(x.Value.Type()))
+	}
+
+	// If either the key expression or the condition expression is eventual, the result is eventual: each of these
+	// values is required to determine which items are present in the result.
+	var liftArgs []Expression
+	if x.Key != nil {
+		liftArgs = append(liftArgs, x.Key)
+	}
+	if x.Condition != nil {
+		liftArgs = append(liftArgs, x.Condition)
+	}
+
+	x.exprType = liftOperationType(resultType, liftArgs...)
+	return diagnostics
+}
+
+func (x *ForExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	return x.typecheck(true, typecheckOperands)
 }
 
 func (x *ForExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -840,6 +996,29 @@ func (x *FunctionCallExpression) Type() Type {
 	return x.Signature.ReturnType
 }
 
+func (x *FunctionCallExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		for _, arg := range x.Args {
+			argDiagnostics := arg.Typecheck(true)
+			diagnostics = append(diagnostics, argDiagnostics...)
+		}
+	}
+
+	var rng hcl.Range
+	if x.Syntax != nil {
+		rng = x.Syntax.Range()
+	}
+
+	// Typecheck the function's arguments.
+	typecheckDiags := typecheckArgs(rng, x.Signature, x.Args...)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	x.Signature.ReturnType = liftOperationType(x.Signature.ReturnType, x.Args...)
+	return diagnostics
+}
+
 func (x *FunctionCallExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	syntax := &hclsyntax.FunctionCallExpr{
 		Name:        x.Name,
@@ -946,6 +1125,40 @@ func (x *IndexExpression) NodeTokens() syntax.NodeTokens {
 	return x.Tokens
 }
 
+// Type returns the type of the index expression.
+func (x *IndexExpression) Type() Type {
+	return x.exprType
+}
+
+func (x *IndexExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		collectionDiags := x.Collection.Typecheck(true)
+		diagnostics = append(diagnostics, collectionDiags...)
+
+		keyDiags := x.Key.Typecheck(true)
+		diagnostics = append(diagnostics, keyDiags...)
+	}
+
+	var rng hcl.Range
+	if x.Syntax != nil {
+		rng = x.Syntax.Collection.Range()
+	}
+
+	collectionType := unwrapIterableSourceType(x.Collection.Type())
+	keyType, valueType, kvDiags := GetCollectionTypes(collectionType, rng)
+	diagnostics = append(diagnostics, kvDiags...)
+
+	if !InputType(keyType).ConversionFrom(x.Key.Type()).Exists() {
+		diagnostics = append(diagnostics, ExprNotConvertible(InputType(keyType), x.Key))
+	}
+
+	resultType := wrapIterableResultType(x.Collection.Type(), valueType)
+	x.exprType = liftOperationType(resultType, x.Key)
+	return diagnostics
+}
+
 func (x *IndexExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	syntax := &hclsyntax.IndexExpr{
 		Collection: &syntaxExpr{expr: x.Collection},
@@ -993,11 +1206,6 @@ func (x *IndexExpression) print(w io.Writer, p *printer) {
 		x.Tokens.GetParentheses(),
 		x.Collection, x.Tokens.GetOpenBracket(), x.Key, x.Tokens.GetCloseBracket(),
 		x.Tokens.GetParentheses())
-}
-
-// Type returns the type of the index expression.
-func (x *IndexExpression) Type() Type {
-	return x.exprType
 }
 
 func (*IndexExpression) isExpression() {}
@@ -1062,6 +1270,28 @@ func (x *LiteralValueExpression) Type() Type {
 		x.exprType = ctyTypeToType(x.Value.Type(), false)
 	}
 	return x.exprType
+}
+
+func (x *LiteralValueExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	typ := NoneType
+	if !x.Value.IsNull() {
+		typ = ctyTypeToType(x.Value.Type(), false)
+	}
+
+	switch {
+	case typ == NoneType || typ == StringType || typ == IntType || typ == NumberType || typ == BoolType:
+		// OK
+	default:
+		var rng hcl.Range
+		if x.Syntax != nil {
+			rng = x.Syntax.Range()
+		}
+		typ, diagnostics = DynamicType, hcl.Diagnostics{unsupportedLiteralValue(x.Value, rng)}
+	}
+
+	return diagnostics
 }
 
 func (x *LiteralValueExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -1167,6 +1397,58 @@ func (x *ObjectConsExpression) NodeTokens() syntax.NodeTokens {
 // Type returns the type of the object construction expression.
 func (x *ObjectConsExpression) Type() Type {
 	return x.exprType
+}
+
+func (x *ObjectConsExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	var keys []Expression
+	for _, item := range x.Items {
+		if typecheckOperands {
+			keyDiags := item.Key.Typecheck(true)
+			diagnostics = append(diagnostics, keyDiags...)
+
+			valDiags := item.Value.Typecheck(true)
+			diagnostics = append(diagnostics, valDiags...)
+		}
+
+		keys = append(keys, item.Key)
+		if !InputType(StringType).ConversionFrom(item.Key.Type()).Exists() {
+			diagnostics = append(diagnostics, objectKeysMustBeStrings(item.Key))
+		}
+	}
+
+	// Attempt to build an object type out of the result. If there are any attribute names that come from variables,
+	// type the result as map(unify(propertyTypes)).
+	properties, isMapType, types := map[string]Type{}, false, []Type{}
+	for _, item := range x.Items {
+		types = append(types, item.Value.Type())
+
+		key := item.Key
+		if template, ok := key.(*TemplateExpression); ok && len(template.Parts) == 1 {
+			key = template.Parts[0]
+		}
+
+		keyLit, ok := key.(*LiteralValueExpression)
+		if ok {
+			key, err := convert.Convert(keyLit.Value, cty.String)
+			if err == nil {
+				properties[key.AsString()] = item.Value.Type()
+				continue
+			}
+		}
+		isMapType = true
+	}
+	var typ Type
+	if isMapType {
+		elementType, _ := UnifyTypes(types...)
+		typ = NewMapType(elementType)
+	} else {
+		typ = NewObjectType(properties)
+	}
+
+	x.exprType = liftOperationType(typ, keys...)
+	return diagnostics
 }
 
 func (x *ObjectConsExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -1384,6 +1666,25 @@ func (x *RelativeTraversalExpression) Type() Type {
 	return GetTraversableType(x.Parts[len(x.Parts)-1])
 }
 
+func (x *RelativeTraversalExpression) typecheck(typecheckOperands, allowMissingVariables bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		sourceDiags := x.Source.Typecheck(true)
+		diagnostics = append(diagnostics, sourceDiags...)
+	}
+
+	parts, partDiags := bindTraversalParts(x.Source.Type(), x.Traversal, allowMissingVariables)
+	diagnostics = append(diagnostics, partDiags...)
+
+	x.Parts = parts
+	return diagnostics
+}
+
+func (x *RelativeTraversalExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	return x.typecheck(typecheckOperands, false)
+}
+
 func (x *RelativeTraversalExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	syntax := &hclsyntax.RelativeTraversalExpr{
 		Source:    &syntaxExpr{expr: x.Source},
@@ -1486,6 +1787,22 @@ func (x *ScopeTraversalExpression) NodeTokens() syntax.NodeTokens {
 	return x.Tokens
 }
 
+// Type returns the type of the scope traversal expression.
+func (x *ScopeTraversalExpression) Type() Type {
+	return GetTraversableType(x.Parts[len(x.Parts)-1])
+}
+
+func (x *ScopeTraversalExpression) typecheck(typecheckOperands, allowMissingVariables bool) hcl.Diagnostics {
+	parts, diagnostics := bindTraversalParts(x.Parts[0], x.Traversal.SimpleSplit().Rel, allowMissingVariables)
+	x.Parts = parts
+
+	return diagnostics
+}
+
+func (x *ScopeTraversalExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	return x.typecheck(typecheckOperands, false)
+}
+
 func (x *ScopeTraversalExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	var diagnostics hcl.Diagnostics
 
@@ -1572,11 +1889,6 @@ func (x *ScopeTraversalExpression) print(w io.Writer, p *printer) {
 	p.fprintf(w, "%)", x.Tokens.GetParentheses())
 }
 
-// Type returns the type of the scope traversal expression.
-func (x *ScopeTraversalExpression) Type() Type {
-	return GetTraversableType(x.Parts[len(x.Parts)-1])
-}
-
 func (*ScopeTraversalExpression) isExpression() {}
 
 type SplatVariable struct {
@@ -1620,6 +1932,64 @@ func (x *SplatExpression) NodeTokens() syntax.NodeTokens {
 // Type returns the type of the splat expression.
 func (x *SplatExpression) Type() Type {
 	return x.exprType
+}
+
+func splatItemType(source Expression, splatSyntax *hclsyntax.SplatExpr) (Expression, Type) {
+	sourceType := unwrapIterableSourceType(source.Type())
+	itemType := sourceType
+	switch sourceType := sourceType.(type) {
+	case *ListType:
+		itemType = sourceType.ElementType
+	case *SetType:
+		itemType = sourceType.ElementType
+	case *TupleType:
+		itemType, _ = UnifyTypes(sourceType.ElementTypes...)
+	default:
+		if sourceType != DynamicType {
+			var tupleSyntax *hclsyntax.TupleConsExpr
+			if splatSyntax != nil {
+				tupleSyntax = &hclsyntax.TupleConsExpr{
+					Exprs:     []hclsyntax.Expression{splatSyntax.Source},
+					SrcRange:  splatSyntax.Source.Range(),
+					OpenRange: splatSyntax.Source.StartRange(),
+				}
+			}
+
+			source = &TupleConsExpression{
+				Syntax:      tupleSyntax,
+				Tokens:      syntax.NewTupleConsTokens(1),
+				Expressions: []Expression{source},
+				exprType:    NewListType(source.Type()),
+			}
+		}
+	}
+	return source, itemType
+}
+
+func (x *SplatExpression) typecheck(retypeItem, typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		sourceDiags := x.Source.Typecheck(true)
+		diagnostics = append(diagnostics, sourceDiags...)
+	}
+
+	if retypeItem {
+		x.Source, x.Item.VariableType = splatItemType(x.Source, x.Syntax)
+	}
+
+	if typecheckOperands {
+		eachDiags := x.Each.Typecheck(true)
+		diagnostics = append(diagnostics, eachDiags...)
+	}
+
+	x.exprType = wrapIterableResultType(x.Source.Type(), NewListType(x.Each.Type()))
+
+	return diagnostics
+}
+
+func (x *SplatExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	return x.typecheck(true, typecheckOperands)
 }
 
 func (x *SplatExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -1719,6 +2089,20 @@ func (x *TemplateExpression) Type() Type {
 	return x.exprType
 }
 
+func (x *TemplateExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		for _, part := range x.Parts {
+			partDiags := part.Typecheck(true)
+			diagnostics = append(diagnostics, partDiags...)
+		}
+	}
+
+	x.exprType = liftOperationType(StringType, x.Parts...)
+	return diagnostics
+}
+
 func (x *TemplateExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	syntax := &hclsyntax.TemplateExpr{
 		Parts: make([]hclsyntax.Expression, len(x.Parts)),
@@ -1804,6 +2188,18 @@ func (x *TemplateJoinExpression) Type() Type {
 	return x.exprType
 }
 
+func (x *TemplateJoinExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		tupleDiags := x.Tuple.Typecheck(true)
+		diagnostics = append(diagnostics, tupleDiags...)
+	}
+
+	x.exprType = liftOperationType(StringType, x.Tuple)
+	return diagnostics
+}
+
 func (x *TemplateJoinExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
 	syntax := &hclsyntax.TemplateJoinExpr{
 		Tuple: &syntaxExpr{expr: x.Tuple},
@@ -1871,6 +2267,23 @@ func (x *TupleConsExpression) NodeTokens() syntax.NodeTokens {
 // Type returns the type of the tuple construction expression.
 func (x *TupleConsExpression) Type() Type {
 	return x.exprType
+}
+
+func (x *TupleConsExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	elementTypes := make([]Type, len(x.Expressions))
+	for i, expr := range x.Expressions {
+		if typecheckOperands {
+			exprDiags := expr.Typecheck(true)
+			diagnostics = append(diagnostics, exprDiags...)
+		}
+
+		elementTypes[i] = expr.Type()
+	}
+
+	x.exprType = NewTupleType(elementTypes...)
+	return diagnostics
 }
 
 func (x *TupleConsExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {
@@ -1987,6 +2400,29 @@ func (x *UnaryOpExpression) NodeTokens() syntax.NodeTokens {
 // Type returns the type of the unary operation.
 func (x *UnaryOpExpression) Type() Type {
 	return x.exprType
+}
+
+func (x *UnaryOpExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
+	var diagnostics hcl.Diagnostics
+
+	if typecheckOperands {
+		operandDiags := x.Operand.Typecheck(true)
+		diagnostics = append(diagnostics, operandDiags...)
+	}
+
+	// Compute the signature for the operator and typecheck the arguments.
+	signature := getOperationSignature(x.Operation)
+	contract.Assert(len(signature.Parameters) == 1)
+
+	var rng hcl.Range
+	if x.Syntax != nil {
+		rng = x.Syntax.Range()
+	}
+	typecheckDiags := typecheckArgs(rng, signature, x.Operand)
+	diagnostics = append(diagnostics, typecheckDiags...)
+
+	x.exprType = liftOperationType(signature.ReturnType, x.Operand)
+	return diagnostics
 }
 
 func (x *UnaryOpExpression) Evaluate(context *hcl.EvalContext) (cty.Value, hcl.Diagnostics) {

--- a/pkg/codegen/hcl2/model/traversable.go
+++ b/pkg/codegen/hcl2/model/traversable.go
@@ -74,8 +74,8 @@ func GetTraverserKey(t hcl.Traverser) (cty.Value, Type) {
 }
 
 // bindTraversalParts computes the type for each element of the given traversal.
-func (b *expressionBinder) bindTraversalParts(receiver Traversable,
-	traversal hcl.Traversal) ([]Traversable, hcl.Diagnostics) {
+func bindTraversalParts(receiver Traversable, traversal hcl.Traversal,
+	allowMissingVariables bool) ([]Traversable, hcl.Diagnostics) {
 
 	parts := make([]Traversable, len(traversal)+1)
 	parts[0] = receiver
@@ -85,7 +85,7 @@ func (b *expressionBinder) bindTraversalParts(receiver Traversable,
 		nextReceiver, partDiags := parts[i].Traverse(part)
 
 		// TODO(pdg): proper options for Traverse
-		if b.options.allowMissingVariables {
+		if allowMissingVariables {
 			var diags hcl.Diagnostics
 			for _, d := range partDiags {
 				if !strings.HasPrefix(d.Summary, "undefined variable") {
@@ -103,7 +103,7 @@ func (b *expressionBinder) bindTraversalParts(receiver Traversable,
 		// OK
 	default:
 		// TODO(pdg): improve this diagnostic
-		if !b.options.allowMissingVariables {
+		if !allowMissingVariables {
 			diagnostics = append(diagnostics, undefinedVariable("", traversal.SourceRange()))
 		}
 	}


### PR DESCRIPTION
This allows consumers to change the inputs to an expression and re-run
typechecking to compute the expression's new type.

This is required for some fixes to the apply rewriter.