### PR TITLE
add plugin download url metadata to package spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Add providerURL field to package definition
+  [#4947](https://github.com/pulumi/pulumi/pull/4947)
+
 - Go program gen: Improved handling for pulumi.Map types
-  [#491](https://github.com/pulumi/pulumi/pull/4914)
+  [#4914](https://github.com/pulumi/pulumi/pull/4914)
 
 - Go SDK: Input type interfaces should declare pointer type impls where appropriate
   [#4911](https://github.com/pulumi/pulumi/pull/4911)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-- Add providerURL field to package definition
+- Add pluginDownloadURL field to package definition
   [#4947](https://github.com/pulumi/pulumi/pull/4947)
 
 - Go program gen: Improved handling for pulumi.Map types

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1221,8 +1221,8 @@ type npmPackage struct {
 }
 
 type npmPulumiManifest struct {
-	Resource    bool   `json:"resource,omitempty"`
-	ProviderURL string `json:"providerURL,omitempty"`
+	Resource          bool   `json:"resource,omitempty"`
+	PluginDownloadURL string `json:"pluginDownloadURL,omitempty"`
 }
 
 func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
@@ -1254,8 +1254,8 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 		},
 		DevDependencies: devDependencies,
 		Pulumi: npmPulumiManifest{
-			Resource:    true,
-			ProviderURL: pkg.ProviderURL,
+			Resource:          true,
+			PluginDownloadURL: pkg.PluginDownloadURL,
 		},
 	}
 

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1221,7 +1221,8 @@ type npmPackage struct {
 }
 
 type npmPulumiManifest struct {
-	Resource bool `json:"resource,omitempty"`
+	Resource    bool   `json:"resource,omitempty"`
+	ProviderURL string `json:"providerURL,omitempty"`
 }
 
 func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
@@ -1253,7 +1254,8 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 		},
 		DevDependencies: devDependencies,
 		Pulumi: npmPulumiManifest{
-			Resource: true,
+			Resource:    true,
+			ProviderURL: pkg.ProviderURL,
 		},
 	}
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -774,7 +774,11 @@ func genPackageMetadata(tool string, pkg *schema.Package, requires map[string]st
 	fmt.Fprintf(w, "    def run(self):\n")
 	fmt.Fprintf(w, "        install.run(self)\n")
 	fmt.Fprintf(w, "        try:\n")
-	fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}'])\n", pkg.Name)
+	if pkg.ProviderURL == "" {
+		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}'])\n", pkg.Name)
+	} else {
+		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}', '--server', '%s'])\n", pkg.Name, pkg.ProviderURL)
+	}
 	fmt.Fprintf(w, "        except OSError as error:\n")
 	fmt.Fprintf(w, "            if error.errno == errno.ENOENT:\n")
 	fmt.Fprintf(w, "                print(\"\"\"\n")

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -774,10 +774,10 @@ func genPackageMetadata(tool string, pkg *schema.Package, requires map[string]st
 	fmt.Fprintf(w, "    def run(self):\n")
 	fmt.Fprintf(w, "        install.run(self)\n")
 	fmt.Fprintf(w, "        try:\n")
-	if pkg.ProviderURL == "" {
+	if pkg.PluginDownloadURL == "" {
 		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}'])\n", pkg.Name)
 	} else {
-		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}', '--server', '%s'])\n", pkg.Name, pkg.ProviderURL)
+		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}', '--server', '%s'])\n", pkg.Name, pkg.PluginDownloadURL)
 	}
 	fmt.Fprintf(w, "        except OSError as error:\n")
 	fmt.Fprintf(w, "            if error.errno == errno.ENOENT:\n")

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -684,7 +684,7 @@ type PackageSpec struct {
 	// LogoURL is the URL for the package's logo, if any.
 	LogoURL string `json:"logoUrl,omitempty"`
 	// PluginDownloadURL is the URL to use to acquire the provider plugin binary, if any.
-	PluginDownloadURLURL string `json:"pluginDownloadURL,omitempty"`
+	PluginDownloadURL string `json:"pluginDownloadURL,omitempty"`
 
 	// Meta contains information for the importer about this package.
 	Meta *MetadataSpec `json:"meta,omitempty"`

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -303,6 +303,8 @@ type Package struct {
 	Repository string
 	// LogoURL is the URL for the package's logo, if any.
 	LogoURL string
+	// ProviderURL is the URL to use to acquire the provider binary, if any.
+	ProviderURL string
 
 	// Types is the list of non-resource types defined by the package.
 	Types []Type
@@ -681,6 +683,8 @@ type PackageSpec struct {
 	Repository string `json:"repository,omitempty"`
 	// LogoURL is the URL for the package's logo, if any.
 	LogoURL string `json:"logoUrl,omitempty"`
+	// ProviderURL is the URL to use to acquire the provider binary, if any.
+	ProviderURL string `json:"providerURL,omitempty"`
 
 	// Meta contains information for the importer about this package.
 	Meta *MetadataSpec `json:"meta,omitempty"`
@@ -783,6 +787,7 @@ func ImportSpec(spec PackageSpec, languages map[string]Language) (*Package, erro
 		License:      spec.License,
 		Attribution:  spec.Attribution,
 		Repository:   spec.Repository,
+		ProviderURL:  spec.ProviderURL,
 		Config:       config,
 		Types:        typeList,
 		Provider:     provider,

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -303,8 +303,8 @@ type Package struct {
 	Repository string
 	// LogoURL is the URL for the package's logo, if any.
 	LogoURL string
-	// ProviderURL is the URL to use to acquire the provider binary, if any.
-	ProviderURL string
+	// PluginDownloadURL is the URL to use to acquire the provider plugin binary, if any.
+	PluginDownloadURL string
 
 	// Types is the list of non-resource types defined by the package.
 	Types []Type
@@ -683,8 +683,8 @@ type PackageSpec struct {
 	Repository string `json:"repository,omitempty"`
 	// LogoURL is the URL for the package's logo, if any.
 	LogoURL string `json:"logoUrl,omitempty"`
-	// ProviderURL is the URL to use to acquire the provider binary, if any.
-	ProviderURL string `json:"providerURL,omitempty"`
+	// PluginDownloadURL is the URL to use to acquire the provider plugin binary, if any.
+	PluginDownloadURLURL string `json:"pluginDownloadURL,omitempty"`
 
 	// Meta contains information for the importer about this package.
 	Meta *MetadataSpec `json:"meta,omitempty"`
@@ -778,22 +778,22 @@ func ImportSpec(spec PackageSpec, languages map[string]Language) (*Package, erro
 	}
 
 	pkg := &Package{
-		moduleFormat: moduleFormatRegexp,
-		Name:         spec.Name,
-		Version:      version,
-		Description:  spec.Description,
-		Keywords:     spec.Keywords,
-		Homepage:     spec.Homepage,
-		License:      spec.License,
-		Attribution:  spec.Attribution,
-		Repository:   spec.Repository,
-		ProviderURL:  spec.ProviderURL,
-		Config:       config,
-		Types:        typeList,
-		Provider:     provider,
-		Resources:    resources,
-		Functions:    functions,
-		Language:     language,
+		moduleFormat:      moduleFormatRegexp,
+		Name:              spec.Name,
+		Version:           version,
+		Description:       spec.Description,
+		Keywords:          spec.Keywords,
+		Homepage:          spec.Homepage,
+		License:           spec.License,
+		Attribution:       spec.Attribution,
+		Repository:        spec.Repository,
+		PluginDownloadURL: spec.PluginDownloadURL,
+		Config:            config,
+		Types:             typeList,
+		Provider:          provider,
+		Resources:         resources,
+		Functions:         functions,
+		Language:          language,
 	}
 	if err := pkg.ImportLanguages(languages); err != nil {
 		return nil, err


### PR DESCRIPTION
This optional field allows providers and plugins to specify a URL to download a provider plugin from. This will allow community plugins to use automatic plugin acquisition

Currently this is just a noop, the same changes need to be passed through to `pulumi-terraform-bridge` as well.