### PR TITLE
Remove duplicated methods

### DIFF
--- a/pkg/codegen/hcl2/model/expression.go
+++ b/pkg/codegen/hcl2/model/expression.go
@@ -37,12 +37,8 @@ type Expression interface {
 	// NodeTokens returns the syntax.Tokens associated with the expression.
 	NodeTokens() syntax.NodeTokens
 
-	// GetLeadingTrivia returns the leading trivia associated with the expression.
-	GetLeadingTrivia() syntax.TriviaList
 	// SetLeadingTrivia sets the leading trivia associated with the expression.
 	SetLeadingTrivia(syntax.TriviaList)
-	// GetTrailingTrivia returns the trailing trivia associated with the expression.
-	GetTrailingTrivia() syntax.TriviaList
 	// SetTrailingTrivia sets the trailing trivia associated with the expression.
 	SetTrailingTrivia(syntax.TriviaList)
 


### PR DESCRIPTION
These functions are throwing a duplicate method error in my IDE because they are already specified in the `printable` interface.  