### PR TITLE
Allow schemas to reference to provider types.

### DIFF
--- a/pkg/codegen/internal/test/testdata/external-resource-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/schema.json
@@ -35,6 +35,13 @@
         }
       },
       "type": "object"
+    },
+    "example::Component": {
+      "properties": {
+        "provider": {
+          "$ref": "/kubernetes/v2.6.3/schema.json#/provider"
+        }
+      }
     }
   },
   "functions": {

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -20,6 +20,7 @@ import (
 	"math"
 	"net/url"
 	"os"
+	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -975,47 +976,35 @@ func (t *types) bindPrimitiveType(name string) (Type, error) {
 	}
 }
 
-// externalSchemaRef contains the parsed fields for an external schema ref.
-type externalSchemaRef struct {
-	Package string          // The package component of the schema ref
-	Version *semver.Version // The version component of the schema ref
-}
-
 // typeSpecRef contains the parsed fields from a type spec reference.
 type typeSpecRef struct {
-	*externalSchemaRef
+	URL *url.URL // The parsed URL
 
-	URL   *url.URL // The parsed URL
-	Token string   // The type token
-	Kind  string   // The kind of reference, either 'resources' or 'types'
+	Package string          // The package component of the schema ref
+	Version *semver.Version // The version component of the schema ref
+
+	Kind  string // The kind of reference: 'resources', 'types', or 'provider'
+	Token string // The type token
 }
 
-// Regexs used to parse type spec refs. These are declared at the package scope to avoid repeatedly recompiling them.
-var refPathRegex = regexp.MustCompile(`^/?(?P<package>\w+)/(?P<version>v?\d+\.\d+\.\d+)/schema\.json$`)
-var refFragmentRegex = regexp.MustCompile(`^/(?P<kind>resources|types)/(?P<token>.*:.*:.*)$`)
+const (
+	resourcesRef = "resources"
+	typesRef     = "types"
+	providerRef  = "provider"
+)
 
-func parseTypeSpecRef(ref string) (typeSpecRef, error) {
+// Regex used to parse external schema paths. This is declared at the package scope to avoid repeated recompilation.
+var refPathRegex = regexp.MustCompile(`^/?(?P<package>\w+)/(?P<version>v[^/]*)/schema\.json$`)
+
+func (t *types) parseTypeSpecRef(ref string) (typeSpecRef, error) {
 	parsedURL, err := url.Parse(ref)
 	if err != nil {
 		return typeSpecRef{}, errors.Wrapf(err, "failed to parse ref URL: %s", ref)
 	}
 
-	fragment, err := url.PathUnescape(parsedURL.Fragment)
-	if err != nil {
-		return typeSpecRef{}, errors.Wrapf(err, "failed to unescape fragment: %s", parsedURL.Fragment)
-	}
-
-	fragmentMatch := refFragmentRegex.FindStringSubmatch(fragment)
-	if len(fragmentMatch) != 3 {
-		return typeSpecRef{}, fmt.Errorf("failed to parse fragment: %s", fragment)
-	}
-
-	result := typeSpecRef{
-		URL:   parsedURL,
-		Kind:  fragmentMatch[1],
-		Token: fragmentMatch[2],
-	}
-
+	// Parse the package name and version if the URL contains a path. If there is no path--if the URL is just a
+	// fragment--then the reference refers to the package being bound.
+	pkgName, pkgVersion := t.pkg.Name, t.pkg.Version
 	if len(parsedURL.Path) > 0 {
 		path, err := url.PathUnescape(parsedURL.Path)
 		if err != nil {
@@ -1033,13 +1022,58 @@ func parseTypeSpecRef(ref string) (typeSpecRef, error) {
 			return typeSpecRef{}, errors.Wrapf(err, "failed to parse package version: %s", versionToken)
 		}
 
-		result.externalSchemaRef = &externalSchemaRef{
-			Package: pkg,
-			Version: &version,
-		}
+		pkgName, pkgVersion = pkg, &version
 	}
 
-	return result, nil
+	// Parse the fragment into a reference kind and token. The fragment is in one of two forms:
+	// 1. #/provider
+	// 2. #/(resources|types)/some:type:token
+	//
+	// Unfortunately, early code generators were lax and emitted unescaped backslashes in the type token, so we can't
+	// just split on "/".
+	fragment := path.Clean(parsedURL.EscapedFragment())
+	if path.IsAbs(fragment) {
+		fragment = fragment[1:]
+	}
+
+	kind, token := "", ""
+	slash := strings.Index(fragment, "/")
+	if slash == -1 {
+		kind = fragment
+	} else {
+		kind, token = fragment[:slash], fragment[slash+1:]
+	}
+
+	switch kind {
+	case "provider":
+		if token != "" {
+			return typeSpecRef{}, fmt.Errorf("invalid provider reference '%v'", ref)
+		}
+		token = "pulumi:providers:" + pkgName
+	case "resources", "types":
+		token, err = url.PathUnescape(token)
+		if err != nil {
+			return typeSpecRef{}, errors.Wrapf(err, "failed to unescape token: %s", token)
+		}
+	default:
+		return typeSpecRef{}, fmt.Errorf("invalid type reference '%v'", ref)
+	}
+
+	return typeSpecRef{
+		URL:     parsedURL,
+		Package: pkgName,
+		Version: pkgVersion,
+		Kind:    kind,
+		Token:   token,
+	}, nil
+}
+
+func versionEquals(a, b *semver.Version) bool {
+	// We treat "nil" as "unconstrained".
+	if a == nil || b == nil {
+		return true
+	}
+	return a.Equals(*b)
 }
 
 func (t *types) bindTypeSpecRef(spec TypeSpec) (Type, error) {
@@ -1055,37 +1089,37 @@ func (t *types) bindTypeSpecRef(spec TypeSpec) (Type, error) {
 		return AnyType, nil
 	}
 
-	ref, err := parseTypeSpecRef(spec.Ref)
+	ref, err := t.parseTypeSpecRef(spec.Ref)
 	if err != nil {
 		return nil, err
 	}
 
-	if ref.externalSchemaRef != nil {
-		pkg, err := t.loader.LoadPackage(ref.externalSchemaRef.Package, ref.externalSchemaRef.Version)
+	// If this is a reference to an external sch
+	referencesExternalSchema := ref.Package != t.pkg.Name || !versionEquals(ref.Version, t.pkg.Version)
+	if referencesExternalSchema {
+		pkg, err := t.loader.LoadPackage(ref.Package, ref.Version)
 		if err != nil {
 			return nil, errors.Wrapf(err, "resolving package %v", ref.URL)
 		}
 
 		switch ref.Kind {
-		case "types":
+		case typesRef:
 			typ, ok := pkg.GetType(ref.Token)
 			if !ok {
-				return nil, fmt.Errorf("type %v not found in package %v",
-					ref.Token, ref.externalSchemaRef.Package)
+				return nil, fmt.Errorf("type %v not found in package %v", ref.Token, ref.Package)
 			}
 			return typ, nil
-		case "resources":
+		case resourcesRef, providerRef:
 			typ, ok := pkg.GetResourceType(ref.Token)
 			if !ok {
-				return nil, fmt.Errorf("resource type %v not found in package %v",
-					ref.Token, ref.externalSchemaRef.Package)
+				return nil, fmt.Errorf("resource type %v not found in package %v", ref.Token, ref.Package)
 			}
 			return typ, nil
 		}
 	}
 
 	switch ref.Kind {
-	case "types":
+	case typesRef:
 		if typ, ok := t.objects[ref.Token]; ok {
 			return typ, nil
 		}
@@ -1105,7 +1139,7 @@ func (t *types) bindTypeSpecRef(spec TypeSpec) (Type, error) {
 			t.tokens[ref.Token] = typ
 		}
 		return typ, nil
-	case "resources":
+	case resourcesRef, providerRef:
 		typ, ok := t.resources[ref.Token]
 		if !ok {
 			typ = &ResourceType{Token: ref.Token}
@@ -1554,6 +1588,12 @@ func bindProvider(pkgName string, spec ResourceSpec, types *types) (*Resource, e
 		return nil, errors.Wrap(err, "error binding provider")
 	}
 	res.IsProvider = true
+
+	types.resources[res.Token] = &ResourceType{
+		Token:    res.Token,
+		Resource: res,
+	}
+
 	return res, nil
 }
 

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -207,6 +207,13 @@ func Test_parseTypeSpecRef(t *testing.T) {
 		return parsed
 	}
 
+	typs := &types{
+		pkg: &Package{
+			Name:    "test",
+			Version: toVersionPtr("1.2.3"),
+		},
+	}
+
 	tests := []struct {
 		name    string
 		ref     string
@@ -217,68 +224,88 @@ func Test_parseTypeSpecRef(t *testing.T) {
 			name: "resourceRef",
 			ref:  "#/resources/example::Resource",
 			want: typeSpecRef{
-				URL:   toURL("#/resources/example::Resource"),
-				Token: "example::Resource",
-				Kind:  "resources",
+				URL:     toURL("#/resources/example::Resource"),
+				Package: "test",
+				Version: toVersionPtr("1.2.3"),
+				Kind:    "resources",
+				Token:   "example::Resource",
 			},
 		},
 		{
 			name: "typeRef",
-			ref:  "#/types/kubernetes:admissionregistration.k8s.io/v1:WebhookClientConfig",
+			ref:  "#/types/kubernetes:admissionregistration.k8s.io%2fv1:WebhookClientConfig",
 			want: typeSpecRef{
-				URL:   toURL("#/types/kubernetes:admissionregistration.k8s.io/v1:WebhookClientConfig"),
-				Token: "kubernetes:admissionregistration.k8s.io/v1:WebhookClientConfig",
-				Kind:  "types",
+				URL:     toURL("#/types/kubernetes:admissionregistration.k8s.io%2fv1:WebhookClientConfig"),
+				Package: "test",
+				Version: toVersionPtr("1.2.3"),
+				Kind:    "types",
+				Token:   "kubernetes:admissionregistration.k8s.io/v1:WebhookClientConfig",
+			},
+		},
+		{
+			name: "providerRef",
+			ref:  "#/provider",
+			want: typeSpecRef{
+				URL:     toURL("#/provider"),
+				Package: "test",
+				Version: toVersionPtr("1.2.3"),
+				Kind:    "provider",
+				Token:   "pulumi:providers:test",
 			},
 		},
 		{
 			name: "externalResourceRef",
-			ref:  "/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet",
+			ref:  "/random/v2.3.1/schema.json#/resources/random:index%2frandomPet:RandomPet",
 			want: typeSpecRef{
-				externalSchemaRef: &externalSchemaRef{
-					Package: "random",
-					Version: toVersionPtr("2.3.1"),
-				},
-				URL:   toURL("/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet"),
-				Token: "random:index/randomPet:RandomPet",
-				Kind:  "resources",
+				URL:     toURL("/random/v2.3.1/schema.json#/resources/random:index%2frandomPet:RandomPet"),
+				Package: "random",
+				Version: toVersionPtr("2.3.1"),
+				Kind:    "resources",
+				Token:   "random:index/randomPet:RandomPet",
 			},
 		},
 		{
 			name:    "invalid externalResourceRef",
-			ref:     "/random/schema.json#/resources/random:index/randomPet:RandomPet",
+			ref:     "/random/schema.json#/resources/random:index%2frandomPet:RandomPet",
 			wantErr: true,
 		},
 		{
 			name: "externalTypeRef",
-			ref:  "/kubernetes/v2.6.3/schema.json#/types/kubernetes:admissionregistration.k8s.io/v1:WebhookClientConfig",
+			ref:  "/kubernetes/v2.6.3/schema.json#/types/kubernetes:admissionregistration.k8s.io%2Fv1:WebhookClientConfig",
 			want: typeSpecRef{
-				externalSchemaRef: &externalSchemaRef{
-					Package: "kubernetes",
-					Version: toVersionPtr("2.6.3"),
-				},
-				URL:   toURL("/kubernetes/v2.6.3/schema.json#/types/kubernetes:admissionregistration.k8s.io/v1:WebhookClientConfig"),
-				Token: "kubernetes:admissionregistration.k8s.io/v1:WebhookClientConfig",
-				Kind:  "types",
+				URL:     toURL("/kubernetes/v2.6.3/schema.json#/types/kubernetes:admissionregistration.k8s.io%2Fv1:WebhookClientConfig"),
+				Package: "kubernetes",
+				Version: toVersionPtr("2.6.3"),
+				Kind:    "types",
+				Token:   "kubernetes:admissionregistration.k8s.io/v1:WebhookClientConfig",
 			},
 		},
 		{
 			name: "externalHostResourceRef",
-			ref:  "https://example.com/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet",
+			ref:  "https://example.com/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet",
 			want: typeSpecRef{
-				externalSchemaRef: &externalSchemaRef{
-					Package: "random",
-					Version: toVersionPtr("2.3.1"),
-				},
-				URL:   toURL("https://example.com/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet"),
-				Token: "random:index/randomPet:RandomPet",
-				Kind:  "resources",
+				URL:     toURL("https://example.com/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"),
+				Package: "random",
+				Version: toVersionPtr("2.3.1"),
+				Kind:    "resources",
+				Token:   "random:index/randomPet:RandomPet",
+			},
+		},
+		{
+			name: "externalProviderRef",
+			ref:  "/kubernetes/v2.6.3/schema.json#/provider",
+			want: typeSpecRef{
+				URL:     toURL("/kubernetes/v2.6.3/schema.json#/provider"),
+				Package: "kubernetes",
+				Version: toVersionPtr("2.6.3"),
+				Kind:    "provider",
+				Token:   "pulumi:providers:kubernetes",
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseTypeSpecRef(tt.ref)
+			got, err := typs.parseTypeSpecRef(tt.ref)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("parseTypeSpecRef() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
These changes extend the type reference parser in the schema package to
accept references of the form "(package/version/schema.json)?#/provider".
These references refer to the package's provider type, which is
otherwise not referenceable, as it is not present in the "resources"
array.