### PR TITLE
[codegen/python] - Include inputs import in provider.py

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -725,7 +725,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	visitObjectTypesFromProperties(res.InputProperties, inputSeen, func(t interface{}) {
 		switch T := t.(type) {
 		case *schema.ObjectType:
-			imports.addType(mod, T.Token, !res.IsProvider)
+			imports.addType(mod, T.Token, true /*input*/)
 		case *schema.ResourceType:
 			imports.addResource(mod, T.Token)
 		}


### PR DESCRIPTION
[`provider.py`](https://github.com/pulumi/pulumi-aws/blob/master/sdk/python/pulumi_aws/provider.py#L21-L22) is missing the `inputs` import. This corrects the issue.