### PR TITLE
Rename engine.plan to engine.deployment.

### DIFF
--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -16,7 +16,7 @@ package engine
 
 import (
 	"context"
-	"sync"
+	"time"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
@@ -73,9 +73,9 @@ func ProjectInfoContext(projinfo *Projinfo, host plugin.Host, config plugin.Conf
 	return pwd, main, ctx, nil
 }
 
-// newPlanContext creates a context for a subsequent planning operation.  Callers must call Close on the
-// resulting context object once they have completed the associated planning operation.
-func newPlanContext(u UpdateInfo, opName string, parentSpan opentracing.SpanContext) (*planContext, error) {
+// newDeploymentContext creates a context for a subsequent deployment. Callers must call Close on the context after the
+// associated deployment completes.
+func newDeploymentContext(u UpdateInfo, opName string, parentSpan opentracing.SpanContext) (*deploymentContext, error) {
 	contract.Require(u != nil, "u")
 
 	// Create a root span for the operation
@@ -88,28 +88,28 @@ func newPlanContext(u UpdateInfo, opName string, parentSpan opentracing.SpanCont
 	}
 	tracingSpan := opentracing.StartSpan("pulumi-plan", opts...)
 
-	return &planContext{
+	return &deploymentContext{
 		Update:      u,
 		TracingSpan: tracingSpan,
 	}, nil
 }
 
-type planContext struct {
+type deploymentContext struct {
 	Update      UpdateInfo       // The update being processed.
 	TracingSpan opentracing.Span // An OpenTracing span to parent plan operations within.
 }
 
-func (ctx *planContext) Close() {
+func (ctx *deploymentContext) Close() {
 	ctx.TracingSpan.Finish()
 }
 
-// planOptions includes a full suite of options for performing a plan and/or deploy operation.
-type planOptions struct {
+// deploymentOptions includes a full suite of options for performing a deployment.
+type deploymentOptions struct {
 	UpdateOptions
 
 	// SourceFunc is a factory that returns an EvalSource to use during planning.  This is the thing that
 	// creates resources to compare against the current checkpoint state (e.g., by evaluating a program, etc).
-	SourceFunc planSourceFunc
+	SourceFunc deploymentSourceFunc
 
 	DOT        bool         // true if we should print the DOT file for this plan.
 	Events     eventEmitter // the channel to write events from the engine to.
@@ -127,13 +127,13 @@ type planOptions struct {
 	trustDependencies bool
 }
 
-// planSourceFunc is a callback that will be used to prepare for, and evaluate, the "new" state for a stack.
-type planSourceFunc func(
-	client deploy.BackendClient, opts planOptions, proj *workspace.Project, pwd, main string,
+// deploymentSourceFunc is a callback that will be used to prepare for, and evaluate, the "new" state for a stack.
+type deploymentSourceFunc func(
+	client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool) (deploy.Source, error)
 
-// plan just uses the standard logic to parse arguments, options, and to create a snapshot and plan.
-func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*planResult, error) {
+// newDeployment creates a new deployment with the given context and options.
+func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions, dryRun bool) (*deployment, error) {
 	contract.Assert(info != nil)
 	contract.Assert(info.Update != nil)
 	contract.Assert(opts.SourceFunc != nil)
@@ -162,9 +162,9 @@ func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*plan
 	// Generate a plan; this API handles all interesting cases (create, update, delete).
 	localPolicyPackPaths := ConvertLocalPolicyPacksToPaths(opts.LocalPolicyPacks)
 
-	var deployment *deploy.Deployment
+	var plan *deploy.Deployment
 	if !opts.isImport {
-		deployment, err = deploy.NewDeployment(
+		plan, err = deploy.NewDeployment(
 			plugctx, target, target.Snapshot, source, localPolicyPackPaths, dryRun, ctx.BackendClient)
 	} else {
 		_, defaultProviderVersions, pluginErr := installPlugins(proj, pwd, main, target, plugctx,
@@ -179,62 +179,79 @@ func plan(ctx *Context, info *planContext, opts planOptions, dryRun bool) (*plan
 			}
 		}
 
-		deployment, err = deploy.NewImportDeployment(plugctx, target, proj.Name, opts.imports, dryRun)
+		plan, err = deploy.NewImportDeployment(plugctx, target, proj.Name, opts.imports, dryRun)
 	}
 
 	if err != nil {
 		contract.IgnoreClose(plugctx)
 		return nil, err
 	}
-	return &planResult{
+	return &deployment{
 		Ctx:        info,
 		Plugctx:    plugctx,
-		Deployment: deployment,
+		Deployment: plan,
 		Options:    opts,
 	}, nil
 }
 
-type planResult struct {
-	Ctx        *planContext       // plan context information.
+type deployment struct {
+	Ctx        *deploymentContext // plan context information.
 	Plugctx    *plugin.Context    // the context containing plugins and their state.
 	Deployment *deploy.Deployment // the plan created by this command.
-	Options    planOptions        // the options used during planning.
+	Options    deploymentOptions  // the options used during planning.
 }
 
-// Chdir changes the directory so that all operations from now on are relative to the project we are working with.
-// It returns a function that, when run, restores the old working directory.
-func (planResult *planResult) Chdir() (func(), error) {
-	return fsutil.Chdir(planResult.Plugctx.Pwd)
+type runActions interface {
+	deploy.Events
+
+	Changes() ResourceChanges
+	MaybeCorrupt() bool
 }
 
-// Walk enumerates all steps in the plan, calling out to the provided action at each step.  It returns four things: the
+// run enumerates all steps in the plan, calling out to the provided action at each step.  It returns four things: the
 // resulting Snapshot, no matter whether an error occurs or not; an error, if something went wrong; the step that
 // failed, if the error is non-nil; and finally the state of the resource modified in the failing step.
-func (planResult *planResult) Walk(cancelCtx *Context, events deploy.Events, preview bool) result.Result {
+func (deployment *deployment) run(cancelCtx *Context, actions runActions, policyPacks map[string]string,
+	preview bool) (ResourceChanges, result.Result) {
+
+	// Change into the plugin context's working directory.
+	chdir, err := fsutil.Chdir(deployment.Plugctx.Pwd)
+	if err != nil {
+		return nil, result.FromError(err)
+	}
+	defer chdir()
+
+	// Create a new context for cancellation and tracing.
 	ctx, cancelFunc := context.WithCancel(context.Background())
 
 	// Inject our opentracing span into the context.
-	if planResult.Ctx.TracingSpan != nil {
-		ctx = opentracing.ContextWithSpan(ctx, planResult.Ctx.TracingSpan)
+	if deployment.Ctx.TracingSpan != nil {
+		ctx = opentracing.ContextWithSpan(ctx, deployment.Ctx.TracingSpan)
 	}
+
+	// Emit an appropriate prelude event.
+	deployment.Options.Events.preludeEvent(preview, deployment.Ctx.Update.GetTarget().Config)
+
+	// Execute the plan.
+	start := time.Now()
 
 	done := make(chan bool)
 	var walkResult result.Result
 	go func() {
 		opts := deploy.Options{
-			Events:            events,
-			Parallel:          planResult.Options.Parallel,
-			Refresh:           planResult.Options.Refresh,
-			RefreshOnly:       planResult.Options.isRefresh,
-			RefreshTargets:    planResult.Options.RefreshTargets,
-			ReplaceTargets:    planResult.Options.ReplaceTargets,
-			DestroyTargets:    planResult.Options.DestroyTargets,
-			UpdateTargets:     planResult.Options.UpdateTargets,
-			TargetDependents:  planResult.Options.TargetDependents,
-			TrustDependencies: planResult.Options.trustDependencies,
-			UseLegacyDiff:     planResult.Options.UseLegacyDiff,
+			Events:            actions,
+			Parallel:          deployment.Options.Parallel,
+			Refresh:           deployment.Options.Refresh,
+			RefreshOnly:       deployment.Options.isRefresh,
+			RefreshTargets:    deployment.Options.RefreshTargets,
+			ReplaceTargets:    deployment.Options.ReplaceTargets,
+			DestroyTargets:    deployment.Options.DestroyTargets,
+			UpdateTargets:     deployment.Options.UpdateTargets,
+			TargetDependents:  deployment.Options.TargetDependents,
+			TrustDependencies: deployment.Options.trustDependencies,
+			UseLegacyDiff:     deployment.Options.UseLegacyDiff,
 		}
-		walkResult = planResult.Deployment.Execute(ctx, opts, preview)
+		walkResult = deployment.Deployment.Execute(ctx, opts, preview)
 		close(done)
 	}()
 
@@ -249,152 +266,27 @@ func (planResult *planResult) Walk(cancelCtx *Context, events deploy.Events, pre
 		}
 	}()
 
+	// Wait for the plan to finish executing or for the user to terminate the run.
+	var res result.Result
 	select {
 	case <-cancelCtx.Cancel.Terminated():
-		return result.WrapIfNonNil(cancelCtx.Cancel.TerminateErr())
+		res = result.WrapIfNonNil(cancelCtx.Cancel.TerminateErr())
 
 	case <-done:
-		return walkResult
-	}
-}
-
-func (planResult *planResult) Close() error {
-	return planResult.Plugctx.Close()
-}
-
-// printPlan prints the plan's result to the plan's Options.Events stream.
-func printPlan(ctx *Context, planResult *planResult, dryRun bool, policies map[string]string,
-) (ResourceChanges, result.Result) {
-
-	planResult.Options.Events.preludeEvent(dryRun, planResult.Ctx.Update.GetTarget().Config)
-
-	// Walk the plan's steps and and pretty-print them out.
-	actions := newPlanActions(planResult.Options)
-	res := planResult.Walk(ctx, actions, true)
-
-	// Emit an event with a summary of operation counts.
-	changes := ResourceChanges(actions.Ops)
-	planResult.Options.Events.previewSummaryEvent(changes, policies)
-
-	if res != nil {
-
-		if res.IsBail() {
-			return nil, res
-		}
-
-		return nil, result.Error("an error occurred while advancing the preview")
+		res = walkResult
 	}
 
-	return changes, nil
+	duration := time.Since(start)
+	changes := actions.Changes()
+
+	// Emit a summary event.
+	deployment.Options.Events.summaryEvent(preview, actions.MaybeCorrupt(), duration, changes, policyPacks)
+
+	return changes, res
 }
 
-type planActions struct {
-	Ops     map[deploy.StepOp]int
-	Opts    planOptions
-	Seen    map[resource.URN]deploy.Step
-	MapLock sync.Mutex
-}
-
-func shouldReportStep(step deploy.Step, opts planOptions) bool {
-	return step.Op() != deploy.OpRemovePendingReplace &&
-		(opts.reportDefaultProviderSteps || !isDefaultProviderStep(step))
-}
-
-func newPlanActions(opts planOptions) *planActions {
-	return &planActions{
-		Ops:  make(map[deploy.StepOp]int),
-		Opts: opts,
-		Seen: make(map[resource.URN]deploy.Step),
-	}
-}
-
-func (acts *planActions) OnResourceStepPre(step deploy.Step) (interface{}, error) {
-	acts.MapLock.Lock()
-	acts.Seen[step.URN()] = step
-	acts.MapLock.Unlock()
-
-	// Skip reporting if necessary.
-	if !shouldReportStep(step, acts.Opts) {
-		return nil, nil
-	}
-
-	acts.Opts.Events.resourcePreEvent(step, true /*planning*/, acts.Opts.Debug)
-
-	return nil, nil
-}
-
-func (acts *planActions) OnResourceStepPost(ctx interface{},
-	step deploy.Step, status resource.Status, err error) error {
-	acts.MapLock.Lock()
-	assertSeen(acts.Seen, step)
-	acts.MapLock.Unlock()
-
-	reportStep := shouldReportStep(step, acts.Opts)
-
-	if err != nil {
-		// We always want to report a failure. If we intend to elide this step overall, though, we report it as a
-		// global message.
-		reportedURN := resource.URN("")
-		if reportStep {
-			reportedURN = step.URN()
-		}
-
-		acts.Opts.Diag.Errorf(diag.GetPreviewFailedError(reportedURN), err)
-	} else if reportStep {
-		op, record := step.Op(), step.Logical()
-		if acts.Opts.isRefresh && op == deploy.OpRefresh {
-			// Refreshes are handled specially.
-			op, record = step.(*deploy.RefreshStep).ResultOp(), true
-		}
-
-		if step.Op() == deploy.OpRead {
-			record = ShouldRecordReadStep(step)
-		}
-
-		// Track the operation if shown and/or if it is a logically meaningful operation.
-		if record {
-			acts.MapLock.Lock()
-			acts.Ops[op]++
-			acts.MapLock.Unlock()
-		}
-
-		acts.Opts.Events.resourceOutputsEvent(op, step, true /*planning*/, acts.Opts.Debug)
-	}
-
-	return nil
-}
-
-func ShouldRecordReadStep(step deploy.Step) bool {
-	contract.Assertf(step.Op() == deploy.OpRead, "Only call this on a Read step")
-
-	// If reading a resource didn't result in any change to the resource, we then want to
-	// record this as a 'same'.  That way, when things haven't actually changed, but a user
-	// app did any 'reads' these don't show up in the resource summary at the end.
-	return step.Old() != nil &&
-		step.New() != nil &&
-		step.Old().Outputs != nil &&
-		step.New().Outputs != nil &&
-		step.Old().Outputs.Diff(step.New().Outputs) != nil
-}
-
-func (acts *planActions) OnResourceOutputs(step deploy.Step) error {
-	acts.MapLock.Lock()
-	assertSeen(acts.Seen, step)
-	acts.MapLock.Unlock()
-
-	// Skip reporting if necessary.
-	if !shouldReportStep(step, acts.Opts) {
-		return nil
-	}
-
-	// Print the resource outputs separately.
-	acts.Opts.Events.resourceOutputsEvent(step.Op(), step, true /*planning*/, acts.Opts.Debug)
-
-	return nil
-}
-
-func (acts *planActions) OnPolicyViolation(urn resource.URN, d plugin.AnalyzeDiagnostic) {
-	acts.Opts.Events.policyViolationEvent(urn, d)
+func (deployment *deployment) Close() error {
+	return deployment.Plugctx.Close()
 }
 
 func assertSeen(seen map[resource.URN]deploy.Step, step deploy.Step) {

--- a/pkg/engine/destroy.go
+++ b/pkg/engine/destroy.go
@@ -29,7 +29,7 @@ func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 
 	defer func() { ctx.Events <- cancelEvent() }()
 
-	info, err := newPlanContext(u, "destroy", ctx.ParentSpan)
+	info, err := newDeploymentContext(u, "destroy", ctx.ParentSpan)
 	if err != nil {
 		return nil, result.FromError(err)
 	}
@@ -41,7 +41,7 @@ func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 	}
 	defer emitter.Close()
 
-	return update(ctx, info, planOptions{
+	return update(ctx, info, deploymentOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newDestroySource,
 		Events:        emitter,
@@ -51,7 +51,7 @@ func Destroy(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 }
 
 func newDestroySource(
-	client deploy.BackendClient, opts planOptions, proj *workspace.Project, pwd, main string,
+	client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool) (deploy.Source, error) {
 
 	// Like Update, we need to gather the set of plugins necessary to delete everything in the snapshot.

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -517,24 +517,13 @@ func (e *eventEmitter) preludeEvent(isPreview bool, cfg config.Map) {
 	})
 }
 
-func (e *eventEmitter) previewSummaryEvent(resourceChanges ResourceChanges, policyPacks map[string]string) {
+func (e *eventEmitter) summaryEvent(preview, maybeCorrupt bool, duration time.Duration, resourceChanges ResourceChanges,
+	policyPacks map[string]string) {
+
 	contract.Requiref(e != nil, "e", "!= nil")
 
 	e.ch <- NewEvent(SummaryEvent, SummaryEventPayload{
-		IsPreview:       true,
-		MaybeCorrupt:    false,
-		Duration:        0,
-		ResourceChanges: resourceChanges,
-		PolicyPacks:     policyPacks,
-	})
-}
-
-func (e *eventEmitter) updateSummaryEvent(maybeCorrupt bool,
-	duration time.Duration, resourceChanges ResourceChanges, policyPacks map[string]string) {
-	contract.Requiref(e != nil, "e", "!= nil")
-
-	e.ch <- NewEvent(SummaryEvent, SummaryEventPayload{
-		IsPreview:       false,
+		IsPreview:       preview,
 		MaybeCorrupt:    maybeCorrupt,
 		Duration:        duration,
 		ResourceChanges: resourceChanges,

--- a/pkg/engine/import.go
+++ b/pkg/engine/import.go
@@ -28,7 +28,7 @@ func Import(u UpdateInfo, ctx *Context, opts UpdateOptions, imports []deploy.Imp
 
 	defer func() { ctx.Events <- cancelEvent() }()
 
-	info, err := newPlanContext(u, "import", ctx.ParentSpan)
+	info, err := newDeploymentContext(u, "import", ctx.ParentSpan)
 	if err != nil {
 		return nil, result.FromError(err)
 	}
@@ -40,7 +40,7 @@ func Import(u UpdateInfo, ctx *Context, opts UpdateOptions, imports []deploy.Imp
 	}
 	defer emitter.Close()
 
-	return update(ctx, info, planOptions{
+	return update(ctx, info, deploymentOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newRefreshSource,
 		Events:        emitter,

--- a/pkg/engine/refresh.go
+++ b/pkg/engine/refresh.go
@@ -29,7 +29,7 @@ func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 
 	defer func() { ctx.Events <- cancelEvent() }()
 
-	info, err := newPlanContext(u, "refresh", ctx.ParentSpan)
+	info, err := newDeploymentContext(u, "refresh", ctx.ParentSpan)
 	if err != nil {
 		return nil, result.FromError(err)
 	}
@@ -44,7 +44,7 @@ func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 	// Force opts.Refresh to true.
 	opts.Refresh = true
 
-	return update(ctx, info, planOptions{
+	return update(ctx, info, deploymentOptions{
 		UpdateOptions: opts,
 		SourceFunc:    newRefreshSource,
 		Events:        emitter,
@@ -54,7 +54,7 @@ func Refresh(u UpdateInfo, ctx *Context, opts UpdateOptions, dryRun bool) (Resou
 	}, dryRun)
 }
 
-func newRefreshSource(client deploy.BackendClient, opts planOptions, proj *workspace.Project, pwd, main string,
+func newRefreshSource(client deploy.BackendClient, opts deploymentOptions, proj *workspace.Project, pwd, main string,
 	target *deploy.Target, plugctx *plugin.Context, dryRun bool) (deploy.Source, error) {
 
 	// Like Update, we need to gather the set of plugins necessary to refresh everything in the snapshot.


### PR DESCRIPTION
This name better suits the semantics of the type, and aligns with the
rename of deploy.Plan to deploy.Deployment. These changes also refactor
the `update` method s.t. previews and updates are more consistent in
their behavior (e.g. duration and resource changes are now reported for
both, incl. on error paths).