### PR TITLE
Respect PULUMI_PYTHON_CMD in scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Respect PULUMI_PYTHON_CMD in scripts.
+  [#5782](https://github.com/pulumi/pulumi/pull/5782)
 
 ## 2.14.0 (2020-11-18)
 

--- a/sdk/python/dist/pulumi-analyzer-policy-python
+++ b/sdk/python/dist/pulumi-analyzer-policy-python
@@ -47,6 +47,6 @@ if [ -n "${virtualenv:-}" ] ; then
         exit 1
     fi
 else
-    # Otherwise, just run python3.
-    python3 -u -m pulumi.policy "$1" "$2"
+    # Otherwise, run either PULUMI_PYTHON_CMD (if set) or python3.
+    "${PULUMI_PYTHON_CMD:-python3}" -u -m pulumi.policy "$1" "$2"
 fi

--- a/sdk/python/dist/pulumi-analyzer-policy-python.cmd
+++ b/sdk/python/dist/pulumi-analyzer-policy-python.cmd
@@ -37,7 +37,12 @@ if defined pulumi_runtime_python_virtualenv (
         exit 1
     )
 ) else (
-    REM Otherwise, just run python. We use `python` instead of `python3` because Windows
-    REM Python installers install only `python.exe` by default.
-    @python -u -m pulumi.policy %pulumi_policy_python_engine_address% %pulumi_policy_python_program%
+    if defined PULUMI_PYTHON_CMD (
+        REM If PULUMI_PYTHON_CMD is defined, run it.
+        "%PULUMI_PYTHON_CMD%" -u -m pulumi.policy %pulumi_policy_python_engine_address% %pulumi_policy_python_program%
+    ) else (
+        REM Otherwise, just run python. We use `python` instead of `python3` because Windows
+        REM Python installers install only `python.exe` by default.
+        @python -u -m pulumi.policy %pulumi_policy_python_engine_address% %pulumi_policy_python_program%
+    )
 )

--- a/sdk/python/dist/pulumi-resource-pulumi-python
+++ b/sdk/python/dist/pulumi-resource-pulumi-python
@@ -35,6 +35,6 @@ if [ -n "${PULUMI_RUNTIME_VIRTUALENV:-}" ] ; then
         exit 1
     fi
 else
-    # Otherwise, just run python3.
-    python3 -u -m pulumi.dynamic $@
+    # Otherwise, run either PULUMI_PYTHON_CMD (if set) or python3.
+    "${PULUMI_PYTHON_CMD:-python3}" -u -m pulumi.dynamic $@
 fi

--- a/sdk/python/dist/pulumi-resource-pulumi-python.cmd
+++ b/sdk/python/dist/pulumi-resource-pulumi-python.cmd
@@ -20,7 +20,12 @@ if defined PULUMI_RUNTIME_VIRTUALENV (
         exit 1
     )
 ) else (
-    REM Otherwise, just run python. We use `python` instead of `python3` because Windows
-    REM Python installers install only `python.exe` by default.
-    @python -u -m pulumi.dynamic %*
+    if defined PULUMI_PYTHON_CMD (
+        REM If PULUMI_PYTHON_CMD is defined, run it.
+        "%PULUMI_PYTHON_CMD%" -u -m pulumi.dynamic %*
+    ) else (
+        REM Otherwise, just run python. We use `python` instead of `python3` because Windows
+        REM Python installers install only `python.exe` by default.
+        @python -u -m pulumi.dynamic %*
+    )
 )


### PR DESCRIPTION
If `PULUMI_PYTHON_CMD` is set, use it instead of running `python` directly.

Fixes https://github.com/pulumi/pulumi/issues/5518