### PR TITLE
Fix bug that could cause Go SDK to drop dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Fix a bug in the Go SDK that could result in dropped resource dependencies.
+  [#5930](https://github.com/pulumi/pulumi/pull/5930)
 
 ## 2.15.5 (2020-12-11)
 

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -184,11 +184,11 @@ func marshalInputAndDetermineSecret(v interface{},
 	destType reflect.Type,
 	await bool) (resource.PropertyValue, []Resource, bool, error) {
 	secret := false
+	var deps []Resource
 	for {
 		valueType := reflect.TypeOf(v)
 
 		// If this is an Input, make sure it is of the proper type and await it if it is an output/
-		var deps []Resource
 		if input, ok := v.(Input); ok {
 			valueType = input.ElementType()
 


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/5928

There's a marshaling loop that can run multiple times for the purposes of unpacking pointer fields. The dependency array was mistakenly declared inside the loop, causing accumulated dependencies to be clobbered if the loop runs more than once. 

A similar issue was fixed for secrets via https://github.com/pulumi/pulumi/pull/4387, but this was missed. Reading through this method in full, it doesn't seem like there are any additional bugs of this category lurking in the loop...

Used the following program to verify the fix locally. The subnet dependency is missing from the state file before this patch, and present with the patch applied. 

```go
package main

import (
	"github.com/pulumi/pulumi-azure/sdk/v3/go/azure/core"
	"github.com/pulumi/pulumi-azure/sdk/v3/go/azure/network"
	"github.com/pulumi/pulumi-azure/sdk/v3/go/azure/storage"
	"github.com/pulumi/pulumi/sdk/v2/go/common/util/logging"
	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
)

func main() {
	logging.InitLogging(true, 9, true)
	pulumi.Run(func(ctx *pulumi.Context) error {
		resourceGroup, err := core.NewResourceGroup(ctx, "testpulumi", &core.ResourceGroupArgs{
			Location: pulumi.String("WestUS"),
		})
		if err != nil {
			return err
		}

		account, err := storage.NewAccount(ctx, "storage", &storage.AccountArgs{
			ResourceGroupName:      resourceGroup.Name,
			AccountTier:            pulumi.String("Standard"),
			AccountReplicationType: pulumi.String("LRS"),
		})
		if err != nil {
			return err
		}

		virtualNetwork, err := network.NewVirtualNetwork(ctx, "vnet", &network.VirtualNetworkArgs{
			ResourceGroupName: resourceGroup.Name,
			Location:          resourceGroup.Location,
			AddressSpaces:     pulumi.StringArray{pulumi.String("10.0.6.0/24")},
		})
		if err != nil {
			return err
		}

		subnet, err := network.NewSubnet(ctx, "subnet", &network.SubnetArgs{
			ResourceGroupName:  resourceGroup.Name,
			VirtualNetworkName: virtualNetwork.Name,
			AddressPrefixes: pulumi.StringArray{
				pulumi.String("10.0.6.0/24"),
			},
		})
		if err != nil {
			return err
		}

		_, err = network.NewNetworkInterface(ctx, "networkinterface", &network.NetworkInterfaceArgs{
			Location:          resourceGroup.Location,
			ResourceGroupName: resourceGroup.Name,
			IpConfigurations: network.NetworkInterfaceIpConfigurationArray{
				&network.NetworkInterfaceIpConfigurationArgs{
					Name:                       pulumi.String("webserveripcfg"),
					Primary:                    pulumi.Bool(true),
					PrivateIpAddressAllocation: pulumi.String("Dynamic"),
					// ==========> BUG:
					// ==========> BUG: why doesn't the following line result in a dependency between the NIC and Subnet?
					// ==========> BUG:
					SubnetId: subnet.ID(),
				},
			},
			// ==========> BUG:
			// ==========> BUG: without this, there is no dependency:
			// ==========> BUG:
			//}, pulumi.DependsOn([]pulumi.Resource{subnet}))
		})
		if err != nil {
			return err
		}

		// Export the connection string for the storage account
		ctx.Export("connectionString", account.PrimaryConnectionString)
		return nil
	})
}
```