### PR TITLE
[codegen/python] Fix edge case in relative import

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -131,6 +131,9 @@ func relPathToRelImport(relPath string) string {
 	// Convert relative path to relative import e.g. "../.." -> "..."
 	// https://realpython.com/absolute-vs-relative-python-imports/#relative-imports
 	relImport := "."
+	if relPath == "." {
+		return relImport
+	}
 	for _, component := range strings.Split(relPath, "/") {
 		if component == ".." {
 			relImport += "."

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -6,6 +6,7 @@ var pathTests = []struct {
 	input    string
 	expected string
 }{
+	{".", "."},
 	{"", "."},
 	{"../", ".."},
 	{"../..", "..."},


### PR DESCRIPTION
Missed the case where the relPath is `.`