### PR TITLE
[codegen/schema] - Expand ObjectTypeSpec to ComplexTypeSpec

### DIFF
--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -66,7 +66,7 @@ func initTestPackageSpec(t *testing.T) {
 		Meta: &schema.MetadataSpec{
 			ModuleFormat: "(.*)(?:/[^/]*)",
 		},
-		Types: map[string]schema.ObjectTypeSpec{
+		Types: map[string]schema.ComplexTypeSpec{
 			// Package-level types.
 			"prov:/getPackageResourceOptions:getPackageResourceOptions": {
 				Description: "Options object for the package-level function getPackageResource.",
@@ -123,7 +123,7 @@ func initTestPackageSpec(t *testing.T) {
 		},
 		Resources: map[string]schema.ResourceSpec{
 			"prov:module/resource:Resource": {
-				ObjectTypeSpec: schema.ObjectTypeSpec{
+				ComplexTypeSpec: schema.ComplexTypeSpec{
 					Description: `This is a module-level resource called Resource.
 {{% examples %}}
 ## Example Usage
@@ -189,7 +189,7 @@ func initTestPackageSpec(t *testing.T) {
 				},
 			},
 			"prov:/packageLevelResource:PackageLevelResource": {
-				ObjectTypeSpec: schema.ObjectTypeSpec{
+				ComplexTypeSpec: schema.ComplexTypeSpec{
 					Description: "This is a package-level resource.",
 				},
 				InputProperties: map[string]schema.PropertySpec{
@@ -206,7 +206,7 @@ func initTestPackageSpec(t *testing.T) {
 			// Package-level Functions.
 			"prov:/getPackageResource:getPackageResource": {
 				Description: "A package-level function.",
-				Inputs: &schema.ObjectTypeSpec{
+				Inputs: &schema.ComplexTypeSpec{
 					Description: "Inputs for getPackageResource.",
 					Type:        "object",
 					Properties: map[string]schema.PropertySpec{
@@ -217,7 +217,7 @@ func initTestPackageSpec(t *testing.T) {
 						},
 					},
 				},
-				Outputs: &schema.ObjectTypeSpec{
+				Outputs: &schema.ComplexTypeSpec{
 					Description: "Outputs for getPackageResource.",
 					Properties:  simpleProperties,
 					Type:        "object",
@@ -227,7 +227,7 @@ func initTestPackageSpec(t *testing.T) {
 			// Module-level Functions.
 			"prov:module/getModuleResource:getModuleResource": {
 				Description: "A module-level function.",
-				Inputs: &schema.ObjectTypeSpec{
+				Inputs: &schema.ComplexTypeSpec{
 					Description: "Inputs for getModuleResource.",
 					Type:        "object",
 					Properties: map[string]schema.PropertySpec{
@@ -238,7 +238,7 @@ func initTestPackageSpec(t *testing.T) {
 						},
 					},
 				},
-				Outputs: &schema.ObjectTypeSpec{
+				Outputs: &schema.ComplexTypeSpec{
 					Description: "Outputs for getModuleResource.",
 					Properties:  simpleProperties,
 					Type:        "object",

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -69,53 +69,61 @@ func initTestPackageSpec(t *testing.T) {
 		Types: map[string]schema.ComplexTypeSpec{
 			// Package-level types.
 			"prov:/getPackageResourceOptions:getPackageResourceOptions": {
-				Description: "Options object for the package-level function getPackageResource.",
-				Type:        "object",
-				Properties:  simpleProperties,
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "Options object for the package-level function getPackageResource.",
+					Type:        "object",
+					Properties:  simpleProperties,
+				},
 			},
 
 			// Module-level types.
 			"prov:module/getModuleResourceOptions:getModuleResourceOptions": {
-				Description: "Options object for the module-level function getModuleResource.",
-				Type:        "object",
-				Properties:  simpleProperties,
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "Options object for the module-level function getModuleResource.",
+					Type:        "object",
+					Properties:  simpleProperties,
+				},
 			},
 			"prov:module/ResourceOptions:ResourceOptions": {
-				Description: "The resource options object.",
-				Type:        "object",
-				Properties: map[string]schema.PropertySpec{
-					"stringProp": {
-						Description: "A string prop.",
-						Language:    pythonMapCase,
-						TypeSpec: schema.TypeSpec{
-							Type: "string",
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "The resource options object.",
+					Type:        "object",
+					Properties: map[string]schema.PropertySpec{
+						"stringProp": {
+							Description: "A string prop.",
+							Language:    pythonMapCase,
+							TypeSpec: schema.TypeSpec{
+								Type: "string",
+							},
 						},
-					},
-					"boolProp": {
-						Description: "A bool prop.",
-						Language:    pythonMapCase,
-						TypeSpec: schema.TypeSpec{
-							Type: "boolean",
+						"boolProp": {
+							Description: "A bool prop.",
+							Language:    pythonMapCase,
+							TypeSpec: schema.TypeSpec{
+								Type: "boolean",
+							},
 						},
-					},
-					"recursiveType": {
-						Description: "I am a recursive type.",
-						Language:    pythonMapCase,
-						TypeSpec: schema.TypeSpec{
-							Ref: "#/types/prov:module/ResourceOptions:ResourceOptions",
+						"recursiveType": {
+							Description: "I am a recursive type.",
+							Language:    pythonMapCase,
+							TypeSpec: schema.TypeSpec{
+								Ref: "#/types/prov:module/ResourceOptions:ResourceOptions",
+							},
 						},
 					},
 				},
 			},
 			"prov:module/ResourceOptions2:ResourceOptions2": {
-				Description: "The resource options object.",
-				Type:        "object",
-				Properties: map[string]schema.PropertySpec{
-					"uniqueProp": {
-						Description: "This is a property unique to this type.",
-						Language:    pythonMapCase,
-						TypeSpec: schema.TypeSpec{
-							Type: "number",
+				ObjectTypeSpec: schema.ObjectTypeSpec{
+					Description: "The resource options object.",
+					Type:        "object",
+					Properties: map[string]schema.PropertySpec{
+						"uniqueProp": {
+							Description: "This is a property unique to this type.",
+							Language:    pythonMapCase,
+							TypeSpec: schema.TypeSpec{
+								Type: "number",
+							},
 						},
 					},
 				},
@@ -123,7 +131,7 @@ func initTestPackageSpec(t *testing.T) {
 		},
 		Resources: map[string]schema.ResourceSpec{
 			"prov:module/resource:Resource": {
-				ComplexTypeSpec: schema.ComplexTypeSpec{
+				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Description: `This is a module-level resource called Resource.
 {{% examples %}}
 ## Example Usage
@@ -189,7 +197,7 @@ func initTestPackageSpec(t *testing.T) {
 				},
 			},
 			"prov:/packageLevelResource:PackageLevelResource": {
-				ComplexTypeSpec: schema.ComplexTypeSpec{
+				ObjectTypeSpec: schema.ObjectTypeSpec{
 					Description: "This is a package-level resource.",
 				},
 				InputProperties: map[string]schema.PropertySpec{
@@ -206,7 +214,7 @@ func initTestPackageSpec(t *testing.T) {
 			// Package-level Functions.
 			"prov:/getPackageResource:getPackageResource": {
 				Description: "A package-level function.",
-				Inputs: &schema.ComplexTypeSpec{
+				Inputs: &schema.ObjectTypeSpec{
 					Description: "Inputs for getPackageResource.",
 					Type:        "object",
 					Properties: map[string]schema.PropertySpec{
@@ -217,7 +225,7 @@ func initTestPackageSpec(t *testing.T) {
 						},
 					},
 				},
-				Outputs: &schema.ComplexTypeSpec{
+				Outputs: &schema.ObjectTypeSpec{
 					Description: "Outputs for getPackageResource.",
 					Properties:  simpleProperties,
 					Type:        "object",
@@ -227,7 +235,7 @@ func initTestPackageSpec(t *testing.T) {
 			// Module-level Functions.
 			"prov:module/getModuleResource:getModuleResource": {
 				Description: "A module-level function.",
-				Inputs: &schema.ComplexTypeSpec{
+				Inputs: &schema.ObjectTypeSpec{
 					Description: "Inputs for getModuleResource.",
 					Type:        "object",
 					Properties: map[string]schema.PropertySpec{
@@ -238,7 +246,7 @@ func initTestPackageSpec(t *testing.T) {
 						},
 					},
 				},
-				Outputs: &schema.ComplexTypeSpec{
+				Outputs: &schema.ObjectTypeSpec{
 					Description: "Outputs for getModuleResource.",
 					Properties:  simpleProperties,
 					Type:        "object",

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -28,7 +28,7 @@ var testPackageSpec = schema.PackageSpec{
 	Meta: &schema.MetadataSpec{
 		ModuleFormat: "(.*)(?:/[^/]*)",
 	},
-	Types: map[string]schema.ObjectTypeSpec{
+	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			Description: "The resource options object.",
 			Type:        "object",

--- a/pkg/codegen/dotnet/doc_test.go
+++ b/pkg/codegen/dotnet/doc_test.go
@@ -30,13 +30,15 @@ var testPackageSpec = schema.PackageSpec{
 	},
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
-			Description: "The resource options object.",
-			Type:        "object",
-			Properties: map[string]schema.PropertySpec{
-				"stringProp": {
-					Description: "A string prop.",
-					TypeSpec: schema.TypeSpec{
-						Type: "string",
+			ObjectTypeSpec: schema.ObjectTypeSpec{
+				Description: "The resource options object.",
+				Type:        "object",
+				Properties: map[string]schema.PropertySpec{
+					"stringProp": {
+						Description: "A string prop.",
+						TypeSpec: schema.TypeSpec{
+							Type: "string",
+						},
 					},
 				},
 			},

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -34,13 +34,15 @@ var testPackageSpec = schema.PackageSpec{
 	},
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
-			Description: "The resource options object.",
-			Type:        "object",
-			Properties: map[string]schema.PropertySpec{
-				"stringProp": {
-					Description: "A string prop.",
-					TypeSpec: schema.TypeSpec{
-						Type: "string",
+			ObjectTypeSpec: schema.ObjectTypeSpec{
+				Description: "The resource options object.",
+				Type:        "object",
+				Properties: map[string]schema.PropertySpec{
+					"stringProp": {
+						Description: "A string prop.",
+						TypeSpec: schema.TypeSpec{
+							Type: "string",
+						},
 					},
 				},
 			},

--- a/pkg/codegen/go/doc_test.go
+++ b/pkg/codegen/go/doc_test.go
@@ -32,7 +32,7 @@ var testPackageSpec = schema.PackageSpec{
 	Meta: &schema.MetadataSpec{
 		ModuleFormat: "(.*)(?:/[^/]*)",
 	},
-	Types: map[string]schema.ObjectTypeSpec{
+	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			Description: "The resource options object.",
 			Type:        "object",

--- a/pkg/codegen/nodejs/doc_test.go
+++ b/pkg/codegen/nodejs/doc_test.go
@@ -31,7 +31,7 @@ var testPackageSpec = schema.PackageSpec{
 	Meta: &schema.MetadataSpec{
 		ModuleFormat: "(.*)(?:/[^/]*)",
 	},
-	Types: map[string]schema.ObjectTypeSpec{
+	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
 			Description: "The resource options object.",
 			Type:        "object",

--- a/pkg/codegen/nodejs/doc_test.go
+++ b/pkg/codegen/nodejs/doc_test.go
@@ -33,13 +33,15 @@ var testPackageSpec = schema.PackageSpec{
 	},
 	Types: map[string]schema.ComplexTypeSpec{
 		"aws:s3/BucketCorsRule:BucketCorsRule": {
-			Description: "The resource options object.",
-			Type:        "object",
-			Properties: map[string]schema.PropertySpec{
-				"stringProp": {
-					Description: "A string prop.",
-					TypeSpec: schema.TypeSpec{
-						Type: "string",
+			ObjectTypeSpec: schema.ObjectTypeSpec{
+				Description: "The resource options object.",
+				Type:        "object",
+				Properties: map[string]schema.PropertySpec{
+					"stringProp": {
+						Description: "A string prop.",
+						TypeSpec: schema.TypeSpec{
+							Type: "string",
+						},
 					},
 				},
 			},

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -128,6 +128,18 @@ func (t *ArrayType) String() string {
 
 func (*ArrayType) isType() {}
 
+// EnumType represents an enum.
+type EnumType struct {
+	// ElementType is the element type of the enum.
+	ElementType Type
+}
+
+func (t *EnumType) String() string {
+	return fmt.Sprintf("Enum<%v>", t.ElementType)
+}
+
+func (*EnumType) isType() {}
+
 // UnionType represents values that may be any one of a specified set of types.
 type UnionType struct {
 	// ElementTypes are the allowable types for the union type.
@@ -575,6 +587,17 @@ type TypeSpec struct {
 	Items *TypeSpec `json:"items,omitempty"`
 	// OneOf indicates that values of the type may be one of any of the listed types.
 	OneOf []TypeSpec `json:"oneOf,omitempty"`
+	// Enum, if set, lists the allowed values for an enum type.
+	Enum []string `json:"enum,omitempty"`
+	// EnumMetadata, if set, is the metadata associated with an enum type.
+	EnumMetadata *EnumMetadataSpec `json:"enumMetadata,omitempty"`
+}
+
+// EnumMetadataSpec is the serializable form of the metadata associated with an enum type.
+type EnumMetadataSpec struct {
+	Name          string        `json:"name"`
+	ModelAsString bool          `json:"modelAsString"`
+	Values        []interface{} `json:"values,omitempty"`
 }
 
 // DefaultSpec is the serializable form of extra information about the default value for a property.
@@ -615,7 +638,7 @@ type ObjectTypeSpec struct {
 	Properties map[string]PropertySpec `json:"properties,omitempty"`
 	// Type must be "object".
 	Type string `json:"type,omitempty"`
-	// Requires is a list of the names of the type's required properties. These properties must be set for inputs and
+	// Required is a list of the names of the type's required properties. These properties must be set for inputs and
 	// will always be set for outputs.
 	Required []string `json:"required,omitempty"`
 	// Language specifies additional language-specific data about the type.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -595,9 +595,12 @@ type TypeSpec struct {
 
 // EnumMetadataSpec is the serializable form of the metadata associated with an enum type.
 type EnumMetadataSpec struct {
-	Name          string        `json:"name"`
-	ModelAsString bool          `json:"modelAsString"`
-	Values        []interface{} `json:"values,omitempty"`
+	// Name is the name of the enum type
+	Name string `json:"name"`
+	// ModelAsString, when true, indicates that an enum should be modelled as a string and not strictly enforced.
+	ModelAsString bool `json:"modelAsString"`
+	// Values contains metadata associated with each value of the enum.
+	Values []interface{} `json:"values,omitempty"`
 }
 
 // DefaultSpec is the serializable form of extra information about the default value for a property.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -750,7 +750,8 @@ type PackageSpec struct {
 
 	// Config describes the set of configuration variables defined by this package.
 	Config ConfigSpec `json:"config"`
-	// Types is a map from type token to ComplexTypeSpec that describes the set of complex types (ie. object, enum) defined by this package.
+	// Types is a map from type token to ComplexTypeSpec that describes the set of complex types (ie. object, enum)
+	// defined by this package.
 	Types map[string]ComplexTypeSpec `json:"types,omitempty"`
 	// Provider describes the provider type for this package.
 	Provider ResourceSpec `json:"provider"`

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -146,6 +146,8 @@ type Enum struct {
 	Value interface{}
 	// Description for the enum value.
 	Description string
+	// Name for the enum.
+	Name string
 }
 
 func (t *EnumType) String() string {
@@ -614,7 +616,17 @@ type EnumMetadataSpec struct {
 	// ModelAsString, when true, indicates that an enum should be modelled as a string and not strictly enforced.
 	ModelAsString bool `json:"modelAsString"`
 	// Values contains metadata associated with each value of the enum.
-	Values []interface{} `json:"values,omitempty"`
+	Values []*EnumValueSpec `json:"values,omitempty"`
+}
+
+// EnumValuesSpec is the serializable form of the values metadata associated with an enum type.
+type EnumValueSpec struct {
+	// Name, if present, overrides the name of the enum value that would usually be derived from the value.
+	Name string `json:"name,omitempty"`
+	// Description of the enum value
+	Description string `json:"description,omitempty"`
+	// Value is the enum value itself and must match an element in the Enum[] list.
+	Value string `json:"value"`
 }
 
 // DefaultSpec is the serializable form of extra information about the default value for a property.
@@ -977,15 +989,11 @@ func (t *types) bindType(spec TypeSpec) (Type, error) {
 		}
 
 		if spec.EnumMetadata.Values != nil {
-			for _, enumValue := range spec.EnumMetadata.Values {
-				var enumItem Enum
-				if value, ok := enumValue.(map[string]interface{})["value"]; ok {
-					enumItem.Value = value
-				}
-				if desc, ok := enumValue.(map[string]interface{})["description"]; ok {
-					if description, ok := desc.(string); ok {
-						enumItem.Description = description
-					}
+			for _, enumValueSpec := range spec.EnumMetadata.Values {
+				enumItem := Enum{
+					Value:       enumValueSpec.Value,
+					Description: enumValueSpec.Description,
+					Name:        enumValueSpec.Name,
 				}
 				enum.Elements = append(enum.Elements, &enumItem)
 			}

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -643,7 +643,7 @@ type ObjectTypeSpec struct {
 	Properties map[string]PropertySpec `json:"properties,omitempty"`
 	// Type must be "object" if this is an object type, or the underlying type for an enum.
 	Type string `json:"type,omitempty"`
-	// Required, if present is a list of the names of an object type's required properties. These properties must be set
+	// Required, if present, is a list of the names of an object type's required properties. These properties must be set
 	// for inputs and will always be set for outputs.
 	Required []string `json:"required,omitempty"`
 	// Language specifies additional language-specific data about the type.

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -52,6 +52,8 @@ const (
 	jsonType    primitiveType = 8
 )
 
+const object = "object"
+
 //nolint: goconst
 func (t primitiveType) String() string {
 	switch t {
@@ -987,7 +989,7 @@ func (t *types) bindType(spec TypeSpec) (Type, error) {
 			t.arrays[elementType] = typ
 		}
 		return typ, nil
-	case "object":
+	case object:
 		elementType := StringType
 		if spec.AdditionalProperties != nil {
 			et, err := t.bindType(*spec.AdditionalProperties)
@@ -1216,7 +1218,7 @@ func bindTypes(pkg *Package, complexTypes map[string]ComplexTypeSpec) (*types, e
 
 	// Declare object and enum types before processing properties.
 	for token, spec := range complexTypes {
-		if spec.Type == "object" {
+		if spec.Type == object {
 			// It's important that we set the token here. This package interns types so that they can be equality-compared
 			// for identity. Types are interned based on their string representation, and the string representation of an
 			// object type is its token. While this doesn't affect object types directly, it breaks the interning of types
@@ -1229,7 +1231,7 @@ func bindTypes(pkg *Package, complexTypes map[string]ComplexTypeSpec) (*types, e
 
 	// Process properties.
 	for token, spec := range complexTypes {
-		if spec.Type == "object" {
+		if spec.Type == object {
 			if err := typs.bindObjectTypeDetails(typs.objects[token], token, spec); err != nil {
 				return nil, errors.Wrapf(err, "failed to bind type %s", token)
 			}


### PR DESCRIPTION
Relax the constraints around ObjectTypeSpec and rename to ComplexTypeSpec to allow for other complex types (i.e. enums) to be included in the types section of the schema. Note: downstream codegen is failing because tfbridge needs changes as a follow-up from this PR (see linked PRs below).

### Downstream changes
- [pulumi-kubernetes](https://github.com/pulumi/pulumi-kubernetes/pull/1322/files)
- [pulumi-terraform-bridge](https://github.com/pulumi/pulumi-terraform-bridge/pull/266)

### Updated schema
Here is an example of what the updated types section will look like with both object and enum types represented.
```jsonc
{
    "types": {
		// A traditional object type
        "azurerm:labservices/v20181015:ResourceSettings": {
            "description": "Represents resource specific settings",
            "properties": {
                "galleryImageResourceId": {
                    "type": "string",
                    "description": "The resource id of the gallery image used for creating the virtual machine"
                },
                "referenceVm": {
                    "$ref": "#/types/azurerm:labservices/v20181015:ReferenceVm",
                    "description": "Details specific to Reference Vm"
                },
                "size": {
                    // Representation of a “relaxed” enum will use “oneOf”, while a strict enum will simply use “$ref”
                    "oneOf": [
                        {"$ref": "azurerm:compute/v20190701:ManagedLabVmSize"},
                        {"type": "string"}
                    ],
                    "description": "The size of the virtual machine"
                }
            },
            "type": "object",
            "required": [
                "referenceVm"
            ]
        },
        // Representation of the enum type itself
        "azurerm:labservices/v20181015:ManagedLabVmSize": {
            "type": "string",
            "enum": [
                {
                    "value": "Basic",
                    "description":"The base VM size"
                },
                {
                    "value": "Standard",
                    "description": "The standard or default VM size"
                },
                {
                    "value": "Performance",
                    "description": "The most performant VM size"
                }
            ]
        }
    }
}
```