### PR TITLE
Only generate top-level README in NodeJS packages

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -962,24 +962,26 @@ func (mod *modContext) gen(fs fs) error {
 		fs.add(p, []byte(contents))
 	}
 
-	// Ensure that the target module directory contains a README.md file.
-	readme := mod.pkg.Language["nodejs"].(NodePackageInfo).Readme
-	if readme == "" {
-		readme = mod.pkg.Description
+	// Ensure that the top-level (provider) module directory contains a README.md file.
+	if mod.mod == "" {
+		readme := mod.pkg.Language["nodejs"].(NodePackageInfo).Readme
+		if readme == "" {
+			readme = mod.pkg.Description
+			if readme != "" && readme[len(readme)-1] != '\n' {
+				readme += "\n"
+			}
+			if mod.pkg.Attribution != "" {
+				if len(readme) != 0 {
+					readme += "\n"
+				}
+				readme += mod.pkg.Attribution
+			}
+		}
 		if readme != "" && readme[len(readme)-1] != '\n' {
 			readme += "\n"
 		}
-		if mod.pkg.Attribution != "" {
-			if len(readme) != 0 {
-				readme += "\n"
-			}
-			readme += mod.pkg.Attribution
-		}
+		fs.add(path.Join(mod.mod, "README.md"), []byte(readme))
 	}
-	if readme != "" && readme[len(readme)-1] != '\n' {
-		readme += "\n"
-	}
-	fs.add(path.Join(mod.mod, "README.md"), []byte(readme))
 
 	// Utilities, config
 	switch mod.mod {


### PR DESCRIPTION
Related to https://github.com/pulumi/pulumi-kubernetes/issues/1053