### PR TITLE
[codegen/python] Fix case mapping.

### DIFF
--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
@@ -9,15 +9,15 @@ web_security_group = aws.ec2.SecurityGroup("webSecurityGroup",
     vpc_id=vpc.id,
     egress=[{
         "protocol": "-1",
-        "fromPort": 0,
-        "toPort": 0,
-        "cidrBlocks": ["0.0.0.0/0"],
+        "from_port": 0,
+        "to_port": 0,
+        "cidr_blocks": ["0.0.0.0/0"],
     }],
     ingress=[{
         "protocol": "tcp",
-        "fromPort": 80,
-        "toPort": 80,
-        "cidrBlocks": ["0.0.0.0/0"],
+        "from_port": 80,
+        "to_port": 80,
+        "cidr_blocks": ["0.0.0.0/0"],
     }])
 # Create an ECS cluster to run a container-based service.
 cluster = aws.ecs.Cluster("cluster")
@@ -50,7 +50,7 @@ web_listener = aws.elasticloadbalancingv2.Listener("webListener",
     port=80,
     default_actions=[{
         "type": "forward",
-        "targetGroupArn": web_target_group.arn,
+        "target_group_arn": web_target_group.arn,
     }])
 # Spin up a load balanced service running NGINX
 app_task = aws.ecs.TaskDefinition("appTask",
@@ -77,11 +77,11 @@ app_service = aws.ecs.Service("appService",
     network_configuration={
         "assignPublicIp": True,
         "subnets": subnets.ids,
-        "securityGroups": [web_security_group.id],
+        "security_groups": [web_security_group.id],
     },
     load_balancers=[{
-        "targetGroupArn": web_target_group.arn,
-        "containerName": "my-app",
+        "target_group_arn": web_target_group.arn,
+        "container_name": "my-app",
         "containerPort": 80,
     }])
 pulumi.export("url", web_load_balancer.dns_name)

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.py
@@ -4,9 +4,9 @@ import pulumi_aws as aws
 # Create a new security group for port 80.
 security_group = aws.ec2.SecurityGroup("securityGroup", ingress=[{
     "protocol": "tcp",
-    "fromPort": 0,
-    "toPort": 0,
-    "cidrBlocks": ["0.0.0.0/0"],
+    "from_port": 0,
+    "to_port": 0,
+    "cidr_blocks": ["0.0.0.0/0"],
 }])
 ami = aws.get_ami(filters=[{
         "name": "name",

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -116,15 +116,7 @@ func (d DocLanguageHelper) GenPropertyCaseMap(pkg *schema.Package, modName, tool
 		return
 	}
 
-	mod := &modContext{
-		pkg:                  pkg,
-		mod:                  modName,
-		tool:                 tool,
-		snakeCaseToCamelCase: snakeCaseToCamelCase,
-		camelCaseToSnakeCase: camelCaseToSnakeCase,
-	}
-
-	mod.recordProperty(prop)
+	recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase)
 }
 
 // GetPropertyName is not implemented for Python because property names in Python must use

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -229,8 +229,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 
 		g.Fgenf(w, "%s(", name)
 
+		casingTable := g.casingTables[pkg]
 		if obj, ok := expr.Args[1].(*model.ObjectConsExpression); ok {
-			g.lowerObjectKeys(expr.Args[1], expr.Signature.Parameters[1].Type)
+			g.lowerObjectKeys(expr.Args[1], casingTable)
 
 			indenter := func(f func()) { f() }
 			if len(obj.Items) > 1 {
@@ -244,7 +245,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 						continue
 					}
 
-					keyVal := key.Value.AsString()
+					keyVal := PyName(key.Value.AsString())
 					if i == 0 {
 						g.Fgenf(w, "%s=%.v", keyVal, item.Value)
 					} else {


### PR DESCRIPTION
Mapping happens at package scope, not type scope. This is what causes
some of the surprising mixes of camel and snake casing in our packages.

In order to accommodate this, build the case mapping tables up front,
and refer to them when performing case mapping.