### PR TITLE
Avoid unnecessary diagnostic messages for programs that use multi-lang components

### DIFF
--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -279,8 +279,6 @@ class Server implements grpc.UntypedServiceImplementation {
             const deserializedInputs = runtime.deserializeProperties(req.getInputs());
             for (const k of Object.keys(deserializedInputs)) {
                 const inputDeps = inputDependencies.get(k);
-                console.log(`${k}: ${inputDeps ? JSON.stringify(inputDeps.getUrnsList()) : []}`);
-
                 const deps = (inputDeps ? <resource.URN[]>inputDeps.getUrnsList() : [])
                     .map(depUrn => new resource.DependencyResource(depUrn));
                 const input = deserializedInputs[k];


### PR DESCRIPTION
Remove a `console.log` call that's adding unnecessary diagnostic messages to programs that use multi-lang components implemented in TS/JS.

Avoids output like the following during `pulumi preview|up`:

```
Diagnostics:
  pulumi:pulumi:Stack (clusterex-dev):
    instanceRoles: ["urn:pulumi:dev::clusterex::aws:iam/role:Role::example-role1","urn:pulumi:dev::clusterex::aws:iam/role:Role::example-role0","urn:pulumi:dev::clusterex::aws:iam/role:Role::example-role2"]
    skipDefaultNodeGroup: []
```