### PR TITLE
Validate and error on invalid cloudUrl formats on pulumi login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ CHANGELOG
   
 - [cli] Ensure old secret provider variables are cleaned up when changing between secret providers
   [#5545](https://github.com/pulumi/pulumi/pull/5545)
+  
+- [cli] Validate cloudUrl formats before `pulumi login` and throw an error if incorrect format specified
+  [#5550](https://github.com/pulumi/pulumi/pull/5545)
 
 ## 2.11.2 (2020-10-01)
 

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -116,6 +116,11 @@ func newLoginCmd() *cobra.Command {
 				if err != nil {
 					return errors.Wrap(err, "could not determine current cloud")
 				}
+			} else {
+				// Ensure we have the correct cloudurl type before logging in
+				if err := validateCloudBackendType(cloudURL); err != nil {
+					return err
+				}
 			}
 
 			var be backend.Backend
@@ -143,4 +148,19 @@ func newLoginCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(&localMode, "local", "l", false, "Use Pulumi in local-only mode")
 
 	return cmd
+}
+
+func validateCloudBackendType(typ string) error {
+	kind := strings.SplitN(typ, ":", 2)[0]
+	supportedKinds := []string{"azblob", "gs", "s3", "file", "https"}
+	for _, supportedKind := range supportedKinds {
+		if kind == supportedKind {
+			return nil
+		}
+	}
+	return errors.Errorf(
+		"unknown backend cloudUrl format '%s' (supported Url formats are: "+
+			"azblob://, gs://, s3://, file:// and https://)",
+		kind,
+	)
 }


### PR DESCRIPTION
Fixes: #3382

```
▶ pulumi login --cloud-url az://myblob
error: unknown backend cloudUrl format 'az' (supported Url formats are: azblob://, gs:// and s3://)
```