### PR TITLE
[codegen/nodejs] - Fix whitespace in genNamespace code

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1018,9 +1018,9 @@ func (mod *modContext) genNamespace(w io.Writer, ns *namespace, input bool, leve
 	sort.Slice(ns.children, func(i, j int) bool {
 		return ns.children[i].name < ns.children[j].name
 	})
-	for i, ns := range ns.children {
-		fmt.Fprintf(w, "%sexport namespace %s {\n", indent, ns.name)
-		mod.genNamespace(w, ns, input, level+1)
+	for i, child := range ns.children {
+		fmt.Fprintf(w, "%sexport namespace %s {\n", indent, child.name)
+		mod.genNamespace(w, child, input, level+1)
 		fmt.Fprintf(w, "%s}\n", indent)
 		if i != len(ns.children)-1 {
 			fmt.Fprintf(w, "\n")


### PR DESCRIPTION
Minor change, the use of `ns` as the element of `ns.children` was preventing the logic from correctly executing.

This effects only the whitespace in `input.ts` and `output.ts` files.