### PR TITLE
[Go Program Gen] Fix various Kubernetes issues

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -32,9 +32,12 @@ type generator struct {
 	scopeTraversalRoots codegen.StringSet
 	arrayHelpers        map[string]*promptToInputArrayHelper
 	isErrAssigned       bool
-	importAliases       map[string]map[string]string
-	importBasePaths     map[string]string
-	modToPkg            map[string]map[string]string
+	// TODO: this should be replaced with a map[string]*schema.Package
+	// once we land https://github.com/pulumi/pulumi/pull/5114
+	// we can rewrite the associated methods in terms of pkg.Schema
+	importAliases   map[string]map[string]string
+	importBasePaths map[string]string
+	modToPkg        map[string]map[string]string
 }
 
 func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics, error) {
@@ -94,7 +97,7 @@ func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics,
 
 	g.genPostamble(&progPostamble, nodes)
 
-	// We must genearte the program first and the preamble second and finally cat the two together.
+	// We must generate the program first and the preamble second and finally cat the two together.
 	// This is because nested object/tuple cons expressions can require imports that aren't
 	// present in resource declarations or invokes alone. Expressions are lowered when the program is generated
 	// and this must happen first so we can access types via __convert intrinsics.

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -156,7 +156,10 @@ func (g *generator) genPreamble(w io.Writer, program *hcl2.Program, stdImports, 
 }
 
 // collect Imports returns two sets of packages imported by the program, std lib packages and pulumi packages
-func (g *generator) collectImports(program *hcl2.Program, stdImports, pulumiImports codegen.StringSet) (codegen.StringSet, codegen.StringSet) {
+func (g *generator) collectImports(
+	program *hcl2.Program,
+	stdImports,
+	pulumiImports codegen.StringSet) (codegen.StringSet, codegen.StringSet) {
 	// Accumulate import statements for the various providers
 	for _, n := range program.Nodes {
 		if r, isResource := n.(*hcl2.Resource); isResource {
@@ -275,9 +278,6 @@ func (g *generator) getPulumiImport(pkg, vPath, mod string) string {
 			} else {
 				imp = fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s/%s", pkg, vPath, pkg, strings.Split(mod, "/")[0])
 			}
-		}
-		if imp == "github.com/pulumi/pulumi-aws/sdk/v2/go/aws/" {
-			mod = ""
 		}
 		imp = fmt.Sprintf("%q", imp)
 	}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -572,7 +572,8 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 			if module == "" || strings.HasPrefix(module, "/") || strings.HasPrefix(module, "index/") {
 				module = pkg
 			}
-			importPrefix := strings.Split(module, "/")[0]
+			importPrefix := g.getModOrAlias(pkg, module)
+			importPrefix = strings.Split(importPrefix, "/")[0]
 			contract.Assert(len(diags) == 0)
 			fmtString := "[]%s.%s"
 			if isInput {
@@ -593,7 +594,8 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 			if module == "" || strings.HasPrefix(module, "/") || strings.HasPrefix(module, "index/") {
 				module = pkg
 			}
-			importPrefix := strings.Split(module, "/")[0]
+			importPrefix := g.getModOrAlias(pkg, module)
+			importPrefix = strings.Split(importPrefix, "/")[0]
 			contract.Assert(len(diags) == 0)
 			member = Title(member)
 			if strings.HasPrefix(member, "Get") {

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -68,13 +68,14 @@ func TestGenProgram(t *testing.T) {
 
 func TestCollectImports(t *testing.T) {
 	g := newTestGenerator(t, "aws-s3-logging.pp")
-	var index bytes.Buffer
-	stdImports, pulumiImports := g.collectImports(&index, g.program)
+	pulumiImports := codegen.NewStringSet()
+	stdImports := codegen.NewStringSet()
+	g.collectImports(g.program, stdImports, pulumiImports)
 	stdVals := stdImports.SortedValues()
 	pulumiVals := pulumiImports.SortedValues()
 	assert.Equal(t, 0, len(stdVals))
 	assert.Equal(t, 1, len(pulumiVals))
-	assert.Equal(t, "github.com/pulumi/pulumi-aws/sdk/v2/go/aws/s3", pulumiVals[0])
+	assert.Equal(t, "\"github.com/pulumi/pulumi-aws/sdk/v2/go/aws/s3\"", pulumiVals[0])
 }
 
 func newTestGenerator(t *testing.T, testFile string) *generator {

--- a/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.go
+++ b/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes/meta/v1"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 

--- a/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.go
+++ b/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes/core/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes/core/v1"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 

--- a/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.go
+++ b/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.go
@@ -7,19 +7,19 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err := core / v1.NewPod(ctx, "bar", &core/v1.PodArgs{
+		_, err := corev1.NewPod(ctx, "bar", &corev1.PodArgs{
 			ApiVersion: pulumi.String("v1"),
 			Kind:       pulumi.String("Pod"),
-			Metadata: &meta.ObjectMetaArgs{
+			Metadata: &metav1.ObjectMetaArgs{
 				Namespace: pulumi.String("foo"),
 				Name:      pulumi.String("bar"),
 			},
-			Spec: &core.PodSpecArgs{
-				Containers: core.ContainerArray{
-					&core.ContainerArgs{
+			Spec: &corev1.PodSpecArgs{
+				Containers: corev1.ContainerArray{
+					&corev1.ContainerArgs{
 						Name:  pulumi.String("nginx"),
 						Image: pulumi.String("nginx:1.14-alpine"),
-						Resources: &core.ResourceRequirementsArgs{
+						Resources: &corev1.ResourceRequirementsArgs{
 							Limits: pulumi.StringMap{
 								"memory": pulumi.String("20Mi"),
 								"cpu":    pulumi.String("0.2"),


### PR DESCRIPTION
Reviewing this commit by commit is best. Commits line up with the following fixes:

1. Use import aliases
2. account for import aliases in expressions
3. Traverse object and tuple cons expressions for imports

(3) is only necessary for Go, as other languages import the package, and then dot into the relevant namespace. The fix for 3 winds up being a little messy as it requires that we collect imports, generate the program, and then collect imports and actually emit the imports. This is because we need to run the collection logic over both the lowered and unlowered program. The unlowered program has easy access to things like JSON builtins that get rewritten to nested applies (would be complex to handle appropriately), the lowered program has all of the __convert intrinsics required to capture the imports for nested object/tuple cons expressions. 

This could be written as one import pass, but it would be far more complicated and unfortunately, I've consumed all the time I have to spend on this issue. 

fixes https://github.com/pulumi/pulumi/issues/5108