### PR TITLE
Add support for getResource to the Python SDK.

### DIFF
--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -272,7 +272,7 @@ func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.Pro
 	contract.Assert(ok)
 	contract.Assert(urn.IsString())
 
-	// TODO(pdg): track secret outputs in the resource map. This is necessary to ensure that the
+	// #5803: track secret outputs in the resource map. This is necessary to ensure that the
 	// `additionalSecretOutputs` option that was provided when the resource was registered is properly respected by
 	// `getResource`.
 

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -272,6 +272,10 @@ func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.Pro
 	contract.Assert(ok)
 	contract.Assert(urn.IsString())
 
+	// TODO(pdg): track secret outputs in the resource map. This is necessary to ensure that the
+	// `additionalSecretOutputs` option that was provided when the resource was registered is properly respected by
+	// `getResource`.
+
 	state, ok := p.resources.get(resource.URN(urn.StringValue()))
 	if !ok {
 		return nil, errors.Errorf("unknown resource %v", urn.StringValue())

--- a/sdk/python/Pipfile.lock
+++ b/sdk/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3b7dc22140f5503eebf92f8736423441b156e5fcfb4b2ad5289e84f3b43a1022"
+            "sha256": "8f39c345effaa48064d02b8c1b617359571fa9d1d3577fa86e82a2692d233481"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -24,52 +24,52 @@
         },
         "grpcio": {
             "hashes": [
-                "sha256:02a4a637a774382d6ac8e65c0a7af4f7f4b9704c980a0a9f4f7bbc1e97c5b733",
-                "sha256:08b6a58c8a83e71af5650f8f879fe14b7b84dce0c4969f3817b42c72989dacf0",
-                "sha256:0aeed3558a0eec0b31700af6072f1c90e8fd5701427849e76bc469554a14b4f5",
-                "sha256:0cebba3907441d5c620f7b491a780ed155140fbd590da0886ecfb1df6ad947b9",
-                "sha256:143b4fe72c01000fc0667bf62ace402a6518939b3511b3c2bec04d44b1d7591c",
-                "sha256:21265511880056d19ce4f809ce3fbe2a3fa98ec1fc7167dbdf30a80d3276202e",
-                "sha256:289671cfe441069f617bf23c41b1fa07053a31ff64de918d1016ac73adda2f73",
-                "sha256:2d5124284f9d29e4f06f674a12ebeb23fc16ce0f96f78a80a6036930642ae5ab",
-                "sha256:2f2eabfd514af8945ee415083a0f849eea6cb3af444999453bb6666fadc10f54",
-                "sha256:3ac453387add933b6cfbc67cc8635f91ff9895299130fc612c3c4b904e91d82a",
-                "sha256:407b4d869ce5c6a20af5b96bb885e3ecaf383e3fb008375919eb26cf8f10d9cd",
-                "sha256:4bb771c4c2411196b778871b519c7e12e87f3fa72b0517b22f952c64ead07958",
-                "sha256:4cef3eb2df338abd9b6164427ede961d351c6bf39b4a01448a65f9e795f56575",
-                "sha256:514b4a6790d6597fc95608f49f2f13fe38329b2058538095f0502b734b98ffd2",
-                "sha256:52143467237bfa77331ed1979dc3e203a1c12511ee37b3ddd9ff41b05804fb10",
-                "sha256:56e2a985efdba8e2282e856470b684e83a3cadd920f04fcd360b4b826ced0dd3",
-                "sha256:592656b10528aa327058d2007f7ab175dc9eb3754b289e24cac36e09129a2f6b",
-                "sha256:5b21d3de520a699cb631cfd3a773a57debeb36b131be366bf832153405cc5404",
-                "sha256:62ce7e86f11e8c4ff772e63c282fb5a7904274258be0034adf37aa679cf96ba0",
-                "sha256:65b06fa2db2edd1b779f9b256e270f7a58d60e40121660d8b5fd6e8b88f122ed",
-                "sha256:6a1b5b7e47600edcaeaa42983b1c19e7a5892c6b98bcde32ae2aa509a99e0436",
-                "sha256:703da25278ee7318acb766be1c6d3b67d392920d002b2d0304e7f3431b74f6c1",
                 "sha256:7744468ee48be3265db798f27e66e118c324d7831a34fd39d5775bcd5a70a2c4",
-                "sha256:7c1ea6ea6daa82031af6eb5b7d1ab56b1193840389ea7cf46d80e98636f8aff5",
-                "sha256:7d292dabf7ded9c062357f8207e20e94095a397d487ffd25aa213a2c3dff0ab4",
-                "sha256:7f727b8b6d9f92fcab19dbc62ec956d8352c6767b97b8ab18754b2dfa84d784f",
-                "sha256:7fda62846ef8d86caf06bd1ecfddcae2c7e59479a4ee28808120e170064d36cc",
-                "sha256:85e56ab125b35b1373205b3802f58119e70ffedfe0d7e2821999126058f7c44f",
-                "sha256:88f2a102cbc67e91f42b4323cec13348bf6255b25f80426088079872bd4f3c5c",
-                "sha256:89add4f4cda9546f61cb8a6988bc5b22101dd8ca4af610dff6f28105d1f78695",
-                "sha256:8cf67b8493bff50fa12b4bc30ab40ce1f1f216eb54145962b525852959b0ab3d",
-                "sha256:a8c84db387907e8d800c383e4c92f39996343adedf635ae5206a684f94df8311",
-                "sha256:abaf30d18874310d4439a23a0afb6e4b5709c4266966401de7c4ae345cc810ee",
-                "sha256:affbb739fde390710190e3540acc9f3e65df25bd192cc0aa554f368288ee0ea2",
-                "sha256:b412f43c99ca72769306293ba83811b241d41b62ca8f358e47e0fdaf7b6fbbd7",
+                "sha256:0cebba3907441d5c620f7b491a780ed155140fbd590da0886ecfb1df6ad947b9",
                 "sha256:b581ddb8df619402c377c81f186ad7f5e2726ad9f8d57047144b352f83f37522",
-                "sha256:bf7de9e847d2d14a0efcd48b290ee181fdbffb2ae54dfa2ec2a935a093730bac",
+                "sha256:8cf67b8493bff50fa12b4bc30ab40ce1f1f216eb54145962b525852959b0ab3d",
+                "sha256:4bb771c4c2411196b778871b519c7e12e87f3fa72b0517b22f952c64ead07958",
+                "sha256:6a1b5b7e47600edcaeaa42983b1c19e7a5892c6b98bcde32ae2aa509a99e0436",
+                "sha256:0aeed3558a0eec0b31700af6072f1c90e8fd5701427849e76bc469554a14b4f5",
+                "sha256:4cef3eb2df338abd9b6164427ede961d351c6bf39b4a01448a65f9e795f56575",
+                "sha256:592656b10528aa327058d2007f7ab175dc9eb3754b289e24cac36e09129a2f6b",
+                "sha256:289671cfe441069f617bf23c41b1fa07053a31ff64de918d1016ac73adda2f73",
                 "sha256:c5030be8a60fb18de1fc8d93d130d57e4296c02f229200df814f6578da00429e",
-                "sha256:c89510381cbf8c8317e14e747a8b53988ad226f0ed240824064a9297b65f921d",
-                "sha256:d386630af995fd4de225d550b6806507ca09f5a650f227fddb29299335cda55e",
-                "sha256:d51ddfb3d481a6a3439db09d4b08447fb9f6b60d862ab301238f37bea8f60a6d",
-                "sha256:dd47fac2878f6102efa211461eb6fa0a6dd7b4899cd1ade6cdcb9fa9748363eb",
-                "sha256:eff55d318a114742ed2a06972f5daacfe3d5ad0c0c0d9146bcaf10acb427e6be",
-                "sha256:f2673c51e8535401c68806d331faba614bcff3ee16373481158a2e74f510b7f6",
+                "sha256:7fda62846ef8d86caf06bd1ecfddcae2c7e59479a4ee28808120e170064d36cc",
+                "sha256:3ac453387add933b6cfbc67cc8635f91ff9895299130fc612c3c4b904e91d82a",
                 "sha256:fa78bd55ec652d4a88ba254c8dae623c9992e2ce647bd17ba1a37ca2b7b42222",
-                "sha256:ffec0b854d2ed6ee98776c7168c778cdd18503642a68d36c00ba0f96d4ccff7c"
+                "sha256:56e2a985efdba8e2282e856470b684e83a3cadd920f04fcd360b4b826ced0dd3",
+                "sha256:7c1ea6ea6daa82031af6eb5b7d1ab56b1193840389ea7cf46d80e98636f8aff5",
+                "sha256:a8c84db387907e8d800c383e4c92f39996343adedf635ae5206a684f94df8311",
+                "sha256:62ce7e86f11e8c4ff772e63c282fb5a7904274258be0034adf37aa679cf96ba0",
+                "sha256:7f727b8b6d9f92fcab19dbc62ec956d8352c6767b97b8ab18754b2dfa84d784f",
+                "sha256:02a4a637a774382d6ac8e65c0a7af4f7f4b9704c980a0a9f4f7bbc1e97c5b733",
+                "sha256:abaf30d18874310d4439a23a0afb6e4b5709c4266966401de7c4ae345cc810ee",
+                "sha256:08b6a58c8a83e71af5650f8f879fe14b7b84dce0c4969f3817b42c72989dacf0",
+                "sha256:407b4d869ce5c6a20af5b96bb885e3ecaf383e3fb008375919eb26cf8f10d9cd",
+                "sha256:dd47fac2878f6102efa211461eb6fa0a6dd7b4899cd1ade6cdcb9fa9748363eb",
+                "sha256:d51ddfb3d481a6a3439db09d4b08447fb9f6b60d862ab301238f37bea8f60a6d",
+                "sha256:bf7de9e847d2d14a0efcd48b290ee181fdbffb2ae54dfa2ec2a935a093730bac",
+                "sha256:ffec0b854d2ed6ee98776c7168c778cdd18503642a68d36c00ba0f96d4ccff7c",
+                "sha256:7d292dabf7ded9c062357f8207e20e94095a397d487ffd25aa213a2c3dff0ab4",
+                "sha256:2d5124284f9d29e4f06f674a12ebeb23fc16ce0f96f78a80a6036930642ae5ab",
+                "sha256:143b4fe72c01000fc0667bf62ace402a6518939b3511b3c2bec04d44b1d7591c",
+                "sha256:f2673c51e8535401c68806d331faba614bcff3ee16373481158a2e74f510b7f6",
+                "sha256:affbb739fde390710190e3540acc9f3e65df25bd192cc0aa554f368288ee0ea2",
+                "sha256:5b21d3de520a699cb631cfd3a773a57debeb36b131be366bf832153405cc5404",
+                "sha256:514b4a6790d6597fc95608f49f2f13fe38329b2058538095f0502b734b98ffd2",
+                "sha256:65b06fa2db2edd1b779f9b256e270f7a58d60e40121660d8b5fd6e8b88f122ed",
+                "sha256:52143467237bfa77331ed1979dc3e203a1c12511ee37b3ddd9ff41b05804fb10",
+                "sha256:85e56ab125b35b1373205b3802f58119e70ffedfe0d7e2821999126058f7c44f",
+                "sha256:21265511880056d19ce4f809ce3fbe2a3fa98ec1fc7167dbdf30a80d3276202e",
+                "sha256:b412f43c99ca72769306293ba83811b241d41b62ca8f358e47e0fdaf7b6fbbd7",
+                "sha256:2f2eabfd514af8945ee415083a0f849eea6cb3af444999453bb6666fadc10f54",
+                "sha256:c89510381cbf8c8317e14e747a8b53988ad226f0ed240824064a9297b65f921d",
+                "sha256:eff55d318a114742ed2a06972f5daacfe3d5ad0c0c0d9146bcaf10acb427e6be",
+                "sha256:89add4f4cda9546f61cb8a6988bc5b22101dd8ca4af610dff6f28105d1f78695",
+                "sha256:88f2a102cbc67e91f42b4323cec13348bf6255b25f80426088079872bd4f3c5c",
+                "sha256:d386630af995fd4de225d550b6806507ca09f5a650f227fddb29299335cda55e",
+                "sha256:703da25278ee7318acb766be1c6d3b67d392920d002b2d0304e7f3431b74f6c1"
             ],
             "index": "pypi",
             "version": "==1.33.2"
@@ -115,21 +115,6 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==2.4.2"
-        },
-        "attrs": {
-            "hashes": [
-                "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6",
-                "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.3.0"
-        },
-        "iniconfig": {
-            "hashes": [
-                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
-                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
-            ],
-            "version": "==1.1.1"
         },
         "isort": {
             "hashes": [
@@ -200,30 +185,6 @@
             ],
             "version": "==0.4.3"
         },
-        "packaging": {
-            "hashes": [
-                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
-                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.4"
-        },
-        "pluggy": {
-            "hashes": [
-                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
-                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==0.13.1"
-        },
-        "py": {
-            "hashes": [
-                "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2",
-                "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==1.9.0"
-        },
         "pylint": {
             "hashes": [
                 "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210",
@@ -231,22 +192,6 @@
             ],
             "index": "pypi",
             "version": "==2.6.0"
-        },
-        "pyparsing": {
-            "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
-            ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.7"
-        },
-        "pytest": {
-            "hashes": [
-                "sha256:4288fed0d9153d9646bfcdf0c0428197dba1ecb27a33bb6e031d002fa88653fe",
-                "sha256:c0a7e94a8cdbc5422a51ccdad8e6f1024795939cc89159a0ae7f0b316ad3823e"
-            ],
-            "index": "pypi",
-            "version": "==6.1.2"
         },
         "six": {
             "hashes": [

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -723,7 +723,7 @@ class Resource:
 
         if urn is not None:
             # This is a resource that already exists. Read its state from the engine.
-            get_resource(self, custom, urn)
+            get_resource(self, props, custom, urn)
         elif opts.id is not None:
             # If this is a custom resource that already exists, read its state from the provider.
             if not custom:

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -378,7 +378,7 @@ class ResourceOptions:
     property must be removed from the resource's options.
     """
 
-    urn: Optional['str']
+    urn: Optional[str]
     """
     The URN of a previously-registered resource of this type to read from the engine.
     """
@@ -399,7 +399,7 @@ class ResourceOptions:
                  import_: Optional[str] = None,
                  custom_timeouts: Optional['CustomTimeouts'] = None,
                  transformations: Optional[List[ResourceTransformation]] = None,
-                 urn: Optional['str'] = None) -> None:
+                 urn: Optional[str] = None) -> None:
         """
         :param Optional[Resource] parent: If provided, the currently-constructing resource should be the child of
                the provided parent resource.

--- a/sdk/python/lib/pulumi/runtime/__init__.py
+++ b/sdk/python/lib/pulumi/runtime/__init__.py
@@ -50,5 +50,8 @@ from ._json import (
 )
 
 from .rpc import (
+    ResourceModule,
+    ResourcePackage,
+    register_resource_module,
     register_resource_package,
 )

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -65,6 +65,54 @@ class InvokeResult:
 
     __iter__ = __await__
 
+async def raw_invoke(tok: str,
+                     props: 'Inputs',
+                     provider_ref: Optional[str] = None,
+                     version: Optional[str] = None,
+                     typ: Optional[type] = None) -> Any:
+
+    # This should have been ensured by the caller.
+    assert typ is None or _types.is_output_type(typ):
+
+    monitor = get_monitor()
+    inputs = await rpc.serialize_properties(props, {})
+    log.debug(f"Invoking function prepared: tok={tok}")
+    req = provider_pb2.InvokeRequest(tok=tok, args=inputs, provider=provider_ref, version=version)
+
+    def do_invoke():
+        try:
+            return monitor.Invoke(req)
+        except grpc.RpcError as exn:
+            # gRPC-python gets creative with their exceptions. grpc.RpcError as a type is useless;
+            # the usefullness come from the fact that it is polymorphically also a grpc.Call and thus has
+            # the .code() member. Pylint doesn't know this because it's not known statically.
+            #
+            # Neither pylint nor I are the only ones who find this confusing:
+            # https://github.com/grpc/grpc/issues/10885#issuecomment-302581315
+            # pylint: disable=no-member
+            if exn.code() == grpc.StatusCode.UNAVAILABLE:
+                sys.exit(0)
+
+            details = exn.details()
+        raise Exception(details)
+
+    resp = await asyncio.get_event_loop().run_in_executor(None, do_invoke)
+
+    log.debug(f"Invoking function completed successfully: tok={tok}")
+    # If the invoke failed, raise an error.
+    if resp.failures:
+        raise Exception(f"invoke of {tok} failed: {resp.failures[0].reason} ({resp.failures[0].property})")
+
+    # Otherwise, return the output properties.
+    ret_obj = getattr(resp, 'return')
+    if ret_obj:
+        deserialized = rpc.deserialize_properties(ret_obj)
+        # If typ is not None, call translate_output_properties to instantiate any output types.
+        return rpc.translate_output_properties(deserialized, lambda prop: prop, typ) if typ else deserialized
+
+    return {}
+
+
 def invoke(tok: str, props: 'Inputs', opts: Optional[InvokeOptions] = None, typ: Optional[type] = None) -> InvokeResult:
     """
     invoke dynamically invokes the function, tok, which is offered by a provider plugin.  The inputs
@@ -91,43 +139,8 @@ def invoke(tok: str, props: 'Inputs', opts: Optional[InvokeOptions] = None, typ:
             provider_ref = f"{provider_urn}::{provider_id}"
             log.debug(f"Invoke using provider {provider_ref}")
 
-        monitor = get_monitor()
-        inputs = await rpc.serialize_properties(props, {})
-        version = opts.version or ""
-        log.debug(f"Invoking function prepared: tok={tok}")
-        req = provider_pb2.InvokeRequest(tok=tok, args=inputs, provider=provider_ref, version=version)
+        
 
-        def do_invoke():
-            try:
-                return monitor.Invoke(req)
-            except grpc.RpcError as exn:
-                # gRPC-python gets creative with their exceptions. grpc.RpcError as a type is useless;
-                # the usefullness come from the fact that it is polymorphically also a grpc.Call and thus has
-                # the .code() member. Pylint doesn't know this because it's not known statically.
-                #
-                # Neither pylint nor I are the only ones who find this confusing:
-                # https://github.com/grpc/grpc/issues/10885#issuecomment-302581315
-                # pylint: disable=no-member
-                if exn.code() == grpc.StatusCode.UNAVAILABLE:
-                    sys.exit(0)
-
-                details = exn.details()
-            raise Exception(details)
-
-        resp = await asyncio.get_event_loop().run_in_executor(None, do_invoke)
-
-        log.debug(f"Invoking function completed successfully: tok={tok}")
-        # If the invoke failed, raise an error.
-        if resp.failures:
-            raise Exception(f"invoke of {tok} failed: {resp.failures[0].reason} ({resp.failures[0].property})")
-
-        # Otherwise, return the output properties.
-        ret_obj = getattr(resp, 'return')
-        if ret_obj:
-            deserialized = rpc.deserialize_properties(ret_obj)
-            # If typ is not None, call translate_output_properties to instantiate any output types.
-            return rpc.translate_output_properties(deserialized, lambda prop: prop, typ) if typ else deserialized
-        return {}
 
     async def do_rpc():
         resp, exn = await RPC_MANAGER.do_rpc("invoke", do_invoke)()

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -159,12 +159,6 @@ def resource_output(res: 'Resource') -> Tuple[Callable[[Any, bool, bool, Optiona
     return (resolve, Output({res}, value_future, known_future, secret_future))
 
 
-def resolved_resource_output(res: 'Resource', value: Any, known: bool, secret: bool) -> 'Output':
-    (resolve, output) = resource_output(res)
-    resolve(value, known, secret, None)
-    return output
-
-
 def get_resource(res: 'Resource', props: 'Inputs', custom: bool, urn: str) -> None:
     log.debug(f"getting resource: urn={urn}")
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -557,11 +557,12 @@ def contains_unknowns(val: Any) -> bool:
     return impl(val, [])
 
 
-async def resolve_outputs(res: 'Resource',
-                          serialized_props: struct_pb2.Struct,
-                          outputs: struct_pb2.Struct,
-                          deps: Mapping[str, Set['Resource']],
-                          resolvers: Dict[str, Resolver]):
+def resolve_outputs(res: 'Resource',
+                    
+                    serialized_props: struct_pb2.Struct,
+                    outputs: struct_pb2.Struct,
+                    deps: Mapping[str, Set['Resource']],
+                    resolvers: Dict[str, Resolver]):
 
     # Produce a combined set of property states, starting with inputs and then applying
     # outputs.  If the same property exists in the inputs and outputs states, the output wins.
@@ -585,10 +586,9 @@ async def resolve_outputs(res: 'Resource',
                 # the user.
                 all_properties[translated_key] = translate_output_properties(deserialize_property(value), res.translate_output_property, types.get(key))
 
-    await resolve_properties(resolvers, all_properties, deps)
+    resolve_properties(resolvers, all_properties, deps)
 
-async def resolve_properties(resolvers: Dict[str, Resolver], all_properties: Dict[str, Any], deps: Mapping[str, Set['Resource']]):
-
+def resolve_properties(resolvers: Dict[str, Resolver], all_properties: Dict[str, Any], deps: Mapping[str, Set['Resource']]):
     for key, value in all_properties.items():
         # Skip "id" and "urn", since we handle those specially.
         if key in ["id", "urn"]:

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -285,12 +285,12 @@ def deserialize_properties(props_struct: struct_pb2.Struct, keep_unknowns: Optio
                 resource_package = _RESOURCE_PACKAGES.get(_package_key(typ_name, version))
                 if resource_package is None:
                     raise Exception(f"Unable to deserialize provider {urn}, no resource package is registered for {typ_name}.")
-                resource = resource_package.construct_provider(urn_name, typ, {}, urn)
+                resource = resource_package.construct_provider(urn_name, typ, urn)
             else:
-                resource_module = _RESOURCE_MODULES.get(_module_key(typ_name, version))
+                resource_module = _RESOURCE_MODULES.get(_module_key(pkg_name+":"+mod_name, version))
                 if resource_module is None:
                     raise Exception(f"Unable to deserialize resource {urn}, no resource module is registered for {mod_name}.")
-                resource_module.construct(urn_name, typ, {}, urn)
+                resource_module.construct(urn_name, typ, urn)
 
             return cast('Resource', resource)
 
@@ -651,7 +651,7 @@ def resolve_outputs_due_to_exception(resolvers: Dict[str, Resolver], exn: Except
 
 class ResourcePackage(ABC):
     @abstractmethod
-    def construct_provider(self, name: str, typ: str, inputs: Mapping[str, Any], urn: str) -> 'ProviderResource':
+    def construct_provider(self, name: str, typ: str, urn: str) -> 'ProviderResource':
         pass
 
 _RESOURCE_PACKAGES: Dict[str, Any] = dict()
@@ -668,7 +668,7 @@ def register_resource_package(typ: str, version: str, package):
 
 class ResourceModule(ABC):
     @abstractmethod
-    def construct(self, name: str, typ: str, inputs: Mapping[str, Any], urn: str) -> 'Resource':
+    def construct(self, name: str, typ: str, urn: str) -> 'Resource':
         pass
 
 _RESOURCE_MODULES: Dict[str, ResourceModule] = dict()
@@ -676,8 +676,8 @@ _RESOURCE_MODULES: Dict[str, ResourceModule] = dict()
 def _module_key(typ: str, version: str) -> str:
     return f"{typ}@{version}"
 
-def register_resource_module(typ: str, version: str, module: ResourceModule):
-    key = _module_key(typ, version)
+def register_resource_module(pkg: str, mod: str, version: str, module: ResourceModule):
+    key = _module_key(pkg+":"+mod, version)
     existing = _RESOURCE_MODULES.get(key, None)
     if existing is not None:
         raise ValueError(f"Cannot re-register module {key}. Previous registration was {existing}, new registration was {module}.")

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -558,7 +558,6 @@ def contains_unknowns(val: Any) -> bool:
 
 
 def resolve_outputs(res: 'Resource',
-                    
                     serialized_props: struct_pb2.Struct,
                     outputs: struct_pb2.Struct,
                     deps: Mapping[str, Set['Resource']],

--- a/tests/integration/get_resource/python/.gitignore
+++ b/tests/integration/get_resource/python/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info

--- a/tests/integration/get_resource/python/Pulumi.yaml
+++ b/tests/integration/get_resource/python/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: get_resource
+description: A simple Python program that gets an existing resource from the engine.
+runtime: python

--- a/tests/integration/get_resource/python/__main__.py
+++ b/tests/integration/get_resource/python/__main__.py
@@ -1,0 +1,36 @@
+# Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+import asyncio
+import pulumi
+
+from pulumi import Output, export, UNKNOWN
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+from pulumi.runtime import is_dry_run
+
+class MyProvider(ResourceProvider):
+    def create(self, props):
+        return CreateResult("0", props)
+
+class MyResource(Resource):
+    foo: Output
+
+    def __init__(self, name, props, opts = None):
+        super().__init__(MyProvider(), name, props, opts)
+
+class GetResource(pulumi.Resource):
+    foo: Output
+
+    def __init__(self, urn):
+        super().__init__("unused", "unused:unused:unused", True, None, None, False, False, urn)
+
+a = MyResource("a", {
+    "foo": "foo",
+})
+
+async def check_get():
+    a_urn = await a.urn.future()
+    a_get = GetResource(a_urn)
+    a_foo = await a_get.foo.future()
+    assert a_foo == "foo"
+
+export("o", check_get())

--- a/tests/integration/get_resource/python/__main__.py
+++ b/tests/integration/get_resource/python/__main__.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+# Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
 
 import asyncio
 import pulumi

--- a/tests/integration/get_resource/python/__main__.py
+++ b/tests/integration/get_resource/python/__main__.py
@@ -3,7 +3,7 @@
 import asyncio
 import pulumi
 
-from pulumi import Output, export, UNKNOWN
+from pulumi import Output, ResourceOptions, export, UNKNOWN
 from pulumi.dynamic import Resource, ResourceProvider, CreateResult
 from pulumi.runtime import is_dry_run
 
@@ -22,7 +22,7 @@ class GetResource(pulumi.Resource):
 
     def __init__(self, urn):
         props = {"foo": None}
-        super().__init__("unused", "unused:unused:unused", True, props, None, False, False, urn)
+        super().__init__("unused", "unused:unused:unused", True, props, ResourceOptions(urn=urn), False, False)
 
 a = MyResource("a", {
     "foo": "foo",

--- a/tests/integration/get_resource/python/__main__.py
+++ b/tests/integration/get_resource/python/__main__.py
@@ -21,7 +21,8 @@ class GetResource(pulumi.Resource):
     foo: Output
 
     def __init__(self, urn):
-        super().__init__("unused", "unused:unused:unused", True, None, None, False, False, urn)
+        props = {"foo": None}
+        super().__init__("unused", "unused:unused:unused", True, props, None, False, False, urn)
 
 a = MyResource("a", {
     "foo": "foo",

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -438,3 +438,16 @@ func TestConstructPython(t *testing.T) {
 	}
 	integration.ProgramTest(t, opts)
 }
+
+func TestGetResourcePython(t *testing.T) {
+	if runtime.GOOS == WindowsOS {
+		t.Skip("Temporarily skipping test on Windows - pulumi/pulumi#3811")
+	}
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join("get_resource", "python"),
+		Dependencies: []string{
+			filepath.Join("..", "..", "sdk", "python", "env", "src"),
+		},
+		AllowEmptyPreviewChanges: true,
+	})
+}


### PR DESCRIPTION
Just what it says on the tin.

These changes take advantage of the fact that Python invokes are
synchronous to fetch the resource state inside of its constructor. The
SDK code generator will be updated to use the new `urn` parameter inside
of each module's implementation of `ResourceModule.construct`.

Part of #2430.