### PR TITLE
Correctly validate project names during 'pulumi new'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Correctly validate project names during 'pulumi new'
+  [#5504](https://github.com/pulumi/pulumi/pull/5504)
 
 ## 2.11.2 (2020-10-01)
 

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -401,17 +401,25 @@ func TestGeneratingProjectWithInvalidPromptedNameFails(t *testing.T) {
 	}
 
 	// Generate-only command is not creating any stacks, so don't bother with with the name uniqueness check.
-	var args = newArgs{
+	err := runNew(newArgs{
 		generateOnly:      true,
 		interactive:       true,
 		prompt:            promptMock("not#valid", ""),
 		secretsProvider:   "default",
 		templateNameOrURL: "typescript",
-	}
-
-	err := runNew(args)
+	})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "project name may only contain")
+
+	err = runNew(newArgs{
+		generateOnly:      true,
+		interactive:       true,
+		prompt:            promptMock("", ""),
+		secretsProvider:   "default",
+		templateNameOrURL: "typescript",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "project name may not be empty")
 }
 
 func TestInvalidTemplateName(t *testing.T) {

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -514,6 +514,10 @@ var (
 // ValidateProjectName ensures a project name is valid, if it is not it returns an error with a message suitable
 // for display to an end user.
 func ValidateProjectName(s string) error {
+	if s == "" {
+		return errors.New("A project name may not be empty")
+	}
+
 	if len(s) > 100 {
 		return errors.New("A project name must be 100 characters or less")
 	}

--- a/sdk/go/common/workspace/templates_test.go
+++ b/sdk/go/common/workspace/templates_test.go
@@ -283,6 +283,11 @@ func TestProjectNames(t *testing.T) {
 			projectName: "Pulumi.Test",
 			expectError: true,
 		},
+		{
+			testName:    "Empty Project Name",
+			projectName: "",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The logic for validating prompted values in 'new' wasn't quite right,
leading to the possibility of creating Pulumi.yaml files with blank
project names.

This manifests in various ways and I've hit it a number of times
over the past few months because of the way we handle project/stack
name conflicts in 'new' -- which itself is a bit annoying too:

https://github.com/pulumi/pulumi/blob/master/pkg/cmd/pulumi/new.go#L206-L207

Because we substitue a default value of "", and because the prompting
logic assumed default values are always valid, we would skip validation
and therefore accept a blank project name.

This generates an invalid Pulumi.yaml which causes errors elsewhere, such as

    error: failed to load Pulumi project located at ".../Pulumi.yaml":
        project is missing a 'name' attribute

I hit this all the time with our getting started guide because I've
gone through it so many times and have leftover stacks from prior
run-throughs. I wouldn't be surprised if a lot of people hit this.

The solution here validates all values, including the default.

Note also that we failed to validate the value used by 'new --yes'
which meant you could bypass all validation by passing --yes, leading
to similar outcomes.

I've added a couple new tests for these cases. There is a risk we
depend on illegal default values somewhere which will now be rejected,
but that would seem strange, and assuming the tests pass, I would
assume that's not true. Let me know if that's wrong.

Fixes pulumi/pulumi#3255.