### PR TITLE
[codegen/nodejs/sdk] Split required {in,out}puts.

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -688,8 +688,33 @@ func visitObjectTypes(t schema.Type, visitor func(*schema.ObjectType), seen code
 }
 
 func (mod *modContext) genType(w io.Writer, obj *schema.ObjectType, input bool, level int) {
+	properties := obj.Properties
+	info, hasInfo := obj.Language["nodejs"]
+	if hasInfo {
+		var requiredProperties []string
+		if input {
+			requiredProperties = info.(NodeObjectInfo).RequiredInputs
+		} else {
+			requiredProperties = info.(NodeObjectInfo).RequiredOutputs
+		}
+
+		if requiredProperties != nil {
+			required := codegen.StringSet{}
+			for _, name := range requiredProperties {
+				required.Add(name)
+			}
+
+			properties = make([]*schema.Property, len(obj.Properties))
+			for i, p := range obj.Properties {
+				copy := *p
+				properties[i] = &copy
+				properties[i].IsRequired = required.Has(p.Name)
+			}
+		}
+	}
+
 	wrapInput := input && !mod.details(obj).functionType
-	mod.genPlainType(w, tokenToName(obj.Token), obj.Comment, obj.Properties, input, wrapInput, false, level)
+	mod.genPlainType(w, tokenToName(obj.Token), obj.Comment, properties, input, wrapInput, false, level)
 }
 
 func (mod *modContext) getTypeImports(t schema.Type, recurse bool, imports map[string]codegen.StringSet, seen codegen.Set) bool {

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -20,7 +20,10 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 )
 
-// NodePackageInfo contains NodeJS specific overrides for a package.
+// Compatibility mode for Kubernetes 2.0 SDK
+const kubernetes20 = "kubernetes20"
+
+// NodePackageInfo contains NodeJS-specific information for a package.
 type NodePackageInfo struct {
 	// Custom name for the NPM package.
 	PackageName string `json:"packageName,omitempty"`
@@ -44,8 +47,13 @@ type NodePackageInfo struct {
 	Compatibility string `json:"compatibility,omitempty"`
 }
 
-// Compatibility mode for Kubernetes 2.0 SDK
-const kubernetes20 = "kubernetes20"
+// NodeObjectInfo contains NodeJS-specific information for an object.
+type NodeObjectInfo struct {
+	// List of properties that are required on the input side of a type.
+	RequiredInputs []string `json:"requiredInputs"`
+	// List of properties that are required on the output side of a type.
+	RequiredOutputs []string `json:"requiredOutputs"`
+}
 
 // Importer implements schema.Language for NodeJS.
 var Importer schema.Language = importer(0)
@@ -64,7 +72,11 @@ func (importer) ImportPropertySpec(property *schema.Property, raw json.RawMessag
 
 // ImportObjectTypeSpec decodes language-specific metadata associated with a ObjectType.
 func (importer) ImportObjectTypeSpec(object *schema.ObjectType, raw json.RawMessage) (interface{}, error) {
-	return raw, nil
+	var info NodeObjectInfo
+	if err := json.Unmarshal([]byte(raw), &info); err != nil {
+		return nil, err
+	}
+	return info, nil
 }
 
 // ImportResourceSpec decodes language-specific metadata associated with a Resource.

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/Sirupsen/logrus v1.0.5 // indirect
 	github.com/aws/aws-sdk-go v1.30.7
 	github.com/blang/semver v3.5.1+incompatible
-	github.com/davecgh/go-spew v1.1.1
 	github.com/djherbis/times v1.2.0
 	github.com/docker/docker v0.0.0-20170504205632-89658bed64c2
 	github.com/dustin/go-humanize v1.0.0

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Sirupsen/logrus v1.0.5 // indirect
 	github.com/aws/aws-sdk-go v1.30.7
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/davecgh/go-spew v1.1.1
 	github.com/djherbis/times v1.2.0
 	github.com/docker/docker v0.0.0-20170504205632-89658bed64c2
 	github.com/dustin/go-humanize v1.0.0


### PR DESCRIPTION
These changes are necessary in order to move tfgen over to the schema
code generator.

The schema generator for tfgen has an annoying behavior for nested types
in which it does not separate input and output types. Worse, the shape
of the type that results from a collision of input and output types is
order-dependent: whichever of the two was observed last wins (note that
the shape is still determenistic, as the order in which types are
recorded is always the same). As a result, the NodeJS code generator
needs to know the set of required properties for the other aspect of the
type in order to generate proper code.

Contributes to
https://github.com/pulumi/pulumi-terraform-bridge/issues/179.