### PR TITLE
[docker/actions] Base64 decode GOOGLE_CREDENTIALS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
 - Export `CustomTimeouts` in the Python SDK
  [#4747](https://github.com/pulumi/pulumi/pull/4747)
 
+- Allow users to specify base64 encoded strings as GOOGLE_CREDENTIALS
+ [#4773](https://github.com/pulumi/pulumi/pull/4773)
+
 ---
 
 ## 2.3.0 (2020-05-27)

--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -79,7 +79,12 @@ fi
 # For Google, we need to authenticate with a service principal for certain authentication operations.
 if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
     export GOOGLE_APPLICATION_CREDENTIALS="$(mktemp).json"
-    echo "$GOOGLE_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+    # Check if GOOGLE_CREDENTIALS is base64 encoded 
+    if [[ $GOOGLE_CREDENTIALS =~ ^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$ ]]; then
+        echo "$GOOGLE_CREDENTIALS"|base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+    else
+        echo "$GOOGLE_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
+    fi
     gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
 fi
 


### PR DESCRIPTION
Hello 👋

This PR make Pulumi Github Action allow using Google credentials that are base64 encoded.

Many workflows and Github Actions, such as [setup-gcloud action](https://github.com/GoogleCloudPlatform/github-actions/blob/master/setup-gcloud/README.md), use a base64 encoded string of Google credentials. This PR will make Pulumi Github Action work without an extra decoding step for users that combine steps requiring base64 encoded strings. There is a simple regex matcher so that it would work with both base64 and raw JSON strings and so it wouldn't be a breaking change.

Thanks for Pulumi ❤️