### PR TITLE
[codegen/python] Fix readme generation

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -156,9 +156,21 @@ func (mod *modContext) gen(fs fs) error {
 		fs.add(filepath.Join(dir, "utilities.py"), buffer.Bytes())
 
 		// Ensure that the top-level (provider) module directory contains a README.md file.
-		readme := mod.pkg.Description
-		if readme != "" && readme[len(readme)-1] != '\n' {
-			readme += "\n"
+		readme := mod.pkg.Language["python"].(PackageInfo).Readme
+		if readme == "" {
+			readme = mod.pkg.Description
+			if readme != "" && readme[len(readme)-1] != '\n' {
+				readme += "\n"
+			}
+			if mod.pkg.Attribution != "" {
+				if len(readme) != 0 {
+					readme += "\n"
+				}
+				readme += mod.pkg.Attribution
+			}
+			if readme != "" && readme[len(readme)-1] != '\n' {
+				readme += "\n"
+			}
 		}
 		fs.add(filepath.Join(dir, "README.md"), []byte(readme))
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -147,22 +147,20 @@ func (mod *modContext) gen(fs fs) error {
 		fs.add(p, []byte(contents))
 	}
 
-	// Ensure that the target module directory contains a README.md file.
-	if mod.mod != "" {
-		readme := mod.pkg.Description
-		if readme != "" && readme[len(readme)-1] != '\n' {
-			readme += "\n"
-		}
-		fs.add(filepath.Join(dir, "README.md"), []byte(readme))
-	}
-
-	// Utilities, config
+	// Utilities, config, readme
 	switch mod.mod {
 	case "":
 		buffer := &bytes.Buffer{}
 		mod.genHeader(buffer, false)
 		fmt.Fprintf(buffer, "%s", utilitiesFile)
 		fs.add(filepath.Join(dir, "utilities.py"), buffer.Bytes())
+
+		// Ensure that the top-level (provider) module directory contains a README.md file.
+		readme := mod.pkg.Description
+		if readme != "" && readme[len(readme)-1] != '\n' {
+			readme += "\n"
+		}
+		fs.add(filepath.Join(dir, "README.md"), []byte(readme))
 
 	case "config":
 		if len(mod.pkg.Config) > 0 {

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -28,6 +28,8 @@ type PropertyInfo struct {
 // PackageInfo tracks Python-specific information associated with a package.
 type PackageInfo struct {
 	Requires map[string]string `json:"requires,omitempty"`
+	// Readme contains the text for the package's README.md files.
+	Readme string `json:"readme,omitempty"`
 }
 
 // Importer implements schema.Language for Python.


### PR DESCRIPTION
Readmes were not being generated for the top-level module but for the submodules instead. This PR corrects that.

Related to: https://github.com/pulumi/pulumi-kubernetes/issues/1085