### PR TITLE
Resolve referenced packages for every TF program

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -44,7 +44,7 @@ func (opts bindOptions) modelOptions() []model.BindOption {
 type binder struct {
 	options bindOptions
 
-	referencedPackages []*schema.Package
+	referencedPackages map[string]*schema.Package
 	typeSchemas        map[model.Type]schema.Type
 
 	tokens syntax.TokenMap
@@ -97,10 +97,11 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 	}
 
 	b := &binder{
-		options:     options,
-		tokens:      syntax.NewTokenMapForFiles(files),
-		typeSchemas: map[model.Type]schema.Type{},
-		root:        model.NewRootScope(syntax.None),
+		options:            options,
+		tokens:             syntax.NewTokenMapForFiles(files),
+		referencedPackages: map[string]*schema.Package{},
+		typeSchemas:        map[model.Type]schema.Type{},
+		root:               model.NewRootScope(syntax.None),
 	}
 
 	// Define null.

--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -80,13 +80,13 @@ func (b *binder) loadReferencedPackageSchemas(n Node) error {
 	contract.Assert(len(diags) == 0)
 
 	for _, name := range packageNames.SortedValues() {
-		if _, ok := b.options.packageCache.entries[name]; ok {
+		if _, ok := b.referencedPackages[name]; ok {
 			continue
 		}
 		if err := b.loadPackageSchema(name); err != nil {
 			return err
 		}
-		b.referencedPackages = append(b.referencedPackages, b.options.packageCache.entries[name].schema)
+		b.referencedPackages[name] = b.options.packageCache.entries[name].schema
 	}
 	return nil
 }

--- a/pkg/codegen/hcl2/program.go
+++ b/pkg/codegen/hcl2/program.go
@@ -100,5 +100,9 @@ func (p *Program) BindExpression(node hclsyntax.Node) (model.Expression, hcl.Dia
 
 // Packages returns the list of package schemas used by this program.
 func (p *Program) Packages() []*schema.Package {
-	return p.binder.referencedPackages
+	values := make([]*schema.Package, 0, len(p.binder.referencedPackages))
+	for _, value := range p.binder.referencedPackages {
+		values = append(values, value)
+	}
+	return values
 }

--- a/pkg/codegen/hcl2/program.go
+++ b/pkg/codegen/hcl2/program.go
@@ -16,6 +16,7 @@ package hcl2
 
 import (
 	"io"
+	"sort"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -100,9 +101,15 @@ func (p *Program) BindExpression(node hclsyntax.Node) (model.Expression, hcl.Dia
 
 // Packages returns the list of package schemas used by this program.
 func (p *Program) Packages() []*schema.Package {
+	keys := make([]string, 0, len(p.binder.referencedPackages))
+	for k := range p.binder.referencedPackages {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
 	values := make([]*schema.Package, 0, len(p.binder.referencedPackages))
-	for _, value := range p.binder.referencedPackages {
-		values = append(values, value)
+	for _, k := range keys {
+		values = append(values, p.binder.referencedPackages[k])
 	}
 	return values
 }


### PR DESCRIPTION
While testing C# program generation for a provider, I found that namespaces aren't resolved correctly.

For a binder, `b.options.packageCache` has a longer lifecycle than `b.referencedPackages`, so it seems wrong to check the former while populating the latter.

This PR changes `referencedPackages` to a map and populates it with unique packages regardless of the cache state.