### PR TITLE
Simplify types more precisely.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Do not oversimplify types for display when running an update or preview.
+  [#5440](https://github.com/pulumi/pulumi/pull/5440)
+
 _(None)_
 
 ## 2.10.2 (2020-09-21)


### PR DESCRIPTION
Instead of simplifying any module that ends with `/<name>`, only simplify
types where `<name>` matches the type name portion after camel-casing.
This continues to simplify tfbridge types like `aws:s3/bucket:Bucket`,
but would not simplify a type like `aws:s3:Bucket`.