### PR TITLE
Fix bug calling `Provider.read`

### DIFF
--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -193,9 +193,7 @@ class Server implements grpc.UntypedServiceImplementation {
             const id = req.getId();
             const props = req.getProperties().toJavaScript();
             if (this.provider.read) {
-                // If there's a read function, consult the provider. Ensure to propagate the special __provider
-                // value too, so that the provider's CRUD operations continue to function after a refresh.
-                const result: any = await this.provider.read(id, props);
+                const result: any = await this.provider.read(id, req.getUrn(), props);
                 resp.setId(result.id);
                 resp.setProperties(structproto.Struct.fromJavaScript(result.props));
             } else {


### PR DESCRIPTION
The call to `read` wasn't passing the URN.

https://github.com/pulumi/pulumi/blob/e8880e21817edaf6decf7dd30ce84be132202d2f/sdk/nodejs/provider/provider.ts#L179

Also delete a comment that doesn't apply here (copy/paste error from the [dynamic provider](https://github.com/pulumi/pulumi/blob/e8880e21817edaf6decf7dd30ce84be132202d2f/sdk/nodejs/cmd/dynamic-provider/index.ts#L229-L230)).