### PR TITLE
Change how submodules are imported to work with Intellisense

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -288,7 +288,7 @@ func (mod *modContext) genInit(exports []string) string {
 
 		fmt.Fprintf(w, "\n# Make subpackages available:\n")
 		fmt.Fprintf(w, "from . import (\n")
-		for i, mod := range mod.children {
+		for _, mod := range mod.children {
 			child := mod.mod
 			if mod.compatibility == kubernetes20 {
 				// Extract version suffix from child modules. Nested versions will have their own __init__.py file.
@@ -297,12 +297,11 @@ func (mod *modContext) genInit(exports []string) string {
 					child = child[match[2]:match[3]]
 				}
 			}
-			if i > 0 {
-				fmt.Fprintf(w, ",\n")
+			if child != "config" {
+				fmt.Fprintf(w, "    %s,\n", PyName(child))
 			}
-			fmt.Fprintf(w, "    %s", PyName(child))
 		}
-		fmt.Fprintf(w, ",\n)\n")
+		fmt.Fprintf(w, ")\n")
 	}
 
 	return w.String()

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -248,13 +248,7 @@ func (mod *modContext) gen(fs fs) error {
 }
 
 func (mod *modContext) submodulesExist() bool {
-	if len(mod.children) <= 0 {
-		return false
-	}
-	if len(mod.children) == 1 && mod.children[0].mod == "config" {
-		return false
-	}
-	return true
+	return len(mod.children) > 0
 }
 
 // genInit emits an __init__.py module, optionally re-exporting other members or submodules.
@@ -297,9 +291,7 @@ func (mod *modContext) genInit(exports []string) string {
 					child = child[match[2]:match[3]]
 				}
 			}
-			if child != "config" {
-				fmt.Fprintf(w, "    %s,\n", PyName(child))
-			}
+			fmt.Fprintf(w, "    %s,\n", PyName(child))
 		}
 		fmt.Fprintf(w, ")\n")
 	}

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -18,8 +18,6 @@ providers and libraries in the Pulumi ecosystem use to create and manage
 resources.
 """
 
-import importlib
-
 # Make all module members inside of this package available as package members.
 from .asset import (
     Asset,
@@ -86,6 +84,4 @@ from .stack_reference import (
     StackReference,
 )
 
-# Make subpackages available.
-for pkg in ['runtime', 'dynamic', 'policy']:
-    importlib.import_module(f'{__name__}.{pkg}')
+from . import runtime, dynamic, policy


### PR DESCRIPTION
IntelliJ/PyCharm is unable to parse the submodules imported using `importlib.import_module()` for autocomplete.
Fixes: https://github.com/pulumi/pulumi/issues/4931

Before:
<img width="575" alt="Screen Shot 2020-07-01 at 9 23 15 PM" src="https://user-images.githubusercontent.com/24326455/86316782-8533f800-bbe2-11ea-9248-e840d1eb4e90.png">
<img width="667" alt="Screen Shot 2020-07-01 at 9 34 57 PM" src="https://user-images.githubusercontent.com/24326455/86316872-cf1cde00-bbe2-11ea-8e05-9818ad63d25f.png">

After:
<img width="533" alt="Screen Shot 2020-07-01 at 9 23 58 PM" src="https://user-images.githubusercontent.com/24326455/86316790-8c5b0600-bbe2-11ea-8a66-e2d30c93f862.png">
<img width="652" alt="Screen Shot 2020-07-01 at 9 34 27 PM" src="https://user-images.githubusercontent.com/24326455/86316880-d2b06500-bbe2-11ea-9447-42d83f7a92cd.png">


