### PR TITLE
Fix C# program gen for Kubernetes examples

### DIFF
--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -48,6 +48,8 @@ type generator struct {
 	diagnostics   hcl.Diagnostics
 }
 
+const pulumiPackage = "pulumi"
+
 func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics, error) {
 	// Linearize the nodes into an order appropriate for procedural code generation.
 	nodes := hcl2.Linearize(program)
@@ -144,7 +146,7 @@ func (g *generator) genPreamble(w io.Writer, program *hcl2.Program) {
 	for _, n := range program.Nodes {
 		if r, isResource := n.(*hcl2.Resource); isResource {
 			pkg, _, _, _ := r.DecomposeToken()
-			if pkg != "pulumi" {
+			if pkg != pulumiPackage {
 				namespace := namespaceName(g.namespaces[pkg], pkg)
 				pulumiUsings.Add(fmt.Sprintf("%s = Pulumi.%[1]s", namespace))
 			}
@@ -271,7 +273,7 @@ func (g *generator) resourceTypeName(r *hcl2.Resource) string {
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diags := r.DecomposeToken()
 	contract.Assert(len(diags) == 0)
-	if pkg == "pulumi" && module == "providers" {
+	if pkg == pulumiPackage && module == "providers" {
 		pkg, module, member = member, "", "Provider"
 	}
 
@@ -292,7 +294,7 @@ func (g *generator) resourceArgsTypeName(r *hcl2.Resource) string {
 	// Compute the resource type from the Pulumi type token.
 	pkg, module, member, diags := r.DecomposeToken()
 	contract.Assert(len(diags) == 0)
-	if pkg == "pulumi" && module == "providers" {
+	if pkg == pulumiPackage && module == "providers" {
 		pkg, module, member = member, "", "Provider"
 	}
 

--- a/pkg/codegen/internal/test/testdata/kubernetes-operator.pp.cs
+++ b/pkg/codegen/internal/test/testdata/kubernetes-operator.pp.cs
@@ -5,46 +5,46 @@ class MyStack : Stack
 {
     public MyStack()
     {
-        var pulumi_kubernetes_operatorDeployment = new Kubernetes.Apps.v1.Deployment("pulumi_kubernetes_operatorDeployment", new Kubernetes.Apps.v1.DeploymentArgs
+        var pulumi_kubernetes_operatorDeployment = new Kubernetes.Apps.V1.Deployment("pulumi_kubernetes_operatorDeployment", new Kubernetes.Types.Inputs.Apps.V1.DeploymentArgs
         {
             ApiVersion = "apps/v1",
             Kind = "Deployment",
-            Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+            Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
             {
                 Name = "pulumi-kubernetes-operator",
             },
-            Spec = new Kubernetes.Apps.Inputs.DeploymentSpecArgs
+            Spec = new Kubernetes.Types.Inputs.Apps.V1.DeploymentSpecArgs
             {
                 Replicas = 1,
-                Selector = new Kubernetes.Meta.Inputs.LabelSelectorArgs
+                Selector = new Kubernetes.Types.Inputs.Meta.V1.LabelSelectorArgs
                 {
                     MatchLabels = 
                     {
                         { "name", "pulumi-kubernetes-operator" },
                     },
                 },
-                Template = new Kubernetes.Core.Inputs.PodTemplateSpecArgs
+                Template = new Kubernetes.Types.Inputs.Core.V1.PodTemplateSpecArgs
                 {
-                    Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+                    Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
                     {
                         Labels = 
                         {
                             { "name", "pulumi-kubernetes-operator" },
                         },
                     },
-                    Spec = new Kubernetes.Core.Inputs.PodSpecArgs
+                    Spec = new Kubernetes.Types.Inputs.Core.V1.PodSpecArgs
                     {
                         ServiceAccountName = "pulumi-kubernetes-operator",
                         ImagePullSecrets = 
                         {
-                            new Kubernetes.Core.Inputs.LocalObjectReferenceArgs
+                            new Kubernetes.Types.Inputs.Core.V1.LocalObjectReferenceArgs
                             {
                                 Name = "pulumi-kubernetes-operator",
                             },
                         },
                         Containers = 
                         {
-                            new Kubernetes.Core.Inputs.ContainerArgs
+                            new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
                             {
                                 Name = "pulumi-kubernetes-operator",
                                 Image = "pulumi/pulumi-kubernetes-operator:v0.0.2",
@@ -59,29 +59,29 @@ class MyStack : Stack
                                 ImagePullPolicy = "Always",
                                 Env = 
                                 {
-                                    new Kubernetes.Core.Inputs.EnvVarArgs
+                                    new Kubernetes.Types.Inputs.Core.V1.EnvVarArgs
                                     {
                                         Name = "WATCH_NAMESPACE",
-                                        ValueFrom = new Kubernetes.Core.Inputs.EnvVarSourceArgs
+                                        ValueFrom = new Kubernetes.Types.Inputs.Core.V1.EnvVarSourceArgs
                                         {
-                                            FieldRef = new Kubernetes.Core.Inputs.ObjectFieldSelectorArgs
+                                            FieldRef = new Kubernetes.Types.Inputs.Core.V1.ObjectFieldSelectorArgs
                                             {
                                                 FieldPath = "metadata.namespace",
                                             },
                                         },
                                     },
-                                    new Kubernetes.Core.Inputs.EnvVarArgs
+                                    new Kubernetes.Types.Inputs.Core.V1.EnvVarArgs
                                     {
                                         Name = "POD_NAME",
-                                        ValueFrom = new Kubernetes.Core.Inputs.EnvVarSourceArgs
+                                        ValueFrom = new Kubernetes.Types.Inputs.Core.V1.EnvVarSourceArgs
                                         {
-                                            FieldRef = new Kubernetes.Core.Inputs.ObjectFieldSelectorArgs
+                                            FieldRef = new Kubernetes.Types.Inputs.Core.V1.ObjectFieldSelectorArgs
                                             {
                                                 FieldPath = "metadata.name",
                                             },
                                         },
                                     },
-                                    new Kubernetes.Core.Inputs.EnvVarArgs
+                                    new Kubernetes.Types.Inputs.Core.V1.EnvVarArgs
                                     {
                                         Name = "OPERATOR_NAME",
                                         Value = "pulumi-kubernetes-operator",
@@ -93,18 +93,18 @@ class MyStack : Stack
                 },
             },
         });
-        var pulumi_kubernetes_operatorRole = new Kubernetes.Rbac.authorization.k8s.io.v1.Role("pulumi_kubernetes_operatorRole", new Kubernetes.Rbac.authorization.k8s.io.v1.RoleArgs
+        var pulumi_kubernetes_operatorRole = new Kubernetes.Rbac.V1.Role("pulumi_kubernetes_operatorRole", new Kubernetes.Types.Inputs.Rbac.V1.RoleArgs
         {
             ApiVersion = "rbac.authorization.k8s.io/v1",
             Kind = "Role",
-            Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+            Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
             {
                 CreationTimestamp = null,
                 Name = "pulumi-kubernetes-operator",
             },
             Rules = 
             {
-                new Kubernetes.Rbac.authorization.k8s.io.Inputs.PolicyRuleArgs
+                new Kubernetes.Types.Inputs.Rbac.V1.PolicyRuleArgs
                 {
                     ApiGroups = 
                     {
@@ -132,7 +132,7 @@ class MyStack : Stack
                         "watch",
                     },
                 },
-                new Kubernetes.Rbac.authorization.k8s.io.Inputs.PolicyRuleArgs
+                new Kubernetes.Types.Inputs.Rbac.V1.PolicyRuleArgs
                 {
                     ApiGroups = 
                     {
@@ -156,7 +156,7 @@ class MyStack : Stack
                         "watch",
                     },
                 },
-                new Kubernetes.Rbac.authorization.k8s.io.Inputs.PolicyRuleArgs
+                new Kubernetes.Types.Inputs.Rbac.V1.PolicyRuleArgs
                 {
                     ApiGroups = 
                     {
@@ -172,7 +172,7 @@ class MyStack : Stack
                         "create",
                     },
                 },
-                new Kubernetes.Rbac.authorization.k8s.io.Inputs.PolicyRuleArgs
+                new Kubernetes.Types.Inputs.Rbac.V1.PolicyRuleArgs
                 {
                     ApiGroups = 
                     {
@@ -191,7 +191,7 @@ class MyStack : Stack
                         "update",
                     },
                 },
-                new Kubernetes.Rbac.authorization.k8s.io.Inputs.PolicyRuleArgs
+                new Kubernetes.Types.Inputs.Rbac.V1.PolicyRuleArgs
                 {
                     ApiGroups = 
                     {
@@ -206,7 +206,7 @@ class MyStack : Stack
                         "get",
                     },
                 },
-                new Kubernetes.Rbac.authorization.k8s.io.Inputs.PolicyRuleArgs
+                new Kubernetes.Types.Inputs.Rbac.V1.PolicyRuleArgs
                 {
                     ApiGroups = 
                     {
@@ -222,7 +222,7 @@ class MyStack : Stack
                         "get",
                     },
                 },
-                new Kubernetes.Rbac.authorization.k8s.io.Inputs.PolicyRuleArgs
+                new Kubernetes.Types.Inputs.Rbac.V1.PolicyRuleArgs
                 {
                     ApiGroups = 
                     {
@@ -245,34 +245,34 @@ class MyStack : Stack
                 },
             },
         });
-        var pulumi_kubernetes_operatorRoleBinding = new Kubernetes.Rbac.authorization.k8s.io.v1.RoleBinding("pulumi_kubernetes_operatorRoleBinding", new Kubernetes.Rbac.authorization.k8s.io.v1.RoleBindingArgs
+        var pulumi_kubernetes_operatorRoleBinding = new Kubernetes.Rbac.V1.RoleBinding("pulumi_kubernetes_operatorRoleBinding", new Kubernetes.Types.Inputs.Rbac.V1.RoleBindingArgs
         {
             Kind = "RoleBinding",
             ApiVersion = "rbac.authorization.k8s.io/v1",
-            Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+            Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
             {
                 Name = "pulumi-kubernetes-operator",
             },
             Subjects = 
             {
-                new Kubernetes.Rbac.authorization.k8s.io.Inputs.SubjectArgs
+                new Kubernetes.Types.Inputs.Rbac.V1.SubjectArgs
                 {
                     Kind = "ServiceAccount",
                     Name = "pulumi-kubernetes-operator",
                 },
             },
-            RoleRef = new Kubernetes.Rbac.authorization.k8s.io.Inputs.RoleRefArgs
+            RoleRef = new Kubernetes.Types.Inputs.Rbac.V1.RoleRefArgs
             {
                 Kind = "Role",
                 Name = "pulumi-kubernetes-operator",
                 ApiGroup = "rbac.authorization.k8s.io",
             },
         });
-        var pulumi_kubernetes_operatorServiceAccount = new Kubernetes.Core.v1.ServiceAccount("pulumi_kubernetes_operatorServiceAccount", new Kubernetes.Core.v1.ServiceAccountArgs
+        var pulumi_kubernetes_operatorServiceAccount = new Kubernetes.Core.V1.ServiceAccount("pulumi_kubernetes_operatorServiceAccount", new Kubernetes.Types.Inputs.Core.V1.ServiceAccountArgs
         {
             ApiVersion = "v1",
             Kind = "ServiceAccount",
-            Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+            Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
             {
                 Name = "pulumi-kubernetes-operator",
             },

--- a/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.cs
+++ b/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.cs
@@ -5,24 +5,24 @@ class MyStack : Stack
 {
     public MyStack()
     {
-        var bar = new Kubernetes.Core.v1.Pod("bar", new Kubernetes.Core.v1.PodArgs
+        var bar = new Kubernetes.Core.V1.Pod("bar", new Kubernetes.Types.Inputs.Core.V1.PodArgs
         {
             ApiVersion = "v1",
             Kind = "Pod",
-            Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+            Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
             {
                 Namespace = "foo",
                 Name = "bar",
             },
-            Spec = new Kubernetes.Core.Inputs.PodSpecArgs
+            Spec = new Kubernetes.Types.Inputs.Core.V1.PodSpecArgs
             {
                 Containers = 
                 {
-                    new Kubernetes.Core.Inputs.ContainerArgs
+                    new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
                     {
                         Name = "nginx",
                         Image = "nginx:1.14-alpine",
-                        Resources = new Kubernetes.Core.Inputs.ResourceRequirementsArgs
+                        Resources = new Kubernetes.Types.Inputs.Core.V1.ResourceRequirementsArgs
                         {
                             Limits = 
                             {


### PR DESCRIPTION
- Replace the simplistic module name parsing with the `tokenToModules` function
- Make the namespace structure aware of the `kubernetes20` compat flag

Part of #5101