### PR TITLE
Don't run container tests

### DIFF
--- a/scripts/publish_packages.sh
+++ b/scripts/publish_packages.sh
@@ -65,7 +65,7 @@ if [[ "${TRAVIS_PUBLISH_PACKAGES:-}" == "true" ]]; then
         -exec dotnet nuget push -k ${NUGET_PUBLISH_KEY} -s https://api.nuget.org/v3/index.json {} ';'
 
     echo "Publishing Docker containers to hub.docker.com:"
-    "${ROOT}/scripts/build-docker.sh" "${NPM_VERSION}" --publish --test
+    "${ROOT}/scripts/build-docker.sh" "${NPM_VERSION}" --publish
 
     echo "Building package docs:"
     "$(go env GOPATH)/src/github.com/pulumi/scripts/ci/build-package-docs.sh" pulumi


### PR DESCRIPTION
Don't run the container runtime tests during the publish step, since they still aren't reliable.