### PR TITLE
Fix feature support checks in the Python SDK.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Fix a bug in the Python SDK that caused incompatibilities with versions of the CLI prior to 
+  2.13.0.
+  [#5702](https://github.com/pulumi/pulumi/pull/5702)
 
 ## 2.13.0 (2020-11-04)
 

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -211,7 +211,7 @@ async def monitor_supports_feature(feature: str) -> bool:
         if not monitor:
             return False
 
-        req = resource_pb2.SupportsFeatureRequest(id="secrets")
+        req = resource_pb2.SupportsFeatureRequest(id=feature)
         def do_rpc_call():
             try:
                 resp = monitor.SupportsFeature(req)


### PR DESCRIPTION
The feature to check should not be hardcoded to "secrets".

Fixes #5697.