### PR TITLE
Disable container tests in cron, too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test_containers_cron:
 
 # The travis_* targets are entrypoints for CI.
 .PHONY: travis_cron travis_push travis_pull_request travis_api
-travis_cron: all test_containers_cron
+travis_cron: all
 travis_push: only_build publish_tgz only_test publish_packages
 travis_pull_request: all
 travis_api: all


### PR DESCRIPTION
I can test this during PRs, no need to keep it failing in cron jobs.