### PR TITLE
Enable pushing to Artifact Registry in actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ CHANGELOG
 
 - Python: Improved error message when `virtualenv` doesn't exist
   [#5069](https://github.com/pulumi/pulumi/pull/5069)
+  
+- Enable pushing to Artifact Registry in actions
+  [#5075](https://github.com/pulumi/pulumi/pull/5075)
 
 ## 2.7.1 (2020-07-22)
 

--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -88,7 +88,7 @@ if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
         echo "$GOOGLE_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
     fi
     gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    gcloud --quiet auth configure-docker
+    gcloud --quiet auth configure-docker $ARTIFACT_REGISTRY_HOSTNAME_LIST
 fi
 
 # Next, run npm install. We always call this, as

--- a/dist/actions/entrypoint.sh
+++ b/dist/actions/entrypoint.sh
@@ -88,7 +88,7 @@ if [ ! -z "$GOOGLE_CREDENTIALS" ]; then
         echo "$GOOGLE_CREDENTIALS" > $GOOGLE_APPLICATION_CREDENTIALS
     fi
     gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS
-    gcloud --quiet auth configure-docker $ARTIFACT_REGISTRY_HOSTNAME_LIST
+    gcloud --quiet auth configure-docker $GOOGLE_DOCKER_HOSTNAME_LIST
 fi
 
 # Next, run npm install. We always call this, as


### PR DESCRIPTION
To authenticate with GCP Artifact Registry, the `gcloud auth configure-docker` command requires a comma separated list of hostnames to add helpers for. https://cloud.google.com/artifact-registry/docs/docker/authentication#gcloud-helper