### PR TITLE
Make credentials.json file writes concurrency safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- [sdk/python] Address potential issues when running multiple `pulumi` processes concurrently.
+  [#5857](https://github.com/pulumi/pulumi/pull/5857)
+
 
 ## 2.15.0 (2020-12-02)
 

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -213,5 +213,23 @@ func StoreCredentials(creds Credentials) error {
 	if err != nil {
 		return errors.Wrapf(err, "marshalling credentials object")
 	}
-	return ioutil.WriteFile(credsFile, raw, 0600)
+
+	tempCredsFile, err := ioutil.TempFile("", "credentials-*.json")
+	if err != nil {
+		return err
+	}
+	_, err = tempCredsFile.Write(raw)
+	if err != nil {
+		return err
+	}
+	err = tempCredsFile.Close()
+	if err != nil {
+		return err
+	}
+	err = os.Rename(tempCredsFile.Name(), credsFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -1,0 +1,30 @@
+package workspace
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcurrentCredentialsWrites(t *testing.T) {
+	creds, err := GetStoredCredentials()
+	assert.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 1000; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			err := StoreCredentials(creds)
+			assert.NoError(t, err)
+		}()
+		go func() {
+			defer wg.Done()
+			_, err := GetStoredCredentials()
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
Running `pulumi` operations in parallel could occasionally result in truncating the `~/.pulumi/credentials.json` file and reading that truncated file from another process before the content could be written.

Instead, use `os.Rename` to atomically replace the file contents.

Concurrent `pulumi` operations could still compete for who gets to write the file first, and could lead to surprising results in some extreme cases.   But we should not see the corrupted file contents any longer.

Fixes #3877.