### PR TITLE
Execute self-contained .NET binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ CHANGELOG
 - Add internal scaffolding for using cross-language components from .NET.
   [#5485](https://github.com/pulumi/pulumi/pull/5485)
 
+- Support self-contained executables as binary option for .NET programs.
+  [#5519](https://github.com/pulumi/pulumi/pull/5519)
+
 ## 2.11.2 (2020-10-01)
 
 - feat(autoapi): expose EnvVars LocalWorkspaceOption to set in ctor

--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -61,7 +61,13 @@ func main() {
 	logging.InitLogging(false, 0, false)
 	cmdutil.InitTracing("pulumi-language-dotnet", "pulumi-language-dotnet", tracing)
 	var dotnetExec string
-	if givenExecutor == "" {
+	switch {
+	case givenExecutor != "":
+		logging.V(3).Infof("language host asked to use specific executor: `%s`", givenExecutor)
+		dotnetExec = givenExecutor
+	case binary != "" && !strings.HasSuffix(binary, ".dll"):
+		logging.V(3).Info("language host requires no .NET SDK for a self-contained binary")
+	default:
 		pathExec, err := exec.LookPath("dotnet")
 		if err != nil {
 			err = errors.Wrap(err, "could not find `dotnet` on the $PATH")
@@ -70,9 +76,6 @@ func main() {
 
 		logging.V(3).Infof("language host identified executor from path: `%s`", pathExec)
 		dotnetExec = pathExec
-	} else {
-		logging.V(3).Infof("language host asked to use specific executor: `%s`", givenExecutor)
-		dotnetExec = givenExecutor
 	}
 
 	// Optionally pluck out the engine so we can do logging, etc.


### PR DESCRIPTION
Resolves #5334 (other than a binary CLI option, which will move to a new issue)

When the `binary` option is specified, this PR runs it as `dotnet foo.dll` for dll files and directly otherwise.

This change looks legit to me but is slightly scary in case I'm missing some other non-dll scenario, so reviews are appreciated.