### PR TITLE
Update Go plugin acquisition to work for users who vendor dependencies

### DIFF
--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -191,7 +191,7 @@ func (host *goLanguageHost) GetRequiredPlugins(ctx context.Context,
 	}
 
 	// don't wire up stderr so non-module users don't see error output from list
-	cmd := exec.Command(gobin, "list", "-m", "-json", "all")
+	cmd := exec.Command(gobin, "list", "-m", "-json", "-mod=mod", "all")
 	cmd.Env = os.Environ()
 
 	stdout, err := cmd.Output()


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/5281

Tested plugin acquisition manually on vendored and non-vendored projects and it works as expected on both. 