### PR TITLE
Add GitHub Actions detection and update the Pulumi CI escape hatch with more CI vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ CHANGELOG
 
 - Export `CustomTimeouts` in the Python SDK
  [#4747](https://github.com/pulumi/pulumi/pull/4747)
+ 
+- Add GitHub Actions CI detection
+ [#4758](https://github.com/pulumi/pulumi/pull/4758)
 
 - Allow users to specify base64 encoded strings as GOOGLE_CREDENTIALS
  [#4773](https://github.com/pulumi/pulumi/pull/4773)

--- a/sdk/go/common/util/ciutil/detect.go
+++ b/sdk/go/common/util/ciutil/detect.go
@@ -84,9 +84,11 @@ var detectors = map[SystemName]system{
 		},
 	},
 
-	GitHub: baseCI{
-		Name:            GitHub,
-		EnvVarsToDetect: []string{"GITHUB_WORKFLOW"},
+	GitHubActions: githubActionsCI{
+		baseCI{
+			Name:            GitHubActions,
+			EnvVarsToDetect: []string{"GITHUB_ACTIONS"},
+		},
 	},
 	GitLab: gitlabCI{
 		baseCI: baseCI{

--- a/sdk/go/common/util/ciutil/generic.go
+++ b/sdk/go/common/util/ciutil/generic.go
@@ -30,9 +30,13 @@ type genericCICI struct {
 func (g genericCICI) DetectVars() Vars {
 	v := Vars{}
 	v.Name = SystemName(os.Getenv("PULUMI_CI_SYSTEM"))
+	v.BranchName = os.Getenv("PULUMI_CI_BRANCH_NAME")
 	v.BuildID = os.Getenv("PULUMI_CI_BUILD_ID")
+	v.BuildNumber = os.Getenv("PULUMI_CI_BUILD_NUMBER")
 	v.BuildType = os.Getenv("PULUMI_CI_BUILD_TYPE")
 	v.BuildURL = os.Getenv("PULUMI_CI_BUILD_URL")
+	v.CommitMessage = os.Getenv("PULUMI_COMMIT_MESSAGE")
+	v.PRNumber = os.Getenv("PULUMI_PR_NUMBER")
 	v.SHA = os.Getenv("PULUMI_CI_PULL_REQUEST_SHA")
 
 	return v

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -1,0 +1,69 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ciutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// githubActionsCI represents the GitHub Actions CI system.
+type githubActionsCI struct {
+	baseCI
+}
+
+// githubPR represents the `pull_request` payload posted by GitHub to trigger
+// workflows for PRs. Note that this is only a partial representation as we
+// don't need anything other than the PR number.
+// See https://developer.github.com/webhooks/event-payloads/#pull_request.
+type githubPR struct {
+	Action string `json:"action"`
+	Number string `json:"number"`
+}
+
+// githubActionsPullRequestEvent represents the webhook payload for a pull_request event.
+// https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
+type githubActionsPullRequestEvent struct {
+	PullRequest githubPR `json:"pull_request"`
+}
+
+// DetectVars detects the Travis env vars.
+// See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables.
+func (t githubActionsCI) DetectVars() Vars {
+	v := Vars{Name: GitHubActions}
+	v.BuildID = os.Getenv("GITHUB_RUN_ID")
+	v.BuildNumber = os.Getenv("GITHUB_RUN_NUMBER")
+	v.BuildType = os.Getenv("GITHUB_EVENT_NAME")
+	v.SHA = os.Getenv("GITHUB_SHA")
+	v.BranchName = os.Getenv("GITHUB_REF")
+	repoSlug := os.Getenv("GITHUB_REPOSITORY")
+	if repoSlug != "" && v.BuildID != "" {
+		v.BuildURL = fmt.Sprintf("https://github.com/%s/actions/runs/%s", repoSlug, v.BuildID)
+	}
+
+	// Try to use the pull_request webhook payload to extract the PR number.
+	// For Pull Requests, GitHub stores the payload of the webhook that triggered the
+	// workflow in a path. The path is identified by GITHUB_EVENT_PATH.
+	if v.BuildType == "pull_request" {
+		eventPath := os.Getenv("GITHUB_EVENT_PATH")
+		var prEvent githubActionsPullRequestEvent
+		// If we fail to un-marshal the payload,
+		if err := json.Unmarshal([]byte(eventPath), &prEvent); err == nil {
+			v.PRNumber = prEvent.PullRequest.Number
+		}
+	}
+	return v
+}

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -42,6 +42,7 @@ type githubActionsPullRequestEvent struct {
 }
 
 // DetectVars detects the GitHub Actions env vars.
+// nolint: lll
 // See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables.
 func (t githubActionsCI) DetectVars() Vars {
 	v := Vars{Name: GitHubActions}

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 )
 
 // githubActionsCI represents the GitHub Actions CI system.
@@ -31,7 +32,7 @@ type githubActionsCI struct {
 // See https://developer.github.com/webhooks/event-payloads/#pull_request.
 type githubPR struct {
 	Action string `json:"action"`
-	Number string `json:"number"`
+	Number int64  `json:"number"`
 }
 
 // githubActionsPullRequestEvent represents the webhook payload for a pull_request event.
@@ -62,7 +63,7 @@ func (t githubActionsCI) DetectVars() Vars {
 		var prEvent githubActionsPullRequestEvent
 		// If we fail to un-marshal the payload,
 		if err := json.Unmarshal([]byte(eventPath), &prEvent); err == nil {
-			v.PRNumber = prEvent.PullRequest.Number
+			v.PRNumber = strconv.FormatInt(prEvent.PullRequest.Number, 10)
 		}
 	}
 	return v

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -41,7 +41,7 @@ type githubActionsPullRequestEvent struct {
 	PullRequest githubPR `json:"pull_request"`
 }
 
-// DetectVars detects the Travis env vars.
+// DetectVars detects the GitHub Actions env vars.
 // See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables.
 func (t githubActionsCI) DetectVars() Vars {
 	v := Vars{Name: GitHubActions}

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -61,7 +61,6 @@ func (t githubActionsCI) DetectVars() Vars {
 	if v.BuildType == "pull_request" {
 		eventPath := os.Getenv("GITHUB_EVENT_PATH")
 		var prEvent githubActionsPullRequestEvent
-		// If we fail to un-marshal the payload,
 		if err := json.Unmarshal([]byte(eventPath), &prEvent); err == nil {
 			v.PRNumber = strconv.FormatInt(prEvent.PullRequest.Number, 10)
 		}

--- a/sdk/go/common/util/ciutil/systems.go
+++ b/sdk/go/common/util/ciutil/systems.go
@@ -37,16 +37,16 @@ const (
 	// to their CI build.
 	GenericCI SystemName = "Generic CI"
 
-	GitHub      SystemName = "GitHub"
-	GitLab      SystemName = "GitLab"
-	GoCD        SystemName = "GoCD"
-	Hudson      SystemName = "Hudson"
-	Jenkins     SystemName = "Jenkins"
-	MagnumCI    SystemName = "Magnum CI"
-	Semaphore   SystemName = "Semaphore"
-	TaskCluster SystemName = "TaskCluster"
-	TeamCity    SystemName = "TeamCity"
-	Travis      SystemName = "Travis CI"
+	GitHubActions SystemName = "GitHub Actions"
+	GitLab        SystemName = "GitLab CI/CD"
+	GoCD          SystemName = "GoCD"
+	Hudson        SystemName = "Hudson"
+	Jenkins       SystemName = "Jenkins"
+	MagnumCI      SystemName = "Magnum CI"
+	Semaphore     SystemName = "Semaphore"
+	TaskCluster   SystemName = "TaskCluster"
+	TeamCity      SystemName = "TeamCity"
+	Travis        SystemName = "Travis CI"
 )
 
 // SystemName is a recognized CI system.


### PR DESCRIPTION
This PR adds the detection logic for GitHub Actions. I have also updated our escape-hatch code for unknown CI systems to allow users to set all CI vars that we support today.

This PR might address the problem reported in https://github.com/pulumi/pulumi/issues/4613.