### PR TITLE
[codegen/schema] Fix a panic caused by parsing bad examples block in a resource description

### DIFF
--- a/pkg/codegen/schema/docs_parser.go
+++ b/pkg/codegen/schema/docs_parser.go
@@ -133,9 +133,11 @@ func (p shortcodeParser) Open(parent ast.Node, reader text.Reader, pc parser.Con
 }
 
 func (p shortcodeParser) Continue(node ast.Node, reader text.Reader, pc parser.Context) parser.State {
-	line, _ := reader.PeekLine()
+	line, seg := reader.PeekLine()
 	pos := pc.BlockOffset()
 	if pos < 0 {
+		return parser.Continue | parser.HasChildren
+	} else if pos > seg.Len() {
 		return parser.Continue | parser.HasChildren
 	}
 


### PR DESCRIPTION
Fixes #4950.

While this fixes the panic, the source of the problem is in our schema generation process that incorrectly included a bad example block in the resource description. I'll open a separate issue in the tf bridge repo to fix that.

EDIT: Opened https://github.com/pulumi/pulumi-terraform-bridge/issues/235 to fix the issue in tfgen.