### PR TITLE
[sdk/go] Add support for untagged outputs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Add support for untagged outputs in Go SDK.
+ [#4640](https://github.com/pulumi/pulumi/pull/4640)
 
 ## 2.2.0 (2020-05-13)
 

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -127,14 +127,15 @@ func TestRegisterResource(t *testing.T) {
 			"baz":  String("zab"),
 			"bang": String("gnab"),
 		}, &res2)
+		assert.NoError(t, err)
 
-		id, known, secret, err = await(res.ID())
+		id, known, secret, err = await(res2.ID())
 		assert.NoError(t, err)
 		assert.True(t, known)
 		assert.False(t, secret)
 		assert.Equal(t, ID("someID"), id)
 
-		urn, known, secret, err = await(res.URN())
+		urn, known, secret, err = await(res2.URN())
 		assert.NoError(t, err)
 		assert.True(t, known)
 		assert.False(t, secret)

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -54,6 +54,12 @@ func (*testResource2Inputs) ElementType() reflect.Type {
 	return reflect.TypeOf((*testResource2Args)(nil))
 }
 
+type testResource3 struct {
+	CustomResourceState
+
+	Outputs MapOutput `pulumi:""`
+}
+
 type invokeArgs struct {
 	Bang string `pulumi:"bang"`
 	Bar  string `pulumi:"bar"`
@@ -85,6 +91,7 @@ func TestRegisterResource(t *testing.T) {
 	}
 
 	err := RunErr(func(ctx *Context) error {
+		// Test struct-tag-based marshaling.
 		var res testResource2
 		err := ctx.RegisterResource("test:resource:type", "resA", &testResource2Inputs{
 			Foo:  String("oof"),
@@ -111,6 +118,33 @@ func TestRegisterResource(t *testing.T) {
 		assert.True(t, known)
 		assert.False(t, secret)
 		assert.Equal(t, "qux", foo)
+
+		// Test map marshaling.
+		var res2 testResource3
+		err = ctx.RegisterResource("test:resource:type", "resA", Map{
+			"foo":  String("oof"),
+			"bar":  String("rab"),
+			"baz":  String("zab"),
+			"bang": String("gnab"),
+		}, &res2)
+
+		id, known, secret, err = await(res.ID())
+		assert.NoError(t, err)
+		assert.True(t, known)
+		assert.False(t, secret)
+		assert.Equal(t, ID("someID"), id)
+
+		urn, known, secret, err = await(res.URN())
+		assert.NoError(t, err)
+		assert.True(t, known)
+		assert.False(t, secret)
+		assert.NotEqual(t, "", urn)
+
+		outputs, known, secret, err := await(res2.Outputs)
+		assert.NoError(t, err)
+		assert.True(t, known)
+		assert.False(t, secret)
+		assert.Equal(t, map[string]interface{}{"foo": "qux"}, outputs)
 
 		return nil
 	}, WithMocks("project", "stack", mocks))


### PR DESCRIPTION
With these changes, a resource struct may tag a field with the empty
string. If such a field is present, any resource outputs that were not
unmarshalled into other fields will be unmarshalled into this field,
which must be a `MapOutput`.

Fixes #4629.