### PR TITLE
[codegen/hcl2] Fix the apply rewriter.

### DIFF
--- a/pkg/codegen/hcl2/intrinsics.go
+++ b/pkg/codegen/hcl2/intrinsics.go
@@ -39,9 +39,7 @@ func isOutput(t model.Type) bool {
 }
 
 // NewApplyCall returns a new expression that represents a call to IntrinsicApply.
-func NewApplyCall(args []*model.ScopeTraversalExpression,
-	then *model.AnonymousFunctionExpression) *model.FunctionCallExpression {
-
+func NewApplyCall(args []model.Expression, then *model.AnonymousFunctionExpression) *model.FunctionCallExpression {
 	signature := model.StaticFunctionSignature{
 		Parameters: make([]model.Parameter, len(args)+1),
 	}
@@ -78,15 +76,9 @@ func NewApplyCall(args []*model.ScopeTraversalExpression,
 }
 
 // ParseApplyCall extracts the apply arguments and the continuation from a call to the apply intrinsic.
-func ParseApplyCall(c *model.FunctionCallExpression) (applyArgs []*model.ScopeTraversalExpression,
+func ParseApplyCall(c *model.FunctionCallExpression) (applyArgs []model.Expression,
 	then *model.AnonymousFunctionExpression) {
 
 	contract.Assert(c.Name == IntrinsicApply)
-
-	args := make([]*model.ScopeTraversalExpression, len(c.Args)-1)
-	for i, a := range c.Args[:len(args)] {
-		args[i] = a.(*model.ScopeTraversalExpression)
-	}
-
-	return args, c.Args[len(c.Args)-1].(*model.AnonymousFunctionExpression)
+	return c.Args[:len(c.Args)-1], c.Args[len(c.Args)-1].(*model.AnonymousFunctionExpression)
 }

--- a/pkg/codegen/hcl2/rewriters.go
+++ b/pkg/codegen/hcl2/rewriters.go
@@ -17,33 +17,62 @@ package hcl2
 import (
 	"fmt"
 
+	"github.com/gedex/inflector"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
 )
 
 type NameInfo interface {
-	IsReservedWord(name string) bool
+	Format(name string) string
 }
 
-// The applyRewriter is responsible for transforming expressions involving Pulumi output properties into a call to the
-// __apply intrinsic and replacing the output properties with appropriate calls to the __applyArg intrinsic.
+// The applyRewriter is responsible for driving the apply rewrite process. The rewriter uses a stack of contexts to
+// deal with the possibility of expressions that observe outputs nested inside expressions that do not.
 type applyRewriter struct {
 	nameInfo      NameInfo
 	applyPromises bool
+
+	activeContext applyRewriteContext
 }
 
-type applyContext struct {
-	applyRewriter
+type applyRewriteContext interface {
+	PreVisit(x model.Expression) (model.Expression, hcl.Diagnostics)
+	PostVisit(x model.Expression) (model.Expression, hcl.Diagnostics)
+}
+
+// An inspectContext is used when we are inside an expression that does not observe eventual values. When it
+// encounters an expression that observes eventual values, it pushes a new observeContext onto the stack.
+type inspectContext struct {
+	*applyRewriter
+
+	parent *observeContext
+
+	root model.Expression
+}
+
+// An observeContext is used when we are inside an expression that does observe eventual values. It is responsible for
+// finding the values that are observed, replacing them with references to apply parameters, and replacing the root
+// expression with a call to the __apply intrinsic.
+type observeContext struct {
+	*applyRewriter
+
+	parent applyRewriteContext
 
 	root            model.Expression
-	applyArgs       []*model.ScopeTraversalExpression
+	applyArgs       []model.Expression
 	callbackParams  []*model.Variable
 	paramReferences []*model.ScopeTraversalExpression
 
 	assignedNames codegen.StringSet
 	nameCounts    map[string]int
+}
+
+func (r *applyRewriter) hasEventualValues(x model.Expression) bool {
+	resolved := model.ResolveOutputs(x.Type())
+	return resolved != x.Type()
 }
 
 func (r *applyRewriter) isEventualType(t model.Type) (model.Type, bool) {
@@ -69,46 +98,103 @@ func (r *applyRewriter) isEventualType(t model.Type) (model.Type, bool) {
 	return nil, false
 }
 
-func (r *applyRewriter) isPromptArg(paramType, argType model.Type) bool {
-	if isEventualArg := model.ResolveOutputs(argType) != argType; !isEventualArg {
+func (r *applyRewriter) isPromptArg(paramType model.Type, arg model.Expression) bool {
+	if !r.hasEventualValues(arg) {
 		return true
 	}
 
 	if union, ok := paramType.(*model.UnionType); ok {
 		for _, t := range union.ElementTypes {
-			if t != model.DynamicType && t.ConversionFrom(argType) != model.NoConversion {
+			if t != model.DynamicType && t.ConversionFrom(arg.Type()) != model.NoConversion {
 				return true
 			}
 		}
 		return false
 	}
-	return paramType != model.DynamicType && paramType.ConversionFrom(argType) != model.NoConversion
+	return paramType != model.DynamicType && paramType.ConversionFrom(arg.Type()) != model.NoConversion
 }
 
-func (r *applyRewriter) isEventualExpr(x model.Expression) bool {
-	if _, isEventual := r.isEventualType(x.Type()); !isEventual {
+func (r *applyRewriter) inspectsEventualValues(x model.Expression) bool {
+	switch x := x.(type) {
+	case *model.ConditionalExpression:
+		return r.hasEventualValues(x.TrueResult) || r.hasEventualValues(x.FalseResult)
+	case *model.FunctionCallExpression:
+		for i, arg := range x.Args {
+			if r.hasEventualValues(arg) && r.isPromptArg(x.Signature.Parameters[i].Type, arg) {
+				return true
+			}
+		}
+		return false
+	case *model.IndexExpression:
+		_, isCollectionEventual := r.isEventualType(x.Collection.Type())
+		return !isCollectionEventual && r.hasEventualValues(x.Collection)
+	case *model.SplatExpression:
+		_, isSourceEventual := r.isEventualType(x.Source.Type())
+		return !isSourceEventual && r.hasEventualValues(x.Source)
+	default:
+		return false
+	}
+}
+
+func (r *applyRewriter) observesEventualValues(x model.Expression) bool {
+	_, isEventual := r.isEventualType(x.Type())
+	if !isEventual {
 		return false
 	}
 
-	call, isCall := x.(*model.FunctionCallExpression)
-	if !isCall {
-		return true
-	}
-
-	for i, arg := range call.Args {
-		if !r.isPromptArg(call.Signature.Parameters[i].Type, arg.Type()) {
+	switch x := x.(type) {
+	case *model.AnonymousFunctionExpression:
+		return false
+	case *model.ConditionalExpression:
+		return r.hasEventualValues(x.Condition)
+	case *model.FunctionCallExpression:
+		for i, arg := range x.Args {
+			if !r.isPromptArg(x.Signature.Parameters[i].Type, arg) {
+				return true
+			}
+		}
+		return false
+	case *model.IndexExpression:
+		if _, isCollectionEventual := r.isEventualType(x.Collection.Type()); isCollectionEventual {
 			return true
 		}
+		return r.hasEventualValues(x.Key)
+	case *model.RelativeTraversalExpression:
+		// A traversal is eventual if at least one of its nonterminals is eventual.
+		for _, p := range x.Parts[:len(x.Parts)-1] {
+			if _, isEventual := r.isEventualType(model.GetTraversableType(p)); isEventual {
+				return true
+			}
+		}
+		return false
+	case *model.ScopeTraversalExpression:
+		// A traversal is eventual if at least one of its nonterminals is eventual.
+		for _, p := range x.Parts[:len(x.Parts)-1] {
+			if _, isEventual := r.isEventualType(model.GetTraversableType(p)); isEventual {
+				return true
+			}
+		}
+		return false
+	case *model.SplatExpression:
+		_, sourceIsEventual := r.isEventualType(x.Source.Type())
+		return sourceIsEventual
+	default:
+		return true
 	}
-	return false
+}
+
+func (r *applyRewriter) preVisit(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+	return r.activeContext.PreVisit(expr)
+}
+
+func (r *applyRewriter) postVisit(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+	return r.activeContext.PostVisit(expr)
 }
 
 // disambiguateName ensures that the given name is unambiguous by appending an integer starting with 1 if necessary.
-func (ctx *applyContext) disambiguateName(name string) string {
+func (ctx *observeContext) disambiguateName(name string) string {
 	if name == "" {
 		name = "arg"
-	} else if ctx.nameInfo.IsReservedWord(name) {
-		name = "_" + name
 	}
 
 	if !ctx.assignedNames.Has(name) {
@@ -122,56 +208,169 @@ func (ctx *applyContext) disambiguateName(name string) string {
 	return name
 }
 
-// bestArgName computes the "best" name for a given apply argument. If this name is unambiguous after all best names
-// have been calculated, it will be assigned to the argument. Otherwise, it will go through the disambiguation process
-// in disambiguateArgName.
-func (ctx *applyContext) bestArgName(x *model.ScopeTraversalExpression) string {
-	switch n := x.Parts[0].(type) {
-	case *ConfigVariable, *LocalVariable, *OutputVariable:
-		return n.(Node).Name()
-	case *Resource:
-		// If dealing with a broken access, use the resource's variable name. Otherwise, use the name
-		// of the traversal's first field.
-		if len(x.Traversal) == 1 {
-			return n.Name()
-		}
-		switch t := x.Traversal[1].(type) {
+func (ctx *observeContext) bestTraversalName(rootName string, traversal hcl.Traversal) string {
+	for i := len(traversal) - 1; i >= 0; i-- {
+		switch t := traversal[i].(type) {
 		case hcl.TraverseAttr:
 			return t.Name
 		case hcl.TraverseIndex:
-			return t.Key.AsString()
-		default:
-			return n.Name()
+			if t.Key.Type().Equals(cty.String) {
+				return t.Key.AsString()
+			}
+			return inflector.Singularize(ctx.bestTraversalName(rootName, traversal[:i]))
 		}
-	case *model.SplatVariable:
-		return n.Name
-	case *model.Variable:
-		return n.Name
+	}
+	return rootName
+}
+
+// bestArgName computes the "best" name for a given apply argument. If this name is unambiguous after all best names
+// have been calculated, it will be assigned to the argument. Otherwise, it will go through the disambiguation process
+// in disambiguateArgName.
+func (ctx *observeContext) bestArgName(x model.Expression) string {
+	switch x := x.(type) {
+	case *model.ForExpression:
+		if x.Key == nil {
+			return inflector.Pluralize(ctx.bestArgName(x.Value))
+		}
+	case *model.FunctionCallExpression:
+		switch x.Name {
+		case IntrinsicApply:
+			if len(x.Args)-1 == 1 {
+				return ctx.bestArgName(x.Args[0])
+			}
+		case "element":
+			return ctx.bestArgName(x.Args[0])
+		case "fileArchive", "fileAsset", "readDir", "readFile":
+			return ctx.bestArgName(x.Args[0])
+		case "lookup":
+			return ctx.bestArgName(x.Args[1])
+		}
+		return x.Name
+	case *model.IndexExpression:
+		switch model.ResolveOutputs(x.Collection.Type()).(type) {
+		case *model.ListType, *model.SetType, *model.TupleType:
+			return inflector.Singularize(ctx.bestArgName(x.Collection))
+		case *model.MapType, *model.ObjectType:
+			return ctx.bestArgName(x.Key)
+		}
+	case *model.LiteralValueExpression:
+		if x.Value.Type().Equals(cty.String) {
+			return x.Value.AsString()
+		}
+	case *model.RelativeTraversalExpression:
+		if n := ctx.bestTraversalName(ctx.bestArgName(x.Source), x.Traversal); n != "" {
+			return n
+		}
+	case *model.ScopeTraversalExpression:
+		if n := ctx.bestTraversalName(x.RootName, x.Traversal[1:]); n != "" {
+			return n
+		}
+	case *model.SplatExpression:
+		return inflector.Pluralize(ctx.bestArgName(x.Each))
+	}
+
+	switch t := model.ResolveOutputs(x.Type()).(type) {
+	case *model.ListType, *model.SetType, *model.TupleType:
+		return "values"
+	case *model.MapType, *model.ObjectType:
+		return "obj"
+	case *model.UnionType:
+		return "value"
 	default:
-		panic(fmt.Errorf("unexpected definition in assignApplyArgName: %T", n))
+		switch t {
+		case model.BoolType:
+			return "b"
+		case model.IntType:
+			return "i"
+		case model.NumberType:
+			return "n"
+		case model.StringType:
+			return "s"
+		case model.DynamicType:
+			return "obj"
+		default:
+			return "v"
+		}
 	}
 }
 
 // disambiguateArgName applies type-specific disambiguation to an argument name.
-func (ctx *applyContext) disambiguateArgName(x *model.ScopeTraversalExpression, bestName string) string {
-	if n, ok := x.Parts[0].(*Resource); ok {
-		// If dealing with a broken access, defer to the generic disambiguator. Otherwise, attempt to disambiguate
-		// by prepending the resource's variable name.
-		if len(x.Traversal) > 1 {
-			return ctx.disambiguateName(n.Name() + titleCase(bestName))
+func (ctx *observeContext) disambiguateArgName(x model.Expression, bestName string) string {
+	if x, ok := x.(*model.ScopeTraversalExpression); ok {
+		if n, ok := x.Parts[0].(*Resource); ok {
+			// If dealing with a broken access, defer to the generic disambiguator. Otherwise, attempt to disambiguate
+			// by prepending the resource's variable name.
+			if len(x.Traversal) > 1 {
+				return ctx.disambiguateName(n.Name() + titleCase(bestName))
+			}
 		}
 	}
 	// Hand off to the generic disambiguator.
 	return ctx.disambiguateName(bestName)
 }
 
-// rewriteScopeTraversalExpression replaces a single access to an ouptut-typed ScopeTraversalExpression with a call to
-// the __applyArg intrinsic.
-func (ctx *applyContext) rewriteScopeTraversalExpression(expr *model.ScopeTraversalExpression,
+// rewriteApplyArg replaces a single expression with an apply paramter.
+func (ctx *observeContext) rewriteApplyArg(applyArg model.Expression, paramType model.Type, traversal hcl.Traversal,
+	parts []model.Traversable, isRoot bool) model.Expression {
+
+	if len(traversal) == 0 && isRoot {
+		return applyArg
+	}
+
+	callbackParam := &model.Variable{
+		Name:         fmt.Sprintf("<arg%d>", len(ctx.callbackParams)),
+		VariableType: paramType,
+	}
+
+	ctx.applyArgs, ctx.callbackParams = append(ctx.applyArgs, applyArg), append(ctx.callbackParams, callbackParam)
+
+	// TODO(pdg): this risks information loss for nested output-typed properties... The `Types` array on traversals
+	// ought to store the original types.
+	resolvedParts := make([]model.Traversable, len(parts)+1)
+	resolvedParts[0] = callbackParam
+	for i, p := range parts {
+		resolvedParts[i+1] = model.ResolveOutputs(model.GetTraversableType(p))
+	}
+
+	result := &model.ScopeTraversalExpression{
+		Parts:     resolvedParts,
+		RootName:  callbackParam.Name,
+		Traversal: hcl.TraversalJoin(hcl.Traversal{hcl.TraverseRoot{Name: callbackParam.Name}}, traversal),
+	}
+	ctx.paramReferences = append(ctx.paramReferences, result)
+	return result
+}
+
+// rewriteRelativeTraversalExpression replaces a single access to an ouptut-typed RelativeTraversalExpression with an
+// apply paramter.
+func (ctx *observeContext) rewriteRelativeTraversalExpression(expr *model.RelativeTraversalExpression,
+	isRoot bool) model.Expression {
+
+	// Compute the type of the apply and callback arguments.
+	paramType := model.ResolveOutputs(expr.Type())
+	parts, traversal := expr.Parts, expr.Traversal
+	for i := range expr.Traversal {
+		partResolvedType, isEventual := paramType, true
+		if i < len(expr.Traversal)-1 {
+			partResolvedType, isEventual = ctx.isEventualType(model.GetTraversableType(expr.Parts[i+1]))
+		}
+		if isEventual {
+			expr.Traversal, expr.Parts = expr.Traversal[:i+1], expr.Parts[:i+1]
+			paramType, traversal, parts = partResolvedType, expr.Traversal[i+1:], expr.Parts[i+1:]
+			break
+		}
+	}
+
+	return ctx.rewriteApplyArg(expr, paramType, traversal, parts, isRoot)
+}
+
+// rewriteScopeTraversalExpression replaces a single access to an ouptut-typed ScopeTraversalExpression with an apply
+// paramter.
+func (ctx *observeContext) rewriteScopeTraversalExpression(expr *model.ScopeTraversalExpression,
 	isRoot bool) model.Expression {
 
 	// If the access is not an output() or a promise(), return the node as-is.
-	_, isEventual := ctx.isEventualType(expr.Type())
+	resolvedType, isEventual := ctx.isEventualType(expr.Type())
 	if !isEventual {
 		// If this is a reference to a named variable, put the name in scope.
 		if definition, ok := expr.Traversal[0].(Node); ok {
@@ -191,73 +390,52 @@ func (ctx *applyContext) rewriteScopeTraversalExpression(expr *model.ScopeTraver
 	var parts []model.Traversable
 	var traversal hcl.Traversal
 
-	splitTraversal := expr.Syntax.Traversal.SimpleSplit()
-	if rootResolvedType, rootIsEventual := ctx.isEventualType(model.GetTraversableType(expr.Parts[0])); rootIsEventual {
+	splitTraversal := expr.Traversal.SimpleSplit()
+	rootResolvedType, rootIsEventual := resolvedType, true
+	if len(splitTraversal.Rel) > 0 {
+		rootResolvedType, rootIsEventual = ctx.isEventualType(model.GetTraversableType(expr.Parts[0]))
+	}
+	if rootIsEventual {
 		applyArg = &model.ScopeTraversalExpression{
 			Parts:     expr.Parts[:1],
 			RootName:  splitTraversal.Abs.RootName(),
 			Traversal: splitTraversal.Abs,
 		}
-		paramType, traversal, parts = rootResolvedType, expr.Syntax.Traversal.SimpleSplit().Rel, expr.Parts[1:]
+		paramType, traversal, parts = rootResolvedType, expr.Traversal.SimpleSplit().Rel, expr.Parts[1:]
 	} else {
 		for i := range splitTraversal.Rel {
-			if resolvedType, isEventual := ctx.isEventualType(model.GetTraversableType(expr.Parts[i+1])); isEventual {
-				absTraversal, relTraversal := expr.Syntax.Traversal[:i+2], expr.Syntax.Traversal[i+2:]
+			partResolvedType, isEventual := resolvedType, true
+			if i < len(splitTraversal.Rel)-1 {
+				partResolvedType, isEventual = ctx.isEventualType(model.GetTraversableType(expr.Parts[i+1]))
+			}
+			if isEventual {
+				absTraversal, relTraversal := expr.Traversal[:i+2], expr.Traversal[i+2:]
 
 				applyArg = &model.ScopeTraversalExpression{
 					Parts:     expr.Parts[:i+2],
 					RootName:  absTraversal.RootName(),
 					Traversal: absTraversal,
 				}
-				paramType, traversal, parts = resolvedType, relTraversal, expr.Parts[i+2:]
+				paramType, traversal, parts = partResolvedType, relTraversal, expr.Parts[i+2:]
 				break
 			}
 		}
 	}
 
-	if len(traversal) == 0 && isRoot {
-		return expr
-	}
-
-	callbackParam := &model.Variable{
-		Name:         fmt.Sprintf("<arg%d>", len(ctx.callbackParams)),
-		VariableType: paramType,
-	}
-
-	ctx.applyArgs, ctx.callbackParams = append(ctx.applyArgs, applyArg), append(ctx.callbackParams, callbackParam)
-
-	// TODO(pdg): this risks information loss for nested output-typed properties... The `Types` array on traversals
-	// ought to store the original types.
-	resolvedParts := make([]model.Traversable, len(parts)+1)
-	resolvedParts[0] = callbackParam
-	for i, p := range parts {
-		resolved, isEventual := ctx.isEventualType(model.GetTraversableType(p))
-		contract.Assert(isEventual)
-		resolvedParts[i+1] = resolved
-	}
-
-	result := &model.ScopeTraversalExpression{
-		Parts:     resolvedParts,
-		RootName:  callbackParam.Name,
-		Traversal: hcl.TraversalJoin(hcl.Traversal{hcl.TraverseRoot{Name: callbackParam.Name}}, traversal),
-	}
-	ctx.paramReferences = append(ctx.paramReferences, result)
-	return result
+	return ctx.rewriteApplyArg(applyArg, paramType, traversal, parts, isRoot)
 }
 
 // rewriteRoot replaces the root node in a bound expression with a call to the __apply intrinsic if necessary.
-func (ctx *applyContext) rewriteRoot(expr model.Expression) model.Expression {
+func (ctx *observeContext) rewriteRoot(expr model.Expression) model.Expression {
 	contract.Require(expr == ctx.root, "expr")
 
-	// Clear the root context so that future calls to enterNode recognize new expression roots.
-	ctx.root = nil
 	if len(ctx.applyArgs) == 0 {
 		return expr
 	}
 
 	// Assign argument names.
 	for i, arg := range ctx.applyArgs {
-		bestName := ctx.bestArgName(arg)
+		bestName := ctx.nameInfo.Format(ctx.bestArgName(arg))
 		ctx.callbackParams[i].Name, ctx.nameCounts[bestName] = bestName, ctx.nameCounts[bestName]+1
 	}
 	for i, param := range ctx.callbackParams {
@@ -294,102 +472,126 @@ func (ctx *applyContext) rewriteRoot(expr model.Expression) model.Expression {
 	return NewApplyCall(ctx.applyArgs, callback)
 }
 
-// rewriteExpression performs the apply rewrite on a single expression, delegating to type-specific functions as
-// necessary.
-func (ctx *applyContext) rewriteExpression(expr model.Expression) (model.Expression, hcl.Diagnostics) {
-	isRoot := expr == ctx.root
-
-	// TODO(pdg): arrays of outputs, for expressions, etc.
-
-	if traversal, isScopeTraversal := expr.(*model.ScopeTraversalExpression); isScopeTraversal {
-		expr = ctx.rewriteScopeTraversalExpression(traversal, isRoot)
-	}
-	if isRoot {
-		ctx.root = expr
-		expr = ctx.rewriteRoot(expr)
-	}
-	return expr, nil
-}
-
-// enterExpression is a pre-order visitor that is used to find roots for bound expression trees. This approach is
-// intended to allow consumers of the apply rewrite to call RewriteApplies on a list or map property that may contain
-// multiple independent bound expressions rather than requiring that they find and rewrite these expressions
-// individually.
-func (ctx *applyContext) enterExpression(expr model.Expression) (model.Expression, hcl.Diagnostics) {
-	if ctx.root == nil {
-		if ctx.isEventualExpr(expr) {
-			ctx.root, ctx.applyArgs, ctx.callbackParams, ctx.paramReferences = expr, nil, nil, nil
-			ctx.assignedNames, ctx.nameCounts = codegen.StringSet{}, map[string]int{}
+func (ctx *observeContext) PreVisit(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+	if ctx.inspectsEventualValues(expr) {
+		if ctx.observesEventualValues(expr) {
+			ctx.activeContext = &observeContext{
+				applyRewriter: ctx.applyRewriter,
+				parent:        ctx,
+				root:          expr,
+				assignedNames: codegen.StringSet{},
+				nameCounts:    map[string]int{},
+			}
+		} else {
+			ctx.activeContext = &inspectContext{
+				applyRewriter: ctx.applyRewriter,
+				parent:        ctx,
+				root:          expr,
+			}
 		}
 	}
 	return expr, nil
 }
 
-// RewriteApplies transforms all bound expression trees in the given Expression that reference output-typed properties
-// into appropriate calls to the __apply and __applyArg intrinsic. Given an expression tree, the rewrite proceeds as
-// follows:
-// - let the list of outputs be an empty list
-// - for each node in post-order:
-//     - if the node is the root of the expression tree:
-//         - if the node is a variable access:
-//             - if the access has an output-typed element on its path, replace the variable access with a call to the
-//               __applyArg intrinsic and append the access to the list of outputs.
-//             - otherwise, the access does not need to be transformed; return it as-is.
-//         - if the list of outputs is empty, the root does not need to be transformed; return it as-is.
-//         - otherwise, replace the root with a call to the __apply intrinstic. The first n arguments to this call are
-//           the elementss of the list of outputs. The final argument is the original root node.
-//     - otherwise, if the root is an output-typed variable access, replace the variable access with a call to the
-//       __applyArg instrinsic and append the access to the list of outputs.
+func (ctx *observeContext) PostVisit(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+	isRoot := expr == ctx.root
+
+	// TODO(pdg): arrays of outputs, for expressions, etc.
+	diagnostics := expr.Typecheck(false)
+	contract.Assert(len(diagnostics) == 0)
+
+	switch x := expr.(type) {
+	case *model.RelativeTraversalExpression:
+		expr = ctx.rewriteRelativeTraversalExpression(x, isRoot)
+	case *model.ScopeTraversalExpression:
+		expr = ctx.rewriteScopeTraversalExpression(x, isRoot)
+	default:
+		_, isEventual := ctx.isEventualType(expr.Type())
+		if isEventual && ctx.inspectsEventualValues(x) {
+			expr = ctx.rewriteApplyArg(x, model.ResolveOutputs(x.Type()), nil, nil, isRoot)
+		}
+	}
+	if isRoot {
+		ctx.root = expr
+		expr = ctx.rewriteRoot(expr)
+
+		ctx.activeContext = ctx.parent
+		return ctx.activeContext.PostVisit(expr)
+	}
+	return expr, nil
+}
+
+func (ctx *inspectContext) PreVisit(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+	if ctx.observesEventualValues(expr) {
+		observeCtx := &observeContext{
+			applyRewriter: ctx.applyRewriter,
+			parent:        ctx,
+			root:          expr,
+			assignedNames: codegen.StringSet{},
+			nameCounts:    map[string]int{},
+		}
+		ctx.activeContext = observeCtx
+	}
+	return expr, nil
+}
+
+func (ctx *inspectContext) PostVisit(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+	if expr == ctx.root {
+		ctx.activeContext = ctx.parent
+		if ctx.parent != nil {
+			return ctx.activeContext.PostVisit(expr)
+		}
+	}
+	return expr, nil
+}
+
+// RewriteApplies transforms all expressions that observe the resolved values of outputs and promises into calls to the
+// __apply intrinsic. Expressions that generate or inspect outputs or promises are passed as arguments to these calls,
+// and are replaced by references to the corresponding parameter.
 //
-// As an example, this transforms the following expression:
-//     (output string
-//         "#!/bin/bash -xe\n\nCA_CERTIFICATE_DIRECTORY=/etc/kubernetes/pki\necho \""
-//         (aws_eks_cluster.demo.certificate_authority.0.data output<unknown> *config.ResourceVariable)
-//         "\" | base64 -d >  $CA_CERTIFICATE_FILE_PATH\nsed -i s,MASTER_ENDPOINT,"
-//         (aws_eks_cluster.demo.endpoint output<string> *config.ResourceVariable)
-//         ",g /var/lib/kubelet/kubeconfig\nsed -i s,CLUSTER_NAME,"
-//         (var.cluster-name string *config.UserVariable)
-//         ",g /var/lib/kubelet/kubeconfig\nsed -i s,REGION,"
-//         (data.aws_region.current.name output<string> *config.ResourceVariable)
-//         ",g /etc/systemd/system/kubelet.servicesed -i s,MASTER_ENDPOINT,"
-//         (aws_eks_cluster.demo.endpoint output<string> *config.ResourceVariable)
-//         ",g /etc/systemd/system/kubelet.service"
-//     )
+// As an example, assuming that resource.id is an output, this transforms the following expression:
+//
+//     toJSON({
+//         Version = "2012-10-17"
+//         Statement = [{
+//             Effect = "Allow"
+//             Principal = "*"
+//             Action = [ "s3:GetObject" ]
+//             Resource = [ "arn:aws:s3:::${resource.id}/*" ]
+//         }]
+//     })
 //
 // into this expression:
-//     (call output<unknown> __apply
-//         (aws_eks_cluster.demo.certificate_authority.0.data output<unknown> *config.ResourceVariable)
-//         (aws_eks_cluster.demo.endpoint output<string> *config.ResourceVariable)
-//         (data.aws_region.current.name output<string> *config.ResourceVariable)
-//         (aws_eks_cluster.demo.endpoint output<string> *config.ResourceVariable)
-//         (output string
-//             "#!/bin/bash -xe\n\nCA_CERTIFICATE_DIRECTORY=/etc/kubernetes/pki\necho \""
-//             (call unknown __applyArg
-//                 0
-//             )
-//             "\" | base64 -d >  $CA_CERTIFICATE_FILE_PATH\nsed -i s,MASTER_ENDPOINT,"
-//             (call string __applyArg
-//                 1
-//             )
-//             ",g /var/lib/kubelet/kubeconfig\nsed -i s,CLUSTER_NAME,"
-//             (var.cluster-name string *config.UserVariable)
-//             ",g /var/lib/kubelet/kubeconfig\nsed -i s,REGION,"
-//             (call string __applyArg
-//                 2
-//             )
-//             ",g /etc/systemd/system/kubelet.servicesed -i s,MASTER_ENDPOINT,"
-//             (call string __applyArg
-//                 3
-//             )
-//             ",g /etc/systemd/system/kubelet.service"
-//         )
-//     )
+//
+//     __apply(resource.id, eval(id, toJSON({
+//         Version = "2012-10-17"
+//         Statement = [{
+//             Effect = "Allow"
+//             Principal = "*"
+//             Action = [ "s3:GetObject" ]
+//             Resource = [ "arn:aws:s3:::${id}/*" ]
+//         }]
+//     })))
+//
+// Here is a more advanced example, assuming that resource is an object whose properties are all outputs, this
+// expression:
+//
+//     "v: ${resource[resource.id]}"
+//
+// is transformed into this expression:
+//
+//     __apply(__apply(resource.id,eval(id, resource[id])),eval(id, "v: ${id}"))
 //
 // This form is amenable to code generation for targets that require that outputs are resolved before their values are
 // accessible (e.g. Pulumi's JS/TS libraries).
 func RewriteApplies(expr model.Expression, nameInfo NameInfo, applyPromises bool) (model.Expression, hcl.Diagnostics) {
-	context := &applyContext{
-		applyRewriter: applyRewriter{nameInfo: nameInfo, applyPromises: applyPromises},
+	applyRewriter := &applyRewriter{
+		nameInfo:      nameInfo,
+		applyPromises: applyPromises,
 	}
-	return model.VisitExpression(expr, context.enterExpression, context.rewriteExpression)
+	applyRewriter.activeContext = &inspectContext{
+		applyRewriter: applyRewriter,
+		root:          expr,
+	}
+	return model.VisitExpression(expr, applyRewriter.preVisit, applyRewriter.postVisit)
 }

--- a/pkg/codegen/hcl2/rewriters.go
+++ b/pkg/codegen/hcl2/rewriters.go
@@ -309,7 +309,7 @@ func (ctx *observeContext) disambiguateArgName(x model.Expression, bestName stri
 	return ctx.disambiguateName(bestName)
 }
 
-// rewriteApplyArg replaces a single expression with an apply paramter.
+// rewriteApplyArg replaces a single expression with an apply parameter.
 func (ctx *observeContext) rewriteApplyArg(applyArg model.Expression, paramType model.Type, traversal hcl.Traversal,
 	parts []model.Traversable, isRoot bool) model.Expression {
 
@@ -342,7 +342,7 @@ func (ctx *observeContext) rewriteApplyArg(applyArg model.Expression, paramType 
 }
 
 // rewriteRelativeTraversalExpression replaces a single access to an ouptut-typed RelativeTraversalExpression with an
-// apply paramter.
+// apply parameter.
 func (ctx *observeContext) rewriteRelativeTraversalExpression(expr *model.RelativeTraversalExpression,
 	isRoot bool) model.Expression {
 
@@ -365,7 +365,7 @@ func (ctx *observeContext) rewriteRelativeTraversalExpression(expr *model.Relati
 }
 
 // rewriteScopeTraversalExpression replaces a single access to an ouptut-typed ScopeTraversalExpression with an apply
-// paramter.
+// parameter.
 func (ctx *observeContext) rewriteScopeTraversalExpression(expr *model.ScopeTraversalExpression,
 	isRoot bool) model.Expression {
 

--- a/pkg/codegen/hcl2/rewriters_test.go
+++ b/pkg/codegen/hcl2/rewriters_test.go
@@ -38,7 +38,7 @@ func TestApplyRewriter(t *testing.T) {
 		},
 		{
 			input:  `"v: ${element(resources.*.id, 0)}"`,
-			output: `__apply(element(resources.*.id, 0),eval(element, "v: ${element}"))`,
+			output: `__apply(element(resources.*.id, 0),eval(ids, "v: ${ids}"))`,
 		},
 		{
 			input:  `"v: ${resource[key]}"`,

--- a/pkg/codegen/hcl2/rewriters_test.go
+++ b/pkg/codegen/hcl2/rewriters_test.go
@@ -1,0 +1,106 @@
+package hcl2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/stretchr/testify/assert"
+)
+
+type nameInfo int
+
+func (nameInfo) IsReservedWord(name string) bool {
+	return false
+}
+
+func TestApplyRewriter(t *testing.T) {
+	cases := []struct {
+		input, output string
+	}{
+		{
+			input:  `"v: ${resource.foo.bar}"`,
+			output: `__apply(resource.foo,eval(foo, "v: ${foo.bar}"))`,
+		},
+		{
+			input:  `"v: ${resource.baz[0]}"`,
+			output: `__apply(resource.baz,eval(baz, "v: ${baz[0]}"))`,
+		},
+		{
+			input:  `"v: ${resources[0].foo.bar}"`,
+			output: `__apply(resources[0].foo,eval(foo, "v: ${foo.bar}"))`,
+		},
+		{
+			input:  `"v: ${resources.*.id[0]}"`,
+			output: `__apply(resources.*.id[0],eval(id, "v: ${id}"))`,
+		},
+		{
+			input:  `"v: ${element(resources.*.id, 0)}"`,
+			output: `__apply(element(resources.*.id, 0),eval(element, "v: ${element}"))`,
+		},
+		{
+			input:  `"v: ${resource[key]}"`,
+			output: `__apply(resource[key],eval(key, "v: ${key}"))`,
+		},
+		{
+			input:  `"v: ${resource[resource.id]}"`,
+			output: `__apply(__apply(resource.id,eval(id, resource[id])),eval(id, "v: ${id}"))`,
+		},
+		{
+			input: `toJSON({
+				Version = "2012-10-17"
+				Statement = [{
+					Effect = "Allow"
+					Principal = "*"
+					Action = [ "s3:GetObject" ]
+					Resource = [ "arn:aws:s3:::${resource.id}/*" ]
+				}]
+			})`,
+			output: `__apply(resource.id,eval(id, toJSON({
+				Version = "2012-10-17"
+				Statement = [{
+					Effect = "Allow"
+					Principal = "*"
+					Action = [ "s3:GetObject" ]
+					Resource = [ "arn:aws:s3:::${id}/*" ]
+				}]
+			})))`,
+		},
+	}
+
+	resourceType := model.NewObjectType(map[string]model.Type{
+		"id": model.NewOutputType(model.StringType),
+		"foo": model.NewOutputType(model.NewObjectType(map[string]model.Type{
+			"bar": model.StringType,
+		})),
+		"baz": model.NewOutputType(model.NewListType(model.StringType)),
+	})
+
+	scope := model.NewRootScope(syntax.None)
+	scope.Define("key", &model.Variable{
+		Name:         "key",
+		VariableType: model.StringType,
+	})
+	scope.Define("resource", &model.Variable{
+		Name:         "resource",
+		VariableType: resourceType,
+	})
+	scope.Define("resources", &model.Variable{
+		Name:         "resources",
+		VariableType: model.NewListType(resourceType),
+	})
+	scope.DefineFunction("element", pulumiBuiltins["element"])
+	scope.DefineFunction("toJSON", pulumiBuiltins["toJSON"])
+
+	for _, c := range cases {
+		expr, diags := model.BindExpressionText(c.input, scope, hcl.Pos{})
+		assert.Len(t, diags, 0)
+
+		expr, diags = RewriteApplies(expr, nameInfo(0), true)
+		assert.Len(t, diags, 0)
+
+		assert.Equal(t, c.output, fmt.Sprintf("%v", expr))
+	}
+}

--- a/pkg/codegen/hcl2/rewriters_test.go
+++ b/pkg/codegen/hcl2/rewriters_test.go
@@ -12,8 +12,8 @@ import (
 
 type nameInfo int
 
-func (nameInfo) IsReservedWord(name string) bool {
-	return false
+func (nameInfo) Format(name string) string {
+	return name
 }
 
 func TestApplyRewriter(t *testing.T) {

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -18,8 +18,8 @@ import (
 
 type nameInfo int
 
-func (nameInfo) IsReservedWord(word string) bool {
-	return isReservedWord(word)
+func (nameInfo) Format(name string) string {
+	return cleanName(name)
 }
 
 func (g *generator) lowerExpression(expr model.Expression) model.Expression {

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -19,8 +19,8 @@ import (
 
 type nameInfo int
 
-func (nameInfo) IsReservedWord(word string) bool {
-	return isReservedWord(word)
+func (nameInfo) Format(name string) string {
+	return PyName(name)
 }
 
 func (g *generator) lowerExpression(expr model.Expression) model.Expression {

--- a/pkg/codegen/python/gen_program_lower.go
+++ b/pkg/codegen/python/gen_program_lower.go
@@ -13,10 +13,15 @@ import (
 // parseProxyApply attempts to match the given parsed apply against the pattern (call __applyArg 0). If the call
 // matches, it returns the ScopeTraversalExpression that corresponds to argument zero, which can then be generated as a
 // proxied apply call.
-func (g *generator) parseProxyApply(args []*model.ScopeTraversalExpression,
+func (g *generator) parseProxyApply(args []model.Expression,
 	then *model.AnonymousFunctionExpression) (*model.ScopeTraversalExpression, bool) {
 
 	if len(args) != 1 {
+		return nil, false
+	}
+
+	arg, ok := args[0].(*model.ScopeTraversalExpression)
+	if !ok {
 		return nil, false
 	}
 
@@ -25,7 +30,7 @@ func (g *generator) parseProxyApply(args []*model.ScopeTraversalExpression,
 		return nil, false
 	}
 
-	traversal := hcl.TraversalJoin(args[0].Traversal, thenTraversal.Traversal[1:])
+	traversal := hcl.TraversalJoin(arg.Traversal, thenTraversal.Traversal[1:])
 	expr, diags := g.program.BindExpression(&hclsyntax.ScopeTraversalExpr{
 		Traversal: traversal,
 		SrcRange:  traversal.SourceRange(),

--- a/pkg/codegen/python/utilities.go
+++ b/pkg/codegen/python/utilities.go
@@ -8,21 +8,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/codegen"
 )
 
-// pythonKeywords is a map of reserved keywords used by python 2 and 3. We use this to avoid generating unspeakable
-// names in the resulting code. This map was sourced by merging the following reference material:
-//
-//     * Python 2: https://docs.python.org/2.5/ref/keywords.html
-//     * Python 3: https://docs.python.org/3/reference/lexical_analysis.html#keywords
-//
-var pythonKeywords = codegen.NewStringSet("false", "none", "true", "and", "as", "assert", "async", "await", "break",
-	"class", "continue", "def", "del", "elif", "else", "except", "exec", "finally", "for", "from", "global", "if",
-	"import", "in", "is", "lambda", "nonlocal", "not", "or", "pass", "print", "raise", "return", "try", "while",
-	"with", "yield")
-
-func isReservedWord(word string) bool {
-	return pythonKeywords.Has(word)
-}
-
 // isLegalIdentifierStart returns true if it is legal for c to be the first character of a Python identifier as per
 // https://docs.python.org/3.7/reference/lexical_analysis.html#identifiers.
 func isLegalIdentifierStart(c rune) bool {

--- a/pkg/codegen/python/utilities.go
+++ b/pkg/codegen/python/utilities.go
@@ -4,8 +4,6 @@ import (
 	"io"
 	"strings"
 	"unicode"
-
-	"github.com/pulumi/pulumi/pkg/v2/codegen"
 )
 
 // isLegalIdentifierStart returns true if it is legal for c to be the first character of a Python identifier as per

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/djherbis/times v1.2.0
 	github.com/docker/docker v0.0.0-20170504205632-89658bed64c2
 	github.com/dustin/go-humanize v1.0.0
+	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.5
 	github.com/google/go-querystring v1.0.0

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -163,6 +163,8 @@ github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813 h1:Uc+IZ7gYqAf/rSGFplbWBSHaGolEQlNLgMgSE3ccnIQ=
+github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813/go.mod h1:P+oSoE9yhSRvsmYyZsshflcR6ePWYLql6UU1amW13IM=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -160,6 +160,7 @@ github.com/fortytw2/leaktest v1.2.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHqu
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813/go.mod h1:P+oSoE9yhSRvsmYyZsshflcR6ePWYLql6UU1amW13IM=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
 github.com/gliderlabs/ssh v0.2.2/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=


### PR DESCRIPTION
Some of the apply rewriter's assumptions were broken by the richer
expressions available in HCL2. These changes fix those broken
assumptions, in particular the assumption that only scope traversal
expressions are sources of eventual values.