### PR TITLE
improve go mod replace logic

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1845,7 +1845,7 @@ func getRewritePath(pkg string, gopath string, depRoot string) string {
 		// Get the package name
 		// This is the value after "github.com/foo/bar"
 		repoName := splitPkg[2]
-		basePath := filepath.Base(sanitizedPkg)
+		basePath := splitPkg[len(splitPkg)-1]
 		if basePath == repoName {
 			depParts = append([]string{depRoot, repoName})
 		} else {

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1878,18 +1878,16 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 			sanitizedPkg = pkg
 		}
 
+		splitPkg := strings.Split(sanitizedPkg, "/")
+
 		if depRoot != "" {
-			// Extract the package name from the full dependency
-			// Must be in the format `pulumi-foo`
-			re := regexp.MustCompile(`(pulumi*-[a-zA-Z0-9]*)+`)
-			pkgName := re.FindString(pkg)
-			if v == "" {
-				return fmt.Errorf("dependency %s not valid - must be a pulumi-foo package", pkg)
-			}
+			// Get the package name
+			// This is the value after "github.com/foo/bar"
+			pkgName := splitPkg[2]
 			depParts = append([]string{depRoot, pkgName, "sdk"})
 			dep = filepath.Join(depParts...)
 		} else {
-			depParts = append([]string{gopath, "src"}, strings.Split(sanitizedPkg, "/")...)
+			depParts = append([]string{gopath, "src"}, splitPkg...)
 			dep = filepath.Join(depParts...)
 		}
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1823,7 +1823,8 @@ func getVirtualenvBinPath(cwd, bin string) (string, error) {
 }
 
 // getSanitizedPkg strips the version string from a go dep
-func getSanitizedPkg(pkg string) string {
+// Note: most of the pulumi modules don't use major version subdirectories for modules
+func getSanitizedModulePath(pkg string) string {
 	re := regexp.MustCompile(`v\d`)
 	v := re.FindString(pkg)
 	if v != "" {
@@ -1836,7 +1837,7 @@ func getSanitizedPkg(pkg string) string {
 func getRewritePath(pkg string, gopath string, depRoot string) string {
 
 	var depParts []string
-	sanitizedPkg := getSanitizedPkg(pkg)
+	sanitizedPkg := getSanitizedModulePath(pkg)
 
 	splitPkg := strings.Split(sanitizedPkg, "/")
 

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1843,8 +1843,13 @@ func getRewritePath(pkg string, gopath string, depRoot string) string {
 	if depRoot != "" {
 		// Get the package name
 		// This is the value after "github.com/foo/bar"
-		pkgName := splitPkg[2]
-		depParts = append([]string{depRoot, pkgName, "sdk"})
+		repoName := splitPkg[2]
+		basePath := filepath.Base(sanitizedPkg)
+		if basePath == repoName {
+			depParts = append([]string{depRoot, repoName})
+		} else {
+			depParts = append([]string{depRoot, repoName, basePath})
+		}
 		return filepath.Join(depParts...)
 	}
 	depParts = append([]string{gopath, "src"}, splitPkg...)

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -68,13 +68,13 @@ func TestRunCommandLog(t *testing.T) {
 }
 
 func TestSanitizedPkg(t *testing.T) {
-	v2 := getSanitizedPkg("github.com/pulumi/pulumi-docker/sdk/v2")
+	v2 := getSanitizedModulePath("github.com/pulumi/pulumi-docker/sdk/v2")
 	assert.Equal(t, "github.com/pulumi/pulumi-docker/sdk", v2)
 
-	v3 := getSanitizedPkg("github.com/pulumi/pulumi-aws/sdk/v3")
+	v3 := getSanitizedModulePath("github.com/pulumi/pulumi-aws/sdk/v3")
 	assert.Equal(t, "github.com/pulumi/pulumi-aws/sdk", v3)
 
-	nonVersion := getSanitizedPkg("github.com/pulumi/pulumi-auth/sdk")
+	nonVersion := getSanitizedModulePath("github.com/pulumi/pulumi-auth/sdk")
 	assert.Equal(t, "github.com/pulumi/pulumi-auth/sdk", nonVersion)
 }
 

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -93,4 +93,9 @@ func TestDepRootCalc(t *testing.T) {
 	dep = getRewritePath("github.com/example/foo/v2", "/gopath", "/my-go-src")
 	assert.Equal(t, "/my-go-src/foo", dep)
 
+	dep = getRewritePath("github.com/example/foo", "/gopath", "/my-go-src")
+	assert.Equal(t, "/my-go-src/foo", dep)
+
+	dep = getRewritePath("github.com/pulumi/pulumi-auth0/sdk", "gopath", "/my-go-src")
+	assert.Equal(t, "/my-go-src/pulumi-auth0/sdk", dep)
 }

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -87,4 +87,10 @@ func TestDepRootCalc(t *testing.T) {
 	dep = getRewritePath("github.com/pulumi/pulumi-gcp/sdk/v3", "/gopath", "/my-go-src")
 	assert.Equal(t, "/my-go-src/pulumi-gcp/sdk", dep)
 
+	dep = getRewritePath("github.com/example/foo/pkg/v2", "/gopath", "/my-go-src")
+	assert.Equal(t, "/my-go-src/foo/pkg", dep)
+
+	dep = getRewritePath("github.com/example/foo/v2", "/gopath", "/my-go-src")
+	assert.Equal(t, "/my-go-src/foo", dep)
+
 }

--- a/pkg/testing/integration/program_test.go
+++ b/pkg/testing/integration/program_test.go
@@ -66,3 +66,25 @@ func TestRunCommandLog(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "output from node\n", string(output))
 }
+
+func TestSanitizedPkg(t *testing.T) {
+	v2 := getSanitizedPkg("github.com/pulumi/pulumi-docker/sdk/v2")
+	assert.Equal(t, "github.com/pulumi/pulumi-docker/sdk", v2)
+
+	v3 := getSanitizedPkg("github.com/pulumi/pulumi-aws/sdk/v3")
+	assert.Equal(t, "github.com/pulumi/pulumi-aws/sdk", v3)
+
+	nonVersion := getSanitizedPkg("github.com/pulumi/pulumi-auth/sdk")
+	assert.Equal(t, "github.com/pulumi/pulumi-auth/sdk", nonVersion)
+}
+
+func TestDepRootCalc(t *testing.T) {
+	var dep string
+
+	dep = getRewritePath("github.com/pulumi/pulumi-docker/sdk/v2", "/gopath", "")
+	assert.Equal(t, "/gopath/src/github.com/pulumi/pulumi-docker/sdk", dep)
+
+	dep = getRewritePath("github.com/pulumi/pulumi-gcp/sdk/v3", "/gopath", "/my-go-src")
+	assert.Equal(t, "/my-go-src/pulumi-gcp/sdk", dep)
+
+}


### PR DESCRIPTION
currently our go module replace logic during tests assumed we're going to use the `GOPATH` which is not always the case, especially in CI.

This commit introduces a new environment variable, `PULUMI_GO_DEP_ROOT` which can be set. If it is set, the `go mod replace` operation will look here for all the dependencies specified in `integration.ProgramTestOptions` instead of the `GOPATH`.

This is especially useful in `CI` because we might not always have control over the `GOPATH`.

Alongside this, I've updated the logic for detecting the version of the module to include more than just `v2` modules.