### PR TITLE
Remove optional identifier before splitting type string.

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -386,6 +386,7 @@ func (mod *modContext) getLanguageModuleName(lang string) string {
 func (mod *modContext) cleanTypeString(t schema.Type, langTypeString, lang, modName string, isInput bool) string {
 	switch lang {
 	case "go", "python":
+		langTypeString = cleanOptionalIdentifier(langTypeString, lang)
 		parts := strings.Split(langTypeString, ".")
 		return parts[len(parts)-1]
 	}


### PR DESCRIPTION
We need to remove the `Optional` wrapper before we split the type string into parts, otherwise we end up with an extra `]` after the type. [Example](https://www.pulumi.com/docs/reference/pkg/aws/lambda/function/#runtime_python)

Note, the example above actually has 2 extra `]` at the end, only one of which is removed by this PR. The other is caused by `Union` types, I have a fix for that incoming.