### PR TITLE
Python SDK changes to support input/output classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ CHANGELOG
 - Add support for extracting jar files in archive resources
   [#5150](https://github.com/pulumi/pulumi/pull/5150)
 
+- SDK changes to support Python input/output classes
+  [#5033](https://github.com/pulumi/pulumi/pull/5033)
 
 ## 2.8.2 (2020-08-07)
 

--- a/sdk/python/lib/pulumi/__init__.py
+++ b/sdk/python/lib/pulumi/__init__.py
@@ -69,6 +69,7 @@ from .output import (
     Output,
     Input,
     Inputs,
+    InputType,
     UNKNOWN,
     contains_unknowns,
 )
@@ -82,6 +83,17 @@ from .log import (
 
 from .stack_reference import (
     StackReference,
+)
+
+# pylint: disable=redefined-builtin
+from ._types import (
+    MISSING,
+    input_type,
+    output_type,
+    property,
+    getter,
+    get,
+    set,
 )
 
 from . import runtime, dynamic, policy

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -491,8 +491,7 @@ def output_type(cls: Type[T]) -> Type[T]:
         python_to_pulumi_table = None
         for python_name, pulumi_name, _ in _py_properties(cls):
             if python_name != pulumi_name:
-                if python_to_pulumi_table is None:
-                    python_to_pulumi_table = {}
+                python_to_pulumi_table = python_to_pulumi_table or {}
                 python_to_pulumi_table[python_name] = pulumi_name
         if python_to_pulumi_table is not None:
             setattr(cls, _PULUMI_PYTHON_TO_PULUMI_TABLE, python_to_pulumi_table)

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -1,0 +1,433 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import builtins
+import functools
+import sys
+import typing
+from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union, cast, get_type_hints
+
+from . import _utils
+
+T = TypeVar('T')
+
+
+_PULUMI_GETTER = "_pulumi_getter"
+_PULUMI_NAME = "_pulumi_name"
+_PULUMI_INPUT_TYPE = "_pulumi_input_type"
+_PULUMI_OUTPUT_TYPE = "_pulumi_output_type"
+_TRANSLATE_PROPERTY = "_translate_property"
+_VALUES = "_values"
+
+
+def is_input_type(cls: type) -> bool:
+    return hasattr(cls, _PULUMI_INPUT_TYPE)
+
+def is_output_type(cls: type) -> bool:
+    return hasattr(cls, _PULUMI_OUTPUT_TYPE)
+
+
+class _MISSING_TYPE:
+    pass
+MISSING = _MISSING_TYPE()
+"""
+MISSING is a singleton sentinel object to detect if a parameter is supplied or not.
+"""
+
+class _Property:
+    """
+    Represents a Pulumi property. It is not meant to be created outside this module,
+    rather, the property() function should be used.
+    """
+    def __init__(self, name: str, default: Any = MISSING) -> None:
+        if not name:
+            raise TypeError("Missing name argument")
+        if not isinstance(name, str):
+            raise TypeError("Expected name to be a string")
+        self.name = name
+        self.default = default
+        self.type: Any = None
+
+
+# This function's return type is deliberately annotated as Any so that type checkers do not
+# complain about assignments that we want to allow like `my_value: str = property("myValue")`.
+# pylint: disable=redefined-builtin
+def property(name: str, default: Any = MISSING) -> Any:
+    """
+    Return an object to identify Pulumi properties.
+
+    name is the Pulumi property name.
+    """
+    return _Property(name, default)
+
+
+def _properties_from_annotations(cls: type) -> Dict[str, _Property]:
+    """
+    Returns a dictionary of properties from annotations defined on the class.
+    """
+
+    # Get annotations that are defined on this class (not base classes).
+    cls_annotations = cls.__dict__.get('__annotations__', {})
+
+    def get_property(cls: type, a_name: str, a_type: Any) -> _Property:
+        default = getattr(cls, a_name, MISSING)
+        p = default if isinstance(default, _Property) else _Property(name=a_name, default=default)
+        p.type = a_type
+        return p
+
+    return {
+        name: get_property(cls, name, type)
+        for name, type in cls_annotations.items()
+    }
+
+
+def _process_class(cls: type, signifier_attr: str) -> Dict[str, Any]:
+    # Get properties.
+    props = _properties_from_annotations(cls)
+
+    # Clean-up class attributes.
+    for name in props:
+        # If the class attribute (which is the default value for this prop)
+        # exists and is of type 'Property', delete the class attribute so
+        # it is not set at all in the post-processed class.
+        if isinstance(getattr(cls, name, None), _Property):
+            delattr(cls, name)
+
+    # Mark this class with the signifier and save the properties.
+    setattr(cls, signifier_attr, True)
+
+    return props
+
+
+def _create_py_property(a_name: str, pulumi_name: str, typ: Any, setter: bool):
+    """
+    Returns a Python property getter that looks up the value using get.
+    """
+    def getter_fn(self):
+        return get(self, pulumi_name)
+    getter_fn.__name__ = a_name
+    getter_fn.__annotations__ = {"return":typ}
+    setattr(getter_fn, _PULUMI_GETTER, True)
+    setattr(getter_fn, _PULUMI_NAME, pulumi_name)
+
+    if setter:
+        def setter_fn(self, value):
+            return set(self, pulumi_name, value)
+        setter_fn.__name__ = a_name
+        setter_fn.__annotations__ = {"value":typ}
+        return builtins.property(fget=getter_fn, fset=setter_fn)
+
+    return builtins.property(fget=getter_fn)
+
+
+def _add_eq(cls: type):
+    # Add an __eq__ method to cls if it isn't a subclass of dict and __eq__ doesn't already exist.
+    # There's no need for a __ne__ method, since Python will call __eq__ and negate it.
+    if not issubclass(cls, dict) and "__eq__" not in cls.__dict__:
+        def eq(self, other):
+            return type(other) is type(self) and getattr(other, _VALUES, None) == getattr(self, _VALUES, None)
+        setattr(cls, "__eq__", eq)
+
+
+def input_type(cls: Type[T]) -> Type[T]:
+    """
+    Returns the same class as was passed in, but marked as an input type.
+    """
+
+    if is_input_type(cls) or is_output_type(cls):
+        raise AssertionError("Cannot apply @input_type and @output_type more than once.")
+
+    # Get the input properties and mark the class as an input type.
+    props = _process_class(cls, _PULUMI_INPUT_TYPE)
+
+    # Create Python properties.
+    for name, prop in props.items():
+        setattr(cls, name, _create_py_property(name, prop.name, prop.type, setter=True))
+
+    # Helper to create a setter function.
+    def create_setter(pulumi_name: str) -> Callable:
+        def setter_fn(self, value):
+            set(self, pulumi_name, value)
+        return setter_fn
+
+    # Now, process the class's properties, replacing properties with empty setters with
+    # an actual setter.
+    for k, v in cls.__dict__.items():
+        if isinstance(v, builtins.property):
+            prop = cast(builtins.property, v)
+            if hasattr(prop.fget, _PULUMI_GETTER) and prop.fset is not None and _utils.is_empty_function(prop.fset):
+                pulumi_name: str = getattr(prop.fget, _PULUMI_NAME)
+                setter_fn = create_setter(pulumi_name)
+                setter_fn.__name__ = prop.fset.__name__
+                setter_fn.__annotations__ = prop.fset.__annotations__
+                # Replace the property with a new property object that has the new setter.
+                setattr(cls, k, prop.setter(setter_fn))
+
+    # Add an __eq__ method if one doesn't already exist.
+    _add_eq(cls)
+
+    return cls
+
+
+def input_type_to_dict(value: Any) -> Dict[str, Any]:
+    """
+    Returns a dict for the input type.
+    """
+    assert is_input_type(type(value))
+    return dict(getattr(value, _VALUES, {}))
+
+
+def output_type(cls: Type[T]) -> Type[T]:
+    """
+    Returns the same class as was passed in, but marked as an output type.
+
+    Python property getters are created for each Pulumi output property
+    defined in the class.
+
+    If the class is not a subclass of dict and doesn't have an __init__()
+    method, an __init__() method is added to the class that accepts a dict
+    representing the outputs.
+    """
+
+    if is_input_type(cls) or is_output_type(cls):
+        raise AssertionError("Cannot apply @input_type and @output_type more than once.")
+
+    # Get the output properties and mark the class as an output type.
+    props = _process_class(cls, _PULUMI_OUTPUT_TYPE)
+
+    # Add an __init__() method that takes a dict (representing outputs) as an arg,
+    # if the class isn't a subclass of dict and doesn't have an __init__() method.
+    if not issubclass(cls, dict) and "__init__" not in cls.__dict__:
+        def init(self, value: dict) -> None:
+            if not isinstance(value, dict):
+                raise TypeError('Expected value to be a dict')
+            setattr(self, _VALUES, value)
+        setattr(cls, "__init__", init)
+
+    # Create Python properties.
+    for name, prop in props.items():
+        setattr(cls, name, _create_py_property(name, prop.name, prop.type, setter=False))
+
+    # Add an __eq__ method if one doesn't already exist.
+    _add_eq(cls)
+
+    return cls
+
+
+def getter(_fn=None, *, name: Optional[str] = None):
+    """
+    Decorator to indicate a function is a Pulumi property getter.
+
+    name is the Pulumi property name. If not set, the name of the function is used.
+    """
+    def decorator(fn: Callable) -> Callable:
+        # If name isn't specified, use the name of the function.
+        pulumi_name = name if name is not None else fn.__name__
+        if _utils.is_empty_function(fn):
+            @functools.wraps(fn)
+            def get_fn(self):
+                return get(self, pulumi_name)
+            fn = get_fn
+        setattr(fn, _PULUMI_GETTER, True)
+        setattr(fn, _PULUMI_NAME, pulumi_name)
+        return fn
+
+    # See if we're being called as @getter or @getter().
+    if _fn is None:
+        # We're called with parens.
+        return decorator
+
+    # We're called as @getter without parens.
+    return decorator(_fn)
+
+
+def get(self, name: str) -> Any:
+    """
+    Used to get values in Pulumi property getters.
+
+    name is the Pulumi property name.
+    """
+
+    if not name:
+        raise TypeError("Missing name argument")
+    if not isinstance(name, str):
+        raise TypeError("Expected name to be a string")
+
+    values: Optional[Dict[str, Any]] = getattr(self, _VALUES, None)
+
+    if hasattr(type(self), _PULUMI_INPUT_TYPE):
+        return values.get(name) if values is not None else None
+
+    if hasattr(type(self), _PULUMI_OUTPUT_TYPE):
+        cls = type(self)
+
+        # If the class has a _translate_property() method, use it to translate
+        # property names, otherwise, use an identity function.
+        translate = getattr(cls, _TRANSLATE_PROPERTY, None)
+        if not callable(translate):
+            translate = lambda self, prop: prop
+
+        # If the class itself is a subclass of dict, get the value from itself,
+        # otherwise, get the value from a private _values attribute.
+        if issubclass(cls, dict):
+            # Grab dict's `get` method instead of calling `self.get` directly
+            # in case the type has a `get` property.
+            return getattr(dict, "get")(self, translate(self, name))
+
+        return values.get(translate(self, name)) if values is not None else None
+
+    raise AssertionError("get can only be used with classes decorated with @input_type or @output_type")
+
+
+def set(self, name: str, value: Any) -> None:
+    """
+    Used to set values in the __init__() method of classes decorated with @input_type.
+
+    name is the Pulumi property name.
+    """
+
+    if not name:
+        raise TypeError("Missing name argument")
+    if not isinstance(name, str):
+        raise TypeError("Expected name to be a string")
+
+    if not hasattr(type(self), _PULUMI_INPUT_TYPE):
+        raise AssertionError("set can only be used with classes decorated with @input_type")
+
+    values = getattr(self, _VALUES, None)
+    if values is None:
+        values = dict()
+        setattr(self, _VALUES, values)
+    values[name] = value
+
+
+# Use the built-in `get_origin` and `get_args` functions on Python 3.8+,
+# otherwise fallback to downlevel implementations.
+if sys.version_info[:2] >= (3, 8):
+    get_origin = typing.get_origin
+    get_args = typing.get_args
+elif sys.version_info[:2] >= (3, 7):
+    def get_origin(tp):
+        if isinstance(tp, typing._GenericAlias):
+            return tp.__origin__
+        return None
+
+    def get_args(tp):
+        if isinstance(tp, typing._GenericAlias):
+            return tp.__args__
+        return ()
+else:
+    def get_origin(tp):
+        if hasattr(tp, "__origin__"):
+            return tp.__origin__
+        return None
+
+    def get_args(tp):
+        if hasattr(tp, "__args__"):
+            return tp.__args__
+        return ()
+
+
+def _is_union_type(tp):
+    if sys.version_info[:2] >= (3, 7):
+        return (tp is Union or
+                isinstance(tp, typing._GenericAlias) and tp.__origin__ is Union)
+    return type(tp) is typing._Union # pylint: disable=unidiomatic-typecheck, no-member
+
+
+def _is_optional_type(tp):
+    if tp is type(None):
+        return True
+    if _is_union_type(tp):
+        return any(_is_optional_type(tt) for tt in get_args(tp))
+    return False
+
+
+def output_type_types(output_type_cls: type) -> Dict[str, type]:
+    """
+    Returns a dict of Pulumi names to type for the output type.
+    """
+    assert is_output_type(output_type_cls)
+
+    # pylint: disable=import-outside-toplevel
+    from . import Output, Input
+
+    result: Dict[str, type] = {}
+
+    for v in output_type_cls.__dict__.values():
+        if isinstance(v, builtins.property):
+            prop = cast(builtins.property, v)
+            if hasattr(prop.fget, _PULUMI_GETTER) and hasattr(prop.fget, _PULUMI_NAME):
+                name: str = getattr(prop.fget, _PULUMI_NAME)
+                 # Get hints via typing.get_type_hints(), which handles forward references.
+                 # Pass Output and Input as locals to typing.get_type_hints() to ensure they are available.
+                cls_hints = get_type_hints(prop.fget, localns={"Output": Output, "Input": Input})  # type: ignore
+                value = cls_hints.get("return")
+                if value is not None:
+                    result[name] = _unwrap_type(value)
+
+    return result
+
+
+def resource_types(resource_cls: type) -> Dict[str, type]:
+    """
+    Returns a dict of Pulumi names to type for the resource.
+    """
+    # pylint: disable=import-outside-toplevel
+    from . import Output, Input
+
+    props = _properties_from_annotations(resource_cls)
+
+    # Get hints via typing.get_type_hints(), which handles forward references.
+    # Pass Output and Input as locals to typing.get_type_hints() to ensure they are available.
+    cls_hints = get_type_hints(resource_cls, localns={"Output": Output, "Input": Input})  # type: ignore
+
+    return {
+        prop.name: _unwrap_type(cls_hints[name])
+        for name, prop in props.items()
+    }
+
+
+def unwrap_optional_type(val: type) -> type:
+    """
+    Unwraps the type T in Optional[T].
+    """
+    # If it is Optional[T], extract the arg T. Note that Optional[T] is really Union[T, None],
+    # and any nested Unions are flattened, so Optional[Union[T, U], None] is Union[T, U, None].
+    # We'll only "unwrap" for the common case of a single arg T for Union[T, None].
+    if _is_optional_type(val):
+        args = get_args(val)
+        if len(args) == 2:
+            assert args[1] is type(None)
+            val = args[0]
+
+    return val
+
+
+def _unwrap_type(val: type) -> type:
+    """
+    Unwraps the type T in Output[T] and Optional[T].
+    """
+    # pylint: disable=import-outside-toplevel
+    from . import Output
+
+    origin = get_origin(val)
+
+    # If it is an Output[T], extract the T arg.
+    if origin is Output:
+        args = get_args(val)
+        assert len(args) == 1
+        val = args[0]
+
+    return unwrap_optional_type(val)

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -315,8 +315,8 @@ def set(self, name: str, value: Any) -> None:
 # Use the built-in `get_origin` and `get_args` functions on Python 3.8+,
 # otherwise fallback to downlevel implementations.
 if sys.version_info[:2] >= (3, 8):
-    get_origin = typing.get_origin
-    get_args = typing.get_args
+    get_origin = typing.get_origin  # pylint: disable=no-member
+    get_args = typing.get_args  # pylint: disable=no-member
 elif sys.version_info[:2] >= (3, 7):
     def get_origin(tp):
         if isinstance(tp, typing._GenericAlias):

--- a/sdk/python/lib/pulumi/_utils.py
+++ b/sdk/python/lib/pulumi/_utils.py
@@ -1,0 +1,57 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import typing
+
+
+# Empty function definitions.
+
+def _empty():
+    ...
+
+def _empty_doc():
+    """Empty function docstring."""
+    ...
+
+_empty_lambda = lambda: None
+
+_empty_lambda_doc = lambda: None
+_empty_lambda_doc.__doc__ = """Empty lambda docstring."""
+
+
+def _consts(fn: typing.Callable) -> tuple:
+    """
+    Returns a tuple of the function's constants excluding the docstring.
+    """
+    return tuple(x for x in fn.__code__.co_consts if x != fn.__doc__)
+
+
+# Precompute constants for each of the empty functions.
+_consts_empty_ = _consts(_empty)
+_consts_empty_doc = _consts(_empty_doc)
+_consts_empty_lambda = _consts(_empty_lambda)
+_consts_empty_lambda_doc = _consts(_empty_lambda_doc)
+
+
+def is_empty_function(fn: typing.Callable) -> bool:
+    """
+    Returns true if the function is empty.
+    """
+    consts = _consts(fn)
+    return (
+        (fn.__code__.co_code == _empty.__code__.co_code and consts == _consts_empty_) or
+        (fn.__code__.co_code == _empty_doc.__code__.co_code and consts == _consts_empty_doc) or
+        (fn.__code__.co_code == _empty_lambda.__code__.co_code and consts == _consts_empty_lambda) or
+        (fn.__code__.co_code == _empty_lambda_doc.__code__.co_code and consts == _consts_empty_lambda_doc)
+    )

--- a/sdk/python/lib/pulumi/_utils.py
+++ b/sdk/python/lib/pulumi/_utils.py
@@ -38,7 +38,7 @@ def _consts(fn: typing.Callable) -> tuple:
 
 
 # Precompute constants for each of the empty functions.
-_consts_empty_ = _consts(_empty)
+_consts_empty = _consts(_empty)
 _consts_empty_doc = _consts(_empty_doc)
 _consts_empty_lambda = _consts(_empty_lambda)
 _consts_empty_lambda_doc = _consts(_empty_lambda_doc)
@@ -50,7 +50,7 @@ def is_empty_function(fn: typing.Callable) -> bool:
     """
     consts = _consts(fn)
     return (
-        (fn.__code__.co_code == _empty.__code__.co_code and consts == _consts_empty_) or
+        (fn.__code__.co_code == _empty.__code__.co_code and consts == _consts_empty) or
         (fn.__code__.co_code == _empty_doc.__code__.co_code and consts == _consts_empty_doc) or
         (fn.__code__.co_code == _empty_lambda.__code__.co_code and consts == _consts_empty_lambda) or
         (fn.__code__.co_code == _empty_lambda_doc.__code__.co_code and consts == _consts_empty_lambda_doc)

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -40,6 +40,7 @@ U = TypeVar('U')
 
 Input = Union[T, Awaitable[T], 'Output[T]']
 Inputs = Mapping[str, Input[Any]]
+InputType = Union[T, Mapping[str, Any]]
 
 
 class Output(Generic[T]):

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -392,6 +392,10 @@ def translate_output_properties(output: Any,
     If output is a primitive (i.e. not a dict or list), the value is returned without modification.
     """
 
+    # If it's a secret, unwrap the value so the output is in alignment with the expected type.
+    if is_rpc_secret(output):
+        output = unwrap_rpc_secret(output)
+
     # Unwrap optional types.
     typ = _types.unwrap_optional_type(typ) if typ else typ
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -369,7 +369,7 @@ def transfer_properties(res: 'Resource', props: 'Inputs') -> Dict[str, Resolver]
         # using res.translate_output_property and then use *that* name to index into the resolvers table.
         log.debug(f"adding resolver {name}")
         resolvers[name] = functools.partial(do_resolve, resolve_value, resolve_is_known, resolve_is_secret)
-        res.__setattr__(name, Output({res}, resolve_value, resolve_is_known, resolve_is_secret))
+        res.__dict__[name] = Output({res}, resolve_value, resolve_is_known, resolve_is_secret)
 
     return resolvers
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -193,7 +193,7 @@ async def serialize_property(value: 'Input[Any]',
         value = _types.input_type_to_dict(value)
         transform_keys = False
 
-    if isinstance(value, Mapping):
+    if isinstance(value, Mapping):  # pylint: disable=bad-option-value,isinstance-second-argument-not-valid-type
         obj = {}
         for k, v in value.items():
             transformed_key = k

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -17,6 +17,7 @@ out of RPC calls.
 """
 import sys
 import asyncio
+import collections
 import functools
 import inspect
 from typing import List, Any, Callable, Dict, Mapping, Optional, Tuple, Union, TYPE_CHECKING, cast, get_type_hints
@@ -408,10 +409,12 @@ def translate_output_properties(output: Any,
             # If typ is a dict, get the type for its values, to pass
             # along for each key.
             origin = _types.get_origin(typ)
-            if origin is dict or Dict:
+            if typ is dict or origin in {dict, Dict, Mapping, collections.abc.Mapping}:
                 args = _types.get_args(typ)
                 if len(args) == 2 and args[0] is str:
                     get_type = lambda k: args[1]
+            else:
+                raise AssertionError(f"Unexpected type; expected 'dict' got '{typ}'")
         translated = {
             output_transformer(k):
                 translate_output_properties(v, output_transformer, get_type(k))
@@ -428,10 +431,12 @@ def translate_output_properties(output: Any,
             # If typ is a list, get the type for its values, to pass
             # along for each item.
             origin = _types.get_origin(typ)
-            if origin is list or List:
+            if typ is list or origin in {list, List}:
                 args = _types.get_args(typ)
                 if len(args) == 1:
                     element_type = args[0]
+            else:
+                raise AssertionError(f"Unexpected type. Expected 'list' got '{typ}'")
         return [translate_output_properties(v, output_transformer, element_type) for v in output]
 
     return output

--- a/sdk/python/lib/test/langhost/invoke_types/__init__.py
+++ b/sdk/python/lib/test/langhost/invoke_types/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/invoke_types/__main__.py
+++ b/sdk/python/lib/test/langhost/invoke_types/__main__.py
@@ -1,0 +1,57 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+from pulumi.runtime import invoke
+
+import outputs
+
+
+def my_function(first_value: str, second_value: float) -> outputs.MyFunctionResult:
+    return invoke("test:index:MyFunction",
+                 props={"firstValue": first_value, "secondValue": second_value},
+                 typ=outputs.MyFunctionResult).value
+
+
+
+def my_other_function(first_value: str, second_value: float) -> outputs.MyOtherFunctionResult:
+    return invoke("test:index:MyOtherFunction",
+                  props={"firstValue": first_value, "secondValue": second_value},
+                  typ=outputs.MyOtherFunctionResult).value
+
+
+def assert_eq(l, r):
+    assert l == r
+
+
+class MyResource(pulumi.CustomResource):
+    first_value: pulumi.Output[str]
+    second_value: pulumi.Output[float]
+
+    def __init__(self, name: str, first_value: str, second_value: float):
+        super().__init__("test:index:MyResource", name, {
+            "first_value": first_value,
+            "second_value": second_value,
+        })
+
+
+result = my_function("hello", 42)
+res = MyResource("resourceA", result.nested.first_value, result.nested.second_value)
+res.first_value.apply(lambda v: assert_eq(v, "hellohello"))
+res.second_value.apply(lambda v: assert_eq(v, 43))
+
+result = my_other_function("world", 100)
+res2 = MyResource("resourceB", result.nested.first_value, result.nested.second_value)
+res2.first_value.apply(lambda v: assert_eq(v, "worldworld"))
+res2.second_value.apply(lambda v: assert_eq(v, 101))

--- a/sdk/python/lib/test/langhost/invoke_types/outputs.py
+++ b/sdk/python/lib/test/langhost/invoke_types/outputs.py
@@ -18,7 +18,7 @@ import outputs
 
 
 @pulumi.output_type
-class MyFunctionNestedResult(dict):
+class MyFunctionNestedResult:
     first_value: str = pulumi.property("firstValue")
     second_value: float = pulumi.property("secondValue")
 
@@ -29,7 +29,11 @@ class MyFunctionResult:
     nested: 'outputs.MyFunctionNestedResult'
 
 @pulumi.output_type
-class MyOtherFunctionNestedResult(dict):
+class MyOtherFunctionNestedResult:
+    def __init__(self, first_value: str, second_value: float):
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
+
     @property
     @pulumi.getter(name="firstValue")
     def first_value(self) -> str:
@@ -42,6 +46,9 @@ class MyOtherFunctionNestedResult(dict):
 
 @pulumi.output_type
 class MyOtherFunctionResult:
+    def __init__(self, nested: 'outputs.MyOtherFunctionNestedResult'):
+        pulumi.set(self, "nested", nested)
+
     @property
     @pulumi.getter
     # Deliberately using a qualified (with `outputs.`) forward reference

--- a/sdk/python/lib/test/langhost/invoke_types/outputs.py
+++ b/sdk/python/lib/test/langhost/invoke_types/outputs.py
@@ -1,0 +1,50 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+
+import outputs
+
+
+@pulumi.output_type
+class MyFunctionNestedResult(dict):
+    first_value: str = pulumi.property("firstValue")
+    second_value: float = pulumi.property("secondValue")
+
+@pulumi.output_type
+class MyFunctionResult:
+    # Deliberately using a qualified (with `outputs.`) forward reference
+    # to mimic our provider codegen, to ensure the type can be resolved.
+    nested: 'outputs.MyFunctionNestedResult'
+
+@pulumi.output_type
+class MyOtherFunctionNestedResult(dict):
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> str:
+        ...
+
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> float:
+        ...
+
+@pulumi.output_type
+class MyOtherFunctionResult:
+    @property
+    @pulumi.getter
+    # Deliberately using a qualified (with `outputs.`) forward reference
+    # to mimic our provider codegen, to ensure the type can be resolved.
+    def nested(self) -> 'outputs.MyOtherFunctionNestedResult':
+        ...

--- a/sdk/python/lib/test/langhost/invoke_types/test_invoke.py
+++ b/sdk/python/lib/test/langhost/invoke_types/test_invoke.py
@@ -1,0 +1,66 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import path
+from ..util import LanghostTest
+
+
+class TestInvoke(LanghostTest):
+    def test_invoke_success(self):
+        self.run_test(
+            program=path.join(self.base_path(), "invoke_types"),
+            expected_resource_count=2)
+
+    def invoke(self, _ctx, token, args, provider, _version):
+        def result(expected_first_value: str, expected_second_value: float):
+            self.assertDictEqual({
+                "firstValue": expected_first_value,
+                "secondValue": expected_second_value,
+            }, args)
+            return ([], {
+                "nested": {
+                    "firstValue": args["firstValue"] * 2,
+                    "secondValue": args["secondValue"] + 1,
+                },
+            })
+
+        if token == "test:index:MyFunction":
+            return result("hello", 42)
+        elif token == "test:index:MyOtherFunction":
+            return result("world", 100)
+        else:
+            self.fail(f"unexpected token {token}")
+
+
+    def register_resource(self, _ctx, _dry_run, ty, name, resource, _deps,
+                          _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
+                          _ignore_changes, _version):
+        if name == "resourceA":
+            self.assertEqual({
+                "first_value": "hellohello",
+                "second_value": 43,
+            }, resource)
+        elif name == "resourceB":
+            self.assertEqual({
+                "first_value": "worldworld",
+                "second_value": 101,
+            }, resource)
+        else:
+            self.fail(f"unknown resource: {name}")
+
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": resource,
+        }

--- a/sdk/python/lib/test/langhost/types/__init__.py
+++ b/sdk/python/lib/test/langhost/types/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/types/__main__.py
+++ b/sdk/python/lib/test/langhost/types/__main__.py
@@ -1,0 +1,394 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+
+import pulumi
+
+
+@pulumi.input_type
+class AdditionalArgs:
+    first_value: pulumi.Input[str] = pulumi.property("firstValue")
+    second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
+
+    def __init__(self, first_value: pulumi.Input[str], second_value: Optional[pulumi.Input[float]] = None):
+        pulumi.set(self, "firstValue", first_value)
+        pulumi.set(self, "secondValue", second_value)
+
+@pulumi.output_type
+class Additional(dict):
+    first_value: str = pulumi.property("firstValue")
+    second_value: Optional[float] = pulumi.property("secondValue")
+
+class AdditionalResource(pulumi.CustomResource):
+    additional: pulumi.Output[Additional]
+
+    def __init__(self, name: str, additional: pulumi.InputType[AdditionalArgs]):
+        super().__init__("test:index:AdditionalResource", name, {"additional": additional})
+
+# Create a resource with input object.
+res = AdditionalResource("testres", additional=AdditionalArgs(first_value="hello", second_value=42))
+
+# Create a resource using the output object of another resource.
+res2 = AdditionalResource("testres2", additional=AdditionalArgs(
+    first_value=res.additional.first_value,
+    second_value=res.additional.second_value,
+))
+
+# Create a resource using the output object of another resource, accessing the output as a dict.
+# Note: the output dict's keys are exactly what is returned from the engine since the resource
+# does not do any translation of property names.
+res3 = AdditionalResource("testres3", additional=AdditionalArgs(
+    first_value=res.additional["firstValue"],
+    second_value=res.additional["secondValue"],
+))
+
+# Create a resource using a dict as the input.
+# Note: These are camel case (not snake_case) since the resource does not do any translation of
+# property names.
+res4 = AdditionalResource("testres4", additional={
+    "firstValue": "hello",
+    "secondValue": 42,
+})
+
+
+# Now, test some resources that use property translations.
+
+SNAKE_TO_CAMEL_CASE_TABLE = {
+    "first_value": "firstValue",
+    "second_value": "secondValue",
+}
+
+CAMEL_TO_SNAKE_CASE_TABLE = {
+    "firstValue": "first_value",
+    "secondValue": "second_value",
+}
+
+@pulumi.input_type
+class ExtraArgs:
+    first_value: pulumi.Input[str] = pulumi.property("firstValue")
+    second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
+
+    def __init__(self, first_value: pulumi.Input[str], second_value: Optional[pulumi.Input[float]] = None):
+        pulumi.set(self, "firstValue", first_value)
+        pulumi.set(self, "secondValue", second_value)
+
+@pulumi.output_type
+class Extra(dict):
+    first_value: str = pulumi.property("firstValue")
+    second_value: Optional[float] = pulumi.property("secondValue")
+
+    def _translate_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+class ExtraResource(pulumi.CustomResource):
+    extra: pulumi.Output[Extra]
+
+    def __init__(self, name: str, extra: pulumi.InputType[ExtraArgs]):
+        super().__init__("test:index:ExtraResource", name, {"extra": extra})
+
+    def translate_output_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+    def translate_input_property(self, prop):
+        return SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
+
+# Create a resource with input object.
+res5 = ExtraResource("testres5", extra=ExtraArgs(first_value="foo", second_value=100))
+
+# Create a resource using the output object of another resource.
+res6 = ExtraResource("testres6", extra=ExtraArgs(
+    first_value=res5.extra.first_value,
+    second_value=res5.extra.second_value,
+))
+
+# Create a resource using the output object of another resource, accessing the output as a dict.
+# Note: the output dict's keys are translated keys.
+res7 = ExtraResource("testres7", extra=ExtraArgs(
+    first_value=res5.extra["first_value"],
+    second_value=res5.extra["second_value"],
+))
+
+# Create a resource using a dict as the input.
+# Note: these are specified as snake_case, and the resource will translate to camelCase.
+res8 = ExtraResource("testres8", extra={
+    "first_value": res5.extra["first_value"],
+    "second_value": res5.extra["second_value"],
+})
+
+
+# Now test some resources that use explicitly declared properties.
+
+@pulumi.input_type
+class SupplementaryArgs:
+    def __init__(self,
+                 first_value: pulumi.Input[str],
+                 second_value: Optional[pulumi.Input[float]] = None,
+                 third: Optional[pulumi.Input[str]] = None,
+                 fourth: Optional[pulumi.Input[str]] = None):
+        pulumi.set(self, "firstValue", first_value)
+        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "third", third)
+        pulumi.set(self, "fourth", fourth)
+
+    # Property with empty getter/setter bodies.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> pulumi.Input[str]:
+        ...
+
+    @first_value.setter
+    def first_value(self, value: pulumi.Input[str]):
+        pulumi.set(self, "firstValue", value)
+
+    # Property with explicitly specified getter/setter bodies.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[pulumi.Input[float]]:
+        return pulumi.get(self, "secondValue")
+
+    @second_value.setter
+    def second_value(self, value: Optional[pulumi.Input[float]]):
+        pulumi.set(self, "secondValue", value)
+
+    # Single word property name that doesn't require a name to be
+    # passed to the getter decorator.
+    @property
+    @pulumi.getter
+    def third(self) -> Optional[pulumi.Input[str]]:
+        ...
+
+    @third.setter
+    def third(self, value: Optional[pulumi.Input[str]]):
+        ...
+
+    # Another single word property name that doesn't require a name to be
+    # passed to the getter decorator, this time using the decorator with
+    # parens.
+    @property
+    @pulumi.getter()
+    def fourth(self) -> Optional[pulumi.Input[str]]:
+        ...
+
+    @third.setter
+    def fourth(self, value: Optional[pulumi.Input[str]]):
+        ...
+
+@pulumi.output_type
+class Supplementary(dict):
+    # Property with empty getter/setter bodies.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> str:
+        ...
+
+    # Property with explicitly specified getter/setter bodies.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[float]:
+        return pulumi.get(self, "secondValue")
+
+    # Single word property name that doesn't require a name to be
+    # passed to the getter decorator.
+    @property
+    @pulumi.getter
+    def third(self) -> str:
+        ...
+
+    # Another single word property name that doesn't require a name to be
+    # passed to the getter decorator, this time using the decorator with
+    # parens.
+    @property
+    @pulumi.getter
+    def fourth(self) -> str:
+        ...
+
+class SupplementaryResource(pulumi.CustomResource):
+    supplementary: pulumi.Output[Supplementary]
+
+    def __init__(self, name: str, supplementary: pulumi.InputType[SupplementaryArgs]):
+        super().__init__("test:index:SupplementaryResource", name, {"supplementary": supplementary})
+
+# Create a resource with input object.
+res9 = SupplementaryResource("testres9", supplementary=SupplementaryArgs(
+    first_value="bar",
+    second_value=200,
+    third="third value",
+    fourth="fourth value",
+))
+
+# Create a resource using the output object of another resource.
+res10 = SupplementaryResource("testres10", supplementary=SupplementaryArgs(
+    first_value=res9.supplementary.first_value,
+    second_value=res9.supplementary.second_value,
+    third=res9.supplementary.third,
+    fourth=res9.supplementary.fourth,
+))
+
+# Create a resource using the output object of another resource, accessing the output as a dict.
+# Note: the output dict's keys are exactly what is returned from the engine since MyResource
+# does not do any translation of property names.
+res11 = SupplementaryResource("testres11", supplementary=SupplementaryArgs(
+    first_value=res9.supplementary["firstValue"],
+    second_value=res9.supplementary["secondValue"],
+    third=res9.supplementary["third"],
+    fourth=res9.supplementary["fourth"],
+))
+
+# Create a resource using a dict as the input.
+# Note: These are camel case (not snake_case) since the resource does not do any translation of
+# property names.
+res12 = SupplementaryResource("testres12", supplementary={
+    "firstValue": "bar",
+    "secondValue": 200,
+    "third": "third value",
+    "fourth": "fourth value",
+})
+
+
+# Now, test some resources that use property translations and explicitly declared properties.
+
+@pulumi.input_type
+class AncillaryArgs:
+    def __init__(self,
+                 first_value: pulumi.Input[str],
+                 second_value: Optional[pulumi.Input[float]] = None,
+                 third: Optional[pulumi.Input[str]] = None,
+                 fourth: Optional[pulumi.Input[str]] = None):
+        pulumi.set(self, "firstValue", first_value)
+        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "third", third)
+        pulumi.set(self, "fourth", fourth)
+
+    # Property with empty getter/setter bodies.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> pulumi.Input[str]:
+        ...
+
+    @first_value.setter
+    def first_value(self, value: pulumi.Input[str]):
+        pulumi.set(self, "firstValue", value)
+
+    # Property with explicitly specified getter/setter bodies.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[pulumi.Input[float]]:
+        return pulumi.get(self, "secondValue")
+
+    @second_value.setter
+    def second_value(self, value: Optional[pulumi.Input[float]]):
+        pulumi.set(self, "secondValue", value)
+
+    # Single word property name that doesn't require a name to be
+    # passed to the getter decorator.
+    @property
+    @pulumi.getter
+    def third(self) -> Optional[pulumi.Input[str]]:
+        ...
+
+    @third.setter
+    def third(self, value: Optional[pulumi.Input[str]]):
+        ...
+
+    # Another single word property name that doesn't require a name to be
+    # passed to the getter decorator, this time using the decorator with
+    # parens.
+    @property
+    @pulumi.getter()
+    def fourth(self) -> Optional[pulumi.Input[str]]:
+        ...
+
+    @third.setter
+    def fourth(self, value: Optional[pulumi.Input[str]]):
+        ...
+
+@pulumi.output_type
+class Ancillary(dict):
+    # Property with empty getter/setter bodies.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> str:
+        ...
+
+    # Property with explicitly specified getter/setter bodies.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[float]:
+        return pulumi.get(self, "secondValue")
+
+    # Single word property name that doesn't require a name to be
+    # passed to the getter decorator.
+    @property
+    @pulumi.getter
+    def third(self) -> str:
+        ...
+
+    # Another single word property name that doesn't require a name to be
+    # passed to the getter decorator, this time using the decorator with
+    # parens.
+    @property
+    @pulumi.getter
+    def fourth(self) -> str:
+        ...
+
+    def _translate_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+class AncillaryResource(pulumi.CustomResource):
+    ancillary: pulumi.Output[Ancillary]
+
+    def __init__(self, name: str, ancillary: pulumi.InputType[AncillaryArgs]):
+        super().__init__("test:index:AncillaryResource", name, {"ancillary": ancillary})
+
+    def translate_output_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+    def translate_input_property(self, prop):
+        return SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
+
+
+# Create a resource with input object.
+res13 = AncillaryResource("testres13", ancillary=SupplementaryArgs(
+    first_value="baz",
+    second_value=500,
+    third="third value!",
+    fourth="fourth!",
+))
+
+# Create a resource using the output object of another resource.
+res14 = AncillaryResource("testres14", ancillary=SupplementaryArgs(
+    first_value=res13.ancillary.first_value,
+    second_value=res13.ancillary.second_value,
+    third=res13.ancillary.third,
+    fourth=res13.ancillary.fourth,
+))
+
+# Create a resource using the output object of another resource, accessing the output as a dict.
+# Note: the output dict's keys are translated keys.
+res15 = AncillaryResource("testres15", ancillary=SupplementaryArgs(
+    first_value=res13.ancillary["first_value"],
+    second_value=res13.ancillary["second_value"],
+    third=res13.ancillary["third"],
+    fourth=res13.ancillary["fourth"],
+))
+
+# Create a resource using a dict as the input.
+# Note: these are specified as snake_case, and the resource will translate to camelCase.
+res16 = AncillaryResource("testres16", ancillary={
+    "first_value": "baz",
+    "second_value": 500,
+    "third": "third value!",
+    "fourth": "fourth!",
+})

--- a/sdk/python/lib/test/langhost/types/__main__.py
+++ b/sdk/python/lib/test/langhost/types/__main__.py
@@ -47,8 +47,6 @@ res2 = AdditionalResource("testres2", additional=AdditionalArgs(
 ))
 
 # Create a resource using the output object of another resource, accessing the output as a dict.
-# Note: the output dict's keys are exactly what is returned from the engine since the resource
-# does not do any translation of property names.
 res3 = AdditionalResource("testres3", additional=AdditionalArgs(
     first_value=res.additional["first_value"],
     second_value=res.additional["second_value"],

--- a/sdk/python/lib/test/langhost/types/__main__.py
+++ b/sdk/python/lib/test/langhost/types/__main__.py
@@ -23,8 +23,8 @@ class AdditionalArgs:
     second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
 
     def __init__(self, first_value: pulumi.Input[str], second_value: Optional[pulumi.Input[float]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
 @pulumi.output_type
 class Additional(dict):
@@ -50,8 +50,8 @@ res2 = AdditionalResource("testres2", additional=AdditionalArgs(
 # Note: the output dict's keys are exactly what is returned from the engine since the resource
 # does not do any translation of property names.
 res3 = AdditionalResource("testres3", additional=AdditionalArgs(
-    first_value=res.additional["firstValue"],
-    second_value=res.additional["secondValue"],
+    first_value=res.additional["first_value"],
+    second_value=res.additional["second_value"],
 ))
 
 # Create a resource using a dict as the input.
@@ -81,8 +81,8 @@ class ExtraArgs:
     second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
 
     def __init__(self, first_value: pulumi.Input[str], second_value: Optional[pulumi.Input[float]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
 @pulumi.output_type
 class Extra(dict):
@@ -137,8 +137,8 @@ class SupplementaryArgs:
                  second_value: Optional[pulumi.Input[float]] = None,
                  third: Optional[pulumi.Input[str]] = None,
                  fourth: Optional[pulumi.Input[str]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
         pulumi.set(self, "third", third)
         pulumi.set(self, "fourth", fourth)
 
@@ -150,17 +150,17 @@ class SupplementaryArgs:
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
-        pulumi.set(self, "firstValue", value)
+        pulumi.set(self, "first_value", value)
 
     # Property with explicitly specified getter/setter bodies.
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[pulumi.Input[float]]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     @second_value.setter
     def second_value(self, value: Optional[pulumi.Input[float]]):
-        pulumi.set(self, "secondValue", value)
+        pulumi.set(self, "second_value", value)
 
     # Single word property name that doesn't require a name to be
     # passed to the getter decorator.
@@ -181,12 +181,18 @@ class SupplementaryArgs:
     def fourth(self) -> Optional[pulumi.Input[str]]:
         ...
 
-    @third.setter
+    @fourth.setter
     def fourth(self, value: Optional[pulumi.Input[str]]):
         ...
 
 @pulumi.output_type
 class Supplementary(dict):
+    def __init__(self, first_value: str, second_value: Optional[float], third: str, fourth: str):
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
+        pulumi.set(self, "third", third)
+        pulumi.set(self, "fourth", fourth)
+
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
@@ -197,7 +203,7 @@ class Supplementary(dict):
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     # Single word property name that doesn't require a name to be
     # passed to the getter decorator.
@@ -237,11 +243,9 @@ res10 = SupplementaryResource("testres10", supplementary=SupplementaryArgs(
 ))
 
 # Create a resource using the output object of another resource, accessing the output as a dict.
-# Note: the output dict's keys are exactly what is returned from the engine since MyResource
-# does not do any translation of property names.
 res11 = SupplementaryResource("testres11", supplementary=SupplementaryArgs(
-    first_value=res9.supplementary["firstValue"],
-    second_value=res9.supplementary["secondValue"],
+    first_value=res9.supplementary["first_value"],
+    second_value=res9.supplementary["second_value"],
     third=res9.supplementary["third"],
     fourth=res9.supplementary["fourth"],
 ))
@@ -266,8 +270,8 @@ class AncillaryArgs:
                  second_value: Optional[pulumi.Input[float]] = None,
                  third: Optional[pulumi.Input[str]] = None,
                  fourth: Optional[pulumi.Input[str]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
         pulumi.set(self, "third", third)
         pulumi.set(self, "fourth", fourth)
 
@@ -279,17 +283,17 @@ class AncillaryArgs:
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
-        pulumi.set(self, "firstValue", value)
+        pulumi.set(self, "first_value", value)
 
     # Property with explicitly specified getter/setter bodies.
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[pulumi.Input[float]]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     @second_value.setter
     def second_value(self, value: Optional[pulumi.Input[float]]):
-        pulumi.set(self, "secondValue", value)
+        pulumi.set(self, "second_value", value)
 
     # Single word property name that doesn't require a name to be
     # passed to the getter decorator.
@@ -310,12 +314,18 @@ class AncillaryArgs:
     def fourth(self) -> Optional[pulumi.Input[str]]:
         ...
 
-    @third.setter
+    @fourth.setter
     def fourth(self, value: Optional[pulumi.Input[str]]):
         ...
 
 @pulumi.output_type
 class Ancillary(dict):
+    def __init__(self, first_value: str, second_value: Optional[float], third: str, fourth: str):
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
+        pulumi.set(self, "third", third)
+        pulumi.set(self, "fourth", fourth)
+
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
@@ -326,7 +336,7 @@ class Ancillary(dict):
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     # Single word property name that doesn't require a name to be
     # passed to the getter decorator.
@@ -339,7 +349,7 @@ class Ancillary(dict):
     # passed to the getter decorator, this time using the decorator with
     # parens.
     @property
-    @pulumi.getter
+    @pulumi.getter()
     def fourth(self) -> str:
         ...
 
@@ -360,7 +370,7 @@ class AncillaryResource(pulumi.CustomResource):
 
 
 # Create a resource with input object.
-res13 = AncillaryResource("testres13", ancillary=SupplementaryArgs(
+res13 = AncillaryResource("testres13", ancillary=AncillaryArgs(
     first_value="baz",
     second_value=500,
     third="third value!",
@@ -368,7 +378,7 @@ res13 = AncillaryResource("testres13", ancillary=SupplementaryArgs(
 ))
 
 # Create a resource using the output object of another resource.
-res14 = AncillaryResource("testres14", ancillary=SupplementaryArgs(
+res14 = AncillaryResource("testres14", ancillary=AncillaryArgs(
     first_value=res13.ancillary.first_value,
     second_value=res13.ancillary.second_value,
     third=res13.ancillary.third,
@@ -377,7 +387,7 @@ res14 = AncillaryResource("testres14", ancillary=SupplementaryArgs(
 
 # Create a resource using the output object of another resource, accessing the output as a dict.
 # Note: the output dict's keys are translated keys.
-res15 = AncillaryResource("testres15", ancillary=SupplementaryArgs(
+res15 = AncillaryResource("testres15", ancillary=AncillaryArgs(
     first_value=res13.ancillary["first_value"],
     second_value=res13.ancillary["second_value"],
     third=res13.ancillary["third"],

--- a/sdk/python/lib/test/langhost/types/test_types.py
+++ b/sdk/python/lib/test/langhost/types/test_types.py
@@ -1,0 +1,62 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from os import path
+from ..util import LanghostTest
+
+
+class TestTypes(LanghostTest):
+    def test_types(self):
+        self.run_test(
+            program=path.join(self.base_path(), "types"),
+            expected_resource_count=16)
+
+    def register_resource(self, ctx, dry_run, ty, name, _resource,
+                          _dependencies, _parent, _custom, _protect,
+                          _provider, _property_deps, _delete_before_replace, _ignore_changes, version):
+        if name in ["testres", "testres2", "testres3", "testres4"]:
+            self.assertIn("additional", _resource)
+            self.assertEqual({
+                "firstValue": "hello",
+                "secondValue": 42,
+            }, _resource["additional"])
+        elif name in ["testres5", "testres6", "testres7", "testres8"]:
+            self.assertIn("extra", _resource)
+            self.assertEqual({
+                "firstValue": "foo",
+                "secondValue": 100,
+            }, _resource["extra"])
+        elif name in ["testres9", "testres10", "testres11", "testres12"]:
+            self.assertIn("supplementary", _resource)
+            self.assertEqual({
+                "firstValue": "bar",
+                "secondValue": 200,
+                "third": "third value",
+                "fourth": "fourth value",
+            }, _resource["supplementary"])
+        elif name in ["testres13", "testres14", "testres15", "testres16"]:
+            self.assertIn("ancillary", _resource)
+            self.assertEqual({
+                "firstValue": "baz",
+                "secondValue": 500,
+                "third": "third value!",
+                "fourth": "fourth!",
+            }, _resource["ancillary"])
+        else:
+            self.fail(f"unknown resource: {name}")
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": _resource,
+        }

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -920,8 +920,8 @@ class FooArgs:
     second_arg: Optional[Input[float]] = pulumi.property("secondArg")
 
     def __init__(self, first_arg: Input[str], second_arg: Optional[Input[float]]=None):
-        pulumi.set(self, "firstArg", first_arg)
-        pulumi.set(self, "secondArg", second_arg)
+        pulumi.set(self, "first_arg", first_arg)
+        pulumi.set(self, "second_arg", second_arg)
 
 
 @input_type
@@ -929,7 +929,7 @@ class BarArgs:
     tag_args: Input[dict] = pulumi.property("tagArgs")
 
     def __init__(self, tag_args: Input[dict]):
-        pulumi.set(self, "tagArgs", tag_args)
+        pulumi.set(self, "tag_args", tag_args)
 
 
 class InputTypeSerializationTests(unittest.TestCase):

--- a/sdk/python/lib/test/test_translate_output_properties.py
+++ b/sdk/python/lib/test/test_translate_output_properties.py
@@ -152,6 +152,117 @@ class BarDeclared(dict):
         return camel_case_to_snake_case.get(prop) or prop
 
 
+@pulumi.output_type
+class InvalidTypeStr(dict):
+    value: str = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> str:
+        ...
+
+@pulumi.output_type
+class InvalidTypeOptionalStr(dict):
+    value: Optional[str] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredOptionalStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> Optional[str]:
+        ...
+
+@pulumi.output_type
+class InvalidTypeDictStr(dict):
+    value: Dict[str, str] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredDictStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> Dict[str, str]:
+        ...
+
+@pulumi.output_type
+class InvalidTypeOptionalDictStr(dict):
+    value: Optional[Dict[str, str]] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredOptionalDictStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> Optional[Dict[str, str]]:
+        ...
+
+@pulumi.output_type
+class InvalidTypeDictOptionalStr(dict):
+    value: Dict[str, Optional[str]] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredDictOptionalStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> Dict[str, Optional[str]]:
+        ...
+
+@pulumi.output_type
+class InvalidTypeOptionalDictOptionalStr(dict):
+    value: Optional[Dict[str, Optional[str]]] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredOptionalDictOptionalStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> Optional[Dict[str, Optional[str]]]:
+        ...
+
+@pulumi.output_type
+class InvalidTypeListStr(dict):
+    value: List[str] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredListStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> List[str]:
+        ...
+
+@pulumi.output_type
+class InvalidTypeOptionalListStr(dict):
+    value: Optional[List[str]] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredOptionalListStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> Optional[List[str]]:
+        ...
+
+@pulumi.output_type
+class InvalidTypeListOptionalStr(dict):
+    value: List[Optional[str]] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredListOptionalStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> List[Optional[str]]:
+        ...
+
+@pulumi.output_type
+class InvalidTypeOptionalListOptionalStr(dict):
+    value: Optional[List[Optional[str]]] = pulumi.property("value")
+
+@pulumi.output_type
+class InvalidTypeDeclaredOptionalListOptionalStr(dict):
+    @property
+    @pulumi.getter
+    def value(self) -> Optional[List[Optional[str]]]:
+        ...
+
+
 class TranslateOutputPropertiesTests(unittest.TestCase):
     def test_translate(self):
         output = {
@@ -305,3 +416,63 @@ class TranslateOutputPropertiesTests(unittest.TestCase):
             assertFoo(result.eighth_optional_optional_arg[0]["blah"][0], "farewell-opt-opt", 1137)
             self.assertIs(result.eighth_optional_optional_optional_arg, result["eighthOptionalOptionalOptionalArg"])
             assertFoo(result.eighth_optional_optional_optional_arg[0]["blah"][0], "farewell-opt-opt-opt", 11137)
+
+    def test_nested_types_raises(self):
+        dict_value = {
+            "firstArg": "hello",
+            "secondArg": 42,
+        }
+        list_value = ["hello"]
+
+        tests = [
+            (InvalidTypeStr, dict_value),
+            (InvalidTypeDeclaredStr, dict_value),
+            (InvalidTypeOptionalStr, dict_value),
+            (InvalidTypeDeclaredOptionalStr, dict_value),
+
+            (InvalidTypeStr, list_value),
+            (InvalidTypeDeclaredStr, list_value),
+            (InvalidTypeOptionalStr, list_value),
+            (InvalidTypeDeclaredOptionalStr, list_value),
+
+            (InvalidTypeDictStr, {"foo": dict_value}),
+            (InvalidTypeDeclaredDictStr, {"foo": dict_value}),
+            (InvalidTypeOptionalDictStr, {"foo": dict_value}),
+            (InvalidTypeDeclaredOptionalDictStr, {"foo": dict_value}),
+            (InvalidTypeDictOptionalStr, {"foo": dict_value}),
+            (InvalidTypeDeclaredDictOptionalStr, {"foo": dict_value}),
+            (InvalidTypeOptionalDictOptionalStr, {"foo": dict_value}),
+            (InvalidTypeDeclaredOptionalDictOptionalStr, {"foo": dict_value}),
+
+            (InvalidTypeDictStr, {"foo": list_value}),
+            (InvalidTypeDeclaredDictStr, {"foo": list_value}),
+            (InvalidTypeOptionalDictStr, {"foo": list_value}),
+            (InvalidTypeDeclaredOptionalDictStr, {"foo": list_value}),
+            (InvalidTypeDictOptionalStr, {"foo": list_value}),
+            (InvalidTypeDeclaredDictOptionalStr, {"foo": list_value}),
+            (InvalidTypeOptionalDictOptionalStr, {"foo": list_value}),
+            (InvalidTypeDeclaredOptionalDictOptionalStr, {"foo": list_value}),
+
+            (InvalidTypeListStr, [dict_value]),
+            (InvalidTypeDeclaredListStr, [dict_value]),
+            (InvalidTypeOptionalListStr, [dict_value]),
+            (InvalidTypeDeclaredOptionalListStr, [dict_value]),
+            (InvalidTypeListOptionalStr, [dict_value]),
+            (InvalidTypeDeclaredListOptionalStr, [dict_value]),
+            (InvalidTypeOptionalListOptionalStr, [dict_value]),
+            (InvalidTypeDeclaredOptionalListOptionalStr, [dict_value]),
+
+            (InvalidTypeListStr, [list_value]),
+            (InvalidTypeDeclaredListStr, [list_value]),
+            (InvalidTypeOptionalListStr, [list_value]),
+            (InvalidTypeDeclaredOptionalListStr, [list_value]),
+            (InvalidTypeListOptionalStr, [list_value]),
+            (InvalidTypeDeclaredListOptionalStr, [list_value]),
+            (InvalidTypeOptionalListOptionalStr, [list_value]),
+            (InvalidTypeDeclaredOptionalListOptionalStr, [list_value]),
+        ]
+
+        for typ, value in tests:
+            output = {"value": value}
+            with self.assertRaises(AssertionError):
+                rpc.translate_output_properties(output, translate_output_property, typ)

--- a/sdk/python/lib/test/test_translate_output_properties.py
+++ b/sdk/python/lib/test/test_translate_output_properties.py
@@ -67,6 +67,39 @@ class Bar(dict):
 
 @pulumi.output_type
 class BarDeclared(dict):
+    def __init__(self,
+                 third_arg: Foo,
+                 third_optional_arg: Optional[Foo],
+                 fourth_arg: Dict[str, Foo],
+                 fourth_optional_arg: Dict[str, Optional[Foo]],
+                 fifth_arg: List[Foo],
+                 fifth_optional_arg: List[Optional[Foo]],
+                 sixth_arg: Dict[str, List[Foo]],
+                 sixth_optional_arg: Dict[str, Optional[List[Foo]]],
+                 sixth_optional_optional_arg: Dict[str, Optional[List[Optional[Foo]]]],
+                 seventh_arg: List[Dict[str, Foo]],
+                 seventh_optional_arg: List[Optional[Dict[str, Foo]]],
+                 seventh_optional_optional_arg: List[Optional[Dict[str, Optional[Foo]]]],
+                 eighth_arg: List[Dict[str, List[Foo]]],
+                 eighth_optional_arg: List[Optional[Dict[str, List[Foo]]]],
+                 eighth_optional_optional_arg: List[Optional[Dict[str, Optional[List[Foo]]]]],
+                 eighth_optional_optional_optional_arg: List[Optional[Dict[str, Optional[List[Optional[Foo]]]]]]):
+        pulumi.set(self, "third_arg", third_arg)
+        pulumi.set(self, "third_optional_arg", third_optional_arg)
+        pulumi.set(self, "fourth_arg", fourth_arg)
+        pulumi.set(self, "fourth_optional_arg", fourth_optional_arg)
+        pulumi.set(self, "fifth_arg", fifth_arg)
+        pulumi.set(self, "fifth_optional_arg", fifth_optional_arg)
+        pulumi.set(self, "sixth_arg", sixth_arg)
+        pulumi.set(self, "sixth_optional_arg", sixth_optional_arg)
+        pulumi.set(self, "sixth_optional_optional_arg", sixth_optional_optional_arg)
+        pulumi.set(self, "seventh_arg", seventh_arg)
+        pulumi.set(self, "seventh_optional_arg", seventh_optional_arg)
+        pulumi.set(self, "seventh_optional_optional_arg", seventh_optional_optional_arg)
+        pulumi.set(self, "eighth_arg", eighth_arg)
+        pulumi.set(self, "eighth_optional_arg", eighth_optional_arg)
+        pulumi.set(self, "eighth_optional_optional_arg", eighth_optional_optional_arg)
+        pulumi.set(self, "eighth_optional_optional_optional_arg", eighth_optional_optional_optional_arg)
 
     @property
     @pulumi.getter(name="thirdArg")
@@ -158,6 +191,9 @@ class InvalidTypeStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredStr(dict):
+    def __init__(self, value: str):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> str:
@@ -169,6 +205,9 @@ class InvalidTypeOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalStr(dict):
+    def __init__(self, value: Optional[str]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[str]:
@@ -180,6 +219,9 @@ class InvalidTypeDictStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredDictStr(dict):
+    def __init__(self, value: Dict[str, str]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Dict[str, str]:
@@ -191,6 +233,9 @@ class InvalidTypeOptionalDictStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalDictStr(dict):
+    def __init__(self, value: Optional[Dict[str, str]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[Dict[str, str]]:
@@ -202,6 +247,9 @@ class InvalidTypeDictOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredDictOptionalStr(dict):
+    def __init__(self, value: Dict[str, Optional[str]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Dict[str, Optional[str]]:
@@ -213,6 +261,9 @@ class InvalidTypeOptionalDictOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalDictOptionalStr(dict):
+    def __init__(self, value: Optional[Dict[str, Optional[str]]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[Dict[str, Optional[str]]]:
@@ -224,6 +275,9 @@ class InvalidTypeListStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredListStr(dict):
+    def __init__(self, value: List[str]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> List[str]:
@@ -235,6 +289,9 @@ class InvalidTypeOptionalListStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalListStr(dict):
+    def __init__(self, value: Optional[List[str]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[List[str]]:
@@ -246,6 +303,9 @@ class InvalidTypeListOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredListOptionalStr(dict):
+    def __init__(self, value: List[Optional[str]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> List[Optional[str]]:
@@ -257,6 +317,9 @@ class InvalidTypeOptionalListOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalListOptionalStr(dict):
+    def __init__(self, value: Optional[List[Optional[str]]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[List[Optional[str]]]:

--- a/sdk/python/lib/test/test_translate_output_properties.py
+++ b/sdk/python/lib/test/test_translate_output_properties.py
@@ -1,0 +1,317 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from typing import Dict, List, Optional
+
+from pulumi.runtime import rpc
+import pulumi
+
+camel_case_to_snake_case = {
+    "firstArg": "first_arg",
+    "secondArg": "second_arg",
+}
+
+
+class FakeCustomResource:
+    """
+    Fake CustomResource class that duck-types to the real CustomResource.
+    This class is substituted for the real CustomResource for the below test.
+    """
+    def __init__(self, id):
+        self.id = id
+
+    def translate_output_property(self, prop: str) -> str:
+        return camel_case_to_snake_case.get(prop) or prop
+
+
+@pulumi.output_type
+class Foo(dict):
+    first_arg: str = pulumi.property("firstArg")
+    second_arg: float = pulumi.property("secondArg")
+
+    def _translate_property(self, prop: str) -> str:
+        return camel_case_to_snake_case.get(prop) or prop
+
+
+@pulumi.output_type
+class Bar(dict):
+    third_arg: Foo = pulumi.property("thirdArg")
+    third_optional_arg: Optional[Foo] = pulumi.property("thirdOptionalArg")
+
+    fourth_arg: Dict[str, Foo] = pulumi.property("fourthArg")
+    fourth_optional_arg: Dict[str, Optional[Foo]] = pulumi.property("fourthOptionalArg")
+
+    fifth_arg: List[Foo] = pulumi.property("fifthArg")
+    fifth_optional_arg: List[Optional[Foo]] = pulumi.property("fifthOptionalArg")
+
+    sixth_arg: Dict[str, List[Foo]] = pulumi.property("sixthArg")
+    sixth_optional_arg: Dict[str, Optional[List[Foo]]] = pulumi.property("sixthOptionalArg")
+    sixth_optional_optional_arg: Dict[str, Optional[List[Optional[Foo]]]] = pulumi.property("sixthOptionalOptionalArg")
+
+    seventh_arg: List[Dict[str, Foo]] = pulumi.property("seventhArg")
+    seventh_optional_arg: List[Optional[Dict[str, Foo]]] = pulumi.property("seventhOptionalArg")
+    seventh_optional_optional_arg: List[Optional[Dict[str, Optional[Foo]]]] = pulumi.property("seventhOptionalOptionalArg")
+
+    eighth_arg: List[Dict[str, List[Foo]]] = pulumi.property("eighthArg")
+    eighth_optional_arg: List[Optional[Dict[str, List[Foo]]]] = pulumi.property("eighthOptionalArg")
+    eighth_optional_optional_arg: List[Optional[Dict[str, Optional[List[Foo]]]]] = pulumi.property("eighthOptionalOptionalArg")
+    eighth_optional_optional_optional_arg: List[Optional[Dict[str, Optional[List[Optional[Foo]]]]]] = pulumi.property("eighthOptionalOptionalOptionalArg")
+
+    def _translate_property(self, prop: str) -> str:
+        return camel_case_to_snake_case.get(prop) or prop
+
+
+@pulumi.output_type
+class BarDeclared(dict):
+
+    @property
+    @pulumi.getter(name="thirdArg")
+    def third_arg(self) -> Foo:
+        ...
+
+    @property
+    @pulumi.getter(name="thirdOptionalArg")
+    def third_optional_arg(self) -> Optional[Foo]:
+        ...
+
+    @property
+    @pulumi.getter(name="fourthArg")
+    def fourth_arg(self) -> Dict[str, Foo]:
+        ...
+
+    @property
+    @pulumi.getter(name="fourthOptionalArg")
+    def fourth_optional_arg(self) -> Dict[str, Optional[Foo]]:
+        ...
+
+    @property
+    @pulumi.getter(name="fifthArg")
+    def fifth_arg(self) -> List[Foo]:
+        ...
+
+    @property
+    @pulumi.getter(name="fifthOptionalArg")
+    def fifth_optional_arg(self) -> List[Optional[Foo]]:
+        ...
+
+    @property
+    @pulumi.getter(name="sixthArg")
+    def sixth_arg(self) -> Dict[str, List[Foo]]:
+        ...
+
+    @property
+    @pulumi.getter(name="sixthOptionalArg")
+    def sixth_optional_arg(self) -> Dict[str, Optional[List[Foo]]]:
+        ...
+
+    @property
+    @pulumi.getter(name="sixthOptionalOptionalArg")
+    def sixth_optional_optional_arg(self) -> Dict[str, Optional[List[Optional[Foo]]]]:
+        ...
+
+    @property
+    @pulumi.getter(name="seventhArg")
+    def seventh_arg(self) -> List[Dict[str, Foo]]:
+        ...
+
+    @property
+    @pulumi.getter(name="seventhOptionalArg")
+    def seventh_optional_arg(self) -> List[Optional[Dict[str, Foo]]]:
+        ...
+
+    @property
+    @pulumi.getter(name="seventhOptionalOptionalArg")
+    def seventh_optional_optional_arg(self) -> List[Optional[Dict[str, Optional[Foo]]]]:
+        ...
+
+    @property
+    @pulumi.getter(name="eighthArg")
+    def eighth_arg(self) -> List[Dict[str, List[Foo]]]:
+        ...
+
+    @property
+    @pulumi.getter(name="eighthOptionalArg")
+    def eighth_optional_arg(self) -> List[Optional[Dict[str, List[Foo]]]]:
+        ...
+
+    @property
+    @pulumi.getter(name="eighthOptionalOptionalArg")
+    def eighth_optional_optional_arg(self) -> List[Optional[Dict[str, Optional[List[Foo]]]]]:
+        ...
+
+    @property
+    @pulumi.getter(name="eighthOptionalOptionalOptionalArg")
+    def eighth_optional_optional_optional_arg(self) -> List[Optional[Dict[str, Optional[List[Optional[Foo]]]]]]:
+        ...
+
+    def _translate_property(self, prop: str) -> str:
+        return camel_case_to_snake_case.get(prop) or prop
+
+
+class TranslateOutputPropertiesTests(unittest.TestCase):
+    def test_translate(self):
+        res = FakeCustomResource("fake")
+        output = {
+            "firstArg": "hello",
+            "secondArg": 42,
+        }
+        result = rpc.translate_output_properties(res, output, Foo)
+        self.assertIsInstance(result, Foo)
+        self.assertEqual(result.first_arg, "hello")
+        self.assertEqual(result["first_arg"], "hello")
+        self.assertEqual(result.second_arg, 42)
+        self.assertEqual(result["second_arg"], 42)
+
+    def test_nested_types(self):
+        def assertFoo(val, first_arg, second_arg):
+            self.assertIsInstance(val, Foo)
+            self.assertEqual(val.first_arg, first_arg)
+            self.assertEqual(val["first_arg"], first_arg)
+            self.assertEqual(val.second_arg, second_arg)
+            self.assertEqual(val["second_arg"], second_arg)
+
+        res = FakeCustomResource("fake")
+        output = {
+            "thirdArg": {
+                "firstArg": "hello",
+                "secondArg": 42,
+            },
+            "thirdOptionalArg": {
+                "firstArg": "hello-opt",
+                "secondArg": 142,
+            },
+            "fourthArg": {
+                "foo": {
+                    "firstArg": "hi",
+                    "secondArg": 41,
+                },
+            },
+            "fourthOptionalArg": {
+                "foo": {
+                    "firstArg": "hi-opt",
+                    "secondArg": 141,
+                },
+            },
+            "fifthArg": [{
+                "firstArg": "bye",
+                "secondArg": 40,
+            }],
+            "fifthOptionalArg": [{
+                "firstArg": "bye-opt",
+                "secondArg": 140,
+            }],
+            "sixthArg": {
+                "bar": [{
+                    "firstArg": "goodbye",
+                    "secondArg": 39,
+                }],
+            },
+            "sixthOptionalArg": {
+                "bar": [{
+                    "firstArg": "goodbye-opt",
+                    "secondArg": 139,
+                }],
+            },
+            "sixthOptionalOptionalArg": {
+                "bar": [{
+                    "firstArg": "goodbye-opt-opt",
+                    "secondArg": 1139,
+                }],
+            },
+            "seventhArg": [{
+                "baz": {
+                    "firstArg": "adios",
+                    "secondArg": 38,
+                },
+            }],
+            "seventhOptionalArg": [{
+                "baz": {
+                    "firstArg": "adios-opt",
+                    "secondArg": 138,
+                },
+            }],
+            "seventhOptionalOptionalArg": [{
+                "baz": {
+                    "firstArg": "adios-opt-opt",
+                    "secondArg": 1138,
+                },
+            }],
+            "eighthArg": [{
+                "blah": [{
+                    "firstArg": "farewell",
+                    "secondArg": 37,
+                }],
+            }],
+            "eighthOptionalArg": [{
+                "blah": [{
+                    "firstArg": "farewell-opt",
+                    "secondArg": 137,
+                }],
+            }],
+            "eighthOptionalOptionalArg": [{
+                "blah": [{
+                    "firstArg": "farewell-opt-opt",
+                    "secondArg": 1137,
+                }],
+            }],
+            "eighthOptionalOptionalOptionalArg": [{
+                "blah": [{
+                    "firstArg": "farewell-opt-opt-opt",
+                    "secondArg": 11137,
+                }],
+            }],
+        }
+
+        for typ in [Bar, BarDeclared]:
+            result = rpc.translate_output_properties(res, output, typ)
+            self.assertIsInstance(result, typ)
+
+            self.assertIs(result.third_arg, result["thirdArg"])
+            assertFoo(result.third_arg, "hello", 42)
+            self.assertIs(result.third_optional_arg, result["thirdOptionalArg"])
+            assertFoo(result.third_optional_arg, "hello-opt", 142)
+
+            self.assertIs(result.fourth_arg, result["fourthArg"])
+            assertFoo(result.fourth_arg["foo"], "hi", 41)
+            self.assertIs(result.fourth_optional_arg, result["fourthOptionalArg"])
+            assertFoo(result.fourth_optional_arg["foo"], "hi-opt", 141)
+
+            self.assertIs(result.fifth_arg, result["fifthArg"])
+            assertFoo(result.fifth_arg[0], "bye", 40)
+            self.assertIs(result.fifth_optional_arg, result["fifthOptionalArg"])
+            assertFoo(result.fifth_optional_arg[0], "bye-opt", 140)
+
+            self.assertIs(result.sixth_arg, result["sixthArg"])
+            assertFoo(result.sixth_arg["bar"][0], "goodbye", 39)
+            self.assertIs(result.sixth_optional_arg, result["sixthOptionalArg"])
+            assertFoo(result.sixth_optional_arg["bar"][0], "goodbye-opt", 139)
+            self.assertIs(result.sixth_optional_optional_arg, result["sixthOptionalOptionalArg"])
+            assertFoo(result.sixth_optional_optional_arg["bar"][0], "goodbye-opt-opt", 1139)
+
+            self.assertIs(result.seventh_arg, result["seventhArg"])
+            assertFoo(result.seventh_arg[0]["baz"], "adios", 38)
+            self.assertIs(result.seventh_optional_arg, result["seventhOptionalArg"])
+            assertFoo(result.seventh_optional_arg[0]["baz"], "adios-opt", 138)
+            self.assertIs(result.seventh_optional_optional_arg, result["seventhOptionalOptionalArg"])
+            assertFoo(result.seventh_optional_optional_arg[0]["baz"], "adios-opt-opt", 1138)
+
+            self.assertIs(result.eighth_arg, result["eighthArg"])
+            assertFoo(result.eighth_arg[0]["blah"][0], "farewell", 37)
+            self.assertIs(result.eighth_optional_arg, result["eighthOptionalArg"])
+            assertFoo(result.eighth_optional_arg[0]["blah"][0], "farewell-opt", 137)
+            self.assertIs(result.eighth_optional_optional_arg, result["eighthOptionalOptionalArg"])
+            assertFoo(result.eighth_optional_optional_arg[0]["blah"][0], "farewell-opt-opt", 1137)
+            self.assertIs(result.eighth_optional_optional_optional_arg, result["eighthOptionalOptionalOptionalArg"])
+            assertFoo(result.eighth_optional_optional_optional_arg[0]["blah"][0], "farewell-opt-opt-opt", 11137)

--- a/sdk/python/lib/test/test_types_input_type.py
+++ b/sdk/python/lib/test/test_types_input_type.py
@@ -1,0 +1,157 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from typing import Optional
+
+import pulumi
+import pulumi._types as _types
+
+
+@pulumi.input_type
+class MyInputType:
+    first_value: pulumi.Input[str] = pulumi.property("firstValue")
+    second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
+
+    def __init__(self,
+                 first_value: pulumi.Input[str],
+                 second_value: Optional[pulumi.Input[float]] = None):
+        pulumi.set(self, "firstValue", first_value)
+        pulumi.set(self, "secondValue", second_value)
+
+
+@pulumi.input_type
+class MyDeclaredPropertiesInputType:
+    def __init__(self,
+                 first_value: pulumi.Input[str],
+                 second_value: Optional[pulumi.Input[float]] = None):
+        pulumi.set(self, "firstValue", first_value)
+        pulumi.set(self, "secondValue", second_value)
+
+    # Property with empty getter/setter bodies.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> pulumi.Input[str]:
+        """First value docstring."""
+        ...
+
+    @first_value.setter
+    def first_value(self, value: pulumi.Input[str]):
+        ...
+
+    # Property with implementations.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[pulumi.Input[float]]:
+        """Second value docstring."""
+        return pulumi.get(self, "secondValue")
+
+    @second_value.setter
+    def second_value(self, value: Optional[pulumi.Input[float]]):
+        pulumi.set(self, "secondValue", value)
+
+
+class InputTypeTests(unittest.TestCase):
+    def test_decorator_raises(self):
+        with self.assertRaises(AssertionError) as cm:
+            @pulumi.input_type
+            @pulumi.input_type
+            class Foo:
+                pass
+
+        with self.assertRaises(AssertionError) as cm:
+            @pulumi.input_type
+            @pulumi.output_type
+            class Bar:
+                pass
+
+    def test_is_input_type(self):
+        types = [
+            MyInputType,
+            MyDeclaredPropertiesInputType,
+        ]
+        for typ in types:
+            self.assertTrue(_types.is_input_type(typ))
+            self.assertEqual(True, typ._pulumi_input_type)
+
+    def test_input_type(self):
+        types = [
+            (MyInputType, False),
+            (MyDeclaredPropertiesInputType, True),
+        ]
+        for typ, has_doc in types:
+            t = typ(first_value="hello", second_value=42)
+            self.assertEqual("hello", t.first_value)
+            self.assertEqual(42, t.second_value)
+            t.first_value = "world"
+            self.assertEqual("world", t.first_value)
+            t.second_value = 500
+            self.assertEqual(500, t.second_value)
+
+            first = typ.first_value
+            self.assertIsInstance(first, property)
+            self.assertTrue(callable(first.fget))
+            self.assertEqual("first_value", first.fget.__name__)
+            self.assertEqual({"return": pulumi.Input[str]}, first.fget.__annotations__)
+            if has_doc:
+                self.assertEqual("First value docstring.", first.fget.__doc__)
+            self.assertEqual(True, first.fget._pulumi_getter)
+            self.assertEqual("firstValue", first.fget._pulumi_name)
+            self.assertTrue(callable(first.fset))
+            self.assertEqual("first_value", first.fset.__name__)
+            self.assertEqual({"value": pulumi.Input[str]}, first.fset.__annotations__)
+
+            second = typ.second_value
+            self.assertIsInstance(second, property)
+            self.assertTrue(callable(second.fget))
+            self.assertEqual("second_value", second.fget.__name__)
+            self.assertEqual({"return": Optional[pulumi.Input[float]]}, second.fget.__annotations__)
+            if has_doc:
+                self.assertEqual("Second value docstring.", second.fget.__doc__)
+            self.assertEqual(True, second.fget._pulumi_getter)
+            self.assertEqual("secondValue", second.fget._pulumi_name)
+            self.assertTrue(callable(second.fset))
+            self.assertEqual("second_value", second.fset.__name__)
+            self.assertEqual({"value": Optional[pulumi.Input[float]]}, second.fset.__annotations__)
+
+            self.assertEqual({
+                "firstValue": "world",
+                "secondValue": 500,
+            }, _types.input_type_to_dict(t))
+
+            self.assertTrue(hasattr(t, "__eq__"))
+            self.assertTrue(t.__eq__(t))
+            self.assertTrue(t == t)
+            self.assertFalse(t != t)
+            self.assertFalse(t == "not equal")
+
+            t2 = typ(first_value="world", second_value=500)
+            self.assertTrue(t.__eq__(t2))
+            self.assertTrue(t == t2)
+            self.assertFalse(t != t2)
+
+            self.assertEqual({
+                "firstValue": "world",
+                "secondValue": 500,
+            }, _types.input_type_to_dict(t2))
+
+            t3 = typ(first_value="foo", second_value=1)
+            self.assertFalse(t.__eq__(t3))
+            self.assertFalse(t == t3)
+            self.assertTrue(t != t3)
+
+            self.assertEqual({
+                "firstValue": "foo",
+                "secondValue": 1,
+            }, _types.input_type_to_dict(t3))

--- a/sdk/python/lib/test/test_types_input_type.py
+++ b/sdk/python/lib/test/test_types_input_type.py
@@ -20,6 +20,12 @@ import pulumi._types as _types
 
 
 @pulumi.input_type
+class MySimpleInputType:
+    first_value: pulumi.Input[str] = pulumi.property("firstValue")
+    second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue", default=None)
+
+
+@pulumi.input_type
 class MyInputType:
     first_value: pulumi.Input[str] = pulumi.property("firstValue")
     second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
@@ -27,8 +33,8 @@ class MyInputType:
     def __init__(self,
                  first_value: pulumi.Input[str],
                  second_value: Optional[pulumi.Input[float]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
 
 @pulumi.input_type
@@ -36,8 +42,8 @@ class MyDeclaredPropertiesInputType:
     def __init__(self,
                  first_value: pulumi.Input[str],
                  second_value: Optional[pulumi.Input[float]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
     # Property with empty getter/setter bodies.
     @property
@@ -55,11 +61,11 @@ class MyDeclaredPropertiesInputType:
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[pulumi.Input[float]]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     @second_value.setter
     def second_value(self, value: Optional[pulumi.Input[float]]):
-        pulumi.set(self, "secondValue", value)
+        pulumi.set(self, "second_value", value)
 
 
 class InputTypeTests(unittest.TestCase):
@@ -87,6 +93,7 @@ class InputTypeTests(unittest.TestCase):
 
     def test_input_type(self):
         types = [
+            (MySimpleInputType, False),
             (MyInputType, False),
             (MyDeclaredPropertiesInputType, True),
         ]
@@ -106,7 +113,6 @@ class InputTypeTests(unittest.TestCase):
             self.assertEqual({"return": pulumi.Input[str]}, first.fget.__annotations__)
             if has_doc:
                 self.assertEqual("First value docstring.", first.fget.__doc__)
-            self.assertEqual(True, first.fget._pulumi_getter)
             self.assertEqual("firstValue", first.fget._pulumi_name)
             self.assertTrue(callable(first.fset))
             self.assertEqual("first_value", first.fset.__name__)
@@ -119,7 +125,6 @@ class InputTypeTests(unittest.TestCase):
             self.assertEqual({"return": Optional[pulumi.Input[float]]}, second.fget.__annotations__)
             if has_doc:
                 self.assertEqual("Second value docstring.", second.fget.__doc__)
-            self.assertEqual(True, second.fget._pulumi_getter)
             self.assertEqual("secondValue", second.fget._pulumi_name)
             self.assertTrue(callable(second.fset))
             self.assertEqual("second_value", second.fset.__name__)

--- a/sdk/python/lib/test/test_types_output_type.py
+++ b/sdk/python/lib/test/test_types_output_type.py
@@ -1,0 +1,223 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from typing import Optional
+
+import pulumi
+import pulumi._types as _types
+
+
+CAMEL_TO_SNAKE_CASE_TABLE = {
+    "firstValue": "first_value",
+    "secondValue": "second_value",
+}
+
+@pulumi.output_type
+class MyOutputType:
+    first_value: str = pulumi.property("firstValue")
+    second_value: Optional[float] = pulumi.property("secondValue")
+
+@pulumi.output_type
+class MyOutputTypeDict(dict):
+    first_value: str = pulumi.property("firstValue")
+    second_value: Optional[float] = pulumi.property("secondValue")
+
+@pulumi.output_type
+class MyOutputTypeTranslated:
+    first_value: str = pulumi.property("firstValue")
+    second_value: Optional[float] = pulumi.property("secondValue")
+
+    def _translate_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+@pulumi.output_type
+class MyOutputTypeDictTranslated(dict):
+    first_value: str = pulumi.property("firstValue")
+    second_value: Optional[float] = pulumi.property("secondValue")
+
+    def _translate_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+
+@pulumi.output_type
+class MyDeclaredPropertiesOutputType:
+    # Property with empty body.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> str:
+        """First value docstring."""
+        ...
+
+    # Property with implementation.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[float]:
+        """Second value docstring."""
+        return pulumi.get(self, "secondValue")
+
+@pulumi.output_type
+class MyDeclaredPropertiesOutputTypeDict(dict):
+    # Property with empty body.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> str:
+        """First value docstring."""
+        ...
+
+    # Property with implementation.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[float]:
+        """Second value docstring."""
+        return pulumi.get(self, "secondValue")
+
+@pulumi.output_type
+class MyDeclaredPropertiesOutputTypeTranslated:
+    # Property with empty body.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> str:
+        """First value docstring."""
+        ...
+
+    # Property with implementation.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[float]:
+        """Second value docstring."""
+        return pulumi.get(self, "secondValue")
+
+    def _translate_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+@pulumi.output_type
+class MyDeclaredPropertiesOutputTypeDictTranslated(dict):
+    # Property with empty body.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> str:
+        """First value docstring."""
+        ...
+
+    # Property with implementation.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[float]:
+        """Second value docstring."""
+        return pulumi.get(self, "secondValue")
+
+    def _translate_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+
+class InputTypeTests(unittest.TestCase):
+    def test_decorator_raises(self):
+        with self.assertRaises(AssertionError) as cm:
+            @pulumi.output_type
+            @pulumi.input_type
+            class Foo:
+                pass
+
+        with self.assertRaises(AssertionError) as cm:
+            @pulumi.output_type
+            @pulumi.input_type
+            class Bar:
+                pass
+
+    def test_is_output_type(self):
+        types = [
+            MyOutputType,
+            MyOutputTypeDict,
+            MyOutputTypeTranslated,
+            MyOutputTypeDictTranslated,
+            MyDeclaredPropertiesOutputType,
+            MyDeclaredPropertiesOutputTypeDict,
+            MyDeclaredPropertiesOutputTypeTranslated,
+            MyDeclaredPropertiesOutputTypeDictTranslated,
+        ]
+        for typ in types:
+            self.assertTrue(_types.is_output_type(typ))
+            self.assertEqual(True, typ._pulumi_output_type)
+
+    def test_output_type_types(self):
+        self.assertEqual({
+            "firstValue": str,
+            "secondValue": float,
+        }, _types.output_type_types(MyOutputType))
+
+    def test_output_type(self):
+        types = [
+            (MyOutputType, "firstValue", "secondValue", False),
+            (MyOutputTypeDict, "firstValue", "secondValue", False),
+            (MyOutputTypeTranslated, "first_value", "second_value", False),
+            (MyOutputTypeDictTranslated, "first_value", "second_value", False),
+            (MyDeclaredPropertiesOutputType, "firstValue", "secondValue", True),
+            (MyDeclaredPropertiesOutputTypeDict, "firstValue", "secondValue", True),
+            (MyDeclaredPropertiesOutputTypeTranslated, "first_value", "second_value", True),
+            (MyDeclaredPropertiesOutputTypeDictTranslated, "first_value", "second_value", True),
+        ]
+        for typ, k1, k2, has_doc in types:
+            self.assertTrue(hasattr(MyOutputType, "__init__"))
+            t = typ({k1: "hello", k2: 42})
+            self.assertEqual("hello", t.first_value)
+            self.assertEqual(42, t.second_value)
+
+            if isinstance(t, dict):
+                self.assertEqual("hello", t[k1])
+                self.assertEqual(42, t[k2])
+
+            first = typ.first_value
+            self.assertIsInstance(first, property)
+            self.assertTrue(callable(first.fget))
+            self.assertEqual("first_value", first.fget.__name__)
+            self.assertEqual({"return": str}, first.fget.__annotations__)
+            if has_doc:
+                self.assertEqual("First value docstring.", first.fget.__doc__)
+            self.assertEqual(True, first.fget._pulumi_getter)
+            self.assertEqual("firstValue", first.fget._pulumi_name)
+
+            second = typ.second_value
+            self.assertIsInstance(second, property)
+            self.assertTrue(callable(second.fget))
+            self.assertEqual("second_value", second.fget.__name__)
+            self.assertEqual({"return": Optional[float]}, second.fget.__annotations__)
+            if has_doc:
+                self.assertEqual("Second value docstring.", second.fget.__doc__)
+            self.assertEqual(True, second.fget._pulumi_getter)
+            self.assertEqual("secondValue", second.fget._pulumi_name)
+
+            self.assertTrue(hasattr(t, "__eq__"))
+            self.assertTrue(t.__eq__(t))
+            self.assertTrue(t == t)
+            self.assertFalse(t != t)
+            self.assertFalse(t == "not equal")
+
+            t2 = typ({k1: "hello", k2: 42})
+            self.assertTrue(t.__eq__(t2))
+            self.assertTrue(t == t2)
+            self.assertFalse(t != t2)
+
+            if isinstance(t2, dict):
+                self.assertEqual("hello", t2[k1])
+                self.assertEqual(42, t2[k2])
+
+            t3 = typ({k1: "foo", k2: 1})
+            self.assertFalse(t.__eq__(t3))
+            self.assertFalse(t == t3)
+            self.assertTrue(t != t3)
+
+            if isinstance(t3, dict):
+                self.assertEqual("foo", t3[k1])
+                self.assertEqual(1, t3[k2])

--- a/sdk/python/lib/test/test_types_output_type.py
+++ b/sdk/python/lib/test/test_types_output_type.py
@@ -27,17 +27,17 @@ CAMEL_TO_SNAKE_CASE_TABLE = {
 @pulumi.output_type
 class MyOutputType:
     first_value: str = pulumi.property("firstValue")
-    second_value: Optional[float] = pulumi.property("secondValue")
+    second_value: Optional[float] = pulumi.property("secondValue", default=None)
 
 @pulumi.output_type
 class MyOutputTypeDict(dict):
     first_value: str = pulumi.property("firstValue")
-    second_value: Optional[float] = pulumi.property("secondValue")
+    second_value: Optional[float] = pulumi.property("secondValue", default=None)
 
 @pulumi.output_type
 class MyOutputTypeTranslated:
     first_value: str = pulumi.property("firstValue")
-    second_value: Optional[float] = pulumi.property("secondValue")
+    second_value: Optional[float] = pulumi.property("secondValue", default=None)
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
@@ -45,7 +45,7 @@ class MyOutputTypeTranslated:
 @pulumi.output_type
 class MyOutputTypeDictTranslated(dict):
     first_value: str = pulumi.property("firstValue")
-    second_value: Optional[float] = pulumi.property("secondValue")
+    second_value: Optional[float] = pulumi.property("secondValue", default=None)
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
@@ -53,6 +53,11 @@ class MyOutputTypeDictTranslated(dict):
 
 @pulumi.output_type
 class MyDeclaredPropertiesOutputType:
+    def __init__(self, first_value: str, second_value: Optional[float] = None):
+        pulumi.set(self, "first_value", first_value)
+        if second_value is not None:
+            pulumi.set(self, "second_value", second_value)
+
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
@@ -65,10 +70,15 @@ class MyDeclaredPropertiesOutputType:
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
 @pulumi.output_type
 class MyDeclaredPropertiesOutputTypeDict(dict):
+    def __init__(self, first_value: str, second_value: Optional[float] = None):
+        pulumi.set(self, "first_value", first_value)
+        if second_value is not None:
+            pulumi.set(self, "second_value", second_value)
+
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
@@ -81,10 +91,15 @@ class MyDeclaredPropertiesOutputTypeDict(dict):
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
 @pulumi.output_type
 class MyDeclaredPropertiesOutputTypeTranslated:
+    def __init__(self, first_value: str, second_value: Optional[float] = None):
+        pulumi.set(self, "first_value", first_value)
+        if second_value is not None:
+            pulumi.set(self, "second_value", second_value)
+
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
@@ -97,13 +112,18 @@ class MyDeclaredPropertiesOutputTypeTranslated:
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
 
 @pulumi.output_type
 class MyDeclaredPropertiesOutputTypeDictTranslated(dict):
+    def __init__(self, first_value: str, second_value: Optional[float] = None):
+        pulumi.set(self, "first_value", first_value)
+        if second_value is not None:
+            pulumi.set(self, "second_value", second_value)
+
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
@@ -116,7 +136,7 @@ class MyDeclaredPropertiesOutputTypeDictTranslated(dict):
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
@@ -150,6 +170,7 @@ class InputTypeTests(unittest.TestCase):
         for typ in types:
             self.assertTrue(_types.is_output_type(typ))
             self.assertEqual(True, typ._pulumi_output_type)
+            self.assertTrue(hasattr(typ, "__init__"))
 
     def test_output_type_types(self):
         self.assertEqual({
@@ -159,24 +180,24 @@ class InputTypeTests(unittest.TestCase):
 
     def test_output_type(self):
         types = [
-            (MyOutputType, "firstValue", "secondValue", False),
-            (MyOutputTypeDict, "firstValue", "secondValue", False),
-            (MyOutputTypeTranslated, "first_value", "second_value", False),
-            (MyOutputTypeDictTranslated, "first_value", "second_value", False),
-            (MyDeclaredPropertiesOutputType, "firstValue", "secondValue", True),
-            (MyDeclaredPropertiesOutputTypeDict, "firstValue", "secondValue", True),
-            (MyDeclaredPropertiesOutputTypeTranslated, "first_value", "second_value", True),
-            (MyDeclaredPropertiesOutputTypeDictTranslated, "first_value", "second_value", True),
+            (MyOutputType, False),
+            (MyOutputTypeDict, False),
+            (MyOutputTypeTranslated, False),
+            (MyOutputTypeDictTranslated, False),
+            (MyDeclaredPropertiesOutputType, True),
+            (MyDeclaredPropertiesOutputTypeDict, True),
+            (MyDeclaredPropertiesOutputTypeTranslated, True),
+            (MyDeclaredPropertiesOutputTypeDictTranslated, True),
         ]
-        for typ, k1, k2, has_doc in types:
-            self.assertTrue(hasattr(MyOutputType, "__init__"))
-            t = typ({k1: "hello", k2: 42})
+        for typ, has_doc in types:
+            self.assertTrue(hasattr(typ, "__init__"))
+            t = _types.output_type_from_dict(typ, {"firstValue": "hello", "secondValue": 42})
             self.assertEqual("hello", t.first_value)
             self.assertEqual(42, t.second_value)
 
             if isinstance(t, dict):
-                self.assertEqual("hello", t[k1])
-                self.assertEqual(42, t[k2])
+                self.assertEqual("hello", t["first_value"])
+                self.assertEqual(42, t["second_value"])
 
             first = typ.first_value
             self.assertIsInstance(first, property)
@@ -185,7 +206,6 @@ class InputTypeTests(unittest.TestCase):
             self.assertEqual({"return": str}, first.fget.__annotations__)
             if has_doc:
                 self.assertEqual("First value docstring.", first.fget.__doc__)
-            self.assertEqual(True, first.fget._pulumi_getter)
             self.assertEqual("firstValue", first.fget._pulumi_name)
 
             second = typ.second_value
@@ -195,7 +215,6 @@ class InputTypeTests(unittest.TestCase):
             self.assertEqual({"return": Optional[float]}, second.fget.__annotations__)
             if has_doc:
                 self.assertEqual("Second value docstring.", second.fget.__doc__)
-            self.assertEqual(True, second.fget._pulumi_getter)
             self.assertEqual("secondValue", second.fget._pulumi_name)
 
             self.assertTrue(hasattr(t, "__eq__"))
@@ -204,20 +223,20 @@ class InputTypeTests(unittest.TestCase):
             self.assertFalse(t != t)
             self.assertFalse(t == "not equal")
 
-            t2 = typ({k1: "hello", k2: 42})
+            t2 = _types.output_type_from_dict(typ, {"firstValue": "hello", "secondValue": 42})
             self.assertTrue(t.__eq__(t2))
             self.assertTrue(t == t2)
             self.assertFalse(t != t2)
 
             if isinstance(t2, dict):
-                self.assertEqual("hello", t2[k1])
-                self.assertEqual(42, t2[k2])
+                self.assertEqual("hello", t2["first_value"])
+                self.assertEqual(42, t2["second_value"])
 
-            t3 = typ({k1: "foo", k2: 1})
+            t3 = _types.output_type_from_dict(typ, {"firstValue": "foo", "secondValue": 1})
             self.assertFalse(t.__eq__(t3))
             self.assertFalse(t == t3)
             self.assertTrue(t != t3)
 
             if isinstance(t3, dict):
-                self.assertEqual("foo", t3[k1])
-                self.assertEqual(1, t3[k2])
+                self.assertEqual("foo", t3["first_value"])
+                self.assertEqual(1, t3["second_value"])

--- a/sdk/python/lib/test/test_types_resource_types.py
+++ b/sdk/python/lib/test/test_types_resource_types.py
@@ -33,7 +33,7 @@ class Resource4(pulumi.Resource):
 class Resource5(pulumi.Resource):
     @property
     @pulumi.getter
-    def foo(self) -> str:
+    def foo(self) -> pulumi.Output[str]:
         ...
 
 class Resource6(pulumi.Resource):
@@ -46,6 +46,31 @@ class Resource7(pulumi.Resource):
     @property
     @pulumi.getter(name="nestedValue")
     def nested_value(self) -> pulumi.Output['Nested']:
+        ...
+
+class Resource8(pulumi.Resource):
+    foo: pulumi.Output
+
+class Resource9(pulumi.Resource):
+    @property
+    @pulumi.getter
+    def foo(self) -> pulumi.Output:
+        ...
+
+class Resource10(pulumi.Resource):
+    foo: str
+
+
+class Resource11(pulumi.Resource):
+    @property
+    @pulumi.getter
+    def foo(self) -> str:
+        ...
+
+class Resource12(pulumi.Resource):
+    @property
+    @pulumi.getter
+    def foo(self):
         ...
 
 
@@ -66,3 +91,14 @@ class ResourceTypesTests(unittest.TestCase):
         self.assertEqual({"foo": str}, resource_types(Resource5))
         self.assertEqual({"nested": Nested}, resource_types(Resource6))
         self.assertEqual({"nestedValue": Nested}, resource_types(Resource7))
+
+        # Non-generic Output excluded from types.
+        self.assertEqual({}, resource_types(Resource8))
+        self.assertEqual({}, resource_types(Resource9))
+
+        # Type annotations not using Output.
+        self.assertEqual({"foo": str}, resource_types(Resource10))
+        self.assertEqual({"foo": str}, resource_types(Resource11))
+
+        # No return type annotation from the property getter.
+        self.assertEqual({}, resource_types(Resource12))

--- a/sdk/python/lib/test/test_types_resource_types.py
+++ b/sdk/python/lib/test/test_types_resource_types.py
@@ -1,0 +1,68 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pulumi._types import resource_types
+import pulumi
+
+
+class Resource1(pulumi.Resource):
+    pass
+
+class Resource2(pulumi.Resource):
+    foo: pulumi.Output[str]
+
+class Resource3(pulumi.Resource):
+    nested: pulumi.Output['Nested']
+
+class Resource4(pulumi.Resource):
+    nested_value: pulumi.Output['Nested'] = pulumi.property("nestedValue")
+
+class Resource5(pulumi.Resource):
+    @property
+    @pulumi.getter
+    def foo(self) -> str:
+        ...
+
+class Resource6(pulumi.Resource):
+    @property
+    @pulumi.getter
+    def nested(self) -> pulumi.Output['Nested']:
+        ...
+
+class Resource7(pulumi.Resource):
+    @property
+    @pulumi.getter(name="nestedValue")
+    def nested_value(self) -> pulumi.Output['Nested']:
+        ...
+
+
+@pulumi.output_type
+class Nested:
+    first: str
+    second: str
+
+
+class ResourceTypesTests(unittest.TestCase):
+    def test_resource_types(self):
+        self.assertEqual({}, resource_types(Resource1))
+
+        self.assertEqual({"foo": str}, resource_types(Resource2))
+        self.assertEqual({"nested": Nested}, resource_types(Resource3))
+        self.assertEqual({"nestedValue": Nested}, resource_types(Resource4))
+
+        self.assertEqual({"foo": str}, resource_types(Resource5))
+        self.assertEqual({"nested": Nested}, resource_types(Resource6))
+        self.assertEqual({"nestedValue": Nested}, resource_types(Resource7))

--- a/sdk/python/lib/test/test_utils.py
+++ b/sdk/python/lib/test/test_utils.py
@@ -1,0 +1,91 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pulumi._utils import is_empty_function
+
+# Function with return value based on input, called in the non_empty function
+# bodies below.
+def compute(val: int) -> str:
+    return f"{val} + {1} = {val + 1}"
+
+class Foo:
+    def empty_a(self) -> str:
+        ...
+
+    def empty_b(self) -> str:
+        """A docstring."""
+        ...
+
+    def empty_c(self, value: str):
+        ...
+
+    def non_empty_a(self) -> str:
+        return "hello"
+
+    def non_empty_b(self) -> str:
+        """A docstring."""
+        return "hello"
+
+    def non_empty_c(self) -> str:
+        return compute(41)
+
+    def non_empty_d(self) -> str:
+        """F's docstring."""
+        return compute(41)
+
+
+empty_lambda_a = lambda: None
+
+empty_lambda_b = lambda: None
+empty_lambda_b.__doc__ = """A docstring."""
+
+non_empty_lambda_a = lambda: "hello"
+
+non_empty_lambda_b = lambda: "hello"
+non_empty_lambda_b.__doc__ = """A docstring."""
+
+non_empty_lambda_c = lambda: compute(41)
+
+non_empty_lambda_d = lambda: compute(41)
+non_empty_lambda_d.__doc__ = """A docstring."""
+
+class IsEmptyFunctionTests(unittest.TestCase):
+    def test_is_empty(self):
+        f = Foo()
+
+        self.assertTrue(is_empty_function(Foo.empty_a))
+        self.assertTrue(is_empty_function(Foo.empty_b))
+        self.assertTrue(is_empty_function(Foo.empty_c))
+        self.assertTrue(is_empty_function(f.empty_a))
+        self.assertTrue(is_empty_function(f.empty_b))
+        self.assertTrue(is_empty_function(f.empty_c))
+
+        self.assertFalse(is_empty_function(Foo.non_empty_a))
+        self.assertFalse(is_empty_function(Foo.non_empty_b))
+        self.assertFalse(is_empty_function(Foo.non_empty_c))
+        self.assertFalse(is_empty_function(Foo.non_empty_d))
+        self.assertFalse(is_empty_function(f.non_empty_a))
+        self.assertFalse(is_empty_function(f.non_empty_b))
+        self.assertFalse(is_empty_function(f.non_empty_c))
+        self.assertFalse(is_empty_function(f.non_empty_d))
+
+        self.assertTrue(is_empty_function(empty_lambda_a))
+        self.assertTrue(is_empty_function(empty_lambda_b))
+
+        self.assertFalse(is_empty_function(non_empty_lambda_a))
+        self.assertFalse(is_empty_function(non_empty_lambda_b))
+        self.assertFalse(is_empty_function(non_empty_lambda_c))
+        self.assertFalse(is_empty_function(non_empty_lambda_d))

--- a/tests/integration/types/python/declared/Pulumi.yaml
+++ b/tests/integration/types/python/declared/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: types_python
+description: A program that uses input/output types with explicitly declared properties.
+runtime: python

--- a/tests/integration/types/python/declared/__main__.py
+++ b/tests/integration/types/python/declared/__main__.py
@@ -9,8 +9,8 @@ from pulumi.dynamic import Resource, ResourceProvider, CreateResult
 @pulumi.input_type
 class AdditionalArgs:
     def __init__(self, first_value: pulumi.Input[str], second_value: Optional[pulumi.Input[float]] = None):
-        self.first_value = first_value
-        self.second_value = second_value
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
     # Property with empty getter/setter bodies.
     @property
@@ -20,7 +20,7 @@ class AdditionalArgs:
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
-        pulumi.set(self, "first_value", value)
+        ...
 
     # Property with explicitly specified getter/setter bodies.
     @property
@@ -34,11 +34,11 @@ class AdditionalArgs:
 
 @pulumi.output_type
 class Additional(dict):
-    def __init__(self, first_value: str, second_value: Optional[float], third: str, fourth: str):
+    def __init__(self, first_value: str, second_value: Optional[float]):
         pulumi.set(self, "first_value", first_value)
         pulumi.set(self, "second_value", second_value)
 
-    # Property with empty getter/setter bodies.
+    # Property with empty getter body.
     @property
     @pulumi.getter(name="firstValue")
     def first_value(self) -> str:
@@ -75,10 +75,12 @@ res2 = MyResource("testres2", additional=AdditionalArgs(
 
 # Create a resource using the output object of another resource, accessing the output as a dict.
 res3 = MyResource("testres3", additional=AdditionalArgs(
-    first_value=res.additional["firstValue"],
-    second_value=res.additional["secondValue"]))
+    first_value=res.additional["first_value"],
+    second_value=res.additional["second_value"]))
 
 # Create a resource using a dict as the input.
+# Note: These are camel case (not snake_case) since the resource does not do any translation of
+# property names.
 res4 = MyResource("testres4", additional={
     "firstValue": "hello",
     "secondValue": 42,

--- a/tests/integration/types/python/declared/__main__.py
+++ b/tests/integration/types/python/declared/__main__.py
@@ -20,20 +20,24 @@ class AdditionalArgs:
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
-        pulumi.set(self, "firstValue", value)
+        pulumi.set(self, "first_value", value)
 
     # Property with explicitly specified getter/setter bodies.
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[pulumi.Input[float]]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     @second_value.setter
     def second_value(self, value: Optional[pulumi.Input[float]]):
-        pulumi.set(self, "secondValue", value)
+        pulumi.set(self, "second_value", value)
 
 @pulumi.output_type
 class Additional(dict):
+    def __init__(self, first_value: str, second_value: Optional[float], third: str, fourth: str):
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
+
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
@@ -44,7 +48,7 @@ class Additional(dict):
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
 current_id = 0
 

--- a/tests/integration/types/python/declared/__main__.py
+++ b/tests/integration/types/python/declared/__main__.py
@@ -1,0 +1,90 @@
+# Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+from typing import Optional
+
+import pulumi
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+
+
+@pulumi.input_type
+class AdditionalArgs:
+    def __init__(self, first_value: pulumi.Input[str], second_value: Optional[pulumi.Input[float]] = None):
+        self.first_value = first_value
+        self.second_value = second_value
+
+    # Property with empty getter/setter bodies.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> pulumi.Input[str]:
+        ...
+
+    @first_value.setter
+    def first_value(self, value: pulumi.Input[str]):
+        pulumi.set(self, "firstValue", value)
+
+    # Property with explicitly specified getter/setter bodies.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[pulumi.Input[float]]:
+        return pulumi.get(self, "secondValue")
+
+    @second_value.setter
+    def second_value(self, value: Optional[pulumi.Input[float]]):
+        pulumi.set(self, "secondValue", value)
+
+@pulumi.output_type
+class Additional(dict):
+    # Property with empty getter/setter bodies.
+    @property
+    @pulumi.getter(name="firstValue")
+    def first_value(self) -> str:
+        ...
+
+    # Property with explicitly specified getter/setter bodies.
+    @property
+    @pulumi.getter(name="secondValue")
+    def second_value(self) -> Optional[float]:
+        return pulumi.get(self, "secondValue")
+
+current_id = 0
+
+class MyResourceProvider(ResourceProvider):
+    def create(self, inputs):
+        global current_id
+        current_id += 1
+        return CreateResult(str(current_id), {"additional": inputs["additional"]})
+
+class MyResource(Resource):
+    additional: pulumi.Output[Additional]
+
+    def __init__(self, name: str, additional: pulumi.InputType[AdditionalArgs]):
+        super().__init__(MyResourceProvider(), name, {"additional": additional})
+
+
+# Create a resource with input object.
+res = MyResource("testres", additional=AdditionalArgs(first_value="hello", second_value=42))
+
+# Create a resource using the output object of another resource.
+res2 = MyResource("testres2", additional=AdditionalArgs(
+    first_value=res.additional.first_value,
+    second_value=res.additional.second_value))
+
+# Create a resource using the output object of another resource, accessing the output as a dict.
+res3 = MyResource("testres3", additional=AdditionalArgs(
+    first_value=res.additional["firstValue"],
+    second_value=res.additional["secondValue"]))
+
+# Create a resource using a dict as the input.
+res4 = MyResource("testres4", additional={
+    "firstValue": "hello",
+    "secondValue": 42,
+})
+
+pulumi.export("res_first_value", res.additional.first_value)
+pulumi.export("res_second_value", res.additional.second_value)
+pulumi.export("res2_first_value", res2.additional.first_value)
+pulumi.export("res2_second_value", res2.additional.second_value)
+pulumi.export("res3_first_value", res3.additional.first_value)
+pulumi.export("res3_second_value", res3.additional.second_value)
+pulumi.export("res4_first_value", res4.additional.first_value)
+pulumi.export("res4_second_value", res4.additional.second_value)

--- a/tests/integration/types/python/simple/Pulumi.yaml
+++ b/tests/integration/types/python/simple/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: types_python
+description: A program that uses input/output types.
+runtime: python

--- a/tests/integration/types/python/simple/__main__.py
+++ b/tests/integration/types/python/simple/__main__.py
@@ -41,10 +41,12 @@ res2 = MyResource("testres2", additional=AdditionalArgs(
 
 # Create a resource using the output object of another resource, accessing the output as a dict.
 res3 = MyResource("testres3", additional=AdditionalArgs(
-    first_value=res.additional["firstValue"],
-    second_value=res.additional["secondValue"]))
+    first_value=res.additional["first_value"],
+    second_value=res.additional["second_value"]))
 
 # Create a resource using a dict as the input.
+# Note: These are camel case (not snake_case) since the resource does not do any translation of
+# property names.
 res4 = MyResource("testres4", additional={
     "firstValue": "hello",
     "secondValue": 42,

--- a/tests/integration/types/python/simple/__main__.py
+++ b/tests/integration/types/python/simple/__main__.py
@@ -1,0 +1,64 @@
+# Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+from typing import Optional
+
+from pulumi import Input, InputType, Output, export, input_type, output_type, property
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+
+
+@input_type
+class AdditionalArgs:
+    first_value: Input[str] = property("firstValue")
+    second_value: Optional[Input[float]] = property("secondValue")
+
+    def __init__(self, first_value: Input[str], second_value: Optional[Input[float]] = None):
+        self.first_value = first_value
+        self.second_value = second_value
+
+@output_type
+class Additional(dict):
+    first_value: str = property("firstValue")
+    second_value: Optional[float] = property("secondValue")
+
+current_id = 0
+
+class MyResourceProvider(ResourceProvider):
+    def create(self, inputs):
+        global current_id
+        current_id += 1
+        return CreateResult(str(current_id), {"additional": inputs["additional"]})
+
+class MyResource(Resource):
+    additional: Output[Additional]
+
+    def __init__(self, name: str, additional: InputType[AdditionalArgs]):
+        super().__init__(MyResourceProvider(), name, {"additional": additional})
+
+
+# Create a resource with input object.
+res = MyResource("testres", additional=AdditionalArgs(first_value="hello", second_value=42))
+
+# Create a resource using the output object of another resource.
+res2 = MyResource("testres2", additional=AdditionalArgs(
+    first_value=res.additional.first_value,
+    second_value=res.additional.second_value))
+
+# Create a resource using the output object of another resource, accessing the output as a dict.
+res3 = MyResource("testres3", additional=AdditionalArgs(
+    first_value=res.additional["firstValue"],
+    second_value=res.additional["secondValue"]))
+
+# Create a resource using a dict as the input.
+res4 = MyResource("testres4", additional={
+    "firstValue": "hello",
+    "secondValue": 42,
+})
+
+export("res_first_value", res.additional.first_value)
+export("res_second_value", res.additional.second_value)
+export("res2_first_value", res2.additional.first_value)
+export("res2_second_value", res2.additional.second_value)
+export("res3_first_value", res3.additional.first_value)
+export("res3_second_value", res3.additional.second_value)
+export("res4_first_value", res4.additional.first_value)
+export("res4_second_value", res4.additional.second_value)

--- a/tests/integration/types/python/simple/__main__.py
+++ b/tests/integration/types/python/simple/__main__.py
@@ -9,16 +9,12 @@ from pulumi.dynamic import Resource, ResourceProvider, CreateResult
 @input_type
 class AdditionalArgs:
     first_value: Input[str] = property("firstValue")
-    second_value: Optional[Input[float]] = property("secondValue")
-
-    def __init__(self, first_value: Input[str], second_value: Optional[Input[float]] = None):
-        self.first_value = first_value
-        self.second_value = second_value
+    second_value: Optional[Input[float]] = property("secondValue", default=None)
 
 @output_type
 class Additional(dict):
     first_value: str = property("firstValue")
-    second_value: Optional[float] = property("secondValue")
+    second_value: Optional[float] = property("secondValue", default=None)
 
 current_id = 0
 

--- a/tests/integration/types/types_test.go
+++ b/tests/integration/types/types_test.go
@@ -1,0 +1,33 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+package ints
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v2/testing/integration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPythonTypes(t *testing.T) {
+	for _, dir := range []string{"simple", "declared"} {
+		d := filepath.Join("python", dir)
+		t.Run(d, func(t *testing.T) {
+			integration.ProgramTest(t, &integration.ProgramTestOptions{
+				Dir: d,
+				Dependencies: []string{
+					filepath.Join("..", "..", "..", "sdk", "python", "env", "src"),
+				},
+				ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+					for _, res := range []string{"", "2", "3", "4"} {
+						assert.Equal(t, "hello", stack.Outputs[fmt.Sprintf("res%s_first_value", res)])
+						assert.Equal(t, 42.0, stack.Outputs[fmt.Sprintf("res%s_second_value", res)])
+					}
+				},
+				UseAutomaticVirtualEnv: true,
+			})
+		})
+	}
+}


### PR DESCRIPTION
SDK changes to support strongly-typed input/output "dataclasses".

PR for provider codegen: https://github.com/pulumi/pulumi/pull/5034

Example diffs:
- AWS: https://github.com/pulumi/pulumi-aws/commit/a77712011c3dc7577a2737b5b3004ee529ea5dc6
- Kubernetes: https://github.com/pulumi/pulumi-kubernetes/commit/ea90ce49b0ef9b760b94be47207eb95fd7f2890b

Fixes https://github.com/pulumi/pulumi/issues/4789
Fixes https://github.com/pulumi/pulumi/issues/5140