### PR TITLE
[codegen/nodejs] SDK generator fixes.

### DIFF
--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -79,7 +79,7 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 		pkg: pkg,
 		mod: moduleName,
 	}
-	typeName := modCtx.typeString(t, input, false, optional)
+	typeName := modCtx.typeString(t, input, false, optional, nil)
 
 	// Remove any package qualifiers from the type name.
 	typeQualifierPackage := "inputs"

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -964,7 +964,7 @@ func (mod *modContext) gen(fs fs) error {
 	// Ensure that the target module directory contains a README.md file.
 	readme := mod.pkg.Language["nodejs"].(NodePackageInfo).Readme
 	if readme == "" {
-		readme := mod.pkg.Description
+		readme = mod.pkg.Description
 		if readme != "" && readme[len(readme)-1] != '\n' {
 			readme += "\n"
 		}

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -26,6 +26,8 @@ type NodePackageInfo struct {
 	PackageName string `json:"packageName,omitempty"`
 	// Description for the NPM package.
 	PackageDescription string `json:"packageDescription,omitempty"`
+	// Readme contains the text for the package's README.md files.
+	Readme string `json:"readme,omityempty"`
 	// NPM dependencies to add to package.json.
 	Dependencies map[string]string `json:"dependencies,omitempty"`
 	// NPM dev-dependencies to add to package.json.


### PR DESCRIPTION
- Add support for constant values in unions (e.g. `"foo" | "bar"`)
- Generate `Input<T | U>` instead of `Input<T> | Input<U>`
- Emit deprecation messages for resources
- Handle nil state inputs
- Allow packages to provide a README
- Remove sync invoke support

These changes are part of
https://github.com/pulumi/pulumi-terraform-bridge/issues/179, and
restore functional parity with the current `tfgen` generator.