### PR TITLE
.NET: Report plugin install errors during `pulumi new`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ CHANGELOG
 - Fix plugin install failures on Windows.
   [#5759](https://github.com/pulumi/pulumi/pull/5759)
 
+- .NET: Report plugin install errors during `pulumi new`.
+  [#5760](https://github.com/pulumi/pulumi/pull/5760)
+
 ## 2.13.2 (2020-11-06)
 
 - Fix a bug that was causing errors when (de)serializing custom resources.

--- a/pkg/engine/plan.go
+++ b/pkg/engine/plan.go
@@ -167,7 +167,8 @@ func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*plan
 		plan, err = deploy.NewPlan(
 			plugctx, target, target.Snapshot, source, localPolicyPackPaths, dryRun, ctx.BackendClient)
 	} else {
-		_, defaultProviderVersions, pluginErr := installPlugins(proj, pwd, main, target, plugctx)
+		_, defaultProviderVersions, pluginErr := installPlugins(proj, pwd, main, target, plugctx,
+			false /*returnInstallErrors*/)
 		if pluginErr != nil {
 			return nil, pluginErr
 		}

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 
 	"github.com/blang/semver"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pulumi/pulumi/pkg/v2/resource/deploy"
@@ -181,7 +182,8 @@ func installPlugin(plugin workspace.PluginInfo) error {
 	logging.V(preparePluginVerboseLog).Infof(
 		"installPlugin(%s, %s): extracting tarball to installation directory", plugin.Name, plugin.Version)
 	if err := plugin.Install(stream); err != nil {
-		return err
+		return errors.Wrapf(err, "installing plugin; run `pulumi plugin install %s %s v%s` to retry manually",
+			plugin.Kind, plugin.Name, plugin.Version)
 	}
 
 	logging.V(7).Infof("installPlugin(%s, %s): successfully installed", plugin.Name, plugin.Version)

--- a/pkg/engine/query.go
+++ b/pkg/engine/query.go
@@ -93,7 +93,7 @@ func newQuerySource(cancel context.Context, client deploy.BackendClient, q Query
 	opts QueryOptions) (deploy.QuerySource, error) {
 
 	allPlugins, defaultProviderVersions, err := installPlugins(q.GetProject(), opts.pwd, opts.main,
-		nil, opts.plugctx)
+		nil, opts.plugctx, false /*returnInstallErrors*/)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The way `pulumi new` installs dependencies for .NET projects is slightly different from other languages. For Node.js, Python, and Go, `pulumi new` runs the appropriate command to install project dependencies (e.g. `npm install`, `pip install`, or `go mod download`). For .NET, it calls the same routine used during `preview|up` to ensure required plugins are installed. For .NET, this ends up running `dotnet build` which implicitly installs Nuget packages, builds the project, and also attempts to determine and install the needed Pulumi plugins. When this operation runs during `preview|up`, and there are failures installing a plugin, the error is logged, but deliberately not returned, because an error will be shown for missing plugins later on during the `preview|up` operation. However, during `pulumi new`, we should show any plugin install errors.

Note: Plugin install failure during `pulumi new` is now much less likely now on Windows with: https://github.com/pulumi/pulumi/pull/5759

Fixes https://github.com/pulumi/pulumi/issues/5685