### PR TITLE
[codegen/python] Add ignorePyNamePanic PackageInfo flag

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1819,6 +1819,8 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info PackageInfo
 	seenTypes := codegen.Set{}
 	buildCaseMappingTables(pkg, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
 
+	ignorePyNamePanic = info.IgnorePyNamePanic
+
 	// group resources, types, and functions into modules
 	modules := map[string]*modContext{}
 

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -42,6 +42,9 @@ type PackageInfo struct {
 	Compatibility string `json:"compatibility,omitempty"`
 	// Indicates whether the package generates input/output classes.
 	UsesIOClasses bool `json:"usesIOClasses,omitempty"`
+	// Indicates whether the package should ignore if some name has a different
+	// result for PyName and PyNameLegacy.
+	IgnorePyNamePanic bool `json:"ignorePyNamePanic,omitempty"`
 }
 
 // Importer implements schema.Language for Python.

--- a/pkg/codegen/python/python.go
+++ b/pkg/codegen/python/python.go
@@ -42,6 +42,8 @@ var useLegacyName = codegen.StringSet{
 	"GetUptimeCheckIPs": struct{}{}, // GCP
 }
 
+var ignorePyNamePanic = false
+
 // excludeFromPanic are names that are ok to have different results from PyName and PyNameLegacy.
 var excludeFromPanic = codegen.StringSet{
 	// The following all show up as properties of nested input/output classes only, so it's OK that the current
@@ -70,13 +72,13 @@ var excludeFromPanic = codegen.StringSet{
 }
 
 // PyName turns a variable or function name, normally using camelCase, to an underscore_case name.
-// It panics if the result is different from PyNameLegacy, unless name is in excludeFromPanic, to help catch
-// unintended breaking changes.
+// It panics if the result is different from PyNameLegacy, unless name is in excludeFromPanic or
+// ignorePyNamePanic is true, to help catch unintended breaking changes.
 // TODO[pulumi/pulumi#5201]: Once all providers have been updated to use this version of the codegen (or later),
 // we can go back and remove the panic.
 func PyName(name string) string {
 	current := pyName(name, useLegacyName.Has(name))
-	if excludeFromPanic.Has(name) {
+	if ignorePyNamePanic || excludeFromPanic.Has(name) {
 		return current
 	}
 	legacy := PyNameLegacy(name)


### PR DESCRIPTION
Some names from CRDs (`emailSANs`, `uriSANs`) triggered the `PyName(...) != PyNameLegacy(...)` panic. I added a `ignorePyNamePanic` flag to the PackageInfo struct to ignore these panics. Once Issue #5201 gets resolved I will remove this.