### PR TITLE
Fix occasional .NET test failure

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/StackTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/StackTests.cs
@@ -10,7 +10,7 @@ using Xunit.Sdk;
 
 namespace Pulumi.Tests
 {
-    public class StackTests
+    public class StackTests : IDisposable
     {
         private class ValidStack : Stack
         {
@@ -100,22 +100,21 @@ namespace Pulumi.Tests
 
             Deployment.Instance = new DeploymentInstance(mock.Object);
 
-            try
-            {
-                // Act
-                var stack = new T();
-                stack.RegisterPropertyOutputs();
+            // Act
+            var stack = new T();
+            stack.RegisterPropertyOutputs();
 
-                // Assert
-                Assert.NotNull(outputs);
-                var values = await outputs!.DataTask;
-                return (stack, values.Value);
-            }
-            finally
-            {
-                // Reset the instance as other tests expect it to be initially null.
-                Deployment.Instance = null!;
-            }
+            // Assert
+            Assert.NotNull(outputs);
+            var values = await outputs!.DataTask;
+            return (stack, values.Value);
+        }
+
+        public void Dispose()
+        {
+            // Always reset the instance after each of these tests as other tests elsewhere
+            // expect it to be initially null.
+            Deployment.Instance = null!;
         }
     }
 }

--- a/sdk/dotnet/Pulumi.Tests/StackTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/StackTests.cs
@@ -100,14 +100,22 @@ namespace Pulumi.Tests
 
             Deployment.Instance = new DeploymentInstance(mock.Object);
 
-            // Act
-            var stack = new T();
-            stack.RegisterPropertyOutputs();
+            try
+            {
+                // Act
+                var stack = new T();
+                stack.RegisterPropertyOutputs();
 
-            // Assert
-            Assert.NotNull(outputs);
-            var values = await outputs!.DataTask;
-            return (stack, values.Value);
+                // Assert
+                Assert.NotNull(outputs);
+                var values = await outputs!.DataTask;
+                return (stack, values.Value);
+            }
+            finally
+            {
+                // Reset the instance as other tests expect it to be initially null.
+                Deployment.Instance = null!;
+            }
         }
     }
 }


### PR DESCRIPTION
I recently added a test of the public mocks support in .NET. [`Deployment.TestAsync`](https://github.com/pulumi/pulumi/blob/653dcf8f1fe536916f1dd2b0e294de9173f38461/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs#L117-L129) throws `NotSupportedException` with "Multiple executions of TestAsync must run serially" if `Deployment.Instance` is not initially `null` before setting it up to use the passed-in mocks.

Occasionally, this exception is being thrown during test runs.

This happens because we have some existing tests that modify `Deployment.Instance` but don't reset it back to `null`. If these tests run before the mocks tests (the .NET unit tests run in random order), the exception is thrown.

The fix is to set `Deployment.Instance` back to `null`, just like we do in [other tests](https://github.com/pulumi/pulumi/blob/66bd3f4aa8f9a90d3de667828dda4bed6e115f6b/sdk/dotnet/Pulumi.Tests/PulumiTest.cs#L23-L25) that set `Deployment.Instance`.

Fixes #4545