### PR TITLE
Create a builtin provider during import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fix a bug that could prevent `pulumi import` from succeeding.
+  [#5730](https://github.com/pulumi/pulumi/pull/5730)
+
 - [Docs] Add support for the generation of Import documentation in the resource docs.
   This documentation will only be available if the resource is importable.
   [#5667](https://github.com/pulumi/pulumi/pull/5667)

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -38,7 +38,14 @@ func (u *updateInfo) GetTarget() *deploy.Target {
 	return &u.target
 }
 
+func ImportOp(imports []deploy.Import) TestOp {
+	return TestOp(func(info UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (ResourceChanges, result.Result) {
+		return Import(info, ctx, opts, imports, dryRun)
+	})
+}
+
 type TestOp func(UpdateInfo, *Context, UpdateOptions, bool) (ResourceChanges, result.Result)
+
 type ValidateFunc func(project workspace.Project, target deploy.Target, entries JournalEntries,
 	events []Event, res result.Result) result.Result
 

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -73,8 +73,10 @@ func NewImportPlan(ctx *plugin.Context, target *Target, projectName tokens.Packa
 		return nil, err
 	}
 
+	builtins := newBuiltinProvider(nil, nil)
+
 	// Create a new provider registry.
-	reg, err := providers.NewRegistry(ctx.Host, oldResources, preview, nil)
+	reg, err := providers.NewRegistry(ctx.Host, oldResources, preview, builtins)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
`pulumi import` may otherwise fail if there are providers in the
statefile.