### PR TITLE
Fix new resource recording.

### DIFF
--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -272,10 +272,6 @@ func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.Pro
 	contract.Assert(ok)
 	contract.Assert(urn.IsString())
 
-	// #5803: track secret outputs in the resource map. This is necessary to ensure that the
-	// `additionalSecretOutputs` option that was provided when the resource was registered is properly respected by
-	// `getResource`.
-
 	state, ok := p.resources.get(resource.URN(urn.StringValue()))
 	if !ok {
 		return nil, errors.Errorf("unknown resource %v", urn.StringValue())

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -282,7 +282,8 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 		}
 	}
 
-	// Ensure that any secrets properties in the output are marked as such.
+	// Ensure that any secrets properties in the output are marked as such and that the resource is tracked in the set
+	// of registered resources.
 	if step.New() != nil {
 		newState := step.New()
 		for _, k := range newState.AdditionalSecretOutputs {
@@ -290,6 +291,7 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 				newState.Outputs[k] = resource.MakeSecret(v)
 			}
 		}
+		se.deployment.news.set(newState.URN, newState)
 	}
 
 	if events != nil {

--- a/pkg/resource/deploy/step_executor.go
+++ b/pkg/resource/deploy/step_executor.go
@@ -291,7 +291,11 @@ func (se *stepExecutor) executeStep(workerID int, step Step) error {
 				newState.Outputs[k] = resource.MakeSecret(v)
 			}
 		}
-		se.deployment.news.set(newState.URN, newState)
+
+		// If this is not a resource that is managed by Pulumi, then we can ignore it.
+		if !newState.External && se.deployment.news != nil {
+			se.deployment.news.set(newState.URN, newState)
+		}
 	}
 
 	if events != nil {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -254,7 +254,6 @@ func (sg *stepGenerator) generateSteps(event RegisterResourceEvent) ([]Step, res
 	// Mark the URN/resource as having been seen. So we can run analyzers on all resources seen, as well as
 	// lookup providers for calculating replacement of resources that use the provider.
 	sg.resourceGoals[urn] = goal
-	sg.deployment.news.set(urn, new)
 	if providers.IsProviderType(goal.Type) {
 		sg.providers[urn] = new
 	}


### PR DESCRIPTION
Record new resources after their operations have been run rather than
before in order to ensure that all state is available and appropriately
marked as secret.

Fixes #5803.