### PR TITLE
[schema/docs] Use a Markdown parser.

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -17,7 +17,7 @@ package codegen
 import (
 	"regexp"
 
-	"github.com/yuin/goldmark/ast"
+	"github.com/pgavlin/goldmark/ast"
 
 	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -16,7 +16,6 @@ package codegen
 
 import (
 	"regexp"
-	"strings"
 
 	"github.com/yuin/goldmark/ast"
 
@@ -114,12 +113,6 @@ func GetAllMatchedGroupsFromRegex(regex *regexp.Regexp, str string) map[string][
 	}
 
 	return groups
-}
-
-// isEmpty returns true if the provided string is effectively
-// empty.
-func isEmpty(s string) bool {
-	return strings.Replace(s, "\n", "", 1) == ""
 }
 
 // ExtractExamplesSection returns the content available between the first {{% examples %}} shortcode.

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -32,9 +32,6 @@ var (
 	// SurroundingTextRE is regexp to match the content between the {{% examples %}} short-code
 	// including the short-codes themselves.
 	SurroundingTextRE = regexp.MustCompile("({{% examples %}}(.|\n)*?{{% /examples %}})")
-	// ExamplesSectionRE is a regexp to match just the content between the {{% examples %}} short-codes.
-	ExamplesSectionRE = regexp.MustCompile(
-		"(?P<examples_start>{{% examples %}})(?P<examples_content>(.|\n)*?)(?P<examples_end>{{% /examples %}})")
 	// IndividualExampleRE is a regexp to match a single example section surrounded by the {{% example %}} short-code.
 	IndividualExampleRE = regexp.MustCompile(
 		"(?P<example_start>{{% example %}})(?P<example_content>(.|\n)*?)(?P<example_end>{{% /example %}})")
@@ -127,7 +124,7 @@ func ExtractExamplesSection(description string) (string, bool) {
 
 	var examples ast.Node
 	err := ast.Walk(parsed, func(n ast.Node, enter bool) (ast.WalkStatus, error) {
-		if shortcode, ok := n.(*schema.Shortcode); ok && string(shortcode.Name) == "examples" {
+		if shortcode, ok := n.(*schema.Shortcode); ok && string(shortcode.Name) == schema.ExamplesShortcode {
 			examples = shortcode
 			return ast.WalkStop, nil
 		}
@@ -162,7 +159,7 @@ func stripNonRelevantExamples(source []byte, node ast.Node, lang string) {
 			}
 		case *schema.Shortcode:
 			switch string(c.Name) {
-			case "example":
+			case schema.ExampleShortcode:
 				hasCode := false
 				for gc := c.FirstChild(); gc != nil; gc = gc.NextSibling() {
 					if gc.Kind() == ast.KindFencedCodeBlock {
@@ -178,7 +175,7 @@ func stripNonRelevantExamples(source []byte, node ast.Node, lang string) {
 					}
 				}
 				node.RemoveChild(node, c)
-			case "examples":
+			case schema.ExamplesShortcode:
 				if first := c.FirstChild(); first != nil {
 					first.SetBlankPreviousLines(c.HasBlankPreviousLines())
 				}

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -179,6 +179,10 @@ func stripNonRelevantExamples(source []byte, node ast.Node, lang string) {
 				}
 				node.RemoveChild(node, c)
 			case "examples":
+				if first := c.FirstChild(); first != nil {
+					first.SetBlankPreviousLines(c.HasBlankPreviousLines())
+				}
+
 				var grandchild, nextGrandchild ast.Node
 				for grandchild = c.FirstChild(); grandchild != nil; grandchild = nextGrandchild {
 					nextGrandchild = grandchild.NextSibling()

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -184,6 +184,7 @@ func stripNonRelevantExamples(source []byte, node ast.Node, lang string) {
 					nextGrandchild = grandchild.NextSibling()
 					node.InsertBefore(node, c, grandchild)
 				}
+				node.RemoveChild(node, c)
 			}
 		}
 	}

--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -170,19 +170,19 @@ func stripNonRelevantExamples(source []byte, node ast.Node, lang string) {
 						break
 					}
 				}
-				if !hasCode {
-					node.RemoveChild(node, c)
-				}
-			case "examples":
-				hasExamples := false
-				for gc := c.FirstChild(); gc != nil; gc = gc.NextSibling() {
-					if shortcode, ok := gc.(*schema.Shortcode); ok && string(shortcode.Name) == "example" {
-						hasExamples = true
-						break
+				if hasCode {
+					var grandchild, nextGrandchild ast.Node
+					for grandchild = c.FirstChild(); grandchild != nil; grandchild = nextGrandchild {
+						nextGrandchild = grandchild.NextSibling()
+						node.InsertBefore(node, c, grandchild)
 					}
 				}
-				if !hasExamples {
-					node.RemoveChild(node, c)
+				node.RemoveChild(node, c)
+			case "examples":
+				var grandchild, nextGrandchild ast.Node
+				for grandchild = c.FirstChild(); grandchild != nil; grandchild = nextGrandchild {
+					nextGrandchild = grandchild.NextSibling()
+					node.InsertBefore(node, c, grandchild)
 				}
 			}
 		}

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -99,12 +99,12 @@ func processExamples(descriptionWithExamples string) ([]exampleSection, error) {
 	}
 
 	// Get the content enclosing the outer examples short code.
-	examplesContent := codegen.ExtractExamplesSection(descriptionWithExamples)
-	if examplesContent == nil {
+	examplesContent, ok := codegen.ExtractExamplesSection(descriptionWithExamples)
+	if !ok {
 		return nil, nil
 	}
 
 	// Within the examples section, identify each example section
 	// which is wrapped in a {{% example %}} shortcode.
-	return getExampleSections(*examplesContent), nil
+	return getExampleSections(examplesContent), nil
 }

--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -22,8 +22,7 @@ import (
 
 func TestExtractExamplesSection(t *testing.T) {
 	t.Run("NonEmptyContent", func(t *testing.T) {
-		expectedContent := `
-something here
+		expectedContent := `something here
 
 and here
 
@@ -31,23 +30,23 @@ and here
 
 ..some..more here..
 `
-		description := `{{% examples %}}` + expectedContent + `{{% /examples %}}`
+		description := "{{% examples %}}\n" + expectedContent + `{{% /examples %}}`
 
-		actualContent := ExtractExamplesSection(description)
-		assert.NotNil(t, actualContent, "content could not be extracted")
-		assert.Equal(t, expectedContent, *actualContent, "strings don't match")
+		actualContent, ok := ExtractExamplesSection(description)
+		assert.True(t, ok, "content could not be extracted")
+		assert.Equal(t, expectedContent, actualContent, "strings don't match")
 	})
 
 	t.Run("EmptyContent", func(t *testing.T) {
 		description := `{{% examples %}}
 {{% /examples %}}`
 
-		actualContent := ExtractExamplesSection(description)
-		assert.Nil(t, actualContent, "expected content to be nil")
+		_, ok := ExtractExamplesSection(description)
+		assert.False(t, ok, "expected content to be nil")
 	})
 }
 
-var codeFence = "```"
+const codeFence = "```"
 
 func TestStripNonRelevantExamples(t *testing.T) {
 	tsCodeSnippet := `### Example 1
@@ -110,10 +109,10 @@ func fakeFunc() {
 ` + codeFence
 
 	example1 := `### Example 1
-	` + tsCodeSnippet + "\n" + goCodeSnippet
+` + tsCodeSnippet + "\n" + goCodeSnippet
 
 	example2 := `### Example 2
-	` + tsCodeSnippet
+` + tsCodeSnippet
 
 	example1ShortCode := `{{% example %}}` + "\n" + example1 + "\n" + `{{% /example %}}`
 	example2ShortCode := `{{% example %}}` + "\n" + example2 + "\n" + `{{% /example %}}`

--- a/pkg/codegen/schema/docs_parser.go
+++ b/pkg/codegen/schema/docs_parser.go
@@ -1,0 +1,165 @@
+package schema
+
+import (
+	"bytes"
+	"io"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+)
+
+// Shortcode represents a shortcode element and its contents, e.g. `{{% examples %}}`.
+type Shortcode struct {
+	ast.BaseBlock
+
+	// Name is the name of the shortcode.
+	Name []byte
+}
+
+func (s *Shortcode) Dump(w io.Writer, source []byte, level int) {
+	m := map[string]string{
+		"Name": string(s.Name),
+	}
+	ast.DumpHelper(w, s, source, level, m, nil)
+}
+
+// KindShortcode is an ast.NodeKind for the Shortcode node.
+var KindShortcode = ast.NewNodeKind("Shortcode")
+
+// Kind implements ast.Node.Kind.
+func (l *Shortcode) Kind() ast.NodeKind {
+	return KindShortcode
+}
+
+// NewShortcode creates a new shortcode with the given name.
+func NewShortcode(name []byte) *Shortcode {
+	return &Shortcode{Name: name}
+}
+
+type shortcodeParser int
+
+// NewShortcodeParser returns a BlockParser that parses shortcode (e.g. `{{% examples %}}`).
+func NewShortcodeParser() parser.BlockParser {
+	return shortcodeParser(0)
+}
+
+func (shortcodeParser) Trigger() []byte {
+	return []byte{'{'}
+}
+
+func (shortcodeParser) parseShortcode(line []byte, pos int) (int, int, int, bool, bool) {
+	// Look for `{{%` to open the shortcode.
+	text := line[pos:]
+	if len(text) < 3 || text[0] != '{' || text[1] != '{' || text[2] != '%' {
+		return 0, 0, 0, false, false
+	}
+	text, pos = text[3:], pos+3
+
+	// Scan through whitespace.
+	for {
+		if len(text) == 0 {
+			return 0, 0, 0, false, false
+		}
+
+		r, sz := utf8.DecodeRune(text)
+		if !unicode.IsSpace(r) {
+			break
+		}
+		text, pos = text[sz:], pos+sz
+	}
+
+	// Check for a '/' to indicate that this is a closing shortcode.
+	isClose := false
+	if text[0] == '/' {
+		isClose = true
+		text, pos = text[1:], pos+1
+	}
+
+	// Find the end of the name and the closing delimiter (`%}}`) for this shortcode.
+	nameStart, nameEnd, inName := pos, pos, true
+	for {
+		if len(text) == 0 {
+			return 0, 0, 0, false, false
+		}
+
+		if len(text) >= 3 && text[0] == '%' && text[1] == '}' && text[2] == '}' {
+			if inName {
+				nameEnd = pos
+			}
+			text, pos = text[3:], pos+3
+			break
+		}
+
+		r, sz := utf8.DecodeRune(text)
+		if inName && unicode.IsSpace(r) {
+			nameEnd, inName = pos, false
+		}
+		text, pos = text[sz:], pos+sz
+	}
+
+	return nameStart, nameEnd, pos, isClose, true
+}
+
+func (p shortcodeParser) Open(parent ast.Node, reader text.Reader, pc parser.Context) (ast.Node, parser.State) {
+	line, _ := reader.PeekLine()
+	pos := pc.BlockOffset()
+	if pos < 0 {
+		return nil, parser.NoChildren
+	}
+
+	nameStart, nameEnd, shortcodeEnd, isClose, ok := p.parseShortcode(line, pos)
+	if !ok || isClose {
+		return nil, parser.NoChildren
+	}
+	name := line[nameStart:nameEnd]
+
+	reader.Advance(shortcodeEnd)
+
+	return NewShortcode(name), parser.HasChildren
+}
+
+func (p shortcodeParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
+	line, _ := reader.PeekLine()
+	pos := pc.BlockOffset()
+	if pos < 0 {
+		return parser.Continue | parser.HasChildren
+	}
+
+	nameStart, nameEnd, shortcodeEnd, isClose, ok := p.parseShortcode(line, pos)
+	if !ok || !isClose {
+		return parser.Continue | parser.HasChildren
+	}
+
+	shortcode := node.(*Shortcode)
+	if !bytes.Equal(line[nameStart:nameEnd], shortcode.Name) {
+		return parser.Continue | parser.HasChildren
+	}
+
+	reader.Advance(shortcodeEnd)
+	return parser.Close
+}
+
+func (shortcodeParser) Close(node ast.Node, reader text.Reader, pc parser.Context) {
+}
+
+// CanInterruptParagraph returns true for shortcodes.
+func (shortcodeParser) CanInterruptParagraph() bool {
+	return true
+}
+
+// CanAcceptIndentedLine returns false for shortcodes; all shortcodes must start at the first column.
+func (shortcodeParser) CanAcceptIndentedLine() bool {
+	return false
+}
+
+// ParseDocs parses the given documentation text as Markdown with shortcodes and returns the AST.
+func ParseDocs(docs []byte) ast.Node {
+	p := goldmark.DefaultParser()
+	p.AddOptions(parser.WithBlockParsers(util.Prioritized(shortcodeParser(0), 50)))
+	return p.Parse(text.NewReader(docs))
+}

--- a/pkg/codegen/schema/docs_parser.go
+++ b/pkg/codegen/schema/docs_parser.go
@@ -13,6 +13,15 @@ import (
 	"github.com/pgavlin/goldmark/util"
 )
 
+const (
+	// ExamplesShortcode is the name for the `{{% examples %}}` shortcode, which demarcates a set of example sections.
+	ExamplesShortcode = "examples"
+
+	// ExampleShortcode is the name for the `{{% example %}}` shortcode, which demarcates the content for a single
+	// example.
+	ExampleShortcode = "example"
+)
+
 // Shortcode represents a shortcode element and its contents, e.g. `{{% examples %}}`.
 type Shortcode struct {
 	ast.BaseBlock

--- a/pkg/codegen/schema/docs_parser.go
+++ b/pkg/codegen/schema/docs_parser.go
@@ -6,11 +6,11 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/yuin/goldmark"
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/parser"
-	"github.com/yuin/goldmark/text"
-	"github.com/yuin/goldmark/util"
+	"github.com/pgavlin/goldmark"
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/parser"
+	"github.com/pgavlin/goldmark/text"
+	"github.com/pgavlin/goldmark/util"
 )
 
 // Shortcode represents a shortcode element and its contents, e.g. `{{% examples %}}`.

--- a/pkg/codegen/schema/docs_parser.go
+++ b/pkg/codegen/schema/docs_parser.go
@@ -32,7 +32,7 @@ func (s *Shortcode) Dump(w io.Writer, source []byte, level int) {
 var KindShortcode = ast.NewNodeKind("Shortcode")
 
 // Kind implements ast.Node.Kind.
-func (l *Shortcode) Kind() ast.NodeKind {
+func (*Shortcode) Kind() ast.NodeKind {
 	return KindShortcode
 }
 

--- a/pkg/codegen/schema/docs_renderer.go
+++ b/pkg/codegen/schema/docs_renderer.go
@@ -107,7 +107,7 @@ func RenderDocs(w io.Writer, source []byte, node ast.Node, options ...RendererOp
 		util.Prioritized(md, 200),
 	}
 	r := renderer.NewRenderer(renderer.WithNodeRenderers(nodeRenderers...))
-	return r.Render(w, []byte(source), node)
+	return r.Render(w, source, node)
 }
 
 // RenderDocsToString is like RenderDocs, but renders to a string instead of a Writer.

--- a/pkg/codegen/schema/docs_renderer.go
+++ b/pkg/codegen/schema/docs_renderer.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"net/url"
 
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/renderer"
+	"github.com/pgavlin/goldmark/renderer/markdown"
+	"github.com/pgavlin/goldmark/util"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/renderer"
-	"github.com/yuin/goldmark/renderer/markdown"
-	"github.com/yuin/goldmark/util"
 )
 
 // A RendererOption controls the behavior of a Renderer.

--- a/pkg/codegen/schema/docs_renderer.go
+++ b/pkg/codegen/schema/docs_renderer.go
@@ -1,0 +1,119 @@
+package schema
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/url"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/renderer"
+	"github.com/yuin/goldmark/renderer/markdown"
+	"github.com/yuin/goldmark/util"
+)
+
+// A RendererOption controls the behavior of a Renderer.
+type RendererOption func(*Renderer)
+
+// A ReferenceRenderer is responsible for rendering references to entities in a schema.
+type ReferenceRenderer func(r *Renderer, w io.Writer, source []byte, link *ast.Link, enter bool) (ast.WalkStatus, error)
+
+// WithReferenceRenderer sets the reference renderer for a renderer.
+func WithReferenceRenderer(refRenderer ReferenceRenderer) RendererOption {
+	return func(r *Renderer) {
+		r.refRenderer = refRenderer
+	}
+}
+
+// A Renderer provides the ability to render parsed documentation back to Markdown source.
+type Renderer struct {
+	md *markdown.Renderer
+
+	refRenderer ReferenceRenderer
+}
+
+// MarkdownRenderer returns the underlying Markdown renderer used by the Renderer.
+func (r *Renderer) MarkdownRenderer() *markdown.Renderer {
+	return r.md
+}
+
+func (r *Renderer) RegisterFuncs(reg renderer.NodeRendererFuncRegisterer) {
+	// blocks
+	reg.Register(KindShortcode, r.renderShortcode)
+
+	// inlines
+	reg.Register(ast.KindLink, r.renderLink)
+}
+
+func (r *Renderer) renderShortcode(w util.BufWriter, source []byte, node ast.Node, enter bool) (ast.WalkStatus, error) {
+	if enter {
+		if err := r.md.OpenBlock(w, source, node); err != nil {
+			return ast.WalkStop, err
+		}
+		if _, err := fmt.Fprintf(r.md.Writer(w), "{{%% %s %%}}\n", string(node.(*Shortcode).Name)); err != nil {
+			return ast.WalkStop, err
+		}
+	} else {
+		if _, err := fmt.Fprintf(r.md.Writer(w), "{{%% /%s %%}}\n", string(node.(*Shortcode).Name)); err != nil {
+			return ast.WalkStop, err
+		}
+		if err := r.md.CloseBlock(w); err != nil {
+			return ast.WalkStop, err
+		}
+	}
+
+	return ast.WalkContinue, nil
+}
+
+func isEntityReference(dest []byte) bool {
+	if len(dest) == 0 {
+		return false
+	}
+
+	parsed, err := url.Parse(string(dest))
+	if err != nil {
+		return false
+	}
+
+	if parsed.IsAbs() {
+		return parsed.Scheme == "schema"
+	}
+
+	return parsed.Host == "" && parsed.Path == "" && parsed.RawQuery == "" && parsed.Fragment != ""
+}
+
+func (r *Renderer) renderLink(w util.BufWriter, source []byte, node ast.Node, enter bool) (ast.WalkStatus, error) {
+	// If this is an entity reference, pass it off to the reference renderer (if any).
+	link := node.(*ast.Link)
+	if r.refRenderer != nil && isEntityReference(link.Destination) {
+		return r.refRenderer(r, w, source, link, enter)
+	}
+
+	return r.md.RenderLink(w, source, node, enter)
+}
+
+// RenderDocs renders parsed documentation to the given Writer. The source that was used to parse the documentation
+// must be provided.
+func RenderDocs(w io.Writer, source []byte, node ast.Node, options ...RendererOption) error {
+	md := &markdown.Renderer{}
+	dr := &Renderer{md: md}
+	for _, o := range options {
+		o(dr)
+	}
+
+	nodeRenderers := []util.PrioritizedValue{
+		util.Prioritized(dr, 100),
+		util.Prioritized(md, 200),
+	}
+	r := renderer.NewRenderer(renderer.WithNodeRenderers(nodeRenderers...))
+	return r.Render(w, []byte(source), node)
+}
+
+// RenderDocsToString is like RenderDocs, but renders to a string instead of a Writer.
+func RenderDocsToString(source []byte, node ast.Node, options ...RendererOption) string {
+	var buf bytes.Buffer
+	err := RenderDocs(&buf, source, node, options...)
+	contract.AssertNoError(err)
+	return buf.String()
+}

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -1,0 +1,202 @@
+package schema
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/url"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/testutil"
+)
+
+var testdataPath = filepath.Join("..", "internal", "test", "testdata")
+
+var nodeAssertions = testutil.DefaultNodeAssertions().Union(testutil.NodeAssertions{
+	KindShortcode: func(t *testing.T, sourceExpected, sourceActual []byte, expected, actual ast.Node) bool {
+		shortcodeExpected, shortcodeActual := expected.(*Shortcode), actual.(*Shortcode)
+		return testutil.AssertEqualBytes(t, shortcodeExpected.Name, shortcodeActual.Name)
+	},
+})
+
+type doc struct {
+	entity  string
+	content string
+}
+
+func getDocsForProperty(parent string, p *Property) []doc {
+	entity := path.Join(parent, p.Name)
+	return []doc{
+		{entity: entity + "/description", content: p.Comment},
+		{entity: entity + "/deprecationMessage", content: p.DeprecationMessage},
+	}
+}
+
+func getDocsForObjectType(path string, t *ObjectType) []doc {
+	if t == nil {
+		return nil
+	}
+
+	docs := []doc{{entity: path + "/description", content: t.Comment}}
+	for _, p := range t.Properties {
+		docs = append(docs, getDocsForProperty(path+"/properties", p)...)
+	}
+	return docs
+}
+
+func getDocsForFunction(f *Function) []doc {
+	entity := "#/functions/" + url.PathEscape(f.Token)
+	docs := []doc{
+		{entity: entity + "/description", content: f.Comment},
+		{entity: entity + "/deprecationMessage", content: f.DeprecationMessage},
+	}
+	docs = append(docs, getDocsForObjectType(entity+"/inputs/properties", f.Inputs)...)
+	docs = append(docs, getDocsForObjectType(entity+"/outputs/properties", f.Outputs)...)
+	return docs
+}
+
+func getDocsForResource(r *Resource, isProvider bool) []doc {
+	var entity string
+	if isProvider {
+		entity = "#/provider"
+	} else {
+		entity = "#/resources/" + url.PathEscape(r.Token)
+	}
+
+	docs := []doc{
+		{entity: entity + "/description", content: r.Comment},
+		{entity: entity + "/deprecationMessage", content: r.DeprecationMessage},
+	}
+	for _, p := range r.InputProperties {
+		docs = append(docs, getDocsForProperty(entity+"/inputProperties", p)...)
+	}
+	for _, p := range r.Properties {
+		docs = append(docs, getDocsForProperty(entity+"/properties", p)...)
+	}
+	docs = append(docs, getDocsForObjectType(entity+"/stateInputs", r.StateInputs)...)
+	return docs
+}
+
+func getDocsForPackage(pkg *Package) []doc {
+	var allDocs []doc
+	for _, p := range pkg.Config {
+		allDocs = append(allDocs, getDocsForProperty("#/config/variables", p)...)
+	}
+	for _, f := range pkg.Functions {
+		allDocs = append(allDocs, getDocsForFunction(f)...)
+	}
+	allDocs = append(allDocs, getDocsForResource(pkg.Provider, true)...)
+	for _, r := range pkg.Resources {
+		allDocs = append(allDocs, getDocsForResource(r, false)...)
+	}
+	for _, t := range pkg.Types {
+		if obj, ok := t.(*ObjectType); ok {
+			allDocs = append(allDocs, getDocsForObjectType("#/types", obj)...)
+		}
+	}
+	return allDocs
+}
+
+func TestParseAndRenderDocs(t *testing.T) {
+	files, err := ioutil.ReadDir(testdataPath)
+	if err != nil {
+		t.Fatalf("could not read test data: %v", err)
+	}
+
+	for _, f := range files {
+		if filepath.Ext(f.Name()) != ".json" {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			path := filepath.Join(testdataPath, f.Name())
+			contents, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path, err)
+			}
+
+			var spec PackageSpec
+			if err = json.Unmarshal(contents, &spec); err != nil {
+				t.Fatalf("could not unmarshal package spec: %v", err)
+			}
+			pkg, err := ImportSpec(spec, nil)
+			if err != nil {
+				t.Fatalf("could not import package: %v", err)
+			}
+
+			for _, doc := range getDocsForPackage(pkg) {
+				t.Run(doc.entity, func(t *testing.T) {
+					original := []byte(doc.content)
+					expected := ParseDocs(original)
+					rendered := []byte(RenderDocsToString(original, expected))
+					actual := ParseDocs(rendered)
+					if !testutil.AssertSameStructure(t, original, rendered, expected, actual, nodeAssertions) {
+						t.Logf("original: %v", doc.content)
+						t.Logf("rendered: %v", string(rendered))
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestReferenceRenderer(t *testing.T) {
+	files, err := ioutil.ReadDir(testdataPath)
+	if err != nil {
+		t.Fatalf("could not read test data: %v", err)
+	}
+
+	for _, f := range files {
+		if filepath.Ext(f.Name()) != ".json" {
+			continue
+		}
+
+		t.Run(f.Name(), func(t *testing.T) {
+			path := filepath.Join(testdataPath, f.Name())
+			contents, err := ioutil.ReadFile(path)
+			if err != nil {
+				t.Fatalf("could not read %v: %v", path, err)
+			}
+
+			var spec PackageSpec
+			if err = json.Unmarshal(contents, &spec); err != nil {
+				t.Fatalf("could not unmarshal package spec: %v", err)
+			}
+			pkg, err := ImportSpec(spec, nil)
+			if err != nil {
+				t.Fatalf("could not import package: %v", err)
+			}
+
+			for _, doc := range getDocsForPackage(pkg) {
+				t.Run(doc.entity, func(t *testing.T) {
+					text := []byte(fmt.Sprintf("[entity](%s)", doc.entity))
+					expected := strings.Replace(doc.entity, "/", "_", -1) + "\n"
+
+					parsed := ParseDocs(text)
+					actual := []byte(RenderDocsToString(text, parsed, WithReferenceRenderer(
+						func(r *Renderer, w io.Writer, src []byte, l *ast.Link, enter bool) (ast.WalkStatus, error) {
+							if !enter {
+								return ast.WalkContinue, nil
+							}
+
+							replaced := bytes.Replace(l.Destination, []byte{'/'}, []byte{'_'}, -1)
+							if _, err := r.MarkdownRenderer().Write(w, replaced); err != nil {
+								return ast.WalkStop, err
+							}
+
+							return ast.WalkSkipChildren, nil
+						})))
+
+					assert.Equal(t, expected, string(actual))
+				})
+			}
+		})
+	}
+}

--- a/pkg/codegen/schema/docs_test.go
+++ b/pkg/codegen/schema/docs_test.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pgavlin/goldmark/ast"
+	"github.com/pgavlin/goldmark/testutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/yuin/goldmark/ast"
-	"github.com/yuin/goldmark/testutil"
 )
 
 var testdataPath = filepath.Join("..", "internal", "test", "testdata")

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -44,8 +44,9 @@ require (
 	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd // indirect
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/spf13/cobra v1.0.0
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.6.1
 	github.com/xeipuuv/gojsonschema v1.2.0
+	github.com/yuin/goldmark v1.1.32
 	github.com/zclconf/go-cty v1.3.1
 	gocloud.dev v0.19.1-0.20200517170643-46480dc2c3dd
 	gocloud.dev/secrets/hashivault v0.19.1-0.20200517170643-46480dc2c3dd
@@ -61,3 +62,5 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 // indirect
 )
+
+replace github.com/yuin/goldmark => github.com/pgavlin/goldmark v1.1.33-0.20200616164752-aaa9ff3e1d61

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/mxschmitt/golang-combinations v1.0.0
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi/sdk/v2 v2.0.0
 	github.com/rjeczalik/notify v0.9.2
@@ -46,7 +47,6 @@ require (
 	github.com/spf13/cobra v1.0.0
 	github.com/stretchr/testify v1.6.1
 	github.com/xeipuuv/gojsonschema v1.2.0
-	github.com/yuin/goldmark v1.1.32
 	github.com/zclconf/go-cty v1.3.1
 	gocloud.dev v0.19.1-0.20200517170643-46480dc2c3dd
 	gocloud.dev/secrets/hashivault v0.19.1-0.20200517170643-46480dc2c3dd
@@ -62,5 +62,3 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 // indirect
 )
-
-replace github.com/yuin/goldmark => github.com/pgavlin/goldmark v1.1.33-0.20200616164752-aaa9ff3e1d61

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -389,6 +389,8 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pgavlin/goldmark v1.1.33-0.20200616164752-aaa9ff3e1d61 h1:iAG3OKZggV42MhJXxcSAtyMNlG+Emxes2m/+K6up6S0=
+github.com/pgavlin/goldmark v1.1.33-0.20200616164752-aaa9ff3e1d61/go.mod h1:ZRWjhQQgWI+UsiBXcU/Y0CVUxKPh86WM9EoJ07KW5fs=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -462,6 +464,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 h1:9VTskZOIRf2vKF3UL8TuWElry5pgUpV1tFSe/e/0m/E=
 github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -752,6 +756,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -389,8 +389,8 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
-github.com/pgavlin/goldmark v1.1.33-0.20200616164752-aaa9ff3e1d61 h1:iAG3OKZggV42MhJXxcSAtyMNlG+Emxes2m/+K6up6S0=
-github.com/pgavlin/goldmark v1.1.33-0.20200616164752-aaa9ff3e1d61/go.mod h1:ZRWjhQQgWI+UsiBXcU/Y0CVUxKPh86WM9EoJ07KW5fs=
+github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386 h1:LoCV5cscNVWyK5ChN/uCoIFJz8jZD63VQiGJIRgr6uo=
+github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386/go.mod h1:MRxHTJrf9FhdfNQ8Hdeh9gmHevC9RJE/fu8M3JIGjoE=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -15,5 +15,5 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi/pkg/v2 v2.0.0
 	github.com/pulumi/pulumi/sdk/v2 v2.0.0
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.6.1
 )

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -442,6 +442,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6 h1:9VTskZOIRf2vKF3UL8TuWElry5pgUpV1tFSe/e/0m/E=
 github.com/texttheater/golang-levenshtein v0.0.0-20191208221605-eb6844b05fc6/go.mod h1:XDKHRm5ThF8YJjx001LtgelzsoaEcvnA7lVWz9EeX3g=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -461,6 +463,7 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.3.1/go.mod h1:YO23e2L18AG+ZYQfSobnY4G65nvwvprPCxBHkufUH1k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
@@ -732,6 +735,8 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -374,6 +374,7 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-buffruneio v0.2.0/go.mod h1:JkE26KsDizTr40EUHkXVtNPvgGtbSNq5BcowyYOWdKo=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386/go.mod h1:MRxHTJrf9FhdfNQ8Hdeh9gmHevC9RJE/fu8M3JIGjoE=
 github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -463,7 +464,6 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.3.1/go.mod h1:YO23e2L18AG+ZYQfSobnY4G65nvwvprPCxBHkufUH1k=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=


### PR DESCRIPTION
In particular, use the parser to filter and extract examples. This also
sets up support for entity references in documentation that can be used
in order to render language-specific names for resources, functions,
types, and properties.

Related to #4632 and #4159.