### PR TITLE
Ensure CLI doesn't panic when using pulumi watch and ComponentResources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ CHANGELOG
 
 - Add internal scaffolding for using cross-language components from Go.
   [#5558](https://github.com/pulumi/pulumi/pull/5558)
+
 - Support python 3.9.
   [#5669](https://github.com/pulumi/pulumi/pull/5669)
+  
+- [cli] Ensure that the CLI doesn't panic when using pulumi watch and using ComponentResources with non-standard naming
+  [#5675](https://github.com/pulumi/pulumi/pull/5675)
 
 ## 2.12.1 (2020-10-23)
 

--- a/pkg/operations/resources.go
+++ b/pkg/operations/resources.go
@@ -16,6 +16,7 @@ package operations
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
@@ -249,6 +250,12 @@ func (ops *resourceOperations) getOperationsProvider() (Provider, error) {
 	if ops.resource == nil || ops.resource.State == nil {
 		return nil, nil
 	}
+
+	tokenSeparators := strings.Count(ops.resource.State.Type.String(), ":")
+	if tokenSeparators != 2 {
+		return nil, nil
+	}
+
 	switch ops.resource.State.Type.Package() {
 	case "cloud":
 		return CloudOperationsProvider(ops.config, ops.resource)


### PR DESCRIPTION
Fixes: #3432
Fixes: #5625

@pgavlin and I had a short convo about this and decided this was the best course of action

When using the following code:

```
import * as pulumi from "@pulumi/pulumi";

class LandingZone extends pulumi.ComponentResource {
    constructor(name: string, args: {}, opts?: pulumi.ComponentResourceOptions) {
        super("custom:LandingZone", name, args, opts);
        this.registerOutputs();
    }
};

const lz = new LandingZone("main", {});

```

The previous behaviour was:

```
▶ pulumi watch
Watching (dev):
19:49:26.191[                    ] Updating...
19:49:27.797[     watch-panic-dev] create pulumi:pulumi:Stack
19:49:29.166[     watch-panic-dev] done create pulumi:pulumi:Stack
19:49:29.415[                main] create custom:LandingZone
19:49:29.866[                main] done create custom:LandingZone
19:49:30.561[                    ] Update complete.
panic: fatal: An assertion has failed: Module member token 'custom:LandingZone' missing module member delimiter

goroutine 122 [running]:
github.com/pulumi/pulumi/sdk/v2/go/common/util/contract.failfast(...)
	/Users/runner/work/pulumi/pulumi/sdk/go/common/util/contract/failfast.go:23
github.com/pulumi/pulumi/sdk/v2/go/common/util/contract.Assertf(0xc000bb4900, 0x5912434, 0x38, 0xc000638c30, 0x1, 0x1)
	/Users/runner/work/pulumi/pulumi/sdk/go/common/util/contract/assert.go:33 +0x1a5
github.com/pulumi/pulumi/sdk/v2/go/common/tokens.ModuleMember.Module(0xc000bb49c0, 0x12, 0x0, 0x18)
	/Users/runner/work/pulumi/pulumi/sdk/go/common/tokens/tokens.go:192 +0xd2
github.com/pulumi/pulumi/sdk/v2/go/common/tokens.ModuleMember.Package(0xc000bb49c0, 0x12, 0x58b325f, 0x1)
	/Users/runner/work/pulumi/pulumi/sdk/go/common/tokens/tokens.go:187 +0x35
github.com/pulumi/pulumi/sdk/v2/go/common/tokens.Type.Package(0xc000bb49c0, 0x12, 0xc0007a6cf8, 0x4010af8)
	/Users/runner/work/pulumi/pulumi/sdk/go/common/tokens/tokens.go:227 +0x70
github.com/pulumi/pulumi/pkg/v2/operations.(*resourceOperations).getOperationsProvider(0xc000c901a0, 0x0, 0xc0008e6f01, 0x16, 0xc000000000)
	/Users/runner/work/pulumi/pulumi/pkg/operations/resources.go:252 +0x65
github.com/pulumi/pulumi/pkg/v2/operations.(*resourceOperations).GetLogs(0xc000c901a0, 0xc000b645a0, 0x0, 0x0, 0x5bd36e0, 0xc000b86320, 0x11dab888)
	/Users/runner/work/pulumi/pulumi/pkg/operations/resources.go:147 +0xb65
github.com/pulumi/pulumi/pkg/v2/operations.(*resourceOperations).GetLogs.func1(0xc000c901a0, 0xc000b86580, 0xc0005ad8c0, 0xc0005ad920)
	/Users/runner/work/pulumi/pulumi/pkg/operations/resources.go:175 +0x5f
created by github.com/pulumi/pulumi/pkg/v2/operations.(*resourceOperations).GetLogs
	/Users/runner/work/pulumi/pulumi/pkg/operations/resources.go:174 +0x1bb
```

The new behaviour is:

```
▶ pulumi watch
Watching (dev):
19:50:18.216[                    ] Updating...
19:50:21.557[                    ] Update complete.
```

It's important to note that `pulumi logs` looks as follows for the same stack even though the ComponentResource has been "deployed"

```
▶ pulumi logs
Collecting logs for stack dev since 2020-11-03T18:56:05.000Z.


```