### PR TITLE
[codegen/nodejs] Add support for ResourceType and isComponent

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -96,45 +96,35 @@ func (mod *modContext) details(t *schema.ObjectType) *typeDetails {
 	return details
 }
 
-func (mod *modContext) tokenToType(tok string, input bool) string {
-	// token := pkg : module : member
-	// module := path/to/module
-
+func (mod *modContext) tokenToModName(tok string) string {
 	components := strings.Split(tok, ":")
 	contract.Assertf(len(components) == 3, "malformed token %v", tok)
 
-	modName, name := mod.pkg.TokenToModule(tok), title(components[2])
+	modName := mod.pkg.TokenToModule(tok)
 	if override, ok := mod.modToPkg[modName]; ok {
 		modName = override
 	}
+
+	if modName != "" {
+		modName = strings.Replace(modName, "/", ".", -1) + "."
+	}
+
+	return modName
+}
+
+func (mod *modContext) tokenToType(tok string, input bool) string {
+	modName, name := mod.tokenToModName(tok), tokenToName(tok)
 
 	root := "outputs."
 	if input {
 		root = "inputs."
 	}
 
-	if modName != "" {
-		modName = strings.Replace(modName, "/", ".", -1) + "."
-	}
-
 	return root + modName + title(name)
 }
 
 func (mod *modContext) tokenToResource(tok string) string {
-	// token := pkg : module : member
-	// module := path/to/module
-
-	components := strings.Split(tok, ":")
-	contract.Assertf(len(components) == 3, "malformed token %v", tok)
-
-	modName, name := mod.pkg.TokenToModule(tok), title(components[2])
-	if override, ok := mod.modToPkg[modName]; ok {
-		modName = override
-	}
-
-	if modName != "" {
-		modName = strings.Replace(modName, "/", ".", -1) + "."
-	}
+	modName, name := mod.tokenToModName(tok), tokenToName(tok)
 
 	return modName + title(name)
 }

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -390,7 +390,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 
 	// Emit a static factory to read instances of this resource unless this is a provider resource.
 	stateType := name + "State"
-	if !r.IsProvider {
+	if !r.IsProvider && !r.IsComponent {
 		fmt.Fprintf(w, "    /**\n")
 		fmt.Fprintf(w, "     * Get an existing %s resource's state with the given name, ID, and optional extra\n", name)
 		fmt.Fprintf(w, "     * properties used to qualify the lookup.\n")

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -388,7 +388,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	// Begin defining the class.
 	fmt.Fprintf(w, "export class %s extends pulumi.%s {\n", name, baseType)
 
-	// Emit a static factory to read instances of this resource unless this is a provider resource.
+	// Emit a static factory to read instances of this resource unless this is a provider resource or ComponentResource.
 	stateType := name + "State"
 	if !r.IsProvider && !r.IsComponent {
 		fmt.Fprintf(w, "    /**\n")

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -655,11 +655,6 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	fmt.Fprintf(w, "            opts.version = utilities.getVersion();\n")
 	fmt.Fprintf(w, "        }\n")
 
-	// If it's a ComponentResource, set the remote option.
-	if r.IsComponent {
-		fmt.Fprintf(w, "        opts.remote = true;\n")
-	}
-
 	// Now invoke the super constructor with the type, name, and a property map.
 	if len(r.Aliases) > 0 {
 		fmt.Fprintf(w, "        const aliasOpts = { aliases: [")
@@ -685,7 +680,12 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 		fmt.Fprintf(w, "        opts = opts ? pulumi.mergeOptions(opts, secretOpts) : secretOpts;\n")
 	}
 
-	fmt.Fprintf(w, "        super(%s.__pulumiType, name, inputs, opts);\n", name)
+	// If it's a ComponentResource, set the remote option.
+	if r.IsComponent {
+		fmt.Fprintf(w, "        super(%s.__pulumiType, name, inputs, opts, true /*remote*/);\n", name)
+	} else {
+		fmt.Fprintf(w, "        super(%s.__pulumiType, name, inputs, opts);\n", name)
+	}
 
 	// Finish the class.
 	fmt.Fprintf(w, "    }\n")

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -489,9 +489,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	argsType := name + "Args"
 	var trailingBrace string
 	switch {
-	case r.IsProvider:
-		trailingBrace = " {"
-	case r.StateInputs == nil:
+	case r.IsProvider, r.StateInputs == nil:
 		trailingBrace = " {"
 	default:
 		trailingBrace = ""

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -54,15 +54,15 @@ func TestGeneratePackage(t *testing.T) {
 				for fileName, file := range files {
 					if fileName == "resource.ts" {
 						// Correct parent class
-						//assert.Contains(t, string(file), "class Resource(pulumi.CustomResource):")
+						assert.Contains(t, string(file), "export class Resource extends pulumi.CustomResource {")
 						// Remote option not set
-						//assert.NotContains(t, string(file), "remote=True)")
+						assert.NotContains(t, string(file), "opts.remote = true;")
 					}
 					if fileName == "otherResource.ts" {
 						// Correct parent class
-						//assert.Contains(t, string(file), "class OtherResource(pulumi.ComponentResource):")
+						assert.Contains(t, string(file), "export class OtherResource extends pulumi.ComponentResource {")
 						// Remote resource option is set
-						//assert.Contains(t, string(file), "remote=True)")
+						assert.Contains(t, string(file), "opts.remote = true;")
 						// Correct import for local resource
 						assert.Contains(t, string(file), `import {Resource} from "./index";`)
 						// Correct type for resource input property

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -30,13 +30,13 @@ func TestGeneratePackage(t *testing.T) {
 						// Correct parent class
 						assert.Contains(t, string(file), "export class Resource extends pulumi.CustomResource {")
 						// Remote option not set
-						assert.NotContains(t, string(file), "opts.remote = true;")
+						assert.NotContains(t, string(file), ", true /*remote*/);")
 					}
 					if fileName == "otherResource.ts" {
 						// Correct parent class
 						assert.Contains(t, string(file), "export class OtherResource extends pulumi.ComponentResource {")
 						// Remote resource option is set
-						assert.Contains(t, string(file), "opts.remote = true;")
+						assert.Contains(t, string(file), "super(OtherResource.__pulumiType, name, inputs, opts, true /*remote*/);")
 						// Correct import for local resource
 						assert.Contains(t, string(file), `import {Resource} from "./index";`)
 						// Correct type for resource input property

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -1,0 +1,109 @@
+package nodejs
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
+	"github.com/stretchr/testify/assert"
+)
+
+//func TestGeneratePackage(t *testing.T) {
+//	// Read in, decode, and import the schema.
+//	schemaBytes, err := ioutil.ReadFile(filepath.Join("..", "internal", "test", "testdata", "schema-simple.json"))
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	var pkgSpec schema.PackageSpec
+//	if err = json.Unmarshal(schemaBytes, &pkgSpec); err != nil {
+//		panic(err)
+//	}
+//
+//	pkg, err := schema.ImportSpec(pkgSpec, nil)
+//	if err != nil {
+//		t.Errorf("ImportSpec() error = %v", err)
+//	}
+//
+//	files, err := GeneratePackage("test", pkg, nil)
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	assert.Contains(t, files, filepath.Join("pulumi_example", "resource.py"))
+//	assert.Contains(t, files, filepath.Join("pulumi_example", "other_resource.py"))
+//}
+
+func TestGeneratePackage(t *testing.T) {
+	tests := []struct {
+		name       string
+		schemaFile string
+		wantErr    bool
+		validator  func(files map[string][]byte)
+	}{
+		{
+			"Simple schema with local resource properties",
+			"simple-resource-schema.json",
+			false,
+			func(files map[string][]byte) {
+				assert.Contains(t, files, "resource.ts")
+				assert.Contains(t, files, "otherResource.ts")
+
+				for fileName, file := range files {
+					if fileName == "resource.ts" {
+						// Correct parent class
+						//assert.Contains(t, string(file), "class Resource(pulumi.CustomResource):")
+						// Remote option not set
+						//assert.NotContains(t, string(file), "remote=True)")
+					}
+					if fileName == "otherResource.ts" {
+						// Correct parent class
+						//assert.Contains(t, string(file), "class OtherResource(pulumi.ComponentResource):")
+						// Remote resource option is set
+						//assert.Contains(t, string(file), "remote=True)")
+						// Correct import for local resource
+						assert.Contains(t, string(file), `import {Resource} from "./index";`)
+						// Correct type for resource input property
+						assert.Contains(t, string(file), "readonly foo?: pulumi.Input<Resource>;")
+						// Correct type for resource property
+						assert.Contains(t, string(file), "public readonly foo!: pulumi.Output<Resource | undefined>;")
+					}
+					if fileName == "argFunction.ts" {
+						// Correct import for local resource
+						assert.Contains(t, string(file), `import {Resource} from "./index";`)
+						// Correct type for function arg
+						assert.Contains(t, string(file), "readonly arg1?: Resource;")
+						// Correct type for result
+						assert.Contains(t, string(file), "readonly result?: Resource;")
+					}
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Read in, decode, and import the schema.
+			schemaBytes, err := ioutil.ReadFile(
+				filepath.Join("..", "internal", "test", "testdata", tt.schemaFile))
+			assert.NoError(t, err)
+
+			var pkgSpec schema.PackageSpec
+			err = json.Unmarshal(schemaBytes, &pkgSpec)
+			assert.NoError(t, err)
+
+			pkg, err := schema.ImportSpec(pkgSpec, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ImportSpec() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			files, err := GeneratePackage("test", pkg, nil)
+			if err != nil {
+				panic(err)
+			}
+			tt.validator(files)
+		})
+	}
+}

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -31,6 +31,8 @@ func TestGeneratePackage(t *testing.T) {
 						assert.Contains(t, string(file), "export class Resource extends pulumi.CustomResource {")
 						// Remote option not set
 						assert.NotContains(t, string(file), ", true /*remote*/);")
+						// CustomResource class contains a get method
+						assert.Contains(t, string(file), "public static get(name: string")
 					}
 					if fileName == "otherResource.ts" {
 						// Correct parent class
@@ -43,6 +45,8 @@ func TestGeneratePackage(t *testing.T) {
 						assert.Contains(t, string(file), "readonly foo?: pulumi.Input<Resource>;")
 						// Correct type for resource property
 						assert.Contains(t, string(file), "public readonly foo!: pulumi.Output<Resource | undefined>;")
+						// ComponentResource class does not contain a get method
+						assert.NotContains(t, string(file), "public static get(name: string")
 					}
 					if fileName == "argFunction.ts" {
 						// Correct import for local resource

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -10,32 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-//func TestGeneratePackage(t *testing.T) {
-//	// Read in, decode, and import the schema.
-//	schemaBytes, err := ioutil.ReadFile(filepath.Join("..", "internal", "test", "testdata", "schema-simple.json"))
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	var pkgSpec schema.PackageSpec
-//	if err = json.Unmarshal(schemaBytes, &pkgSpec); err != nil {
-//		panic(err)
-//	}
-//
-//	pkg, err := schema.ImportSpec(pkgSpec, nil)
-//	if err != nil {
-//		t.Errorf("ImportSpec() error = %v", err)
-//	}
-//
-//	files, err := GeneratePackage("test", pkg, nil)
-//	if err != nil {
-//		panic(err)
-//	}
-//
-//	assert.Contains(t, files, filepath.Join("pulumi_example", "resource.py"))
-//	assert.Contains(t, files, filepath.Join("pulumi_example", "other_resource.py"))
-//}
-
 func TestGeneratePackage(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi/issues/5358
Fix https://github.com/pulumi/pulumi/issues/5410

Here's the generated file:
```ts
import * as pulumi from "@pulumi/pulumi";
import * as utilities from "./utilities";

import {Resource} from "./index";

export class OtherResource extends pulumi.ComponentResource {
    /**
     * Get an existing OtherResource resource's state with the given name, ID, and optional extra
     * properties used to qualify the lookup.
     *
     * @param name The _unique_ name of the resulting resource.
     * @param id The _unique_ provider ID of the resource to lookup.
     * @param opts Optional settings to control the behavior of the CustomResource.
     */
    public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.ComponentResourceOptions): OtherResource {
        return new OtherResource(name, undefined as any, { ...opts, id: id });
    }

    /** @internal */
    public static readonly __pulumiType = 'example::OtherResource';

    /**
     * Returns true if the given object is an instance of OtherResource.  This is designed to work even
     * when multiple copies of the Pulumi SDK have been loaded into the same process.
     */
    public static isInstance(obj: any): obj is OtherResource {
        if (obj === undefined || obj === null) {
            return false;
        }
        return obj['__pulumiType'] === OtherResource.__pulumiType;
    }

    public readonly foo!: pulumi.Output<Resource | undefined>;

    /**
     * Create a OtherResource resource with the given unique name, arguments, and options.
     *
     * @param name The _unique_ name of the resource.
     * @param args The arguments to use to populate this resource's properties.
     * @param opts A bag of options that control this resource's behavior.
     */
    constructor(name: string, args?: OtherResourceArgs, opts?: pulumi.ComponentResourceOptions) {
        let inputs: pulumi.Inputs = {};
        if (!(opts && opts.id)) {
            inputs["foo"] = args ? args.foo : undefined;
        } else {
            inputs["foo"] = undefined /*out*/;
        }
        if (!opts) {
            opts = {}
        }

        if (!opts.version) {
            opts.version = utilities.getVersion();
        }
        super(OtherResource.__pulumiType, name, inputs, opts, true /*remote*/);
    }
}

/**
 * The set of arguments for constructing a OtherResource resource.
 */
export interface OtherResourceArgs {
    readonly foo?: pulumi.Input<Resource>;
}
```