### PR TITLE
Enable resource reference feature by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - Re-apply fix for running multiple `pulumi` processes concurrently.
   [#5893](https://github.com/pulumi/pulumi/issues/5893)
 
+- Enable resource reference feature by default.
+  [#5905](https://github.com/pulumi/pulumi/pull/5905)
+
 ## 2.15.4 (2020-12-08)
 
 - Fix a problem where `pulumi import` could panic on an import error due to missing error message.

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -531,7 +531,12 @@ func (rm *resmon) SupportsFeature(ctx context.Context,
 	case "secrets":
 		hasSupport = true
 	case "resourceReferences":
-		hasSupport = cmdutil.IsTruthy(os.Getenv("PULUMI_EXPERIMENTAL_RESOURCE_REFERENCES"))
+		hasSupport = true
+
+		// Allow the resource reference feature to be disabled by explicitly setting an env var.
+		if v, ok := os.LookupEnv("PULUMI_DISABLE_RESOURCE_REFERENCES"); ok && cmdutil.IsTruthy(v) {
+			hasSupport = false
+		}
 	}
 
 	logging.V(5).Infof("ResourceMonitor.SupportsFeature(id: %s) = %t", req.Id, hasSupport)

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.cs
@@ -49,6 +49,10 @@ namespace Pulumi
         internal static IDeploymentInternal InternalInstance
             => Instance.Internal;
 
+        private static readonly bool _disableResourceReferences =
+            Environment.GetEnvironmentVariable("PULUMI_DISABLE_RESOURCE_REFERENCES") == "1" ||
+            string.Equals(Environment.GetEnvironmentVariable("PULUMI_DISABLE_RESOURCE_REFERENCES"), "TRUE", StringComparison.OrdinalIgnoreCase);
+
         private readonly string _projectName;
         private readonly string _stackName;
         private readonly bool _isDryRun;

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Invoke.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Invoke.cs
@@ -54,6 +54,7 @@ namespace Pulumi
                 Provider = provider ?? "",
                 Version = options?.Version ?? "",
                 Args = serialized,
+                AcceptResources = !_disableResourceReferences,
             });
 
             if (result.Failures.Count > 0)

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_ReadResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_ReadResource.cs
@@ -37,6 +37,7 @@ namespace Pulumi
                 Properties = prepareResult.SerializedProps,
                 Version = options?.Version ?? "",
                 AcceptSecrets = true,
+                AcceptResources = !_disableResourceReferences,
             };
 
             request.Dependencies.AddRange(prepareResult.AllDirectDependencyURNs);

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResource.cs
@@ -78,6 +78,7 @@ namespace Pulumi
                 Version = options.Version ?? "",
                 ImportId = customOpts?.ImportId ?? "",
                 AcceptSecrets = true,
+                AcceptResources = !_disableResourceReferences,
                 DeleteBeforeReplace = deleteBeforeReplace ?? false,
                 DeleteBeforeReplaceDefined = deleteBeforeReplace != null,
                 CustomTimeouts = new RegisterResourceRequest.Types.CustomTimeouts

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1155,7 +1155,11 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 		return nil, nil, err
 	}
 
-	resp, err := client.Invoke(p.ctx.Request(), &pulumirpc.InvokeRequest{Tok: string(tok), Args: margs})
+	resp, err := client.Invoke(p.ctx.Request(), &pulumirpc.InvokeRequest{
+		Tok:             string(tok),
+		Args:            margs,
+		AcceptResources: p.acceptResources,
+	})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)
 		logging.V(7).Infof("%s failed: %v", label, rpcError.Message())
@@ -1216,7 +1220,11 @@ func (p *provider) StreamInvoke(
 	}
 
 	streamClient, err := client.StreamInvoke(
-		p.ctx.Request(), &pulumirpc.InvokeRequest{Tok: string(tok), Args: margs})
+		p.ctx.Request(), &pulumirpc.InvokeRequest{
+			Tok:             string(tok),
+			Args:            margs,
+			AcceptResources: p.acceptResources,
+		})
 	if err != nil {
 		rpcError := rpcerror.Convert(err)
 		logging.V(7).Infof("%s failed: %v", label, rpcError.Message())

--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -203,6 +203,7 @@ function createInvokeRequest(tok: string, serialized: any, provider: string | un
     req.setArgs(obj);
     req.setProvider(provider);
     req.setVersion(opts.version || "");
+    req.setAcceptresources(!utils.disableResourceReferences);
     return req;
 }
 

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -216,6 +216,7 @@ export function readResource(res: Resource, t: string, name: string, props: Inpu
         req.setDependenciesList(Array.from(resop.allDirectDependencyURNs));
         req.setVersion(opts.version || "");
         req.setAcceptsecrets(true);
+        req.setAcceptresources(!utils.disableResourceReferences);
         req.setAdditionalsecretoutputsList((<any>opts).additionalSecretOutputs || []);
 
         // Now run the operation, serializing the invocation if necessary.
@@ -305,6 +306,7 @@ export function registerResource(res: Resource, t: string, name: string, custom:
         req.setIgnorechangesList(opts.ignoreChanges || []);
         req.setVersion(opts.version || "");
         req.setAcceptsecrets(true);
+        req.setAcceptresources(!utils.disableResourceReferences);
         req.setAdditionalsecretoutputsList((<any>opts).additionalSecretOutputs || []);
         req.setAliasesList(resop.aliases);
         req.setImportid(resop.import || "");

--- a/sdk/nodejs/utils.ts
+++ b/sdk/nodejs/utils.ts
@@ -57,3 +57,8 @@ export function values(obj: object): any[] {
 export function union<T>(set1: Set<T>, set2: Set<T>) {
     return new Set([...set1, ...set2]);
 }
+
+/** @internal */
+export const disableResourceReferences: boolean =
+    process.env.PULUMI_DISABLE_RESOURCE_REFERENCES === "1" ||
+    (process.env.PULUMI_DISABLE_RESOURCE_REFERENCES ?? "").toUpperCase() === "TRUE";

--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import os
 import sys
 from typing import Any, Awaitable, Optional, TYPE_CHECKING
 import grpc
@@ -94,8 +95,15 @@ def invoke(tok: str, props: 'Inputs', opts: Optional[InvokeOptions] = None, typ:
         monitor = get_monitor()
         inputs = await rpc.serialize_properties(props, {})
         version = opts.version or ""
+        accept_resources = not (os.getenv("PULUMI_DISABLE_RESOURCE_REFERENCES", "").upper() in {"TRUE", "1"})
         log.debug(f"Invoking function prepared: tok={tok}")
-        req = provider_pb2.InvokeRequest(tok=tok, args=inputs, provider=provider_ref, version=version)
+        req = provider_pb2.InvokeRequest(
+            tok=tok,
+            args=inputs,
+            provider=provider_ref,
+            version=version,
+            acceptResources=accept_resources,
+        )
 
         def do_invoke():
             try:

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import os
 import sys
 import traceback
 
@@ -282,6 +283,7 @@ def read_resource(res: 'CustomResource', ty: str, name: str, props: 'Inputs', op
                 additional_secret_outputs = map(
                     res.translate_input_property, opts.additional_secret_outputs)
 
+            accept_resources = not (os.getenv("PULUMI_DISABLE_RESOURCE_REFERENCES", "").upper() in {"TRUE", "1"})
             req = resource_pb2.ReadResourceRequest(
                 type=ty,
                 name=name,
@@ -292,6 +294,7 @@ def read_resource(res: 'CustomResource', ty: str, name: str, props: 'Inputs', op
                 dependencies=resolver.dependencies,
                 version=opts.version or "",
                 acceptSecrets=True,
+                acceptResources=accept_resources,
                 additionalSecretOutputs=additional_secret_outputs,
             )
 
@@ -416,6 +419,7 @@ def register_resource(res: 'Resource',
                 else:
                     raise Exception("Expected custom_timeouts to be a CustomTimeouts object")
 
+            accept_resources = not (os.getenv("PULUMI_DISABLE_RESOURCE_REFERENCES", "").upper() in {"TRUE", "1"})
             req = resource_pb2.RegisterResourceRequest(
                 type=ty,
                 name=name,
@@ -431,6 +435,7 @@ def register_resource(res: 'Resource',
                 ignoreChanges=ignore_changes,
                 version=opts.version or "",
                 acceptSecrets=True,
+                acceptResources=accept_resources,
                 additionalSecretOutputs=additional_secret_outputs,
                 importId=opts.import_,
                 customTimeouts=custom_timeouts,


### PR DESCRIPTION
Unless the PULUMI_DISABLE_RESOURCE_REFERENCES flag
is explicitly set to a truthy value, the resource reference feature is now
enabled by default.

Fix #5838 