### PR TITLE
Update NPM test to install @pulumi/pulumi 2.0

### DIFF
--- a/pkg/npm/npm_test.go
+++ b/pkg/npm/npm_test.go
@@ -52,7 +52,7 @@ func testInstall(t *testing.T, expectedBin string) {
 	packageJSON := []byte(`{
 	    "name": "test-package",
 	    "dependencies": {
-	        "@pulumi/pulumi": "^1.0.0"
+	        "@pulumi/pulumi": "^2.0.0"
 	    }
 	}`)
 	assert.NoError(t, ioutil.WriteFile(packageJSONFilename, packageJSON, 0644))


### PR DESCRIPTION
Future proof this test by depending on `@pulumi/pulumi` 2.0. `@pulumi/pulumi` 1.x depends on the native `grpc` package. In the future, when we run on future versions of Node.js, prebuilt native binaries for `grpc` might not be available which could result in this test failing.

In `@pulumi/pulumi` 2.0, we have moved to using `@grpc/grpc-js`, a pure JavaScript implementation, which doesn’t have this problem.