### PR TITLE
Ensure pulumi history marks secrets that can't be un-encrypted as such

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- [cli] Ensure `pulumi history` annotes when secrets are unable to be decrypted
+  [#5701](https://github.com/pulumi/pulumi/pull/5701)
 
 ## 2.13.0 (2020-11-04)
 


### PR DESCRIPTION
This changes this:

```
▶ pulumi stack history --json --show-secrets
error: bad value
```

to this

```
▶ pulumi stack history --json --show-secrets
[
  {
    "kind": "update",
    "startTime": "2020-11-06T00:20:16.000Z",
    "message": "",
    "environment": {
      "exec.kind": "cli"
    },
    "config": {
      "aws:region": {
        "value": "us-east-1",
        "secret": false
      },
      "history:MySecretPassword": {
        "value": "Password1234!",
        "secret": true
      }
    },
    "result": "succeeded",
    "endTime": "2020-11-06T00:20:29.000Z",
    "resourceChanges": {
      "same": 1,
      "update": 1
    }
  },
  {
    "kind": "import",
    "startTime": "2020-11-06T00:19:28.000Z",
    "message": "",
    "environment": {},
    "config": {},
    "result": "succeeded",
    "endTime": "2020-11-06T00:19:29.000Z",
    "resourceChanges": {
      "create": 0,
      "delete": 0,
      "same": 2,
      "update": 1
    }
  },
  {
    "kind": "update",
    "startTime": "2020-11-06T00:02:29.000Z",
    "message": "",
    "environment": {
      "exec.kind": "cli"
    },
    "config": {
      "aws:region": {
        "value": "us-east-1",
        "secret": false
      },
      "history:MySecretPassword": {
        "value": "ERROR_UNABLE_TO_DECRYPT",
        "secret": true
      }
    },
    "result": "succeeded",
    "endTime": "2020-11-06T00:02:43.000Z",
    "resourceChanges": {
      "create": 2
    }
  }
]
```