### PR TITLE
[codegen/schema] Add IsComponent to resource schema

### DIFF
--- a/pkg/codegen/internal/test/testdata/simple-resource-schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema.json
@@ -29,6 +29,7 @@
       "type": "object"
     },
     "example::OtherResource": {
+      "isComponent": true,
       "properties": {
         "foo": {
           "$ref": "#/resources/example::Resource"

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -737,9 +737,14 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	// Export only the symbols we want exported.
 	fmt.Fprintf(w, "__all__ = ['%s']\n\n", name)
 
-	baseType := "pulumi.CustomResource"
-	if res.IsProvider {
+	var baseType string
+	switch {
+	case res.IsProvider:
 		baseType = "pulumi.ProviderResource"
+	case res.IsComponent:
+		baseType = "pulumi.ComponentResource"
+	default:
+		baseType = "pulumi.CustomResource"
 	}
 
 	if !res.IsProvider && res.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
@@ -894,7 +899,12 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	fmt.Fprintf(w, "            '%s',\n", tok)
 	fmt.Fprintf(w, "            resource_name,\n")
 	fmt.Fprintf(w, "            __props__,\n")
-	fmt.Fprintf(w, "            opts)\n")
+	if res.IsComponent {
+		fmt.Fprintf(w, "            opts,\n")
+		fmt.Fprintf(w, "            remote=True)\n")
+	} else {
+		fmt.Fprintf(w, "            opts)\n")
+	}
 	fmt.Fprintf(w, "\n")
 
 	if !res.IsProvider {

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -44,14 +44,24 @@ func TestGeneratePackage(t *testing.T) {
 	}{
 		{
 			"Simple schema with local resource properties",
-			"schema-simple.json",
+			"simple-resource-schema.json",
 			false,
 			func(files map[string][]byte) {
 				assert.Contains(t, files, filepath.Join("pulumi_example", "resource.py"))
 				assert.Contains(t, files, filepath.Join("pulumi_example", "other_resource.py"))
 
 				for fileName, file := range files {
+					if fileName == filepath.Join("pulumi_example", "resource.py") {
+						// Correct parent class
+						assert.Contains(t, string(file), "class Resource(pulumi.CustomResource):")
+						// Remote option not set
+						assert.NotContains(t, string(file), "remote=True)")
+					}
 					if fileName == filepath.Join("pulumi_example", "other_resource.py") {
+						// Correct parent class
+						assert.Contains(t, string(file), "class OtherResource(pulumi.ComponentResource):")
+						// Remote resource option is set
+						assert.Contains(t, string(file), "remote=True)")
 						// Correct import for local resource
 						assert.Contains(t, string(file), "from . import Resource")
 						// Correct type for resource input property

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -305,6 +305,8 @@ type Resource struct {
 	DeprecationMessage string
 	// Language specifies additional language-specific data about the resource.
 	Language map[string]interface{}
+	// IsComponent indicates whether the resource is a ComponentResource.
+	IsComponent bool
 }
 
 // Function describes a Pulumi function.
@@ -706,6 +708,8 @@ type ResourceSpec struct {
 	DeprecationMessage string `json:"deprecationMessage,omitempty"`
 	// Language specifies additional language-specific data about the resource.
 	Language map[string]json.RawMessage `json:"language,omitempty"`
+	// IsComponent indicates whether the resource is a ComponentResource.
+	IsComponent bool `json:"isComponent,omitempty"`
 }
 
 // FunctionSpec is the serializable form of a function description.
@@ -1388,6 +1392,7 @@ func bindResource(token string, spec ResourceSpec, types *types) (*Resource, err
 		Aliases:            aliases,
 		DeprecationMessage: spec.DeprecationMessage,
 		Language:           language,
+		IsComponent:        spec.IsComponent,
 	}, nil
 }
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -129,7 +129,7 @@ func TestImportResourceRef(t *testing.T) {
 	}{
 		{
 			"valid",
-			"schema-simple.json",
+			"simple-resource-schema.json",
 			false,
 			func(pkg *Package) {
 				for _, r := range pkg.Resources {


### PR DESCRIPTION
Fix #5357 

Generated Python code:
```py
class OtherResource(pulumi.ComponentResource):
    def __init__(__self__,
                 resource_name: str,
                 opts: Optional[pulumi.ResourceOptions] = None,
                 foo: Optional[pulumi.Input['Resource']] = None,
                 __props__=None,
                 __name__=None,
                 __opts__=None):
        """
        Create a OtherResource resource with the given unique name, props, and options.
        :param str resource_name: The name of the resource.
        :param pulumi.ResourceOptions opts: Options for the resource.
        """
        if __name__ is not None:
            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
            resource_name = __name__
        if __opts__ is not None:
            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
            opts = __opts__
        if opts is None:
            opts = pulumi.ResourceOptions()
        if not isinstance(opts, pulumi.ResourceOptions):
            raise TypeError('Expected resource options to be a ResourceOptions instance')
        if opts.version is None:
            opts.version = _utilities.get_version()
        if opts.id is None:
            if __props__ is not None:
                raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
            __props__ = dict()

            __props__['foo'] = foo
        super(OtherResource, __self__).__init__(
            'example::OtherResource',
            resource_name,
            __props__,
            opts,
            remote=True)
```