### PR TITLE
[hcl2/model] Propagate annotations in InputType.

### DIFF
--- a/pkg/codegen/hcl2/model/type_eventuals.go
+++ b/pkg/codegen/hcl2/model/type_eventuals.go
@@ -148,7 +148,7 @@ func InputType(t Type) Type {
 		for k, t := range t.Properties {
 			properties[k] = InputType(t)
 		}
-		src = NewObjectType(properties)
+		src = NewObjectType(properties, t.Annotations...)
 	default:
 		src = t
 	}


### PR DESCRIPTION
When creating the inputty version of an `ObjectType`, ensure that the
result carries any annotations present on the original type.