### PR TITLE
[codegen/nodejs] Refactor GeneratePackage method

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1305,8 +1305,8 @@ func genTypeScriptProjectFile(info NodePackageInfo, files fs) string {
 	return w.String()
 }
 
-// generatePackageContextMap groups resources, types, and functions into NodeJS packages.
-func generatePackageContextMap(tool string, pkg *schema.Package, info NodePackageInfo) (map[string]*modContext, error) {
+// generateModuleContextMap groups resources, types, and functions into NodeJS packages.
+func generateModuleContextMap(tool string, pkg *schema.Package, info NodePackageInfo) (map[string]*modContext, error) {
 	// group resources, types, and functions into NodeJS packages
 	modules := map[string]*modContext{}
 
@@ -1444,7 +1444,7 @@ func LanguageResources(tool string, pkg *schema.Package) (map[string]LanguageRes
 	}
 	info, _ := pkg.Language["nodejs"].(NodePackageInfo)
 
-	modules, err := generatePackageContextMap(tool, pkg, info)
+	modules, err := generateModuleContextMap(tool, pkg, info)
 	if err != nil {
 		return nil, err
 	}
@@ -1485,7 +1485,7 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 	}
 	info, _ := pkg.Language["nodejs"].(NodePackageInfo)
 
-	modules, err := generatePackageContextMap(tool, pkg, info)
+	modules, err := generateModuleContextMap(tool, pkg, info)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1436,7 +1436,7 @@ type LanguageProperty struct {
 
 // LanguageResources returns a map of resources that can be used by downstream codegen. The map
 // key is the resource schema token.
-func LanguageResources(tool string, pkg *schema.Package) (map[string]LanguageResource, error) {
+func LanguageResources(pkg *schema.Package) (map[string]LanguageResource, error) {
 	resources := map[string]LanguageResource{}
 
 	if err := pkg.ImportLanguages(map[string]schema.Language{"nodejs": Importer}); err != nil {
@@ -1444,15 +1444,12 @@ func LanguageResources(tool string, pkg *schema.Package) (map[string]LanguageRes
 	}
 	info, _ := pkg.Language["nodejs"].(NodePackageInfo)
 
-	modules, err := generateModuleContextMap(tool, pkg, info)
+	modules, err := generateModuleContextMap("", pkg, info)
 	if err != nil {
 		return nil, err
 	}
 
 	for modName, mod := range modules {
-		if modName == "" {
-			continue
-		}
 		for _, r := range mod.resources {
 			packagePath := strings.Replace(modName, "/", ".", -1)
 			lr := LanguageResource{


### PR DESCRIPTION
- Split out common functionality into generateModuleContextMap method
- Add LanguageResource and LanguageProperty structs for use by downstream
codegen tools
- Add LanguageResources function for use by downstream codegen tools

Related to https://github.com/pulumi/pulumi-kubernetes/issues/1053