### PR TITLE
[codegen] Don't log deprecation warnings in k8s SDKs

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -398,7 +398,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		}
 
 		fmt.Fprintf(w, "    public static get(name: string, id: pulumi.Input<pulumi.ID>, %sopts?: pulumi.CustomResourceOptions): %s {\n", stateParam, name)
-		if r.DeprecationMessage != "" {
+		if r.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 			fmt.Fprintf(w, "        pulumi.log.warn(\"%s is deprecated: %s\")\n", name, r.DeprecationMessage)
 		}
 		fmt.Fprintf(w, "        return new %s(name, %s{ ...opts, id: id });\n", name, stateRef)
@@ -499,7 +499,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 			fmt.Fprintf(w, "    constructor(name: string, argsOrState?: %s | %s, opts?: pulumi.CustomResourceOptions) {\n",
 				argsType, stateType)
 		}
-		if r.DeprecationMessage != "" {
+		if r.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 			fmt.Fprintf(w, "        pulumi.log.warn(\"%s is deprecated: %s\")\n", name, r.DeprecationMessage)
 		}
 		fmt.Fprintf(w, "        let inputs: pulumi.Inputs = {};\n")
@@ -652,7 +652,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) {
 		retty = title(name) + "Result"
 	}
 	fmt.Fprintf(w, "export function %s(%sopts?: pulumi.InvokeOptions): Promise<%s> {\n", name, argsig, retty)
-	if fun.DeprecationMessage != "" {
+	if fun.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 		fmt.Fprintf(w, "    pulumi.log.warn(\"%s is deprecated: %s\")\n", name, fun.DeprecationMessage)
 	}
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -427,7 +427,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		baseType = "pulumi.ProviderResource"
 	}
 
-	if !res.IsProvider && res.DeprecationMessage != "" {
+	if !res.IsProvider && res.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 		escaped := strings.ReplaceAll(res.DeprecationMessage, `"`, `\"`)
 		fmt.Fprintf(w, "warnings.warn(\"%s\", DeprecationWarning)\n\n", escaped)
 	}
@@ -463,7 +463,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		}
 	}
 
-	if res.DeprecationMessage != "" {
+	if res.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 		escaped := strings.ReplaceAll(res.DeprecationMessage, `"`, `\"`)
 		fmt.Fprintf(w, "    warnings.warn(\"%s\", DeprecationWarning)\n\n", escaped)
 	}
@@ -479,7 +479,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	// compatibility, we still emit them, but we don't emit documentation for them.
 	fmt.Fprintf(w, ", __props__=None, __name__=None, __opts__=None):\n")
 	mod.genInitDocstring(w, res)
-	if res.DeprecationMessage != "" {
+	if res.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 		fmt.Fprintf(w, "        pulumi.log.warn(\"%s is deprecated: %s\")\n", name, res.DeprecationMessage)
 	}
 	fmt.Fprintf(w, "        if __name__ is not None:\n")


### PR DESCRIPTION
The k8s SDK logs deprecations warnings as part of the
provider logic, and includes a flag to suppress these
warnings. Including them in the SDKs breaks this logic.

Related to https://github.com/pulumi/pulumi-kubernetes/issues/1150