### PR TITLE
[codegen/docs] Restore the API type links for C#.

### DIFF
--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -56,6 +56,8 @@ type functionDocArgs struct {
 	// NestedTypes is a slice of the nested types used in the input and
 	// output properties.
 	NestedTypes []docNestedType
+
+	PackageDetails packageDetails
 }
 
 // getFunctionResourceInfo returns a map of per-language information about
@@ -324,6 +326,12 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		funcNameMap[lang] = docHelper.GetFunctionName(mod.mod, f)
 	}
 
+	packageDetails := packageDetails{
+		Repository: mod.pkg.Repository,
+		License:    mod.pkg.License,
+		Notes:      mod.pkg.Attribution,
+	}
+
 	args := functionDocArgs{
 		Header: mod.genFunctionHeader(f),
 
@@ -340,6 +348,8 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		OutputProperties: outputProps,
 
 		NestedTypes: nestedTypes,
+
+		PackageDetails: packageDetails,
 	}
 
 	return args

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -65,6 +65,10 @@ The following output properties are available:
 > See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.go.InputType "") (ne .APIDocLinks.go.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
 
+{{ htmlSafe "{{% choosable language csharp %}}" }}
+> See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.csharp.InputType "") (ne .APIDocLinks.csharp.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} API doc for this type.
+{{ htmlSafe "{{% /choosable %}}" }}
+
 {{ template "properties" .Properties }}
 {{ end }}
 

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -65,11 +65,15 @@ The following output properties are available:
 > See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.go.InputType "") (ne .APIDocLinks.go.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
 
+{{- if (hasDocLinksForLang .APIDocLinks "csharp") }}
 {{ htmlSafe "{{% choosable language csharp %}}" }}
 > See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.csharp.InputType "") (ne .APIDocLinks.csharp.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
+{{- end }}
 
 {{ template "properties" .Properties }}
 {{ end }}
 
 {{ end }}
+
+{{ template "package_details" .PackageDetails }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -166,6 +166,10 @@ The following state arguments are supported:
 > See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.go.InputType "") (ne .APIDocLinks.go.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
 
+{{ htmlSafe "{{% choosable language csharp %}}" }}
+> See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.csharp.InputType "") (ne .APIDocLinks.csharp.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} API doc for this type.
+{{ htmlSafe "{{% /choosable %}}" }}
+
 {{ template "properties" .Properties }}
 {{ end }}
 

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -166,9 +166,11 @@ The following state arguments are supported:
 > See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.go.InputType "") (ne .APIDocLinks.go.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
 
+{{- if (hasDocLinksForLang .APIDocLinks "csharp") }}
 {{ htmlSafe "{{% choosable language csharp %}}" }}
 > See the {{ if ne .APIDocLinks.csharp.InputType "" }}<a href="{{ .APIDocLinks.csharp.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.csharp.InputType "") (ne .APIDocLinks.csharp.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.csharp.OutputType "" }}<a href="{{ .APIDocLinks.csharp.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
+{{- end }}
 
 {{ template "properties" .Properties }}
 {{ end }}


### PR DESCRIPTION
Fixes #4242.

We previously removed the links to the C# types from the resource docs because there were differences in the property type names between the old code gen and the Pulumi schema-based code gen. Since then the C# code gen used by the providers has been switched to use the schema-based one. So we can restore the links in our docs now.

~~I am creating this in a draft mode while I still evaluate the links to the types.~~

EDIT: I opened a docs [PR](https://github.com/pulumi/docs/pull/3196) to get the preview for AWS resource docs. I added an exclusion for k8s still because there are still differences in the C# code gen between what the k8s package currently uses and what the Pulumi schema-based code gen generates. Here's an [overview](https://github.com/pulumi/pulumi-kubernetes/issues/1072) of those differences.