### PR TITLE
[codegen/{nodejs,python}] Parse more proxy applies

### DIFF
--- a/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.ts
@@ -5,4 +5,4 @@ const logs = new aws.s3.Bucket("logs", {});
 const bucket = new aws.s3.Bucket("bucket", {loggings: [{
     targetBucket: logs.bucket,
 }]});
-export const targetBucket = bucket.loggings.apply(loggings => loggings[0].targetBucket);
+export const targetBucket = bucket.loggings[0].targetBucket;


### PR DESCRIPTION
Specifically, handle index and relative traversal expressions, and clean
up the code a little bit.

This should also help us pick up more `pulumi.interpolate` calls in TS.