### PR TITLE
[codegen/python] Fix resource outputs type annotations

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -902,7 +902,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		} else {
 			fmt.Fprintf(w, "    @pulumi.getter(name=%q)\n", prop.Name)
 		}
-		fmt.Fprintf(w, "    def %s(self) -> %s:\n", pname, ty)
+		fmt.Fprintf(w, "    def %s(self) -> pulumi.Output[%s]:\n", pname, ty)
 		if prop.Comment != "" {
 			printComment(w, prop.Comment, "        ")
 		}


### PR DESCRIPTION
Sigh, in my haste to convert the resource instance variables to Python properties (to get docstrings in hover tooltips), I completely forgot to specify the type annotation as `Output[T]`. 🤦 

Nothing is broken due to this (Python is untyped afterall), but it doesn't lead to a great experience in IDEs since `apply` isn't available on non-`Output` types.

https://github.com/pulumi/pulumi/commit/78edb28590887593c91ffcb31baa52286150528f#diff-d0ce7edb4e9de69a22487a52ef8e39bfL431