### PR TITLE
[hcl2] Fix tokens and printing for TraverseIndex.

### DIFF
--- a/pkg/codegen/hcl2/syntax/tokens.go
+++ b/pkg/codegen/hcl2/syntax/tokens.go
@@ -732,6 +732,10 @@ func (t *FunctionCallTokens) GetOpenParen() Token {
 
 func (t *FunctionCallTokens) GetCommas(argCount int) []Token {
 	if t == nil {
+		if argCount == 0 {
+			return nil
+		}
+
 		commas := make([]Token, argCount-1)
 		for i := 0; i < len(commas); i++ {
 			commas[i] = Token{Raw: newRawToken(hclsyntax.TokenComma)}
@@ -1204,6 +1208,10 @@ func (t *TupleConsTokens) GetOpenBracket() Token {
 
 func (t *TupleConsTokens) GetCommas(elementCount int) []Token {
 	if t == nil {
+		if elementCount == 0 {
+			return nil
+		}
+
 		commas := make([]Token, elementCount-1)
 		for i := 0; i < len(commas); i++ {
 			commas[i] = Token{Raw: newRawToken(hclsyntax.TokenComma)}


### PR DESCRIPTION
The tokens that make up the "key" portion of an index traversal
(e.g. `"foo"` in `a["foo"]`) are structured like those that make up a
block label: an open quote token, a string literal token, and a close
quote token. The token mapper did not account for that fact, and instead
recorded the key token as the open quote. These changes correct that
error, and adjust the code in `literalText` to allow for
properly-escaped and quoted strings where necessary.