### PR TITLE
Ensure secret provider variables are cleaned up when changing secret providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ CHANGELOG
 
 - Support self-contained executables as binary option for .NET programs.
   [#5519](https://github.com/pulumi/pulumi/pull/5519)
+  
+- [cli] Ensure old secret provider variables are cleaned up when changing between secret providers
+  [#5545](https://github.com/pulumi/pulumi/pull/5545)
 
 ## 2.11.2 (2020-10-01)
 

--- a/pkg/cmd/pulumi/crypto_cloud.go
+++ b/pkg/cmd/pulumi/crypto_cloud.go
@@ -40,6 +40,13 @@ func newCloudSecretsManager(stackName tokens.QName, configFile, secretsProvider 
 		return nil, err
 	}
 
+	// Only a passphrase provider has an encryption salt. So changing a secrets provider
+	// from passphrase to a cloud secrets provider should ensure that we remove the enryptionsalt
+	// as it's a legacy artifact and needs to be removed
+	if info.EncryptionSalt != "" {
+		info.EncryptionSalt = ""
+	}
+
 	var secretsManager *cloud.Manager
 	if info.EncryptedKey == "" {
 		dataKey, err := cloud.GenerateNewDataKey(secretsProvider)


### PR DESCRIPTION
Fixes: #5509

When changing from a passphrase provider to a cloud secrets provider,
the encryptionsalt is not required, so we should ensure this is removed

This follows the same style functionality when moving from a passphrase to a saas secrets provider