### PR TITLE
[codegen/docs] Don't emit API links in Azure NextGen resource docs

### DIFF
--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -92,12 +92,17 @@ func (mod *modContext) getFunctionResourceInfo(f *schema.Function) map[string]pr
 			panic(errors.Errorf("cannot generate function resource info for unhandled language %q", lang))
 		}
 
+		var link string
+		if mod.emitAPILinks {
+			link = docLangHelper.GetDocLinkForResourceType(mod.pkg, mod.mod, resultTypeName)
+		}
+
 		parts := strings.Split(resultTypeName, ".")
 		displayName := parts[len(parts)-1]
 		resourceMap[lang] = propertyType{
 			Name:        resultTypeName,
 			DisplayName: displayName,
-			Link:        docLangHelper.GetDocLinkForResourceType(mod.pkg, mod.mod, resultTypeName),
+			Link:        link,
 		}
 	}
 
@@ -111,12 +116,17 @@ func (mod *modContext) genFunctionTS(f *schema.Function, funcName string) []form
 	var params []formalParam
 
 	if f.Inputs != nil {
+		var argsTypeLink string
+		if mod.emitAPILinks {
+			argsTypeLink = docLangHelper.GetDocLinkForResourceType(mod.pkg, mod.mod, argsType)
+		}
+
 		params = append(params, formalParam{
 			Name:         "args",
 			OptionalFlag: "",
 			Type: propertyType{
 				Name: argsType,
-				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg, mod.mod, argsType),
+				Link: argsTypeLink,
 			},
 		})
 	}
@@ -148,12 +158,17 @@ func (mod *modContext) genFunctionGo(f *schema.Function, funcName string) []form
 	}
 
 	if f.Inputs != nil {
+		var argsTypeLink string
+		if mod.emitAPILinks {
+			argsTypeLink = docLangHelper.GetDocLinkForResourceType(mod.pkg, mod.mod, argsType)
+		}
+
 		params = append(params, formalParam{
 			Name:         "args",
 			OptionalFlag: "*",
 			Type: propertyType{
 				Name: argsType,
-				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg, mod.mod, argsType),
+				Link: argsTypeLink,
 			},
 		})
 	}
@@ -187,13 +202,18 @@ func (mod *modContext) genFunctionCS(f *schema.Function, funcName string) []form
 	docLangHelper := getLanguageDocHelper("csharp")
 	var params []formalParam
 	if f.Inputs != nil {
+		var argsTypeLink string
+		if mod.emitAPILinks {
+			argsTypeLink = docLangHelper.GetDocLinkForResourceType(mod.pkg, "", argLangTypeName)
+		}
+
 		params = append(params, formalParam{
 			Name:         "args",
 			OptionalFlag: "",
 			DefaultValue: "",
 			Type: propertyType{
 				Name: argsType,
-				Link: docLangHelper.GetDocLinkForResourceType(mod.pkg, "", argLangTypeName),
+				Link: argsTypeLink,
 			},
 		})
 	}

--- a/pkg/codegen/docs/gen_kubernetes.go
+++ b/pkg/codegen/docs/gen_kubernetes.go
@@ -131,9 +131,10 @@ func getKubernetesMod(pkg *schema.Package, token string, modules map[string]*mod
 	mod, ok := modules[modName]
 	if !ok {
 		mod = &modContext{
-			pkg:  pkg,
-			mod:  modName,
-			tool: tool,
+			pkg:          pkg,
+			mod:          modName,
+			tool:         tool,
+			emitAPILinks: true,
 		}
 
 		if modName != "" {

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -264,7 +264,7 @@ func TestResourceNestedPropertyPythonCasing(t *testing.T) {
 	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "importing spec")
 
-	modules := generateModulesFromSchemaPackage(unitTestTool, schemaPkg)
+	modules := generateModulesFromSchemaPackage(unitTestTool, schemaPkg, true)
 	mod := modules["module"]
 	for _, r := range mod.resources {
 		nestedTypes := mod.genNestedTypes(r, true)
@@ -374,7 +374,7 @@ func TestResourceDocHeader(t *testing.T) {
 		},
 	}
 
-	modules := generateModulesFromSchemaPackage(unitTestTool, schemaPkg)
+	modules := generateModulesFromSchemaPackage(unitTestTool, schemaPkg, true)
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			mod, ok := modules[test.ModuleName]

--- a/pkg/codegen/docs/templates/function.tmpl
+++ b/pkg/codegen/docs/templates/function.tmpl
@@ -63,13 +63,17 @@ The following output properties are available:
 
 {{ range .NestedTypes }}
 <h4 id="{{ .AnchorID }}">{{ htmlSafe .Name }}</h4>
+{{ if (hasDocLinksForLang .APIDocLinks "nodejs") -}}
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
 > See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
+{{- end }}
 
+{{ if (hasDocLinksForLang .APIDocLinks "go") -}}
 {{ htmlSafe "{{% choosable language go %}}" }}
 > See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.go.InputType "") (ne .APIDocLinks.go.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
+{{- end }}
 
 {{- if (hasDocLinksForLang .APIDocLinks "csharp") }}
 {{ htmlSafe "{{% choosable language csharp %}}" }}

--- a/pkg/codegen/docs/templates/language_sdk_links.tmpl
+++ b/pkg/codegen/docs/templates/language_sdk_links.tmpl
@@ -1,4 +1,5 @@
 {{ define "language_sdk_links" }}
+{{ if . -}}
 <dl class="tabular">
 {{ range $key,$value := . }}
     <dt>{{ $key }}</dt>
@@ -6,3 +7,4 @@
 {{ end }}
 </dl>
 {{ end }}
+{{- end }}

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -162,13 +162,17 @@ The following state arguments are supported:
 
 {{ range .NestedTypes }}
 <h4 id="{{ .AnchorID }}">{{ htmlSafe .Name }}</h4>
+{{ if (hasDocLinksForLang .APIDocLinks "nodejs") -}}
 {{ htmlSafe "{{% choosable language nodejs %}}" }}
 > See the {{ if ne .APIDocLinks.nodejs.InputType "" }}<a href="{{ .APIDocLinks.nodejs.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.nodejs.InputType "") (ne .APIDocLinks.nodejs.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.nodejs.OutputType "" }}<a href="{{ .APIDocLinks.nodejs.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
+{{- end }}
 
+{{ if (hasDocLinksForLang .APIDocLinks "go") -}}
 {{ htmlSafe "{{% choosable language go %}}" }}
 > See the {{ if ne .APIDocLinks.go.InputType "" }}<a href="{{ .APIDocLinks.go.InputType }}">input</a>{{ end }} {{ if and (ne .APIDocLinks.go.InputType "") (ne .APIDocLinks.go.OutputType "") }}and{{ end }} {{ if ne .APIDocLinks.go.OutputType "" }}<a href="{{ .APIDocLinks.go.OutputType }}">output</a>{{ end }} API doc for this type.
 {{ htmlSafe "{{% /choosable %}}" }}
+{{- end }}
 
 {{- if (hasDocLinksForLang .APIDocLinks "csharp") }}
 {{ htmlSafe "{{% choosable language csharp %}}" }}

--- a/pkg/codegen/docs/templates/utils.tmpl
+++ b/pkg/codegen/docs/templates/utils.tmpl
@@ -2,7 +2,7 @@
 {{ define "linkify_param" }}<span class="nx">{{ if ne .Link "" }}<a href="{{ .Link }}">{{ end }}{{ if ne .DisplayName "" }}{{ .DisplayName }}{{ else }}{{ .Name }}{{ end }}{{ if ne .Link "" }}</a>{{ end }}</span>{{ end }}
 
 <!-- linkify_go_param is used to wrap constructor/function params in an anchor tag specifically for go constuctors. We are treating this as a snowflake for now. -->
-{{ define "linkify_go_param" }}<span class="nx"><a href="{{ .Link }}">New{{ if ne .DisplayName "" }}{{ .DisplayName }}{{ else }}{{ .Name }}{{ end }}</a></span>{{ end }}
+{{ define "linkify_go_param" }}<span class="nx">{{ if ne .Link "" }}<a href="{{ .Link }}">{{ end }}New{{ if ne .DisplayName "" }}{{ .DisplayName }}{{ else }}{{ .Name }}{{ end }}{{ if ne .Link "" }}</a>{{ end }}</span>{{ end }}
 
 <!-- linkify wraps any propertyType instance in an anchor tag. The display name/name is rendered as-is by passing it through the htmlSafe function
 to avoid double-encoding html characters, which is typical of properties type names. -->


### PR DESCRIPTION
We're not going to generate language-specific API docs for the Azure NextGen provider, only resource docs. This change makes it so the resource docs do not emit any links to nonexistent API docs.

Part of https://github.com/pulumi/docs/issues/4071