### PR TITLE
Populate package for doc args types

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -662,7 +662,8 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) []formalParam {
 	name := resourceName(r)
 	argsSchemaType := &schema.ObjectType{
-		Token: r.Token,
+		Token:   r.Token,
+		Package: mod.pkg,
 	}
 	// Get the C#-specific name for the args type, which will be the fully-qualified name.
 	characteristics := propertyCharacteristics{

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -187,7 +187,8 @@ func (mod *modContext) genFunctionGo(f *schema.Function, funcName string) []form
 func (mod *modContext) genFunctionCS(f *schema.Function, funcName string) []formalParam {
 	argsType := funcName + "Args"
 	argsSchemaType := &schema.ObjectType{
-		Token: f.Token,
+		Token:   f.Token,
+		Package: mod.pkg,
 	}
 
 	characteristics := propertyCharacteristics{


### PR DESCRIPTION
This fixes a panic during docs generation which occurs in the recent .NET codegen block which evaluates the package of an object type

https://github.com/pulumi/docs/runs/1443615556?check_suite_focus=true#step:15:83