### PR TITLE
Docgen changes for Python input/output types

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -889,7 +889,8 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 		}
 		propLangName := name
 
-		// This if check can be removed once all providers have UsesIOClasses set to true in their schema.
+		// TODO[pulumi/pulumi#5145]: Delete this if check once all providers have UsesIOClasses set to true in their
+		// schema.
 		if lang == "python" && !pythonPkgInfo.UsesIOClasses {
 			pyName := python.PyName(prop.Name)
 			// The default casing for a Python property name is snake_case unless

--- a/pkg/codegen/docs/templates/constructor_params.tmpl
+++ b/pkg/codegen/docs/templates/constructor_params.tmpl
@@ -6,4 +6,4 @@
 
 {{ define "csharp_formal_param" }}{{ template "linkify_param" .Type }}<span class="p">{{ .OptionalFlag }} </span><span class="nx">{{ .Name }}{{ .DefaultValue }}{{ end }}
 
-{{ define "py_formal_param" }}{{ .Name }}{{ .DefaultValue }}{{ end }}
+{{ define "py_formal_param" }}<span class="nx">{{ .Name }}</span><span class="p">:</span> {{ template "linkify_param" .Type }}{{ .DefaultValue }}{{ end }}

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -24,7 +24,7 @@
 
 <!-- Python -->
 {{ print "{{% choosable language python %}}" }}
-<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">function </span> {{ .FunctionName.python }}(</span>{{ htmlSafe .FunctionArgs.python }}<span class="p">)</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span>{{ .FunctionName.python }}(</span>{{ htmlSafe .FunctionArgs.python }}<span class="p">) -&gt;</span> {{ .FunctionResult.python.Name }}</code></pre></div>
 {{ print "{{% /choosable %}}" }}
 
 <!-- Go -->

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -31,7 +31,7 @@
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language python %}}" }}
-<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span>{{ template "linkify_param" .ConstructorResource.python }}<span class="p">(resource_name, </span>{{ htmlSafe .ConstructorParams.python }}<span class="p">)</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span>{{ template "linkify_param" .ConstructorResource.python }}<span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">, </span>{{ htmlSafe .ConstructorParams.python }}<span class="p">)</span></code></pre></div>
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language go %}}" }}
@@ -111,7 +111,8 @@ Get an existing {{.Header.Title}} resource's state with the given name, ID, and 
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language python %}}" }}
-<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">static </span><span class="nf">get</span><span class="p">(resource_name, id, opts=None, </span>{{ htmlSafe .LookupParams.python }}<span class="p">, __props__=None)</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@staticmethod</span>
+<span class="k">def </span><span class="nf">get</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">, </span><span class="nx">id</span><span class="p">:</span> <span class="nx">str</span><span class="p">, </span><span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">, </span>{{ htmlSafe .LookupParams.python }}<span class="p">) -&gt;</span> {{ .ConstructorResource.python.Name }}</code></pre></div>
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language go %}}" }}

--- a/pkg/codegen/docs/templates/utils.tmpl
+++ b/pkg/codegen/docs/templates/utils.tmpl
@@ -1,5 +1,5 @@
 <!-- linkify_param is used to wrap constructor/function params in an anchor tag. -->
-{{ define "linkify_param" }}<span class="nx"><a href="{{ .Link }}">{{ if ne .DisplayName "" }}{{ .DisplayName }}{{ else }}{{ .Name }}{{ end }}</a></span>{{ end }}
+{{ define "linkify_param" }}<span class="nx">{{ if ne .Link "" }}<a href="{{ .Link }}">{{ end }}{{ if ne .DisplayName "" }}{{ .DisplayName }}{{ else }}{{ .Name }}{{ end }}{{ if ne .Link "" }}</a>{{ end }}</span>{{ end }}
 
 <!-- linkify_go_param is used to wrap constructor/function params in an anchor tag specifically for go constuctors. We are treating this as a snowflake for now. -->
 {{ define "linkify_go_param" }}<span class="nx"><a href="{{ .Link }}">New{{ if ne .DisplayName "" }}{{ .DisplayName }}{{ else }}{{ .Name }}{{ end }}</a></span>{{ end }}

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -81,8 +81,8 @@ func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
 
 // GetLanguageTypeString returns the Python-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string {
-	// This check and call to GetLanguageTypeStringLegacy can be deleted once all providers have
-	// UsesIOClasses set to true in their schema.
+	// TODO[pulumi/pulumi#5145]: Delete this if check once all providers have UsesIOClasses set to true in their
+	// schema.
 	if pythonPkgInfo, ok := pkg.Language["python"].(PackageInfo); !ok || !pythonPkgInfo.UsesIOClasses {
 		return d.GetLanguageTypeStringLegacy(pkg, moduleName, t, input, optional)
 	}
@@ -106,7 +106,8 @@ func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName
 	return typeName
 }
 
-// GetLanguageTypeStringLegacy returns the legacy types and should be deleted once all providers have UsesIOClasses set to true in their schema.
+// TODO[pulumi/pulumi#5145]: Delete this function once all providers have UsesIOClasses set to true in their schema.
+// GetLanguageTypeStringLegacy returns the legacy type strings.
 func (d DocLanguageHelper) GetLanguageTypeStringLegacy(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string {
 	name := pyType(t)
 
@@ -151,7 +152,8 @@ func (d DocLanguageHelper) GetFunctionName(modName string, f *schema.Function) s
 	return PyName(tokenToName(f.Token))
 }
 
-// GetResourceFunctionResultName is not implemented for Python and returns an empty string.
+// GetResourceFunctionResultName returns the name of the result type when a function is used to lookup
+// an existing resource.
 func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *schema.Function) string {
 	return title(tokenToName(f.Token)) + "Result"
 }

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -726,7 +726,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	// If there's an argument type, emit it.
 	for _, prop := range res.InputProperties {
 		ty := mod.typeString(prop.Type, true, true, true /*optional*/, true /*acceptMapping*/)
-		fmt.Fprintf(w, ",\n                 %s: %s = None", initParamName(prop.Name), ty)
+		fmt.Fprintf(w, ",\n                 %s: %s = None", InitParamName(prop.Name), ty)
 	}
 
 	// Old versions of TFGen emitted parameters named __name__ and __opts__. In order to preserve backwards
@@ -759,7 +759,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 
 	ins := stringSet{}
 	for _, prop := range res.InputProperties {
-		pname := initParamName(prop.Name)
+		pname := InitParamName(prop.Name)
 		var arg interface{}
 		var err error
 
@@ -1397,7 +1397,7 @@ func (mod *modContext) genInitDocstring(w io.Writer, res *schema.Resource) {
 	fmt.Fprintln(b, ":param str resource_name: The name of the resource.")
 	fmt.Fprintln(b, ":param pulumi.ResourceOptions opts: Options for the resource.")
 	for _, prop := range res.InputProperties {
-		mod.genPropDocstring(b, initParamName(prop.Name), prop, true /*wrapInput*/, true /*acceptMapping*/)
+		mod.genPropDocstring(b, InitParamName(prop.Name), prop, true /*wrapInput*/, true /*acceptMapping*/)
 	}
 
 	// printComment handles the prefix and triple quotes.
@@ -1596,8 +1596,8 @@ func pyClassName(name string) string {
 	return EnsureKeywordSafe(name)
 }
 
-// initParamName returns a PyName-encoded name but also deduplicates the name against built-in parameters of resource __init__.
-func initParamName(name string) string {
+// InitParamName returns a PyName-encoded name but also deduplicates the name against built-in parameters of resource __init__.
+func InitParamName(name string) string {
 	result := PyName(name)
 	switch result {
 	case "resource_name", "opts":


### PR DESCRIPTION
Resource doc changes for Python:

- Types are included in constructor/function args
- The property names for input/output types are now always snake_case, regardless of the generated mapping tables, to match the new input/output classes
- Some other minor tweaks to function/constructor signatures (e.g. removed the `__props__` arg, as it's not meant to be used directly; use `@staticmethod` for static `get` methods).

I've opened a [Draft PR](https://github.com/pulumi/docs/pull/3906) in the docs repo that isn't meant to be merged, but demonstrates these changes for the AWS and K8s providers.

- View [this commit](https://github.com/pulumi/docs/pull/3906/commits/5b13017dc5b599191f81993173b383397d1877aa) to see the diff
- See the [preview](http://pulumi-docs-origin-pr-3906-b57027e1.s3-website.us-west-2.amazonaws.com) of the site (e.g. [Bucket](http://pulumi-docs-origin-pr-3906-b57027e1.s3-website.us-west-2.amazonaws.com/docs/reference/pkg/aws/s3/bucket/#create), [GetBucket](http://pulumi-docs-origin-pr-3906-b57027e1.s3-website.us-west-2.amazonaws.com/docs/reference/pkg/aws/s3/getbucket/#using))

Fixes https://github.com/pulumi/pulumi/issues/4791