### PR TITLE
Narrow a few interfaces.

### DIFF
--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -332,7 +332,7 @@ func renderDiffResourcePreEvent(
 	seen map[resource.URN]engine.StepEventMetadata,
 	opts Options) string {
 
-	seen[payload.Metadata.URN] = payload.Metadata
+	seen[payload.Metadata.Res.URN] = payload.Metadata
 	if payload.Metadata.Op == deploy.OpRefresh || payload.Metadata.Op == deploy.OpImport {
 		return ""
 	}
@@ -360,7 +360,7 @@ func renderDiffResourceOutputsEvent(
 		indent := engine.GetIndent(payload.Metadata, seen)
 
 		refresh := false // are these outputs from a refresh?
-		if m, has := seen[payload.Metadata.URN]; has && m.Op == deploy.OpRefresh {
+		if m, has := seen[payload.Metadata.Res.URN]; has && m.Op == deploy.OpRefresh {
 			refresh = true
 			summary := engine.GetResourcePropertiesSummary(payload.Metadata, indent)
 			fprintIgnoreError(out, opts.Color.Colorize(summary))

--- a/pkg/backend/display/display.go
+++ b/pkg/backend/display/display.go
@@ -119,7 +119,7 @@ func (s *nopSpinner) Reset() {
 
 // isRootStack returns true if the step pertains to the rootmost stack component.
 func isRootStack(step engine.StepEventMetadata) bool {
-	return isRootURN(step.URN)
+	return isRootURN(step.Res.URN)
 }
 
 func isRootURN(urn resource.URN) bool {

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -176,7 +176,7 @@ func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMeta
 	return apitype.StepEventMetadata{
 		Op:   string(md.Op),
 		URN:  string(md.URN),
-		Type: string(md.Type),
+		Type: string(md.URN.Type()),
 
 		Old: convertStepEventStateMetadata(md.Old),
 		New: convertStepEventStateMetadata(md.New),

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -175,8 +175,8 @@ func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMeta
 
 	return apitype.StepEventMetadata{
 		Op:   string(md.Op),
-		URN:  string(md.URN),
-		Type: string(md.URN.Type()),
+		URN:  string(md.Res.URN),
+		Type: string(md.Res.URN.Type()),
 
 		Old: convertStepEventStateMetadata(md.Old),
 		New: convertStepEventStateMetadata(md.New),

--- a/pkg/backend/display/json.go
+++ b/pkg/backend/display/json.go
@@ -147,7 +147,7 @@ func ShowJSONEvents(op string, action apitype.UpdateKind, events <-chan engine.E
 
 				step := &previewStep{
 					Op:             m.Op,
-					URN:            m.URN,
+					URN:            m.Res.URN,
 					Provider:       m.Provider,
 					DiffReasons:    m.Diffs,
 					ReplaceReasons: m.Keys,

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -185,13 +185,13 @@ func simplifyTypeName(typ tokens.Type) string {
 func getEventUrnAndMetadata(event engine.Event) (resource.URN, *engine.StepEventMetadata) {
 	if event.Type == engine.ResourcePreEvent {
 		payload := event.Payload.(engine.ResourcePreEventPayload)
-		return payload.Metadata.URN, &payload.Metadata
+		return payload.Metadata.Res.URN, &payload.Metadata
 	} else if event.Type == engine.ResourceOutputsEvent {
 		payload := event.Payload.(engine.ResourceOutputsEventPayload)
-		return payload.Metadata.URN, &payload.Metadata
+		return payload.Metadata.Res.URN, &payload.Metadata
 	} else if event.Type == engine.ResourceOperationFailed {
 		payload := event.Payload.(engine.ResourceOperationFailedPayload)
-		return payload.Metadata.URN, &payload.Metadata
+		return payload.Metadata.Res.URN, &payload.Metadata
 	} else if event.Type == engine.DiagEvent {
 		return event.Payload.(engine.DiagEventPayload).URN, nil
 	} else if event.Type == engine.PolicyViolationEvent {
@@ -922,7 +922,7 @@ func (display *ProgressDisplay) getRowForURN(urn resource.URN, metadata *engine.
 	}
 
 	// First time we're hearing about this resource. Create an initial nearly-empty status for it.
-	step := engine.StepEventMetadata{URN: urn, Op: deploy.OpSame}
+	step := engine.StepEventMetadata{Res: &engine.StepEventStateMetadata{URN: urn}, Op: deploy.OpSame}
 	if metadata != nil {
 		step = *metadata
 	}
@@ -1054,7 +1054,7 @@ func (display *ProgressDisplay) processNormalEvent(event engine.Event) {
 		step := event.Payload.(engine.ResourceOutputsEventPayload).Metadata
 
 		// Is this the stack outputs event? If so, we'll need to print it out at the end of the plan.
-		if step.URN == display.stackUrn {
+		if step.Res.URN == display.stackUrn {
 			display.seenStackOutputs = true
 		}
 

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -272,7 +272,7 @@ func (data *resourceRowData) ContainsOutputsStep(op deploy.StepOp) bool {
 func (data *resourceRowData) ColorizedSuffix() string {
 	if !data.IsDone() && data.display.isTerminal {
 		op := data.display.getStepOp(data.step)
-		if op != deploy.OpSame || isRootURN(data.step.URN) {
+		if op != deploy.OpSame || isRootURN(data.step.Res.URN) {
 			suffixes := data.display.suffixesArray
 			ellipses := suffixes[(data.tick+data.display.currentTick)%len(suffixes)]
 
@@ -286,7 +286,7 @@ func (data *resourceRowData) ColorizedSuffix() string {
 func (data *resourceRowData) ColorizedColumns() []string {
 	step := data.step
 
-	urn := data.step.URN
+	urn := data.step.Res.URN
 	if urn == "" {
 		// If we don't have a URN yet, mock parent it to the global stack.
 		urn = resource.DefaultRootStackURN(data.display.stack, data.display.proj)

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -62,20 +62,20 @@ func ShowWatchEvents(op string, action apitype.UpdateKind, events <-chan engine.
 		case engine.ResourcePreEvent:
 			p := e.Payload.(engine.ResourcePreEventPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.URN.Name()),
-					"%s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
+				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.Res.URN.Name()),
+					"%s %s\n", p.Metadata.Op, p.Metadata.Res.URN.Type())
 			}
 		case engine.ResourceOutputsEvent:
 			p := e.Payload.(engine.ResourceOutputsEventPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.URN.Name()),
-					"done %s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
+				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.Res.URN.Name()),
+					"done %s %s\n", p.Metadata.Op, p.Metadata.Res.URN.Type())
 			}
 		case engine.ResourceOperationFailed:
 			p := e.Payload.(engine.ResourceOperationFailedPayload)
 			if shouldShow(p.Metadata, opts) {
-				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.URN.Name()),
-					"failed %s %s\n", p.Metadata.Op, p.Metadata.URN.Type())
+				PrintfWithWatchPrefix(time.Now(), string(p.Metadata.Res.URN.Name()),
+					"failed %s %s\n", p.Metadata.Op, p.Metadata.Res.URN.Type())
 			}
 		default:
 			contract.Failf("unknown event type '%s'", e.Type)

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -127,7 +127,7 @@ func (sm *SnapshotManager) RegisterResourceOutputs(step deploy.Step) error {
 // intent to mutate before the mutation occurs.
 func (sm *SnapshotManager) BeginMutation(step deploy.Step) (engine.SnapshotMutation, error) {
 	contract.Require(step != nil, "step != nil")
-	logging.V(9).Infof("SnapshotManager: Beginning mutation for step `%s` on resource `%s`", step.Op(), step.URN())
+	logging.V(9).Infof("SnapshotManager: Beginning mutation for step `%s` on resource `%s`", step.Op(), step.Res().URN)
 
 	switch step.Op() {
 	case deploy.OpSame:
@@ -280,7 +280,7 @@ func (ssm *sameSnapshotMutation) End(step deploy.Step, successful bool) error {
 }
 
 func (sm *SnapshotManager) doCreate(step deploy.Step) (engine.SnapshotMutation, error) {
-	logging.V(9).Infof("SnapshotManager.doCreate(%s)", step.URN())
+	logging.V(9).Infof("SnapshotManager.doCreate(%s)", step.Res().URN)
 	err := sm.mutate(func() bool {
 		sm.markOperationPending(step.New(), resource.OperationTypeCreating)
 		return true
@@ -324,7 +324,7 @@ func (csm *createSnapshotMutation) End(step deploy.Step, successful bool) error 
 }
 
 func (sm *SnapshotManager) doUpdate(step deploy.Step) (engine.SnapshotMutation, error) {
-	logging.V(9).Infof("SnapshotManager.doUpdate(%s)", step.URN())
+	logging.V(9).Infof("SnapshotManager.doUpdate(%s)", step.Res().URN)
 	err := sm.mutate(func() bool {
 		sm.markOperationPending(step.New(), resource.OperationTypeUpdating)
 		return true
@@ -354,7 +354,7 @@ func (usm *updateSnapshotMutation) End(step deploy.Step, successful bool) error 
 }
 
 func (sm *SnapshotManager) doDelete(step deploy.Step) (engine.SnapshotMutation, error) {
-	logging.V(9).Infof("SnapshotManager.doDelete(%s)", step.URN())
+	logging.V(9).Infof("SnapshotManager.doDelete(%s)", step.Res().URN)
 	err := sm.mutate(func() bool {
 		sm.markOperationPending(step.Old(), resource.OperationTypeDeleting)
 		return true
@@ -395,7 +395,7 @@ func (rsm *replaceSnapshotMutation) End(step deploy.Step, successful bool) error
 }
 
 func (sm *SnapshotManager) doRead(step deploy.Step) (engine.SnapshotMutation, error) {
-	logging.V(9).Infof("SnapshotManager.doRead(%s)", step.URN())
+	logging.V(9).Infof("SnapshotManager.doRead(%s)", step.Res().URN)
 	err := sm.mutate(func() bool {
 		sm.markOperationPending(step.New(), resource.OperationTypeReading)
 		return true
@@ -460,7 +460,7 @@ func (rsm *removePendingReplaceSnapshotMutation) End(step deploy.Step, successfu
 }
 
 func (sm *SnapshotManager) doImport(step deploy.Step) (engine.SnapshotMutation, error) {
-	logging.V(9).Infof("SnapshotManager.doImport(%s)", step.URN())
+	logging.V(9).Infof("SnapshotManager.doImport(%s)", step.Res().URN)
 	err := sm.mutate(func() bool {
 		sm.markOperationPending(step.New(), resource.OperationTypeImporting)
 		return true

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -60,7 +60,7 @@ func printStepHeader(b io.StringWriter, step StepEventMetadata) {
 		// show a locked symbol, since we are either newly protecting this resource, or retaining protection.
 		extra = " 🔒"
 	}
-	writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.Type), step.Op, extra))
+	writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.URN.Type()), step.Op, extra))
 }
 
 func GetIndentationString(indent int) string {

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -60,7 +60,7 @@ func printStepHeader(b io.StringWriter, step StepEventMetadata) {
 		// show a locked symbol, since we are either newly protecting this resource, or retaining protection.
 		extra = " 🔒"
 	}
-	writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.URN.Type()), step.Op, extra))
+	writeString(b, fmt.Sprintf("%s: (%s)%s\n", string(step.Res.URN.Type()), step.Op, extra))
 }
 
 func GetIndentationString(indent int) string {
@@ -117,7 +117,7 @@ func GetResourcePropertiesSummary(step StepEventMetadata, indent int) string {
 	var b bytes.Buffer
 
 	op := step.Op
-	urn := step.URN
+	urn := step.Res.URN
 	old := step.Old
 
 	// Print the indentation.
@@ -296,7 +296,7 @@ func GetResourceOutputsPropertiesString(
 	step StepEventMetadata, indent int, planning, debug, refresh, showSames bool) string {
 
 	// During the actual update we always show all the outputs for the stack, even if they are unchanged.
-	if !showSames && !planning && step.URN.Type() == resource.RootStackType {
+	if !showSames && !planning && step.Res.URN.Type() == resource.RootStackType {
 		showSames = true
 	}
 
@@ -321,7 +321,7 @@ func GetResourceOutputsPropertiesString(
 			step.Op == deploy.OpReadReplacement ||
 			step.Op == deploy.OpImport ||
 			step.Op == deploy.OpImportReplacement ||
-			step.URN.Type() == resource.RootStackType
+			step.Res.URN.Type() == resource.RootStackType
 		if !printOutputDuringPlanning {
 			return ""
 		}
@@ -353,7 +353,7 @@ func GetResourceOutputsPropertiesString(
 
 		// If this is the root stack type, we want to strip out any nested resource outputs that are not known if
 		// they have no corresponding output in the old state.
-		if planning && step.URN.Type() == resource.RootStackType {
+		if planning && step.Res.URN.Type() == resource.RootStackType {
 			massageStackPreviewOutputDiff(outputDiff, false)
 		}
 	}

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -120,7 +120,6 @@ type ResourcePreEventPayload struct {
 type StepEventMetadata struct {
 	Op           deploy.StepOp                  // the operation performed by this step.
 	URN          resource.URN                   // the resource URN (for before and after).
-	Type         tokens.Type                    // the type affected by this step.
 	Old          *StepEventStateMetadata        // the state of the resource before performing this step.
 	New          *StepEventStateMetadata        // the state of the resource after performing this step.
 	Res          *StepEventStateMetadata        // the latest state for the resource that is known (worst case, old).
@@ -274,8 +273,7 @@ func makeStepEventMetadata(op deploy.StepOp, step deploy.Step, debug bool) StepE
 
 	return StepEventMetadata{
 		Op:           op,
-		URN:          step.URN(),
-		Type:         step.Type(),
+		URN:          step.Res().URN,
 		Keys:         keys,
 		Diffs:        diffs,
 		DetailedDiff: detailedDiff,

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -119,7 +119,6 @@ type ResourcePreEventPayload struct {
 // StepEventMetadata contains the metadata associated with a step the engine is performing.
 type StepEventMetadata struct {
 	Op           deploy.StepOp                  // the operation performed by this step.
-	URN          resource.URN                   // the resource URN (for before and after).
 	Old          *StepEventStateMetadata        // the state of the resource before performing this step.
 	New          *StepEventStateMetadata        // the state of the resource after performing this step.
 	Res          *StepEventStateMetadata        // the latest state for the resource that is known (worst case, old).
@@ -273,7 +272,6 @@ func makeStepEventMetadata(op deploy.StepOp, step deploy.Step, debug bool) StepE
 
 	return StepEventMetadata{
 		Op:           op,
-		URN:          step.Res().URN,
 		Keys:         keys,
 		Diffs:        diffs,
 		DetailedDiff: detailedDiff,

--- a/pkg/engine/lifecycle_test.go
+++ b/pkg/engine/lifecycle_test.go
@@ -119,7 +119,7 @@ func (j *Journal) Snap(base *deploy.Snapshot) *deploy.Snapshot {
 	resources, dones := []*resource.State{}, make(map[*resource.State]bool)
 	ops, doneOps := []resource.Operation{}, make(map[*resource.State]bool)
 	for _, e := range j.Entries {
-		logging.V(7).Infof("%v %v (%v)", e.Step.Op(), e.Step.URN(), e.Kind)
+		logging.V(7).Infof("%v %v (%v)", e.Step.Op(), e.Step.Res().URN, e.Kind)
 
 		// Begin journal entries add pending operations to the snapshot. As we see success or failure
 		// entries, we'll record them in doneOps.
@@ -229,7 +229,7 @@ func AssertSameSteps(t *testing.T, expected []StepSummary, actual []deploy.Step)
 		act := actual[0]
 		actual = actual[1:]
 
-		if !assert.Equal(t, exp.Op, act.Op()) || !assert.Equal(t, exp.URN, act.URN()) {
+		if !assert.Equal(t, exp.Op, act.Op()) || !assert.Equal(t, exp.URN, act.Res().URN) {
 			return false
 		}
 	}
@@ -672,7 +672,7 @@ func TestSingleResourceDefaultProviderUpgrade(t *testing.T) {
 		// Should see only sames: the default provider should be injected into the old state before the update
 		// runs.
 		for _, entry := range j.Entries {
-			switch urn := entry.Step.URN(); urn {
+			switch urn := entry.Step.Res().URN; urn {
 			case provURN, resURN:
 				expect := deploy.OpSame
 				if isRefresh {
@@ -707,7 +707,7 @@ func TestSingleResourceDefaultProviderUpgrade(t *testing.T) {
 			// runs.
 			deleted := make(map[resource.URN]bool)
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN, resURN:
 					deleted[urn] = true
 					assert.Equal(t, deploy.OpDelete, entry.Step.Op())
@@ -783,7 +783,7 @@ func TestSingleResourceDefaultProviderReplace(t *testing.T) {
 					continue
 				}
 
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					replacedProvider = true
 				case resURN:
@@ -875,7 +875,7 @@ func TestSingleResourceExplicitProviderReplace(t *testing.T) {
 					continue
 				}
 
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					replacedProvider = true
 				case resURN:
@@ -967,7 +967,7 @@ func TestSingleResourceExplicitProviderDeleteBeforeReplace(t *testing.T) {
 					continue
 				}
 
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					if entry.Step.Op() == deploy.OpDeleteReplaced {
 						assert.False(t, createdProvider)
@@ -1114,7 +1114,7 @@ func TestDestroyWithPendingDelete(t *testing.T) {
 			deletedID0, deletedID1 := false, false
 			for _, entry := range j.Entries {
 				// Ignore non-terminal steps and steps that affect the injected default provider.
-				if entry.Kind != JournalEntrySuccess || entry.Step.URN() != resURN ||
+				if entry.Kind != JournalEntrySuccess || entry.Step.Res().URN != resURN ||
 					(entry.Step.Op() != deploy.OpDelete && entry.Step.Op() != deploy.OpDeleteReplaced) {
 					continue
 				}
@@ -1188,7 +1188,7 @@ func TestUpdateWithPendingDelete(t *testing.T) {
 			deletedID0, deletedID1 := false, false
 			for _, entry := range j.Entries {
 				// Ignore non-terminal steps and steps that affect the injected default provider.
-				if entry.Kind != JournalEntrySuccess || entry.Step.URN() != resURN ||
+				if entry.Kind != JournalEntrySuccess || entry.Step.Res().URN != resURN ||
 					(entry.Step.Op() != deploy.OpDelete && entry.Step.Op() != deploy.OpDeleteReplaced) {
 					continue
 				}
@@ -1674,8 +1674,8 @@ func validateRefreshDeleteCombination(t *testing.T, names []string, targets []st
 				for _, entry := range j.Entries {
 					if len(refreshTargets) > 0 {
 						// should only see changes to urns we explicitly asked to change
-						assert.Containsf(t, refreshTargets, entry.Step.URN(),
-							"Refreshed a resource that wasn't a target: %v", entry.Step.URN())
+						assert.Containsf(t, refreshTargets, entry.Step.Res().URN,
+							"Refreshed a resource that wasn't a target: %v", entry.Step.Res().URN)
 					}
 
 					assert.Equal(t, deploy.OpRefresh, entry.Step.Op())
@@ -1843,8 +1843,8 @@ func validateRefreshBasicsCombination(t *testing.T, names []string, targets []st
 			for _, entry := range j.Entries {
 				if len(refreshTargets) > 0 {
 					// should only see changes to urns we explicitly asked to change
-					assert.Containsf(t, refreshTargets, entry.Step.URN(),
-						"Refreshed a resource that wasn't a target: %v", entry.Step.URN())
+					assert.Containsf(t, refreshTargets, entry.Step.Res().URN,
+						"Refreshed a resource that wasn't a target: %v", entry.Step.Res().URN)
 				}
 
 				assert.Equal(t, deploy.OpRefresh, entry.Step.Op())
@@ -2375,7 +2375,7 @@ func TestUpdatePartialFailure(t *testing.T) {
 
 			assertIsErrorOrBailResult(t, res)
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case resURN:
 					assert.Equal(t, deploy.OpUpdate, entry.Step.Op())
 					switch entry.Kind {
@@ -2482,7 +2482,7 @@ func TestStackReference(t *testing.T) {
 
 			assert.Nil(t, res)
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case resURN:
 					switch entry.Step.Op() {
 					case deploy.OpCreateReplacement, deploy.OpDeleteReplaced, deploy.OpReplace:
@@ -2811,7 +2811,7 @@ func TestDeleteBeforeReplace(t *testing.T) {
 			replaced := make(map[resource.URN]bool)
 			for _, entry := range j.Entries {
 				if entry.Step.Op() == deploy.OpReplace {
-					replaced[entry.Step.URN()] = true
+					replaced[entry.Step.Res().URN] = true
 				}
 			}
 
@@ -3255,7 +3255,7 @@ func TestDefaultProviderDiff(t *testing.T) {
 								continue
 							}
 
-							switch entry.Step.URN().Name().String() {
+							switch entry.Step.Res().URN.Name().String() {
 							case resName, resBName:
 								assert.Equal(t, expectedStep, entry.Step.Op())
 							}
@@ -3376,7 +3376,7 @@ func TestDefaultProviderDiffReplacement(t *testing.T) {
 								continue
 							}
 
-							switch entry.Step.URN().Name().String() {
+							switch entry.Step.Res().URN.Name().String() {
 							case resName:
 								assert.Subset(t, expectedSteps, []deploy.StepOp{entry.Step.Op()})
 							case resBName:
@@ -3500,7 +3500,7 @@ func TestAliases(t *testing.T) {
 						}
 
 						for _, entry := range j.Entries {
-							if entry.Step.Type() == "pulumi:providers:pkgA" {
+							if entry.Step.Res().URN.Type() == "pulumi:providers:pkgA" {
 								continue
 							}
 							switch entry.Kind {
@@ -3804,7 +3804,7 @@ func TestPersistentDiff(t *testing.T) {
 			for _, e := range events {
 				if e.Type == ResourcePreEvent {
 					p := e.Payload.(ResourcePreEventPayload).Metadata
-					if p.URN == resURN {
+					if p.Res.URN == resURN {
 						assert.Equal(t, deploy.OpUpdate, p.Op)
 						found = true
 					}
@@ -3825,7 +3825,7 @@ func TestPersistentDiff(t *testing.T) {
 			for _, e := range events {
 				if e.Type == ResourcePreEvent {
 					p := e.Payload.(ResourcePreEventPayload).Metadata
-					if p.URN == resURN {
+					if p.Res.URN == resURN {
 						assert.Equal(t, deploy.OpSame, p.Op)
 						found = true
 					}
@@ -3885,7 +3885,7 @@ func TestDetailedDiffReplace(t *testing.T) {
 			for _, e := range events {
 				if e.Type == ResourcePreEvent {
 					p := e.Payload.(ResourcePreEventPayload).Metadata
-					if p.URN == resURN && p.Op == deploy.OpReplace {
+					if p.Res.URN == resURN && p.Op == deploy.OpReplace {
 						found = true
 					}
 				}
@@ -3973,7 +3973,7 @@ func TestImport(t *testing.T) {
 	snap, res := TestOp(Update).Run(project, p.GetTarget(nil), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					assert.Equal(t, deploy.OpCreate, entry.Step.Op())
 				case resURN:
@@ -3991,7 +3991,7 @@ func TestImport(t *testing.T) {
 	snap, res = TestOp(Update).Run(project, p.GetTarget(snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN, resURN:
 					assert.Equal(t, deploy.OpSame, entry.Step.Op())
 				default:
@@ -4007,7 +4007,7 @@ func TestImport(t *testing.T) {
 	snap, res = TestOp(Update).Run(project, p.GetTarget(snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					assert.Equal(t, deploy.OpSame, entry.Step.Op())
 				case resURN:
@@ -4029,7 +4029,7 @@ func TestImport(t *testing.T) {
 	_, res = TestOp(Destroy).Run(project, p.GetTarget(snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN, resURN:
 					assert.Equal(t, deploy.OpDelete, entry.Step.Op())
 				default:
@@ -4045,7 +4045,7 @@ func TestImport(t *testing.T) {
 	snap, res = TestOp(Update).Run(project, p.GetTarget(nil), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN, resURN:
 					assert.Equal(t, deploy.OpCreate, entry.Step.Op())
 				default:
@@ -4066,7 +4066,7 @@ func TestImport(t *testing.T) {
 	snap, res = TestOp(Update).Run(project, p.GetTarget(snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN, resURN:
 					assert.Equal(t, deploy.OpSame, entry.Step.Op())
 				default:
@@ -4083,7 +4083,7 @@ func TestImport(t *testing.T) {
 	_, res = TestOp(Update).Run(project, p.GetTarget(snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					assert.Equal(t, deploy.OpSame, entry.Step.Op())
 				case resURN:
@@ -4106,7 +4106,7 @@ func TestImport(t *testing.T) {
 	snap, res = TestOp(Update).Run(project, p.GetTarget(nil), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					assert.Equal(t, deploy.OpCreate, entry.Step.Op())
 				case resURN:
@@ -4125,7 +4125,7 @@ func TestImport(t *testing.T) {
 	_, res = TestOp(Update).Run(project, p.GetTarget(snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					assert.Equal(t, deploy.OpSame, entry.Step.Op())
 				case resURN:
@@ -4211,7 +4211,7 @@ func TestImportWithDifferingImportIdentifierFormat(t *testing.T) {
 	snap, res := TestOp(Update).Run(project, p.GetTarget(nil), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN:
 					assert.Equal(t, deploy.OpCreate, entry.Step.Op())
 				case resURN:
@@ -4229,7 +4229,7 @@ func TestImportWithDifferingImportIdentifierFormat(t *testing.T) {
 	snap, res = TestOp(Update).Run(project, p.GetTarget(snap), p.Options, false, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, j *Journal, _ []Event, res result.Result) result.Result {
 			for _, entry := range j.Entries {
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case provURN, resURN:
 					assert.Equal(t, deploy.OpSame, entry.Step.Op())
 				default:
@@ -4349,7 +4349,7 @@ func TestProviderDiffMissingOldOutputs(t *testing.T) {
 					continue
 				}
 
-				switch urn := entry.Step.URN(); urn {
+				switch urn := entry.Step.Res().URN; urn {
 				case providerURN:
 					replacedProvider = true
 				case resURN:
@@ -4600,7 +4600,7 @@ func destroySpecificTargets(
 			deleted := make(map[resource.URN]bool)
 			for _, entry := range j.Entries {
 				assert.Equal(t, deploy.OpDelete, entry.Step.Op())
-				deleted[entry.Step.URN()] = true
+				deleted[entry.Step.Res().URN] = true
 			}
 
 			for _, target := range p.Options.DestroyTargets {
@@ -4693,9 +4693,9 @@ func updateSpecificTargets(t *testing.T, targets []string) {
 			sames := make(map[resource.URN]bool)
 			for _, entry := range j.Entries {
 				if entry.Step.Op() == deploy.OpUpdate {
-					updated[entry.Step.URN()] = true
+					updated[entry.Step.Res().URN] = true
 				} else if entry.Step.Op() == deploy.OpSame {
-					sames[entry.Step.URN()] = true
+					sames[entry.Step.Res().URN] = true
 				} else {
 					assert.FailNowf(t, "", "Got a step that wasn't a same/update: %v", entry.Step.Op())
 				}
@@ -4803,9 +4803,9 @@ func TestCreateDuringTargetedUpdate_CreateMentionedAsTarget(t *testing.T) {
 			assert.True(t, len(j.Entries) > 0)
 
 			for _, entry := range j.Entries {
-				if entry.Step.URN() == resA {
+				if entry.Step.Res().URN == resA {
 					assert.Equal(t, deploy.OpSame, entry.Step.Op())
-				} else if entry.Step.URN() == resB {
+				} else if entry.Step.Res().URN == resB {
 					assert.Equal(t, deploy.OpCreate, entry.Step.Op())
 				}
 			}
@@ -5072,7 +5072,7 @@ func TestDependencyChangeDBR(t *testing.T) {
 
 				resBDeleted, resBSame := false, false
 				for _, entry := range j.Entries {
-					if entry.Step.URN() == urnB {
+					if entry.Step.Res().URN == urnB {
 						switch entry.Step.Op() {
 						case deploy.OpDelete, deploy.OpDeleteReplaced:
 							resBDeleted = true
@@ -5148,9 +5148,9 @@ func TestReplaceSpecificTargets(t *testing.T) {
 			sames := make(map[resource.URN]bool)
 			for _, entry := range j.Entries {
 				if entry.Step.Op() == deploy.OpReplace {
-					replaced[entry.Step.URN()] = true
+					replaced[entry.Step.Res().URN] = true
 				} else if entry.Step.Op() == deploy.OpSame {
-					sames[entry.Step.URN()] = true
+					sames[entry.Step.Res().URN] = true
 				}
 			}
 

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -266,7 +266,7 @@ func newPlanActions(opts planOptions) *planActions {
 
 func (acts *planActions) OnResourceStepPre(step deploy.Step) (interface{}, error) {
 	acts.MapLock.Lock()
-	acts.Seen[step.URN()] = step
+	acts.Seen[step.Res().URN] = step
 	acts.MapLock.Unlock()
 
 	// Skip reporting if necessary.
@@ -292,7 +292,7 @@ func (acts *planActions) OnResourceStepPost(ctx interface{},
 		// global message.
 		reportedURN := resource.URN("")
 		if reportStep {
-			reportedURN = step.URN()
+			reportedURN = step.Res().URN
 		}
 
 		acts.Opts.Diag.Errorf(diag.GetPreviewFailedError(reportedURN), err)
@@ -354,10 +354,10 @@ func (acts *planActions) OnPolicyViolation(urn resource.URN, d plugin.AnalyzeDia
 }
 
 func assertSeen(seen map[resource.URN]deploy.Step, step deploy.Step) {
-	_, has := seen[step.URN()]
-	contract.Assertf(has, "URN '%v' had not been marked as seen", step.URN())
+	_, has := seen[step.Res().URN]
+	contract.Assertf(has, "URN '%v' had not been marked as seen", step.Res().URN)
 }
 
 func isDefaultProviderStep(step deploy.Step) bool {
-	return providers.IsDefaultProvider(step.URN())
+	return providers.IsDefaultProvider(step.Res().URN)
 }

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -504,7 +504,7 @@ func newUpdateActions(context *Context, u UpdateInfo, opts planOptions) *updateA
 func (acts *updateActions) OnResourceStepPre(step deploy.Step) (interface{}, error) {
 	// Ensure we've marked this step as observed.
 	acts.MapLock.Lock()
-	acts.Seen[step.URN()] = step
+	acts.Seen[step.Res().URN] = step
 	acts.MapLock.Unlock()
 
 	// Skip reporting if necessary.
@@ -540,7 +540,7 @@ func (acts *updateActions) OnResourceStepPost(
 
 		errorURN := resource.URN("")
 		if reportStep {
-			errorURN = step.URN()
+			errorURN = step.Res().URN
 		}
 
 		// Issue a true, bonafide error.
@@ -589,7 +589,7 @@ func (acts *updateActions) OnResourceStepPost(
 	if status == resource.StatusPartialFailure && step.Op() == deploy.OpUpdate {
 		logging.V(7).Infof(
 			"OnResourceStepPost(%s): Step is partially-failed update, saving old inputs instead of new inputs",
-			step.URN())
+			step.Res().URN)
 		new := step.New()
 		old := step.Old()
 		contract.Assert(new != nil)

--- a/pkg/resource/deploy/plan.go
+++ b/pkg/resource/deploy/plan.go
@@ -282,12 +282,7 @@ func NewPlan(ctx *plugin.Context, target *Target, prev *Snapshot, source Source,
 	}, nil
 }
 
-func (p *Plan) Ctx() *plugin.Context                   { return p.ctx }
-func (p *Plan) Target() *Target                        { return p.target }
-func (p *Plan) Diag() diag.Sink                        { return p.ctx.Diag }
-func (p *Plan) Prev() *Snapshot                        { return p.prev }
-func (p *Plan) Olds() map[resource.URN]*resource.State { return p.olds }
-func (p *Plan) Source() Source                         { return p.source }
+func (p *Plan) diag() diag.Sink { return p.ctx.Diag }
 
 func (p *Plan) GetProvider(ref providers.Reference) (plugin.Provider, bool) {
 	return p.providers.GetProvider(ref)
@@ -303,7 +298,7 @@ func (p *Plan) generateURN(parent resource.URN, ty tokens.Type, name tokens.QNam
 		parentType = parent.QualifiedType()
 	}
 
-	return resource.NewURN(p.Target().Name, p.source.Project(), parentType, ty, name)
+	return resource.NewURN(p.target.Name, p.source.Project(), parentType, ty, name)
 }
 
 // defaultProviderURN generates the URN for the global provider given a package.

--- a/pkg/resource/deploy/plan_executor.go
+++ b/pkg/resource/deploy/plan_executor.go
@@ -82,9 +82,9 @@ func (pe *planExecutor) checkTargets(targets []resource.URN, op StepOp) result.R
 
 			logging.V(7).Infof("Resource to %v (%v) could not be found in the stack.", op, target)
 			if strings.Contains(string(target), "$") {
-				pe.plan.Diag().Errorf(diag.GetTargetCouldNotBeFoundError(), target)
+				pe.plan.diag().Errorf(diag.GetTargetCouldNotBeFoundError(), target)
 			} else {
-				pe.plan.Diag().Errorf(diag.GetTargetCouldNotBeFoundDidYouForgetError(), target)
+				pe.plan.diag().Errorf(diag.GetTargetCouldNotBeFoundDidYouForgetError(), target)
 			}
 		}
 	}
@@ -108,7 +108,7 @@ func (pe *planExecutor) reportExecResult(message string, preview bool) {
 
 // reportError reports a single error to the executor's diag stream with the indicated URN for context.
 func (pe *planExecutor) reportError(urn resource.URN, err error) {
-	pe.plan.Diag().Errorf(diag.RawMessage(urn, err.Error()))
+	pe.plan.diag().Errorf(diag.RawMessage(urn, err.Error()))
 }
 
 // Execute executes a plan to completion, using the given cancellation context and running a preview
@@ -343,7 +343,7 @@ func (pe *planExecutor) performDeletes(
 	if targetsOpt != nil {
 		resourceToStep := make(map[*resource.State]Step)
 		for _, step := range deleteSteps {
-			resourceToStep[pe.plan.olds[step.URN()]] = step
+			resourceToStep[pe.plan.olds[step.Res().URN]] = step
 		}
 
 		pe.rebuildBaseState(resourceToStep, false /*refresh*/)
@@ -400,7 +400,7 @@ func (pe *planExecutor) retirePendingDeletes(callerCtx context.Context, opts Opt
 	// Submit the deletes for execution and wait for them all to retire.
 	for _, antichain := range antichains {
 		for _, step := range antichain {
-			pe.plan.Ctx().StatusDiag.Infof(diag.RawMessage(step.URN(), "completing deletion from previous update"))
+			pe.plan.ctx.StatusDiag.Infof(diag.RawMessage(step.Res().URN, "completing deletion from previous update"))
 		}
 
 		tok := stepExec.ExecuteParallel(antichain)

--- a/pkg/resource/deploy/source.go
+++ b/pkg/resource/deploy/source.go
@@ -39,8 +39,6 @@ type Source interface {
 
 	// Project returns the package name of the Pulumi project we are obtaining resources from.
 	Project() tokens.PackageName
-	// Info returns a serializable payload that can be used to stamp snapshots for future reconciliation.
-	Info() interface{}
 
 	// Iterate begins iterating the source. Error is non-nil upon failure; otherwise, a valid iterator is returned.
 	Iterate(ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, result.Result)

--- a/pkg/resource/deploy/source_error.go
+++ b/pkg/resource/deploy/source_error.go
@@ -35,7 +35,6 @@ type errorSource struct {
 
 func (src *errorSource) Close() error                { return nil }
 func (src *errorSource) Project() tokens.PackageName { return src.project }
-func (src *errorSource) Info() interface{}           { return nil }
 
 func (src *errorSource) Iterate(
 	ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, result.Result) {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -41,11 +41,11 @@ import (
 
 // EvalRunInfo provides information required to execute and deploy resources within a package.
 type EvalRunInfo struct {
-	Proj    *workspace.Project `json:"proj" yaml:"proj"`                         // the package metadata.
-	Pwd     string             `json:"pwd" yaml:"pwd"`                           // the package's working directory.
-	Program string             `json:"program" yaml:"program"`                   // the path to the program.
-	Args    []string           `json:"args,omitempty" yaml:"args,omitempty"`     // any arguments to pass to the package.
-	Target  *Target            `json:"target,omitempty" yaml:"target,omitempty"` // the target being deployed into.
+	Proj    *workspace.Project // the package metadata.
+	Pwd     string             // the package's working directory.
+	Program string             // the path to the program.
+	Args    []string           // any arguments to pass to the package.
+	Target  *Target            // the target being deployed into.
 }
 
 // NewEvalSource returns a planning source that fetches resources by evaluating a package with a set of args and
@@ -77,13 +77,6 @@ func (src *evalSource) Close() error {
 func (src *evalSource) Project() tokens.PackageName {
 	return src.runinfo.Proj.Name
 }
-
-// Stack is the name of the stack being targeted by this evaluation source.
-func (src *evalSource) Stack() tokens.QName {
-	return src.runinfo.Target.Name
-}
-
-func (src *evalSource) Info() interface{} { return src.runinfo }
 
 // Iterate will spawn an evaluator coroutine and prepare to interact with it on subsequent calls to Next.
 func (src *evalSource) Iterate(

--- a/pkg/resource/deploy/source_fixed.go
+++ b/pkg/resource/deploy/source_fixed.go
@@ -35,7 +35,6 @@ type fixedSource struct {
 
 func (src *fixedSource) Close() error                { return nil }
 func (src *fixedSource) Project() tokens.PackageName { return src.ctx }
-func (src *fixedSource) Info() interface{}           { return nil }
 
 func (src *fixedSource) Iterate(
 	ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, result.Result) {

--- a/pkg/resource/deploy/source_null.go
+++ b/pkg/resource/deploy/source_null.go
@@ -32,7 +32,6 @@ type nullSource struct {
 
 func (src *nullSource) Close() error                { return nil }
 func (src *nullSource) Project() tokens.PackageName { return "" }
-func (src *nullSource) Info() interface{}           { return nil }
 
 func (src *nullSource) Iterate(
 	ctx context.Context, opts Options, providers ProviderSource) (SourceIterator, result.Result) {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -111,7 +111,7 @@ func (sg *stepGenerator) GenerateReadSteps(event ReadResourceEvent) ([]Step, res
 		nil, /* customTimeouts */
 		"",  /* importID */
 	)
-	old, hasOld := sg.plan.Olds()[urn]
+	old, hasOld := sg.plan.olds[urn]
 
 	// If the snapshot has an old resource for this URN and it's not external, we're going
 	// to have to delete the old resource and conceptually replace it with the resource we
@@ -176,9 +176,9 @@ func (sg *stepGenerator) GenerateSteps(event RegisterResourceEvent) ([]Step, res
 				// Give a particular error in that case to let them know.  Also mark that we're
 				// in an error state so that we eventually will error out of the entire
 				// application run.
-				d := diag.GetResourceWillBeCreatedButWasNotSpecifiedInTargetList(step.URN())
+				d := diag.GetResourceWillBeCreatedButWasNotSpecifiedInTargetList(step.Res().URN)
 
-				sg.plan.Diag().Errorf(d, step.URN(), urn)
+				sg.plan.diag().Errorf(d, step.Res().URN, urn)
 				sg.sawError = true
 
 				if !sg.plan.preview {
@@ -209,7 +209,7 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 	if sg.urns[urn] {
 		invalid = true
 		// TODO[pulumi/pulumi-framework#19]: improve this error message!
-		sg.plan.Diag().Errorf(diag.GetDuplicateResourceURNError(urn), urn)
+		sg.plan.diag().Errorf(diag.GetDuplicateResourceURNError(urn), urn)
 	}
 	sg.urns[urn] = true
 
@@ -221,14 +221,14 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 	var old *resource.State
 	var hasOld bool
 	for _, urnOrAlias := range append([]resource.URN{urn}, goal.Aliases...) {
-		old, hasOld = sg.plan.Olds()[urnOrAlias]
+		old, hasOld = sg.plan.olds[urnOrAlias]
 		if hasOld {
 			oldInputs = old.Inputs
 			oldOutputs = old.Outputs
 			if urnOrAlias != urn {
 				if previousAliasURN, alreadyAliased := sg.aliased[urnOrAlias]; alreadyAliased {
 					invalid = true
-					sg.plan.Diag().Errorf(diag.GetDuplicateResourceAliasError(urn), urnOrAlias, urn, previousAliasURN)
+					sg.plan.diag().Errorf(diag.GetDuplicateResourceAliasError(urn), urnOrAlias, urn, previousAliasURN)
 				}
 				sg.aliased[urnOrAlias] = urn
 			}
@@ -725,7 +725,7 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt map[resource.URN]bool) ([]St
 	if allowedResourcesToDelete != nil {
 		filtered := []Step{}
 		for _, step := range dels {
-			if _, has := allowedResourcesToDelete[step.URN()]; has {
+			if _, has := allowedResourcesToDelete[step.Res().URN]; has {
 				filtered = append(filtered, step)
 			}
 		}
@@ -735,7 +735,7 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt map[resource.URN]bool) ([]St
 
 	deletingUnspecifiedTarget := false
 	for _, step := range dels {
-		urn := step.URN()
+		urn := step.Res().URN
 		if targetsOpt != nil && !targetsOpt[urn] && !sg.opts.TargetDependents {
 			d := diag.GetResourceWillBeDestroyedButWasNotSpecifiedInTargetList(urn)
 
@@ -744,7 +744,7 @@ func (sg *stepGenerator) GenerateDeletes(targetsOpt map[resource.URN]bool) ([]St
 			// re-running the operation.
 			//
 			// Mark that step generation entered an error state so that the entire app run fails.
-			sg.plan.Diag().Errorf(d, urn)
+			sg.plan.diag().Errorf(d, urn)
 			sg.sawError = true
 
 			deletingUnspecifiedTarget = true
@@ -814,7 +814,7 @@ func (sg *stepGenerator) determineAllowedResourcesToDeleteFromTargets(
 			}
 
 			if _, has := resourcesToDelete[res.Parent]; has {
-				sg.plan.Diag().Errorf(diag.GetCannotDeleteParentResourceWithoutAlsoDeletingChildError(res.Parent),
+				sg.plan.diag().Errorf(diag.GetCannotDeleteParentResourceWithoutAlsoDeletingChildError(res.Parent),
 					res.Parent, res.URN)
 				return nil, result.Bail()
 			}
@@ -1084,10 +1084,10 @@ func issueCheckErrors(plan *Plan, new *resource.State, urn resource.URN, failure
 	inputs := new.Inputs
 	for _, failure := range failures {
 		if failure.Property != "" {
-			plan.Diag().Errorf(diag.GetResourcePropertyInvalidValueError(urn),
+			plan.diag().Errorf(diag.GetResourcePropertyInvalidValueError(urn),
 				new.Type, urn.Name(), failure.Property, inputs[failure.Property], failure.Reason)
 		} else {
-			plan.Diag().Errorf(
+			plan.diag().Errorf(
 				diag.GetResourceInvalidError(urn), new.Type, urn.Name(), failure.Reason)
 		}
 	}
@@ -1150,12 +1150,12 @@ func (sg *stepGenerator) loadResourceProvider(
 	contract.Assert(provider != "")
 	ref, refErr := providers.ParseReference(provider)
 	if refErr != nil {
-		sg.plan.Diag().Errorf(diag.GetBadProviderError(urn), provider, urn, refErr)
+		sg.plan.diag().Errorf(diag.GetBadProviderError(urn), provider, urn, refErr)
 		return nil, result.Bail()
 	}
 	p, ok := sg.plan.GetProvider(ref)
 	if !ok {
-		sg.plan.Diag().Errorf(diag.GetUnknownProviderError(urn), provider, urn)
+		sg.plan.diag().Errorf(diag.GetUnknownProviderError(urn), provider, urn)
 		return nil, result.Bail()
 	}
 	return p, nil
@@ -1340,7 +1340,7 @@ func (sg *stepGenerator) AnalyzeResources() result.Result {
 				}
 			}
 			if urn == "" {
-				urn = resource.DefaultRootStackURN(sg.plan.Target().Name, sg.plan.source.Project())
+				urn = resource.DefaultRootStackURN(sg.plan.target.Name, sg.plan.source.Project())
 			}
 			sg.opts.Events.OnPolicyViolation(urn, d)
 		}


### PR DESCRIPTION
- Remove `Info` from `Source`. This method was not used.
- Remove `Stack` from `EvalSource`. This method was not used.
- Remove `Type` and `URN` from `Step`. These values are available via
  `Res().URN.Type()` and `Res().URN`, respectively. This removes the
  possibility of inconsistencies between the type, URN, and state of the
  resource associated with a `Step`.