### PR TITLE
[codegen] Generate correct opts type for ComponentResources

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -511,6 +511,7 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 
 	var argsType string
 	var argsDocLink string
+	optsType := "CustomResourceOptions"
 	// The args type for k8s package differs from the rest depending on whether we are dealing with
 	// overlay resources or regular k8s resources.
 	if isKubernetesPackage(mod.pkg) {
@@ -526,6 +527,10 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 			argsType = name
 			// The args types themselves are all under the input types module path, so use the input type link for the args type.
 			argsDocLink = docLangHelper.GetDocLinkForResourceInputOrOutputType(mod.pkg, modName, argsType, true)
+		}
+
+		if mod.isComponentResource() {
+			optsType = "ComponentResourceOptions"
 		}
 	} else {
 		argsType = name + "Args"
@@ -560,8 +565,8 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 			Name:         "opts",
 			OptionalFlag: "?",
 			Type: propertyType{
-				Name: "CustomResourceOptions",
-				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "CustomResourceOptions"),
+				Name: optsType,
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, optsType),
 			},
 			Comment: ctorOptsArgComment,
 		},
@@ -630,6 +635,8 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 	}
 
 	var argLangTypeName string
+	optsType := "CustomResourceOptions"
+
 	// Constructor argument types in the k8s package for C# use a different namespace path.
 	// K8s overlay resources are in the same namespace path as the resource itself.
 	if isKubernetesPackage(mod.pkg) {
@@ -647,6 +654,10 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 			}
 		} else {
 			argLangTypeName = "Pulumi.Kubernetes." + name + "Args"
+		}
+
+		if mod.isComponentResource() {
+			optsType = "ComponentResourceOptions"
 		}
 	} else {
 		argLangType := mod.typeString(argsSchemaType, "csharp", characteristics, false)
@@ -686,8 +697,8 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 			OptionalFlag: "?",
 			DefaultValue: " = null",
 			Type: propertyType{
-				Name: "CustomResourceOptions",
-				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, "Pulumi.CustomResourceOptions"),
+				Name: optsType,
+				Link: docLangHelper.GetDocLinkForPulumiType(mod.pkg, fmt.Sprintf("Pulumi.%s", optsType)),
 			},
 			Comment: ctorOptsArgComment,
 		},

--- a/pkg/codegen/docs/gen_kubernetes.go
+++ b/pkg/codegen/docs/gen_kubernetes.go
@@ -39,6 +39,11 @@ func (mod *modContext) isKubernetesOverlayModule() bool {
 		strings.HasPrefix(mod.mod, "helm") || strings.HasPrefix(mod.mod, "yaml")
 }
 
+func (mod *modContext) isComponentResource() bool {
+	// TODO: Support this more generally. For now, only the Helm and YAML overlays use ComponentResources.
+	return strings.HasPrefix(mod.mod, "helm") || strings.HasPrefix(mod.mod, "yaml")
+}
+
 // getKubernetesOverlayPythonFormalParams returns the formal params to render
 // for a Kubernetes overlay resource. These resources do not follow convention
 // that other resources do, so it is best to manually set these.


### PR DESCRIPTION
The docs generator previously assumed that the opts parameter
for every resource was of the CustomResource type. This is
incorrect for the YAML and Helm overlays, which are
ComponentResources. This should be handled more generally
once our schema supports ComponentResources, but this fixes
the docs for now.

Related to https://github.com/pulumi/docs/issues/3541 