### PR TITLE
Report feature "resourceReferences" is not supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Fix a bug that was causing errors when (de)serializing custom resources.
+  [#5709](https://github.com/pulumi/pulumi/pull/5709)
 
 ## 2.13.1 (2020-11-06)
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -532,7 +532,7 @@ func (rm *resmon) SupportsFeature(ctx context.Context,
 	hasSupport := false
 
 	switch req.Id {
-	case "secrets", "resourceReferences":
+	case "secrets":
 		hasSupport = true
 	}
 


### PR DESCRIPTION
This feature isn't fully supported yet, so stop reporting it is.

I verified this allows the `aws-ts-eks` example to work, where it'd previously error during `pulumi up`.

Fixes https://github.com/pulumi/pulumi/issues/5705