### PR TITLE
Support secret default values in schema and codegen

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -447,6 +447,9 @@ func (pt *plainType) genInputType(w io.Writer, level int) error {
 				return err
 			}
 			propertyName := pt.mod.propertyName(prop)
+			if prop.DefaultValue.Secret {
+				dv = fmt.Sprintf("Output.CreateSecret(%s)", dv)
+			}
 			fmt.Fprintf(w, "%s        %s = %s;\n", indent, propertyName, dv)
 		}
 	}

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -716,8 +716,14 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource) error {
 				t = "pulumi.Any"
 			}
 
+			if p.DefaultValue.Secret {
+				v = fmt.Sprintf("pulumi.ToSecret(%s).(%s)", v, pkg.outputType(p.Type, false))
+			} else {
+				v = fmt.Sprintf("%s(%s)", t, v)
+			}
+
 			fmt.Fprintf(w, "\tif args.%s == nil {\n", Title(p.Name))
-			fmt.Fprintf(w, "\t\targs.%s = %s(%s)\n", Title(p.Name), t, v)
+			fmt.Fprintf(w, "\t\targs.%s = %s\n", Title(p.Name), v)
 			fmt.Fprintf(w, "\t}\n")
 		}
 	}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -532,6 +532,9 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 					return err
 				}
 				arg = fmt.Sprintf("(%s) || %s", arg, dv)
+				if prop.DefaultValue.Secret {
+					arg = fmt.Sprintf("pulumi.secret(%s)", arg)
+				}
 			}
 
 			// provider properties must be marshaled as JSON strings.

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -415,6 +415,9 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 			if err != nil {
 				return "", err
 			}
+			if prop.DefaultValue.Secret {
+				dv = fmt.Sprintf("Output.secret(%s)", dv)
+			}
 			fmt.Fprintf(w, "            if %s is None:\n", pname)
 			fmt.Fprintf(w, "                %s = %s\n", pname, dv)
 		}

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -197,6 +197,8 @@ type DefaultValue struct {
 	Value interface{}
 	// Environment specifies a set of environment variables to probe for a default value.
 	Environment []string
+	// Secret specifies whether the default value is a secret value
+	Secret bool
 	// Language specifies additional language-specific data about the default value.
 	Language map[string]interface{}
 }
@@ -550,6 +552,8 @@ type TypeSpec struct {
 type DefaultSpec struct {
 	// Environment specifies a set of environment variables to probe for a default value.
 	Environment []string `json:"environment,omitempty"`
+	// Secret specifies whether the default value is a secret value
+	Secret bool `json:"secret,omitempty"`
 	// Language specifies additional language-specific data about the default value.
 	Language map[string]json.RawMessage `json:"language,omitempty"`
 }
@@ -974,7 +978,7 @@ func bindDefaultValue(value interface{}, spec *DefaultSpec, typ Type) (*DefaultV
 			language[name] = raw
 		}
 
-		dv.Environment, dv.Language = spec.Environment, language
+		dv.Environment, dv.Language, dv.Secret = spec.Environment, language, spec.Secret
 	}
 	return dv, nil
 }


### PR DESCRIPTION
Currently, the secretness is only applied to default values used as input values for resources.  It is not applied to the defaults expoed in the `config` modules.  Doing the latter may also be desired - but (a) it would be a breaking change as the types would need to change from primitives to Outputs and (b) users can always manually wrap value retreived from this module with `pulumi.secret` if desired (a choice they do not have for the default resource inputs case).

Part of pulumi/pulumi-azure#576.