### PR TITLE
Automation API - add recovery APIs (cancel/export/import)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ CHANGELOG
 - Automation API - support streaming output for Up/Refresh/Destroy operations.
   [#5367](https://github.com/pulumi/pulumi/pull/5367)
 
+- Automation API - add recovery APIs (cancel/export/import)
+  [#5369](https://github.com/pulumi/pulumi/pull/5369)
+
 ## 2.10.0 (2020-09-10)
 
 - feat(autoapi): add Upsert methods for stacks

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -70,7 +70,7 @@ func newCancelCmd() *cobra.Command {
 			// Ensure the user really wants to do this.
 			stackName := string(s.Ref().Name())
 			prompt := fmt.Sprintf("This will irreversibly cancel the currently running update for '%s'!", stackName)
-			if !yes && !confirmPrompt(prompt, stackName, opts) {
+			if cmdutil.Interactive() && (!yes && !confirmPrompt(prompt, stackName, opts)) {
 				fmt.Println("confirmation declined")
 				return result.Bail()
 			}

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -1005,6 +1005,78 @@ func TestProgressStreams(t *testing.T) {
 	assert.Equal(t, desOut.String(), dRes.StdOut, "expected stdout writers to contain same contents")
 }
 
+func TestImportExportStack(t *testing.T) {
+	ctx := context.Background()
+	sName := fmt.Sprintf("int_test%d", rangeIn(10000000, 99999999))
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
+	cfg := ConfigMap{
+		"bar": ConfigValue{
+			Value: "abc",
+		},
+		"buzz": ConfigValue{
+			Value:  "secret",
+			Secret: true,
+		},
+	}
+
+	// initialize
+	s, err := NewStackInlineSource(ctx, stackName, pName, func(ctx *pulumi.Context) error {
+		c := config.New(ctx, "")
+		ctx.Export("exp_static", pulumi.String("foo"))
+		ctx.Export("exp_cfg", pulumi.String(c.Get("bar")))
+		ctx.Export("exp_secret", c.GetSecret("buzz"))
+		return nil
+	})
+	if err != nil {
+		t.Errorf("failed to initialize stack, err: %v", err)
+		t.FailNow()
+	}
+
+	defer func() {
+		// -- pulumi stack rm --
+		err = s.Workspace().RemoveStack(ctx, s.Name())
+		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
+	}()
+
+	err = s.SetAllConfig(ctx, cfg)
+	if err != nil {
+		t.Errorf("failed to set config, err: %v", err)
+		t.FailNow()
+	}
+
+	// -- pulumi up --
+	_, err = s.Up(ctx)
+	if err != nil {
+		t.Errorf("up failed, err: %v", err)
+		t.FailNow()
+	}
+
+	// -- pulumi stack export --
+	state, err := s.Export(ctx)
+	if err != nil {
+		t.Errorf("export failed, err: %v", err)
+		t.FailNow()
+	}
+
+	// -- pulumi stack import --
+	err = s.Import(ctx, state)
+	if err != nil {
+		t.Errorf("import failed, err: %v", err)
+		t.FailNow()
+	}
+
+	// -- pulumi destroy --
+
+	dRes, err := s.Destroy(ctx)
+	if err != nil {
+		t.Errorf("destroy failed, err: %v", err)
+		t.FailNow()
+	}
+
+	assert.Equal(t, "destroy", dRes.Summary.Kind)
+	assert.Equal(t, "succeeded", dRes.Summary.Result)
+}
+
 func getTestOrg() string {
 	testOrg := "pulumi-test"
 	if _, set := os.LookupEnv("PULUMI_TEST_ORG"); set {

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -575,6 +575,36 @@ func (s *Stack) Info(ctx context.Context) (StackSummary, error) {
 	return info, nil
 }
 
+// Cancel stops a stack's currently running update. It returns an error if no update is currently running.
+// Note that this operation is _very dangerous_, and may leave the stack in an inconsistent state
+// if a resource operation was pending when the update was canceled.
+// This command is not supported for local backends.
+func (s *Stack) Cancel(ctx context.Context) error {
+	err := s.Workspace().SelectStack(ctx, s.Name())
+	if err != nil {
+		return errors.Wrap(err, "failed to cancel update")
+	}
+
+	stdout, stderr, errCode, err := s.runPulumiCmdSync(ctx, nil /* additionalOutput */, "cancel", "--yes")
+	if err != nil {
+		return newAutoError(errors.Wrap(err, "failed to cancel update"), stdout, stderr, errCode)
+	}
+
+	return nil
+}
+
+// Export exports the deployment state of the stack.
+// This can be combined with Stack.Import to edit a stack's state (such as recovery from failed deployments).
+func (s *Stack) Export(ctx context.Context) (apitype.UntypedDeployment, error) {
+	return s.Workspace().ExportStack(ctx, s.Name())
+}
+
+// Import imports the specified deployment state into the stack.
+// This can be combined with Stack.Export to edit a stack's state (such as recovery from failed deployments).
+func (s *Stack) Import(ctx context.Context, state apitype.UntypedDeployment) error {
+	return s.Workspace().ImportStack(ctx, s.Name(), state)
+}
+
 // UpdateSummary provides a summary of a Stack lifecycle operation (up/preview/refresh/destroy).
 type UpdateSummary struct {
 	Kind        string            `json:"kind"`

--- a/sdk/go/x/auto/workspace.go
+++ b/sdk/go/x/auto/workspace.go
@@ -17,6 +17,7 @@ package auto
 import (
 	"context"
 
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
@@ -96,6 +97,12 @@ type Workspace interface {
 	Program() pulumi.RunFunc
 	// SetProgram sets the program associated with the Workspace to the specified `pulumi.RunFunc`.
 	SetProgram(pulumi.RunFunc)
+	// ExportStack exports the deployment state of the stack matching the given name.
+	// This can be combined with ImportStack to edit a stack's state (such as recovery from failed deployments).
+	ExportStack(context.Context, string) (apitype.UntypedDeployment, error)
+	// ImportStack imports the specified deployment state into a pre-existing stack.
+	// This can be combined with ExportStack to edit a stack's state (such as recovery from failed deployments).
+	ImportStack(context.Context, string, apitype.UntypedDeployment) error
 }
 
 // ConfigValue is a configuration value used by a Pulumi program.


### PR DESCRIPTION
This PR provides coverage over the Pulumi "recovery" APIs. `pulumi cancel` `pulumi stack export` `pulumi stack import`. We'll improve our story over time, but for now, we'll start with exposing the existing tools. 

Note that I exposed import/export as workspace level operations as their implementation requires intermediate on-disk files (this is the characteristic that defines local workspace). We can revise this in the future by extending the command to accept JSON input from a flag. 

Closes: https://github.com/pulumi/pulumi/issues/5362
Closes: https://github.com/pulumi/pulumi/issues/5296