### PR TITLE
[dotnet] Allow resources to define outputs of Output<object>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ CHANGELOG
   (fixes [#5014](https://github.com/pulumi/pulumi/issues/5014))
   [#5406](https://github.com/pulumi/pulumi/pull/5406)
 
+- .NET SDK: Support `Output<object>` for resource output properties
+  (fixes [#5446](https://github.com/pulumi/pulumi/issues/5446))
+  [#5465](https://github.com/pulumi/pulumi/pull/5465)
+
 _(None)_
 
 ## 2.10.2 (2020-09-21)

--- a/sdk/dotnet/Pulumi.Tests/Serialization/ComplexTypeConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/ComplexTypeConverterTests.cs
@@ -22,11 +22,12 @@ namespace Pulumi.Tests.Serialization
             public readonly double D;
             public readonly ImmutableArray<bool> Array;
             public readonly ImmutableDictionary<string, int> Dict;
+            public readonly object Obj;
 
             [OutputConstructor]
             public ComplexType1(
                 string s, bool b, int i, double d,
-                ImmutableArray<bool> array, ImmutableDictionary<string, int> dict)
+                ImmutableArray<bool> array, ImmutableDictionary<string, int> dict, object obj)
             {
                 S = s;
                 B = b;
@@ -34,6 +35,7 @@ namespace Pulumi.Tests.Serialization
                 D = d;
                 Array = array;
                 Dict = dict;
+                Obj = obj;
             }
         }
 
@@ -48,6 +50,7 @@ namespace Pulumi.Tests.Serialization
                 { "d", 1.5 },
                 { "array", new List<object> { true, false } },
                 { "dict", new Dictionary<object, object> { { "k", 10 } } },
+                { "obj", "test" }
             }));
 
             Assert.Equal("str", data.Value.S);
@@ -56,6 +59,7 @@ namespace Pulumi.Tests.Serialization
             Assert.Equal(1.5, data.Value.D);
             AssertEx.SequenceEqual(ImmutableArray<bool>.Empty.Add(true).Add(false), data.Value.Array);
             AssertEx.MapEqual(ImmutableDictionary<string, int>.Empty.Add("k", 10), data.Value.Dict);
+            Assert.Equal("test", data.Value.Obj);
 
             Assert.True(data.IsKnown);
         }
@@ -98,6 +102,7 @@ namespace Pulumi.Tests.Serialization
                         { "d", 1.1 },
                         { "array", new List<object> { false, false } },
                         { "dict", new Dictionary<object, object> { { "k", 1 } } },
+                        { "obj", 50.0 },
                     }
                 },
                 {
@@ -112,6 +117,7 @@ namespace Pulumi.Tests.Serialization
                             { "d", 2.2 },
                             { "array", new List<object> { false, true } },
                             { "dict", new Dictionary<object, object> { { "k", 2 } } },
+                            { "obj", true },
                         }
                     }
                 },
@@ -129,6 +135,7 @@ namespace Pulumi.Tests.Serialization
                                 { "d", 3.3 },
                                 { "array", new List<object> { true, false } },
                                 { "dict", new Dictionary<object, object> { { "k", 3 } } },
+                                { "obj", new Dictionary<object, object> { { "o", 5.5 } } },
                             }
                         }
                     }
@@ -142,6 +149,7 @@ namespace Pulumi.Tests.Serialization
             Assert.Equal(1.1, value.D);
             AssertEx.SequenceEqual(ImmutableArray<bool>.Empty.Add(false).Add(false), value.Array);
             AssertEx.MapEqual(ImmutableDictionary<string, int>.Empty.Add("k", 1), value.Dict);
+            Assert.Equal(50.0, value.Obj);
 
             Assert.Single(data.C2Array);
             value = data.C2Array[0];
@@ -151,6 +159,7 @@ namespace Pulumi.Tests.Serialization
             Assert.Equal(2.2, value.D);
             AssertEx.SequenceEqual(ImmutableArray<bool>.Empty.Add(false).Add(true), value.Array);
             AssertEx.MapEqual(ImmutableDictionary<string, int>.Empty.Add("k", 2), value.Dict);
+            Assert.Equal(true, value.Obj);
 
             Assert.Single(data.C2Map);
             var (key, val) = data.C2Map.Single();
@@ -163,6 +172,7 @@ namespace Pulumi.Tests.Serialization
             Assert.Equal(3.3, value.D);
             AssertEx.SequenceEqual(ImmutableArray<bool>.Empty.Add(true).Add(false), value.Array);
             AssertEx.MapEqual(ImmutableDictionary<string, int>.Empty.Add("k", 3), value.Dict);
+            AssertEx.MapEqual(ImmutableDictionary<string, object>.Empty.Add("o", 5.5), (IDictionary<string, object>)value.Obj);
         }
 
         #endregion

--- a/sdk/dotnet/Pulumi/Serialization/Converter.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Converter.cs
@@ -86,6 +86,9 @@ namespace Pulumi.Serialization
                 return ((int)d, exception);
             }
 
+            if (targetType == typeof(object))
+                return (val, null);
+
             if (targetType == typeof(Asset))
                 return TryEnsureType<Asset>(context, val);
 
@@ -310,6 +313,7 @@ namespace Pulumi.Serialization
                 targetType == typeof(int) ||
                 targetType == typeof(double) ||
                 targetType == typeof(string) ||
+                targetType == typeof(object) ||
                 targetType == typeof(Asset) ||
                 targetType == typeof(Archive) ||
                 targetType == typeof(AssetOrArchive) ||


### PR DESCRIPTION
Several resources in Azure NextGen provider expose untyped properties that are mapped to "Any" in the schema and `object` in .NET. This PR introduces `object` type to output deserialization in the .NET SDK, where the incoming value is returned as-is.

Tested in Azure NextGen and the output was returned successfully and available in stack outputs too.

Resolves #5446 