### PR TITLE
Ensure CLI doesn't panic when pulumi watch is used with policies enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+- [cli] Ensure that the CLI doesn't panic when using pulumi watch and policies are enabled
+  [#5569](https://github.com/pulumi/pulumi/pull/5569)
+
 
 ## 2.12.0 (2020-10-14)
 

--- a/pkg/backend/display/watch.go
+++ b/pkg/backend/display/watch.go
@@ -50,6 +50,9 @@ func ShowWatchEvents(op string, action apitype.UpdateKind, events <-chan engine.
 		case engine.PreludeEvent, engine.SummaryEvent, engine.StdoutColorEvent:
 			// Ignore it
 			continue
+		case engine.PolicyViolationEvent:
+			// At this point in time, we don't handle policy events as part of pulumi watch
+			continue
 		case engine.DiagEvent:
 			// Skip any ephemeral or debug messages, and elide all colorization.
 			p := e.Payload().(engine.DiagEventPayload)


### PR DESCRIPTION
Fixes: #5561