### PR TITLE
Ensure Authenticated to GCR when GOOGLE_CREDENTIALS supplied to action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ CHANGELOG
 
 - Fix panic on `pulumi up` prompt after preview when filtering and hitting arrow keys.
   [#4808](https://github.com/pulumi/pulumi/pull/4808)
+  
+- Ensure GitHub Action authenticates to GCR when `$GOOGLE_CREDENTIALS` specified
+  [#4812](https://github.com/pulumi/pulumi/pull/4812)
+  
 
 ## 2.4.0 (2020-06-10)
 - Turn program generation NYIs into diagnostic errors

--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -86,6 +86,7 @@ if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
         echo "$GOOGLE_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
     fi
     gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
+    gcloud --quiet auth configure-docker
 fi
 
 # Next, run npm install. We always call this, as


### PR DESCRIPTION
Fixes: #4811 

This is in line with what we need to do in the examples repo when we supply GCP Credentials