### PR TITLE
[codegen/python] Emit array types as Sequence[T] instead of List[T]

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -219,7 +219,7 @@ func (mod *modContext) genHeader(w io.Writer, needsSDK, needsJSON bool, imports 
 		fmt.Fprintf(w, "import warnings\n")
 		fmt.Fprintf(w, "import pulumi\n")
 		fmt.Fprintf(w, "import pulumi.runtime\n")
-		fmt.Fprintf(w, "from typing import Any, Dict, List, Mapping, Optional, Tuple, Union\n")
+		fmt.Fprintf(w, "from typing import Any, Mapping, Optional, Sequence, Union\n")
 		fmt.Fprintf(w, "from %s import _utilities, _tables\n", relImport)
 		for _, imp := range imports.strings() {
 			fmt.Fprintf(w, "%s\n", imp)
@@ -1492,7 +1492,7 @@ func (mod *modContext) typeString(t schema.Type, input, wrapInput, optional, acc
 	var typ string
 	switch t := t.(type) {
 	case *schema.ArrayType:
-		typ = fmt.Sprintf("List[%s]", mod.typeString(t.ElementType, input, wrapInput, false, acceptMapping))
+		typ = fmt.Sprintf("Sequence[%s]", mod.typeString(t.ElementType, input, wrapInput, false, acceptMapping))
 	case *schema.MapType:
 		typ = fmt.Sprintf("Mapping[str, %s]", mod.typeString(t.ElementType, input, wrapInput, false, acceptMapping))
 	case *schema.ObjectType:


### PR DESCRIPTION
https://github.com/pulumi/pulumi/pull/5282 needs to be released before any providers adopting this change are released.

We currently emit array types as `List[T]` for Python, but `List[T]` is invariant, which causes type checkers like mypy to produce errors when values like `["foo", "bar"]` are passed as args typed as `List[pulumi.Input[str]]` (since `Input[str]` is an alias for `Union[T, Awaitable[T], Output[T]]`. To address this, we should move to using [`Sequence[T]`](https://docs.python.org/3/library/typing.html#typing.Sequence) which is covariant, and does not have this problem.

We actually already do this for `Dict` vs. `Mapping`, emitting map types as `Mapping[str, T]` rather than `Dict[str, T]` because `Mapping[str, T]` is covariant for the value. This change makes us consistent for array types.

These are the codegen changes to emit `Sequence[T]` rather than `List[T]`

Part of https://github.com/pulumi/pulumi/issues/5278