### PR TITLE
Fix union types in resource docs

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -2,6 +2,8 @@ on:
   repository_dispatch:
     types: [ run-acceptance-tests-command ]
   pull_request:
+    paths-ignore:
+      - 'pkg/codegen/docs/**'
 
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
     - 'pkg/codegen/**'
+    - '!pkg/codegen/docs/**'
     - '.github/workflows/codegen-test.yml'
 
 env:

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -162,7 +162,7 @@ type property struct {
 	DisplayName        string
 	Name               string
 	Comment            string
-	Type               propertyType
+	Types              []propertyType
 	DeprecationMessage string
 	Link               string
 
@@ -918,6 +918,15 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 
 		propID := strings.ToLower(propLangName + propertyLangSeparator + lang)
 
+		propTypes := make([]propertyType, 0)
+		if typ, isUnion := prop.Type.(*schema.UnionType); isUnion {
+			for _, elementType := range typ.ElementTypes {
+				propTypes = append(propTypes, mod.typeString(elementType, lang, characteristics, true))
+			}
+		} else {
+			propTypes = append(propTypes, mod.typeString(prop.Type, lang, characteristics, true))
+		}
+
 		docProperties = append(docProperties, property{
 			ID:                 propID,
 			DisplayName:        wbr(propLangName),
@@ -927,7 +936,7 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 			IsRequired:         prop.IsRequired,
 			IsInput:            input,
 			Link:               "#" + propID,
-			Type:               mod.typeString(prop.Type, lang, characteristics, true),
+			Types:              propTypes,
 		})
 	}
 

--- a/pkg/codegen/docs/templates/properties.tmpl
+++ b/pkg/codegen/docs/templates/properties.tmpl
@@ -8,7 +8,10 @@
             title="{{ if .IsInput -}}{{- if .IsRequired -}}Required{{- else -}}Optional{{- end -}}{{- end -}}{{- if .DeprecationMessage -}}, Deprecated{{- end -}}">
         <span id="{{ htmlSafe .ID }}">{{ template "linkify_wo_style" . }}</span> 
         <span class="property-indicator"></span>
-        <span class="property-type">{{- if eq .Type.Link "#" "" -}}{{- htmlSafe .Type.DisplayName -}}{{- else -}}{{ template "linkify" .Type }}{{- end -}}</span>
+        {{ range $index, $type := .Types }}
+            {{- if gt $index 0 -}}<span class="property-type"> | </span>{{- end -}}
+            <span class="property-type">{{- if eq .Link "#" "" -}}{{- htmlSafe .DisplayName -}}{{- else -}}{{ template "linkify" . }}{{- end -}}</span>
+        {{- end }}
     </dt>
     <dd>
         {{- print "{{% md %}}" -}}{{- htmlSafe .Comment -}}{{- print "{{% /md %}}" -}}


### PR DESCRIPTION
Treat union types as separate `propertyType`s so we can have separate links. This corrects an issue where union types have an extra `]` at the end [in python](https://github.com/pulumi/docs/pull/4769/files#diff-38ea811bf02d4a3a4b1c104ff357002f2324c68b93a1055f380326592f769e09R3316) but more generally, it standardizes how union types are emitted in the docs.

This PR also changes the github workflow to only run docs-related tests when the path is `pkg/codegen/docs/**`.

