### PR TITLE
[codegen] Use nullish coalescing for config/provider defaults

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -547,7 +547,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 				if err != nil {
 					return err
 				}
-				arg = fmt.Sprintf("(%s) || %s", arg, dv)
+				arg = fmt.Sprintf("(%s) ?? %s", arg, dv)
 			}
 
 			// provider properties must be marshaled as JSON strings.
@@ -893,7 +893,7 @@ func (mod *modContext) genConfig(w io.Writer, variables []*schema.Property) erro
 			if err != nil {
 				return err
 			}
-			configFetch += " || " + v
+			configFetch += " ?? " + v
 		}
 
 		fmt.Fprintf(w, "export let %s: %s = %s;\n",

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -547,7 +547,13 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 				if err != nil {
 					return err
 				}
-				arg = fmt.Sprintf("(%s) ?? %s", arg, dv)
+				// Note: this logic isn't quite correct, but already exists in all of the TF-based providers.
+				// Specifically, this doesn't work right if the first value is set to false but the default value
+				// is true. The Kubernetes provider didn't include this logic, so use the correct ?? operator there.
+				arg = fmt.Sprintf("(%s) || %s", arg, dv)
+				if mod.compatibility == kubernetes20 {
+					arg = fmt.Sprintf("(%s) ?? %s", arg, dv)
+				}
 			}
 
 			// provider properties must be marshaled as JSON strings.
@@ -893,7 +899,10 @@ func (mod *modContext) genConfig(w io.Writer, variables []*schema.Property) erro
 			if err != nil {
 				return err
 			}
-			configFetch += " ?? " + v
+			// Note: this logic isn't quite correct, but already exists in all of the TF-based providers.
+			// Specifically, this doesn't work right if the first value is set to false but the default value
+			// is true.
+			configFetch += " || " + v
 		}
 
 		fmt.Fprintf(w, "export let %s: %s = %s;\n",

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1378,7 +1378,7 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info NodePackage
 
 	// Create the config module if necessary.
 	if len(pkg.Config) > 0 &&
-		info.Compatibility != kubernetes20 { // TODO: k8s SDK currently doesn't use config. This should be standardized.
+		info.Compatibility != kubernetes20 { // k8s SDK doesn't use config.
 		_ = getMod("config")
 	}
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1279,7 +1279,7 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 
 	// Create the config module if necessary.
 	if len(pkg.Config) > 0 &&
-		info.Compatibility != kubernetes20 { // TODO: k8s SDK currently doesn't use config. This should be standardized.
+		info.Compatibility != kubernetes20 { // k8s SDK doesn't use config.
 		_ = getMod("config")
 	}
 


### PR DESCRIPTION
For NodeJS SDKs, rather than falling back to default values
using the || operator, use the nullish coalescing operator (??).
This avoid situations where the primary value is set to false,
and then is overridden by the default value.

Downstream change looks like this:

Old
```ts
inputs["enableDryRun"] = pulumi.output((args ? args.enableDryRun : undefined) || <any>utilities.getEnvBoolean("PULUMI_K8S_ENABLE_DRY_RUN")).apply(JSON.stringify);
```
New
```ts
inputs["enableDryRun"] = pulumi.output((args ? args.enableDryRun : undefined) ?? <any>utilities.getEnvBoolean("PULUMI_K8S_ENABLE_DRY_RUN")).apply(JSON.stringify);
```