### PR TITLE
Add `pulumi console` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ CHANGELOG
 - Automation API - add recovery APIs (cancel/export/import)
   [#5369](https://github.com/pulumi/pulumi/pull/5369)
 
+- Add `pulumi console` command which  opens the currently selected stack in the Pulumi console.
+  [#5368](https://github.com/pulumi/pulumi/pull/5368)
+
 ## 2.10.0 (2020-09-10)
 
 - feat(autoapi): add Upsert methods for stacks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - [sdk/go] Add missing Version field to invokeOptions
   [#5401](https://github.com/pulumi/pulumi/pull/5401)
 
+- Add `pulumi console` command which opens the currently selected stack in the Pulumi console.
+  [#5368](https://github.com/pulumi/pulumi/pull/5368)
+
 ## 2.10.1 (2020-09-16)
 
 - feat(autoapi): add GetPermalink for operation result
@@ -34,9 +37,6 @@ CHANGELOG
 
 - Automation API - add recovery APIs (cancel/export/import)
   [#5369](https://github.com/pulumi/pulumi/pull/5369)
-
-- Add `pulumi console` command which opens the currently selected stack in the Pulumi console.
-  [#5368](https://github.com/pulumi/pulumi/pull/5368)
 
 ## 2.10.0 (2020-09-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ CHANGELOG
 - Automation API - add recovery APIs (cancel/export/import)
   [#5369](https://github.com/pulumi/pulumi/pull/5369)
 
-- Add `pulumi console` command which  opens the currently selected stack in the Pulumi console.
+- Add `pulumi console` command which opens the currently selected stack in the Pulumi console.
   [#5368](https://github.com/pulumi/pulumi/pull/5368)
 
 ## 2.10.0 (2020-09-10)

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -1,0 +1,81 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/skratchdot/open-golang/open"
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/pkg/v2/backend/display"
+	"github.com/pulumi/pulumi/pkg/v2/backend/httpstate"
+	"github.com/pulumi/pulumi/pkg/v2/backend/state"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/cmdutil"
+)
+
+func newConsoleCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "console",
+		Short: "Opens the current stack in the Pulumi console",
+		Args:  cmdutil.NoArgs,
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			opts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+			backend, err := currentBackend(opts)
+			if err != nil {
+				return err
+			}
+			stack, err := state.CurrentStack(commandContext(), backend)
+			if err != nil {
+				return err
+			}
+
+			// Do a type assertion in order to determine if this is a cloud backend based on whether the assertion
+			// succeeds or not.
+			cloudBackend, isCloud := backend.(httpstate.Backend)
+			if isCloud {
+				// Open the stack specific URL (e.g. app.pulumi.com/{org}/{project}/{stack}) for this
+				// stack if a stack is selected and is a cloud stack, else open the cloud backend URL
+				// home page, e.g. app.pulumi.com.
+				if s, ok := stack.(httpstate.Stack); ok {
+					if consoleURL, err := s.ConsoleURL(); err == nil {
+						launchConsole(consoleURL)
+					} else {
+						// Open the cloud backend home page if retrieving the stack
+						// console URL fails.
+						launchConsole(cloudBackend.URL())
+					}
+				} else {
+					launchConsole(cloudBackend.URL())
+				}
+				return nil
+			}
+			fmt.Println("This command is currently only supported when using a Pulumi managed backend" +
+				"For more information please visit, https://www.pulumi.com/pricing")
+			return nil
+		}),
+	}
+	return cmd
+}
+
+// launchConsole attmepts to open the console in the browser using the specified URL.
+func launchConsole(url string) {
+	if openErr := open.Run(url); openErr != nil {
+		fmt.Printf("We couldn't launch your web browser for some reason. \n"+
+			"Please visit: %s", url)
+	}
+}

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -65,7 +65,7 @@ func newConsoleCmd() *cobra.Command {
 				return nil
 			}
 			fmt.Println("This command is not available for your backend. " +
-				"To migrate to the Pulumi managed backend, " +
+				"To migrate to the Pulumi Service backend, " +
 				"please see https://www.pulumi.com/docs/intro/concepts/state/#adopting-the-pulumi-service-backend")
 			return nil
 		}),
@@ -73,7 +73,7 @@ func newConsoleCmd() *cobra.Command {
 	return cmd
 }
 
-// launchConsole attmepts to open the console in the browser using the specified URL.
+// launchConsole attempts to open the console in the browser using the specified URL.
 func launchConsole(url string) {
 	if openErr := open.Run(url); openErr != nil {
 		fmt.Printf("We couldn't launch your web browser for some reason. \n"+

--- a/pkg/cmd/pulumi/console.go
+++ b/pkg/cmd/pulumi/console.go
@@ -29,7 +29,7 @@ import (
 func newConsoleCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "console",
-		Short: "Opens the current stack in the Pulumi console",
+		Short: "Opens the current stack in the Pulumi Console",
 		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			opts := display.Options{
@@ -64,8 +64,9 @@ func newConsoleCmd() *cobra.Command {
 				}
 				return nil
 			}
-			fmt.Println("This command is currently only supported when using a Pulumi managed backend" +
-				"For more information please visit, https://www.pulumi.com/pricing")
+			fmt.Println("This command is not available for your backend. " +
+				"To migrate to the Pulumi managed backend, " +
+				"please see https://www.pulumi.com/docs/intro/concepts/state/#adopting-the-pulumi-service-backend")
 			return nil
 		}),
 	}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -207,6 +207,7 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.AddCommand(newPluginCmd())
 	cmd.AddCommand(newVersionCmd())
 	cmd.AddCommand(newHistoryCmd())
+	cmd.AddCommand(newConsoleCmd())
 
 	// Less common, and thus hidden, commands:
 	cmd.AddCommand(newGenCompletionCmd(cmd))


### PR DESCRIPTION
Adding the `pulumi console` command to open console url for the current stack.

I am currently looking into the "nice to have" feature called out in the issue to open the most recent update, but for now here is the base functionality. If it is a lot more work, I'll break it off to a separate issue just to keep things moving.

Resolves: #5233