### PR TITLE
Add F# operators for InputUnion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Add F# operators for InputUnion.
+ [#4699](https://github.com/pulumi/pulumi/pull/4699)
+
 - Add support for untagged outputs in Go SDK.
  [#4640](https://github.com/pulumi/pulumi/pull/4640)
 

--- a/sdk/dotnet/Pulumi.FSharp/Library.fs
+++ b/sdk/dotnet/Pulumi.FSharp/Library.fs
@@ -33,6 +33,17 @@ module Ops =
             result.Add item
         result
 
+    /// <summary>
+    /// Wraps a raw value for the first type into an <see cref="InputUnion{'a,'b}" />.
+    /// </summary>
+    let inputUnion1Of2<'a, 'b> (valA: 'a) = InputUnion<'a, 'b>.op_Implicit(valA)
+
+    /// <summary>
+    /// Wraps a raw value for the second type into an <see cref="InputUnion{'a,'b}" />.
+    /// </summary>
+    let inputUnion2Of2<'a, 'b> (valB: 'b) = InputUnion<'a, 'b>.op_Implicit(valB)
+
+
 /// <summary>
 /// Pulumi deployment functions.
 /// </summary>


### PR DESCRIPTION
Having to write `InputUnion.op_Implicit(80)` to create an `InputUnion` isn't very nice in F#, added operators so you should be able to write write:

```
let x: InputUnion<int, string> = inputUnion1Of1 80
let y: InputUnion<int, string> = inputUnion2Of2 "hello world"
```