### PR TITLE
expose execution kind via update metadata

### DIFF
--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -85,6 +85,9 @@ const (
 	// CIPRNumber is the PR number, for which the current CI job may be executing.
 	// Combining this information with the `VCSRepoKind` will give us the PR URL.
 	CIPRNumber = "ci.pr.number"
+
+	// ExecutionKind indicates how the update was executed. One of "cli", "auto.local", or "auto.inline".
+	ExecutionKind = "exec.kind"
 )
 
 // UpdateInfo describes a previous update.

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -34,6 +34,7 @@ func newDestroyCmd() *cobra.Command {
 	var stack string
 
 	var message string
+	var execKind string
 
 	// Flags for engine.UpdateOptions.
 	var diffDisplay bool
@@ -101,7 +102,7 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root)
+			m, err := getUpdateMetadata(message, root, execKind)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
@@ -210,5 +211,11 @@ func newDestroyCmd() *cobra.Command {
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")
 	}
+
+	// internal flag
+	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+
 	return cmd
 }

--- a/pkg/cmd/pulumi/host.go
+++ b/pkg/cmd/pulumi/host.go
@@ -34,6 +34,7 @@ func newHostCmd() *cobra.Command {
 	var debug bool
 	var expectNop bool
 	var message string
+	var execKind string
 	var stack string
 	var configArray []string
 	var path bool
@@ -119,6 +120,11 @@ func newHostCmd() *cobra.Command {
 				return result.FromError(errors.Wrap(err, "getting stack configuration"))
 			}
 
+			m, err := getUpdateMetadata(message, root, execKind)
+			if err != nil {
+				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
+			}
+
 			operation := s.Update
 			if isPreview {
 				operation = s.Preview
@@ -130,7 +136,7 @@ func newHostCmd() *cobra.Command {
 				Proj:               proj,
 				Root:               root,
 				Opts:               opts,
-				M:                  &backend.UpdateMetadata{}, // TODO: let this be passed in.
+				M:                  m,
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
 				Scopes:             cancellationScopesWithoutInterrupt,
@@ -232,5 +238,11 @@ func newHostCmd() *cobra.Command {
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")
 	}
+
+	// internal flag
+	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+
 	return cmd
 }

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -30,6 +30,7 @@ func newPreviewCmd() *cobra.Command {
 	var debug bool
 	var expectNop bool
 	var message string
+	var execKind string
 	var stack string
 	var configArray []string
 	var configPath bool
@@ -110,7 +111,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root)
+			m, err := getUpdateMetadata(message, root, execKind)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
@@ -258,5 +259,11 @@ func newPreviewCmd() *cobra.Command {
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")
 	}
+
+	// internal flag
+	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+
 	return cmd
 }

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -32,6 +32,7 @@ func newRefreshCmd() *cobra.Command {
 	var debug bool
 	var expectNop bool
 	var message string
+	var execKind string
 	var stack string
 
 	// Flags for engine.UpdateOptions.
@@ -100,7 +101,7 @@ func newRefreshCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root)
+			m, err := getUpdateMetadata(message, root, execKind)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
@@ -202,5 +203,11 @@ func newRefreshCmd() *cobra.Command {
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")
 	}
+
+	// internal flag
+	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+
 	return cmd
 }

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -47,6 +47,7 @@ func newUpCmd() *cobra.Command {
 	var debug bool
 	var expectNop bool
 	var message string
+	var execKind string
 	var stack string
 	var configArray []string
 	var path bool
@@ -89,7 +90,7 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(err)
 		}
 
-		m, err := getUpdateMetadata(message, root)
+		m, err := getUpdateMetadata(message, root, execKind)
 		if err != nil {
 			return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 		}
@@ -266,7 +267,7 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(err)
 		}
 
-		m, err := getUpdateMetadata(message, root)
+		m, err := getUpdateMetadata(message, root, execKind)
 		if err != nil {
 			return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 		}
@@ -465,6 +466,12 @@ func newUpCmd() *cobra.Command {
 			&eventLogPath, "event-log", "",
 			"Log events to a file at this path")
 	}
+
+	// internal flag
+	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -32,6 +32,7 @@ import (
 func newWatchCmd() *cobra.Command {
 	var debug bool
 	var message string
+	var execKind string
 	var stack string
 	var configArray []string
 	var configPath bool
@@ -97,7 +98,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root)
+			m, err := getUpdateMetadata(message, root, execKind)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
@@ -186,6 +187,10 @@ func newWatchCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&showSames, "show-sames", false,
 		"Show resources that don't need be updated because they haven't changed, alongside those that do")
+
+	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
 
 	return cmd
 }

--- a/sdk/go/common/constant/exec_kind.go
+++ b/sdk/go/common/constant/exec_kind.go
@@ -1,0 +1,13 @@
+package constant
+
+// ExecKindAutoLocal is a flag used to indentify a command as originating
+// from automation API using a traditional Pulumi project.
+const ExecKindAutoLocal = "auto.local"
+
+// ExecKindAutoInline is a flag used to indentify a command as originating
+// from automation API using an inline Pulumi project.
+const ExecKindAutoInline = "auto.inline"
+
+// ExecKindCLI is a flag used to indentify a command as originating
+// from the CLI using a traditional Pulumi project.
+const ExecKindCLI = "cli"


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/5054

Adds a new field to UpdateMetadata.Environment `exec.kind` which is set to one of `auto.local` for traditional programs driven by automation API, `cli` for traditional programs that don't use automation API, or `auto.inline` for automation API programs using inline source (host most). 

This field can be picked up by various backends to expose more information about the source of an update (Was this deployed by hand, as a part of an automation API deployment in CI, etc.). 

Implemented as a string flag so that there's the flexibility to expand in the future. 