### PR TITLE
[codegen/nodejs] Fix omitted output properties in constructor

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -522,6 +522,13 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 			fmt.Fprintf(w, "%sinputs[\"%s\"] = %s;\n", prefix, prop.Name, arg)
 		}
 
+		for _, prop := range r.Properties {
+			prefix := "            "
+			if !ins.Has(prop.Name) {
+				fmt.Fprintf(w, "%sinputs[\"%s\"] = undefined /*out*/;\n", prefix, prop.Name)
+			}
+		}
+
 		return nil
 	}
 
@@ -584,11 +591,6 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	}
 	var secretProps []string
 	for _, prop := range r.Properties {
-		prefix := "            "
-		if !ins.Has(prop.Name) {
-			fmt.Fprintf(w, "%sinputs[\"%s\"] = undefined /*out*/;\n", prefix, prop.Name)
-		}
-
 		if prop.Secret {
 			secretProps = append(secretProps, prop.Name)
 		}


### PR DESCRIPTION
Changed the codegen in 6fd72dc0 but missed a condition that
is causing incorrect code in pulumi-kubernetes. This change
correctly generates inputs in both conditional branches.