### PR TITLE
[codegen/schema] Support default union types.

### DIFF
--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -170,3 +170,36 @@ jobs:
           use-provider-dir: true
           pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
           github-actions-token: ${{ secrets.GITHUB_TOKEN }}
+
+  downstream-kubernetes:
+    name: Test Kubernetes Downstream
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14.x
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.6.10
+      - name: Install Pulumi CLI
+        uses: pulumi/action-install-pulumi-cli@releases/v1
+
+      - name: Check out source code
+        uses: actions/checkout@master
+      - name: Test Downstream
+        uses: pulumi/action-test-provider-downstream@releases/v4
+        env:
+          GOPROXY: "https://proxy.golang.org"
+        with:
+          replacements: github.com/pulumi/pulumi/pkg/v2=pulumi/pkg,github.com/pulumi/pulumi/sdk/v2=pulumi/sdk
+          downstream-name: pulumi-kubernetes
+          downstream-url: https://github.com/pulumi/pulumi-kubernetes
+          use-provider-dir: true
+          pulumi-bot-token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          github-actions-token: ${{ secrets.GITHUB_TOKEN }}

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -45,6 +45,8 @@ type NodePackageInfo struct {
 	ModuleToPackage map[string]string `json:"moduleToPackage,omitempty"`
 	// Toggle compatibility mode for a specified target.
 	Compatibility string `json:"compatibility,omitempty"`
+	// Disable support for unions in output types.
+	DisableUnionOutputTypes bool `json:"disableUnionOutputTypes,omitempty"`
 }
 
 // NodeObjectInfo contains NodeJS-specific information for an object.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -53,6 +53,7 @@ const (
 	jsonType    primitiveType = 8
 )
 
+//nolint: goconst
 func (t primitiveType) String() string {
 	switch t {
 	case boolType:


### PR DESCRIPTION
Add support for union types that indicate a default type for targets
that do not support unions, or do not support unions in certain
positions (e.g. output properties). The NodeJS backend makes use of this
in combination with a new flag, `disableUnionOutputTypes`, to avoid
generating unions in output types.

These changes also refactor the various module ->
package/module/namespace mapping methods so that these entities can be
fetched by their language name rather than their token.