### PR TITLE
Avoid raising unexpected type errors with `Any`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)
+
+- Python SDK: Avoid raising an error when an output has a type annotation of Any
+  and the value is a list or dict.
+  [#5238](https://github.com/pulumi/pulumi/pull/5238)
 
 ## 2.9.0 (2020-08-19)
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -399,6 +399,11 @@ def translate_output_properties(output: Any,
     # Unwrap optional types.
     typ = _types.unwrap_optional_type(typ) if typ else typ
 
+    # If the typ is Any, set it to None to treat it as if we don't have any type information,
+    # to avoid raising errors about unexpected types, since it could be any type.
+    if typ is Any:
+        typ = None
+
     if isinstance(output, dict):
         # Function called to lookup a type for a given key.
         # The default always returns None.


### PR DESCRIPTION
Avoid raising an `AssertionError` due to unexpected types when a type is annotated as `Any`.

Fixes #5237