### PR TITLE
Avoid stack overflow in Python codegen in case of recursive types

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -54,6 +54,7 @@ var (
 	// casing.
 	snakeCaseToCamelCase map[string]string
 	camelCaseToSnakeCase map[string]string
+	seenCasingTypes      codegen.Set
 
 	// The language-specific info objects for a certain package (provider).
 	goPkgInfo     go_gen.GoPackageInfo
@@ -129,6 +130,7 @@ func init() {
 
 	snakeCaseToCamelCase = map[string]string{}
 	camelCaseToSnakeCase = map[string]string{}
+	seenCasingTypes = codegen.Set{}
 	langModuleNameLookup = map[string]string{}
 }
 
@@ -1698,14 +1700,14 @@ func getMod(pkg *schema.Package, token string, modules map[string]*modContext, t
 	return mod
 }
 
-func generatePythonPropertyCaseMaps(mod *modContext, r *schema.Resource) {
+func generatePythonPropertyCaseMaps(mod *modContext, r *schema.Resource, seenTypes codegen.Set) {
 	pyLangHelper := getLanguageDocHelper("python").(*python.DocLanguageHelper)
 	for _, p := range r.Properties {
-		pyLangHelper.GenPropertyCaseMap(mod.pkg, mod.mod, mod.tool, p, snakeCaseToCamelCase, camelCaseToSnakeCase)
+		pyLangHelper.GenPropertyCaseMap(mod.pkg, mod.mod, mod.tool, p, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 	}
 
 	for _, p := range r.InputProperties {
-		pyLangHelper.GenPropertyCaseMap(mod.pkg, mod.mod, mod.tool, p, snakeCaseToCamelCase, camelCaseToSnakeCase)
+		pyLangHelper.GenPropertyCaseMap(mod.pkg, mod.mod, mod.tool, p, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 	}
 }
 
@@ -1738,7 +1740,7 @@ func generateModulesFromSchemaPackage(tool string, pkg *schema.Package) map[stri
 		mod := getMod(pkg, r.Token, modules, tool)
 		mod.resources = append(mod.resources, r)
 
-		generatePythonPropertyCaseMaps(mod, r)
+		generatePythonPropertyCaseMaps(mod, r, seenCasingTypes)
 	}
 
 	scanK8SResource := func(r *schema.Resource) {

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -125,13 +125,13 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *sche
 }
 
 // GenPropertyCaseMap generates the case maps for a property.
-func (d DocLanguageHelper) GenPropertyCaseMap(pkg *schema.Package, modName, tool string, prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string) {
+func (d DocLanguageHelper) GenPropertyCaseMap(pkg *schema.Package, modName, tool string, prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string, seenTypes codegen.Set) {
 	if err := pkg.ImportLanguages(map[string]schema.Language{"python": Importer}); err != nil {
 		fmt.Printf("error building case map for %q in module %q", prop.Name, modName)
 		return
 	}
 
-	recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase)
+	recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 }
 
 // GetPropertyName is not implemented for Python because property names in Python must use

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -937,28 +937,28 @@ func (mod *modContext) genPropertyConversionTables() string {
 //
 // Once all resources have been emitted, the table is written out to a format usable for implementations of
 // translate_input_property and translate_output_property.
-func buildCaseMappingTables(pkg *schema.Package, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string) {
+func buildCaseMappingTables(pkg *schema.Package, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string, seenTypes codegen.Set) {
 	for _, r := range pkg.Resources {
 		// Calculate casing tables. We do this up front because our docstring generator (which is run during
 		// genResource) requires them.
 		for _, prop := range r.Properties {
-			recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase)
+			recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 		}
 		for _, prop := range r.InputProperties {
-			recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase)
+			recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 		}
 	}
 	for _, typ := range pkg.Types {
 		typ, ok := typ.(*schema.ObjectType)
 		if ok {
 			for _, prop := range typ.Properties {
-				recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase)
+				recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 			}
 		}
 	}
 }
 
-func recordProperty(prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string) {
+func recordProperty(prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string, seenTypes codegen.Set) {
 	mapCase := true
 	if python, ok := prop.Language["python"]; ok {
 		mapCase = python.(PropertyInfo).MapCase
@@ -980,16 +980,13 @@ func recordProperty(prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnak
 	}
 
 	if obj, ok := prop.Type.(*schema.ObjectType); ok {
-		for _, p := range obj.Properties {
-			// Skip the nested type's property if the property's type is the same
-			// as that of the nested type itself.
-			// For example, the JSONSchemaProps type in Kubernetes has properties whose
-			// type is itself. This can lead to infinite recursion.
-			if p.Type == prop.Type {
-				continue
-			}
+		if !seenTypes.Has(prop.Type) {
+			// Avoid infinite calls in case of recursive types.
+			seenTypes.Add(prop.Type)
 
-			recordProperty(p, snakeCaseToCamelCase, camelCaseToSnakeCase)
+			for _, p := range obj.Properties {
+				recordProperty(p, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
+			}
 		}
 	}
 }
@@ -1303,7 +1300,8 @@ func getDefaultValue(dv *schema.DefaultValue, t schema.Type) (string, error) {
 func generateModuleContextMap(tool string, pkg *schema.Package, info PackageInfo, extraFiles map[string][]byte) (map[string]*modContext, error) {
 	// Build case mapping tables
 	snakeCaseToCamelCase, camelCaseToSnakeCase := map[string]string{}, map[string]string{}
-	buildCaseMappingTables(pkg, snakeCaseToCamelCase, camelCaseToSnakeCase)
+	seenTypes := codegen.Set{}
+	buildCaseMappingTables(pkg, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 
 	// group resources, types, and functions into modules
 	modules := map[string]*modContext{}

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -78,7 +78,8 @@ func newGenerator(program *hcl2.Program) (*generator, error) {
 
 		// Build the case mapping table.
 		camelCaseToSnakeCase := map[string]string{}
-		buildCaseMappingTables(p, nil, camelCaseToSnakeCase)
+		seenTypes := codegen.Set{}
+		buildCaseMappingTables(p, nil, camelCaseToSnakeCase, seenTypes)
 		casingTables[PyName(p.Name)] = camelCaseToSnakeCase
 
 		// Annotate nested types to indicate they are dictionaries.


### PR DESCRIPTION
Got a stack overflow exception while generating the Python SDK for the (prototype) Azure RM provider. It has types referencing each other, which kills the casing building function.