### PR TITLE
[codegen/hcl2] Fix nested apply rewrites

### DIFF
--- a/pkg/codegen/hcl2/rewrite_apply.go
+++ b/pkg/codegen/hcl2/rewrite_apply.go
@@ -150,6 +150,10 @@ func (r *applyRewriter) inspectsEventualValues(x model.Expression) bool {
 	case *model.ForExpression:
 		return r.hasEventualElements(x.Collection)
 	case *model.FunctionCallExpression:
+		_, isEventual := r.isEventualType(x.Signature.ReturnType)
+		if isEventual {
+			return true
+		}
 		for i, arg := range x.Args {
 			if r.hasEventualValues(arg) && r.isPromptArg(x.Signature.Parameters[i].Type, arg) {
 				return true


### PR DESCRIPTION
Rewrites that should produce nested applies due to functions that return
eventual types were instead producing a single top-level apply. These
changes fix that by considering a function that produces an eventual
value as inspecting eventual values.