### PR TITLE
chore(actions): support custom stack name from env

### DIFF
--- a/docker/actions/entrypoint.sh
+++ b/docker/actions/entrypoint.sh
@@ -50,11 +50,13 @@ if [ ! -z "$PULUMI_CI" ]; then
     # Respect the branch mappings file for stack selection. Note that this is *not* required, but if the file
     # is missing, the caller of this script will need to pass `-s <stack-name>` to specify the stack explicitly.
     if [ ! -z "$BRANCH" ]; then
-        if [ -e $ROOT/.pulumi/ci.json ]; then
-            PULUMI_STACK_NAME=$(cat $ROOT/.pulumi/ci.json | jq -r ".\"$BRANCH\"")
-        else
-            # If there's no stack mapping file, we are on master, and there's a single stack, use it.
-            PULUMI_STACK_NAME=$(pulumi stack ls | awk 'FNR == 2 {print $1}' | sed 's/\*//g')
+        if [ -z "$PULUMI_STACK_NAME" ]; then
+            if [ -e $ROOT/.pulumi/ci.json ]; then
+                PULUMI_STACK_NAME=$(cat $ROOT/.pulumi/ci.json | jq -r ".\"$BRANCH\"")
+            else
+                # If there's no stack mapping file, we are on master, and there's a single stack, use it.
+                PULUMI_STACK_NAME=$(pulumi stack ls | awk 'FNR == 2 {print $1}' | sed 's/\*//g')
+            fi
         fi
 
         if [ ! -z "$PULUMI_STACK_NAME" ] && [ "$PULUMI_STACK_NAME" != "null" ]; then


### PR DESCRIPTION
Users can define the stack name to deploy multiple environments using multiple AWS accounts in the same branch.

```
      - uses: docker://pulumi/actions
        with:
          args: up
        env:
          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_01 }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_01 }}
          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
          PULUMI_CI: up
          PULUMI_ROOT: infra
          PULUMI_STACK_NAME: stack_a

      - uses: docker://pulumi/actions
        with:
          args: up
        env:
          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_02 }}
          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_02 }}
          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
          PULUMI_CI: up
          PULUMI_ROOT: infra
          PULUMI_STACK_NAME: stack_b
```

