### PR TITLE
[codegen/*] Add support for resource options.

### DIFF
--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -354,7 +354,7 @@ func (g *generator) genResourceOptions(opts *hcl2.ResourceOptions) string {
 	var result bytes.Buffer
 	appendOption := func(name string, value model.Expression) {
 		if result.Len() == 0 {
-			_, err := fmt.Fprint(&result, ", new CustomResourceOptions {")
+			_, err := fmt.Fprintf(&result, ", new CustomResourceOptions\n%s{", g.Indent)
 			g.Indent += "    "
 			contract.IgnoreError(err)
 		}

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -38,6 +38,7 @@ func (nameInfo) Format(name string) string {
 
 // lowerExpression amends the expression with intrinsics for C# generation.
 func (g *generator) lowerExpression(expr model.Expression, typ model.Type) model.Expression {
+	expr = hcl2.RewritePropertyReferences(expr)
 	expr, diags := hcl2.RewriteApplies(expr, nameInfo(0), !g.asyncInit)
 	contract.Assert(len(diags) == 0)
 	expr = hcl2.RewriteConversions(expr, typ)

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -243,6 +243,8 @@ func (g *generator) genNode(w io.Writer, n hcl2.Node) {
 	}
 }
 
+var resourceType = model.MustNewOpaqueType("pulumi.Resource")
+
 func (g *generator) lowerResourceOptions(opts *hcl2.ResourceOptions) (*model.Block, []interface{}) {
 	if opts == nil {
 		return nil, nil
@@ -275,7 +277,7 @@ func (g *generator) lowerResourceOptions(opts *hcl2.ResourceOptions) (*model.Blo
 		appendOption("Provider", opts.Provider, model.DynamicType)
 	}
 	if opts.DependsOn != nil {
-		appendOption("DependsOn", opts.DependsOn, model.NewListType(model.DynamicType))
+		appendOption("DependsOn", opts.DependsOn, model.NewListType(resourceType))
 	}
 	if opts.Protect != nil {
 		appendOption("Protect", opts.Protect, model.BoolType)

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -746,6 +746,7 @@ func (nameInfo) Format(name string) string {
 // lowerExpression amends the expression with intrinsics for Go generation.
 func (g *generator) lowerExpression(expr model.Expression, typ model.Type, isInput bool) (
 	model.Expression, []interface{}) {
+	expr = hcl2.RewritePropertyReferences(expr)
 	expr, diags := hcl2.RewriteApplies(expr, nameInfo(0), false /*TODO*/)
 	expr = hcl2.RewriteConversions(expr, typ)
 	expr, tTemps, ternDiags := g.rewriteTernaries(expr, g.ternaryTempSpiller)

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -177,11 +177,6 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 	case hcl2.IntrinsicApply:
 		g.genApply(w, expr)
-	// case intrinsicAwait:
-	// g.genNYI(w, "call %v", expr.Name)
-	// g.Fgenf(w, "await %.17v", expr.Args[0])
-	// case intrinsicOutput:
-	// g.Fgenf(w, "Output.Create(%.v)", expr.Args[0])
 	case "element":
 		g.genNYI(w, "element")
 	case "entries":
@@ -648,7 +643,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 		return fmt.Sprintf("map[string]%s", valType)
 	case *model.ListType:
 		argTypeName := g.argumentTypeName(nil, destType.ElementType, isInput)
-		if strings.HasPrefix(argTypeName, "pulumi.") {
+		if strings.HasPrefix(argTypeName, "pulumi.") && argTypeName != "pulumi.Resource" {
 			return fmt.Sprintf("%sArray", argTypeName)
 		}
 		return fmt.Sprintf("[]%s", argTypeName)
@@ -669,7 +664,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 
 		if elmType != nil {
 			argTypeName := g.argumentTypeName(nil, elmType, isInput)
-			if strings.HasPrefix(argTypeName, "pulumi.") {
+			if strings.HasPrefix(argTypeName, "pulumi.") && argTypeName != "pulumi.Resource" {
 				return fmt.Sprintf("%sArray", argTypeName)
 			}
 			return fmt.Sprintf("[]%s", argTypeName)

--- a/pkg/codegen/hcl2/binder_resource.go
+++ b/pkg/codegen/hcl2/binder_resource.go
@@ -149,7 +149,7 @@ func (s *optionsScopes) GetScopesForBlock(block *hclsyntax.Block) (model.Scopes,
 
 func (s *optionsScopes) GetScopeForAttribute(attr *hclsyntax.Attribute) (*model.Scope, hcl.Diagnostics) {
 	if attr.Name == "ignoreChanges" {
-		obj, ok := s.resource.InputType.(*model.ObjectType)
+		obj, ok := model.ResolveOutputs(s.resource.InputType).(*model.ObjectType)
 		if !ok {
 			return nil, nil
 		}
@@ -297,6 +297,9 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 					t = model.NewUnionType(model.BoolType, model.NumberType, model.NewListType(model.DynamicType),
 						model.NewMapType(model.DynamicType))
 					resourceOptions.Range = item.Value
+				case "parent":
+					t = model.DynamicType
+					resourceOptions.Parent = item.Value
 				case "provider":
 					t = model.DynamicType
 					resourceOptions.Provider = item.Value

--- a/pkg/codegen/hcl2/resource.go
+++ b/pkg/codegen/hcl2/resource.go
@@ -28,6 +28,8 @@ type ResourceOptions struct {
 
 	// An expression to range over when instantiating the resource.
 	Range model.Expression
+	// The resource's parent, if any.
+	Parent model.Expression
 	// The provider to use.
 	Provider model.Expression
 	// The explicit dependencies of the resource.

--- a/pkg/codegen/hcl2/rewrite_properties.go
+++ b/pkg/codegen/hcl2/rewrite_properties.go
@@ -1,0 +1,69 @@
+package hcl2
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func RewritePropertyReferences(expr model.Expression) model.Expression {
+	rewriter := func(expr model.Expression) (model.Expression, hcl.Diagnostics) {
+		traversal, ok := expr.(*model.ScopeTraversalExpression)
+		if !ok {
+			return expr, nil
+		}
+
+		p, ok := traversal.Parts[len(traversal.Parts)-1].(*ResourceProperty)
+		if !ok {
+			return expr, nil
+		}
+
+		var buffer bytes.Buffer
+		for _, t := range p.Path {
+			var err error
+			switch t := t.(type) {
+			case hcl.TraverseRoot:
+				_, err = fmt.Fprint(&buffer, t.Name)
+			case hcl.TraverseAttr:
+				_, err = fmt.Fprintf(&buffer, ".%s", t.Name)
+			case hcl.TraverseIndex:
+				switch t.Key.Type() {
+				case cty.String:
+					_, err = fmt.Fprintf(&buffer, ".%s", t.Key.AsString())
+				case cty.Number:
+					idx, _ := t.Key.AsBigFloat().Int64()
+					_, err = fmt.Fprintf(&buffer, "[%d]", idx)
+				default:
+					contract.Failf("unexpected traversal index of type %v", t.Key.Type())
+				}
+			}
+			contract.IgnoreError(err)
+		}
+
+		// TODO: transfer internal trivia
+
+		propertyPath := cty.StringVal(buffer.String())
+		value := &model.TemplateExpression{
+			Parts: []model.Expression{
+				&model.LiteralValueExpression{
+					Tokens: syntax.NewLiteralValueTokens(propertyPath),
+					Value:  propertyPath,
+				},
+			},
+		}
+		value.SetLeadingTrivia(expr.GetLeadingTrivia())
+		value.SetTrailingTrivia(expr.GetTrailingTrivia())
+		diags := value.Typecheck(false)
+		contract.Assert(len(diags) == 0)
+		return value, nil
+	}
+
+	expr, diags := model.VisitExpression(expr, model.IdentityVisitor, rewriter)
+	contract.Assert(len(diags) == 0)
+	return expr
+}

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.cs
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.cs
@@ -162,7 +162,8 @@ class MyStack : Stack
                     ContainerPort = 80,
                 },
             },
-        }, new CustomResourceOptions {
+        }, new CustomResourceOptions
+        {
             DependsOn = 
             {
                 webListener,

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.cs
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.cs
@@ -162,6 +162,11 @@ class MyStack : Stack
                     ContainerPort = 80,
                 },
             },
+        }, new CustomResourceOptions {
+            DependsOn = 
+            {
+                webListener,
+            },
         });
         this.Url = webLoadBalancer.DnsName;
     }

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
@@ -166,7 +166,9 @@ func main() {
 					ContainerPort:  pulumi.Int(80),
 				},
 			},
-		})
+		}, pulumi.DependsOn([]string{
+			webListener,
+		}))
 		if err != nil {
 			return err
 		}

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.go
@@ -166,7 +166,7 @@ func main() {
 					ContainerPort:  pulumi.Int(80),
 				},
 			},
-		}, pulumi.DependsOn([]string{
+		}, pulumi.DependsOn([]pulumi.Resource{
 			webListener,
 		}))
 		if err != nil {

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
@@ -83,5 +83,6 @@ app_service = aws.ecs.Service("appService",
         "target_group_arn": web_target_group.arn,
         "container_name": "my-app",
         "containerPort": 80,
-    }])
+    }],
+    opts=ResourceOptions(dependsOn=[web_listener]))
 pulumi.export("url", web_load_balancer.dns_name)

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.py
@@ -84,5 +84,5 @@ app_service = aws.ecs.Service("appService",
         "container_name": "my-app",
         "containerPort": 80,
     }],
-    opts=ResourceOptions(dependsOn=[web_listener]))
+    opts=ResourceOptions(depends_on=[web_listener]))
 pulumi.export("url", web_load_balancer.dns_name)

--- a/pkg/codegen/internal/test/testdata/aws-fargate.pp.ts
+++ b/pkg/codegen/internal/test/testdata/aws-fargate.pp.ts
@@ -93,5 +93,7 @@ const appService = new aws.ecs.Service("appService", {
         containerName: "my-app",
         containerPort: 80,
     }],
+}, {
+    dependsOn: [webListener],
 });
 export const url = webLoadBalancer.dnsName;

--- a/pkg/codegen/internal/test/testdata/resource-options.pp
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp
@@ -1,0 +1,12 @@
+resource provider "pulumi:providers:aws" {
+	region = "us-west-2"
+}
+
+resource bucket1 "aws:s3:Bucket" {
+	options {
+		provider = provider
+		dependsOn = [provider]
+		protect = true
+		ignoreChanges = [bucket, lifecycleRules[0]]
+	}
+}

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.cs
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.cs
@@ -1,0 +1,29 @@
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var provider = new Aws.Provider("provider", new Aws.ProviderArgs
+        {
+            Region = "us-west-2",
+        });
+        var bucket1 = new Aws.S3.Bucket("bucket1", new Aws.S3.BucketArgs
+        {
+        }, new CustomResourceOptions {
+            Provider = provider,
+            DependsOn = 
+            {
+                provider,
+            },
+            Protect = true,
+            IgnoreChanges = 
+            {
+                "bucket",
+                "lifecycleRules[0]",
+            },
+        });
+    }
+
+}

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.cs
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.cs
@@ -11,7 +11,8 @@ class MyStack : Stack
         });
         var bucket1 = new Aws.S3.Bucket("bucket1", new Aws.S3.BucketArgs
         {
-        }, new CustomResourceOptions {
+        }, new CustomResourceOptions
+        {
             Provider = provider,
             DependsOn = 
             {

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.go
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/providers"
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/s3"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		provider, err := providers.Newaws(ctx, "provider", &providers.awsArgs{
+			Region: pulumi.String("us-west-2"),
+		})
+		if err != nil {
+			return err
+		}
+		_, err = s3.NewBucket(ctx, "bucket1", nil, pulumi.Provider(provider), pulumi.DependsOn([]string{
+			provider,
+		}), pulumi.Protect(true), pulumi.IgnoreChanges([]string{
+			"bucket",
+			"lifecycleRules[0]",
+		}))
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.go
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.go
@@ -14,7 +14,7 @@ func main() {
 		if err != nil {
 			return err
 		}
-		_, err = s3.NewBucket(ctx, "bucket1", nil, pulumi.Provider(provider), pulumi.DependsOn([]string{
+		_, err = s3.NewBucket(ctx, "bucket1", nil, pulumi.Provider(provider), pulumi.DependsOn([]pulumi.Resource{
 			provider,
 		}), pulumi.Protect(true), pulumi.IgnoreChanges([]string{
 			"bucket",

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.py
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.py
@@ -4,9 +4,9 @@ import pulumi_pulumi as pulumi
 
 provider = pulumi.providers.Aws("provider", region="us-west-2")
 bucket1 = aws.s3.Bucket("bucket1", opts=ResourceOptions(provider=provider,
-    dependsOn=[provider],
+    depends_on=[provider],
     protect=True,
-    ignoreChanges=[
+    ignore_changes=[
         "bucket",
         "lifecycleRules[0]",
     ]))

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.py
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.py
@@ -1,0 +1,12 @@
+import pulumi
+import pulumi_aws as aws
+import pulumi_pulumi as pulumi
+
+provider = pulumi.providers.Aws("provider", region="us-west-2")
+bucket1 = aws.s3.Bucket("bucket1", opts=ResourceOptions(provider=provider,
+    dependsOn=[provider],
+    protect=True,
+    ignoreChanges=[
+        "bucket",
+        "lifecycleRules[0]",
+    ]))

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.ts
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.ts
@@ -1,0 +1,13 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const provider = new aws.Provider("provider", {region: "us-west-2"});
+const bucket1 = new aws.s3.Bucket("bucket1", {}, {
+    provider: provider,
+    dependsOn: [provider],
+    protect: true,
+    ignoreChanges: [
+        "bucket",
+        "lifecycleRules[0]",
+    ],
+});

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -27,6 +27,7 @@ func (g *generator) lowerExpression(expr model.Expression) model.Expression {
 	if g.asyncMain {
 		expr = g.awaitInvokes(expr)
 	}
+	expr = hcl2.RewritePropertyReferences(expr)
 	expr, _ = hcl2.RewriteApplies(expr, nameInfo(0), !g.asyncMain)
 	expr, _ = g.lowerProxyApplies(expr)
 	return expr

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -248,13 +248,13 @@ func (g *generator) lowerResourceOptions(opts *hcl2.ResourceOptions) (*model.Blo
 		appendOption("provider", opts.Provider)
 	}
 	if opts.DependsOn != nil {
-		appendOption("dependsOn", opts.DependsOn)
+		appendOption("depends_on", opts.DependsOn)
 	}
 	if opts.Protect != nil {
 		appendOption("protect", opts.Protect)
 	}
 	if opts.IgnoreChanges != nil {
-		appendOption("ignoreChanges", opts.IgnoreChanges)
+		appendOption("ignore_changes", opts.IgnoreChanges)
 	}
 
 	return block, temps

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -26,6 +26,7 @@ func (nameInfo) Format(name string) string {
 func (g *generator) lowerExpression(expr model.Expression) (model.Expression, []*quoteTemp) {
 	// TODO(pdg): diagnostics
 
+	expr = hcl2.RewritePropertyReferences(expr)
 	expr, _ = hcl2.RewriteApplies(expr, nameInfo(0), false)
 	expr, _ = g.lowerProxyApplies(expr)
 	expr, quotes, _ := g.rewriteQuotes(expr)


### PR DESCRIPTION
The PCL binder has supported resource options for some time, but these
options haven't been used or processed by the various code generators.
These options--particularly the parent and provider options0--are
critical for import codegen. These changes implement the basic set of
options, and add a note about fleshing out the rest as necessary.

One component of these changes is a new rewriter that rewrites property
references into property paths that are understood by the Pulumi engine.
This rewriter is used to preprocess the contents of the `ignoreChanges`
resource option.

Fixes #4923.