### PR TITLE
Update Python resource ref deserialization.

### DIFF
--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -8,6 +8,7 @@ protobuf = ">=3.6.0"
 grpcio = ">=1.9.1,!=1.30.0"
 dill = ">=0.3.0"
 six = ">=1.12.0"
+semver = ">=2.8.1"
 
 [dev-packages]
 pylint = ">=2.1"

--- a/sdk/python/Pipfile.lock
+++ b/sdk/python/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3b7dc22140f5503eebf92f8736423441b156e5fcfb4b2ad5289e84f3b43a1022"
+            "sha256": "9cd597f60021dae702cd200db0169810b0c1e5ece359c495f625c5e476a724c5"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -97,6 +97,14 @@
             ],
             "index": "pypi",
             "version": "==3.14.0"
+        },
+        "semver": {
+            "hashes": [
+                "sha256:ced8b23dceb22134307c1b8abfa523da14198793d9787ac838e70e29e77458d4",
+                "sha256:fa0fe2722ee1c3f57eac478820c3a5ae2f624af8264cbdf9000c980ff7f75e3f"
+            ],
+            "index": "pypi",
+            "version": "==2.13.0"
         },
         "six": {
             "hashes": [

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -36,6 +36,8 @@ setup(name='pulumi',
       install_requires=[
           'protobuf>=3.6.0',
           'dill>=0.3.0',
-          'grpcio>=1.9.1,!=1.30.0'
+          'grpcio>=1.9.1,!=1.30.0',
+          'six>=1.12.0',
+          'semver>=2.8.1'
       ],
       zip_safe=False)


### PR DESCRIPTION
There are two significant changes in this commit: one to the way
resource packages/modules are stored and retrieved, and one to resource
ref deserialization in the face of missing resource packages/modules.

Resource packages and modules no longer require an exact version match
during deserialization. Instead, the newest compatible version of the
package or module is selected. If no version was specified, the newest
version of the package or module will be chosen. As a special case, a
package or module that has no version will always be treated as the best
version for that package or module.

If a resource package or module is not found when attempting to
deserialize a resource reference, the SDK no longer emits an error, and
instead deserializes the reference as its URN or ID (if present). This
accommodates providers that have not yet been updated to include the
appropriate factory registrations.