### PR TITLE
Respect `disableProviderPreview` in providers.

### DIFF
--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -96,11 +96,12 @@ func NewProvider(host Host, ctx *Context, pkg tokens.Package, version *semver.Ve
 	contract.Assertf(plug != nil, "unexpected nil resource plugin for %s", pkg)
 
 	return &provider{
-		ctx:       ctx,
-		pkg:       pkg,
-		plug:      plug,
-		clientRaw: pulumirpc.NewResourceProviderClient(plug.Conn),
-		cfgdone:   make(chan bool),
+		ctx:                    ctx,
+		pkg:                    pkg,
+		plug:                   plug,
+		clientRaw:              pulumirpc.NewResourceProviderClient(plug.Conn),
+		cfgdone:                make(chan bool),
+		disableProviderPreview: disableProviderPreview,
 	}, nil
 }
 


### PR DESCRIPTION
This parameter was not actually stamped into the `provider` value, thus
eliminating its effect.