### PR TITLE
Added --suppress-permalink option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ CHANGELOG
 - Add support for extracting jar files in archive resources
   [#5150](https://github.com/pulumi/pulumi/pull/5150)
 
+- Added `--suppress-permalink` option to suppress the permalink output
+  (fixes [#4103](https://github.com/pulumi/pulumi/issues/4103))
+  [#5177](https://github.com/pulumi/pulumi/pull/5177)
 
 ## 2.8.2 (2020-08-07)
 

--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -39,7 +39,7 @@ import (
 type ApplierOptions struct {
 	// DryRun indicates if the update should not change any resource state and instead just preview changes.
 	DryRun bool
-	// ShowLink indicates if a link to the update persisted result should be displayed.
+	// ShowLink indicates if a link to the update persisted result can be displayed.
 	ShowLink bool
 }
 

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	ShowSameResources    bool                // true to show the resources that aren't updated in addition to updates.
 	ShowReads            bool                // true to show resources that are being read in
 	SuppressOutputs      bool                // true to suppress output summarization, e.g. if contains sensitive info.
+	SuppressPermaLink    bool                // true to suppress state permalink
 	SummaryDiff          bool                // true if diff display should be summarized.
 	IsInteractive        bool                // true if we should display things interactively.
 	Type                 Type                // type of display (rich diff, progress, or query).

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -569,7 +569,7 @@ func (b *localBackend) apply(
 	}
 
 	// Make sure to print a link to the stack's checkpoint before exiting.
-	if opts.ShowLink && !op.Opts.Display.JSONDisplay {
+	if !op.Opts.Display.SuppressPermaLink && opts.ShowLink && !op.Opts.Display.JSONDisplay {
 		// Note we get a real signed link for aws/azure/gcp links.  But no such option exists for
 		// file:// links so we manually create the link ourselves.
 		var link string

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -911,7 +911,7 @@ func (b *cloudBackend) apply(
 		return nil, result.FromError(err)
 	}
 
-	if opts.ShowLink && !op.Opts.Display.JSONDisplay {
+	if !op.Opts.Display.SuppressPermaLink && opts.ShowLink && !op.Opts.Display.JSONDisplay {
 		// Print a URL at the end of the update pointing to the Pulumi Service.
 		var link string
 		base := b.cloudConsoleStackPath(update.StackIdentifier)

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -45,6 +45,7 @@ func newDestroyCmd() *cobra.Command {
 	var showSames bool
 	var skipPreview bool
 	var suppressOutputs bool
+	var suppressPermaLink bool
 	var yes bool
 	var targets *[]string
 	var targetDependents bool
@@ -84,6 +85,7 @@ func newDestroyCmd() *cobra.Command {
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
 				SuppressOutputs:      suppressOutputs,
+				SuppressPermaLink:    suppressPermaLink,
 				IsInteractive:        interactive,
 				Type:                 displayType,
 				EventLogPath:         eventLogPath,
@@ -195,6 +197,9 @@ func newDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
+	cmd.PersistentFlags().BoolVar(
+		&suppressPermaLink, "suppress-permalink", false,
+		"Suppress display of the state permalink")
 
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -47,6 +47,7 @@ func newPreviewCmd() *cobra.Command {
 	var showSames bool
 	var showReads bool
 	var suppressOutputs bool
+	var suppressPermaLink bool
 	var targets []string
 	var replaces []string
 	var targetReplaces []string
@@ -82,6 +83,7 @@ func newPreviewCmd() *cobra.Command {
 				ShowSameResources:    showSames,
 				ShowReads:            showReads,
 				SuppressOutputs:      suppressOutputs,
+				SuppressPermaLink:    suppressPermaLink,
 				IsInteractive:        cmdutil.Interactive(),
 				Type:                 displayType,
 				JSONDisplay:          jsonDisplay,
@@ -247,6 +249,9 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
+	cmd.PersistentFlags().BoolVar(
+		&suppressPermaLink, "suppress-permalink", false,
+		"Suppress display of the state permalink")
 
 	if hasDebugCommands() {
 		cmd.PersistentFlags().StringVar(

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -43,6 +43,7 @@ func newRefreshCmd() *cobra.Command {
 	var showSames bool
 	var skipPreview bool
 	var suppressOutputs bool
+	var suppressPermaLink bool
 	var yes bool
 	var targets *[]string
 
@@ -82,6 +83,7 @@ func newRefreshCmd() *cobra.Command {
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
 				SuppressOutputs:      suppressOutputs,
+				SuppressPermaLink:    suppressPermaLink,
 				IsInteractive:        interactive,
 				Type:                 displayType,
 				EventLogPath:         eventLogPath,
@@ -191,6 +193,9 @@ func newRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the refresh after previewing it")
+	cmd.PersistentFlags().BoolVar(
+		&suppressPermaLink, "suppress-permalink", false,
+		"Suppress display of the state permalink")
 
 	if hasDebugCommands() {
 		cmd.PersistentFlags().StringVar(

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -64,6 +64,7 @@ func newUpCmd() *cobra.Command {
 	var showReads bool
 	var skipPreview bool
 	var suppressOutputs bool
+	var suppressPermaLink bool
 	var yes bool
 	var secretsProvider string
 	var targets []string
@@ -359,6 +360,7 @@ func newUpCmd() *cobra.Command {
 				ShowSameResources:    showSames,
 				ShowReads:            showReads,
 				SuppressOutputs:      suppressOutputs,
+				SuppressPermaLink:    suppressPermaLink,
 				IsInteractive:        interactive,
 				Type:                 displayType,
 				EventLogPath:         eventLogPath,
@@ -454,6 +456,9 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the update after previewing it")
+	cmd.PersistentFlags().BoolVar(
+		&suppressPermaLink, "suppress-permalink", false,
+		"Suppress display of the state permalink")
 
 	if hasDebugCommands() {
 		cmd.PersistentFlags().StringVar(

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -72,6 +72,7 @@ func newWatchCmd() *cobra.Command {
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
 				SuppressOutputs:      true,
+				SuppressPermaLink:    true,
 				IsInteractive:        false,
 				Type:                 display.DisplayWatch,
 				Debug:                debug,

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -450,6 +450,22 @@ func TestPermaLinkSuppressed(t *testing.T) {
 	})
 }
 
+// TestPermaLink ensures that a permalink is displayed by default
+func TestPermaLink(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          filepath.Join("stack_outputs", "nodejs"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        false,
+		Verbose:      true,
+		Stdout:       stdout,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			output := stdout.String()
+			assert.Contains(t, output, "PermaLink:")
+		},
+	})
+}
+
 // TestStackParenting tests out that stacks and components are parented correctly.
 func TestStackParenting(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -433,6 +433,23 @@ func TestStackOutputsSuppressed(t *testing.T) {
 	})
 }
 
+// TestPermaLinkIsSuppressed ensures that the state permalink is not displayed
+func TestPermaLinkSuppressed(t *testing.T) {
+	stdout := &bytes.Buffer{}
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:                    filepath.Join("stack_outputs", "nodejs"),
+		Dependencies:           []string{"@pulumi/pulumi"},
+		Quick:                  false,
+		Verbose:                true,
+		Stdout:                 stdout,
+		UpdateCommandlineFlags: []string{"--suppress-permalink"},
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			output := stdout.String()
+			assert.NotContains(t, output, "PermaLink:")
+		},
+	})
+}
+
 // TestStackParenting tests out that stacks and components are parented correctly.
 func TestStackParenting(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{


### PR DESCRIPTION
## Issue

https://github.com/pulumi/pulumi/issues/4103

We should allow the ability to suppress the permalink output entirely, regardless of the backend type.

## Intent of this PR
`pulumi up/preview/refresh/destroy` will now accept `--suppress-permalink` which will not display the state permalink in the log output. This supports all types of backends

This behavior follows that of `--suppress-output`

## Testing

* Added integration tests `TestPermaLinkSuppressed` and `TestPermaLink` to automatically check the output
* Tested locally by building the `cmd` project and invoking up/preview/refresh/destroy

```console
> pulumi up -y --suppress-permalink

Previewing update (sm-example):
     Type                 Name                       Plan
     pulumi:pulumi:Stack  sm-example

Resources:
    2 unchanged

Updating (example-sticky):
     Type                 Name                       Status
     pulumi:pulumi:Stack  sm-example

Resources:
    2 unchanged

Duration: 4s
```