### PR TITLE
Ensure Project Stack is not loaded and saved unnecessariliy for default secrets manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ CHANGELOG
 
 - Support publishing and consuming Policy Packs using any runtime
   [#5102](https://github.com/pulumi/pulumi/pull/5102)
+  
+- Fix regression where any CLI integration for any stack with a default
+  secrets provider would sort the config alphabetically and new stacks created
+  would get created with an empty map `{}` in the config file
+  [#5132](https://github.com/pulumi/pulumi/pull/5132)
 
 
 ## 2.8.1 (2020-08-05)

--- a/pkg/cmd/pulumi/crypto_http.go
+++ b/pkg/cmd/pulumi/crypto_http.go
@@ -42,14 +42,45 @@ func newServiceSecretsManager(s httpstate.Stack, stackName tokens.QName, configF
 	client := s.Backend().(httpstate.Backend).Client()
 	id := s.StackIdentifier()
 
-	// Let's ensure these are empty as they should be for a service secrets manager
-	info.SecretsProvider = ""
-	info.EncryptedKey = ""
-	info.EncryptionSalt = ""
-
-	if err := workspace.SaveProjectStack(stackName, info); err != nil {
-		return nil, err
+	// We should only save the ProjectStack at this point IF we have changed the
+	// secrets provider. To change the secrets provider to a serviceSecretsManager
+	// we would need to ensure that there are no remnants of the old secret manager
+	// To remove those remnants, we would set those values to be empty in the project
+	// stack, as per changeProjectStackSecretDetails func.
+	// If we do not check to see if the secrets provider has changed, then we will actually
+	// reload the configuration file to be sorted or an empty {} when creating a stack
+	// this is not the desired behaviour
+	if changeProjectStackSecretDetails(info) {
+		if err := workspace.SaveProjectStack(stackName, info); err != nil {
+			return nil, err
+		}
 	}
 
 	return service.NewServiceSecretsManager(client, id)
+}
+
+// A passphrase secrets provider has an encryption salt, therefore, changing
+// from passphrase to serviceSecretsManager requires the encryption salt
+// to be removed
+// A cloud secrets manager has an encryption key and a secrets provider,
+// therefore, changing from cloud to serviceSecretsManager requires the
+// encryption key and secrets provider to be removed
+// Regardless of what the current secrets provider is, all of these values
+// need to be empty otherwise `getStackSecretsManager` in crypto.go can
+// potentially return the incorrect secret type for the stack
+func changeProjectStackSecretDetails(info *workspace.ProjectStack) bool {
+	var requiresSave bool
+	if info.SecretsProvider != "" {
+		info.SecretsProvider = ""
+		requiresSave = true
+	}
+	if info.EncryptedKey != "" {
+		info.EncryptedKey = ""
+		requiresSave = true
+	}
+	if info.EncryptionSalt != "" {
+		info.EncryptionSalt = ""
+		requiresSave = true
+	}
+	return requiresSave
 }

--- a/pkg/cmd/pulumi/crypto_http_test.go
+++ b/pkg/cmd/pulumi/crypto_http_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/workspace"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestChangeProjectStackSecretDetails(t *testing.T) {
+	//projStack := &workspace.ProjectStack{
+	//	Name:    tokens.PackageName("test-package"),
+	//	Runtime: workspace.NewProjectRuntimeInfo("nodejs", nil),
+	//}
+	//
+	//assert.Equal(t, "foo", prettyKeyForProject(config.MustMakeKey("test-package", "foo"), proj))
+	//assert.Equal(t, "other-package:bar", prettyKeyForProject(config.MustMakeKey("other-package", "bar"), proj))
+	tests := []struct {
+		TestName     string
+		ProjectStack workspace.ProjectStack
+		Expected     bool
+	}{
+		{
+			TestName: "Expects to save stack when existing secrets manager is cloud",
+			ProjectStack: workspace.ProjectStack{
+				Config:          make(config.Map),
+				SecretsProvider: "awskms://alias/TestProvider?region=us-west-2",
+				EncryptedKey:    "AQICAHhAA+FYp21DcGwS7xUizcOsoZihxKtWVCjZpgsK7owkfQF3sftIrKkJOJ0VYq69rHxvAAAAfjB8Bgkqhk",
+			},
+			Expected: true,
+		},
+		{
+			TestName: "Expects to save stack when existing secrets manager is passphrase",
+			ProjectStack: workspace.ProjectStack{
+				Config:         make(config.Map),
+				EncryptionSalt: "v1:/AQICAHhAA+FYp21DcGwS7xUizcOsoZihxKtWVCjZpgsK7owkfQF3sftIrKkJOJ0VYq69rHxvAAAAfjB8Bgkqhk",
+			},
+			Expected: true,
+		},
+		{
+			TestName: "Does not expect to save stack when existing secrets manager is service",
+			ProjectStack: workspace.ProjectStack{
+				Config: make(config.Map),
+			},
+			Expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.TestName, func(t *testing.T) {
+			requiresProjectSave := changeProjectStackSecretDetails(&test.ProjectStack)
+			assert.Equal(t, test.Expected, requiresProjectSave)
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #5126

In the newServiceSecretsManager, we were loading and saving the project stack
without understanding if any changes had actually been made - e.g. changing the
stack to be a new secrets provider

This has now been guarded against, tests added to understand when it will
actually be saved and we no longer get unnecessary config sorting when interacting
with a default stack AND no longer get an empty config map in our config
file when we initiate a new stack with a default secrets provider