### PR TITLE
[codegen/python] Don't use __all__

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -255,7 +255,7 @@ func (mod *modContext) genInit(exports []string) string {
 
 		fmt.Fprintf(w, "import importlib\n")
 		fmt.Fprintf(w, "# Make subpackages available:\n")
-		fmt.Fprintf(w, "__all__ = [")
+		fmt.Fprintf(w, "submodules = [")
 		for i, mod := range mod.children {
 			child := mod.mod
 			if mod.compatibility == kubernetes20 {
@@ -271,7 +271,7 @@ func (mod *modContext) genInit(exports []string) string {
 			fmt.Fprintf(w, "'%s'", PyName(child))
 		}
 		fmt.Fprintf(w, "]\n")
-		fmt.Fprintf(w, "for pkg in __all__:\n")
+		fmt.Fprintf(w, "for pkg in submodules:\n")
 		fmt.Fprintf(w, "    if pkg != 'config':\n")
 		fmt.Fprintf(w, "        importlib.import_module(f'{__name__}.{pkg}')\n")
 	}

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -248,7 +248,7 @@ func (mod *modContext) genInit(exports []string) string {
 	mod.genHeader(w, false)
 
 	if len(mod.children) > 0 {
-		fmt.Fprintf(w, "import importlib\n\n")
+		fmt.Fprintf(w, "import importlib\n")
 	}
 
 	// Import anything to export flatly that is a direct export rather than sub-module.

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -247,6 +247,10 @@ func (mod *modContext) genInit(exports []string) string {
 	w := &bytes.Buffer{}
 	mod.genHeader(w, false)
 
+	if len(mod.children) > 0 {
+		fmt.Fprintf(w, "import importlib\n\n")
+	}
+
 	// Import anything to export flatly that is a direct export rather than sub-module.
 	if len(exports) > 0 {
 		sort.Slice(exports, func(i, j int) bool {
@@ -271,8 +275,7 @@ func (mod *modContext) genInit(exports []string) string {
 			return PyName(mod.children[i].mod) < PyName(mod.children[j].mod)
 		})
 
-		fmt.Fprintf(w, "\nimport importlib\n")
-		fmt.Fprintf(w, "# Make subpackages available:\n")
+		fmt.Fprintf(w, "\n# Make subpackages available:\n")
 		fmt.Fprintf(w, "submodules = [\n")
 		for i, mod := range mod.children {
 			child := mod.mod

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -247,41 +247,8 @@ func (mod *modContext) genInit(exports []string) string {
 	w := &bytes.Buffer{}
 	mod.genHeader(w, false)
 
-	// If there are subpackages, export them in the __all__ variable.
-	if len(mod.children) > 0 {
-		sort.Slice(mod.children, func(i, j int) bool {
-			return PyName(mod.children[i].mod) < PyName(mod.children[j].mod)
-		})
-
-		fmt.Fprintf(w, "import importlib\n")
-		fmt.Fprintf(w, "# Make subpackages available:\n")
-		fmt.Fprintf(w, "submodules = [")
-		for i, mod := range mod.children {
-			child := mod.mod
-			if mod.compatibility == kubernetes20 {
-				// Extract version suffix from child modules. Nested versions will have their own __init__.py file.
-				// Example: apps/v1beta1 -> v1beta1
-				if match := k8sVersionSuffix.FindStringSubmatchIndex(child); len(match) != 0 {
-					child = child[match[2]:match[3]]
-				}
-			}
-			if i > 0 {
-				fmt.Fprintf(w, ", ")
-			}
-			fmt.Fprintf(w, "'%s'", PyName(child))
-		}
-		fmt.Fprintf(w, "]\n")
-		fmt.Fprintf(w, "for pkg in submodules:\n")
-		fmt.Fprintf(w, "    if pkg != 'config':\n")
-		fmt.Fprintf(w, "        importlib.import_module(f'{__name__}.{pkg}')\n")
-	}
-
-	// Now, import anything to export flatly that is a direct export rather than sub-module.
+	// Import anything to export flatly that is a direct export rather than sub-module.
 	if len(exports) > 0 {
-		if len(mod.children) > 0 {
-			fmt.Fprintf(w, "\n")
-		}
-
 		sort.Slice(exports, func(i, j int) bool {
 			return PyName(exports[i]) < PyName(exports[j])
 		})
@@ -296,6 +263,35 @@ func (mod *modContext) genInit(exports []string) string {
 			}
 			fmt.Fprintf(w, "from .%s import *\n", name)
 		}
+	}
+
+	// If there are subpackages, import them with importlib.
+	if len(mod.children) > 0 {
+		sort.Slice(mod.children, func(i, j int) bool {
+			return PyName(mod.children[i].mod) < PyName(mod.children[j].mod)
+		})
+
+		fmt.Fprintf(w, "\nimport importlib\n")
+		fmt.Fprintf(w, "# Make subpackages available:\n")
+		fmt.Fprintf(w, "submodules = [\n")
+		for i, mod := range mod.children {
+			child := mod.mod
+			if mod.compatibility == kubernetes20 {
+				// Extract version suffix from child modules. Nested versions will have their own __init__.py file.
+				// Example: apps/v1beta1 -> v1beta1
+				if match := k8sVersionSuffix.FindStringSubmatchIndex(child); len(match) != 0 {
+					child = child[match[2]:match[3]]
+				}
+			}
+			if i > 0 {
+				fmt.Fprintf(w, ",\n")
+			}
+			fmt.Fprintf(w, "    '%s'", PyName(child))
+		}
+		fmt.Fprintf(w, ",\n]\n")
+		fmt.Fprintf(w, "for pkg in submodules:\n")
+		fmt.Fprintf(w, "    if pkg != 'config':\n")
+		fmt.Fprintf(w, "        importlib.import_module(f'{__name__}.{pkg}')\n")
 	}
 
 	return w.String()

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -88,5 +88,4 @@ import importlib
 # Make subpackages available.
 submodules = ['runtime', 'dynamic', 'policy']
 for pkg in submodules:
-    if pkg != 'config':
-        importlib.import_module(f'{__name__}.{pkg}')
+    importlib.import_module(f'{__name__}.{pkg}')

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -87,6 +87,5 @@ from .stack_reference import (
 )
 
 # Make subpackages available.
-submodules = ['runtime', 'dynamic', 'policy']
-for pkg in submodules:
+for pkg in ['runtime', 'dynamic', 'policy']:
     importlib.import_module(f'{__name__}.{pkg}')

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -18,6 +18,8 @@ providers and libraries in the Pulumi ecosystem use to create and manage
 resources.
 """
 
+import importlib
+
 # Make all module members inside of this package available as package members.
 from .asset import (
     Asset,
@@ -84,7 +86,6 @@ from .stack_reference import (
     StackReference,
 )
 
-import importlib
 # Make subpackages available.
 submodules = ['runtime', 'dynamic', 'policy']
 for pkg in submodules:

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -18,9 +18,6 @@ providers and libraries in the Pulumi ecosystem use to create and manage
 resources.
 """
 
-# Make subpackages available.
-__all__ = ['runtime', 'dynamic', 'policy']
-
 # Make all module members inside of this package available as package members.
 from .asset import (
     Asset,
@@ -86,3 +83,10 @@ from .log import (
 from .stack_reference import (
     StackReference,
 )
+
+import importlib
+# Make subpackages available.
+submodules = ['runtime', 'dynamic', 'policy']
+for pkg in submodules:
+    if pkg != 'config':
+        importlib.import_module(f'{__name__}.{pkg}')


### PR DESCRIPTION
`__all__` is a list of public objects of a module. Using it overrides the default of hiding everything that begins with an underscore. So if we use `__all__` we must list everything we want to make available publicly, including classes (which we currently do not). - [[source]](https://stackoverflow.com/questions/44834/can-someone-explain-all-in-python)

The way we are currently using `__all__` isn't leveraging this functionality, we are just using it as a list of submodules we want to import. So, renaming the list to `submodules` (or really anything else) means we use the default functionality of making all classes available publicly, and we can get rid of the warning in IDEs like IntelliJ and PyCharm.

Also some whitespace changes and reorganizing to make the linter happy.

Before:
<img width="943" alt="Screen Shot 2020-06-22 at 11 37 34 AM" src="https://user-images.githubusercontent.com/24326455/85344886-b7887b80-b4a5-11ea-9bb2-ab939f90d2be.png">

After:
<img width="732" alt="Screen Shot 2020-06-22 at 4 31 47 PM" src="https://user-images.githubusercontent.com/24326455/85344935-e1da3900-b4a5-11ea-812c-71b5698a533d.png">
