### PR TITLE
Download plugins from get.pulumi.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ CHANGELOG
 - Add support for publishing Python policy packs.
   [#4644](https://github.com/pulumi/pulumi/pull/4644)
 
+- Improve download perf by fetching plugins from a CDN.
+  [#4692](https://github.com/pulumi/pulumi/pull/4692)
+
 ## 2.2.1 (2020-05-13)
 - Add new brew target to fix homebrew builds
  [#4633](https://github.com/pulumi/pulumi/pull/4633)

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -193,9 +193,9 @@ func (info PluginInfo) Download() (io.ReadCloser, int64, error) {
 	if serverURL == "" {
 		serverURL = "https://get.pulumi.com/releases/plugins"
 	}
+	serverURL = strings.TrimSuffix(serverURL, "/")
 
 	endpoint := fmt.Sprintf("%s/pulumi-%s-%s-v%s-%s-%s.tar.gz", serverURL, info.Kind, info.Name, info.Version, os, arch)
-	endpoint = strings.ReplaceAll(endpoint, "//", "/")
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, -1, err

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"runtime"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/blang/semver"
@@ -190,10 +191,11 @@ func (info PluginInfo) Download() (io.ReadCloser, int64, error) {
 	// is hosted by Pulumi.
 	serverURL := info.ServerURL
 	if serverURL == "" {
-		serverURL = "https://api.pulumi.com/releases/plugins"
+		serverURL = "https://get.pulumi.com/releases/plugins"
 	}
 
 	endpoint := fmt.Sprintf("%s/pulumi-%s-%s-v%s-%s-%s.tar.gz", serverURL, info.Kind, info.Name, info.Version, os, arch)
+	endpoint = strings.ReplaceAll(endpoint, "//", "/")
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
 		return nil, -1, err


### PR DESCRIPTION
Switch to downloading plugins from https://get.pulumi.com, instead of https://api.pulumi.com. Also remove the long-since deprecated `--cloud-url` flag to `pulumi plugin install`.

Part of https://github.com/pulumi/pulumi-service/issues/3068.

## Download plugins from https://get.pulumi.com

https://get.pulumi.com is served by a CDN, whereas https://api.pulumi.com is generally located in the US West. So switching to download plugins from https://get.pulumi.com should lead to a substantial improvement in download speeds for clients outside of the US.

https://api.pulumi.com will continue to serve plugins for backwards compatibility, though by returning a 301 redirect to https://get.pulumi.com. (Which the Golang HTTP client will honor by default.)

It's possible that this could lead to problems for newer CLIs however, if for some reason there is a plugin that isn't available from https://get.pulumi.com that was available to https://api.pulumi.com. (As there are different underlying S3 buckets they serve from.) However, at this point we've (1) updated all of our resource provider repos to publish plugins to both locations and (2) copied all existing plugins from the older bucket to the newer bucket. So I believe it is the case that https://get.pulumi.com will have everything.

## Removing old flag

Technically this is a breaking change, but I'm inclined to believe it is safe. (But please push back if you think it's a bad idea.)

We replaced the `--cloud-url` flag with `--server` in May, 2019. And at that time hid it from our generated documentation, and issued a warning if you used `--cloud-url` instead of `--server`.
https://github.com/pulumi/pulumi/commit/917f3738c54288f4fc770de83b736ff920bc9d9b

That commit appears to have been first shipped in v0.17.15, before v1.0 or v2.0 earlier this year. And the entire time it hasn't been displayed in `pulumi plugin install --help` nor our [documentation](https://www.pulumi.com/docs/reference/cli/pulumi_plugin_install/). So while I cannot confirm it "isn't used by anyone, ever" I think it's a reasonably safe assumption.

