### PR TITLE
Remove known_types decorators

### DIFF
--- a/sdk/python/lib/pulumi/asset.py
+++ b/sdk/python/lib/pulumi/asset.py
@@ -31,14 +31,14 @@ class Asset:
 
 @known_types.file_asset
 class FileAsset(Asset):
-    path: str
-
     """
     A FileAsset is a kind of asset produced from a given path to a file on
     the local filesysetm.
     """
+    path: str
 
     def __init__(self, path: Union[str, PathLike]) -> None:
+
         if not isinstance(path, (str, PathLike)):
             raise TypeError("FileAsset path must be a string or os.PathLike")
         self.path = fspath(path)
@@ -46,11 +46,11 @@ class FileAsset(Asset):
 
 @known_types.string_asset
 class StringAsset(Asset):
-    text: str
-
     """
     A StringAsset is a kind of asset produced from an in-memory UTF-8 encoded string.
     """
+    text: str
+
     def __init__(self, text: str) -> None:
         if not isinstance(text, str):
             raise TypeError("StringAsset data must be a string")
@@ -59,14 +59,14 @@ class StringAsset(Asset):
 
 @known_types.remote_asset
 class RemoteAsset(Asset):
-    uri: str
-
     """
     A RemoteAsset is a kind of asset produced from a given URI string. The URI's scheme
     dictates the protocol for fetching contents: "file://" specifies a local file, "http://"
     and "https://" specify HTTP and HTTPS, respectively. Note that specific providers may recognize
     alternative schemes; this is merely the base-most set that all providers support.
     """
+    uri: str
+
     def __init__(self, uri: str) -> None:
         if not isinstance(uri, str):
             raise TypeError("RemoteAsset URI must be a string")
@@ -76,17 +76,17 @@ class RemoteAsset(Asset):
 @known_types.archive
 class Archive:
     """
-    Asset represents a collection of named assets.
+    Archive represents a collection of named assets.
     """
 
 
 @known_types.asset_archive
 class AssetArchive(Archive):
-    assets: Dict[str, Union[Asset, Archive]]
-
     """
     An AssetArchive is an archive created from an in-memory collection of named assets or other archives.
     """
+    assets: Dict[str, Union[Asset, Archive]]
+
     def __init__(self, assets: Dict[str, Union[Asset, Archive]]) -> None:
         if not isinstance(assets, dict):
             raise TypeError("AssetArchive assets must be a dictionary")
@@ -100,12 +100,12 @@ class AssetArchive(Archive):
 
 @known_types.file_archive
 class FileArchive(Archive):
-    path: str
-
     """
     A FileArchive is a file-based archive, or collection of file-based assets.  This can be
     a raw directory or a single archive file in one of the supported formats (.tar, .tar.gz, or .zip).
     """
+    path: str
+
     def __init__(self, path: str) -> None:
         if not isinstance(path, str):
             raise TypeError("FileArchive path must be a string")
@@ -114,13 +114,13 @@ class FileArchive(Archive):
 
 @known_types.remote_archive
 class RemoteArchive(Archive):
-    uri: str
-
     """
     A RemoteArchive is a file-based archive fetched from a remote location.  The URI's scheme dictates
     the protocol for fetching contents: "file://" specifies a local file, "http://" and "https://"
     specify HTTP and HTTPS, respectively, and specific providers may recognize custom schemes.
     """
+    uri: str
+
     def __init__(self, uri: str) -> None:
         if not isinstance(uri, str):
             raise TypeError("RemoteArchive URI must be a string")

--- a/sdk/python/lib/pulumi/asset.py
+++ b/sdk/python/lib/pulumi/asset.py
@@ -18,10 +18,7 @@ Assets are the Pulumi notion of data blobs that can be passed to resources.
 from os import PathLike, fspath
 from typing import Dict, Union
 
-from .runtime import known_types
 
-
-@known_types.asset
 class Asset:
     """
     Asset represents a single blob of text or data that is managed as a first
@@ -29,11 +26,10 @@ class Asset:
     """
 
 
-@known_types.file_asset
 class FileAsset(Asset):
     """
     A FileAsset is a kind of asset produced from a given path to a file on
-    the local filesysetm.
+    the local filesystem.
     """
     path: str
 
@@ -44,7 +40,6 @@ class FileAsset(Asset):
         self.path = fspath(path)
 
 
-@known_types.string_asset
 class StringAsset(Asset):
     """
     A StringAsset is a kind of asset produced from an in-memory UTF-8 encoded string.
@@ -57,7 +52,6 @@ class StringAsset(Asset):
         self.text = text
 
 
-@known_types.remote_asset
 class RemoteAsset(Asset):
     """
     A RemoteAsset is a kind of asset produced from a given URI string. The URI's scheme
@@ -73,14 +67,12 @@ class RemoteAsset(Asset):
         self.uri = uri
 
 
-@known_types.archive
 class Archive:
     """
     Archive represents a collection of named assets.
     """
 
 
-@known_types.asset_archive
 class AssetArchive(Archive):
     """
     An AssetArchive is an archive created from an in-memory collection of named assets or other archives.
@@ -98,7 +90,6 @@ class AssetArchive(Archive):
         self.assets = assets
 
 
-@known_types.file_archive
 class FileArchive(Archive):
     """
     A FileArchive is a file-based archive, or collection of file-based assets.  This can be
@@ -112,7 +103,6 @@ class FileArchive(Archive):
         self.path = path
 
 
-@known_types.remote_archive
 class RemoteArchive(Archive):
     """
     A RemoteArchive is a file-based archive fetched from a remote location.  The URI's scheme dictates

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -30,7 +30,6 @@ from typing import (
 )
 
 from . import runtime
-from .runtime import known_types
 from .runtime import rpc
 
 if TYPE_CHECKING:
@@ -43,7 +42,6 @@ Input = Union[T, Awaitable[T], 'Output[T]']
 Inputs = Mapping[str, Input[Any]]
 
 
-@known_types.output
 class Output(Generic[T]):
     """
     Output helps encode the relationship between Resources in a Pulumi application. Specifically an
@@ -371,7 +369,6 @@ class Output(Generic[T]):
         return Output.all(*transformed_items).apply("".join) # type: ignore
 
 
-@known_types.unknown
 class Unknown:
     """
     Unknown represents a value that is unknown.

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -221,7 +221,6 @@ class Output(Generic[T]):
         """
         return self.apply(lambda v: UNKNOWN if isinstance(v, Unknown) else getattr(v, item), True)
 
-
     def __getitem__(self, key: Any) -> 'Output[Any]':
         """
         Syntax sugar for looking up attributes dynamically off of outputs.
@@ -377,10 +376,12 @@ class Unknown:
     def __init__(self):
         pass
 
+
 UNKNOWN = Unknown()
 """
 UNKNOWN is the singleton unknown value.
 """
+
 
 def contains_unknowns(val: Any) -> bool:
     return rpc.contains_unknowns(val)

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -17,6 +17,7 @@ from typing import Optional, List, Any, Mapping, Union, Callable, TYPE_CHECKING,
 
 import copy
 
+from .runtime import known_types
 from .runtime.resource import _register_resource, register_resource_outputs, _read_resource
 from .runtime.settings import get_root_resource
 
@@ -881,9 +882,8 @@ def export(name: str, value: Any):
     :param str name: The name to assign to this output.
     :param Any value: The value of this output.
     """
-    from .runtime.stack import Stack
     res = cast('Stack', get_root_resource())
-    if isinstance(res, Stack):
+    if known_types.is_stack(res):
         res.output(name, value)
     else:
         raise Exception("Failed to export output. Root resource is not an instance of 'Stack'")

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -25,6 +25,7 @@ from .metadata import get_project, get_stack
 
 if TYPE_CHECKING:
     from .output import Input, Inputs, Output
+    from .runtime.stack import Stack
 
 
 class CustomTimeouts:
@@ -76,7 +77,7 @@ def inherited_child_alias(
 #   * parentAliasName: "app"
 #   * aliasName: "app-function"
 #   * childAlias: "urn:pulumi:stackname::projectname::aws:s3/bucket:Bucket::app-function"
-    from . import Output
+    from . import Output  # pylint: disable=import-outside-toplevel
     alias_name = Output.from_input(child_name)
     if child_name.startswith(parent_name):
         alias_name = Output.from_input(parent_alias).apply(
@@ -159,7 +160,7 @@ class Alias:
     """
 
     # Ignoring type errors associated with the ellipsis constant being assigned to a string value.
-    # We use it as a internal sentinal value, and don't need to expose this in the user facing type system.
+    # We use it as a internal sentinel value, and don't need to expose this in the user facing type system.
     # https://docs.python.org/3/library/constants.html#Ellipsis
     def __init__(self,
                  name: Optional[str] = ..., # type: ignore
@@ -183,7 +184,7 @@ def collapse_alias_to_urn(
     """
     collapse_alias_to_urn turns an Alias into a URN given a set of default data
     """
-    from . import Output
+    from . import Output  # pylint: disable=import-outside-toplevel
 
     def collapse_alias_to_urn_worker(inner: Union[Alias, str]) -> 'Output[str]':
         if isinstance(inner, str):
@@ -205,6 +206,7 @@ def collapse_alias_to_urn(
 
     inputAlias: 'Output[Union[Alias, str]]' = Output.from_input(alias)
     return inputAlias.apply(collapse_alias_to_urn_worker)
+
 
 class ResourceTransformationArgs:
     """
@@ -248,6 +250,7 @@ class ResourceTransformationArgs:
         self.props = props
         self.opts = opts
 
+
 class ResourceTransformationResult:
     """
     ResourceTransformationResult is the result that must be returned by a resource transformation
@@ -271,6 +274,7 @@ class ResourceTransformationResult:
         self.props = props
         self.opts = opts
 
+
 ResourceTransformation = Callable[[ResourceTransformationArgs], Optional[ResourceTransformationResult]]
 """
 ResourceTransformation is the callback signature for the `transformations` resource option.  A
@@ -280,6 +284,7 @@ actually being created.  The effect will be as though those props and opts were 
 of the original call to the `Resource` constructor.  If the transformation returns undefined,
 this indicates that the resource will not be transformed.
 """
+
 
 class ResourceOptions:
     """
@@ -455,7 +460,7 @@ class ResourceOptions:
             values from each options object. Both original collections in each options object will
             be unchanged.
 
-        2. Simple scaler values from `opts2` (i.e. strings, numbers, bools) will replace the values
+        2. Simple scalar values from `opts2` (i.e. strings, numbers, bools) will replace the values
             from `opts1`.
 
         3. For the purposes of merging `depends_on`, `provider` and `providers` are always treated
@@ -547,6 +552,7 @@ def _merge_lists(dest, source):
         return dest
 
     return dest + source
+
 
 # !!! IMPORTANT !!! If you add a new attribute to this type, make sure to verify that merge_options
 # works properly for it.
@@ -899,7 +905,7 @@ def create_urn(
     create_urn computes a URN from the combination of a resource name, resource type, optional
     parent, optional project and optional stack.
     """
-    from . import Output
+    from . import Output  # pylint: disable=import-outside-toplevel
     parent_prefix: Optional['Output[str]'] = None
     if parent is not None:
         parent_urn = None

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -163,11 +163,11 @@ class Alias:
     # We use it as a internal sentinel value, and don't need to expose this in the user facing type system.
     # https://docs.python.org/3/library/constants.html#Ellipsis
     def __init__(self,
-                 name: Optional[str] = ..., # type: ignore
-                 type_: Optional[str] = ..., # type: ignore
-                 parent: Optional[Union['Resource', 'Input[str]']] = ..., # type: ignore
-                 stack: Optional['Input[str]'] = ..., # type: ignore
-                 project: Optional['Input[str]'] = ...) -> None: # type: ignore
+                 name: Optional[str] = ...,  # type: ignore
+                 type_: Optional[str] = ...,  # type: ignore
+                 parent: Optional[Union['Resource', 'Input[str]']] = ...,  # type: ignore
+                 stack: Optional['Input[str]'] = ...,  # type: ignore
+                 project: Optional['Input[str]'] = ...) -> None:  # type: ignore
 
         self.name = name
         self.type_ = type_
@@ -186,7 +186,7 @@ def collapse_alias_to_urn(
     """
     from . import Output  # pylint: disable=import-outside-toplevel
 
-    def collapse_alias_to_urn_worker(inner: Union[Alias, str]) -> 'Output[str]':
+    def collapse_alias_to_urn_worker(inner: Union[Alias, str]) -> Output[str]:
         if isinstance(inner, str):
             return Output.from_input(inner)
 
@@ -204,7 +204,7 @@ def collapse_alias_to_urn(
 
         return create_urn(name, type_, parent, project, stack)
 
-    inputAlias: 'Output[Union[Alias, str]]' = Output.from_input(alias)
+    inputAlias: Output[Union[Alias, str]] = Output.from_input(alias)
     return inputAlias.apply(collapse_alias_to_urn_worker)
 
 
@@ -906,7 +906,7 @@ def create_urn(
     parent, optional project and optional stack.
     """
     from . import Output  # pylint: disable=import-outside-toplevel
-    parent_prefix: Optional['Output[str]'] = None
+    parent_prefix: Optional[Output[str]] = None
     if parent is not None:
         parent_urn = None
         if isinstance(parent, Resource):

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -13,17 +13,19 @@
 # limitations under the License.
 import asyncio
 import sys
-from typing import Any, Awaitable
+from typing import Any, Awaitable, TYPE_CHECKING
 import grpc
 
 from .. import log
-from ..output import Inputs
 from ..invoke import InvokeOptions
 from ..runtime.proto import provider_pb2
 from . import rpc
 from .rpc_manager import RPC_MANAGER
 from .settings import get_monitor
 from .sync_await import _sync_await
+
+if TYPE_CHECKING:
+    from .. import Inputs
 
 # This setting overrides a hardcoded maximum protobuf size in the python protobuf bindings. This avoids deserialization
 # exceptions on large gRPC payloads, but makes it possible to use enough memory to cause an OOM error instead [1].
@@ -57,7 +59,7 @@ class InvokeResult:
 
     __iter__ = __await__
 
-def invoke(tok: str, props: Inputs, opts: InvokeOptions = None) -> InvokeResult:
+def invoke(tok: str, props: 'Inputs', opts: InvokeOptions = None) -> InvokeResult:
     """
     invoke dynamically invokes the function, tok, which is offered by a provider plugin.  The inputs
     can be a bag of computed values (Ts or Awaitable[T]s), and the result is a Awaitable[Any] that

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The known_types module lazy loads classes defined in the parent module to
+The known_types module lazily loads classes defined in the parent module to
 allow for type checking.
 
 Python strictly disallows circular references between imported packages.
@@ -21,8 +21,8 @@ it is not allowed for `pulumi.runtime` to reach back to the `pulumi` top-level
 to reference types that are defined there.
 
 In order to break this circular reference, and to be clear about what types
-the runtime knows about and treats specially, we lazy load the types within the
-functions themselves.
+the runtime knows about and treats specially, we defer loading of the types from
+within the functions themselves.
 
 This implementation allows for overriding types used as stubs for testing
 (see test/test_next_serialize.py)

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -73,7 +73,7 @@ def is_asset(obj: Any) -> bool:
     """
     Returns true if the given type is an Asset, false otherwise.
     """
-    from .. import Asset
+    from .. import Asset  # pylint: disable=import-outside-toplevel
     return isinstance(obj, _asset_resource_type or Asset)
 
 
@@ -81,7 +81,7 @@ def is_archive(obj: Any) -> bool:
     """
     Returns true if the given type is an Archive, false otherwise.
     """
-    from .. import Archive
+    from .. import Archive  # pylint: disable=import-outside-toplevel
     return isinstance(obj, _archive_resource_type or Archive)
 
 
@@ -89,7 +89,7 @@ def is_custom_resource(obj: Any) -> bool:
     """
     Returns true if the given type is a CustomResource, false otherwise.
     """
-    from .. import CustomResource
+    from .. import CustomResource  # pylint: disable=import-outside-toplevel
     return isinstance(obj, _custom_resource_type or CustomResource)
 
 
@@ -97,7 +97,7 @@ def is_custom_timeouts(obj: Any) -> bool:
     """
     Returns true if the given type is a CustomTimeouts, false otherwise.
     """
-    from .. import CustomTimeouts
+    from .. import CustomTimeouts  # pylint: disable=import-outside-toplevel
     return isinstance(obj, _custom_timeouts_type or CustomTimeouts)
 
 
@@ -105,7 +105,7 @@ def is_stack(obj: Any) -> bool:
     """
     Returns true if the given type is an Output, false otherwise.
     """
-    from .stack import Stack
+    from .stack import Stack  # pylint: disable=import-outside-toplevel
     return isinstance(obj, _stack_resource_type or Stack)
 
 
@@ -113,7 +113,7 @@ def is_output(obj: Any) -> bool:
     """
     Returns true if the given type is an Output, false otherwise.
     """
-    from .. import Output
+    from .. import Output  # pylint: disable=import-outside-toplevel
     return isinstance(obj, _output_type or Output)
 
 
@@ -121,5 +121,5 @@ def is_unknown(obj: Any) -> bool:
     """
     Returns true if the given object is an Unknown, false otherwise.
     """
-    from ..output import Unknown
+    from ..output import Unknown  # pylint: disable=import-outside-toplevel
     return isinstance(obj, _unknown_type or Unknown)

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -71,235 +71,58 @@ _output_type: Optional[type] = None
 _unknown_type: Optional[type] = None
 """The type of unknown. Filled-in as the Pulumi package is initializing."""
 
-def asset(class_obj: type) -> type:
-    """
-    Decorator to annotate the Asset class. Registers the decorated class
-    as the Asset known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _asset_resource_type
-    _asset_resource_type = class_obj
-    return class_obj
-
-
-def file_asset(class_obj: type) -> type:
-    """
-    Decorator to annotate the FileAsset class. Registers the decorated class
-    as the FileAsset known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _file_asset_resource_type
-    _file_asset_resource_type = class_obj
-    return class_obj
-
-
-def string_asset(class_obj: type) -> type:
-    """
-    Decorator to annotate the StringAsset class. Registers the decorated class
-    as the StringAsset known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _string_asset_resource_type
-    _string_asset_resource_type = class_obj
-    return class_obj
-
-
-def remote_asset(class_obj: type) -> type:
-    """
-    Decorator to annotate the RemoteAsset class. Registers the decorated class
-    as the RemoteAsset known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _remote_asset_resource_type
-    _remote_asset_resource_type = class_obj
-    return class_obj
-
-
-def archive(class_obj: type) -> type:
-    """
-    Decorator to annotate the Archive class. Registers the decorated class
-    as the Archive known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _archive_resource_type
-    _archive_resource_type = class_obj
-    return class_obj
-
-
-def asset_archive(class_obj: type) -> type:
-    """
-    Decorator to annotate the AssetArchive class. Registers the decorated class
-    as the AssetArchive known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _asset_archive_resource_type
-    _asset_archive_resource_type = class_obj
-    return class_obj
-
-
-def file_archive(class_obj: type) -> type:
-    """
-    Decorator to annotate the FileArchive class. Registers the decorated class
-    as the FileArchive known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _file_archive_resource_type
-    _file_archive_resource_type = class_obj
-    return class_obj
-
-
-def remote_archive(class_obj: type) -> type:
-    """
-    Decorator to annotate the RemoteArchive class. Registers the decorated class
-    as the RemoteArchive known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _remote_archive_resource_type
-    _remote_archive_resource_type = class_obj
-    return class_obj
-
-
-def custom_resource(class_obj: type) -> type:
-    """
-    Decorator to annotate the CustomResource class. Registers the decorated class
-    as the CustomResource known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _custom_resource_type
-    _custom_resource_type = class_obj
-    return class_obj
-
-def custom_timeouts(class_obj: type) -> type:
-    """
-    Decorator to annotate the CustomTimeouts class. Registers the decorated class
-    as the CustomTimeouts known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _custom_timeouts_type
-    _custom_timeouts_type = class_obj
-    return class_obj
-
-def stack(class_obj: type) -> type:
-    """
-    Decorator to annotate the Stack class. Registers the decorated class
-    as the Stack known type.
-    """
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _stack_resource_type
-    _stack_resource_type = class_obj
-    return class_obj
-
-
-def output(class_obj: type) -> type:
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _output_type
-    _output_type = class_obj
-    return class_obj
-
-
-def unknown(class_obj: type) -> type:
-    assert isinstance(class_obj, type), "class_obj is not a Class"
-    global _unknown_type
-    _unknown_type = class_obj
-    return class_obj
-
-
-def new_file_asset(*args: Any) -> Any:
-    """
-    Instantiates a new FileAsset, passing the given arguments to the constructor.
-    """
-    return _file_asset_resource_type(*args) # type: ignore
-
-
-def new_string_asset(*args: Any) -> Any:
-    """
-    Instantiates a new StringAsset, passing the given arguments to the constructor.
-    """
-    return _string_asset_resource_type(*args) # type: ignore
-
-
-def new_remote_asset(*args: Any) -> Any:
-    """
-    Instantiates a new StringAsset, passing the given arguments to the constructor.
-    """
-    return _remote_asset_resource_type(*args) # type: ignore
-
-
-def new_asset_archive(*args: Any) -> Any:
-    """
-    Instantiates a new AssetArchive, passing the given arguments to the constructor.
-    """
-    return _asset_archive_resource_type(*args) # type: ignore
-
-
-def new_file_archive(*args: Any) -> Any:
-    """
-    Instantiates a new FileArchive, passing the given arguments to the constructor.
-    """
-    return _file_archive_resource_type(*args) # type: ignore
-
-
-def new_remote_archive(*args: Any) -> Any:
-    """
-    Instantiates a new StringArchive, passing the given arguments to the constructor.
-    """
-    return _remote_archive_resource_type(*args) # type: ignore
-
-
-def new_output(*args: Any) -> Any:
-    """
-    Instantiates a new Output, passing the given arguments to the constructor.
-    """
-    return _output_type(*args) # type: ignore
-
-
-def new_unknown(*args: Any) -> Any:
-    """
-    Instantiates a new Unknown, passing the given arguments to the constructor.
-    """
-    return _unknown_type(*args) # type: ignore
-
 
 def is_asset(obj: Any) -> bool:
     """
     Returns true if the given type is an Asset, false otherwise.
     """
-    return _asset_resource_type is not None and isinstance(obj, _asset_resource_type)
+    from .. import Asset
+    return isinstance(obj, _asset_resource_type or Asset)
 
 
 def is_archive(obj: Any) -> bool:
     """
     Returns true if the given type is an Archive, false otherwise.
     """
-    return _archive_resource_type is not None and isinstance(obj, _archive_resource_type)
+    from .. import Archive
+    return isinstance(obj, _archive_resource_type or Archive)
 
 
 def is_custom_resource(obj: Any) -> bool:
     """
     Returns true if the given type is a CustomResource, false otherwise.
     """
-    return _custom_resource_type is not None and isinstance(obj, _custom_resource_type)
+    from .. import CustomResource
+    return isinstance(obj, _custom_resource_type or CustomResource)
+
 
 def is_custom_timeouts(obj: Any) -> bool:
     """
     Returns true if the given type is a CustomTimeouts, false otherwise.
     """
-    return _custom_timeouts_type is not None and isinstance(obj, _custom_timeouts_type)
+    from .. import CustomTimeouts
+    return isinstance(obj, _custom_timeouts_type or CustomTimeouts)
+
 
 def is_stack(obj: Any) -> bool:
     """
     Returns true if the given type is an Output, false otherwise.
     """
-    return _stack_resource_type is not None and isinstance(obj, _stack_resource_type)
+    from .stack import Stack
+    return isinstance(obj, _stack_resource_type or Stack)
+
 
 def is_output(obj: Any) -> bool:
     """
     Returns true if the given type is an Output, false otherwise.
     """
-    return _output_type is not None and isinstance(obj, _output_type)
+    from .. import Output
+    return isinstance(obj, _output_type or Output)
+
 
 def is_unknown(obj: Any) -> bool:
     """
     Returns true if the given object is an Unknown, false otherwise.
     """
-    return _unknown_type is not None and isinstance(obj, _unknown_type)
+    from ..output import Unknown
+    return isinstance(obj, _unknown_type or Unknown)

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-The known_types module contains state for keeping track of types that
-are known to be special in the Pulumi type system.
+The known_types module lazy loads classes defined in the parent module to
+allow for type checking.
 
 Python strictly disallows circular references between imported packages.
 Because the Pulumi top-level module depends on the `pulumi.runtime` submodule,
@@ -21,55 +21,52 @@ it is not allowed for `pulumi.runtime` to reach back to the `pulumi` top-level
 to reference types that are defined there.
 
 In order to break this circular reference, and to be clear about what types
-the runtime knows about and treats specially, this module exports a number of
-"known type" decorators that can be applied to types in `pulumi` to indicate
-that they are specially treated.
+the runtime knows about and treats specially, we lazy load the types within the
+functions themselves.
 
-The implementation of this mechanism is that, for every known type, that type
-is stashed away in a global variable. Whenever the runtime wants to do a type
-test using that type (or instantiate an instance of this type), it uses the
-functions defined in this module to do so.
+This implementation allows for overriding types used as stubs for testing
+(see test/test_next_serialize.py)
 """
 from typing import Any, Optional
 
 _custom_resource_type: Optional[type] = None
-"""The type of CustomResource. Filled-in as the Pulumi package is initializing."""
+"""The type of CustomResource."""
 
 _custom_timeouts_type: Optional[type] = None
-"""The type of CustomTimeouts. Filled-in as the Pulumi package is initializing."""
+"""The type of CustomTimeouts."""
 
 _asset_resource_type: Optional[type] = None
-"""The type of Asset. Filled-in as the Pulumi package is initializing."""
+"""The type of Asset."""
 
 _file_asset_resource_type: Optional[type] = None
-"""The type of FileAsset. Filled-in as the Pulumi package is initializing."""
+"""The type of FileAsset."""
 
 _string_asset_resource_type: Optional[type] = None
-"""The type of StringAsset. Filled-in as the Pulumi package is initializing."""
+"""The type of StringAsset."""
 
 _remote_asset_resource_type: Optional[type] = None
-"""The type of RemoteAsset. Filled-in as the Pulumi package is initializing."""
+"""The type of RemoteAsset."""
 
 _archive_resource_type: Optional[type] = None
-"""The type of Archive. Filled-in as the Pulumi package is initializing."""
+"""The type of Archive."""
 
 _asset_archive_resource_type: Optional[type] = None
-"""The type of AssetArchive. Filled-in as the Pulumi package is initializing."""
+"""The type of AssetArchive."""
 
 _file_archive_resource_type: Optional[type] = None
-"""The type of FileArchive. Filled-in as the Pulumi package is initializing."""
+"""The type of FileArchive."""
 
 _remote_archive_resource_type: Optional[type] = None
-"""The type of RemoteArchive. Filled-in as the Pulumi package is initializing."""
+"""The type of RemoteArchive."""
 
 _stack_resource_type: Optional[type] = None
-"""The type of Stack. Filled-in as the Pulumi package is initializing."""
+"""The type of Stack."""
 
 _output_type: Optional[type] = None
-"""The type of Output. Filled-in as the Pulumi package is initializing."""
+"""The type of Output."""
 
 _unknown_type: Optional[type] = None
-"""The type of unknown. Filled-in as the Pulumi package is initializing."""
+"""The type of unknown."""
 
 
 def is_asset(obj: Any) -> bool:

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -27,8 +27,8 @@ within the functions themselves.
 from typing import Any, Optional
 
 
-# We override this global in test/test_next_serialize.py to stub the CustomResource
-# type. TODO: Rework the test to remove the need for this global.
+# We override this global in test/test_next_serialize.py to stub the CustomResource type.
+# TODO: Rework the test to remove the need for this global. https://github.com/pulumi/pulumi/issues/5000
 _custom_resource_type: Optional[type] = None
 """The type of CustomResource."""
 

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -24,49 +24,13 @@ In order to break this circular reference, and to be clear about what types
 the runtime knows about and treats specially, we defer loading of the types from
 within the functions themselves.
 
-This implementation allows for overriding types used as stubs for testing
-(see test/test_next_serialize.py)
+This implementation allows for overriding the CustomResource type used as a stub
+for testing (see test/test_next_serialize.py)
 """
 from typing import Any, Optional
 
 _custom_resource_type: Optional[type] = None
 """The type of CustomResource."""
-
-_custom_timeouts_type: Optional[type] = None
-"""The type of CustomTimeouts."""
-
-_asset_resource_type: Optional[type] = None
-"""The type of Asset."""
-
-_file_asset_resource_type: Optional[type] = None
-"""The type of FileAsset."""
-
-_string_asset_resource_type: Optional[type] = None
-"""The type of StringAsset."""
-
-_remote_asset_resource_type: Optional[type] = None
-"""The type of RemoteAsset."""
-
-_archive_resource_type: Optional[type] = None
-"""The type of Archive."""
-
-_asset_archive_resource_type: Optional[type] = None
-"""The type of AssetArchive."""
-
-_file_archive_resource_type: Optional[type] = None
-"""The type of FileArchive."""
-
-_remote_archive_resource_type: Optional[type] = None
-"""The type of RemoteArchive."""
-
-_stack_resource_type: Optional[type] = None
-"""The type of Stack."""
-
-_output_type: Optional[type] = None
-"""The type of Output."""
-
-_unknown_type: Optional[type] = None
-"""The type of unknown."""
 
 
 def is_asset(obj: Any) -> bool:
@@ -74,7 +38,7 @@ def is_asset(obj: Any) -> bool:
     Returns true if the given type is an Asset, false otherwise.
     """
     from .. import Asset  # pylint: disable=import-outside-toplevel
-    return isinstance(obj, _asset_resource_type or Asset)
+    return isinstance(obj, Asset)
 
 
 def is_archive(obj: Any) -> bool:
@@ -82,7 +46,7 @@ def is_archive(obj: Any) -> bool:
     Returns true if the given type is an Archive, false otherwise.
     """
     from .. import Archive  # pylint: disable=import-outside-toplevel
-    return isinstance(obj, _archive_resource_type or Archive)
+    return isinstance(obj, Archive)
 
 
 def is_custom_resource(obj: Any) -> bool:
@@ -98,7 +62,7 @@ def is_custom_timeouts(obj: Any) -> bool:
     Returns true if the given type is a CustomTimeouts, false otherwise.
     """
     from .. import CustomTimeouts  # pylint: disable=import-outside-toplevel
-    return isinstance(obj, _custom_timeouts_type or CustomTimeouts)
+    return isinstance(obj, CustomTimeouts)
 
 
 def is_stack(obj: Any) -> bool:
@@ -106,7 +70,7 @@ def is_stack(obj: Any) -> bool:
     Returns true if the given type is an Output, false otherwise.
     """
     from .stack import Stack  # pylint: disable=import-outside-toplevel
-    return isinstance(obj, _stack_resource_type or Stack)
+    return isinstance(obj, Stack)
 
 
 def is_output(obj: Any) -> bool:
@@ -114,7 +78,7 @@ def is_output(obj: Any) -> bool:
     Returns true if the given type is an Output, false otherwise.
     """
     from .. import Output  # pylint: disable=import-outside-toplevel
-    return isinstance(obj, _output_type or Output)
+    return isinstance(obj, Output)
 
 
 def is_unknown(obj: Any) -> bool:
@@ -122,4 +86,4 @@ def is_unknown(obj: Any) -> bool:
     Returns true if the given object is an Unknown, false otherwise.
     """
     from ..output import Unknown  # pylint: disable=import-outside-toplevel
-    return isinstance(obj, _unknown_type or Unknown)
+    return isinstance(obj, Unknown)

--- a/sdk/python/lib/pulumi/runtime/known_types.py
+++ b/sdk/python/lib/pulumi/runtime/known_types.py
@@ -23,12 +23,12 @@ to reference types that are defined there.
 In order to break this circular reference, and to be clear about what types
 the runtime knows about and treats specially, we defer loading of the types from
 within the functions themselves.
-
-This implementation allows for overriding the CustomResource type used as a stub
-for testing (see test/test_next_serialize.py)
 """
 from typing import Any, Optional
 
+
+# We override this global in test/test_next_serialize.py to stub the CustomResource
+# type. TODO: Rework the test to remove the need for this global.
 _custom_resource_type: Optional[type] = None
 """The type of CustomResource."""
 

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -27,7 +27,6 @@ from .settings import Settings, configure, get_stack, get_project, get_root_reso
 from .sync_await import _sync_await
 from ..runtime.proto import engine_pb2, engine_pb2_grpc, provider_pb2, resource_pb2, resource_pb2_grpc
 from ..runtime.stack import Stack, run_pulumi_func
-from ..output import Output
 
 if TYPE_CHECKING:
     from ..resource import Resource
@@ -35,6 +34,7 @@ if TYPE_CHECKING:
 
 def test(fn):
     def wrapper(*args, **kwargs):
+        from .. import Output
         _sync_await(run_pulumi_func(lambda: _sync_await(Output.from_input(fn(*args, **kwargs)).future())))
     return wrapper
 

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -34,7 +34,7 @@ if TYPE_CHECKING:
 
 def test(fn):
     def wrapper(*args, **kwargs):
-        from .. import Output
+        from .. import Output  # pylint: disable=import-outside-toplevel
         _sync_await(run_pulumi_func(lambda: _sync_await(Output.from_input(fn(*args, **kwargs)).future())))
     return wrapper
 
@@ -119,11 +119,11 @@ class MockMonitor:
         return resource_pb2.RegisterResourceResponse(urn=urn, id=id_, object=obj_proto)
 
     def RegisterResourceOutputs(self, request):
-        #pylint: disable=unused-argument
+        # pylint: disable=unused-argument
         return empty_pb2.Empty()
 
     def SupportsFeature(self, request):
-        #pylint: disable=unused-argument
+        # pylint: disable=unused-argument
         return type('SupportsFeatureResponse', (object,), {'hasSupport' : True})
 
 

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -72,7 +72,7 @@ async def prepare_resource(res: 'Resource',
                            custom: bool,
                            props: 'Inputs',
                            opts: Optional['ResourceOptions']) -> ResourceResolverOperations:
-    from .. import Output
+    from .. import Output  # pylint: disable=import-outside-toplevel
     log.debug(f"resource {props} preparing to wait for dependencies")
     # Before we can proceed, all our dependencies must be finished.
     explicit_urn_dependencies = []
@@ -152,7 +152,7 @@ class _ResourceResult(NamedTuple):
 # pylint: disable=too-many-locals,too-many-statements
 
 def _read_resource(res: 'CustomResource', ty: str, name: str, props: 'Inputs', opts: 'ResourceOptions') -> _ResourceResult:
-    from .. import Output
+    from .. import Output  # pylint: disable=import-outside-toplevel
     if opts.id is None:
         raise Exception(
             "Cannot read resource whose options are lacking an ID value")
@@ -235,7 +235,7 @@ def _read_resource(res: 'CustomResource', ty: str, name: str, props: 'Inputs', o
                 additionalSecretOutputs=additional_secret_outputs,
             )
 
-            from ..resource import create_urn # pylint: disable=import-outside-toplevel
+            from ..resource import create_urn  # pylint: disable=import-outside-toplevel
             mock_urn = await create_urn(name, ty, resolver.parent_urn).future()
 
             def do_rpc_call():
@@ -292,7 +292,7 @@ def _register_resource(res: 'Resource',
                        opts: Optional['ResourceOptions']) -> _ResourceResult:
     log.debug(f"registering resource: ty={ty}, name={name}, custom={custom}")
     monitor = settings.get_monitor()
-    from .. import Output
+    from .. import Output  # pylint: disable=import-outside-toplevel
 
     # Prepare the resource.
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -211,7 +211,7 @@ def deserialize_properties(props_struct: struct_pb2.Struct, keep_unknowns: Optio
     # We assume that we are deserializing properties that we got from a Resource RPC endpoint,
     # which has type `Struct` in our gRPC proto definition.
     if _special_sig_key in props_struct:
-        from .. import FileAsset, StringAsset, RemoteAsset, AssetArchive, FileArchive, RemoteArchive
+        from .. import FileAsset, StringAsset, RemoteAsset, AssetArchive, FileArchive, RemoteArchive  # pylint: disable=import-outside-toplevel
         if props_struct[_special_sig_key] == _special_asset_sig:
             # This is an asset. Re-hydrate this object into an Asset.
             if "path" in props_struct:
@@ -270,7 +270,7 @@ def deserialize_property(value: Any, keep_unknowns: Optional[bool] = None) -> An
     Deserializes a single protobuf value (either `Struct` or `ListValue`) into idiomatic
     Python values.
     """
-    from ..output import Unknown
+    from ..output import Unknown  # pylint: disable=import-outside-toplevel
     if value == UNKNOWN:
         return Unknown() if settings.is_dry_run() or keep_unknowns else None
 
@@ -323,7 +323,7 @@ result in the exception being re-thrown.
 
 
 def transfer_properties(res: 'Resource', props: 'Inputs') -> Dict[str, Resolver]:
-    from .. import Output
+    from .. import Output  # pylint: disable=import-outside-toplevel
     resolvers: Dict[str, Resolver] = {}
     for name in props.keys():
         if name in ["id", "urn"]:

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -29,6 +29,7 @@ from .. import log
 if TYPE_CHECKING:
     from .. import Output
 
+
 async def run_pulumi_func(func: Callable):
     try:
         func()
@@ -72,6 +73,7 @@ async def run_pulumi_func(func: Callable):
     if RPC_MANAGER.unhandled_exception is not None:
         raise RPC_MANAGER.unhandled_exception.with_traceback(RPC_MANAGER.exception_traceback)
 
+
 async def run_in_stack(func: Callable):
     """
     Run the given function inside of a new stack resource.  This ensures that any stack export calls
@@ -112,6 +114,7 @@ class Stack(ComponentResource):
         """
         self.outputs[name] = value
 
+
 # Note: we use a List here instead of a set as many objects are unhashable.  This is inefficient,
 # but python seems to offer no alternative.
 def massage(attr: Any, seen: List[Any]):
@@ -122,8 +125,7 @@ def massage(attr: Any, seen: List[Any]):
     lists or dictionaries as appropriate.  In general, iterable things are turned into lists, and
     dictionary-like things are turned into dictionaries.
     """
-
-    from .. import Output
+    from .. import Output  # pylint: disable=import-outside-toplevel
 
     # Basic primitive types (numbers, booleans, strings, etc.) don't need any special handling.
     if is_primitive(attr):
@@ -207,6 +209,7 @@ def is_primitive(attr: Any) -> bool:
         pass
 
     return True
+
 
 def register_stack_transformation(t: ResourceTransformation):
     """

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -18,16 +18,16 @@ Support for automatic stack components.
 import asyncio
 import collections
 from inspect import isawaitable
-from typing import Callable, Any, Dict, List
+from typing import Callable, Any, Dict, List, TYPE_CHECKING
 
 from ..resource import ComponentResource, Resource, ResourceTransformation
 from .settings import get_project, get_stack, get_root_resource, is_dry_run, set_root_resource
 from .rpc_manager import RPC_MANAGER
 from .sync_await import _all_tasks, _get_current_task
 from .. import log
-from . import known_types
 
-from ..output import Output
+if TYPE_CHECKING:
+    from .. import Output
 
 async def run_pulumi_func(func: Callable):
     try:
@@ -81,7 +81,6 @@ async def run_in_stack(func: Callable):
     await run_pulumi_func(lambda: Stack(func))
 
 
-@known_types.stack
 class Stack(ComponentResource):
     """
     A synthetic stack component that automatically parents resources as the program runs.
@@ -124,8 +123,9 @@ def massage(attr: Any, seen: List[Any]):
     dictionary-like things are turned into dictionaries.
     """
 
-    # Basic primitive types (numbers, booleans, strings, etc.) don't need any special handling.
+    from .. import Output
 
+    # Basic primitive types (numbers, booleans, strings, etc.) don't need any special handling.
     if is_primitive(attr):
         return attr
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/4979

The `@known_types` decorators prevent Intellisense from functioning correctly in VSCode. We were using them as a workaround to avoid circular references between imported packages. We can instead use a combination of [forward references](https://www.python.org/dev/peps/pep-0484/#forward-references) (which we were already doing to some extent) and deferring the imports to when they are needed (which we were also already doing in some cases).

There is follow-up work to standardize docstrings across the SDK which I'll do in a separate PR.

Before:
<img width="365" alt="Screen Shot 2020-07-01 at 3 24 17 PM" src="https://user-images.githubusercontent.com/24326455/86947685-f7d03680-c100-11ea-881f-33033326cda8.png">


After:
<img width="606" alt="Screen Shot 2020-07-08 at 9 51 26 AM" src="https://user-images.githubusercontent.com/24326455/86947435-a2942500-c100-11ea-90d2-19f9cb22a0f7.png">

