### PR TITLE
Support publishing Python policy packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ CHANGELOG
 - Allow `pulumi.export` calls from Python unit tests.
   [#4670](https://github.com/pulumi/pulumi/pull/4670)
 
+- Add support for publishing Python policy packs.
+  [#4644](https://github.com/pulumi/pulumi/pull/4644)
+
 ## 2.2.1 (2020-05-13)
 - Add new brew target to fix homebrew builds
  [#4633](https://github.com/pulumi/pulumi/pull/4633)

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -754,8 +754,6 @@ func (pc *Client) RemovePolicyPackByVersion(ctx context.Context, orgName string,
 
 // DownloadPolicyPack applies a `PolicyPack` to the Pulumi organization.
 func (pc *Client) DownloadPolicyPack(ctx context.Context, url string) ([]byte, error) {
-	fmt.Println("Downloading policy pack")
-
 	getS3Req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to download compressed PolicyPack")

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -177,7 +177,7 @@ func (pack *cloudPolicyPack) Publish(
 
 	var packTarball []byte
 
-	// TODO[pulumi/pulumi#1307]: move to the language plugins so we don't have to hard code here.
+	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
 	runtime := op.PolicyPack.Runtime.Name()
 	if strings.EqualFold(runtime, "nodejs") {
 		packTarball, err = npm.Pack(op.PlugCtx.Pwd, os.Stderr)
@@ -296,7 +296,7 @@ func installRequiredPolicy(finalDir string, tarball []byte) error {
 		return errors.Wrapf(err, "failed to load policy project at %s", finalDir)
 	}
 
-	// TODO[pulumi/pulumi#1307]: move to the language plugins so we don't have to hard code here.
+	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
 	if strings.EqualFold(proj.Runtime.Name(), "nodejs") {
 		return completeNodeJSInstall(finalDir)
 	} else if strings.EqualFold(proj.Runtime.Name(), "python") {

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -189,7 +189,7 @@ func (pack *cloudPolicyPack) Publish(
 		// npm pack puts all the files in a "package" subdirectory inside the .tgz it produces, so we'll do
 		// the same for Python. That way, after unpacking, we can look for the PulumiPolicy.yaml inside the
 		// package directory to determine the runtime of the policy pack.
-		packTarball, err = archive.Tgz(op.PlugCtx.Pwd, "package", true /*useDefaultExcludes*/)
+		packTarball, err = archive.TGZ(op.PlugCtx.Pwd, "package", true /*useDefaultExcludes*/)
 		if err != nil {
 			return result.FromError(
 				errors.Wrap(err, "could not publish policies because of error creating the .tgz"))
@@ -276,7 +276,7 @@ func installRequiredPolicy(finalDir string, tarball []byte) error {
 	}()
 
 	// Uncompress the policy pack.
-	err = archive.Untgz(tarball, tempDir)
+	err = archive.UnTGZ(tarball, tempDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -562,7 +562,7 @@ func saveConfig(stack backend.Stack, c config.Map) error {
 
 // installDependencies will install dependencies for the project, e.g. by running `npm install` for nodejs projects.
 func installDependencies(proj *workspace.Project, root string) error {
-	// TODO[pulumi/pulumi#1307]: move to the language plugins so we don't have to hard code here.
+	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
 	if strings.EqualFold(proj.Runtime.Name(), "nodejs") {
 		if bin, err := nodeInstallDependencies(); err != nil {
 			return errors.Wrapf(err, "%s install failed; rerun manually to try again, "+

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -186,7 +186,7 @@ func runNewPolicyPack(args newPolicyArgs) error {
 }
 
 func installPolicyPackDependencies(proj *workspace.PolicyPackProject) error {
-	// TODO[pulumi/pulumi#1307]: move to the language plugins so we don't have to hard code here.
+	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
 	if strings.EqualFold(proj.Runtime.Name(), "nodejs") {
 		if bin, err := nodeInstallDependencies(); err != nil {
 			return errors.Wrapf(err, "`%s install` failed; rerun manually to try again.", bin)

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -413,6 +413,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 h1:G04eS0JkAIVZfaJLjla9dNxkJCPiKIGZlw9AfOhzOD0=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -119,6 +119,7 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.9.1
+	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.5.1

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -150,6 +150,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 h1:G04eS0JkAIVZfaJLjla9dNxkJCPiKIGZlw9AfOhzOD0=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -12,51 +12,52 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package archive provides support for creating zip archives of local folders and returning the
-// in-memory buffer. This is how we pass Pulumi program source to the Cloud for hosted scenarios,
-// for execution in a different environment and creating the resources off of the local machine.
+// Package archive provides support for creating .tar.gz/.tgz archives of local folders and returning the
+// in-memory buffer.
 package archive
 
 import (
 	"archive/tar"
-	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/pkg/util/logging"
-	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/logging"
 )
 
-// Process returns an in-memory buffer with the archived contents of the provided file path.
-func Process(path string, useDefaultExcludes bool) (*bytes.Buffer, error) {
+// Tgz adds the contents of the provided directory to an in-memory .tar.gz/.tgz and returns the bytes.
+func Tgz(dir, prefixPathInsideTar string, useDefaultExcludes bool) ([]byte, error) {
 	buffer := &bytes.Buffer{}
-	writer := zip.NewWriter(buffer)
+	gw := gzip.NewWriter(buffer)
+	writer := tar.NewWriter(gw)
 
-	// We trim `path` from the pathname of every file we add to the zip, but we actaually
-	// want to ensure the files directly under `path` are not added with a path prefix,
-	// so we add an extra os.PathSeparator here to the end of the string if it doesn't
-	// already end with one.
-	if !os.IsPathSeparator(path[len(path)-1]) {
-		path = path + string(os.PathSeparator)
+	// We trim `dir` from the pathname of every file we add, but we actually want to ensure the files
+	// directly under `path` are not added with a path prefix, so we add an extra os.PathSeparator
+	// here to the end of the string if it doesn't already end with one.
+	if !os.IsPathSeparator(dir[len(dir)-1]) {
+		dir = dir + string(os.PathSeparator)
 	}
 
-	if err := addDirectoryToZip(writer, path, path, useDefaultExcludes, nil); err != nil {
+	if err := addDirectoryToTar(writer, dir, dir, prefixPathInsideTar, useDefaultExcludes, nil); err != nil {
 		return nil, err
 	}
+
+	// Close the tar and gzip writers to flush and write footers.
 	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	if err := gw.Close(); err != nil {
 		return nil, err
 	}
 
 	logging.V(5).Infof("project archive is %v bytes", buffer.Len())
 
-	return buffer, nil
+	return buffer.Bytes(), nil
 }
 
 // Untgz uncompresses a .tar.gz/.tgz file into a specific directory.
@@ -113,15 +114,20 @@ func Untgz(tarball []byte, dir string) error {
 	return nil
 }
 
-func addDirectoryToZip(writer *zip.Writer, root string, dir string,
+const (
+	gitDir        = ".git"
+	gitIgnoreFile = ".gitignore"
+)
+
+func addDirectoryToTar(writer *tar.Writer, root, dir, prefixPathInsideTar string,
 	useDefaultIgnores bool, ignores *ignoreState) error {
-	ignoreFilePath := path.Join(dir, workspace.IgnoreFile)
+	ignoreFilePath := filepath.Join(dir, gitIgnoreFile)
 
 	// If there is an ignorefile, process it before looking at any child paths.
 	if stat, err := os.Stat(ignoreFilePath); err == nil && !stat.IsDir() {
 		logging.V(9).Infof("processing ignore file in %v", dir)
 
-		ignore, err := newPulumiIgnorerIgnorer(ignoreFilePath)
+		ignore, err := newGitIgnoreIgnorer(ignoreFilePath)
 		if err != nil {
 			return errors.Wrapf(err, "could not read ignore file in %v", dir)
 		}
@@ -130,23 +136,10 @@ func addDirectoryToZip(writer *zip.Writer, root string, dir string,
 	}
 
 	if useDefaultIgnores {
-		dotGitPath := path.Join(dir, ".git")
+		dotGitPath := filepath.Join(dir, gitDir)
 		if stat, err := os.Stat(dotGitPath); err == nil {
 			ignores = ignores.Append(newPathIgnorer(dotGitPath, stat.IsDir()))
 		}
-
-		// If there is a package.json file here, let's build a node_modules ignorer from it.
-		packageJSONFilePath := path.Join(dir, packageJSONFileName)
-		if stat, err := os.Stat(packageJSONFilePath); err == nil && !stat.IsDir() {
-			logging.V(9).Infof("building ignore filter from package.json in %v", dir)
-			ignore, err := newNodeModulesIgnorer(packageJSONFilePath)
-			if err != nil {
-				return errors.Wrapf(err, "could not read ignores from package.json file in %v", dir)
-			}
-
-			ignores = ignores.Append(ignore)
-		}
-
 	}
 
 	file, err := os.Open(dir)
@@ -162,7 +155,7 @@ func addDirectoryToZip(writer *zip.Writer, root string, dir string,
 	}
 
 	for _, info := range infos {
-		fullName := path.Join(dir, info.Name())
+		fullName := filepath.Join(dir, info.Name())
 
 		if !info.IsDir() && ignores.IsIgnored(fullName) {
 			logging.V(9).Infof("skip archiving of %v due to ignore file", fullName)
@@ -178,15 +171,28 @@ func addDirectoryToZip(writer *zip.Writer, root string, dir string,
 		}
 
 		if info.Mode().IsDir() {
-			err = addDirectoryToZip(writer, root, fullName, useDefaultIgnores, ignores)
+			err = addDirectoryToTar(writer, root, fullName, prefixPathInsideTar, useDefaultIgnores, ignores)
 			if err != nil {
 				return err
 			}
 		} else if info.Mode().IsRegular() {
 			logging.V(9).Infof("adding %v to archive", fullName)
 
-			w, err := writer.Create(convertPathsForZip(strings.TrimPrefix(fullName, root)))
+			header, err := tar.FileInfoHeader(info, info.Name())
 			if err != nil {
+				return err
+			}
+
+			// Specify the file name, by removing the root prefix.
+			// If prefixPathInsideTar is set, use it as a prefix path inside the tar (this, for example,
+			// enables all files to be added in the tar file within a "packages" parent directory).
+			name := strings.TrimPrefix(fullName, root)
+			if prefixPathInsideTar != "" {
+				name = filepath.Join(prefixPathInsideTar, name)
+			}
+			header.Name = filepath.ToSlash(name)
+
+			if err := writer.WriteHeader(header); err != nil {
 				return err
 			}
 
@@ -196,7 +202,7 @@ func addDirectoryToZip(writer *zip.Writer, root string, dir string,
 			}
 			// no defer because we want to close file as soon as possible (right after we call Copy)
 
-			_, err = io.Copy(w, file)
+			_, err = io.Copy(writer, file)
 			contract.IgnoreClose(file)
 			if err != nil {
 				return err
@@ -207,13 +213,4 @@ func addDirectoryToZip(writer *zip.Writer, root string, dir string,
 	}
 
 	return nil
-}
-
-// convertPathsForZip ensures that '/' is uses at the path separator in zip files.
-func convertPathsForZip(path string) string {
-	if os.PathSeparator != '/' {
-		return strings.Replace(path, string(os.PathSeparator), "/", -1)
-	}
-
-	return path
 }

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -30,8 +30,8 @@ import (
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/logging"
 )
 
-// Tgz adds the contents of the provided directory to an in-memory .tar.gz/.tgz and returns the bytes.
-func Tgz(dir, prefixPathInsideTar string, useDefaultExcludes bool) ([]byte, error) {
+// TGZ adds the contents of the provided directory to an in-memory .tar.gz/.tgz and returns the bytes.
+func TGZ(dir, prefixPathInsideTar string, useDefaultExcludes bool) ([]byte, error) {
 	buffer := &bytes.Buffer{}
 	gw := gzip.NewWriter(buffer)
 	writer := tar.NewWriter(gw)
@@ -60,8 +60,8 @@ func Tgz(dir, prefixPathInsideTar string, useDefaultExcludes bool) ([]byte, erro
 	return buffer.Bytes(), nil
 }
 
-// Untgz uncompresses a .tar.gz/.tgz file into a specific directory.
-func Untgz(tarball []byte, dir string) error {
+// UnTGZ uncompresses a .tar.gz/.tgz file into a specific directory.
+func UnTGZ(tarball []byte, dir string) error {
 	tarReader := bytes.NewReader(tarball)
 	gzr, err := gzip.NewReader(tarReader)
 	if err != nil {

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -19,15 +19,45 @@ package archive
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"io"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/pkg/util/logging"
+	"github.com/pulumi/pulumi/pkg/workspace"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 )
+
+// Process returns an in-memory buffer with the archived contents of the provided file path.
+func Process(path string, useDefaultExcludes bool) (*bytes.Buffer, error) {
+	buffer := &bytes.Buffer{}
+	writer := zip.NewWriter(buffer)
+
+	// We trim `path` from the pathname of every file we add to the zip, but we actaually
+	// want to ensure the files directly under `path` are not added with a path prefix,
+	// so we add an extra os.PathSeparator here to the end of the string if it doesn't
+	// already end with one.
+	if !os.IsPathSeparator(path[len(path)-1]) {
+		path = path + string(os.PathSeparator)
+	}
+
+	if err := addDirectoryToZip(writer, path, path, useDefaultExcludes, nil); err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+
+	logging.V(5).Infof("project archive is %v bytes", buffer.Len())
+
+	return buffer, nil
+}
 
 // Untgz uncompresses a .tar.gz/.tgz file into a specific directory.
 func Untgz(tarball []byte, dir string) error {
@@ -81,4 +111,109 @@ func Untgz(tarball []byte, dir string) error {
 	}
 
 	return nil
+}
+
+func addDirectoryToZip(writer *zip.Writer, root string, dir string,
+	useDefaultIgnores bool, ignores *ignoreState) error {
+	ignoreFilePath := path.Join(dir, workspace.IgnoreFile)
+
+	// If there is an ignorefile, process it before looking at any child paths.
+	if stat, err := os.Stat(ignoreFilePath); err == nil && !stat.IsDir() {
+		logging.V(9).Infof("processing ignore file in %v", dir)
+
+		ignore, err := newPulumiIgnorerIgnorer(ignoreFilePath)
+		if err != nil {
+			return errors.Wrapf(err, "could not read ignore file in %v", dir)
+		}
+
+		ignores = ignores.Append(ignore)
+	}
+
+	if useDefaultIgnores {
+		dotGitPath := path.Join(dir, ".git")
+		if stat, err := os.Stat(dotGitPath); err == nil {
+			ignores = ignores.Append(newPathIgnorer(dotGitPath, stat.IsDir()))
+		}
+
+		// If there is a package.json file here, let's build a node_modules ignorer from it.
+		packageJSONFilePath := path.Join(dir, packageJSONFileName)
+		if stat, err := os.Stat(packageJSONFilePath); err == nil && !stat.IsDir() {
+			logging.V(9).Infof("building ignore filter from package.json in %v", dir)
+			ignore, err := newNodeModulesIgnorer(packageJSONFilePath)
+			if err != nil {
+				return errors.Wrapf(err, "could not read ignores from package.json file in %v", dir)
+			}
+
+			ignores = ignores.Append(ignore)
+		}
+
+	}
+
+	file, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+	// No defer because we want to close file as soon as possible (right after we call Readdir).
+
+	infos, err := file.Readdir(-1)
+	contract.IgnoreClose(file)
+	if err != nil {
+		return err
+	}
+
+	for _, info := range infos {
+		fullName := path.Join(dir, info.Name())
+
+		if !info.IsDir() && ignores.IsIgnored(fullName) {
+			logging.V(9).Infof("skip archiving of %v due to ignore file", fullName)
+			continue
+		}
+
+		// Resolve symlinks (Readdir above calls os.Lstat which does not follow symlinks).
+		if info.Mode()&os.ModeSymlink == os.ModeSymlink {
+			info, err = os.Stat(fullName)
+			if err != nil {
+				return err
+			}
+		}
+
+		if info.Mode().IsDir() {
+			err = addDirectoryToZip(writer, root, fullName, useDefaultIgnores, ignores)
+			if err != nil {
+				return err
+			}
+		} else if info.Mode().IsRegular() {
+			logging.V(9).Infof("adding %v to archive", fullName)
+
+			w, err := writer.Create(convertPathsForZip(strings.TrimPrefix(fullName, root)))
+			if err != nil {
+				return err
+			}
+
+			file, err := os.Open(fullName)
+			if err != nil {
+				return err
+			}
+			// no defer because we want to close file as soon as possible (right after we call Copy)
+
+			_, err = io.Copy(w, file)
+			contract.IgnoreClose(file)
+			if err != nil {
+				return err
+			}
+		} else {
+			logging.V(9).Infof("ignoring special file %v with mode %v", fullName, info.Mode())
+		}
+	}
+
+	return nil
+}
+
+// convertPathsForZip ensures that '/' is uses at the path separator in zip files.
+func convertPathsForZip(path string) string {
+	if os.PathSeparator != '/' {
+		return strings.Replace(path, string(os.PathSeparator), "/", -1)
+	}
+
+	return path
 }

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -1,0 +1,128 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/util/contract"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIngoreSimple(t *testing.T) {
+	doArchiveTest(t,
+		fileContents{name: ".pulumiignore", contents: []byte("node_modules/pulumi/"), shouldRetain: true},
+		fileContents{name: "included.txt", shouldRetain: true},
+		fileContents{name: "node_modules/included.txt", shouldRetain: true},
+		fileContents{name: "node_modules/pulumi/excluded.txt", shouldRetain: false},
+		fileContents{name: "node_modules/pulumi/excluded/excluded.txt", shouldRetain: false})
+}
+
+func TestIgnoreNegate(t *testing.T) {
+	doArchiveTest(t,
+		fileContents{name: ".pulumiignore", contents: []byte("/*\n!/foo\n/foo/*\n!/foo/bar"), shouldRetain: false},
+		fileContents{name: "excluded.txt", shouldRetain: false},
+		fileContents{name: "foo/excluded.txt", shouldRetain: false},
+		fileContents{name: "foo/baz/exlcuded.txt", shouldRetain: false},
+		fileContents{name: "foo/bar/included.txt", shouldRetain: true})
+}
+
+func TestNested(t *testing.T) {
+	doArchiveTest(t,
+		fileContents{name: ".pulumiignore", contents: []byte("node_modules/pulumi/"), shouldRetain: true},
+		fileContents{name: "node_modules/.pulumiignore", contents: []byte("@pulumi/"), shouldRetain: true},
+		fileContents{name: "included.txt", shouldRetain: true},
+		fileContents{name: "node_modules/included.txt", shouldRetain: true},
+		fileContents{name: "node_modules/pulumi/excluded.txt", shouldRetain: false},
+		fileContents{name: "node_modules/@pulumi/pulumi-cloud/excluded.txt", shouldRetain: false})
+}
+
+func doArchiveTest(t *testing.T, files ...fileContents) {
+	archive, err := archiveContents(files...)
+	assert.NoError(t, err)
+
+	fmt.Println(archive.Len())
+
+	r, err := zip.NewReader(bytes.NewReader(archive.Bytes()), int64(archive.Len()))
+	assert.NoError(t, err)
+
+	checkFiles(t, files, r.File)
+}
+
+func archiveContents(files ...fileContents) (*bytes.Buffer, error) {
+	dir, err := ioutil.TempDir("", "archive-test")
+	if err != nil {
+		return nil, err
+	}
+
+	defer func() {
+		contract.IgnoreError(os.RemoveAll(dir))
+	}()
+
+	for _, file := range files {
+		err := os.MkdirAll(path.Dir(path.Join(dir, file.name)), 0755)
+		if err != nil {
+			return nil, err
+		}
+
+		err = ioutil.WriteFile(path.Join(dir, file.name), file.contents, 0644)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return Process(dir, false)
+}
+
+func checkFiles(t *testing.T, expected []fileContents, actual []*zip.File) {
+	var expectedFiles []string
+	var actualFiles []string
+
+	for _, f := range expected {
+		if f.shouldRetain {
+			expectedFiles = append(expectedFiles, f.name)
+		}
+	}
+
+	for _, f := range actual {
+
+		// Ignore any directories (we only care that the files themselves are correct)
+		if strings.HasSuffix(f.Name, "/") {
+			continue
+		}
+
+		actualFiles = append(actualFiles, f.Name)
+	}
+
+	sort.Strings(expectedFiles)
+	sort.Strings(actualFiles)
+
+	assert.Equal(t, expectedFiles, actualFiles)
+}
+
+type fileContents struct {
+	name         string
+	contents     []byte
+	shouldRetain bool
+}

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -125,7 +125,7 @@ func archiveContents(prefixPathInsideTar string, files ...fileContents) ([]byte,
 		}
 	}
 
-	return Tgz(dir, prefixPathInsideTar, true /*useDefaultExcludes*/)
+	return TGZ(dir, prefixPathInsideTar, true /*useDefaultExcludes*/)
 }
 
 func checkFiles(t *testing.T, prefixPathInsideTar string, expected []fileContents, r *tar.Reader) {

--- a/sdk/go/common/util/archive/ignorer.go
+++ b/sdk/go/common/util/archive/ignorer.go
@@ -1,0 +1,40 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+type ignorer interface {
+	IsIgnored(f string) bool
+}
+
+type ignoreState struct {
+	ignorer ignorer
+	next    *ignoreState
+}
+
+func (s *ignoreState) Append(ignorer ignorer) *ignoreState {
+	return &ignoreState{ignorer: ignorer, next: s}
+}
+
+func (s *ignoreState) IsIgnored(path string) bool {
+	if s == nil {
+		return false
+	}
+
+	if s.ignorer.IsIgnored(path) {
+		return true
+	}
+
+	return s.next.IsIgnored(path)
+}

--- a/sdk/go/common/util/archive/ignorer_gitignore.go
+++ b/sdk/go/common/util/archive/ignorer_gitignore.go
@@ -21,22 +21,21 @@ import (
 	ignore "github.com/sabhiram/go-gitignore"
 )
 
-// newPulumiIgnorerIgnorer creates an ignorer based on the contents of a .pulumiignore file, which
-// has the same semantics as a .gitignore file
-func newPulumiIgnorerIgnorer(pathToPulumiIgnore string) (ignorer, error) {
+// newGitIgnoreIgnorer creates an ignorer based on the contents of a .gitignore file.
+func newGitIgnoreIgnorer(pathToPulumiIgnore string) (ignorer, error) {
 	gitIgnorer, err := ignore.CompileIgnoreFile(pathToPulumiIgnore)
 	if err != nil {
 		return nil, err
 	}
 
-	return &pulumiIgnoreIgnorer{root: path.Dir(pathToPulumiIgnore), ignorer: gitIgnorer}, nil
+	return &gitIngoreIgnorer{root: path.Dir(pathToPulumiIgnore), ignorer: gitIgnorer}, nil
 }
 
-type pulumiIgnoreIgnorer struct {
+type gitIngoreIgnorer struct {
 	root    string
 	ignorer *ignore.GitIgnore
 }
 
-func (g *pulumiIgnoreIgnorer) IsIgnored(f string) bool {
+func (g *gitIngoreIgnorer) IsIgnored(f string) bool {
 	return g.ignorer.MatchesPath(strings.TrimPrefix(f, g.root))
 }

--- a/sdk/go/common/util/archive/ignorer_path.go
+++ b/sdk/go/common/util/archive/ignorer_path.go
@@ -1,0 +1,46 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"os"
+	"strings"
+)
+
+// newPathIgnorer creates an ignorer based that ignores either a single file (when dir is false) or
+// and entire directory tree (when dir is true).
+func newPathIgnorer(path string, isDir bool) ignorer {
+	if !isDir {
+		return &fileIgnorer{path: path}
+	}
+
+	return &directoryIgnorer{path: path + string(os.PathSeparator)}
+}
+
+type fileIgnorer struct {
+	path string
+}
+
+func (fi *fileIgnorer) IsIgnored(f string) bool {
+	return f == fi.path
+}
+
+type directoryIgnorer struct {
+	path string
+}
+
+func (di *directoryIgnorer) IsIgnored(f string) bool {
+	return strings.HasPrefix(f, di.path)
+}

--- a/sdk/go/common/util/archive/ignorer_pulumiignore.go
+++ b/sdk/go/common/util/archive/ignorer_pulumiignore.go
@@ -1,0 +1,42 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package archive
+
+import (
+	"path"
+	"strings"
+
+	ignore "github.com/sabhiram/go-gitignore"
+)
+
+// newPulumiIgnorerIgnorer creates an ignorer based on the contents of a .pulumiignore file, which
+// has the same semantics as a .gitignore file
+func newPulumiIgnorerIgnorer(pathToPulumiIgnore string) (ignorer, error) {
+	gitIgnorer, err := ignore.CompileIgnoreFile(pathToPulumiIgnore)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pulumiIgnoreIgnorer{root: path.Dir(pathToPulumiIgnore), ignorer: gitIgnorer}, nil
+}
+
+type pulumiIgnoreIgnorer struct {
+	root    string
+	ignorer *ignore.GitIgnore
+}
+
+func (g *pulumiIgnoreIgnorer) IsIgnored(f string) bool {
+	return g.ignorer.MatchesPath(strings.TrimPrefix(f, g.root))
+}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -248,7 +248,7 @@ func (info PluginInfo) Install(tarball io.ReadCloser) error {
 			return err
 		}
 
-		return archive.Untgz(tarballBytes, tempDir)
+		return archive.UnTGZ(tarballBytes, tempDir)
 	})()
 	if err != nil {
 		return err

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -116,18 +116,7 @@ func (proj *Project) Save(path string) error {
 	contract.Require(path != "", "path")
 	contract.Require(proj != nil, "proj")
 	contract.Requiref(proj.Validate() == nil, "proj", "Validate()")
-
-	m, err := marshallerForPath(path)
-	if err != nil {
-		return err
-	}
-
-	b, err := m.Marshal(proj)
-	if err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(path, b, 0644)
+	return save(path, proj, false /*mkDirAll*/)
 }
 
 type PolicyPackProject struct {
@@ -158,6 +147,14 @@ func (proj *PolicyPackProject) Validate() error {
 	return nil
 }
 
+// Save writes a project definition to a file.
+func (proj *PolicyPackProject) Save(path string) error {
+	contract.Require(path != "", "path")
+	contract.Require(proj != nil, "proj")
+	contract.Requiref(proj.Validate() == nil, "proj", "Validate()")
+	return save(path, proj, false /*mkDirAll*/)
+}
+
 // ProjectStack holds stack specific information about a project.
 type ProjectStack struct {
 	// SecretsProvider is this stack's secrets provider.
@@ -176,22 +173,7 @@ type ProjectStack struct {
 func (ps *ProjectStack) Save(path string) error {
 	contract.Require(path != "", "path")
 	contract.Require(ps != nil, "ps")
-
-	m, err := marshallerForPath(path)
-	if err != nil {
-		return err
-	}
-
-	b, err := m.Marshal(ps)
-	if err != nil {
-		return err
-	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
-	}
-
-	return ioutil.WriteFile(path, b, 0644)
+	return save(path, ps, true /*mkDirAll*/)
 }
 
 type ProjectRuntimeInfo struct {
@@ -212,6 +194,13 @@ func (info *ProjectRuntimeInfo) Name() string {
 
 func (info *ProjectRuntimeInfo) Options() map[string]interface{} {
 	return info.options
+}
+
+func (info *ProjectRuntimeInfo) SetOption(key string, value interface{}) {
+	if info.options == nil {
+		info.options = make(map[string]interface{})
+	}
+	info.options[key] = value
 }
 
 func (info ProjectRuntimeInfo) MarshalYAML() (interface{}, error) {
@@ -369,4 +358,27 @@ func marshallerForPath(path string) (encoding.Marshaler, error) {
 	}
 
 	return m, nil
+}
+
+func save(path string, value interface{}, mkDirAll bool) error {
+	contract.Require(path != "", "path")
+	contract.Require(value != nil, "value")
+
+	m, err := marshallerForPath(path)
+	if err != nil {
+		return err
+	}
+
+	b, err := m.Marshal(value)
+	if err != nil {
+		return err
+	}
+
+	if mkDirAll {
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			return err
+		}
+	}
+
+	return ioutil.WriteFile(path, b, 0644)
 }

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -133,6 +133,10 @@ func (proj *Project) Save(path string) error {
 type PolicyPackProject struct {
 	// Runtime is a required runtime that executes code.
 	Runtime ProjectRuntimeInfo `json:"runtime" yaml:"runtime"`
+	// Version specifies the version of the policy pack. If set, it will override the
+	// version specified in `package.json` for Node.js policy packs.
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
 	// Main is an optional override for the program's main entry-point location.
 	Main string `json:"main,omitempty" yaml:"main,omitempty"`
 

--- a/sdk/nodejs/cmd/run-policy-pack/index.ts
+++ b/sdk/nodejs/cmd/run-policy-pack/index.ts
@@ -95,7 +95,7 @@ function main(args: string[]): void {
     const argv: minimist.ParsedArgs = minimist(args, {});
 
     // Finally, ensure we have a program to run.
-    if (argv._.length !== 2) {
+    if (argv._.length < 2) {
         return printErrorUsageAndExit("error: Usage: RUN <engine-address> <program>");
     }
 

--- a/sdk/python/dist/pulumi-analyzer-policy-python
+++ b/sdk/python/dist/pulumi-analyzer-policy-python
@@ -1,2 +1,43 @@
 #!/bin/sh
-python3 -u -m pulumi.policy $@
+
+# Parse the -virtualenv command line argument.
+virtualenv=""
+for arg in "$@"
+do
+    case $arg in
+        -virtualenv=*)
+        virtualenv="${arg#*=}"
+        break
+        ;;
+    esac
+done
+
+if [ -n "${virtualenv:-}" ] ; then
+    # Remove trailing slash.
+    virtualenv=${virtualenv%/}
+
+    # Make the path absolute (if not already).
+    case $virtualenv in
+        /*) : ;;
+        *) virtualenv=$PWD/$virtualenv;;
+    esac
+
+    # If python exists in the virtual environment, set PATH and run it.
+    if [ -f "$virtualenv/bin/python" ]; then
+        # Update PATH and unset PYTHONHOME.
+        PATH="$virtualenv/bin:$PATH"
+        export PATH
+        if [ -n "${PYTHONHOME:-}" ] ; then
+            unset PYTHONHOME
+        fi
+
+        # Run python from the virtual environment.
+        "$virtualenv/bin/python" -u -m pulumi.policy "$1" "$2"
+    else
+        echo "\"$virtualenv\" doesn't appear to be a virtual environment"
+        exit 1
+    fi
+else
+    # Otherwise, just run python3.
+    python3 -u -m pulumi.policy "$1" "$2"
+fi

--- a/sdk/python/dist/pulumi-analyzer-policy-python.cmd
+++ b/sdk/python/dist/pulumi-analyzer-policy-python.cmd
@@ -1,5 +1,38 @@
 @echo off
-setlocal
-REM We use `python` instead of `python3` because Windows Python installers
-REM install only `python.exe` by default.
-@python -u -m pulumi.policy %*
+
+:: Save the first two arguments.
+set "pulumi_policy_python_engine_address=%1"
+set "pulumi_policy_python_program=%2"
+
+:: Parse the -virtualenv command line argument.
+set pulumi_policy_python_virtualenv=
+:parse
+if "%~1"=="" goto endparse
+if "%~1"=="-virtualenv" (
+    :: Get the value as a fully-qualified path.
+    set "pulumi_policy_python_virtualenv=%~f2"
+    goto endparse
+)
+shift /1
+goto parse
+:endparse
+
+if defined pulumi_policy_python_virtualenv (
+    :: If python exists in the virtual environment, set PATH and run it.
+    if exist "%pulumi_policy_python_virtualenv%\Scripts\python.exe" (
+        :: Update PATH and unset PYTHONHOME.
+        set "PATH=%pulumi_policy_python_virtualenv%\Scripts;%PATH%"
+        set PYTHONHOME=
+
+        :: Run python from the virtual environment.
+        "%pulumi_policy_python_virtualenv%\Scripts\python.exe" -u -m pulumi.policy %pulumi_policy_python_engine_address% %pulumi_policy_python_program%
+        exit /B
+    ) else (
+        echo "%pulumi_policy_python_virtualenv%" doesn't appear to be a virtual environment
+        exit 1
+    )
+) else (
+    :: Otherwise, just run python. We use `python` instead of `python3` because Windows
+    :: Python installers install only `python.exe` by default.
+    @python -u -m pulumi.policy %pulumi_policy_python_engine_address% %pulumi_policy_python_program%
+)

--- a/sdk/python/dist/pulumi-analyzer-policy-python.cmd
+++ b/sdk/python/dist/pulumi-analyzer-policy-python.cmd
@@ -1,15 +1,15 @@
 @echo off
 
-:: Save the first two arguments.
+REM Save the first two arguments.
 set "pulumi_policy_python_engine_address=%1"
 set "pulumi_policy_python_program=%2"
 
-:: Parse the -virtualenv command line argument.
+REM Parse the -virtualenv command line argument.
 set pulumi_policy_python_virtualenv=
 :parse
 if "%~1"=="" goto endparse
 if "%~1"=="-virtualenv" (
-    :: Get the value as a fully-qualified path.
+    REM Get the value as a fully-qualified path.
     set "pulumi_policy_python_virtualenv=%~f2"
     goto endparse
 )
@@ -18,13 +18,13 @@ goto parse
 :endparse
 
 if defined pulumi_policy_python_virtualenv (
-    :: If python exists in the virtual environment, set PATH and run it.
+    REM If python exists in the virtual environment, set PATH and run it.
     if exist "%pulumi_policy_python_virtualenv%\Scripts\python.exe" (
-        :: Update PATH and unset PYTHONHOME.
+        REM Update PATH and unset PYTHONHOME.
         set "PATH=%pulumi_policy_python_virtualenv%\Scripts;%PATH%"
         set PYTHONHOME=
 
-        :: Run python from the virtual environment.
+        REM Run python from the virtual environment.
         "%pulumi_policy_python_virtualenv%\Scripts\python.exe" -u -m pulumi.policy %pulumi_policy_python_engine_address% %pulumi_policy_python_program%
         exit /B
     ) else (
@@ -32,7 +32,7 @@ if defined pulumi_policy_python_virtualenv (
         exit 1
     )
 ) else (
-    :: Otherwise, just run python. We use `python` instead of `python3` because Windows
-    :: Python installers install only `python.exe` by default.
+    REM Otherwise, just run python. We use `python` instead of `python3` because Windows
+    REM Python installers install only `python.exe` by default.
     @python -u -m pulumi.policy %pulumi_policy_python_engine_address% %pulumi_policy_python_program%
 )

--- a/sdk/python/lib/pulumi/policy/__main__.py
+++ b/sdk/python/lib/pulumi/policy/__main__.py
@@ -22,7 +22,7 @@ import pulumi.runtime
 
 
 def main():
-    if len(sys.argv) != 3:
+    if len(sys.argv) < 3:
         # For whatever reason, sys.stderr.write is not picked up by the engine as a message, but 'print' is. The Python
         # langhost automatically flushes stdout and stderr on shutdown, so we don't need to do it here - just trust that
         # Python does the sane thing when printing to stderr.

--- a/sdk/python/python.go
+++ b/sdk/python/python.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package python
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func Command(arg ...string) (*exec.Cmd, error) {
+	var err error
+	var pythonCmds []string
+	var pythonPath string
+
+	if pythonCmd := os.Getenv("PULUMI_PYTHON_CMD"); pythonCmd != "" {
+		pythonCmds = []string{pythonCmd}
+	} else {
+		// Look for "python3" by default, but fallback to `python` if not found as some Python 3
+		// distributions (in particular the default python.org Windows installation) do not include
+		// a `python3` binary.
+		pythonCmds = []string{"python3", "python"}
+	}
+
+	for _, pythonCmd := range pythonCmds {
+		pythonPath, err = exec.LookPath(pythonCmd)
+		// Break on the first cmd we find on the path (if any)
+		if err == nil {
+			break
+		}
+	}
+	if err != nil {
+		return nil, fmt.Errorf(
+			"Failed to locate any of %q on your PATH.  Have you installed Python 3.6 or greater?",
+			pythonCmds)
+	}
+
+	return exec.Command(pythonPath, arg...), nil
+}

--- a/sdk/python/python.go
+++ b/sdk/python/python.go
@@ -67,22 +67,6 @@ func VirtualEnvCommand(virtualEnvDir string, name string, arg ...string) *exec.C
 	return exec.Command(cmdPath, arg...)
 }
 
-// IsVirtualEnv returns true if the specified directory contains python and pip binaries.
-func IsVirtualEnv(dir string) bool {
-	fileExists := func(file string) bool {
-		if runtime.GOOS == windows {
-			file = fmt.Sprintf("%s.exe", file)
-		}
-		if info, err := os.Stat(file); err == nil && !info.IsDir() {
-			return true
-		}
-		return false
-	}
-
-	return fileExists(filepath.Join(dir, virtualEnvBinDirName(), "python")) &&
-		fileExists(filepath.Join(dir, virtualEnvBinDirName(), "pip"))
-}
-
 // ActivateVirtualEnv takes an array of environment variables (same format as os.Environ()) and path to
 // a virtual environment directory, and returns a new "activated" array with the virtual environment's
 // "bin" dir ("Scripts" on Windows) prepended to the `PATH` environment variable and `PYTHONHOME` variable

--- a/sdk/python/python.go
+++ b/sdk/python/python.go
@@ -18,8 +18,15 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
 )
 
+const windows = "windows"
+
+// Command returns an *exec.Cmd for running `python`. If the `PULUMI_PYTHON_CMD` variable is set
+// it will be looked for on `PATH`, otherwise, `python3` and `python` will be looked for.
 func Command(arg ...string) (*exec.Cmd, error) {
 	var err error
 	var pythonCmds []string
@@ -48,4 +55,66 @@ func Command(arg ...string) (*exec.Cmd, error) {
 	}
 
 	return exec.Command(pythonPath, arg...), nil
+}
+
+// VirtualEnvCommand returns an *exec.Cmd for running a command from the specified virtual environment
+// directory.
+func VirtualEnvCommand(virtualEnvDir string, name string, arg ...string) *exec.Cmd {
+	if runtime.GOOS == windows {
+		name = fmt.Sprintf("%s.exe", name)
+	}
+	cmdPath := filepath.Join(virtualEnvDir, virtualEnvBinDirName(), name)
+	return exec.Command(cmdPath, arg...)
+}
+
+// IsVirtualEnv returns true if the specified directory contains python and pip binaries.
+func IsVirtualEnv(dir string) bool {
+	fileExists := func(file string) bool {
+		if runtime.GOOS == windows {
+			file = fmt.Sprintf("%s.exe", file)
+		}
+		if info, err := os.Stat(file); err == nil && !info.IsDir() {
+			return true
+		}
+		return false
+	}
+
+	return fileExists(filepath.Join(dir, virtualEnvBinDirName(), "python")) &&
+		fileExists(filepath.Join(dir, virtualEnvBinDirName(), "pip"))
+}
+
+// ActivateVirtualEnv takes an array of environment variables (same format as os.Environ()) and path to
+// a virtual environment directory, and returns a new "activated" array with the virtual environment's
+// "bin" dir ("Scripts" on Windows) prepended to the `PATH` environment variable and `PYTHONHOME` variable
+// removed.
+func ActivateVirtualEnv(environ []string, virtualEnvDir string) []string {
+	virtualEnvBin := filepath.Join(virtualEnvDir, virtualEnvBinDirName())
+	var hasPath bool
+	var result []string
+	for _, env := range environ {
+		if strings.HasPrefix(env, "PATH=") {
+			hasPath = true
+			// Prepend the virtual environment bin directory to PATH so any calls to run
+			// python or pip will use the binaries in the virtual environment.
+			originalValue := env[len("PATH="):]
+			path := fmt.Sprintf("PATH=%s%s%s", virtualEnvBin, string(os.PathListSeparator), originalValue)
+			result = append(result, path)
+		} else if strings.HasPrefix(env, "PYTHONHOME=") {
+			// Skip PYTHONHOME to "unset" this value.
+		} else {
+			result = append(result, env)
+		}
+	}
+	if !hasPath {
+		path := fmt.Sprintf("PATH=%s", virtualEnvBin)
+		result = append(result, path)
+	}
+	return result
+}
+
+func virtualEnvBinDirName() string {
+	if runtime.GOOS == windows {
+		return "Scripts"
+	}
+	return "bin"
 }

--- a/sdk/python/python_test.go
+++ b/sdk/python/python_test.go
@@ -1,0 +1,105 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package python
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsVirtualEnv(t *testing.T) {
+	// Create a new empty test directory.
+	tempdir, _ := ioutil.TempDir("", "test-env")
+	defer os.RemoveAll(tempdir)
+
+	// Assert the empty test directory is not a virtual environment.
+	assert.False(t, IsVirtualEnv(tempdir))
+
+	// Create and run a python command to create a virtual environment.
+	venvDir := filepath.Join(tempdir, "venv")
+	cmd, err := Command("-m", "venv", venvDir)
+	assert.NoError(t, err)
+	err = cmd.Run()
+	assert.NoError(t, err)
+
+	// Assert the new venv directory is a virtual environment.
+	assert.True(t, IsVirtualEnv(venvDir))
+}
+
+func TestActivateVirtualEnv(t *testing.T) {
+	venvName := "venv"
+	venvDir := filepath.Join(venvName, "bin")
+	if runtime.GOOS == windows {
+		venvDir = filepath.Join(venvName, "Scripts")
+	}
+
+	tests := []struct {
+		input    []string
+		expected []string
+	}{
+		{
+			input:    []string{"PYTHONHOME=foo", "PATH=bar", "FOO=blah"},
+			expected: []string{fmt.Sprintf("PATH=%s%sbar", venvDir, string(os.PathListSeparator)), "FOO=blah"},
+		},
+		{
+			input:    []string{"PYTHONHOME=foo", "FOO=blah"},
+			expected: []string{"FOO=blah", fmt.Sprintf("PATH=%s", venvDir)},
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%#v", test.input), func(t *testing.T) {
+			actual := ActivateVirtualEnv(test.input, venvName)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestRunningPipInVirtualEnvironment(t *testing.T) {
+	// Skip during short test runs since this test involves downloading dependencies.
+	if testing.Short() {
+		t.Skip("Skipped in short test run")
+	}
+
+	// Create a new empty test directory.
+	tempdir, _ := ioutil.TempDir("", "test-env")
+	defer os.RemoveAll(tempdir)
+
+	// Create and run a python command to create a virtual environment.
+	venvDir := filepath.Join(tempdir, "venv")
+	cmd, err := Command("-m", "venv", venvDir)
+	assert.NoError(t, err)
+	err = cmd.Run()
+	assert.NoError(t, err)
+
+	// Create a requirements.txt file in the temp directory.
+	requirementsFile := filepath.Join(tempdir, "requirements.txt")
+	assert.NoError(t, ioutil.WriteFile(requirementsFile, []byte("pulumi==2.0.0\n"), 0644))
+
+	// Create a command to run pip from the virtual environment.
+	pipCmd := VirtualEnvCommand(venvDir, "pip", "install", "-r", "requirements.txt")
+	pipCmd.Dir = tempdir
+	pipCmd.Env = ActivateVirtualEnv(os.Environ(), venvDir)
+
+	// Run the command.
+	if output, err := pipCmd.CombinedOutput(); err != nil {
+		assert.Failf(t, "pip install command failed with output: %s", string(output))
+	}
+}

--- a/sdk/python/python_test.go
+++ b/sdk/python/python_test.go
@@ -25,25 +25,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsVirtualEnv(t *testing.T) {
-	// Create a new empty test directory.
-	tempdir, _ := ioutil.TempDir("", "test-env")
-	defer os.RemoveAll(tempdir)
-
-	// Assert the empty test directory is not a virtual environment.
-	assert.False(t, IsVirtualEnv(tempdir))
-
-	// Create and run a python command to create a virtual environment.
-	venvDir := filepath.Join(tempdir, "venv")
-	cmd, err := Command("-m", "venv", venvDir)
-	assert.NoError(t, err)
-	err = cmd.Run()
-	assert.NoError(t, err)
-
-	// Assert the new venv directory is a virtual environment.
-	assert.True(t, IsVirtualEnv(venvDir))
-}
-
 func TestActivateVirtualEnv(t *testing.T) {
 	venvName := "venv"
 	venvDir := filepath.Join(venvName, "bin")

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -401,6 +401,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v2.1.0+incompatible/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94 h1:G04eS0JkAIVZfaJLjla9dNxkJCPiKIGZlw9AfOhzOD0=
+github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94/go.mod h1:b18R55ulyQ/h3RaWyloPyER7fWQVZvimKKhnI5OfrJQ=
 github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=


### PR DESCRIPTION
This PR adds support for publishing Python policy packs to the service, and downloading/using such policy packs when applied to stacks in an organization.

## Design
Reminder: For Node.js policy packs, we run `npm pack`  to package up the code and upload the `.tgz` to the service. When downloading, we manually extract that `.tgz` file and then run `npm install` to install its dependencies.

I explored a few different approaches to packaging up the Python policy pack code (alternatives discussed below). In the end, I went with a simple and pragmatic approach:

- **Packaging**: We simply `.tgz` the contents of the  Python policy pack, ignoring any `.git` directories and anything specified in `.gitignore` (similar to what `npm pack` does). The policy pack version is specified in `PulumiPolicy.yaml`.

- **Downloading/Installing**: When downloading the policy pack, we manually extract the `.tgz` the same as we do for Node.js policy packs. If it is a Python policy pack, we create a virtual environment for it by running `python -m venv venv` (using the same approach for looking up the `python` binary as we use for running Python programs). If there is a `requirements.txt` file, we run `pip` in the virtual environment to install dependencies in the virtual environment.

* **Running**: When we run the policy pack, we ensure the `python` from the virtual environment is used by prepending the path to the virtual environment’s `bin` directory (`Scripts` on Windows) to the `PATH` environment variable used to execute the analyzer plugin (effectively doing the same thing as the virtual environment’s `activate` script).

## Commits
Summary of commits in this PR:

1. The first commit simply factors out the existing code for running `python` so we can use it in more places than just running Python Pulumi programs.

2. The second commit resurrects some old code we had for archiving a directory of code, for PPCs, that had been deleted. This commit brings back the code as it was before it was deleted (originally at `pkg/util/archive`).

3. The third commit modifies the archive code to use the `.tgz` format rather than `.zip` so we can package Python policy packs in the same format used for Node.js.

4. The fourth commit adds support for specifying the policy pack version in `PulumiPolicy.yaml`. This is how the version is specified for Python policy packs. Node.js policy packs can continue to set the version in `package.json`, but if set in `PulumiPolicy.yaml`, the `PulumiPolicy.yaml` value will be used.

5. The fifth commit builds on top of the former commits to add support for publishing Python policy packs to the service and downloading/using such policy packs when applied to a stack in an organization.

Fixes https://github.com/pulumi/pulumi-policy/issues/211

## Alternatives Considered
I initially went down the path of packaging it via `setuptools` — the same way you’d package something to be published to PyPi. This ended up requiring a lot of additional boilerplate (you’d need a `setup.py` with several parameters set, a `MANIFEST.in` file with an entry to include `PulumiPolicy.yaml` in the package), moving away from using `requirements.txt` to specifying the dependencies in `setup.py`, etc. This all added up to making Python policy packs feel significantly different than regular Python Pulumi programs.

I also briefly explored using [executable Python zip archives](https://docs.python.org/3/library/zipapp.html). The challenge here is around dependencies. According to the [docs](https://docs.python.org/3/library/zipapp.html#creating-standalone-applications-with-zipapp), to create a standalone zipapp you must bundle required dependencies inside the archive — which isn’t going to work for us if someone has dependencies that aren't cross-platform.