### PR TITLE
Fix infinite recursion bug for Go SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (unreleased)
 
+- Fix infinite recursion bug for Go SDK
+  [#4516](https://github.com/pulumi/pulumi/pull/4516)
+
 - Order secretOutputNames when used in stack references
   [#4489](https://github.com/pulumi/pulumi/pull/4489)
 

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -454,6 +454,8 @@ func gatherDependencies(v interface{}) []Resource {
 	return deps
 }
 
+var resourceType = reflect.TypeOf((*Resource)(nil)).Elem()
+
 func gatherDependencySet(v reflect.Value, deps map[Resource]struct{}) {
 	for {
 		// Check for an Output that we can pull dependencies off of.
@@ -461,6 +463,14 @@ func gatherDependencySet(v reflect.Value, deps map[Resource]struct{}) {
 			output := v.Convert(outputType).Interface().(Output)
 			for _, d := range output.dependencies() {
 				deps[d] = struct{}{}
+			}
+			return
+		}
+		// Check for an actual Resource.
+		if v.Type().Implements(resourceType) {
+			if v.CanInterface() {
+				resource := v.Convert(resourceType).Interface().(Resource)
+				deps[resource] = struct{}{}
 			}
 			return
 		}


### PR DESCRIPTION
gatherDependencySet was not checking for Resources
in the dependency set, which could lead to infinite
recursion.