### PR TITLE
Allow display output to be explicitly redirected.

### DIFF
--- a/pkg/backend/display/diff.go
+++ b/pkg/backend/display/diff.go
@@ -41,10 +41,18 @@ func ShowDiffEvents(op string, action apitype.UpdateKind,
 
 	prefix := fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op)
 
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
 	var spinner cmdutil.Spinner
 	var ticker *time.Ticker
-
-	if opts.IsInteractive {
+	if stdout == os.Stdout && stderr == os.Stderr && opts.IsInteractive {
 		spinner, ticker = cmdutil.NewSpinnerAndTicker(prefix, nil, 8 /*timesPerSecond*/)
 	} else {
 		spinner = &nopSpinner{}
@@ -66,11 +74,11 @@ func ShowDiffEvents(op string, action apitype.UpdateKind,
 		case event := <-events:
 			spinner.Reset()
 
-			out := os.Stdout
+			out := stdout
 			if event.Type == engine.DiagEvent {
 				payload := event.Payload().(engine.DiagEventPayload)
 				if payload.Severity == diag.Error || payload.Severity == diag.Warning {
-					out = os.Stderr
+					out = stderr
 				}
 			}
 

--- a/pkg/backend/display/options.go
+++ b/pkg/backend/display/options.go
@@ -14,7 +14,11 @@
 
 package display
 
-import "github.com/pulumi/pulumi/sdk/v2/go/common/diag/colors"
+import (
+	"io"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/diag/colors"
+)
 
 // Type of output to display.
 type Type int
@@ -45,4 +49,6 @@ type Options struct {
 	JSONDisplay          bool                // true if we should emit the entire diff as JSON.
 	EventLogPath         string              // the path to the file to use for logging events, if any.
 	Debug                bool                // true to enable debug output.
+	Stdout               io.Writer           // the writer to use for stdout. Defaults to os.Stdout if unset.
+	Stderr               io.Writer           // the writer to use for stderr. Defaults to os.Stderr if unset.
 }

--- a/pkg/backend/display/progress.go
+++ b/pkg/backend/display/progress.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"sort"
 	"strings"
@@ -271,12 +272,29 @@ func (display *ProgressDisplay) writeBlankLine() {
 // ShowProgressEvents displays the engine events with docker's progress view.
 func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName, proj tokens.PackageName,
 	events <-chan engine.Event, done chan<- bool, opts Options, isPreview bool) {
+
+	stdout := opts.Stdout
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	stderr := opts.Stderr
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+
 	// Create a ticker that will update all our status messages once a second.  Any
 	// in-flight resources will get a varying .  ..  ... ticker appended to them to
 	// let the user know what is still being worked on.
-	spinner, ticker := cmdutil.NewSpinnerAndTicker(
-		fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op),
-		nil, 1 /*timesPerSecond*/)
+	var spinner cmdutil.Spinner
+	var ticker *time.Ticker
+	if stdout == os.Stdout && stderr == os.Stderr && opts.IsInteractive {
+		spinner, ticker = cmdutil.NewSpinnerAndTicker(
+			fmt.Sprintf("%s%s...", cmdutil.EmojiOr("✨ ", "@ "), op),
+			nil, 1 /*timesPerSecond*/)
+	} else {
+		spinner = &nopSpinner{}
+		ticker = time.NewTicker(math.MaxInt64)
+	}
 
 	// The channel we push progress messages into, and which ShowProgressOutput pulls
 	// from to display to the console.
@@ -299,15 +317,19 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName
 		nonInteractiveSpinner:  spinner,
 	}
 
-	terminalWidth, terminalHeight, err := terminal.GetSize(int(os.Stdout.Fd()))
-	if err == nil {
-		// If the terminal has a size, use it.
-		display.isTerminal = opts.IsInteractive
-		display.terminalWidth = terminalWidth
-		display.terminalHeight = terminalHeight
-	} else {
-		// Else assume we are not displaying in a terminal.
-		display.isTerminal = false
+	// Assume we are not displaying in a terminal by default.
+	display.isTerminal = false
+	if stdout == os.Stdout {
+		terminalWidth, terminalHeight, err := terminal.GetSize(int(os.Stdout.Fd()))
+		if err == nil {
+			// If the terminal has a size, use it.
+			display.isTerminal = opts.IsInteractive
+			display.terminalWidth = terminalWidth
+			display.terminalHeight = terminalHeight
+
+			// Fetch the canonical stdout stream, configured appropriately.
+			_, stdout, _ = term.StdStreams()
+		}
 	}
 
 	go func() {
@@ -319,7 +341,6 @@ func ShowProgressEvents(op string, action apitype.UpdateKind, stack tokens.QName
 		close(progressOutput)
 	}()
 
-	_, stdout, _ := term.StdStreams()
 	ShowProgressOutput(progressOutput, stdout, display.isTerminal)
 
 	ticker.Stop()


### PR DESCRIPTION
This is intended to make it easier to write tests for components (e.g.
the backends) that consume these packages.