### PR TITLE
Fixed issue #5014 (Missing Pulumi console tags on Windows)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ CHANGELOG
 - [sdk/go] Add missing Version field to invokeOptions
   [#5401](https://github.com/pulumi/pulumi/pull/5401)
 
+- Pulumi Windows CLI now uploads all VCS information to console
+  (fixes [#5014](https://github.com/pulumi/pulumi/issues/5014))
+  [#5406](https://github.com/pulumi/pulumi/pull/5406)
+
 ## 2.10.1 (2020-09-16)
 
 - feat(autoapi): add GetPermalink for operation result

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -17,7 +17,6 @@ package gitutil
 import (
 	"fmt"
 	"net/url"
-	"path"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -80,7 +79,7 @@ func GetGitRepository(dir string) (*git.Repository, error) {
 	}
 
 	// Open the git repo in the .git folder's parent, not the .git folder itself.
-	repo, err := git.PlainOpen(path.Join(gitRoot, ".."))
+	repo, err := git.PlainOpen(filepath.Dir(gitRoot))
 	if err == git.ErrRepositoryNotExists {
 		return nil, nil
 	}


### PR DESCRIPTION
The existing `path.Join(gitRoot, "..")` function appears to have unexpected behavior on Windows. Instead of appending `..` and returning gitRoot's parent directory, it replaces the whole string with a single dot. The fix changes the code to instead use `filepath.Dir(gitRoot)`, which correctly returns the parent directory.

This seems to be the only instance in which `path.Join()` is used with `..` in the entire repository. There are some usages of a function called `filepath.Join()` with dots, but they work correctly.

Fixes #5014