### PR TITLE
Add GH actions for downstream codegen testing.

### DIFF
--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -1,0 +1,173 @@
+name: Downstream Codegen Testing
+on: [pull_request]
+
+jobs:
+  downstream-aws:
+    name: Test AWS Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replace: github.com/pulumi/pulumi/pkg/v2
+          replace-with: pulumi/pkg
+          downstream-name: pulumi-aws
+          downstream-url: https://github.com/pulumi/pulumi-aws
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+          use-provider-dir: true
+
+  downstream-azure:
+    name: Test Azure Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replace: github.com/pulumi/pulumi/pkg/v2
+          replace-with: pulumi/pkg
+          downstream-name: pulumi-azure
+          downstream-url: https://github.com/pulumi/pulumi-azure
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+          use-provider-dir: true
+
+  downstream-gcp:
+    name: Test GCP Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replace: github.com/pulumi/pulumi/pkg/v2
+          replace-with: pulumi/pkg
+          downstream-name: pulumi-gcp
+          downstream-url: https://github.com/pulumi/pulumi-gcp
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+          use-provider-dir: true
+
+  downstream-azuread:
+    name: Test AzureAD Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replace: github.com/pulumi/pulumi/pkg/v2
+          replace-with: pulumi/pkg
+          downstream-name: pulumi-azuread
+          downstream-url: https://github.com/pulumi/pulumi-azuread
+          use-provider-dir: true
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+
+  downstream-random:
+    name: Test Random Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replace: github.com/pulumi/pulumi/pkg/v2
+          replace-with: pulumi/pkg
+          downstream-name: pulumi-random
+          downstream-url: https://github.com/pulumi/pulumi-random
+          use-provider-dir: true
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -1,5 +1,8 @@
 name: Downstream Codegen Testing
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+    - 'pkg/codegen/**'
 
 jobs:
   downstream-aws:
@@ -24,12 +27,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v4
+        uses: pulumi/action-test-provider-downstream@releases/v5
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
-          replace: github.com/pulumi/pulumi/pkg/v2
-          replace-with: pulumi/pkg
+          replacements: github.com/pulumi/pulumi/pkg/v2=pulumi/pkg,github.com/pulumi/pulumi/sdk/v2=pulumi/sdk
           downstream-name: pulumi-aws
           downstream-url: https://github.com/pulumi/pulumi-aws
           pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -58,12 +60,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v4
+        uses: pulumi/action-test-provider-downstream@releases/v5
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
-          replace: github.com/pulumi/pulumi/pkg/v2
-          replace-with: pulumi/pkg
+          replacements: github.com/pulumi/pulumi/pkg/v2=pulumi/pkg,github.com/pulumi/pulumi/sdk/v2=pulumi/sdk
           downstream-name: pulumi-azure
           downstream-url: https://github.com/pulumi/pulumi-azure
           pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -92,12 +93,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v4
+        uses: pulumi/action-test-provider-downstream@releases/v5
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
-          replace: github.com/pulumi/pulumi/pkg/v2
-          replace-with: pulumi/pkg
+          replacements: github.com/pulumi/pulumi/pkg/v2=pulumi/pkg,github.com/pulumi/pulumi/sdk/v2=pulumi/sdk
           downstream-name: pulumi-gcp
           downstream-url: https://github.com/pulumi/pulumi-gcp
           pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
@@ -126,12 +126,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v4
+        uses: pulumi/action-test-provider-downstream@releases/v5
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
-          replace: github.com/pulumi/pulumi/pkg/v2
-          replace-with: pulumi/pkg
+          replacements: github.com/pulumi/pulumi/pkg/v2=pulumi/pkg,github.com/pulumi/pulumi/sdk/v2=pulumi/sdk
           downstream-name: pulumi-azuread
           downstream-url: https://github.com/pulumi/pulumi-azuread
           use-provider-dir: true
@@ -160,12 +159,11 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v4
+        uses: pulumi/action-test-provider-downstream@releases/v5
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
-          replace: github.com/pulumi/pulumi/pkg/v2
-          replace-with: pulumi/pkg
+          replacements: github.com/pulumi/pulumi/pkg/v2=pulumi/pkg,github.com/pulumi/pulumi/sdk/v2=pulumi/sdk
           downstream-name: pulumi-random
           downstream-url: https://github.com/pulumi/pulumi-random
           use-provider-dir: true

--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -1,4 +1,4 @@
-name: Downstream Codegen Testing
+name: Downstream Codegen Tests
 on:
   pull_request:
     paths:

--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v5
+        uses: pulumi/action-test-provider-downstream@releases/v4
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
@@ -61,7 +61,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v5
+        uses: pulumi/action-test-provider-downstream@releases/v4
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
@@ -94,7 +94,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v5
+        uses: pulumi/action-test-provider-downstream@releases/v4
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
@@ -127,7 +127,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v5
+        uses: pulumi/action-test-provider-downstream@releases/v4
         env:
           GOPROXY: "https://proxy.golang.org"
         with:
@@ -160,7 +160,7 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@master
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v5
+        uses: pulumi/action-test-provider-downstream@releases/v4
         env:
           GOPROXY: "https://proxy.golang.org"
         with:

--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
     - 'pkg/codegen/**'
+    - '.github/workflows/codegen-test.yml'
 
 jobs:
   downstream-aws:


### PR DESCRIPTION
These changes port the downstream codegen testing actions from
https://github.com/pulumi/pulumi-terraform-bridge to this repository.
`github.com/pulumi/pulumi/pkg/v2` is replaced with the PR HEAD.