### PR TITLE
[codegen/python] Add 'property' to keywords

### DIFF
--- a/pkg/codegen/python/python.go
+++ b/pkg/codegen/python/python.go
@@ -279,6 +279,7 @@ var Keywords = codegen.NewStringSet(
 	"or",
 	"pass",
 	"print",
+	"property",
 	"raise",
 	"return",
 	"try",


### PR DESCRIPTION
If a resource has a property called 'property', the following code is generated:

```py
    @property
    @pulumi.getter
    def property(self) -> pulumi.Input[str]:
        """
        The track property type.
        """
        return pulumi.get(self, "property")
```

which causes an error: `TypeError: 'property' object is not callable`

This PR adds `property` to the list of keywords. I think it's not a keyword per se, so I welcome any suggestions that would be more correct.

After the fix, the property name becomes `property_` and the error is gone.

One thing that worries me is that the code would use `property_` also as the string key:

```py
pulumi.set(__self__, "property_", property_)
```

Won't this propagate the escaped name to the state?