### PR TITLE
Fix setup.py

### DIFF
--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -16,9 +16,14 @@
 
 from setuptools import setup, find_packages
 
+
 def readme():
-    with open('README.md', encoding='utf-8') as f:
-        return f.read()
+    try:
+        with open('README.md', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        return ''
+
 
 setup(name='pulumi',
       version='${VERSION}',


### PR DESCRIPTION
A local pip install i.e. `pip install -e path/to/dir` fails because there is no README.md file in the python sdk directory. 