### PR TITLE
Improve user message when pulumi plugin rm --all has no plugins to remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ CHANGELOG
 - [cli] Ensure old secret provider variables are cleaned up when changing between secret providers
   [#5545](https://github.com/pulumi/pulumi/pull/5545)
 
+- [cli] Improve user experience when pulumi plugin rm --all finds no plugins
+  to remove. The previous behaviour was an error and should not be so.
+  [#5547](https://github.com/pulumi/pulumi/pull/5547)
+
 ## 2.11.2 (2020-10-01)
 
 - feat(autoapi): expose EnvVars LocalWorkspaceOption to set in ctor

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/diag"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/go-multierror"
@@ -89,7 +90,9 @@ func newPluginRmCmd() *cobra.Command {
 			}
 
 			if len(deletes) == 0 {
-				return errors.New("no plugins found")
+				cmdutil.Diag().Infof(
+					diag.Message("", "no plugins found to uninstall"))
+				return nil
 			}
 
 			// Confirm that the user wants to do this (unless --yes was passed), and do the deletes.


### PR DESCRIPTION
Fixes: #5376

```                                                                                                                                                                                          ⍉
pulumi plugin rm --all --yes
no plugins found to uninstall
echo $?
0
```