### PR TITLE
Enable container runtime tests for cron jobs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,21 @@ publish_packages:
 	$(call STEP_MESSAGE)
 	./scripts/publish_packages.sh
 
+# Run the integration tests for our DockerHub containers. We do so only via the
+# "Travis Cron" job type, because (1) the tests can only be ran _after_ we publish
+# the current SDK version, since it is required by the Docker build. And (2) the
+# tests (currently) aren't reliable enough to run as part of every push to master.
+#
+# So instead we run the ~daily on master. Where we know the current SDK version
+# will have been published.
+.PHONY: test_containers_cron
+test_containers:
+	$(call STEP_MESSAGE)
+	./scripts/build-docker.sh $$(./scripts/get-version HEAD) --test
+
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
-travis_cron: all
+travis_cron: all test_containers_cron
 travis_push: only_build publish_tgz only_test publish_packages
 travis_pull_request: all
 travis_api: all

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ publish_packages:
 .PHONY: test_containers_cron
 test_containers:
 	$(call STEP_MESSAGE)
-	./scripts/build-docker.sh $$(./scripts/get-version HEAD) --test
+	./scripts/build-docker.sh ${VERSION} --test
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -29,9 +29,15 @@ echo_header() {
 }
 
 test_containers() {
+    echo_header "Executing container runtime tests"
+
+    # Run the container tests, note that we also build the binaries into /tmp for the next step.
+    pushd ${ROOT}/tests
+    GOOS=linux go test -c -o /tmp/pulumi-test-containers ${ROOT}/tests/containers/...
+    popd
+
     # Run tests _within_ the "pulumi" container, ensuring that the CLI is installed
     # and working correctly.
-    echo_header "Executing container runtime tests"
     docker run -e RUN_CONTAINER_TESTS=true \
         -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
         --volume /tmp:/src \
@@ -41,13 +47,9 @@ test_containers() {
 
     # The actions container should fetch program dependencies from NPM, PIP, etc. before
     # executing. These tests just shell out to docker run to confirm that.
-    # Disabled due to https://github.com/pulumi/pulumi/issues/4136
-    # echo_header "Executing container entrypoint tests"
-    # RUN_CONTAINER_TESTS=true go test ${ROOT}/tests/containers/... -test.run TestPulumiActionsImage -test.v
-
-    # In case there are any other unit tests defined in the module, run those as well.
-	pushd ${ROOT}/tests
-    GOOS=linux go test -c -o /tmp/pulumi-test-containers ${ROOT}/tests/containers/...
+    echo_header "Executing container entrypoint tests"
+    pushd ${ROOT}/tests/containers
+    RUN_CONTAINER_TESTS=true go test . -test.run TestPulumiActionsImage -test.v
     popd
 }
 

--- a/tests/containers/containers_test.go
+++ b/tests/containers/containers_test.go
@@ -148,7 +148,7 @@ func testRuntimeWorksInContainer(t *testing.T, runtime, container string) {
 		// Container to run.
 		container,
 		// Flags to the container's entry point (`pulumi`).
-		"up", "--stack", stackName)
+		"up", "--stack", stackName, "--yes")
 
 	assert.Contains(t, stdout, "Hello from "+runtime,
 		"Looking for indication stack update was successful in container output.")


### PR DESCRIPTION
This PR adds a new `make test_containers_cron` target that will execute as part of Travis CI's Cron jobs.  (Which are [configured](https://travis-ci.com/github/pulumi/pulumi/settings) to run on `master` once a day.)

Running the container tests locally works fine on my machine, but it's likely there are still problems with the test that needs to be worked out when ran on Linux. (i.e. #4136) But with this PR, it will be much easier to (1) confirm these tests are still failing on CI and if so, (2) debug/fix them.

I'll keep an eye out on the #builds channel and Travis CI to make sure these start passing again. Let me know what you think about this approach.