### PR TITLE
Add pointer output types for resources

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -508,7 +508,7 @@ func genInputMethods(w io.Writer, name, receiverType, elementType string, ptrMet
 		fmt.Fprintf(w, "}\n\n")
 
 		fmt.Fprintf(w, "func (i %s) To%sPtrOutputWithContext(ctx context.Context) %sPtrOutput {\n", receiverType, Title(name), name)
-		fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%[1]sOutput).To%[1]sPtrOutputWithContext(ctx)\n", name)
+		fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%sPtrOutput)\n", name)
 		fmt.Fprintf(w, "}\n\n")
 	}
 }
@@ -1063,16 +1063,27 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource) error {
 	fmt.Fprintf(w, "\tTo%[1]sOutput() %[1]sOutput\n", name)
 	fmt.Fprintf(w, "\tTo%[1]sOutputWithContext(ctx context.Context) %[1]sOutput\n", name)
 	fmt.Fprintf(w, "}\n\n")
-	genInputMethods(w, name, "*"+name, name, false, true)
+	genInputMethods(w, name, "*"+name, name, true, true)
+	fmt.Fprintf(w, "type %sPtrInput interface {\n", name)
+	fmt.Fprintf(w, "\tpulumi.Input\n\n")
+	fmt.Fprintf(w, "\tTo%[1]sPtrOutput() %[1]sPtrOutput\n", name)
+	fmt.Fprintf(w, "\tTo%[1]sPtrOutputWithContext(ctx context.Context) %[1]sPtrOutput\n", name)
+	fmt.Fprintf(w, "}\n\n")
 
 	// Emit the resource output type.
 	fmt.Fprintf(w, "type %sOutput struct {\n", name)
 	fmt.Fprintf(w, "\t*pulumi.OutputState\n")
 	fmt.Fprintf(w, "}\n\n")
 	genOutputMethods(w, name, name, true)
+	//genOutputMethods(w, name, name+"Output", true)
+	fmt.Fprintf(w, "type %sPtrOutput struct {\n", name)
+	fmt.Fprintf(w, "\t*pulumi.OutputState\n")
+	fmt.Fprintf(w, "}\n\n")
+	genOutputMethods(w, name+"Ptr", "*"+name, true)
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "func init() {\n")
 	fmt.Fprintf(w, "\tpulumi.RegisterOutputType(%sOutput{})\n", name)
+	fmt.Fprintf(w, "\tpulumi.RegisterOutputType(%sPtrOutput{})\n", name)
 	fmt.Fprintf(w, "}\n\n")
 
 	return nil

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -499,7 +499,12 @@ func genInputMethods(w io.Writer, name, receiverType, elementType string, ptrMet
 	fmt.Fprintf(w, "}\n\n")
 
 	fmt.Fprintf(w, "func (i %s) To%sOutputWithContext(ctx context.Context) %sOutput {\n", receiverType, Title(name), name)
-	fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%sOutput)\n", name)
+	if strings.HasSuffix(name, "Ptr") && !ptrMethods {
+		base := name[:len(name)-3]
+		fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%sOutput).To%sOutput()\n", base, Title(name))
+	} else {
+		fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%sOutput)\n", name)
+	}
 	fmt.Fprintf(w, "}\n\n")
 
 	if ptrMethods {
@@ -508,7 +513,11 @@ func genInputMethods(w io.Writer, name, receiverType, elementType string, ptrMet
 		fmt.Fprintf(w, "}\n\n")
 
 		fmt.Fprintf(w, "func (i %s) To%sPtrOutputWithContext(ctx context.Context) %sPtrOutput {\n", receiverType, Title(name), name)
-		fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%sPtrOutput)\n", name)
+		if strings.HasSuffix(receiverType, "Args") {
+			fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%[1]sOutput).To%[1]sPtrOutput()\n", name)
+		} else {
+			fmt.Fprintf(w, "\treturn pulumi.ToOutputWithContext(ctx, i).(%sPtrOutput)\n", name)
+		}
 		fmt.Fprintf(w, "}\n\n")
 	}
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/provider.go
@@ -59,6 +59,21 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
+	return i.ToProviderPtrOutputWithContext(context.Background())
+}
+
+func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
+}
+
+type ProviderPtrInput interface {
+	pulumi.Input
+
+	ToProviderPtrOutput() ProviderPtrOutput
+	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
+}
+
 type ProviderOutput struct {
 	*pulumi.OutputState
 }
@@ -75,6 +90,23 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
+type ProviderPtrOutput struct {
+	*pulumi.OutputState
+}
+
+func (ProviderPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**Provider)(nil))
+}
+
+func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
+	return o
+}
+
+func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
+	return o
+}
+
 func init() {
 	pulumi.RegisterOutputType(ProviderOutput{})
+	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
@@ -52,7 +52,7 @@ func (i ContainerArgs) ToContainerPtrOutput() ContainerPtrOutput {
 }
 
 func (i ContainerArgs) ToContainerPtrOutputWithContext(ctx context.Context) ContainerPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ContainerOutput).ToContainerPtrOutputWithContext(ctx)
+	return pulumi.ToOutputWithContext(ctx, i).(ContainerPtrOutput)
 }
 
 // ContainerPtrInput is an input type that accepts ContainerArgs, ContainerPtr and ContainerPtrOutput values.

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
@@ -52,7 +52,7 @@ func (i ContainerArgs) ToContainerPtrOutput() ContainerPtrOutput {
 }
 
 func (i ContainerArgs) ToContainerPtrOutputWithContext(ctx context.Context) ContainerPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ContainerPtrOutput)
+	return pulumi.ToOutputWithContext(ctx, i).(ContainerOutput).ToContainerPtrOutput()
 }
 
 // ContainerPtrInput is an input type that accepts ContainerArgs, ContainerPtr and ContainerPtrOutput values.
@@ -85,7 +85,7 @@ func (i *containerPtrType) ToContainerPtrOutput() ContainerPtrOutput {
 }
 
 func (i *containerPtrType) ToContainerPtrOutputWithContext(ctx context.Context) ContainerPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ContainerPtrOutput)
+	return pulumi.ToOutputWithContext(ctx, i).(ContainerOutput).ToContainerPtrOutput()
 }
 
 type ContainerOutput struct{ *pulumi.OutputState }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -100,6 +100,21 @@ func (i *RubberTree) ToRubberTreeOutputWithContext(ctx context.Context) RubberTr
 	return pulumi.ToOutputWithContext(ctx, i).(RubberTreeOutput)
 }
 
+func (i *RubberTree) ToRubberTreePtrOutput() RubberTreePtrOutput {
+	return i.ToRubberTreePtrOutputWithContext(context.Background())
+}
+
+func (i *RubberTree) ToRubberTreePtrOutputWithContext(ctx context.Context) RubberTreePtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(RubberTreePtrOutput)
+}
+
+type RubberTreePtrInput interface {
+	pulumi.Input
+
+	ToRubberTreePtrOutput() RubberTreePtrOutput
+	ToRubberTreePtrOutputWithContext(ctx context.Context) RubberTreePtrOutput
+}
+
 type RubberTreeOutput struct {
 	*pulumi.OutputState
 }
@@ -116,6 +131,23 @@ func (o RubberTreeOutput) ToRubberTreeOutputWithContext(ctx context.Context) Rub
 	return o
 }
 
+type RubberTreePtrOutput struct {
+	*pulumi.OutputState
+}
+
+func (RubberTreePtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**RubberTree)(nil))
+}
+
+func (o RubberTreePtrOutput) ToRubberTreePtrOutput() RubberTreePtrOutput {
+	return o
+}
+
+func (o RubberTreePtrOutput) ToRubberTreePtrOutputWithContext(ctx context.Context) RubberTreePtrOutput {
+	return o
+}
+
 func init() {
 	pulumi.RegisterOutputType(RubberTreeOutput{})
+	pulumi.RegisterOutputType(RubberTreePtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/otherResource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/otherResource.go
@@ -63,6 +63,21 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutput)
 }
 
+func (i *OtherResource) ToOtherResourcePtrOutput() OtherResourcePtrOutput {
+	return i.ToOtherResourcePtrOutputWithContext(context.Background())
+}
+
+func (i *OtherResource) ToOtherResourcePtrOutputWithContext(ctx context.Context) OtherResourcePtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(OtherResourcePtrOutput)
+}
+
+type OtherResourcePtrInput interface {
+	pulumi.Input
+
+	ToOtherResourcePtrOutput() OtherResourcePtrOutput
+	ToOtherResourcePtrOutputWithContext(ctx context.Context) OtherResourcePtrOutput
+}
+
 type OtherResourceOutput struct {
 	*pulumi.OutputState
 }
@@ -79,6 +94,23 @@ func (o OtherResourceOutput) ToOtherResourceOutputWithContext(ctx context.Contex
 	return o
 }
 
+type OtherResourcePtrOutput struct {
+	*pulumi.OutputState
+}
+
+func (OtherResourcePtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**OtherResource)(nil))
+}
+
+func (o OtherResourcePtrOutput) ToOtherResourcePtrOutput() OtherResourcePtrOutput {
+	return o
+}
+
+func (o OtherResourcePtrOutput) ToOtherResourcePtrOutputWithContext(ctx context.Context) OtherResourcePtrOutput {
+	return o
+}
+
 func init() {
 	pulumi.RegisterOutputType(OtherResourceOutput{})
+	pulumi.RegisterOutputType(OtherResourcePtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/provider.go
@@ -59,6 +59,21 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
+func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
+	return i.ToProviderPtrOutputWithContext(context.Background())
+}
+
+func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
+}
+
+type ProviderPtrInput interface {
+	pulumi.Input
+
+	ToProviderPtrOutput() ProviderPtrOutput
+	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
+}
+
 type ProviderOutput struct {
 	*pulumi.OutputState
 }
@@ -75,6 +90,23 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
+type ProviderPtrOutput struct {
+	*pulumi.OutputState
+}
+
+func (ProviderPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**Provider)(nil))
+}
+
+func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
+	return o
+}
+
+func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
+	return o
+}
+
 func init() {
 	pulumi.RegisterOutputType(ProviderOutput{})
+	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/resource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/resource.go
@@ -88,6 +88,21 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
+func (i *Resource) ToResourcePtrOutput() ResourcePtrOutput {
+	return i.ToResourcePtrOutputWithContext(context.Background())
+}
+
+func (i *Resource) ToResourcePtrOutputWithContext(ctx context.Context) ResourcePtrOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(ResourcePtrOutput)
+}
+
+type ResourcePtrInput interface {
+	pulumi.Input
+
+	ToResourcePtrOutput() ResourcePtrOutput
+	ToResourcePtrOutputWithContext(ctx context.Context) ResourcePtrOutput
+}
+
 type ResourceOutput struct {
 	*pulumi.OutputState
 }
@@ -104,6 +119,23 @@ func (o ResourceOutput) ToResourceOutputWithContext(ctx context.Context) Resourc
 	return o
 }
 
+type ResourcePtrOutput struct {
+	*pulumi.OutputState
+}
+
+func (ResourcePtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**Resource)(nil))
+}
+
+func (o ResourcePtrOutput) ToResourcePtrOutput() ResourcePtrOutput {
+	return o
+}
+
+func (o ResourcePtrOutput) ToResourcePtrOutputWithContext(ctx context.Context) ResourcePtrOutput {
+	return o
+}
+
 func init() {
 	pulumi.RegisterOutputType(ResourceOutput{})
+	pulumi.RegisterOutputType(ResourcePtrOutput{})
 }


### PR DESCRIPTION
This is needed to allow external resource references to comply with convention on being modeled as pointers when not marked as required in the schema. See https://github.com/pulumi/pulumi/issues/5794

Unblocks #5826 