### PR TITLE
Export the CustomTimeouts class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 - Improve dev version detection logic
  [#4732](https://github.com/pulumi/pulumi/pull/4732)
 
+- Export `CustomTimeouts` in the Python SDK
+ [#4747](https://github.com/pulumi/pulumi/pull/4747)
+
 ---
 
 ## 2.3.0 (2020-05-27)

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -56,6 +56,7 @@ from .resource import (
     Alias,
     Resource,
     CustomResource,
+    CustomTimeouts,
     ComponentResource,
     ProviderResource,
     ResourceOptions,

--- a/tests/integration/custom_timeouts/python/failure/__main__.py
+++ b/tests/integration/custom_timeouts/python/failure/__main__.py
@@ -1,7 +1,6 @@
 # Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
 
-from pulumi import ComponentResource, Resource, ResourceOptions
-from pulumi.resource import CustomTimeouts
+from pulumi import ComponentResource, CustomTimeouts, Resource, ResourceOptions
 
 class Resource1(ComponentResource):
     def __init__(self, name, opts=None):

--- a/tests/integration/custom_timeouts/python/success/__main__.py
+++ b/tests/integration/custom_timeouts/python/success/__main__.py
@@ -1,7 +1,6 @@
 # Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
 
-from pulumi import ComponentResource, Resource, ResourceOptions
-from pulumi.resource import CustomTimeouts
+from pulumi import ComponentResource, CustomTimeouts, Resource, ResourceOptions
 
 class Resource1(ComponentResource):
     def __init__(self, name, opts=None):


### PR DESCRIPTION
This class was available in the pulumi.resource module, but was not exported from the core `pulumi` module as intended for all public APIs at this level.