### PR TITLE
[codegen] Add a code generator for resource state.

### DIFF
--- a/pkg/codegen/importer/hcl2.go
+++ b/pkg/codegen/importer/hcl2.go
@@ -1,0 +1,467 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v2/resource/deploy/providers"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// Null represents Pulumi HCL2's `null` variable.
+var Null = &model.Variable{
+	Name:         "null",
+	VariableType: model.NoneType,
+}
+
+// GenerateHCL2Definition generates a Pulumi HCL2 definition for a given resource.
+func GenerateHCL2Definition(loader schema.Loader, state *resource.State, names NameTable) (*model.Block, error) {
+	// TODO: pull the package version from the resource's provider
+	pkg, err := loader.LoadPackage(string(state.Type.Package()), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r, ok := pkg.GetResource(string(state.Type))
+	if !ok {
+		return nil, fmt.Errorf("unknown resource type '%v'", r)
+	}
+
+	var items []model.BodyItem
+	for _, p := range r.InputProperties {
+		x, err := generatePropertyValue(p, state.Inputs[resource.PropertyKey(p.Name)])
+		if err != nil {
+			return nil, err
+		}
+		if x != nil {
+			items = append(items, &model.Attribute{
+				Name:  p.Name,
+				Value: x,
+			})
+		}
+	}
+
+	resourceOptions, err := makeResourceOptions(state, names)
+	if err != nil {
+		return nil, err
+	}
+	if resourceOptions != nil {
+		items = append(items, resourceOptions)
+	}
+
+	typ, name := state.URN.Type(), state.URN.Name()
+	return &model.Block{
+		Tokens: syntax.NewBlockTokens("resource", string(name), string(typ)),
+		Type:   "resource",
+		Labels: []string{string(name), string(typ)},
+		Body: &model.Body{
+			Items: items,
+		},
+	}, nil
+}
+
+func newVariableReference(name string) model.Expression {
+	return model.VariableReference(&model.Variable{
+		Name:         name,
+		VariableType: model.DynamicType,
+	})
+}
+
+func appendResourceOption(block *model.Block, name string, value model.Expression) *model.Block {
+	if block == nil {
+		block = &model.Block{
+			Tokens: syntax.NewBlockTokens("options"),
+			Type:   "options",
+			Body:   &model.Body{},
+		}
+	}
+	block.Body.Items = append(block.Body.Items, &model.Attribute{
+		Tokens: syntax.NewAttributeTokens(name),
+		Name:   name,
+		Value:  value,
+	})
+	return block
+}
+
+func makeResourceOptions(state *resource.State, names NameTable) (*model.Block, error) {
+	var resourceOptions *model.Block
+	if state.Parent != "" && state.Parent.Type() != resource.RootStackType {
+		name, ok := names[state.Parent]
+		if !ok {
+			return nil, fmt.Errorf("no name for parent %v", state.Parent)
+		}
+		resourceOptions = appendResourceOption(resourceOptions, "parent", newVariableReference(name))
+	}
+	if state.Provider != "" {
+		ref, err := providers.ParseReference(state.Provider)
+		if err != nil {
+			return nil, fmt.Errorf("invalid provider reference %v: %w", state.Provider, err)
+		}
+		if !providers.IsDefaultProvider(ref.URN()) {
+			name, ok := names[ref.URN()]
+			if !ok {
+				return nil, fmt.Errorf("no name for provider %v", state.Parent)
+			}
+			resourceOptions = appendResourceOption(resourceOptions, "provider", newVariableReference(name))
+		}
+	}
+	if len(state.Dependencies) != 0 {
+		deps := make([]model.Expression, len(state.Dependencies))
+		for i, d := range state.Dependencies {
+			name, ok := names[d]
+			if !ok {
+				return nil, fmt.Errorf("no name for resource %v", d)
+			}
+			deps[i] = newVariableReference(name)
+		}
+		resourceOptions = appendResourceOption(resourceOptions, "dependsOn", &model.TupleConsExpression{
+			Tokens:      syntax.NewTupleConsTokens(len(deps)),
+			Expressions: deps,
+		})
+	}
+	if state.Protect {
+		resourceOptions = appendResourceOption(resourceOptions, "protect", &model.LiteralValueExpression{
+			Tokens: syntax.NewLiteralValueTokens(cty.True),
+			Value:  cty.True,
+		})
+	}
+	return resourceOptions, nil
+}
+
+// typeRank orders types by their simplicity.
+func typeRank(t schema.Type) int {
+	switch t {
+	case schema.BoolType:
+		return 1
+	case schema.IntType:
+		return 2
+	case schema.NumberType:
+		return 3
+	case schema.StringType:
+		return 4
+	case schema.ArchiveType:
+		return 5
+	case schema.AssetType:
+		return 6
+	case schema.JSONType:
+		return 7
+	case schema.AnyType:
+		return 13
+	default:
+		switch t.(type) {
+		case *schema.TokenType:
+			return 8
+		case *schema.ArrayType:
+			return 9
+		case *schema.MapType:
+			return 10
+		case *schema.ObjectType:
+			return 11
+		case *schema.UnionType:
+			return 12
+		default:
+			return int(math.MaxInt32)
+		}
+	}
+}
+
+// simplerType returns true if T is simpler than U.
+//
+// The first-order ranking is:
+//
+//   bool < int < number < string < archive < asset < json < token < array < map < object < union < any
+//
+// Additional rules apply to composite types of the same kind:
+// - array(T) is simpler than array(U) if T is simpler than U
+// - map(T) is simpler than map(U) if T is simpler than U
+// - object({ ... }) is simpler than object({ ... }) if the former has a greater number of required properties that are
+//   simpler than the latter's required properties
+// - union(...) is simpler than union(...) if the former's simplest element type is simpler than the latter's simplest
+//   element type
+func simplerType(t, u schema.Type) bool {
+	tRank, uRank := typeRank(t), typeRank(u)
+	if tRank < uRank {
+		return true
+	} else if tRank > uRank {
+		return false
+	}
+
+	switch t := t.(type) {
+	case *schema.TokenType:
+		u := u.(*schema.TokenType)
+		if t.UnderlyingType != nil && u.UnderlyingType != nil {
+			return simplerType(t.UnderlyingType, u.UnderlyingType)
+		}
+		return false
+	case *schema.ArrayType:
+		return simplerType(t.ElementType, u.(*schema.ArrayType).ElementType)
+	case *schema.MapType:
+		return simplerType(t.ElementType, u.(*schema.ArrayType).ElementType)
+	case *schema.ObjectType:
+		// Count how many of T's required properties are simpler than U's required properties and vice versa.
+		uu := u.(*schema.ObjectType)
+		tscore, nt, uscore := 0, 0, 0
+		for _, p := range t.Properties {
+			if p.IsRequired {
+				nt++
+				for _, q := range uu.Properties {
+					if q.IsRequired {
+						if simplerType(p.Type, q.Type) {
+							tscore++
+						}
+						if simplerType(q.Type, p.Type) {
+							uscore++
+						}
+					}
+				}
+			}
+		}
+
+		// If the number of T's required properties that are simpler that U's required properties exceeds the number
+		// of U's required properties that are simpler than T's required properties, T is simpler.
+		if tscore > uscore {
+			return true
+		}
+		if tscore < uscore {
+			return false
+		}
+
+		// If the above counts are equal, T is simpler if it has fewer required properties.
+		nu := 0
+		for _, q := range uu.Properties {
+			if q.IsRequired {
+				nu++
+			}
+		}
+
+		return nt < nu
+	case *schema.UnionType:
+		// Pick whichever has the simplest element type.
+		var simplestElementType schema.Type
+		for _, t := range t.ElementTypes {
+			if simplestElementType == nil || simplerType(t, simplestElementType) {
+				simplestElementType = t
+			}
+		}
+		for _, u := range u.(*schema.UnionType).ElementTypes {
+			if simplestElementType == nil || simplerType(u, simplestElementType) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+// zeroValue constructs a zero value of the given type.
+func zeroValue(t schema.Type) model.Expression {
+	switch t := t.(type) {
+	case *schema.MapType:
+		return &model.ObjectConsExpression{}
+	case *schema.ArrayType:
+		return &model.TupleConsExpression{}
+	case *schema.UnionType:
+		// If there is a default type, create a value of that type.
+		if t.DefaultType != nil {
+			return zeroValue(t.DefaultType)
+		}
+		// Otherwise, pick the simplest type in the list.
+		var simplestType schema.Type
+		for _, t := range t.ElementTypes {
+			if simplestType == nil || simplerType(t, simplestType) {
+				simplestType = t
+			}
+		}
+		return zeroValue(simplestType)
+	case *schema.ObjectType:
+		var items []model.ObjectConsItem
+		for _, p := range t.Properties {
+			if p.IsRequired {
+				items = append(items, model.ObjectConsItem{
+					Key: &model.LiteralValueExpression{
+						Value: cty.StringVal(p.Name),
+					},
+					Value: zeroValue(p.Type),
+				})
+			}
+		}
+		return &model.ObjectConsExpression{Items: items}
+	case *schema.TokenType:
+		if t.UnderlyingType != nil {
+			return zeroValue(t.UnderlyingType)
+		}
+		return model.VariableReference(Null)
+	}
+	switch t {
+	case schema.BoolType:
+		x, err := generateValue(t, resource.NewBoolProperty(false))
+		contract.IgnoreError(err)
+		return x
+	case schema.IntType, schema.NumberType:
+		x, err := generateValue(t, resource.NewNumberProperty(0))
+		contract.IgnoreError(err)
+		return x
+	case schema.StringType:
+		x, err := generateValue(t, resource.NewStringProperty(""))
+		contract.IgnoreError(err)
+		return x
+	case schema.ArchiveType, schema.AssetType:
+		return model.VariableReference(Null)
+	case schema.JSONType, schema.AnyType:
+		return &model.ObjectConsExpression{}
+	default:
+		contract.Failf("unexpected schema type %v", t)
+		return nil
+	}
+}
+
+// generatePropertyValue generates the value for the given property. If the value is absent and the property is
+// required, a zero value for the property's type is generated. If the value is absent and the property is not
+// required, no value is generated (i.e. this function returns nil).
+func generatePropertyValue(property *schema.Property, value resource.PropertyValue) (model.Expression, error) {
+	if !value.HasValue() {
+		if !property.IsRequired {
+			return nil, nil
+		}
+		return zeroValue(property.Type), nil
+	}
+
+	return generateValue(property.Type, value)
+}
+
+// generateValue generates a value from the given property value. The given type may or may not match the shape of the
+// given value.
+func generateValue(typ schema.Type, value resource.PropertyValue) (model.Expression, error) {
+	switch {
+	case value.IsArchive():
+		return nil, fmt.Errorf("NYI: archives")
+	case value.IsArray():
+		elementType := schema.AnyType
+		if typ, ok := typ.(*schema.ArrayType); ok {
+			elementType = typ.ElementType
+		}
+
+		arr := value.ArrayValue()
+		exprs := make([]model.Expression, len(arr))
+		for i, v := range arr {
+			x, err := generateValue(elementType, v)
+			if err != nil {
+				return nil, err
+			}
+			exprs[i] = x
+		}
+		return &model.TupleConsExpression{
+			Tokens:      syntax.NewTupleConsTokens(len(exprs)),
+			Expressions: exprs,
+		}, nil
+	case value.IsAsset():
+		return nil, fmt.Errorf("NYI: assets")
+	case value.IsBool():
+		return &model.LiteralValueExpression{
+			Value: cty.BoolVal(value.BoolValue()),
+		}, nil
+	case value.IsComputed() || value.IsOutput():
+		return nil, fmt.Errorf("cannot define computed values")
+	case value.IsNull():
+		return model.VariableReference(Null), nil
+	case value.IsNumber():
+		return &model.LiteralValueExpression{
+			Value: cty.NumberFloatVal(value.NumberValue()),
+		}, nil
+	case value.IsObject():
+		obj := value.ObjectValue()
+		items := make([]model.ObjectConsItem, 0, len(obj))
+
+		if objectType, ok := typ.(*schema.ObjectType); ok {
+			for _, p := range objectType.Properties {
+				x, err := generatePropertyValue(p, obj[resource.PropertyKey(p.Name)])
+				if err != nil {
+					return nil, err
+				}
+				if x != nil {
+					items = append(items, model.ObjectConsItem{
+						Key: &model.LiteralValueExpression{
+							Value: cty.StringVal(p.Name),
+						},
+						Value: x,
+					})
+				}
+			}
+		} else {
+			elementType := schema.AnyType
+			if mapType, ok := typ.(*schema.MapType); ok {
+				elementType = mapType.ElementType
+			}
+
+			for _, k := range obj.StableKeys() {
+				// Ignore internal properties.
+				if strings.HasPrefix(string(k), "__") {
+					continue
+				}
+
+				x, err := generateValue(elementType, obj[k])
+				if err != nil {
+					return nil, err
+				}
+				items = append(items, model.ObjectConsItem{
+					Key: &model.LiteralValueExpression{
+						Value: cty.StringVal(string(k)),
+					},
+					Value: x,
+				})
+			}
+		}
+		return &model.ObjectConsExpression{
+			Tokens: syntax.NewObjectConsTokens(len(items)),
+			Items:  items,
+		}, nil
+	case value.IsSecret():
+		arg, err := generateValue(typ, value.SecretValue().Element)
+		if err != nil {
+			return nil, err
+		}
+		return &model.FunctionCallExpression{
+			Name: "secret",
+			Signature: model.StaticFunctionSignature{
+				Parameters: []model.Parameter{{
+					Name: "value",
+					Type: arg.Type(),
+				}},
+				ReturnType: model.NewOutputType(arg.Type()),
+			},
+			Args: []model.Expression{arg},
+		}, nil
+	case value.IsString():
+		return &model.TemplateExpression{
+			Parts: []model.Expression{
+				&model.LiteralValueExpression{
+					Value: cty.StringVal(value.StringValue()),
+				},
+			},
+		}, nil
+	default:
+		contract.Failf("unexpected property value %v", value)
+		return nil, nil
+	}
+}

--- a/pkg/codegen/importer/hcl2_test.go
+++ b/pkg/codegen/importer/hcl2_test.go
@@ -1,0 +1,274 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/internal/test"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v2/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/v2/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/stretchr/testify/assert"
+	"github.com/zclconf/go-cty/cty"
+)
+
+var testdataPath = filepath.Join("..", "internal", "test", "testdata")
+
+const parentName = "parent"
+const providerName = "provider"
+
+var parentURN = resource.NewURN("stack", "project", "", "my::parent", "parent")
+var providerURN = resource.NewURN("stack", "project", "", providers.MakeProviderType("pkg"), "provider")
+
+var names = NameTable{
+	parentURN:   parentName,
+	providerURN: providerName,
+}
+
+func renderExpr(t *testing.T, x model.Expression) resource.PropertyValue {
+	switch x := x.(type) {
+	case *model.LiteralValueExpression:
+		return renderLiteralValue(t, x)
+	case *model.ScopeTraversalExpression:
+		return renderScopeTraversal(t, x)
+	case *model.TemplateExpression:
+		return renderTemplate(t, x)
+	case *model.TupleConsExpression:
+		return renderTupleCons(t, x)
+	case *model.ObjectConsExpression:
+		return renderObjectCons(t, x)
+	case *model.FunctionCallExpression:
+		return renderFunctionCall(t, x)
+	default:
+		assert.Failf(t, "", "unexpected expression of type %T", x)
+		return resource.NewNullProperty()
+	}
+}
+
+func renderLiteralValue(t *testing.T, x *model.LiteralValueExpression) resource.PropertyValue {
+	switch x.Value.Type() {
+	case cty.Bool:
+		return resource.NewBoolProperty(x.Value.True())
+	case cty.Number:
+		f, _ := x.Value.AsBigFloat().Float64()
+		return resource.NewNumberProperty(f)
+	case cty.String:
+		return resource.NewStringProperty(x.Value.AsString())
+	default:
+		assert.Failf(t, "", "unexpected literal of type %v", x.Value.Type())
+		return resource.NewNullProperty()
+	}
+}
+
+func renderTemplate(t *testing.T, x *model.TemplateExpression) resource.PropertyValue {
+	if !assert.Len(t, x.Parts, 1) {
+		return resource.NewStringProperty("")
+	}
+	return renderLiteralValue(t, x.Parts[0].(*model.LiteralValueExpression))
+}
+
+func renderObjectCons(t *testing.T, x *model.ObjectConsExpression) resource.PropertyValue {
+	obj := resource.PropertyMap{}
+	for _, item := range x.Items {
+		kv := renderExpr(t, item.Key)
+		if !assert.True(t, kv.IsString()) {
+			continue
+		}
+		obj[resource.PropertyKey(kv.StringValue())] = renderExpr(t, item.Value)
+	}
+	return resource.NewObjectProperty(obj)
+}
+
+func renderScopeTraversal(t *testing.T, x *model.ScopeTraversalExpression) resource.PropertyValue {
+	if !assert.Len(t, x.Traversal, 1) {
+		return resource.NewNullProperty()
+	}
+
+	switch x.RootName {
+	case "parent":
+		return resource.NewStringProperty(string(parentURN))
+	case "provider":
+		return resource.NewStringProperty(string(providerURN))
+	default:
+		assert.Failf(t, "", "unexpected variable reference %v", x.RootName)
+		return resource.NewNullProperty()
+	}
+}
+
+func renderTupleCons(t *testing.T, x *model.TupleConsExpression) resource.PropertyValue {
+	arr := make([]resource.PropertyValue, len(x.Expressions))
+	for i, x := range x.Expressions {
+		arr[i] = renderExpr(t, x)
+	}
+	return resource.NewArrayProperty(arr)
+}
+
+func renderFunctionCall(t *testing.T, x *model.FunctionCallExpression) resource.PropertyValue {
+	switch x.Name {
+	case "secret":
+		if !assert.Len(t, x.Args, 1) {
+			return resource.NewNullProperty()
+		}
+		return resource.MakeSecret(renderExpr(t, x.Args[0]))
+	default:
+		assert.Failf(t, "", "unexpected call to %v", x.Name)
+		return resource.NewNullProperty()
+	}
+}
+
+func renderResource(t *testing.T, r *hcl2.Resource) *resource.State {
+	inputs := resource.PropertyMap{}
+	for _, attr := range r.Inputs {
+		inputs[resource.PropertyKey(attr.Name)] = renderExpr(t, attr.Value)
+	}
+
+	protect := false
+	var parent resource.URN
+	var providerRef string
+	if r.Options != nil {
+		if r.Options.Protect != nil {
+			v, diags := r.Options.Protect.Evaluate(&hcl.EvalContext{})
+			if assert.Len(t, diags, 0) && assert.Equal(t, cty.Bool, v.Type()) {
+				protect = v.True()
+			}
+		}
+		if r.Options.Parent != nil {
+			v := renderExpr(t, r.Options.Parent)
+			if assert.True(t, v.IsString()) {
+				parent = resource.URN(v.StringValue())
+			}
+		}
+		if r.Options.Provider != nil {
+			v := renderExpr(t, r.Options.Provider)
+			if assert.True(t, v.IsString()) {
+				providerRef = v.StringValue() + "::id"
+			}
+		}
+	}
+
+	// Pull the raw token from the resource.
+	token := tokens.Type(r.Definition.Labels[1])
+
+	var parentType tokens.Type
+	if parent != "" {
+		parentType = parent.QualifiedType()
+	}
+	return &resource.State{
+		Type:     token,
+		URN:      resource.NewURN("stack", "project", parentType, token, tokens.QName(r.Name())),
+		Custom:   true,
+		Inputs:   inputs,
+		Parent:   parent,
+		Provider: providerRef,
+		Protect:  protect,
+	}
+}
+
+type testCases struct {
+	Resources []apitype.ResourceV3 `json:"resources"`
+}
+
+func readTestCases(path string) (testCases, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return testCases{}, err
+	}
+	defer contract.IgnoreClose(f)
+
+	var cases testCases
+	if err = json.NewDecoder(f).Decode(&cases); err != nil {
+		return testCases{}, err
+	}
+	return cases, nil
+}
+
+func TestGenerateHCL2Definition(t *testing.T) {
+	loader := schema.NewPluginLoader(test.NewHost(testdataPath))
+
+	cases, err := readTestCases("testdata/cases.json")
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	for _, s := range cases.Resources {
+		t.Run(string(s.URN), func(t *testing.T) {
+			state, err := stack.DeserializeResource(s, config.NopDecrypter, config.NopEncrypter)
+			if !assert.NoError(t, err) {
+				t.Fatal()
+			}
+
+			block, err := GenerateHCL2Definition(loader, state, names)
+			if !assert.NoError(t, err) {
+				t.Fatal()
+			}
+
+			text := fmt.Sprintf("%v", block)
+
+			parser := syntax.NewParser()
+			err = parser.ParseFile(strings.NewReader(text), string(state.URN)+".pp")
+			if !assert.NoError(t, err) || !assert.False(t, parser.Diagnostics.HasErrors()) {
+				t.Fatal()
+			}
+
+			p, diags, err := hcl2.BindProgram(parser.Files, hcl2.Loader(loader), hcl2.AllowMissingVariables)
+			assert.NoError(t, err)
+			assert.False(t, diags.HasErrors())
+
+			if !assert.Len(t, p.Nodes, 1) {
+				t.Fatal()
+			}
+
+			res, isResource := p.Nodes[0].(*hcl2.Resource)
+			if !assert.True(t, isResource) {
+				t.Fatal()
+			}
+
+			actualState := renderResource(t, res)
+
+			assert.Equal(t, state.Type, actualState.Type)
+			assert.Equal(t, state.URN, actualState.URN)
+			assert.Equal(t, state.Parent, actualState.Parent)
+			assert.Equal(t, state.Provider, actualState.Provider)
+			assert.Equal(t, state.Protect, actualState.Protect)
+			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
+				actual, err := stack.SerializeResource(actualState, config.NopEncrypter, false)
+				contract.IgnoreError(err)
+
+				sb, err := json.MarshalIndent(s, "", "    ")
+				contract.IgnoreError(err)
+
+				ab, err := json.MarshalIndent(actual, "", "    ")
+				contract.IgnoreError(err)
+
+				t.Logf("%v\n\n%v\n\n%v\n", text, string(sb), string(ab))
+			}
+		})
+	}
+}

--- a/pkg/codegen/importer/hcl2_test.go
+++ b/pkg/codegen/importer/hcl2_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -271,4 +272,61 @@ func TestGenerateHCL2Definition(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSimplerType(t *testing.T) {
+	types := []schema.Type{
+		schema.BoolType,
+		schema.IntType,
+		schema.NumberType,
+		schema.StringType,
+		schema.AssetType,
+		schema.ArchiveType,
+		schema.JSONType,
+		&schema.ArrayType{ElementType: schema.BoolType},
+		&schema.ArrayType{ElementType: schema.IntType},
+		&schema.MapType{ElementType: schema.BoolType},
+		&schema.MapType{ElementType: schema.IntType},
+		&schema.ObjectType{},
+		&schema.ObjectType{
+			Properties: []*schema.Property{
+				{
+					Name:       "foo",
+					Type:       schema.BoolType,
+					IsRequired: true,
+				},
+			},
+		},
+		&schema.ObjectType{
+			Properties: []*schema.Property{
+				{
+					Name:       "foo",
+					Type:       schema.IntType,
+					IsRequired: true,
+				},
+			},
+		},
+		&schema.ObjectType{
+			Properties: []*schema.Property{
+				{
+					Name:       "foo",
+					Type:       schema.IntType,
+					IsRequired: true,
+				},
+				{
+					Name:       "bar",
+					Type:       schema.IntType,
+					IsRequired: true,
+				},
+			},
+		},
+		&schema.UnionType{ElementTypes: []schema.Type{schema.BoolType, schema.IntType}},
+		&schema.UnionType{ElementTypes: []schema.Type{schema.IntType, schema.JSONType}},
+		&schema.UnionType{ElementTypes: []schema.Type{schema.NumberType, schema.StringType}},
+		schema.AnyType,
+	}
+
+	assert.True(t, sort.SliceIsSorted(types, func(i, j int) bool {
+		return simplerType(types[i], types[j])
+	}))
 }

--- a/pkg/codegen/importer/language.go
+++ b/pkg/codegen/importer/language.go
@@ -1,0 +1,108 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/hashicorp/hcl/v2"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+)
+
+// A LangaugeGenerator generates code for a given Pulumi program to an io.Writer.
+type LanguageGenerator func(w io.Writer, p *hcl2.Program) error
+
+// A NameTable maps URNs to language-specific variable names.
+type NameTable map[resource.URN]string
+
+// A DiagnosticsError captures HCL2 diagnostics.
+type DiagnosticsError struct {
+	diagnostics         hcl.Diagnostics
+	newDiagnosticWriter func(w io.Writer, width uint, color bool) hcl.DiagnosticWriter
+}
+
+func (e *DiagnosticsError) Diagnostics() hcl.Diagnostics {
+	return e.diagnostics
+}
+
+// NewDiagnosticWriter returns an hcl.DiagnosticWriter that can be used to render the error's diagnostics.
+func (e *DiagnosticsError) NewDiagnosticWriter(w io.Writer, width uint, color bool) hcl.DiagnosticWriter {
+	return e.newDiagnosticWriter(w, width, color)
+}
+
+func (e *DiagnosticsError) Error() string {
+	var text bytes.Buffer
+	err := e.NewDiagnosticWriter(&text, 0, false).WriteDiagnostics(e.diagnostics)
+	contract.IgnoreError(err)
+	return text.String()
+}
+
+func (e *DiagnosticsError) String() string {
+	return e.Error()
+}
+
+// GenerateLanguageDefintions generates a list of resource definitions from the given resource states.
+func GenerateLanguageDefinitions(w io.Writer, loader schema.Loader, gen LanguageGenerator, states []*resource.State,
+	names NameTable) error {
+
+	var hcl2Text bytes.Buffer
+	for i, state := range states {
+		hcl2Def, err := GenerateHCL2Definition(loader, state, names)
+		if err != nil {
+			return err
+		}
+
+		pre := ""
+		if i > 0 {
+			pre = "\n"
+		}
+		_, err = fmt.Fprintf(&hcl2Text, "%s%v", pre, hcl2Def)
+		contract.IgnoreError(err)
+	}
+
+	parser := syntax.NewParser()
+	if err := parser.ParseFile(&hcl2Text, string("anonymous.pp")); err != nil {
+		return err
+	}
+	if parser.Diagnostics.HasErrors() {
+		// HCL2 text generation should always generate proper code.
+		return fmt.Errorf("internal error: %w", &DiagnosticsError{
+			diagnostics:         parser.Diagnostics,
+			newDiagnosticWriter: parser.NewDiagnosticWriter,
+		})
+	}
+
+	program, diags, err := hcl2.BindProgram(parser.Files, hcl2.Loader(loader), hcl2.AllowMissingVariables)
+	if err != nil {
+		return err
+	}
+	if diags.HasErrors() {
+		// It is possible that the provided states do not contain appropriately-shaped inputs, so this may be user
+		// error.
+		return &DiagnosticsError{
+			diagnostics:         diags,
+			newDiagnosticWriter: program.NewDiagnosticWriter,
+		}
+	}
+
+	return gen(w, program)
+}

--- a/pkg/codegen/importer/language_test.go
+++ b/pkg/codegen/importer/language_test.go
@@ -1,0 +1,85 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package importer
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/internal/test"
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+	"github.com/pulumi/pulumi/pkg/v2/resource/stack"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateLanguageDefinition(t *testing.T) {
+	loader := schema.NewPluginLoader(test.NewHost(testdataPath))
+
+	cases, err := readTestCases("testdata/cases.json")
+	if !assert.NoError(t, err) {
+		t.Fatal()
+	}
+
+	for _, s := range cases.Resources {
+		t.Run(string(s.URN), func(t *testing.T) {
+			state, err := stack.DeserializeResource(s, config.NopDecrypter, config.NopEncrypter)
+			if !assert.NoError(t, err) {
+				t.Fatal()
+			}
+
+			var actualState *resource.State
+			err = GenerateLanguageDefinitions(ioutil.Discard, loader, func(_ io.Writer, p *hcl2.Program) error {
+				if !assert.Len(t, p.Nodes, 1) {
+					t.Fatal()
+				}
+
+				res, isResource := p.Nodes[0].(*hcl2.Resource)
+				if !assert.True(t, isResource) {
+					t.Fatal()
+				}
+
+				actualState = renderResource(t, res)
+				return nil
+			}, []*resource.State{state}, names)
+			if !assert.NoError(t, err) {
+				t.Fatal()
+			}
+
+			assert.Equal(t, state.Type, actualState.Type)
+			assert.Equal(t, state.URN, actualState.URN)
+			assert.Equal(t, state.Parent, actualState.Parent)
+			assert.Equal(t, state.Provider, actualState.Provider)
+			assert.Equal(t, state.Protect, actualState.Protect)
+			if !assert.True(t, actualState.Inputs.DeepEquals(state.Inputs)) {
+				actual, err := stack.SerializeResource(actualState, config.NopEncrypter, false)
+				contract.IgnoreError(err)
+
+				sb, err := json.MarshalIndent(s, "", "    ")
+				contract.IgnoreError(err)
+
+				ab, err := json.MarshalIndent(actual, "", "    ")
+				contract.IgnoreError(err)
+
+				t.Logf("%v\n\n%v\n", string(sb), string(ab))
+			}
+		})
+	}
+}

--- a/pkg/codegen/importer/testdata/cases.json
+++ b/pkg/codegen/importer/testdata/cases.json
@@ -1,0 +1,1561 @@
+{
+    "resources": [
+		{
+			"urn": "urn:pulumi:stack::project::aws:autoscaling/group:Group::Group",
+			"custom": true,
+			"type": "aws:autoscaling/group:Group",
+			"inputs": {
+				"availabilityZones": [
+					"foobar",
+					"foobar"
+				],
+				"forceDelete": false,
+				"healthCheckGracePeriod": 42,
+				"launchConfiguration": "foobar",
+				"maxSize": 42,
+				"metricsGranularity": "foobar",
+				"minSize": 42,
+				"name": "foobar",
+				"protectFromScaleIn": false,
+				"vpcZoneIdentifiers": [
+					"foobar",
+					"foobar"
+				],
+				"waitForCapacityTimeout": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudformation/stack:Stack::Stack",
+			"custom": true,
+			"type": "aws:cloudformation/stack:Stack",
+			"inputs": {
+				"name": "foobar",
+				"templateBody": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudwatch/dashboard:Dashboard::Dashboard",
+			"custom": true,
+			"type": "aws:cloudwatch/dashboard:Dashboard",
+			"inputs": {
+				"dashboardBody": "foobar",
+				"dashboardName": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudwatch/logGroup:LogGroup::LogGroup",
+			"custom": true,
+			"type": "aws:cloudwatch/logGroup:LogGroup",
+			"inputs": {
+				"name": "foobar",
+				"retentionInDays": 42
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudwatch/logMetricFilter:LogMetricFilter::LogMetricFilter",
+			"custom": true,
+			"type": "aws:cloudwatch/logMetricFilter:LogMetricFilter",
+			"inputs": {
+				"logGroupName": "foobar",
+				"metricTransformation": {
+					"name": "foobar",
+					"namespace": "foobar",
+					"value": "foobar"
+				},
+				"name": "foobar",
+				"pattern": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
+			"custom": true,
+			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
+			"inputs": {
+				"actionsEnabled": true,
+				"alarmActions": [
+					"foobar"
+				],
+				"alarmDescription": "foobar",
+				"comparisonOperator": "foobar",
+				"dimensions": {
+					"AutoScalingGroupName": "foobar"
+				},
+				"evaluationPeriods": 42,
+				"metricName": "foobar",
+				"name": "foobar",
+				"namespace": "foobar",
+				"period": 42,
+				"statistic": "foobar",
+				"threshold": 42,
+				"treatMissingData": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
+			"custom": true,
+			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
+			"inputs": {
+				"actionsEnabled": true,
+				"alarmActions": [
+					"foobar"
+				],
+				"alarmDescription": "foobar",
+				"comparisonOperator": "foobar",
+				"dimensions": {
+					"DBClusterIdentifier": "foobar"
+				},
+				"evaluationPeriods": 42,
+				"metricName": "foobar",
+				"name": "foobar",
+				"namespace": "foobar",
+				"period": 42,
+				"statistic": "foobar",
+				"threshold": 42,
+				"treatMissingData": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
+			"custom": true,
+			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
+			"inputs": {
+				"actionsEnabled": true,
+				"alarmActions": [
+					"foobar"
+				],
+				"alarmDescription": "foobar",
+				"comparisonOperator": "foobar",
+				"dimensions": {
+					"LoadBalancer": "foobar"
+				},
+				"evaluationPeriods": 42,
+				"metricName": "foobar",
+				"name": "foobar",
+				"namespace": "foobar",
+				"period": 42,
+				"statistic": "foobar",
+				"threshold": 42,
+				"treatMissingData": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
+			"custom": true,
+			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
+			"inputs": {
+				"actionsEnabled": true,
+				"alarmActions": [
+					"foobar"
+				],
+				"alarmDescription": "foobar",
+				"comparisonOperator": "foobar",
+				"dimensions": {
+					"LoadBalancer": "foobar",
+					"TargetGroup": "foobar"
+				},
+				"evaluationPeriods": 42,
+				"metricName": "foobar",
+				"name": "foobar",
+				"namespace": "foobar",
+				"period": 42,
+				"statistic": "foobar",
+				"threshold": 42,
+				"treatMissingData": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
+			"custom": true,
+			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
+			"inputs": {
+				"actionsEnabled": true,
+				"alarmActions": [
+					"foobar"
+				],
+				"alarmDescription": "foobar",
+				"comparisonOperator": "foobar",
+				"evaluationPeriods": 42,
+				"metricName": "foobar",
+				"name": "foobar",
+				"namespace": "foobar",
+				"period": 42,
+				"statistic": "foobar",
+				"threshold": 42,
+				"treatMissingData": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/eip:Eip::Eip",
+			"custom": true,
+			"type": "aws:ec2/eip:Eip",
+			"inputs": {
+				"vpc": true
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/flowLog:FlowLog::FlowLog",
+			"custom": true,
+			"type": "aws:ec2/flowLog:FlowLog",
+			"inputs": {
+				"iamRoleArn": "foobar",
+				"logDestination": "foobar",
+				"logDestinationType": "foobar",
+				"maxAggregationInterval": 42,
+				"trafficType": "foobar",
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/internetGateway:InternetGateway::InternetGateway",
+			"custom": true,
+			"type": "aws:ec2/internetGateway:InternetGateway",
+			"inputs": {
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/launchConfiguration:LaunchConfiguration::LaunchConfiguration",
+			"custom": true,
+			"type": "aws:ec2/launchConfiguration:LaunchConfiguration",
+			"inputs": {
+				"associatePublicIpAddress": false,
+				"ebsBlockDevices": [
+					{
+						"deleteOnTermination": true,
+						"deviceName": "foobar",
+						"volumeSize": 42,
+						"volumeType": "foobar"
+					}
+				],
+				"enableMonitoring": true,
+				"iamInstanceProfile": "foobar",
+				"imageId": "foobar",
+				"instanceType": "foobar",
+				"name": "foobar",
+				"placementTenancy": "foobar",
+				"rootBlockDevice": {
+					"deleteOnTermination": true,
+					"volumeSize": 42,
+					"volumeType": "foobar"
+				},
+				"securityGroups": [
+					"foobar"
+				],
+				"userData": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/launchConfiguration:LaunchConfiguration::LaunchConfiguration",
+			"custom": true,
+			"type": "aws:ec2/launchConfiguration:LaunchConfiguration",
+			"inputs": {
+				"associatePublicIpAddress": true,
+				"enableMonitoring": true,
+				"imageId": "foobar",
+				"instanceType": "foobar",
+				"namePrefix": "foobar",
+				"securityGroups": [
+					"foobar"
+				],
+				"userData": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/natGateway:NatGateway::NatGateway",
+			"custom": true,
+			"type": "aws:ec2/natGateway:NatGateway",
+			"inputs": {
+				"allocationId": "foobar",
+				"subnetId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/routeTable:RouteTable::RouteTable",
+			"custom": true,
+			"type": "aws:ec2/routeTable:RouteTable",
+			"inputs": {
+				"routes": [
+					{
+						"cidrBlock": "foobar",
+						"gatewayId": "foobar"
+					}
+				],
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/routeTableAssociation:RouteTableAssociation::RouteTableAssociation",
+			"custom": true,
+			"type": "aws:ec2/routeTableAssociation:RouteTableAssociation",
+			"inputs": {
+				"routeTableId": "foobar",
+				"subnetId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
+			"custom": true,
+			"type": "aws:ec2/securityGroup:SecurityGroup",
+			"inputs": {
+				"description": "foobar",
+				"egress": [
+					{
+						"cidrBlocks": [
+							"foobar"
+						],
+						"fromPort": 42,
+						"protocol": "foobar",
+						"self": false,
+						"toPort": 42
+					}
+				],
+				"ingress": [
+					{
+						"cidrBlocks": [
+							"foobar"
+						],
+						"fromPort": 42,
+						"protocol": "foobar",
+						"self": false,
+						"toPort": 42
+					}
+				],
+				"name": "foobar",
+				"revokeRulesOnDelete": false,
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
+			"custom": true,
+			"type": "aws:ec2/securityGroup:SecurityGroup",
+			"inputs": {
+				"description": "foobar",
+				"egress": [
+					{
+						"cidrBlocks": [
+							"foobar"
+						],
+						"fromPort": 42,
+						"protocol": "foobar",
+						"self": false,
+						"toPort": 42
+					}
+				],
+				"ingress": [
+					{
+						"cidrBlocks": [
+							"foobar"
+						],
+						"fromPort": 42,
+						"protocol": "foobar",
+						"self": false,
+						"toPort": 42
+					},
+					{
+						"cidrBlocks": [
+							"foobar"
+						],
+						"fromPort": 42,
+						"protocol": "foobar",
+						"self": false,
+						"toPort": 42
+					}
+				],
+				"name": "foobar",
+				"revokeRulesOnDelete": false,
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
+			"custom": true,
+			"type": "aws:ec2/securityGroup:SecurityGroup",
+			"inputs": {
+				"description": "foobar",
+				"egress": [
+					{
+						"cidrBlocks": [
+							"foobar"
+						],
+						"fromPort": 42,
+						"protocol": "foobar",
+						"self": false,
+						"toPort": 42
+					}
+				],
+				"ingress": [
+					{
+						"cidrBlocks": [
+							"foobar"
+						],
+						"fromPort": 42,
+						"protocol": "foobar",
+						"self": false,
+						"toPort": 42
+					},
+					{
+						"fromPort": 42,
+						"protocol": "foobar",
+						"securityGroups": [
+							"foobar"
+						],
+						"self": false,
+						"toPort": 42
+					}
+				],
+				"name": "foobar",
+				"revokeRulesOnDelete": false,
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
+			"custom": true,
+			"type": "aws:ec2/securityGroup:SecurityGroup",
+			"inputs": {
+				"description": "foobar",
+				"ingress": [
+					{
+						"fromPort": 42,
+						"protocol": "foobar",
+						"securityGroups": [
+							"foobar"
+						],
+						"self": false,
+						"toPort": 42
+					},
+					{
+						"fromPort": 42,
+						"protocol": "foobar",
+						"securityGroups": [
+							"foobar"
+						],
+						"self": false,
+						"toPort": 42
+					}
+				],
+				"name": "foobar",
+				"revokeRulesOnDelete": false,
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/subnet:Subnet::Subnet",
+			"custom": true,
+			"type": "aws:ec2/subnet:Subnet",
+			"inputs": {
+				"assignIpv6AddressOnCreation": false,
+				"availabilityZone": "foobar",
+				"cidrBlock": "foobar",
+				"mapPublicIpOnLaunch": false,
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/subnet:Subnet::Subnet",
+			"custom": true,
+			"type": "aws:ec2/subnet:Subnet",
+			"inputs": {
+				"assignIpv6AddressOnCreation": false,
+				"availabilityZone": "foobar",
+				"cidrBlock": "foobar",
+				"mapPublicIpOnLaunch": true,
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/vpc:Vpc::Vpc",
+			"custom": true,
+			"type": "aws:ec2/vpc:Vpc",
+            "inputs": {
+                "cidrBlock": ""
+            }
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ec2/vpc:Vpc::Vpc",
+			"custom": true,
+			"type": "aws:ec2/vpc:Vpc",
+			"inputs": {
+				"assignGeneratedIpv6CidrBlock": false,
+				"cidrBlock": "foobar",
+				"enableDnsHostnames": true,
+				"enableDnsSupport": true,
+				"instanceTenancy": "foobar",
+				"tags": {
+					"Name": "foobar"
+				}
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ecs/cluster:Cluster::Cluster",
+			"custom": true,
+			"type": "aws:ecs/cluster:Cluster",
+			"inputs": {
+				"name": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ecs/service:Service::Service",
+			"custom": true,
+			"type": "aws:ecs/service:Service",
+			"inputs": {
+				"cluster": "foobar",
+				"deploymentMaximumPercent": 42,
+				"deploymentMinimumHealthyPercent": 42,
+				"desiredCount": 42,
+				"enableEcsManagedTags": false,
+				"iamRole": "foobar",
+				"loadBalancers": [
+					{
+						"containerName": "foobar",
+						"containerPort": 42,
+						"targetGroupArn": "foobar"
+					}
+				],
+				"name": "foobar",
+				"orderedPlacementStrategies": [
+					{
+						"field": "foobar",
+						"type": "foobar"
+					}
+				],
+				"schedulingStrategy": "foobar",
+				"taskDefinition": "foobar",
+				"waitForSteadyState": true
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:ecs/taskDefinition:TaskDefinition::TaskDefinition",
+			"custom": true,
+			"type": "aws:ecs/taskDefinition:TaskDefinition",
+			"inputs": {
+				"containerDefinitions": "foobar",
+				"family": "foobar",
+				"networkMode": "foobar",
+				"taskRoleArn": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/listener:Listener::Listener",
+			"custom": true,
+			"type": "aws:elasticloadbalancingv2/listener:Listener",
+			"inputs": {
+				"certificateArn": "foobar",
+				"defaultActions": [
+					{
+						"fixedResponse": {
+							"contentType": "foobar",
+							"statusCode": "foobar"
+						},
+						"targetGroupArn": "foobar",
+						"type": "foobar"
+					}
+				],
+				"loadBalancerArn": "foobar",
+				"port": 42,
+				"protocol": "foobar",
+				"sslPolicy": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/listener:Listener::Listener",
+			"custom": true,
+			"type": "aws:elasticloadbalancingv2/listener:Listener",
+			"inputs": {
+				"defaultActions": [
+					{
+						"fixedResponse": {
+							"contentType": "foobar",
+							"statusCode": "foobar"
+						},
+						"targetGroupArn": "foobar",
+						"type": "foobar"
+					}
+				],
+				"loadBalancerArn": "foobar",
+				"port": 42,
+				"protocol": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/listenerRule:ListenerRule::ListenerRule",
+			"custom": true,
+			"type": "aws:elasticloadbalancingv2/listenerRule:ListenerRule",
+			"inputs": {
+				"actions": [
+					{
+						"targetGroupArn": "foobar",
+						"type": "foobar"
+					}
+				],
+				"conditions": [
+					{
+						"field": "foobar",
+						"values": "foobar"
+					},
+					{
+						"field": "foobar",
+						"values": "foobar"
+					}
+				],
+				"listenerArn": "foobar",
+				"priority": 42
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/loadBalancer:LoadBalancer::LoadBalancer",
+			"custom": true,
+			"type": "aws:elasticloadbalancingv2/loadBalancer:LoadBalancer",
+			"inputs": {
+				"accessLogs": {
+					"bucket": "foobar",
+					"enabled": true,
+					"prefix": "foobar"
+				},
+				"dropInvalidHeaderFields": false,
+				"enableCrossZoneLoadBalancing": false,
+				"enableDeletionProtection": false,
+				"enableHttp2": true,
+				"idleTimeout": 42,
+				"internal": false,
+				"loadBalancerType": "foobar",
+				"name": "foobar",
+				"securityGroups": [
+					"foobar"
+				],
+				"subnets": [
+					"foobar",
+					"foobar"
+				]
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/targetGroup:TargetGroup::TargetGroup",
+			"custom": true,
+			"type": "aws:elasticloadbalancingv2/targetGroup:TargetGroup",
+			"inputs": {
+				"deregistrationDelay": 42,
+				"healthCheck": {
+					"enabled": true,
+					"healthyThreshold": 42,
+					"interval": 42,
+					"matcher": "foobar",
+					"path": "foobar",
+					"port": "foobar",
+					"protocol": "foobar",
+					"timeout": 42,
+					"unhealthyThreshold": 42
+				},
+				"lambdaMultiValueHeadersEnabled": false,
+				"name": "foobar",
+				"port": 42,
+				"protocol": "foobar",
+				"proxyProtocolV2": false,
+				"slowStart": 42,
+				"targetType": "foobar",
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:elasticloadbalancingv2/targetGroup:TargetGroup::TargetGroup",
+			"custom": true,
+			"type": "aws:elasticloadbalancingv2/targetGroup:TargetGroup",
+			"inputs": {
+				"deregistrationDelay": 42,
+				"lambdaMultiValueHeadersEnabled": false,
+				"name": "foobar",
+				"port": 42,
+				"protocol": "foobar",
+				"proxyProtocolV2": false,
+				"slowStart": 42,
+				"targetType": "foobar",
+				"vpcId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:iam/instanceProfile:InstanceProfile::InstanceProfile",
+			"custom": true,
+			"type": "aws:iam/instanceProfile:InstanceProfile",
+			"inputs": {
+				"name": "foobar",
+				"path": "foobar",
+				"roles": [
+					"foobar"
+				]
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:iam/role:Role::Role",
+			"custom": true,
+			"type": "aws:iam/role:Role",
+			"inputs": {
+				"assumeRolePolicy": "foobar",
+				"forceDetachPolicies": false,
+				"maxSessionDuration": 42,
+				"name": "foobar",
+				"path": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:iam/rolePolicy:RolePolicy::RolePolicy",
+			"custom": true,
+			"type": "aws:iam/rolePolicy:RolePolicy",
+			"inputs": {
+				"name": "foobar",
+				"policy": "foobar",
+				"role": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:iam/rolePolicyAttachment:RolePolicyAttachment::RolePolicyAttachment",
+			"custom": true,
+			"type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+			"inputs": {
+				"policyArn": "foobar",
+				"role": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:iam/serviceLinkedRole:ServiceLinkedRole::ServiceLinkedRole",
+			"custom": true,
+			"type": "aws:iam/serviceLinkedRole:ServiceLinkedRole",
+			"inputs": {
+				"awsServiceName": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:kms/key:Key::Key",
+			"custom": true,
+			"type": "aws:kms/key:Key",
+			"inputs": {
+				"customerMasterKeySpec": "foobar",
+				"enableKeyRotation": true,
+				"isEnabled": true,
+				"keyUsage": "foobar",
+				"policy": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:rds/cluster:Cluster::Cluster",
+			"custom": true,
+			"type": "aws:rds/cluster:Cluster",
+			"inputs": {
+				"backupRetentionPeriod": 42,
+				"copyTagsToSnapshot": false,
+				"databaseName": "foobar",
+				"dbSubnetGroupName": "foobar",
+				"deletionProtection": true,
+				"enableHttpEndpoint": false,
+				"engine": "foobar",
+				"engineMode": "foobar",
+				"finalSnapshotIdentifier": "foobar",
+				"masterPassword": "foobar",
+				"masterUsername": "foobar",
+				"skipFinalSnapshot": false,
+				"storageEncrypted": true,
+				"vpcSecurityGroupIds": [
+					"foobar"
+				]
+			},
+			"protect": true
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:rds/clusterInstance:ClusterInstance::ClusterInstance",
+			"custom": true,
+			"type": "aws:rds/clusterInstance:ClusterInstance",
+			"inputs": {
+				"autoMinorVersionUpgrade": true,
+				"clusterIdentifier": "foobar",
+				"copyTagsToSnapshot": false,
+				"dbParameterGroupName": "foobar",
+				"engine": "foobar",
+				"instanceClass": "foobar",
+				"monitoringInterval": 42,
+				"monitoringRoleArn": "foobar",
+				"promotionTier": 42,
+				"publiclyAccessible": false
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:rds/parameterGroup:ParameterGroup::ParameterGroup",
+			"custom": true,
+			"type": "aws:rds/parameterGroup:ParameterGroup",
+			"inputs": {
+				"description": "foobar",
+				"family": "foobar",
+				"name": "foobar",
+				"parameters": [
+					{
+						"applyMethod": "foobar",
+						"name": "foobar",
+						"value": "foobar"
+					},
+					{
+						"applyMethod": "foobar",
+						"name": "foobar",
+						"value": "foobar"
+					},
+					{
+						"applyMethod": "foobar",
+						"name": "foobar",
+						"value": "foobar"
+					},
+					{
+						"applyMethod": "foobar",
+						"name": "foobar",
+						"value": "foobar"
+					},
+					{
+						"applyMethod": "foobar",
+						"name": "foobar",
+						"value": "foobar"
+					}
+				]
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:rds/subnetGroup:SubnetGroup::SubnetGroup",
+			"custom": true,
+			"type": "aws:rds/subnetGroup:SubnetGroup",
+			"inputs": {
+				"description": "foobar",
+				"name": "foobar",
+				"subnetIds": [
+					"foobar",
+					"foobar"
+				]
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:route53/record:Record::Record",
+			"custom": true,
+			"type": "aws:route53/record:Record",
+			"inputs": {
+				"aliases": [
+					{
+						"evaluateTargetHealth": true,
+						"name": "foobar",
+						"zoneId": "foobar"
+					}
+				],
+				"name": "foobar",
+				"type": "foobar",
+				"zoneId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:route53/record:Record::Record",
+			"custom": true,
+			"type": "aws:route53/record:Record",
+			"inputs": {
+				"name": "foobar",
+				"records": [
+					"foobar"
+				],
+				"ttl": 42,
+				"type": "foobar",
+				"zoneId": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:route53/zone:Zone::Zone",
+			"custom": true,
+			"type": "aws:route53/zone:Zone"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:s3/bucket:Bucket::Bucket",
+			"custom": true,
+			"type": "aws:s3/bucket:Bucket",
+			"inputs": {
+				"acl": "foobar",
+				"bucket": "foobar",
+				"forceDestroy": false
+			},
+			"protect": true
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:s3/bucket:Bucket::Bucket",
+			"custom": true,
+			"type": "aws:s3/bucket:Bucket",
+			"inputs": {
+				"acl": "foobar",
+				"bucket": "foobar",
+				"forceDestroy": false,
+				"replicationConfiguration": {
+					"role": "foobar",
+					"rules": [
+						{
+							"destination": {
+								"bucket": "foobar"
+							},
+							"priority": 42,
+							"status": "foobar"
+						}
+					]
+				},
+				"versioning": {
+					"enabled": true,
+					"mfaDelete": false
+				}
+			},
+			"protect": true
+		},
+		{
+			"urn": "urn:pulumi:stack::project::aws:s3/bucketPolicy:BucketPolicy::BucketPolicy",
+			"custom": true,
+			"type": "aws:s3/bucketPolicy:BucketPolicy",
+			"inputs": {
+				"bucket": "foobar",
+				"policy": "foobar"
+			}
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:acm/certificate:Certificate::Certificate",
+			"custom": true,
+			"type": "aws:acm/certificate:Certificate",
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:cloudwatch/eventRule:EventRule::EventRule",
+			"custom": true,
+			"type": "aws:cloudwatch/eventRule:EventRule",
+			"inputs": {
+				"description": "foobar",
+				"isEnabled": true,
+				"name": "foobar",
+				"scheduleExpression": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:cloudwatch/eventTarget:EventTarget::EventTarget",
+			"custom": true,
+			"type": "aws:cloudwatch/eventTarget:EventTarget",
+			"inputs": {
+				"arn": "foobar",
+				"ecsTarget": {
+					"group": "foobar",
+					"launchType": "foobar",
+					"networkConfiguration": {
+						"assignPublicIp": true,
+						"securityGroups": [
+							"foobar"
+						],
+						"subnets": [
+							"foobar"
+						]
+					},
+					"taskCount": 42,
+					"taskDefinitionArn": "foobar"
+				},
+				"roleArn": "foobar",
+				"rule": "foobar",
+				"targetId": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:cloudwatch/logGroup:LogGroup::LogGroup",
+			"custom": true,
+			"type": "aws:cloudwatch/logGroup:LogGroup",
+			"inputs": {
+				"name": "foobar",
+				"retentionInDays": 42
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:cloudwatch/metricAlarm:MetricAlarm::MetricAlarm",
+			"custom": true,
+			"type": "aws:cloudwatch/metricAlarm:MetricAlarm",
+			"inputs": {
+				"actionsEnabled": true,
+				"alarmActions": [
+					"foobar"
+				],
+				"alarmDescription": "foobar",
+				"comparisonOperator": "foobar",
+				"dimensions": {
+					"ClientId": "foobar",
+					"DomainName": "foobar"
+				},
+				"evaluationPeriods": 42,
+				"metricName": "foobar",
+				"name": "foobar",
+				"namespace": "foobar",
+				"period": 42,
+				"statistic": "foobar",
+				"threshold": 42,
+				"treatMissingData": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
+			"custom": true,
+			"type": "aws:ec2/securityGroup:SecurityGroup",
+			"inputs": {
+				"description": "foobar",
+				"name": "foobar",
+				"revokeRulesOnDelete": false,
+				"vpcId": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroup:SecurityGroup::SecurityGroup",
+			"custom": true,
+			"type": "aws:ec2/securityGroup:SecurityGroup",
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroupRule:SecurityGroupRule::SecurityGroupRule",
+			"custom": true,
+			"type": "aws:ec2/securityGroupRule:SecurityGroupRule",
+			"inputs": {
+				"cidrBlocks": [
+					"foobar"
+				],
+				"description": "foobar",
+				"fromPort": 42,
+				"protocol": "foobar",
+				"securityGroupId": "foobar",
+				"self": false,
+				"toPort": 42,
+				"type": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroupRule:SecurityGroupRule::SecurityGroupRule",
+			"custom": true,
+			"type": "aws:ec2/securityGroupRule:SecurityGroupRule",
+			"inputs": {
+				"cidrBlocks": [
+					"foobar"
+				],
+				"fromPort": 42,
+				"protocol": "foobar",
+				"securityGroupId": "foobar",
+				"self": false,
+				"toPort": 42,
+				"type": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroupRule:SecurityGroupRule::SecurityGroupRule",
+			"custom": true,
+			"type": "aws:ec2/securityGroupRule:SecurityGroupRule",
+			"inputs": {
+				"cidrBlocks": [
+					"foobar",
+					"foobar"
+				],
+				"fromPort": 42,
+				"protocol": "foobar",
+				"securityGroupId": "foobar",
+				"self": false,
+				"toPort": 42,
+				"type": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ec2/securityGroupRule:SecurityGroupRule::SecurityGroupRule",
+			"custom": true,
+			"type": "aws:ec2/securityGroupRule:SecurityGroupRule",
+			"inputs": {
+				"fromPort": 42,
+				"protocol": "foobar",
+				"securityGroupId": "foobar",
+				"self": true,
+				"toPort": 42,
+				"type": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ecr/lifecyclePolicy:LifecyclePolicy::LifecyclePolicy",
+			"custom": true,
+			"type": "aws:ecr/lifecyclePolicy:LifecyclePolicy",
+			"inputs": {
+				"policy": "foobar",
+				"repository": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ecr/repository:Repository::Repository",
+			"custom": true,
+			"type": "aws:ecr/repository:Repository",
+			"inputs": {
+				"imageTagMutability": "foobar",
+				"name": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ecs/cluster:Cluster::Cluster",
+			"custom": true,
+			"type": "aws:ecs/cluster:Cluster",
+			"inputs": {
+				"name": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ecs/service:Service::Service",
+			"custom": true,
+			"type": "aws:ecs/service:Service",
+			"inputs": {
+				"cluster": "foobar",
+				"deploymentMaximumPercent": 42,
+				"deploymentMinimumHealthyPercent": 42,
+				"desiredCount": 42,
+				"enableEcsManagedTags": false,
+				"launchType": "foobar",
+				"loadBalancers": [
+					{
+						"containerName": "foobar",
+						"containerPort": 42,
+						"targetGroupArn": "foobar"
+					}
+				],
+				"name": "foobar",
+				"networkConfiguration": {
+					"assignPublicIp": true,
+					"securityGroups": [
+						"foobar"
+					],
+					"subnets": [
+						"foobar"
+					]
+				},
+				"schedulingStrategy": "foobar",
+				"taskDefinition": "foobar",
+				"waitForSteadyState": true
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ecs/service:Service::Service",
+			"custom": true,
+			"type": "aws:ecs/service:Service",
+			"inputs": {
+				"cluster": "foobar",
+				"deploymentMaximumPercent": 42,
+				"deploymentMinimumHealthyPercent": 42,
+				"desiredCount": 42,
+				"enableEcsManagedTags": false,
+				"launchType": "foobar",
+				"loadBalancers": [
+					{
+						"containerName": "foobar",
+						"containerPort": 42,
+						"targetGroupArn": "foobar"
+					}
+				],
+				"name": "foobar",
+				"networkConfiguration": {
+					"assignPublicIp": true,
+					"securityGroups": [
+						"foobar"
+					],
+					"subnets": [
+						"foobar",
+						"foobar"
+					]
+				},
+				"schedulingStrategy": "foobar",
+				"taskDefinition": "foobar",
+				"waitForSteadyState": true
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ecs/taskDefinition:TaskDefinition::TaskDefinition",
+			"custom": true,
+			"type": "aws:ecs/taskDefinition:TaskDefinition",
+			"inputs": {
+				"containerDefinitions": "foobar",
+				"cpu": "foobar",
+				"executionRoleArn": "foobar",
+				"family": "foobar",
+				"memory": "foobar",
+				"networkMode": "foobar",
+				"requiresCompatibilities": [
+					"foobar"
+				],
+				"taskRoleArn": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:ecs/taskDefinition:TaskDefinition::TaskDefinition",
+			"custom": true,
+			"type": "aws:ecs/taskDefinition:TaskDefinition",
+			"inputs": {
+				"containerDefinitions": {
+					"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+					"ciphertext": "\"foobar\""
+				},
+				"cpu": {
+					"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+					"ciphertext": "\"foobar\""
+				},
+				"executionRoleArn": "foobar",
+				"family": {
+					"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+					"ciphertext": "\"foobar\""
+				},
+				"memory": {
+					"4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
+					"ciphertext": "\"foobar\""
+				},
+				"networkMode": "foobar",
+				"requiresCompatibilities": [
+					"foobar"
+				],
+				"taskRoleArn": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:elasticsearch/domain:Domain::Domain",
+			"custom": true,
+			"type": "aws:elasticsearch/domain:Domain",
+			"inputs": {
+				"accessPolicies": "foobar",
+				"clusterConfig": {
+					"dedicatedMasterCount": 42,
+					"dedicatedMasterEnabled": false,
+					"instanceCount": 42,
+					"instanceType": "foobar"
+				},
+				"domainName": "foobar",
+				"ebsOptions": {
+					"ebsEnabled": true,
+					"volumeSize": 42,
+					"volumeType": "foobar"
+				},
+				"elasticsearchVersion": "foobar",
+				"encryptAtRest": {
+					"enabled": false
+				},
+				"tags": {
+					"category": "foobar",
+					"pulumiStack": "foobar"
+				},
+				"vpcOptions": {
+					"securityGroupIds": [
+						"foobar"
+					],
+					"subnetIds": [
+						"foobar"
+					]
+				}
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:iam/policy:Policy::Policy",
+			"custom": true,
+			"type": "aws:iam/policy:Policy",
+			"inputs": {
+				"name": "foobar",
+				"path": "foobar",
+				"policy": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent",
+			"protect": true
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:iam/policyAttachment:PolicyAttachment::PolicyAttachment",
+			"custom": true,
+			"type": "aws:iam/policyAttachment:PolicyAttachment",
+			"inputs": {
+				"name": "foobar",
+				"policyArn": "foobar",
+				"roles": [
+					"foobar"
+				]
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent",
+			"protect": true
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:iam/role:Role::Role",
+			"custom": true,
+			"type": "aws:iam/role:Role",
+			"inputs": {
+				"assumeRolePolicy": "foobar",
+				"forceDetachPolicies": false,
+				"maxSessionDuration": 42,
+				"name": "foobar",
+				"path": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:iam/role:Role::Role",
+			"custom": true,
+			"type": "aws:iam/role:Role",
+			"inputs": {
+				"assumeRolePolicy": "foobar",
+				"forceDetachPolicies": false,
+				"maxSessionDuration": 42,
+				"name": "foobar",
+				"path": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent",
+			"protect": true
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:iam/rolePolicy:RolePolicy::RolePolicy",
+			"custom": true,
+			"type": "aws:iam/rolePolicy:RolePolicy",
+			"inputs": {
+				"name": "foobar",
+				"policy": "foobar",
+				"role": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:iam/rolePolicyAttachment:RolePolicyAttachment::RolePolicyAttachment",
+			"custom": true,
+			"type": "aws:iam/rolePolicyAttachment:RolePolicyAttachment",
+			"inputs": {
+				"policyArn": "foobar",
+				"role": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:lambda/function:Function::Function",
+			"custom": true,
+			"type": "aws:lambda/function:Function",
+			"inputs": {
+				"code": "archive",
+				"handler": "foobar",
+				"memorySize": 42,
+				"name": "foobar",
+				"publish": false,
+				"reservedConcurrentExecutions": 42,
+				"role": "foobar",
+				"runtime": "foobar",
+				"timeout": 42
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:lambda/permission:Permission::Permission",
+			"custom": true,
+			"type": "aws:lambda/permission:Permission",
+			"inputs": {
+				"action": "foobar",
+				"function": "foobar",
+				"principal": "foobar",
+				"sourceArn": "foobar",
+				"statementId": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:lb/listener:Listener::Listener",
+			"custom": true,
+			"type": "aws:lb/listener:Listener",
+			"inputs": {
+				"certificateArn": "foobar",
+				"defaultActions": [
+					{
+						"targetGroupArn": "foobar",
+						"type": "foobar"
+					}
+				],
+				"loadBalancerArn": "foobar",
+				"port": 42,
+				"protocol": "foobar",
+				"sslPolicy": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:lb/listener:Listener::Listener",
+			"custom": true,
+			"type": "aws:lb/listener:Listener",
+			"inputs": {
+				"defaultActions": [
+					{
+						"targetGroupArn": "foobar",
+						"type": "foobar"
+					}
+				],
+				"loadBalancerArn": "foobar",
+				"port": 42,
+				"protocol": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:lb/loadBalancer:LoadBalancer::LoadBalancer",
+			"custom": true,
+			"type": "aws:lb/loadBalancer:LoadBalancer",
+			"inputs": {
+				"dropInvalidHeaderFields": false,
+				"enableCrossZoneLoadBalancing": false,
+				"enableDeletionProtection": false,
+				"enableHttp2": true,
+				"idleTimeout": 42,
+				"internal": false,
+				"loadBalancerType": "foobar",
+				"name": "foobar",
+				"securityGroups": [
+					"foobar"
+				],
+				"subnets": [
+					"foobar",
+					"foobar"
+				],
+				"tags": {
+					"Name": "foobar",
+					"category": "foobar",
+					"pulumiStack": "foobar"
+				}
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:lb/loadBalancer:LoadBalancer::LoadBalancer",
+			"custom": true,
+			"type": "aws:lb/loadBalancer:LoadBalancer",
+			"inputs": {
+				"dropInvalidHeaderFields": false,
+				"enableCrossZoneLoadBalancing": false,
+				"enableDeletionProtection": false,
+				"enableHttp2": true,
+				"idleTimeout": 42,
+				"internal": true,
+				"loadBalancerType": "foobar",
+				"name": "foobar",
+				"securityGroups": [
+					"foobar"
+				],
+				"subnets": [
+					"foobar",
+					"foobar"
+				],
+				"tags": {
+					"Name": "foobar",
+					"category": "foobar",
+					"pulumiStack": "foobar"
+				}
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:lb/targetGroup:TargetGroup::TargetGroup",
+			"custom": true,
+			"type": "aws:lb/targetGroup:TargetGroup",
+			"inputs": {
+				"deregistrationDelay": 42,
+				"healthCheck": {
+					"enabled": true,
+					"healthyThreshold": 42,
+					"interval": 42,
+					"matcher": "foobar",
+					"path": "foobar",
+					"port": "foobar",
+					"protocol": "foobar",
+					"unhealthyThreshold": 42
+				},
+				"lambdaMultiValueHeadersEnabled": false,
+				"name": "foobar",
+				"port": 42,
+				"protocol": "foobar",
+				"proxyProtocolV2": false,
+				"slowStart": 42,
+				"tags": {
+					"Name": "foobar",
+					"category": "foobar",
+					"pulumiStack": "foobar"
+				},
+				"targetType": "foobar",
+				"vpcId": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:lb/targetGroup:TargetGroup::TargetGroup",
+			"custom": true,
+			"type": "aws:lb/targetGroup:TargetGroup",
+			"inputs": {
+				"deregistrationDelay": 42,
+				"lambdaMultiValueHeadersEnabled": false,
+				"name": "foobar",
+				"port": 42,
+				"protocol": "foobar",
+				"proxyProtocolV2": false,
+				"slowStart": 42,
+				"tags": {
+					"Name": "foobar"
+				},
+				"targetType": "foobar",
+				"vpcId": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:s3/bucket:Bucket::Bucket",
+			"custom": true,
+			"type": "aws:s3/bucket:Bucket",
+			"inputs": {
+				"acl": "foobar",
+				"bucket": "foobar",
+				"forceDestroy": false,
+				"region": "foobar",
+				"versioning": {
+					"enabled": true,
+					"mfaDelete": false
+				}
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent",
+			"protect": true,
+			"provider": "urn:pulumi:stack::project::pulumi:providers:pkg::provider::id"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:sns/topic:Topic::Topic",
+			"custom": true,
+			"type": "aws:sns/topic:Topic",
+			"inputs": {
+				"name": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::my$aws:sns/topicSubscription:TopicSubscription::TopicSubscription",
+			"custom": true,
+			"type": "aws:sns/topicSubscription:TopicSubscription",
+			"inputs": {
+				"confirmationTimeoutInMinutes": 42,
+				"endpoint": "foobar",
+				"endpointAutoConfirms": false,
+				"protocol": "foobar",
+				"rawMessageDelivery": false,
+				"topic": "foobar"
+			},
+			"parent": "urn:pulumi:stack::project::my::parent::parent"
+		},
+		{
+			"urn": "urn:pulumi:stack::project::random:index/randomId:RandomId::RandomId",
+			"custom": true,
+			"type": "random:index/randomId:RandomId",
+			"inputs": {
+				"byteLength": 42,
+				"prefix": "foobar"
+			}
+		}
+    ]
+}

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -73,7 +73,7 @@ func (l *pluginLoader) LoadPackage(pkg string, version *semver.Version) (*Packag
 	if p, ok := l.entries[pkg]; ok {
 		return p, nil
 	}
-	l.entries[pkg] = p
+	l.entries[key] = p
 
 	return p, nil
 }


### PR DESCRIPTION
Add a new package, `codegen/importer`, that can generate definitions for
resource states in PCL or TS/Python/C#/Go. The pipeline is relatively
simple: given a list of resource states, generate a PCL program in
memory, bind it, and pass it to the language-specific code generator.
This builds upon the existing PCL IR, and can be used with the currently
supported code generators.

Related to #1635.