### PR TITLE
[Go program gen]: namespaceless resources

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -243,7 +243,7 @@ func (g *generator) genNode(w io.Writer, n hcl2.Node) {
 
 func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
-	resName := r.Name()
+	resName := makeValidIdentifier(r.Name())
 	pkg, mod, typ, _ := r.DecomposeToken()
 	if mod == "" || strings.HasPrefix(mod, "/") || strings.HasPrefix(mod, "index/") {
 		mod = pkg
@@ -404,8 +404,8 @@ func (g *generator) genLocalVariable(w io.Writer, v *hcl2.LocalVariable) {
 	isInput := false
 	expr, temps := g.lowerExpression(v.Definition.Value, v.Type(), isInput)
 	g.genTemps(w, temps)
-	name := v.Name()
-	if !g.scopeTraversalRoots.Has(name) {
+	name := makeValidIdentifier(v.Name())
+	if !g.scopeTraversalRoots.Has(v.Name()) {
 		name = "_"
 	}
 	switch expr := expr.(type) {

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -146,8 +146,11 @@ func (g *generator) collectImports(w io.Writer, program *hcl2.Program) (codegen.
 			if version > 1 {
 				vPath = fmt.Sprintf("/v%d", version)
 			}
-
-			pulumiImports.Add(fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s/%s", pkg, vPath, pkg, mod))
+			if mod == "" {
+				pulumiImports.Add(fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s", pkg, vPath, pkg))
+			} else {
+				pulumiImports.Add(fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s/%s", pkg, vPath, pkg, mod))
+			}
 		}
 
 		diags := n.VisitExpressions(nil, func(n model.Expression) (model.Expression, hcl.Diagnostics) {

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -261,7 +261,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 	}
 
 	instantiate := func(varName, resourceName string, w io.Writer) {
-		if g.scopeTraversalRoots.Has(varName) || strings.HasPrefix(varName, "_") {
+		if g.scopeTraversalRoots.Has(varName) || strings.HasPrefix(varName, "__") {
 			g.Fgenf(w, "%s, err := %s.New%s(ctx, %s, ", varName, mod, typ, resourceName)
 		} else {
 			assignment := ":="
@@ -298,7 +298,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		// ahead of range statement declaration generate the resource instantiation
 		// to detect and removed unused k,v variables
 		var buf bytes.Buffer
-		instantiate("_res", fmt.Sprintf(`fmt.Sprintf("%s-%%v", key0)`, resName), &buf)
+		instantiate("__res", fmt.Sprintf(`fmt.Sprintf("%s-%%v", key0)`, resName), &buf)
 		instantiation := buf.String()
 		isValUsed := strings.Contains(instantiation, "val0")
 		valVar := "_"
@@ -308,7 +308,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 		g.Fgenf(w, "for key0, %s := range %.v {\n", valVar, rangeExpr)
 		g.Fgen(w, instantiation)
-		g.Fgenf(w, "%s = append(%s, _res)\n", resName, resName)
+		g.Fgenf(w, "%s = append(%s, __res)\n", resName, resName)
 		g.Fgenf(w, "}\n")
 
 	} else {

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -241,7 +241,10 @@ func (g *generator) genNode(w io.Writer, n hcl2.Node) {
 func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 	resName := r.Name()
-	_, mod, typ, _ := r.DecomposeToken()
+	pkg, mod, typ, _ := r.DecomposeToken()
+	if mod == "" || strings.HasPrefix(mod, "/") || strings.HasPrefix(mod, "index/") {
+		mod = pkg
+	}
 
 	// Add conversions to input properties
 	for _, input := range r.Inputs {

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -470,7 +470,7 @@ func (g *generator) genScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 			contract.Failf("unexpected traversal on range expression: %s", part)
 		}
 	} else {
-		g.Fgen(w, rootName)
+		g.Fgen(w, makeValidIdentifier(rootName))
 		isRootResource := false
 		g.genRelativeTraversal(w, expr.Traversal.SimpleSplit().Rel, expr.Parts[1:], isRootResource)
 	}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -17,6 +17,8 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
+const keywordRange = "range"
+
 func (g *generator) GetPrecedence(expr model.Expression) int {
 	// TODO: Current values copied from Node, update based on
 	// https://golang.org/ref/spec
@@ -227,7 +229,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		// g.Fgenf(w, "%.20v.Length", expr.Args[0])
 	case "lookup":
 		g.genNYI(w, "Lookup")
-	case "range":
+	case keywordRange:
 		g.genNYI(w, "call %v", expr.Name)
 		// g.genRange(w, expr, false)
 	case "readFile":
@@ -459,7 +461,7 @@ func (g *generator) genScopeTraversalExpression(w io.Writer, expr *model.ScopeTr
 	// TODO: this isn't exhaustively correct as "range" could be a legit var name
 	// instead we should probably use a fn call expression here for entries/range
 	// similar to other languages
-	if rootName == "range" {
+	if rootName == keywordRange {
 		part := expr.Traversal[1].(hcl.TraverseAttr).Name
 		switch part {
 		case "value":

--- a/pkg/codegen/go/utilities.go
+++ b/pkg/codegen/go/utilities.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gen
+
+import (
+	"strings"
+	"unicode"
+)
+
+// isReservedWord returns true if s is a Go reserved word as per
+// https://golang.org/ref/spec#Keywords
+func isReservedWord(s string) bool {
+	switch s {
+	case "break", "default", "func", " interface", "select",
+		"case", "defer", "go", "map", "struct",
+		"chan", "else", "goto", "package", "switch",
+		"const", "fallthrough", "if", "range", "type",
+		"continue", "for", "import", "return", "var":
+		return true
+
+	default:
+		return false
+	}
+}
+
+// isLegalIdentifierStart returns true if it is legal for c to be the first character of a Go identifier as per
+// https://golang.org/ref/spec#Identifiers
+func isLegalIdentifierStart(c rune) bool {
+	return c == '_' || unicode.In(c, unicode.Letter)
+}
+
+// isLegalIdentifierPart returns true if it is legal for c to be part of a Go identifier (besides the first character)
+// https://golang.org/ref/spec#Identifiers
+func isLegalIdentifierPart(c rune) bool {
+	return c == '_' ||
+		unicode.In(c, unicode.Letter, unicode.Digit)
+}
+
+// makeValidIdentifier replaces characters that are not allowed in Go identifiers with underscores. A reserved word is
+// prefixed with _. No attempt is made to ensure that the result is unique.
+func makeValidIdentifier(name string) string {
+	var builder strings.Builder
+	firstChar := 0
+	for i, c := range name {
+		// ptr dereference
+		if i == 0 && c == '&' {
+			firstChar++
+		}
+		if i == firstChar && !isLegalIdentifierStart(c) || i > 0 && !isLegalIdentifierPart(c) {
+			builder.WriteRune('_')
+		} else {
+			builder.WriteRune(c)
+		}
+	}
+	name = builder.String()
+	if isReservedWord(name) {
+		return "_" + name
+	}
+	return name
+}

--- a/pkg/codegen/internal/test/host.go
+++ b/pkg/codegen/internal/test/host.go
@@ -10,5 +10,8 @@ func NewHost(schemaDirectoryPath string) plugin.Host {
 	return deploytest.NewPluginHost(nil, nil, nil,
 		deploytest.NewProviderLoader("aws", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return AWS(schemaDirectoryPath)
+		}),
+		deploytest.NewProviderLoader("random", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return Random(schemaDirectoryPath)
 		}))
 }

--- a/pkg/codegen/internal/test/providers.go
+++ b/pkg/codegen/internal/test/providers.go
@@ -23,3 +23,15 @@ func AWS(schemaDirectoryPath string) (plugin.Provider, error) {
 		},
 	}, nil
 }
+
+func Random(schemaDirectoryPath string) (plugin.Provider, error) {
+	schema, err := GetSchema(schemaDirectoryPath, "random")
+	if err != nil {
+		return nil, err
+	}
+	return &deploytest.Provider{
+		GetSchemaF: func(version int) ([]byte, error) {
+			return schema, nil
+		},
+	}, nil
+}

--- a/pkg/codegen/internal/test/testdata/aws-eks.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-eks.pp.go
@@ -55,7 +55,7 @@ func main() {
 		}
 		var vpcSubnet []*ec2.Subnet
 		for key0, val0 := range zones.Names {
-			_res, err := ec2.NewSubnet(ctx, fmt.Sprintf("vpcSubnet-%v", key0), &ec2.SubnetArgs{
+			__res, err := ec2.NewSubnet(ctx, fmt.Sprintf("vpcSubnet-%v", key0), &ec2.SubnetArgs{
 				AssignIpv6AddressOnCreation: pulumi.Bool(false),
 				VpcId:                       eksVpc.ID(),
 				MapPublicIpOnLaunch:         pulumi.Bool(true),
@@ -68,18 +68,18 @@ func main() {
 			if err != nil {
 				return err
 			}
-			vpcSubnet = append(vpcSubnet, _res)
+			vpcSubnet = append(vpcSubnet, __res)
 		}
 		var rta []*ec2.RouteTableAssociation
 		for key0, _ := range zones.Names {
-			_res, err := ec2.NewRouteTableAssociation(ctx, fmt.Sprintf("rta-%v", key0), &ec2.RouteTableAssociationArgs{
+			__res, err := ec2.NewRouteTableAssociation(ctx, fmt.Sprintf("rta-%v", key0), &ec2.RouteTableAssociationArgs{
 				RouteTableId: eksRouteTable.ID(),
 				SubnetId:     vpcSubnet[key0].ID(),
 			})
 			if err != nil {
 				return err
 			}
-			rta = append(rta, _res)
+			rta = append(rta, __res)
 		}
 		var splat0 pulumi.StringArray
 		for _, val0 := range vpcSubnet {

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
@@ -32,7 +32,7 @@ func main() {
 		}
 		var files []*s3.BucketObject
 		for key0, val0 := range fileNames0 {
-			_res, err := s3.NewBucketObject(ctx, fmt.Sprintf("files-%v", key0), &s3.BucketObjectArgs{
+			__res, err := s3.NewBucketObject(ctx, fmt.Sprintf("files-%v", key0), &s3.BucketObjectArgs{
 				Bucket:      siteBucket.ID(),
 				Key:         pulumi.String(val0),
 				Source:      pulumi.NewFileAsset(fmt.Sprintf("%v%v%v", siteDir, "/", val0)),
@@ -41,7 +41,7 @@ func main() {
 			if err != nil {
 				return err
 			}
-			files = append(files, _res)
+			files = append(files, __res)
 		}
 		_, err = s3.NewBucketPolicy(ctx, "bucketPolicy", &s3.BucketPolicyArgs{
 			Bucket: siteBucket.ID(),

--- a/pkg/codegen/internal/test/testdata/random-pet.pp
+++ b/pkg/codegen/internal/test/testdata/random-pet.pp
@@ -1,0 +1,3 @@
+resource random_pet "random:index/randomPet:RandomPet" {
+  prefix = "doggo"
+}

--- a/pkg/codegen/internal/test/testdata/random-pet.pp.cs
+++ b/pkg/codegen/internal/test/testdata/random-pet.pp.cs
@@ -1,0 +1,14 @@
+using Pulumi;
+using Random = Pulumi.Random;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var random_pet = new Random.RandomPet("random_pet", new Random.RandomPetArgs
+        {
+            Prefix = "doggo",
+        });
+    }
+
+}

--- a/pkg/codegen/internal/test/testdata/random-pet.pp.go
+++ b/pkg/codegen/internal/test/testdata/random-pet.pp.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-random/sdk/v2/go/random/"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err = random.NewRandomPet(ctx, "random_pet", &random.RandomPetArgs{
+			Prefix: pulumi.String("doggo"),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/internal/test/testdata/random-pet.pp.go
+++ b/pkg/codegen/internal/test/testdata/random-pet.pp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-random/sdk/v2/go/random/"
+	"github.com/pulumi/pulumi-random/sdk/v2/go/random"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 

--- a/pkg/codegen/internal/test/testdata/random-pet.pp.go
+++ b/pkg/codegen/internal/test/testdata/random-pet.pp.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err = random.NewRandomPet(ctx, "random_pet", &random.RandomPetArgs{
+		_, err := random.NewRandomPet(ctx, "random_pet", &random.RandomPetArgs{
 			Prefix: pulumi.String("doggo"),
 		})
 		if err != nil {

--- a/pkg/codegen/internal/test/testdata/random-pet.pp.py
+++ b/pkg/codegen/internal/test/testdata/random-pet.pp.py
@@ -1,0 +1,4 @@
+import pulumi
+import pulumi_random as random
+
+random_pet = random.RandomPet("random_pet", prefix="doggo")

--- a/pkg/codegen/internal/test/testdata/random-pet.pp.ts
+++ b/pkg/codegen/internal/test/testdata/random-pet.pp.ts
@@ -1,0 +1,4 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as random from "@pulumi/random";
+
+const random_pet = new random.RandomPet("random_pet", {prefix: "doggo"});

--- a/pkg/codegen/internal/test/testdata/random.json
+++ b/pkg/codegen/internal/test/testdata/random.json
@@ -1,0 +1,762 @@
+{
+    "name": "random",
+    "version": "v2.2.0",
+    "description": "A Pulumi package to safely use randomness in Pulumi programs.",
+    "keywords": [
+        "pulumi",
+        "random"
+    ],
+    "homepage": "https://pulumi.io",
+    "license": "Apache-2.0",
+    "attribution": "This Pulumi package is based on the [`random` Terraform Provider](https://github.com/terraform-providers/terraform-provider-random).",
+    "repository": "https://github.com/pulumi/pulumi-random",
+    "meta": {
+        "moduleFormat": "(.*)(?:/[^/]*)"
+    },
+    "config": {},
+    "provider": {
+        "description": "The provider type for the random package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n"
+    },
+    "resources": {
+        "random:index/randomId:RandomId": {
+            "description": "The resource `random..RandomId` generates random numbers that are intended to be\nused as unique identifiers for other resources.\n\nThis resource *does* use a cryptographic random number generator in order\nto minimize the chance of collisions, making the results of this resource\nwhen a 16-byte identifier is requested of equivalent uniqueness to a\ntype-4 UUID.\n\nThis resource can be used in conjunction with resources that have\nthe `create_before_destroy` lifecycle flag set to avoid conflicts with\nunique names during the brief period where both the old and new resources\nexist concurrently.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\nThe following example shows how to generate a unique name for an AWS EC2\ninstance that changes each time a new AMI id is selected.\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\nconst serverRandomId = new random.RandomId(\"server\", {\n    byteLength: 8,\n    keepers: {\n        // Generate a new id each time we switch to a new AMI id\n        ami_id: var_ami_id,\n    },\n});\nconst serverInstance = new aws.ec2.Instance(\"server\", {\n    ami: serverRandomId.keepers.apply(keepers =\u003e keepers.amiId),\n    tags: {\n        Name: pulumi.interpolate`web-server ${serverRandomId.hex}`,\n    },\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\nimport pulumi_random as random\n\nserver_random_id = random.RandomId(\"serverRandomId\",\n    byte_length=8,\n    keepers={\n        \"ami_id\": var[\"ami_id\"],\n    })\nserver_instance = aws.ec2.Instance(\"serverInstance\",\n    ami=server_random_id.keepers[\"amiId\"],\n    tags={\n        \"Name\": server_random_id.hex.apply(lambda hex: f\"web-server {hex}\"),\n    })\n```\n```csharp\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var serverRandomId = new Random.RandomId(\"serverRandomId\", new Random.RandomIdArgs\n        {\n            ByteLength = 8,\n            Keepers = \n            {\n                { \"ami_id\", @var.Ami_id },\n            },\n        });\n        var serverInstance = new Aws.Ec2.Instance(\"serverInstance\", new Aws.Ec2.InstanceArgs\n        {\n            Ami = serverRandomId.Keepers.Apply(keepers =\u003e keepers.AmiId),\n            Tags = \n            {\n                { \"Name\", serverRandomId.Hex.Apply(hex =\u003e $\"web-server {hex}\") },\n            },\n        });\n    }\n\n}\n```\n\n{{% /example %}}\n{{% /examples %}}\n",
+            "properties": {
+                "b64": {
+                    "type": "string",
+                    "deprecationMessage": "Use b64_url for old behavior, or b64_std for standard base64 encoding"
+                },
+                "b64Std": {
+                    "type": "string",
+                    "description": "The generated id presented in base64 without additional transformations.\n"
+                },
+                "b64Url": {
+                    "type": "string",
+                    "description": "The generated id presented in base64, using the URL-friendly character set: case-sensitive letters, digits and the characters `_` and `-`.\n"
+                },
+                "byteLength": {
+                    "type": "integer",
+                    "description": "The number of random bytes to produce. The\nminimum value is 1, which produces eight bits of randomness.\n"
+                },
+                "dec": {
+                    "type": "string",
+                    "description": "The generated id presented in non-padded decimal digits.\n"
+                },
+                "hex": {
+                    "type": "string",
+                    "description": "The generated id presented in padded hexadecimal digits. This result will always be twice as long as the requested byte length.\n"
+                },
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "prefix": {
+                    "type": "string",
+                    "description": "Arbitrary string to prefix the output value with. This\nstring is supplied as-is, meaning it is not guaranteed to be URL-safe or\nbase64 encoded.\n"
+                }
+            },
+            "required": [
+                "b64",
+                "b64Std",
+                "b64Url",
+                "byteLength",
+                "dec",
+                "hex"
+            ],
+            "inputProperties": {
+                "byteLength": {
+                    "type": "integer",
+                    "description": "The number of random bytes to produce. The\nminimum value is 1, which produces eight bits of randomness.\n"
+                },
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "prefix": {
+                    "type": "string",
+                    "description": "Arbitrary string to prefix the output value with. This\nstring is supplied as-is, meaning it is not guaranteed to be URL-safe or\nbase64 encoded.\n"
+                }
+            },
+            "requiredInputs": [
+                "byteLength"
+            ],
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering RandomId resources.\n",
+                "properties": {
+                    "b64": {
+                        "type": "string",
+                        "deprecationMessage": "Use b64_url for old behavior, or b64_std for standard base64 encoding"
+                    },
+                    "b64Std": {
+                        "type": "string",
+                        "description": "The generated id presented in base64 without additional transformations.\n"
+                    },
+                    "b64Url": {
+                        "type": "string",
+                        "description": "The generated id presented in base64, using the URL-friendly character set: case-sensitive letters, digits and the characters `_` and `-`.\n"
+                    },
+                    "byteLength": {
+                        "type": "integer",
+                        "description": "The number of random bytes to produce. The\nminimum value is 1, which produces eight bits of randomness.\n"
+                    },
+                    "dec": {
+                        "type": "string",
+                        "description": "The generated id presented in non-padded decimal digits.\n"
+                    },
+                    "hex": {
+                        "type": "string",
+                        "description": "The generated id presented in padded hexadecimal digits. This result will always be twice as long as the requested byte length.\n"
+                    },
+                    "keepers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "pulumi.json#/Any"
+                        },
+                        "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": "Arbitrary string to prefix the output value with. This\nstring is supplied as-is, meaning it is not guaranteed to be URL-safe or\nbase64 encoded.\n"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "random:index/randomInteger:RandomInteger": {
+            "description": "The resource `random..RandomInteger` generates random values from a given range, described by the `min` and `max` attributes of a given resource.\n\nThis resource can be used in conjunction with resources that have\nthe `create_before_destroy` lifecycle flag set, to avoid conflicts with\nunique names during the brief period where both the old and new resources\nexist concurrently.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\nThe following example shows how to generate a random priority between 1 and 50000 for\na `aws_alb_listener_rule` resource:\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\nconst priority = new random.RandomInteger(\"priority\", {\n    keepers: {\n        // Generate a new integer each time we switch to a new listener ARN\n        listener_arn: var_listener_arn,\n    },\n    max: 50000,\n    min: 1,\n});\nconst main = new aws.alb.ListenerRule(\"main\", {\n    actions: [{\n        targetGroupArn: var_target_group_arn,\n        type: \"forward\",\n    }],\n    listenerArn: var_listener_arn,\n    priority: priority.result,\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\nimport pulumi_random as random\n\npriority = random.RandomInteger(\"priority\",\n    keepers={\n        \"listener_arn\": var[\"listener_arn\"],\n    },\n    max=50000,\n    min=1)\nmain = aws.alb.ListenerRule(\"main\",\n    actions=[{\n        \"target_group_arn\": var[\"target_group_arn\"],\n        \"type\": \"forward\",\n    }],\n    listener_arn=var[\"listener_arn\"],\n    priority=priority.result)\n```\n```csharp\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var priority = new Random.RandomInteger(\"priority\", new Random.RandomIntegerArgs\n        {\n            Keepers = \n            {\n                { \"listener_arn\", @var.Listener_arn },\n            },\n            Max = 50000,\n            Min = 1,\n        });\n        var main = new Aws.Alb.ListenerRule(\"main\", new Aws.Alb.ListenerRuleArgs\n        {\n            Actions = \n            {\n                new Aws.Alb.Inputs.ListenerRuleActionArgs\n                {\n                    TargetGroupArn = @var.Target_group_arn,\n                    Type = \"forward\",\n                },\n            },\n            ListenerArn = @var.Listener_arn,\n            Priority = priority.Result,\n        });\n    }\n\n}\n```\n\nThe result of the above will set a random priority.\n\n{{% /example %}}\n{{% /examples %}}\n",
+            "properties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "max": {
+                    "type": "integer",
+                    "description": "The maximum inclusive value of the range.\n"
+                },
+                "min": {
+                    "type": "integer",
+                    "description": "The minimum inclusive value of the range.\n"
+                },
+                "result": {
+                    "type": "integer",
+                    "description": "(int) The random Integer result.\n"
+                },
+                "seed": {
+                    "type": "string",
+                    "description": "A custom seed to always produce the same value.\n"
+                }
+            },
+            "required": [
+                "max",
+                "min",
+                "result"
+            ],
+            "inputProperties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "max": {
+                    "type": "integer",
+                    "description": "The maximum inclusive value of the range.\n"
+                },
+                "min": {
+                    "type": "integer",
+                    "description": "The minimum inclusive value of the range.\n"
+                },
+                "seed": {
+                    "type": "string",
+                    "description": "A custom seed to always produce the same value.\n"
+                }
+            },
+            "requiredInputs": [
+                "max",
+                "min"
+            ],
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering RandomInteger resources.\n",
+                "properties": {
+                    "keepers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "pulumi.json#/Any"
+                        },
+                        "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                    },
+                    "max": {
+                        "type": "integer",
+                        "description": "The maximum inclusive value of the range.\n"
+                    },
+                    "min": {
+                        "type": "integer",
+                        "description": "The minimum inclusive value of the range.\n"
+                    },
+                    "result": {
+                        "type": "integer",
+                        "description": "(int) The random Integer result.\n"
+                    },
+                    "seed": {
+                        "type": "string",
+                        "description": "A custom seed to always produce the same value.\n"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "random:index/randomPassword:RandomPassword": {
+            "description": "\u003e **Note:** Requires random provider version \u003e= 2.2.0\n\nIdentical to random..RandomString with the exception that the\nresult is treated as sensitive and, thus, _not_ displayed in console output.\n\n\u003e **Note:** All attributes including the generated password will be stored in\nthe raw state as plain-text. [Read more about sensitive data in\nstate](https://www.terraform.io/docs/state/sensitive-data.html).\n\nThis resource *does* use a cryptographic random number generator.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\nconst password = new random.RandomPassword(\"password\", {\n    length: 16,\n    special: true,\n    overrideSpecial: `_%@`,\n});\nconst example = new aws.rds.Instance(\"example\", {\n    instanceClass: \"db.t3.micro\",\n    allocatedStorage: 64,\n    engine: \"mysql\",\n    username: \"someone\",\n    password: random_string.password.result,\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\nimport pulumi_random as random\n\npassword = random.RandomPassword(\"password\",\n    length=16,\n    special=True,\n    override_special=\"_%@\")\nexample = aws.rds.Instance(\"example\",\n    instance_class=\"db.t3.micro\",\n    allocated_storage=64,\n    engine=\"mysql\",\n    username=\"someone\",\n    password=random_string[\"password\"][\"result\"])\n```\n```csharp\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var password = new Random.RandomPassword(\"password\", new Random.RandomPasswordArgs\n        {\n            Length = 16,\n            Special = true,\n            OverrideSpecial = \"_%@\",\n        });\n        var example = new Aws.Rds.Instance(\"example\", new Aws.Rds.InstanceArgs\n        {\n            InstanceClass = \"db.t3.micro\",\n            AllocatedStorage = 64,\n            Engine = \"mysql\",\n            Username = \"someone\",\n            Password = random_string.Password.Result,\n        });\n    }\n\n}\n```\n\n{{% /example %}}\n{{% /examples %}}\n",
+            "properties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    }
+                },
+                "length": {
+                    "type": "integer"
+                },
+                "lower": {
+                    "type": "boolean"
+                },
+                "minLower": {
+                    "type": "integer"
+                },
+                "minNumeric": {
+                    "type": "integer"
+                },
+                "minSpecial": {
+                    "type": "integer"
+                },
+                "minUpper": {
+                    "type": "integer"
+                },
+                "number": {
+                    "type": "boolean"
+                },
+                "overrideSpecial": {
+                    "type": "string"
+                },
+                "result": {
+                    "type": "string"
+                },
+                "special": {
+                    "type": "boolean"
+                },
+                "upper": {
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "length",
+                "result"
+            ],
+            "inputProperties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    }
+                },
+                "length": {
+                    "type": "integer"
+                },
+                "lower": {
+                    "type": "boolean"
+                },
+                "minLower": {
+                    "type": "integer"
+                },
+                "minNumeric": {
+                    "type": "integer"
+                },
+                "minSpecial": {
+                    "type": "integer"
+                },
+                "minUpper": {
+                    "type": "integer"
+                },
+                "number": {
+                    "type": "boolean"
+                },
+                "overrideSpecial": {
+                    "type": "string"
+                },
+                "special": {
+                    "type": "boolean"
+                },
+                "upper": {
+                    "type": "boolean"
+                }
+            },
+            "requiredInputs": [
+                "length"
+            ],
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering RandomPassword resources.\n",
+                "properties": {
+                    "keepers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "pulumi.json#/Any"
+                        }
+                    },
+                    "length": {
+                        "type": "integer"
+                    },
+                    "lower": {
+                        "type": "boolean"
+                    },
+                    "minLower": {
+                        "type": "integer"
+                    },
+                    "minNumeric": {
+                        "type": "integer"
+                    },
+                    "minSpecial": {
+                        "type": "integer"
+                    },
+                    "minUpper": {
+                        "type": "integer"
+                    },
+                    "number": {
+                        "type": "boolean"
+                    },
+                    "overrideSpecial": {
+                        "type": "string"
+                    },
+                    "result": {
+                        "type": "string"
+                    },
+                    "special": {
+                        "type": "boolean"
+                    },
+                    "upper": {
+                        "type": "boolean"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "random:index/randomPet:RandomPet": {
+            "description": "The resource `random..RandomPet` generates random pet names that are intended to be\nused as unique identifiers for other resources.\n\nThis resource can be used in conjunction with resources that have\nthe `create_before_destroy` lifecycle flag set, to avoid conflicts with\nunique names during the brief period where both the old and new resources\nexist concurrently.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\nThe following example shows how to generate a unique pet name for an AWS EC2\ninstance that changes each time a new AMI id is selected.\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\nconst serverRandomPet = new random.RandomPet(\"server\", {\n    keepers: {\n        // Generate a new pet name each time we switch to a new AMI id\n        ami_id: var_ami_id,\n    },\n});\nconst serverInstance = new aws.ec2.Instance(\"server\", {\n    ami: serverRandomPet.keepers.apply(keepers =\u003e keepers.amiId),\n    tags: {\n        Name: pulumi.interpolate`web-server-${serverRandomPet.id}`,\n    },\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\nimport pulumi_random as random\n\nserver_random_pet = random.RandomPet(\"serverRandomPet\", keepers={\n    \"ami_id\": var[\"ami_id\"],\n})\nserver_instance = aws.ec2.Instance(\"serverInstance\",\n    ami=server_random_pet.keepers[\"amiId\"],\n    tags={\n        \"Name\": server_random_pet.id.apply(lambda id: f\"web-server-{id}\"),\n    })\n```\n```csharp\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var serverRandomPet = new Random.RandomPet(\"serverRandomPet\", new Random.RandomPetArgs\n        {\n            Keepers = \n            {\n                { \"ami_id\", @var.Ami_id },\n            },\n        });\n        var serverInstance = new Aws.Ec2.Instance(\"serverInstance\", new Aws.Ec2.InstanceArgs\n        {\n            Ami = serverRandomPet.Keepers.Apply(keepers =\u003e keepers.AmiId),\n            Tags = \n            {\n                { \"Name\", serverRandomPet.Id.Apply(id =\u003e $\"web-server-{id}\") },\n            },\n        });\n    }\n\n}\n```\n\nThe result of the above will set the Name of the AWS Instance to\n`web-server-simple-snake`.\n\n{{% /example %}}\n{{% /examples %}}\n",
+            "properties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "length": {
+                    "type": "integer",
+                    "description": "The length (in words) of the pet name.\n"
+                },
+                "prefix": {
+                    "type": "string",
+                    "description": "A string to prefix the name with.\n"
+                },
+                "separator": {
+                    "type": "string",
+                    "description": "The character to separate words in the pet name.\n"
+                }
+            },
+            "inputProperties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "length": {
+                    "type": "integer",
+                    "description": "The length (in words) of the pet name.\n"
+                },
+                "prefix": {
+                    "type": "string",
+                    "description": "A string to prefix the name with.\n"
+                },
+                "separator": {
+                    "type": "string",
+                    "description": "The character to separate words in the pet name.\n"
+                }
+            },
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering RandomPet resources.\n",
+                "properties": {
+                    "keepers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "pulumi.json#/Any"
+                        },
+                        "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                    },
+                    "length": {
+                        "type": "integer",
+                        "description": "The length (in words) of the pet name.\n"
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": "A string to prefix the name with.\n"
+                    },
+                    "separator": {
+                        "type": "string",
+                        "description": "The character to separate words in the pet name.\n"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "random:index/randomShuffle:RandomShuffle": {
+            "description": "The resource `random..RandomShuffle` generates a random permutation of a list\nof strings given as an argument.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as aws from \"@pulumi/aws\";\nimport * as random from \"@pulumi/random\";\n\nconst az = new random.RandomShuffle(\"az\", {\n    inputs: [\n        \"us-west-1a\",\n        \"us-west-1c\",\n        \"us-west-1d\",\n        \"us-west-1e\",\n    ],\n    resultCount: 2,\n});\nconst example = new aws.elb.LoadBalancer(\"example\", {\n    // Place the ELB in any two of the given availability zones, selected\n    // at random.\n    availabilityZones: az.results,\n});\n```\n```python\nimport pulumi\nimport pulumi_aws as aws\nimport pulumi_random as random\n\naz = random.RandomShuffle(\"az\",\n    inputs=[\n        \"us-west-1a\",\n        \"us-west-1c\",\n        \"us-west-1d\",\n        \"us-west-1e\",\n    ],\n    result_count=2)\nexample = aws.elb.LoadBalancer(\"example\", availability_zones=az.results)\n```\n```csharp\nusing Pulumi;\nusing Aws = Pulumi.Aws;\nusing Random = Pulumi.Random;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var az = new Random.RandomShuffle(\"az\", new Random.RandomShuffleArgs\n        {\n            Inputs = \n            {\n                \"us-west-1a\",\n                \"us-west-1c\",\n                \"us-west-1d\",\n                \"us-west-1e\",\n            },\n            ResultCount = 2,\n        });\n        var example = new Aws.Elb.LoadBalancer(\"example\", new Aws.Elb.LoadBalancerArgs\n        {\n            AvailabilityZones = az.Results,\n        });\n    }\n\n}\n```\n\n{{% /example %}}\n{{% /examples %}}\n",
+            "properties": {
+                "inputs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "The list of strings to shuffle.\n"
+                },
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "resultCount": {
+                    "type": "integer",
+                    "description": "The number of results to return. Defaults to\nthe number of items in the `input` list. If fewer items are requested,\nsome elements will be excluded from the result. If more items are requested,\nitems will be repeated in the result but not more frequently than the number\nof items in the input list.\n"
+                },
+                "results": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Random permutation of the list of strings given in `input`.\n"
+                },
+                "seed": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "inputs",
+                "results"
+            ],
+            "inputProperties": {
+                "inputs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "The list of strings to shuffle.\n"
+                },
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "resultCount": {
+                    "type": "integer",
+                    "description": "The number of results to return. Defaults to\nthe number of items in the `input` list. If fewer items are requested,\nsome elements will be excluded from the result. If more items are requested,\nitems will be repeated in the result but not more frequently than the number\nof items in the input list.\n"
+                },
+                "seed": {
+                    "type": "string"
+                }
+            },
+            "requiredInputs": [
+                "inputs"
+            ],
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering RandomShuffle resources.\n",
+                "properties": {
+                    "inputs": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "The list of strings to shuffle.\n"
+                    },
+                    "keepers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "pulumi.json#/Any"
+                        },
+                        "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                    },
+                    "resultCount": {
+                        "type": "integer",
+                        "description": "The number of results to return. Defaults to\nthe number of items in the `input` list. If fewer items are requested,\nsome elements will be excluded from the result. If more items are requested,\nitems will be repeated in the result but not more frequently than the number\nof items in the input list.\n"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "description": "Random permutation of the list of strings given in `input`.\n"
+                    },
+                    "seed": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "random:index/randomString:RandomString": {
+            "description": "The resource `random..RandomString` generates a random permutation of alphanumeric\ncharacters and optionally special characters.\n\nThis resource *does* use a cryptographic random number generator.\n\nHistorically this resource's intended usage has been ambiguous as the original example\nused it in a password. For backwards compatibility it will\ncontinue to exist. For unique ids please use random_id, for sensitive\nrandom values please use random_password.\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as random from \"@pulumi/random\";\n\nconst randomRandomString = new random.RandomString(\"random\", {\n    length: 16,\n    overrideSpecial: \"/@£$\",\n    special: true,\n});\n```\n```python\nimport pulumi\nimport pulumi_random as random\n\nrandom = random.RandomString(\"random\",\n    length=16,\n    override_special=\"/@£$$\",\n    special=True)\n```\n```csharp\nusing Pulumi;\nusing Random = Pulumi.Random;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var random = new Random.RandomString(\"random\", new Random.RandomStringArgs\n        {\n            Length = 16,\n            OverrideSpecial = \"/@£$$\",\n            Special = true,\n        });\n    }\n\n}\n```\n\n{{% /example %}}\n{{% /examples %}}\n",
+            "properties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "length": {
+                    "type": "integer",
+                    "description": "The length of the string desired\n"
+                },
+                "lower": {
+                    "type": "boolean",
+                    "description": "(default true) Include lowercase alphabet characters\nin random string.\n"
+                },
+                "minLower": {
+                    "type": "integer",
+                    "description": "(default 0) Minimum number of lowercase alphabet\ncharacters in random string.\n"
+                },
+                "minNumeric": {
+                    "type": "integer",
+                    "description": "(default 0) Minimum number of numeric characters\nin random string.\n"
+                },
+                "minSpecial": {
+                    "type": "integer",
+                    "description": "(default 0) Minimum number of special characters\nin random string.\n"
+                },
+                "minUpper": {
+                    "type": "integer",
+                    "description": "(default 0) Minimum number of uppercase alphabet\ncharacters in random string.\n"
+                },
+                "number": {
+                    "type": "boolean",
+                    "description": "(default true) Include numeric characters in random\nstring.\n"
+                },
+                "overrideSpecial": {
+                    "type": "string",
+                    "description": "Supply your own list of special characters to\nuse for string generation.  This overrides the default character list in the special\nargument.  The special argument must still be set to true for any overwritten\ncharacters to be used in generation.\n"
+                },
+                "result": {
+                    "type": "string",
+                    "description": "Random string generated.\n"
+                },
+                "special": {
+                    "type": "boolean",
+                    "description": "(default true) Include special characters in random\nstring. These are `!@#$%\u0026*()-_=+[]{}\u003c\u003e:?`\n"
+                },
+                "upper": {
+                    "type": "boolean",
+                    "description": "(default true) Include uppercase alphabet characters\nin random string.\n"
+                }
+            },
+            "required": [
+                "length",
+                "result"
+            ],
+            "inputProperties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "length": {
+                    "type": "integer",
+                    "description": "The length of the string desired\n"
+                },
+                "lower": {
+                    "type": "boolean",
+                    "description": "(default true) Include lowercase alphabet characters\nin random string.\n"
+                },
+                "minLower": {
+                    "type": "integer",
+                    "description": "(default 0) Minimum number of lowercase alphabet\ncharacters in random string.\n"
+                },
+                "minNumeric": {
+                    "type": "integer",
+                    "description": "(default 0) Minimum number of numeric characters\nin random string.\n"
+                },
+                "minSpecial": {
+                    "type": "integer",
+                    "description": "(default 0) Minimum number of special characters\nin random string.\n"
+                },
+                "minUpper": {
+                    "type": "integer",
+                    "description": "(default 0) Minimum number of uppercase alphabet\ncharacters in random string.\n"
+                },
+                "number": {
+                    "type": "boolean",
+                    "description": "(default true) Include numeric characters in random\nstring.\n"
+                },
+                "overrideSpecial": {
+                    "type": "string",
+                    "description": "Supply your own list of special characters to\nuse for string generation.  This overrides the default character list in the special\nargument.  The special argument must still be set to true for any overwritten\ncharacters to be used in generation.\n"
+                },
+                "special": {
+                    "type": "boolean",
+                    "description": "(default true) Include special characters in random\nstring. These are `!@#$%\u0026*()-_=+[]{}\u003c\u003e:?`\n"
+                },
+                "upper": {
+                    "type": "boolean",
+                    "description": "(default true) Include uppercase alphabet characters\nin random string.\n"
+                }
+            },
+            "requiredInputs": [
+                "length"
+            ],
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering RandomString resources.\n",
+                "properties": {
+                    "keepers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "pulumi.json#/Any"
+                        },
+                        "description": "Arbitrary map of values that, when changed, will\ntrigger a new id to be generated. See\nthe main provider documentation for more information.\n"
+                    },
+                    "length": {
+                        "type": "integer",
+                        "description": "The length of the string desired\n"
+                    },
+                    "lower": {
+                        "type": "boolean",
+                        "description": "(default true) Include lowercase alphabet characters\nin random string.\n"
+                    },
+                    "minLower": {
+                        "type": "integer",
+                        "description": "(default 0) Minimum number of lowercase alphabet\ncharacters in random string.\n"
+                    },
+                    "minNumeric": {
+                        "type": "integer",
+                        "description": "(default 0) Minimum number of numeric characters\nin random string.\n"
+                    },
+                    "minSpecial": {
+                        "type": "integer",
+                        "description": "(default 0) Minimum number of special characters\nin random string.\n"
+                    },
+                    "minUpper": {
+                        "type": "integer",
+                        "description": "(default 0) Minimum number of uppercase alphabet\ncharacters in random string.\n"
+                    },
+                    "number": {
+                        "type": "boolean",
+                        "description": "(default true) Include numeric characters in random\nstring.\n"
+                    },
+                    "overrideSpecial": {
+                        "type": "string",
+                        "description": "Supply your own list of special characters to\nuse for string generation.  This overrides the default character list in the special\nargument.  The special argument must still be set to true for any overwritten\ncharacters to be used in generation.\n"
+                    },
+                    "result": {
+                        "type": "string",
+                        "description": "Random string generated.\n"
+                    },
+                    "special": {
+                        "type": "boolean",
+                        "description": "(default true) Include special characters in random\nstring. These are `!@#$%\u0026*()-_=+[]{}\u003c\u003e:?`\n"
+                    },
+                    "upper": {
+                        "type": "boolean",
+                        "description": "(default true) Include uppercase alphabet characters\nin random string.\n"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "random:index/randomUuid:RandomUuid": {
+            "description": "The resource `random..RandomUuid` generates random uuid string that is intended to be\nused as unique identifiers for other resources.\n\nThis resource uses the `hashicorp/go-uuid` to generate a UUID-formatted string\nfor use with services needed a unique string identifier.\n\n\n{{% examples %}}\n## Example Usage\n{{% example %}}\n\nThe following example shows how to generate a unique name for an Azure Resource Group.\n\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as azure from \"@pulumi/azure\";\nimport * as random from \"@pulumi/random\";\n\nconst testRandomUuid = new random.RandomUuid(\"test\", {});\nconst testResourceGroup = new azure.core.ResourceGroup(\"test\", {\n    location: \"Central US\",\n});\n```\n```python\nimport pulumi\nimport pulumi_azure as azure\nimport pulumi_random as random\n\ntest_random_uuid = random.RandomUuid(\"testRandomUuid\")\ntest_resource_group = azure.core.ResourceGroup(\"testResourceGroup\", location=\"Central US\")\n```\n```csharp\nusing Pulumi;\nusing Azure = Pulumi.Azure;\nusing Random = Pulumi.Random;\n\nclass MyStack : Stack\n{\n    public MyStack()\n    {\n        var testRandomUuid = new Random.RandomUuid(\"testRandomUuid\", new Random.RandomUuidArgs\n        {\n        });\n        var testResourceGroup = new Azure.Core.ResourceGroup(\"testResourceGroup\", new Azure.Core.ResourceGroupArgs\n        {\n            Location = \"Central US\",\n        });\n    }\n\n}\n```\n\n{{% /example %}}\n{{% /examples %}}\n",
+            "properties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new uuid to be generated. See\nthe main provider documentation for more information.\n"
+                },
+                "result": {
+                    "type": "string",
+                    "description": "The generated uuid presented in string format.\n"
+                }
+            },
+            "required": [
+                "result"
+            ],
+            "inputProperties": {
+                "keepers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "pulumi.json#/Any"
+                    },
+                    "description": "Arbitrary map of values that, when changed, will\ntrigger a new uuid to be generated. See\nthe main provider documentation for more information.\n"
+                }
+            },
+            "stateInputs": {
+                "description": "Input properties used for looking up and filtering RandomUuid resources.\n",
+                "properties": {
+                    "keepers": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "pulumi.json#/Any"
+                        },
+                        "description": "Arbitrary map of values that, when changed, will\ntrigger a new uuid to be generated. See\nthe main provider documentation for more information.\n"
+                    },
+                    "result": {
+                        "type": "string",
+                        "description": "The generated uuid presented in string format.\n"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    },
+    "language": {
+        "csharp": {
+            "namespaces": {
+                "random": "Random"
+            },
+            "packageReferences": {
+                "Pulumi": "2.*",
+                "System.Collections.Immutable": "1.6.0"
+            }
+        },
+        "nodejs": {
+            "dependencies": {
+                "@pulumi/pulumi": "^2.0.0"
+            },
+            "devDependencies": {
+                "@types/node": "^8.0.0"
+            },
+            "disableUnionOutputTypes": true,
+            "packageDescription": "A Pulumi package to safely use randomness in Pulumi programs.",
+            "packageName": "",
+            "readme": "\u003e This provider is a derived work of the [Terraform Provider](https://github.com/terraform-providers/terraform-provider-random)\n\u003e distributed under [MPL 2.0](https://www.mozilla.org/en-US/MPL/2.0/). If you encounter a bug or missing feature,\n\u003e first check the [`pulumi/pulumi-random` repo](https://github.com/pulumi/pulumi-random/issues); however, if that doesn't turn up anything,\n\u003e please consult the source [`terraform-providers/terraform-provider-random` repo](https://github.com/terraform-providers/terraform-provider-random/issues).",
+            "typescriptVersion": ""
+        },
+        "python": {
+            "requires": {
+                "pulumi": "\u003e=2.0.0,\u003c3.0.0"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Code examples for random and AzureAD were failing to generate due to resources in the root namespace "/index". This change handles that case. Also adds a schema and mocks for testing "random" programs to verify. 

fixes #4906
fixes https://github.com/pulumi/pulumi/issues/4900