### PR TITLE
Convert primitive types in C# program gen

### DIFF
--- a/pkg/codegen/hcl2/rewrite_convert_test.go
+++ b/pkg/codegen/hcl2/rewrite_convert_test.go
@@ -18,7 +18,7 @@ func TestRewriteConversions(t *testing.T) {
 	}{
 		{
 			input:  `"1" + 2`,
-			output: `__convert("1") + 2`,
+			output: `1 + 2`,
 		},
 		{
 			input:  `{a: "b"}`,
@@ -50,7 +50,7 @@ func TestRewriteConversions(t *testing.T) {
 		},
 		{
 			input:  `{a: "1" + 2}`,
-			output: `{a: __convert( "1") + 2}`,
+			output: `{a: 1 + 2}`,
 			to: model.NewObjectType(map[string]model.Type{
 				"a": model.NumberType,
 			}),
@@ -78,7 +78,7 @@ func TestRewriteConversions(t *testing.T) {
 		},
 		{
 			input:  `!"true"`,
-			output: `!__convert("true")`,
+			output: `!true`,
 			to:     model.BoolType,
 		},
 		{


### PR DESCRIPTION
TF examples aren't particularly consistent about using correct primitive types in property assignments. So, a property of type `integer` (e.g. `Port`) may get a `string` value (e.g. `"443"`), or vice versa. AWS examples have instances of these inconsistencies for bool, double, int to string and back.

This PR adds conversions between these primitive types to generated C# programs, either by converting a literal in place (the most common case), or adding a conversion call.