### PR TITLE
Introduce k8s compatibility mode to C# codegen

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -294,7 +294,7 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			typ = "Archive"
 		case schema.AssetType:
 			typ = "AssetOrArchive"
-		case schema.JsonType:
+		case schema.JSONType:
 			if wrapInput {
 				typ = "InputJson"
 				wrapInput = false

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -294,17 +294,15 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			typ = "Archive"
 		case schema.AssetType:
 			typ = "AssetOrArchive"
+		case schema.JsonType:
+			if wrapInput {
+				typ = "InputJson"
+				wrapInput = false
+			} else {
+				typ = "System.Text.Json.JsonElement"
+			}
 		case schema.AnyType:
 			typ = "object"
-			// TODO(msh): Remove this check when https://github.com/pulumi/pulumi-terraform-bridge/issues/132 is ready.
-			if mod.isK8sCompatMode() {
-				if wrapInput {
-					typ = "InputJson"
-					wrapInput = false
-				} else {
-					typ = "System.Text.Json.JsonElement"
-				}
-			}
 		}
 	}
 

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -132,6 +132,7 @@ type modContext struct {
 	tool          string
 	namespaceName string
 	namespaces    map[string]string
+	compatibility string
 }
 
 func (mod *modContext) propertyName(p *schema.Property) string {
@@ -170,16 +171,28 @@ func tokenToFunctionName(tok string) string {
 	return tokenToName(tok)
 }
 
-func (mod *modContext) tokenToNamespace(tok string) string {
+func (mod *modContext) isK8sCompatMode() bool {
+	return mod.compatibility == "kubernetes20"
+}
+
+func (mod *modContext) tokenToNamespace(tok string, qualifier string) string {
 	components := strings.Split(tok, ":")
 	contract.Assertf(len(components) == 3, "malformed token %v", tok)
 
 	pkg, nsName := "Pulumi."+namespaceName(mod.namespaces, components[0]), mod.pkg.TokenToModule(tok)
-	if nsName == "" {
-		return pkg
+
+	if mod.isK8sCompatMode() {
+		return pkg + ".Types." + qualifier + "." + namespaceName(mod.namespaces, nsName)
 	}
 
-	return pkg + "." + namespaceName(mod.namespaces, nsName)
+	typ := pkg
+	if nsName != "" {
+		typ += "." + namespaceName(mod.namespaces, nsName)
+	}
+	if qualifier != "" {
+		typ += "." + qualifier
+	}
+	return typ
 }
 
 func (mod *modContext) typeString(t schema.Type, qualifier string, input, state, wrapInput, requireInitializers, optional bool) string {
@@ -212,11 +225,9 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 		wrapInput = false
 		typ = fmt.Sprintf(mapFmt, mod.typeString(t.ElementType, qualifier, input, state, false, false, false))
 	case *schema.ObjectType:
-		typ = mod.tokenToNamespace(t.Token)
-		if typ == mod.namespaceName {
+		typ = mod.tokenToNamespace(t.Token, qualifier)
+		if (typ == mod.namespaceName && qualifier == "") || typ == mod.namespaceName+"."+qualifier {
 			typ = qualifier
-		} else if qualifier != "" {
-			typ += "." + qualifier
 		}
 		if typ != "" {
 			typ += "."
@@ -237,7 +248,7 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 		}
 
 		typ = tokenToName(t.Token)
-		if ns := mod.tokenToNamespace(t.Token); ns != mod.namespaceName {
+		if ns := mod.tokenToNamespace(t.Token, qualifier); ns != mod.namespaceName {
 			typ = ns + "." + typ
 		}
 	case *schema.UnionType:
@@ -284,6 +295,14 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			typ = "AssetOrArchive"
 		case schema.AnyType:
 			typ = "object"
+			if mod.isK8sCompatMode() {
+				if wrapInput {
+					typ = "InputJson"
+					wrapInput = false
+				} else {
+					typ = "System.Text.Json.JsonElement"
+				}
+			}
 		}
 	}
 
@@ -382,14 +401,34 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 	}
 }
 
+// Set to avoid generating a class with the same name twice.
+var generatedTypes = codegen.Set{}
+
 func (pt *plainType) genInputType(w io.Writer, level int) error {
+	// The way the legacy codegen for kubernetes is structured, inputs for a resource args type and resource args
+	// subtype could become a single class because of the name + namespace clash. We use a set of generated types
+	// to prevent generating classes with equal full names in multiple files. The check should be removed if we
+	// ever change the namespacing in the k8s SDK to the standard one.
+	if pt.mod.isK8sCompatMode() {
+		key := pt.mod.namespaceName + pt.name
+		if generatedTypes.Has(key) {
+			return nil
+		}
+		generatedTypes.Add(key)
+	}
+
 	indent := strings.Repeat("    ", level)
 
 	fmt.Fprintf(w, "\n")
 
+	sealed := "sealed "
+	if pt.mod.isK8sCompatMode() && (pt.res == nil || !pt.res.IsProvider) {
+		sealed = ""
+	}
+
 	// Open the class.
 	printComment(w, pt.comment, indent)
-	fmt.Fprintf(w, "%spublic sealed class %s : Pulumi.%s\n", indent, pt.name, pt.baseClass)
+	fmt.Fprintf(w, "%spublic %sclass %s : Pulumi.%s\n", indent, sealed, pt.name, pt.baseClass)
 	fmt.Fprintf(w, "%s{\n", indent)
 
 	// Declare each input property.
@@ -432,7 +471,8 @@ func (pt *plainType) genOutputType(w io.Writer, level int) {
 	// Generate each output field.
 	for _, prop := range pt.properties {
 		fieldName := pt.mod.propertyName(prop)
-		fieldType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, false, false, false, false, !prop.IsRequired)
+		required := prop.IsRequired || pt.mod.isK8sCompatMode()
+		fieldType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, false, false, false, false, !required)
 		printComment(w, prop.Comment, indent+"    ")
 		fmt.Fprintf(w, "%s    public readonly %s %s;\n", indent, fieldType, fieldName)
 	}
@@ -447,7 +487,8 @@ func (pt *plainType) genOutputType(w io.Writer, level int) {
 	// Generate the constructor parameters.
 	for i, prop := range pt.properties {
 		paramName := csharpIdentifier(prop.Name)
-		paramType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, false, false, false, false, !prop.IsRequired)
+		required := prop.IsRequired || pt.mod.isK8sCompatMode()
+		paramType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, false, false, false, false, !required)
 
 		terminator := ""
 		if i != len(pt.properties)-1 {
@@ -580,6 +621,9 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	// Open the class.
 	className := name
 	baseType := "Pulumi.CustomResource"
+	if mod.isK8sCompatMode() {
+		baseType = "KubernetesResource"
+	}
 	if r.IsProvider {
 		baseType = "Pulumi.ProviderResource"
 	}
@@ -594,7 +638,8 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		// Write the property attribute
 		wireName := prop.Name
 		propertyName := mod.propertyName(prop)
-		propertyType := mod.typeString(prop.Type, "Outputs", false, false, false, false, !prop.IsRequired)
+		required := prop.IsRequired || mod.isK8sCompatMode()
+		propertyType := mod.typeString(prop.Type, "Outputs", false, false, false, false, !required)
 
 		// Workaround the fact that provider inputs come back as strings.
 		if r.IsProvider && !schema.IsPrimitiveType(prop.Type) {
@@ -614,7 +659,11 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	}
 
 	// Emit the class constructor.
-	argsType := className + "Args"
+	argsClassName := className + "Args"
+	if mod.isK8sCompatMode() && !r.IsProvider {
+		argsClassName = fmt.Sprintf("%s.%sArgs", mod.tokenToNamespace(r.Token, "Inputs"), className)
+	}
+	argsType := argsClassName
 
 	var argsDefault string
 	allOptionalInputs := true
@@ -623,7 +672,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		allOptionalInputs = allOptionalInputs && !prop.IsRequired
 		hasConstInputs = hasConstInputs || prop.ConstValue != nil
 	}
-	if allOptionalInputs {
+	if allOptionalInputs || mod.isK8sCompatMode() {
 		// If the number of required input properties was zero, we can make the args object optional.
 		argsDefault = " = null"
 		argsType += "?"
@@ -655,6 +704,13 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	fmt.Fprintf(w, "        {\n")
 	fmt.Fprintf(w, "        }\n")
 
+	if mod.isK8sCompatMode() {
+		fmt.Fprintf(w, "        internal %s(string name, ImmutableDictionary<string, object?> dictionary, CustomResourceOptions? options = null)\n", className)
+		fmt.Fprintf(w, "            : base(\"%s\", name, new DictionaryResourceArgs(dictionary), MakeResourceOptions(options, \"\"))\n", tok)
+		fmt.Fprintf(w, "        {\n")
+		fmt.Fprintf(w, "        }\n")
+	}
+
 	// Write a private constructor for the use of `Get`.
 	if !r.IsProvider {
 		stateParam, stateRef := "", "null"
@@ -674,7 +730,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		fmt.Fprintf(w, "\n")
 		fmt.Fprintf(w, "        private static %[1]s MakeArgs(%[1]s args)\n", argsType)
 		fmt.Fprintf(w, "        {\n")
-		fmt.Fprintf(w, "            args ??= new %sArgs();\n", className)
+		fmt.Fprintf(w, "            args ??= new %s();\n", argsClassName)
 		for _, prop := range r.InputProperties {
 			if prop.ConstValue != nil {
 				v, err := primitiveValue(prop.ConstValue)
@@ -743,6 +799,16 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	// Close the class.
 	fmt.Fprintf(w, "    }\n")
 
+	// Arguments are in a different namespace for the Kubernetes SDK.
+	if mod.isK8sCompatMode() && !r.IsProvider {
+		// Close the namespace.
+		fmt.Fprintf(w, "}\n")
+
+		// Open the namespace.
+		fmt.Fprintf(w, "namespace %s\n", mod.tokenToNamespace(r.Token, "Inputs"))
+		fmt.Fprintf(w, "{\n")
+	}
+
 	// Generate the resource args type.
 	args := &plainType{
 		mod:                   mod,
@@ -783,7 +849,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) error {
 	className := tokenToFunctionName(fun.Token)
 
-	fmt.Fprintf(w, "namespace %s\n", mod.tokenToNamespace(fun.Token))
+	fmt.Fprintf(w, "namespace %s\n", mod.tokenToNamespace(fun.Token, ""))
 	fmt.Fprintf(w, "{\n")
 
 	var typeParameter string
@@ -1162,7 +1228,7 @@ func (mod *modContext) gen(fs fs) error {
 			buffer := &bytes.Buffer{}
 			mod.genPulumiHeader(buffer)
 
-			fmt.Fprintf(buffer, "namespace %s.Inputs\n", mod.namespaceName)
+			fmt.Fprintf(buffer, "namespace %s\n", mod.tokenToNamespace(t.Token, "Inputs"))
 			fmt.Fprintf(buffer, "{\n")
 			if err := mod.genType(buffer, t, "Inputs", true, false, 1); err != nil {
 				return err
@@ -1175,7 +1241,7 @@ func (mod *modContext) gen(fs fs) error {
 			buffer := &bytes.Buffer{}
 			mod.genPulumiHeader(buffer)
 
-			fmt.Fprintf(buffer, "namespace %s.Inputs\n", mod.namespaceName)
+			fmt.Fprintf(buffer, "namespace %s\n", mod.tokenToNamespace(t.Token, "Inputs"))
 			fmt.Fprintf(buffer, "{\n")
 			if err := mod.genType(buffer, t, "Inputs", true, true, 1); err != nil {
 				return err
@@ -1188,7 +1254,7 @@ func (mod *modContext) gen(fs fs) error {
 			buffer := &bytes.Buffer{}
 			mod.genPulumiHeader(buffer)
 
-			fmt.Fprintf(buffer, "namespace %s.Outputs\n", mod.namespaceName)
+			fmt.Fprintf(buffer, "namespace %s\n", mod.tokenToNamespace(t.Token, "Outputs"))
 			fmt.Fprintf(buffer, "{\n")
 			if err := mod.genType(buffer, t, "Outputs", false, false, 1); err != nil {
 				return err
@@ -1318,6 +1384,7 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 				namespaces:    info.Namespaces,
 				typeDetails:   details,
 				propertyNames: propertyNames,
+				compatibility: info.Compatibility,
 			}
 
 			if modName != "" {

--- a/pkg/codegen/dotnet/importer.go
+++ b/pkg/codegen/dotnet/importer.go
@@ -29,6 +29,7 @@ type CSharpPropertyInfo struct {
 type CSharpPackageInfo struct {
 	PackageReferences map[string]string `json:"packageReferences,omitempty"`
 	Namespaces        map[string]string `json:"namespaces,omitempty"`
+	Compatibility     string            `json:"compatibility,omitempty"`
 }
 
 // Importer implements schema.Language for .NET.

--- a/pkg/codegen/dotnet/importer.go
+++ b/pkg/codegen/dotnet/importer.go
@@ -27,9 +27,10 @@ type CSharpPropertyInfo struct {
 
 // CSharpPackageInfo represents the C# language-specific info for a package.
 type CSharpPackageInfo struct {
-	PackageReferences map[string]string `json:"packageReferences,omitempty"`
-	Namespaces        map[string]string `json:"namespaces,omitempty"`
-	Compatibility     string            `json:"compatibility,omitempty"`
+	PackageReferences      map[string]string `json:"packageReferences,omitempty"`
+	Namespaces             map[string]string `json:"namespaces,omitempty"`
+	Compatibility          string            `json:"compatibility,omitempty"`
+	DictionaryConstructors bool              `json:"dictionaryConstructors,omitempty"`
 }
 
 // Importer implements schema.Language for .NET.

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -197,6 +197,8 @@ func (pkg *pkgContext) plainType(t schema.Type, optional bool) string {
 			return "pulumi.Archive"
 		case schema.AssetType:
 			return "pulumi.AssetOrArchive"
+		case schema.JsonType:
+			fallthrough
 		case schema.AnyType:
 			return "interface{}"
 		}
@@ -242,6 +244,8 @@ func (pkg *pkgContext) inputType(t schema.Type, optional bool) string {
 			return "pulumi.ArchiveInput"
 		case schema.AssetType:
 			return "pulumi.AssetOrArchiveInput"
+		case schema.JsonType:
+			fallthrough
 		case schema.AnyType:
 			return "pulumi.Input"
 		}
@@ -293,6 +297,8 @@ func (pkg *pkgContext) outputType(t schema.Type, optional bool) string {
 			return "pulumi.ArchiveOutput"
 		case schema.AssetType:
 			return "pulumi.AssetOrArchiveOutput"
+		case schema.JsonType:
+			fallthrough
 		case schema.AnyType:
 			return "pulumi.AnyOutput"
 		}

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -197,7 +197,7 @@ func (pkg *pkgContext) plainType(t schema.Type, optional bool) string {
 			return "pulumi.Archive"
 		case schema.AssetType:
 			return "pulumi.AssetOrArchive"
-		case schema.JsonType:
+		case schema.JSONType:
 			fallthrough
 		case schema.AnyType:
 			return "interface{}"
@@ -244,7 +244,7 @@ func (pkg *pkgContext) inputType(t schema.Type, optional bool) string {
 			return "pulumi.ArchiveInput"
 		case schema.AssetType:
 			return "pulumi.AssetOrArchiveInput"
-		case schema.JsonType:
+		case schema.JSONType:
 			fallthrough
 		case schema.AnyType:
 			return "pulumi.Input"
@@ -297,7 +297,7 @@ func (pkg *pkgContext) outputType(t schema.Type, optional bool) string {
 			return "pulumi.ArchiveOutput"
 		case schema.AssetType:
 			return "pulumi.AssetOrArchiveOutput"
-		case schema.JsonType:
+		case schema.JSONType:
 			fallthrough
 		case schema.AnyType:
 			return "pulumi.AnyOutput"

--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -191,7 +191,7 @@ func (b *binder) schemaTypeToType(src schema.Type) (result model.Type) {
 			return ArchiveType
 		case schema.AssetType:
 			return AssetType
-		case schema.JsonType:
+		case schema.JSONType:
 			fallthrough
 		case schema.AnyType:
 			return model.DynamicType

--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -191,6 +191,8 @@ func (b *binder) schemaTypeToType(src schema.Type) (result model.Type) {
 			return ArchiveType
 		case schema.AssetType:
 			return AssetType
+		case schema.JsonType:
+			fallthrough
 		case schema.AnyType:
 			return model.DynamicType
 		default:

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -168,6 +168,8 @@ func (mod *modContext) typeString(t schema.Type, input, wrapInput, optional bool
 			typ = "pulumi.asset.Archive"
 		case schema.AssetType:
 			typ = "pulumi.asset.Asset | pulumi.asset.Archive"
+		case schema.JsonType:
+			fallthrough
 		case schema.AnyType:
 			typ = "any"
 		}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -168,7 +168,7 @@ func (mod *modContext) typeString(t schema.Type, input, wrapInput, optional bool
 			typ = "pulumi.asset.Archive"
 		case schema.AssetType:
 			typ = "pulumi.asset.Asset | pulumi.asset.Archive"
-		case schema.JsonType:
+		case schema.JSONType:
 			fallthrough
 		case schema.AnyType:
 			typ = "any"

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -49,6 +49,7 @@ const (
 	archiveType primitiveType = 5
 	assetType   primitiveType = 6
 	anyType     primitiveType = 7
+	jsonType    primitiveType = 8
 )
 
 func (t primitiveType) String() string {
@@ -65,6 +66,8 @@ func (t primitiveType) String() string {
 		return "pulumi:pulumi:Archive"
 	case assetType:
 		return "pulumi:pulumi:Asset"
+	case jsonType:
+		fallthrough
 	case anyType:
 		return "pulumi:pulumi:Any"
 	default:
@@ -94,6 +97,8 @@ var (
 	ArchiveType Type = archiveType
 	// AssetType represents the set of Pulumi Asset values.
 	AssetType Type = assetType
+	// JsonType represents the set of JSON-encoded values.
+	JsonType Type = jsonType
 	// AnyType represents the complete set of values.
 	AnyType Type = anyType
 )
@@ -793,6 +798,8 @@ func (t *types) bindType(spec TypeSpec) (Type, error) {
 			return ArchiveType, nil
 		case "pulumi.json#/Asset":
 			return AssetType, nil
+		case "pulumi.json#/Json":
+			return JsonType, nil
 		case "pulumi.json#/Any":
 			return AnyType, nil
 		}

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -97,8 +97,8 @@ var (
 	ArchiveType Type = archiveType
 	// AssetType represents the set of Pulumi Asset values.
 	AssetType Type = assetType
-	// JsonType represents the set of JSON-encoded values.
-	JsonType Type = jsonType
+	// JSONType represents the set of JSON-encoded values.
+	JSONType Type = jsonType
 	// AnyType represents the complete set of values.
 	AnyType Type = anyType
 )
@@ -799,7 +799,7 @@ func (t *types) bindType(spec TypeSpec) (Type, error) {
 		case "pulumi.json#/Asset":
 			return AssetType, nil
 		case "pulumi.json#/Json":
-			return JsonType, nil
+			return JSONType, nil
 		case "pulumi.json#/Any":
 			return AnyType, nil
 		}


### PR DESCRIPTION
The flag allows us to (mostly) reuse the C# codegen for `pulumi-kubernetes` without making significant breaking changes in the generated code.
At the same time, these changes zero changes in TF-based providers (tested with AWS and Azure).