### PR TITLE
Pulumi-language-go and pulumi new now checks go version is at least 1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ CHANGELOG
 - Support python 3.9 on Windows.
   [#5739](https://github.com/pulumi/pulumi/pull/5739)
 
+- `pulumi-language-go` and `pulumi new` now explicitly requires Go 1.14.0.
+  [#5741](https://github.com/pulumi/pulumi/pull/5741)
+
 ## 2.13.2 (2020-11-06)
 
 - Fix a bug that was causing errors when (de)serializing custom resources.

--- a/sdk/go/common/util/goversion/version.go
+++ b/sdk/go/common/util/goversion/version.go
@@ -1,0 +1,45 @@
+package goversion
+
+import (
+	"github.com/blang/semver"
+	"github.com/pkg/errors"
+	"os/exec"
+	"strings"
+)
+
+var minGoVersion = semver.MustParse("1.14.0")
+
+// CheckMinimumGoVersion checks to make sure we are running at least minGoVersion
+func CheckMinimumGoVersion(gobin string) error {
+	cmd := exec.Command(gobin, "version")
+	stdout, err := cmd.Output()
+	if err != nil {
+		return errors.Wrap(err, "determining go version")
+	}
+
+	return checkMinimumGoVersion(string(stdout))
+}
+
+// checkMinimumGoVersion checks to make sure we are running at least go 1.14.0
+// expected format of goVersionOutput: go version go<version> <os/arch>
+func checkMinimumGoVersion(goVersionOutput string) error {
+	split := strings.Split(goVersionOutput, " ")
+	if len(split) <= 2 {
+		return errors.Errorf("unexpected format for go version output: \"%s\"", goVersionOutput)
+
+	}
+	version := strings.TrimSpace(split[2])
+	if strings.HasPrefix(version, "go") {
+		version = version[2:]
+	}
+
+	currVersion, err := semver.ParseTolerant(version)
+	if err != nil {
+		return errors.Wrap(err, "parsing go version")
+	}
+
+	if currVersion.LT(minGoVersion) {
+		return errors.Errorf("go version must be %s or higher (%s detected)", minGoVersion.String(), version)
+	}
+	return nil
+}

--- a/sdk/go/common/util/goversion/version_test.go
+++ b/sdk/go/common/util/goversion/version_test.go
@@ -1,0 +1,51 @@
+package goversion
+
+import (
+	"errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func Test_checkMinimumGoVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		goVersionOutput string
+		err             error
+	}{
+		{
+			name:            "ExactVersion",
+			goVersionOutput: "go version go1.14.0 darwin/amd64",
+		},
+		{
+			name:            "NewerVersion",
+			goVersionOutput: "go version go1.15.1 darwin/amd64",
+		},
+		{
+			name:            "OlderGoVersion",
+			goVersionOutput: "go version go1.13.8 linux/amd64",
+			err:             errors.New("go version must be 1.14.0 or higher (1.13.8 detected)"),
+		},
+		{
+			name:            "MalformedVersion",
+			goVersionOutput: "go version xyz",
+			err:             errors.New("parsing go version failed: Invalid character(s) found in major number \"xyz\""),
+		},
+		{
+			name:            "GarbageVersionOutput",
+			goVersionOutput: "gobble gobble",
+			err:             errors.New("unexpected format for go version output: \"gobble gobble\""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkMinimumGoVersion(tt.goVersionOutput)
+			if err != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.err.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/sdk/go/common/util/goversion/version_test.go
+++ b/sdk/go/common/util/goversion/version_test.go
@@ -29,7 +29,7 @@ func Test_checkMinimumGoVersion(t *testing.T) {
 		{
 			name:            "MalformedVersion",
 			goVersionOutput: "go version xyz",
-			err:             errors.New("parsing go version failed: Invalid character(s) found in major number \"xyz\""),
+			err:             errors.New("parsing go version: Invalid character(s) found in major number \"xyz\""),
 		},
 		{
 			name:            "GarbageVersionOutput",

--- a/sdk/go/pulumi-language-go/main.go
+++ b/sdk/go/pulumi-language-go/main.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/buildutil"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/executable"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/goversion"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/logging"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/rpcutil"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/version"
@@ -177,8 +178,10 @@ func (m *modInfo) getPlugin() (*pulumirpc.PluginDependency, error) {
 }
 
 // GetRequiredPlugins computes the complete set of anticipated plugins required by a program.
-// We strictly enforce the requirement for go modules support and go 1.14.0+ and fail with
-// an appropriate message if these requirements are not met.
+// We're lenient here as this relies on the `go list` command and the use of modules.
+// If the consumer insists on using some other form of dependency management tool like
+// dep or glide, the list command fails with "go list -m: not using modules".
+// However, we do enforce that go 1.14.0 or higher is installed.
 func (host *goLanguageHost) GetRequiredPlugins(ctx context.Context,
 	req *pulumirpc.GetRequiredPluginsRequest) (*pulumirpc.GetRequiredPluginsResponse, error) {
 
@@ -189,23 +192,17 @@ func (host *goLanguageHost) GetRequiredPlugins(ctx context.Context,
 		return nil, errors.Wrap(err, "couldn't find go binary")
 	}
 
-	cmd := exec.Command(gobin, "version")
-	stdout, err := cmd.Output()
-	if err != nil {
-		return nil, fmt.Errorf("failed to determine go version: %w", err)
-	}
-	rawVersion := string(stdout)
-	if err = checkMinimumGoVersion(rawVersion); err != nil {
+	if err = goversion.CheckMinimumGoVersion(gobin); err != nil {
 		return nil, err
 	}
 
 	// don't wire up stderr so non-module users don't see error output from list
-	cmd = exec.Command(gobin, "list", "-m", "-json", "-mod=mod", "all")
+	cmd := exec.Command(gobin, "list", "-m", "-json", "-mod=mod", "all")
 	cmd.Env = os.Environ()
-	stdout, err = cmd.Output()
+	stdout, err := cmd.Output()
 	if err != nil {
 		logging.V(5).Infof("GetRequiredPlugins: Error discovering plugin requirements using go modules: %s", err.Error())
-		return nil, fmt.Errorf("failure discovering program dependencies: %w", err)
+		return &pulumirpc.GetRequiredPluginsResponse{}, nil
 	}
 
 	plugins := []*pulumirpc.PluginDependency{}
@@ -238,32 +235,6 @@ func (host *goLanguageHost) GetRequiredPlugins(ctx context.Context,
 	return &pulumirpc.GetRequiredPluginsResponse{
 		Plugins: plugins,
 	}, nil
-}
-
-var minGoVersion = semver.MustParse("1.14.0")
-
-// checkMinimumGoVersion checks to make sure we are running at least go 1.14.0
-// expected format of goVersionOutput: go version go<version> <os/arch>
-func checkMinimumGoVersion(goVersionOutput string) error {
-	split := strings.Split(goVersionOutput, " ")
-	if len(split) <= 2 {
-		return fmt.Errorf("unexpected format for go version output: \"%s\"", goVersionOutput)
-
-	}
-	version := strings.TrimSpace(split[2])
-	if strings.HasPrefix(version, "go") {
-		version = version[2:]
-	}
-
-	currVersion, err := semver.ParseTolerant(version)
-	if err != nil {
-		return fmt.Errorf("parsing go version failed: %w", err)
-	}
-
-	if currVersion.LT(minGoVersion) {
-		return fmt.Errorf("go version must be %s or higher (%s detected)", minGoVersion.String(), version)
-	}
-	return nil
 }
 
 // RPC endpoint for LanguageRuntimeServer::Run

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -63,4 +65,47 @@ func TestGetPlugin(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, nonZeroPatchPlugin.Name, "kubernetes")
 	assert.Equal(t, nonZeroPatchPlugin.Version, "v1.5.8")
+}
+
+func Test_checkMinimumGoVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		goVersionOutput string
+		err             error
+	}{
+		{
+			name:            "ExactVersion",
+			goVersionOutput: "go version go1.14.0 darwin/amd64",
+		},
+		{
+			name:            "NewerVersion",
+			goVersionOutput: "go version go1.15.1 darwin/amd64",
+		},
+		{
+			name:            "OlderGoVersion",
+			goVersionOutput: "go version go1.13.8 linux/amd64",
+			err:             errors.New("go version must be 1.14.0 or higher (1.13.8 detected)"),
+		},
+		{
+			name:            "MalformedVersion",
+			goVersionOutput: "go version xyz",
+			err:             errors.New("parsing go version failed: Invalid character(s) found in major number \"xyz\""),
+		},
+		{
+			name:            "GarbageVersionOutput",
+			goVersionOutput: "gobble gobble",
+			err:             errors.New("unexpected format for go version output: \"gobble gobble\""),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := checkMinimumGoVersion(tt.goVersionOutput)
+			if err != nil {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.err.Error())
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
 }

--- a/sdk/go/pulumi-language-go/main_test.go
+++ b/sdk/go/pulumi-language-go/main_test.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"errors"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -65,47 +63,4 @@ func TestGetPlugin(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, nonZeroPatchPlugin.Name, "kubernetes")
 	assert.Equal(t, nonZeroPatchPlugin.Version, "v1.5.8")
-}
-
-func Test_checkMinimumGoVersion(t *testing.T) {
-	tests := []struct {
-		name            string
-		goVersionOutput string
-		err             error
-	}{
-		{
-			name:            "ExactVersion",
-			goVersionOutput: "go version go1.14.0 darwin/amd64",
-		},
-		{
-			name:            "NewerVersion",
-			goVersionOutput: "go version go1.15.1 darwin/amd64",
-		},
-		{
-			name:            "OlderGoVersion",
-			goVersionOutput: "go version go1.13.8 linux/amd64",
-			err:             errors.New("go version must be 1.14.0 or higher (1.13.8 detected)"),
-		},
-		{
-			name:            "MalformedVersion",
-			goVersionOutput: "go version xyz",
-			err:             errors.New("parsing go version failed: Invalid character(s) found in major number \"xyz\""),
-		},
-		{
-			name:            "GarbageVersionOutput",
-			goVersionOutput: "gobble gobble",
-			err:             errors.New("unexpected format for go version output: \"gobble gobble\""),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := checkMinimumGoVersion(tt.goVersionOutput)
-			if err != nil {
-				require.Error(t, err)
-				assert.EqualError(t, err, tt.err.Error())
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
 }


### PR DESCRIPTION
Fixes #5724
This change enforces that the go version is at least 1.14.0 for go projects. 

Now the following error is seen when running `pulumi up` on an incompatible version:
```
# pulumi up
Previewing update (dev)

View Live: https://app.pulumi.com/.../dev/previews/...


error: failed to discover plugin requirements: go version must be 1.14.0 or higher (1.13.8 detected)
```

and the following when `pulumi new` is invoked:
```
pulumi new gcp-go

Enter a value or leave blank to accept the (default), and press <ENTER>.
Press ^C at any time to quit.

project name: (new-project)
project description: (A minimal Google Cloud Go Pulumi program)
Created project 'new-project'

Please enter your desired stack name.
To create a stack in an organization, use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).
stack name: (dev)
Created stack 'dev'

gcp:project: The Google Cloud project to deploy into:
Saved config

Installing dependencies...

error: go version must be 1.14.0 or higher (1.13.8 detected)
```