### PR TITLE
[dotnet] Add a lock around child resource manipulation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ CHANGELOG
 - [sdk/python] Fix ResourceOptions annotations and doc strings.
   [#5559](https://github.com/pulumi/pulumi/pull/5559)
 
+- [sdk/dotnet] Fix HashSet concurrency issue.
+  [#5563](https://github.com/pulumi/pulumi/pull/5563)
+
 ## 2.11.2 (2020-10-01)
 
 - feat(autoapi): expose EnvVars LocalWorkspaceOption to set in ctor

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
@@ -151,7 +151,12 @@ namespace Pulumi
                 {
                     if (resource is ComponentResource)
                     {
-                        AddTransitivelyReferencedChildResourcesOfComponentResources(resource.ChildResources, result);
+                        HashSet<Resource> childResources = new HashSet<Resource>();
+                        lock (resource.ChildResources)
+                        {
+                            childResources.AddRange(resource.ChildResources);
+                        }
+                        AddTransitivelyReferencedChildResourcesOfComponentResources(childResources, result);
                     }
                 }
             }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
@@ -151,10 +151,10 @@ namespace Pulumi
                 {
                     if (resource is ComponentResource)
                     {
-                        HashSet<Resource> childResources = new HashSet<Resource>();
+                        HashSet<Resource> childResources;
                         lock (resource.ChildResources)
                         {
-                            childResources.AddRange(resource.ChildResources);
+                            childResources = new HashSet<Resource>(resource.ChildResources);
                         }
                         AddTransitivelyReferencedChildResourcesOfComponentResources(childResources, result);
                     }

--- a/sdk/dotnet/Pulumi/Resources/Resource.cs
+++ b/sdk/dotnet/Pulumi/Resources/Resource.cs
@@ -188,7 +188,10 @@ namespace Pulumi
             if (options.Parent != null)
             {
                 this._parentResource = options.Parent;
-                this._parentResource.ChildResources.Add(this);
+                lock (this._parentResource.ChildResources)
+                {
+                    this._parentResource.ChildResources.Add(this);
+                }
 
                 if (options.Protect == null)
                     options.Protect = options.Parent._protect;


### PR DESCRIPTION
Add a lock around child resource manipulation to prevent hashset concurrency issues. Fix #4821