### PR TITLE
[codegen/nodejs] - Update enum generation

### DIFF
--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/types/enums/index.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/types/enums/index.ts
@@ -5,23 +5,27 @@
 import * as tree from "./tree";
 export {tree};
 
-export const RedContainerColor: ContainerColor = "red";
-export const BlueContainerColor: ContainerColor = "blue";
-export const YellowContainerColor: ContainerColor = "yellow";
+export const ContainerColor = {
+    Red: "red",
+    Blue: "blue",
+    Yellow: "yellow",
+} as const;
 
 /**
  * plant container colors
  */
-export type ContainerColor = "red" | "blue" | "yellow";
+export type ContainerColor = (typeof ContainerColor)[keyof typeof ContainerColor];
 
-export const FourInchContainerSize: ContainerSize = 4;
-export const SixInchContainerSize: ContainerSize = 6;
-/**
- * @deprecated Eight inch pots are no longer supported.
- */
-export const EightInchContainerSize: ContainerSize = 8;
+export const ContainerSize = {
+    FourInch: 4,
+    SixInch: 6,
+    /**
+     * @deprecated Eight inch pots are no longer supported.
+     */
+    EightInch: 8,
+} as const;
 
 /**
  * plant container sizes
  */
-export type ContainerSize = 4 | 6 | 8;
+export type ContainerSize = (typeof ContainerSize)[keyof typeof ContainerSize];

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/types/enums/tree/v1/index.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/types/enums/tree/v1/index.ts
@@ -2,20 +2,22 @@
 // *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 
-/**
- * A burgundy rubber tree.
- */
-export const BurgundyRubberTreeVariety: RubberTreeVariety = "Burgundy";
-/**
- * A ruby rubber tree.
- */
-export const RubyRubberTreeVariety: RubberTreeVariety = "Ruby";
-/**
- * A tineke rubber tree.
- */
-export const TinekeRubberTreeVariety: RubberTreeVariety = "Tineke";
+export const RubberTreeVariety = {
+    /**
+     * A burgundy rubber tree.
+     */
+    Burgundy: "Burgundy",
+    /**
+     * A ruby rubber tree.
+     */
+    Ruby: "Ruby",
+    /**
+     * A tineke rubber tree.
+     */
+    Tineke: "Tineke",
+} as const;
 
 /**
  * types of rubber trees
  */
-export type RubberTreeVariety = "Burgundy" | "Ruby" | "Tineke";
+export type RubberTreeVariety = (typeof RubberTreeVariety)[keyof typeof RubberTreeVariety];

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1110,37 +1110,27 @@ func makeSafeEnumName(name string) string {
 }
 
 func (mod *modContext) genEnum(w io.Writer, enum *schema.EnumType) {
+	indent := "    "
 	enumName := tokenToName(enum.Token)
+	fmt.Fprintf(w, "export const %s = {\n", enumName)
 	for _, e := range enum.Elements {
 		if e.Name == "" {
 			e.Name = fmt.Sprintf("%v", e.Value)
 		}
 		e.Name = makeSafeEnumName(e.Name)
-		printComment(w, e.Comment, e.DeprecationMessage, "")
-		fmt.Fprintf(w, "export const %[1]s%[2]s: %[2]s = ", e.Name, enumName)
+		printComment(w, e.Comment, e.DeprecationMessage, indent)
+		fmt.Fprintf(w, "%s%s: ", indent, e.Name)
 		if val, ok := e.Value.(string); ok {
-			fmt.Fprintf(w, "%q;\n", val)
+			fmt.Fprintf(w, "%q,\n", val)
 		} else {
-			fmt.Fprintf(w, "%v;\n", e.Value)
+			fmt.Fprintf(w, "%v,\n", e.Value)
 		}
 	}
+	fmt.Fprintf(w, "} as const;\n")
 	fmt.Fprintf(w, "\n")
 
 	printComment(w, enum.Comment, "", "")
-	fmt.Fprintf(w, "export type %s = ", enumName)
-	for i, e := range enum.Elements {
-		if val, ok := e.Value.(string); ok {
-			fmt.Fprintf(w, "%q", val)
-		} else {
-			fmt.Fprintf(w, "%v", e.Value)
-		}
-
-		if i == len(enum.Elements)-1 {
-			fmt.Fprintf(w, ";\n")
-		} else {
-			fmt.Fprintf(w, " | ")
-		}
-	}
+	fmt.Fprintf(w, "export type %[1]s = (typeof %[1]s)[keyof typeof %[1]s];\n", enumName)
 }
 
 type fs map[string][]byte


### PR DESCRIPTION
I went with @justinvp's suggestion of updating how our TS enums are emitted (more details in #5494) instead of adding nodejs-specific name overrides. This allows us to keep standardized naming for the newly generated enums, while also allowing us to support the existing constants as extra overlays. We also get the added benefit of a cleaner/more idiomatic enum interface while still allowing us to use string literals. Thanks for the suggestion @justinvp!

Resolves #5494 

WIP pulumi-aws PR: https://github.com/pulumi/pulumi-aws/pull/1151