### PR TITLE
Add resource modules.

### DIFF
--- a/sdk/dotnet/Pulumi/Deployment/Deployment_ResourceModules.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_ResourceModules.cs
@@ -9,7 +9,7 @@ namespace Pulumi
     {
         public static void RegisterResourceModule(string name, string version, IResourceModule module)
         {
-            ResourceModules.RegisterResourceModule(name, version, package);
+            ResourceModules.RegisterResourceModule(name, version, module);
         }
     }
 }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_ResourceModules.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_ResourceModules.cs
@@ -7,7 +7,7 @@ namespace Pulumi
 {
     public partial class Deployment
     {
-        public static void RegisterResourceModule(string name, string version, IResourceModule package)
+        public static void RegisterResourceModule(string name, string version, IResourceModule module)
         {
             ResourceModules.RegisterResourceModule(name, version, package);
         }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_ResourceModules.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_ResourceModules.cs
@@ -1,0 +1,15 @@
+// Copyright 2016-2020, Pulumi Corporation
+
+using System;
+using Pulumi.Serialization;
+
+namespace Pulumi
+{
+    public partial class Deployment
+    {
+        public static void RegisterResourceModule(string name, string version, IResourceModule package)
+        {
+            ResourceModules.RegisterResourceModule(name, version, package);
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -232,7 +232,7 @@ override Pulumi.Union<T0, T1>.ToString() -> string
 static Pulumi.ComponentResourceOptions.Merge(Pulumi.ComponentResourceOptions options1, Pulumi.ComponentResourceOptions options2) -> Pulumi.ComponentResourceOptions
 static Pulumi.CustomResourceOptions.Merge(Pulumi.CustomResourceOptions options1, Pulumi.CustomResourceOptions options2) -> Pulumi.CustomResourceOptions
 static Pulumi.Deployment.Instance.get -> Pulumi.DeploymentInstance
-static Pulumi.Deployment.RegisterResourceModule(string name, string version, Pulumi.IResourceModule package) -> void
+static Pulumi.Deployment.RegisterResourceModule(string name, string version, Pulumi.IResourceModule module) -> void
 static Pulumi.Deployment.RegisterResourcePackage(string name, string version, Pulumi.IResourcePackage package) -> void
 static Pulumi.Deployment.RunAsync(System.Action action) -> System.Threading.Tasks.Task<int>
 static Pulumi.Deployment.RunAsync(System.Func<System.Collections.Generic.IDictionary<string, object>> func) -> System.Threading.Tasks.Task<int>

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -175,8 +175,9 @@ Pulumi.ResourceTransformationResult
 Pulumi.ResourceTransformationResult.Args.get -> Pulumi.ResourceArgs
 Pulumi.ResourceTransformationResult.Options.get -> Pulumi.ResourceOptions
 Pulumi.ResourceTransformationResult.ResourceTransformationResult(Pulumi.ResourceArgs args, Pulumi.ResourceOptions options) -> void
+Pulumi.IResourceModule
+Pulumi.IResourceModule.Construct(string name, string type, System.Collections.Generic.IDictionary<string, object> args, string urn) -> Pulumi.Resource
 Pulumi.IResourcePackage
-Pulumi.IResourcePackage.Construct(string name, string type, System.Collections.Generic.IDictionary<string, object> args, string urn) -> Pulumi.Resource
 Pulumi.IResourcePackage.ConstructProvider(string name, string type, System.Collections.Generic.IDictionary<string, object> args, string urn) -> Pulumi.ProviderResource
 Pulumi.Stack
 Pulumi.Stack.Stack(Pulumi.StackOptions options = null) -> void
@@ -231,6 +232,7 @@ override Pulumi.Union<T0, T1>.ToString() -> string
 static Pulumi.ComponentResourceOptions.Merge(Pulumi.ComponentResourceOptions options1, Pulumi.ComponentResourceOptions options2) -> Pulumi.ComponentResourceOptions
 static Pulumi.CustomResourceOptions.Merge(Pulumi.CustomResourceOptions options1, Pulumi.CustomResourceOptions options2) -> Pulumi.CustomResourceOptions
 static Pulumi.Deployment.Instance.get -> Pulumi.DeploymentInstance
+static Pulumi.Deployment.RegisterResourceModule(string name, string version, Pulumi.IResourceModule package) -> void
 static Pulumi.Deployment.RegisterResourcePackage(string name, string version, Pulumi.IResourcePackage package) -> void
 static Pulumi.Deployment.RunAsync(System.Action action) -> System.Threading.Tasks.Task<int>
 static Pulumi.Deployment.RunAsync(System.Func<System.Collections.Generic.IDictionary<string, object>> func) -> System.Threading.Tasks.Task<int>

--- a/sdk/dotnet/Pulumi/Serialization/Deserializer.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Deserializer.cs
@@ -249,15 +249,15 @@ namespace Pulumi.Serialization
                     throw new InvalidOperationException($"Unable to deserialize provider {urn}, no resource package is registered for type {typeName}.");
                 }
                 resource = package.ConstructProvider(urnName, type, null, urn);
-                return true
+                return true;
             }
 
             IResourceModule? module;
-            if (!ResourceModules.TryGetResourcePackage(modName, version, out module))
+            if (!ResourceModules.TryGetResourceModule(modName, version, out module))
             {
                 throw new InvalidOperationException($"Unable to deserialize resource {urn}, no module is registered for {modName}.");
             }
-            resource = module.Construct(urnName, type, null, urn) :
+            resource = module.Construct(urnName, type, null, urn);
             return true;
         }
 

--- a/sdk/dotnet/Pulumi/Serialization/ResourceModules.cs
+++ b/sdk/dotnet/Pulumi/Serialization/ResourceModules.cs
@@ -28,12 +28,12 @@ namespace Pulumi
             return _resourceModules.TryGetValue(ModuleKey(name, version), out package);
         }
 
-        public static void RegisterResourceModule(string name, string version, IResourceModule package)
+        public static void RegisterResourceModule(string name, string version, IResourceModule module)
         {
             var key = ModuleKey(name, version);
-            if (!_resourceModules.TryAdd(key, package))
+            if (!_resourceModules.TryAdd(key, module))
             {
-                throw new InvalidOperationException($"Cannot re-register package {key}.");
+                throw new InvalidOperationException($"Cannot re-register module {key}.");
             }
         }
     }

--- a/sdk/dotnet/Pulumi/Serialization/ResourceModules.cs
+++ b/sdk/dotnet/Pulumi/Serialization/ResourceModules.cs
@@ -1,0 +1,40 @@
+// Copyright 2016-2019, Pulumi Corporation
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+
+namespace Pulumi
+{
+    public interface IResourceModule
+    {
+        Resource Construct(string name, string type, IDictionary<string, object?>? args, string urn);
+    }
+
+    internal static class ResourceModules
+    {
+        internal static ConcurrentDictionary<string, IResourceModule> _resourceModules = new ConcurrentDictionary<string, IResourceModule>();
+
+        private static string ModuleKey(string name, string version)
+        {
+            return $"{name}@{version}";
+        }
+
+        internal static bool TryGetResourceModule(string name, string version, [NotNullWhen(true)] out IResourceModule? package)
+        {
+            return _resourceModules.TryGetValue(ModuleKey(name, version), out package);
+        }
+
+        public static void RegisterResourceModule(string name, string version, IResourceModule package)
+        {
+            var key = ModuleKey(name, version);
+            if (!_resourceModules.TryAdd(key, package))
+            {
+                throw new InvalidOperationException($"Cannot re-register package {key}.");
+            }
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Serialization/ResourceModules.cs
+++ b/sdk/dotnet/Pulumi/Serialization/ResourceModules.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2019, Pulumi Corporation
+// Copyright 2016-2020, Pulumi Corporation
 
 using System;
 using System.Collections.Concurrent;
@@ -16,7 +16,7 @@ namespace Pulumi
 
     internal static class ResourceModules
     {
-        internal static ConcurrentDictionary<string, IResourceModule> _resourceModules = new ConcurrentDictionary<string, IResourceModule>();
+        internal static readonly ConcurrentDictionary<string, IResourceModule> _resourceModules = new ConcurrentDictionary<string, IResourceModule>();
 
         private static string ModuleKey(string name, string version)
         {

--- a/sdk/dotnet/Pulumi/Serialization/ResourcePackages.cs
+++ b/sdk/dotnet/Pulumi/Serialization/ResourcePackages.cs
@@ -11,7 +11,6 @@ namespace Pulumi
 {
     public interface IResourcePackage
     {
-        Resource Construct(string name, string type, IDictionary<string, object?>? args, string urn);
         ProviderResource ConstructProvider(string name, string type, IDictionary<string, object?>? args, string urn);
     }
 

--- a/sdk/go/common/util/archive/archive.go
+++ b/sdk/go/common/util/archive/archive.go
@@ -76,7 +76,9 @@ func UnTGZ(tarball []byte, dir string) error {
 			return errors.Wrapf(err, "untarring")
 		}
 
-		// nolint:gosec
+		// TODO: check the name to ensure that it does not contain path traversal characters.
+		//
+		//nolint: gosec
 		path := filepath.Join(dir, header.Name)
 
 		switch header.Typeflag {

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -711,9 +711,9 @@ func moduleKey(name, version string) string {
 }
 
 // RegisterResourceModule register a resource module with the Pulumi runtime.
-func RegisterResourceModule(name, version string, pkg ResourceModule) {
+func RegisterResourceModule(name, version string, module ResourceModule) {
 	key := moduleKey(name, version)
-	existing, hasExisting := resourceModules.LoadOrStore(key, pkg)
+	existing, hasExisting := resourceModules.LoadOrStore(key, module)
 	if hasExisting {
 		panic(fmt.Errorf("a resource module for %v is already registered: %v", key, existing))
 	}

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -581,9 +581,9 @@ export function suppressUnhandledGrpcRejections<T>(p: Promise<T>): Promise<T> {
 /**
  * A ResourcePackage is a type that understands how to construct resource providers given a name, type, args, and URN.
  */
-export type ResourcePackage = {
+export interface ResourcePackage {
     constructProvider(name: string, type: string, args: any, opts: { urn: string }): ProviderResource;
-};
+}
 
 const resourcePackages = new Map<string, ResourcePackage>();
 
@@ -596,7 +596,7 @@ function packageKey(name: string, version: string): string {
  * the package name and version that are deserialized by the current instance of the Pulumi JavaScript SDK.
  */
 export function registerResourcePackage(name: string, version: string, pkg: ResourcePackage) {
-    const key = packageKey(pkgName, version);
+    const key = packageKey(name, version);
     const existing = resourcePackages.get(key);
     if (existing) {
         throw new Error(`Cannot re-register package ${key}. Previous registration was ${existing}, new registration was ${pkg}.`);
@@ -607,9 +607,9 @@ export function registerResourcePackage(name: string, version: string, pkg: Reso
 /**
  * A ResourceModule is a type that understands how to construct resources given a name, type, args, and URN.
  */
-export type ResourceModule = {
+export interface ResourceModule {
     construct(name: string, type: string, args: any, opts: { urn: string }): Resource;
-};
+}
 
 const resourceModules = new Map<string, ResourceModule>();
 
@@ -625,7 +625,7 @@ export function registerResourceModule(name: string, version: string, module: Re
     const key = moduleKey(name, version);
     const existing = resourceModules.get(key);
     if (existing) {
-        throw new Error(`Cannot re-register module ${key}. Previous registration was ${existing}, new registration was ${pkg}.`);
+        throw new Error(`Cannot re-register module ${key}. Previous registration was ${existing}, new registration was ${module}.`);
     }
     resourceModules.set(key, module);
 }

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -516,25 +516,28 @@ export function deserializeProperty(prop: any): any {
 
                     const urnParts = urn.split("::");
                     const qualifiedType = urnParts[2];
+                    const urnName = urnParts[3];
 
                     const type = qualifiedType.split("$").pop()!;
                     const typeParts = type.split(":");
-                    let pkgName = typeParts[0];
+                    const pkgName = typeParts[0];
                     const modName = typeParts.length > 1 ? typeParts[1] : "";
                     const typName = typeParts.length > 2 ? typeParts[2] : "";
                     const isProvider = pkgName === "pulumi" && modName === "providers";
+
                     if (isProvider) {
-                        pkgName = typName;
+                        const resourcePackage = resourcePackages.get(packageKey(typName, version || ""));
+                        if (!resourcePackage) {
+                            throw new Error(`Unable to deserialize provider ${urn}, no resource package is registered for ${typName}.`);
+                        }
+                        return resourcePackage.constructProvider(urnName, type, {}, { urn });
                     }
 
-                    const resourcePackage = resourcePackages.get(packageKey(pkgName, version || ""));
-                    if (!resourcePackage) {
-                        throw new Error(`Unable to deserialize resource URN ${urn}, no resource package is registered for type ${type}.`);
+                    const resourceModule = resourceModules.get(moduleKey(modName, version || ""));
+                    if (!resourceModule) {
+                        throw new Error(`Unable to deserialize resource ${urn}, no module is registered for ${modName}.`);
                     }
-                    const urnName = urnParts[3];
-                    return !isProvider ?
-                        resourcePackage.construct(urnName, type, {}, { urn }) :
-                        resourcePackage.constructProvider(urnName, type, {}, { urn });
+                    return resourceModule.construct(urnName, type, {}, { urn });
                 default:
                     throw new Error(`Unrecognized signature '${sig}' when unmarshaling resource property`);
             }
@@ -576,10 +579,9 @@ export function suppressUnhandledGrpcRejections<T>(p: Promise<T>): Promise<T> {
 }
 
 /**
- * A ResourcePackage is a package that understands how to construct resources given a name, type, args, and URN.
+ * A ResourcePackage is a type that understands how to construct resource providers given a name, type, args, and URN.
  */
 export type ResourcePackage = {
-    construct(name: string, type: string, args: any, opts: { urn: string }): Resource;
     constructProvider(name: string, type: string, args: any, opts: { urn: string }): ProviderResource;
 };
 
@@ -590,7 +592,7 @@ function packageKey(name: string, version: string): string {
 }
 
 /**
- * registerResourcePackage registers a resource package that will be used to construct resources for any URNs matching
+ * registerResourcePackage registers a resource package that will be used to construct providers for any URNs matching
  * the package name and version that are deserialized by the current instance of the Pulumi JavaScript SDK.
  */
 export function registerResourcePackage(pkgName: string, version: string, pkg: ResourcePackage) {
@@ -600,4 +602,30 @@ export function registerResourcePackage(pkgName: string, version: string, pkg: R
         throw new Error(`Cannot re-register package ${key}. Previous registration was ${existing}, new registration was ${pkg}.`);
     }
     resourcePackages.set(key, pkg);
+}
+
+/**
+ * A ResourceModule is a type that understands how to construct resources given a name, type, args, and URN.
+ */
+export type ResourceModule = {
+    construct(name: string, type: string, args: any, opts: { urn: string }): Resource;
+};
+
+const resourceModules = new Map<string, ResourceModule>();
+
+function moduleKey(name: string, version: string): string {
+    return `${name}@${version}`;
+}
+
+/**
+ * registerResourceModule registers a resource module that will be used to construct resources for any URNs matching
+ * the module name and version that are deserialized by the current instance of the Pulumi JavaScript SDK.
+ */
+export function registerResourceModule(pkgName: string, version: string, pkg: ResourceModule) {
+    const key = moduleKey(pkgName, version);
+    const existing = resourceModules.get(key);
+    if (existing) {
+        throw new Error(`Cannot re-register module ${key}. Previous registration was ${existing}, new registration was ${pkg}.`);
+    }
+    resourceModules.set(key, pkg);
 }

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -595,7 +595,7 @@ function packageKey(name: string, version: string): string {
  * registerResourcePackage registers a resource package that will be used to construct providers for any URNs matching
  * the package name and version that are deserialized by the current instance of the Pulumi JavaScript SDK.
  */
-export function registerResourcePackage(pkgName: string, version: string, pkg: ResourcePackage) {
+export function registerResourcePackage(name: string, version: string, pkg: ResourcePackage) {
     const key = packageKey(pkgName, version);
     const existing = resourcePackages.get(key);
     if (existing) {
@@ -621,11 +621,11 @@ function moduleKey(name: string, version: string): string {
  * registerResourceModule registers a resource module that will be used to construct resources for any URNs matching
  * the module name and version that are deserialized by the current instance of the Pulumi JavaScript SDK.
  */
-export function registerResourceModule(pkgName: string, version: string, pkg: ResourceModule) {
-    const key = moduleKey(pkgName, version);
+export function registerResourceModule(name: string, version: string, module: ResourceModule) {
+    const key = moduleKey(name, version);
     const existing = resourceModules.get(key);
     if (existing) {
         throw new Error(`Cannot re-register module ${key}. Previous registration was ${existing}, new registration was ${pkg}.`);
     }
-    resourceModules.set(key, pkg);
+    resourceModules.set(key, module);
 }

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -663,7 +663,7 @@ def register_resource_package(typ: str, version: str, package):
 
 RESOURCE_MODULES: Dict[str, Any] = dict()
 
-def module_key(typ: str, version: str) -> str:
+def _module_key(typ: str, version: str) -> str:
     return f"{typ}@{version}"
 
 def register_resource_module(typ: str, version: str, module):

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -661,7 +661,7 @@ def register_resource_package(typ: str, version: str, package):
         raise ValueError(f"Cannot re-register package {key}. Previous registration was {existing}, new registration was {package}.")
     RESOURCE_PACKAGES[key] = package
 
-RESOURCE_MODULES: Dict[str, Any] = dict()
+_RESOURCE_MODULES: Dict[str, Any] = dict()
 
 def _module_key(typ: str, version: str) -> str:
     return f"{typ}@{version}"


### PR DESCRIPTION
This is necessary due to the way we've factored the libraries imported
by users into modules. The primary alternative is to ensure that each
child module imports the root module for a package and registers itself
with that package where necessary to prevent circular dependencies. This
simplifies the core SDKs slightly at the cost of greater complications
in the generated SDKs; the approach taken by these changes seems like a
more maintainable option.

The `ResourcePackage` types remain for the use of the root module for
a package, which will register itself in order to construct providers.

Contributes to #2430.