### PR TITLE
Fix outstanding issues with build

### DIFF
--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -33,7 +33,7 @@ jobs:
           dockerfile: docker/actions/Dockerfile
           additional-tags: ${{ env.VERSION }}
           tag-latest: true
-          build-args: PULUMI_VERSION=${{ env.VERSION }}
+          build-args: PULUMI_VERSION=v${{ env.VERSION }}
   base:
     name: base sdk image build
     runs-on: ubuntu-latest

--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: dawidd6/action-homebrew-bump-formula@v3
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.PULUMI_BOT_TOKEN}}
           formula: pulumi
           tag: ${{env.VERSION}}
           revision: ${{env.COMMIT_SHA}}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-      - v*.*.*
+      - v*.*.*-**
     paths-ignore:
       - 'CHANGELOG.md'
       - 'README.md'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,39 +17,61 @@ env:
   TRAVIS_PUBLISH_PACKAGES: true
 
 jobs:
+  # sends a repository dispatch to this repo, to build the docker images
+  # note, the tagging format is unfortunately different for the two sets of images
+  # FIXME: consolidate the tagging to always include a v
   docker:
-    name: Build Docker Images
+    name: Build Slim Docker Images
     runs-on: ubuntu-latest
     needs: publish-sdks
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Set tag version
+        run: |
+          echo "PULUMI_LATEST_TAG::$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           event-type: docker-build
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"ref": "${{ env.PULUMI_LATEST_TAG }}", "sha": "${{ github.sha }}"}'
+  # This sends a repository dispatch job to the docs repo
+  # chocolatey build needs to be triggered from here
   docs:
     name: Build Package Docs
     runs-on: ubuntu-latest
     needs: publish-sdks
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Set tag version
+        run: |
+          echo "PULUMI_LATEST_TAG::$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          event-type: homebrew-bump
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          repository: pulumi/docs
+          event-type: pulumi-cli
+          client-payload: '{"ref": "v${{ env.PULUMI_LATEST_TAG }}", "sha": "${{ github.sha }}"}'
+  # Sends a repository dispatch job to the homebrew build
   homebrew:
     name: Update Homebrew
     runs-on: macos-latest
     needs: publish-sdks
     steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Set tag version
+        run: |
+          echo "PULUMI_LATEST_TAG::$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.PULUMI_BOT_TOKEN }}
           event-type: homebrew-bump
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"ref": "v${{ env.PULUMI_LATEST_TAG }}", "sha": "${{ github.sha }}"}'
 
   publish-sdks:
     name: Publish SDKs
@@ -92,10 +114,10 @@ jobs:
           git fetch --quiet --prune --unshallow --tags
       - name: Update path
         run: |
-          echo "::add-path::${{ runner.temp }}/opt/pulumi/bin"
+          echo "${{ runner.temp }}/opt/pulumi/bin" >> $GITHUB_PATH
       - name: Set Go Dep path
         run: |
-          echo "::set-env name=PULUMI_GO_DEP_ROOT::$(dirname $(pwd))"
+          echo "PULUMI_GO_DEP_ROOT::$(dirname $(pwd)" >> $GITHUB_ENV
       - name: Ensure
         run: |
           make ensure
@@ -133,7 +155,8 @@ jobs:
           role-session-name: pulumi@githubActions
           role-to-assume: ${{ secrets.AWS_UPLOAD_ROLE_ARN }}
       - name: Set Release Version
-        run: echo "::set-env name=GORELEASER_CURRENT_TAG::v$(pulumictl get version --language generic -o)"
+        run: |
+          echo "GORELEASER_CURRENT_TAG::v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,21 @@ env:
   TRAVIS_PUBLISH_PACKAGES: true
 
 jobs:
+  chocolatey:
+    name: Chocolatey update
+    runs-on: ubuntu-latest
+    needs: publish-sdks
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Set tag version
+        run: |
+          echo "PULUMI_LATEST_TAG::$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
+      - name: Repository Dispatch
+        run: |
+          pulumictl create choco-deploy ${{ env.PULUMI_LATEST_TAG }}
+         env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN}}
   # sends a repository dispatch to this repo, to build the docker images
   # note, the tagging format is unfortunately different for the two sets of images
   # FIXME: consolidate the tagging to always include a v
@@ -55,6 +70,8 @@ jobs:
           repository: pulumi/docs
           event-type: pulumi-cli
           client-payload: '{"ref": "v${{ env.PULUMI_LATEST_TAG }}", "sha": "${{ github.sha }}"}'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN}}
   # Sends a repository dispatch job to the homebrew build
   homebrew:
     name: Update Homebrew


### PR DESCRIPTION
This PR fixes some of the outstanding issues with the build

- sends a repository dispatch directly to the docs repo
- fixes the versioning issues with the docker builds
- fixes the homebrew token

Only thing outstanding now is chocolatey builds. Those depends on the docs builds, which are in the docs repo, so we need to address that separately (and trigger it manually for now)