### PR TITLE
[codegen/docs] Various Go-related fixes

### DIFF
--- a/.github/workflows/res-docs-test.yml
+++ b/.github/workflows/res-docs-test.yml
@@ -91,6 +91,7 @@ jobs:
           title: Preview resource docs changes for pulumi/pulumi#${{ steps.regenerate-resource-docs.outputs.prNumber }}
           body: |
             This PR was auto-generated from pulumi/pulumi#${{ steps.regenerate-resource-docs.outputs.prNumber }}.
+
             By default, this PR contains regenerated docs for AWS and Kubernetes only.
           # Assign the draft PR to the author of the current PR.
           assignees: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/res-docs-test.yml
+++ b/.github/workflows/res-docs-test.yml
@@ -64,6 +64,8 @@ jobs:
           PR_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
           BRANCH_NAME="${GITHUB_ACTOR}/${PR_NUMBER}-test-generator-changes"
 
+          # If generating docs for more providers here, be sure to update
+          # the description of the draft PR that is opened in the next step.
           pushd docs
           ./scripts/gen_resource_docs.sh aws true
           ./scripts/gen_resource_docs.sh kubernetes true
@@ -86,10 +88,12 @@ jobs:
           committer: Pulumi Bot <bot@pulumi.com>
           author: Pulumi Bot <bot@pulumi.com>
           commit-message: Regenerate resource docs
-          title: Preview resource docs changes caused by generator changes
+          title: Preview resource docs changes for pulumi/pulumi#${{ steps.regenerate-resource-docs.outputs.prNumber }}
           body: |
             This PR was auto-generated from pulumi/pulumi#${{ steps.regenerate-resource-docs.outputs.prNumber }}.
-          assignees: ${{ github.actor }}
+            By default, this PR contains regenerated docs for AWS and Kubernetes only.
+          # Assign the draft PR to the author of the current PR.
+          assignees: ${{ github.event.pull_request.user.login }}
           branch: ${{ steps.regenerate-resource-docs.outputs.branchName }}
           request-to-parent: false
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1444,10 +1444,10 @@ func (mod *modContext) gen(fs fs) error {
 		title := resourceName(r)
 		buffer := &bytes.Buffer{}
 		// Don't include the "go" language in the language chooser
-		// for the helm/v2 and yaml modules in the k8s package. These
-		// are "overlay" modules. The resources under those modules are
-		// not available in Go.
-		if isK8s && mod.isKubernetesOverlayModule() {
+		// for the k8s package's apiextensions module. The
+		// "overlay" resource called CustomResource (not to be confused
+		// with CustomResourceDefintion) is not available in Go yet.
+		if isK8s && mod.mod == "apiextensions" && title == "CustomResource" {
 			data.LangChooserLanguages = "typescript,python,csharp"
 		}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -200,7 +200,9 @@ type resourceDocArgs struct {
 
 	Tool string
 	// LangChooserLanguages is a comma-separated list of languages to pass to the
-	// language chooser shortcode.
+	// language chooser shortcode. Use this to customize the languages shown for a
+	// resource. By default, the language chooser will show all languages supported
+	// by Pulumi for all resources.
 	LangChooserLanguages string
 
 	// Comment represents the introductory resource comment.
@@ -1443,13 +1445,6 @@ func (mod *modContext) gen(fs fs) error {
 
 		title := resourceName(r)
 		buffer := &bytes.Buffer{}
-		// Don't include the "go" language in the language chooser
-		// for the k8s package's apiextensions module. The
-		// "overlay" resource called CustomResource (not to be confused
-		// with CustomResourceDefintion) is not available in Go yet.
-		if isK8s && mod.mod == "apiextensions" && title == "CustomResource" {
-			data.LangChooserLanguages = "typescript,python,csharp"
-		}
 
 		err := templates.ExecuteTemplate(buffer, "resource.tmpl", data)
 		if err != nil {

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -152,7 +152,7 @@ func (mod *modContext) genFunctionGo(f *schema.Function, funcName string) []form
 	if f.Inputs != nil {
 		params = append(params, formalParam{
 			Name:         "args",
-			OptionalFlag: "",
+			OptionalFlag: "*",
 			Type: propertyType{
 				Name: argsType,
 				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg, mod.mod, argsType),

--- a/pkg/codegen/docs/templates/constructor_params.tmpl
+++ b/pkg/codegen/docs/templates/constructor_params.tmpl
@@ -1,9 +1,9 @@
 {{ define "param_separator" }}<span class="p">, </span>{{ end }}
 
-{{ define "go_formal_param" }}<span class="nx">{{ .Name }}</span> {{ .OptionalFlag }}{{ template "linkify_param" .Type }}{{ end }}
+{{ define "go_formal_param" }}<span class="nx">{{ .Name }}</span><span class="p"> {{ .OptionalFlag }}</span>{{ template "linkify_param" .Type }}{{ end }}
 
-{{ define "ts_formal_param" }}<span class="nx">{{ .Name }}</span>{{ .OptionalFlag }}: {{ template "linkify_param" .Type }}{{ end }}
+{{ define "ts_formal_param" }}<span class="nx">{{ .Name }}</span><span class="p">{{ .OptionalFlag }}:</span> {{ template "linkify_param" .Type }}{{ end }}
 
-{{ define "csharp_formal_param" }}{{ template "linkify_param" .Type }}{{ .OptionalFlag }} <span class="nx">{{ .Name }}{{ .DefaultValue }}{{ end }}
+{{ define "csharp_formal_param" }}{{ template "linkify_param" .Type }}<span class="p">{{ .OptionalFlag }} </span><span class="nx">{{ .Name }}{{ .DefaultValue }}{{ end }}
 
 {{ define "py_formal_param" }}{{ .Name }}{{ .DefaultValue }}{{ end }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -29,10 +29,10 @@
 
 <!-- Go -->
 {{ print "{{% choosable language go %}}" }}
-{{- if ne .FunctionName.go .Header.Title }}
-// This function's name in Go will not match the name used in other languages.
-{{ end }}
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>{{ .FunctionName.go }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.go }}<span class="p">) (*{{ template "linkify_param" .FunctionResult.go }}, error)</span></code></pre></div>
+{{- if ne .FunctionName.go .Header.Title }}
+> This function's name was changed for the Go SDK to avoid conflicts with another similarly named function in the package.
+{{ end }}
 {{ print "{{% /choosable %}}" }}
 
 <!-- C# -->

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -30,7 +30,7 @@
 <!-- Go -->
 {{ print "{{% choosable language go %}}" }}
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>{{ .FunctionName.go }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.go }}<span class="p">) (*{{ template "linkify_param" .FunctionResult.go }}, error)</span></code></pre></div>
-{{- if ne .FunctionName.go .Header.Title }}
+{{ if ne .FunctionName.go .Header.Title }}
 > This function's name was changed for the Go SDK to avoid conflicts with another similarly named function in the package.
 {{ end }}
 {{ print "{{% /choosable %}}" }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -29,6 +29,9 @@
 
 <!-- Go -->
 {{ print "{{% choosable language go %}}" }}
+{{- if ne .FunctionName.go .Header.Title }}
+// This function's name in Go will not match the name used in other languages.
+{{ end }}
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>{{ .FunctionName.go }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.go }}<span class="p">) (*{{ template "linkify_param" .FunctionResult.go }}, error)</span></code></pre></div>
 {{ print "{{% /choosable %}}" }}
 

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -31,7 +31,7 @@
 {{ print "{{% choosable language go %}}" }}
 <div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span>{{ .FunctionName.go }}<span class="p">(</span>{{ htmlSafe .FunctionArgs.go }}<span class="p">) (*{{ template "linkify_param" .FunctionResult.go }}, error)</span></code></pre></div>
 {{ if ne .FunctionName.go .Header.Title }}
-> This function's name was changed for the Go SDK to avoid conflicts with another similarly named function in the package.
+> Note: This function is named `{{ .FunctionName.go }}` in the Go SDK.
 {{ end }}
 {{ print "{{% /choosable %}}" }}
 


### PR DESCRIPTION
Related to pulumi/docs#3254, pulumi/docs#3192, pulumi/docs#3276.

* Remove all exclusions for conditionally showing the languages in the lang chooser.
  * This was done for k8s overlay resources, so that we could hide the Go language. They are all now supported in Go as of [v2.2.0](https://github.com/pulumi/pulumi-kubernetes/releases/tag/v2.2.0).
* Show a note in the Go "New*" function snippet that lets the user know the function name can be different from other languages and that it is not an error.
* Make the `args` input param optional for Functions in Go.
* Some other minor cleanup.