### PR TITLE
[codegen] Allow ImportBasePath to override presumed golang import path

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -277,6 +277,12 @@ func (g *generator) getPulumiImport(pkg, vPath, mod string) string {
 		imp = fmt.Sprintf("github.com/pulumi/pulumi-%s/sdk%s/go/%s", pkg, vPath, pkg)
 	}
 
+	// All providers don't follow the sdk/go/<package> scheme. Allow ImportBasePath as
+	// a means to override this assumption.
+	if info.ImportBasePath != "" {
+		imp = fmt.Sprintf("%s/%s", info.ImportBasePath, mod)
+	}
+
 	if alias, ok := info.PackageImportAliases[imp]; ok {
 		return fmt.Sprintf("%s %q", alias, imp)
 	}


### PR DESCRIPTION
Go programgen seems to assume a certain import layout but not all providers follow it (e.g. ...sdk/<pkg>), e.g. the Azure nextgen provider. This change allows the ImportBasePath to be used as an override.