### PR TITLE
Support recursive object types in pkg/codegen model

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -696,7 +696,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 				elmType = t
 			}
 
-			if !elmType.Equals(t) {
+			if !elmType.Equals(t, map[model.Type]struct{}{}) {
 				elmType = nil
 				break
 			}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -696,7 +696,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 				elmType = t
 			}
 
-			if !elmType.Equals(t, map[model.Type]struct{}{}) {
+			if !elmType.Equals(t, nil) {
 				elmType = nil
 				break
 			}

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -696,7 +696,7 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 				elmType = t
 			}
 
-			if !elmType.Equals(t, nil) {
+			if !elmType.Equals(t) {
 				elmType = nil
 				break
 			}

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -61,11 +61,11 @@ var (
 )
 
 func assignableFrom(dest, src Type, assignableFrom func() bool) bool {
-	return dest.Equals(src, map[Type]struct{}{}) || dest == DynamicType || assignableFrom()
+	return dest.Equals(src, nil) || dest == DynamicType || assignableFrom()
 }
 
 func conversionFrom(dest, src Type, unifying bool, conversionFrom func() ConversionKind) ConversionKind {
-	if dest.Equals(src, map[Type]struct{}{}) || dest == DynamicType {
+	if dest.Equals(src, nil) || dest == DynamicType {
 		return SafeConversion
 	}
 	if src, isUnion := src.(*UnionType); isUnion {
@@ -86,7 +86,7 @@ func unify(t0, t1 Type, unify func() (Type, ConversionKind)) (Type, ConversionKi
 	}
 
 	switch {
-	case t0.Equals(t1, map[Type]struct{}{}):
+	case t0.Equals(t1, nil):
 		return t0, SafeConversion
 	case t1 == DynamicType:
 		// The dynamic type unifies with any other type by selecting that other type.
@@ -144,7 +144,7 @@ func UnifyTypes(types ...Type) (safeType Type, unsafeType Type) {
 		unsafeType = NoneType
 	}
 
-	contract.Assertf(unsafeType.Equals(safeType, map[Type]struct{}{}) || unsafeType.ConversionFrom(safeType).Exists(),
+	contract.Assertf(unsafeType.Equals(safeType, nil) || unsafeType.ConversionFrom(safeType).Exists(),
 		"no conversion from %v to %v", safeType, unsafeType)
 	return safeType, unsafeType
 }

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -35,11 +35,12 @@ func (k ConversionKind) Exists() bool {
 type Type interface {
 	Definition
 
-	Equals(other Type, seen map[Type]struct{}) bool
+	Equals(other Type) bool
 	AssignableFrom(src Type) bool
 	ConversionFrom(src Type) ConversionKind
 	String() string
 
+	equals(other Type, seen map[Type]struct{}) bool
 	conversionFrom(src Type, unifying bool) ConversionKind
 	unify(other Type) (Type, ConversionKind)
 	isType()
@@ -61,11 +62,11 @@ var (
 )
 
 func assignableFrom(dest, src Type, assignableFrom func() bool) bool {
-	return dest.Equals(src, nil) || dest == DynamicType || assignableFrom()
+	return dest.Equals(src) || dest == DynamicType || assignableFrom()
 }
 
 func conversionFrom(dest, src Type, unifying bool, conversionFrom func() ConversionKind) ConversionKind {
-	if dest.Equals(src, nil) || dest == DynamicType {
+	if dest.Equals(src) || dest == DynamicType {
 		return SafeConversion
 	}
 	if src, isUnion := src.(*UnionType); isUnion {
@@ -86,7 +87,7 @@ func unify(t0, t1 Type, unify func() (Type, ConversionKind)) (Type, ConversionKi
 	}
 
 	switch {
-	case t0.Equals(t1, nil):
+	case t0.Equals(t1):
 		return t0, SafeConversion
 	case t1 == DynamicType:
 		// The dynamic type unifies with any other type by selecting that other type.
@@ -144,7 +145,7 @@ func UnifyTypes(types ...Type) (safeType Type, unsafeType Type) {
 		unsafeType = NoneType
 	}
 
-	contract.Assertf(unsafeType.Equals(safeType, nil) || unsafeType.ConversionFrom(safeType).Exists(),
+	contract.Assertf(unsafeType.Equals(safeType) || unsafeType.ConversionFrom(safeType).Exists(),
 		"no conversion from %v to %v", safeType, unsafeType)
 	return safeType, unsafeType
 }

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -51,13 +51,13 @@ func (t *ListType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnosti
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *ListType) Equals(other Type) bool {
+func (t *ListType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 
 	otherList, ok := other.(*ListType)
-	return ok && t.ElementType.Equals(otherList.ElementType)
+	return ok && t.ElementType.Equals(otherList.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. A list(T) is assignable

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -51,13 +51,17 @@ func (t *ListType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnosti
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *ListType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *ListType) Equals(other Type) bool {
+	return t.equals(other, nil)
+}
+
+func (t *ListType) equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 
 	otherList, ok := other.(*ListType)
-	return ok && t.ElementType.Equals(otherList.ElementType, seen)
+	return ok && t.ElementType.equals(otherList.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. A list(T) is assignable

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -51,13 +51,17 @@ func (*MapType) SyntaxNode() hclsyntax.Node {
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *MapType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *MapType) Equals(other Type) bool {
+	return t.equals(other, nil)
+}
+
+func (t *MapType) equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 
 	otherMap, ok := other.(*MapType)
-	return ok && t.ElementType.Equals(otherMap.ElementType, seen)
+	return ok && t.ElementType.equals(otherMap.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. A map(T) is assignable

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -51,13 +51,13 @@ func (*MapType) SyntaxNode() hclsyntax.Node {
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *MapType) Equals(other Type) bool {
+func (t *MapType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 
 	otherMap, ok := other.(*MapType)
-	return ok && t.ElementType.Equals(otherMap.ElementType)
+	return ok && t.ElementType.Equals(otherMap.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. A map(T) is assignable

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -30,7 +30,7 @@ func (noneType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostics)
 	return NoneType, hcl.Diagnostics{unsupportedReceiverType(NoneType, traverser.SourceRange())}
 }
 
-func (noneType) Equals(other Type) bool {
+func (noneType) Equals(other Type, seen map[Type]struct{}) bool {
 	return other == NoneType
 }
 

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -30,7 +30,11 @@ func (noneType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostics)
 	return NoneType, hcl.Diagnostics{unsupportedReceiverType(NoneType, traverser.SourceRange())}
 }
 
-func (noneType) Equals(other Type, seen map[Type]struct{}) bool {
+func (n noneType) Equals(other Type) bool {
+	return n.equals(other, nil)
+}
+
+func (noneType) equals(other Type, seen map[Type]struct{}) bool {
 	return other == NoneType
 }
 

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -85,8 +85,12 @@ func (t *ObjectType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
-	if _, ok := seen[t]; ok {
-		return true
+	if seen != nil {
+		if _, ok := seen[t]; ok {
+			return true
+		}
+	} else {
+		seen = map[Type]struct{}{}
 	}
 	seen[t] = struct{}{}
 

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -81,7 +81,11 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *ObjectType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *ObjectType) Equals(other Type) bool {
+	return t.equals(other, nil)
+}
+
+func (t *ObjectType) equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
@@ -102,7 +106,7 @@ func (t *ObjectType) Equals(other Type, seen map[Type]struct{}) bool {
 		return false
 	}
 	for k, t := range t.Properties {
-		if u, ok := otherObject.Properties[k]; !ok || !t.Equals(u, seen) {
+		if u, ok := otherObject.Properties[k]; !ok || !t.equals(u, seen) {
 			return false
 		}
 	}

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -81,10 +81,14 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *ObjectType) Equals(other Type) bool {
+func (t *ObjectType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
+	if _, ok := seen[t]; ok {
+		return true
+	}
+	seen[t] = struct{}{}
 
 	otherObject, ok := other.(*ObjectType)
 	if !ok {
@@ -94,7 +98,7 @@ func (t *ObjectType) Equals(other Type) bool {
 		return false
 	}
 	for k, t := range t.Properties {
-		if u, ok := otherObject.Properties[k]; !ok || !t.Equals(u) {
+		if u, ok := otherObject.Properties[k]; !ok || !t.Equals(u, seen) {
 			return false
 		}
 	}

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -79,7 +79,7 @@ func (t *OpaqueType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *OpaqueType) Equals(other Type) bool {
+func (t *OpaqueType) Equals(other Type, seen map[Type]struct{}) bool {
 	return t == other
 }
 

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -79,7 +79,11 @@ func (t *OpaqueType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *OpaqueType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *OpaqueType) Equals(other Type) bool {
+	return t.equals(other, nil)
+}
+
+func (t *OpaqueType) equals(other Type, seen map[Type]struct{}) bool {
 	return t == other
 }
 

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -47,12 +47,12 @@ func (t *OutputType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *OutputType) Equals(other Type) bool {
+func (t *OutputType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 	otherOutput, ok := other.(*OutputType)
-	return ok && t.ElementType.Equals(otherOutput.ElementType)
+	return ok && t.ElementType.Equals(otherOutput.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. An output(T) is assignable

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -47,12 +47,16 @@ func (t *OutputType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *OutputType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *OutputType) Equals(other Type) bool {
+	return t.equals(other, nil)
+}
+
+func (t *OutputType) equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 	otherOutput, ok := other.(*OutputType)
-	return ok && t.ElementType.Equals(otherOutput.ElementType, seen)
+	return ok && t.ElementType.equals(otherOutput.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. An output(T) is assignable

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -47,12 +47,16 @@ func (t *PromiseType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagno
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *PromiseType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *PromiseType) Equals(other Type) bool {
+	return t.equals(other, nil)
+}
+
+func (t *PromiseType) equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 	otherPromise, ok := other.(*PromiseType)
-	return ok && t.ElementType.Equals(otherPromise.ElementType, seen)
+	return ok && t.ElementType.equals(otherPromise.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. A promise(T) is assignable

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -47,12 +47,12 @@ func (t *PromiseType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagno
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *PromiseType) Equals(other Type) bool {
+func (t *PromiseType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 	otherPromise, ok := other.(*PromiseType)
-	return ok && t.ElementType.Equals(otherPromise.ElementType)
+	return ok && t.ElementType.Equals(otherPromise.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. A promise(T) is assignable

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -44,12 +44,12 @@ func (t *SetType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostic
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *SetType) Equals(other Type) bool {
+func (t *SetType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 	otherSet, ok := other.(*SetType)
-	return ok && t.ElementType.Equals(otherSet.ElementType)
+	return ok && t.ElementType.Equals(otherSet.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. A set(T) is assignable

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -44,12 +44,16 @@ func (t *SetType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostic
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *SetType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *SetType) Equals(other Type) bool {
+	return t.equals(other, nil)
+
+}
+func (t *SetType) equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
 	otherSet, ok := other.(*SetType)
-	return ok && t.ElementType.Equals(otherSet.ElementType, seen)
+	return ok && t.ElementType.equals(otherSet.ElementType, seen)
 }
 
 // AssignableFrom returns true if this type is assignable from the indicated source type. A set(T) is assignable

--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -681,7 +681,7 @@ func TestRecursiveObjectType(t *testing.T) {
 	propsOther["next"] = linkedListTypeOther
 
 	// Equals
-	assert.True(t, linkedListType.Equals(linkedListTypeOther, nil))
+	assert.True(t, linkedListType.Equals(linkedListTypeOther))
 
 	// Contains eventuals
 	hasOutputs, hasPromises := ContainsEventuals(linkedListType)
@@ -690,7 +690,7 @@ func TestRecursiveObjectType(t *testing.T) {
 
 	// Resolving eventuals
 	resolvedLinkedListType := ResolveOutputs(linkedListType)
-	assert.True(t, resolvedLinkedListType.(*UnionType).ElementTypes[1].(*ObjectType).Properties["data"].Equals(IntType, nil))
+	assert.True(t, resolvedLinkedListType.(*UnionType).ElementTypes[1].(*ObjectType).Properties["data"].Equals(IntType))
 	hasOutputs, _ = ContainsEventuals(resolvedLinkedListType)
 	assert.False(t, hasOutputs)
 

--- a/pkg/codegen/hcl2/model/type_test.go
+++ b/pkg/codegen/hcl2/model/type_test.go
@@ -666,3 +666,36 @@ func TestUnifyType(t *testing.T) {
 	//	assert.Equal(t, t0, unifyTypes(t0, t1))
 	//	assert.Equal(t, t0, unifyTypes(t1, t0))
 }
+
+func TestRecursiveObjectType(t *testing.T) {
+	props := map[string]Type{
+		"data": NewOutputType(IntType),
+	}
+	linkedListType := NewOptionalType(NewObjectType(props))
+	props["next"] = linkedListType
+
+	propsOther := map[string]Type{
+		"data": NewOutputType(IntType),
+	}
+	linkedListTypeOther := NewOptionalType(NewObjectType(propsOther))
+	propsOther["next"] = linkedListTypeOther
+
+	// Equals
+	assert.True(t, linkedListType.Equals(linkedListTypeOther, nil))
+
+	// Contains eventuals
+	hasOutputs, hasPromises := ContainsEventuals(linkedListType)
+	assert.True(t, hasOutputs)
+	assert.False(t, hasPromises)
+
+	// Resolving eventuals
+	resolvedLinkedListType := ResolveOutputs(linkedListType)
+	assert.True(t, resolvedLinkedListType.(*UnionType).ElementTypes[1].(*ObjectType).Properties["data"].Equals(IntType, nil))
+	hasOutputs, _ = ContainsEventuals(resolvedLinkedListType)
+	assert.False(t, hasOutputs)
+
+	// InputType conversion
+	inputLinkedListType := InputType(resolvedLinkedListType)
+	hasOutputs, _ = ContainsEventuals(inputLinkedListType)
+	assert.True(t, hasOutputs)
+}

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -70,7 +70,7 @@ func (t *TupleType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnost
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *TupleType) Equals(other Type) bool {
+func (t *TupleType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
@@ -82,7 +82,7 @@ func (t *TupleType) Equals(other Type) bool {
 		return false
 	}
 	for i, t := range t.ElementTypes {
-		if !t.Equals(otherTuple.ElementTypes[i]) {
+		if !t.Equals(otherTuple.ElementTypes[i], seen) {
 			return false
 		}
 	}

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -70,7 +70,11 @@ func (t *TupleType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnost
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *TupleType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *TupleType) Equals(other Type) bool {
+	return t.equals(other, nil)
+}
+
+func (t *TupleType) equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
@@ -82,7 +86,7 @@ func (t *TupleType) Equals(other Type, seen map[Type]struct{}) bool {
 		return false
 	}
 	for i, t := range t.ElementTypes {
-		if !t.Equals(otherTuple.ElementTypes[i], seen) {
+		if !t.equals(otherTuple.ElementTypes[i], seen) {
 			return false
 		}
 	}

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -50,7 +50,7 @@ func NewUnionType(types ...Type) Type {
 
 	dst := 0
 	for src := 0; src < len(elementTypes); {
-		for src < len(elementTypes) && elementTypes[src].Equals(elementTypes[dst], map[Type]struct{}{}) {
+		for src < len(elementTypes) && elementTypes[src].Equals(elementTypes[dst], nil) {
 			src++
 		}
 		dst++

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -50,7 +50,7 @@ func NewUnionType(types ...Type) Type {
 
 	dst := 0
 	for src := 0; src < len(elementTypes); {
-		for src < len(elementTypes) && elementTypes[src].Equals(elementTypes[dst]) {
+		for src < len(elementTypes) && elementTypes[src].Equals(elementTypes[dst], map[Type]struct{}{}) {
 			src++
 		}
 		dst++
@@ -113,7 +113,7 @@ func (t *UnionType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnost
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *UnionType) Equals(other Type) bool {
+func (t *UnionType) Equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
@@ -125,7 +125,7 @@ func (t *UnionType) Equals(other Type) bool {
 		return false
 	}
 	for i, t := range t.ElementTypes {
-		if !t.Equals(otherUnion.ElementTypes[i]) {
+		if !t.Equals(otherUnion.ElementTypes[i], seen) {
 			return false
 		}
 	}

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -50,7 +50,7 @@ func NewUnionType(types ...Type) Type {
 
 	dst := 0
 	for src := 0; src < len(elementTypes); {
-		for src < len(elementTypes) && elementTypes[src].Equals(elementTypes[dst], nil) {
+		for src < len(elementTypes) && elementTypes[src].Equals(elementTypes[dst]) {
 			src++
 		}
 		dst++
@@ -113,7 +113,11 @@ func (t *UnionType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnost
 }
 
 // Equals returns true if this type has the same identity as the given type.
-func (t *UnionType) Equals(other Type, seen map[Type]struct{}) bool {
+func (t *UnionType) Equals(other Type) bool {
+	return t.equals(other, nil)
+}
+
+func (t *UnionType) equals(other Type, seen map[Type]struct{}) bool {
 	if t == other {
 		return true
 	}
@@ -125,7 +129,7 @@ func (t *UnionType) Equals(other Type, seen map[Type]struct{}) bool {
 		return false
 	}
 	for i, t := range t.ElementTypes {
-		if !t.Equals(otherUnion.ElementTypes[i], seen) {
+		if !t.equals(otherUnion.ElementTypes[i], seen) {
 			return false
 		}
 	}

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -479,6 +479,7 @@ github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -513,6 +514,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/zclconf/go-cty v1.2.0/go.mod h1:hOPWgoHbaTUnI5k4D2ld+GRpFJSCe6bCM7m1q/N4PQ8=
 github.com/zclconf/go-cty v1.3.1 h1:QIOZl+CKKdkv4l2w3lG23nNzXgLoxsWLSEdg1MlX4p0=
 github.com/zclconf/go-cty v1.3.1/go.mod h1:YO23e2L18AG+ZYQfSobnY4G65nvwvprPCxBHkufUH1k=
+github.com/zclconf/go-cty v1.6.1 h1:wHtZ+LSSQVwUSb+XIJ5E9hgAQxyWATZsAWT+ESJ9dQ0=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/5228.

I am not positive this addresses every place in `pkg/codegen/hcl2/model` where we assume types will be non-recursive, but it addresses all the cases that appear to currently be blocking the new `arm2pulumi` tool.