### PR TITLE
Increase visibility of console link

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -108,7 +108,7 @@ func PreviewThenPrompt(ctx context.Context, kind apitype.UpdateKind, stack Stack
 	// confirm the prompt.
 	opts := ApplierOptions{
 		DryRun:   true,
-		ShowLink: false,
+		ShowLink: true,
 	}
 
 	changes, res := apply(ctx, kind, stack, op, opts, eventsChannel)

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -901,7 +901,7 @@ func (b *cloudBackend) apply(
 	if !(op.Opts.Display.JSONDisplay || op.Opts.Display.Type == display.DisplayWatch) {
 		// Print a banner so it's clear this is going to the cloud.
 		fmt.Printf(op.Opts.Display.Color.Colorize(
-			colors.SpecHeadline+"%s (%s):"+colors.Reset+"\n"), actionLabel, stack.Ref())
+			colors.SpecHeadline+"%s (%s)"+colors.Reset+"\n\n"), actionLabel, stack.Ref())
 	}
 
 	// Create an update object to persist results.
@@ -912,24 +912,29 @@ func (b *cloudBackend) apply(
 	}
 
 	if opts.ShowLink && !op.Opts.Display.JSONDisplay {
-		// Print a URL at the end of the update pointing to the Pulumi Service.
-		var link string
-		base := b.cloudConsoleStackPath(update.StackIdentifier)
-		if !opts.DryRun {
-			link = b.CloudConsoleURL(base, "updates", strconv.Itoa(version))
-		} else {
-			link = b.CloudConsoleURL(base, "previews", update.UpdateID)
-		}
-		if link != "" {
-			defer func() {
-				fmt.Printf(op.Opts.Display.Color.Colorize(
-					colors.SpecHeadline+"Permalink: "+
-						colors.Underline+colors.BrightBlue+"%s"+colors.Reset+"\n"), link)
-			}()
-		}
+		// Print a URL at the beginning of the update pointing to the Pulumi Service.
+		b.printLink(op, opts, update, version)
 	}
 
 	return b.runEngineAction(ctx, kind, stack.Ref(), op, update, token, events, opts.DryRun)
+}
+
+// printLink prints a link to the update in the Pulumi Service.
+func (b *cloudBackend) printLink(
+	op backend.UpdateOperation, opts backend.ApplierOptions,
+	update client.UpdateIdentifier, version int) {
+	var link string
+	base := b.cloudConsoleStackPath(update.StackIdentifier)
+	if !opts.DryRun {
+		link = b.CloudConsoleURL(base, "updates", strconv.Itoa(version))
+	} else {
+		link = b.CloudConsoleURL(base, "previews", update.UpdateID)
+	}
+	if link != "" {
+		fmt.Printf(op.Opts.Display.Color.Colorize(
+			colors.SpecHeadline+"View Live: "+
+				colors.Underline+colors.BrightBlue+"%s"+colors.Reset+"\n\n"), link)
+	}
 }
 
 // query executes a query program against the resource outputs of a stack hosted in the Pulumi


### PR DESCRIPTION
This PR will display a link to the Console at the beginning of an update instead of the end, and adds a link at the beginning of a dry run Preview.  The phrase "View Live" provides a call to action to go along with the link.

Before:
![image](https://user-images.githubusercontent.com/41454626/91209138-1e056200-e6c0-11ea-81f8-f290c68aa527.png)


After:
![image](https://user-images.githubusercontent.com/41454626/91506441-edbbf000-e886-11ea-85e4-ef7e5bab4580.png)


