### PR TITLE
Enable resource reference feature by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ CHANGELOG
   
 - [cli] Ensure `pulumi stack change-secrets-provider` allows rotating the key in Azure KeyVault
   [#5842](https://github.com/pulumi/pulumi/pull/5842/)
+  
+- Enable resource reference feature by default.
+  [#5848](https://github.com/pulumi/pulumi/pull/5848)
 
 ## 2.14.0 (2020-11-18)
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -531,7 +531,12 @@ func (rm *resmon) SupportsFeature(ctx context.Context,
 	case "secrets":
 		hasSupport = true
 	case "resourceReferences":
-		hasSupport = cmdutil.IsTruthy(os.Getenv("PULUMI_EXPERIMENTAL_RESOURCE_REFERENCES"))
+		hasSupport = true
+
+		// If the experimental flag is explicitly set to a falsy value, disable this feature.
+		if v, ok := os.LookupEnv("PULUMI_EXPERIMENTAL_RESOURCE_REFERENCES"); ok && !cmdutil.IsTruthy(v) {
+			hasSupport = false
+		}
 	}
 
 	logging.V(5).Infof("ResourceMonitor.SupportsFeature(id: %s) = %t", req.Id, hasSupport)

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -533,8 +533,8 @@ func (rm *resmon) SupportsFeature(ctx context.Context,
 	case "resourceReferences":
 		hasSupport = true
 
-		// If the experimental flag is explicitly set to a falsy value, disable this feature.
-		if v, ok := os.LookupEnv("PULUMI_EXPERIMENTAL_RESOURCE_REFERENCES"); ok && !cmdutil.IsTruthy(v) {
+		// Allow the resource reference feature to be disabled by explicitly setting an env var.
+		if v, ok := os.LookupEnv("PULUMI_DISABLE_RESOURCE_REFERENCES"); ok && cmdutil.IsTruthy(v) {
 			hasSupport = false
 		}
 	}


### PR DESCRIPTION
Unless the PULUMI_DISABLE_RESOURCE_REFERENCES flag
is explicitly set to a truthy value, the resource reference feature is now
enabled by default.

Fix #5838 