### PR TITLE
Full name for aliases in .NET codegen

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -591,7 +591,7 @@ func (mod *modContext) getDefaultValue(dv *schema.DefaultValue, t schema.Type) (
 }
 
 func genAlias(w io.Writer, alias *schema.Alias) {
-	fmt.Fprintf(w, "new Alias { ")
+	fmt.Fprintf(w, "new Pulumi.Alias { ")
 
 	parts := []string{}
 	if alias.Name != nil {


### PR DESCRIPTION
If a resource is called `Alias` and it has Pulumi aliases, .NET generated code fails to compile (also for any resource in the same namespace as `Alias`). This PR uses the full name for Pulumi aliases.