### PR TITLE
[codegen/docs] Add a new template for examples section

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -40,10 +40,11 @@ var (
 	H3TitleRE = regexp.MustCompile("(### .*)")
 
 	// The following regexp's match the code snippet blocks in a single example section.
+
 	// TSCodeSnippetRE is a regexp to match a TypeScript code snippet.
-	TSCodeSnippetRE     = regexp.MustCompile("(```(typescript))((.|\n)*?)(```)")
+	TSCodeSnippetRE = regexp.MustCompile("(```(typescript))((.|\n)*?)(```)")
 	// GoCodeSnippetRE is a regexp to match a Go code snippet.
-	GoCodeSnippetRE     = regexp.MustCompile("(```(go))((.|\n)*?)(```)")
+	GoCodeSnippetRE = regexp.MustCompile("(```(go))((.|\n)*?)(```)")
 	// PythonCodeSnippetRE is a regexp to match a Python code snippet.
 	PythonCodeSnippetRE = regexp.MustCompile("(```(python))((.|\n)*?)(```)")
 	// CSharpCodeSnippetRE is a regexp to match a C# code snippet.

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -26,17 +26,27 @@ var (
 	// It's the `?P<group_name>` where group_name can be any name.
 	// When changing the group names, be sure to change the reference to
 	// the corresponding group name below where they are used as well.
+
+	// SurroundingTextRE is regexp to match the content between the {{% examples %}} short-code
+	// including the short-codes themselves.
 	SurroundingTextRE = regexp.MustCompile("({{% examples %}}(.|\n)*?{{% /examples %}})")
+	// ExamplesSectionRE is a regexp to match just the content between the {{% examples %}} short-codes.
 	ExamplesSectionRE = regexp.MustCompile(
 		"(?P<examples_start>{{% examples %}})(?P<examples_content>(.|\n)*?)(?P<examples_end>{{% /examples %}})")
+	// IndividualExampleRE is a regexp to match a single example section surrounded by the {{% example %}} short-code.
 	IndividualExampleRE = regexp.MustCompile(
 		"(?P<example_start>{{% example %}})(?P<example_content>(.|\n)*?)(?P<example_end>{{% /example %}})")
+	// H3TitleRE is a regexp to match an h3 title tag.
 	H3TitleRE = regexp.MustCompile("(### .*)")
 
 	// The following regexp's match the code snippet blocks in a single example section.
+	// TSCodeSnippetRE is a regexp to match a TypeScript code snippet.
 	TSCodeSnippetRE     = regexp.MustCompile("(```(typescript))((.|\n)*?)(```)")
+	// GoCodeSnippetRE is a regexp to match a Go code snippet.
 	GoCodeSnippetRE     = regexp.MustCompile("(```(go))((.|\n)*?)(```)")
+	// PythonCodeSnippetRE is a regexp to match a Python code snippet.
 	PythonCodeSnippetRE = regexp.MustCompile("(```(python))((.|\n)*?)(```)")
+	// CSharpCodeSnippetRE is a regexp to match a C# code snippet.
 	CSharpCodeSnippetRE = regexp.MustCompile("(```(csharp))((.|\n)*?)(```)")
 )
 
@@ -62,6 +72,7 @@ type exampleParts struct {
 	Snippet string
 }
 
+// GetFirstMatchedGroupsFromRegex returns the groups for the first match of a regexp.
 func GetFirstMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string]string {
 	groups := map[string]string{}
 
@@ -82,6 +93,7 @@ func GetFirstMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string
 	return groups
 }
 
+// GetAllMatchedGroupsFromRegex returns all matches and the respective groups for a regexp.
 func GetAllMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string][]string {
 	// Get all matching groups.
 	matches := regex.FindAllStringSubmatch(str, -1)
@@ -103,6 +115,8 @@ func GetAllMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string][
 	return groups
 }
 
+// isEmpty returns true if the provided string is effectively
+// empty.
 func isEmpty(s string) bool {
 	return strings.Replace(s, "\n", "", 1) == ""
 }

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -26,18 +26,18 @@ var (
 	// It's the `?P<group_name>` where group_name can be any name.
 	// When changing the group names, be sure to change the reference to
 	// the corresponding group name below where they are used as well.
-	surroundingTextRE = regexp.MustCompile("({{% examples %}}(.|\n)*?{{% /examples %}})")
-	examplesSectionRE = regexp.MustCompile(
+	SurroundingTextRE = regexp.MustCompile("({{% examples %}}(.|\n)*?{{% /examples %}})")
+	ExamplesSectionRE = regexp.MustCompile(
 		"(?P<examples_start>{{% examples %}})(?P<examples_content>(.|\n)*?)(?P<examples_end>{{% /examples %}})")
-	individualExampleRE = regexp.MustCompile(
+	IndividualExampleRE = regexp.MustCompile(
 		"(?P<example_start>{{% example %}})(?P<example_content>(.|\n)*?)(?P<example_end>{{% /example %}})")
-	h3TitleRE = regexp.MustCompile("(### .*)")
+	H3TitleRE = regexp.MustCompile("(### .*)")
 
 	// The following regexp's match the code snippet blocks in a single example section.
-	tsCodeSnippetRE     = regexp.MustCompile("(```(typescript))((.|\n)*?)(```)")
-	goCodeSnippetRE     = regexp.MustCompile("(```(go))((.|\n)*?)(```)")
-	pythonCodeSnippetRE = regexp.MustCompile("(```(python))((.|\n)*?)(```)")
-	csharpCodeSnippetRE = regexp.MustCompile("(```(csharp))((.|\n)*?)(```)")
+	TSCodeSnippetRE     = regexp.MustCompile("(```(typescript))((.|\n)*?)(```)")
+	GoCodeSnippetRE     = regexp.MustCompile("(```(go))((.|\n)*?)(```)")
+	PythonCodeSnippetRE = regexp.MustCompile("(```(python))((.|\n)*?)(```)")
+	CSharpCodeSnippetRE = regexp.MustCompile("(```(csharp))((.|\n)*?)(```)")
 )
 
 // DocLanguageHelper is an interface for extracting language-specific information from a Pulumi schema.
@@ -62,7 +62,7 @@ type exampleParts struct {
 	Snippet string
 }
 
-func getFirstMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string]string {
+func GetFirstMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string]string {
 	groups := map[string]string{}
 
 	// Get all matching groups.
@@ -82,7 +82,7 @@ func getFirstMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string
 	return groups
 }
 
-func getAllMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string][]string {
+func GetAllMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string][]string {
 	// Get all matching groups.
 	matches := regex.FindAllStringSubmatch(str, -1)
 	// Get the named groups in our regex.
@@ -107,17 +107,17 @@ func isEmpty(s string) bool {
 	return strings.Replace(s, "\n", "", 1) == ""
 }
 
-// extractExamplesSection returns the content available between the {{% examples %}} shortcode.
+// ExtractExamplesSection returns the content available between the {{% examples %}} shortcode.
 // Otherwise returns nil.
-func extractExamplesSection(description string) *string {
-	examples := getFirstMatchedGroupsFromRegex(examplesSectionRE, description)
+func ExtractExamplesSection(description string) *string {
+	examples := GetFirstMatchedGroupsFromRegex(ExamplesSectionRE, description)
 	if content, ok := examples["examples_content"]; ok && !isEmpty(content) {
 		return &content
 	}
 	return nil
 }
 
-func identifyExampleParts(exampleContent string, lang string) *exampleParts {
+func extractExampleParts(exampleContent string, lang string) *exampleParts {
 	codeFence := "```" + lang
 	langSnippetIndex := strings.Index(exampleContent, codeFence)
 	// If there is no snippet for the provided language in this example,
@@ -129,27 +129,27 @@ func identifyExampleParts(exampleContent string, lang string) *exampleParts {
 	var snippet string
 	switch lang {
 	case "csharp":
-		snippet = csharpCodeSnippetRE.FindString(exampleContent)
+		snippet = CSharpCodeSnippetRE.FindString(exampleContent)
 	case "go":
-		snippet = goCodeSnippetRE.FindString(exampleContent)
+		snippet = GoCodeSnippetRE.FindString(exampleContent)
 	case "python":
-		snippet = pythonCodeSnippetRE.FindString(exampleContent)
+		snippet = PythonCodeSnippetRE.FindString(exampleContent)
 	case "typescript":
-		snippet = tsCodeSnippetRE.FindString(exampleContent)
+		snippet = TSCodeSnippetRE.FindString(exampleContent)
 	}
 
 	return &exampleParts{
-		Title:   h3TitleRE.FindString(exampleContent),
+		Title:   H3TitleRE.FindString(exampleContent),
 		Snippet: snippet,
 	}
 }
 
 func getExamplesForLang(examplesContent string, lang string) []exampleParts {
 	examples := make([]exampleParts, 0)
-	exampleMatches := getAllMatchedGroupsFromRegex(individualExampleRE, examplesContent)
+	exampleMatches := GetAllMatchedGroupsFromRegex(IndividualExampleRE, examplesContent)
 	if matchedExamples, ok := exampleMatches["example_content"]; ok {
 		for _, ex := range matchedExamples {
-			exampleParts := identifyExampleParts(ex, lang)
+			exampleParts := extractExampleParts(ex, lang)
 			if exampleParts == nil || exampleParts.Snippet == "" {
 				continue
 			}
@@ -169,10 +169,10 @@ func StripNonRelevantExamples(description string, lang string) string {
 	// Replace the entire section (including the shortcodes themselves) enclosing the
 	// examples section, with a placeholder, which itself will be replaced appropriately
 	// later.
-	newDescription := surroundingTextRE.ReplaceAllString(description, "{{ .Examples }}")
+	newDescription := SurroundingTextRE.ReplaceAllString(description, "{{ .Examples }}")
 
 	// Get the content enclosing the outer examples short code.
-	examplesContent := extractExamplesSection(description)
+	examplesContent := ExtractExamplesSection(description)
 	if examplesContent == nil {
 		return strings.ReplaceAll(newDescription, "{{ .Examples }}", "")
 	}

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -24,7 +24,7 @@ func extractExampleCodeSnippets(exampleContent string) map[string]string {
 		codeFence := "```" + lang
 		langSnippetIndex := strings.Index(exampleContent, codeFence)
 		// If there is no snippet for the provided language in this example,
-		// then just return nil.
+		// then use a placeholder text for it.
 		if langSnippetIndex < 0 {
 			snippets[lang] = defaultMissingExampleSnippetPlaceholder
 			continue

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -1,3 +1,21 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Pulling out some of the repeated strings tokens into constants would harm readability, so we just ignore the
+// goconst linter's warning.
+//
+// nolint: lll, goconst
 package docs
 
 import (

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -32,6 +32,9 @@ type exampleSection struct {
 	Snippets map[string]string
 }
 
+// extractExampleCodeSnippets returns a map of code snippets by language.
+// For any language that was missing in the provided example content, a
+// placeholder snippet is set.
 func extractExampleCodeSnippets(exampleContent string) map[string]string {
 	snippets := map[string]string{}
 	for _, lang := range supportedLanguages {
@@ -65,6 +68,9 @@ func extractExampleCodeSnippets(exampleContent string) map[string]string {
 	return snippets
 }
 
+// getExampleSections returns a slice of all example sections organized
+// by title and the code snippets. Returns an empty slice if examples
+// were not detected due to bad formatting or otherwise.
 func getExampleSections(examplesContent string) []exampleSection {
 	examples := make([]exampleSection, 0)
 	exampleMatches := codegen.GetAllMatchedGroupsFromRegex(codegen.IndividualExampleRE, examplesContent)
@@ -84,6 +90,9 @@ func getExampleSections(examplesContent string) []exampleSection {
 	return examples
 }
 
+// processExamples extracts the examples section from a resource or a function description
+// and individually wraps in {{% example lang %}} short-codes. It also adds placeholder
+// short-codes for missing languages.
 func processExamples(descriptionWithExamples string) ([]exampleSection, error) {
 	if descriptionWithExamples == "" {
 		return nil, nil

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -1,0 +1,83 @@
+package docs
+
+import (
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen"
+)
+
+const defaultMissingExampleSnippetPlaceholder = "Coming soon!"
+
+type exampleSection struct {
+	Title string
+	// Snippets is a map of language to its code snippet, if any.
+	Snippets map[string]string
+}
+
+func extractExampleCodeSnippets(exampleContent string) map[string]string {
+	snippets := map[string]string{}
+	for _, lang := range supportedLanguages {
+		var snippet string
+		if lang == "nodejs" {
+			lang = "typescript"
+		}
+		codeFence := "```" + lang
+		langSnippetIndex := strings.Index(exampleContent, codeFence)
+		// If there is no snippet for the provided language in this example,
+		// then just return nil.
+		if langSnippetIndex < 0 {
+			snippet = defaultMissingExampleSnippetPlaceholder
+			continue
+		}
+
+		switch lang {
+		case "csharp":
+			snippet = codegen.CSharpCodeSnippetRE.FindString(exampleContent)
+		case "go":
+			snippet = codegen.GoCodeSnippetRE.FindString(exampleContent)
+		case "python":
+			snippet = codegen.PythonCodeSnippetRE.FindString(exampleContent)
+		case "typescript":
+			snippet = codegen.TSCodeSnippetRE.FindString(exampleContent)
+		}
+
+		snippets[lang] = snippet
+	}
+
+	return snippets
+}
+
+func getExampleSections(examplesContent string) []exampleSection {
+	examples := make([]exampleSection, 0)
+	exampleMatches := codegen.GetAllMatchedGroupsFromRegex(codegen.IndividualExampleRE, examplesContent)
+	if matchedExamples, ok := exampleMatches["example_content"]; ok {
+		for _, ex := range matchedExamples {
+			snippets := extractExampleCodeSnippets(ex)
+			if snippets == nil || len(snippets) == 0 {
+				continue
+			}
+
+			examples = append(examples, exampleSection{
+				Title:    codegen.H3TitleRE.FindString(ex),
+				Snippets: snippets,
+			})
+		}
+	}
+	return examples
+}
+
+func processExamples(descriptionWithExamples string) ([]exampleSection, error) {
+	if descriptionWithExamples == "" {
+		return nil, nil
+	}
+
+	// Get the content enclosing the outer examples short code.
+	examplesContent := codegen.ExtractExamplesSection(descriptionWithExamples)
+	if examplesContent == nil {
+		return nil, nil
+	}
+
+	// Within the examples section, identify each example section
+	// which is wrapped in a {{% example %}} shortcode.
+	return getExampleSections(*examplesContent), nil
+}

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -26,7 +26,7 @@ func extractExampleCodeSnippets(exampleContent string) map[string]string {
 		// If there is no snippet for the provided language in this example,
 		// then just return nil.
 		if langSnippetIndex < 0 {
-			snippet = defaultMissingExampleSnippetPlaceholder
+			snippets[lang] = defaultMissingExampleSnippetPlaceholder
 			continue
 		}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -205,6 +205,7 @@ type resourceDocArgs struct {
 
 	// Comment represents the introductory resource comment.
 	Comment            string
+	ExamplesSection    []exampleSection
 	DeprecationMessage string
 
 	// ConstructorParams is a map from language to the rendered HTML for the constructor's
@@ -1273,13 +1274,21 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 
 	stateParam := name + "State"
 
+	// Replace the entire section (including the shortcodes themselves) enclosing the
+	// examples section, with an empty string.
+	newDescription := codegen.SurroundingTextRE.ReplaceAllString(r.Comment, "")
+	examplesSection, err := processExamples(r.Comment)
+	if err != nil {
+		panic(err)
+	}
 	data := resourceDocArgs{
 		Header: mod.genResourceHeader(r),
 
 		Tool: mod.tool,
 
-		Comment:            r.Comment,
+		Comment:            newDescription,
 		DeprecationMessage: r.DeprecationMessage,
+		ExamplesSection:    examplesSection,
 
 		ConstructorParams:      renderedCtorParams,
 		ConstructorParamsTyped: typedCtorParams,

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1274,19 +1274,28 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 
 	stateParam := name + "State"
 
-	// Replace the entire section (including the shortcodes themselves) enclosing the
-	// examples section, with an empty string.
-	newDescription := codegen.SurroundingTextRE.ReplaceAllString(r.Comment, "")
 	examplesSection, err := processExamples(r.Comment)
 	if err != nil {
 		panic(err)
+	}
+
+	resourceComment := r.Comment
+	// If we managed to extract examples out of the description, then modify the original
+	// description to remove the examples section.
+	// We may not have been able to extract examples from the description because:
+	// - There is no examples section.
+	// - Or the examples section is not properly wrapped in the expected short-codes.
+	if len(examplesSection) > 0 {
+		// Replace the entire section (including the shortcodes themselves) enclosing the
+		// examples section, with an empty string.
+		resourceComment = codegen.SurroundingTextRE.ReplaceAllString(r.Comment, "")
 	}
 	data := resourceDocArgs{
 		Header: mod.genResourceHeader(r),
 
 		Tool: mod.tool,
 
-		Comment:            newDescription,
+		Comment:            resourceComment,
 		DeprecationMessage: r.DeprecationMessage,
 		ExamplesSection:    examplesSection,
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1443,7 +1443,7 @@ func (mod *modContext) gen(fs fs) error {
 		// are "overlay" modules. The resources under those modules are
 		// not available in Go.
 		if isK8s && mod.isKubernetesOverlayModule() {
-			data.LangChooserLanguages = "javascript,typescript,python,csharp"
+			data.LangChooserLanguages = "typescript,python,csharp"
 		}
 
 		err := templates.ExecuteTemplate(buffer, "resource.tmpl", data)

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -334,12 +334,21 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		Notes:      mod.pkg.Attribution,
 	}
 
-	// Replace the entire section (including the shortcodes themselves) enclosing the
-	// examples section, with an empty string.
-	newDescription := codegen.SurroundingTextRE.ReplaceAllString(f.Comment, "")
 	examplesSection, err := processExamples(f.Comment)
 	if err != nil {
 		panic(err)
+	}
+
+	functionComment := f.Comment
+	// If we managed to extract examples out of the description, then modify the original
+	// description to remove the examples section.
+	// We may not have been able to extract examples from the description because:
+	// - There is no examples section.
+	// - Or the examples section is not properly wrapped in the expected short-codes.
+	if len(examplesSection) > 0 {
+		// Replace the entire section (including the shortcodes themselves) enclosing the
+		// examples section, with an empty string.
+		functionComment = codegen.SurroundingTextRE.ReplaceAllString(f.Comment, "")
 	}
 	args := functionDocArgs{
 		Header: mod.genFunctionHeader(f),
@@ -350,7 +359,7 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		FunctionArgs:   mod.genFunctionArgs(f, funcNameMap),
 		FunctionResult: mod.getFunctionResourceInfo(f),
 
-		Comment:            newDescription,
+		Comment:            functionComment,
 		DeprecationMessage: f.DeprecationMessage,
 		ExamplesSection:    examplesSection,
 

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -371,10 +371,16 @@ func TestExamplesProcessing(t *testing.T) {
 	assert.Equal(t, "### Basic Example", examplesSection[0].Title)
 	assert.Equal(t, "### Custom Sub-Domain Example", examplesSection[1].Title)
 	expectedLangSnippets := []string{"typescript", "python"}
+	otherLangSnippets := []string{"csharp", "go"}
 	for _, e := range examplesSection {
 		for _, lang := range expectedLangSnippets {
 			_, ok := e.Snippets[lang]
 			assert.True(t, ok, "Could not find %s snippet", lang)
+		}
+		for _, lang := range otherLangSnippets {
+			snippet, ok := e.Snippets[lang]
+			assert.True(t, ok, "Expected to find default placeholders for other languages")
+			assert.Contains(t, "Coming soon!", snippet)
 		}
 	}
 }

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -31,6 +31,7 @@ import (
 const (
 	unitTestTool    = "Pulumi Resource Docs Unit Test"
 	providerPackage = "prov"
+	codeFence       = "```"
 )
 
 var (
@@ -123,7 +124,32 @@ func initTestPackageSpec(t *testing.T) {
 		Resources: map[string]schema.ResourceSpec{
 			"prov:module/resource:Resource": {
 				ObjectTypeSpec: schema.ObjectTypeSpec{
-					Description: "This is a module-level resource called Resource. \n\n{{% examples %}}\n## Example Usage\n\n{{% example %}}\n### Basic Example\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as digitalocean from \"@pulumi/digitalocean\";\n\n// Create a new Spaces Bucket\nconst mybucket = new digitalocean.SpacesBucket(\"mybucket\", {\n    region: \"sfo2\",\n    acl: \"public-read\",\n});\n// Add a CDN endpoint to the Spaces Bucket\nconst mycdn = new digitalocean.Cdn(\"mycdn\", {origin: mybucket.bucketDomainName});\nexport const fqdn = mycdn.endpoint;\n```\n```python\nimport pulumi\nimport pulumi_digitalocean as digitalocean\n\n# Create a new Spaces Bucket\nmybucket = digitalocean.SpacesBucket(\"mybucket\",\n    region=\"sfo2\",\n    acl=\"public-read\")\n# Add a CDN endpoint to the Spaces Bucket\nmycdn = digitalocean.Cdn(\"mycdn\", origin=mybucket.bucket_domain_name)\npulumi.export(\"fqdn\", mycdn.endpoint)\n```\n\n{{% /example %}}\n{{% example %}}\n### Custom Sub-Domain Example\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as digitalocean from \"@pulumi/digitalocean\";\n\n// Create a new Spaces Bucket\nconst mybucket = new digitalocean.SpacesBucket(\"mybucket\", {\n    region: \"sfo2\",\n    acl: \"public-read\",\n});\n// Create a DigitalOcean managed Let's Encrypt Certificate\nconst cert = new digitalocean.Certificate(\"cert\", {\n    type: \"lets_encrypt\",\n    domains: [\"static.example.com\"],\n});\n// Add a CDN endpoint with a custom sub-domain to the Spaces Bucket\nconst mycdn = new digitalocean.Cdn(\"mycdn\", {\n    origin: mybucket.bucketDomainName,\n    customDomain: \"static.example.com\",\n    certificateId: cert.id,\n});\n```\n```python\nimport pulumi\nimport pulumi_digitalocean as digitalocean\n\n# Create a new Spaces Bucket\nmybucket = digitalocean.SpacesBucket(\"mybucket\",\n    region=\"sfo2\",\n    acl=\"public-read\")\n# Create a DigitalOcean managed Let's Encrypt Certificate\ncert = digitalocean.Certificate(\"cert\",\n    type=\"lets_encrypt\",\n    domains=[\"static.example.com\"])\n# Add a CDN endpoint with a custom sub-domain to the Spaces Bucket\nmycdn = digitalocean.Cdn(\"mycdn\",\n    origin=mybucket.bucket_domain_name,\n    custom_domain=\"static.example.com\",\n    certificate_id=cert.id)\n```\n\n{{% /example %}}\n{{% /examples %}}\n",
+					Description: `This is a module-level resource called Resource.
+{{% examples %}}
+## Example Usage
+
+{{% example %}}
+### Basic Example
+
+` + codeFence + `typescript
+					// Some TypeScript code.
+` + codeFence + `
+` + codeFence + `python
+					# Some Python code.
+` + codeFence + `
+{{% /example %}}
+{{% example %}}
+### Custom Sub-Domain Example
+
+` + codeFence + `typescript
+					// Some typescript code
+` + codeFence + `
+` + codeFence + `python
+					# Some Python code.
+` + codeFence + `
+{{% /example %}}
+{{% /examples %}}
+`,
 				},
 				InputProperties: map[string]schema.PropertySpec{
 					"integerProp": {

--- a/pkg/codegen/docs/templates/examples.tmpl
+++ b/pkg/codegen/docs/templates/examples.tmpl
@@ -6,7 +6,7 @@
 {{ .Title }}
 {{ range $key, $val := .Snippets }}
 {{- print "{{% example " }}{{ $key }}{{ print " %}}" }}
-{{ $val }}
+{{ htmlSafe $val }}
 {{ print "{{% /example %}}" }}
 {{- end }}
 

--- a/pkg/codegen/docs/templates/examples.tmpl
+++ b/pkg/codegen/docs/templates/examples.tmpl
@@ -1,0 +1,15 @@
+{{ define "examples" -}}
+{{ print "{{% examples %}}" }}
+## Example Usage
+
+{{- range . }}
+{{ .Title }}
+{{ range $key, $val := .Snippets }}
+{{- print "{{% example " }}{{ $key }}{{ print " % }}" }}
+{{ $val }}
+{{ print "{{% /example %}}" }}
+{{- end }}
+
+{{- print "{{% /examples %}}" }}
+
+{{- end }}

--- a/pkg/codegen/docs/templates/examples.tmpl
+++ b/pkg/codegen/docs/templates/examples.tmpl
@@ -2,6 +2,8 @@
 {{ print "{{% examples %}}" }}
 ## Example Usage
 
+{{< chooser language "typescript,python,go,csharp" / >}}
+
 {{- range . }}
 {{ .Title }}
 

--- a/pkg/codegen/docs/templates/examples.tmpl
+++ b/pkg/codegen/docs/templates/examples.tmpl
@@ -2,7 +2,7 @@
 {{ print "{{% examples %}}" }}
 ## Example Usage
 
-{{< chooser language "typescript,python,go,csharp" / >}}
+{{ htmlSafe "{{< chooser language \"typescript,python,go,csharp\" / >}}" }}
 
 {{- range . }}
 {{ .Title }}
@@ -11,7 +11,7 @@
 {{ print "{{% example " }}{{ $key }}{{ print " %}}" }}
 {{ htmlSafe $val }}
 {{ print "{{% /example %}}" }}
-{{- end }}
+{{ end }}
 
 {{- end }}
 {{ print "{{% /examples %}}" }}

--- a/pkg/codegen/docs/templates/examples.tmpl
+++ b/pkg/codegen/docs/templates/examples.tmpl
@@ -4,13 +4,14 @@
 
 {{- range . }}
 {{ .Title }}
-{{ range $key, $val := .Snippets }}
-{{- print "{{% example " }}{{ $key }}{{ print " %}}" }}
+
+{{- range $key, $val := .Snippets }}
+{{ print "{{% example " }}{{ $key }}{{ print " %}}" }}
 {{ htmlSafe $val }}
 {{ print "{{% /example %}}" }}
 {{- end }}
 
 {{- end }}
-{{- print "{{% /examples %}}" }}
+{{ print "{{% /examples %}}" }}
 
 {{- end }}

--- a/pkg/codegen/docs/templates/examples.tmpl
+++ b/pkg/codegen/docs/templates/examples.tmpl
@@ -5,7 +5,7 @@
 {{- range . }}
 {{ .Title }}
 {{ range $key, $val := .Snippets }}
-{{- print "{{% example " }}{{ $key }}{{ print " % }}" }}
+{{- print "{{% example " }}{{ $key }}{{ print " %}}" }}
 {{ $val }}
 {{ print "{{% /example %}}" }}
 {{- end }}

--- a/pkg/codegen/docs/templates/examples.tmpl
+++ b/pkg/codegen/docs/templates/examples.tmpl
@@ -10,6 +10,7 @@
 {{ print "{{% /example %}}" }}
 {{- end }}
 
+{{- end }}
 {{- print "{{% /examples %}}" }}
 
 {{- end }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -4,6 +4,7 @@
 {{ htmlSafe "<!-- Do not edit by hand unless you're certain you know what you are doing! -->" }}
 
 {{ htmlSafe .Comment }}
+{{ template "examples" .ExamplesSection }}
 
 {{- if .DeprecationMessage }}
 <p class="resource-deprecated">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -4,7 +4,9 @@
 {{ htmlSafe "<!-- Do not edit by hand unless you're certain you know what you are doing! -->" }}
 
 {{ htmlSafe .Comment }}
+{{- if ne (len .ExamplesSection) 0 }}
 {{ template "examples" .ExamplesSection }}
+{{- end }}
 
 {{- if .DeprecationMessage }}
 <p class="resource-deprecated">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -15,7 +15,7 @@
 <!-- Input properties -->
 ## Using {{ .Header.Title }} {#using}
 
-{{ htmlSafe "{{< chooser language \"javascript,typescript,python,go,csharp\" / >}}" }}
+{{ htmlSafe "{{< chooser language \"typescript,python,go,csharp\" / >}}" }}
 
 <!-- TS/JS -->
 {{ print "{{% choosable language nodejs %}}" }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -4,6 +4,7 @@
 {{ htmlSafe "<!-- Do not edit by hand unless you're certain you know what you are doing! -->" }}
 
 {{ htmlSafe .Comment }}
+{{ template "examples" .ExamplesSection }}
 
 {{- if .DeprecationMessage }}
 <p class="resource-deprecated">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -4,7 +4,9 @@
 {{ htmlSafe "<!-- Do not edit by hand unless you're certain you know what you are doing! -->" }}
 
 {{ htmlSafe .Comment }}
+{{- if ne (len .ExamplesSection) 0 }}
 {{ template "examples" .ExamplesSection }}
+{{- end }}
 
 {{- if .DeprecationMessage }}
 <p class="resource-deprecated">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -16,7 +16,7 @@
 ## Create a {{ .Header.Title }} Resource {#create}
 
 {{- if eq .LangChooserLanguages "" }}
-{{ htmlSafe "{{< chooser language \"javascript,typescript,python,go,csharp\" / >}}" }}
+{{ htmlSafe "{{< chooser language \"typescript,python,go,csharp\" / >}}" }}
 {{- else }}
 {{ htmlSafe "{{< chooser language \"" }}{{ .LangChooserLanguages }}{{ htmlSafe "\" / >}}" }}
 {{- end }}
@@ -101,7 +101,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 Get an existing {{.Header.Title}} resource's state with the given name, ID, and optional extra properties used to qualify the lookup.
 
 {{- if eq .LangChooserLanguages "" }}
-{{ htmlSafe "{{< chooser language \"javascript,typescript,python,go,csharp\" / >}}" }}
+{{ htmlSafe "{{< chooser language \"typescript,python,go,csharp\" / >}}" }}
 {{- else }}
 {{ htmlSafe "{{< chooser language \"" }}{{ .LangChooserLanguages }}{{ htmlSafe "\" / >}}" }}
 {{- end }}

--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -33,7 +33,7 @@ and here
 `
 		description := `{{% examples %}}` + expectedContent + `{{% /examples %}}`
 
-		actualContent := extractExamplesSection(description)
+		actualContent := ExtractExamplesSection(description)
 		assert.NotNil(t, actualContent, "content could not be extracted")
 		assert.Equal(t, expectedContent, *actualContent, "strings don't match")
 	})
@@ -42,7 +42,7 @@ and here
 		description := `{{% examples %}}
 {{% /examples %}}`
 
-		actualContent := extractExamplesSection(description)
+		actualContent := ExtractExamplesSection(description)
 		assert.Nil(t, actualContent, "expected content to be nil")
 	})
 }


### PR DESCRIPTION
This PR extracts the (if any) examples in the description and turns it into a template-consumable structure so we can render it any way we want to.

Note that this does rely on the fact that the examples are generated in the schema with the appropriate short-codes. In the event that that does not happen, instead of not showing any examples, we would render the description as-is, because the resource docs generator does not know how to process them. From what I have observed this is only a problem for some smaller packages where some pages have the problem with the title.