### PR TITLE
Set default namespace for go config for configless of get/try/require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Set default config namespace for Get/Try/Require methods in Go SDK.
+  [4802](https://github.com/pulumi/pulumi/pull/4802)
+
 - Improve typing for Go SDK secret config values
  [#4800](https://github.com/pulumi/pulumi/pull/4800)
 

--- a/sdk/go/pulumi/config/get.go
+++ b/sdk/go/pulumi/config/get.go
@@ -16,20 +16,30 @@ package config
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/spf13/cast"
 
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
+func ensureKey(ctx *pulumi.Context, key string) string {
+	if !strings.Contains(key, ":") {
+		key = ctx.Project() + ":" + key
+	}
+	return key
+}
+
 // Get loads an optional configuration value by its key, or returns "" if it doesn't exist.
 func Get(ctx *pulumi.Context, key string) string {
+	key = ensureKey(ctx, key)
 	v, _ := ctx.GetConfig(key)
 	return v
 }
 
 // GetObject attempts to load an optional configuration value by its key into the specified output variable.
 func GetObject(ctx *pulumi.Context, key string, output interface{}) error {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return json.Unmarshal([]byte(v), output)
 	}
@@ -39,6 +49,7 @@ func GetObject(ctx *pulumi.Context, key string, output interface{}) error {
 
 // GetBool loads an optional configuration value by its key, as a bool, or returns false if it doesn't exist.
 func GetBool(ctx *pulumi.Context, key string) bool {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToBool(v)
 	}
@@ -47,6 +58,7 @@ func GetBool(ctx *pulumi.Context, key string) bool {
 
 // GetFloat32 loads an optional configuration value by its key, as a float32, or returns 0 if it doesn't exist.
 func GetFloat32(ctx *pulumi.Context, key string) float32 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToFloat32(v)
 	}
@@ -55,6 +67,7 @@ func GetFloat32(ctx *pulumi.Context, key string) float32 {
 
 // GetFloat64 loads an optional configuration value by its key, as a float64, or returns 0 if it doesn't exist.
 func GetFloat64(ctx *pulumi.Context, key string) float64 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToFloat64(v)
 	}
@@ -63,6 +76,7 @@ func GetFloat64(ctx *pulumi.Context, key string) float64 {
 
 // GetInt loads an optional configuration value by its key, as a int, or returns 0 if it doesn't exist.
 func GetInt(ctx *pulumi.Context, key string) int {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToInt(v)
 	}
@@ -71,6 +85,7 @@ func GetInt(ctx *pulumi.Context, key string) int {
 
 // GetInt16 loads an optional configuration value by its key, as a int16, or returns 0 if it doesn't exist.
 func GetInt16(ctx *pulumi.Context, key string) int16 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToInt16(v)
 	}
@@ -79,6 +94,7 @@ func GetInt16(ctx *pulumi.Context, key string) int16 {
 
 // GetInt32 loads an optional configuration value by its key, as a int32, or returns 0 if it doesn't exist.
 func GetInt32(ctx *pulumi.Context, key string) int32 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToInt32(v)
 	}
@@ -87,6 +103,7 @@ func GetInt32(ctx *pulumi.Context, key string) int32 {
 
 // GetInt64 loads an optional configuration value by its key, as a int64, or returns 0 if it doesn't exist.
 func GetInt64(ctx *pulumi.Context, key string) int64 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToInt64(v)
 	}
@@ -95,6 +112,7 @@ func GetInt64(ctx *pulumi.Context, key string) int64 {
 
 // GetInt8 loads an optional configuration value by its key, as a int8, or returns 0 if it doesn't exist.
 func GetInt8(ctx *pulumi.Context, key string) int8 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToInt8(v)
 	}
@@ -103,6 +121,7 @@ func GetInt8(ctx *pulumi.Context, key string) int8 {
 
 // GetUint loads an optional configuration value by its key, as a uint, or returns 0 if it doesn't exist.
 func GetUint(ctx *pulumi.Context, key string) uint {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToUint(v)
 	}
@@ -111,6 +130,7 @@ func GetUint(ctx *pulumi.Context, key string) uint {
 
 // GetUint16 loads an optional configuration value by its key, as a uint16, or returns 0 if it doesn't exist.
 func GetUint16(ctx *pulumi.Context, key string) uint16 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToUint16(v)
 	}
@@ -119,6 +139,7 @@ func GetUint16(ctx *pulumi.Context, key string) uint16 {
 
 // GetUint32 loads an optional configuration value by its key, as a uint32, or returns 0 if it doesn't exist.
 func GetUint32(ctx *pulumi.Context, key string) uint32 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToUint32(v)
 	}
@@ -127,6 +148,7 @@ func GetUint32(ctx *pulumi.Context, key string) uint32 {
 
 // GetUint64 loads an optional configuration value by its key, as a uint64, or returns 0 if it doesn't exist.
 func GetUint64(ctx *pulumi.Context, key string) uint64 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToUint64(v)
 	}
@@ -135,6 +157,7 @@ func GetUint64(ctx *pulumi.Context, key string) uint64 {
 
 // GetUint8 loads an optional configuration value by its key, as a uint8, or returns 0 if it doesn't exist.
 func GetUint8(ctx *pulumi.Context, key string) uint8 {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.ToUint8(v)
 	}
@@ -143,12 +166,14 @@ func GetUint8(ctx *pulumi.Context, key string) uint8 {
 
 // GetSecret loads an optional configuration value by its key, or "" if it does not exist, into a secret Output.
 func GetSecret(ctx *pulumi.Context, key string) pulumi.StringOutput {
+	key = ensureKey(ctx, key)
 	v, _ := ctx.GetConfig(key)
 	return pulumi.ToSecret(pulumi.String(v)).(pulumi.StringOutput)
 }
 
 // GetSecretObject attempts to load an optional configuration value by its key into the specified output variable.
 func GetSecretObject(ctx *pulumi.Context, key string, output interface{}) (pulumi.Output, error) {
+	key = ensureKey(ctx, key)
 	if err := GetObject(ctx, key, output); err != nil {
 		return nil, err
 	}
@@ -159,77 +184,90 @@ func GetSecretObject(ctx *pulumi.Context, key string, output interface{}) (pulum
 // GetSecretBool loads an optional bool configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretBool(ctx *pulumi.Context, key string) pulumi.BoolOutput {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetBool(ctx, key)).(pulumi.BoolOutput)
 }
 
 // GetSecretFloat32 loads an optional float32 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretFloat32(ctx *pulumi.Context, key string) pulumi.Float32Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetFloat32(ctx, key)).(pulumi.Float32Output)
 }
 
 // GetSecretFloat64 loads an optional float64 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretFloat64(ctx *pulumi.Context, key string) pulumi.Float64Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetFloat64(ctx, key)).(pulumi.Float64Output)
 }
 
 // GetSecretInt loads an optional int configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretInt(ctx *pulumi.Context, key string) pulumi.IntOutput {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetInt(ctx, key)).(pulumi.IntOutput)
 }
 
 // GetSecretInt16 loads an optional int16 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretInt16(ctx *pulumi.Context, key string) pulumi.Int16Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetInt16(ctx, key)).(pulumi.Int16Output)
 }
 
 // GetSecretInt32 loads an optional int32 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretInt32(ctx *pulumi.Context, key string) pulumi.Int32Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetInt32(ctx, key)).(pulumi.Int32Output)
 }
 
 // GetSecretInt64 loads an optional int64 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretInt64(ctx *pulumi.Context, key string) pulumi.Int64Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetInt64(ctx, key)).(pulumi.Int64Output)
 }
 
 // GetSecretInt8 loads an optional int8 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretInt8(ctx *pulumi.Context, key string) pulumi.Int8Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetInt8(ctx, key)).(pulumi.Int8Output)
 }
 
 // GetSecretUint loads an optional uint configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretUint(ctx *pulumi.Context, key string) pulumi.UintOutput {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetUint(ctx, key)).(pulumi.UintOutput)
 }
 
 // GetSecretUint16 loads an optional uint16 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretUint16(ctx *pulumi.Context, key string) pulumi.Uint16Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetUint16(ctx, key)).(pulumi.Uint16Output)
 }
 
 // GetSecretUint32 loads an optional uint32 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretUint32(ctx *pulumi.Context, key string) pulumi.Uint32Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetUint32(ctx, key)).(pulumi.Uint32Output)
 }
 
 // GetSecretUint64 loads an optional uint64 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretUint64(ctx *pulumi.Context, key string) pulumi.Uint64Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetUint64(ctx, key)).(pulumi.Uint64Output)
 }
 
 // GetSecretUint8 loads an optional uint8 configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecretUint8(ctx *pulumi.Context, key string) pulumi.Uint8Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(GetUint8(ctx, key)).(pulumi.Uint8Output)
 }

--- a/sdk/go/pulumi/config/require.go
+++ b/sdk/go/pulumi/config/require.go
@@ -25,6 +25,7 @@ import (
 
 // Require loads a configuration value by its key, or panics if it doesn't exist.
 func Require(ctx *pulumi.Context, key string) string {
+	key = ensureKey(ctx, key)
 	v, ok := ctx.GetConfig(key)
 	if !ok {
 		contract.Failf("missing required configuration variable '%s'; run `pulumi config` to set", key)
@@ -35,6 +36,7 @@ func Require(ctx *pulumi.Context, key string) string {
 // RequireObject loads an optional configuration value by its key into the output variable,
 // or panics if unable to do so.
 func RequireObject(ctx *pulumi.Context, key string, output interface{}) {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	if err := json.Unmarshal([]byte(v), output); err != nil {
 		contract.Failf("unable to unmarshall required configuration variable '%s'; %s", key, err.Error())
@@ -43,78 +45,91 @@ func RequireObject(ctx *pulumi.Context, key string, output interface{}) {
 
 // RequireBool loads an optional configuration value by its key, as a bool, or panics if it doesn't exist.
 func RequireBool(ctx *pulumi.Context, key string) bool {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToBool(v)
 }
 
 // RequireFloat32 loads an optional configuration value by its key, as a float32, or panics if it doesn't exist.
 func RequireFloat32(ctx *pulumi.Context, key string) float32 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToFloat32(v)
 }
 
 // RequireFloat64 loads an optional configuration value by its key, as a float64, or panics if it doesn't exist.
 func RequireFloat64(ctx *pulumi.Context, key string) float64 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToFloat64(v)
 }
 
 // RequireInt loads an optional configuration value by its key, as a int, or panics if it doesn't exist.
 func RequireInt(ctx *pulumi.Context, key string) int {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToInt(v)
 }
 
 // RequireInt16 loads an optional configuration value by its key, as a int16, or panics if it doesn't exist.
 func RequireInt16(ctx *pulumi.Context, key string) int16 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToInt16(v)
 }
 
 // RequireInt32 loads an optional configuration value by its key, as a int32, or panics if it doesn't exist.
 func RequireInt32(ctx *pulumi.Context, key string) int32 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToInt32(v)
 }
 
 // RequireInt64 loads an optional configuration value by its key, as a int64, or panics if it doesn't exist.
 func RequireInt64(ctx *pulumi.Context, key string) int64 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToInt64(v)
 }
 
 // RequireInt8 loads an optional configuration value by its key, as a int8, or panics if it doesn't exist.
 func RequireInt8(ctx *pulumi.Context, key string) int8 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToInt8(v)
 }
 
 // RequireUint loads an optional configuration value by its key, as a uint, or panics if it doesn't exist.
 func RequireUint(ctx *pulumi.Context, key string) uint {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToUint(v)
 }
 
 // RequireUint16 loads an optional configuration value by its key, as a uint16, or panics if it doesn't exist.
 func RequireUint16(ctx *pulumi.Context, key string) uint16 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToUint16(v)
 }
 
 // RequireUint32 loads an optional configuration value by its key, as a uint32, or panics if it doesn't exist.
 func RequireUint32(ctx *pulumi.Context, key string) uint32 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToUint32(v)
 }
 
 // RequireUint64 loads an optional configuration value by its key, as a uint64, or panics if it doesn't exist.
 func RequireUint64(ctx *pulumi.Context, key string) uint64 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToUint64(v)
 }
 
 // RequireUint8 loads an optional configuration value by its key, as a uint8, or panics if it doesn't exist.
 func RequireUint8(ctx *pulumi.Context, key string) uint8 {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.ToUint8(v)
 }
@@ -122,12 +137,14 @@ func RequireUint8(ctx *pulumi.Context, key string) uint8 {
 // RequireSecret loads a configuration value by its key returning it wrapped in a secret Output,
 // or panics if it doesn't exist.
 func RequireSecret(ctx *pulumi.Context, key string) pulumi.StringOutput {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(Require(ctx, key)).(pulumi.StringOutput)
 }
 
 // RequireSecretObject loads an optional configuration value by its key into the output variable,
 // returning it wrapped in a secret Output, or panics if unable to do so.
 func RequireSecretObject(ctx *pulumi.Context, key string, output interface{}) pulumi.Output {
+	key = ensureKey(ctx, key)
 	RequireObject(ctx, key, output)
 	return pulumi.ToSecret(output)
 }
@@ -135,77 +152,90 @@ func RequireSecretObject(ctx *pulumi.Context, key string, output interface{}) pu
 // RequireSecretBool loads an optional configuration value by its key,
 // as a bool wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretBool(ctx *pulumi.Context, key string) pulumi.BoolOutput {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireBool(ctx, key)).(pulumi.BoolOutput)
 }
 
 // RequireSecretFloat32 loads an optional configuration value by its key,
 // as a float32 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretFloat32(ctx *pulumi.Context, key string) pulumi.Float32Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireFloat32(ctx, key)).(pulumi.Float32Output)
 }
 
 // RequireSecretFloat64 loads an optional configuration value by its key,
 // as a float64 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretFloat64(ctx *pulumi.Context, key string) pulumi.Float64Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireFloat64(ctx, key)).(pulumi.Float64Output)
 }
 
 // RequireSecretInt loads an optional configuration value by its key,
 // as a int wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretInt(ctx *pulumi.Context, key string) pulumi.IntOutput {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireInt(ctx, key)).(pulumi.IntOutput)
 }
 
 // RequireSecretInt16 loads an optional configuration value by its key,
 // as a int16 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretInt16(ctx *pulumi.Context, key string) pulumi.Int16Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireInt16(ctx, key)).(pulumi.Int16Output)
 }
 
 // RequireSecretInt32 loads an optional configuration value by its key,
 // as a int32 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretInt32(ctx *pulumi.Context, key string) pulumi.Int32Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireInt32(ctx, key)).(pulumi.Int32Output)
 }
 
 // RequireSecretInt64 loads an optional configuration value by its key,
 // as a int64 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretInt64(ctx *pulumi.Context, key string) pulumi.Int64Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireInt64(ctx, key)).(pulumi.Int64Output)
 }
 
 // RequireSecretInt8 loads an optional configuration value by its key,
 // as a int8 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretInt8(ctx *pulumi.Context, key string) pulumi.Int8Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireInt8(ctx, key)).(pulumi.Int8Output)
 }
 
 // RequireSecretUint loads an optional configuration value by its key,
 // as a uint wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretUint(ctx *pulumi.Context, key string) pulumi.UintOutput {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireUint(ctx, key)).(pulumi.UintOutput)
 }
 
 // RequireSecretUint16 loads an optional configuration value by its key,
 // as a uint16 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretUint16(ctx *pulumi.Context, key string) pulumi.Uint16Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireUint16(ctx, key)).(pulumi.Uint16Output)
 }
 
 // RequireSecretUint32 loads an optional configuration value by its key,
 // as a uint32 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretUint32(ctx *pulumi.Context, key string) pulumi.Uint32Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireUint32(ctx, key)).(pulumi.Uint32Output)
 }
 
 // RequireSecretUint64 loads an optional configuration value by its key,
 // as a uint64 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretUint64(ctx *pulumi.Context, key string) pulumi.Uint64Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireUint64(ctx, key)).(pulumi.Uint64Output)
 }
 
 // RequireSecretUint8 loads an optional configuration value by its key,
 // as a uint8 wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecretUint8(ctx *pulumi.Context, key string) pulumi.Uint8Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(RequireUint8(ctx, key)).(pulumi.Uint8Output)
 }

--- a/sdk/go/pulumi/config/try.go
+++ b/sdk/go/pulumi/config/try.go
@@ -25,6 +25,7 @@ import (
 
 // Try loads a configuration value by its key, returning a non-nil error if it doesn't exist.
 func Try(ctx *pulumi.Context, key string) (string, error) {
+	key = ensureKey(ctx, key)
 	v, ok := ctx.GetConfig(key)
 	if !ok {
 		return "",
@@ -36,6 +37,7 @@ func Try(ctx *pulumi.Context, key string) (string, error) {
 // TryObject loads an optional configuration value by its key into the output variable,
 // or returns an error if unable to do so.
 func TryObject(ctx *pulumi.Context, key string, output interface{}) error {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return err
@@ -45,6 +47,7 @@ func TryObject(ctx *pulumi.Context, key string, output interface{}) error {
 
 // TryBool loads an optional configuration value by its key, as a bool, or returns an error if it doesn't exist.
 func TryBool(ctx *pulumi.Context, key string) (bool, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return false, err
@@ -54,6 +57,7 @@ func TryBool(ctx *pulumi.Context, key string) (bool, error) {
 
 // TryFloat32 loads an optional configuration value by its key, as a float32, or returns an error if it doesn't exist.
 func TryFloat32(ctx *pulumi.Context, key string) (float32, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -63,6 +67,7 @@ func TryFloat32(ctx *pulumi.Context, key string) (float32, error) {
 
 // TryFloat64 loads an optional configuration value by its key, as a float64, or returns an error if it doesn't exist.
 func TryFloat64(ctx *pulumi.Context, key string) (float64, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -72,6 +77,7 @@ func TryFloat64(ctx *pulumi.Context, key string) (float64, error) {
 
 // TryInt loads an optional configuration value by its key, as a int, or returns an error if it doesn't exist.
 func TryInt(ctx *pulumi.Context, key string) (int, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -81,6 +87,7 @@ func TryInt(ctx *pulumi.Context, key string) (int, error) {
 
 // TryInt16 loads an optional configuration value by its key, as a int16, or returns an error if it doesn't exist.
 func TryInt16(ctx *pulumi.Context, key string) (int16, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -90,6 +97,7 @@ func TryInt16(ctx *pulumi.Context, key string) (int16, error) {
 
 // TryInt32 loads an optional configuration value by its key, as a int32, or returns an error if it doesn't exist.
 func TryInt32(ctx *pulumi.Context, key string) (int32, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -99,6 +107,7 @@ func TryInt32(ctx *pulumi.Context, key string) (int32, error) {
 
 // TryInt64 loads an optional configuration value by its key, as a int64, or returns an error if it doesn't exist.
 func TryInt64(ctx *pulumi.Context, key string) (int64, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -108,6 +117,7 @@ func TryInt64(ctx *pulumi.Context, key string) (int64, error) {
 
 // TryInt8 loads an optional configuration value by its key, as a int8, or returns an error if it doesn't exist.
 func TryInt8(ctx *pulumi.Context, key string) (int8, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -117,6 +127,7 @@ func TryInt8(ctx *pulumi.Context, key string) (int8, error) {
 
 // TryUint loads an optional configuration value by its key, as a uint, or returns an error if it doesn't exist.
 func TryUint(ctx *pulumi.Context, key string) (uint, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -126,6 +137,7 @@ func TryUint(ctx *pulumi.Context, key string) (uint, error) {
 
 // TryUint16 loads an optional configuration value by its key, as a uint16, or returns an error if it doesn't exist.
 func TryUint16(ctx *pulumi.Context, key string) (uint16, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -135,6 +147,7 @@ func TryUint16(ctx *pulumi.Context, key string) (uint16, error) {
 
 // TryUint32 loads an optional configuration value by its key, as a uint32, or returns an error if it doesn't exist.
 func TryUint32(ctx *pulumi.Context, key string) (uint32, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -144,6 +157,7 @@ func TryUint32(ctx *pulumi.Context, key string) (uint32, error) {
 
 // TryUint64 loads an optional configuration value by its key, as a uint64, or returns an error if it doesn't exist.
 func TryUint64(ctx *pulumi.Context, key string) (uint64, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -153,6 +167,7 @@ func TryUint64(ctx *pulumi.Context, key string) (uint64, error) {
 
 // TryUint8 loads an optional configuration value by its key, as a uint8, or returns an error if it doesn't exist.
 func TryUint8(ctx *pulumi.Context, key string) (uint8, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return 0, err
@@ -162,6 +177,7 @@ func TryUint8(ctx *pulumi.Context, key string) (uint8, error) {
 
 // TrySecret loads a configuration value by its key, returning a non-nil error if it doesn't exist.
 func TrySecret(ctx *pulumi.Context, key string) (pulumi.StringOutput, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		var empty pulumi.StringOutput
@@ -173,6 +189,7 @@ func TrySecret(ctx *pulumi.Context, key string) (pulumi.StringOutput, error) {
 // TrySecretObject loads a configuration value by its key into the output variable,
 // or returns an error if unable to do so.
 func TrySecretObject(ctx *pulumi.Context, key string, output interface{}) (pulumi.Output, error) {
+	key = ensureKey(ctx, key)
 	err := TryObject(ctx, key, output)
 	if err != nil {
 		return nil, err
@@ -184,6 +201,7 @@ func TrySecretObject(ctx *pulumi.Context, key string, output interface{}) (pulum
 // TrySecretBool loads an optional configuration value by its key, as a bool,
 // or returns an error if it doesn't exist.
 func TrySecretBool(ctx *pulumi.Context, key string) (pulumi.BoolOutput, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryBool(ctx, key)
 	if err != nil {
 		var empty pulumi.BoolOutput
@@ -195,6 +213,7 @@ func TrySecretBool(ctx *pulumi.Context, key string) (pulumi.BoolOutput, error) {
 // TrySecretFloat32 loads an optional configuration value by its key, as a float32,
 // or returns an error if it doesn't exist.
 func TrySecretFloat32(ctx *pulumi.Context, key string) (pulumi.Float32Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryFloat32(ctx, key)
 	if err != nil {
 		var empty pulumi.Float32Output
@@ -206,6 +225,7 @@ func TrySecretFloat32(ctx *pulumi.Context, key string) (pulumi.Float32Output, er
 // TrySecretFloat64 loads an optional configuration value by its key, as a float64,
 // or returns an error if it doesn't exist.
 func TrySecretFloat64(ctx *pulumi.Context, key string) (pulumi.Float64Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryFloat64(ctx, key)
 	if err != nil {
 		var empty pulumi.Float64Output
@@ -217,6 +237,7 @@ func TrySecretFloat64(ctx *pulumi.Context, key string) (pulumi.Float64Output, er
 // TrySecretInt loads an optional configuration value by its key, as a int,
 // or returns an error if it doesn't exist.
 func TrySecretInt(ctx *pulumi.Context, key string) (pulumi.IntOutput, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryInt(ctx, key)
 	if err != nil {
 		var empty pulumi.IntOutput
@@ -228,6 +249,7 @@ func TrySecretInt(ctx *pulumi.Context, key string) (pulumi.IntOutput, error) {
 // TrySecretInt16 loads an optional configuration value by its key, as a int16,
 // or returns an error if it doesn't exist.
 func TrySecretInt16(ctx *pulumi.Context, key string) (pulumi.Int16Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryInt16(ctx, key)
 	if err != nil {
 		var empty pulumi.Int16Output
@@ -239,6 +261,7 @@ func TrySecretInt16(ctx *pulumi.Context, key string) (pulumi.Int16Output, error)
 // TrySecretInt32 loads an optional configuration value by its key, as a int32,
 // or returns an error if it doesn't exist.
 func TrySecretInt32(ctx *pulumi.Context, key string) (pulumi.Int32Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryInt32(ctx, key)
 	if err != nil {
 		var empty pulumi.Int32Output
@@ -250,6 +273,7 @@ func TrySecretInt32(ctx *pulumi.Context, key string) (pulumi.Int32Output, error)
 // TrySecretInt64 loads an optional configuration value by its key, as a int64,
 // or returns an error if it doesn't exist.
 func TrySecretInt64(ctx *pulumi.Context, key string) (pulumi.Int64Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryInt64(ctx, key)
 	if err != nil {
 		var empty pulumi.Int64Output
@@ -261,6 +285,7 @@ func TrySecretInt64(ctx *pulumi.Context, key string) (pulumi.Int64Output, error)
 // TrySecretInt8 loads an optional configuration value by its key, as a int8,
 // or returns an error if it doesn't exist.
 func TrySecretInt8(ctx *pulumi.Context, key string) (pulumi.Int8Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryInt8(ctx, key)
 	if err != nil {
 		var empty pulumi.Int8Output
@@ -272,6 +297,7 @@ func TrySecretInt8(ctx *pulumi.Context, key string) (pulumi.Int8Output, error) {
 // TrySecretUint loads an optional configuration value by its key, as a uint,
 // or returns an error if it doesn't exist.
 func TrySecretUint(ctx *pulumi.Context, key string) (pulumi.UintOutput, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryUint(ctx, key)
 	if err != nil {
 		var empty pulumi.UintOutput
@@ -283,6 +309,7 @@ func TrySecretUint(ctx *pulumi.Context, key string) (pulumi.UintOutput, error) {
 // TrySecretUint16 loads an optional configuration value by its key, as a uint16,
 // or returns an error if it doesn't exist.
 func TrySecretUint16(ctx *pulumi.Context, key string) (pulumi.Uint16Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryUint16(ctx, key)
 	if err != nil {
 		var empty pulumi.Uint16Output
@@ -294,6 +321,7 @@ func TrySecretUint16(ctx *pulumi.Context, key string) (pulumi.Uint16Output, erro
 // TrySecretUint32 loads an optional configuration value by its key, as a uint32,
 // or returns an error if it doesn't exist.
 func TrySecretUint32(ctx *pulumi.Context, key string) (pulumi.Uint32Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryUint32(ctx, key)
 	if err != nil {
 		var empty pulumi.Uint32Output
@@ -305,6 +333,7 @@ func TrySecretUint32(ctx *pulumi.Context, key string) (pulumi.Uint32Output, erro
 // TrySecretUint64 loads an optional configuration value by its key, as a uint64,
 // or returns an error if it doesn't exist.
 func TrySecretUint64(ctx *pulumi.Context, key string) (pulumi.Uint64Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryUint64(ctx, key)
 	if err != nil {
 		var empty pulumi.Uint64Output
@@ -316,6 +345,7 @@ func TrySecretUint64(ctx *pulumi.Context, key string) (pulumi.Uint64Output, erro
 // TrySecretUint8 loads an optional configuration value by its key, as a uint8,
 // or returns an error if it doesn't exist.
 func TrySecretUint8(ctx *pulumi.Context, key string) (pulumi.Uint8Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := TryUint8(ctx, key)
 	if err != nil {
 		var empty pulumi.Uint8Output

--- a/sdk/go/pulumi/templates/config-get.go.template
+++ b/sdk/go/pulumi/templates/config-get.go.template
@@ -16,20 +16,30 @@ package config
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/spf13/cast"
 
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
+func ensureKey(ctx *pulumi.Context, key string) string {
+	if !strings.Contains(key, ":") {
+		key = ctx.Project() + ":" + key
+	}
+	return key
+}
+
 // Get loads an optional configuration value by its key, or returns "" if it doesn't exist.
 func Get(ctx *pulumi.Context, key string) string {
+	key = ensureKey(ctx, key)
 	v, _ := ctx.GetConfig(key)
 	return v
 }
 
 // GetObject attempts to load an optional configuration value by its key into the specified output variable.
 func GetObject(ctx *pulumi.Context, key string, output interface{}) error {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return json.Unmarshal([]byte(v), output)
 	}
@@ -41,6 +51,7 @@ func GetObject(ctx *pulumi.Context, key string, output interface{}) error {
 {{if .GenerateConfig}}
 // Get{{.Name}} loads an optional configuration value by its key, as a {{.Type}}, or returns {{.DefaultConfig}} if it doesn't exist.
 func Get{{.Name}}(ctx *pulumi.Context, key string) {{.Type}} {
+	key = ensureKey(ctx, key)
 	if v, ok := ctx.GetConfig(key); ok {
 		return cast.To{{.Name}}(v)
 	}
@@ -51,12 +62,14 @@ func Get{{.Name}}(ctx *pulumi.Context, key string) {{.Type}} {
 {{end}}
 // GetSecret loads an optional configuration value by its key, or "" if it does not exist, into a secret Output.
 func GetSecret(ctx *pulumi.Context, key string) pulumi.StringOutput {
+	key = ensureKey(ctx, key)
 	v, _ := ctx.GetConfig(key)
 	return pulumi.ToSecret(pulumi.String(v)).(pulumi.StringOutput)
 }
 
 // GetSecretObject attempts to load an optional configuration value by its key into the specified output variable.
 func GetSecretObject(ctx *pulumi.Context, key string, output interface{}) (pulumi.Output, error) {
+	key = ensureKey(ctx, key)
 	if err := GetObject(ctx, key, output); err != nil {
 		return nil, err
 	}
@@ -69,6 +82,7 @@ func GetSecretObject(ctx *pulumi.Context, key string, output interface{}) (pulum
 // GetSecret{{.Name}} loads an optional {{.Type}} configuration value by its key,
 // or false if it does not exist, into a secret Output.
 func GetSecret{{.Name}}(ctx *pulumi.Context, key string) pulumi.{{.Name}}Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(Get{{.Name}}(ctx, key)).(pulumi.{{.Name}}Output)
 }
 {{end}}

--- a/sdk/go/pulumi/templates/config-require.go.template
+++ b/sdk/go/pulumi/templates/config-require.go.template
@@ -25,6 +25,7 @@ import (
 
 // Require loads a configuration value by its key, or panics if it doesn't exist.
 func Require(ctx *pulumi.Context, key string) string {
+	key = ensureKey(ctx, key)
 	v, ok := ctx.GetConfig(key)
 	if !ok {
 		contract.Failf("missing required configuration variable '%s'; run `pulumi config` to set", key)
@@ -35,6 +36,7 @@ func Require(ctx *pulumi.Context, key string) string {
 // RequireObject loads an optional configuration value by its key into the output variable,
 // or panics if unable to do so.
 func RequireObject(ctx *pulumi.Context, key string, output interface{}) {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	if err := json.Unmarshal([]byte(v), output); err != nil {
 		contract.Failf("unable to unmarshall required configuration variable '%s'; %s", key, err.Error())
@@ -45,6 +47,7 @@ func RequireObject(ctx *pulumi.Context, key string, output interface{}) {
 {{if .GenerateConfig}}
 // Require{{.Name}} loads an optional configuration value by its key, as a {{.Type}}, or panics if it doesn't exist.
 func Require{{.Name}}(ctx *pulumi.Context, key string) {{.Type}} {
+	key = ensureKey(ctx, key)
 	v := Require(ctx, key)
 	return cast.To{{.Name}}(v)
 }
@@ -54,12 +57,14 @@ func Require{{.Name}}(ctx *pulumi.Context, key string) {{.Type}} {
 // RequireSecret loads a configuration value by its key returning it wrapped in a secret Output,
 // or panics if it doesn't exist.
 func RequireSecret(ctx *pulumi.Context, key string) pulumi.StringOutput {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(Require(ctx, key)).(pulumi.StringOutput)
 }
 
 // RequireSecretObject loads an optional configuration value by its key into the output variable,
 // returning it wrapped in a secret Output, or panics if unable to do so.
 func RequireSecretObject(ctx *pulumi.Context, key string, output interface{}) pulumi.Output {
+	key = ensureKey(ctx, key)
 	RequireObject(ctx, key, output)
 	return pulumi.ToSecret(output)
 }
@@ -69,6 +74,7 @@ func RequireSecretObject(ctx *pulumi.Context, key string, output interface{}) pu
 // RequireSecret{{.Name}} loads an optional configuration value by its key,
 // as a {{.Type}} wrapped in a secret Output, or panics if it doesn't exist.
 func RequireSecret{{.Name}}(ctx *pulumi.Context, key string) pulumi.{{.Name}}Output {
+	key = ensureKey(ctx, key)
 	return pulumi.ToSecret(Require{{.Name}}(ctx, key)).(pulumi.{{.Name}}Output)
 }
 {{end}}

--- a/sdk/go/pulumi/templates/config-try.go.template
+++ b/sdk/go/pulumi/templates/config-try.go.template
@@ -25,6 +25,7 @@ import (
 
 // Try loads a configuration value by its key, returning a non-nil error if it doesn't exist.
 func Try(ctx *pulumi.Context, key string) (string, error) {
+	key = ensureKey(ctx, key)
 	v, ok := ctx.GetConfig(key)
 	if !ok {
 		return "",
@@ -36,6 +37,7 @@ func Try(ctx *pulumi.Context, key string) (string, error) {
 // TryObject loads an optional configuration value by its key into the output variable,
 // or returns an error if unable to do so.
 func TryObject(ctx *pulumi.Context, key string, output interface{}) error {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return err
@@ -47,6 +49,7 @@ func TryObject(ctx *pulumi.Context, key string, output interface{}) error {
 {{if .GenerateConfig}}
 // Try{{.Name}} loads an optional configuration value by its key, as a {{.Type}}, or returns an error if it doesn't exist.
 func Try{{.Name}}(ctx *pulumi.Context, key string) ({{.Type}}, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		return {{.DefaultConfig}}, err
@@ -59,6 +62,7 @@ func Try{{.Name}}(ctx *pulumi.Context, key string) ({{.Type}}, error) {
 
 // TrySecret loads a configuration value by its key, returning a non-nil error if it doesn't exist.
 func TrySecret(ctx *pulumi.Context, key string) (pulumi.StringOutput, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try(ctx, key)
 	if err != nil {
 		var empty pulumi.StringOutput
@@ -70,6 +74,7 @@ func TrySecret(ctx *pulumi.Context, key string) (pulumi.StringOutput, error) {
 // TrySecretObject loads a configuration value by its key into the output variable,
 // or returns an error if unable to do so.
 func TrySecretObject(ctx *pulumi.Context, key string, output interface{}) (pulumi.Output, error) {
+	key = ensureKey(ctx, key)
 	err := TryObject(ctx, key, output)
 	if err != nil {
 		return nil, err
@@ -83,6 +88,7 @@ func TrySecretObject(ctx *pulumi.Context, key string, output interface{}) (pulum
 // TrySecret{{.Name}} loads an optional configuration value by its key, as a {{.Type}},
 // or returns an error if it doesn't exist.
 func TrySecret{{.Name}}(ctx *pulumi.Context, key string) (pulumi.{{.Name}}Output, error) {
+	key = ensureKey(ctx, key)
 	v, err := Try{{.Name}}(ctx, key)
 	if err != nil {
 		var empty pulumi.{{.Name}}Output

--- a/tests/integration/config_basic/go/main.go
+++ b/tests/integration/config_basic/go/main.go
@@ -57,6 +57,11 @@ func main() {
 			if value != test.Expected {
 				return fmt.Errorf("%q not the expected value; got %q", test.Key, value)
 			}
+			// config-less form
+			value = config.Require(ctx, test.Key)
+			if value != test.Expected {
+				return fmt.Errorf("%q not the expected value; got %q", test.Key, value)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/4296

As far as I can tell, other languages don't expose the config-less form of get/try/require methods. Exposing these in go was probably a bug, but given that removing them would be breaking this is the next best thing.

This change reverses the logic used in the "pulumi config set" command: https://github.com/pulumi/pulumi/blob/8bc3d0e906cc7eed09a4e85a1a70e8f64d8767b3/pkg/cmd/pulumi/config.go#L381

Given that you can't set a "namespace-less" config key, this change seems correct. Updated the integration test coverage to include this behavior. 