### PR TITLE
[codegen/python] Fix nested quotes.

### DIFF
--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -1147,6 +1147,17 @@ func (x *IndexExpression) Typecheck(typecheckOperands bool) hcl.Diagnostics {
 		rng = x.Syntax.Collection.Range()
 	}
 
+	if lit, ok := x.Key.(*LiteralValueExpression); ok {
+		traverser := hcl.TraverseIndex{
+			Key: lit.Value,
+		}
+		valueType, traverseDiags := x.Collection.Type().Traverse(traverser)
+		if len(traverseDiags) == 0 {
+			x.exprType = valueType.(Type)
+			return diagnostics
+		}
+	}
+
 	collectionType := unwrapIterableSourceType(x.Collection.Type())
 	keyType, valueType, kvDiags := GetCollectionTypes(collectionType, rng)
 	diagnostics = append(diagnostics, kvDiags...)

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.py
@@ -11,10 +11,10 @@ site_dir = "www"
 # For each file in the directory, create an S3 object stored in `siteBucket`
 files = []
 for range in [{"key": k, "value": v} for [k, v] in enumerate(os.listdir(site_dir))]:
-    files.append(aws.s3.BucketObject(f"files-${range.key}",
+    files.append(aws.s3.BucketObject(f"files-{range['key']}",
         bucket=site_bucket.id,
-        key=range.value,
-        source=pulumi.FileAsset(f"{site_dir}/{range.value}"),
+        key=range["value"],
+        source=pulumi.FileAsset(f"{site_dir}/{range['value']}"),
         content_type=(lambda: raise Exception("FunctionCallExpression: mimeType (aws-s3-folder.pp:19,16-37)"))()))
 # set the MIME type of the file
 # Set the access policy for the bucket so all objects are readable

--- a/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.py
@@ -5,4 +5,4 @@ logs = aws.s3.Bucket("logs")
 bucket = aws.s3.Bucket("bucket", loggings=[{
     "targetBucket": logs.bucket,
 }])
-pulumi.export("targetBucket", bucket.loggings[0].targetBucket)
+pulumi.export("targetBucket", bucket.loggings[0]["targetBucket"])

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -1,3 +1,4 @@
+//nolint: goconst
 package python
 
 import (

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
-	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -23,12 +22,13 @@ func (nameInfo) Format(name string) string {
 	return PyName(name)
 }
 
-func (g *generator) lowerExpression(expr model.Expression) model.Expression {
+func (g *generator) lowerExpression(expr model.Expression) (model.Expression, []*quoteTemp) {
 	// TODO(pdg): diagnostics
 
 	expr, _ = hcl2.RewriteApplies(expr, nameInfo(0), false)
 	expr, _ = g.lowerProxyApplies(expr)
-	return expr
+	expr, quotes, _ := g.rewriteQuotes(expr)
+	return expr, quotes
 }
 
 func (g *generator) GetPrecedence(expr model.Expression) int {
@@ -172,15 +172,9 @@ func functionName(tokenArg model.Expression) (string, string, string, hcl.Diagno
 	token := tokenArg.(*model.TemplateExpression).Parts[0].(*model.LiteralValueExpression).Value.AsString()
 	tokenRange := tokenArg.SyntaxNode().Range()
 
-	// Compute the function name from the Pulumi type token.
+	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diagnostics := hcl2.DecomposeToken(token, tokenRange)
-
-	components := strings.Split(module, ".")
-	for i, component := range components {
-		components[i] = PyName(component)
-	}
-
-	return cleanName(pkg), strings.Join(components, "."), title(member), diagnostics
+	return cleanName(pkg), strings.Replace(module, "/", ".", -1), title(member), diagnostics
 }
 
 var functionImports = map[string]string{
@@ -321,24 +315,13 @@ func (g *generator) genEscapedString(w runeWriter, v string, escapeNewlines, esc
 	}
 }
 
-func (g *generator) genStringLiteral(w io.Writer, v string) {
+func (g *generator) genStringLiteral(w io.Writer, quotes, v string) {
 	builder := &strings.Builder{}
-	newlines := strings.Count(v, "\n")
-	if newlines == 0 || newlines == 1 && (v[0] == '\n' || v[len(v)-1] == '\n') {
-		// This string either does not contain newlines or contains a single leading or trailing newline, so we'll
-		// Generate a short string literal. Quotes, backslashes, and newlines will be escaped in conformance with
-		// https://docs.python.org/3.7/reference/lexical_analysis.html#literals.
-		builder.WriteRune('"')
-		g.genEscapedString(builder, v, true, false)
-		builder.WriteRune('"')
-	} else {
-		// This string does contain newlines, so we'll generate a long string literal. "${", backquotes, and
-		// backslashes will be escaped in conformance with
-		// https://docs.python.org/3.7/reference/lexical_analysis.html#literals.
-		builder.WriteString(`"""`)
-		g.genEscapedString(builder, v, false, false)
-		builder.WriteString(`"""`)
-	}
+
+	builder.WriteString(quotes)
+	escapeNewlines := quotes == `"` || quotes == `'`
+	g.genEscapedString(builder, v, escapeNewlines, false)
+	builder.WriteString(quotes)
 
 	g.Fgenf(w, "%s", builder.String())
 }
@@ -360,7 +343,8 @@ func (g *generator) GenLiteralValueExpression(w io.Writer, expr *model.LiteralVa
 			g.Fgenf(w, "%g", f)
 		}
 	case model.StringType:
-		g.genStringLiteral(w, expr.Value.AsString())
+		quotes := g.quotes[expr]
+		g.genStringLiteral(w, quotes, expr.Value.AsString())
 	default:
 		contract.Failf("unexpected literal type in GenLiteralValueExpression: %v (%v)", expr.Type(),
 			expr.SyntaxNode().Range())
@@ -382,7 +366,7 @@ func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsE
 }
 
 func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, parts []model.Traversable) {
-	for i, traverser := range traversal {
+	for _, traverser := range traversal {
 		var key cty.Value
 		switch traverser := traverser.(type) {
 		case hcl.TraverseAttr:
@@ -396,25 +380,17 @@ func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, p
 		switch key.Type() {
 		case cty.String:
 			keyVal := key.AsString()
-
-			receiver := parts[i]
-			if receiver, ok := receiver.(model.TypedTraversable); ok {
-				annotations := receiver.Type().GetAnnotations()
-				if len(annotations) == 1 {
-					keyVal = g.mapObjectKey(keyVal, annotations[0].(*schema.ObjectType))
-				}
-			}
-
-			if isLegalIdentifier(keyVal) {
-				g.Fgenf(w, ".%s", keyVal)
-			} else {
-				g.Fgenf(w, "[%q]", keyVal)
-			}
+			contract.Assert(isLegalIdentifier(keyVal))
+			g.Fgenf(w, ".%s", keyVal)
 		case cty.Number:
 			idx, _ := key.AsBigFloat().Int64()
 			g.Fgenf(w, "[%d]", idx)
 		default:
-			g.Fgenf(w, "[%q]", key.AsString())
+			keyExpr := &model.LiteralValueExpression{Value: key}
+			diags := keyExpr.Typecheck(false)
+			contract.Ignore(diags)
+
+			g.Fgenf(w, "[%v]", keyExpr)
 		}
 	}
 }
@@ -439,44 +415,24 @@ func (g *generator) GenSplatExpression(w io.Writer, expr *model.SplatExpression)
 }
 
 func (g *generator) GenTemplateExpression(w io.Writer, expr *model.TemplateExpression) {
-	if len(expr.Parts) == 1 {
-		if lit, ok := expr.Parts[0].(*model.LiteralValueExpression); ok && lit.Type() == model.StringType {
-			g.GenLiteralValueExpression(w, lit)
-			return
-		}
-	}
+	quotes := g.quotes[expr]
+	escapeNewlines := quotes == `"` || quotes == `'`
 
-	formatted, isMultiLine, quotes := false, false, `"`
-	for i, part := range expr.Parts {
-		if lit, ok := part.(*model.LiteralValueExpression); ok {
-			if !isMultiLine && lit.Type() == model.StringType {
-				v := lit.Value.AsString()
-				switch strings.Count(v, "\n") {
-				case 0:
-					continue
-				case 1:
-					if i == 0 && v[0] == '\n' || i == len(expr.Parts)-1 && v[len(v)-1] == '\n' {
-						continue
-					}
-				}
-				isMultiLine, quotes = true, `"""`
-			}
-		} else {
-			formatted = true
+	prefix := ""
+	for _, part := range expr.Parts {
+		if lit, ok := part.(*model.LiteralValueExpression); !ok || lit.Type() != model.StringType {
+			prefix = "f"
+			break
 		}
 	}
 
 	b := bufio.NewWriter(w)
 	defer b.Flush()
 
-	prefix := ""
-	if formatted {
-		prefix = "f"
-	}
 	g.Fprintf(b, "%s%s", prefix, quotes)
 	for _, expr := range expr.Parts {
 		if lit, ok := expr.(*model.LiteralValueExpression); ok && lit.Type() == model.StringType {
-			g.genEscapedString(b, lit.Value.AsString(), !isMultiLine, formatted)
+			g.genEscapedString(b, lit.Value.AsString(), escapeNewlines, true)
 		} else {
 			g.Fgenf(b, "{%.v}", expr)
 		}

--- a/pkg/codegen/python/gen_program_lower.go
+++ b/pkg/codegen/python/gen_program_lower.go
@@ -65,27 +65,6 @@ func (g *generator) lowerProxyApplies(expr model.Expression) (model.Expression, 
 	return model.VisitExpression(expr, model.IdentityVisitor, rewriter)
 }
 
-func (g *generator) mapObjectKey(key string, obj *schema.ObjectType) string {
-	if obj == nil {
-		return key
-	}
-
-	prop, ok := obj.Property(key)
-	if !ok {
-		return key
-	}
-
-	mapCase := true
-	if info, ok := prop.Language["python"]; ok {
-		mapCase = info.(PropertyInfo).MapCase
-	}
-	if mapCase {
-		return PyName(key)
-	}
-
-	return key
-}
-
 func (g *generator) getObjectSchema(typ model.Type) *schema.ObjectType {
 	typ = model.ResolveOutputs(typ)
 

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -1,0 +1,322 @@
+package python
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func (g *generator) mapObjectKey(key string, obj *schema.ObjectType) string {
+	if obj == nil {
+		return key
+	}
+
+	prop, ok := obj.Property(key)
+	if !ok {
+		return key
+	}
+
+	mapCase := true
+	if info, ok := prop.Language["python"]; ok {
+		mapCase = info.(PropertyInfo).MapCase
+	}
+	if mapCase {
+		return PyName(key)
+	}
+
+	return key
+}
+
+func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expression, parts []model.Traversable) (model.Expression, hcl.Diagnostics) {
+	// TODO(pdg): transfer trivia
+
+	var rootName string
+	var currentTraversal hcl.Traversal
+	currentParts := []model.Traversable{parts[0]}
+	currentExpression := source
+
+	if len(traversal) > 0 {
+		if root, isRoot := traversal[0].(hcl.TraverseRoot); isRoot {
+			traversal = traversal[1:]
+			rootName, currentTraversal = root.Name, hcl.Traversal{root}
+		}
+	}
+
+	var diagnostics hcl.Diagnostics
+	for i, traverser := range traversal {
+		var key cty.Value
+		switch traverser := traverser.(type) {
+		case hcl.TraverseAttr:
+			key = cty.StringVal(traverser.Name)
+		case hcl.TraverseIndex:
+			key = traverser.Key
+		default:
+			contract.Failf("unexpected traverser of type %T (%v)", traverser, traverser.SourceRange())
+		}
+
+		if key.Type() != cty.String {
+			currentTraversal = append(currentTraversal, traverser)
+			currentParts = append(currentParts, parts[i+1])
+			continue
+		}
+
+		keyVal, objectKey := key.AsString(), false
+
+		receiver := parts[i]
+		if receiver, ok := receiver.(model.TypedTraversable); ok {
+			annotations := receiver.Type().GetAnnotations()
+			if len(annotations) == 1 {
+				obj := annotations[0].(*schema.ObjectType)
+				if info, ok := obj.Language["python"].(objectTypeInfo); !ok || !info.isDictionary {
+					objectKey = true
+				}
+				keyVal = g.mapObjectKey(keyVal, obj)
+
+				switch t := traverser.(type) {
+				case hcl.TraverseAttr:
+					t.Name = keyVal
+					traverser, traversal[i] = t, t
+				case hcl.TraverseIndex:
+					t.Key = cty.StringVal(keyVal)
+					traverser, traversal[i] = t, t
+				}
+			}
+		}
+
+		if objectKey && isLegalIdentifier(keyVal) {
+			currentTraversal = append(currentTraversal, traverser)
+			currentParts = append(currentParts, parts[i+1])
+			continue
+		}
+
+		if currentExpression == nil {
+			contract.Assert(rootName != "")
+			currentExpression = &model.ScopeTraversalExpression{
+				RootName:  rootName,
+				Traversal: currentTraversal,
+				Parts:     currentParts,
+			}
+			checkDiags := currentExpression.Typecheck(false)
+			diagnostics = append(diagnostics, checkDiags...)
+
+			currentTraversal, currentParts = nil, nil
+		} else if len(currentTraversal) > 0 {
+			currentExpression = &model.RelativeTraversalExpression{
+				Source:    currentExpression,
+				Traversal: currentTraversal,
+				Parts:     currentParts,
+			}
+			checkDiags := currentExpression.Typecheck(false)
+			diagnostics = append(diagnostics, checkDiags...)
+
+			currentTraversal, currentParts = nil, []model.Traversable{currentExpression.Type()}
+		}
+
+		currentExpression = &model.IndexExpression{
+			Collection: currentExpression,
+			Key: &model.LiteralValueExpression{
+				Value: cty.StringVal(keyVal),
+			},
+		}
+		checkDiags := currentExpression.Typecheck(false)
+		diagnostics = append(diagnostics, checkDiags...)
+	}
+
+	if currentExpression == source {
+		return nil, nil
+	}
+
+	return currentExpression, diagnostics
+}
+
+type quoteTemp struct {
+	Name         string
+	VariableType model.Type
+	Value        model.Expression
+}
+
+func (qt *quoteTemp) Type() model.Type {
+	return qt.VariableType
+}
+
+func (qt *quoteTemp) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	return qt.VariableType.Traverse(traverser)
+}
+
+func (qt *quoteTemp) SyntaxNode() hclsyntax.Node {
+	return syntax.None
+}
+
+type quoteAllocations struct {
+	quotes map[model.Expression]string
+	temps  []*quoteTemp
+}
+
+type quoteAllocator struct {
+	allocations *quoteAllocations
+	allocated   codegen.StringSet
+	stack       []model.Expression
+}
+
+func (qa *quoteAllocator) allocate(longString bool) (string, bool) {
+	if longString {
+		if !qa.allocated.Has(`"`) && !qa.allocated.Has(`"""`) {
+			qa.allocated.Add(`"""`)
+			return `"""`, true
+		}
+
+		if !qa.allocated.Has(`'`) && !qa.allocated.Has(`'''`) {
+			qa.allocated.Add(`'''`)
+			return `'''`, true
+		}
+
+		return "", false
+	}
+
+	if !qa.allocated.Has(`"`) {
+		qa.allocated.Add(`"`)
+		return `"`, true
+	}
+
+	if !qa.allocated.Has(`'`) {
+		qa.allocated.Add(`'`)
+		return `'`, true
+	}
+
+	return "", false
+}
+
+func (qa *quoteAllocator) free(quotes string) {
+	qa.allocated.Delete(quotes)
+}
+
+func (qa *quoteAllocator) inTemplate() bool {
+	if len(qa.stack) < 2 {
+		return false
+	}
+	_, isTemplate := qa.stack[len(qa.stack)-2].(*model.TemplateExpression)
+	return isTemplate
+}
+
+func (qa *quoteAllocator) allocateExpression(x model.Expression) (model.Expression, hcl.Diagnostics) {
+	qa.stack = append(qa.stack, x)
+
+	var longString bool
+	switch x := x.(type) {
+	case *model.LiteralValueExpression:
+		if x.Type() != model.StringType || qa.inTemplate() {
+			return x, nil
+		}
+		v := x.Value.AsString()
+		switch strings.Count(v, "\n") {
+		case 0:
+			// OK
+		case 1:
+			longString = v[0] != '\n' && v[len(v)-1] != '\n'
+		default:
+			longString = true
+		}
+	case *model.TemplateExpression:
+		for i, part := range x.Parts {
+			if lit, ok := part.(*model.LiteralValueExpression); ok && lit.Type() == model.StringType {
+				v := lit.Value.AsString()
+				switch strings.Count(v, "\n") {
+				case 0:
+					continue
+				case 1:
+					if i == 0 && v[0] == '\n' || i == len(x.Parts)-1 && v[len(v)-1] == '\n' {
+						continue
+					}
+				}
+				longString = true
+				break
+			}
+		}
+	default:
+		return x, nil
+	}
+
+	if quote, ok := qa.allocate(longString); ok {
+		qa.allocations.quotes[x] = quote
+		return x, nil
+	}
+
+	allocator := &quoteAllocator{allocated: codegen.StringSet{}, allocations: qa.allocations}
+	value, valueDiags := model.VisitExpression(x, allocator.allocateExpression, allocator.freeExpression)
+
+	temp := &quoteTemp{
+		Name:         fmt.Sprintf("str%d", len(qa.allocations.temps)),
+		VariableType: x.Type(),
+		Value:        value,
+	}
+	qa.allocations.temps = append(qa.allocations.temps, temp)
+
+	return &model.ScopeTraversalExpression{
+		RootName:  temp.Name,
+		Traversal: hcl.Traversal{hcl.TraverseRoot{Name: ""}},
+		Parts:     []model.Traversable{temp},
+	}, valueDiags
+}
+
+func (qa *quoteAllocator) freeExpression(x model.Expression) (model.Expression, hcl.Diagnostics) {
+	defer func() {
+		qa.stack = qa.stack[:len(qa.stack)-1]
+	}()
+
+	switch x := x.(type) {
+	case *model.LiteralValueExpression:
+		if x.Type() != model.StringType || qa.inTemplate() {
+			return x, nil
+		}
+		// OK
+	case *model.TemplateExpression:
+		// OK
+	default:
+		return x, nil
+	}
+
+	quotes, ok := qa.allocations.quotes[x]
+	contract.Assert(ok)
+	qa.free(quotes)
+	return x, nil
+}
+
+func (g *generator) rewriteQuotes(x model.Expression) (model.Expression, []*quoteTemp, hcl.Diagnostics) {
+	var diagnostics hcl.Diagnostics
+
+	// First, rewrite traversals that require string indices into index expressions.
+	x, rewriteDiags := model.VisitExpression(x, nil, func(x model.Expression) (model.Expression, hcl.Diagnostics) {
+		switch x := x.(type) {
+		case *model.RelativeTraversalExpression:
+			idx, diags := g.rewriteTraversal(x.Traversal, x.Source, x.Parts)
+			if idx != nil {
+				return idx, diags
+			}
+		case *model.ScopeTraversalExpression:
+			idx, diags := g.rewriteTraversal(x.Traversal, nil, x.Parts)
+			if idx != nil {
+				return idx, diags
+			}
+		}
+		return x, nil
+	})
+	diagnostics = append(diagnostics, rewriteDiags...)
+
+	// Then lift any expressions that cannot be allocated quotes into temps.
+	allocations := &quoteAllocations{
+		quotes: g.quotes,
+	}
+	allocator := &quoteAllocator{allocated: codegen.StringSet{}, allocations: allocations}
+	x, rewriteDiags = model.VisitExpression(x, allocator.allocateExpression, allocator.freeExpression)
+	diagnostics = append(diagnostics, rewriteDiags...)
+
+	return x, allocations.temps, diagnostics
+}

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -35,7 +35,9 @@ func (g *generator) mapObjectKey(key string, obj *schema.ObjectType) string {
 	return key
 }
 
-func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expression, parts []model.Traversable) (model.Expression, hcl.Diagnostics) {
+func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expression,
+	parts []model.Traversable) (model.Expression, hcl.Diagnostics) {
+
 	// TODO(pdg): transfer trivia
 
 	var rootName string

--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -35,6 +35,10 @@ func (ss StringSet) Add(s string) {
 	ss[s] = struct{}{}
 }
 
+func (ss StringSet) Delete(s string) {
+	delete(ss, s)
+}
+
 func (ss StringSet) Has(s string) bool {
 	_, ok := ss[s]
 	return ok


### PR DESCRIPTION
Unlike most languages with interpolated strings, Python's formatted
string literals do not allow the nesting of quotes. For example,
this expression is not legal Python:

    f"Foo {"bar"} baz"

If an interpolation requires quotes, those quotes nust differ from the
quotes used by the enclosing literal. We can fix the previous example
by rewriting it with single quotes:

    f"Foo {'bar'} baz"

However, this presents a problem if there are more than two levels of
nesting, as Python only has two kinds of quotes (four if the outermost
string uses """ or '''): in this case, the expression becomes
unspellable, and must be assigned to a local that is then used in place
of the original expression. So this:

    f"Foo {bar[f'index {baz["qux"]}']} zed"

becomes this:

    index = "qux"
    f"Foo {bar[f'index {baz[index]}']}"

To put it bluntly, Python code generation reqiures register allocation,
but for quotes. These changes implement exactly that.