### PR TITLE
Codegen changes to prepare for C# Kubernetes schema

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -67,6 +67,7 @@ func Title(s string) string {
 
 func csharpIdentifier(s string) string {
 	// Some schema field names may look like $ref or $schema. Remove the leading $ to make a valid identifier.
+	// This could lead to a clash if both `$foo` and `foo` are defined, but we don't try to de-duplicate now.
 	if strings.HasPrefix(s, "$") {
 		s = s[1:]
 	}

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -503,7 +503,7 @@ func primitiveValue(value interface{}) (string, error) {
 	}
 }
 
-func (pkg *modContext) getConstValue(cv interface{}) (string, error) {
+func (mod *modContext) getConstValue(cv interface{}) (string, error) {
 	var val string
 	if cv != nil {
 		v, err := primitiveValue(cv)

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -68,7 +68,7 @@ func Title(s string) string {
 func csharpIdentifier(s string) string {
 	// Some schema field names may look like $ref or $schema. Remove the leading $ to make a valid identifier.
 	if strings.HasPrefix(s, "$") {
-		s = s[2:]
+		s = s[1:]
 	}
 
 	switch s {

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -64,9 +64,13 @@ type typeDetails struct {
 
 // Title converts the input string to a title case
 // where only the initial letter is upper-cased.
+// It also removes $-prefix if any.
 func Title(s string) string {
 	if s == "" {
 		return ""
+	}
+	if s[0] == '$' {
+		return Title(s[1:])
 	}
 	runes := []rune(s)
 	return string(append([]rune{unicode.ToUpper(runes[0])}, runes[1:]...))
@@ -1072,7 +1076,7 @@ func generatePackageContextMap(tool string, pkg *schema.Package, goInfo GoPackag
 	}
 
 	if len(pkg.Config) > 0 {
-		_ = getPkg(":config/config:")
+		_ = getPkg(":config:")
 	}
 
 	// For any optional properties, we must generate a pointer type for the corresponding property type.

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1208,7 +1208,7 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 
 	// Create the config module if necessary.
 	if len(pkg.Config) > 0 {
-		_ = getMod(":config/config:")
+		_ = getMod(":config:")
 	}
 
 	for _, v := range pkg.Config {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1179,7 +1179,7 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 
 	// Create the config module if necessary.
 	if len(pkg.Config) > 0 {
-		_ = getMod(":config/config:")
+		_ = getMod(":config:")
 	}
 
 	scanResource := func(r *schema.Resource) error {

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -509,11 +509,18 @@ func (pkg *Package) TokenToModule(tok string) string {
 		return ""
 	}
 
-	matches := pkg.moduleFormat.FindStringSubmatch(components[1])
-	if len(matches) < 2 || matches[1] == "index" {
+	switch components[1] {
+	case "config":
+		return "config"
+	case "providers":
 		return ""
+	default:
+		matches := pkg.moduleFormat.FindStringSubmatch(components[1])
+		if len(matches) < 2 || matches[1] == "index" {
+			return ""
+		}
+		return matches[1]
 	}
-	return matches[1]
 }
 
 // TypeSpec is the serializable form of a reference to a type.


### PR DESCRIPTION
This is part 1 of https://github.com/pulumi/pulumi-kubernetes/issues/1084

Changes to the core schema-based code-gen that
1. Are needed for k8s C# generation
2. Have no meaningful effect on TF-based providers (tested on AWS and Azure)
3. Do not require any special mode for k8s-only backward compatibility

The next PR will introduce the rest of the changes behind k8s-specific flags.