### PR TITLE
Fix C# (and a bit of Node.js) program gen based on errors from AWS

### DIFF
--- a/pkg/codegen/dotnet/utilities.go
+++ b/pkg/codegen/dotnet/utilities.go
@@ -31,7 +31,11 @@ func isReservedWord(s string) bool {
 		"sizeof", "stackalloc", "static", "string", "struct", "switch", "this", "throw", "true", "try", "typeof",
 		"uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual", "void", "volatile", "while":
 		return true
-
+	// Treat contextual keywords as keywords, as we don't validate the context around them.
+	case "add", "alias", "ascending", "async", "await", "by", "descending", "dynamic", "equals", "from", "get",
+		"global", "group", "into", "join", "let", "nameof", "on", "orderby", "partial", "remove", "select", "set",
+		"unmanaged", "value", "var", "when", "where", "yield":
+		return true
 	default:
 		return false
 	}
@@ -73,5 +77,5 @@ func makeValidIdentifier(name string) string {
 
 // propertyName returns a name as a valid identifier in title case.
 func propertyName(name string) string {
-	return Title(makeValidIdentifier(name))
+	return makeValidIdentifier(Title(name))
 }

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -242,6 +242,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 	optionsBag := ""
 
 	name := r.Name()
+	variableName := makeValidIdentifier(name)
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))
 	for _, l := range r.Definition.Tokens.GetLabels(nil) {
@@ -280,16 +281,16 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		rangeExpr := g.lowerExpression(r.Options.Range)
 
 		if model.InputType(model.BoolType).ConversionFrom(rangeType) == model.SafeConversion {
-			g.Fgenf(w, "%slet %s: %s | undefined;\n", g.Indent, name, qualifiedMemberName)
+			g.Fgenf(w, "%slet %s: %s | undefined;\n", g.Indent, variableName, qualifiedMemberName)
 			g.Fgenf(w, "%sif (%.v) {\n", g.Indent, rangeExpr)
 			g.Indented(func() {
-				g.Fgenf(w, "%s%s = ", g.Indent, name)
+				g.Fgenf(w, "%s%s = ", g.Indent, variableName)
 				instantiate(g.makeResourceName(name, ""))
 				g.Fgenf(w, ";\n")
 			})
 			g.Fgenf(w, "%s}\n", g.Indent)
 		} else {
-			g.Fgenf(w, "%sconst %s: %s[];\n", g.Indent, name, qualifiedMemberName)
+			g.Fgenf(w, "%sconst %s: %s[];\n", g.Indent, variableName, qualifiedMemberName)
 
 			resKey := "key"
 			if model.InputType(model.NumberType).ConversionFrom(rangeExpr.Type()) != model.NoConversion {
@@ -305,14 +306,14 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 			resName := g.makeResourceName(name, "range."+resKey)
 			g.Indented(func() {
-				g.Fgenf(w, "%s%s.push(", g.Indent, name)
+				g.Fgenf(w, "%s%s.push(", g.Indent, variableName)
 				instantiate(resName)
 				g.Fgenf(w, ");\n")
 			})
 			g.Fgenf(w, "%s}\n", g.Indent)
 		}
 	} else {
-		g.Fgenf(w, "%sconst %s = ", g.Indent, name)
+		g.Fgenf(w, "%sconst %s = ", g.Indent, variableName)
 		instantiate(g.makeResourceName(name, ""))
 		g.Fgenf(w, ";\n")
 	}

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -515,7 +515,7 @@ func (g *generator) GenRelativeTraversalExpression(w io.Writer, expr *model.Rela
 }
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
-	rootName := expr.RootName
+	rootName := makeValidIdentifier(expr.RootName)
 	if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
 		rootName = "__item"
 	}


### PR DESCRIPTION
I generated C# examples in the AWS provider locally and made a tool that compiles all examples and reports errors in an actionable way.

I fixed some errors that were found in C# generation (and one in Node.js). Remaining errors are probably problems in the examples themselves or in our HCL compiler frontend. I'll report those separately.