### PR TITLE
Revert "Enable resource reference feature by default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@ CHANGELOG
 
 - [cli] Ensure `pulumi stack change-secrets-provider` allows rotating the key in Azure KeyVault
   [#5842](https://github.com/pulumi/pulumi/pull/5842/)
-  
-- Enable resource reference feature by default.
-  [#5848](https://github.com/pulumi/pulumi/pull/5848)
 
 ## 2.14.0 (2020-11-18)
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -531,12 +531,7 @@ func (rm *resmon) SupportsFeature(ctx context.Context,
 	case "secrets":
 		hasSupport = true
 	case "resourceReferences":
-		hasSupport = true
-
-		// Allow the resource reference feature to be disabled by explicitly setting an env var.
-		if v, ok := os.LookupEnv("PULUMI_DISABLE_RESOURCE_REFERENCES"); ok && cmdutil.IsTruthy(v) {
-			hasSupport = false
-		}
+		hasSupport = cmdutil.IsTruthy(os.Getenv("PULUMI_EXPERIMENTAL_RESOURCE_REFERENCES"))
 	}
 
 	logging.V(5).Infof("ResourceMonitor.SupportsFeature(id: %s) = %t", req.Id, hasSupport)


### PR DESCRIPTION
To de-risk the Pulumi v2.15.0 release, temporarily revert 679d40950f54c3c22827bec9e9bad4edcd27dacb. Use of resource references will require `PULUMI_EXPERIMENTAL_RESOURCE_REFERENCES=1` to be set until the feature has been enabled by default.