### PR TITLE
Fix error in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ publish_packages:
 # So instead we run the ~daily on master. Where we know the current SDK version
 # will have been published.
 .PHONY: test_containers_cron
-test_containers:
+test_containers_cron:
 	$(call STEP_MESSAGE)
 	./scripts/build-docker.sh ${VERSION} --test
 


### PR DESCRIPTION
For Travis CI cron jobs we define Makefile target `travis_cron: all test_containers_cron`. However, `test_containers_cron` is never defined anywhere. (We register the `.PHONY`, but not the actual build target.) 🤦 

This fixes that.

With this change the `test_containers_cron` target will now be ran ~daily on Travis CI, which we expect to fail. (So I can debug whatever issues are in between Docker and Travis CI, as part of #4136.)