### PR TITLE
Re-apply #5857

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Re-apply fix for running multiple `pulumi` processes concurrently.
+  [#5893](https://github.com/pulumi/pulumi/issues/5893)
 
 ## 2.15.4 (2020-12-08)
 

--- a/sdk/go/common/workspace/creds_test.go
+++ b/sdk/go/common/workspace/creds_test.go
@@ -1,0 +1,30 @@
+package workspace
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConcurrentCredentialsWrites(t *testing.T) {
+	creds, err := GetStoredCredentials()
+	assert.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 1000; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			err := StoreCredentials(creds)
+			assert.NoError(t, err)
+		}()
+		go func() {
+			defer wg.Done()
+			_, err := GetStoredCredentials()
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
This re-applies the fix in #5857 to make credentials.json writes concurrency safe.

The original fix used `path.Dir` instead of `filepath.Dir` - which led to not placing the temp file in the same folder (and drive) as the renamed file target on Windows.  This led to errors on Windows environments where the working directory was on a different drive than the `~/.pulumi` directory (https://github.com/pulumi/pulumi/issues/5879).  

The change to use `filepath.Dir` instead ensures that even on Windows, the true directory containing the credentials file is used for the temp file as well.

Fixes #3877.