### PR TITLE
[codegen/*] - Align makeValidIdentifier between languages

### DIFF
--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -70,6 +70,7 @@ func TestMakeSafeEnumName(t *testing.T) {
 		{"+", "", true},
 		{"*", "Asterisk", false},
 		{"0", "Zero", false},
+		{"8.3", "_8_3", false},
 		{"Microsoft-Windows-Shell-Startup", "Microsoft_Windows_Shell_Startup", false},
 		{"Microsoft.Batch", "Microsoft_Batch", false},
 		{"readonly", "@Readonly", false},

--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -60,35 +60,3 @@ func TestGeneratePackage(t *testing.T) {
 		})
 	}
 }
-
-func TestMakeSafeEnumName(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-		wantErr  bool
-	}{
-		{"+", "", true},
-		{"*", "Asterisk", false},
-		{"0", "Zero", false},
-		{"8.3", "_8_3", false},
-		{"Microsoft-Windows-Shell-Startup", "Microsoft_Windows_Shell_Startup", false},
-		{"Microsoft.Batch", "Microsoft_Batch", false},
-		{"readonly", "@Readonly", false},
-		{"SystemAssigned, UserAssigned", "SystemAssigned_UserAssigned", false},
-		{"Dev(NoSLA)_Standard_D11_v2", "Dev_NoSLA_Standard_D11_v2", false},
-		{"Standard_E8as_v4+1TB_PS", "Standard_E8as_v4_1TB_PS", false},
-		{"Equals", "EqualsValue", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got, err := makeSafeEnumName(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("makeSafeEnumName() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.expected {
-				t.Errorf("makeSafeEnumName() got = %v, want %v", got, tt.expected)
-			}
-		})
-	}
-}

--- a/pkg/codegen/dotnet/utilities.go
+++ b/pkg/codegen/dotnet/utilities.go
@@ -65,6 +65,10 @@ func isLegalIdentifierPart(c rune) bool {
 func makeValidIdentifier(name string) string {
 	var builder strings.Builder
 	for i, c := range name {
+		if i == 0 && c == '@' {
+			builder.WriteRune(c)
+			continue
+		}
 		if !isLegalIdentifierPart(c) {
 			builder.WriteRune('_')
 		} else {

--- a/pkg/codegen/dotnet/utilities.go
+++ b/pkg/codegen/dotnet/utilities.go
@@ -65,9 +65,12 @@ func isLegalIdentifierPart(c rune) bool {
 func makeValidIdentifier(name string) string {
 	var builder strings.Builder
 	for i, c := range name {
-		if i == 0 && !isLegalIdentifierStart(c) || i > 0 && !isLegalIdentifierPart(c) {
+		if !isLegalIdentifierPart(c) {
 			builder.WriteRune('_')
 		} else {
+			if i == 0 && !isLegalIdentifierStart(c) {
+				builder.WriteRune('_')
+			}
 			builder.WriteRune(c)
 		}
 	}

--- a/pkg/codegen/dotnet/utilities_test.go
+++ b/pkg/codegen/dotnet/utilities_test.go
@@ -1,4 +1,4 @@
-package gen
+package dotnet
 
 import "testing"
 
@@ -14,10 +14,11 @@ func TestMakeSafeEnumName(t *testing.T) {
 		{"8.3", "_8_3", false},
 		{"Microsoft-Windows-Shell-Startup", "Microsoft_Windows_Shell_Startup", false},
 		{"Microsoft.Batch", "Microsoft_Batch", false},
-		{"readonly", "Readonly", false},
+		{"readonly", "@Readonly", false},
 		{"SystemAssigned, UserAssigned", "SystemAssigned_UserAssigned", false},
 		{"Dev(NoSLA)_Standard_D11_v2", "Dev_NoSLA_Standard_D11_v2", false},
 		{"Standard_E8as_v4+1TB_PS", "Standard_E8as_v4_1TB_PS", false},
+		{"Equals", "EqualsValue", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -38,7 +39,7 @@ func Test_makeValidIdentifier(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"&opts0", "&opts0"},
+		{"@default", "@default"},
 		{"8", "_8"},
 	}
 	for _, tt := range tests {

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -219,34 +219,3 @@ func TestEnumUsage(t *testing.T) {
 		}, pulumi.WithMocks("project", "stack", mocks(1))))
 	})
 }
-
-func TestMakeSafeEnumName(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-		wantErr  bool
-	}{
-		{"+", "", true},
-		{"*", "Asterisk", false},
-		{"0", "Zero", false},
-		{"8.3", "_8_3", false},
-		{"Microsoft-Windows-Shell-Startup", "Microsoft_Windows_Shell_Startup", false},
-		{"Microsoft.Batch", "Microsoft_Batch", false},
-		{"readonly", "Readonly", false},
-		{"SystemAssigned, UserAssigned", "SystemAssigned_UserAssigned", false},
-		{"Dev(NoSLA)_Standard_D11_v2", "Dev_NoSLA_Standard_D11_v2", false},
-		{"Standard_E8as_v4+1TB_PS", "Standard_E8as_v4_1TB_PS", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.input, func(t *testing.T) {
-			got, err := makeSafeEnumName(tt.input)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("makeSafeEnumName() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.expected {
-				t.Errorf("makeSafeEnumName() got = %v, want %v", got, tt.expected)
-			}
-		})
-	}
-}

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -219,3 +219,34 @@ func TestEnumUsage(t *testing.T) {
 		}, pulumi.WithMocks("project", "stack", mocks(1))))
 	})
 }
+
+func TestMakeSafeEnumName(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{"+", "", true},
+		{"*", "Asterisk", false},
+		{"0", "Zero", false},
+		{"8.3", "_8_3", false},
+		{"Microsoft-Windows-Shell-Startup", "Microsoft_Windows_Shell_Startup", false},
+		{"Microsoft.Batch", "Microsoft_Batch", false},
+		{"readonly", "Readonly", false},
+		{"SystemAssigned, UserAssigned", "SystemAssigned_UserAssigned", false},
+		{"Dev(NoSLA)_Standard_D11_v2", "Dev_NoSLA_Standard_D11_v2", false},
+		{"Standard_E8as_v4+1TB_PS", "Standard_E8as_v4_1TB_PS", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := makeSafeEnumName(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("makeSafeEnumName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("makeSafeEnumName() got = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/codegen/go/utilities.go
+++ b/pkg/codegen/go/utilities.go
@@ -58,9 +58,12 @@ func makeValidIdentifier(name string) string {
 		if i == 0 && c == '&' {
 			firstChar++
 		}
-		if i == firstChar && !isLegalIdentifierStart(c) || i > 0 && !isLegalIdentifierPart(c) {
+		if !isLegalIdentifierPart(c) {
 			builder.WriteRune('_')
 		} else {
+			if i == firstChar && !isLegalIdentifierStart(c) {
+				builder.WriteRune('_')
+			}
 			builder.WriteRune(c)
 		}
 	}

--- a/pkg/codegen/go/utilities.go
+++ b/pkg/codegen/go/utilities.go
@@ -52,16 +52,16 @@ func isLegalIdentifierPart(c rune) bool {
 // prefixed with _. No attempt is made to ensure that the result is unique.
 func makeValidIdentifier(name string) string {
 	var builder strings.Builder
-	firstChar := 0
 	for i, c := range name {
 		// ptr dereference
 		if i == 0 && c == '&' {
-			firstChar++
+			builder.WriteRune(c)
+			continue
 		}
 		if !isLegalIdentifierPart(c) {
 			builder.WriteRune('_')
 		} else {
-			if i == firstChar && !isLegalIdentifierStart(c) {
+			if i == 0 && !isLegalIdentifierStart(c) {
 				builder.WriteRune('_')
 			}
 			builder.WriteRune(c)

--- a/pkg/codegen/go/utilities_test.go
+++ b/pkg/codegen/go/utilities_test.go
@@ -1,0 +1,20 @@
+package gen
+
+import "testing"
+
+func Test_makeValidIdentifier(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"&opts0", "&opts0"},
+		{"8", "_8"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := makeValidIdentifier(tt.input); got != tt.expected {
+				t.Errorf("makeValidIdentifier() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -67,6 +67,7 @@ func TestMakeSafeEnumName(t *testing.T) {
 		{"+", "", true},
 		{"*", "Asterisk", false},
 		{"0", "Zero", false},
+		{"8.3", "_8_3", false},
 		{"Microsoft-Windows-Shell-Startup", "Microsoft_Windows_Shell_Startup", false},
 		{"Microsoft.Batch", "Microsoft_Batch", false},
 		{"readonly", "Readonly", false},

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -44,6 +44,7 @@ func TestMakeSafeEnumName(t *testing.T) {
 		{"+", "", true},
 		{"*", "ASTERISK", false},
 		{"0", "ZERO", false},
+		{"8.3", "_8_3", false},
 		{"Microsoft-Windows-Shell-Startup", "MICROSOFT_WINDOWS_SHELL_STARTUP", false},
 		{"Microsoft.Batch", "MICROSOFT_BATCH", false},
 		{"readonly", "READONLY", false},


### PR DESCRIPTION
Currently, in [python](https://github.com/pulumi/pulumi/blob/master/pkg/codegen/python/utilities.go#L45) and [nodejs](https://github.com/pulumi/pulumi/blob/master/pkg/codegen/nodejs/utilities.go#L87), `makeValidIdentifier` adds an underscore **before** the starting character (i.e., `8` -> `_8`), but in C# and Go it **replaces** the starting character (i.e., `8` -> `_`). This PR updates the latter to match the former.