### PR TITLE
[codegen/hcl2] Add a template trivia constructor

### DIFF
--- a/pkg/codegen/hcl2/syntax/tokens.go
+++ b/pkg/codegen/hcl2/syntax/tokens.go
@@ -203,6 +203,26 @@ type TemplateDelimiter struct {
 	bytes []byte
 }
 
+// NewTemplateDelimiter creates a new TemplateDelimiter value with the given delimiter type. If the token type is not a
+// template delimiter, this function will panic.
+func NewTemplateDelimiter(typ hclsyntax.TokenType) TemplateDelimiter {
+	var s string
+	switch typ {
+	case hclsyntax.TokenTemplateInterp:
+		s = "${"
+	case hclsyntax.TokenTemplateControl:
+		s = "%{"
+	case hclsyntax.TokenTemplateSeqEnd:
+		s = "}"
+	default:
+		panic(fmt.Errorf("%v is not a template delimiter", typ))
+	}
+	return TemplateDelimiter{
+		Type:  typ,
+		bytes: []byte(s),
+	}
+}
+
 // Range returns the range of the delimiter in the source file.
 func (t TemplateDelimiter) Range() hcl.Range {
 	return t.rng


### PR DESCRIPTION
Just what it says on the tin. Currently it's not possible to create a
valid value of this type because the `bytes` field is unexported. This
constructor fixes that.