### PR TITLE
Python: Ignore internal properties when unmarshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Python SDK: Avoid raising an error when internal properties don't match the
+  expected type.
+  [#5251](https://github.com/pulumi/pulumi/pull/5251)
 
 ## 2.9.1 (2020-08-127
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -255,6 +255,13 @@ def deserialize_properties(props_struct: struct_pb2.Struct, keep_unknowns: Optio
     # since we can only set secret outputs on top level properties.
     output = {}
     for k, v in list(props_struct.items()):
+        # Unilaterally skip properties considered internal by the Pulumi engine.
+        # These don't actually contribute to the exposed shape of the object, do
+        # not need to be passed back to the engine, and often will not match the
+        # expected type we are deserializing into.
+        if k.startswith("__"):
+            continue
+
         value = deserialize_property(v, keep_unknowns)
         # We treat values that deserialize to "None" as if they don't exist.
         if value is not None:

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -259,7 +259,8 @@ def deserialize_properties(props_struct: struct_pb2.Struct, keep_unknowns: Optio
         # These don't actually contribute to the exposed shape of the object, do
         # not need to be passed back to the engine, and often will not match the
         # expected type we are deserializing into.
-        if k.startswith("__"):
+        # Keep "__provider" as it's the property name used by Python dynamic providers.
+        if k.startswith("__") and k != "__provider":
             continue
 
         value = deserialize_property(v, keep_unknowns)

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -918,11 +918,14 @@ class DeserializationTests(unittest.TestCase):
         all_props["a"] = "b"
         all_props["__defaults"] = []
         all_props["c"] = {"foo": "bar", "__defaults": []}
+        all_props["__provider"] = "serialized_dynamic_provider"
+        all_props["__other"] = "baz"
 
         val = rpc.deserialize_properties(all_props)
         self.assertEqual({
             "a": "b",
             "c": {"foo": "bar"},
+            "__provider": "serialized_dynamic_provider",
         }, val)
 
 @input_type

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -913,6 +913,17 @@ class DeserializationTests(unittest.TestCase):
         self.assertEqual(val["listWithMap"]["value"][0]["regular"], "a normal value")
         self.assertEqual(val["listWithMap"]["value"][0]["secret"], "a secret value")
 
+    def test_internal_property(self):
+        all_props = struct_pb2.Struct()
+        all_props["a"] = "b"
+        all_props["__defaults"] = []
+        all_props["c"] = {"foo": "bar", "__defaults": []}
+
+        val = rpc.deserialize_properties(all_props)
+        self.assertEqual({
+            "a": "b",
+            "c": {"foo": "bar"},
+        }, val)
 
 @input_type
 class FooArgs:


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/5250

We recently added some checks to Python that will error if the type annotations don't match the types of the output values from the engine. The engine sometimes returns "internal" keys amongst the values, which cause the error to be raised because the types do not match.

For example, we may have a output property annotated as `Mapped[str, str]`, but during preview the value from the engine is `{"foo": "bar", "__defaults": []}`. The map contains `"__defaults"` with a value of `[]` and `list` and `str` don't match, so we raise the error.

This addresses the issue by filtering out these "internal" properties from the engine, like we do in other languages (e.g. [.NET](https://github.com/pulumi/pulumi/pull/3560), [Go](https://github.com/pulumi/pulumi/pull/3996)).