### PR TITLE
Remove author name and committer name. Fixes #5430

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ CHANGELOG
 - [sdk/dotnet] Fix HashSet concurrency issue.
   [#5563](https://github.com/pulumi/pulumi/pull/5563)
 
+- [cli] Remove author name and committer name
+  [#5567](https://github.com/pulumi/pulumi/pull/5567)
+
 ## 2.11.2 (2020-10-01)
 
 - feat(autoapi): expose EnvVars LocalWorkspaceOption to set in ctor

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -624,9 +624,7 @@ func addGitCommitMetadata(repo *git.Repository, repoRoot string, m *backend.Upda
 	}
 
 	// Store committer and author information.
-	m.Environment[backend.GitCommitter] = commit.Committer.Name
 	m.Environment[backend.GitCommitterEmail] = commit.Committer.Email
-	m.Environment[backend.GitAuthor] = commit.Author.Name
 	m.Environment[backend.GitAuthorEmail] = commit.Author.Email
 
 	// If the worktree is dirty, set a bit, as this could be a mistake.


### PR DESCRIPTION
This PR fixes #5430 where the author and committer names were being sent from the CLI.