### PR TITLE
Ensure we have an import error before using in import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Fix a problem where `pulumi import` could panic on an import error due to missing error message. 
+  [#5884](https://github.com/pulumi/pulumi/pull/5884)
 
 ## 2.15.3 (2020-12-07)
 

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -456,7 +456,7 @@ func (ex *deploymentExecutor) importResources(callerCtx context.Context, opts Op
 	canceled := callerCtx.Err() != nil
 
 	if res != nil || stepExec.Errored() {
-		if res.Error() != nil {
+		if res != nil && res.Error() != nil {
 			ex.reportExecResult(fmt.Sprintf("failed: %s", res.Error()), preview)
 		} else {
 			ex.reportExecResult("failed", preview)


### PR DESCRIPTION
Without this, we can panic. 

Fixes: https://github.com/pulumi/pulumi/issues/5883
Fixes: https://github.com/pulumi/pulumi/issues/5860
Fixes: https://github.com/pulumi/pulumi/issues/5876
Fixes: https://github.com/pulumi/pulumi-aws/issues/1252

Previous behaviour:

```
     Type                 Name                 Plan
 +   pulumi:pulumi:Stack  import-post-dev      create.
 =   └─ aws:iam:Policy    AdministratorAccess  import.
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x4a80f56]

goroutine 73 [running]:
github.com/pulumi/pulumi/pkg/v2/resource/deploy.(*deploymentExecutor).importResources(0xc000eefa60, 0x5c10020, 0xc00151c4e0, 0x869c2a8, 0xc0005b2dc0, 0x7fffffff, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/runner/work/pulumi/pulumi/pkg/resource/deploy/deployment_executor.go:459 +0x276
github.com/pulumi/pulumi/pkg/v2/resource/deploy.(*deploymentExecutor).Execute(0xc000eefa60, 0x5c10020, 0xc00151c4e0, 0x869c2a8, 0xc0005b2dc0, 0x7fffffff, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/runner/work/pulumi/pulumi/pkg/resource/deploy/deployment_executor.go:138 +0x1247
github.com/pulumi/pulumi/pkg/v2/resource/deploy.(*Deployment).Execute(...)
	/Users/runner/work/pulumi/pulumi/pkg/resource/deploy/deployment.go:383
github.com/pulumi/pulumi/pkg/v2/engine.(*deployment).run.func1(0x5c1ac60, 0xc0005b2dc0, 0xc0005b3180, 0x5c10020, 0xc00151c4e0, 0xc00151c401, 0xc000e91f10, 0xc0000a3aa0)
	/Users/runner/work/pulumi/pulumi/pkg/engine/deployment.go:251 +0x267
created by github.com/pulumi/pulumi/pkg/v2/engine.(*deployment).run
	/Users/runner/work/pulumi/pulumi/pkg/engine/deployment.go:237 +0x306
```

New behaviour:

```
     Type                 Name                 Plan       Info
 +   pulumi:pulumi:Stack  import-post-dev      create     1 error
 =   └─ aws:iam:Policy    AdministratorAccess  import     1 error

Diagnostics:
  pulumi:pulumi:Stack (import-post-dev):
    error: preview failed

  aws:iam:Policy (AdministratorAccess):
    error: Preview failed: refreshing urn:pulumi:dev::import-post::aws:iam/policy:Policy::AdministratorAccess: 1 error occurred:
    	* Error reading IAM policy AdministratorAccess: InvalidParameter: 1 validation error(s) found.
    - minimum field size of 20, GetPolicyInput.PolicyArn.
```