### PR TITLE
Fix NRE in C# mocks and include the stack to result again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ CHANGELOG
 - Add support for untagged outputs in Go SDK.
  [#4640](https://github.com/pulumi/pulumi/pull/4640)
 
-- Fix a tegression in .NET unit testing.
+- Fix a Regression in .NET unit testing.
  [#4656](https://github.com/pulumi/pulumi/pull/4656)
 
 ## 2.2.1 (2020-05-13)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - Add support for untagged outputs in Go SDK.
  [#4640](https://github.com/pulumi/pulumi/pull/4640)
 
+- Fix a tegression in .NET unit testing.
+ [#4656](https://github.com/pulumi/pulumi/pull/4656)
+
 ## 2.2.1 (2020-05-13)
 - Add new brew target to fix homebrew builds
  [#4633](https://github.com/pulumi/pulumi/pull/4633)

--- a/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
@@ -38,6 +38,18 @@ namespace Pulumi.Tests.Mocks
             var ip = await instance.PublicIp.GetValueAsync();
             Assert.Equal("203.0.113.12", ip);
         }
+        
+        [Fact]
+        public async Task TestStack()
+        {
+            var resources = await Testing.RunAsync<MyStack>();
+
+            var stack = resources.OfType<MyStack>().FirstOrDefault();
+            Assert.NotNull(stack);
+
+            var ip = await stack.PublicIp.GetValueAsync();
+            Assert.Equal("203.0.113.12", ip);
+        }
     }
 
     public static class Testing

--- a/sdk/dotnet/Pulumi.Tests/Mocks/TestStack.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/TestStack.cs
@@ -19,9 +19,13 @@ namespace Pulumi.Tests.Mocks
 
     public class MyStack : Stack
     {
+        [Output("publicIp")]
+        public Output<string> PublicIp { get; private set; } = null!;
+
         public MyStack()
         {
             var myInstance = new Instance("instance", new InstanceArgs());
+            this.PublicIp = myInstance.PublicIp;
         }
     }
 }

--- a/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
@@ -49,22 +49,23 @@ namespace Pulumi.Testing
 
         public async Task<RegisterResourceResponse> RegisterResourceAsync(Resource resource, RegisterResourceRequest request)
         {
+            lock (this.Resources)
+            {
+                this.Resources.Add(resource);
+            }
+
             if (request.Type == Stack._rootPulumiStackTypeName)
             {
                 return new RegisterResourceResponse
                 {
                     Urn = NewUrn(request.Parent, request.Type, request.Name),
+                    Object = new Struct(),
                 };
             }
 
             var (id, state) = await _mocks.NewResourceAsync(request.Type, request.Name, ToDictionary(request.Object),
                 request.Provider, request.ImportId).ConfigureAwait(false);
             
-            lock (this.Resources)
-            {
-                this.Resources.Add(resource);
-            }
-
             return new RegisterResourceResponse
             {
                 Id = id ?? request.ImportId,


### PR DESCRIPTION
Fix #4655

Fixes both points:
- If response data is null, the NRE is thrown at https://github.com/pulumi/pulumi/blob/30b12cff49c614de67c5388f003d8b65f22fae3c/sdk/dotnet/Pulumi/Deployment/Deployment_ReadOrRegisterResource.cs#L95
- Returning the stack was already something we used in examples in 2.0, so we should keep that behavior