### PR TITLE
Small UX change to the output of policy violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ CHANGELOG
 - Correct error message on KeyNotFoundException against StackReference.
   [#5740](https://github.com/pulumi/pulumi/pull/5740)
 
+- [cli] Small UX change on the policy violations output to render as `type: name`
+  [#5773](https://github.com/pulumi/pulumi/pull/5773)
+
 ## 2.13.2 (2020-11-06)
 
 - Fix a bug that was causing errors when (de)serializing custom resources.

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -845,8 +845,8 @@ func (display *ProgressDisplay) printPolicyViolations() bool {
 			policyEvent.PolicyPackName,
 			policyEvent.PolicyPackVersion, colors.Reset,
 			policyEvent.PolicyName,
-			policyEvent.ResourceURN.Name(),
-			policyEvent.ResourceURN.Type())
+			policyEvent.ResourceURN.Type(),
+			policyEvent.ResourceURN.Name())
 		display.writeSimpleMessage(policyNameLine)
 
 		// The message may span multiple lines, so we massage it so it will be indented properly.


### PR DESCRIPTION
Fixes: #5626

It used to be:

```
Policy Violations:
    [advisory]  aws v0.1.20200912  allowed-image-owner (demo-aws-ts-webserver-server-0: aws:ec2/instance:Instance)
    Check machine image is from an approved publisher.
    Publisher [137112412989] is not one of [self,099720109477].

```

Notice that it was name: type

We would rather this was type: name

```
Policy Violations:
    [advisory]  aws v0.1.20200912  allowed-image-owner (aws:ec2/instance:Instance: demo-aws-ts-webserver-server-0)
    Check machine image is from an approved publisher.
    Publisher [137112412989] is not one of [self,099720109477].

```