### PR TITLE
[codegen/nodejs] Await invokes in async contexts.

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -113,7 +113,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		b.root.DefineFunction(name, fn)
 	}
 	// Define the invoke function.
-	b.root.DefineFunction("invoke", model.NewFunction(model.GenericFunctionSignature(b.bindInvokeSignature)))
+	b.root.DefineFunction(Invoke, model.NewFunction(model.GenericFunctionSignature(b.bindInvokeSignature)))
 
 	var diagnostics hcl.Diagnostics
 

--- a/pkg/codegen/hcl2/invoke.go
+++ b/pkg/codegen/hcl2/invoke.go
@@ -21,8 +21,10 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+const Invoke = "invoke"
+
 func getInvokeToken(call *hclsyntax.FunctionCallExpr) (string, hcl.Range, bool) {
-	if call.Name != "invoke" || len(call.Args) < 1 {
+	if call.Name != Invoke || len(call.Args) < 1 {
 		return "", hcl.Range{}, false
 	}
 	template, ok := call.Args[0].(*hclsyntax.TemplateExpr)

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.ts
@@ -29,9 +29,9 @@ export = async () => {
         },
     });
     // Subnets, one for each AZ in a region
-    const zones = aws.getAvailabilityZones({});
+    const zones = await aws.getAvailabilityZones({});
     const vpcSubnet: aws.ec2.Subnet[];
-    for (const range of (await zones.then(zones => zones.names)).map((k, v) => {key: k, value: v})) {
+    for (const range of zones.names.map((k, v) => {key: k, value: v})) {
         vpcSubnet.push(new aws.ec2.Subnet(`vpcSubnet-${range.key}`, {
             assignIpv6AddressOnCreation: false,
             vpcId: eksVpc.id,
@@ -44,13 +44,13 @@ export = async () => {
         }));
     }
     const rta: aws.ec2.RouteTableAssociation[];
-    for (const range of (await zones.then(zones => zones.names)).map((k, v) => {key: k, value: v})) {
+    for (const range of zones.names.map((k, v) => {key: k, value: v})) {
         rta.push(new aws.ec2.RouteTableAssociation(`rta-${range.key}`, {
             routeTableId: eksRouteTable.id,
-            subnetId: vpcSubnet.then(vpcSubnet => vpcSubnet[range.key].id),
+            subnetId: vpcSubnet[range.key].id,
         }));
     }
-    const subnetIds = vpcSubnet.then(vpcSubnet => vpcSubnet.map(__item => __item.id));
+    const subnetIds = vpcSubnet.map(__item => __item.id);
     const eksSecurityGroup = new aws.ec2.SecurityGroup("eksSecurityGroup", {
         vpcId: eksVpc.id,
         description: "Allow all HTTP(s) traffic to EKS Cluster",

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -277,7 +277,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 	if r.Options != nil && r.Options.Range != nil {
 		rangeType := model.ResolveOutputs(r.Options.Range.Type())
-		rangeExpr := newAwaitCall(g.lowerExpression(r.Options.Range))
+		rangeExpr := g.lowerExpression(r.Options.Range)
 
 		if model.InputType(model.BoolType).ConversionFrom(rangeType) == model.SafeConversion {
 			g.Fgenf(w, "%slet %s: %s | undefined;\n", g.Indent, name, qualifiedMemberName)

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -274,7 +274,7 @@ var functionImports = map[string]string{
 }
 
 func (g *generator) getFunctionImports(x *model.FunctionCallExpression) string {
-	if x.Name != "invoke" {
+	if x.Name != hcl2.Invoke {
 		return functionImports[x.Name]
 	}
 
@@ -317,7 +317,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "new pulumi.asset.FileArchive(%.v)", expr.Args[0])
 	case "fileAsset":
 		g.Fgenf(w, "new pulumi.asset.FileAsset(%.v)", expr.Args[0])
-	case "invoke":
+	case hcl2.Invoke:
 		pkg, module, fn, diags := functionName(expr.Args[0])
 		contract.Assert(len(diags) == 0)
 		if module != "" {

--- a/pkg/codegen/nodejs/gen_program_lower.go
+++ b/pkg/codegen/nodejs/gen_program_lower.go
@@ -231,7 +231,7 @@ func (g *generator) awaitInvokes(x model.Expression) model.Expression {
 	rewriter := func(x model.Expression) (model.Expression, hcl.Diagnostics) {
 		// Ignore the node if it is not a call to invoke.
 		call, ok := x.(*model.FunctionCallExpression)
-		if !ok || call.Name != "invoke" {
+		if !ok || call.Name != hcl2.Invoke {
 			return x, nil
 		}
 

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -186,7 +186,7 @@ var functionImports = map[string]string{
 }
 
 func (g *generator) getFunctionImports(x *model.FunctionCallExpression) string {
-	if x.Name != "invoke" {
+	if x.Name != hcl2.Invoke {
 		return functionImports[x.Name]
 	}
 
@@ -207,7 +207,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "pulumi.FileArchive(%.v)", expr.Args[0])
 	case "fileAsset":
 		g.Fgenf(w, "pulumi.FileAsset(%.v)", expr.Args[0])
-	case "invoke":
+	case hcl2.Invoke:
 		pkg, module, fn, diags := functionName(expr.Args[0])
 		contract.Assert(len(diags) == 0)
 		if module != "" {


### PR DESCRIPTION
If we are generating code into an async context (e.g. an async main),
await calls to invoke rather than leaving them as promises. This results
in more idiomatic code withing such contexts.