### PR TITLE
Replace equal and deepEqual with strictEqual and deepStrictEqual

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -38,9 +38,9 @@ describe("LocalWorkspace", () => {
         for (const ext of ["yaml", "yml", "json"]) {
             const ws = await LocalWorkspace.create({ workDir: upath.joinSafe(__dirname, "data", ext) });
             const settings = await ws.stackSettings("dev");
-            assert.equal(settings.secretsProvider, "abc");
-            assert.equal(settings.config!["plain"], "plain");
-            assert.equal(settings.config!["secure"].secure, "secret");
+            assert.strictEqual(settings.secretsProvider, "abc");
+            assert.strictEqual(settings.config!["plain"], "plain");
+            assert.strictEqual(settings.config!["secure"].secure, "secret");
         }
     }));
 
@@ -99,23 +99,23 @@ describe("LocalWorkspace", () => {
         } catch (error) {
             caught++;
         }
-        assert.equal(caught, 1, "expected config get on empty value to throw");
+        assert.strictEqual(caught, 1, "expected config get on empty value to throw");
 
         let values = await stack.getAllConfig();
-        assert.equal(Object.keys(values).length, 0, "expected stack config to be empty");
+        assert.strictEqual(Object.keys(values).length, 0, "expected stack config to be empty");
         await stack.setAllConfig(config);
         values = await stack.getAllConfig();
-        assert.equal(values[plainKey].value, "abc");
-        assert.equal(values[plainKey].secret, false);
-        assert.equal(values[secretKey].value, "def");
-        assert.equal(values[secretKey].secret, true);
+        assert.strictEqual(values[plainKey].value, "abc");
+        assert.strictEqual(values[plainKey].secret, false);
+        assert.strictEqual(values[secretKey].value, "def");
+        assert.strictEqual(values[secretKey].secret, true);
 
         await stack.removeConfig("plain");
         values = await stack.getAllConfig();
-        assert.equal(Object.keys(values).length, 1, "expected stack config to be empty");
+        assert.strictEqual(Object.keys(values).length, 1, "expected stack config to be empty");
         await stack.setConfig("foo", { value: "bar" });
         values = await stack.getAllConfig();
-        assert.equal(Object.keys(values).length, 2, "expected stack config to be empty");
+        assert.strictEqual(Object.keys(values).length, 2, "expected stack config to be empty");
 
         await ws.removeStack(stackName);
     }));
@@ -132,9 +132,9 @@ describe("LocalWorkspace", () => {
             stackNames[i] = stackName;
             await Stack.create(stackName, ws);
             const stackSummary = await ws.stack();
-            assert.equal(stackSummary?.current, true);
+            assert.strictEqual(stackSummary?.current, true);
             const stacks = await ws.listStacks();
-            assert.equal(stacks.length, i + 1);
+            assert.strictEqual(stacks.length, i + 1);
         }
 
         for (const name of stackNames) {
@@ -150,9 +150,9 @@ describe("LocalWorkspace", () => {
         const stackName = `int_test${getTestSuffix()}`;
         const stack = await Stack.create(stackName, ws);
         const histroy = await stack.history();
-        assert.equal(histroy.length, 0);
+        assert.strictEqual(histroy.length, 0);
         const info = await stack.info();
-        assert.equal(typeof (info), "undefined");
+        assert.strictEqual(typeof (info), "undefined");
         await ws.removeStack(stackName);
     }));
     it(`runs through the stack lifecycle with a local program`, asyncTest(async () => {
@@ -168,15 +168,15 @@ describe("LocalWorkspace", () => {
 
         // pulumi up
         const upRes = await stack.up();
-        assert.equal(Object.keys(upRes.outputs).length, 3);
-        assert.equal(upRes.outputs["exp_static"].value, "foo");
-        assert.equal(upRes.outputs["exp_static"].secret, false);
-        assert.equal(upRes.outputs["exp_cfg"].value, "abc");
-        assert.equal(upRes.outputs["exp_cfg"].secret, false);
-        assert.equal(upRes.outputs["exp_secret"].value, "secret");
-        assert.equal(upRes.outputs["exp_secret"].secret, true);
-        assert.equal(upRes.summary.kind, "update");
-        assert.equal(upRes.summary.result, "succeeded");
+        assert.strictEqual(Object.keys(upRes.outputs).length, 3);
+        assert.strictEqual(upRes.outputs["exp_static"].value, "foo");
+        assert.strictEqual(upRes.outputs["exp_static"].secret, false);
+        assert.strictEqual(upRes.outputs["exp_cfg"].value, "abc");
+        assert.strictEqual(upRes.outputs["exp_cfg"].secret, false);
+        assert.strictEqual(upRes.outputs["exp_secret"].value, "secret");
+        assert.strictEqual(upRes.outputs["exp_secret"].secret, true);
+        assert.strictEqual(upRes.summary.kind, "update");
+        assert.strictEqual(upRes.summary.result, "succeeded");
 
         // pulumi preview
         await stack.preview();
@@ -184,13 +184,13 @@ describe("LocalWorkspace", () => {
 
         // pulumi refresh
         const refRes = await stack.refresh();
-        assert.equal(refRes.summary.kind, "refresh");
-        assert.equal(refRes.summary.result, "succeeded");
+        assert.strictEqual(refRes.summary.kind, "refresh");
+        assert.strictEqual(refRes.summary.result, "succeeded");
 
         // pulumi destroy
         const destroyRes = await stack.destroy();
-        assert.equal(destroyRes.summary.kind, "destroy");
-        assert.equal(destroyRes.summary.result, "succeeded");
+        assert.strictEqual(destroyRes.summary.kind, "destroy");
+        assert.strictEqual(destroyRes.summary.result, "succeeded");
 
         await stack.workspace.removeStack(stackName);
     }));
@@ -215,15 +215,15 @@ describe("LocalWorkspace", () => {
 
         // pulumi up
         const upRes = await stack.up();
-        assert.equal(Object.keys(upRes.outputs).length, 3);
-        assert.equal(upRes.outputs["exp_static"].value, "foo");
-        assert.equal(upRes.outputs["exp_static"].secret, false);
-        assert.equal(upRes.outputs["exp_cfg"].value, "abc");
-        assert.equal(upRes.outputs["exp_cfg"].secret, false);
-        assert.equal(upRes.outputs["exp_secret"].value, "secret");
-        assert.equal(upRes.outputs["exp_secret"].secret, true);
-        assert.equal(upRes.summary.kind, "update");
-        assert.equal(upRes.summary.result, "succeeded");
+        assert.strictEqual(Object.keys(upRes.outputs).length, 3);
+        assert.strictEqual(upRes.outputs["exp_static"].value, "foo");
+        assert.strictEqual(upRes.outputs["exp_static"].secret, false);
+        assert.strictEqual(upRes.outputs["exp_cfg"].value, "abc");
+        assert.strictEqual(upRes.outputs["exp_cfg"].secret, false);
+        assert.strictEqual(upRes.outputs["exp_secret"].value, "secret");
+        assert.strictEqual(upRes.outputs["exp_secret"].secret, true);
+        assert.strictEqual(upRes.summary.kind, "update");
+        assert.strictEqual(upRes.summary.result, "succeeded");
 
         // pulumi preview
         await stack.preview();
@@ -231,13 +231,13 @@ describe("LocalWorkspace", () => {
 
         // pulumi refresh
         const refRes = await stack.refresh();
-        assert.equal(refRes.summary.kind, "refresh");
-        assert.equal(refRes.summary.result, "succeeded");
+        assert.strictEqual(refRes.summary.kind, "refresh");
+        assert.strictEqual(refRes.summary.result, "succeeded");
 
         // pulumi destroy
         const destroyRes = await stack.destroy();
-        assert.equal(destroyRes.summary.kind, "destroy");
-        assert.equal(destroyRes.summary.result, "succeeded");
+        assert.strictEqual(destroyRes.summary.kind, "destroy");
+        assert.strictEqual(destroyRes.summary.result, "succeeded");
 
         await stack.workspace.removeStack(stackName);
     }));

--- a/sdk/nodejs/tests/config.spec.ts
+++ b/sdk/nodejs/tests/config.spec.ts
@@ -49,10 +49,10 @@ describe("config", () => {
         assert.strictEqual(42.333, config.getNumber("num"));
         assert.strictEqual(42.333, config.requireNumber("num"));
         assert.strictEqual(undefined, config.getNumber("nummissing"));
-        assert.deepEqual([ 0, false, 2, "foo" ], config.getObject<any>("array"));
-        assert.deepEqual([ 0, false, 2, "foo" ], config.requireObject<any>("array"));
-        assert.deepEqual({ "foo": "bar", "mim": [] }, config.getObject<any>("struct"));
-        assert.deepEqual({ "foo": "bar", "mim": [] }, config.requireObject<any>("struct"));
+        assert.deepStrictEqual([ 0, false, 2, "foo" ], config.getObject<any>("array"));
+        assert.deepStrictEqual([ 0, false, 2, "foo" ], config.requireObject<any>("array"));
+        assert.deepStrictEqual({ "foo": "bar", "mim": [] }, config.getObject<any>("struct"));
+        assert.deepStrictEqual({ "foo": "bar", "mim": [] }, config.requireObject<any>("struct"));
         assert.strictEqual(undefined, config.getObject<any>("complexmissing"));
         // ensure requireX throws when missing:
         assert.throws(() => { config.requireBoolean("missing"); });

--- a/sdk/nodejs/tests/iterable.spec.ts
+++ b/sdk/nodejs/tests/iterable.spec.ts
@@ -31,9 +31,9 @@ describe("iterable", () => {
 
         const result = iterable.toObject(instances, i => [i.id, i.privateIp]);
         const isKnown = await result.isKnown;
-        assert.equal(isKnown, true);
+        assert.strictEqual(isKnown, true);
         const value = await result.promise();
-        assert.deepEqual(value, { "i-1234": "192.168.1.2", "i-5678": "192.168.1.5" });
+        assert.deepStrictEqual(value, { "i-1234": "192.168.1.2", "i-5678": "192.168.1.5" });
     }));
     it("groupBy does its job", asyncTest(async () => {
         interface Instance {
@@ -49,8 +49,8 @@ describe("iterable", () => {
 
         const result = iterable.groupBy(instances, i => [i.availabilityZone, i.id]);
         const isKnown = await result.isKnown;
-        assert.equal(isKnown, true);
+        assert.strictEqual(isKnown, true);
         const value = await result.promise();
-        assert.deepEqual(value, { "us-east-1a": ["i-1234", "i-5678"], "us-west-2c": ["i-1538"] });
+        assert.deepStrictEqual(value, { "us-east-1a": ["i-1234", "i-5678"], "us-west-2c": ["i-1538"] });
     }));
 });

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -71,10 +71,10 @@ describe("output", () => {
         const output2 = output1.apply(v => new Output(new Set(), Promise.resolve("inner"), Promise.resolve(true), Promise.resolve(false), Promise.resolve(new Set())));
 
         const isKnown = await output2.isKnown;
-        assert.equal(isKnown, true);
+        assert.strictEqual(isKnown, true);
 
         const value = await output2.promise();
-        assert.equal(value, "inner");
+        assert.strictEqual(value, "inner");
     }));
 
     it("propagates false isKnown bit from inner Output", asyncTest(async () => {
@@ -84,10 +84,10 @@ describe("output", () => {
         const output2 = output1.apply(v => new Output(new Set(), Promise.resolve("inner"), Promise.resolve(false), Promise.resolve(false), Promise.resolve(new Set())));
 
         const isKnown = await output2.isKnown;
-        assert.equal(isKnown, false);
+        assert.strictEqual(isKnown, false);
 
         const value = await output2.promise();
-        assert.equal(value, "inner");
+        assert.strictEqual(value, "inner");
     }));
 
     it("can not await if isKnown is a rejected promise.", asyncTest(async () => {
@@ -118,10 +118,10 @@ describe("output", () => {
         const output2 = output1.apply(v => new Output(new Set(), Promise.resolve("inner"), Promise.resolve(true), Promise.resolve(true), Promise.resolve(new Set())));
 
         const isSecret = await output2.isSecret;
-        assert.equal(isSecret, true);
+        assert.strictEqual(isSecret, true);
 
         const value = await output2.promise();
-        assert.equal(value, "inner");
+        assert.strictEqual(value, "inner");
     }));
 
      it("retains true isSecret bit from outer Output", asyncTest(async () => {
@@ -131,10 +131,10 @@ describe("output", () => {
         const output2 = output1.apply(v => new Output(new Set(), Promise.resolve("inner"), Promise.resolve(true), Promise.resolve(false), Promise.resolve(new Set())));
 
         const isSecret = await output2.isSecret;
-        assert.equal(isSecret, true);
+        assert.strictEqual(isSecret, true);
 
         const value = await output2.promise();
-        assert.equal(value, "inner");
+        assert.strictEqual(value, "inner");
     }));
 
     describe("apply", () => {
@@ -149,8 +149,8 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => v + 1);
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), 1);
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), 1);
         }));
 
         it("can run on known awaitable value during preview", asyncTest(async () => {
@@ -159,8 +159,8 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => Promise.resolve("inner"));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("can run on known known output value during preview", asyncTest(async () => {
@@ -169,8 +169,8 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => createOutput("inner", true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("can run on known unknown output value during preview", asyncTest(async () => {
@@ -179,8 +179,8 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => createOutput("inner", false));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("produces unknown default on unknown during preview", asyncTest(async () => {
@@ -189,8 +189,8 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => v + 1);
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("produces unknown default on unknown awaitable during preview", asyncTest(async () => {
@@ -199,8 +199,8 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => Promise.resolve("inner"));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("produces unknown default on unknown known output during preview", asyncTest(async () => {
@@ -209,8 +209,8 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => createOutput("inner", true));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("produces unknown default on unknown unknown output during preview", asyncTest(async () => {
@@ -219,8 +219,8 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => createOutput("inner", false));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("preserves secret on known during preview", asyncTest(async () => {
@@ -229,9 +229,9 @@ describe("output", () => {
             const out = createOutput(0, true, true);
             const r = out.apply(v => v + 1);
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), 1);
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), 1);
         }));
 
         it("preserves secret on known awaitable during preview", asyncTest(async () => {
@@ -240,9 +240,9 @@ describe("output", () => {
             const out = createOutput(0, true, true);
             const r = out.apply(v => Promise.resolve("inner"));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on known known output during preview", asyncTest(async () => {
@@ -251,9 +251,9 @@ describe("output", () => {
             const out = createOutput(0, true, true);
             const r = out.apply(v => createOutput("inner", true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on known unknown output during preview", asyncTest(async () => {
@@ -262,9 +262,9 @@ describe("output", () => {
             const out = createOutput(0, true, true);
             const r = out.apply(v => createOutput("inner", false));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on unknown during preview", asyncTest(async () => {
@@ -273,9 +273,9 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply(v => v + 1);
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("preserves secret on unknown awaitable during preview", asyncTest(async () => {
@@ -284,9 +284,9 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply(v => Promise.resolve("inner"));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("preserves secret on unknown known output during preview", asyncTest(async () => {
@@ -295,9 +295,9 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply(v => createOutput("inner", true));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("preserves secret on unknown unknown output during preview", asyncTest(async () => {
@@ -306,9 +306,9 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply(v => createOutput("inner", false));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("propagates secret on known known output during preview", asyncTest(async () => {
@@ -317,9 +317,9 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => createOutput("inner", true, true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("propagates secret on known unknown output during preview", asyncTest(async () => {
@@ -328,9 +328,9 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => createOutput("inner", false, true));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("does not propagate secret on unknown known output during preview", asyncTest(async () => {
@@ -339,9 +339,9 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => createOutput("inner", true, true));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, false);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, false);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("does not propagate secret on unknown unknown output during preview", asyncTest(async () => {
@@ -350,9 +350,9 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => createOutput("inner", false, true));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, false);
-            assert.equal(await r.promise(), undefined);
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, false);
+            assert.strictEqual(await r.promise(), undefined);
         }));
 
         it("can run on known value", asyncTest(async () => {
@@ -361,8 +361,8 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => v + 1);
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), 1);
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), 1);
         }));
 
         it("can run on known awaitable value", asyncTest(async () => {
@@ -371,8 +371,8 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => Promise.resolve("inner"));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("can run on known known output value", asyncTest(async () => {
@@ -381,8 +381,8 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => createOutput("inner", true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("can run on unknown known output value", asyncTest(async () => {
@@ -391,8 +391,8 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => createOutput("inner", false));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("produces known on unknown", asyncTest(async () => {
@@ -401,8 +401,8 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => v + 1);
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), 1);
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), 1);
         }));
 
         it("produces known on unknown awaitable", asyncTest(async () => {
@@ -411,8 +411,8 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => Promise.resolve("inner"));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("produces known on unknown known output", asyncTest(async () => {
@@ -421,8 +421,8 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => createOutput("inner", true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("produces unknown on unknown unknown output", asyncTest(async () => {
@@ -431,8 +431,8 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => createOutput("inner", false));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on known", asyncTest(async () => {
@@ -441,9 +441,9 @@ describe("output", () => {
             const out = createOutput(0, true, true);
             const r = out.apply(v => v + 1);
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), 1);
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), 1);
         }));
 
         it("preserves secret on known awaitable", asyncTest(async () => {
@@ -452,9 +452,9 @@ describe("output", () => {
             const out = createOutput(0, true, true);
             const r = out.apply(v => Promise.resolve("inner"));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on known known output", asyncTest(async () => {
@@ -463,9 +463,9 @@ describe("output", () => {
             const out = createOutput(0, true, true);
             const r = out.apply(v => createOutput("inner", true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on known known output", asyncTest(async () => {
@@ -474,9 +474,9 @@ describe("output", () => {
             const out = createOutput(0, true, true);
             const r = out.apply(v => createOutput("inner", false));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on unknown", asyncTest(async () => {
@@ -485,9 +485,9 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply(v => v + 1);
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), 1);
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), 1);
         }));
 
         it("preserves secret on unknown awaitable", asyncTest(async () => {
@@ -496,9 +496,9 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply(v => Promise.resolve("inner"));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on unknown known output", asyncTest(async () => {
@@ -507,9 +507,9 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply(v => createOutput("inner", true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("preserves secret on unknown known output", asyncTest(async () => {
@@ -518,9 +518,9 @@ describe("output", () => {
             const out = createOutput(0, false, true);
             const r = out.apply(v => createOutput("inner", false));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("propagates secret on known known output", asyncTest(async () => {
@@ -529,9 +529,9 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => createOutput("inner", true, true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("propagates secret on known unknown output", asyncTest(async () => {
@@ -540,9 +540,9 @@ describe("output", () => {
             const out = createOutput(0, true);
             const r = out.apply(v => createOutput("inner", false, true));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("propagates secret on unknown known output", asyncTest(async () => {
@@ -551,9 +551,9 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => createOutput("inner", true, true));
 
-            assert.equal(await r.isKnown, true);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, true);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
 
         it("propagates secret on unknown uknown output", asyncTest(async () => {
@@ -562,9 +562,9 @@ describe("output", () => {
             const out = createOutput(0, false);
             const r = out.apply(v => createOutput("inner", false, true));
 
-            assert.equal(await r.isKnown, false);
-            assert.equal(await r.isSecret, true);
-            assert.equal(await r.promise(), "inner");
+            assert.strictEqual(await r.isKnown, false);
+            assert.strictEqual(await r.isSecret, true);
+            assert.strictEqual(await r.promise(), "inner");
         }));
     });
 
@@ -593,13 +593,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, true);
+            assert.strictEqual(isKnown, true);
 
             const value = await result.promise();
-            assert.equal(value, "foo");
+            assert.strictEqual(value, "foo");
 
             const secret = await result.isSecret;
-            assert.equal(secret, false);
+            assert.strictEqual(secret, false);
         }));
 
         it("choose between known and known output, secret", asyncTest(async () => {
@@ -611,13 +611,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, true);
+            assert.strictEqual(isKnown, true);
 
             const value = await result.promise();
-            assert.equal(value, "foo");
+            assert.strictEqual(value, "foo");
 
             const secret = await result.isSecret;
-            assert.equal(secret, true);
+            assert.strictEqual(secret, true);
         }));
 
         it("choose between known and unknown output, non-secret", asyncTest(async () => {
@@ -629,13 +629,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, true);
+            assert.strictEqual(isKnown, true);
 
             const value = await result.promise();
-            assert.equal(value, "foo");
+            assert.strictEqual(value, "foo");
 
             const secret = await result.isSecret;
-            assert.equal(secret, false);
+            assert.strictEqual(secret, false);
         }));
 
         it("choose between known and unknown output, secret", asyncTest(async () => {
@@ -647,13 +647,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, true);
+            assert.strictEqual(isKnown, true);
 
             const value = await result.promise();
-            assert.equal(value, "foo");
+            assert.strictEqual(value, "foo");
 
             const secret = await result.isSecret;
-            assert.equal(secret, true);
+            assert.strictEqual(secret, true);
         }));
 
         it("choose between unknown and known output, non-secret", asyncTest(async () => {
@@ -665,13 +665,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, true);
+            assert.strictEqual(isKnown, true);
 
             const value = await result.promise();
-            assert.equal(value, "bar");
+            assert.strictEqual(value, "bar");
 
             const secret = await result.isSecret;
-            assert.equal(secret, false);
+            assert.strictEqual(secret, false);
         }));
 
         it("choose between unknown and known output, secret", asyncTest(async () => {
@@ -683,13 +683,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, true);
+            assert.strictEqual(isKnown, true);
 
             const value = await result.promise();
-            assert.equal(value, "bar");
+            assert.strictEqual(value, "bar");
 
             const secret = await result.isSecret;
-            assert.equal(secret, true);
+            assert.strictEqual(secret, true);
         }));
 
         it("choose between unknown and unknown output, non-secret", asyncTest(async () => {
@@ -701,13 +701,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, false);
+            assert.strictEqual(isKnown, false);
 
             const value = await result.promise();
-            assert.equal(value, undefined);
+            assert.strictEqual(value, undefined);
 
             const secret = await result.isSecret;
-            assert.equal(secret, false);
+            assert.strictEqual(secret, false);
         }));
 
         it("choose between unknown and unknown output, secret1", asyncTest(async () => {
@@ -719,13 +719,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, false);
+            assert.strictEqual(isKnown, false);
 
             const value = await result.promise();
-            assert.equal(value, undefined);
+            assert.strictEqual(value, undefined);
 
             const secret = await result.isSecret;
-            assert.equal(secret, false);
+            assert.strictEqual(secret, false);
         }));
 
         it("choose between unknown and unknown output, secret2", asyncTest(async () => {
@@ -737,13 +737,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, false);
+            assert.strictEqual(isKnown, false);
 
             const value = await result.promise();
-            assert.equal(value, undefined);
+            assert.strictEqual(value, undefined);
 
             const secret = await result.isSecret;
-            assert.equal(secret, true);
+            assert.strictEqual(secret, true);
         }));
 
         it("choose between unknown and unknown output, secret3", asyncTest(async () => {
@@ -755,13 +755,13 @@ describe("output", () => {
             const result = or(o1, o2);
 
             const isKnown = await result.isKnown;
-            assert.equal(isKnown, false);
+            assert.strictEqual(isKnown, false);
 
             const value = await result.promise();
-            assert.equal(value, undefined);
+            assert.strictEqual(value, undefined);
 
             const secret = await result.isSecret;
-            assert.equal(secret, true);
+            assert.strictEqual(secret, true);
         }));
 
         it("is unknown if the value is or contains unknowns", asyncTest(async () => {
@@ -771,9 +771,9 @@ describe("output", () => {
             const o2 = new Output(new Set(), Promise.resolve(["foo", unknown]), Promise.resolve(true), Promise.resolve(false), Promise.resolve(new Set()));
             const o3 = new Output(new Set(), Promise.resolve({"foo": "foo", unknown}), Promise.resolve(true), Promise.resolve(false), Promise.resolve(new Set()));
 
-            assert.equal(await o1.isKnown, false);
-            assert.equal(await o2.isKnown, false);
-            assert.equal(await o3.isKnown, false);
+            assert.strictEqual(await o1.isKnown, false);
+            assert.strictEqual(await o2.isKnown, false);
+            assert.strictEqual(await o3.isKnown, false);
         }));
 
         it("is unknown if the result after apply is unknown or contains unknowns", asyncTest(async () => {
@@ -787,76 +787,76 @@ describe("output", () => {
             const r5 = (<any>o1.apply(v => [v, unknown])).apply((v: any) => v, true);
             const r6 = (<any>o1.apply(v => <any>{v, unknown})).apply((v: any) => v, true);
 
-            assert.equal(await r1.isKnown, false);
-            assert.equal(await r2.isKnown, false);
-            assert.equal(await r3.isKnown, false);
-            assert.equal(await r4.isKnown, false);
-            assert.equal(await r5.isKnown, false);
-            assert.equal(await r6.isKnown, false);
+            assert.strictEqual(await r1.isKnown, false);
+            assert.strictEqual(await r2.isKnown, false);
+            assert.strictEqual(await r3.isKnown, false);
+            assert.strictEqual(await r4.isKnown, false);
+            assert.strictEqual(await r5.isKnown, false);
+            assert.strictEqual(await r6.isKnown, false);
         }));
     });
 
     describe("concat", () => {
         it ("handles no args", asyncTest(async () => {
             const result = concat();
-            assert.equal(await result.promise(), "");
+            assert.strictEqual(await result.promise(), "");
         }));
 
         it ("handles empty string arg", asyncTest(async () => {
             const result = concat("");
-            assert.equal(await result.promise(), "");
+            assert.strictEqual(await result.promise(), "");
         }));
 
         it ("handles non-empty string arg", asyncTest(async () => {
             const result = concat("a");
-            assert.equal(await result.promise(), "a");
+            assert.strictEqual(await result.promise(), "a");
         }));
 
         it ("handles promise string arg", asyncTest(async () => {
             const result = concat(Promise.resolve("a"));
-            assert.equal(await result.promise(), "a");
+            assert.strictEqual(await result.promise(), "a");
         }));
 
         it ("handles output string arg", asyncTest(async () => {
             const result = concat(output("a"));
-            assert.equal(await result.promise(), "a");
+            assert.strictEqual(await result.promise(), "a");
         }));
 
         it ("handles multiple args", asyncTest(async () => {
             const result = concat("http://", output("a"), ":", 80);
-            assert.equal(await result.promise(), "http://a:80");
+            assert.strictEqual(await result.promise(), "http://a:80");
         }));
     });
 
     describe("interpolate", () => {
         it ("handles empty interpolation", asyncTest(async () => {
             const result = interpolate ``;
-            assert.equal(await result.promise(), "");
+            assert.strictEqual(await result.promise(), "");
         }));
 
         it ("handles no placeholders arg", asyncTest(async () => {
             const result = interpolate `a`;
-            assert.equal(await result.promise(), "a");
+            assert.strictEqual(await result.promise(), "a");
         }));
 
         it ("handles string placeholders arg", asyncTest(async () => {
             const result = interpolate `${"a"}`;
-            assert.equal(await result.promise(), "a");
+            assert.strictEqual(await result.promise(), "a");
         }));
 
         it ("handles promise placeholders arg", asyncTest(async () => {
             const result = interpolate `${Promise.resolve("a")}`;
-            assert.equal(await result.promise(), "a");
+            assert.strictEqual(await result.promise(), "a");
         }));
 
         it ("handles output placeholders arg", asyncTest(async () => {
             const result = interpolate `${output("a")}`;
-            assert.equal(await result.promise(), "a");
+            assert.strictEqual(await result.promise(), "a");
         }));
 
         it ("handles multiple args", asyncTest(async () => {
             const result = interpolate `http://${output("a")}:${80}/`;
-            assert.equal(await result.promise(), "http://a:80/");
+            assert.strictEqual(await result.promise(), "http://a:80/");
         }));
     });
 
@@ -864,24 +864,24 @@ describe("output", () => {
         it("lifts properties from inner object", asyncTest(async () => {
             const output1 = output({ a: 1, b: true, c: "str", d: [2], e: { f: 3 }, g: undefined, h: null });
 
-            assert.equal(await output1.a.promise(), 1);
-            assert.equal(await output1.b.promise(), true);
-            assert.equal(await output1.c.promise(), "str");
+            assert.strictEqual(await output1.a.promise(), 1);
+            assert.strictEqual(await output1.b.promise(), true);
+            assert.strictEqual(await output1.c.promise(), "str");
 
             // Can lift both outer arrays as well as array accesses
-            assert.deepEqual(await output1.d.promise(), [2]);
-            assert.equal(await output1.d[0].promise(), 2);
+            assert.deepStrictEqual(await output1.d.promise(), [2]);
+            assert.strictEqual(await output1.d[0].promise(), 2);
 
             // Can lift nested objects as well as their properties.
-            assert.deepEqual(await output1.e.promise(), { f: 3 });
-            assert.equal(await output1.e.f.promise(), 3);
+            assert.deepStrictEqual(await output1.e.promise(), { f: 3 });
+            assert.strictEqual(await output1.e.f.promise(), 3);
 
             assert.strictEqual(await output1.g.promise(), undefined);
             assert.strictEqual(await output1.h.promise(), null);
 
             // Unspecified things can be lifted, but produce 'undefined'.
             assert.notEqual((<any>output1).z, undefined);
-            assert.equal(await (<any>output1).z.promise(), undefined);
+            assert.strictEqual(await (<any>output1).z.promise(), undefined);
         }));
 
         it("prefers Output members over lifted members", asyncTest(async () => {
@@ -909,90 +909,90 @@ describe("output", () => {
                 baz: Promise.resolve(unknown),
                 qux: mockOutput(false, undefined),
             });
-            assert.equal(await output1.isKnown, false);
+            assert.strictEqual(await output1.isKnown, false);
 
             const result1 = output1.foo;
-            assert.equal(await result1.isKnown, true);
-            assert.equal(await (<any>result1).promise(/*withUnknowns*/ true), "foo");
+            assert.strictEqual(await result1.isKnown, true);
+            assert.strictEqual(await (<any>result1).promise(/*withUnknowns*/ true), "foo");
 
             const result2 = output1.bar;
-            assert.equal(await result2.isKnown, false);
-            assert.equal(await (<any>result2).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result2.isKnown, false);
+            assert.strictEqual(await (<any>result2).promise(/*withUnknowns*/ true), unknown);
 
             const result3 = output1.baz;
-            assert.equal(await result3.isKnown, false);
-            assert.equal(await (<any>result3).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result3.isKnown, false);
+            assert.strictEqual(await (<any>result3).promise(/*withUnknowns*/ true), unknown);
 
             const result4 = output1.qux;
-            assert.equal(await result4.isKnown, false);
-            assert.equal(await (<any>result4).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result4.isKnown, false);
+            assert.strictEqual(await (<any>result4).promise(/*withUnknowns*/ true), unknown);
 
             const result5 = (<any>output1.baz).qux;
-            assert.equal(await result5.isKnown, false);
-            assert.equal(await (<any>result5).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result5.isKnown, false);
+            assert.strictEqual(await (<any>result5).promise(/*withUnknowns*/ true), unknown);
 
             const output2 = output([ "foo", unknown, mockOutput(false, undefined) ]);
-            assert.equal(await output2.isKnown, false);
+            assert.strictEqual(await output2.isKnown, false);
 
             const result6 = output2[0];
-            assert.equal(await result6.isKnown, true);
-            assert.equal(await (<any>result6).promise(/*withUnknowns*/ true), "foo");
+            assert.strictEqual(await result6.isKnown, true);
+            assert.strictEqual(await (<any>result6).promise(/*withUnknowns*/ true), "foo");
 
             const result7 = output2[1];
-            assert.equal(await result7.isKnown, false);
-            assert.equal(await (<any>result7).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result7.isKnown, false);
+            assert.strictEqual(await (<any>result7).promise(/*withUnknowns*/ true), unknown);
 
             const result8 = output2[2];
-            assert.equal(await result8.isKnown, false);
-            assert.equal(await (<any>result8).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result8.isKnown, false);
+            assert.strictEqual(await (<any>result8).promise(/*withUnknowns*/ true), unknown);
 
             const output3 = all([ unknown, mockOutput(false, undefined), output([ "foo", unknown ])]);
-            assert.equal(await output3.isKnown, false);
+            assert.strictEqual(await output3.isKnown, false);
 
             const result9 = output3[0];
-            assert.equal(await result9.isKnown, false);
-            assert.equal(await (<any>result9).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result9.isKnown, false);
+            assert.strictEqual(await (<any>result9).promise(/*withUnknowns*/ true), unknown);
 
             const result10 = output3[1];
-            assert.equal(await result10.isKnown, false);
-            assert.equal(await (<any>result10).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result10.isKnown, false);
+            assert.strictEqual(await (<any>result10).promise(/*withUnknowns*/ true), unknown);
 
             const result11 = output3[2];
-            assert.equal(await result11.isKnown, false);
+            assert.strictEqual(await result11.isKnown, false);
 
             const result12 = (<any>result11)[0];
-            assert.equal(await result12.isKnown, true);
-            assert.equal(await (<any>result12).promise(/*withUnknowns*/ true), "foo");
+            assert.strictEqual(await result12.isKnown, true);
+            assert.strictEqual(await (<any>result12).promise(/*withUnknowns*/ true), "foo");
 
             const result13 = (<any>result11)[1];
-            assert.equal(await result13.isKnown, false);
-            assert.equal(await (<any>result13).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result13.isKnown, false);
+            assert.strictEqual(await (<any>result13).promise(/*withUnknowns*/ true), unknown);
 
             const output4 = all({
                 foo: unknown,
                 bar: mockOutput(false, undefined),
                 baz: output({ foo: "foo", qux: unknown }),
             });
-            assert.equal(await output4.isKnown, false);
+            assert.strictEqual(await output4.isKnown, false);
 
             const result14 = output4.foo;
-            assert.equal(await result14.isKnown, false);
-            assert.equal(await (<any>result14).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result14.isKnown, false);
+            assert.strictEqual(await (<any>result14).promise(/*withUnknowns*/ true), unknown);
 
             const result15 = output4.bar;
-            assert.equal(await result15.isKnown, false);
-            assert.equal(await (<any>result15).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result15.isKnown, false);
+            assert.strictEqual(await (<any>result15).promise(/*withUnknowns*/ true), unknown);
 
             const result16 = output4.baz;
-            assert.equal(await result16.isKnown, false);
+            assert.strictEqual(await result16.isKnown, false);
 
             const result17 = (<any>result16).foo;
-            assert.equal(await result17.isKnown, true);
-            assert.equal(await (<any>result17).promise(/*withUnknowns*/ true), "foo");
+            assert.strictEqual(await result17.isKnown, true);
+            assert.strictEqual(await (<any>result17).promise(/*withUnknowns*/ true), "foo");
 
             const result18 = (<any>result16).qux;
-            assert.equal(await result18.isKnown, false);
-            assert.equal(await (<any>result18).promise(/*withUnknowns*/ true), unknown);
+            assert.strictEqual(await result18.isKnown, false);
+            assert.strictEqual(await (<any>result18).promise(/*withUnknowns*/ true), unknown);
         }));
     });
 });

--- a/sdk/nodejs/tests/resource.spec.ts
+++ b/sdk/nodejs/tests/resource.spec.ts
@@ -38,7 +38,7 @@ describe("createUrn", () => {
     before(() => {
         runtime._setTestModeEnabled(true);
         runtime._setProject("myproject");
-        runtime._setStack("mystack"); 
+        runtime._setStack("mystack");
     });
 
     after(() => {
@@ -49,18 +49,18 @@ describe("createUrn", () => {
 
     it("handles name and type", asyncTest(async () => {
         const urn = await createUrn("n", "t").promise();
-        assert.equal(urn, "urn:pulumi:mystack::myproject::t::n");
+        assert.strictEqual(urn, "urn:pulumi:mystack::myproject::t::n");
     }));
 
     it("handles name and type and parent", asyncTest(async () => {
         const res = new MyResource("myres");
         const urn = await createUrn("n", "t", res).promise();
-        assert.equal(urn, "urn:pulumi:mystack::myproject::my:mod:MyResource$t::n");
+        assert.strictEqual(urn, "urn:pulumi:mystack::myproject::my:mod:MyResource$t::n");
     }));
 
     it("handles name and type and parent with parent", asyncTest(async () => {
         const res = new MyParentResource("myres");
         const urn = await createUrn("n", "t", res.child).promise();
-        assert.equal(urn, "urn:pulumi:mystack::myproject::my:mod:MyParentResource$my:mod:MyResource$t::n");
+        assert.strictEqual(urn, "urn:pulumi:mystack::myproject::my:mod:MyParentResource$my:mod:MyResource$t::n");
     }));
 });

--- a/sdk/nodejs/tests/runtime/asyncIterableUtil.spec.ts
+++ b/sdk/nodejs/tests/runtime/asyncIterableUtil.spec.ts
@@ -32,7 +32,7 @@ describe("PushableAsyncIterable", () => {
         asyncTest(async () => {
             const queue = new PushableAsyncIterable<number>();
             queue.complete();
-            assert.deepEqual(await enumerate(queue), []);
+            assert.deepStrictEqual(await enumerate(queue), []);
         }),
     );
 
@@ -42,7 +42,7 @@ describe("PushableAsyncIterable", () => {
             const queue = new PushableAsyncIterable<number>();
             queue.push(1);
             queue.complete();
-            assert.deepEqual(await enumerate(queue), [1]);
+            assert.deepStrictEqual(await enumerate(queue), [1]);
         }),
     );
 
@@ -54,7 +54,7 @@ describe("PushableAsyncIterable", () => {
             queue.push(2);
             queue.push(3);
             queue.complete();
-            assert.deepEqual(await enumerate(queue), [1, 2, 3]);
+            assert.deepStrictEqual(await enumerate(queue), [1, 2, 3]);
         }),
     );
 
@@ -64,14 +64,14 @@ describe("PushableAsyncIterable", () => {
             const queue = new PushableAsyncIterable<number>();
             const queueIter = queue[Symbol.asyncIterator]();
             const terminates = new Promise(async resolve => {
-                assert.deepEqual(await queueIter.next(), { value: undefined, done: true });
-                assert.deepEqual(await queueIter.next(), { value: undefined, done: true });
-                assert.deepEqual(await queueIter.next(), { value: undefined, done: true });
+                assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
+                assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
+                assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
                 resolve();
             });
             queue.complete();
             await terminates;
-            assert.deepEqual(await queueIter.next(), { value: undefined, done: true });
+            assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
         }),
     );
 
@@ -82,20 +82,20 @@ describe("PushableAsyncIterable", () => {
             const queueIter = queue[Symbol.asyncIterator]();
             queue.push(1);
             queue.push(2);
-            assert.deepEqual(await queueIter.next(), { value: 1, done: false });
+            assert.deepStrictEqual(await queueIter.next(), { value: 1, done: false });
             queue.push(3);
-            assert.deepEqual(await queueIter.next(), { value: 2, done: false });
-            assert.deepEqual(await queueIter.next(), { value: 3, done: false });
+            assert.deepStrictEqual(await queueIter.next(), { value: 2, done: false });
+            assert.deepStrictEqual(await queueIter.next(), { value: 3, done: false });
             queue.push(4);
             queue.push(5);
             queue.push(6);
             queue.push(7);
-            assert.deepEqual(await queueIter.next(), { value: 4, done: false });
-            assert.deepEqual(await queueIter.next(), { value: 5, done: false });
-            assert.deepEqual(await queueIter.next(), { value: 6, done: false });
-            assert.deepEqual(await queueIter.next(), { value: 7, done: false });
+            assert.deepStrictEqual(await queueIter.next(), { value: 4, done: false });
+            assert.deepStrictEqual(await queueIter.next(), { value: 5, done: false });
+            assert.deepStrictEqual(await queueIter.next(), { value: 6, done: false });
+            assert.deepStrictEqual(await queueIter.next(), { value: 7, done: false });
             queue.complete();
-            assert.deepEqual(await queueIter.next(), { value: undefined, done: true });
+            assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
         }),
     );
 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/003.one_complex_resource/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/003.one_complex_resource/index.js
@@ -35,43 +35,43 @@ class MyResource extends pulumi.CustomResource {
 let res = new MyResource("testResource1");
 res.urn.apply(urn => {
     console.log(`URN: ${urn}`);
-    assert.equal(urn, "test:index:MyResource::testResource1");
+    assert.strictEqual(urn, "test:index:MyResource::testResource1");
 });
 res.id.apply(id => {
     console.log(`ID: ${id}`);
-    assert.equal(id, "testResource1");
+    assert.strictEqual(id, "testResource1");
 });
 res.outprop1.apply(prop => {
     console.log(`OutProp1: ${prop}`);
-    assert.equal(prop, "output properties ftw");
+    assert.strictEqual(prop, "output properties ftw");
 });
 res.outprop2.apply(prop => {
     console.log(`OutProp2: ${prop}`);
-    assert.equal(prop, 998.6);
+    assert.strictEqual(prop, 998.6);
 });
 res.outprop3.apply(prop => {
     console.log(`OutProp3: ${prop}`);
-    assert.equal(prop, undefined);
+    assert.strictEqual(prop, undefined);
 });
 
 let resOutput = pulumi.output(res);
 resOutput.urn.apply(urn => {
     console.log(`URN: ${urn}`);
-    assert.equal(urn, "test:index:MyResource::testResource1");
+    assert.strictEqual(urn, "test:index:MyResource::testResource1");
 });
 resOutput.id.apply(id => {
     console.log(`ID: ${id}`);
-    assert.equal(id, "testResource1");
+    assert.strictEqual(id, "testResource1");
 });
 resOutput.outprop1.apply(prop => {
     console.log(`OutProp1: ${prop}`);
-    assert.equal(prop, "output properties ftw");
+    assert.strictEqual(prop, "output properties ftw");
 });
 resOutput.outprop2.apply(prop => {
     console.log(`OutProp2: ${prop}`);
-    assert.equal(prop, 998.6);
+    assert.strictEqual(prop, 998.6);
 });
 resOutput.outprop3.apply(prop => {
     console.log(`OutProp3: ${prop}`);
-    assert.equal(prop, undefined);
+    assert.strictEqual(prop, undefined);
 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/004.ten_complex_resources/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/004.ten_complex_resources/index.js
@@ -9,30 +9,30 @@ for (let i = 0; i < 10; i++) {
     let res = new MyResource(name, i);
     res.urn.apply(urn => {
         console.log(`${name}.URN: ${urn}`);
-        assert.equal(urn, "test:index:MyResource::" + name);
+        assert.strictEqual(urn, "test:index:MyResource::" + name);
     });
     res.id.apply(id => {
         if (id) {
             console.log(`${name}.ID: ${id}`);
-            assert.equal(id, name);
+            assert.strictEqual(id, name);
         }
     });
     res.outseq.apply(seq => {
         if (seq) {
             console.log(`${name}.Seq: ${seq}`);
-            assert.equal(seq, i);
+            assert.strictEqual(seq, i);
         }
     });
     res.outprop1.apply(prop => {
         if (prop) {
             console.log(`${name}.OutProp1: ${prop}`);
-            assert.equal(prop, "output properties ftw");
+            assert.strictEqual(prop, "output properties ftw");
         }
     });
     res.outprop2.apply(prop => {
         if (prop) {
             console.log(`${name}.OutProp2: ${prop}`);
-            assert.equal(prop, 998.6);
+            assert.strictEqual(prop, 998.6);
         }
     });
 }

--- a/sdk/nodejs/tests/runtime/langhost/cases/005.resource_thens/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/005.resource_thens/index.js
@@ -25,24 +25,24 @@ class ResourceB extends pulumi.CustomResource {
 let a = new ResourceA("resourceA");
 a.urn.apply(urn => {
     console.log(`A.URN: ${urn}`);
-    assert.equal(urn, "test:index:ResourceA::resourceA");
+    assert.strictEqual(urn, "test:index:ResourceA::resourceA");
 });
 a.id.apply(id => {
     if (id) {
         console.log(`A.ID: ${id}`);
-        assert.equal(id, "resourceA");
+        assert.strictEqual(id, "resourceA");
     }
 });
 a.inprop.apply(prop => {
     if (prop) {
         console.log(`A.InProp: ${prop}`);
-        assert.equal(prop, 777);
+        assert.strictEqual(prop, 777);
     }
 });
 a.outprop.apply(prop => {
     if (prop) {
         console.log(`A.OutProp: ${prop}`);
-        assert.equal(prop, "output yeah");
+        assert.strictEqual(prop, "output yeah");
     }
 });
 
@@ -50,24 +50,24 @@ a.outprop.apply(prop => {
 let b = new ResourceB("resourceB", a);
 b.urn.apply(urn => {
     console.log(`B.URN: ${urn}`);
-    assert.equal(urn, "test:index:ResourceB::resourceB");
+    assert.strictEqual(urn, "test:index:ResourceB::resourceB");
 });
 b.id.apply(id => {
     if (id) {
         console.log(`B.ID: ${id}`);
-        assert.equal(id, "resourceB");
+        assert.strictEqual(id, "resourceB");
     }
 });
 b.otherIn.apply(prop => {
     if (prop) {
         console.log(`B.OtherIn: ${prop}`);
-        assert.equal(prop, 777);
+        assert.strictEqual(prop, 777);
     }
 });
 b.otherOut.apply(prop => {
     if (prop) {
         console.log(`B.OtherOut: ${prop}`);
-        assert.equal(prop, "output yeah");
+        assert.strictEqual(prop, "output yeah");
     }
 });
 

--- a/sdk/nodejs/tests/runtime/langhost/cases/009.invoke/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/009.invoke/index.js
@@ -15,11 +15,11 @@ let result2 = pulumi.runtime.invoke("invoke:index:echo", args);
 
 // When invoking asynchronously: Ensure the properties are *not* present on the result.
 for (const key in args) {
-    assert.notDeepEqual(result2[key], args[key]);
+    assert.notDeepStrictEqual(result2[key], args[key]);
 }
 
 // When invoking asynchronously: Ensure the properties are available asynchronously through normal
 // Promise semantics.
 result2.then(v => {
-    assert.deepEqual(v, args);
+    assert.deepStrictEqual(v, args);
 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/010.runtime_settings/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/010.runtime_settings/index.js
@@ -3,20 +3,20 @@
 const assert = require("assert");
 const pulumi = require("../../../../../");
 
-assert.equal(pulumi.getProject(), "runtimeSettingsProject");
-assert.equal(pulumi.getStack(), "runtimeSettingsStack");
+assert.strictEqual(pulumi.getProject(), "runtimeSettingsProject");
+assert.strictEqual(pulumi.getStack(), "runtimeSettingsStack");
 
 const config = new pulumi.Config("myBag");
-assert.equal(config.getNumber("A"), 42);
-assert.equal(config.requireNumber("A"), 42);
-assert.equal(config.get("bbbb"), "a string o' b's");
-assert.equal(config.require("bbbb"), "a string o' b's");
-assert.equal(config.get("missingC"), undefined);
+assert.strictEqual(config.getNumber("A"), 42);
+assert.strictEqual(config.requireNumber("A"), 42);
+assert.strictEqual(config.get("bbbb"), "a string o' b's");
+assert.strictEqual(config.require("bbbb"), "a string o' b's");
+assert.strictEqual(config.get("missingC"), undefined);
 
 // ensure the older format works as well
 const configOld = new pulumi.Config("myBag:config");
-assert.equal(configOld.getNumber("A"), 42);
-assert.equal(configOld.requireNumber("A"), 42);
-assert.equal(configOld.get("bbbb"), "a string o' b's");
-assert.equal(configOld.require("bbbb"), "a string o' b's");
-assert.equal(configOld.get("missingC"), undefined);
+assert.strictEqual(configOld.getNumber("A"), 42);
+assert.strictEqual(configOld.requireNumber("A"), 42);
+assert.strictEqual(configOld.get("bbbb"), "a string o' b's");
+assert.strictEqual(configOld.require("bbbb"), "a string o' b's");
+assert.strictEqual(configOld.get("missingC"), undefined);

--- a/sdk/nodejs/tests/runtime/langhost/cases/014.read_resource/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/014.read_resource/index.js
@@ -15,5 +15,5 @@ res.id.apply(id => assert.strictEqual(id, "abc123"));
 res.urn.apply(urn => assert.strictEqual(urn, "test:read:resource::foo"));
 res.a.apply(a => assert.strictEqual(a, inputs.a)); // same as input
 res.b.apply(b => assert.strictEqual(b, true)); // output changed to true
-res.c.apply(c => assert.deepEqual(c, inputs.c)); // same as input
+res.c.apply(c => assert.deepStrictEqual(c, inputs.c)); // same as input
 res.d.apply(d => assert.strictEqual(d, "and then, out of nowhere ...")); // from the inputs

--- a/sdk/nodejs/tests/runtime/langhost/cases/015.runtime_sxs/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/015.runtime_sxs/index.js
@@ -26,7 +26,7 @@ assert(pulumi1.runtime !== pulumi2.runtime);
 assert.strictEqual(pulumi1.runtime.isDryRun(), pulumi2.runtime.isDryRun(), "pulumi1.runtime.isDryRun() !== pulumi2.runtime.isDryRun()");
 assert.strictEqual(pulumi1.runtime.getProject(), pulumi2.runtime.getProject(), "pulumi1.runtime.getProject() !== pulumi2.runtime.getProject()");
 assert.strictEqual(pulumi1.runtime.getStack(), pulumi2.runtime.getStack(), "pulumi1.runtime.getStack() !== pulumi2.runtime.getStack()");
-assert.deepEqual(pulumi1.runtime.allConfig(), pulumi2.runtime.allConfig(), "pulumi1.runtime.allConfig() !== pulumi2.runtime.getStack()");
+assert.deepStrictEqual(pulumi1.runtime.allConfig(), pulumi2.runtime.allConfig(), "pulumi1.runtime.allConfig() !== pulumi2.runtime.getStack()");
 
 // Check that the two runtimes agree on the root resource
 pulumi1.runtime.getRootResource().then(r => {

--- a/sdk/nodejs/tests/runtime/langhost/cases/017.parent_defaults/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/017.parent_defaults/index.js
@@ -40,7 +40,7 @@ function createResources(name, createChildren, parent) {
 	// Override provider
 	const provider = new Provider(`${name}-p`, { parent });
 	const r3 = new Resource(`${name}/r3`, createChildren, { parent, provider });
-	assert.equal(r3.getProvider("test:index:Resource"), provider);
+	assert.strictEqual(r3.getProvider("test:index:Resource"), provider);
 }
 
 function createComponents(name, createChildren, parent) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/041.component_opt_single_provider/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/041.component_opt_single_provider/index.js
@@ -40,7 +40,7 @@ function createResources(name, createChildren, parent) {
 	// Override provider
 	const provider = new Provider(`${name}-p`, { parent });
 	const r3 = new Resource(`${name}/r3`, createChildren, { parent, provider });
-	assert.equal(r3.getProvider("test:index:Resource"), provider);
+	assert.strictEqual(r3.getProvider("test:index:Resource"), provider);
 }
 
 function createComponents(name, createChildren, parent) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/042.component_opt_providers_array/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/042.component_opt_providers_array/index.js
@@ -40,7 +40,7 @@ function createResources(name, createChildren, parent) {
 	// Override provider
 	const provider = new Provider(`${name}-p`, { parent });
 	const r3 = new Resource(`${name}/r3`, createChildren, { parent, provider });
-	assert.equal(r3.getProvider("test:index:Resource"), provider);
+	assert.strictEqual(r3.getProvider("test:index:Resource"), provider);
 }
 
 function createComponents(name, createChildren, parent) {

--- a/sdk/nodejs/tests/runtime/langhost/cases/060.provider_invokes/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/060.provider_invokes/index.js
@@ -22,5 +22,5 @@ let args = {
 
 let result2 = pulumi.runtime.invoke("test:index:echo", args, { provider });
 result2.then((v) => {
-	assert.deepEqual(v, args);
+	assert.deepStrictEqual(v, args);
 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/061.provider_in_parent_invokes/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/061.provider_in_parent_invokes/index.js
@@ -29,5 +29,5 @@ let args = {
 
 let result2 = pulumi.runtime.invoke("test:index:echo", args, { parent });
 result2.then((v) => {
-	assert.deepEqual(v, args);
+	assert.deepStrictEqual(v, args);
 });

--- a/sdk/nodejs/tests/runtime/langhost/cases/062.providerref_invokes/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/062.providerref_invokes/index.js
@@ -23,11 +23,11 @@ let pulumi = require("../../../../../");
 
     let result1 = await pulumi.runtime.invoke("test:index:echo", args, { provider });
     for (const key in args) {
-        assert.deepEqual(result1[key], args[key]);
+        assert.deepStrictEqual(result1[key], args[key]);
     }
 
     let result2 = pulumi.runtime.invoke("test:index:echo", args, { provider, async: false });
     result2.then((v) => {
-        assert.deepEqual(v, args);
+        assert.deepStrictEqual(v, args);
     });
 })();

--- a/sdk/nodejs/tests/runtime/langhost/cases/063.providerref_in_parent_invokes/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/063.providerref_in_parent_invokes/index.js
@@ -31,11 +31,11 @@ let pulumi = require("../../../../../");
 
     let result1 = await pulumi.runtime.invoke("test:index:echo", args, { parent });
     for (const key in args) {
-        assert.deepEqual(result1[key], args[key]);
+        assert.deepStrictEqual(result1[key], args[key]);
     }
 
     let result2 = pulumi.runtime.invoke("test:index:echo", args, { parent, async: false });
     result2.then((v) => {
-        assert.deepEqual(v, args);
+        assert.deepStrictEqual(v, args);
     });
 })();

--- a/sdk/nodejs/tests/runtime/langhost/cases/064.async_components/index.js
+++ b/sdk/nodejs/tests/runtime/langhost/cases/064.async_components/index.js
@@ -29,10 +29,10 @@ class CompResource extends pulumi.ComponentResource {
 
 const comp = new CompResource("comp", {});
 comp.a.apply(v => {
-    assert.equal(v, 1);
+    assert.strictEqual(v, 1);
 });
 comp.b.apply(v => {
-    assert.equal(v, 2);
+    assert.strictEqual(v, 2);
 });
 
 // Have a custom resource depend on the async component.  We should still pick up 'a' and 'b' as

--- a/sdk/nodejs/tests/runtime/langhost/run.spec.ts
+++ b/sdk/nodejs/tests/runtime/langhost/run.spec.ts
@@ -125,7 +125,7 @@ describe("rpc", () => {
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any) => {
                 assert.strictEqual(t, "test:index:MyResource");
                 assert.strictEqual(name, "testResource1");
-                assert.deepEqual(res, {
+                assert.deepStrictEqual(res, {
                     inpropB1: false,
                     inpropB2: true,
                     inpropN: 42,
@@ -170,7 +170,7 @@ describe("rpc", () => {
                 assert(!isNaN(seqnum),
                     `Expected ${name} to be of the form ${prefix}N; missing N seqnum`);
                 ctx.seen[name] = true;
-                assert.deepEqual(res, {
+                assert.deepStrictEqual(res, {
                     inseq: seqnum,
                     inpropB1: false,
                     inpropB2: true,
@@ -207,7 +207,7 @@ describe("rpc", () => {
                 switch (t) {
                     case "test:index:ResourceA": {
                         assert.strictEqual(name, "resourceA");
-                        assert.deepEqual(res, { inprop: 777 });
+                        assert.deepStrictEqual(res, { inprop: 777 });
                         if (!dryrun) {
                             id = name;
                             props = { outprop: "output yeah" };
@@ -216,18 +216,18 @@ describe("rpc", () => {
                     }
                     case "test:index:ResourceB": {
                         assert.strictEqual(name, "resourceB");
-                        assert.deepEqual(dependencies, ["test:index:ResourceA::resourceA"]);
+                        assert.deepStrictEqual(dependencies, ["test:index:ResourceA::resourceA"]);
 
                         if (dryrun) {
                             // If this is a dry-run, we will have no known values.
-                            assert.deepEqual(res, {
+                            assert.deepStrictEqual(res, {
                                 otherIn: runtime.unknownValue,
                                 otherOut: runtime.unknownValue,
                             });
                         }
                         else {
                             // Otherwise, we will:
-                            assert.deepEqual(res, {
+                            assert.deepStrictEqual(res, {
                                 otherIn: 777,
                                 otherOut: "output yeah",
                             });
@@ -255,7 +255,7 @@ describe("rpc", () => {
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any) => {
                 assert.strictEqual(t, "test:index:FileResource");
                 assert.strictEqual(name, "file1");
-                assert.deepEqual(res, {
+                assert.deepStrictEqual(res, {
                     data: {
                         [runtime.specialSigKey]: runtime.specialAssetSig,
                         __pulumiAsset: true,
@@ -271,7 +271,7 @@ describe("rpc", () => {
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any) => {
                 assert.strictEqual(t, "test:index:FileResource");
                 assert.strictEqual(name, "file1");
-                assert.deepEqual(res, {
+                assert.deepStrictEqual(res, {
                     data: "The test worked!\n\nIf you can see some data!\n\n",
                 });
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
@@ -307,7 +307,7 @@ describe("rpc", () => {
             invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "");
                 assert.strictEqual(tok, "invoke:index:echo");
-                assert.deepEqual(args, {
+                assert.deepStrictEqual(args, {
                     a: "hello",
                     b: true,
                     c: [0.99, 42, { z: "x" }],
@@ -358,7 +358,7 @@ describe("rpc", () => {
             program: path.join(base, "012.assets_archive"),
             expectResourceCount: 1,
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any) => {
-                assert.deepEqual(res, {
+                assert.deepStrictEqual(res, {
                     "archive": {
                         "4dabf18193072939515e22adb298388d": "0def7320c3a5731c473e5ecbe6d01bc7",
                         "__pulumiArchive": true,
@@ -423,7 +423,7 @@ describe("rpc", () => {
                 assert.strictEqual(t, "test:read:resource");
                 assert.strictEqual(name, "foo");
                 assert.strictEqual(id, "abc123");
-                assert.deepEqual(state, {
+                assert.deepStrictEqual(state, {
                     a: "fizzz",
                     b: false,
                     c: [0.73, "x", { zed: 923 }],
@@ -524,7 +524,7 @@ describe("rpc", () => {
             registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
                                       t: string, name: string, res: any, outputs: any | undefined) => {
                 assert.strictEqual(t, "pulumi:pulumi:Stack");
-                assert.deepEqual(outputs, {
+                assert.deepStrictEqual(outputs, {
                     a: {
                         x: 99,
                         y: "z",
@@ -791,7 +791,7 @@ describe("rpc", () => {
                 propertyDeps?: any, ignoreChanges?: string[],
             ) => {
                 if (name === "testResource") {
-                    assert.deepEqual(ignoreChanges, ["ignoredProperty"]);
+                    assert.deepStrictEqual(ignoreChanges, ["ignoredProperty"]);
                 }
                 return {
                     urn: makeUrn(t, name),
@@ -888,7 +888,7 @@ describe("rpc", () => {
             registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
                                       t: string, name: string, res: any, outputs: any | undefined) => {
                 assert.strictEqual(t, "pulumi:pulumi:Stack");
-                assert.deepEqual(outputs, {
+                assert.deepStrictEqual(outputs, {
                     "m": { "a": { "b": 1 } },
                     "n": { "a": { "b": 1 } },
                     "o": { "b": 1 },
@@ -913,7 +913,7 @@ describe("rpc", () => {
             registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
                                       t: string, name: string, res: any, outputs: any | undefined) => {
                 assert.strictEqual(t, "pulumi:pulumi:Stack");
-                assert.deepEqual(outputs, {
+                assert.deepStrictEqual(outputs, {
                     a: {
                         x: 99,
                         y: "z",
@@ -940,7 +940,7 @@ describe("rpc", () => {
             registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
                                       t: string, name: string, res: any, outputs: any | undefined) => {
                 assert.strictEqual(t, "pulumi:pulumi:Stack");
-                assert.deepEqual(outputs, {
+                assert.deepStrictEqual(outputs, {
                     a: {
                         x: 99,
                         y: "z",
@@ -967,7 +967,7 @@ describe("rpc", () => {
             registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
                                       t: string, name: string, res: any, outputs: any | undefined) => {
                 assert.strictEqual(t, "pulumi:pulumi:Stack");
-                assert.deepEqual(outputs, {
+                assert.deepStrictEqual(outputs, {
                     a: {
                         x: 99,
                         y: "z",
@@ -996,7 +996,7 @@ describe("rpc", () => {
             registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
                                       t: string, name: string, res: any, outputs: any | undefined) => {
                 assert.strictEqual(t, "pulumi:pulumi:Stack");
-                assert.deepEqual(outputs, {});
+                assert.deepStrictEqual(outputs, {});
             },
         },
         "resource_creation_in_function_with_result": {
@@ -1015,7 +1015,7 @@ describe("rpc", () => {
             registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
                                       t: string, name: string, res: any, outputs: any | undefined) => {
                 assert.strictEqual(t, "pulumi:pulumi:Stack");
-                assert.deepEqual(outputs, { a: 1 });
+                assert.deepStrictEqual(outputs, { a: 1 });
             },
         },
         "resource_creation_in_async_function_with_result": {
@@ -1034,7 +1034,7 @@ describe("rpc", () => {
             registerResourceOutputs: (ctx: any, dryrun: boolean, urn: URN,
                                       t: string, name: string, res: any, outputs: any | undefined) => {
                 assert.strictEqual(t, "pulumi:pulumi:Stack");
-                assert.deepEqual(outputs, { a: 1 });
+                assert.deepStrictEqual(outputs, { a: 1 });
             },
         },
         "provider_invokes": {
@@ -1046,7 +1046,7 @@ describe("rpc", () => {
             invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "pulumi:providers:test::p::1");
                 assert.strictEqual(tok, "test:index:echo");
-                assert.deepEqual(args, {
+                assert.deepStrictEqual(args, {
                     a: "hello",
                     b: true,
                     c: [0.99, 42, { z: "x" }],
@@ -1066,7 +1066,7 @@ describe("rpc", () => {
             invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "pulumi:providers:test::p::1");
                 assert.strictEqual(tok, "test:index:echo");
-                assert.deepEqual(args, {
+                assert.deepStrictEqual(args, {
                     a: "hello",
                     b: true,
                     c: [0.99, 42, { z: "x" }],
@@ -1085,7 +1085,7 @@ describe("rpc", () => {
             invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "pulumi:providers:test::p::1");
                 assert.strictEqual(tok, "test:index:echo");
-                assert.deepEqual(args, {
+                assert.deepStrictEqual(args, {
                     a: "hello",
                     b: true,
                     c: [0.99, 42, { z: "x" }],
@@ -1101,7 +1101,7 @@ describe("rpc", () => {
             registerResource: (ctx: any, dryrun: boolean, t: string, name: string, res: any, dependencies?: string[],
                                custom?: boolean, protect?: boolean, parent?: string, provider?: string) => {
                 if (name === "c") {
-                    assert.equal(provider, "");
+                    assert.strictEqual(provider, "");
                 }
 
                 return { urn: makeUrn(t, name), id: name === "p" ? "1" : undefined, props: undefined };
@@ -1109,7 +1109,7 @@ describe("rpc", () => {
             invoke: (ctx: any, tok: string, args: any, version: string, provider: string) => {
                 assert.strictEqual(provider, "pulumi:providers:test::p::1");
                 assert.strictEqual(tok, "test:index:echo");
-                assert.deepEqual(args, {
+                assert.deepStrictEqual(args, {
                     a: "hello",
                     b: true,
                     c: [0.99, 42, { z: "x" }],
@@ -1130,7 +1130,7 @@ describe("rpc", () => {
                     dependencies.sort();
                     // resources 'c' and 'd' should see resources 'a' and 'b' as dependencies (even
                     // though they are async constructed by the component)
-                    assert.deepEqual(dependencies, ["test:index:CustResource::a", "test:index:CustResource::b"]);
+                    assert.deepStrictEqual(dependencies, ["test:index:CustResource::a", "test:index:CustResource::b"]);
                 }
 
                 return { urn: makeUrn(t, name), id: undefined, props: undefined };
@@ -1144,7 +1144,7 @@ describe("rpc", () => {
                 const longString = "a".repeat(1024 * 1024 * 5);
                 assert.strictEqual(t, "test:index:MyLargeStringResource");
                 assert.strictEqual(name, "testResource1");
-                assert.deepEqual(res, { "largeStringProp": longString });
+                assert.deepStrictEqual(res, { "largeStringProp": longString });
                 return {
                     urn: makeUrn(t, name),
                     id: name,

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -34,12 +34,12 @@ describe("runtime", () => {
             const transfer = gstruct.Struct.fromJavaScript(
                 await runtime.serializeProperties("test", inputs));
             const result = runtime.deserializeProperties(transfer);
-            assert.equal(result.aNum, 42);
-            assert.equal(result.bStr, "a string");
-            assert.equal(result.cUnd, undefined);
-            assert.deepEqual(result.dArr, [ "x", 42, true, null ]);
-            assert.equal(result.id, "foo");
-            assert.equal(result.urn, "bar");
+            assert.strictEqual(result.aNum, 42);
+            assert.strictEqual(result.bStr, "a string");
+            assert.strictEqual(result.cUnd, undefined);
+            assert.deepStrictEqual(result.dArr, [ "x", 42, true, null ]);
+            assert.strictEqual(result.id, "foo");
+            assert.strictEqual(result.urn, "bar");
         }));
         it("marshals secrets correctly", asyncTest(async () => {
             runtime._setTestModeEnabled(true);
@@ -51,8 +51,8 @@ describe("runtime", () => {
             const transfer = gstruct.Struct.fromJavaScript(
                 await runtime.serializeProperties("test", inputs));
             const result = runtime.deserializeProperties(transfer);
-            assert.equal(result.secret1, 1);
-            assert.equal(result.secret2, undefined);
+            assert.strictEqual(result.secret1, 1);
+            assert.strictEqual(result.secret2, undefined);
             runtime._setTestModeEnabled(false);
         }));
     });
@@ -91,29 +91,29 @@ describe("runtime", () => {
             const result = runtime.deserializeProperties(props);
 
             // Regular had no secrets in it, so it is returned as is.
-            assert.equal(result.regular, "a normal value");
+            assert.strictEqual(result.regular, "a normal value");
 
             // One of the elements in the list was a secret, so the secretness is promoted to top level.
-            assert.equal(result.list[runtime.specialSigKey], runtime.specialSecretSig);
-            assert.equal(result.list.value[0], "a normal value");
-            assert.equal(result.list.value[1], "another value");
-            assert.equal(result.list.value[2], "a secret value");
+            assert.strictEqual(result.list[runtime.specialSigKey], runtime.specialSecretSig);
+            assert.strictEqual(result.list.value[0], "a normal value");
+            assert.strictEqual(result.list.value[1], "another value");
+            assert.strictEqual(result.list.value[2], "a secret value");
 
             // One of the values of the map was a secret, so the secretness is promoted to top level.
-            assert.equal(result.map[runtime.specialSigKey], runtime.specialSecretSig);
-            assert.equal(result.map.value.regular, "a normal value");
-            assert.equal(result.map.value.secret, "a secret value");
+            assert.strictEqual(result.map[runtime.specialSigKey], runtime.specialSecretSig);
+            assert.strictEqual(result.map.value.regular, "a normal value");
+            assert.strictEqual(result.map.value.secret, "a secret value");
 
             // The nested map had a secret in one of the values, so the entire thing becomes a secret.
-            assert.equal(result.mapWithList[runtime.specialSigKey], runtime.specialSecretSig);
-            assert.equal(result.mapWithList.value.regular, "a normal value");
-            assert.equal(result.mapWithList.value.list[0], "a normal value");
-            assert.equal(result.mapWithList.value.list[1], "a secret value");
+            assert.strictEqual(result.mapWithList[runtime.specialSigKey], runtime.specialSecretSig);
+            assert.strictEqual(result.mapWithList.value.regular, "a normal value");
+            assert.strictEqual(result.mapWithList.value.list[0], "a normal value");
+            assert.strictEqual(result.mapWithList.value.list[1], "a secret value");
 
             // An array element contained a secret (via a nested map), so the entrie array becomes a secret.
-            assert.equal(result.listWithMap[runtime.specialSigKey], runtime.specialSecretSig);
-            assert.equal(result.listWithMap.value[0].regular, "a normal value");
-            assert.equal(result.listWithMap.value[0].secret, "a secret value");
+            assert.strictEqual(result.listWithMap[runtime.specialSigKey], runtime.specialSecretSig);
+            assert.strictEqual(result.listWithMap.value[0].regular, "a normal value");
+            assert.strictEqual(result.listWithMap.value[0].secret, "a secret value");
         });
     });
 });

--- a/sdk/nodejs/tests/runtime/tsClosureCases.ts
+++ b/sdk/nodejs/tests/runtime/tsClosureCases.ts
@@ -6619,7 +6619,7 @@ function compareTextWithWildcards(expected: string, actual: string) {
     if (!expected.includes(wildcard)) {
         // We get a nice diff view if we diff the entire string, so do that
         // if we didn't get a wildcard.
-        assert.equal(actual, expected);
+        assert.strictEqual(actual, expected);
         return;
     }
 
@@ -6648,7 +6648,7 @@ function compareTextWithWildcards(expected: string, actual: string) {
             const line = actualLines[actualIndex++].trim();
             const index = expectedLine.indexOf(wildcard);
             const indexAfter = index + wildcard.length;
-            assert.equal(line.substring(0, index), expectedLine.substring(0, index));
+            assert.strictEqual(line.substring(0, index), expectedLine.substring(0, index));
 
             if (indexAfter === expectedLine.length) {
                 continue;
@@ -6660,9 +6660,9 @@ function compareTextWithWildcards(expected: string, actual: string) {
                 }
             }
 
-            assert.equal(line.substring(repetitionIndex), expectedLine.substring(indexAfter));
+            assert.strictEqual(line.substring(repetitionIndex), expectedLine.substring(indexAfter));
         } else {
-            assert.equal(actualLines[actualIndex++].trim(), expectedLine);
+            assert.strictEqual(actualLines[actualIndex++].trim(), expectedLine);
         }
     }
 }

--- a/sdk/nodejs/tests/testmode.spec.ts
+++ b/sdk/nodejs/tests/testmode.spec.ts
@@ -50,15 +50,15 @@ describe("testMode", () => {
             let res: FakeResource | undefined;
             assert.doesNotThrow(() => { res = new FakeResource("fake", { x: 42 }); });
             const x = await new Promise((resolve) => res!.x!.apply(resolve));
-            assert.equal(x, 42);
+            assert.strictEqual(x, 42);
             // Fetching the project name while in test mode succeeds.
             let project: string | undefined;
             assert.doesNotThrow(() => { project = runtime.getProject(); });
-            assert.equal(project, testProject);
+            assert.strictEqual(project, testProject);
             // Fetching the stack name while in test mode succeeds.
             let stack: string | undefined;
             assert.doesNotThrow(() => { stack = runtime.getStack(); });
-            assert.equal(stack, testStack);
+            assert.strictEqual(stack, testStack);
         } finally {
             runtime._setTestModeEnabled(false);
             runtime._setProject("");


### PR DESCRIPTION
assert.Equal and assert.deepEqual have been deprecated in favor of assert.strictEqual and assert.deepStrictEqual