### PR TITLE
[sdk/go] Implement getResource in the mock monitor

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -70,3 +70,6 @@ This change is marked breaking because it also renames `OnOutput` to `OnStandard
 - [cli] Ensure the user has the correct access to the secrets manager before using it as part of
   `pulumi stack export --show-secrets`.
   [#6215](https://github.com/pulumi/pulumi/pull/6210)
+
+- [sdk/go] Implement getResource in the mock monitor.
+  [#5923](https://github.com/pulumi/pulumi/pull/5923)

--- a/sdk/go/pulumi/run_test.go
+++ b/sdk/go/pulumi/run_test.go
@@ -288,15 +288,15 @@ type testInstanceResourceInput interface {
 	ToTestInstanceResourceOutputWithContext(ctx context.Context) testInstanceResourceOutput
 }
 
-func (testInstanceResource) ElementType() reflect.Type {
+func (*testInstanceResource) ElementType() reflect.Type {
 	return reflect.TypeOf((*testInstanceResource)(nil)).Elem()
 }
 
-func (i testInstanceResource) ToTestInstanceResourceOutput() testInstanceResourceOutput {
+func (i *testInstanceResource) ToTestInstanceResourceOutput() testInstanceResourceOutput {
 	return i.ToTestInstanceResourceOutputWithContext(context.Background())
 }
 
-func (i testInstanceResource) ToTestInstanceResourceOutputWithContext(ctx context.Context) testInstanceResourceOutput {
+func (i *testInstanceResource) ToTestInstanceResourceOutputWithContext(ctx context.Context) testInstanceResourceOutput {
 	return ToOutputWithContext(ctx, i).(testInstanceResourceOutput)
 }
 
@@ -305,7 +305,7 @@ type testInstanceResourceOutput struct {
 }
 
 func (testInstanceResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*testInstanceResourceOutput)(nil)).Elem()
+	return reflect.TypeOf((*testInstanceResource)(nil)).Elem()
 }
 
 func (o testInstanceResourceOutput) ToTestInstanceResourceOutput() testInstanceResourceOutput {
@@ -378,7 +378,7 @@ func TestRegisterResourceWithResourceReferences(t *testing.T) {
 
 		var mycustom testMyCustomResource
 		err = ctx.RegisterResource("pkg:index:MyCustom", "mycustom", &testMyCustomResourceInputs{
-			Instance: instance,
+			Instance: &instance,
 		}, &mycustom)
 		assert.NoError(t, err)
 


### PR DESCRIPTION
Part of #5832
Related to https://github.com/pulumi/pulumi/pull/5914
Related to https://github.com/pulumi/pulumi/pull/5919
Related to https://github.com/pulumi/pulumi/pull/5921