### PR TITLE
[Go Program Gen] Support for EKS example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Go program gen improvements (splat, all, index, traversal, range)
+  [#4831](https://github.com/pulumi/pulumi/pull/4831)
+
 - Go program gen improvements (resource range, readDir, fileArchive)
   [#4818](https://github.com/pulumi/pulumi/pull/4818)
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -24,6 +24,7 @@ type generator struct {
 	jsonTempSpiller     *jsonSpiller
 	ternaryTempSpiller  *tempSpiller
 	readDirTempSpiller  *readDirSpiller
+	splatSpiller        *splatSpiller
 	scopeTraversalRoots codegen.StringSet
 }
 
@@ -36,6 +37,7 @@ func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics,
 		jsonTempSpiller:     &jsonSpiller{},
 		ternaryTempSpiller:  &tempSpiller{},
 		readDirTempSpiller:  &readDirSpiller{},
+		splatSpiller:        &splatSpiller{},
 		scopeTraversalRoots: codegen.NewStringSet(),
 	}
 
@@ -183,7 +185,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 	}
 
 	instantiate := func(varName, resourceName string) {
-		if g.scopeTraversalRoots.Has(varName) {
+		if g.scopeTraversalRoots.Has(varName) || strings.HasPrefix(varName, "_") {
 			g.Fgenf(w, "%s, err := %s.New%s(ctx, %s, ", varName, mod, typ, resourceName)
 		} else {
 			g.Fgenf(w, "_, err = %s.New%s(ctx, %s, ", mod, typ, resourceName)
@@ -210,8 +212,11 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		rangeExpr, temps := g.lowerExpression(r.Options.Range, rangeType, false)
 		g.genTemps(w, temps)
 
+		g.Fgenf(w, "var %s []*%s.%s\n", resName, mod, typ)
+
 		g.Fgenf(w, "for i0, val0 := range %.v {\n", rangeExpr)
-		instantiate("_", fmt.Sprintf("\"%s-\"+ string(i0)", resName))
+		instantiate("_res", fmt.Sprintf("\"%s-\"+ string(i0)", resName))
+		g.Fgenf(w, "%s = append(%s, _res)\n", resName, resName)
 		g.Fgenf(w, "}\n")
 
 	} else {
@@ -290,6 +295,12 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 			valVar := fmt.Sprintf("val%s", tmpSuffix)
 			g.Fgenf(w, "for %s, %s := range %s {\n", iVar, valVar, t.Name)
 			g.Fgenf(w, "%s[%s] = %s.Name()\n", namesVar, iVar, valVar)
+			g.Fgenf(w, "}\n")
+		case *splatTemp:
+			argTyp := argumentTypeName(t.Value.Each, t.Value.Each.Type(), false)
+			g.Fgenf(w, "var %s []%s\n", t.Name, argTyp)
+			g.Fgenf(w, "for _, val0 := range %.v {\n", t.Value.Source)
+			g.Fgenf(w, "%s = append(%s, %.v)\n", t.Name, t.Name, t.Value.Each)
 			g.Fgenf(w, "}\n")
 		default:
 			contract.Failf("unexpected temp type: %v", t)

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -214,8 +214,8 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 		g.Fgenf(w, "var %s []*%s.%s\n", resName, mod, typ)
 
-		g.Fgenf(w, "for i0, val0 := range %.v {\n", rangeExpr)
-		instantiate("_res", fmt.Sprintf("\"%s-\"+ string(i0)", resName))
+		g.Fgenf(w, "for key0, val0 := range %.v {\n", rangeExpr)
+		instantiate("_res", fmt.Sprintf(`fmt.Sprintf("%s-%%v", key0)`, resName))
 		g.Fgenf(w, "%s = append(%s, _res)\n", resName, resName)
 		g.Fgenf(w, "}\n")
 
@@ -291,7 +291,7 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 			g.Fgenf(w, "}\n")
 			namesVar := fmt.Sprintf("fileNames%s", tmpSuffix)
 			g.Fgenf(w, "%s := make([]string, len(%s))\n", namesVar, t.Name)
-			iVar := fmt.Sprintf("i%s", tmpSuffix)
+			iVar := fmt.Sprintf("key%s", tmpSuffix)
 			valVar := fmt.Sprintf("val%s", tmpSuffix)
 			g.Fgenf(w, "for %s, %s := range %s {\n", iVar, valVar, t.Name)
 			g.Fgenf(w, "%s[%s] = %s.Name()\n", namesVar, iVar, valVar)

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -130,7 +130,18 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	switch expr.Name {
 	case hcl2.IntrinsicInput:
 		isInput := true
+		// bypass passthrough __convert expressions that might require prefix: "pulumi.*"
+		if c, ok := expr.Args[0].(*model.FunctionCallExpression); ok && c.Name == hcl2.IntrinsicConvert {
+			switch c := c.Args[0].(type) {
+			case *model.RelativeTraversalExpression, *model.ScopeTraversalExpression:
+				expr.Args[0] = c
+				g.GenFunctionCallExpression(w, expr)
+				return
+			}
+		}
 		switch arg := expr.Args[0].(type) {
+		case *model.RelativeTraversalExpression:
+			g.genRelativeTraversalExpression(w, arg, isInput)
 		case *model.ScopeTraversalExpression:
 			g.genScopeTraversalExpression(w, arg, isInput)
 		default:
@@ -179,6 +190,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case hcl2.Invoke:
 		_, module, fn, diags := functionName(expr.Args[0])
 		contract.Assert(len(diags) == 0)
+		if module == "" {
+			module = "aws"
+		}
 		name := fmt.Sprintf("%s.%s", module, fn)
 
 		optionsBag := ""
@@ -215,8 +229,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	}
 }
 
-// GenIndexExpression generates code for an IndexExpression.
-func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) { /*TODO*/ }
+func (g *generator) GenIndexExpression(w io.Writer, expr *model.IndexExpression) {
+	g.Fgenf(w, "%.20v[%.v]", expr.Collection, expr.Key)
+}
 
 func (g *generator) GenLiteralValueExpression(w io.Writer, expr *model.LiteralValueExpression) {
 	g.genLiteralValueExpression(w, expr, expr.Type())
@@ -335,12 +350,40 @@ func (g *generator) genObjectConsExpression(w io.Writer, expr *model.ObjectConsE
 		}
 
 		g.Fgenf(w, "}")
+	} else {
+		g.Fgenf(w, "nil")
+	}
+}
+
+func (g *generator) genRelativeTraversalExpression(w io.Writer, expr *model.RelativeTraversalExpression, isInput bool) {
+
+	if _, ok := expr.Parts[0].(*model.PromiseType); ok {
+		isInput = false
+	}
+	if _, ok := expr.Parts[0].(*hcl2.Resource); ok {
+		isInput = false
+	}
+	if isInput {
+		g.Fgenf(w, "%s(", argumentTypeName(expr, expr.Type(), isInput))
+	}
+	g.GenRelativeTraversalExpression(w, expr)
+	if isInput {
+		g.Fgenf(w, ")")
 	}
 }
 
 func (g *generator) GenRelativeTraversalExpression(w io.Writer, expr *model.RelativeTraversalExpression) {
 	g.Fgenf(w, "%.20v", expr.Source)
-	g.genRelativeTraversal(w, expr.Traversal, expr.Parts, nil)
+	isRootResource := false
+	if ie, ok := expr.Source.(*model.IndexExpression); ok {
+		if se, ok := ie.Collection.(*model.ScopeTraversalExpression); ok {
+			if _, ok := se.Parts[0].(*hcl2.Resource); ok {
+				isRootResource = true
+			}
+			isRootResource = true
+		}
+	}
+	g.genRelativeTraversal(w, expr.Traversal, expr.Parts, isRootResource)
 }
 
 func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression) {
@@ -350,18 +393,17 @@ func (g *generator) GenScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 
 func (g *generator) genScopeTraversalExpression(w io.Writer, expr *model.ScopeTraversalExpression, isInput bool) {
 	rootName := expr.RootName
-	// TODO splat
-	// if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
-	// 	rootName = "__item"
-	// }
+
+	if _, ok := expr.Parts[0].(*model.SplatVariable); ok {
+		rootName = "val0"
+	}
 
 	genIDCall := false
 
-	var objType *schema.ObjectType
 	if resource, ok := expr.Parts[0].(*hcl2.Resource); ok {
 		isInput = false
 		if schemaType, ok := hcl2.GetSchemaForType(resource.InputType); ok {
-			objType, _ = schemaType.(*schema.ObjectType)
+			_, _ = schemaType.(*schema.ObjectType)
 			// convert .id into .ID()
 			last := expr.Traversal[len(expr.Traversal)-1]
 			if attr, ok := last.(hcl.TraverseAttr); ok && attr.Name == "id" {
@@ -382,13 +424,14 @@ func (g *generator) genScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 		case "value":
 			g.Fgenf(w, "val0")
 		case "key":
-			g.Fgenf(w, "key0")
+			g.Fgenf(w, "i0")
 		default:
 			contract.Failf("unexpected traversal on range expression: %s", part)
 		}
 	} else {
 		g.Fgen(w, rootName)
-		g.genRelativeTraversal(w, expr.Traversal.SimpleSplit().Rel, expr.Parts, objType)
+		isRootResource := false
+		g.genRelativeTraversal(w, expr.Traversal.SimpleSplit().Rel, expr.Parts[1:], isRootResource)
 	}
 
 	if isInput {
@@ -401,7 +444,9 @@ func (g *generator) genScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 }
 
 // GenSplatExpression generates code for a SplatExpression.
-func (g *generator) GenSplatExpression(w io.Writer, expr *model.SplatExpression) { /*TODO*/ }
+func (g *generator) GenSplatExpression(w io.Writer, expr *model.SplatExpression) {
+	contract.Failf("unlowered splat expression @ %v", expr.SyntaxNode().Range())
+}
 
 // GenTemplateExpression generates code for a TemplateExpression.
 func (g *generator) GenTemplateExpression(w io.Writer, expr *model.TemplateExpression) {
@@ -533,9 +578,15 @@ func argumentTypeName(expr model.Expression, destType model.Type, isInput bool) 
 			return destType.Name
 		}
 	case *model.ObjectType:
+		if isInput {
+			return "pulumi.Map"
+		}
 		return "map[string]interface{}"
 	case *model.MapType:
 		valType := argumentTypeName(nil, destType.ElementType, isInput)
+		if isInput {
+			return fmt.Sprintf("pulumi.%sMap", Title(valType))
+		}
 		return fmt.Sprintf("map[string]%s", valType)
 	case *model.ListType:
 		argTypeName := argumentTypeName(nil, destType.ElementType, isInput)
@@ -588,10 +639,9 @@ func argumentTypeName(expr model.Expression, destType model.Type, isInput bool) 
 	return ""
 }
 
-func (g *generator) genRelativeTraversal(w io.Writer,
-	traversal hcl.Traversal, parts []model.Traversable, objType *schema.ObjectType) {
+func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, parts []model.Traversable, isRootResource bool) {
 
-	for _, part := range traversal {
+	for i, part := range traversal {
 		var key cty.Value
 		switch part := part.(type) {
 		case hcl.TraverseAttr:
@@ -609,7 +659,15 @@ func (g *generator) genRelativeTraversal(w io.Writer,
 
 		switch key.Type() {
 		case cty.String:
-			g.Fgenf(w, ".%s", Title(key.AsString()))
+			shouldConvert := isRootResource
+			if _, ok := parts[i].(*model.OutputType); ok {
+				shouldConvert = true
+			}
+			if key.AsString() == "id" && shouldConvert {
+				g.Fgenf(w, ".ID()")
+			} else {
+				g.Fgenf(w, ".%s", Title(key.AsString()))
+			}
 		case cty.Number:
 			idx, _ := key.AsBigFloat().Int64()
 			g.Fgenf(w, "[%d]", idx)
@@ -626,7 +684,7 @@ func (nameInfo) Format(name string) string {
 	return name
 }
 
-// lowerExpression amends the expression with intrinsics for C# generation.
+// lowerExpression amends the expression with intrinsics for Go generation.
 func (g *generator) lowerExpression(expr model.Expression, typ model.Type, isInput bool) (
 	model.Expression, []interface{}) {
 	expr, diags := hcl2.RewriteApplies(expr, nameInfo(0), false /*TODO*/)
@@ -634,6 +692,7 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type, isInp
 	expr, tTemps, ternDiags := g.rewriteTernaries(expr, g.ternaryTempSpiller)
 	expr, jTemps, jsonDiags := g.rewriteToJSON(expr, g.jsonTempSpiller)
 	expr, rTemps, readDirDiags := g.rewriteReadDir(expr, g.readDirTempSpiller)
+	expr, sTemps, splatDiags := g.rewriteSplat(expr, g.splatSpiller)
 
 	if isInput {
 		expr = rewriteInputs(expr)
@@ -648,9 +707,13 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type, isInp
 	for _, t := range rTemps {
 		temps = append(temps, t)
 	}
+	for _, t := range sTemps {
+		temps = append(temps, t)
+	}
 	diags = append(diags, ternDiags...)
 	diags = append(diags, jsonDiags...)
 	diags = append(diags, readDirDiags...)
+	diags = append(diags, splatDiags...)
 	contract.Assert(len(diags) == 0)
 	return expr, temps
 }
@@ -681,7 +744,14 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 		// If we only have a single output, just generate a normal `.Apply`
 		g.Fgenf(w, "%.v.ApplyT(%.v)%s", applyArgs[0], then, typeAssertion)
 	} else {
-		// TODO
+		g.Fgenf(w, "pulumi.All(%.v", applyArgs[0])
+		applyArgs = applyArgs[1:]
+		for _, a := range applyArgs {
+			g.Fgenf(w, ",%.v", a)
+		}
+		// TODO need lowering step to rewrite then arugment references
+		// in terms of scope traversal from all result: val[i] etc.
+		g.Fgenf(w, ").Apply(%.v)%s", then, typeAssertion)
 	}
 }
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -380,7 +380,6 @@ func (g *generator) GenRelativeTraversalExpression(w io.Writer, expr *model.Rela
 			if _, ok := se.Parts[0].(*hcl2.Resource); ok {
 				isRootResource = true
 			}
-			isRootResource = true
 		}
 	}
 	g.genRelativeTraversal(w, expr.Traversal, expr.Parts, isRootResource)
@@ -639,7 +638,8 @@ func argumentTypeName(expr model.Expression, destType model.Type, isInput bool) 
 	return ""
 }
 
-func (g *generator) genRelativeTraversal(w io.Writer, traversal hcl.Traversal, parts []model.Traversable, isRootResource bool) {
+func (g *generator) genRelativeTraversal(w io.Writer,
+	traversal hcl.Traversal, parts []model.Traversable, isRootResource bool) {
 
 	for i, part := range traversal {
 		var key cty.Value
@@ -749,7 +749,7 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 		for _, a := range applyArgs {
 			g.Fgenf(w, ",%.v", a)
 		}
-		// TODO need lowering step to rewrite then arugment references
+		// TODO need lowering step to rewrite then argument references
 		// in terms of scope traversal from all result: val[i] etc.
 		g.Fgenf(w, ").Apply(%.v)%s", then, typeAssertion)
 	}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -188,10 +188,10 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "fileAsset":
 		g.Fgenf(w, "pulumi.NewFileAsset(%.v)", expr.Args[0])
 	case hcl2.Invoke:
-		_, module, fn, diags := functionName(expr.Args[0])
+		pkg, module, fn, diags := functionName(expr.Args[0])
 		contract.Assert(len(diags) == 0)
 		if module == "" {
-			module = "aws"
+			module = pkg
 		}
 		name := fmt.Sprintf("%s.%s", module, fn)
 
@@ -401,8 +401,7 @@ func (g *generator) genScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 
 	if resource, ok := expr.Parts[0].(*hcl2.Resource); ok {
 		isInput = false
-		if schemaType, ok := hcl2.GetSchemaForType(resource.InputType); ok {
-			_, _ = schemaType.(*schema.ObjectType)
+		if _, ok := hcl2.GetSchemaForType(resource.InputType); ok {
 			// convert .id into .ID()
 			last := expr.Traversal[len(expr.Traversal)-1]
 			if attr, ok := last.(hcl.TraverseAttr); ok && attr.Name == "id" {

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -563,7 +563,7 @@ func argumentTypeName(expr model.Expression, destType model.Type, isInput bool) 
 				return "pulumi.Float64"
 			}
 			return "float64"
-		case model.StringType:
+		case model.StringType, model.DynamicType:
 			if isInput {
 				return "pulumi.String"
 			}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -208,7 +208,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "%.v", expr.Args[1])
 		g.Fgenf(w, "%v)", optionsBag)
 	case "length":
-		g.Fgenf(w, "%.20v.Length", expr.Args[0])
+		g.genNYI(w, "call %v", expr.Name)
+		// g.Fgenf(w, "%.20v.Length", expr.Args[0])
 	case "lookup":
 		g.genNYI(w, "Lookup")
 	case "range":
@@ -219,7 +220,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "readDir":
 		contract.Failf("unlowered toJSON function expression @ %v", expr.SyntaxNode().Range())
 	case "split":
-		g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])
+		g.genNYI(w, "call %v", expr.Name)
+		// g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])
 	case "toJSON":
 		contract.Failf("unlowered toJSON function expression @ %v", expr.SyntaxNode().Range())
 	case "mimeType":
@@ -416,13 +418,16 @@ func (g *generator) genScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 		g.Fgenf(w, "%s(", argumentTypeName(expr, expr.Type(), isInput))
 	}
 
+	// TODO: this isn't exhaustively correct as "range" could be a legit var name
+	// instead we should probably use a fn call expression here for entries/range
+	// similar to other languages
 	if rootName == "range" {
 		part := expr.Traversal[1].(hcl.TraverseAttr).Name
 		switch part {
 		case "value":
 			g.Fgenf(w, "val0")
 		case "key":
-			g.Fgenf(w, "i0")
+			g.Fgenf(w, "key0")
 		default:
 			contract.Failf("unexpected traversal on range expression: %s", part)
 		}

--- a/pkg/codegen/go/gen_program_splat.go
+++ b/pkg/codegen/go/gen_program_splat.go
@@ -1,0 +1,63 @@
+package gen
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+)
+
+type splatTemp struct {
+	Name  string
+	Value *model.SplatExpression
+}
+
+func (st *splatTemp) Type() model.Type {
+	return st.Value.Type()
+}
+
+func (st *splatTemp) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	return st.Type().Traverse(traverser)
+}
+
+func (st *splatTemp) SyntaxNode() hclsyntax.Node {
+	return syntax.None
+}
+
+type splatSpiller struct {
+	temps []*splatTemp
+	count int
+}
+
+func (ss *splatSpiller) spillExpression(x model.Expression) (model.Expression, hcl.Diagnostics) {
+	var temp *splatTemp
+	switch x := x.(type) {
+	case *model.SplatExpression:
+		temp = &splatTemp{
+			Name:  fmt.Sprintf("splat%d", ss.count),
+			Value: x,
+		}
+		ss.temps = append(ss.temps, temp)
+		ss.count++
+	default:
+		return x, nil
+	}
+	return &model.ScopeTraversalExpression{
+		RootName:  temp.Name,
+		Traversal: hcl.Traversal{hcl.TraverseRoot{Name: ""}},
+		Parts:     []model.Traversable{temp},
+	}, nil
+}
+
+func (g *generator) rewriteSplat(
+	x model.Expression,
+	spiller *splatSpiller,
+) (model.Expression, []*splatTemp, hcl.Diagnostics) {
+	spiller.temps = nil
+	x, diags := model.VisitExpression(x, spiller.spillExpression, nil)
+
+	return x, spiller.temps, diags
+
+}

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -30,6 +30,7 @@ func TestGenProgram(t *testing.T) {
 		// TODO: include all test files
 		if filepath.Base(f.Name()) != "aws-s3-logging.pp" &&
 			filepath.Base(f.Name()) != "aws-s3-folder.pp" &&
+			filepath.Base(f.Name()) != "aws-eks.pp" &&
 			filepath.Base(f.Name()) != "aws-fargate.pp" {
 			continue
 		}
@@ -122,6 +123,7 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 			jsonTempSpiller:     &jsonSpiller{},
 			ternaryTempSpiller:  &tempSpiller{},
 			readDirTempSpiller:  &readDirSpiller{},
+			splatSpiller:        &splatSpiller{},
 			scopeTraversalRoots: codegen.NewStringSet(),
 		}
 		g.Formatter = format.NewFormatter(g)

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -53,12 +53,12 @@ func main() {
 			return err
 		}
 		var vpcSubnet []*ec2.Subnet
-		for i0, val0 := range zones.Names {
-			_res, err := ec2.NewSubnet(ctx, "vpcSubnet-"+string(i0), &ec2.SubnetArgs{
+		for key0, val0 := range zones.Names {
+			_res, err := ec2.NewSubnet(ctx, fmt.Sprintf("vpcSubnet-%v", key0), &ec2.SubnetArgs{
 				AssignIpv6AddressOnCreation: pulumi.Bool(false),
 				VpcId:                       eksVpc.ID(),
 				MapPublicIpOnLaunch:         pulumi.Bool(true),
-				CidrBlock:                   pulumi.String(fmt.Sprintf("%v%v%v", "10.100.", i0, ".0/24")),
+				CidrBlock:                   pulumi.String(fmt.Sprintf("%v%v%v", "10.100.", key0, ".0/24")),
 				AvailabilityZone:            pulumi.String(val0),
 				Tags: map[string]interface{}{
 					"Name": fmt.Sprintf("%v%v", "pulumi-sn-", val0),
@@ -70,10 +70,10 @@ func main() {
 			vpcSubnet = append(vpcSubnet, _res)
 		}
 		var rta []*ec2.RouteTableAssociation
-		for i0, val0 := range zones.Names {
-			_res, err := ec2.NewRouteTableAssociation(ctx, "rta-"+string(i0), &ec2.RouteTableAssociationArgs{
+		for key0, val0 := range zones.Names {
+			_res, err := ec2.NewRouteTableAssociation(ctx, fmt.Sprintf("rta-%v", key0), &ec2.RouteTableAssociationArgs{
 				RouteTableId: eksRouteTable.ID(),
-				SubnetId:     vpcSubnet[i0].ID(),
+				SubnetId:     vpcSubnet[key0].ID(),
 			})
 			if err != nil {
 				return err

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/ec2"
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/eks"
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		eksVpc, err := ec2.NewVpc(ctx, "eksVpc", &ec2.VpcArgs{
+			CidrBlock:          pulumi.String("10.100.0.0/16"),
+			InstanceTenancy:    pulumi.String("default"),
+			EnableDnsHostnames: pulumi.Bool(true),
+			EnableDnsSupport:   pulumi.Bool(true),
+			Tags: map[string]interface{}{
+				"Name": "pulumi-eks-vpc",
+			},
+		})
+		if err != nil {
+			return err
+		}
+		eksIgw, err := ec2.NewInternetGateway(ctx, "eksIgw", &ec2.InternetGatewayArgs{
+			VpcId: eksVpc.ID(),
+			Tags: map[string]interface{}{
+				"Name": "pulumi-vpc-ig",
+			},
+		})
+		if err != nil {
+			return err
+		}
+		eksRouteTable, err := ec2.NewRouteTable(ctx, "eksRouteTable", &ec2.RouteTableArgs{
+			VpcId: eksVpc.ID(),
+			Routes: ec2.RouteTableRouteArray{
+				&ec2.RouteTableRouteArgs{
+					CidrBlock: pulumi.String("0.0.0.0/0"),
+					GatewayId: eksIgw.ID(),
+				},
+			},
+			Tags: map[string]interface{}{
+				"Name": "pulumi-vpc-rt",
+			},
+		})
+		if err != nil {
+			return err
+		}
+		zones, err := aws.LookupAvailabilityZones(ctx, nil, nil)
+		if err != nil {
+			return err
+		}
+		var vpcSubnet []*ec2.Subnet
+		for i0, val0 := range zones.Names {
+			_res, err := ec2.NewSubnet(ctx, "vpcSubnet-"+string(i0), &ec2.SubnetArgs{
+				AssignIpv6AddressOnCreation: pulumi.Bool(false),
+				VpcId:                       eksVpc.ID(),
+				MapPublicIpOnLaunch:         pulumi.Bool(true),
+				CidrBlock:                   pulumi.String(fmt.Sprintf("%v%v%v", "10.100.", i0, ".0/24")),
+				AvailabilityZone:            pulumi.String(val0),
+				Tags: map[string]interface{}{
+					"Name": fmt.Sprintf("%v%v", "pulumi-sn-", val0),
+				},
+			})
+			if err != nil {
+				return err
+			}
+			vpcSubnet = append(vpcSubnet, _res)
+		}
+		var rta []*ec2.RouteTableAssociation
+		for i0, val0 := range zones.Names {
+			_res, err := ec2.NewRouteTableAssociation(ctx, "rta-"+string(i0), &ec2.RouteTableAssociationArgs{
+				RouteTableId: eksRouteTable.ID(),
+				SubnetId:     vpcSubnet[i0].ID(),
+			})
+			if err != nil {
+				return err
+			}
+			rta = append(rta, _res)
+		}
+		var splat0 []pulumi.String
+		for _, val0 := range vpcSubnet {
+			splat0 = append(splat0, val0.ID())
+		}
+		subnetIds := splat0
+		eksSecurityGroup, err := ec2.NewSecurityGroup(ctx, "eksSecurityGroup", &ec2.SecurityGroupArgs{
+			VpcId:       eksVpc.ID(),
+			Description: pulumi.String("Allow all HTTP(s) traffic to EKS Cluster"),
+			Tags: map[string]interface{}{
+				"Name": "pulumi-cluster-sg",
+			},
+			Ingress: ec2.SecurityGroupIngressArray{
+				&ec2.SecurityGroupIngressArgs{
+					CidrBlocks: pulumi.StringArray{
+						pulumi.String("0.0.0.0/0"),
+					},
+					FromPort:    pulumi.Int(443),
+					ToPort:      pulumi.Int(443),
+					Protocol:    pulumi.String("tcp"),
+					Description: pulumi.String("Allow pods to communicate with the cluster API Server."),
+				},
+				&ec2.SecurityGroupIngressArgs{
+					CidrBlocks: pulumi.StringArray{
+						pulumi.String("0.0.0.0/0"),
+					},
+					FromPort:    pulumi.Int(80),
+					ToPort:      pulumi.Int(80),
+					Protocol:    pulumi.String("tcp"),
+					Description: pulumi.String("Allow internet access to pods"),
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		tmpJSON0, err := json.Marshal(map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []map[string]interface{}{
+				map[string]interface{}{
+					"Action": "sts:AssumeRole",
+					"Principal": map[string]interface{}{
+						"Service": "eks.amazonaws.com",
+					},
+					"Effect": "Allow",
+					"Sid":    "",
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		json0 := string(tmpJSON0)
+		eksRole, err := iam.NewRole(ctx, "eksRole", &iam.RoleArgs{
+			AssumeRolePolicy: pulumi.String(json0),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = iam.NewRolePolicyAttachment(ctx, "servicePolicyAttachment", &iam.RolePolicyAttachmentArgs{
+			Role:      eksRole.ID(),
+			PolicyArn: pulumi.String("arn:aws:iam::aws:policy/AmazonEKSServicePolicy"),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = iam.NewRolePolicyAttachment(ctx, "clusterPolicyAttachment", &iam.RolePolicyAttachmentArgs{
+			Role:      eksRole.ID(),
+			PolicyArn: pulumi.String("arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"),
+		})
+		if err != nil {
+			return err
+		}
+		tmpJSON1, err := json.Marshal(map[string]interface{}{
+			"Version": "2012-10-17",
+			"Statement": []map[string]interface{}{
+				map[string]interface{}{
+					"Action": "sts:AssumeRole",
+					"Principal": map[string]interface{}{
+						"Service": "ec2.amazonaws.com",
+					},
+					"Effect": "Allow",
+					"Sid":    "",
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		json1 := string(tmpJSON1)
+		ec2Role, err := iam.NewRole(ctx, "ec2Role", &iam.RoleArgs{
+			AssumeRolePolicy: pulumi.String(json1),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = iam.NewRolePolicyAttachment(ctx, "workerNodePolicyAttachment", &iam.RolePolicyAttachmentArgs{
+			Role:      ec2Role.ID(),
+			PolicyArn: pulumi.String("arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = iam.NewRolePolicyAttachment(ctx, "cniPolicyAttachment", &iam.RolePolicyAttachmentArgs{
+			Role:      ec2Role.ID(),
+			PolicyArn: pulumi.String("arn:aws:iam::aws:policy/AmazonEKSCNIPolicy"),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = iam.NewRolePolicyAttachment(ctx, "registryPolicyAttachment", &iam.RolePolicyAttachmentArgs{
+			Role:      ec2Role.ID(),
+			PolicyArn: pulumi.String("arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"),
+		})
+		if err != nil {
+			return err
+		}
+		eksCluster, err := eks.NewCluster(ctx, "eksCluster", &eks.ClusterArgs{
+			RoleArn: eksRole.Arn,
+			Tags: map[string]interface{}{
+				"Name": "pulumi-eks-cluster",
+			},
+			VpcConfig: &eks.ClusterVpcConfigArgs{
+				PublicAccessCidrs: pulumi.StringArray{
+					pulumi.String("0.0.0.0/0"),
+				},
+				SecurityGroupIds: pulumi.StringArray{
+					eksSecurityGroup.ID(),
+				},
+				SubnetIds: subnetIds,
+			},
+		})
+		if err != nil {
+			return err
+		}
+		_, err = eks.NewNodeGroup(ctx, "nodeGroup", &eks.NodeGroupArgs{
+			ClusterName:   eksCluster.Name,
+			NodeGroupName: pulumi.String("pulumi-eks-nodegroup"),
+			NodeRoleArn:   ec2Role.Arn,
+			SubnetIds:     subnetIds,
+			Tags: map[string]interface{}{
+				"Name": "pulumi-cluster-nodeGroup",
+			},
+			ScalingConfig: &eks.NodeGroupScalingConfigArgs{
+				DesiredSize: pulumi.Int(2),
+				MaxSize:     pulumi.Int(2),
+				MinSize:     pulumi.Int(1),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("clusterName", eksCluster.Name)
+		ctx.Export("kubeconfig", pulumi.All(eksCluster.Endpoint, eksCluster.CertificateAuthority, eksCluster.Name).Apply(func(endpoint string, certificateAuthority eks.ClusterCertificateAuthority, name string) (pulumi.String, error) {
+			var _zero pulumi.String
+			tmpJSON2, err := json.Marshal(map[string]interface{}{
+				"apiVersion": "v1",
+				"clusters": []map[string]interface{}{
+					map[string]interface{}{
+						"cluster": map[string]interface{}{
+							"server":                     endpoint,
+							"certificate-authority-data": certificateAuthority.Data,
+						},
+						"name": "kubernetes",
+					},
+				},
+				"contexts": []map[string]interface{}{
+					map[string]interface{}{
+						"contest": map[string]interface{}{
+							"cluster": "kubernetes",
+							"user":    "aws",
+						},
+					},
+				},
+				"current-context": "aws",
+				"kind":            "Config",
+				"users": []map[string]interface{}{
+					map[string]interface{}{
+						"name": "aws",
+						"user": map[string]interface{}{
+							"exec": map[string]interface{}{
+								"apiVersion": "client.authentication.k8s.io/v1alpha1",
+								"command":    "aws-iam-authenticator",
+							},
+							"args": []string{
+								"token",
+								"-i",
+								name,
+							},
+						},
+					},
+				},
+			})
+			if err != nil {
+				return _zero, err
+			}
+			json2 := string(tmpJSON2)
+			return pulumi.String(json2), nil
+		}).(pulumi.StringOutput))
+		return nil
+	})
+}

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
@@ -30,8 +30,9 @@ func main() {
 		for i0, val0 := range files0 {
 			fileNames0[i0] = val0.Name()
 		}
+		var files []*s3.BucketObject
 		for i0, val0 := range fileNames0 {
-			_, err = s3.NewBucketObject(ctx, "files-"+string(i0), &s3.BucketObjectArgs{
+			_res, err := s3.NewBucketObject(ctx, "files-"+string(i0), &s3.BucketObjectArgs{
 				Bucket:      siteBucket.ID(),
 				Key:         pulumi.String(val0),
 				Source:      pulumi.NewFileAsset(fmt.Sprintf("%v%v%v", siteDir, "/", val0)),
@@ -40,6 +41,7 @@ func main() {
 			if err != nil {
 				return err
 			}
+			files = append(files, _res)
 		}
 		_, err = s3.NewBucketPolicy(ctx, "bucketPolicy", &s3.BucketPolicyArgs{
 			Bucket: siteBucket.ID(),

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
@@ -27,12 +27,12 @@ func main() {
 			return err
 		}
 		fileNames0 := make([]string, len(files0))
-		for i0, val0 := range files0 {
-			fileNames0[i0] = val0.Name()
+		for key0, val0 := range files0 {
+			fileNames0[key0] = val0.Name()
 		}
 		var files []*s3.BucketObject
-		for i0, val0 := range fileNames0 {
-			_res, err := s3.NewBucketObject(ctx, "files-"+string(i0), &s3.BucketObjectArgs{
+		for key0, val0 := range fileNames0 {
+			_res, err := s3.NewBucketObject(ctx, fmt.Sprintf("files-%v", key0), &s3.BucketObjectArgs{
 				Bucket:      siteBucket.ID(),
 				Key:         pulumi.String(val0),
 				Source:      pulumi.NewFileAsset(fmt.Sprintf("%v%v%v", siteDir, "/", val0)),


### PR DESCRIPTION
Go program gen splat, namespaceless invoke, index, improved rel trave……rsal/range expressions

fixes https://github.com/pulumi/pulumi/issues/4825

Includes support for the following expressions:
- splat
- namespaceless invoke
- improved relative traversal
- improved range expr
- ID() calls within relative traversal
- prelim support for .All()

There are a few outstanding issues here:
- [Fix fix param traversals for .All anon expression bodies](https://github.com/pulumi/pulumi/issues/4832)
- [Map types](https://github.com/pulumi/pulumi/issues/4762) (tried to fix this for the only example so far`Tags`, but there are no annotations on the type and will require further massaging).
- [Detect type difference between pulumi.String and pulumi.ID](https://github.com/pulumi/pulumi/issues/4833)

Would like to get this change in and follow up on these items. 