### PR TITLE
[codegen/*] Add join and toBase64 functions.

### DIFF
--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -15,7 +15,6 @@
 package dotnet
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"math/big"
@@ -289,14 +288,16 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case hcl2.Invoke:
 		_, name := g.functionName(expr.Args[0])
 
-		optionsBag := ""
-		if len(expr.Args) == 3 {
-			var buf bytes.Buffer
-			g.Fgenf(&buf, ", %.v", expr.Args[2])
-			optionsBag = buf.String()
+		g.Fprintf(w, "%s.InvokeAsync(", name)
+		if len(expr.Args) >= 2 {
+			g.Fgenf(w, "%.v", expr.Args[1])
 		}
-
-		g.Fgenf(w, "%s.InvokeAsync(%.v%v)", name, expr.Args[1], optionsBag)
+		if len(expr.Args) == 3 {
+			g.Fgenf(w, ", %.v", expr.Args[2])
+		}
+		g.Fprint(w, ")")
+	case "join":
+		g.Fgenf(w, "string.Join(%v, %v)", expr.Args[0], expr.Args[1])
 	case "length":
 		g.Fgenf(w, "%.20v.Length", expr.Args[0])
 	case "lookup":
@@ -314,6 +315,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "Output.CreateSecret(%v)", expr.Args[0])
 	case "split":
 		g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])
+	case "toBase64":
+		g.Fgen(w, "Convert.ToBase64String(%v)", expr.Args[0])
 	case "toJSON":
 		g.Fgen(w, "JsonSerializer.Serialize(")
 		g.genDictionary(w, expr.Args[0])

--- a/pkg/codegen/dotnet/gen_program_expressions.go
+++ b/pkg/codegen/dotnet/gen_program_expressions.go
@@ -241,6 +241,7 @@ var functionNamespaces = map[string][]string{
 	"readDir":  {"System.IO", "System.Linq"},
 	"readFile": {"System.IO"},
 	"toJSON":   {"System.Text.Json", "System.Collections.Generic"},
+	"toBase64": {"System"},
 }
 
 func (g *generator) genFunctionUsings(x *model.FunctionCallExpression) []string {
@@ -316,7 +317,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "split":
 		g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])
 	case "toBase64":
-		g.Fgen(w, "Convert.ToBase64String(%v)", expr.Args[0])
+		g.Fgenf(w, "Convert.ToBase64String(System.Text.UTF8.GetBytes(%v))", expr.Args[0])
 	case "toJSON":
 		g.Fgen(w, "JsonSerializer.Serialize(")
 		g.genDictionary(w, expr.Args[0])

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -419,8 +419,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 	resName := makeValidIdentifier(r.Name())
 	pkg, mod, typ, _ := r.DecomposeToken()
-	mod = strings.ToLower(strings.Replace(mod, "/", ".", -1))
-	if mod == "" {
+	if mod == "" || strings.HasPrefix(mod, "/") || strings.HasPrefix(mod, "index/") {
 		mod = pkg
 	}
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -605,7 +605,7 @@ func (g *generator) genLocalVariable(w io.Writer, v *hcl2.LocalVariable) {
 			g.Fgenf(w, "if err != nil {\n")
 			g.Fgenf(w, "return err\n")
 			g.Fgenf(w, "}\n")
-		default:
+		case "join", "toBase64", "mimeType", "fileAsset":
 			g.Fgenf(w, "%s := %.3v;\n", name, expr)
 		}
 	default:

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -419,7 +419,8 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 	resName := makeValidIdentifier(r.Name())
 	pkg, mod, typ, _ := r.DecomposeToken()
-	if mod == "" || strings.HasPrefix(mod, "/") || strings.HasPrefix(mod, "index/") {
+	mod = strings.ToLower(strings.Replace(mod, "/", ".", -1))
+	if mod == "" {
 		mod = pkg
 	}
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -605,6 +605,8 @@ func (g *generator) genLocalVariable(w io.Writer, v *hcl2.LocalVariable) {
 			g.Fgenf(w, "if err != nil {\n")
 			g.Fgenf(w, "return err\n")
 			g.Fgenf(w, "}\n")
+		default:
+			g.Fgenf(w, "%s := %.3v;\n", name, expr)
 		}
 	default:
 		g.Fgenf(w, "%s := %.3v;\n", name, expr)

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -194,14 +194,18 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 		name := fmt.Sprintf("%s.%s", module, fn)
 
-		g.Fprintf(w, "%s(ctx", name)
-		for _, a := range expr.Args {
-			g.Fgenf(w, ", %.v", a)
+		optionsBag := ""
+		var buf bytes.Buffer
+		if len(expr.Args) == 3 {
+			g.Fgenf(&buf, ", %.v", expr.Args[2])
+		} else {
+			g.Fgenf(&buf, ", nil")
 		}
-		for i := 0; i < 2-len(expr.Args); i++ {
-			g.Fprint(w, ", nil")
-		}
-		g.Fprint(w, ")")
+		optionsBag = buf.String()
+
+		g.Fgenf(w, "%s(ctx, ", name)
+		g.Fgenf(w, "%.v", expr.Args[1])
+		g.Fgenf(w, "%v)", optionsBag)
 	case "join":
 		g.Fgenf(w, "strings.Join(%v, %v)", expr.Args[1], expr.Args[0])
 	case "length":

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -194,18 +194,16 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 		name := fmt.Sprintf("%s.%s", module, fn)
 
-		optionsBag := ""
-		var buf bytes.Buffer
-		if len(expr.Args) == 3 {
-			g.Fgenf(&buf, ", %.v", expr.Args[2])
-		} else {
-			g.Fgenf(&buf, ", nil")
+		g.Fprintf(w, "%s(ctx", name)
+		for _, a := range expr.Args {
+			g.Fgenf(w, ", %.v", a)
 		}
-		optionsBag = buf.String()
-
-		g.Fgenf(w, "%s(ctx, ", name)
-		g.Fgenf(w, "%.v", expr.Args[1])
-		g.Fgenf(w, "%v)", optionsBag)
+		for i := 0; i < 2-len(expr.Args); i++ {
+			g.Fprint(w, ", nil")
+		}
+		g.Fprint(w, ")")
+	case "join":
+		g.Fgenf(w, "strings.Join(%v, %v)", expr.Args[1], expr.Args[0])
 	case "length":
 		g.genNYI(w, "call %v", expr.Name)
 		// g.Fgenf(w, "%.20v.Length", expr.Args[0])
@@ -227,6 +225,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "split":
 		g.genNYI(w, "call %v", expr.Name)
 		// g.Fgenf(w, "%.20v.Split(%v)", expr.Args[1], expr.Args[0])
+	case "toBase64":
+		g.Fgenf(w, "base64.StdEncoding.EncodeToString([]byte(%v))", expr.Args[0])
 	case "toJSON":
 		contract.Failf("unlowered toJSON function expression @ %v", expr.SyntaxNode().Range())
 	case "mimeType":
@@ -943,9 +943,11 @@ func (g *generator) functionName(tokenArg model.Expression) (string, string, str
 }
 
 var functionPackages = map[string][]string{
-	"toJSON":   {"encoding/json"},
-	"readDir":  {"io/ioutil"},
+	"join":     {"strings"},
 	"mimeType": {"mime", "path"},
+	"readDir":  {"io/ioutil"},
+	"toBase64": {"encoding/base64"},
+	"toJSON":   {"encoding/json"},
 }
 
 func (g *generator) genFunctionPackages(x *model.FunctionCallExpression) []string {

--- a/pkg/codegen/hcl2/functions.go
+++ b/pkg/codegen/hcl2/functions.go
@@ -91,6 +91,19 @@ var pulumiBuiltins = map[string]*model.Function{
 		}},
 		ReturnType: AssetType,
 	}),
+	"join": model.NewFunction(model.StaticFunctionSignature{
+		Parameters: []model.Parameter{
+			{
+				Name: "separator",
+				Type: model.StringType,
+			},
+			{
+				Name: "strings",
+				Type: model.NewListType(model.StringType),
+			},
+		},
+		ReturnType: model.StringType,
+	}),
 	"length": model.NewFunction(model.GenericFunctionSignature(
 		func(args []model.Expression) (model.StaticFunctionSignature, hcl.Diagnostics) {
 			var diagnostics hcl.Diagnostics
@@ -223,6 +236,13 @@ var pulumiBuiltins = map[string]*model.Function{
 			},
 		},
 		ReturnType: model.NewListType(model.StringType),
+	}),
+	"toBase64": model.NewFunction(model.StaticFunctionSignature{
+		Parameters: []model.Parameter{{
+			Name: "value",
+			Type: model.StringType,
+		}},
+		ReturnType: model.StringType,
 	}),
 	"toJSON": model.NewFunction(model.StaticFunctionSignature{
 		Parameters: []model.Parameter{{

--- a/pkg/codegen/internal/test/program_driver.go
+++ b/pkg/codegen/internal/test/program_driver.go
@@ -82,6 +82,10 @@ var programTests = []programTest{
 		ProgramFile: "secret",
 		Description: "Secret",
 	},
+	{
+		ProgramFile: "functions",
+		Description: "Functions",
+	},
 }
 
 type langConfig struct {
@@ -149,7 +153,7 @@ func TestProgramCodegen(
 
 			expectedFile := pclFile + "." + cfg.extension
 			expected, err := ioutil.ReadFile(expectedFile)
-			if err != nil {
+			if err != nil && os.Getenv("PULUMI_ACCEPT") == "" {
 				t.Fatalf("could not read %v: %v", expectedFile, err)
 			}
 
@@ -188,6 +192,7 @@ func TestProgramCodegen(
 			if os.Getenv("PULUMI_ACCEPT") != "" {
 				err := ioutil.WriteFile(expectedFile, files[cfg.outputFile], 0600)
 				require.NoError(t, err)
+				return
 			}
 
 			assert.Equal(t, string(expected), string(files[cfg.outputFile]))

--- a/pkg/codegen/internal/test/testdata/functions.pp
+++ b/pkg/codegen/internal/test/testdata/functions.pp
@@ -1,0 +1,3 @@
+encoded = toBase64("haha business")
+
+joined = join("-", ["haha", "business"])

--- a/pkg/codegen/internal/test/testdata/functions.pp.cs
+++ b/pkg/codegen/internal/test/testdata/functions.pp.cs
@@ -1,0 +1,15 @@
+using Pulumi;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var encoded = Convert.ToBase64String(%v)("haha business");
+        var joined = string.Join("-", 
+        {
+            "haha",
+            "business",
+        });
+    }
+
+}

--- a/pkg/codegen/internal/test/testdata/functions.pp.cs
+++ b/pkg/codegen/internal/test/testdata/functions.pp.cs
@@ -1,10 +1,11 @@
+using System;
 using Pulumi;
 
 class MyStack : Stack
 {
     public MyStack()
     {
-        var encoded = Convert.ToBase64String(%v)("haha business");
+        var encoded = Convert.ToBase64String(System.Text.UTF8.GetBytes("haha business"));
         var joined = string.Join("-", 
         {
             "haha",

--- a/pkg/codegen/internal/test/testdata/functions.pp.go
+++ b/pkg/codegen/internal/test/testdata/functions.pp.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"encoding/base64"
+	"strings"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_ := base64.StdEncoding.EncodeToString([]byte("haha business"))
+		_ := strings.Join([]string{
+			"haha",
+			"business",
+		}, "-")
+		return nil
+	})
+}

--- a/pkg/codegen/internal/test/testdata/functions.pp.py
+++ b/pkg/codegen/internal/test/testdata/functions.pp.py
@@ -1,0 +1,8 @@
+import pulumi
+import base64
+
+encoded = base64.b64encode("haha business".encode()).decode()
+joined = "-".join([
+    "haha",
+    "business",
+])

--- a/pkg/codegen/internal/test/testdata/functions.pp.ts
+++ b/pkg/codegen/internal/test/testdata/functions.pp.ts
@@ -1,0 +1,7 @@
+import * as pulumi from "@pulumi/pulumi";
+
+const encoded = (new Buffer("haha business")).toString("base64");
+const joined = [
+    "haha",
+    "business",
+].join("-");

--- a/pkg/codegen/internal/test/testdata/functions.pp.ts
+++ b/pkg/codegen/internal/test/testdata/functions.pp.ts
@@ -1,6 +1,6 @@
 import * as pulumi from "@pulumi/pulumi";
 
-const encoded = (new Buffer("haha business")).toString("base64");
+const encoded = Buffer.from("haha business").toString("base64");
 const joined = [
     "haha",
     "business",

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -234,7 +234,8 @@ func resourceTypeName(r *hcl2.Resource) (string, string, string, hcl.Diagnostics
 		}
 	}
 
-	return makeValidIdentifier(pkg), strings.Replace(module, "/", ".", -1), title(member), diagnostics
+	module = strings.ToLower(strings.Replace(module, "/", ".", -1))
+	return makeValidIdentifier(pkg), module, title(member), diagnostics
 }
 
 // makeResourceName returns the expression that should be emitted for a resource's "name" parameter given its base name

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -354,7 +354,7 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 	case "split":
 		g.Fgenf(w, "%.20v.split(%v)", expr.Args[1], expr.Args[0])
 	case "toBase64":
-		g.Fgenf(w, "(new Buffer(%v)).toString(\"base64\")", expr.Args[0])
+		g.Fgenf(w, "Buffer.from(%v).toString(\"base64\")", expr.Args[0])
 	case "toJSON":
 		g.Fgenf(w, "JSON.stringify(%v)", expr.Args[0])
 	default:

--- a/pkg/codegen/nodejs/gen_program_expressions.go
+++ b/pkg/codegen/nodejs/gen_program_expressions.go
@@ -326,14 +326,16 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 		name := fmt.Sprintf("%s%s.%s", makeValidIdentifier(pkg), module, fn)
 
-		optionsBag := ""
-		if len(expr.Args) == 3 {
-			var buf bytes.Buffer
-			g.Fgenf(&buf, ", %.v", expr.Args[2])
-			optionsBag = buf.String()
+		g.Fprintf(w, "%s(", name)
+		if len(expr.Args) >= 2 {
+			g.Fgenf(w, "%.v", expr.Args[1])
 		}
-
-		g.Fgenf(w, "%s(%.v%v)", name, expr.Args[1], optionsBag)
+		if len(expr.Args) == 3 {
+			g.Fgenf(w, ", %.v", expr.Args[2])
+		}
+		g.Fprint(w, ")")
+	case "join":
+		g.Fgenf(w, "%.20v.join(%v)", expr.Args[1], expr.Args[0])
 	case "length":
 		g.Fgenf(w, "%.20v.length", expr.Args[0])
 	case "lookup":
@@ -351,6 +353,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "pulumi.secret(%v)", expr.Args[0])
 	case "split":
 		g.Fgenf(w, "%.20v.split(%v)", expr.Args[1], expr.Args[0])
+	case "toBase64":
+		g.Fgenf(w, "(new Buffer(%v)).toString(\"base64\")", expr.Args[0])
 	case "toJSON":
 		g.Fgenf(w, "JSON.stringify(%v)", expr.Args[0])
 	default:

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -185,6 +185,7 @@ var functionImports = map[string]string{
 	"fileArchive": "pulumi",
 	"fileAsset":   "pulumi",
 	"readDir":     "os",
+	"toBase64":    "base64",
 	"toJSON":      "json",
 }
 
@@ -225,6 +226,11 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 		name := fmt.Sprintf("%s%s.%s", pkg, module, PyName(fn))
 
+		if len(expr.Args) == 1 {
+			g.Fprintf(w, "%s()", name)
+			return
+		}
+
 		optionsBag := ""
 		if len(expr.Args) == 3 {
 			var buf bytes.Buffer
@@ -260,6 +266,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		}
 
 		g.Fgenf(w, "%v)", optionsBag)
+	case "join":
+		g.Fgenf(w, "%.16v.join(%v)", expr.Args[0], expr.Args[1])
 	case "length":
 		g.Fgenf(w, "len(%.v)", expr.Args[0])
 	case "lookup":
@@ -286,6 +294,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "pulumi.secret(%v)", expr.Args[0])
 	case "split":
 		g.Fgenf(w, "%.16v.split(%.v)", expr.Args[1], expr.Args[0])
+	case "toBase64":
+		g.Fgenf(w, "base64.b64encode(%.16v.encode()).decode()", expr.Args[0])
 	case "toJSON":
 		g.Fgenf(w, "json.dumps(%.v)", expr.Args[0])
 	default:


### PR DESCRIPTION
- `join` joins an array of strings using a specified separator
- `toBase64` converts a string to its Base64 representation

These changes also contain fixes for invokes with inputs that are absent
or optional.