### PR TITLE
improve dev version detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+- Improve dev version detection logic
+ [#4732](https://github.com/pulumi/pulumi/pull/4732)
 
 ---
 

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -501,7 +502,8 @@ func isDevVersion(s semver.Version) bool {
 		return false
 	}
 
-	return !s.Pre[0].IsNum && strings.HasPrefix("dev", s.Pre[0].VersionStr)
+	devStrings := regexp.MustCompile(`alpha|beta|dev|rc`)
+	return !s.Pre[0].IsNum && devStrings.MatchString(s.Pre[0].VersionStr)
 }
 
 func confirmPrompt(prompt string, name string, opts display.Options) bool {

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -1,0 +1,35 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsDevVersion(t *testing.T) {
+
+	// This function primarily focuses on the "Pre" section of the semver string
+	// So we'll focus on testing that
+	stableVer, _ := semver.ParseTolerant("1.0.0")
+	devVer, _ := semver.ParseTolerant("v1.0.0-dev")
+	alphaVer, _ := semver.ParseTolerant("v1.0.0-alpha.1590772212+g4ff08363.dirty")
+
+	assert.False(t, isDevVersion(stableVer))
+	assert.True(t, isDevVersion(devVer))
+	assert.True(t, isDevVersion(alphaVer))
+
+}

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -22,8 +22,8 @@ import (
 
 func TestIsDevVersion(t *testing.T) {
 
-	// This function primarily focuses on the "Pre" section of the semver string
-	// So we'll focus on testing that
+	// This function primarily focuses on the "Pre" section of the semver string,
+	// so we'll focus on testing that.
 	stableVer, _ := semver.ParseTolerant("1.0.0")
 	devVer, _ := semver.ParseTolerant("v1.0.0-dev")
 	alphaVer, _ := semver.ParseTolerant("v1.0.0-alpha.1590772212+g4ff08363.dirty")

--- a/pkg/cmd/pulumi/pulumi_test.go
+++ b/pkg/cmd/pulumi/pulumi_test.go
@@ -27,9 +27,13 @@ func TestIsDevVersion(t *testing.T) {
 	stableVer, _ := semver.ParseTolerant("1.0.0")
 	devVer, _ := semver.ParseTolerant("v1.0.0-dev")
 	alphaVer, _ := semver.ParseTolerant("v1.0.0-alpha.1590772212+g4ff08363.dirty")
+	betaVer, _ := semver.ParseTolerant("v1.0.0-beta.1590772212")
+	rcVer, _ := semver.ParseTolerant("v1.0.0-rc.1")
 
 	assert.False(t, isDevVersion(stableVer))
 	assert.True(t, isDevVersion(devVer))
 	assert.True(t, isDevVersion(alphaVer))
+	assert.True(t, isDevVersion(betaVer))
+	assert.True(t, isDevVersion(rcVer))
 
 }


### PR DESCRIPTION
Currently the `isDevVersion` function only tests for "dev" versions.
When installing pulumi from Homebrew with the `--HEAD` flag we get an
alpha version locally. This can mean the user gets the upgrade prompt
when it's not valid.

This change changes the logic to check against a regex for all the
possible semver `pre` versions.

It also adds a unit test to ensure we're getting the right result