### PR TITLE
Fix lint errors.

### DIFF
--- a/pkg/cmd/pulumi/gen_markdown.go
+++ b/pkg/cmd/pulumi/gen_markdown.go
@@ -81,7 +81,7 @@ func newGenMarkdownCmd(root *cobra.Command) *cobra.Command {
 				// We do this because we're already including the command as the front matter title.
 				result := replaceH2Pattern.ReplaceAllString(string(b), "")
 
-				if err := ioutil.WriteFile(file, []byte(result), 0666); err != nil {
+				if err := ioutil.WriteFile(file, []byte(result), 0600); err != nil {
 					return err
 				}
 			}

--- a/pkg/npm/npm_test.go
+++ b/pkg/npm/npm_test.go
@@ -55,7 +55,7 @@ func testInstall(t *testing.T, expectedBin string) {
 	        "@pulumi/pulumi": "^2.0.0"
 	    }
 	}`)
-	assert.NoError(t, ioutil.WriteFile(packageJSONFilename, packageJSON, 0644))
+	assert.NoError(t, ioutil.WriteFile(packageJSONFilename, packageJSON, 0600))
 
 	// Install dependencies, passing nil for stdout and stderr, which connects
 	// them to the file descriptor for the null device (os.DevNull).

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -98,7 +98,7 @@ func writeCommandOutput(commandName, runDir string, output []byte) (string, erro
 
 	logFile := filepath.Join(logFileDir, commandName+uniqueSuffix()+".log")
 
-	if err := ioutil.WriteFile(logFile, output, 0644); err != nil {
+	if err := ioutil.WriteFile(logFile, output, 0600); err != nil {
 		return "", errors.Wrapf(err, "Failed to write '%s'", logFile)
 	}
 

--- a/sdk/go/common/resource/asset_test.go
+++ b/sdk/go/common/resource/asset_test.go
@@ -382,6 +382,7 @@ func TestArchiveZipFiles(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+//nolint: gosec
 func TestNestedArchive(t *testing.T) {
 	// Create temp dir and place some files.
 	dirName, err := ioutil.TempDir("", "")
@@ -421,6 +422,7 @@ func TestNestedArchive(t *testing.T) {
 	assert.Equal(t, "fake.txt", files[2].Name)
 }
 
+//nolint: gosec
 func TestFileReferencedThroughMultiplePaths(t *testing.T) {
 	// Create temp dir and place some files.
 	dirName, err := ioutil.TempDir("", "")

--- a/sdk/go/common/testing/environment.go
+++ b/sdk/go/common/testing/environment.go
@@ -56,7 +56,7 @@ func WriteYarnRCForTest(root string) error {
 	// https://github.com/yarnpkg/yarn/issues/4563 as well
 	return ioutil.WriteFile(
 		filepath.Join(root, ".yarnrc"),
-		[]byte("--mutex network\n--network-concurrency 1\n"), 0644)
+		[]byte("--mutex network\n--network-concurrency 1\n"), 0600)
 }
 
 // NewGoEnvironment returns a new Environment object, located in a GOPATH temp directory.

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -103,6 +103,9 @@ func UnTGZ(tarball []byte, dir string) error {
 				return errors.Wrapf(err, "opening file %s for untar", path)
 			}
 			defer contract.IgnoreClose(dst)
+
+			// We're not concerned with potential tarbombs, so disable gosec.
+			//nolint: gosec
 			if _, err = io.Copy(dst, r); err != nil {
 				return errors.Wrapf(err, "untarring file %s", path)
 			}

--- a/sdk/go/common/util/archive/archive_test.go
+++ b/sdk/go/common/util/archive/archive_test.go
@@ -119,7 +119,7 @@ func archiveContents(prefixPathInsideTar string, files ...fileContents) ([]byte,
 			return nil, err
 		}
 
-		err = ioutil.WriteFile(filepath.Join(dir, name), file.contents, 0644)
+		err = ioutil.WriteFile(filepath.Join(dir, name), file.contents, 0600)
 		if err != nil {
 			return nil, err
 		}

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -380,5 +380,7 @@ func save(path string, value interface{}, mkDirAll bool) error {
 		}
 	}
 
+	// Changing the permissions on these file is ~ a breaking change, so disable golint.
+	//nolint: gosec
 	return ioutil.WriteFile(path, b, 0644)
 }

--- a/sdk/python/python_test.go
+++ b/sdk/python/python_test.go
@@ -91,7 +91,7 @@ func TestRunningPipInVirtualEnvironment(t *testing.T) {
 
 	// Create a requirements.txt file in the temp directory.
 	requirementsFile := filepath.Join(tempdir, "requirements.txt")
-	assert.NoError(t, ioutil.WriteFile(requirementsFile, []byte("pulumi==2.0.0\n"), 0644))
+	assert.NoError(t, ioutil.WriteFile(requirementsFile, []byte("pulumi==2.0.0\n"), 0600))
 
 	// Create a command to run pip from the virtual environment.
 	pipCmd := VirtualEnvCommand(venvDir, "pip", "install", "-r", "requirements.txt")


### PR DESCRIPTION
These errors appear when using golangci-lint 1.27.0.