### PR TITLE
[sdk/nodejs] Implement getResource in the mock monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ CHANGELOG
 - [cli] Prevent a panic when using `pulumi import` with local filesystems
   [#5906](https://github.com/pulumi/pulumi/issues/5906)
 
+- [sdk/nodejs] Fix issue that would cause unit tests using mocks to fail with unhandled errors when
+  a resource references another resources that's been registered with `registerResourceModule`.
+  [#5914](https://github.com/pulumi/pulumi/pull/5914)
+
 ## 2.15.4 (2020-12-08)
 
 - Fix a problem where `pulumi import` could panic on an import error due to missing error message.

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -45,6 +45,7 @@ istanbul_tests:: build
 	./node_modules/.bin/istanbul test --print none _mocha -- --timeout 90000 'bin/tests/**/*.spec.js'
 	./node_modules/.bin/istanbul report text-summary
 	./node_modules/.bin/istanbul report text
+	./node_modules/.bin/istanbul test --print none _mocha -- 'bin/tests_with_mocks/**/*.spec.js'
 
 sxs_tests:: build
 	pushd tests/sxs_ts_3.6 && yarn ; tsc ; popd

--- a/sdk/nodejs/tests_with_mocks/mocks.spec.ts
+++ b/sdk/nodejs/tests_with_mocks/mocks.spec.ts
@@ -1,0 +1,125 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as assert from "assert";
+import * as pulumi from "../index";
+import { CustomResourceOptions } from "../resource";
+
+pulumi.runtime.setMocks({
+    call: (token: string, args: any, provider?: string) => {
+        switch (token) {
+            case "test:index:MyFunction":
+                return { out_value: 59 };
+            default:
+                return {};
+        }
+    },
+    newResource: (type: string, name: string, inputs: any): {id: string, state: any} => {
+        switch (type) {
+            case "aws:ec2/instance:Instance":
+                const state = {
+                    arn: "arn:aws:ec2:us-west-2:123456789012:instance/i-1234567890abcdef0",
+                    instanceState: "running",
+                    primaryNetworkInterfaceId: "eni-12345678",
+                    privateDns: "ip-10-0-1-17.ec2.internal",
+                    publicDns: "ec2-203-0-113-12.compute-1.amazonaws.com",
+                    publicIP: "203.0.113.12",
+                };
+                return { id: "i-1234567890abcdef0", state: { ...inputs, ...state } };
+            case "pkg:index:MyCustom":
+                return { id: name + "_id", state: inputs };
+            default:
+                return { id: "", state: {} };
+        }
+    },
+});
+
+class MyComponent extends pulumi.ComponentResource {
+    outprop: pulumi.Output<string>;
+    constructor(name: string, inprop: pulumi.Input<string>, opts?: pulumi.ComponentResourceOptions) {
+        super("pkg:index:MyComponent", name, {}, opts);
+        this.outprop = pulumi.output(inprop).apply(x => `output: ${x}`);
+    }
+}
+
+class Instance extends pulumi.CustomResource {
+    publicIP!: pulumi.Output<string>;
+    constructor(name: string, opts?: CustomResourceOptions) {
+        const props = { publicIP: undefined };
+        super("aws:ec2/instance:Instance", name, props, opts);
+    }
+}
+
+pulumi.runtime.registerResourceModule("aws", "ec2/instance", {
+    construct: (name: string, type: string, urn: string): pulumi.Resource => {
+        switch (type) {
+            case "aws:ec2/instance:Instance":
+                return new Instance(name, { urn });
+            default:
+                throw new Error(`unknown resource type ${type}`);
+        }
+    },
+});
+
+class MyCustom extends pulumi.CustomResource {
+    instance!: pulumi.Output<Instance>;
+    constructor(name: string, props?: Record<string, any>, opts?: CustomResourceOptions) {
+        super("pkg:index:MyCustom", name, props, opts);
+    }
+}
+
+async function invoke(): Promise<number> {
+    const value = await pulumi.runtime.invoke("test:index:MyFunction", { value: 41 });
+    return value["out_value"];
+}
+
+const mycomponent = new MyComponent("mycomponent", "hello");
+const myinstance = new Instance("instance");
+const mycustom = new MyCustom("mycustom", { instance: myinstance });
+const invokeResult = invoke();
+
+describe("mocks", function() {
+    describe("component", function() {
+        it("has expected output value", done => {
+            mycomponent.outprop.apply(outprop => {
+                assert.strictEqual(outprop, "output: hello");
+                done();
+            });
+        });
+    });
+
+    describe("custom", function() {
+        it("instance has expected output value", done => {
+            myinstance.publicIP.apply(ip => {
+                assert.strictEqual(ip, "203.0.113.12");
+                done();
+            });
+        });
+
+        it("mycustom has expected output value", done => {
+            mycustom.instance.apply(instance => {
+                done();
+            });
+        });
+    });
+
+    describe("invoke", function() {
+        it("has expected result", done => {
+            invokeResult.then(value => {
+                assert.strictEqual(value, 59);
+                done();
+            });
+        });
+    });
+});

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -94,6 +94,8 @@
         "tests/runtime/props.spec.ts",
         "tests/runtime/langhost/run.spec.ts",
 
-        "tests/automation/localWorkspace.spec.ts"
+        "tests/automation/localWorkspace.spec.ts",
+
+        "tests_with_mocks/mocks.spec.ts",
     ]
 }


### PR DESCRIPTION
Otherwise, unit tests for programs that reference resources that have been registered with `registerResourceModule` fail with unhandled exceptions.

We didn't have any existing tests for mocks for Node.js, so I added some based on the [ones we have for Python](https://github.com/pulumi/pulumi/blob/master/sdk/python/lib/test_with_mocks/test_testing_with_mocks.py), and augmented it to cover this case. The new test fails before the change to the SDK, and passes afterwards.

Part of https://github.com/pulumi/pulumi/issues/5832