### PR TITLE
Ensure the CLI doesn't panic when trying to build a graph for a stack with no snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ CHANGELOG
   
 - [cli] Ensure that the CLI doesn't panic when using pulumi watch and using ComponentResources with non-standard naming
   [#5675](https://github.com/pulumi/pulumi/pull/5675)
+  
+- [cli] Ensure that the CLI doesn't panic when trying to assemble a graph on a stack that has no snapshot available
+  [#5678](https://github.com/pulumi/pulumi/pull/5678)
 
 ## 2.12.1 (2020-10-23)
 

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -15,6 +15,7 @@
 package main
 
 import (
+	"github.com/pkg/errors"
 	"os"
 	"strings"
 
@@ -63,6 +64,11 @@ func newStackGraphCmd() *cobra.Command {
 			snap, err := s.Snapshot(commandContext())
 			if err != nil {
 				return err
+			}
+
+			// This will prevent a panic when trying to assemble a dependencyGraph when no snapshot is found
+			if snap == nil {
+				return errors.Errorf("unable to find snapshot for stack %q", stackName)
 			}
 
 			dg := makeDependencyGraph(snap)


### PR DESCRIPTION
Fixes: #4952