### PR TITLE
[codegen/python] - Include single word props in casing tables.

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -975,20 +975,14 @@ func recordProperty(prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnak
 	}
 	if mapCase {
 		snakeCaseName := PyNameLegacy(prop.Name)
-		// If the property is a single word, don't add it to the tables.
-		containsOneUnderscore := strings.Count(snakeCaseName, "_") == 1
-		endsWithUnderscore := strings.HasSuffix(snakeCaseName, "_")
-		singleWordProp := containsOneUnderscore && endsWithUnderscore
-		if !singleWordProp {
-			if snakeCaseToCamelCase != nil {
-				if _, ok := snakeCaseToCamelCase[snakeCaseName]; !ok {
-					snakeCaseToCamelCase[snakeCaseName] = prop.Name
-				}
+		if snakeCaseToCamelCase != nil {
+			if _, ok := snakeCaseToCamelCase[snakeCaseName]; !ok {
+				snakeCaseToCamelCase[snakeCaseName] = prop.Name
 			}
-			if camelCaseToSnakeCase != nil {
-				if _, ok := camelCaseToSnakeCase[prop.Name]; !ok {
-					camelCaseToSnakeCase[prop.Name] = snakeCaseName
-				}
+		}
+		if camelCaseToSnakeCase != nil {
+			if _, ok := camelCaseToSnakeCase[prop.Name]; !ok {
+				camelCaseToSnakeCase[prop.Name] = snakeCaseName
 			}
 		}
 	}


### PR DESCRIPTION
This reverts the changes from https://github.com/pulumi/pulumi/pull/4895 which was a change made during the conversion of the k8s provider to use schema-based codegen. In fact, these words do need to be included in the casing tables as they are protected keywords and result in unexpected behavior and failures downstream.

Resolves: https://github.com/pulumi/pulumi-azure/issues/658