### PR TITLE
[codegen/docs] Fix the case used in links for Node.js and Python modules.

### DIFF
--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -119,7 +119,7 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	if modName == "" {
 		displayName = fmt.Sprintf("@pulumi/%s", pkg.Name)
 	} else {
-		displayName = fmt.Sprintf("@pulumi/%s/%s", pkg.Name, modName)
+		displayName = fmt.Sprintf("@pulumi/%s/%s", pkg.Name, strings.ToLower(modName))
 	}
 	link = d.GetDocLinkForResourceType(pkg, modName, "")
 	return displayName, link

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -194,7 +194,7 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	if modName == "" {
 		displayName = fmt.Sprintf("pulumi_%s", pkg.Name)
 	} else {
-		displayName = fmt.Sprintf("pulumi_%s/%s", pkg.Name, strings.ToLower(modName))
+		displayName = fmt.Sprintf("pulumi_%s/%s", pkg.Name, PyName(modName))
 	}
 	link = fmt.Sprintf("/docs/reference/pkg/python/%s", displayName)
 	return displayName, link

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -194,7 +194,7 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	if modName == "" {
 		displayName = fmt.Sprintf("pulumi_%s", pkg.Name)
 	} else {
-		displayName = fmt.Sprintf("pulumi_%s/%s", pkg.Name, PyName(modName))
+		displayName = fmt.Sprintf("pulumi_%s/%s", pkg.Name, strings.ToLower(modName))
 	}
 	link = fmt.Sprintf("/docs/reference/pkg/python/%s", displayName)
 	return displayName, link


### PR DESCRIPTION
Related to https://github.com/pulumi/docs/issues/3870.