### PR TITLE
.NET: Disable parallel xUnit tests

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/Pulumi.Tests.csproj
+++ b/sdk/dotnet/Pulumi.Tests/Pulumi.Tests.csproj
@@ -18,4 +18,9 @@
     <ProjectReference Include="..\Pulumi\Pulumi.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Unfortunately, we depend on static state. So we configure xUnit's runner to disable parallelization. -->
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/sdk/dotnet/Pulumi.Tests/xunit.runner.json
+++ b/sdk/dotnet/Pulumi.Tests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+    "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Despite having the `[assembly: CollectionBehavior(DisableTestParallelization = true)]` attribute, it appears `dotnet test` is still running tests in parallel. To address, use a configuration file to disable parallelization.

Based on: https://github.com/xunit/xunit/issues/1169#issuecomment-287521557

Fixes https://github.com/pulumi/pulumi/issues/4545 🤞 