### PR TITLE
[codegen/nodejs] Fix #4563.

### DIFF
--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.ts
@@ -50,7 +50,7 @@ export = async () => {
             subnetId: vpcSubnet.then(vpcSubnet => vpcSubnet[range.key].id),
         }));
     }
-    const subnetIds = pulumi.all([pulumi.output(vpcSubnet), __item.id]).apply(([vpcSubnet, id]) => vpcSubnet.map(__item => id));
+    const subnetIds = pulumi.all([vpcSubnet, __item.id]).apply(([vpcSubnet, id]) => vpcSubnet.map(__item => id));
     const eksSecurityGroup = new aws.ec2.SecurityGroup("eksSecurityGroup", {
         vpcId: eksVpc.id,
         description: "Allow all HTTP(s) traffic to EKS Cluster",

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -176,11 +176,11 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 
 	// If all of the arguments are promises, use promise methods. If any argument is an output, convert all other args
 	// to outputs and use output methods.
-	isOutput := make([]bool, len(applyArgs))
 	anyOutputs := false
-	for i, arg := range applyArgs {
-		isOutput[i] = isOutputType(arg.Type())
-		anyOutputs = anyOutputs || isOutput[i]
+	for _, arg := range applyArgs {
+		if isOutputType(arg.Type()) {
+			anyOutputs = true
+		}
 	}
 
 	apply, all := "then", "Promise.all"
@@ -198,11 +198,7 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 			if i > 0 {
 				g.Fgen(w, ", ")
 			}
-			if anyOutputs && !isOutput[i] {
-				g.Fgenf(w, "pulumi.output(%.v)", o)
-			} else {
-				g.Fgenf(w, "%v", o)
-			}
+			g.Fgenf(w, "%v", o)
 		}
 		g.Fgenf(w, "]).%v(%.v)", apply, then)
 	}


### PR DESCRIPTION
Do not wrap non-output-typed arguments to `pulumi.all` in
`pulumi.output`. `pulumi.all` does this implicitly.

Fixes #4563.