### PR TITLE
Don't mark provider token string types with json attribute in C#

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -341,13 +341,10 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 	}
 	if pt.res != nil && pt.res.IsProvider {
 		json := true
-		switch prop.Type {
-		case schema.StringType:
+		if prop.Type == schema.StringType {
 			json = false
-		default:
-			if t, ok := prop.Type.(*schema.TokenType); ok && t.UnderlyingType == schema.StringType {
-				json = false
-			}
+		} else if t, ok := prop.Type.(*schema.TokenType); ok && t.UnderlyingType == schema.StringType {
+			json = false
 		}
 		if json {
 			attributeArgs += ", json: true"

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -345,11 +345,8 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 		case schema.StringType:
 			json = false
 		default:
-			switch t := prop.Type.(type) {
-			case *schema.TokenType:
-				if t.UnderlyingType == schema.StringType {
-					json = false
-				}
+			if t, ok := prop.Type.(*schema.TokenType); ok && t.UnderlyingType == schema.StringType {
+				json = false
 			}
 		}
 		if json {

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -339,8 +339,22 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 	if prop.IsRequired {
 		attributeArgs = ", required: true"
 	}
-	if pt.res != nil && pt.res.IsProvider && prop.Type != schema.StringType {
-		attributeArgs += ", json: true"
+	if pt.res != nil && pt.res.IsProvider {
+		json := true
+		switch prop.Type {
+		case schema.StringType:
+			json = false
+		default:
+			switch t := prop.Type.(type) {
+			case *schema.TokenType:
+				if t.UnderlyingType == schema.StringType {
+					json = false
+				}
+			}
+		}
+		if json {
+			attributeArgs += ", json: true"
+		}
 	}
 
 	// Next generate the input property itself. The way this is generated depends on the type of the property:


### PR DESCRIPTION
Fix for https://github.com/pulumi/pulumi-aws/issues/966
The `region` property of the AWS provider is a token string type and is currently marked as `json: true` by mistake. That's a regression from when we switced to schema-based C# codegen.