### PR TITLE
Speed up .NET programs with large number of resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGELOG
 - Add logic to parce pulumi venv on github action
   [#4994](https://github.com/pulumi/pulumi/pull/4994)
 
+- Better performance for stacks with many resources using the .NET SDK
+  [#5015](https://github.com/pulumi/pulumi/pull/5015)
+
 ## 2.6.1 (2020-07-09)
 
 - Fix a panic in the display during CLI operations

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
@@ -119,7 +119,9 @@ namespace Pulumi
                             // Log the descriptions of completed tasks.
                             var descriptions = _inFlightTasks[task];
                             foreach (var description in descriptions)
+                            {
                                 Serilog.Log.Information($"Completed task: {description}");
+                            }
 
                             // Check if all the tasks are completed and signal the completion source if so.
                             if (Interlocked.Decrement(ref remaining) == 0)

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Runner.cs
@@ -1,7 +1,8 @@
-﻿// Copyright 2016-2019, Pulumi Corporation
+﻿// Copyright 2016-2020, Pulumi Corporation
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Pulumi
@@ -92,6 +93,7 @@ namespace Pulumi
                     {
                         if (_inFlightTasks.Count == 0)
                         {
+                            // No more tasks in flight: exit the loop.
                             break;
                         }
 
@@ -99,24 +101,54 @@ namespace Pulumi
                         tasks.AddRange(_inFlightTasks.Keys);
                     }
 
-                    // Now, wait for one of them to finish.
-                    var task = await Task.WhenAny(tasks).ConfigureAwait(false);
-                    List<string> descriptions;
-                    lock (_inFlightTasks)
+                    // Wait for one of the two events to happen:
+                    // 1. All tasks in the list complete successfully, or
+                    // 2. Any task throws an exception.
+                    // There's no standard API with this semantics, so we create a custom completion source that is
+                    // completed when remaining count is zero, or when an exception is thrown.
+                    var remaining = tasks.Count;
+                    var tcs = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    tasks.ForEach(HandleCompletion);
+                    async void HandleCompletion(Task task)
                     {
-                        // Once finished, remove it from the set of tasks that are running.
-                        descriptions = _inFlightTasks[task];
-                        _inFlightTasks.Remove(task);
+                        try
+                        {
+                            // Wait for the task completion.
+                            await task.ConfigureAwait(false);
+
+                            // Log the descriptions of completed tasks.
+                            var descriptions = _inFlightTasks[task];
+                            foreach (var description in descriptions)
+                                Serilog.Log.Information($"Completed task: {description}");
+
+                            // Check if all the tasks are completed and signal the completion source if so.
+                            if (Interlocked.Decrement(ref remaining) == 0)
+                            {
+                                tcs.TrySetResult(0);
+                            }
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            tcs.TrySetCanceled();
+                        }
+                        catch (Exception ex)
+                        {
+                            tcs.TrySetException(ex);
+                        }
+                        finally
+                        {
+                            // Once finished, remove the task from the set of tasks that are running.
+                            lock (_inFlightTasks)
+                            {
+                                _inFlightTasks.Remove(task);
+                            }
+                        }
                     }
-
-                    foreach (var description in descriptions)
-                        Serilog.Log.Information($"Completed task: {description}");
-
+                    
                     try
                     {
-                        // Now actually await that completed task so that we will realize any exceptions
-                        // is may have thrown.
-                        await task.ConfigureAwait(false);
+                        // Now actually await that combined task and realize any exceptions it may have thrown.
+                        await tcs.Task.ConfigureAwait(false);
                     }
                     catch (Exception e)
                     {

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
@@ -21,26 +21,26 @@ namespace Pulumi
             var type = res.GetResourceType();
             var name = res.GetResourceName();
 
-            Log.Debug($"Gathering explicit dependencies: t={type}, name={name}, custom={custom}");
+            LogExcessive($"Gathering explicit dependencies: t={type}, name={name}, custom={custom}");
             var explicitDirectDependencies = new HashSet<Resource>(
                 await GatherExplicitDependenciesAsync(options.DependsOn).ConfigureAwait(false));
-            Log.Debug($"Gathered explicit dependencies: t={type}, name={name}, custom={custom}");
+            LogExcessive($"Gathered explicit dependencies: t={type}, name={name}, custom={custom}");
 
             // Serialize out all our props to their final values.  In doing so, we'll also collect all
             // the Resources pointed to by any Dependency objects we encounter, adding them to 'propertyDependencies'.
-            Log.Debug($"Serializing properties: t={type}, name={name}, custom={custom}");
+            LogExcessive($"Serializing properties: t={type}, name={name}, custom={custom}");
             var dictionary = await args.ToDictionaryAsync().ConfigureAwait(false);
             var (serializedProps, propertyToDirectDependencies) =
                 await SerializeResourcePropertiesAsync(label, dictionary).ConfigureAwait(false);
-            Log.Debug($"Serialized properties: t={type}, name={name}, custom={custom}");
+            LogExcessive($"Serialized properties: t={type}, name={name}, custom={custom}");
 
             // Wait for the parent to complete.
             // If no parent was provided, parent to the root resource.
-            Log.Debug($"Getting parent urn: t={type}, name={name}, custom={custom}");
+            LogExcessive($"Getting parent urn: t={type}, name={name}, custom={custom}");
             var parentURN = options.Parent != null
                 ? await options.Parent.Urn.GetValueAsync().ConfigureAwait(false)
                 : await GetRootResourceAsync(type).ConfigureAwait(false);
-            Log.Debug($"Got parent urn: t={type}, name={name}, custom={custom}");
+            LogExcessive($"Got parent urn: t={type}, name={name}, custom={custom}");
 
             string? providerRef = null;
             if (custom)
@@ -89,6 +89,12 @@ namespace Pulumi
                 allDirectDependencyURNs,
                 propertyToDirectDependencyURNs,
                 aliases);
+
+            void LogExcessive(string message)
+            {
+                if (_excessiveDebugOutput)
+                    Log.Debug(message);
+            }
         }
 
         private static Task<ImmutableArray<Resource>> GatherExplicitDependenciesAsync(InputList<Resource> resources)

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Serialization.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Serialization.cs
@@ -12,7 +12,7 @@ namespace Pulumi
 {
     public partial class Deployment
     {
-        internal static bool _excessiveDebugOutput = true;
+        internal static bool _excessiveDebugOutput = false;
 
         /// <summary>
         /// <see cref="SerializeResourcePropertiesAsync"/> walks the props object passed in,


### PR DESCRIPTION
The current event awaiting loop in the .NET SDK is ~O(N^2), which is definitely noticeable with ~1k resources. Also, we log a lot of excessive debug information, which makes a larger multiplier to N.

This PR speeds up the await loop to ~O(N) and removes the excessive debug output.

Resolves #5001 

cc @CyrusNajmabadi if you are around, in case I miss some original intent of that loop.