### PR TITLE
Implement `PropertyPath.Add`.

### DIFF
--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -133,6 +133,14 @@ func TestPropertyPath(t *testing.T) {
 			u, ok := parsed.Get(value)
 			assert.True(t, ok)
 			assert.Equal(t, v, u)
+
+			vv := PropertyValue{}
+			vv, ok = parsed.Add(vv, v)
+			assert.True(t, ok)
+
+			u, ok = parsed.Get(vv)
+			assert.True(t, ok)
+			assert.Equal(t, v, u)
 		})
 	}
 


### PR DESCRIPTION
This function adds a property value to another property at a given path,
creating containing properties as required. If the property cannot be
added because of a mismatch between the value types required by the path
and the values present in the destination, the add will fail. If a value
already exists at the given path, the add will succeed.