### PR TITLE
Read .NET plugin name from version.txt

### DIFF
--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -93,6 +93,12 @@ namespace {{.Namespace}}
             using var stream = assembly.GetManifestResourceStream("{{.Namespace}}.version.txt");
             using var reader = new StreamReader(stream ?? throw new NotSupportedException("Missing embedded version.txt file"));
             version = reader.ReadToEnd().Trim();
+            var parts = version.Split("\n");
+            if (parts.Length == 2)
+            {
+                // The first part is the provider name.
+                version = parts[1];
+            }
         }
     }
 }

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -97,7 +97,7 @@ namespace {{.Namespace}}
             if (parts.Length == 2)
             {
                 // The first part is the provider name.
-                version = parts[1];
+                version = parts[1].Trim();
             }
         }
     }

--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -330,6 +330,13 @@ func (host *dotnetLanguageHost) DeterminePluginDependency(
 	name := strings.ToLower(packageName[len("Pulumi."):])
 
 	version := strings.TrimSpace(bytes.NewBuffer(b).String())
+	parts := strings.SplitN(version, "\n", 2)
+	if len(parts) == 2 {
+		// version.txt may contain two lines, in which case it's "plugin name\nversion"
+		name = parts[0]
+		version = parts[1]
+	}
+
 	if !strings.HasPrefix(version, "v") {
 		// Version file has stripped off the "v" that we need. So add it back here.
 		version = fmt.Sprintf("v%v", version)

--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -333,8 +333,8 @@ func (host *dotnetLanguageHost) DeterminePluginDependency(
 	parts := strings.SplitN(version, "\n", 2)
 	if len(parts) == 2 {
 		// version.txt may contain two lines, in which case it's "plugin name\nversion"
-		name = parts[0]
-		version = parts[1]
+		name = strings.TrimSpace(parts[0])
+		version = strings.TrimSpace(parts[1])
 	}
 
 	if !strings.HasPrefix(version, "v") {


### PR DESCRIPTION
The existing plugin discovery mechanism doesn't form for Azure NextGen: the NuGet name `Pulumi.AzureNextGen` is translated to the plugin name `azurenextgen` instead of `azure-nextgen`. See https://github.com/pulumi/pulumi-azure-nextgen/issues/70

Basically, there is simingly no way to recover the `dash` in the name without extra metadata. I see two options:

- Hard-code the knowledge about `-nextgen` in the plugin acquisition function
- Add the plugin name to the `version.txt` file next to plugin version

This PR implements the latter. `version.txt` may now be

```
azure-nextgen
0.2.3
```

One downside is that older language plugin versions may get confused about the new format in Azure NextGen `version.txt`. Seems ok-ish as it won't be worse than the current behavior.