### PR TITLE
Only mount a directory with the test binary into the container

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -32,15 +32,16 @@ test_containers() {
     echo_header "Executing container runtime tests"
 
     # Run the container tests, note that we also build the binaries into /tmp for the next step.
+    TEST_BIN_DIRECTORY=$(mktemp -d)
     pushd ${ROOT}/tests
-    GOOS=linux go test -c -o /tmp/pulumi-test-containers ${ROOT}/tests/containers/...
+    GOOS=linux go test -c -o ${TEST_BIN_DIRECTORY} ${ROOT}/tests/containers/...
     popd
 
     # Run tests _within_ the "pulumi" container, ensuring that the CLI is installed
     # and working correctly.
     docker run -e RUN_CONTAINER_TESTS=true \
         -e PULUMI_ACCESS_TOKEN=${PULUMI_ACCESS_TOKEN} \
-        --volume /tmp:/src \
+        --volume ${TEST_BIN_DIRECTORY}:/src \
         --entrypoint /bin/bash \
         pulumi/pulumi:latest \
         -c "pip install pipenv && /src/pulumi-test-containers -test.parallel=1 -test.v -test.run TestPulumiDockerImage"


### PR DESCRIPTION
I don't understand why we are getting the particular error in https://github.com/pulumi/pulumi/issues/4638, but it seems like a reasonable guess that blindly mounting all of `/tmp` into the container would cause issues. (What if its on a network drive, or contains a bazillion files, or `$TMP` is pointed at some _other_ directory.)

So instead we just create a temp directory via `mktemp -d`, which on my Mac returns something like `/var/folders/rt/g0__c2v509n389gkx0zx48t80000gn/T/tmp.nKq6HMO9`. And put the test output into that.

🤞 fixes #4638