### PR TITLE
Ensure EncryptionKey is regenerated when changing secrets provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ CHANGELOG
 
 - [sdk/dotnet] Add support for dependency injection into TStack instance by adding an overload to `Deployment.RunAsync`. The overload accepts an `IServiceProvider` that is used to create the instance of TStack. Also added a new method `Deployment.TestWithServiceProviderAsync` for testing stacks that use dependency injection. 
   [#5723](https://github.com/pulumi/pulumi/pull/5723/)
+  
+- [cli] Ensure `pulumi stack change-secrets-provider` allows rotating the key in Azure KeyVault
+  [#5842](https://github.com/pulumi/pulumi/pull/5842/)
 
 ## 2.14.0 (2020-11-18)
 

--- a/pkg/cmd/pulumi/crypto_cloud.go
+++ b/pkg/cmd/pulumi/crypto_cloud.go
@@ -48,7 +48,10 @@ func newCloudSecretsManager(stackName tokens.QName, configFile, secretsProvider 
 	}
 
 	var secretsManager *cloud.Manager
-	if info.EncryptedKey == "" {
+
+	// if there is no key OR the secrets provider is changing
+	// then we need to generate the new key based on the new secrets provider
+	if info.EncryptedKey == "" || info.SecretsProvider != secretsProvider {
 		dataKey, err := cloud.GenerateNewDataKey(secretsProvider)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Fixes: #5835

when rotating a key in the Azure KeyVault secrets provider, we had
the following error:

```
error: secrets (code=InvalidArgument): keyvault.BaseClient#Decrypt: Failure responding to request: StatusCode=400 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="BadParameter" Message="The parameter is incorrect.\r\n"
```

This was because we were not regenerating the EncrytpionKey when
we were changing the secrets provider. Therefore, we now ensure
that this key is regenerated and we can successfully change the secrets provider

```
▶ pulumi stack init dev --secrets-provider="azurekeyvault://stack72kv10.vault.azure.net/keys/pulumi-secret"
Created stack 'dev'

▶ pulumi config set MyDBRootPassword Password1234! --secret

▶ pulumi config --show-secrets
KEY               VALUE
MyDBRootPassword  Password1234!

▶ pulumi stack change-secrets-provider "azurekeyvault://stack72kv20.vault.azure.net/keys/pulumi-secret"

▶ pulumi config --show-secrets
KEY               VALUE
MyDBRootPassword  Password1234!
```