### PR TITLE
[codegen] Tweak docs and example generation for azure-nextgen

### DIFF
--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -48,7 +48,7 @@ func (d DocLanguageHelper) GetDocLinkForPulumiType(pkg *schema.Package, typeName
 
 // GetDocLinkForResourceType returns the godoc URL for a type belonging to a resource provider.
 func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, moduleName string, typeName string) string {
-	path := fmt.Sprintf("%s/%s", pkg.Name, moduleName)
+	path := fmt.Sprintf("%s/%s", goPackage(pkg.Name), moduleName)
 	typeNameParts := strings.Split(typeName, ".")
 	typeName = typeNameParts[len(typeNameParts)-1]
 	typeName = strings.TrimPrefix(typeName, "*")
@@ -131,9 +131,9 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	var displayName string
 	var link string
 	if modName == "" {
-		displayName = fmt.Sprintf("%s", pkg.Name)
+		displayName = goPackage(pkg.Name)
 	} else {
-		displayName = fmt.Sprintf("%s/%s", pkg.Name, modName)
+		displayName = fmt.Sprintf("%s/%s", goPackage(pkg.Name), modName)
 	}
 	link = d.GetDocLinkForResourceType(pkg, modName, "")
 	return displayName, link

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -179,7 +179,7 @@ func (g *generator) genPreamble(w io.Writer, program *hcl2.Program) {
 		if pkg == "@pulumi/pulumi" {
 			continue
 		}
-		as := path.Base(pkg)
+		as := makeValidIdentifier(path.Base(pkg))
 		if as != pkg {
 			imports = append(imports, fmt.Sprintf("import * as %v from \"%v\";", as, pkg))
 		} else {

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -161,7 +161,7 @@ func (g *generator) genPreamble(w io.Writer, program *hcl2.Program) {
 	for _, n := range program.Nodes {
 		if r, isResource := n.(*hcl2.Resource); isResource {
 			pkg, _, _, _ := r.DecomposeToken()
-			importSet.Add("@pulumi/" + makeValidIdentifier(pkg))
+			importSet.Add("@pulumi/" + pkg)
 		}
 		diags := n.VisitExpressions(nil, func(n model.Expression) (model.Expression, hcl.Diagnostics) {
 			if call, ok := n.(*model.FunctionCallExpression); ok {

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -221,9 +221,9 @@ func (d DocLanguageHelper) GetModuleDocLink(pkg *schema.Package, modName string)
 	var displayName string
 	var link string
 	if modName == "" {
-		displayName = fmt.Sprintf("pulumi_%s", pkg.Name)
+		displayName = pyPack(pkg.Name)
 	} else {
-		displayName = fmt.Sprintf("pulumi_%s/%s", pkg.Name, strings.ToLower(modName))
+		displayName = fmt.Sprintf("%s/%s", pyPack(pkg.Name), strings.ToLower(modName))
 	}
 	link = fmt.Sprintf("/docs/reference/pkg/python/%s", displayName)
 	return displayName, link


### PR DESCRIPTION
Tweak docs and example generation so that azure-nextgen is represented correctly:

- `import * as azure_nextgen from "@pulumi/azure-nextgen";` in TS examples
- `pulumi_azure_nextgen` Python package name
- Go package name and link