### PR TITLE
Go program gen: All.Apply func rewriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Go program gen All().Apply rewriter
+  [#4858](https://github.com/pulumi/pulumi/pull/4858)
+
 - Go program gen improvements (multiline strings, get/lookup disambiguation, invoke improvements)
   [#4850](https://github.com/pulumi/pulumi/pull/4850)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Go program gen handling for prompt optional primitives
+  [#4875](https://github.com/pulumi/pulumi/pull/4875)
+
 - Go program gen All().Apply rewriter
   [#4858](https://github.com/pulumi/pulumi/pull/4858)
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -27,6 +27,7 @@ type generator struct {
 	ternaryTempSpiller  *tempSpiller
 	readDirTempSpiller  *readDirSpiller
 	splatSpiller        *splatSpiller
+	optionalSpiller     *optionalSpiller
 	scopeTraversalRoots codegen.StringSet
 }
 
@@ -47,6 +48,7 @@ func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics,
 		ternaryTempSpiller:  &tempSpiller{},
 		readDirTempSpiller:  &readDirSpiller{},
 		splatSpiller:        &splatSpiller{},
+		optionalSpiller:     &optionalSpiller{},
 		scopeTraversalRoots: codegen.NewStringSet(),
 	}
 
@@ -359,6 +361,8 @@ func (g *generator) genTempsMultiReturn(w io.Writer, temps []interface{}, zeroVa
 			g.Fgenf(w, "for _, val0 := range %.v {\n", t.Value.Source)
 			g.Fgenf(w, "%s = append(%s, %.v)\n", t.Name, t.Name, t.Value.Each)
 			g.Fgenf(w, "}\n")
+		case *optionalTemp:
+			g.Fgenf(w, "%s := %.v\n", t.Name, t.Value)
 		default:
 			contract.Failf("unexpected temp type: %v", t)
 		}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -735,6 +735,7 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type, isInp
 	expr, jTemps, jsonDiags := g.rewriteToJSON(expr, g.jsonTempSpiller)
 	expr, rTemps, readDirDiags := g.rewriteReadDir(expr, g.readDirTempSpiller)
 	expr, sTemps, splatDiags := g.rewriteSplat(expr, g.splatSpiller)
+	expr, oTemps, optDiags := g.rewriteOptionals(expr, g.optionalSpiller)
 
 	if isInput {
 		expr = rewriteInputs(expr)
@@ -752,10 +753,14 @@ func (g *generator) lowerExpression(expr model.Expression, typ model.Type, isInp
 	for _, t := range sTemps {
 		temps = append(temps, t)
 	}
+	for _, t := range oTemps {
+		temps = append(temps, t)
+	}
 	diags = append(diags, ternDiags...)
 	diags = append(diags, jsonDiags...)
 	diags = append(diags, readDirDiags...)
 	diags = append(diags, splatDiags...)
+	diags = append(diags, optDiags...)
 	contract.Assert(len(diags) == 0)
 	return expr, temps
 }

--- a/pkg/codegen/go/gen_program_optionals.go
+++ b/pkg/codegen/go/gen_program_optionals.go
@@ -1,0 +1,125 @@
+package gen
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+)
+
+type optionalTemp struct {
+	Name  string
+	Value model.Expression
+}
+
+func (ot *optionalTemp) Type() model.Type {
+	return ot.Value.Type()
+}
+
+func (ot *optionalTemp) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Diagnostics) {
+	return ot.Type().Traverse(traverser)
+}
+
+func (ot *optionalTemp) SyntaxNode() hclsyntax.Node {
+	return syntax.None
+}
+
+type optionalSpiller struct {
+	temps []*optionalTemp
+	count int
+}
+
+func (os *optionalSpiller) spillExpressionHelper(
+	x model.Expression,
+	destType model.Type,
+	isInvoke bool,
+) (model.Expression, hcl.Diagnostics) {
+	var temp *optionalTemp
+	switch x := x.(type) {
+	case *model.FunctionCallExpression:
+		if x.Name == "invoke" {
+			// recurse into invoke args
+			isInvoke = true
+			_, diags := os.spillExpressionHelper(x.Args[1], x.Args[1].Type(), isInvoke)
+			return x, diags
+		}
+		if x.Name == hcl2.IntrinsicConvert {
+			// propagate convert type
+			_, diags := os.spillExpressionHelper(x.Args[0], x.Signature.ReturnType, isInvoke)
+			return x, diags
+		}
+	case *model.ObjectConsExpression:
+		// only rewrite invoke args (required to be prompt values in Go)
+		// pulumi.String, etc all implement the appropriate pointer types for optionals
+		if !isInvoke {
+			return x, nil
+		}
+		if schemaType, ok := hcl2.GetSchemaForType(destType); ok {
+			if schemaType, ok := schemaType.(*schema.ObjectType); ok {
+				var optionalPrimitives []string
+				for _, v := range schemaType.Properties {
+					isPrimitive := false
+					primitives := []schema.Type{
+						schema.NumberType,
+						schema.BoolType,
+						schema.IntType,
+						schema.StringType,
+					}
+					for _, p := range primitives {
+						if p == v.Type {
+							isPrimitive = true
+							break
+						}
+					}
+					if isPrimitive && !v.IsRequired {
+						optionalPrimitives = append(optionalPrimitives, v.Name)
+					}
+				}
+				for i, item := range x.Items {
+					// keys for schematized objects should be simple strings
+					if key, ok := item.Key.(*model.LiteralValueExpression); ok {
+						if key.Type() == model.StringType {
+							strKey := key.Value.AsString()
+							for _, op := range optionalPrimitives {
+								if strKey == op {
+									temp = &optionalTemp{
+										Name:  fmt.Sprintf("opt%d", os.count),
+										Value: item.Value,
+									}
+									os.temps = append(os.temps, temp)
+									os.count++
+									x.Items[i].Value = &model.ScopeTraversalExpression{
+										RootName:  fmt.Sprintf("&%s", temp.Name),
+										Traversal: hcl.Traversal{hcl.TraverseRoot{Name: ""}},
+										Parts:     []model.Traversable{temp},
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return x, nil
+}
+
+func (os *optionalSpiller) spillExpression(x model.Expression) (model.Expression, hcl.Diagnostics) {
+	isInvoke := false
+	return os.spillExpressionHelper(x, x.Type(), isInvoke)
+}
+
+func (g *generator) rewriteOptionals(
+	x model.Expression,
+	spiller *optionalSpiller,
+) (model.Expression, []*optionalTemp, hcl.Diagnostics) {
+	spiller.temps = nil
+	x, diags := model.VisitExpression(x, spiller.spillExpression, nil)
+
+	return x, spiller.temps, diags
+
+}

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -117,6 +117,7 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 			ternaryTempSpiller:  &tempSpiller{},
 			readDirTempSpiller:  &readDirSpiller{},
 			splatSpiller:        &splatSpiller{},
+			optionalSpiller:     &optionalSpiller{},
 			scopeTraversalRoots: codegen.NewStringSet(),
 		}
 		g.Formatter = format.NewFormatter(g)

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -233,7 +233,10 @@ func main() {
 			return err
 		}
 		ctx.Export("clusterName", eksCluster.Name)
-		ctx.Export("kubeconfig", pulumi.All(eksCluster.Endpoint, eksCluster.CertificateAuthority, eksCluster.Name).ApplyT(func(endpoint string, certificateAuthority eks.ClusterCertificateAuthority, name string) (pulumi.String, error) {
+		ctx.Export("kubeconfig", pulumi.All(eksCluster.Endpoint, eksCluster.CertificateAuthority, eksCluster.Name).ApplyT(func(_args []interface{}) (pulumi.String, error) {
+			endpoint := _args[0].(string)
+			certificateAuthority := _args[1].(eks.ClusterCertificateAuthority)
+			name := _args[2].(string)
 			var _zero pulumi.String
 			tmpJSON2, err := json.Marshal(map[string]interface{}{
 				"apiVersion": "v1",

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
@@ -12,8 +12,9 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
+		opt0 := true
 		vpc, err := ec2.LookupVpc(ctx, &ec2.LookupVpcArgs{
-			Default: true,
+			Default: &opt0,
 		}, nil)
 		if err != nil {
 			return err

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
@@ -25,6 +25,7 @@ func main() {
 		if err != nil {
 			return err
 		}
+		opt0 := true
 		ami, err := aws.GetAmi(ctx, &aws.GetAmiArgs{
 			Filters: []aws.GetAmiFilter{
 				aws.GetAmiFilter{
@@ -37,7 +38,7 @@ func main() {
 			Owners: []string{
 				"137112412989",
 			},
-			MostRecent: true,
+			MostRecent: &opt0,
 		}, nil)
 		if err != nil {
 			return err


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/4832

Other languages like javascript take advantage of destructuring to simplify `All.Apply` by generating something like `[a1, a2, a3]`, this allows the body to be emitted in an unmodified state. Go doesn't support this syntax so we create a set of variable declarations with type assertions to prepend to the body that shadow the original variables:
```go
a1 := _args[0].(string) 
a2 := _args[1].(aws.Foo)
...
// temps
// rest of body
```

In this manner, we can leave the body untouched and don't have to mess around with rewriting all of the scope traversal expressions, generating type assertions inline, etc. 