### PR TITLE
[codegen/python] Fix the type annotation of the `<Resource>.get` function's `id` arg

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -867,7 +867,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	if !res.IsProvider {
 		fmt.Fprintf(w, "    @staticmethod\n")
 		fmt.Fprintf(w, "    def get(resource_name: str,\n")
-		fmt.Fprintf(w, "            id: str,\n")
+		fmt.Fprintf(w, "            id: pulumi.Input[str],\n")
 		fmt.Fprintf(w, "            opts: Optional[pulumi.ResourceOptions] = None")
 
 		if res.StateInputs != nil {
@@ -1413,7 +1413,7 @@ func (mod *modContext) genGetDocstring(w io.Writer, res *schema.Resource) {
 	fmt.Fprintln(b, "")
 
 	fmt.Fprintln(b, ":param str resource_name: The unique name of the resulting resource.")
-	fmt.Fprintln(b, ":param str id: The unique provider ID of the resource to lookup.")
+	fmt.Fprintln(b, ":param pulumi.Input[str] id: The unique provider ID of the resource to lookup.")
 	fmt.Fprintln(b, ":param pulumi.ResourceOptions opts: Options for the resource.")
 	if res.StateInputs != nil {
 		for _, prop := range res.StateInputs.Properties {


### PR DESCRIPTION
It's supposed to be `pulumi.Input[str]` per the annotation on `pulumi.ResourceOptions`:

https://github.com/pulumi/pulumi/blob/2470d59efbd308ec786dc8b67e982ccaf78e7c9c/sdk/python/lib/pulumi/resource.py#L363

It was changed from `str` to `pulumi.Input[str]` in the Python SDK in https://github.com/pulumi/pulumi/pull/3116 to match TypeScript, but looks like the provider codegen was never updated.

This makes Python consistent with the other languages, e.g. [bucket.ts](https://github.com/pulumi/pulumi-aws/blob/5f6f8530bb8881ac88eed302c22299018aa39e81/sdk/nodejs/s3/bucket.ts#L304), [Bucket.cs](https://github.com/pulumi/pulumi-aws/blob/5f6f8530bb8881ac88eed302c22299018aa39e81/sdk/dotnet/S3/Bucket.cs#L639), and [bucket.go](https://github.com/pulumi/pulumi-aws/blob/5f6f8530bb8881ac88eed302c22299018aa39e81/sdk/go/aws/s3/bucket.go#L456).