### PR TITLE
[docker/actions] unset GOOGLE_CREDENTIALS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGELOG
 - Go SDK: Input type interfaces should declare pointer type impls where appropriate
   [#4911](https://github.com/pulumi/pulumi/pull/4911)
 
+- Fixes issue where base64-encoded GOOGLE_CREDENTIALS causes problems with other commands
+  [#4972](https://github.com/pulumi/pulumi/pull/4972)
+
 ## 2.5.0 (2020-06-25)
 
 - Go program gen: prompt array conversion, unused range vars, id handling

--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -82,6 +82,8 @@ if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
     # Check if GOOGLE_CREDENTIALS is base64 encoded 
     if [[ $GOOGLE_CREDENTIALS =~ ^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$ ]]; then
         echo "$GOOGLE_CREDENTIALS"|base64 -d > $GOOGLE_APPLICATION_CREDENTIALS
+        # unset for other gcloud commands using this variable.
+        unset GOOGLE_CREDENTIALS
     else
         echo "$GOOGLE_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
     fi


### PR DESCRIPTION
Hello 👋

This PR will fix issue where base64 encoded GOOGLE_CREDENTIALS causes commands/invocations to fail.

Example issue:
```
Error: invocation of gcp:container/getRegistryImage:getRegistryImage returned an error:
could not validate provider configuration:

1 error occurred:
* JSON credentials in "***" are not valid: invalid character 'e' looking for beginning of value
```

I've pushed these changes to this: https://hub.docker.com/r/cobraz/pulumi-actions-bugfixing
Tested on my own Github Actions setup.

Thanks for Pulumi ❤️