### PR TITLE
Don't try decrypt values on community PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,16 @@ sudo: true
 git:
   depth: false
 before_install:
-- openssl aes-256-cbc -K $encrypted_342342ee5e49_key -iv $encrypted_342342ee5e49_iv
-  -in gcp-credentials.json.enc -out gcp-credentials.json -d
+- |
+  if [ "$TRAVIS_PULL_REQUEST_SLUG" != "pulumi/pulumi" ]; 
+  then 
+    echo "Not decrypting gcp credentials";
+    export COMMUNITY_PR="true"
+  else 
+    echo "Decrypting gcp credentials"
+    openssl aes-256-cbc -K $encrypted_342342ee5e49_key -iv $encrypted_342342ee5e49_iv -in gcp-credentials.json.enc -out gcp-credentials.json -d
+    export COMMUNITY_PR="false"
+  fi
 - git clone https://github.com/pulumi/scripts ${GOPATH}/src/github.com/pulumi/scripts
 - source ${GOPATH}/src/github.com/pulumi/scripts/ci/prepare-environment.sh
 - source ${PULUMI_SCRIPTS}/ci/keep-failed-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,10 @@ before_install:
 - |
   if [ "$TRAVIS_PULL_REQUEST_SLUG" != "pulumi/pulumi" ]; 
   then 
-    echo "Not decrypting gcp credentials";
-    export COMMUNITY_PR="true"
+    echo "Community PR - Not decrypting gcp credentials";
   else 
     echo "Decrypting gcp credentials"
     openssl aes-256-cbc -K $encrypted_342342ee5e49_key -iv $encrypted_342342ee5e49_iv -in gcp-credentials.json.enc -out gcp-credentials.json -d
-    export COMMUNITY_PR="false"
   fi
 - git clone https://github.com/pulumi/scripts ${GOPATH}/src/github.com/pulumi/scripts
 - source ${GOPATH}/src/github.com/pulumi/scripts/ci/prepare-environment.sh

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -807,8 +807,9 @@ func removeStack(t *testing.T, name string) {
 }
 
 func skipIfShort(t *testing.T) {
-	if os.Getenv("COMMUNITY_PR") == "true" {
-		t.Skip("Skipped for community PRs")
+	_, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN")
+	if !ok {
+		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")
 	}
 	if testing.Short() {
 		t.Skip("Skipped in short test run")

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -807,6 +807,9 @@ func removeStack(t *testing.T, name string) {
 }
 
 func skipIfShort(t *testing.T) {
+	if os.Getenv("COMMUNITY_PR") == "true" {
+		t.Skip("Skipped for community PRs")
+	}
 	if testing.Short() {
 		t.Skip("Skipped in short test run")
 	}

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -52,7 +52,7 @@ func TestCreatingStackWithArgsSpecifiedName(t *testing.T) {
 }
 
 func TestFailInInteractiveWithoutYes(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -72,7 +72,7 @@ func TestFailInInteractiveWithoutYes(t *testing.T) {
 }
 
 func TestCreatingStackWithPromptedName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -94,7 +94,7 @@ func TestCreatingStackWithPromptedName(t *testing.T) {
 }
 
 func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -119,7 +119,7 @@ func TestCreatingStackWithArgsSpecifiedOrgName(t *testing.T) {
 }
 
 func TestCreatingStackWithPromptedOrgName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -143,7 +143,7 @@ func TestCreatingStackWithPromptedOrgName(t *testing.T) {
 }
 
 func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -170,7 +170,7 @@ func TestCreatingStackWithArgsSpecifiedFullNameSucceeds(t *testing.T) {
 }
 
 func TestCreatingProjectWithDefaultName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -196,7 +196,7 @@ func TestCreatingProjectWithDefaultName(t *testing.T) {
 }
 
 func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -223,7 +223,7 @@ func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {
 }
 
 func TestCreatingProjectWithPromptedName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -247,7 +247,7 @@ func TestCreatingProjectWithPromptedName(t *testing.T) {
 }
 
 func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -274,7 +274,7 @@ func TestCreatingProjectWithExistingArgsSpecifiedNameFails(t *testing.T) {
 }
 
 func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -299,7 +299,7 @@ func TestCreatingProjectWithExistingPromptedNameFails(t *testing.T) {
 }
 
 func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -330,7 +330,7 @@ func TestGeneratingProjectWithExistingArgsSpecifiedNameSucceeds(t *testing.T) {
 }
 
 func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -359,7 +359,7 @@ func TestGeneratingProjectWithExistingPromptedNameSucceeds(t *testing.T) {
 }
 
 func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -388,7 +388,7 @@ func TestGeneratingProjectWithInvalidArgsSpecifiedNameFails(t *testing.T) {
 }
 
 func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -415,7 +415,7 @@ func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 }
 
 func TestInvalidTemplateName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	t.Run("NoTemplateSpecified", func(t *testing.T) {
 		t.Parallel()
@@ -806,7 +806,7 @@ func removeStack(t *testing.T, name string) {
 	assert.NoError(t, err)
 }
 
-func skipIfShort(t *testing.T) {
+func skipIfShortOrNoPulumiAccessToken(t *testing.T) {
 	_, ok := os.LookupEnv("PULUMI_ACCESS_TOKEN")
 	if !ok {
 		t.Skipf("Skipping: PULUMI_ACCESS_TOKEN is not set")

--- a/pkg/cmd/pulumi/policy_new_test.go
+++ b/pkg/cmd/pulumi/policy_new_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestCreatingPolicyPackWithArgsSpecifiedName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -43,7 +43,7 @@ func TestCreatingPolicyPackWithArgsSpecifiedName(t *testing.T) {
 }
 
 func TestCreatingPolicyPackWithPromptedName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	tempdir, _ := ioutil.TempDir("", "test-env")
 	defer os.RemoveAll(tempdir)
@@ -62,7 +62,7 @@ func TestCreatingPolicyPackWithPromptedName(t *testing.T) {
 }
 
 func TestInvalidPolicyPackTemplateName(t *testing.T) {
-	skipIfShort(t)
+	skipIfShortOrNoPulumiAccessToken(t)
 
 	// A template that will never exist.
 	const nonExistantTemplate = "this-is-not-the-template-youre-looking-for"

--- a/pkg/npm/npm_test.go
+++ b/pkg/npm/npm_test.go
@@ -33,6 +33,10 @@ func TestYarnInstall(t *testing.T) {
 }
 
 func testInstall(t *testing.T, expectedBin string) {
+	// Skip for community PRs
+	if os.Getenv("COMMUNITY_PR") == "true" {
+		t.Skip("Skipped for community PRs")
+	}
 	// Skip during short test runs since this test involves downloading dependencies.
 	if testing.Short() {
 		t.Skip("Skipped in short test run")

--- a/pkg/npm/npm_test.go
+++ b/pkg/npm/npm_test.go
@@ -33,10 +33,6 @@ func TestYarnInstall(t *testing.T) {
 }
 
 func testInstall(t *testing.T, expectedBin string) {
-	// Skip for community PRs
-	if os.Getenv("COMMUNITY_PR") == "true" {
-		t.Skip("Skipped for community PRs")
-	}
 	// Skip during short test runs since this test involves downloading dependencies.
 	if testing.Short() {
 		t.Skip("Skipped in short test run")


### PR DESCRIPTION
When a community member sends a pull request to the repo, travis can't
decrypt some environment variables which include decrypting the GCP
credentials.
In addition to this, there are a few tests that run that require the
`PULUMI_ACCESS_TOKEN` which can't be used.

This PR does 2 things:

- Adds a check to the GCP credentials decryption which checks the source
  of the PR (whether it's from within the local repo, or a fork)
- Sets an environment variable: `COMMUNITY_PRS` which is used downstream
  during some tests. If the var exists, some tests are skipped

This should enhance the experience for community pull requests
significantly

Fixes #4508

For an example of this in action, see #4507 