### PR TITLE
Map python resource options to provider options

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -948,11 +948,9 @@ func (mod *modContext) genPropertyConversionTables() string {
 // Once all resources have been emitted, the table is written out to a format usable for implementations of
 // translate_input_property and translate_output_property.
 func buildCaseMappingTables(pkg *schema.Package, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string, seenTypes codegen.Set) {
-	// Add provider input properties to translation table - this is unique to Python codegen.
-	if pkg.Provider != nil { // Can pkg.Provider even be nil?
-		for _, p := range pkg.Provider.InputProperties {
-			recordProperty(p, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
-		}
+	// Add provider input properties to translation tables.
+	for _, p := range pkg.Provider.InputProperties {
+		recordProperty(p, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 	}
 
 	for _, r := range pkg.Resources {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -948,6 +948,13 @@ func (mod *modContext) genPropertyConversionTables() string {
 // Once all resources have been emitted, the table is written out to a format usable for implementations of
 // translate_input_property and translate_output_property.
 func buildCaseMappingTables(pkg *schema.Package, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string, seenTypes codegen.Set) {
+	// Add provider input properties to translation table - this is unique to Python codegen.
+	if pkg.Provider != nil { // Can pkg.Provider even be nil?
+		for _, p := range pkg.Provider.InputProperties {
+			recordProperty(p, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
+		}
+	}
+
 	for _, r := range pkg.Resources {
 		// Calculate casing tables. We do this up front because our docstring generator (which is run during
 		// genResource) requires them.


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi-kubernetes/issues/1244

An issue was introduced by https://github.com/pulumi/pulumi-kubernetes/pull/1160, when we switched the codegen for k8s over to using the schema-based codegen.

> The schema-based codegen creates __props__ using snake_case keys, which will be translated to camelCase names during serialization via the mapping tables when passed to the engine. This is consistent with what we used to do for the TF-based codegen.
However, the previous k8s codegen always created __props__ with the camelCase names. When we switched the k8s provder over to use the schema-based codegen, we're now creating __props__ with the snake_case names. And unfortunately, names like suppress_deprecation_warnings are missing from the k8s mapping tables, so it doesn't get translated to suppressDeprecationWarnings when passed through the engine.

 This at least affects the kubernetes provider but perhaps others. e.g. the generated config value is `kubernetes:config:suppress_deprecation_warnings` instead of `kubernetes:config:suppressDeprecationWarnings` as expected by the [provider](https://github.com/pulumi/pulumi-kubernetes/blob/master/provider/pkg/provider/provider.go#L399).

Adding the input properties of the provider to the snake case mapping table to allow translation.