### PR TITLE
Ensure Passphrase Secret Manager is available to use with new config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 _(none)_
+- Fix a bug where passphrase managers were not being
+  recognised correctly when getting the configuration
+  for the current stack. 
+  **Please Note:**
+  This specific bug may have caused the stack config
+  file to remove the password encryption salt.
+  [#5110](https://github.com/pulumi/pulumi/pull/5110)
 
 ## 2.8.0 (2020-08-04)
 

--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -53,12 +53,6 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 	}
 
 	sm, err := func() (secrets.Manager, error) {
-		if ps.SecretsProvider == "" {
-			switch s.(type) {
-			case httpstate.Stack:
-				return newServiceSecretsManager(s.(httpstate.Stack), s.Ref().Name(), stackConfigFile)
-			}
-		}
 		if ps.SecretsProvider != passphrase.Type && ps.SecretsProvider != "default" && ps.SecretsProvider != "" {
 			return newCloudSecretsManager(s.Ref().Name(), stackConfigFile, ps.SecretsProvider)
 		}
@@ -70,6 +64,8 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 		switch s.(type) {
 		case filestate.Stack:
 			return newPassphraseSecretsManager(s.Ref().Name(), stackConfigFile)
+		case httpstate.Stack:
+			return newServiceSecretsManager(s.(httpstate.Stack), s.Ref().Name(), stackConfigFile)
 		}
 
 		return nil, errors.Errorf("unknown stack type %s", reflect.TypeOf(s))


### PR DESCRIPTION
Fixes: #5104

This reverts a code change that was checking initially for the
SecretsProvider of the currentStack being an empty string. When it
was an empty string, we were checking the backend type and we were
setting a serviceSecretsManager. This wasn't correct, the logic
needed to check for an empty SecretsProvider AND an empty EncryptionSalt

The important part is that it needed to check for the EncryptionSalt
to make sure it wasn't a passphrase secrets manger

I am 99% confident that this bug only affected those users who interacted directly with the configuration of the stack from the CLI i.e ran a command `pulumi config x`