### PR TITLE
Go program gen: resource range, readDir, template strings, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Go program gen improvements (resource range, readDir, fileArchive)
+  [#4818](https://github.com/pulumi/pulumi/pull/4818)
+
 - Set default config namespace for Get/Try/Require methods in Go SDK.
-  [4802](https://github.com/pulumi/pulumi/pull/4802)
+  [#4802](https://github.com/pulumi/pulumi/pull/4802)
 
 - Improve typing for Go SDK secret config values
  [#4800](https://github.com/pulumi/pulumi/pull/4800)

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -23,6 +23,7 @@ type generator struct {
 	diagnostics        hcl.Diagnostics
 	jsonTempSpiller    *jsonSpiller
 	ternaryTempSpiller *tempSpiller
+	readDirTempSpiller *readDirSpiller
 }
 
 func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics, error) {
@@ -33,6 +34,7 @@ func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics,
 		program:            program,
 		jsonTempSpiller:    &jsonSpiller{},
 		ternaryTempSpiller: &tempSpiller{},
+		readDirTempSpiller: &readDirSpiller{},
 	}
 
 	g.Formatter = format.NewFormatter(g)
@@ -114,6 +116,11 @@ func (g *generator) collectImports(w io.Writer, program *hcl2.Program) (codegen.
 					stdImports.Add(fnPkg)
 				}
 			}
+			if t, ok := n.(*model.TemplateExpression); ok {
+				if len(t.Parts) > 1 {
+					stdImports.Add("fmt")
+				}
+			}
 			return n, nil
 		})
 		contract.Assert(len(diags) == 0)
@@ -159,21 +166,36 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		g.genTemps(w, temps)
 	}
 
-	g.Fgenf(w, "%s, err := %s.New%s(ctx, \"%[1]s\", ", resName, mod, typ)
-	if len(r.Inputs) > 0 {
-		g.Fgenf(w, "&%s.%sArgs{\n", mod, typ)
-		for _, attr := range r.Inputs {
-			g.Fgenf(w, "%s: ", strings.Title(attr.Name))
-			g.Fgenf(w, "%.v,\n", attr.Value)
+	instantiate := func(varName, resourceName string) {
+		g.Fgenf(w, "%s, err := %s.New%s(ctx, %s, ", varName, mod, typ, resourceName)
+		if len(r.Inputs) > 0 {
+			g.Fgenf(w, "&%s.%sArgs{\n", mod, typ)
+			for _, attr := range r.Inputs {
+				g.Fgenf(w, "%s: ", strings.Title(attr.Name))
+				g.Fgenf(w, "%.v,\n", attr.Value)
 
+			}
+			g.Fgenf(w, "})\n")
+		} else {
+			g.Fgenf(w, "nil)\n")
 		}
-		g.Fgenf(w, "})\n")
-	} else {
-		g.Fgenf(w, "nil)\n")
+		g.Fgenf(w, "if err != nil {\n")
+		g.Fgenf(w, "return err\n")
+		g.Fgenf(w, "}\n")
 	}
-	g.Fgenf(w, "if err != nil {\n")
-	g.Fgenf(w, "return err\n")
-	g.Fgenf(w, "}\n")
+
+	if r.Options != nil && r.Options.Range != nil {
+		rangeType := model.ResolveOutputs(r.Options.Range.Type())
+		rangeExpr, temps := g.lowerExpression(r.Options.Range, rangeType, false)
+		g.genTemps(w, temps)
+
+		g.Fgenf(w, "for i0, val0 := range %.v {\n", rangeExpr)
+		instantiate("_", fmt.Sprintf("\"%s-\"+ string(i0)", resName))
+		g.Fgenf(w, "}\n")
+
+	} else {
+		instantiate(resName, fmt.Sprintf("\"%s\"", resName))
+	}
 
 }
 
@@ -183,8 +205,30 @@ func (g *generator) genOutputAssignment(w io.Writer, v *hcl2.OutputVariable) {
 	g.genTemps(w, temps)
 	g.Fgenf(w, "ctx.Export(\"%s\", %.3v)\n", v.Name(), expr)
 }
-
 func (g *generator) genTemps(w io.Writer, temps []interface{}) {
+	singleReturn := ""
+	g.genTempsMultiReturn(w, temps, singleReturn)
+}
+
+func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroValueType string) {
+	genZeroValueDecl := false
+
+	if zeroValueType != "" {
+		for _, t := range temps {
+			switch t.(type) {
+			case *jsonTemp, *readDirTemp:
+				genZeroValueDecl = true
+			default:
+			}
+		}
+		if genZeroValueDecl {
+			// TODO add entropy to var name
+			// currently only used inside anonymous functions (no scope collisions)
+			g.Fgenf(w, "var _zero %s\n", zeroValueType)
+		}
+
+	}
+
 	for _, t := range temps {
 		switch t := t.(type) {
 		case *ternaryTemp:
@@ -202,9 +246,32 @@ func (g *generator) genTemps(w io.Writer, temps []interface{}) {
 			args := stripInputs(t.Value.Args[0])
 			g.Fgenf(w, "%.v)\n", args)
 			g.Fgenf(w, "if err != nil {\n")
-			g.Fgenf(w, "return err\n")
+			if genZeroValueDecl {
+				g.Fgenf(w, "return _zero, err\n")
+			} else {
+				g.Fgenf(w, "return err\n")
+			}
 			g.Fgenf(w, "}\n")
 			g.Fgenf(w, "%s := string(%s)\n", t.Name, bytesVar)
+		case *readDirTemp:
+			tmpSuffix := strings.Split(t.Name, "files")[1]
+			g.Fgenf(w, "%s, err := ioutil.ReadDir(%.v)\n", t.Name, t.Value.Args[0])
+			g.Fgenf(w, "if err != nil {\n")
+			if genZeroValueDecl {
+				g.Fgenf(w, "return _zero, err\n")
+			} else {
+				g.Fgenf(w, "return err\n")
+			}
+			g.Fgenf(w, "}\n")
+			namesVar := fmt.Sprintf("fileNames%s", tmpSuffix)
+			g.Fgenf(w, "%s := make([]string, len(%s))\n", namesVar, t.Name)
+			iVar := fmt.Sprintf("i%s", tmpSuffix)
+			valVar := fmt.Sprintf("val%s", tmpSuffix)
+			g.Fgenf(w, "for %s, %s := range %s {\n", iVar, valVar, t.Name)
+			g.Fgenf(w, "%s[%s] = %s.Name()\n", namesVar, iVar, valVar)
+			g.Fgenf(w, "}\n")
+		default:
+			contract.Failf("unexpected temp type: %v", t)
 		}
 	}
 }

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -309,13 +309,13 @@ func (g *generator) genLocalVariable(w io.Writer, v *hcl2.LocalVariable) {
 	case *model.FunctionCallExpression:
 		switch expr.Name {
 		case hcl2.Invoke:
-			g.Fgenf(w, "%s, err := %.3v;\n", v.Name(), expr)
+			g.Fgenf(w, "%s, err := %.3v;\n", name, expr)
 			g.Fgenf(w, "if err != nil {\n")
 			g.Fgenf(w, "return err\n")
 			g.Fgenf(w, "}\n")
 		}
 	default:
-		g.Fgenf(w, "%s := %.3v;\n", v.Name(), expr)
+		g.Fgenf(w, "%s := %.3v;\n", name, expr)
 
 	}
 

--- a/pkg/codegen/go/gen_program_inputs.go
+++ b/pkg/codegen/go/gen_program_inputs.go
@@ -58,7 +58,8 @@ func modifyInputs(
 			return x
 		}
 		switch expr.Name {
-
+		case "mimeType":
+			return modf(x)
 		case hcl2.IntrinsicConvert:
 			switch rt := expr.Signature.ReturnType.(type) {
 			case *model.UnionType:

--- a/pkg/codegen/go/gen_program_read_dir.go
+++ b/pkg/codegen/go/gen_program_read_dir.go
@@ -1,0 +1,70 @@
+package gen
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+)
+
+type readDirTemp struct {
+	Name  string
+	Value *model.FunctionCallExpression
+}
+
+func (rt *readDirTemp) Type() model.Type {
+	return rt.Value.Type()
+}
+
+func (rt *readDirTemp) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	return rt.Type().Traverse(traverser)
+}
+
+func (rt *readDirTemp) SyntaxNode() hclsyntax.Node {
+	return syntax.None
+}
+
+type readDirSpiller struct {
+	temps []*readDirTemp
+	count int
+}
+
+func (rs *readDirSpiller) spillExpression(x model.Expression) (model.Expression, hcl.Diagnostics) {
+	var temp *readDirTemp
+	scopeName := ""
+	switch x := x.(type) {
+	case *model.FunctionCallExpression:
+		switch x.Name {
+		case "readDir":
+			scopeName = fmt.Sprintf("fileNames%d", rs.count)
+			temp = &readDirTemp{
+				Name:  fmt.Sprintf("files%d", rs.count),
+				Value: x,
+			}
+			rs.temps = append(rs.temps, temp)
+			rs.count++
+		default:
+			return x, nil
+		}
+	default:
+		return x, nil
+	}
+	return &model.ScopeTraversalExpression{
+		RootName:  scopeName,
+		Traversal: hcl.Traversal{hcl.TraverseRoot{Name: ""}},
+		Parts:     []model.Traversable{temp},
+	}, nil
+}
+
+func (g *generator) rewriteReadDir(
+	x model.Expression,
+	spiller *readDirSpiller,
+) (model.Expression, []*readDirTemp, hcl.Diagnostics) {
+	spiller.temps = nil
+	x, diags := model.VisitExpression(x, spiller.spillExpression, nil)
+
+	return x, spiller.temps, diags
+
+}

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/pulumi/pulumi/pkg/v2/codegen"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model/format"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
@@ -117,10 +118,11 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 		}
 
 		g := &generator{
-			program:            program,
-			jsonTempSpiller:    &jsonSpiller{},
-			ternaryTempSpiller: &tempSpiller{},
-			readDirTempSpiller: &readDirSpiller{},
+			program:             program,
+			jsonTempSpiller:     &jsonSpiller{},
+			ternaryTempSpiller:  &tempSpiller{},
+			readDirTempSpiller:  &readDirSpiller{},
+			scopeTraversalRoots: codegen.NewStringSet(),
 		}
 		g.Formatter = format.NewFormatter(g)
 		return g

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -28,6 +28,7 @@ func TestGenProgram(t *testing.T) {
 		}
 		// TODO: include all test files
 		if filepath.Base(f.Name()) != "aws-s3-logging.pp" &&
+			filepath.Base(f.Name()) != "aws-s3-folder.pp" &&
 			filepath.Base(f.Name()) != "aws-fargate.pp" {
 			continue
 		}
@@ -63,7 +64,7 @@ func TestGenProgram(t *testing.T) {
 			files, diags, err := GenerateProgram(program)
 			assert.NoError(t, err)
 			if diags.HasErrors() {
-				t.Fatalf("failed to bind program: %v", diags)
+				t.Fatalf("failed to generate program: %v", diags)
 			}
 			assert.Equal(t, string(expected), string(files["main.go"]))
 		})
@@ -119,6 +120,7 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 			program:            program,
 			jsonTempSpiller:    &jsonSpiller{},
 			ternaryTempSpiller: &tempSpiller{},
+			readDirTempSpiller: &readDirSpiller{},
 		}
 		g.Formatter = format.NewFormatter(g)
 		return g

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
@@ -77,7 +77,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		taskExecRolePolicyAttachment, err := iam.NewRolePolicyAttachment(ctx, "taskExecRolePolicyAttachment", &iam.RolePolicyAttachmentArgs{
+		_, err = iam.NewRolePolicyAttachment(ctx, "taskExecRolePolicyAttachment", &iam.RolePolicyAttachmentArgs{
 			Role:      taskExecRole.Name,
 			PolicyArn: pulumi.String("arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"),
 		})
@@ -146,7 +146,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		appService, err := ecs.NewService(ctx, "appService", &ecs.ServiceArgs{
+		_, err = ecs.NewService(ctx, "appService", &ecs.ServiceArgs{
 			Cluster:        cluster.Arn,
 			DesiredCount:   pulumi.Int(5),
 			LaunchType:     pulumi.String("FARGATE"),

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
@@ -31,7 +31,7 @@ func main() {
 			fileNames0[i0] = val0.Name()
 		}
 		for i0, val0 := range fileNames0 {
-			_, err := s3.NewBucketObject(ctx, "files-"+string(i0), &s3.BucketObjectArgs{
+			_, err = s3.NewBucketObject(ctx, "files-"+string(i0), &s3.BucketObjectArgs{
 				Bucket:      siteBucket.ID(),
 				Key:         pulumi.String(val0),
 				Source:      pulumi.NewFileAsset(fmt.Sprintf("%v%v%v", siteDir, "/", val0)),
@@ -41,7 +41,7 @@ func main() {
 				return err
 			}
 		}
-		bucketPolicy, err := s3.NewBucketPolicy(ctx, "bucketPolicy", &s3.BucketPolicyArgs{
+		_, err = s3.NewBucketPolicy(ctx, "bucketPolicy", &s3.BucketPolicyArgs{
 			Bucket: siteBucket.ID(),
 			Policy: siteBucket.ID().ApplyT(func(id string) (pulumi.String, error) {
 				var _zero pulumi.String

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"mime"
+	"path"
+
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		siteBucket, err := s3.NewBucket(ctx, "siteBucket", &s3.BucketArgs{
+			Website: &s3.BucketWebsiteArgs{
+				IndexDocument: pulumi.String("index.html"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		siteDir := "www"
+		files0, err := ioutil.ReadDir(siteDir)
+		if err != nil {
+			return err
+		}
+		fileNames0 := make([]string, len(files0))
+		for i0, val0 := range files0 {
+			fileNames0[i0] = val0.Name()
+		}
+		for i0, val0 := range fileNames0 {
+			_, err := s3.NewBucketObject(ctx, "files-"+string(i0), &s3.BucketObjectArgs{
+				Bucket:      siteBucket.ID(),
+				Key:         pulumi.String(val0),
+				Source:      pulumi.NewFileAsset(fmt.Sprintf("%v%v%v", siteDir, "/", val0)),
+				ContentType: pulumi.String(mime.TypeByExtension(path.Ext(val0))),
+			})
+			if err != nil {
+				return err
+			}
+		}
+		bucketPolicy, err := s3.NewBucketPolicy(ctx, "bucketPolicy", &s3.BucketPolicyArgs{
+			Bucket: siteBucket.ID(),
+			Policy: siteBucket.ID().ApplyT(func(id string) (pulumi.String, error) {
+				var _zero pulumi.String
+				tmpJSON0, err := json.Marshal(map[string]interface{}{
+					"Version": "2012-10-17",
+					"Statement": []map[string]interface{}{
+						map[string]interface{}{
+							"Effect":    "Allow",
+							"Principal": "*",
+							"Action": []string{
+								"s3:GetObject",
+							},
+							"Resource": []string{
+								fmt.Sprintf("%v%v%v", "arn:aws:s3:::", id, "/*"),
+							},
+						},
+					},
+				})
+				if err != nil {
+					return _zero, err
+				}
+				json0 := string(tmpJSON0)
+				return pulumi.String(json0), nil
+			}).(pulumi.StringOutput),
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("bucketName", siteBucket.Bucket)
+		ctx.Export("websiteUrl", siteBucket.WebsiteEndpoint)
+		return nil
+	})
+}


### PR DESCRIPTION
Everything needed to support the s3-folder example. Also added a step to build a set of scope traversal tools allowing later replacement of unused variable declarations with `_`.
Fixes https://github.com/pulumi/pulumi/issues/4781
Fixes https://github.com/pulumi/pulumi/issues/4771