### PR TITLE
Improve the output when installing plugins

### DIFF
--- a/pkg/cmd/pulumi/plugin_install.go
+++ b/pkg/cmd/pulumi/plugin_install.go
@@ -16,9 +16,10 @@ package main
 
 import (
 	"fmt"
-	"github.com/pulumi/pulumi/sdk/v2/go/common/util/logging"
 	"io"
 	"os"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/logging"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -96,8 +97,6 @@ func newPluginInstallCmd() *cobra.Command {
 			// Now for each kind, name, version pair, download it from the release website, and install it.
 			for _, install := range installs {
 				label := fmt.Sprintf("[%s plugin %s]", install.Kind, install)
-				cmdutil.Diag().Infoerrf(
-					diag.Message("", "%s installing"), label)
 
 				// If the plugin already exists, don't download it unless --reinstall was passed.  Note that
 				// by default we accept plugins with >= constraints, unless --exact was passed which requires ==.
@@ -114,6 +113,9 @@ func newPluginInstallCmd() *cobra.Command {
 						}
 					}
 				}
+
+				cmdutil.Diag().Infoerrf(
+					diag.Message("", "%s installing"), label)
 
 				// If we got here, actually try to do the download.
 				var source string


### PR DESCRIPTION
Two improvements:

1. Don't display "[resource plugin <foo>] installing" if the plugin is already installed.

2. Close the plugin download progress bar before displaying any subsequent output, and only show output of `npm install` when there is an error.

Fixes https://github.com/pulumi/pulumi/issues/5807