### PR TITLE
[hcl2] Fix tokenless body item printing.

### DIFF
--- a/pkg/codegen/hcl2/model/attribute.go
+++ b/pkg/codegen/hcl2/model/attribute.go
@@ -49,6 +49,14 @@ func (a *Attribute) HasTrailingTrivia() bool {
 	return a.Value.HasTrailingTrivia()
 }
 
+func (a *Attribute) GetLeadingTrivia() syntax.TriviaList {
+	return a.Tokens.GetName(a.Name).LeadingTrivia
+}
+
+func (a *Attribute) GetTrailingTrivia() syntax.TriviaList {
+	return a.Value.GetTrailingTrivia()
+}
+
 func (a *Attribute) Format(f fmt.State, c rune) {
 	a.print(f, &printer{})
 }

--- a/pkg/codegen/hcl2/model/block.go
+++ b/pkg/codegen/hcl2/model/block.go
@@ -52,6 +52,14 @@ func (b *Block) HasTrailingTrivia() bool {
 	return b.Tokens != nil
 }
 
+func (b *Block) GetLeadingTrivia() syntax.TriviaList {
+	return b.Tokens.GetType(b.Type).LeadingTrivia
+}
+
+func (b *Block) GetTrailingTrivia() syntax.TriviaList {
+	return b.Tokens.GetCloseBrace().TrailingTrivia
+}
+
 func (b *Block) Format(f fmt.State, c rune) {
 	b.print(f, &printer{})
 }
@@ -94,9 +102,6 @@ func (b *Block) print(w io.Writer, p *printer) {
 	p.indented(func() {
 		b.Body.print(w, p)
 	})
-	if !b.Body.HasTrailingTrivia() {
-		p.fprintf(w, "\n")
-	}
 
 	if b.Tokens != nil {
 		p.fprintf(w, "%v", b.Tokens.GetCloseBrace())

--- a/pkg/codegen/hcl2/model/body.go
+++ b/pkg/codegen/hcl2/model/body.go
@@ -61,6 +61,23 @@ func (b *Body) HasTrailingTrivia() bool {
 	return len(b.Items) > 0 && b.Items[len(b.Items)-1].HasTrailingTrivia()
 }
 
+func (b *Body) GetLeadingTrivia() syntax.TriviaList {
+	if len(b.Items) == 0 {
+		return nil
+	}
+	return b.Items[0].GetLeadingTrivia()
+}
+
+func (b *Body) GetTrailingTrivia() syntax.TriviaList {
+	if eof := b.Tokens.GetEndOfFile(); eof != nil {
+		return eof.TrailingTrivia
+	}
+	if len(b.Items) == 0 {
+		return nil
+	}
+	return b.Items[len(b.Items)-1].GetTrailingTrivia()
+}
+
 func (b *Body) Format(f fmt.State, c rune) {
 	b.print(f, &printer{})
 }
@@ -69,6 +86,9 @@ func (b *Body) print(w io.Writer, p *printer) {
 	// Print the items, separated by newlines.
 	for _, item := range b.Items {
 		p.fprintf(w, "% v", item)
+		if !item.GetTrailingTrivia().EndsOnNewLine() {
+			p.fprintf(w, "\n")
+		}
 	}
 
 	// If the body has an end-of-file token, print it.

--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -1556,6 +1556,7 @@ func (x *ObjectConsExpression) print(w io.Writer, p *printer) {
 	p.fprintf(w, "%(%v", x.Tokens.GetParentheses(), x.Tokens.GetOpenBrace(len(x.Items)))
 
 	// Print the items.
+	trailingNewline := false
 	p.indented(func() {
 		items := x.Tokens.GetItems(len(x.Items))
 		for i, item := range x.Items {
@@ -1568,9 +1569,15 @@ func (x *ObjectConsExpression) print(w io.Writer, p *printer) {
 				p.fprintf(w, "\n%s", p.indent)
 			}
 			p.fprintf(w, "%v% v% v", item.Key, tokens.Equals, item.Value)
+			if item.Value.GetTrailingTrivia().EndsOnNewLine() {
+				trailingNewline = true
+			}
 
 			if tokens.Comma != nil {
 				p.fprintf(w, "%v", tokens.Comma)
+				if tokens.Comma.TrailingTrivia.EndsOnNewLine() {
+					trailingNewline = true
+				}
 			}
 		}
 
@@ -1585,7 +1592,11 @@ func (x *ObjectConsExpression) print(w io.Writer, p *printer) {
 	})
 
 	if x.Tokens != nil {
-		p.fprintf(w, "%v%)", x.Tokens.CloseBrace, x.Tokens.Parentheses)
+		pre := ""
+		if !trailingNewline {
+			pre = "\n" + p.indent
+		}
+		p.fprintf(w, "%s%v%)", pre, x.Tokens.CloseBrace, x.Tokens.Parentheses)
 	} else {
 		p.fprintf(w, "\n%s}", p.indent)
 	}

--- a/pkg/codegen/hcl2/model/print_test.go
+++ b/pkg/codegen/hcl2/model/print_test.go
@@ -1,0 +1,26 @@
+package model
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+func TestPrintNoTokens(t *testing.T) {
+	b := &Block{
+		Type: "block", Body: &Body{
+			Items: []BodyItem{
+				&Attribute{
+					Name: "attribute",
+					Value: &LiteralValueExpression{
+						Value: cty.True,
+					},
+				},
+			},
+		},
+	}
+	expected := "block {\n    attribute = true\n}"
+	assert.Equal(t, expected, fmt.Sprintf("%v", b))
+}

--- a/pkg/codegen/hcl2/model/printer.go
+++ b/pkg/codegen/hcl2/model/printer.go
@@ -19,6 +19,8 @@ import (
 	"io"
 
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
 )
 
 type printable interface {
@@ -28,6 +30,10 @@ type printable interface {
 	HasLeadingTrivia() bool
 	// HasTrailingTrivia returns true if the value has associated trailing trivia.
 	HasTrailingTrivia() bool
+	// GetLeadingTrivia returns the leading trivia for this value, if any.
+	GetLeadingTrivia() syntax.TriviaList
+	// GetTrailingTrivia returns the trailing trivia for this value, if any.
+	GetTrailingTrivia() syntax.TriviaList
 }
 
 type printer struct {
@@ -50,7 +56,7 @@ func (p *printer) format(f fmt.State, c rune, pp printable) {
 	if f.Flag(' ') && !pp.HasLeadingTrivia() {
 		switch pp.(type) {
 		case BodyItem:
-			p.fprintf(f, "\n%s", p.indent)
+			p.fprintf(f, "%s", p.indent)
 		case Expression:
 			p.fprintf(f, " ")
 		}


### PR DESCRIPTION
In general, each item in an HCL2 body must be followed by a trailing
newline. The printer did not properly insert these newlines for body
items without any associated tokens/trivia, or with trivia that did not
include a trailing new line.

Related to #1635.