### PR TITLE
Fixed ResourceOption deepcopy bug in stack_reference.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 - Fixed ResourceOptions issue with stack references in Python SDK
- [#4553](https://github.com/pulumi/pulumi/pull/4553)
+ [#4553](https://github.com/pulumi/pulumi/pull/4553) 
 
 - Add runTask to F# Deployment module
   [#3858](https://github.com/pulumi/pulumi/pull/3858)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
+- Fixed ResourceOptions issue with stack references in Python SDK
+ [#4553](https://github.com/pulumi/pulumi/pull/4553)
 
 - Add runTask to F# Deployment module
   [#3858](https://github.com/pulumi/pulumi/pull/3858)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 - Fixed ResourceOptions issue with stack references in Python SDK
- [#4553](https://github.com/pulumi/pulumi/pull/4553) 
+ [#4553](https://github.com/pulumi/pulumi/pull/4553)
 
 - Add runTask to F# Deployment module
   [#3858](https://github.com/pulumi/pulumi/pull/3858)

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -52,7 +52,7 @@ class StackReference(CustomResource):
         """
 
         target_stack = stack_name if stack_name is not None else name
-        opts = ResourceOptions.merge(opts, ResourceOptions(id = target_stack))
+        opts = ResourceOptions.merge(opts, ResourceOptions(id=target_stack))
 
         super().__init__("pulumi:pulumi:StackReference", name, {
             "name": target_stack,

--- a/sdk/python/lib/pulumi/stack_reference.py
+++ b/sdk/python/lib/pulumi/stack_reference.py
@@ -52,8 +52,7 @@ class StackReference(CustomResource):
         """
 
         target_stack = stack_name if stack_name is not None else name
-        opts = deepcopy(opts) if opts is not None else ResourceOptions()
-        opts.id = target_stack
+        opts = ResourceOptions.merge(opts, ResourceOptions(id = target_stack))
 
         super().__init__("pulumi:pulumi:StackReference", name, {
             "name": target_stack,


### PR DESCRIPTION
Replaced copy statements with `ResourceOptions.merge` in `stack_reference.py`. If a set of `ResourceOptions` is passed with `parent` set then the resource creation fails due to `deepcopy` failing.

Minimum code to reproduce:
```
from typing import Optional
from pulumi import ResourceOptions, StackReference, ComponentResource

class SomeComponent(ComponentResource):
    def __init__(self, name: str, stack_name: str, opts: Optional[ResourceOptions] = None):
        super().__init__("some_component", name, {}, opts)

        self.stack_reference: StackReference = StackReference(
            name = f"{name}-stack_reference",
            opts = ResourceOptions(parent=self),
            stack_name = stack_name
        )

stack_name: str = "REDACTED"

SomeComponent("example_of_problem", stack_name)
```