### PR TITLE
[codegen/schema] Path unescape type tokens in refs

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/url"
 	"regexp"
 	"sort"
 	"strings"
@@ -802,7 +803,10 @@ func (t *types) bindType(spec TypeSpec) (Type, error) {
 			return nil, errors.Errorf("failed to parse ref %s", spec.Ref)
 		}
 
-		token := spec.Ref[len("#/types/"):]
+		token, err := url.PathUnescape(spec.Ref[len("#/types/"):])
+		if err != nil {
+			return nil, errors.Errorf("failed to parse ref %s", spec.Ref)
+		}
 		if typ, ok := t.objects[token]; ok {
 			return typ, nil
 		}


### PR DESCRIPTION
Some type tokens contain characters that are not valid in a single
URL path element (`/` in particular). These type tokens may be
path-escaped, and should be unescaped before they are interpreted.