### PR TITLE
Docs for versioned modules

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1728,6 +1728,8 @@ func getMod(pkg *schema.Package, token string, modules map[string]*modContext, t
 			// If the parent name is blank, it means this is the package-level.
 			if parentName == "." || parentName == "" {
 				parentName = ":index:"
+			} else {
+				parentName = ":" + parentName + ":"
 			}
 			parent := getMod(pkg, parentName, modules, tool)
 			parent.children = append(parent.children, mod)


### PR DESCRIPTION
Apply the fix from [kubernetes](https://github.com/pulumi/pulumi/blob/master/pkg/codegen/docs/gen_kubernetes.go#L144-L146) doc gen to all providers. Without this, a new provider with modules of format `foo/v123` generates `v123` at the top-level index page instead of having `foo` there.