### PR TITLE
Escape `"""` in Python doc comments.

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -88,7 +88,8 @@ func printComment(w io.Writer, comment string, indent string) {
 		if l == "" {
 			fmt.Fprintf(w, "\n")
 		} else {
-			fmt.Fprintf(w, "%s%s\n", indent, l)
+			escaped := strings.ReplaceAll(l, `"""`, `\"\"\"`)
+			fmt.Fprintf(w, "%s%s\n", indent, escaped)
 		}
 	}
 	fmt.Fprintf(w, "%s\"\"\"\n", indent)


### PR DESCRIPTION
With the addition of Python examples, doc comments may now contain
triple quotes. These must be escaped in order to avoid malformed source
files.

Fixes #4568.