### PR TITLE
Speed up doc generation by avoiding repeated python language import

### DIFF
--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -160,9 +160,11 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *sche
 
 // GenPropertyCaseMap generates the case maps for a property.
 func (d DocLanguageHelper) GenPropertyCaseMap(pkg *schema.Package, modName, tool string, prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string, seenTypes codegen.Set) {
-	if err := pkg.ImportLanguages(map[string]schema.Language{"python": Importer}); err != nil {
-		fmt.Printf("error building case map for %q in module %q", prop.Name, modName)
-		return
+	if _, imported := pkg.Language["python"]; !imported {
+		if err := pkg.ImportLanguages(map[string]schema.Language{"python": Importer}); err != nil {
+			fmt.Printf("error building case map for %q in module %q", prop.Name, modName)
+			return
+		}
 	}
 
 	recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/5184

Repeated imports seem to really slow down doc generation as discovered by @mikhailshilkov in associated ticket.