### PR TITLE
Makefile: properly encode dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,13 @@ generate::
 	echo "Generate static assets bundle for docs generator"
 	cd pkg && go generate ./codegen/docs/gen.go
 
-build::
+build:: generate
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v2/version.Version=${VERSION}" ${PROJECT}
 
-install::
+install:: generate
 	cd pkg && GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/v2/version.Version=${VERSION}" ${PROJECT}
 
-dist::
+dist:: build
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v2/version.Version=${VERSION}" ${PROJECT}
 
 lint::
@@ -59,10 +59,10 @@ lint::
 		pushd $$DIR ; golangci-lint run -c ../.golangci.yml --timeout 5m ; popd ; \
 	done
 
-test_fast::
+test_fast:: build
 	cd pkg && $(GO_TEST_FAST) ${PROJECT_PKGS}
 
-test_all::
+test_all:: build $(SUB_PROJECTS:%=%_install)
 	cd pkg && $(GO_TEST) ${PROJECT_PKGS}
 	cd tests && $(GO_TEST) -v -p=1 ${TESTS_PKGS}
 

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -41,12 +41,12 @@ build::
 install_plugin::
 	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/sdk/v2/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
-install:: install_plugin
+install:: build install_plugin
 	echo "Copying NuGet packages to ${PULUMI_NUGET}"
 	[ ! -e "$(PULUMI_NUGET)" ] || rm -rf "$(PULUMI_NUGET)/*"
 	find . -name '*.nupkg' -exec cp -p {} ${PULUMI_NUGET} \;
 
-dotnet_test::
+dotnet_test:: install
 	# include the version prefix/suffix to avoid generating a separate nupkg file
 	dotnet test /p:VersionPrefix=${VERSION_PREFIX} /p:VersionSuffix=${VERSION_SUFFIX}
 	# work around a bug where running `dotnet test` disables console stdinput display

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -20,7 +20,7 @@ install:: install_plugin
 
 test_all:: test_fast
 
-test_fast::
+test_fast:: install
 	go test -count=1 -cover -parallel ${TESTPARALLELISM} ${PROJECT_PKGS}
 
 dist::

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -31,21 +31,21 @@ build_plugin::
 
 build:: build_package build_plugin
 
-install_package::
+install_package:: build
 	cp dist/pulumi-resource-pulumi-nodejs "$(PULUMI_BIN)"
 	cp dist/pulumi-analyzer-policy "$(PULUMI_BIN)"
 
-install_plugin::
+install_plugin:: build
 	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/sdk/v2/go/common/version.Version=${VERSION}" ${LANGUAGE_HOST}
 
 install:: install_package install_plugin
 
-istanbul_tests::
-	./node_modules/.bin/istanbul test --print none _mocha -- --timeout 15000 'bin/tests/**/*.spec.js'
+istanbul_tests:: build
+	./node_modules/.bin/istanbul test --print none _mocha -- --timeout 30000 'bin/tests/**/*.spec.js'
 	./node_modules/.bin/istanbul report text-summary
 	./node_modules/.bin/istanbul report text
 
-sxs_tests::
+sxs_tests:: build
 	pushd tests/sxs_ts_3.6 && yarn ; tsc ; popd
 	pushd tests/sxs_ts_latest && yarn ; tsc ; popd
 
@@ -55,7 +55,7 @@ test_fast:: sxs_tests istanbul_tests
 test_all:: sxs_tests istanbul_tests
 	$(GO_TEST) ${PROJECT_PKGS}
 
-dist::
+dist:: build
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v2/go/common/version.Version=${VERSION}" ${LANGUAGE_HOST}
 	cp dist/pulumi-resource-pulumi-nodejs "$$(go env GOPATH)"/bin/
 	cp dist/pulumi-analyzer-policy "$$(go env GOPATH)"/bin/

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -27,18 +27,18 @@ lint::
 	pipenv run mypy ./lib/pulumi --config-file=mypy.ini
 	pipenv run pylint ./lib/pulumi --rcfile=.pylintrc
 
-install_package::
+install_package:: build_package
 	cp ./cmd/pulumi-language-python-exec "$(PULUMI_BIN)"
 	cp ./dist/pulumi-resource-pulumi-python "$(PULUMI_BIN)"
 	cp ./dist/pulumi-analyzer-policy-python "$(PULUMI_BIN)"
 
-install_plugin::
+install_plugin:: build_plugin
 	GOBIN=$(PULUMI_BIN) go install \
 		  -ldflags "-X github.com/pulumi/pulumi/sdk/v2/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
 install:: install_package install_plugin
 
-test_fast::
+test_fast:: build
 	pipenv run pip install ./env/src
 	pipenv run python -m unittest discover -s lib/test -v
 


### PR DESCRIPTION
This allows for the use of `make -j`, which speeds up a full build
dramatically at the cost of rather incomprehensible logs.