### PR TITLE
Check for nil resource and invoke options in Go SDK

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -161,7 +161,9 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 
 	options := &invokeOptions{}
 	for _, o := range opts {
-		o.applyInvokeOption(options)
+		if o != nil {
+			o.applyInvokeOption(options)
+		}
 	}
 
 	var providerRef string
@@ -534,10 +536,7 @@ func applyTransformations(t, name string, props Input, resource Resource, opts [
 
 		res := transformation(args)
 		if res != nil {
-			resOptions := &resourceOptions{}
-			for _, o := range res.Opts {
-				o.applyResourceOption(resOptions)
-			}
+			resOptions := merge(res.Opts...)
 
 			if resOptions.Parent != nil && resOptions.Parent.URN() != options.Parent.URN() {
 				return nil, nil, nil, errors.New("transformations cannot currently be used to change the `parent` of a resource")

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -229,7 +229,9 @@ func (o resourceOrInvokeOption) applyInvokeOption(opts *invokeOptions) {
 func merge(opts ...ResourceOption) *resourceOptions {
 	options := &resourceOptions{}
 	for _, o := range opts {
-		o.applyResourceOption(options)
+		if o != nil {
+			o.applyResourceOption(options)
+		}
 	}
 	return options
 }


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi/issues/5269

Since our option types are interfaces, you can specify a nil value which will cause a panic. This change guards against that. 