### PR TITLE
Python: Improved error message when `virtualenv` doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ CHANGELOG
 - Add ability to create a stack based on the config from an existing stack
   [#5062](https://github.com/pulumi/pulumi/pull/5062)
 
+- Python: Improved error message when `virtualenv` doesn't exist
+  [#5069](https://github.com/pulumi/pulumi/pull/5069)
+
 ## 2.7.1 (2020-07-22)
 
 - Fix logic to parse pulumi venv on github action

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -751,8 +751,11 @@ func pythonCommands() []string {
 		commands = append(commands, "source venv/bin/activate")
 	}
 
-	// Install dependencies within the virtualenv
-	commands = append(commands, "pip3 install -r requirements.txt")
+	// Update pip, setuptools, and wheel within the virtualenv.
+	commands = append(commands, "python -m pip install --upgrade pip setuptools wheel")
+
+	// Install dependencies within the virtualenv.
+	commands = append(commands, "python -m pip install -r requirements.txt")
 
 	return commands
 }

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -178,7 +178,7 @@ func (host *pythonLanguageHost) Run(ctx context.Context, req *pulumirpc.RunReque
 			virtualenv = filepath.Join(cwd, virtualenv)
 		}
 		if !python.IsVirtualEnv(virtualenv) {
-			return nil, errors.Errorf("%q doesn't appear to be a virtual environment", virtualenv)
+			return nil, python.NewVirtualEnvError(host.virtualenv, virtualenv)
 		}
 		cmd = python.VirtualEnvCommand(virtualenv, "python", args...)
 	} else {

--- a/sdk/python/dist/pulumi-analyzer-policy-python
+++ b/sdk/python/dist/pulumi-analyzer-policy-python
@@ -34,7 +34,16 @@ if [ -n "${virtualenv:-}" ] ; then
         # Run python from the virtual environment.
         "$virtualenv/bin/python" -u -m pulumi.policy "$1" "$2"
     else
-        echo "\"$virtualenv\" doesn't appear to be a virtual environment"
+        if [ -d "$virtualenv" ]; then
+            1>&2 echo "The 'virtualenv' option in PulumiPolicy.yaml is set to \"$virtualenv\", but \"$virtualenv\" doesn't appear to be a virtual environment."
+        else
+            1>&2 echo "The 'virtualenv' option in PulumiPolicy.yaml is set to \"$virtualenv\", but \"$virtualenv\" doesn't exist."
+        fi
+        1>&2 echo "Run the following commands to create the virtual environment and install dependencies into it:"
+        1>&2 echo "    1. python3 -m venv $virtualenv"
+        1>&2 echo "    2. $virtualenv/bin/python -m pip install --upgrade pip setuptools wheel"
+        1>&2 echo "    3. $virtualenv/bin/python -m pip install -r $PWD/requirements.txt"
+        1>&2 echo "For more information see: https://www.pulumi.com/docs/intro/languages/python/#virtual-environments"
         exit 1
     fi
 else

--- a/sdk/python/dist/pulumi-analyzer-policy-python.cmd
+++ b/sdk/python/dist/pulumi-analyzer-policy-python.cmd
@@ -28,7 +28,12 @@ if defined pulumi_runtime_python_virtualenv (
         "%pulumi_runtime_python_virtualenv%\Scripts\python.exe" -u -m pulumi.policy %pulumi_policy_python_engine_address% %pulumi_policy_python_program%
         exit /B
     ) else (
-        echo "%pulumi_runtime_python_virtualenv%" doesn't appear to be a virtual environment
+        echo The 'virtualenv' option in PulumiPolicy.yaml is set to %pulumi_runtime_python_virtualenv%, but %pulumi_runtime_python_virtualenv% doesn't appear to be a virtual environment. 1>&2
+        echo Run the following commands to create the virtual environment and install dependencies into it: 1>&2
+        echo     1. python -m venv %pulumi_runtime_python_virtualenv% 1>&2
+        echo     2. %pulumi_runtime_python_virtualenv%\Scripts\python.exe -m pip install --upgrade pip setuptools wheel 1>&2
+        echo     3. %pulumi_runtime_python_virtualenv%\Scripts\python.exe -m pip install -r %cd%\requirements.txt 1>&2
+        echo For more information see: https://www.pulumi.com/docs/intro/languages/python/#virtual-environments 1>&2
         exit 1
     )
 ) else (

--- a/sdk/python/dist/pulumi-resource-pulumi-python
+++ b/sdk/python/dist/pulumi-resource-pulumi-python
@@ -22,7 +22,16 @@ if [ -n "${PULUMI_RUNTIME_VIRTUALENV:-}" ] ; then
         # Run python from the virtual environment.
         "$PULUMI_RUNTIME_VIRTUALENV/bin/python" -u -m pulumi.dynamic $@
     else
-        echo "\"$PULUMI_RUNTIME_VIRTUALENV\" doesn't appear to be a virtual environment"
+        if [ -d "$PULUMI_RUNTIME_VIRTUALENV" ]; then
+            1>&2 echo "The 'virtualenv' option in Pulumi.yaml is set to \"$PULUMI_RUNTIME_VIRTUALENV\", but \"$PULUMI_RUNTIME_VIRTUALENV\" doesn't appear to be a virtual environment."
+        else
+            1>&2 echo "The 'virtualenv' option in Pulumi.yaml is set to \"$PULUMI_RUNTIME_VIRTUALENV\", but \"$PULUMI_RUNTIME_VIRTUALENV\" doesn't exist."
+        fi
+        1>&2 echo "Run the following commands to create the virtual environment and install dependencies into it:"
+        1>&2 echo "    1. python3 -m venv $PULUMI_RUNTIME_VIRTUALENV"
+        1>&2 echo "    2. $PULUMI_RUNTIME_VIRTUALENV/bin/python -m pip install --upgrade pip setuptools wheel"
+        1>&2 echo "    3. $PULUMI_RUNTIME_VIRTUALENV/bin/python -m pip install -r $PWD/requirements.txt"
+        1>&2 echo "For more information see: https://www.pulumi.com/docs/intro/languages/python/#virtual-environments"
         exit 1
     fi
 else

--- a/sdk/python/dist/pulumi-resource-pulumi-python.cmd
+++ b/sdk/python/dist/pulumi-resource-pulumi-python.cmd
@@ -11,7 +11,12 @@ if defined PULUMI_RUNTIME_VIRTUALENV (
         "%PULUMI_RUNTIME_VIRTUALENV%\Scripts\python.exe" -u -m pulumi.dynamic %*
         exit /B
     ) else (
-        echo "%PULUMI_RUNTIME_VIRTUALENV%" doesn't appear to be a virtual environment
+        echo The 'virtualenv' option in Pulumi.yaml is set to %PULUMI_RUNTIME_VIRTUALENV%, but %PULUMI_RUNTIME_VIRTUALENV% doesn't appear to be a virtual environment. 1>&2
+        echo Run the following commands to create the virtual environment and install dependencies into it: 1>&2
+        echo     1. python -m venv %PULUMI_RUNTIME_VIRTUALENV% 1>&2
+        echo     2. %PULUMI_RUNTIME_VIRTUALENV%\Scripts\python.exe -m pip install --upgrade pip setuptools wheel 1>&2
+        echo     3. %PULUMI_RUNTIME_VIRTUALENV%\Scripts\python.exe -m pip install -r %cd%\requirements.txt 1>&2
+        echo For more information see: https://www.pulumi.com/docs/intro/languages/python/#virtual-environments 1>&2
         exit 1
     )
 ) else (


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/4879