### PR TITLE
Properly resize arrays when adding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Fix a problem where `pulumi import` could panic on importing arrays and sets, due to
+  incorrect array resizing logic. [#5872](https://github.com/pulumi/pulumi/pull/5872).
 
 ## 2.15.1 (2020-12-04)
 

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -187,10 +187,9 @@ func (p PropertyPath) Add(dest, v PropertyValue) (PropertyValue, bool) {
 			case dest.IsArray():
 				// If the destination array does exist, ensure that it is large enough to accommodate the requested
 				// index.
-				arr := dest.ArrayValue()
-				if key >= len(arr) {
-					arr = append(make([]PropertyValue, key+1-len(arr)), arr...)
-					v.V = arr
+				if arr := dest.ArrayValue(); key >= len(arr) {
+					dest = NewArrayProperty(append(make([]PropertyValue, key+1-len(arr)), arr...))
+					set(dest)
 				}
 			default:
 				return PropertyValue{}, false

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -170,3 +170,12 @@ func TestPropertyPath(t *testing.T) {
 		})
 	}
 }
+
+func TestAddResizePropertyPath(t *testing.T) {
+	// Regression test for https://github.com/pulumi/pulumi/issues/5871:
+	// Ensure that adding a new element beyond the size of an array will resize it.
+	path, err := ParsePropertyPath("[1]")
+	assert.Nil(t, err)
+	_, ok := path.Add(NewArrayProperty([]PropertyValue{}), NewNumberProperty(42))
+	assert.True(t, ok)
+}


### PR DESCRIPTION
The current logic attempts to update the array but, because
append may need to allocate a new array with adequate space,
the code can currently leave dest referring to the old,
under-sized array. The solution is to use the set(dest)
logic that already exists and is used for the IsNull case.

Added a test case that would fail before this fix and now passes.

This fixes pulumi/pulumi#5871.