### PR TITLE
[Go Program Gen] Improved handling for pulumi.Map types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Go program gen: Improved handling for pulumi.Map types
+  [#491](https://github.com/pulumi/pulumi/pull/4914)
+
 - Go SDK: Input type interfaces should declare pointer type impls where appropriate
   [#4911](https://github.com/pulumi/pulumi/pull/4911)
 

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -636,7 +636,22 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 			return destType.Name
 		}
 	case *model.ObjectType:
+
 		if isInput {
+			// check for element type uniformity and return appropriate type if so
+			allSameType := true
+			var elmType string
+			for _, v := range destType.Properties {
+				valType := g.argumentTypeName(nil, v, true)
+				if elmType != "" && elmType != valType {
+					allSameType = false
+					break
+				}
+				elmType = valType
+			}
+			if allSameType && elmType != "" {
+				return fmt.Sprintf("%sMap", elmType)
+			}
 			return "pulumi.Map"
 		}
 		return "map[string]interface{}"

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -18,7 +18,7 @@ func main() {
 			InstanceTenancy:    pulumi.String("default"),
 			EnableDnsHostnames: pulumi.Bool(true),
 			EnableDnsSupport:   pulumi.Bool(true),
-			Tags: pulumi.Map{
+			Tags: pulumi.StringMap{
 				"Name": pulumi.String("pulumi-eks-vpc"),
 			},
 		})
@@ -27,7 +27,7 @@ func main() {
 		}
 		eksIgw, err := ec2.NewInternetGateway(ctx, "eksIgw", &ec2.InternetGatewayArgs{
 			VpcId: eksVpc.ID(),
-			Tags: pulumi.Map{
+			Tags: pulumi.StringMap{
 				"Name": pulumi.String("pulumi-vpc-ig"),
 			},
 		})
@@ -42,7 +42,7 @@ func main() {
 					GatewayId: eksIgw.ID(),
 				},
 			},
-			Tags: pulumi.Map{
+			Tags: pulumi.StringMap{
 				"Name": pulumi.String("pulumi-vpc-rt"),
 			},
 		})
@@ -61,7 +61,7 @@ func main() {
 				MapPublicIpOnLaunch:         pulumi.Bool(true),
 				CidrBlock:                   pulumi.String(fmt.Sprintf("%v%v%v", "10.100.", key0, ".0/24")),
 				AvailabilityZone:            pulumi.String(val0),
-				Tags: pulumi.Map{
+				Tags: pulumi.StringMap{
 					"Name": pulumi.String(fmt.Sprintf("%v%v", "pulumi-sn-", val0)),
 				},
 			})
@@ -89,7 +89,7 @@ func main() {
 		eksSecurityGroup, err := ec2.NewSecurityGroup(ctx, "eksSecurityGroup", &ec2.SecurityGroupArgs{
 			VpcId:       eksVpc.ID(),
 			Description: pulumi.String("Allow all HTTP(s) traffic to EKS Cluster"),
-			Tags: pulumi.Map{
+			Tags: pulumi.StringMap{
 				"Name": pulumi.String("pulumi-cluster-sg"),
 			},
 			Ingress: ec2.SecurityGroupIngressArray{
@@ -199,7 +199,7 @@ func main() {
 		}
 		eksCluster, err := eks.NewCluster(ctx, "eksCluster", &eks.ClusterArgs{
 			RoleArn: eksRole.Arn,
-			Tags: pulumi.Map{
+			Tags: pulumi.StringMap{
 				"Name": pulumi.String("pulumi-eks-cluster"),
 			},
 			VpcConfig: &eks.ClusterVpcConfigArgs{
@@ -220,7 +220,7 @@ func main() {
 			NodeGroupName: pulumi.String("pulumi-eks-nodegroup"),
 			NodeRoleArn:   ec2Role.Arn,
 			SubnetIds:     subnetIds,
-			Tags: pulumi.Map{
+			Tags: pulumi.StringMap{
 				"Name": pulumi.String("pulumi-cluster-nodeGroup"),
 			},
 			ScalingConfig: &eks.NodeGroupScalingConfigArgs{

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
@@ -44,7 +44,7 @@ func main() {
 			return err
 		}
 		server, err := ec2.NewInstance(ctx, "server", &ec2.InstanceArgs{
-			Tags: pulumi.Map{
+			Tags: pulumi.StringMap{
 				"Name": pulumi.String("web-server-www"),
 			},
 			InstanceType: pulumi.String("t2.micro"),


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/4903

Also went ahead and refreshed the local aws schema. When doing this, I noticed that the `version` field is no longer populated, and as a result my code was panicking on dereference of `p.Version.Major`. I manually added the version field into the AWS schema, but wanted to double check that this field is populated at runtime @pgavlin 