### PR TITLE
add plugin management utils to node Automation API

### DIFF
--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -383,7 +383,7 @@ func (l *LocalWorkspace) InstallPlugin(ctx context.Context, name string, version
 
 // RemovePlugin deletes the plugin matching the specified name and verision.
 func (l *LocalWorkspace) RemovePlugin(ctx context.Context, name string, version string) error {
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "plugin", "rm", "resource", name, version)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "plugin", "rm", "resource", name, version, "--yes")
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "failed to remove plugin"), stdout, stderr, errCode)
 	}

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -44,6 +44,13 @@ describe("LocalWorkspace", () => {
         }
     }));
 
+    it(`adds/removes/lists plugins successfully`, asyncTest(async () => {
+        const ws = await LocalWorkspace.create({});
+        await ws.installPlugin("aws", "v3.0.0");
+        await ws.removePlugin("aws", "3.0.0");
+        await ws.listPlugins();
+    }));
+
     it(`create/select/remove LocalWorkspace stack`, asyncTest(async () => {
         const projectSettings: ProjectSettings = {
             name: "node_test",

--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -336,7 +336,7 @@ export class LocalWorkspace implements Workspace {
      * @param stackName The stack to remove
      */
     async removeStack(stackName: string): Promise<void> {
-            await this.runPulumiCmd(["stack", "rm", "--yes", stackName]);
+        await this.runPulumiCmd(["stack", "rm", "--yes", stackName]);
     }
     /**
      * Returns the value associated with the specified stack name and key,
@@ -458,19 +458,29 @@ export class LocalWorkspace implements Workspace {
      *
      * @param name the name of the plugin.
      * @param version the version of the plugin e.g. "v1.0.0".
+     * @param kind the kind of plugin, defaults to "resource"
      */
-    async installPlugin(name: string, version: string): Promise<void> {
-        await this.runPulumiCmd(["plugin", "install", "resource", name, version]);
+    async installPlugin(name: string, version: string, kind = "resource"): Promise<void> {
+        await this.runPulumiCmd(["plugin", "install", kind, name, version]);
     }
     /**
      * Removes a plugin from the Workspace matching the specified name and version.
      *
-     * @param name the name of the plugin.
-     * @param versionRange the semver range to check when removing plugins matching the given name
+     * @param name the optional name of the plugin.
+     * @param versionRange optional semver range to check when removing plugins matching the given name
      *  e.g. "1.0.0", ">1.0.0".
+     * @param kind he kind of plugin, defaults to "resource".
      */
-    async removePlugin(name: string, versionRange: string): Promise<void> {
-        await this.runPulumiCmd(["plugin", "rm", "resource", name, versionRange, "--yes"]);
+    async removePlugin(name?: string, versionRange?: string, kind = "resource"): Promise<void> {
+        const args = ["plugin", "rm", kind];
+        if (name) {
+            args.push(name);
+        }
+        if (versionRange) {
+            args.push(versionRange);
+        }
+        args.push("--yes");
+        await this.runPulumiCmd(args);
     }
     /**
      * Returns a list of all plugins installed in the Workspace.
@@ -612,6 +622,6 @@ function getStackSettingsName(name: string): string {
 type StackInitializer = (name: string, workspace: Workspace) => Promise<Stack>;
 
 function defaultProject(projectName: string) {
-    const settings: ProjectSettings = { name: projectName, runtime: "nodejs"};
+    const settings: ProjectSettings = { name: projectName, runtime: "nodejs" };
     return settings;
 }

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -287,7 +287,7 @@ export class Stack {
             }
         }
 
-        const refResult = await this.runPulumiCmd(args);
+        const refResult = await this.runPulumiCmd(args, opts?.onOutput);
         const summary = await this.info();
         const result: RefreshResult = {
             stdout: refResult.stdout,
@@ -322,7 +322,7 @@ export class Stack {
             }
         }
 
-        const preResult = await this.runPulumiCmd(args);
+        const preResult = await this.runPulumiCmd(args, opts?.onOutput);
         const summary = await this.info();
         const result: DestroyResult = {
             stdout: preResult.stdout,

--- a/sdk/nodejs/x/automation/workspace.ts
+++ b/sdk/nodejs/x/automation/workspace.ts
@@ -171,16 +171,18 @@ export interface Workspace {
      *
      * @param name the name of the plugin.
      * @param version the version of the plugin e.g. "v1.0.0".
+     * @param kind the kind of plugin e.g. "resource"
      */
-    installPlugin(name: string, version: string): Promise<void>;
+    installPlugin(name: string, version: string, kind?: string): Promise<void>;
     /**
      * Removes a plugin from the Workspace matching the specified name and version.
      *
-     * @param name the name of the plugin.
-     * @param versionRange the semver range to check when removing plugins matching the given name
+     * @param name the optional name of the plugin.
+     * @param versionRange optional semver range to check when removing plugins matching the given name
      *  e.g. "1.0.0", ">1.0.0".
+     * @param kind he kind of plugin e.g. "resource"
      */
-    removePlugin(name: string, versionRange: string): Promise<void>;
+    removePlugin(name?: string, versionRange?: string, kind?: string): Promise<void>;
     /**
      * Returns a list of all plugins installed in the Workspace.
      */

--- a/sdk/nodejs/x/automation/workspace.ts
+++ b/sdk/nodejs/x/automation/workspace.ts
@@ -166,6 +166,25 @@ export interface Workspace {
      * This queries underlying backend and may return stacks not present in the Workspace (as Pulumi.<stack>.yaml files).
      */
     listStacks(): Promise<StackSummary[]>;
+    /**
+     * Installs a plugin in the Workspace, for example to use cloud providers like AWS or GCP.
+     *
+     * @param name the name of the plugin.
+     * @param version the version of the plugin e.g. "v1.0.0".
+     */
+    installPlugin(name: string, version: string): Promise<void>;
+    /**
+     * Removes a plugin from the Workspace matching the specified name and version.
+     *
+     * @param name the name of the plugin.
+     * @param versionRange the semver range to check when removing plugins matching the given name
+     *  e.g. "1.0.0", ">1.0.0".
+     */
+    removePlugin(name: string, versionRange: string): Promise<void>;
+    /**
+     * Returns a list of all plugins installed in the Workspace.
+     */
+    listPlugins(): Promise<PluginInfo[]>;
     // TODO import/export
 }
 
@@ -192,3 +211,16 @@ export type PulumiFn = () => Promise<Record<string, any> | void>;
 export interface WhoAmIResult {
     user: string;
 }
+
+export interface PluginInfo {
+    name: string;
+    path: string;
+    kind: PluginKind;
+    version?: string;
+    size: number;
+    installTime: Date;
+    lastUsedTime: Date;
+    serverURL: string;
+}
+
+export type PluginKind = "analyzer" | "language" | "resource";


### PR DESCRIPTION
Noticed that I missed this during the initial impl. Also fixed an issue that existed in Go with `plugin rm` that I discovered during testing (a missing `--yes` flag). 