### PR TITLE
[codegen/docs] Use the correct format for package name when module name is empty

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -895,12 +895,41 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 	return docProperties
 }
 
+func getDockerImagePythonFormalParams() []formalParam {
+	return []formalParam{
+		{
+			Name: "image_name",
+		},
+		{
+			Name: "build",
+		},
+		{
+			Name:         "local_image_name",
+			DefaultValue: "=None",
+		},
+		{
+			Name:         "registry",
+			DefaultValue: "=None",
+		},
+		{
+			Name:         "skip_push",
+			DefaultValue: "=None",
+		},
+		{
+			Name:         "opts",
+			DefaultValue: "=None",
+		},
+	}
+}
+
 // Returns the rendered HTML for the resource's constructor, as well as the specific arguments.
 func (mod *modContext) genConstructors(r *schema.Resource, allOptionalInputs bool) (map[string]string, map[string][]formalParam) {
 	renderedParams := make(map[string]string)
 	formalParams := make(map[string][]formalParam)
 	isK8sOverlayMod := mod.isKubernetesOverlayModule()
 	isK8sPackage := isKubernetesPackage(mod.pkg)
+	isDockerImageResource := mod.pkg.Name == "docker" && resourceName(r) == "Image"
+
 	for _, lang := range supportedLanguages {
 		var (
 			paramTemplate string
@@ -926,6 +955,9 @@ func (mod *modContext) genConstructors(r *schema.Resource, allOptionalInputs boo
 			// Kubernetes overlay resources use a different ordering of formal params in Python.
 			if isK8sOverlayMod {
 				params = getKubernetesOverlayPythonFormalParams(mod.mod)
+				break
+			} else if isDockerImageResource {
+				params = getDockerImagePythonFormalParams()
 				break
 			}
 

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -39,22 +39,28 @@ func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName
 
 // GetDocLinkForResourceType returns the Python API doc for a type belonging to a resource provider.
 func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, modName, typeName string) string {
-	var path string
 	// The k8s module names contain the domain names. For now we are stripping them off manually so they link correctly.
 	if modName != "" {
 		modName = strings.ReplaceAll(modName, ".k8s.io", "")
 		modName = strings.ReplaceAll(modName, ".apiserver", "")
 		modName = strings.ReplaceAll(modName, ".authorization", "")
 	}
+
+	var path string
+	var fqdnTypeName string
 	switch {
 	case pkg.Name != "" && modName != "":
 		path = fmt.Sprintf("pulumi_%s/%s", pkg.Name, modName)
+		fqdnTypeName = fmt.Sprintf("pulumi_%s.%s.%s", pkg.Name, modName, typeName)
 	case pkg.Name == "" && modName != "":
 		path = modName
+		fqdnTypeName = fmt.Sprintf("%s.%s", modName, typeName)
 	case pkg.Name != "" && modName == "":
 		path = fmt.Sprintf("pulumi_%s", pkg.Name)
+		fqdnTypeName = fmt.Sprintf("pulumi_%s.%s", pkg.Name, typeName)
 	}
-	return fmt.Sprintf("/docs/reference/pkg/python/%[1]s/#%[1]s.%[2]s", path, typeName)
+
+	return fmt.Sprintf("/docs/reference/pkg/python/%s/#%s", path, fqdnTypeName)
 }
 
 // GetDocLinkForResourceInputOrOutputType is not implemented at this time for Python.

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -54,7 +54,7 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, modNam
 	case pkg.Name != "" && modName == "":
 		path = fmt.Sprintf("pulumi_%s", pkg.Name)
 	}
-	return fmt.Sprintf("/docs/reference/pkg/python/%s/#%s", path, typeName)
+	return fmt.Sprintf("/docs/reference/pkg/python/%[1]s/#%[1]s.%[2]s", path, typeName)
 }
 
 // GetDocLinkForResourceInputOrOutputType is not implemented at this time for Python.

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -52,7 +52,7 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, modNam
 	case pkg.Name == "" && modName != "":
 		path = modName
 	case pkg.Name != "" && modName == "":
-		path = pkg.Name
+		path = fmt.Sprintf("pulumi_%s", pkg.Name)
 	}
 	return fmt.Sprintf("/docs/reference/pkg/python/%s/#%s", path, typeName)
 }


### PR DESCRIPTION
This PR fixes the Python-specific URL generated for a resource when the resource has an empty module name. For example, all of the resources in the Docker package are at the index-level and do not have a module name. So for example, in the `Container` page, click on the Python [function](https://www.pulumi.com/docs/reference/pkg/docker/container/?language=python#create) under the "Create a Container Resource" heading, will result in a 404 because the URL is incorrect.

I have also expanded this PR to allow other `ComponentResource`s to have custom ordering of formal params than our schematized resources. This is needed to support generating the correct resource docs for the Docker's `Image` component.

The fix in this PR is also needed for https://github.com/pulumi/docs/pull/3671.