### PR TITLE
[Go Program Gen] multiline strings, get/lookup disambiguation, webserver example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Go program gen improvements (multiline strings, get/lookup disambiguation, invoke improvements)
+  [#4850](https://github.com/pulumi/pulumi/pull/4850)
+
 - Go program gen improvements (splat, all, index, traversal, range)
   [#4831](https://github.com/pulumi/pulumi/pull/4831)
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model/format"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 )
 
@@ -20,6 +21,7 @@ type generator struct {
 	// The formatter to use when generating code.
 	*format.Formatter
 	program             *hcl2.Program
+	contexts            map[string]map[string]*pkgContext
 	diagnostics         hcl.Diagnostics
 	jsonTempSpiller     *jsonSpiller
 	ternaryTempSpiller  *tempSpiller
@@ -32,8 +34,15 @@ func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics,
 	// Linearize the nodes into an order appropriate for procedural code generation.
 	nodes := hcl2.Linearize(program)
 
+	contexts := make(map[string]map[string]*pkgContext)
+
+	for _, pkg := range program.Packages() {
+		contexts[pkg.Name] = getPackages("tool", pkg)
+	}
+
 	g := &generator{
 		program:             program,
+		contexts:            contexts,
 		jsonTempSpiller:     &jsonSpiller{},
 		ternaryTempSpiller:  &tempSpiller{},
 		readDirTempSpiller:  &readDirSpiller{},
@@ -66,6 +75,15 @@ func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics,
 		"main.go": formattedSource,
 	}
 	return files, g.diagnostics, nil
+}
+
+func getPackages(tool string, pkg *schema.Package) map[string]*pkgContext {
+	if err := pkg.ImportLanguages(map[string]schema.Language{"go": Importer}); err != nil {
+		return nil
+	}
+
+	goInfo, _ := pkg.Language["go"].(GoPackageInfo)
+	return generatePackageContextMap(tool, pkg, goInfo)
 }
 
 func (g *generator) collectScopeRoots(n hcl2.Node) {
@@ -129,6 +147,45 @@ func (g *generator) collectImports(w io.Writer, program *hcl2.Program) (codegen.
 		}
 
 		diags := n.VisitExpressions(nil, func(n model.Expression) (model.Expression, hcl.Diagnostics) {
+			if call, ok := n.(*model.FunctionCallExpression); ok {
+				if call.Name == hcl2.Invoke {
+					tokenArg := call.Args[0]
+					token := tokenArg.(*model.TemplateExpression).Parts[0].(*model.LiteralValueExpression).Value.AsString()
+					tokenRange := tokenArg.SyntaxNode().Range()
+					pkg, mod, _, diagnostics := hcl2.DecomposeToken(token, tokenRange)
+
+					contract.Assert(len(diagnostics) == 0)
+
+					version := -1
+					for _, p := range program.Packages() {
+						if p.Name == pkg {
+							version = int(p.Version.Major)
+							break
+						}
+					}
+
+					if version == -1 {
+						panic(errors.Errorf("could not find package information for resource with type token:\n\n%s", token))
+					}
+
+					vPath := fmt.Sprintf("/v%d", version)
+					if version <= 1 {
+						vPath = ""
+					}
+
+					// namespaceless invokes "aws:index:..."
+					if mod == "" {
+						pulumiImports.Add(fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s", pkg, vPath, pkg))
+					} else {
+						pulumiImports.Add(fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s/%s", pkg, vPath, pkg, mod))
+					}
+				}
+			}
+			return n, nil
+		})
+		contract.Assert(len(diags) == 0)
+
+		diags = n.VisitExpressions(nil, func(n model.Expression) (model.Expression, hcl.Diagnostics) {
 			if call, ok := n.(*model.FunctionCallExpression); ok {
 				for _, fnPkg := range g.genFunctionPackages(call) {
 					stdImports.Add(fnPkg)
@@ -260,7 +317,7 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 		case *ternaryTemp:
 			// TODO derive from ambient context
 			isInput := false
-			g.Fgenf(w, "var %s %s\n", t.Name, argumentTypeName(t.Value.TrueResult, t.Type(), isInput))
+			g.Fgenf(w, "var %s %s\n", t.Name, g.argumentTypeName(t.Value.TrueResult, t.Type(), isInput))
 			g.Fgenf(w, "if %.v {\n", t.Value.Condition)
 			g.Fgenf(w, "%s = %.v\n", t.Name, t.Value.TrueResult)
 			g.Fgenf(w, "} else {\n")
@@ -297,7 +354,7 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 			g.Fgenf(w, "%s[%s] = %s.Name()\n", namesVar, iVar, valVar)
 			g.Fgenf(w, "}\n")
 		case *splatTemp:
-			argTyp := argumentTypeName(t.Value.Each, t.Value.Each.Type(), false)
+			argTyp := g.argumentTypeName(t.Value.Each, t.Value.Each.Type(), false)
 			g.Fgenf(w, "var %s []%s\n", t.Name, argTyp)
 			g.Fgenf(w, "for _, val0 := range %.v {\n", t.Value.Source)
 			g.Fgenf(w, "%s = append(%s, %.v)\n", t.Name, t.Name, t.Value.Each)
@@ -330,4 +387,24 @@ func (g *generator) genLocalVariable(w io.Writer, v *hcl2.LocalVariable) {
 
 	}
 
+}
+
+func (g *generator) useLookupInvokeForm(token string) bool {
+	pkg, module, member, _ := hcl2.DecomposeToken(token, *new(hcl.Range))
+	modSplit := strings.Split(module, "/")
+	mod := modSplit[0]
+	if mod == "index" {
+		mod = ""
+	}
+	fn := Title(member)
+	if len(modSplit) >= 2 {
+		fn = Title(modSplit[1])
+	}
+	fnLookup := "Lookup" + fn[3:]
+	pkgContext := g.contexts[pkg][mod]
+	if pkgContext.names.has(fnLookup) {
+		return true
+	}
+
+	return false
 }

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -776,7 +776,7 @@ func (g *generator) genApply(w io.Writer, expr *model.FunctionCallExpression) {
 		}
 		// TODO need lowering step to rewrite then argument references
 		// in terms of scope traversal from all result: val[i] etc.
-		g.Fgenf(w, ").Apply(%.v)%s", then, typeAssertion)
+		g.Fgenf(w, ").ApplyT(%.v)%s", then, typeAssertion)
 	}
 }
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -850,9 +850,6 @@ func (g *generator) functionName(tokenArg model.Expression) (string, string, str
 
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diagnostics := hcl2.DecomposeToken(token, tokenRange)
-	// GetResource -> LookupResource
-	// TODO figure out how to deal with get/lookup ambiguity
-	// https://github.com/pulumi/pulumi/blob/adfa8116fbf61ad328568fe4b53e32c751f30553/pkg/codegen/go/gen.go#L1171
 	if strings.HasPrefix(member, "get") {
 		if g.useLookupInvokeForm(token) {
 			member = strings.Replace(member, "get", "lookup", 1)

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -305,7 +305,12 @@ func (g *generator) GenObjectConsExpression(w io.Writer, expr *model.ObjectConsE
 	g.genObjectConsExpression(w, expr, expr.Type(), isInput)
 }
 
-func (g *generator) genObjectConsExpression(w io.Writer, expr *model.ObjectConsExpression, destType model.Type, isInput bool) {
+func (g *generator) genObjectConsExpression(
+	w io.Writer,
+	expr *model.ObjectConsExpression,
+	destType model.Type,
+	isInput bool,
+) {
 	if len(expr.Items) > 0 {
 		var temps []interface{}
 		isInput = isInput || isInputty(destType)

--- a/pkg/codegen/go/gen_program_inputs.go
+++ b/pkg/codegen/go/gen_program_inputs.go
@@ -83,6 +83,7 @@ func modifyInputs(
 		for _, item := range expr.Items {
 			item.Value = modifyInputs(item.Value, modf)
 		}
+		x = modf(x)
 	case *model.TupleConsExpression:
 		for i, item := range expr.Expressions {
 			expr.Expressions[i] = modifyInputs(item, modf)

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -27,13 +27,6 @@ func TestGenProgram(t *testing.T) {
 		if filepath.Ext(f.Name()) != ".pp" {
 			continue
 		}
-		// TODO: include all test files
-		if filepath.Base(f.Name()) != "aws-s3-logging.pp" &&
-			filepath.Base(f.Name()) != "aws-s3-folder.pp" &&
-			filepath.Base(f.Name()) != "aws-eks.pp" &&
-			filepath.Base(f.Name()) != "aws-fargate.pp" {
-			continue
-		}
 
 		t.Run(f.Name(), func(t *testing.T) {
 			path := filepath.Join(testdataPath, f.Name())

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws"
 	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/ec2"
 	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/eks"
 	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/iam"
@@ -48,7 +49,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		zones, err := aws.LookupAvailabilityZones(ctx, nil, nil)
+		zones, err := aws.GetAvailabilityZones(ctx, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -233,7 +233,7 @@ func main() {
 			return err
 		}
 		ctx.Export("clusterName", eksCluster.Name)
-		ctx.Export("kubeconfig", pulumi.All(eksCluster.Endpoint, eksCluster.CertificateAuthority, eksCluster.Name).Apply(func(endpoint string, certificateAuthority eks.ClusterCertificateAuthority, name string) (pulumi.String, error) {
+		ctx.Export("kubeconfig", pulumi.All(eksCluster.Endpoint, eksCluster.CertificateAuthority, eksCluster.Name).ApplyT(func(endpoint string, certificateAuthority eks.ClusterCertificateAuthority, name string) (pulumi.String, error) {
 			var _zero pulumi.String
 			tmpJSON2, err := json.Marshal(map[string]interface{}{
 				"apiVersion": "v1",

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -18,8 +18,8 @@ func main() {
 			InstanceTenancy:    pulumi.String("default"),
 			EnableDnsHostnames: pulumi.Bool(true),
 			EnableDnsSupport:   pulumi.Bool(true),
-			Tags: map[string]interface{}{
-				"Name": "pulumi-eks-vpc",
+			Tags: pulumi.Map{
+				"Name": pulumi.String("pulumi-eks-vpc"),
 			},
 		})
 		if err != nil {
@@ -27,8 +27,8 @@ func main() {
 		}
 		eksIgw, err := ec2.NewInternetGateway(ctx, "eksIgw", &ec2.InternetGatewayArgs{
 			VpcId: eksVpc.ID(),
-			Tags: map[string]interface{}{
-				"Name": "pulumi-vpc-ig",
+			Tags: pulumi.Map{
+				"Name": pulumi.String("pulumi-vpc-ig"),
 			},
 		})
 		if err != nil {
@@ -42,8 +42,8 @@ func main() {
 					GatewayId: eksIgw.ID(),
 				},
 			},
-			Tags: map[string]interface{}{
-				"Name": "pulumi-vpc-rt",
+			Tags: pulumi.Map{
+				"Name": pulumi.String("pulumi-vpc-rt"),
 			},
 		})
 		if err != nil {
@@ -61,8 +61,8 @@ func main() {
 				MapPublicIpOnLaunch:         pulumi.Bool(true),
 				CidrBlock:                   pulumi.String(fmt.Sprintf("%v%v%v", "10.100.", key0, ".0/24")),
 				AvailabilityZone:            pulumi.String(val0),
-				Tags: map[string]interface{}{
-					"Name": fmt.Sprintf("%v%v", "pulumi-sn-", val0),
+				Tags: pulumi.Map{
+					"Name": pulumi.String(fmt.Sprintf("%v%v", "pulumi-sn-", val0)),
 				},
 			})
 			if err != nil {
@@ -89,8 +89,8 @@ func main() {
 		eksSecurityGroup, err := ec2.NewSecurityGroup(ctx, "eksSecurityGroup", &ec2.SecurityGroupArgs{
 			VpcId:       eksVpc.ID(),
 			Description: pulumi.String("Allow all HTTP(s) traffic to EKS Cluster"),
-			Tags: map[string]interface{}{
-				"Name": "pulumi-cluster-sg",
+			Tags: pulumi.Map{
+				"Name": pulumi.String("pulumi-cluster-sg"),
 			},
 			Ingress: ec2.SecurityGroupIngressArray{
 				&ec2.SecurityGroupIngressArgs{
@@ -199,8 +199,8 @@ func main() {
 		}
 		eksCluster, err := eks.NewCluster(ctx, "eksCluster", &eks.ClusterArgs{
 			RoleArn: eksRole.Arn,
-			Tags: map[string]interface{}{
-				"Name": "pulumi-eks-cluster",
+			Tags: pulumi.Map{
+				"Name": pulumi.String("pulumi-eks-cluster"),
 			},
 			VpcConfig: &eks.ClusterVpcConfigArgs{
 				PublicAccessCidrs: pulumi.StringArray{
@@ -220,8 +220,8 @@ func main() {
 			NodeGroupName: pulumi.String("pulumi-eks-nodegroup"),
 			NodeRoleArn:   ec2Role.Arn,
 			SubnetIds:     subnetIds,
-			Tags: map[string]interface{}{
-				"Name": "pulumi-cluster-nodeGroup",
+			Tags: pulumi.Map{
+				"Name": pulumi.String("pulumi-cluster-nodeGroup"),
 			},
 			ScalingConfig: &eks.NodeGroupScalingConfigArgs{
 				DesiredSize: pulumi.Int(2),

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
@@ -18,7 +18,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		subnets, err := ec2.LookupSubnetIds(ctx, &ec2.LookupSubnetIdsArgs{
+		subnets, err := ec2.GetSubnetIds(ctx, &ec2.GetSubnetIdsArgs{
 			VpcId: vpc.Id,
 		}, nil)
 		if err != nil {

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
@@ -43,8 +43,8 @@ func main() {
 			return err
 		}
 		server, err := ec2.NewInstance(ctx, "server", &ec2.InstanceArgs{
-			Tags: map[string]interface{}{
-				"Name": "web-server-www",
+			Tags: pulumi.Map{
+				"Name": pulumi.String("web-server-www"),
 			},
 			InstanceType: pulumi.String("t2.micro"),
 			SecurityGroups: pulumi.StringArray{

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws"
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/ec2"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		securityGroup, err := ec2.NewSecurityGroup(ctx, "securityGroup", &ec2.SecurityGroupArgs{
+			Ingress: ec2.SecurityGroupIngressArray{
+				&ec2.SecurityGroupIngressArgs{
+					Protocol: pulumi.String("tcp"),
+					FromPort: pulumi.Int(0),
+					ToPort:   pulumi.Int(0),
+					CidrBlocks: pulumi.StringArray{
+						pulumi.String("0.0.0.0/0"),
+					},
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		ami, err := aws.GetAmi(ctx, &aws.GetAmiArgs{
+			Filters: []aws.GetAmiFilter{
+				aws.GetAmiFilter{
+					Name: "name",
+					Values: []string{
+						"amzn-ami-hvm-*-x86_64-ebs",
+					},
+				},
+			},
+			Owners: []string{
+				"137112412989",
+			},
+			MostRecent: true,
+		}, nil)
+		if err != nil {
+			return err
+		}
+		server, err := ec2.NewInstance(ctx, "server", &ec2.InstanceArgs{
+			Tags: map[string]interface{}{
+				"Name": "web-server-www",
+			},
+			InstanceType: pulumi.String("t2.micro"),
+			SecurityGroups: pulumi.StringArray{
+				securityGroup.Name,
+			},
+			Ami:      pulumi.String(ami.Id),
+			UserData: pulumi.String(fmt.Sprintf("%v%v%v", "#!/bin/bash\n", "echo \"Hello, World!\" > index.html\n", "nohup python -m SimpleHTTPServer 80 &\n")),
+		})
+		if err != nil {
+			return err
+		}
+		ctx.Export("publicIp", server.PublicIp)
+		ctx.Export("publicHostName", server.PublicDns)
+		return nil
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/4836
Fixes https://github.com/pulumi/pulumi/issues/4770

In addition to the title items, I also added support for "namespaceless" invokes for things under the "index" or "" module. This also illuminated an import bug, where we weren't scanning invoke functions for packages so I added support for this.

Pushed another commit to fix https://github.com/pulumi/pulumi/issues/4762 (inputty map types for pulumi.Map (Tags))