### PR TITLE
Temporarily disable resource ref support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ CHANGELOG
 
 - Fix a bug in the Go SDK that could result in dropped resource dependencies.
   [#5930](https://github.com/pulumi/pulumi/pull/5930)
+  
+- Temporarily disable resource ref feature.
+  [#5932](https://github.com/pulumi/pulumi/pull/5932)
 
 ## 2.15.5 (2020-12-11)
 

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -531,7 +531,8 @@ func (rm *resmon) SupportsFeature(ctx context.Context,
 	case "secrets":
 		hasSupport = true
 	case "resourceReferences":
-		hasSupport = true
+		// TODO: Temporarily disabling resource ref support (https://github.com/pulumi/pulumi-kubernetes/issues/1405)
+		hasSupport = false
 
 		// Allow the resource reference feature to be disabled by explicitly setting an env var.
 		if v, ok := os.LookupEnv("PULUMI_DISABLE_RESOURCE_REFERENCES"); ok && cmdutil.IsTruthy(v) {


### PR DESCRIPTION
Disable resource ref support until https://github.com/pulumi/pulumi-kubernetes/issues/1405
is fixed. This bug currently affects Python users with recent versions of the pulumi SDK
who are using the pulumi-kubernetes provider.