### PR TITLE
[codegen/{hcl2,schema}] Abstract package loading.

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -30,7 +30,7 @@ import (
 
 type bindOptions struct {
 	allowMissingVariables bool
-	host                  plugin.Host
+	loader                schema.Loader
 	packageCache          *PackageCache
 }
 
@@ -59,8 +59,12 @@ func AllowMissingVariables(options *bindOptions) {
 }
 
 func PluginHost(host plugin.Host) BindOption {
+	return Loader(schema.NewPluginLoader(host))
+}
+
+func Loader(loader schema.Loader) BindOption {
 	return func(options *bindOptions) {
-		options.host = host
+		options.loader = loader
 	}
 }
 
@@ -78,7 +82,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		o(&options)
 	}
 
-	if options.host == nil {
+	if options.loader == nil {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return nil, nil, err
@@ -87,7 +91,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		if err != nil {
 			return nil, nil, err
 		}
-		options.host = ctx.Host
+		options.loader = schema.NewPluginLoader(ctx.Host)
 
 		defer contract.IgnoreClose(ctx)
 	}

--- a/pkg/codegen/hcl2/binder_schema_test.go
+++ b/pkg/codegen/hcl2/binder_schema_test.go
@@ -4,14 +4,15 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v2/codegen/internal/test"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 )
 
 func BenchmarkLoadPackage(b *testing.B) {
-	host := test.NewHost(testdataPath)
+	loader := schema.NewPluginLoader(test.NewHost(testdataPath))
 
 	for n := 0; n < b.N; n++ {
-		_, err := NewPackageCache().loadPackageSchema(host, "aws")
+		_, err := NewPackageCache().loadPackageSchema(loader, "aws")
 		contract.AssertNoError(err)
 	}
 }

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -1,0 +1,79 @@
+package schema
+
+import (
+	"sync"
+
+	"github.com/blang/semver"
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
+)
+
+type Loader interface {
+	LoadPackage(pkg string, version *semver.Version) (*Package, error)
+}
+
+type pluginLoader struct {
+	m sync.RWMutex
+
+	host    plugin.Host
+	entries map[string]*Package
+}
+
+func NewPluginLoader(host plugin.Host) Loader {
+	return &pluginLoader{
+		host:    host,
+		entries: map[string]*Package{},
+	}
+}
+
+func (l *pluginLoader) getPackage(key string) (*Package, bool) {
+	l.m.RLock()
+	defer l.m.RUnlock()
+
+	p, ok := l.entries[key]
+	return p, ok
+}
+
+func (l *pluginLoader) LoadPackage(pkg string, version *semver.Version) (*Package, error) {
+	key := pkg + "@"
+	if version != nil {
+		key += version.String()
+	}
+
+	if p, ok := l.getPackage(key); ok {
+		return p, nil
+	}
+
+	provider, err := l.host.Provider(tokens.Package(pkg), version)
+	if err != nil {
+		return nil, err
+	}
+
+	schemaFormatVersion := 0
+	schemaBytes, err := provider.GetSchema(schemaFormatVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	var spec PackageSpec
+	if err := jsoniter.Unmarshal(schemaBytes, &spec); err != nil {
+		return nil, err
+	}
+
+	p, err := ImportSpec(spec, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	l.m.Lock()
+	defer l.m.Unlock()
+
+	if p, ok := l.entries[pkg]; ok {
+		return p, nil
+	}
+	l.entries[pkg] = p
+
+	return p, nil
+}

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -316,6 +316,9 @@ type Package struct {
 	Functions []*Function
 	// Language specifies additional language-specific data about the package.
 	Language map[string]interface{}
+
+	resourceTable map[string]*Resource
+	functionTable map[string]*Function
 }
 
 // Language provides hooks for importing language-specific metadata in a package.
@@ -539,6 +542,16 @@ func (pkg *Package) TokenToModule(tok string) string {
 	}
 }
 
+func (pkg *Package) GetResource(token string) (*Resource, bool) {
+	r, ok := pkg.resourceTable[token]
+	return r, ok
+}
+
+func (pkg *Package) GetFunction(token string) (*Function, bool) {
+	f, ok := pkg.functionTable[token]
+	return f, ok
+}
+
 // TypeSpec is the serializable form of a reference to a type.
 type TypeSpec struct {
 	// Type is the primitive or composite type, if any. May be "bool", "integer", "number", "string", "array", or
@@ -736,12 +749,12 @@ func ImportSpec(spec PackageSpec, languages map[string]Language) (*Package, erro
 		return nil, errors.Wrap(err, "binding provider")
 	}
 
-	resources, err := bindResources(spec.Resources, types)
+	resources, resourceTable, err := bindResources(spec.Resources, types)
 	if err != nil {
 		return nil, errors.Wrap(err, "binding resources")
 	}
 
-	functions, err := bindFunctions(spec.Functions, types)
+	functions, functionTable, err := bindFunctions(spec.Functions, types)
 	if err != nil {
 		return nil, errors.Wrap(err, "binding functions")
 	}
@@ -774,21 +787,23 @@ func ImportSpec(spec PackageSpec, languages map[string]Language) (*Package, erro
 	}
 
 	pkg := &Package{
-		moduleFormat: moduleFormatRegexp,
-		Name:         spec.Name,
-		Version:      version,
-		Description:  spec.Description,
-		Keywords:     spec.Keywords,
-		Homepage:     spec.Homepage,
-		License:      spec.License,
-		Attribution:  spec.Attribution,
-		Repository:   spec.Repository,
-		Config:       config,
-		Types:        typeList,
-		Provider:     provider,
-		Resources:    resources,
-		Functions:    functions,
-		Language:     language,
+		moduleFormat:  moduleFormatRegexp,
+		Name:          spec.Name,
+		Version:       version,
+		Description:   spec.Description,
+		Keywords:      spec.Keywords,
+		Homepage:      spec.Homepage,
+		License:       spec.License,
+		Attribution:   spec.Attribution,
+		Repository:    spec.Repository,
+		Config:        config,
+		Types:         typeList,
+		Provider:      provider,
+		Resources:     resources,
+		Functions:     functions,
+		Language:      language,
+		resourceTable: resourceTable,
+		functionTable: functionTable,
 	}
 	if err := pkg.ImportLanguages(languages); err != nil {
 		return nil, err
@@ -1186,13 +1201,15 @@ func bindProvider(pkgName string, spec ResourceSpec, types *types) (*Resource, e
 	return res, nil
 }
 
-func bindResources(specs map[string]ResourceSpec, types *types) ([]*Resource, error) {
+func bindResources(specs map[string]ResourceSpec, types *types) ([]*Resource, map[string]*Resource, error) {
+	resourceTable := map[string]*Resource{}
 	var resources []*Resource
 	for token, spec := range specs {
 		res, err := bindResource(token, spec, types)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error binding resource %v", token)
+			return nil, nil, errors.Wrapf(err, "error binding resource %v", token)
 		}
+		resourceTable[token] = res
 		resources = append(resources, res)
 	}
 
@@ -1200,7 +1217,7 @@ func bindResources(specs map[string]ResourceSpec, types *types) ([]*Resource, er
 		return resources[i].Token < resources[j].Token
 	})
 
-	return resources, nil
+	return resources, resourceTable, nil
 }
 
 func bindFunction(token string, spec FunctionSpec, types *types) (*Function, error) {
@@ -1237,13 +1254,15 @@ func bindFunction(token string, spec FunctionSpec, types *types) (*Function, err
 	}, nil
 }
 
-func bindFunctions(specs map[string]FunctionSpec, types *types) ([]*Function, error) {
+func bindFunctions(specs map[string]FunctionSpec, types *types) ([]*Function, map[string]*Function, error) {
+	functionTable := map[string]*Function{}
 	var functions []*Function
 	for token, spec := range specs {
 		f, err := bindFunction(token, spec, types)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error binding function %v", token)
+			return nil, nil, errors.Wrapf(err, "error binding function %v", token)
 		}
+		functionTable[token] = f
 		functions = append(functions, f)
 	}
 
@@ -1251,5 +1270,5 @@ func bindFunctions(specs map[string]FunctionSpec, types *types) ([]*Function, er
 		return functions[i].Token < functions[j].Token
 	})
 
-	return functions, nil
+	return functions, functionTable, nil
 }


### PR DESCRIPTION
Instead of requiring a plugin host for package loading in the HCL2
binder, define a much narrower interface that exposes the ability to
fetch the schema for a package at a specific version. This interface is
defined in the schema package, which also exposes a caching loader that
is backed by provider plugins.

These changes also add some convenience methods to `*schema.Package` for
fast access to particular resources and functions.

Related to #1635.