### PR TITLE
[codegen/*] Add support for explicit secrets.

### DIFF
--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -310,6 +310,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "File.ReadAllText(%v)", expr.Args[0])
 	case "readDir":
 		g.Fgenf(w, "Directory.GetFiles(%.v).Select(Path.GetFileName)", expr.Args[0])
+	case "secret":
+		g.Fgenf(w, "Output.CreateSecret(%v)", expr.Args[0])
 	case "split":
 		g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])
 	case "toJSON":

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -231,6 +231,9 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.genNYI(w, "ReadFile")
 	case "readDir":
 		contract.Failf("unlowered toJSON function expression @ %v", expr.SyntaxNode().Range())
+	case "secret":
+		// TODO: generate an appropriate type assertion
+		g.Fgenf(w, "pulumi.ToSecret(%v)", expr.Args[0])
 	case "split":
 		g.genNYI(w, "call %v", expr.Name)
 		// g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])

--- a/pkg/codegen/hcl2/functions.go
+++ b/pkg/codegen/hcl2/functions.go
@@ -196,6 +196,21 @@ var pulumiBuiltins = map[string]*model.Function{
 		}},
 		ReturnType: model.StringType,
 	}),
+	"secret": model.NewFunction(model.GenericFunctionSignature(
+		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
+			valueType := model.Type(model.DynamicType)
+			if len(args) == 1 {
+				valueType = args[0].Type()
+			}
+
+			return model.StaticFunctionSignature{
+				Parameters: []model.Parameter{{
+					Name: "value",
+					Type: valueType,
+				}},
+				ReturnType: model.NewOutputType(valueType),
+			}, nil
+		})),
 	"split": model.NewFunction(model.StaticFunctionSignature{
 		Parameters: []model.Parameter{
 			{

--- a/pkg/codegen/internal/test/testdata/secret.pp
+++ b/pkg/codegen/internal/test/testdata/secret.pp
@@ -1,0 +1,3 @@
+resource dbCluster "aws:rds:Cluster" {
+	masterPassword = secret("foobar")
+}

--- a/pkg/codegen/internal/test/testdata/secret.pp.cs
+++ b/pkg/codegen/internal/test/testdata/secret.pp.cs
@@ -1,0 +1,14 @@
+using Pulumi;
+using Aws = Pulumi.Aws;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var dbCluster = new Aws.Rds.Cluster("dbCluster", new Aws.Rds.ClusterArgs
+        {
+            MasterPassword = Output.CreateSecret("foobar"),
+        });
+    }
+
+}

--- a/pkg/codegen/internal/test/testdata/secret.pp.go
+++ b/pkg/codegen/internal/test/testdata/secret.pp.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err = rds.NewCluster(ctx, "dbCluster", &rds.ClusterArgs{
+		_, err := rds.NewCluster(ctx, "dbCluster", &rds.ClusterArgs{
 			MasterPassword: pulumi.ToSecret("foobar").(pulumi.StringOutput),
 		})
 		if err != nil {

--- a/pkg/codegen/internal/test/testdata/secret.pp.go
+++ b/pkg/codegen/internal/test/testdata/secret.pp.go
@@ -8,7 +8,7 @@ import (
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err = rds.NewCluster(ctx, "dbCluster", &rds.ClusterArgs{
-			MasterPassword: pulumi.ToSecret("foobar"),
+			MasterPassword: pulumi.ToSecret("foobar").(pulumi.StringOutput),
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/internal/test/testdata/secret.pp.go
+++ b/pkg/codegen/internal/test/testdata/secret.pp.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/rds"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err = rds.NewCluster(ctx, "dbCluster", &rds.ClusterArgs{
+			MasterPassword: pulumi.ToSecret("foobar"),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/internal/test/testdata/secret.pp.py
+++ b/pkg/codegen/internal/test/testdata/secret.pp.py
@@ -1,0 +1,4 @@
+import pulumi
+import pulumi_aws as aws
+
+db_cluster = aws.rds.Cluster("dbCluster", master_password=pulumi.secret("foobar"))

--- a/pkg/codegen/internal/test/testdata/secret.pp.ts
+++ b/pkg/codegen/internal/test/testdata/secret.pp.ts
@@ -1,0 +1,4 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as aws from "@pulumi/aws";
+
+const dbCluster = new aws.rds.Cluster("dbCluster", {masterPassword: pulumi.secret("foobar")});

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -347,6 +347,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "fs.readFileSync(%v)", expr.Args[0])
 	case "readDir":
 		g.Fgenf(w, "fs.readDirSync(%v)", expr.Args[0])
+	case "secret":
+		g.Fgenf(w, "pulumi.secret(%v)", expr.Args[0])
 	case "split":
 		g.Fgenf(w, "%.20v.split(%v)", expr.Args[1], expr.Args[0])
 	case "toJSON":

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -274,6 +274,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "(lambda path: open(path).read())(%.v)", expr.Args[0])
 	case "readDir":
 		g.Fgenf(w, "os.listdir(%.v)", expr.Args[0])
+	case "secret":
+		g.Fgenf(w, "pulumi.secret(%v)", expr.Args[0])
 	case "split":
 		g.Fgenf(w, "%.16v.split(%.v)", expr.Args[1], expr.Args[0])
 	case "toJSON":

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -11,7 +11,7 @@ using Pulumi.Serialization;
 namespace Pulumi
 {
     /// <summary>
-    /// Useful static utility methods for both creating and working wit <see cref="Output{T}"/>s.
+    /// Useful static utility methods for both creating and working with <see cref="Output{T}"/>s.
     /// </summary>
     public static partial class Output
     {


### PR DESCRIPTION
- Add a new builtin function, secret, that marks its input value as
  secret
- Add support for this function to the various code generators

Note that the Go code generation isn't really correct, as it is missing
a type assertion.

Fixes #4924.