### PR TITLE
Ensure top-level precedence to avoid flaky tests

### DIFF
--- a/pkg/codegen/go/gen_program_expression_test.go
+++ b/pkg/codegen/go/gen_program_expression_test.go
@@ -45,7 +45,6 @@ func TestLiteralExpression(t *testing.T) {
 }
 
 func TestBinaryOpExpression(t *testing.T) {
-	t.Skip("Skipping test due to https://github.com/pulumi/pulumi/issues/4885")
 	env := environment(map[string]interface{}{
 		"a": model.BoolType,
 		"b": model.BoolType,

--- a/pkg/codegen/hcl2/model/format/gen.go
+++ b/pkg/codegen/hcl2/model/format/gen.go
@@ -176,7 +176,10 @@ func (e *Formatter) Fgenf(w io.Writer, format string, args ...interface{}) {
 	for i := range args {
 		if node, ok := args[i].(model.Expression); ok {
 			args[i] = Func(func(f fmt.State, c rune) {
-				parentPrecedence, _ := f.Precision()
+				parentPrecedence := 0
+				if pp, ok := f.Precision(); ok {
+					parentPrecedence = pp
+				}
 				rhs := c == 'o'
 				e.gen(f, parentPrecedence, rhs, node)
 			})


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi/issues/4885

I'm not able to reproduce the original failure. However, the parenthesis is likely added due to messed-up precedence [here](https://github.com/pulumi/pulumi/blob/3be1ea9592b305df8aeb83c3810aee9bb8adeb7a/pkg/codegen/hcl2/model/format/gen.go#L113-L119).

This PR makes sure to set `parentPrecedence` to `0` if `f.Precision()` returns `false` as the second result. Most commonly, the first result is `0`, but not always! 

With old code, if I run `go test -run TestBinaryOpExpression -count=10 -parallel 10` and log `parentPrecedence` if `ok` is `false`, I occasionally get `2`, `6`, and `14`. A `14` would activate the parenthesis adding logic.