### PR TITLE
Fix NodeJS codegen to handle recursive types

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -979,7 +979,7 @@ func bindDefaultValue(value interface{}, spec *DefaultSpec, typ Type) (*DefaultV
 	return dv, nil
 }
 
-// bindProperties binds the map of property specs and list of required properties into a sorted list of peroperties and
+// bindProperties binds the map of property specs and list of required properties into a sorted list of properties and
 // a lookup table.
 func (t *types) bindProperties(properties map[string]PropertySpec,
 	required []string) ([]*Property, map[string]*Property, error) {


### PR DESCRIPTION
Track the input/output types that have been encountered
and don't recurse into previously seen types.