### PR TITLE
Refactor lifecycle tests.

### DIFF
--- a/pkg/engine/journal.go
+++ b/pkg/engine/journal.go
@@ -1,0 +1,203 @@
+package engine
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/pulumi/pulumi/pkg/v2/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v2/secrets"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/logging"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/workspace"
+)
+
+var _ = SnapshotManager((*Journal)(nil))
+
+type JournalEntryKind int
+
+const (
+	JournalEntryBegin   JournalEntryKind = 0
+	JournalEntrySuccess JournalEntryKind = 1
+	JournalEntryFailure JournalEntryKind = 2
+	JournalEntryOutputs JournalEntryKind = 4
+)
+
+type JournalEntry struct {
+	Kind JournalEntryKind
+	Step deploy.Step
+}
+
+type JournalEntries []JournalEntry
+
+func (entries JournalEntries) Snap(base *deploy.Snapshot) *deploy.Snapshot {
+	// Build up a list of current resources by replaying the journal.
+	resources, dones := []*resource.State{}, make(map[*resource.State]bool)
+	ops, doneOps := []resource.Operation{}, make(map[*resource.State]bool)
+	for _, e := range entries {
+		logging.V(7).Infof("%v %v (%v)", e.Step.Op(), e.Step.URN(), e.Kind)
+
+		// Begin journal entries add pending operations to the snapshot. As we see success or failure
+		// entries, we'll record them in doneOps.
+		switch e.Kind {
+		case JournalEntryBegin:
+			switch e.Step.Op() {
+			case deploy.OpCreate, deploy.OpCreateReplacement:
+				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeCreating))
+			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
+				ops = append(ops, resource.NewOperation(e.Step.Old(), resource.OperationTypeDeleting))
+			case deploy.OpRead, deploy.OpReadReplacement:
+				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeReading))
+			case deploy.OpUpdate:
+				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeUpdating))
+			case deploy.OpImport, deploy.OpImportReplacement:
+				ops = append(ops, resource.NewOperation(e.Step.New(), resource.OperationTypeImporting))
+			}
+		case JournalEntryFailure, JournalEntrySuccess:
+			switch e.Step.Op() {
+			// nolint: lll
+			case deploy.OpCreate, deploy.OpCreateReplacement, deploy.OpRead, deploy.OpReadReplacement, deploy.OpUpdate,
+				deploy.OpImport, deploy.OpImportReplacement:
+				doneOps[e.Step.New()] = true
+			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
+				doneOps[e.Step.Old()] = true
+			}
+		}
+
+		// Now mark resources done as necessary.
+		if e.Kind == JournalEntrySuccess {
+			switch e.Step.Op() {
+			case deploy.OpSame, deploy.OpUpdate:
+				resources = append(resources, e.Step.New())
+				dones[e.Step.Old()] = true
+			case deploy.OpCreate, deploy.OpCreateReplacement:
+				resources = append(resources, e.Step.New())
+				if old := e.Step.Old(); old != nil && old.PendingReplacement {
+					dones[old] = true
+				}
+			case deploy.OpDelete, deploy.OpDeleteReplaced, deploy.OpReadDiscard, deploy.OpDiscardReplaced:
+				if old := e.Step.Old(); !old.PendingReplacement {
+					dones[old] = true
+				}
+			case deploy.OpReplace:
+				// do nothing.
+			case deploy.OpRead, deploy.OpReadReplacement:
+				resources = append(resources, e.Step.New())
+				if e.Step.Old() != nil {
+					dones[e.Step.Old()] = true
+				}
+			case deploy.OpRemovePendingReplace:
+				dones[e.Step.Old()] = true
+			case deploy.OpImport, deploy.OpImportReplacement:
+				resources = append(resources, e.Step.New())
+				dones[e.Step.New()] = true
+			}
+		}
+	}
+
+	// Append any resources from the base snapshot that were not produced by the current snapshot.
+	// See backend.SnapshotManager.snap for why this works.
+	if base != nil {
+		for _, res := range base.Resources {
+			if !dones[res] {
+				resources = append(resources, res)
+			}
+		}
+	}
+
+	// Append any pending operations.
+	var operations []resource.Operation
+	for _, op := range ops {
+		if !doneOps[op.Resource] {
+			operations = append(operations, op)
+		}
+	}
+
+	// If we have a base snapshot, copy over its secrets manager.
+	var secretsManager secrets.Manager
+	if base != nil {
+		secretsManager = base.SecretsManager
+	}
+
+	manifest := deploy.Manifest{}
+	manifest.Magic = manifest.NewMagic()
+	return deploy.NewSnapshot(manifest, secretsManager, resources, operations)
+
+}
+
+type Journal struct {
+	entries JournalEntries
+	events  chan JournalEntry
+	cancel  chan bool
+	done    chan bool
+}
+
+func (j *Journal) Entries() []JournalEntry {
+	<-j.done
+
+	return j.entries
+}
+
+func (j *Journal) Close() error {
+	close(j.cancel)
+	<-j.done
+
+	return nil
+}
+
+func (j *Journal) BeginMutation(step deploy.Step) (SnapshotMutation, error) {
+	select {
+	case j.events <- JournalEntry{Kind: JournalEntryBegin, Step: step}:
+		return j, nil
+	case <-j.cancel:
+		return nil, errors.New("journal closed")
+	}
+}
+
+func (j *Journal) End(step deploy.Step, success bool) error {
+	kind := JournalEntryFailure
+	if success {
+		kind = JournalEntrySuccess
+	}
+	select {
+	case j.events <- JournalEntry{Kind: kind, Step: step}:
+		return nil
+	case <-j.cancel:
+		return errors.New("journal closed")
+	}
+}
+
+func (j *Journal) RegisterResourceOutputs(step deploy.Step) error {
+	select {
+	case j.events <- JournalEntry{Kind: JournalEntryOutputs, Step: step}:
+		return nil
+	case <-j.cancel:
+		return errors.New("journal closed")
+	}
+}
+
+func (j *Journal) RecordPlugin(plugin workspace.PluginInfo) error {
+	return nil
+}
+
+func (j *Journal) Snap(base *deploy.Snapshot) *deploy.Snapshot {
+	return j.entries.Snap(base)
+}
+
+func NewJournal() *Journal {
+	j := &Journal{
+		events: make(chan JournalEntry),
+		cancel: make(chan bool),
+		done:   make(chan bool),
+	}
+	go func() {
+		for {
+			select {
+			case <-j.cancel:
+				close(j.done)
+				return
+			case e := <-j.events:
+				j.entries = append(j.entries, e)
+			}
+		}
+	}()
+	return j
+}

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -1,3 +1,4 @@
+//nolint:golint
 package lifecycletest
 
 import (

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -1,0 +1,329 @@
+package lifecycletest
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/mitchellh/copystructure"
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/pulumi/pulumi/pkg/v2/engine"
+	"github.com/pulumi/pulumi/pkg/v2/resource/deploy"
+	"github.com/pulumi/pulumi/pkg/v2/resource/deploy/providers"
+	"github.com/pulumi/pulumi/pkg/v2/util/cancel"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/result"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/workspace"
+)
+
+type updateInfo struct {
+	project workspace.Project
+	target  deploy.Target
+}
+
+func (u *updateInfo) GetRoot() string {
+	return ""
+}
+
+func (u *updateInfo) GetProject() *workspace.Project {
+	return &u.project
+}
+
+func (u *updateInfo) GetTarget() *deploy.Target {
+	return &u.target
+}
+
+type TestOp func(UpdateInfo, *Context, UpdateOptions, bool) (ResourceChanges, result.Result)
+type ValidateFunc func(project workspace.Project, target deploy.Target, entries JournalEntries,
+	events []Event, res result.Result) result.Result
+
+func (op TestOp) Run(project workspace.Project, target deploy.Target, opts UpdateOptions,
+	dryRun bool, backendClient deploy.BackendClient, validate ValidateFunc) (*deploy.Snapshot, result.Result) {
+
+	return op.RunWithContext(context.Background(), project, target, opts, dryRun, backendClient, validate)
+}
+
+func (op TestOp) RunWithContext(
+	callerCtx context.Context, project workspace.Project,
+	target deploy.Target, opts UpdateOptions, dryRun bool,
+	backendClient deploy.BackendClient, validate ValidateFunc) (*deploy.Snapshot, result.Result) {
+
+	// Create an appropriate update info and context.
+	info := &updateInfo{project: project, target: target}
+
+	cancelCtx, cancelSrc := cancel.NewContext(context.Background())
+	done := make(chan bool)
+	defer close(done)
+	go func() {
+		select {
+		case <-callerCtx.Done():
+			cancelSrc.Cancel()
+		case <-done:
+		}
+	}()
+
+	events := make(chan Event)
+	journal := NewJournal()
+
+	ctx := &Context{
+		Cancel:          cancelCtx,
+		Events:          events,
+		SnapshotManager: journal,
+		BackendClient:   backendClient,
+	}
+
+	// Begin draining events.
+	var firedEvents []Event
+	go func() {
+		for e := range events {
+			firedEvents = append(firedEvents, e)
+		}
+	}()
+
+	// Run the step and its validator.
+	_, res := op(info, ctx, opts, dryRun)
+	contract.IgnoreClose(journal)
+
+	if dryRun {
+		return nil, res
+	}
+	if validate != nil {
+		res = validate(project, target, journal.Entries(), firedEvents, res)
+	}
+
+	snap := journal.Snap(target.Snapshot)
+	if res == nil && snap != nil {
+		res = result.WrapIfNonNil(snap.VerifyIntegrity())
+	}
+	return snap, res
+}
+
+type TestStep struct {
+	Op            TestOp
+	ExpectFailure bool
+	SkipPreview   bool
+	Validate      ValidateFunc
+}
+
+type TestPlan struct {
+	Project        string
+	Stack          string
+	Runtime        string
+	RuntimeOptions map[string]interface{}
+	Config         config.Map
+	Decrypter      config.Decrypter
+	BackendClient  deploy.BackendClient
+	Options        UpdateOptions
+	Steps          []TestStep
+}
+
+//nolint: goconst
+func (p *TestPlan) getNames() (stack tokens.QName, project tokens.PackageName, runtime string) {
+	project = tokens.PackageName(p.Project)
+	if project == "" {
+		project = "test"
+	}
+	runtime = p.Runtime
+	if runtime == "" {
+		runtime = "test"
+	}
+	stack = tokens.QName(p.Stack)
+	if stack == "" {
+		stack = "test"
+	}
+	return stack, project, runtime
+}
+
+func (p *TestPlan) NewURN(typ tokens.Type, name string, parent resource.URN) resource.URN {
+	stack, project, _ := p.getNames()
+	var pt tokens.Type
+	if parent != "" {
+		pt = parent.Type()
+	}
+	return resource.NewURN(stack, project, pt, typ, tokens.QName(name))
+}
+
+func (p *TestPlan) NewProviderURN(pkg tokens.Package, name string, parent resource.URN) resource.URN {
+	return p.NewURN(providers.MakeProviderType(pkg), name, parent)
+}
+
+func (p *TestPlan) GetProject() workspace.Project {
+	_, projectName, runtime := p.getNames()
+
+	return workspace.Project{
+		Name:    projectName,
+		Runtime: workspace.NewProjectRuntimeInfo(runtime, p.RuntimeOptions),
+	}
+}
+
+func (p *TestPlan) GetTarget(snapshot *deploy.Snapshot) deploy.Target {
+	stack, _, _ := p.getNames()
+
+	cfg := p.Config
+	if cfg == nil {
+		cfg = config.Map{}
+	}
+
+	return deploy.Target{
+		Name:      stack,
+		Config:    cfg,
+		Decrypter: p.Decrypter,
+		Snapshot:  snapshot,
+	}
+}
+
+func assertIsErrorOrBailResult(t *testing.T, res result.Result) {
+	assert.NotNil(t, res)
+}
+
+// CloneSnapshot makes a deep copy of the given snapshot and returns a pointer to the clone.
+func CloneSnapshot(t *testing.T, snap *deploy.Snapshot) *deploy.Snapshot {
+	t.Helper()
+	if snap != nil {
+		copiedSnap := copystructure.Must(copystructure.Copy(*snap)).(deploy.Snapshot)
+		assert.True(t, reflect.DeepEqual(*snap, copiedSnap))
+		return &copiedSnap
+	}
+
+	return snap
+}
+
+func (p *TestPlan) Run(t *testing.T, snapshot *deploy.Snapshot) *deploy.Snapshot {
+	project := p.GetProject()
+	snap := snapshot
+	for _, step := range p.Steps {
+		// note: it's really important that the preview and update operate on different snapshots.  the engine can and
+		// does mutate the snapshot in-place, even in previews, and sharing a snapshot between preview and update can
+		// cause state changes from the preview to persist even when doing an update.
+		if !step.SkipPreview {
+			previewSnap := CloneSnapshot(t, snap)
+			previewTarget := p.GetTarget(previewSnap)
+			_, res := step.Op.Run(project, previewTarget, p.Options, true, p.BackendClient, step.Validate)
+			if step.ExpectFailure {
+				assertIsErrorOrBailResult(t, res)
+				continue
+			}
+
+			assert.Nil(t, res)
+		}
+
+		var res result.Result
+		target := p.GetTarget(snap)
+		snap, res = step.Op.Run(project, target, p.Options, false, p.BackendClient, step.Validate)
+		if step.ExpectFailure {
+			assertIsErrorOrBailResult(t, res)
+			continue
+		}
+
+		if res != nil {
+			if res.IsBail() {
+				t.Logf("Got unexpected bail result")
+				t.FailNow()
+			} else {
+				t.Logf("Got unexpected error result: %v", res.Error())
+				t.FailNow()
+			}
+		}
+
+		assert.Nil(t, res)
+	}
+
+	return snap
+}
+
+func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
+	return []TestStep{
+		// Initial update
+		{
+			Op: Update,
+			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
+				_ []Event, res result.Result) result.Result {
+
+				// Should see only creates.
+				for _, entry := range entries {
+					assert.Equal(t, deploy.OpCreate, entry.Step.Op())
+				}
+				assert.Len(t, entries.Snap(target.Snapshot).Resources, resCount)
+				return res
+			},
+		},
+		// No-op refresh
+		{
+			Op: Refresh,
+			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
+				_ []Event, res result.Result) result.Result {
+
+				// Should see only refresh-sames.
+				for _, entry := range entries {
+					assert.Equal(t, deploy.OpRefresh, entry.Step.Op())
+					assert.Equal(t, deploy.OpSame, entry.Step.(*deploy.RefreshStep).ResultOp())
+				}
+				assert.Len(t, entries.Snap(target.Snapshot).Resources, resCount)
+				return res
+			},
+		},
+		// No-op update
+		{
+			Op: Update,
+			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
+				_ []Event, res result.Result) result.Result {
+
+				// Should see only sames.
+				for _, entry := range entries {
+					assert.Equal(t, deploy.OpSame, entry.Step.Op())
+				}
+				assert.Len(t, entries.Snap(target.Snapshot).Resources, resCount)
+				return res
+			},
+		},
+		// No-op refresh
+		{
+			Op: Refresh,
+			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
+				_ []Event, res result.Result) result.Result {
+
+				// Should see only referesh-sames.
+				for _, entry := range entries {
+					assert.Equal(t, deploy.OpRefresh, entry.Step.Op())
+					assert.Equal(t, deploy.OpSame, entry.Step.(*deploy.RefreshStep).ResultOp())
+				}
+				assert.Len(t, entries.Snap(target.Snapshot).Resources, resCount)
+				return res
+			},
+		},
+		// Destroy
+		{
+			Op: Destroy,
+			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
+				_ []Event, res result.Result) result.Result {
+
+				// Should see only deletes.
+				for _, entry := range entries {
+					switch entry.Step.Op() {
+					case deploy.OpDelete, deploy.OpReadDiscard:
+						// ok
+					default:
+						assert.Fail(t, "expected OpDelete or OpReadDiscard")
+					}
+				}
+				assert.Len(t, entries.Snap(target.Snapshot).Resources, 0)
+				return res
+			},
+		},
+		// No-op refresh
+		{
+			Op: Refresh,
+			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
+				_ []Event, res result.Result) result.Result {
+
+				assert.Len(t, entries, 0)
+				assert.Len(t, entries.Snap(target.Snapshot).Resources, 0)
+				return res
+			},
+		},
+	}
+}

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -286,7 +286,7 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 				_ []Event, res result.Result) result.Result {
 
-				// Should see only referesh-sames.
+				// Should see only refresh-sames.
 				for _, entry := range entries {
 					assert.Equal(t, deploy.OpRefresh, entry.Step.Op())
 					assert.Equal(t, deploy.OpSame, entry.Step.(*deploy.RefreshStep).ResultOp())

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -144,7 +144,7 @@ func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*plan
 	contract.Assert(proj != nil)
 	contract.Assert(target != nil)
 	projinfo := &Projinfo{Proj: proj, Root: info.Update.GetRoot()}
-	pwd, main, plugctx, err := ProjectInfoContext(projinfo, opts.host, target,
+	pwd, main, plugctx, err := ProjectInfoContext(projinfo, opts.Host, target,
 		opts.Diag, opts.StatusDiag, opts.DisableProviderPreview, info.TracingSpan)
 	if err != nil {
 		return nil, err

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -71,7 +71,7 @@ func Query(ctx *Context, q QueryInfo, opts UpdateOptions) result.Result {
 	contract.Assert(proj != nil)
 
 	pwd, main, plugctx, err := ProjectInfoContext(&Projinfo{Proj: proj, Root: q.GetRoot()},
-		opts.host, nil, diag, statusDiag, false, tracingSpan)
+		opts.Host, nil, diag, statusDiag, false, tracingSpan)
 	if err != nil {
 		return result.FromError(err)
 	}
@@ -81,7 +81,7 @@ func Query(ctx *Context, q QueryInfo, opts UpdateOptions) result.Result {
 		Events:      emitter,
 		Diag:        diag,
 		StatusDiag:  statusDiag,
-		host:        opts.host,
+		host:        opts.Host,
 		pwd:         pwd,
 		main:        main,
 		plugctx:     plugctx,

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -139,7 +139,7 @@ type UpdateOptions struct {
 	reportDefaultProviderSteps bool
 
 	// the plugin host to use for this update
-	host plugin.Host
+	Host plugin.Host
 }
 
 // ResourceChanges contains the aggregate resource changes by operation type.


### PR DESCRIPTION
Move these tests to a new package, `lifecycletest`, that also exposes
APIs that allow consumers to implement their own lifecycle tests. This
is intended to ease the burden of testing plugin implementations and to
set the stage for cleaning up the lifecycle tests themselves.

This involves two changes to the public API, only one of which is
strictly necessary:

- The `host` field of `UpdateOptions` is now exported
- The `Journal` type has been moved from test-only code to the package
  proper

The former change is necessary, as it is the mechanism by which package
consumers may inject their own plugin loaders. I was reluctant to expose
this field originally because I wanted to ensure that the behavior of
packages that embed Pulumi is consistent with that of the Pulumi CLI
with respect to plugin loading. I now believe that the risk of consumers
changing this behavior outside of test scenarios is low enough that we
can expose this field. This may also be useful for future scenarios,
e.g. statically linking providers and Pulumi programs.

The latter change is not necessary, but fleshes out the engine package
into a more complete toolkit. Downstream consumers may use the Journal
type to conveniently implement snapshotting.