### PR TITLE
Stack output generation for s3 logging example

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -111,13 +111,13 @@ func (g *generator) genNode(w io.Writer, n hcl2.Node) {
 	switch n := n.(type) {
 	case *hcl2.Resource:
 		g.genResource(w, n)
+	case *hcl2.OutputVariable:
+		g.genOutputAssignment(w, n)
 		// TODO
 		// case *hcl2.ConfigVariable:
 		// 	g.genConfigVariable(w, n)
 		// case *hcl2.LocalVariable:
 		// 	g.genLocalVariable(w, n)
-		// case *hcl2.OutputVariable:
-		// 	g.genOutputAssignment(w, n)
 	}
 }
 
@@ -149,4 +149,8 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 	g.Fgenf(w, "return err\n")
 	g.Fgenf(w, "}\n")
 
+}
+
+func (g *generator) genOutputAssignment(w io.Writer, v *hcl2.OutputVariable) {
+	g.Fgenf(w, "ctx.Export(\"%s\", %.3v)\n", v.Name(), g.lowerExpression(v.Value, v.Type()))
 }

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -74,7 +74,7 @@ func TestCollectImports(t *testing.T) {
 	var index bytes.Buffer
 	imports := g.collectImports(&index, g.program).SortedValues()
 	assert.Equal(t, 1, len(imports))
-	assert.Equal(t, "github.com/pulumi/pulumi-aws/sdk/go/aws/s3", imports[0])
+	assert.Equal(t, "github.com/pulumi/pulumi-aws/sdk/v2/go/aws/s3", imports[0])
 }
 
 func newTestGenerator(t *testing.T, testFile string) *generator {

--- a/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-s3-logging.pp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-aws/sdk/go/aws/s3"
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/s3"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
@@ -21,6 +21,9 @@ func main() {
 		if err != nil {
 			return err
 		}
+		ctx.Export("targetBucket", bucket.Loggings.ApplyT(func(loggings []s3.BucketLogging) (string, error) {
+			return loggings[0].TargetBucket, nil
+		}).(pulumi.StringOutput))
 		return nil
 	})
 }


### PR DESCRIPTION
This rounds out the E2E testing baseline for the simplest [example program](https://github.com/pulumi/pulumi/blob/master/pkg/codegen/internal/test/testdata/aws-s3-logging.pp). Once again lots of TODOs in here and incomplete logic that will be filled out via expression driven development going forward. 

One thing I could use some input on is how to determine whether a type is "inputty" (`s3.BucketLoggingArray`) vs just a standard type (`[]s3.BucketLogging`). I have something in place that works for this example but don't imagine that it's a permanent solution. 