### PR TITLE
[sdk/go] Add missing Version field to invokeOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- [sdk/go] Add missing Version field to invokeOptions
+  [#5401](https://github.com/pulumi/pulumi/pull/5401)
 
 ## 2.10.1 (2020-09-16)
 

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -210,6 +210,7 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 		Tok:      tok,
 		Args:     rpcArgs,
 		Provider: providerRef,
+		Version:  options.Version,
 	})
 	if err != nil {
 		logging.V(9).Infof("Invoke(%s, ...): error: %v", tok, err)

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -326,9 +326,14 @@ func Timeouts(o *CustomTimeouts) ResourceOption {
 // An optional version, corresponding to the version of the provider plugin that should be used when operating on
 // this resource. This version overrides the version information inferred from the current package and should
 // rarely be used.
-func Version(o string) ResourceOption {
-	return resourceOption(func(ro *resourceOptions) {
-		ro.Version = o
+func Version(o string) ResourceOrInvokeOption {
+	return resourceOrInvokeOption(func(ro *resourceOptions, io *invokeOptions) {
+		switch {
+		case ro != nil:
+			ro.Version = o
+		case io != nil:
+			io.Version = o
+		}
 	})
 }
 

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -192,6 +192,8 @@ type invokeOptions struct {
 	Parent Resource
 	// Provider is an optional provider resource to use for this invoke.
 	Provider ProviderResource
+	// Version is an optional version of the provider plugin to use for the invoke.
+	Version string
 }
 
 type ResourceOption interface {


### PR DESCRIPTION
Fix #5400 