### PR TITLE
Use the GH webhook payload to parse PR details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGELOG
 - Fix panic on `pulumi up` prompt after preview when filtering and hitting arrow keys.
   [#4808](https://github.com/pulumi/pulumi/pull/4808)
 
+- Fix GitHub Actions environment detection for PRs.
+  [#4817](https://github.com/pulumi/pulumi/pull/4817)
+
 ## 2.4.0 (2020-06-10)
 - Turn program generation NYIs into diagnostic errors
  [#4794](https://github.com/pulumi/pulumi/pull/4794)

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -75,9 +75,9 @@ func (t githubActionsCI) DetectVars() Vars {
 }
 
 // TryGetEvent returns the GitHub webhook payload found in the GitHub Actions environment.
-// GitHub stores the JSON payload of the webhook that triggered the  workflow in a path.
+// GitHub stores the JSON payload of the webhook that triggered the workflow in a path.
 // The path is set as the value of the env var GITHUB_EVENT_PATH. Returns nil if an error
-// is encountered of the GITHUB_EVENT_PATH is not set.
+// is encountered or the GITHUB_EVENT_PATH is not set.
 func (t githubActionsCI) GetPREvent() *githubActionsPullRequestEvent {
 	eventPath := os.Getenv("GITHUB_EVENT_PATH")
 	if eventPath == "" {

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -63,7 +63,7 @@ func (t githubActionsCI) DetectVars() Vars {
 
 	v.SHA = os.Getenv("GITHUB_SHA")
 	if v.BuildType == "pull_request" {
-		event := t.TryGetEvent()
+		event := t.GetPREvent()
 		if event != nil {
 			prNumber := strconv.FormatInt(event.Number, 10)
 			v.PRNumber = prNumber
@@ -78,18 +78,18 @@ func (t githubActionsCI) DetectVars() Vars {
 // GitHub stores the JSON payload of the webhook that triggered the  workflow in a path.
 // The path is set as the value of the env var GITHUB_EVENT_PATH. Returns nil if an error
 // is encountered of the GITHUB_EVENT_PATH is not set.
-func (t githubActionsCI) TryGetEvent() *githubActionsPullRequestEvent {
+func (t githubActionsCI) GetPREvent() *githubActionsPullRequestEvent {
 	eventPath := os.Getenv("GITHUB_EVENT_PATH")
 	if eventPath == "" {
 		return nil
 	}
 
-	var prEvent githubActionsPullRequestEvent
 	b, err := ioutil.ReadFile(eventPath)
 	if err != nil {
 		return nil
 	}
 
+	var prEvent githubActionsPullRequestEvent
 	if err := json.Unmarshal(b, &prEvent); err != nil {
 		return nil
 	}

--- a/sdk/go/common/util/ciutil/github_actions.go
+++ b/sdk/go/common/util/ciutil/github_actions.go
@@ -17,6 +17,7 @@ package ciutil
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strconv"
 )
@@ -26,45 +27,72 @@ type githubActionsCI struct {
 	baseCI
 }
 
+type githubPRHead struct {
+	SHA string `json:"sha"`
+	Ref string `json:"ref"`
+}
+
 // githubPR represents the `pull_request` payload posted by GitHub to trigger
 // workflows for PRs. Note that this is only a partial representation as we
 // don't need anything other than the PR number.
 // See https://developer.github.com/webhooks/event-payloads/#pull_request.
 type githubPR struct {
-	Action string `json:"action"`
-	Number int64  `json:"number"`
+	Head githubPRHead `json:"head"`
 }
 
 // githubActionsPullRequestEvent represents the webhook payload for a pull_request event.
 // https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
 type githubActionsPullRequestEvent struct {
+	Action      string   `json:"action"`
+	Number      int64    `json:"number"`
 	PullRequest githubPR `json:"pull_request"`
 }
 
 // DetectVars detects the GitHub Actions env vars.
-// nolint: lll
-// See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables.
+// See https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables.
 func (t githubActionsCI) DetectVars() Vars {
 	v := Vars{Name: GitHubActions}
 	v.BuildID = os.Getenv("GITHUB_RUN_ID")
 	v.BuildNumber = os.Getenv("GITHUB_RUN_NUMBER")
 	v.BuildType = os.Getenv("GITHUB_EVENT_NAME")
-	v.SHA = os.Getenv("GITHUB_SHA")
 	v.BranchName = os.Getenv("GITHUB_REF")
 	repoSlug := os.Getenv("GITHUB_REPOSITORY")
 	if repoSlug != "" && v.BuildID != "" {
 		v.BuildURL = fmt.Sprintf("https://github.com/%s/actions/runs/%s", repoSlug, v.BuildID)
 	}
 
-	// Try to use the pull_request webhook payload to extract the PR number.
-	// For Pull Requests, GitHub stores the payload of the webhook that triggered the
-	// workflow in a path. The path is identified by GITHUB_EVENT_PATH.
+	v.SHA = os.Getenv("GITHUB_SHA")
 	if v.BuildType == "pull_request" {
-		eventPath := os.Getenv("GITHUB_EVENT_PATH")
-		var prEvent githubActionsPullRequestEvent
-		if err := json.Unmarshal([]byte(eventPath), &prEvent); err == nil {
-			v.PRNumber = strconv.FormatInt(prEvent.PullRequest.Number, 10)
+		event := t.TryGetEvent()
+		if event != nil {
+			prNumber := strconv.FormatInt(event.Number, 10)
+			v.PRNumber = prNumber
+			v.SHA = event.PullRequest.Head.SHA
+			v.BranchName = event.PullRequest.Head.Ref
 		}
 	}
 	return v
+}
+
+// TryGetEvent returns the GitHub webhook payload found in the GitHub Actions environment.
+// GitHub stores the JSON payload of the webhook that triggered the  workflow in a path.
+// The path is set as the value of the env var GITHUB_EVENT_PATH. Returns nil if an error
+// is encountered of the GITHUB_EVENT_PATH is not set.
+func (t githubActionsCI) TryGetEvent() *githubActionsPullRequestEvent {
+	eventPath := os.Getenv("GITHUB_EVENT_PATH")
+	if eventPath == "" {
+		return nil
+	}
+
+	var prEvent githubActionsPullRequestEvent
+	b, err := ioutil.ReadFile(eventPath)
+	if err != nil {
+		return nil
+	}
+
+	if err := json.Unmarshal(b, &prEvent); err != nil {
+		return nil
+	}
+
+	return &prEvent
 }


### PR DESCRIPTION
Related to #4758 and #4613.

In a previous PR, I added the CI env vars detection for GH Actions. Unfortunately, it looks like there is some problem with the values of `GITHUB_REF` and `GITHUB_SHA` for a PR. It looks like the example shown in the [doc](https://help.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables) is not what we are actually seeing. To demonstrate this, I opened a draft [PR](https://github.com/pulumi/docs/pull/3584/checks?check_run_id=766615693) in our docs repo, which has an extra step to print out the [env vars](https://github.com/pulumi/docs/pull/3584/checks?check_run_id=766615693#step:12:1) and the [event JSON](https://github.com/pulumi/docs/pull/3584/checks?check_run_id=766615693#step:13:7) separately. Note how the value of the `GITHUB_REF` value does not match the documented example of `ref/heads/<branch name>`. And for `GITHUB_SHA` -- I actually can't even tell what this SHA is. It doesn't look like it is the value of anything that I can correlate. Perhaps I read the docs incorrectly and misunderstood what they were supposed to be.

In any case, if you look at the event JSON, the values that we are looking to use are correctly specified in there, including the `pull_request.head.ref`, which has the PR branch name and the SHA value in `pull_request.head.sha`.

In addition to the problem with the values of the two env vars, the PR number extraction was incorrect. In the previous PR, I was trying to unmarshal the value of the `GITHUB_EVENT_PATH` directly, which will never work since it is just the _path_ to the JSON file that actually contains the event. This would have only caused us to _not_ set the `ci.pr.number` env metadata key. I have fixed this as well now.