### PR TITLE
[codegen] Add support for caching package schemas.

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -28,22 +28,57 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-type binder struct {
-	options []model.BindOption
-	host    plugin.Host
+type bindOptions struct {
+	allowMissingVariables bool
+	host                  plugin.Host
+	packageCache          *PackageCache
+}
 
-	packageSchemas map[string]*packageSchema
-	typeSchemas    map[model.Type]schema.Type
+func (opts bindOptions) modelOptions() []model.BindOption {
+	if opts.allowMissingVariables {
+		return []model.BindOption{model.AllowMissingVariables}
+	}
+	return nil
+}
+
+type binder struct {
+	options bindOptions
+
+	referencedPackages []*schema.Package
+	typeSchemas        map[model.Type]schema.Type
 
 	tokens syntax.TokenMap
 	nodes  []Node
 	root   *model.Scope
 }
 
+type BindOption func(*bindOptions)
+
+func AllowMissingVariables(options *bindOptions) {
+	options.allowMissingVariables = true
+}
+
+func PluginHost(host plugin.Host) BindOption {
+	return func(options *bindOptions) {
+		options.host = host
+	}
+}
+
+func Cache(cache *PackageCache) BindOption {
+	return func(options *bindOptions) {
+		options.packageCache = cache
+	}
+}
+
 // BindProgram performs semantic analysis on the given set of HCL2 files that represent a single program. The given
 // host, if any, is used for loading any resource plugins necessary to extract schema information.
-func BindProgram(files []*syntax.File, host plugin.Host, opts ...model.BindOption) (*Program, hcl.Diagnostics, error) {
-	if host == nil {
+func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagnostics, error) {
+	var options bindOptions
+	for _, o := range opts {
+		o(&options)
+	}
+
+	if options.host == nil {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return nil, nil, err
@@ -52,18 +87,20 @@ func BindProgram(files []*syntax.File, host plugin.Host, opts ...model.BindOptio
 		if err != nil {
 			return nil, nil, err
 		}
-		host = ctx.Host
+		options.host = ctx.Host
 
 		defer contract.IgnoreClose(ctx)
 	}
 
+	if options.packageCache == nil {
+		options.packageCache = NewPackageCache()
+	}
+
 	b := &binder{
-		options:        opts,
-		host:           host,
-		tokens:         syntax.NewTokenMapForFiles(files),
-		packageSchemas: map[string]*packageSchema{},
-		typeSchemas:    map[model.Type]schema.Type{},
-		root:           model.NewRootScope(syntax.None),
+		options:     options,
+		tokens:      syntax.NewTokenMapForFiles(files),
+		typeSchemas: map[model.Type]schema.Type{},
+		root:        model.NewRootScope(syntax.None),
 	}
 
 	// Define null.
@@ -196,5 +233,5 @@ func (b *binder) declareNode(name string, n Node) hcl.Diagnostics {
 }
 
 func (b *binder) bindExpression(node hclsyntax.Node) (model.Expression, hcl.Diagnostics) {
-	return model.BindExpression(node, b.root, b.tokens, b.options...)
+	return model.BindExpression(node, b.root, b.tokens, b.options.modelOptions()...)
 }

--- a/pkg/codegen/hcl2/binder_nodes.go
+++ b/pkg/codegen/hcl2/binder_nodes.go
@@ -101,7 +101,7 @@ func (b *binder) getDependencies(node Node) []Node {
 }
 
 func (b *binder) bindConfigVariable(node *ConfigVariable) hcl.Diagnostics {
-	block, diagnostics := model.BindBlock(node.syntax, model.StaticScope(b.root), b.tokens, b.options...)
+	block, diagnostics := model.BindBlock(node.syntax, model.StaticScope(b.root), b.tokens, b.options.modelOptions()...)
 	if defaultValue, ok := block.Body.Attribute("default"); ok {
 		node.DefaultValue = defaultValue.Value
 		if model.InputType(node.typ).ConversionFrom(node.DefaultValue.Type()) == model.NoConversion {
@@ -113,13 +113,13 @@ func (b *binder) bindConfigVariable(node *ConfigVariable) hcl.Diagnostics {
 }
 
 func (b *binder) bindLocalVariable(node *LocalVariable) hcl.Diagnostics {
-	attr, diagnostics := model.BindAttribute(node.syntax, b.root, b.tokens, b.options...)
+	attr, diagnostics := model.BindAttribute(node.syntax, b.root, b.tokens, b.options.modelOptions()...)
 	node.Definition = attr
 	return diagnostics
 }
 
 func (b *binder) bindOutputVariable(node *OutputVariable) hcl.Diagnostics {
-	block, diagnostics := model.BindBlock(node.syntax, model.StaticScope(b.root), b.tokens, b.options...)
+	block, diagnostics := model.BindBlock(node.syntax, model.StaticScope(b.root), b.tokens, b.options.modelOptions()...)
 	if value, ok := block.Body.Attribute("value"); ok {
 		node.Value = value.Value
 		if model.InputType(node.typ).ConversionFrom(node.Value.Type()) == model.NoConversion {

--- a/pkg/codegen/hcl2/binder_resource.go
+++ b/pkg/codegen/hcl2/binder_resource.go
@@ -57,7 +57,7 @@ func (b *binder) bindResourceTypes(node *Resource) hcl.Diagnostics {
 		pkg, isProvider = name, true
 	}
 
-	pkgSchema, ok := b.packageSchemas[pkg]
+	pkgSchema, ok := b.options.packageCache.entries[pkg]
 	if !ok {
 		return hcl.Diagnostics{unknownPackage(pkg, tokenRange)}
 	}
@@ -174,7 +174,7 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 	for _, block := range node.syntax.Body.Blocks {
 		if block.Type == "options" {
 			if rng, hasRange := block.Body.Attributes["range"]; hasRange {
-				expr, _ := model.BindExpression(rng.Expr, b.root, b.tokens, b.options...)
+				expr, _ := model.BindExpression(rng.Expr, b.root, b.tokens, b.options.modelOptions()...)
 				switch {
 				case model.InputType(model.BoolType).ConversionFrom(expr.Type()) == model.SafeConversion:
 					node.VariableType = model.NewOptionalType(node.VariableType)
@@ -191,7 +191,7 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 
 	// Bind the resource's body.
 	scopes := newResourceScopes(b.root, node, rangeKey, rangeValue)
-	block, blockDiags := model.BindBlock(node.syntax, scopes, b.tokens, b.options...)
+	block, blockDiags := model.BindBlock(node.syntax, scopes, b.tokens, b.options.modelOptions()...)
 	diagnostics = append(diagnostics, blockDiags...)
 
 	var options *model.Block

--- a/pkg/codegen/hcl2/binder_test.go
+++ b/pkg/codegen/hcl2/binder_test.go
@@ -41,7 +41,7 @@ func TestBindProgram(t *testing.T) {
 				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 			}
 
-			_, diags, err := BindProgram(parser.Files, test.NewHost(testdataPath))
+			_, diags, err := BindProgram(parser.Files, PluginHost(test.NewHost(testdataPath)))
 			assert.NoError(t, err)
 			if diags.HasErrors() {
 				t.Fatalf("failed to bind program: %v", diags)

--- a/pkg/codegen/hcl2/invoke.go
+++ b/pkg/codegen/hcl2/invoke.go
@@ -77,7 +77,7 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return signature, diagnostics
 	}
 
-	pkgSchema, ok := b.packageSchemas[pkg]
+	pkgSchema, ok := b.options.packageCache.entries[pkg]
 	if !ok {
 		return signature, hcl.Diagnostics{unknownPackage(pkg, tokenRange)}
 	}

--- a/pkg/codegen/hcl2/program.go
+++ b/pkg/codegen/hcl2/program.go
@@ -16,7 +16,6 @@ package hcl2
 
 import (
 	"io"
-	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -101,15 +100,5 @@ func (p *Program) BindExpression(node hclsyntax.Node) (model.Expression, hcl.Dia
 
 // Packages returns the list of package schemas used by this program.
 func (p *Program) Packages() []*schema.Package {
-	names := make([]string, 0, len(p.binder.packageSchemas))
-	for name := range p.binder.packageSchemas {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	packages := make([]*schema.Package, len(names))
-	for i, name := range names {
-		packages[i] = p.binder.packageSchemas[name].schema
-	}
-	return packages
+	return p.binder.referencedPackages
 }

--- a/pkg/codegen/nodejs/gen_program_test.go
+++ b/pkg/codegen/nodejs/gen_program_test.go
@@ -46,7 +46,7 @@ func TestGenProgram(t *testing.T) {
 				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 			}
 
-			program, diags, err := hcl2.BindProgram(parser.Files, test.NewHost(testdataPath))
+			program, diags, err := hcl2.BindProgram(parser.Files, hcl2.PluginHost(test.NewHost(testdataPath)))
 			if err != nil {
 				t.Fatalf("could not bind program: %v", err)
 			}

--- a/pkg/codegen/python/gen_program_test.go
+++ b/pkg/codegen/python/gen_program_test.go
@@ -46,7 +46,7 @@ func TestGenProgram(t *testing.T) {
 				t.Fatalf("failed to parse files: %v", parser.Diagnostics)
 			}
 
-			program, diags, err := hcl2.BindProgram(parser.Files, test.NewHost(testdataPath))
+			program, diags, err := hcl2.BindProgram(parser.Files, hcl2.PluginHost(test.NewHost(testdataPath)))
 			if err != nil {
 				t.Fatalf("could not bind program: %v", err)
 			}


### PR DESCRIPTION
If a single process is going to bind and generate multiple programs, it
is useful to be able to cache package schemas in order to avoid the
(large) overhead of deserializing schemas multiple times.