### PR TITLE
[codegen/dotnet] Don't append Result to mixed output type names

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -1473,14 +1473,20 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info CSharpPacka
 		mod.functions = append(mod.functions, f)
 		if f.Inputs != nil {
 			visitObjectTypes(f.Inputs, func(t *schema.ObjectType) {
-				getModFromToken(t.Token).details(t).inputType = true
-				getModFromToken(t.Token).details(t).functionType = true
+				details := getModFromToken(t.Token).details(t)
+				if !details.inputType {
+					details.inputType = true
+					details.functionType = true
+				}
 			})
 		}
 		if f.Outputs != nil {
 			visitObjectTypes(f.Outputs, func(t *schema.ObjectType) {
-				getModFromToken(t.Token).details(t).outputType = true
-				getModFromToken(t.Token).details(t).functionType = true
+				details := getModFromToken(t.Token).details(t)
+				if !details.outputType {
+					details.outputType = true
+					details.functionType = true
+				}
 			})
 		}
 	}


### PR DESCRIPTION
Problem: every output class in AzureRM .NET SDK gets "Result" appended to its name. That's because the same types are used for both resources and corresponding invokes.

This PR stops appending "Result" for types that service both resources and functions. The input type change is for symmetry and shouldn't affect any existing provider.

AFAIK, this change does not affect TF-based providers (tried with Azure locally).