### PR TITLE
Allow `pulumi.export` calls from unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ CHANGELOG
 - Increase the MaxCallRecvMsgSize for all RPC calls. 
   [#4455](https://github.com/pulumi/pulumi/pull/4455)
 
+- Allow `pulumi.export` calls from Python unit tests.
+  [#4518](https://github.com/pulumi/pulumi/pull/4518)
+
 ## 2.0.0 (2020-04-16)
 
 - CLI behavior change.  Commands in non-interactive mode (i.e. when `pulumi` has its output piped to

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -80,6 +80,16 @@ async def run_in_stack(func: Callable):
     """
     await run_pulumi_func(lambda: Stack(func))
 
+async def _run_test(func: Callable):
+    """
+    Run the given function after ensuring a new stack resource has been initialized. This is meant
+    for internal runtime use only.
+    """
+    if get_root_resource() is None:
+        Stack(lambda: None)
+
+    await run_pulumi_func(func)
+
 @known_types.stack
 class Stack(ComponentResource):
     """

--- a/sdk/python/lib/test/langhost/testing_with_mocks/__main__.py
+++ b/sdk/python/lib/test/langhost/testing_with_mocks/__main__.py
@@ -11,9 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import pulumi
 
 import resources
-
-pulumi.export("outprop", resources.mycomponent.outprop)
-pulumi.export("public_ip", resources.myinstance.public_ip)

--- a/sdk/python/lib/test/langhost/testing_with_mocks/resources.py
+++ b/sdk/python/lib/test/langhost/testing_with_mocks/resources.py
@@ -29,3 +29,6 @@ myinstance = Instance("instance",
                       name="myvm",
                       value=pulumi.Output.secret("secret_value"))
 invoke_result = do_invoke()
+
+
+pulumi.export("instance_public_ip", myinstance.public_ip)

--- a/sdk/python/lib/test/langhost/testing_with_mocks/resources.py
+++ b/sdk/python/lib/test/langhost/testing_with_mocks/resources.py
@@ -30,5 +30,5 @@ myinstance = Instance("instance",
                       value=pulumi.Output.secret("secret_value"))
 invoke_result = do_invoke()
 
-
-pulumi.export("instance_public_ip", myinstance.public_ip)
+pulumi.export("outprop", mycomponent.outprop)
+pulumi.export("public_ip", myinstance.public_ip)


### PR DESCRIPTION
This change allows importing modules with calls to `pulumi.export` in unit tests.

I'm not certain this is the best way to address this. Also, we could decide to simply not make this change at all, and just require structuring the program in a way that avoids `pulumi.export` calls from being imported in tests (as is the case today).

## Before

Previously, you'd have to structure the Python program in a way that avoids the `pulumi.export` from being called from unit tests, such as:

```python
# __main__.py

import pulumi

import infra

pulumi.export('group', infra.group)
pulumi.export('server', infra.server)
pulumi.export('publicIp', infra.server.public_ip)
pulumi.export('publicHostName', infra.server.public_dns)
```

```python
# infra.py

import pulumi
from pulumi_aws import ec2

group = ec2.SecurityGroup('web-secgrp', ingress=[
    # Uncomment to fail a test:
    #{ "protocol": "tcp", "from_port": 22, "to_port": 22, "cidr_blocks": ["0.0.0.0/0"] },
    { "protocol": "tcp", "from_port": 80, "to_port": 80, "cidr_blocks": ["0.0.0.0/0"] },
])

user_data = '#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &'

server = ec2.Instance('web-server-www;',
    instance_type="t2.micro",
    security_groups=[ group.name ], # reference the group object above
    # Comment out to fail a test:
    tags={'Name': 'webserver'},     # name tag
    ami="ami-c55673a0")             # AMI for us-east-2 (Ohio)
    # Uncomment to fail a test:
    #user_data=user_data)           # start a simple web server
```

```python
# test_ec2.py

import unittest
import pulumi

class MyMocks(pulumi.runtime.Mocks):
    def new_resource(self, type_, name, inputs, provider, id_):
        return [name + '_id', inputs]
    def call(self, token, args, provider):
        return {}

pulumi.runtime.set_mocks(MyMocks())

# Now actually import the code that creates resources, and then test it.
import infra

class TestingWithMocks(unittest.TestCase):
    # Test if the service has tags and a name tag.
    @pulumi.runtime.test
    def test_server_tags(self):
        def check_tags(args):
            urn, tags = args
            self.assertIsNotNone(tags, f'server {urn} must have tags')
            self.assertIn('Name', tags, 'server {urn} must have a name tag')

        return pulumi.Output.all(infra.server.urn, infra.server.tags).apply(check_tags)
```

This is the approach we use today in our [example](https://github.com/pulumi/examples/tree/master/testing-unit-py) and [test](https://github.com/pulumi/pulumi/tree/master/sdk/python/lib/test/langhost/testing_with_mocks).

## After

With this change, you can now call `pulumi.export` directly from `infra.py`:

```python
# __main__.py

import infra
```

```python
# infra.py

import pulumi
from pulumi_aws import ec2

group = ec2.SecurityGroup('web-secgrp', ingress=[
    # Uncomment to fail a test:
    #{ "protocol": "tcp", "from_port": 22, "to_port": 22, "cidr_blocks": ["0.0.0.0/0"] },
    { "protocol": "tcp", "from_port": 80, "to_port": 80, "cidr_blocks": ["0.0.0.0/0"] },
])

user_data = '#!/bin/bash echo "Hello, World!" > index.html nohup python -m SimpleHTTPServer 80 &'

server = ec2.Instance('web-server-www;',
    instance_type="t2.micro",
    security_groups=[ group.name ], # reference the group object above
    # Comment out to fail a test:
    tags={'Name': 'webserver'},     # name tag
    ami="ami-c55673a0")             # AMI for us-east-2 (Ohio)
    # Uncomment to fail a test:
    #user_data=user_data)           # start a simple web server

pulumi.export('group', group)
pulumi.export('server', server)
pulumi.export('publicIp', server.public_ip)
pulumi.export('publicHostName', server.public_dns)
```

Fixes #4478