### PR TITLE
Don't call IMocks.NewResourceAsync for the root stack resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - Add support for generating Fish completions
   [#4401](https://github.com/pulumi/pulumi/pull/4401)
 
+- Don't call IMocks.NewResourceAsync for the root stack resource
+  [#4527](https://github.com/pulumi/pulumi/pull/4527)
+
 ## 2.1.0 (2020-04-28)
 
 - Fix infinite recursion bug for Go SDK

--- a/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
@@ -1,0 +1,69 @@
+// Copyright 2016-2020, Pulumi Corporation
+
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Pulumi.Testing;
+using Xunit;
+
+namespace Pulumi.Tests.Mocks
+{
+    class MyMocks : IMocks
+    {
+        public Task<object> CallAsync(string token, ImmutableDictionary<string, object> args, string? provider)
+        {
+            return Task.FromResult<object>(args);
+        }
+
+        public Task<(string id, object state)> NewResourceAsync(string type, string name, ImmutableDictionary<string, object> inputs, string? provider, string? id)
+        {
+            Assert.NotEqual("pulumi:pulumi:Stack", type);
+
+            switch (type)
+            {
+                case "aws:ec2/instance:Instance":
+                    return Task.FromResult<(string, object)>(("i-1234567890abcdef0", new Dictionary<string, object> {
+                        { "publicIp", "203.0.113.12" },
+                    }));
+
+                default:
+                    return Task.FromResult<(string, object)>(("", new Dictionary<string, object>()));
+            }
+        }
+    }
+
+    public partial class MocksTests
+    {
+        [Fact]
+        public async Task TestCustom()
+        {
+            var resources = await Testing.RunAsync<MyStack>();
+
+            var instance = resources.OfType<Instance>().FirstOrDefault();
+            Assert.NotNull(instance);
+
+            var ip = await instance.PublicIp.GetValueAsync();
+            Assert.Equal("203.0.113.12", ip);
+        }
+    }
+
+    public static class Testing
+    {
+        public static Task<ImmutableArray<Resource>> RunAsync<T>() where T : Stack, new()
+        {
+            return Deployment.TestAsync<T>(new MyMocks(), new TestOptions { IsPreview = false });
+        }
+
+        public static Task<T> GetValueAsync<T>(this Output<T> output)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            output.Apply(v =>
+            {
+                tcs.SetResult(v);
+                return v;
+            });
+            return tcs.Task;
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
@@ -18,18 +18,10 @@ namespace Pulumi.Tests.Mocks
 
         public Task<(string id, object state)> NewResourceAsync(string type, string name, ImmutableDictionary<string, object> inputs, string? provider, string? id)
         {
-            Assert.NotEqual("pulumi:pulumi:Stack", type);
-
-            switch (type)
-            {
-                case "aws:ec2/instance:Instance":
-                    return Task.FromResult<(string, object)>(("i-1234567890abcdef0", new Dictionary<string, object> {
-                        { "publicIp", "203.0.113.12" },
-                    }));
-
-                default:
-                    return Task.FromResult<(string, object)>(("", new Dictionary<string, object>()));
-            }
+            Assert.Equal("aws:ec2/instance:Instance", type);
+            return Task.FromResult<(string, object)>(("i-1234567890abcdef0", new Dictionary<string, object> {
+                { "publicIp", "203.0.113.12" },
+            }));
         }
     }
 

--- a/sdk/dotnet/Pulumi.Tests/Mocks/TestStack.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/TestStack.cs
@@ -1,0 +1,27 @@
+// Copyright 2016-2020, Pulumi Corporation
+
+namespace Pulumi.Tests.Mocks
+{
+    public partial class Instance : Pulumi.CustomResource
+    {
+        [Output("publicIp")]
+        public Output<string> PublicIp { get; private set; } = null!;
+
+        public Instance(string name, InstanceArgs args, CustomResourceOptions? options = null)
+            : base("aws:ec2/instance:Instance", name, args ?? new InstanceArgs(), options)
+        {
+        }
+    }
+
+    public sealed class InstanceArgs : Pulumi.ResourceArgs
+    {
+    }
+
+    public class MyStack : Stack
+    {
+        public MyStack()
+        {
+            var myInstance = new Instance("instance", new InstanceArgs());
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs
@@ -122,7 +122,7 @@ namespace Pulumi
             lock (_instanceLock)
             {
                 if (_instance != null)
-                    throw new NotSupportedException($"Mulitple executions of {nameof(TestAsync)} must run serially. Please configure your unit test suite to run tests one-by-one.");
+                    throw new NotSupportedException($"Multiple executions of {nameof(TestAsync)} must run serially. Please configure your unit test suite to run tests one-by-one.");
 
                 deployment = new Deployment(engine, monitor, options);
                 Instance = new DeploymentInstance(deployment);

--- a/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
@@ -49,6 +49,14 @@ namespace Pulumi.Testing
 
         public async Task<RegisterResourceResponse> RegisterResourceAsync(Resource resource, RegisterResourceRequest request)
         {
+            if (request.Type == Stack._rootPulumiStackTypeName)
+            {
+                return new RegisterResourceResponse
+                {
+                    Urn = NewUrn(request.Parent, request.Type, request.Name),
+                };
+            }
+
             var (id, state) = await _mocks.NewResourceAsync(request.Type, request.Name, ToDictionary(request.Object),
                 request.Provider, request.ImportId).ConfigureAwait(false);
             


### PR DESCRIPTION
Do not call `IMocks.NewResourceAsync` for the root stack resource. Also add a basic mocks test. (And fix a typo I noticed while working on this.)

Fixes #4524