### PR TITLE
change how secrets provider parameters are passed via automation api

### DIFF
--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -324,7 +324,7 @@ func (l *LocalWorkspace) Stack(ctx context.Context) (*StackSummary, error) {
 func (l *LocalWorkspace) CreateStack(ctx context.Context, stackName string) error {
 	args := []string{"stack", "init", stackName}
 	if l.secretsProvider != "" {
-		args = append(args, fmt.Sprintf("--secrets-provider=%s", l.secretsProvider))
+		args = append(args, "--secrets-provider", l.secretsProvider)
 	}
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {


### PR DESCRIPTION
Fixes: #5397
```
▶ go run main.go
Creating workspace
Successfully setup workspace
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi whoami --non-interactive
============ end raw command==============
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi stack init stack72/aws-cs-eks/privateRepo11 --secrets-provider awskms://alias/ChangeSecretsProvider?region=us-west-2 --non-interactive
============ end raw command==============
Starting stack destroy
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi stack select stack72/aws-cs-eks/privateRepo11 --non-interactive
============ end raw command==============
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi destroy --yes --skip-preview --exec-kind=auto.local --non-interactive
============ end raw command==============
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi stack select stack72/aws-cs-eks/privateRepo11 --non-interactive
============ end raw command==============
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi history --json --show-secrets --non-interactive
============ end raw command==============
Stack successfully destroyed
```

```
▶ go run main.go
Creating workspace
Successfully setup workspace
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi whoami --non-interactive
============ end raw command==============
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi stack init stack72/aws-cs-eks/privateRepo12 --secrets-provider awskms:///arn:aws:kms:us-west-2:xxxxxxxxxxxx:alias/ChangeSecretsProvider?region=us-west-2 --non-interactive
============ end raw command==============
Starting stack destroy
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi stack select stack72/aws-cs-eks/privateRepo12 --non-interactive
============ end raw command==============
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi destroy --yes --skip-preview --exec-kind=auto.local --non-interactive
============ end raw command==============
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi stack select stack72/aws-cs-eks/privateRepo12 --non-interactive
============ end raw command==============
============ raw command ==============
/Users/stack72/.pulumi/bin/pulumi history --json --show-secrets --non-interactive
============ end raw command==============
Stack successfully destroyed
```