### PR TITLE
[codegen/hcl2] Fix descent in RewriteConversions.

### DIFF
--- a/pkg/codegen/hcl2/rewrite_convert_test.go
+++ b/pkg/codegen/hcl2/rewrite_convert_test.go
@@ -48,9 +48,51 @@ func TestRewriteConversions(t *testing.T) {
 				"a": model.StringType,
 			}, &schema.ObjectType{})),
 		},
+		{
+			input:  `{a: "1" + 2}`,
+			output: `{a: __convert( "1") + 2}`,
+			to: model.NewObjectType(map[string]model.Type{
+				"a": model.NumberType,
+			}),
+		},
+		{
+			input:  `[{a: "b"}]`,
+			output: "[\n    __convert({a: \"b\"})]",
+			to: model.NewListType(model.NewObjectType(map[string]model.Type{
+				"a": model.StringType,
+			}, &schema.ObjectType{})),
+		},
+		{
+			input:  `[for v in ["b"]: {a: v}]`,
+			output: `[for v in ["b"]: __convert( {a: v})]`,
+			to: model.NewListType(model.NewObjectType(map[string]model.Type{
+				"a": model.StringType,
+			}, &schema.ObjectType{})),
+		},
+		{
+			input:  `true ? {a: "b"} : {a: "c"}`,
+			output: `true ? __convert( {a: "b"}) : __convert( {a: "c"})`,
+			to: model.NewObjectType(map[string]model.Type{
+				"a": model.StringType,
+			}, &schema.ObjectType{}),
+		},
+		{
+			input:  `!"true"`,
+			output: `!__convert("true")`,
+			to:     model.BoolType,
+		},
+		{
+			input:  `["a"][i]`,
+			output: `["a"][__convert(i)]`,
+			to:     model.StringType,
+		},
 	}
 
 	scope := model.NewRootScope(syntax.None)
+	scope.Define("i", &model.Variable{
+		Name:         "i",
+		VariableType: model.StringType,
+	})
 	for _, c := range cases {
 		expr, diags := model.BindExpressionText(c.input, scope, hcl.Pos{})
 		assert.Len(t, diags, 0)
@@ -60,6 +102,43 @@ func TestRewriteConversions(t *testing.T) {
 			to = expr.Type()
 		}
 		expr = RewriteConversions(expr, to)
+		assert.Equal(t, c.output, fmt.Sprintf("%v", expr))
+	}
+}
+
+func TestRewriteConversionsAfterApply(t *testing.T) {
+	cases := []struct {
+		input, output string
+	}{
+		{
+			input:  `f({id: v.id})`,
+			output: `__apply(v,eval(v, f(__convert({id: v.id}))))`,
+		},
+	}
+
+	scope := model.NewRootScope(syntax.None)
+	scope.DefineFunction("f", model.NewFunction(model.StaticFunctionSignature{
+		Parameters: []model.Parameter{{
+			Name: "args",
+			Type: model.NewObjectType(map[string]model.Type{
+				"id": model.StringType,
+			}, &schema.ObjectType{}),
+		}},
+		ReturnType: model.DynamicType,
+	}))
+	scope.Define("v", &model.Variable{
+		Name: "v",
+		VariableType: model.NewOutputType(model.NewObjectType(map[string]model.Type{
+			"id": model.StringType,
+		})),
+	})
+
+	for _, c := range cases {
+		expr, diags := model.BindExpressionText(c.input, scope, hcl.Pos{})
+		assert.Len(t, diags, 0)
+
+		expr, _ = RewriteApplies(expr, nameInfo(0), false)
+		expr = RewriteConversions(expr, expr.Type())
 		assert.Equal(t, c.output, fmt.Sprintf("%v", expr))
 	}
 }


### PR DESCRIPTION
Descend into anonymous function expressions, the operands to conditional
expressions, and the value in for expressions.