### PR TITLE
[codegen/docs] Reimplement example extraction.

### DIFF
--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -46,8 +46,7 @@ func decomposeDocstring(docstring string) docInfo {
 		return docInfo{}
 	}
 
-	languages := codegen.NewStringSet(supportedLanguages...)
-	languages.Add("typescript")
+	languages := codegen.NewStringSet(snippetLanguages...)
 
 	source := []byte(docstring)
 	parsed := schema.ParseDocs(source)

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -68,7 +68,7 @@ func decomposeDocstring(docstring string) docInfo {
 				if exampleShortcode == nil {
 					exampleShortcode, title, snippets = shortcode, "", map[string]string{}
 				} else if !enter && shortcode == exampleShortcode {
-					for _, l := range supportedLanguages {
+					for _, l := range snippetLanguages {
 						if _, ok := snippets[l]; !ok {
 							snippets[l] = defaultMissingExampleSnippetPlaceholder
 						}

--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -85,6 +85,9 @@ func decomposeDocstring(docstring string) docInfo {
 			}
 			return ast.WalkContinue, nil
 		}
+		if exampleShortcode == nil {
+			return ast.WalkContinue, nil
+		}
 
 		switch n := n.(type) {
 		case *ast.Heading:

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -44,6 +44,7 @@ import (
 
 var (
 	supportedLanguages = []string{"csharp", "go", "nodejs", "python"}
+	snippetLanguages   = []string{"csharp", "go", "python", "typescript"}
 	templates          *template.Template
 	packagedTemplates  map[string][]byte
 	docHelpers         map[string]codegen.DocLanguageHelper

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1284,30 +1284,15 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 
 	stateParam := name + "State"
 
-	examplesSection, err := processExamples(r.Comment)
-	if err != nil {
-		panic(err)
-	}
-
-	resourceComment := r.Comment
-	// If we managed to extract examples out of the description, then modify the original
-	// description to remove the examples section.
-	// We may not have been able to extract examples from the description because:
-	// - There is no examples section.
-	// - Or the examples section is not properly wrapped in the expected short-codes.
-	if len(examplesSection) > 0 {
-		// Replace the entire section (including the shortcodes themselves) enclosing the
-		// examples section, with an empty string.
-		resourceComment = codegen.SurroundingTextRE.ReplaceAllString(r.Comment, "")
-	}
+	docInfo := decomposeDocstring(r.Comment)
 	data := resourceDocArgs{
 		Header: mod.genResourceHeader(r),
 
 		Tool: mod.tool,
 
-		Comment:            resourceComment,
+		Comment:            docInfo.description,
 		DeprecationMessage: r.DeprecationMessage,
-		ExamplesSection:    examplesSection,
+		ExamplesSection:    docInfo.examples,
 
 		ConstructorParams:      renderedCtorParams,
 		ConstructorParamsTyped: typedCtorParams,

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -21,7 +21,6 @@ package docs
 import (
 	"bytes"
 	"fmt"
-	"github.com/pulumi/pulumi/pkg/v2/codegen"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -338,22 +337,7 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		Notes:      mod.pkg.Attribution,
 	}
 
-	examplesSection, err := processExamples(f.Comment)
-	if err != nil {
-		panic(err)
-	}
-
-	functionComment := f.Comment
-	// If we managed to extract examples out of the description, then modify the original
-	// description to remove the examples section.
-	// We may not have been able to extract examples from the description because:
-	// - There is no examples section.
-	// - Or the examples section is not properly wrapped in the expected short-codes.
-	if len(examplesSection) > 0 {
-		// Replace the entire section (including the shortcodes themselves) enclosing the
-		// examples section, with an empty string.
-		functionComment = codegen.SurroundingTextRE.ReplaceAllString(f.Comment, "")
-	}
+	docInfo := decomposeDocstring(f.Comment)
 	args := functionDocArgs{
 		Header: mod.genFunctionHeader(f),
 
@@ -363,9 +347,9 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 		FunctionArgs:   mod.genFunctionArgs(f, funcNameMap),
 		FunctionResult: mod.getFunctionResourceInfo(f),
 
-		Comment:            functionComment,
+		Comment:            docInfo.description,
 		DeprecationMessage: f.DeprecationMessage,
-		ExamplesSection:    examplesSection,
+		ExamplesSection:    docInfo.examples,
 
 		InputProperties:  inputProps,
 		OutputProperties: outputProps,

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -388,9 +388,8 @@ func TestExamplesProcessing(t *testing.T) {
 	initTestPackageSpec(t)
 
 	description := testPackageSpec.Resources["prov:module/resource:Resource"].Description
-	examplesSection, err := processExamples(description)
-	assert.NoError(t, err)
-	assert.NotEmpty(t, examplesSection)
+	docInfo := decomposeDocstring(description)
+	examplesSection := docInfo.examples
 
 	// The resource under test has two examples and both have TS and Python examples.
 	assert.Equal(t, 2, len(examplesSection))

--- a/pkg/codegen/docs_test.go
+++ b/pkg/codegen/docs_test.go
@@ -20,35 +20,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtractExamplesSection(t *testing.T) {
-	t.Run("NonEmptyContent", func(t *testing.T) {
-		expectedContent := `something here
-
-and here
-
-.... and there
-
-..some..more here..
-`
-		description := "{{% examples %}}\n" + expectedContent + `{{% /examples %}}`
-
-		actualContent, ok := ExtractExamplesSection(description)
-		assert.True(t, ok, "content could not be extracted")
-		assert.Equal(t, expectedContent, actualContent, "strings don't match")
-	})
-
-	t.Run("EmptyContent", func(t *testing.T) {
-		description := `{{% examples %}}
-{{% /examples %}}`
-
-		_, ok := ExtractExamplesSection(description)
-		assert.False(t, ok, "expected content to be nil")
-	})
-}
-
 const codeFence = "```"
 
-func TestStripNonRelevantExamples(t *testing.T) {
+func TestFilterExamples(t *testing.T) {
 	tsCodeSnippet := `### Example 1
 ` + codeFence + `typescript
 import * as path from path;
@@ -74,7 +48,7 @@ func fakeFunc() {
 {{% /examples %}}`
 
 	t.Run("ContainsRelevantCodeSnippet", func(t *testing.T) {
-		strippedDescription := StripNonRelevantExamples(description, "typescript")
+		strippedDescription := FilterExamples(description, "typescript")
 		assert.NotEmpty(t, strippedDescription, "content could not be extracted")
 		assert.Contains(t, strippedDescription, leadingDescription, "expected to at least find the leading description")
 	})
@@ -83,14 +57,14 @@ func fakeFunc() {
 	// the description contains only one Example without any Python code snippet,
 	// we should expect an empty string in this test.
 	t.Run("DoesNotContainRelevantSnippet", func(t *testing.T) {
-		strippedDescription := StripNonRelevantExamples(description, "python")
+		strippedDescription := FilterExamples(description, "python")
 		assert.Contains(t, strippedDescription, leadingDescription, "expected to at least find the leading description")
 		// Should not contain any examples sections.
 		assert.NotContains(t, strippedDescription, "### ", "expected to not have any examples but found at least one")
 	})
 }
 
-func TestTestStripNonRelevantExamplesFromMultipleExampleSections(t *testing.T) {
+func TestTestFilterExamplesFromMultipleExampleSections(t *testing.T) {
 	tsCodeSnippet := codeFence + `typescript
 import * as path from path;
 
@@ -119,14 +93,14 @@ func fakeFunc() {
 	description := `{{% examples %}}` + "\n" + example1ShortCode + "\n" + example2ShortCode + "\n" + `{{% /examples %}}`
 
 	t.Run("EveryExampleHasRelevantCodeSnippet", func(t *testing.T) {
-		strippedDescription := StripNonRelevantExamples(description, "typescript")
+		strippedDescription := FilterExamples(description, "typescript")
 		assert.NotEmpty(t, strippedDescription, "content could not be extracted")
 		assert.Contains(t, strippedDescription, "Example 1", "expected Example 1 section")
 		assert.Contains(t, strippedDescription, "Example 2", "expected Example 2 section")
 	})
 
 	t.Run("SomeExamplesHaveRelevantCodeSnippet", func(t *testing.T) {
-		strippedDescription := StripNonRelevantExamples(description, "go")
+		strippedDescription := FilterExamples(description, "go")
 		assert.NotEmpty(t, strippedDescription, "content could not be extracted")
 		assert.Contains(t, strippedDescription, "Example 1", "expected Example 1 section")
 		assert.NotContains(t, strippedDescription, "Example 2",

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -624,7 +624,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	fmt.Fprintf(w, "{\n")
 
 	// Write the TypeDoc/JSDoc for the resource class
-	printComment(w, codegen.StripNonRelevantExamples(r.Comment, "csharp"), "    ")
+	printComment(w, codegen.FilterExamples(r.Comment, "csharp"), "    ")
 
 	// Open the class.
 	className := name

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -311,7 +311,7 @@ func (pkg *pkgContext) outputType(t schema.Type, optional bool) string {
 }
 
 func printComment(w io.Writer, comment string, indent bool) int {
-	comment = codegen.StripNonRelevantExamples(comment, "go")
+	comment = codegen.FilterExamples(comment, "go")
 
 	lines := strings.Split(comment, "\n")
 	for len(lines) > 0 && lines[len(lines)-1] == "" {

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -366,7 +366,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	name := resourceName(r)
 
 	// Write the TypeDoc/JSDoc for the resource class
-	printComment(w, codegen.StripNonRelevantExamples(r.Comment, "typescript"), r.DeprecationMessage, "")
+	printComment(w, codegen.FilterExamples(r.Comment, "typescript"), r.DeprecationMessage, "")
 
 	baseType := "CustomResource"
 	if r.IsProvider {
@@ -616,7 +616,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) {
 	name := tokenToFunctionName(fun.Token)
 
 	// Write the TypeDoc/JSDoc for the data source function.
-	printComment(w, codegen.StripNonRelevantExamples(fun.Comment, "typescript"), "", "")
+	printComment(w, codegen.FilterExamples(fun.Comment, "typescript"), "", "")
 
 	if fun.DeprecationMessage != "" {
 		fmt.Fprintf(w, "/** @deprecated %s */\n", fun.DeprecationMessage)

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -631,7 +631,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	// If this func has documentation, write it at the top of the docstring, otherwise use a generic comment.
 	docs := &bytes.Buffer{}
 	if fun.Comment != "" {
-		fmt.Fprintln(docs, codegen.StripNonRelevantExamples(fun.Comment, "python"))
+		fmt.Fprintln(docs, codegen.FilterExamples(fun.Comment, "python"))
 	} else {
 		fmt.Fprintln(docs, "Use this data source to access information about an existing resource.")
 	}
@@ -952,7 +952,7 @@ func (mod *modContext) genInitDocstring(w io.Writer, res *schema.Resource) {
 
 	// If this resource has documentation, write it at the top of the docstring, otherwise use a generic comment.
 	if res.Comment != "" {
-		fmt.Fprintln(b, codegen.StripNonRelevantExamples(res.Comment, "python"))
+		fmt.Fprintln(b, codegen.FilterExamples(res.Comment, "python"))
 	} else {
 		fmt.Fprintf(b, "Create a %s resource with the given unique name, props, and options.\n", tokenToName(res.Token))
 	}


### PR DESCRIPTION
Use the schema package's Markdown parser and walk its AST to extract
examples.

These changes also rename StripNonRelevantExamples to FilterExamples.

This is preperatory work for #4159 and #4632.