### PR TITLE
[sdk/python] Use Python properties for resource outputs and input/output type updates

### DIFF
--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -491,8 +491,7 @@ def output_type(cls: Type[T]) -> Type[T]:
         python_to_pulumi_table = None
         for python_name, pulumi_name, _ in _py_properties(cls):
             if python_name != pulumi_name:
-                if python_to_pulumi_table is None:
-                    python_to_pulumi_table = {}
+                python_to_pulumi_table = python_to_pulumi_table or {}
                 python_to_pulumi_table[python_name] = pulumi_name
         if python_to_pulumi_table is not None:
             setattr(cls, _PULUMI_PYTHON_TO_PULUMI_TABLE, python_to_pulumi_table)

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -369,7 +369,7 @@ def transfer_properties(res: 'Resource', props: 'Inputs') -> Dict[str, Resolver]
         # using res.translate_output_property and then use *that* name to index into the resolvers table.
         log.debug(f"adding resolver {name}")
         resolvers[name] = functools.partial(do_resolve, resolve_value, resolve_is_known, resolve_is_secret)
-        res.__setattr__(name, Output({res}, resolve_value, resolve_is_known, resolve_is_secret))
+        res.__dict__[name] = Output({res}, resolve_value, resolve_is_known, resolve_is_secret)
 
     return resolvers
 

--- a/sdk/python/lib/test/langhost/invoke_types/outputs.py
+++ b/sdk/python/lib/test/langhost/invoke_types/outputs.py
@@ -18,7 +18,7 @@ import outputs
 
 
 @pulumi.output_type
-class MyFunctionNestedResult(dict):
+class MyFunctionNestedResult:
     first_value: str = pulumi.property("firstValue")
     second_value: float = pulumi.property("secondValue")
 
@@ -29,7 +29,11 @@ class MyFunctionResult:
     nested: 'outputs.MyFunctionNestedResult'
 
 @pulumi.output_type
-class MyOtherFunctionNestedResult(dict):
+class MyOtherFunctionNestedResult:
+    def __init__(self, first_value: str, second_value: float):
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
+
     @property
     @pulumi.getter(name="firstValue")
     def first_value(self) -> str:
@@ -42,6 +46,9 @@ class MyOtherFunctionNestedResult(dict):
 
 @pulumi.output_type
 class MyOtherFunctionResult:
+    def __init__(self, nested: 'outputs.MyOtherFunctionNestedResult'):
+        pulumi.set(self, "nested", nested)
+
     @property
     @pulumi.getter
     # Deliberately using a qualified (with `outputs.`) forward reference

--- a/sdk/python/lib/test/langhost/types/__main__.py
+++ b/sdk/python/lib/test/langhost/types/__main__.py
@@ -23,8 +23,8 @@ class AdditionalArgs:
     second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
 
     def __init__(self, first_value: pulumi.Input[str], second_value: Optional[pulumi.Input[float]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
 @pulumi.output_type
 class Additional(dict):
@@ -50,8 +50,8 @@ res2 = AdditionalResource("testres2", additional=AdditionalArgs(
 # Note: the output dict's keys are exactly what is returned from the engine since the resource
 # does not do any translation of property names.
 res3 = AdditionalResource("testres3", additional=AdditionalArgs(
-    first_value=res.additional["firstValue"],
-    second_value=res.additional["secondValue"],
+    first_value=res.additional["first_value"],
+    second_value=res.additional["second_value"],
 ))
 
 # Create a resource using a dict as the input.
@@ -81,8 +81,8 @@ class ExtraArgs:
     second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
 
     def __init__(self, first_value: pulumi.Input[str], second_value: Optional[pulumi.Input[float]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
 @pulumi.output_type
 class Extra(dict):
@@ -137,8 +137,8 @@ class SupplementaryArgs:
                  second_value: Optional[pulumi.Input[float]] = None,
                  third: Optional[pulumi.Input[str]] = None,
                  fourth: Optional[pulumi.Input[str]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
         pulumi.set(self, "third", third)
         pulumi.set(self, "fourth", fourth)
 
@@ -150,17 +150,17 @@ class SupplementaryArgs:
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
-        pulumi.set(self, "firstValue", value)
+        pulumi.set(self, "first_value", value)
 
     # Property with explicitly specified getter/setter bodies.
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[pulumi.Input[float]]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     @second_value.setter
     def second_value(self, value: Optional[pulumi.Input[float]]):
-        pulumi.set(self, "secondValue", value)
+        pulumi.set(self, "second_value", value)
 
     # Single word property name that doesn't require a name to be
     # passed to the getter decorator.
@@ -181,12 +181,18 @@ class SupplementaryArgs:
     def fourth(self) -> Optional[pulumi.Input[str]]:
         ...
 
-    @third.setter
+    @fourth.setter
     def fourth(self, value: Optional[pulumi.Input[str]]):
         ...
 
 @pulumi.output_type
 class Supplementary(dict):
+    def __init__(self, first_value: str, second_value: Optional[float], third: str, fourth: str):
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
+        pulumi.set(self, "third", third)
+        pulumi.set(self, "fourth", fourth)
+
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
@@ -197,7 +203,7 @@ class Supplementary(dict):
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     # Single word property name that doesn't require a name to be
     # passed to the getter decorator.
@@ -237,11 +243,9 @@ res10 = SupplementaryResource("testres10", supplementary=SupplementaryArgs(
 ))
 
 # Create a resource using the output object of another resource, accessing the output as a dict.
-# Note: the output dict's keys are exactly what is returned from the engine since MyResource
-# does not do any translation of property names.
 res11 = SupplementaryResource("testres11", supplementary=SupplementaryArgs(
-    first_value=res9.supplementary["firstValue"],
-    second_value=res9.supplementary["secondValue"],
+    first_value=res9.supplementary["first_value"],
+    second_value=res9.supplementary["second_value"],
     third=res9.supplementary["third"],
     fourth=res9.supplementary["fourth"],
 ))
@@ -266,8 +270,8 @@ class AncillaryArgs:
                  second_value: Optional[pulumi.Input[float]] = None,
                  third: Optional[pulumi.Input[str]] = None,
                  fourth: Optional[pulumi.Input[str]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
         pulumi.set(self, "third", third)
         pulumi.set(self, "fourth", fourth)
 
@@ -279,17 +283,17 @@ class AncillaryArgs:
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
-        pulumi.set(self, "firstValue", value)
+        pulumi.set(self, "first_value", value)
 
     # Property with explicitly specified getter/setter bodies.
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[pulumi.Input[float]]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     @second_value.setter
     def second_value(self, value: Optional[pulumi.Input[float]]):
-        pulumi.set(self, "secondValue", value)
+        pulumi.set(self, "second_value", value)
 
     # Single word property name that doesn't require a name to be
     # passed to the getter decorator.
@@ -310,12 +314,18 @@ class AncillaryArgs:
     def fourth(self) -> Optional[pulumi.Input[str]]:
         ...
 
-    @third.setter
+    @fourth.setter
     def fourth(self, value: Optional[pulumi.Input[str]]):
         ...
 
 @pulumi.output_type
 class Ancillary(dict):
+    def __init__(self, first_value: str, second_value: Optional[float], third: str, fourth: str):
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
+        pulumi.set(self, "third", third)
+        pulumi.set(self, "fourth", fourth)
+
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
@@ -326,7 +336,7 @@ class Ancillary(dict):
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     # Single word property name that doesn't require a name to be
     # passed to the getter decorator.
@@ -339,7 +349,7 @@ class Ancillary(dict):
     # passed to the getter decorator, this time using the decorator with
     # parens.
     @property
-    @pulumi.getter
+    @pulumi.getter()
     def fourth(self) -> str:
         ...
 
@@ -360,7 +370,7 @@ class AncillaryResource(pulumi.CustomResource):
 
 
 # Create a resource with input object.
-res13 = AncillaryResource("testres13", ancillary=SupplementaryArgs(
+res13 = AncillaryResource("testres13", ancillary=AncillaryArgs(
     first_value="baz",
     second_value=500,
     third="third value!",
@@ -368,7 +378,7 @@ res13 = AncillaryResource("testres13", ancillary=SupplementaryArgs(
 ))
 
 # Create a resource using the output object of another resource.
-res14 = AncillaryResource("testres14", ancillary=SupplementaryArgs(
+res14 = AncillaryResource("testres14", ancillary=AncillaryArgs(
     first_value=res13.ancillary.first_value,
     second_value=res13.ancillary.second_value,
     third=res13.ancillary.third,
@@ -377,7 +387,7 @@ res14 = AncillaryResource("testres14", ancillary=SupplementaryArgs(
 
 # Create a resource using the output object of another resource, accessing the output as a dict.
 # Note: the output dict's keys are translated keys.
-res15 = AncillaryResource("testres15", ancillary=SupplementaryArgs(
+res15 = AncillaryResource("testres15", ancillary=AncillaryArgs(
     first_value=res13.ancillary["first_value"],
     second_value=res13.ancillary["second_value"],
     third=res13.ancillary["third"],

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -920,8 +920,8 @@ class FooArgs:
     second_arg: Optional[Input[float]] = pulumi.property("secondArg")
 
     def __init__(self, first_arg: Input[str], second_arg: Optional[Input[float]]=None):
-        pulumi.set(self, "firstArg", first_arg)
-        pulumi.set(self, "secondArg", second_arg)
+        pulumi.set(self, "first_arg", first_arg)
+        pulumi.set(self, "second_arg", second_arg)
 
 
 @input_type
@@ -929,7 +929,7 @@ class BarArgs:
     tag_args: Input[dict] = pulumi.property("tagArgs")
 
     def __init__(self, tag_args: Input[dict]):
-        pulumi.set(self, "tagArgs", tag_args)
+        pulumi.set(self, "tag_args", tag_args)
 
 
 class InputTypeSerializationTests(unittest.TestCase):

--- a/sdk/python/lib/test/test_translate_output_properties.py
+++ b/sdk/python/lib/test/test_translate_output_properties.py
@@ -67,6 +67,39 @@ class Bar(dict):
 
 @pulumi.output_type
 class BarDeclared(dict):
+    def __init__(self,
+                 third_arg: Foo,
+                 third_optional_arg: Optional[Foo],
+                 fourth_arg: Dict[str, Foo],
+                 fourth_optional_arg: Dict[str, Optional[Foo]],
+                 fifth_arg: List[Foo],
+                 fifth_optional_arg: List[Optional[Foo]],
+                 sixth_arg: Dict[str, List[Foo]],
+                 sixth_optional_arg: Dict[str, Optional[List[Foo]]],
+                 sixth_optional_optional_arg: Dict[str, Optional[List[Optional[Foo]]]],
+                 seventh_arg: List[Dict[str, Foo]],
+                 seventh_optional_arg: List[Optional[Dict[str, Foo]]],
+                 seventh_optional_optional_arg: List[Optional[Dict[str, Optional[Foo]]]],
+                 eighth_arg: List[Dict[str, List[Foo]]],
+                 eighth_optional_arg: List[Optional[Dict[str, List[Foo]]]],
+                 eighth_optional_optional_arg: List[Optional[Dict[str, Optional[List[Foo]]]]],
+                 eighth_optional_optional_optional_arg: List[Optional[Dict[str, Optional[List[Optional[Foo]]]]]]):
+        pulumi.set(self, "third_arg", third_arg)
+        pulumi.set(self, "third_optional_arg", third_optional_arg)
+        pulumi.set(self, "fourth_arg", fourth_arg)
+        pulumi.set(self, "fourth_optional_arg", fourth_optional_arg)
+        pulumi.set(self, "fifth_arg", fifth_arg)
+        pulumi.set(self, "fifth_optional_arg", fifth_optional_arg)
+        pulumi.set(self, "sixth_arg", sixth_arg)
+        pulumi.set(self, "sixth_optional_arg", sixth_optional_arg)
+        pulumi.set(self, "sixth_optional_optional_arg", sixth_optional_optional_arg)
+        pulumi.set(self, "seventh_arg", seventh_arg)
+        pulumi.set(self, "seventh_optional_arg", seventh_optional_arg)
+        pulumi.set(self, "seventh_optional_optional_arg", seventh_optional_optional_arg)
+        pulumi.set(self, "eighth_arg", eighth_arg)
+        pulumi.set(self, "eighth_optional_arg", eighth_optional_arg)
+        pulumi.set(self, "eighth_optional_optional_arg", eighth_optional_optional_arg)
+        pulumi.set(self, "eighth_optional_optional_optional_arg", eighth_optional_optional_optional_arg)
 
     @property
     @pulumi.getter(name="thirdArg")
@@ -158,6 +191,9 @@ class InvalidTypeStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredStr(dict):
+    def __init__(self, value: str):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> str:
@@ -169,6 +205,9 @@ class InvalidTypeOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalStr(dict):
+    def __init__(self, value: Optional[str]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[str]:
@@ -180,6 +219,9 @@ class InvalidTypeDictStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredDictStr(dict):
+    def __init__(self, value: Dict[str, str]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Dict[str, str]:
@@ -191,6 +233,9 @@ class InvalidTypeOptionalDictStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalDictStr(dict):
+    def __init__(self, value: Optional[Dict[str, str]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[Dict[str, str]]:
@@ -202,6 +247,9 @@ class InvalidTypeDictOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredDictOptionalStr(dict):
+    def __init__(self, value: Dict[str, Optional[str]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Dict[str, Optional[str]]:
@@ -213,6 +261,9 @@ class InvalidTypeOptionalDictOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalDictOptionalStr(dict):
+    def __init__(self, value: Optional[Dict[str, Optional[str]]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[Dict[str, Optional[str]]]:
@@ -224,6 +275,9 @@ class InvalidTypeListStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredListStr(dict):
+    def __init__(self, value: List[str]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> List[str]:
@@ -235,6 +289,9 @@ class InvalidTypeOptionalListStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalListStr(dict):
+    def __init__(self, value: Optional[List[str]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[List[str]]:
@@ -246,6 +303,9 @@ class InvalidTypeListOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredListOptionalStr(dict):
+    def __init__(self, value: List[Optional[str]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> List[Optional[str]]:
@@ -257,6 +317,9 @@ class InvalidTypeOptionalListOptionalStr(dict):
 
 @pulumi.output_type
 class InvalidTypeDeclaredOptionalListOptionalStr(dict):
+    def __init__(self, value: Optional[List[Optional[str]]]):
+        pulumi.set(self, "value", value)
+
     @property
     @pulumi.getter
     def value(self) -> Optional[List[Optional[str]]]:

--- a/sdk/python/lib/test/test_types_input_type.py
+++ b/sdk/python/lib/test/test_types_input_type.py
@@ -20,6 +20,12 @@ import pulumi._types as _types
 
 
 @pulumi.input_type
+class MySimpleInputType:
+    first_value: pulumi.Input[str] = pulumi.property("firstValue")
+    second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue", default=None)
+
+
+@pulumi.input_type
 class MyInputType:
     first_value: pulumi.Input[str] = pulumi.property("firstValue")
     second_value: Optional[pulumi.Input[float]] = pulumi.property("secondValue")
@@ -27,8 +33,8 @@ class MyInputType:
     def __init__(self,
                  first_value: pulumi.Input[str],
                  second_value: Optional[pulumi.Input[float]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
 
 @pulumi.input_type
@@ -36,8 +42,8 @@ class MyDeclaredPropertiesInputType:
     def __init__(self,
                  first_value: pulumi.Input[str],
                  second_value: Optional[pulumi.Input[float]] = None):
-        pulumi.set(self, "firstValue", first_value)
-        pulumi.set(self, "secondValue", second_value)
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
 
     # Property with empty getter/setter bodies.
     @property
@@ -55,11 +61,11 @@ class MyDeclaredPropertiesInputType:
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[pulumi.Input[float]]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     @second_value.setter
     def second_value(self, value: Optional[pulumi.Input[float]]):
-        pulumi.set(self, "secondValue", value)
+        pulumi.set(self, "second_value", value)
 
 
 class InputTypeTests(unittest.TestCase):
@@ -87,6 +93,7 @@ class InputTypeTests(unittest.TestCase):
 
     def test_input_type(self):
         types = [
+            (MySimpleInputType, False),
             (MyInputType, False),
             (MyDeclaredPropertiesInputType, True),
         ]
@@ -106,7 +113,6 @@ class InputTypeTests(unittest.TestCase):
             self.assertEqual({"return": pulumi.Input[str]}, first.fget.__annotations__)
             if has_doc:
                 self.assertEqual("First value docstring.", first.fget.__doc__)
-            self.assertEqual(True, first.fget._pulumi_getter)
             self.assertEqual("firstValue", first.fget._pulumi_name)
             self.assertTrue(callable(first.fset))
             self.assertEqual("first_value", first.fset.__name__)
@@ -119,7 +125,6 @@ class InputTypeTests(unittest.TestCase):
             self.assertEqual({"return": Optional[pulumi.Input[float]]}, second.fget.__annotations__)
             if has_doc:
                 self.assertEqual("Second value docstring.", second.fget.__doc__)
-            self.assertEqual(True, second.fget._pulumi_getter)
             self.assertEqual("secondValue", second.fget._pulumi_name)
             self.assertTrue(callable(second.fset))
             self.assertEqual("second_value", second.fset.__name__)

--- a/sdk/python/lib/test/test_types_output_type.py
+++ b/sdk/python/lib/test/test_types_output_type.py
@@ -27,17 +27,17 @@ CAMEL_TO_SNAKE_CASE_TABLE = {
 @pulumi.output_type
 class MyOutputType:
     first_value: str = pulumi.property("firstValue")
-    second_value: Optional[float] = pulumi.property("secondValue")
+    second_value: Optional[float] = pulumi.property("secondValue", default=None)
 
 @pulumi.output_type
 class MyOutputTypeDict(dict):
     first_value: str = pulumi.property("firstValue")
-    second_value: Optional[float] = pulumi.property("secondValue")
+    second_value: Optional[float] = pulumi.property("secondValue", default=None)
 
 @pulumi.output_type
 class MyOutputTypeTranslated:
     first_value: str = pulumi.property("firstValue")
-    second_value: Optional[float] = pulumi.property("secondValue")
+    second_value: Optional[float] = pulumi.property("secondValue", default=None)
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
@@ -45,7 +45,7 @@ class MyOutputTypeTranslated:
 @pulumi.output_type
 class MyOutputTypeDictTranslated(dict):
     first_value: str = pulumi.property("firstValue")
-    second_value: Optional[float] = pulumi.property("secondValue")
+    second_value: Optional[float] = pulumi.property("secondValue", default=None)
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
@@ -53,6 +53,11 @@ class MyOutputTypeDictTranslated(dict):
 
 @pulumi.output_type
 class MyDeclaredPropertiesOutputType:
+    def __init__(self, first_value: str, second_value: Optional[float] = None):
+        pulumi.set(self, "first_value", first_value)
+        if second_value is not None:
+            pulumi.set(self, "second_value", second_value)
+
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
@@ -65,10 +70,15 @@ class MyDeclaredPropertiesOutputType:
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
 @pulumi.output_type
 class MyDeclaredPropertiesOutputTypeDict(dict):
+    def __init__(self, first_value: str, second_value: Optional[float] = None):
+        pulumi.set(self, "first_value", first_value)
+        if second_value is not None:
+            pulumi.set(self, "second_value", second_value)
+
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
@@ -81,10 +91,15 @@ class MyDeclaredPropertiesOutputTypeDict(dict):
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
 @pulumi.output_type
 class MyDeclaredPropertiesOutputTypeTranslated:
+    def __init__(self, first_value: str, second_value: Optional[float] = None):
+        pulumi.set(self, "first_value", first_value)
+        if second_value is not None:
+            pulumi.set(self, "second_value", second_value)
+
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
@@ -97,13 +112,18 @@ class MyDeclaredPropertiesOutputTypeTranslated:
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
 
 @pulumi.output_type
 class MyDeclaredPropertiesOutputTypeDictTranslated(dict):
+    def __init__(self, first_value: str, second_value: Optional[float] = None):
+        pulumi.set(self, "first_value", first_value)
+        if second_value is not None:
+            pulumi.set(self, "second_value", second_value)
+
     # Property with empty body.
     @property
     @pulumi.getter(name="firstValue")
@@ -116,7 +136,7 @@ class MyDeclaredPropertiesOutputTypeDictTranslated(dict):
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
         """Second value docstring."""
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     def _translate_property(self, prop):
         return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
@@ -150,6 +170,7 @@ class InputTypeTests(unittest.TestCase):
         for typ in types:
             self.assertTrue(_types.is_output_type(typ))
             self.assertEqual(True, typ._pulumi_output_type)
+            self.assertTrue(hasattr(typ, "__init__"))
 
     def test_output_type_types(self):
         self.assertEqual({
@@ -159,24 +180,24 @@ class InputTypeTests(unittest.TestCase):
 
     def test_output_type(self):
         types = [
-            (MyOutputType, "firstValue", "secondValue", False),
-            (MyOutputTypeDict, "firstValue", "secondValue", False),
-            (MyOutputTypeTranslated, "first_value", "second_value", False),
-            (MyOutputTypeDictTranslated, "first_value", "second_value", False),
-            (MyDeclaredPropertiesOutputType, "firstValue", "secondValue", True),
-            (MyDeclaredPropertiesOutputTypeDict, "firstValue", "secondValue", True),
-            (MyDeclaredPropertiesOutputTypeTranslated, "first_value", "second_value", True),
-            (MyDeclaredPropertiesOutputTypeDictTranslated, "first_value", "second_value", True),
+            (MyOutputType, False),
+            (MyOutputTypeDict, False),
+            (MyOutputTypeTranslated, False),
+            (MyOutputTypeDictTranslated, False),
+            (MyDeclaredPropertiesOutputType, True),
+            (MyDeclaredPropertiesOutputTypeDict, True),
+            (MyDeclaredPropertiesOutputTypeTranslated, True),
+            (MyDeclaredPropertiesOutputTypeDictTranslated, True),
         ]
-        for typ, k1, k2, has_doc in types:
-            self.assertTrue(hasattr(MyOutputType, "__init__"))
-            t = typ({k1: "hello", k2: 42})
+        for typ, has_doc in types:
+            self.assertTrue(hasattr(typ, "__init__"))
+            t = _types.output_type_from_dict(typ, {"firstValue": "hello", "secondValue": 42})
             self.assertEqual("hello", t.first_value)
             self.assertEqual(42, t.second_value)
 
             if isinstance(t, dict):
-                self.assertEqual("hello", t[k1])
-                self.assertEqual(42, t[k2])
+                self.assertEqual("hello", t["first_value"])
+                self.assertEqual(42, t["second_value"])
 
             first = typ.first_value
             self.assertIsInstance(first, property)
@@ -185,7 +206,6 @@ class InputTypeTests(unittest.TestCase):
             self.assertEqual({"return": str}, first.fget.__annotations__)
             if has_doc:
                 self.assertEqual("First value docstring.", first.fget.__doc__)
-            self.assertEqual(True, first.fget._pulumi_getter)
             self.assertEqual("firstValue", first.fget._pulumi_name)
 
             second = typ.second_value
@@ -195,7 +215,6 @@ class InputTypeTests(unittest.TestCase):
             self.assertEqual({"return": Optional[float]}, second.fget.__annotations__)
             if has_doc:
                 self.assertEqual("Second value docstring.", second.fget.__doc__)
-            self.assertEqual(True, second.fget._pulumi_getter)
             self.assertEqual("secondValue", second.fget._pulumi_name)
 
             self.assertTrue(hasattr(t, "__eq__"))
@@ -204,20 +223,20 @@ class InputTypeTests(unittest.TestCase):
             self.assertFalse(t != t)
             self.assertFalse(t == "not equal")
 
-            t2 = typ({k1: "hello", k2: 42})
+            t2 = _types.output_type_from_dict(typ, {"firstValue": "hello", "secondValue": 42})
             self.assertTrue(t.__eq__(t2))
             self.assertTrue(t == t2)
             self.assertFalse(t != t2)
 
             if isinstance(t2, dict):
-                self.assertEqual("hello", t2[k1])
-                self.assertEqual(42, t2[k2])
+                self.assertEqual("hello", t2["first_value"])
+                self.assertEqual(42, t2["second_value"])
 
-            t3 = typ({k1: "foo", k2: 1})
+            t3 = _types.output_type_from_dict(typ, {"firstValue": "foo", "secondValue": 1})
             self.assertFalse(t.__eq__(t3))
             self.assertFalse(t == t3)
             self.assertTrue(t != t3)
 
             if isinstance(t3, dict):
-                self.assertEqual("foo", t3[k1])
-                self.assertEqual(1, t3[k2])
+                self.assertEqual("foo", t3["first_value"])
+                self.assertEqual(1, t3["second_value"])

--- a/sdk/python/lib/test/test_types_resource_types.py
+++ b/sdk/python/lib/test/test_types_resource_types.py
@@ -1,0 +1,68 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pulumi._types import resource_types
+import pulumi
+
+
+class Resource1(pulumi.Resource):
+    pass
+
+class Resource2(pulumi.Resource):
+    foo: pulumi.Output[str]
+
+class Resource3(pulumi.Resource):
+    nested: pulumi.Output['Nested']
+
+class Resource4(pulumi.Resource):
+    nested_value: pulumi.Output['Nested'] = pulumi.property("nestedValue")
+
+class Resource5(pulumi.Resource):
+    @property
+    @pulumi.getter
+    def foo(self) -> str:
+        ...
+
+class Resource6(pulumi.Resource):
+    @property
+    @pulumi.getter
+    def nested(self) -> pulumi.Output['Nested']:
+        ...
+
+class Resource7(pulumi.Resource):
+    @property
+    @pulumi.getter(name="nestedValue")
+    def nested_value(self) -> pulumi.Output['Nested']:
+        ...
+
+
+@pulumi.output_type
+class Nested:
+    first: str
+    second: str
+
+
+class ResourceTypesTests(unittest.TestCase):
+    def test_resource_types(self):
+        self.assertEqual({}, resource_types(Resource1))
+
+        self.assertEqual({"foo": str}, resource_types(Resource2))
+        self.assertEqual({"nested": Nested}, resource_types(Resource3))
+        self.assertEqual({"nestedValue": Nested}, resource_types(Resource4))
+
+        self.assertEqual({"foo": str}, resource_types(Resource5))
+        self.assertEqual({"nested": Nested}, resource_types(Resource6))
+        self.assertEqual({"nestedValue": Nested}, resource_types(Resource7))

--- a/tests/integration/types/python/declared/__main__.py
+++ b/tests/integration/types/python/declared/__main__.py
@@ -20,20 +20,24 @@ class AdditionalArgs:
 
     @first_value.setter
     def first_value(self, value: pulumi.Input[str]):
-        pulumi.set(self, "firstValue", value)
+        pulumi.set(self, "first_value", value)
 
     # Property with explicitly specified getter/setter bodies.
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[pulumi.Input[float]]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
     @second_value.setter
     def second_value(self, value: Optional[pulumi.Input[float]]):
-        pulumi.set(self, "secondValue", value)
+        pulumi.set(self, "second_value", value)
 
 @pulumi.output_type
 class Additional(dict):
+    def __init__(self, first_value: str, second_value: Optional[float], third: str, fourth: str):
+        pulumi.set(self, "first_value", first_value)
+        pulumi.set(self, "second_value", second_value)
+
     # Property with empty getter/setter bodies.
     @property
     @pulumi.getter(name="firstValue")
@@ -44,7 +48,7 @@ class Additional(dict):
     @property
     @pulumi.getter(name="secondValue")
     def second_value(self) -> Optional[float]:
-        return pulumi.get(self, "secondValue")
+        return pulumi.get(self, "second_value")
 
 current_id = 0
 

--- a/tests/integration/types/python/simple/__main__.py
+++ b/tests/integration/types/python/simple/__main__.py
@@ -9,16 +9,12 @@ from pulumi.dynamic import Resource, ResourceProvider, CreateResult
 @input_type
 class AdditionalArgs:
     first_value: Input[str] = property("firstValue")
-    second_value: Optional[Input[float]] = property("secondValue")
-
-    def __init__(self, first_value: Input[str], second_value: Optional[Input[float]] = None):
-        self.first_value = first_value
-        self.second_value = second_value
+    second_value: Optional[Input[float]] = property("secondValue", default=None)
 
 @output_type
 class Additional(dict):
     first_value: str = property("firstValue")
-    second_value: Optional[float] = property("secondValue")
+    second_value: Optional[float] = property("secondValue", default=None)
 
 current_id = 0
 


### PR DESCRIPTION
This is a PR into my `justin/pyio_sdk` feature branch. Once any feedback is addressed and these changes are merged, I'll merge the feature branch into master.

Two commits:

### Use Python properties for resource outputs

This enables docstrings to show up when hovering over properties in PyCharm and VS Code (w/ Pylance).

The property values are stored in and retrieved from the object's `__dict__`, which allows existing things like `export("res", res)` to continue to work the same as before, and aligns the input/output types to store values in `__dict__` the same way.

### Changes to input/output types

Two main changes:

1. Previously, if an @output_type class didn't have an __init__ method, one would be added by the decorator that accepted a single dict argument representing the output properties. This commit makes it so that instead of accepting a single dict argument, it accepts individual arguments for each property based on annotations defined on the class. Classes decorated with @input_type now do the same thing.

    Note: I was considering also adding a `__repr__` method as well, but ran out of time, so decided to cut this. It's pretty low priority and we could decide to add it in the future.


2. Values in input/output types are now stored in `self.__dict__` as snake_case Python names, rather than being stored in `self._values` as camelCase Pulumi names, to be consistent with how values are stored for resources. This allows these types to work the same as resources when passed to `pulumi.export`. There are two exceptions for output types: (a) if the class is a subclass of dict, the values are stored in the dict itself (rather than __dict__), and (b) if the output class has a `_translate_property` method, the names will be the translated names from calling that method.


Related PR (provider codegen changes): https://github.com/pulumi/pulumi/pull/5180

Fixes https://github.com/pulumi/pulumi/issues/5142
Fixes https://github.com/pulumi/pulumi/issues/5141