### PR TITLE
[codegen/docs] Lower-case the module name for Go.

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -348,6 +348,8 @@ func (mod *modContext) getLanguageModuleName(lang string) string {
 
 	switch lang {
 	case "go":
+		// Go module names use lowercase.
+		modName = strings.ToLower(modName)
 		if override, ok := goPkgInfo.ModuleToPackage[modName]; ok {
 			modName = override
 		}


### PR DESCRIPTION
Fixes https://github.com/pulumi/docs/issues/4037.

The resource docs GHA workflow failed in this PR because the latest tag for k8s uses a pattern that the build script in our docs repo does not handle. To get around that, I have opened a draft PR to preview the effect of this change on AWS and k8s docs manually https://github.com/pulumi/docs/pull/4055.