### PR TITLE
Add support for publishing/downloading policy packs to/from a service-managed local filesystem

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pulumi/pulumi/pkg/v2/backend/policypack"
 	"io"
 	"net/http"
 	"path"
@@ -31,6 +30,7 @@ import (
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 
+	"github.com/pulumi/pulumi/pkg/v2/backend/policypack"
 	"github.com/pulumi/pulumi/pkg/v2/engine"
 	"github.com/pulumi/pulumi/pkg/v2/util/validation"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"

--- a/pkg/backend/policypack.go
+++ b/pkg/backend/policypack.go
@@ -62,3 +62,5 @@ type PolicyPack interface {
 	// all Policy Groups before it can be removed.
 	Remove(ctx context.Context, op PolicyPackOperation) error
 }
+
+

--- a/pkg/backend/policypack/store.go
+++ b/pkg/backend/policypack/store.go
@@ -1,0 +1,107 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package policypack
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	schemeFile  = "file://"
+	schemeHTTPS = "https://"
+)
+
+func publishLocal(url string, archive io.Reader) error {
+	path := url
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return errors.Wrapf(err, "MkdirAll failed for path '%s'", path)
+	}
+
+	f, err := os.OpenFile(path, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return errors.Wrapf(err, "Open failed for path '%s'", path)
+	}
+	defer contract.IgnoreClose(f)
+
+	_, uploadErr := io.Copy(f, archive)
+	return uploadErr
+}
+
+func publishRemote(url string, archive io.Reader) error {
+	putS3Req, err := http.NewRequest(http.MethodPut, url, archive)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to upload compressed PolicyPack")
+	}
+
+	_, uploadErr := http.DefaultClient.Do(putS3Req)
+	return uploadErr
+}
+
+// Publish publishes the provided archive to the URI based on the scheme.
+// Currently supported schemes include https:// and file://.
+func Publish(ctx context.Context, url string, archive io.Reader) error {
+	var err error
+	switch {
+	case strings.HasPrefix(url, schemeHTTPS):
+		err = publishRemote(url, archive)
+	case strings.HasPrefix(url, schemeFile), strings.HasPrefix(url, "/"):
+		err = publishLocal(url, archive)
+	default:
+		return errors.Errorf("unknown scheme found in URL %v", url)
+	}
+	return err
+}
+
+func downloadRemoteFile(url string) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to download compressed PolicyPack")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to download compressed PolicyPack")
+	}
+	defer resp.Body.Close()
+
+	tarball, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Failed to download compressed PolicyPack")
+	}
+
+	return tarball, nil
+}
+
+func Download(ctx context.Context, url string) ([]byte, error) {
+	var b []byte
+	var err error
+	switch {
+	case strings.HasPrefix(url, schemeHTTPS):
+		b, err = downloadRemoteFile(url)
+	case strings.HasPrefix(url, schemeFile), strings.HasPrefix(url, "/"):
+		b, err = ioutil.ReadFile(url)
+	default:
+		return nil, errors.Errorf("unknown scheme found in URL %v", url)
+	}
+	return b, err
+}


### PR DESCRIPTION
I was working on something unrelated and needed this functionality, so I implemented this for my own sake since it wasn't too much work. This could be useful for [self-hosted](https://www.pulumi.com/docs/guides/self-hosted/) installations of Pulumi Service that uses an NAS for its object store. 

Creating this as a draft PR because I am happy to help get this PR to its final state, if need be, or defer to someone else who might want to take this over. Just thought this might be useful for someone else working on this to reuse any part of this, if they want to.

I am not sure how helpful these console output statements are, but here they are:

### Publishing the policy pack
```
➜  policy-playground /opt/pulumi/bin/pulumi policy publish saml-org
Obtaining policy metadata from policy plugin
Compressing policy pack
Uploading policy pack to Pulumi service
Publishing "aws-typescript" - version 0.0.3 to "saml-org"

Permalink: http://localhost:3000/saml-org/policypacks/aws-typescript/0.0.3
```

### Running a simple Pulumi app with the policy applied to the default group
```
➜  policy-playground-2 pulumi policy ls saml-org
NAME            VERSIONS
aws-typescript  0.0.3

➜  policy-playground-2 pulumi whoami -v         
User: praneetloke
Backend URL: http://localhost:3000/praneetloke

➜  policy-playground-2 AWS_PROFILE=pulumi-dev-sandbox /opt/pulumi/bin/pulumi preview
Previewing update (saml-org/dev):
Installing policy pack aws-typescript 0.0.3...
[resource plugin aws-2.5.0] installing
Finished installing policy pack

     Type                 Name                     Plan       
 +   pulumi:pulumi:Stack  policy-playground-2-dev  create     
 +   └─ aws:s3:Bucket     my-bucket                create     
 
Policy Violations:
    [advisory]  aws-typescript v0.0.3  s3-no-public-read (my-bucket: aws:s3/bucket:Bucket)
    Prohibits setting the publicRead or publicReadWrite permission on AWS S3 buckets.
    You cannot set public-read or public-read-write on an S3 bucket. Read more about ACLs here: https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html
    
Permalink: http://localhost:3000/saml-org/policy-playground-2/dev/previews/e25e6748-3bd2-43de-91e6-ad3598a7959c
```

The `saml-org` in the output above is in my instance of self-hosted Pulumi Service.