### PR TITLE
Turn Automation API unmarshaling error into AutoError for Go SDK preview ops

### DIFF
--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -255,7 +255,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 
 	err = json.Unmarshal([]byte(stdout), &res)
 	if err != nil {
-		return res, errors.Wrap(err, "unable to unmarshal preview result")
+		return res, newAutoError(errors.Wrap(err, "unable to unmarshal preview result"), stdout, stderr, code)
 	}
 
 	return res, nil


### PR DESCRIPTION
@elsesiy reported an issue with unmarshalling Automation API preview results. I've turned the error into an `AutoError` so that the resulting message provides more useful diagnostics. 

https://github.com/pulumi/pulumi/issues/5470#issuecomment-723374166