### PR TITLE
[sdk/nodejs] Use `log.error` to log uncaught errors

### DIFF
--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -19,6 +19,7 @@ import * as grpc from "@grpc/grpc-js";
 
 import { Provider } from "./provider";
 
+import * as log from "../log";
 import { Inputs, Output, output } from "../output";
 import * as resource from "../resource";
 import * as runtime from "../runtime";
@@ -414,7 +415,9 @@ export async function main(provider: Provider, args: string[]) {
     const uncaughtHandler = (err: Error) => {
         if (!uncaughtErrors.has(err)) {
             uncaughtErrors.add(err);
-            console.error(err.stack || err.message || ("" + err));
+            // Use `pulumi.log.error` here to tell the engine there was a fatal error, which should
+            // stop processing subsequent resource operations.
+            log.error(err.stack || err.message || ("" + err));
         }
     };
 


### PR DESCRIPTION
`log.error` will call the engine's `log` gRPC endpoint (if the engine is available; otherwise it will write to `console.error`) with `LogSeverity.ERROR`, which tell the engine to stop processing further resource operations.

Without this, any uncaught errors (such as input validation errors done inside `apply`) would be written to stderr, but wouldn't actually result in an update error.

Fixes https://github.com/pulumi/pulumi-eks/issues/480