### PR TITLE
Fix plugin install failures on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ CHANGELOG
 - Update .NET `Grpc` libraries to 2.33.1 and `Protobuf` to 3.13.0 (forked to increase
   the recursion limit) [#5757](https://github.com/pulumi/pulumi/pull/5757)
 
+- Fix plugin install failures on Windows.
+  [#5759](https://github.com/pulumi/pulumi/pull/5759)
+
 ## 2.13.2 (2020-11-06)
 
 - Fix a bug that was causing errors when (de)serializing custom resources.

--- a/sdk/go/common/workspace/plugins_install_test.go
+++ b/sdk/go/common/workspace/plugins_install_test.go
@@ -20,11 +20,14 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -58,48 +61,163 @@ func createTGZ(files map[string][]byte) ([]byte, error) {
 	return buffer.Bytes(), nil
 }
 
+func prepareTestDir(t *testing.T, files map[string][]byte) (string, io.ReadCloser, PluginInfo) {
+	if files == nil {
+		files = map[string][]byte{}
+	}
+
+	// Add plugin binary to included files.
+	files["pulumi-resource-test"] = nil
+
+	tgz, err := createTGZ(files)
+	assert.NoError(t, err)
+	tarball := ioutil.NopCloser(bytes.NewReader(tgz))
+
+	dir, err := ioutil.TempDir("", "plugins-test-dir")
+	assert.NoError(t, err)
+
+	v1 := semver.MustParse("0.1.0")
+	plugin := PluginInfo{
+		Name:      "test",
+		Kind:      ResourcePlugin,
+		Version:   &v1,
+		PluginDir: dir,
+	}
+
+	return dir, tarball, plugin
+}
+
+func assertPluginInstalled(t *testing.T, dir string, plugin PluginInfo) {
+	info, err := os.Stat(filepath.Join(dir, plugin.Dir()))
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	info, err = os.Stat(filepath.Join(dir, plugin.Dir(), plugin.File()))
+	assert.NoError(t, err)
+	assert.False(t, info.IsDir())
+
+	info, err = os.Stat(filepath.Join(dir, plugin.Dir()+".partial"))
+	assert.Error(t, err)
+	assert.True(t, os.IsNotExist(err))
+
+	assert.True(t, HasPlugin(plugin))
+
+	has, err := HasPluginGTE(plugin)
+	assert.NoError(t, err)
+	assert.True(t, has)
+
+	plugins, err := getPlugins(dir)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(plugins))
+	assert.Equal(t, plugin.Name, plugins[0].Name)
+	assert.Equal(t, plugin.Kind, plugins[0].Kind)
+	assert.Equal(t, *plugin.Version, *plugins[0].Version)
+}
+
+func testDeletePlugin(t *testing.T, dir string, plugin PluginInfo) {
+	err := plugin.Delete()
+	assert.NoError(t, err)
+
+	paths := []string{
+		filepath.Join(dir, plugin.Dir()),
+		filepath.Join(dir, plugin.Dir()+".partial"),
+		filepath.Join(dir, plugin.Dir()+".lock"),
+	}
+	for _, path := range paths {
+		_, err := os.Stat(path)
+		assert.Error(t, err)
+		assert.True(t, os.IsNotExist(err))
+	}
+}
+
 func testPluginInstall(t *testing.T, expectedDir string, files map[string][]byte) {
 	// Skip during short test runs since this test involves downloading dependencies.
 	if testing.Short() {
 		t.Skip("Skipped in short test run")
 	}
 
-	tgz, err := createTGZ(files)
+	dir, tarball, plugin := prepareTestDir(t, files)
+	defer os.RemoveAll(dir)
+
+	err := plugin.Install(tarball)
 	assert.NoError(t, err)
 
-	finalDirRoot, err := ioutil.TempDir("", "final-dir")
-	assert.NoError(t, err)
-	defer os.RemoveAll(finalDirRoot)
-	finalDir := filepath.Join(finalDirRoot, "final")
+	assertPluginInstalled(t, dir, plugin)
 
-	err = installPlugin(finalDir, ioutil.NopCloser(bytes.NewReader(tgz)))
-	assert.NoError(t, err)
-
-	info, err := os.Stat(filepath.Join(finalDir, expectedDir))
+	info, err := os.Stat(filepath.Join(dir, plugin.Dir(), expectedDir))
 	assert.NoError(t, err)
 	assert.True(t, info.IsDir())
+
+	testDeletePlugin(t, dir, plugin)
 }
 
 func TestInstallNoDeps(t *testing.T) {
 	name := "foo.txt"
 	content := []byte("hello\n")
 
-	tgz, err := createTGZ(map[string][]byte{name: content})
+	dir, tarball, plugin := prepareTestDir(t, map[string][]byte{name: content})
+	defer os.RemoveAll(dir)
+
+	err := plugin.Install(tarball)
 	assert.NoError(t, err)
 
-	finalDirRoot, err := ioutil.TempDir("", "final-dir")
-	assert.NoError(t, err)
-	defer os.RemoveAll(finalDirRoot)
-	finalDir := filepath.Join(finalDirRoot, "final")
+	assertPluginInstalled(t, dir, plugin)
 
-	err = installPlugin(finalDir, ioutil.NopCloser(bytes.NewReader(tgz)))
-	assert.NoError(t, err)
-
-	info, err := os.Stat(filepath.Join(finalDir, name))
-	assert.NoError(t, err)
-	assert.False(t, info.IsDir())
-
-	b, err := ioutil.ReadFile(filepath.Join(finalDir, name))
+	b, err := ioutil.ReadFile(filepath.Join(dir, plugin.Dir(), name))
 	assert.NoError(t, err)
 	assert.Equal(t, content, b)
+
+	testDeletePlugin(t, dir, plugin)
+}
+
+func TestInstallCleansOldFiles(t *testing.T) {
+	dir, tarball, plugin := prepareTestDir(t, nil)
+	defer os.RemoveAll(dir)
+
+	// Leftover temp dirs.
+	tempDir1, err := ioutil.TempDir(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	assert.NoError(t, err)
+	tempDir2, err := ioutil.TempDir(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	assert.NoError(t, err)
+	tempDir3, err := ioutil.TempDir(dir, fmt.Sprintf("%s.tmp", plugin.Dir()))
+	assert.NoError(t, err)
+
+	// Leftover partial file.
+	partialPath := filepath.Join(dir, plugin.Dir()+".partial")
+	err = ioutil.WriteFile(partialPath, nil, 0600)
+	assert.NoError(t, err)
+
+	err = plugin.Install(tarball)
+	assert.NoError(t, err)
+
+	assertPluginInstalled(t, dir, plugin)
+
+	// Verify leftover files were removed.
+	for _, path := range []string{tempDir1, tempDir2, tempDir3, partialPath} {
+		_, err := os.Stat(path)
+		assert.Error(t, err)
+		assert.True(t, os.IsNotExist(err))
+	}
+
+	testDeletePlugin(t, dir, plugin)
+}
+
+func TestGetPluginsSkipsPartial(t *testing.T) {
+	dir, tarball, plugin := prepareTestDir(t, nil)
+	defer os.RemoveAll(dir)
+
+	err := plugin.Install(tarball)
+	assert.NoError(t, err)
+
+	err = ioutil.WriteFile(filepath.Join(dir, plugin.Dir()+".partial"), nil, 0600)
+	assert.NoError(t, err)
+
+	assert.False(t, HasPlugin(plugin))
+
+	has, err := HasPluginGTE(plugin)
+	assert.Error(t, err)
+	assert.False(t, has)
+
+	plugins, err := getPlugins(dir)
+	assert.Equal(t, 0, len(plugins))
 }


### PR DESCRIPTION
When installing a plugin, previous versions of Pulumi extracted the plugin tarball to a temp directory and then renamed the temp directory to the final plugin directory. This was done to prevent concurrent installs: if a process fails to rename the temp dir because the final dir already exists, it means another process already installed the plugin. Unfortunately, on Windows the rename operation often fails due to aggressive virus scanners opening files in the temp dir.

In order to provide reliable plugin installs on Windows, we now extract the tarball directly into the final directory, and use file locks to prevent concurrent installs from toppling over one another.

During install, a lock file is created in the plugin cache directory with the same name as the plugin's final directory but suffixed with `.lock`. The process that obtains the lock is responsible for extracting the tarball. Before it does that, it cleans up any previous temp directories of failed installs of previous versions of Pulumi. Then it creates an empty `.partial` file next to the `.lock` file. The `.partial` file indicates an installation is in-progress. The `.partial` file is deleted when installation is complete, indicating the plugin was successfully installed. If a failure occurs during installation, the`.partial` file will remain indicating the plugin wasn't fully installed. The next time the plugin is installed, the old installation directory will be removed and replaced with a fresh install.

This is the same approach Go uses for installing modules in its module cache.

Fixes https://github.com/pulumi/pulumi/issues/2695