### PR TITLE
[codegen/hcl2] Add a conversion insertion pass.

### DIFF
--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -222,8 +222,8 @@ func GetSchemaForType(t model.Type) (schema.Type, bool) {
 		schemas := codegen.Set{}
 		for _, t := range t.ElementTypes {
 			if s, ok := GetSchemaForType(t); ok {
-				if s, ok := s.(*schema.UnionType); ok {
-					for _, s := range s.ElementTypes {
+				if union, ok := s.(*schema.UnionType); ok {
+					for _, s := range union.ElementTypes {
 						schemas.Add(s)
 					}
 				} else {

--- a/pkg/codegen/hcl2/intrinsics.go
+++ b/pkg/codegen/hcl2/intrinsics.go
@@ -22,6 +22,8 @@ import (
 const (
 	// IntrinsicApply is the name of the apply intrinsic.
 	IntrinsicApply = "__apply"
+	// IntrinsicConvert is the name of the conversion intrinsic.
+	IntrinsicConvert = "__convert"
 )
 
 func isOutput(t model.Type) bool {
@@ -81,4 +83,26 @@ func ParseApplyCall(c *model.FunctionCallExpression) (applyArgs []model.Expressi
 
 	contract.Assert(c.Name == IntrinsicApply)
 	return c.Args[:len(c.Args)-1], c.Args[len(c.Args)-1].(*model.AnonymousFunctionExpression)
+}
+
+// NewConvertCall returns a new expression that represents a call to IntrinsicConvert.
+func NewConvertCall(from model.Expression, to model.Type) *model.FunctionCallExpression {
+	return &model.FunctionCallExpression{
+		Name: IntrinsicConvert,
+		Signature: model.StaticFunctionSignature{
+			Parameters: []model.Parameter{{
+				Name: "from",
+				Type: from.Type(),
+			}},
+			ReturnType: to,
+		},
+		Args: []model.Expression{from},
+	}
+}
+
+// ParseConvertCall extracts the value being converted and the type it is being converted to from a call to the convert
+// intrinsic.
+func ParseConvertCall(c *model.FunctionCallExpression) (model.Expression, model.Type) {
+	contract.Assert(c.Name == IntrinsicConvert)
+	return c.Args[0], c.Signature.ReturnType
 }

--- a/pkg/codegen/hcl2/model/binder_expression.go
+++ b/pkg/codegen/hcl2/model/binder_expression.go
@@ -164,6 +164,11 @@ func encapsulateType(t Type) cty.Value {
 	return cty.CapsuleVal(typeCapsule, &t)
 }
 
+// MakeTraverser returns an hcl.TraverseIndex with a key of the appropriate type.
+func MakeTraverser(t Type) hcl.TraverseIndex {
+	return hcl.TraverseIndex{Key: encapsulateType(t)}
+}
+
 // getOperationSignature returns the equivalent StaticFunctionSignature for a given Operation. This signature can be
 // used for typechecking the operation's arguments.
 func getOperationSignature(op *hclsyntax.Operation) StaticFunctionSignature {

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -64,9 +64,6 @@ func assignableFrom(dest, src Type, assignableFrom func() bool) bool {
 	if dest == src || dest == DynamicType {
 		return true
 	}
-	if src, isUnion := src.(*UnionType); isUnion {
-		return src.assignableTo(dest)
-	}
 	if src == DynamicType {
 		return false
 	}

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -37,7 +37,6 @@ type Type interface {
 
 	AssignableFrom(src Type) bool
 	ConversionFrom(src Type) ConversionKind
-	GetAnnotations() []interface{}
 	String() string
 
 	conversionFrom(src Type, unifying bool) ConversionKind

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -104,10 +104,6 @@ func (t *ListType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
-func (t *ListType) GetAnnotations() []interface{} {
-	return nil
-}
-
 func (t *ListType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("list(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -103,10 +103,6 @@ func (t *MapType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
-func (t *MapType) GetAnnotations() []interface{} {
-	return nil
-}
-
 func (t *MapType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("map(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -46,10 +46,6 @@ func (noneType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
-func (noneType) GetAnnotations() []interface{} {
-	return nil
-}
-
 func (noneType) String() string {
 	return "none"
 }

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -186,10 +186,6 @@ func (t *ObjectType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
-func (t *ObjectType) GetAnnotations() []interface{} {
-	return t.Annotations
-}
-
 func (t *ObjectType) String() string {
 	if t.s == "" {
 		var properties []string
@@ -198,7 +194,12 @@ func (t *ObjectType) String() string {
 		}
 		sort.Strings(properties)
 
-		t.s = fmt.Sprintf("object({%s})", strings.Join(properties, ", "))
+		annotations := ""
+		if len(t.Annotations) != 0 {
+			annotations = fmt.Sprintf(", annotated(%p)", t)
+		}
+
+		t.s = fmt.Sprintf("object({%s}%v)", strings.Join(properties, ", "), annotations)
 	}
 	return t.s
 }

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -28,6 +28,8 @@ import (
 type OpaqueType struct {
 	// Name is the type's name.
 	Name string
+	// Annotations records any annotations associated with the object type.
+	Annotations []interface{}
 
 	s string
 }
@@ -42,8 +44,8 @@ func GetOpaqueType(name string) (*OpaqueType, bool) {
 }
 
 // MustNewOpaqueType creates a new opaque type with the given name.
-func MustNewOpaqueType(name string) *OpaqueType {
-	t, err := NewOpaqueType(name)
+func MustNewOpaqueType(name string, annotations ...interface{}) *OpaqueType {
+	t, err := NewOpaqueType(name, annotations...)
 	if err != nil {
 		panic(err)
 	}
@@ -51,12 +53,12 @@ func MustNewOpaqueType(name string) *OpaqueType {
 }
 
 // NewOpaqueType creates a new opaque type with the given name.
-func NewOpaqueType(name string) (*OpaqueType, error) {
+func NewOpaqueType(name string, annotations ...interface{}) (*OpaqueType, error) {
 	if _, ok := opaqueTypes[name]; ok {
 		return nil, errors.Errorf("opaque type %s is already defined", name)
 	}
 
-	t := &OpaqueType{Name: name}
+	t := &OpaqueType{Name: name, Annotations: annotations}
 	opaqueTypes[name] = t
 	return t, nil
 }
@@ -131,10 +133,6 @@ func (t *OpaqueType) conversionFrom(src Type, unifying bool) ConversionKind {
 
 func (t *OpaqueType) ConversionFrom(src Type) ConversionKind {
 	return t.conversionFrom(src, false)
-}
-
-func (t *OpaqueType) GetAnnotations() []interface{} {
-	return nil
 }
 
 func (t *OpaqueType) String() string {

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -88,10 +88,6 @@ func (t *OutputType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
-func (t *OutputType) GetAnnotations() []interface{} {
-	return t.ElementType.GetAnnotations()
-}
-
 func (t *OutputType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("output(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -82,10 +82,6 @@ func (t *PromiseType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
-func (t *PromiseType) GetAnnotations() []interface{} {
-	return t.ElementType.GetAnnotations()
-}
-
 func (t *PromiseType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("promise(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -89,10 +89,6 @@ func (t *SetType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
-func (t *SetType) GetAnnotations() []interface{} {
-	return nil
-}
-
 func (t *SetType) String() string {
 	if t.s == "" {
 		t.s = fmt.Sprintf("set(%v)", t.ElementType)

--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -386,7 +386,6 @@ func TestUnionType(t *testing.T) {
 
 	// Test that union(T_0, ..., T_N) is assignable from union(U_0, ..., U_M) if union(T_0, ..., T_N) is assignable
 	// from all of U_0 through U_M.
-	assert.True(t, typ.AssignableFrom(NewUnionType(BoolType, IntType)))
 	assert.True(t, NewUnionType(NoneType, StringType).ConversionFrom(typ).Exists())
 
 	// Test that union(T_0, ..., T_N) is _not_ assignable from union(U_0, ..., U_M) if union(T_0, ..., T_N) is not

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -189,10 +189,6 @@ func (t *TupleType) conversionFrom(src Type, unifying bool) ConversionKind {
 	})
 }
 
-func (t *TupleType) GetAnnotations() []interface{} {
-	return nil
-}
-
 func (t *TupleType) String() string {
 	if t.s == "" {
 		elements := make([]string, len(t.ElementTypes))

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -171,10 +171,6 @@ func (t *UnionType) conversionTo(dest Type, unifying bool) ConversionKind {
 	return conversionKind
 }
 
-func (t *UnionType) GetAnnotations() []interface{} {
-	return nil
-}
-
 func (t *UnionType) String() string {
 	if t.s == "" {
 		elements := make([]string, len(t.ElementTypes))

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -134,15 +134,6 @@ func (t *UnionType) AssignableFrom(src Type) bool {
 	})
 }
 
-func (t *UnionType) assignableTo(dest Type) bool {
-	for _, t := range t.ElementTypes {
-		if !dest.AssignableFrom(t) {
-			return false
-		}
-	}
-	return true
-}
-
 func (t *UnionType) ConversionFrom(src Type) ConversionKind {
 	return t.conversionFrom(src, false)
 }

--- a/pkg/codegen/hcl2/rewrite_convert.go
+++ b/pkg/codegen/hcl2/rewrite_convert.go
@@ -1,0 +1,85 @@
+package hcl2
+
+import (
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func sameAnnotations(xt, yt model.Type) bool {
+	x, y := xt.GetAnnotations(), yt.GetAnnotations()
+	if len(x) != len(y) {
+		return false
+	}
+	for i := range x {
+		if x[i] != y[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func RewriteConversions(x model.Expression, to model.Type) model.Expression {
+	switch x := x.(type) {
+	case *model.BinaryOpExpression:
+		x.LeftOperand = RewriteConversions(x.LeftOperand, model.InputType(x.LeftOperandType()))
+		x.RightOperand = RewriteConversions(x.RightOperand, model.InputType(x.RightOperandType()))
+	case *model.ConditionalExpression:
+		x.Condition = RewriteConversions(x.Condition, model.InputType(model.BoolType))
+	case *model.ForExpression:
+		if x.Key != nil {
+			x.Key = RewriteConversions(x.Key, model.InputType(model.StringType))
+		}
+		if x.Condition != nil {
+			x.Condition = RewriteConversions(x.Condition, model.InputType(model.BoolType))
+		}
+	case *model.FunctionCallExpression:
+		args := x.Args
+		for _, param := range x.Signature.Parameters {
+			if len(args) == 0 {
+				break
+			}
+			args[0] = RewriteConversions(args[0], model.InputType(param.Type))
+			args = args[1:]
+		}
+		if x.Signature.VarargsParameter != nil {
+			for i := range args {
+				args[i] = RewriteConversions(args[i], model.InputType(x.Signature.VarargsParameter.Type))
+			}
+		}
+	case *model.IndexExpression:
+		x.Key = RewriteConversions(x.Key, x.KeyType())
+	case *model.ObjectConsExpression:
+		for i := range x.Items {
+			item := &x.Items[i]
+
+			var traverser hcl.Traverser
+			if lit, ok := item.Key.(*model.LiteralValueExpression); ok {
+				traverser = hcl.TraverseIndex{Key: lit.Value}
+			} else {
+				traverser = model.MakeTraverser(model.StringType)
+			}
+			valueType, diags := to.Traverse(traverser)
+			contract.Ignore(diags)
+
+			item.Key = RewriteConversions(item.Key, model.InputType(model.StringType))
+			item.Value = RewriteConversions(item.Value, model.InputType(valueType.(model.Type)))
+		}
+	case *model.TupleConsExpression:
+		for i := range x.Expressions {
+			valueType, diags := to.Traverse(hcl.TraverseIndex{Key: cty.NumberIntVal(int64(i))})
+			contract.Ignore(diags)
+
+			x.Expressions[i] = RewriteConversions(x.Expressions[i], valueType.(model.Type))
+		}
+	case *model.UnaryOpExpression:
+		x.Operand = RewriteConversions(x.Operand, x.OperandType())
+	}
+
+	// If the expression's type is directly assignable to the destination type, no conversion is necessary.
+	if to.AssignableFrom(x.Type()) && sameAnnotations(to, x.Type()) {
+		return x
+	}
+	return NewConvertCall(x, to)
+}

--- a/pkg/codegen/hcl2/rewrite_convert_test.go
+++ b/pkg/codegen/hcl2/rewrite_convert_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,10 +29,24 @@ func TestRewriteConversions(t *testing.T) {
 		},
 		{
 			input:  `{a: "b"}`,
+			output: `{a: "b"}`,
+			to: model.InputType(model.NewObjectType(map[string]model.Type{
+				"a": model.StringType,
+			})),
+		},
+		{
+			input:  `{a: "b"}`,
 			output: `__convert({a: "b"})`,
 			to: model.NewObjectType(map[string]model.Type{
 				"a": model.StringType,
-			}, "annotation"),
+			}, &schema.ObjectType{}),
+		},
+		{
+			input:  `{a: "b"}`,
+			output: `__convert({a: "b"})`,
+			to: model.InputType(model.NewObjectType(map[string]model.Type{
+				"a": model.StringType,
+			}, &schema.ObjectType{})),
 		},
 	}
 
@@ -47,5 +62,4 @@ func TestRewriteConversions(t *testing.T) {
 		expr = RewriteConversions(expr, to)
 		assert.Equal(t, c.output, fmt.Sprintf("%v", expr))
 	}
-
 }

--- a/pkg/codegen/hcl2/rewrite_convert_test.go
+++ b/pkg/codegen/hcl2/rewrite_convert_test.go
@@ -1,0 +1,51 @@
+package hcl2
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRewriteConversions(t *testing.T) {
+	cases := []struct {
+		input, output string
+		to            model.Type
+	}{
+		{
+			input:  `"1" + 2`,
+			output: `__convert("1") + 2`,
+		},
+		{
+			input:  `{a: "b"}`,
+			output: `{a: "b"}`,
+			to: model.NewObjectType(map[string]model.Type{
+				"a": model.StringType,
+			}),
+		},
+		{
+			input:  `{a: "b"}`,
+			output: `__convert({a: "b"})`,
+			to: model.NewObjectType(map[string]model.Type{
+				"a": model.StringType,
+			}, "annotation"),
+		},
+	}
+
+	scope := model.NewRootScope(syntax.None)
+	for _, c := range cases {
+		expr, diags := model.BindExpressionText(c.input, scope, hcl.Pos{})
+		assert.Len(t, diags, 0)
+
+		to := c.to
+		if to == nil {
+			to = expr.Type()
+		}
+		expr = RewriteConversions(expr, to)
+		assert.Equal(t, c.output, fmt.Sprintf("%v", expr))
+	}
+
+}

--- a/pkg/codegen/python/gen_program_lower.go
+++ b/pkg/codegen/python/gen_program_lower.go
@@ -5,7 +5,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/codegen"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
-	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -102,25 +101,6 @@ func (g *generator) lowerProxyApplies(expr model.Expression) (model.Expression, 
 		return expr, nil
 	}
 	return model.VisitExpression(expr, model.IdentityVisitor, rewriter)
-}
-
-func (g *generator) getObjectSchema(typ model.Type) *schema.ObjectType {
-	typ = model.ResolveOutputs(typ)
-
-	if union, ok := typ.(*model.UnionType); ok {
-		for _, t := range union.ElementTypes {
-			if obj := g.getObjectSchema(t); obj != nil {
-				return obj
-			}
-		}
-		return nil
-	}
-
-	annotations := typ.GetAnnotations()
-	if len(annotations) == 1 {
-		return annotations[0].(*schema.ObjectType)
-	}
-	return nil
 }
 
 func (g *generator) lowerObjectKeys(expr model.Expression, camelCaseToSnakeCase map[string]string) {

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v2/codegen"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
@@ -52,8 +53,8 @@ func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expre
 		keyVal, objectKey := key.AsString(), false
 
 		receiver := parts[i]
-		if annotations := model.GetTraversableType(receiver).GetAnnotations(); len(annotations) == 1 {
-			obj := annotations[0].(*schema.ObjectType)
+		if schemaType, ok := hcl2.GetSchemaForType(model.GetTraversableType(receiver)); ok {
+			obj := schemaType.(*schema.ObjectType)
 
 			info, ok := obj.Language["python"].(objectTypeInfo)
 			if ok {


### PR DESCRIPTION
Add a rewriter that reifies implicit conversions into a call to the
`__convert` intrinsic. Code generators can recognize this intrinsic and
use it to generate appropriate conversion code.