### PR TITLE
[sdk/python] Add pulumi.runtime.to_json utility

### DIFF
--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -44,3 +44,7 @@ from .stack import (
 from .invoke import (
     invoke,
 )
+
+from ._json import (
+    to_json,
+)

--- a/sdk/python/lib/pulumi/runtime/_json.py
+++ b/sdk/python/lib/pulumi/runtime/_json.py
@@ -1,0 +1,45 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import abc
+import json
+from typing import Any
+
+from .. import _types
+
+
+def _to_json_serializable_obj(obj: Any) -> Any:
+    """
+    Convert `obj` into an object suitable for JSON serialization, converting input types into dicts.
+    """
+    # Exclude some built-in types that are instances of Sequence that we don't want to treat as sequences here.
+    # From: https://github.com/python/cpython/blob/master/Lib/_collections_abc.py
+    if isinstance(obj, abc.Sequence) and not isinstance(obj, (tuple, str, range, memoryview, bytes, bytearray)):
+        return [_to_json_serializable_obj(v) for v in obj]
+
+    if _types.is_input_type(type(obj)):
+        obj = _types.input_type_to_dict(obj)
+
+    if isinstance(obj, abc.Mapping):
+        return {k: _to_json_serializable_obj(v) for k, v in obj.items()}
+
+    return obj
+
+
+def to_json(obj: Any) -> str:
+    """
+    Serialize `obj` to a JSON formatted `str`.
+    """
+    serializable_obj = _to_json_serializable_obj(obj)
+    return json.dumps(serializable_obj)

--- a/sdk/python/lib/test/test_runtime_to_json.py
+++ b/sdk/python/lib/test/test_runtime_to_json.py
@@ -1,0 +1,53 @@
+# Copyright 2016-2020, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from typing import Mapping, Optional, Sequence
+
+import pulumi
+from pulumi.runtime import to_json
+
+class ToJSONTests(unittest.TestCase):
+    def test_to_json_basic_types(self):
+        self.assertEqual('{}', to_json({}))
+        self.assertEqual('[]', to_json([]))
+        self.assertEqual('"hello"', to_json("hello"))
+        self.assertEqual('42', to_json(42))
+        self.assertEqual('{"hello": 42}', to_json({"hello": 42}))
+        self.assertEqual('[1, 2, 3]', to_json([1, 2, 3]))
+        self.assertEqual('["a", "b", "c"]', to_json(["a", "b", "c"]))
+        self.assertEqual('{"hello": [1, 2, 3]}', to_json({"hello": [1, 2, 3]}))
+        self.assertEqual('[{"hello": 42}]', to_json([{"hello": 42}]))
+
+    def test_to_json_basic_input_type(self):
+        @pulumi.input_type
+        class ProviderAssumeRoleArgs:
+            role_arn: Optional[pulumi.Input[str]] = pulumi.property("roleArn")
+            tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]
+
+        assume_role = ProviderAssumeRoleArgs(role_arn="some-arn", tags={"hello": "world"})
+        self.assertEqual('{"roleArn": "some-arn", "tags": {"hello": "world"}}', to_json(assume_role))
+
+    def test_to_json_nested_input_type(self):
+        @pulumi.input_type
+        class ProviderFeaturesNetworkArgs:
+            relaxed_locking: Optional[pulumi.Input[bool]] = pulumi.property("relaxedLocking")
+
+        @pulumi.input_type
+        class ProviderFeaturesArgs:
+            network: Optional[pulumi.Input[ProviderFeaturesNetworkArgs]]
+
+        features = ProviderFeaturesArgs(network=ProviderFeaturesNetworkArgs(relaxed_locking=False))
+        self.assertEqual('{"network": {"relaxedLocking": false}}', to_json(features))


### PR DESCRIPTION
Non-string provider inputs must be projected as JSON formatted strings. The current codegen simply calls `json.dumps` for such properties, but this does not work for the new input types, which aren't JSON serializable.

This commit adds a new `pulumi.runtime.to_json` utility function to the core SDK, which is capable of serializing both raw dicts and input types as JSON. The codegen will be updated to make use of this new function rather than `json.dumps`.

It's exposed from `pulumi.runtime` rather than `pulumi` because it isn't really meant to be used directly by users, but rather from our generated code. Being under `pulumi.runtime` seems sufficiently "hidden" from common use. I decided to add this utility to the SDK, as I didn't want to expose `is_input_type` and `input_type_to_dict` just yet (though, it may be useful to expose them eventually).

Codegen PR: https://github.com/pulumi/pulumi/pull/5308

Part of https://github.com/pulumi/pulumi/issues/5212