### PR TITLE
[codegen/docs] - Remove primitive type links

### DIFF
--- a/pkg/codegen/docs.go
+++ b/pkg/codegen/docs.go
@@ -29,7 +29,6 @@ type DocLanguageHelper interface {
 	GetDocLinkForPulumiType(pkg *schema.Package, typeName string) string
 	GetDocLinkForResourceInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
 	GetDocLinkForFunctionInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string
-	GetDocLinkForBuiltInType(typeName string) string
 	GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string
 
 	GetFunctionName(modName string, f *schema.Function) string

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -493,11 +493,6 @@ func (mod *modContext) typeString(t schema.Type, lang string, characteristics pr
 			elements = append(elements, elementLangType.DisplayName)
 		}
 		langTypeString = strings.Join(elements, " | ")
-	default:
-		// Check if type is primitive/built-in type if no match for cases listed above.
-		if schema.IsPrimitiveType(t) {
-			href = docLanguageHelper.GetDocLinkForBuiltInType(t.String())
-		}
 	}
 
 	// Strip the namespace/module prefix for the type's display name.
@@ -601,7 +596,6 @@ func (mod *modContext) genConstructorTS(r *schema.Resource, argsOptional bool) [
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 			Comment: ctorNameArgComment,
 		},
@@ -657,7 +651,6 @@ func (mod *modContext) genConstructorGo(r *schema.Resource, argsOptional bool) [
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 			Comment: ctorNameArgComment,
 		},
@@ -744,7 +737,6 @@ func (mod *modContext) genConstructorCS(r *schema.Resource, argsOptional bool) [
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 			Comment: ctorNameArgComment,
 		},
@@ -1151,7 +1143,6 @@ func (mod *modContext) getTSLookupParams(r *schema.Resource, stateParam string) 
 
 			Type: propertyType{
 				Name: "string",
-				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{
@@ -1203,7 +1194,6 @@ func (mod *modContext) getGoLookupParams(r *schema.Resource, stateParam string) 
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{
@@ -1252,7 +1242,6 @@ func (mod *modContext) getCSLookupParams(r *schema.Resource, stateParam string) 
 			Name: "name",
 			Type: propertyType{
 				Name: "string",
-				Link: docLangHelper.GetDocLinkForBuiltInType("string"),
 			},
 		},
 		{

--- a/pkg/codegen/dotnet/doc.go
+++ b/pkg/codegen/dotnet/doc.go
@@ -61,13 +61,6 @@ func (d DocLanguageHelper) GetDocLinkForResourceType(pkg *schema.Package, _, typ
 	return fmt.Sprintf("/docs/reference/pkg/dotnet/Pulumi%s/%s.html", packageNamespace, typeName)
 }
 
-// GetDocLinkForBuiltInType returns the C# URL for a built-in type.
-// Currently not using the typeName parameter because the returned link takes to a general
-// top -level page containing info for all built in types.
-func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
-	return "https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/built-in-types"
-}
-
 // GetDocLinkForResourceInputOrOutputType returns the doc link for an input or output type of a Resource.
 func (d DocLanguageHelper) GetDocLinkForResourceInputOrOutputType(pkg *schema.Package, moduleName, typeName string, input bool) string {
 	return d.GetDocLinkForResourceType(pkg, moduleName, typeName)

--- a/pkg/codegen/go/doc.go
+++ b/pkg/codegen/go/doc.go
@@ -81,11 +81,6 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 	return link + "Args"
 }
 
-// GetDocLinkForBuiltInType returns the godoc URL for a built-in type.
-func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
-	return fmt.Sprintf("https://golang.org/pkg/builtin/#%s", typeName)
-}
-
 // GetLanguageTypeString returns the Go-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string {
 	modPkg, ok := d.packages[moduleName]

--- a/pkg/codegen/nodejs/doc.go
+++ b/pkg/codegen/nodejs/doc.go
@@ -68,11 +68,6 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 	return d.GetDocLinkForResourceInputOrOutputType(pkg, modName, typeName, input)
 }
 
-// GetDocLinkForBuiltInType returns the URL for a built-in type.
-func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
-	return fmt.Sprintf("https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/%s", typeName)
-}
-
 // GetLanguageTypeString returns the language-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string {
 	modCtx := &modContext{

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -72,13 +72,6 @@ func (d DocLanguageHelper) GetDocLinkForFunctionInputOrOutputType(pkg *schema.Pa
 	return ""
 }
 
-// GetDocLinkForBuiltInType returns the Python URL for a built-in type.
-// Currently not using the typeName parameter because the returned link takes to a general
-// top-level page containing info for all built in types.
-func (d DocLanguageHelper) GetDocLinkForBuiltInType(typeName string) string {
-	return "https://docs.python.org/3/library/stdtypes.html"
-}
-
 // GetLanguageTypeString returns the Python-specific type given a Pulumi schema type.
 func (d DocLanguageHelper) GetLanguageTypeString(pkg *schema.Package, moduleName string, t schema.Type, input, optional bool) string {
 	typeDetails := map[*schema.ObjectType]*typeDetails{}


### PR DESCRIPTION
The primitive type links go to external sites and aren't consistent or particularly helpful. This PR removes primitive type links from the resource docs.