### PR TITLE
go program gen: prompt array conversion, unused range vars, id handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Go program gen: prompt array conversion, unused range vars, id handling
+  [#4884](https://github.com/pulumi/pulumi/pull/4884)
+
 - Go program gen handling for prompt optional primitives
   [#4875](https://github.com/pulumi/pulumi/pull/4875)
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -300,7 +300,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		g.Fgenf(w, "}\n")
 
 	} else {
-		instantiate(resName, fmt.Sprintf("\"%s\"", resName), w)
+		instantiate(resName, fmt.Sprintf("%q", resName), w)
 	}
 
 }

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -119,6 +119,7 @@ func newTestGenerator(t *testing.T, testFile string) *generator {
 			splatSpiller:        &splatSpiller{},
 			optionalSpiller:     &optionalSpiller{},
 			scopeTraversalRoots: codegen.NewStringSet(),
+			arrayHelpers:        make(map[string]*promptToInputArrayHelper),
 		}
 		g.Formatter = format.NewFormatter(g)
 		return g

--- a/pkg/codegen/go/gen_program_utils.go
+++ b/pkg/codegen/go/gen_program_utils.go
@@ -35,18 +35,14 @@ func (p *promptToInputArrayHelper) generateHelperMethod(w io.Writer) {
 
 func (p *promptToInputArrayHelper) getFnName() string {
 	parts := strings.Split(p.destType, ".")
-	if len(parts) != 2 {
-		contract.Failf("promptToInputArrayHelper destType expected to have two parts.")
-	}
+	contract.Assertf(len(parts) == 2, "promptToInputArrayHelper destType expected to have two parts.")
 	return fmt.Sprintf("to%s%s", Title(parts[0]), Title(parts[1]))
 }
 
 func (p *promptToInputArrayHelper) getPromptItemType() string {
 	inputType := p.getInputItemType()
 	parts := strings.Split(inputType, ".")
-	if len(parts) != 2 {
-		contract.Failf("promptToInputArrayHelper destType expected to have two parts.")
-	}
+	contract.Assertf(len(parts) == 2, "promptToInputArrayHelper destType expected to have two parts.")
 	typ := parts[1]
 	if t, ok := primitives[typ]; ok {
 		return t

--- a/pkg/codegen/go/gen_program_utils.go
+++ b/pkg/codegen/go/gen_program_utils.go
@@ -1,0 +1,60 @@
+package gen
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+)
+
+type promptToInputArrayHelper struct {
+	destType string
+}
+
+var primitives = map[string]string{
+	"String":  "string",
+	"Bool":    "bool",
+	"Int":     "int",
+	"Int64":   "int64",
+	"Float64": "float64",
+}
+
+func (p *promptToInputArrayHelper) generateHelperMethod(w io.Writer) {
+	promptType := p.getPromptItemType()
+	inputType := p.getInputItemType()
+	fnName := p.getFnName()
+	fmt.Fprintf(w, "func %s(arr []%s) %s {\n", fnName, promptType, p.destType)
+	fmt.Fprintf(w, "var pulumiArr %s\n", p.destType)
+	fmt.Fprintf(w, "for _, v := range arr {\n")
+	fmt.Fprintf(w, "pulumiArr = append(pulumiArr, %s(v))\n", inputType)
+	fmt.Fprintf(w, "}\n")
+	fmt.Fprintf(w, "return pulumiArr\n")
+	fmt.Fprintf(w, "}\n")
+}
+
+func (p *promptToInputArrayHelper) getFnName() string {
+	parts := strings.Split(p.destType, ".")
+	if len(parts) != 2 {
+		contract.Failf("promptToInputArrayHelper destType expected to have two parts.")
+	}
+	return fmt.Sprintf("to%s%s", Title(parts[0]), Title(parts[1]))
+}
+
+func (p *promptToInputArrayHelper) getPromptItemType() string {
+	inputType := p.getInputItemType()
+	parts := strings.Split(inputType, ".")
+	if len(parts) != 2 {
+		contract.Failf("promptToInputArrayHelper destType expected to have two parts.")
+	}
+	typ := parts[1]
+	if t, ok := primitives[typ]; ok {
+		return t
+	}
+
+	return typ
+}
+
+func (p *promptToInputArrayHelper) getInputItemType() string {
+	return strings.TrimSuffix(p.destType, "Array")
+}

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -71,7 +71,7 @@ func main() {
 			vpcSubnet = append(vpcSubnet, _res)
 		}
 		var rta []*ec2.RouteTableAssociation
-		for key0, val0 := range zones.Names {
+		for key0, _ := range zones.Names {
 			_res, err := ec2.NewRouteTableAssociation(ctx, fmt.Sprintf("rta-%v", key0), &ec2.RouteTableAssociationArgs{
 				RouteTableId: eksRouteTable.ID(),
 				SubnetId:     vpcSubnet[key0].ID(),
@@ -81,7 +81,7 @@ func main() {
 			}
 			rta = append(rta, _res)
 		}
-		var splat0 []pulumi.String
+		var splat0 pulumi.StringArray
 		for _, val0 := range vpcSubnet {
 			splat0 = append(splat0, val0.ID())
 		}

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
@@ -86,7 +86,7 @@ func main() {
 			return err
 		}
 		webLoadBalancer, err := elasticloadbalancingv2.NewLoadBalancer(ctx, "webLoadBalancer", &elasticloadbalancingv2.LoadBalancerArgs{
-			Subnets: pulumi.StringArray(subnets.Ids),
+			Subnets: toPulumiStringArray(subnets.Ids),
 			SecurityGroups: pulumi.StringArray{
 				webSecurityGroup.ID(),
 			},
@@ -154,7 +154,7 @@ func main() {
 			TaskDefinition: appTask.Arn,
 			NetworkConfiguration: &ecs.ServiceNetworkConfigurationArgs{
 				AssignPublicIp: pulumi.Bool(true),
-				Subnets:        pulumi.StringArray(subnets.Ids),
+				Subnets:        toPulumiStringArray(subnets.Ids),
 				SecurityGroups: pulumi.StringArray{
 					webSecurityGroup.ID(),
 				},
@@ -173,4 +173,11 @@ func main() {
 		ctx.Export("url", webLoadBalancer.DnsName)
 		return nil
 	})
+}
+func toPulumiStringArray(arr []string) pulumi.StringArray {
+	var pulumiArr pulumi.StringArray
+	for _, v := range arr {
+		pulumiArr = append(pulumiArr, pulumi.String(v))
+	}
+	return pulumiArr
 }


### PR DESCRIPTION
This closes out the last of the known issues causing compilation errors in examples. (deeper quality pass over the providers is still pending: https://github.com/pulumi/pulumi/issues/4783)

Fixes: https://github.com/pulumi/pulumi/issues/4833, https://github.com/pulumi/pulumi/issues/4852, and https://github.com/pulumi/pulumi/issues/4769

The ID issue turned out to be bad typing on the destination array (easy fix), the unused range vars was a simple static change, so the prompt array conversion is the meat here. 

Rather than doing a complicated lowering step ahead of time, I just wrap the scope traversal expressions in a helper function call as suggested by @lblackstone for something similar in a previous review. In this case, the resulting code is substantially simpler to generate as we're already detecting the proper situation at generate time from within scope traversal expressions.