### PR TITLE
[codegen/nodejs] Fix constructors to populate inputs on get

### DIFF
--- a/.github/workflows/codegen-test.yml
+++ b/.github/workflows/codegen-test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.11
+          python-version: 3.6.x
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install pulumictl
@@ -60,7 +60,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.11
+          python-version: 3.6.x
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install pulumictl
@@ -97,7 +97,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.11
+          python-version: 3.6.x
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install pulumictl
@@ -134,7 +134,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.11
+          python-version: 3.6.x
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install pulumictl
@@ -171,7 +171,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.11
+          python-version: 3.6.x
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install pulumictl
@@ -208,7 +208,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6.11
+          python-version: 3.6.x
       - name: Install Pulumi CLI
         uses: pulumi/action-install-pulumi-cli@releases/v1
       - name: Install pulumictl

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -569,7 +569,6 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 			}
 			// The get case:
 			fmt.Fprintf(w, "        } else {\n")
-			fmt.Fprintf(w, "            const args = argsOrState as %s | undefined;\n", argsType)
 			for _, prop := range r.Properties {
 				fmt.Fprintf(w, "            inputs[\"%[1]s\"] = undefined /*out*/;\n", prop.Name)
 			}

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -555,6 +555,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 			}
 			// The creation case (with args):
 			fmt.Fprintf(w, "        } else {\n")
+			fmt.Fprintf(w, "            const args = argsOrState as %s | undefined;\n", argsType)
 			err := genInputProps()
 			if err != nil {
 				return err


### PR DESCRIPTION
Related to https://github.com/pulumi/pulumi-kubernetes/issues/1280

Generates the following constructor for k8s ConfigMap:
```ts
    constructor(name: string, argsOrState?: ConfigMapArgs, opts?: pulumi.CustomResourceOptions) {
        let inputs: pulumi.Inputs = {};
        if (!(opts && opts.id)) {
            const args = argsOrState as ConfigMapArgs | undefined;
            inputs["apiVersion"] = "v1";
            inputs["binaryData"] = args ? args.binaryData : undefined;
            inputs["data"] = args ? args.data : undefined;
            inputs["immutable"] = args ? args.immutable : undefined;
            inputs["kind"] = "ConfigMap";
            inputs["metadata"] = args ? args.metadata : undefined;
        } else {
            inputs["apiVersion"] = undefined /*out*/;
            inputs["binaryData"] = undefined /*out*/;
            inputs["data"] = undefined /*out*/;
            inputs["immutable"] = undefined /*out*/;
            inputs["kind"] = undefined /*out*/;
            inputs["metadata"] = undefined /*out*/;
        }
        if (!opts) {
            opts = {}
        }

        if (!opts.version) {
            opts.version = utilities.getVersion();
        }
        super(ConfigMap.__pulumiType, name, inputs, opts);
    }
```