### PR TITLE
Make args optional in Node.js if state inputs aren't defined

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -460,8 +460,8 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	fmt.Fprintf(w, "     * @param opts A bag of options that control this resource's behavior.\n")
 	fmt.Fprintf(w, "     */\n")
 
-	// k8s provider "get" methods don't require args, so make args optional.
-	if mod.compatibility == kubernetes20 {
+	// If "get" methods don't require args, make args optional.
+	if r.StateInputs == nil {
 		allOptionalInputs = true
 	}
 


### PR DESCRIPTION
**Problem**: if a native provider defines no state inputs, Node.js generation is broken - the generated code passes `undefined` for `args` where undefined is not expected.

Kubernetes introduces a fix for this behind a compat flag, but I believe this should be generalized. This line:

https://github.com/pulumi/pulumi/blob/736019f7ce63d35266a846a8fe13a70baafa7006/pkg/codegen/nodejs/gen.go#L395

assigns `undefined`, so we should use the same condition to allow `undefined`.