### PR TITLE
[codegen/hcl2/model] Remove type caches.

### DIFF
--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -248,8 +248,7 @@ func requiresAsyncInit(r *hcl2.Resource) bool {
 		return false
 	}
 
-	t := r.Options.Range.Type()
-	return model.ResolveOutputs(t) != t
+	return model.ContainsPromises(r.Options.Range.Type())
 }
 
 // resourceTypeName computes the C# class name for the given resource.

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -35,6 +35,7 @@ func (k ConversionKind) Exists() bool {
 type Type interface {
 	Definition
 
+	Equals(other Type) bool
 	AssignableFrom(src Type) bool
 	ConversionFrom(src Type) ConversionKind
 	String() string
@@ -60,7 +61,7 @@ var (
 )
 
 func assignableFrom(dest, src Type, assignableFrom func() bool) bool {
-	if dest == src || dest == DynamicType {
+	if dest.Equals(src) || dest == DynamicType {
 		return true
 	}
 	if src == DynamicType {
@@ -70,7 +71,7 @@ func assignableFrom(dest, src Type, assignableFrom func() bool) bool {
 }
 
 func conversionFrom(dest, src Type, unifying bool, conversionFrom func() ConversionKind) ConversionKind {
-	if dest == src || dest == DynamicType {
+	if dest.Equals(src) || dest == DynamicType {
 		return SafeConversion
 	}
 	if src, isUnion := src.(*UnionType); isUnion {
@@ -91,7 +92,7 @@ func unify(t0, t1 Type, unify func() (Type, ConversionKind)) (Type, ConversionKi
 	}
 
 	switch {
-	case t0 == t1:
+	case t0.Equals(t1):
 		return t0, SafeConversion
 	case t1 == DynamicType:
 		// The dynamic type unifies with any other type by selecting that other type.
@@ -149,7 +150,7 @@ func UnifyTypes(types ...Type) (safeType Type, unsafeType Type) {
 		unsafeType = NoneType
 	}
 
-	contract.Assertf(unsafeType == safeType || unsafeType.ConversionFrom(safeType).Exists(),
+	contract.Assertf(unsafeType.Equals(safeType) || unsafeType.ConversionFrom(safeType).Exists(),
 		"no conversion from %v to %v", safeType, unsafeType)
 	return safeType, unsafeType
 }

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -30,6 +30,10 @@ func (noneType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostics)
 	return NoneType, hcl.Diagnostics{unsupportedReceiverType(NoneType, traverser.SourceRange())}
 }
 
+func (noneType) Equals(other Type) bool {
+	return other == NoneType
+}
+
 func (noneType) AssignableFrom(src Type) bool {
 	return assignableFrom(NoneType, src, func() bool {
 		return false

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -78,6 +78,11 @@ func (t *OpaqueType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 	return DynamicType, hcl.Diagnostics{unsupportedReceiverType(t, traverser.SourceRange())}
 }
 
+// Equals returns true if this type has the same identity as the given type.
+func (t *OpaqueType) Equals(other Type) bool {
+	return t == other
+}
+
 // AssignableFrom returns true if this type is assignable from the indicated source type. A token(name) is assignable
 // from token(name).
 func (t *OpaqueType) AssignableFrom(src Type) bool {
@@ -131,6 +136,17 @@ func (t *OpaqueType) conversionFrom(src Type, unifying bool) ConversionKind {
 	return t.conversionFromImpl(src, unifying, true)
 }
 
+// ConversionFrom returns the kind of conversion (if any) that is possible from the source type to this type.
+//
+// In general, an opaque type is only convertible from itself (in addition to the standard dynamic and union
+// conversions). However, there are special rules for the builtin types:
+//
+// - The dynamic type is safely convertible from any other type, and is unsafely convertible _to_ any other type
+// - The string type is safely convertible from bool, number, and int
+// - The number type is safely convertible from int and unsafely convertible from string
+// - The int type is unsafely convertible from string
+// - The bool type is unsafely convertible from string
+//
 func (t *OpaqueType) ConversionFrom(src Type) ConversionKind {
 	return t.conversionFrom(src, false)
 }

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -26,24 +26,12 @@ import (
 type OutputType struct {
 	// ElementType is the element type of the output.
 	ElementType Type
-
-	s string
 }
-
-// The set of output types, indexed by element type.
-var outputTypes = map[Type]*OutputType{}
 
 // NewOutputType creates a new output type with the given element type after replacing any output or promise types
 // within the element type with their respective element types.
 func NewOutputType(elementType Type) *OutputType {
-	elementType = ResolveOutputs(elementType)
-	if t, ok := outputTypes[elementType]; ok {
-		return t
-	}
-
-	t := &OutputType{ElementType: elementType}
-	outputTypes[elementType] = t
-	return t
+	return &OutputType{ElementType: ResolveOutputs(elementType)}
 }
 
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.
@@ -56,6 +44,15 @@ func (*OutputType) SyntaxNode() hclsyntax.Node {
 func (t *OutputType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostics) {
 	element, diagnostics := t.ElementType.Traverse(traverser)
 	return NewOutputType(element.(Type)), diagnostics
+}
+
+// Equals returns true if this type has the same identity as the given type.
+func (t *OutputType) Equals(other Type) bool {
+	if t == other {
+		return true
+	}
+	otherOutput, ok := other.(*OutputType)
+	return ok && t.ElementType.Equals(otherOutput.ElementType)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. An output(T) is assignable
@@ -72,6 +69,9 @@ func (t *OutputType) AssignableFrom(src Type) bool {
 	})
 }
 
+// ConversionFrom returns the kind of conversion (if any) that is possible from the source type to this type. An
+// output(T) is convertible from a type U, output(U), or promise(U) if U is convertible to T. If the conversion from
+// U to T is unsafe, the entire conversion is unsafe. Otherwise, the conversion is safe.
 func (t *OutputType) ConversionFrom(src Type) ConversionKind {
 	return t.conversionFrom(src, false)
 }
@@ -89,10 +89,7 @@ func (t *OutputType) conversionFrom(src Type, unifying bool) ConversionKind {
 }
 
 func (t *OutputType) String() string {
-	if t.s == "" {
-		t.s = fmt.Sprintf("output(%v)", t.ElementType)
-	}
-	return t.s
+	return fmt.Sprintf("output(%v)", t.ElementType)
 }
 
 func (t *OutputType) unify(other Type) (Type, ConversionKind) {

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -34,17 +34,9 @@ type TupleType struct {
 	s            string
 }
 
-// The set of tuple types, indexed by string representation.
-var tupleTypes = map[string]*TupleType{}
-
 // NewTupleType creates a new tuple type with the given element types.
 func NewTupleType(elementTypes ...Type) Type {
-	t := &TupleType{ElementTypes: elementTypes}
-	if t, ok := tupleTypes[t.String()]; ok {
-		return t
-	}
-	tupleTypes[t.String()] = t
-	return t
+	return &TupleType{ElementTypes: elementTypes}
 }
 
 // SyntaxNode returns the syntax node for the type. This is always syntax.None.
@@ -75,6 +67,26 @@ func (t *TupleType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnost
 		return DynamicType, hcl.Diagnostics{tupleIndexOutOfRange(len(t.ElementTypes), traverser.SourceRange())}
 	}
 	return t.ElementTypes[int(elementIndex)], nil
+}
+
+// Equals returns true if this type has the same identity as the given type.
+func (t *TupleType) Equals(other Type) bool {
+	if t == other {
+		return true
+	}
+	otherTuple, ok := other.(*TupleType)
+	if !ok {
+		return false
+	}
+	if len(t.ElementTypes) != len(otherTuple.ElementTypes) {
+		return false
+	}
+	for i, t := range t.ElementTypes {
+		if !t.Equals(otherTuple.ElementTypes[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type..

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -205,8 +205,7 @@ func requiresAsyncMain(r *hcl2.Resource) bool {
 		return false
 	}
 
-	t := r.Options.Range.Type()
-	return model.ResolveOutputs(t) != t
+	return model.ContainsPromises(r.Options.Range.Type())
 }
 
 // resourceTypeName computes the NodeJS package, module, and type name for the given resource.

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -109,6 +109,7 @@ github.com/aws/aws-sdk-go v1.30.7 h1:IaXfqtioP6p9SFAnNfsqdNczbR5UNbYqvcZUSsCAdTY
 github.com/aws/aws-sdk-go v1.30.7/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
@@ -272,6 +273,7 @@ github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.1.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -350,6 +352,7 @@ github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b h1:j7+1HpAFS1zy5+Q4qx1fWh90gTKwiN4QCGoY9TWyyO4=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mitchellh/cli v1.0.0 h1:iGBIsUe3+HZ/AD/Vd7DErOt5sU9fa8Uj7A2s1aggv1Y=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
@@ -359,6 +362,7 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/go-testing-interface v1.0.0 h1:fzU/JVNcaqHQEcVFAKeR41fkiLdIPrefOvVG1VZ96U0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mitchellh/go-wordwrap v1.0.0 h1:6GlHJ/LTGMrIJbwgdqdl2eEH8o+Exx/0m8ir9Gns0u4=
@@ -433,6 +437,7 @@ github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EE
 github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=


### PR DESCRIPTION
These caches caused memory leaks in programs that instantiated large
numbers of ephemeral types (e.g. `tfgen`). Type equality checks should
now be done via `Type.Equals`. Sets of types should use `Type.String` as
a key.