### PR TITLE
Adding a Repository Dispatch event for homebrew bump script

### DIFF
--- a/.github/workflows/homebrew-bump.yml
+++ b/.github/workflows/homebrew-bump.yml
@@ -1,0 +1,21 @@
+env:
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  VERSION: ${{ github.event.client_payload.ref }}
+  COMMIT_SHA: ${{ github.event.client_payload.commitSha }}
+
+on:
+  repository_dispatch:
+    types:
+      - homebrew-bump
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          formula: pulumi
+          tag: ${{env.VERSION}}
+          revision: ${{env.COMMIT_SHA}}


### PR DESCRIPTION
This replaces the work in scripts/update_homebrew.sh

This isn't hooked into any builds right now - this is just the mechanism that we need to invoke