### PR TITLE
[codegen/docs] Use the C# namespaces override map for links

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -969,8 +969,12 @@ func (mod *modContext) getConstructorResourceInfo(resourceTypeName string) map[s
 		case "nodejs", "go":
 			// Intentionally left blank.
 		case "csharp":
+			namespace := title(mod.pkg.Name, lang)
+			if ns, ok := csharpPkgInfo.Namespaces[mod.pkg.Name]; ok {
+				namespace = ns
+			}
 			if mod.mod == "" {
-				resourceTypeName = fmt.Sprintf("Pulumi.%s.%s", title(mod.pkg.Name, lang), resourceTypeName)
+				resourceTypeName = fmt.Sprintf("Pulumi.%s.%s", namespace, resourceTypeName)
 				break
 			}
 
@@ -980,7 +984,7 @@ func (mod *modContext) getConstructorResourceInfo(resourceTypeName string) map[s
 				goPkgName := getLanguageModuleName(mod.pkg, mod.mod, "go")
 				modName = getLanguageModuleName(mod.pkg, goPkgName, "csharp")
 			}
-			resourceTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", title(mod.pkg.Name, lang), modName, resourceTypeName)
+			resourceTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", namespace, modName, resourceTypeName)
 		case "python":
 			// Pulumi's Python language SDK does not have "types" yet, so we will skip it for now.
 			continue
@@ -1087,7 +1091,11 @@ func (mod *modContext) getGoLookupParams(r *schema.Resource, stateParam string) 
 
 func (mod *modContext) getCSLookupParams(r *schema.Resource, stateParam string) []formalParam {
 	modName := getLanguageModuleName(mod.pkg, mod.mod, "csharp")
-	stateParamFQDN := fmt.Sprintf("Pulumi.%s.%s.%s", title(mod.pkg.Name, "csharp"), modName, stateParam)
+	namespace := title(mod.pkg.Name, "csharp")
+	if ns, ok := csharpPkgInfo.Namespaces[mod.pkg.Name]; ok {
+		namespace = ns
+	}
+	stateParamFQDN := fmt.Sprintf("Pulumi.%s.%s.%s", namespace, modName, stateParam)
 
 	docLangHelper := getLanguageDocHelper("csharp")
 	return []formalParam{

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -76,11 +76,15 @@ func (mod *modContext) getFunctionResourceInfo(f *schema.Function) map[string]pr
 		case "go":
 			resultTypeName = docLangHelper.GetResourceFunctionResultName(mod.mod, f)
 		case "csharp":
+			namespace := title(mod.pkg.Name, lang)
+			if ns, ok := csharpPkgInfo.Namespaces[mod.pkg.Name]; ok {
+				namespace = ns
+			}
 			resultTypeName = docLangHelper.GetResourceFunctionResultName(mod.mod, f)
 			if mod.mod == "" {
-				resultTypeName = fmt.Sprintf("Pulumi.%s.%s", strings.Title(mod.pkg.Name), resultTypeName)
+				resultTypeName = fmt.Sprintf("Pulumi.%s.%s", namespace, resultTypeName)
 			} else {
-				resultTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", strings.Title(mod.pkg.Name), strings.Title(mod.mod), resultTypeName)
+				resultTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", namespace, title(mod.mod, lang), resultTypeName)
 			}
 
 		case "python":

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -46,7 +46,7 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, _, typ
 	if pkg == nil {
 		packageNamespace = ""
 	} else if pkg.Name != "" {
-		packageNamespace = "." + Title(pkg.Name)
+		packageNamespace = "." + namespaceName(d.Namespaces, pkg.Name)
 	}
 	return fmt.Sprintf("/docs/reference/pkg/dotnet/Pulumi%s/%s.html", packageNamespace, typeName)
 }
@@ -122,9 +122,9 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	var displayName string
 	var link string
 	if modName == "" {
-		displayName = fmt.Sprintf("Pulumi.%s", Title(pkg.Name))
+		displayName = fmt.Sprintf("Pulumi.%s", namespaceName(d.Namespaces, pkg.Name))
 	} else {
-		displayName = fmt.Sprintf("Pulumi.%s.%s", Title(pkg.Name), modName)
+		displayName = fmt.Sprintf("Pulumi.%s.%s", namespaceName(d.Namespaces, pkg.Name), modName)
 	}
 	link = d.GetDocLinkForResourceType(pkg, "", displayName)
 	return displayName, link


### PR DESCRIPTION
I noticed that the package names for a lot of providers were incorrectly generated in links while working on regenerating resource docs for all providers. I was verifying the links to modules for various packages whereas it was previously buried within constructor types and args. We do already use the C# language info override map while generating property type names of nested types using the doc language helper interface implementation for .NET, but there were a few places in the resource docs generator where it wasn't being used.