### PR TITLE
[Go Program Gen] Only generate a single literal when traversing a union type

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -307,10 +307,15 @@ func (g *generator) genLiteralValueExpression(w io.Writer, expr *model.LiteralVa
 		}
 	// handles the __convert intrinsic assuming that the union type will have an opaque type containing the dest type
 	case *model.UnionType:
+		var didGenerate bool
 		for _, t := range destType.ElementTypes {
+			if didGenerate {
+				break
+			}
 			switch t := t.(type) {
 			case *model.OpaqueType:
 				g.genLiteralValueExpression(w, expr, t)
+				didGenerate = true
 				break
 			}
 		}

--- a/pkg/codegen/internal/test/testdata/kubernetes-template.pp
+++ b/pkg/codegen/internal/test/testdata/kubernetes-template.pp
@@ -1,0 +1,22 @@
+resource argocd_serverDeployment "kubernetes:apps/v1:Deployment" {
+	apiVersion = "apps/v1"
+	kind = "Deployment"
+	metadata = {
+		name = "argocd-server"
+	}
+	spec = {
+		template = {
+			spec = {
+				containers = [
+					{
+						readinessProbe = {
+							httpGet = {
+								port = 8080
+							}
+						}
+					}
+				]
+			}
+		}
+	}
+}

--- a/pkg/codegen/internal/test/testdata/kubernetes-template.pp.cs
+++ b/pkg/codegen/internal/test/testdata/kubernetes-template.pp.cs
@@ -5,27 +5,27 @@ class MyStack : Stack
 {
     public MyStack()
     {
-        var argocd_serverDeployment = new Kubernetes.Apps.v1.Deployment("argocd_serverDeployment", new Kubernetes.Apps.v1.DeploymentArgs
+        var argocd_serverDeployment = new Kubernetes.Apps.V1.Deployment("argocd_serverDeployment", new Kubernetes.Types.Inputs.Apps.V1.DeploymentArgs
         {
             ApiVersion = "apps/v1",
             Kind = "Deployment",
-            Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+            Metadata = new Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs
             {
                 Name = "argocd-server",
             },
-            Spec = new Kubernetes.Apps.Inputs.DeploymentSpecArgs
+            Spec = new Kubernetes.Types.Inputs.Apps.V1.DeploymentSpecArgs
             {
-                Template = new Kubernetes.Core.Inputs.PodTemplateSpecArgs
+                Template = new Kubernetes.Types.Inputs.Core.V1.PodTemplateSpecArgs
                 {
-                    Spec = new Kubernetes.Core.Inputs.PodSpecArgs
+                    Spec = new Kubernetes.Types.Inputs.Core.V1.PodSpecArgs
                     {
                         Containers = 
                         {
-                            new Kubernetes.Core.Inputs.ContainerArgs
+                            new Kubernetes.Types.Inputs.Core.V1.ContainerArgs
                             {
-                                ReadinessProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                                ReadinessProbe = new Kubernetes.Types.Inputs.Core.V1.ProbeArgs
                                 {
-                                    HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                                    HttpGet = new Kubernetes.Types.Inputs.Core.V1.HTTPGetActionArgs
                                     {
                                         Port = 8080,
                                     },

--- a/pkg/codegen/internal/test/testdata/kubernetes-template.pp.cs
+++ b/pkg/codegen/internal/test/testdata/kubernetes-template.pp.cs
@@ -1,0 +1,41 @@
+using Pulumi;
+using Kubernetes = Pulumi.Kubernetes;
+
+class MyStack : Stack
+{
+    public MyStack()
+    {
+        var argocd_serverDeployment = new Kubernetes.Apps.v1.Deployment("argocd_serverDeployment", new Kubernetes.Apps.v1.DeploymentArgs
+        {
+            ApiVersion = "apps/v1",
+            Kind = "Deployment",
+            Metadata = new Kubernetes.Meta.Inputs.ObjectMetaArgs
+            {
+                Name = "argocd-server",
+            },
+            Spec = new Kubernetes.Apps.Inputs.DeploymentSpecArgs
+            {
+                Template = new Kubernetes.Core.Inputs.PodTemplateSpecArgs
+                {
+                    Spec = new Kubernetes.Core.Inputs.PodSpecArgs
+                    {
+                        Containers = 
+                        {
+                            new Kubernetes.Core.Inputs.ContainerArgs
+                            {
+                                ReadinessProbe = new Kubernetes.Core.Inputs.ProbeArgs
+                                {
+                                    HttpGet = new Kubernetes.Core.Inputs.HTTPGetActionArgs
+                                    {
+                                        Port = 8080,
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+    }
+
+}

--- a/pkg/codegen/internal/test/testdata/kubernetes-template.pp.go
+++ b/pkg/codegen/internal/test/testdata/kubernetes-template.pp.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	appsv1 "github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes/apps/v1"
+	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes/core/v1"
+	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes/meta/v1"
+	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_, err := appsv1.NewDeployment(ctx, "argocd_serverDeployment", &appsv1.DeploymentArgs{
+			ApiVersion: pulumi.String("apps/v1"),
+			Kind:       pulumi.String("Deployment"),
+			Metadata: &metav1.ObjectMetaArgs{
+				Name: pulumi.String("argocd-server"),
+			},
+			Spec: &appsv1.DeploymentSpecArgs{
+				Template: &corev1.PodTemplateSpecArgs{
+					Spec: &corev1.PodSpecArgs{
+						Containers: corev1.ContainerArray{
+							&corev1.ContainerArgs{
+								ReadinessProbe: &corev1.ProbeArgs{
+									HttpGet: &corev1.HTTPGetActionArgs{
+										Port: pulumi.Int(8080),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/internal/test/testdata/kubernetes-template.pp.py
+++ b/pkg/codegen/internal/test/testdata/kubernetes-template.pp.py
@@ -1,0 +1,22 @@
+import pulumi
+import pulumi_kubernetes as kubernetes
+
+argocd_server_deployment = kubernetes.apps.v1.Deployment("argocd_serverDeployment",
+    api_version="apps/v1",
+    kind="Deployment",
+    metadata={
+        "name": "argocd-server",
+    },
+    spec={
+        "template": {
+            "spec": {
+                "containers": [{
+                    "readiness_probe": {
+                        "http_get": {
+                            "port": 8080,
+                        },
+                    },
+                }],
+            },
+        },
+    })

--- a/pkg/codegen/internal/test/testdata/kubernetes-template.pp.ts
+++ b/pkg/codegen/internal/test/testdata/kubernetes-template.pp.ts
@@ -1,0 +1,23 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as kubernetes from "@pulumi/kubernetes";
+
+const argocd_serverDeployment = new kubernetes.apps.v1.Deployment("argocd_serverDeployment", {
+    apiVersion: "apps/v1",
+    kind: "Deployment",
+    metadata: {
+        name: "argocd-server",
+    },
+    spec: {
+        template: {
+            spec: {
+                containers: [{
+                    readinessProbe: {
+                        httpGet: {
+                            port: 8080,
+                        },
+                    },
+                }],
+            },
+        },
+    },
+});


### PR DESCRIPTION
The loop was not breaking after the initial generation, and as a result, the generator continued generating literals against all of the types, eventually encountering ones that are not expected (int source to string destination) causing a panic.

Fixes the issue observed in https://github.com/pulumi/kube2pulumi/pull/31