### PR TITLE
Trying to solve Python build on windows

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -25,8 +25,8 @@ jobs:
         platform: [windows-latest]
         go-version: [1.15.x]
         node-version: [10.x]
-        python-version: [3.7]
-        dotnet: ['3.1.301']
+        python-version: [3.7.x]
+        dotnet: [3.1.x]
     runs-on: ${{ matrix.platform }}
     env:
       GOPATH: ${{ github.workspace }}
@@ -44,7 +44,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python Deps

--- a/.github/workflows/windows-pr.yml
+++ b/.github/workflows/windows-pr.yml
@@ -18,8 +18,8 @@ jobs:
         platform: [windows-latest]
         go-version: [1.15.x]
         node-version: [10.x]
-        python-version: [3.7]
-        dotnet: ['3.1.301']
+        python-version: [3.7.x]
+        dotnet: [3.1.x]
     runs-on: ${{ matrix.platform }}
     env:
       GOPATH: ${{ github.workspace }}
@@ -37,7 +37,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python Deps

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -23,8 +23,8 @@ jobs:
         platform: [windows-latest]
         go-version: [1.15.x]
         node-version: [10.x]
-        python-version: [3.7]
-        dotnet: ['3.1.301']
+        python-version: [3.7.x]
+        dotnet: [3.1.x]
     runs-on: ${{ matrix.platform }}
     env:
       GOPATH: ${{ github.workspace }}
@@ -42,7 +42,7 @@ jobs:
       with:
         go-version: ${{ matrix.go-version }}
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Python Deps

--- a/build.proj
+++ b/build.proj
@@ -200,7 +200,7 @@
 
   <Target Name="PythonDependencies">
     <MakeDir Directories="$(PythonSdkDirectory)\env\src"/>
-    <Exec Command="pipenv install"
+    <Exec Command="pipenv --python 3.7 install --dev"
           WorkingDirectory="$(PythonSdkDirectory)\env\src" />
   </Target>
   


### PR DESCRIPTION
Fixes: #5648

Recently, GHA windows image was updated with Python 3.9. We didn't specific a specific version of Python when creating a Pipenv so it was using the latest version installed - marking this as a specific version ignores the 3.9 installed as default