### PR TITLE
[codegen/python] Fix unintended name changes from PyName and some whitespace cleanup

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -588,7 +588,6 @@ func (mod *modContext) genAwaitableType(w io.Writer, obj *schema.ObjectType) str
 	baseName, awaitableName := awaitableTypeNames(obj.Token)
 
 	// Produce a class definition with optional """ comment.
-	fmt.Fprint(w, "\n\n")
 	fmt.Fprint(w, "@pulumi.output_type\n")
 	fmt.Fprintf(w, "class %s:\n", baseName)
 	printComment(w, obj.Comment, "    ")
@@ -636,7 +635,7 @@ func (mod *modContext) genAwaitableType(w io.Writer, obj *schema.ObjectType) str
 	}
 
 	// Produce an awaitable subclass.
-	fmt.Fprint(w, "\n\n")
+	fmt.Fprint(w, "\n")
 	fmt.Fprintf(w, "class %s(%s):\n", awaitableName, baseName)
 
 	// Emit __await__ and __iter__ in order to make this type awaitable.
@@ -979,7 +978,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 
 	if fun.DeprecationMessage != "" {
 		escaped := strings.ReplaceAll(fun.DeprecationMessage, `"`, `\"`)
-		fmt.Fprintf(w, "warnings.warn(\"%s\", DeprecationWarning)\n", escaped)
+		fmt.Fprintf(w, "warnings.warn(\"%s\", DeprecationWarning)\n\n", escaped)
 	}
 
 	// If there is a return type, emit it.
@@ -987,7 +986,7 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	var rets []*schema.Property
 	if fun.Outputs != nil {
 		retTypeName, rets = mod.genAwaitableType(w, fun.Outputs), fun.Outputs.Properties
-		fmt.Fprintf(w, "\n")
+		fmt.Fprintf(w, "\n\n")
 	}
 
 	var args []*schema.Property
@@ -996,9 +995,11 @@ func (mod *modContext) genFunction(fun *schema.Function) (string, error) {
 	}
 
 	// Write out the function signature.
-	fmt.Fprint(w, "\n")
 	def := fmt.Sprintf("def %s(", name)
-	indent := strings.Repeat(" ", len(def))
+	var indent string
+	if len(args) > 0 {
+		indent = strings.Repeat(" ", len(def))
+	}
 	fmt.Fprintf(w, def)
 	for i, arg := range args {
 		var ind string

--- a/pkg/codegen/python/python.go
+++ b/pkg/codegen/python/python.go
@@ -15,6 +15,7 @@
 package python
 
 import (
+	"fmt"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -22,9 +23,52 @@ import (
 	"github.com/pulumi/pulumi/pkg/v2/codegen"
 )
 
+// useLegacyName are names that should return the result of PyNameLegacy from PyName, for compatibility.
+var useLegacyName = codegen.StringSet{
+	// The following property name of a nested type is a case where the newer algorithm produces an incorrect name
+	// (`open_xjson_ser_de`). It should be the legacy name of `open_x_json_ser_de`.
+	// TODO[pulumi/pulumi#5199]: We should see if we can fix this in the algorithm of PyName so it doesn't need to
+	// be special-cased in this set.
+	"openXJsonSerDe": struct{}{}, // AWS
+
+	// The following function name has already shipped with the legacy name (`get_public_i_ps`).
+	// TODO[pulumi/pulumi#5200]: Consider emitting two functions: one with the correct name (`get_public_ips`)
+	// and another function with the legacy name (`get_public_i_ps`) marked as deprecated.
+	"GetPublicIPs": struct{}{}, // Azure
+
+	// The following function name has already shipped with the legacy name (`get_uptime_check_i_ps`).
+	// TODO[pulumi/pulumi#5200]: Consider emitting two functions: one with the correct name (`get_uptime_check_ips`)
+	// and another function with the legacy name (`get_uptime_check_i_ps`) marked as deprecated.
+	"GetUptimeCheckIPs": struct{}{}, // GCP
+}
+
+// excludeFromPanic are names that are ok to have different results from PyName and PyNameLegacy.
+var excludeFromPanic = codegen.StringSet{
+	// The following all show up as properties of nested input/output classes only, so it's OK that the current
+	// and legacy names are different since we haven't previously generated any input/output classes (hence no
+	// breaking change).
+	"nonResourceURLs": struct{}{}, // K8s
+	"targetWWNs":      struct{}{}, // K8s
+	"podCIDRs":        struct{}{}, // K8s
+	"podIPs":          struct{}{}, // K8s
+	"externalIPs":     struct{}{}, // K8s
+}
+
 // PyName turns a variable or function name, normally using camelCase, to an underscore_case name.
+// It panics if the result is different from PyNameLegacy, unless name is in excludeFromPanic, to help catch
+// unintended breaking changes.
+// TODO[pulumi/pulumi#5201]: Once all providers have been updated to use this version of the codegen (or later),
+// we can go back and remove the panic.
 func PyName(name string) string {
-	return pyName(name, false /*legacy*/)
+	current := pyName(name, useLegacyName.Has(name))
+	if excludeFromPanic.Has(name) {
+		return current
+	}
+	legacy := PyNameLegacy(name)
+	if current != legacy {
+		panic(fmt.Sprintf("PyName(%[1]q) != PyNameLegacy(%[1]q) (%q != %q)", name, current, legacy))
+	}
+	return current
 }
 
 // Deprecated: Use PyName instead.

--- a/pkg/codegen/python/python_test.go
+++ b/pkg/codegen/python/python_test.go
@@ -21,11 +21,24 @@ var pyNameTests = []struct {
 	{"podCIDRSet", "pod_cidr_set", "pod_cidr_set"},
 	{"Sha256Hash", "sha256_hash", "sha256_hash"},
 	{"SHA256Hash", "sha256_hash", "sha256_hash"},
+
+	// PyName should return the legacy name for these:
+	{"openXJsonSerDe", "open_x_json_ser_de", "open_x_json_ser_de"},
+	{"GetPublicIPs", "get_public_i_ps", "get_public_i_ps"},
+	{"GetUptimeCheckIPs", "get_uptime_check_i_ps", "get_uptime_check_i_ps"},
 }
 
 func TestPyName(t *testing.T) {
 	for _, tt := range pyNameTests {
 		t.Run(tt.input, func(t *testing.T) {
+			// TODO[pulumi/pulumi#5201]: Once the assertion has been removed, we can remove this `if` block.
+			// Prevent this input from panic'ing.
+			if tt.input == "someTHINGsAREWeird" {
+				result := pyName(tt.input, false /*legacy*/)
+				assert.Equal(t, tt.expected, result)
+				return
+			}
+
 			result := PyName(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})


### PR DESCRIPTION
The first commit cleans up some whitespace.

The second commit makes PyName panic if the result doesn't match PyNameLegacy(name), unless name is in an exclusion list. This is to help catch unintended breaking changes.

I've run these changes on AWS, Azure, AzureAD, GCP, Random, and Kubernetes.

I expect when we run on all the other providers, we may have to add more names to the `excludeFromPanic` set or `useLegacyName` set, depending on the situation.

Once all providers have been updated to use this version of the codegen (and we've added to `useLegacyName` and `excludeFromPanic` as appropriate), we can go back and remove the panic behavior along with the `excludeFromPanic` behavior. This is tracked by https://github.com/pulumi/pulumi/issues/5201