### PR TITLE
[sdk/python] Improve `ResourceOptions.merge` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ CHANGELOG
 - Ensure Go accessor methods correctly support nested fields of optional outputs
   [#4456](https://github.com/pulumi/pulumi/pull/4456)
 
+- Improve `ResourceOptions.merge` type in Python SDK
+  [#4484](https://github.com/pulumi/pulumi/pull/4484)
 
 ## 2.0.0 (2020-04-16)
 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -444,7 +444,7 @@ class ResourceOptions:
 
     # pylint: disable=method-hidden
     @staticmethod
-    def merge(opts1: 'ResourceOptions', opts2: 'ResourceOptions') -> 'ResourceOptions':
+    def merge(opts1: Optional['ResourceOptions'], opts2: Optional['ResourceOptions']) -> 'ResourceOptions':
         """
         merge produces a new ResourceOptions object with the respective attributes of the `opts1`
         instance in it with the attributes of `opts2` merged over them.


### PR DESCRIPTION
The implementation correctly handles `None` inputs, so the type should allow these as well.