### PR TITLE
[codegen/docs] Remove the module name translation that was required for Kubernetes' provider resource

### DIFF
--- a/pkg/codegen/docs/gen_kubernetes.go
+++ b/pkg/codegen/docs/gen_kubernetes.go
@@ -93,8 +93,8 @@ func getKubernetesOverlayPythonFormalParams(modName string) []formalParam {
 func getKubernetesMod(pkg *schema.Package, token string, modules map[string]*modContext, tool string) *modContext {
 	modName := pkg.TokenToModule(token)
 	// Kubernetes' moduleFormat in the schema will match everything
-	// in the token. This prevents us from adding the "Provider"
-	// resource as a child module of the package level :index: module.
+	// in the token. So strip some well-known domain name parts from the module
+	// names.
 	modName = strings.TrimSuffix(modName, ".k8s.io")
 	modName = strings.TrimSuffix(modName, ".apiserver")
 	modName = strings.TrimSuffix(modName, ".authorization")

--- a/pkg/codegen/docs/gen_kubernetes.go
+++ b/pkg/codegen/docs/gen_kubernetes.go
@@ -95,13 +95,9 @@ func getKubernetesMod(pkg *schema.Package, token string, modules map[string]*mod
 	// Kubernetes' moduleFormat in the schema will match everything
 	// in the token. This prevents us from adding the "Provider"
 	// resource as a child module of the package level :index: module.
-	if modName == "providers" {
-		modName = ""
-	} else {
-		modName = strings.TrimSuffix(modName, ".k8s.io")
-		modName = strings.TrimSuffix(modName, ".apiserver")
-		modName = strings.TrimSuffix(modName, ".authorization")
-	}
+	modName = strings.TrimSuffix(modName, ".k8s.io")
+	modName = strings.TrimSuffix(modName, ".apiserver")
+	modName = strings.TrimSuffix(modName, ".authorization")
 
 	mod, ok := modules[modName]
 	if !ok {

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -88,9 +88,6 @@ func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
 
 // GetLanguageTypeString returns the Go-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string {
-	if moduleName == "" && pkg.Name == "kubernetes" {
-		moduleName = "providers"
-	}
 	modPkg, ok := d.packages[moduleName]
 	if !ok {
 		glog.Errorf("cannot calculate type string for type %q. could not find a package for module %q", t.String(), moduleName)


### PR DESCRIPTION
Previously, the Pulumi schema's `TokenToModule()` method would return the module name as `providers` for the Kubernetes package. This is due to the Kubernetes package using the default `moduleFormat` regex, which basically selects all of the characters in the second part of the token `pkg:module:resource`, i.e. it will have selected `module`. But `providers` is a special module and the resource `Provider` should actually appear at the package-level index rather than as another module called `providers` with a resource called `Provider`. To reverse the effect of the module format, the resource doc generator accounted for this and had exclusions in how the module name was calculated when the `providers` module token was encountered.

The `TokenToModule` method was recently [changed](https://github.com/pulumi/pulumi/pull/4531/files#diff-5c67d4f6968106eea4630a54ad6592c8R516) to account for such special case module names and return the appropriate module name, i.e., an empty string for the `providers` module, which would indicate that the `Provider` resource belongs to the root module.

This PR removes those exclusions now that the `TokenToModule` method accounts for such special module tokens.