### PR TITLE
[codegen] Adjust Go/Python package naming for Azure NextGen

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -992,7 +992,7 @@ func (pkg *pkgContext) genHeader(w io.Writer, goImports []string, importedPackag
 
 	var pkgName string
 	if pkg.mod == "" {
-		pkgName = pkg.pkg.Name
+		pkgName = goPackage(pkg.pkg.Name)
 	} else {
 		pkgName = path.Base(pkg.mod)
 	}
@@ -1274,7 +1274,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 
 	files := map[string][]byte{}
 	setFile := func(relPath, contents string) {
-		relPath = path.Join(pkg.Name, relPath)
+		relPath = path.Join(goPackage(pkg.Name), relPath)
 		if _, ok := files[relPath]; ok {
 			panic(errors.Errorf("duplicate file: %s", relPath))
 		}
@@ -1288,7 +1288,7 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 		files[relPath] = formattedSource
 	}
 
-	name := pkg.Name
+	name := goPackage(pkg.Name)
 	for _, mod := range pkgMods {
 		pkg := packages[mod]
 
@@ -1377,6 +1377,11 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 	}
 
 	return files, nil
+}
+
+// goPackage returns the suggested package name for the given string.
+func goPackage(name string) string {
+	return strings.Split(name, "-")[0]
 }
 
 const utilitiesFile = `

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -35,3 +35,8 @@ func TestInputUsage(t *testing.T) {
 			" of `FooInput` via:\n\n\t\t FooArgs{...}\n ",
 		usage)
 }
+
+func TestGoPackageName(t *testing.T) {
+	assert.Equal(t, "aws", goPackage("aws"))
+	assert.Equal(t, "azure", goPackage("azure-nextgen"))
+}

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -39,4 +39,5 @@ func TestInputUsage(t *testing.T) {
 func TestGoPackageName(t *testing.T) {
 	assert.Equal(t, "aws", goPackage("aws"))
 	assert.Equal(t, "azure", goPackage("azure-nextgen"))
+	assert.Equal(t, "", goPackage(""))
 }

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1590,7 +1590,7 @@ func isStringType(t schema.Type) bool {
 
 // pyPack returns the suggested package name for the given string.
 func pyPack(s string) string {
-	return "pulumi_" + s
+	return "pulumi_" + strings.ReplaceAll(s, "-", "_")
 }
 
 // pyClassName turns a raw name into one that is suitable as a Python class name.


### PR DESCRIPTION
No other providers use dashes in their names except the new `azure-nextgen` one. This PR normalizes the folder structure 

- In Go, the package `azure` gets generated (the module is still `azure-nextgen`
- In Python, the module is `pulumi_azure_nextgen`