### PR TITLE
Respect logging verbosity as part of pulumi plugin install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ CHANGELOG
   
 - [cli] Ensure old secret provider variables are cleaned up when changing between secret providers
   [#5545](https://github.com/pulumi/pulumi/pull/5545)
+  
+- [cli] Respect logging verbosity as part of pulumi plugin install commands
+  [#5549](https://github.com/pulumi/pulumi/pull/5549)
 
 - [cli] Accept `-f` as a shorthand for `--skip-preview` on `pulumi up`, `pulumi refresh` and `pulumi destroy` operations
   [#5556](https://github.com/pulumi/pulumi/pull/5556)


### PR DESCRIPTION
Fixes: #4427
Fixes: #3609

By default, there is no indepth logging:

```
pulumi plugin install resource azure-nextgen v0.2.1
[resource plugin azure-nextgen-0.2.1] installing
Downloading plugin: 17.82 MiB / 17.82 MiB [=========================] 100.00% 2s
Moving plugin... done.
```

We can increase the logging verosity get more detailed logging:
```
pulumi plugin install resource azure-nextgen v0.2.1 -v=1 --logtostderr
[resource plugin azure-nextgen-0.2.1] installing
I1010 19:30:58.472772    7128 plugins.go:201] azure-nextgen downloading from https://get.pulumi.com/releases/plugins
Downloading plugin: 0 B / 17.82 MiB [----------------------------------]   0.00%I1010 19:30:58.704168    7128 plugin_install.go:136] [resource plugin azure-nextgen-0.2.1] installing tarball ...
Downloading plugin: 17.82 MiB / 17.82 MiB [=========================] 100.00% 3s
Moving plugin...I1010 19:31:01.874427    7128 plugins.go:304] moving plugin from "/Users/myuser/.pulumi/plugins/resource-azure-nextgen-v0.2.1.tmp884796935" to "/Users/myuser/.pulumi/plugins/resource-azure-nextgen-v0.2.1"
 done.
```

The most verbose logging level will log the request and response headers
```
pulumi plugin install resource azure-nextgen v0.2.1 -v=9 --logtostderr
I1010 19:29:46.989150    7089 sink.go:146] defaultSink::Infoerr([resource plugin azure-nextgen-0.2.1] installing)
[resource plugin azure-nextgen-0.2.1] installing
I1010 19:29:46.989295    7089 plugins.go:591] SelectCompatiblePlugin(..., azure-nextgen): beginning
I1010 19:29:46.989300    7089 plugins.go:630] SelectCompatiblePlugin(..., azure-nextgen): failed to find match
I1010 19:29:46.989323    7089 plugins.go:201] azure-nextgen downloading from https://get.pulumi.com/releases/plugins
I1010 19:29:46.989333    7089 plugins.go:208] full plugin download url: https://get.pulumi.com/releases/plugins/pulumi-resource-azure-nextgen-v0.2.1-darwin-amd64.tar.gz
I1010 19:29:46.989360    7089 plugins.go:218] plugin install request headers: map[User-Agent:[pulumi-cli/1 (; darwin)]]
I1010 19:29:47.242941    7089 plugins.go:225] plugin install response headers: map[Accept-Ranges:[bytes] Age:[370098] Content-Disposition:[attachment; filename=pulumi-resource-azure-nextgen-v0.2.1-darwin-amd64.tar.gz] Content-Length:[18684382] Content-Type:[application/x-gzip] Date:[Tue, 06 Oct 2020 11:41:30 GMT] Etag:["518f2e7efd46fe5b7be9508dc785b9c9-4"] Last-Modified:[Sat, 03 Oct 2020 20:57:45 GMT] Server:[AmazonS3] Via:[1.1 198b7d1bb217783eef010e6636984c9f.cloudfront.net (CloudFront)] X-Amz-Cf-Id:[aaC3Q0WcecspsFbWROLxXnD6iF7sYoAfShQKYiS2xkFKAWlFRBu-1Q==] X-Amz-Cf-Pop:[MAN50-C2] X-Cache:[Hit from cloudfront]]
Downloading plugin: 0 B / 17.82 MiB [----------------------------------]   0.00%I1010 19:29:47.243189    7089 plugin_install.go:136] [resource plugin azure-nextgen-0.2.1] installing tarball ...
Downloading plugin: 17.82 MiB / 17.82 MiB [=========================] 100.00% 2s
Moving plugin...I1010 19:29:50.031099    7089 plugins.go:304] moving plugin from "/Users/myuser/.pulumi/plugins/resource-azure-nextgen-v0.2.1.tmp960784076" to "/Users/myuser/.pulumi/plugins/resource-azure-nextgen-v0.2.1"
 done.
```