### PR TITLE
Fix bug with ComponentResource resource refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGELOG
 
 - [sdk/dotnet] Add collection initializers for smooth support of Union<T, U> as element type
   [#5938](https://github.com/pulumi/pulumi/pull/5938)
+  
+- Fix a bug in the core engine where ComponentResource state would be accessed before initialization.
+  [#5949](https://github.com/pulumi/pulumi/pull/5949)
 
 ## 2.15.6 (2020-12-12)
 

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -1930,6 +1930,7 @@ func TestComponentOutputs(t *testing.T) {
 		err = monitor.RegisterResourceOutputs(urn, resource.PropertyMap{
 			"foo": resource.NewStringProperty("bar"),
 		})
+		assert.NoError(t, err)
 		return nil
 	})
 	host := deploytest.NewPluginHost(nil, nil, program)

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -134,8 +134,7 @@ func TestSingleResourceDiffUnavailable(t *testing.T) {
 	snap, res := TestOp(Update).Run(project, p.GetTarget(nil), p.Options, false, p.BackendClient, nil)
 	assert.Nil(t, res)
 
-	// Now change the inputs to our resource and run a preview.
-	inputs = resource.PropertyMap{"foo": resource.NewStringProperty("bar")}
+	// Now run a preview. Expect a warning because the diff is unavailable.
 	_, res = TestOp(Update).Run(project, p.GetTarget(snap), p.Options, true, p.BackendClient,
 		func(_ workspace.Project, _ deploy.Target, _ JournalEntries,
 			events []Event, res result.Result) result.Result {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -929,10 +929,20 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 
 	// Filter out partially-known values if the requestor does not support them.
 	outputs := result.State.Outputs
+
+	// Local ComponentResources may contain unresolved resource refs, so ignore those outputs.
 	if !req.GetCustom() && !remote {
-		// Local ComponentResources may contain unresolved resource refs, so ignore those outputs.
+		// In the case of a SameStep, the old resource outputs are returned to the language host after the step is
+		// executed. The outputs of a ComponentResource may depend on resources that have not been registered at the
+		// time the ComponentResource is itself registered, as the outputs are set by a later call to
+		// RegisterResourceOutputs. Therefore, when the SameStep returns the old resource outputs for a
+		// ComponentResource, it may return references to resources that have not yet been registered, which will cause
+		// the SDK's calls to getResource to fail when it attempts to resolve those references.
+		//
+		// Work on a more targeted fix is tracked in https://github.com/pulumi/pulumi/issues/5978
 		outputs = resource.PropertyMap{}
 	}
+
 	if !req.GetSupportsPartialValues() {
 		logging.V(5).Infof("stripping unknowns from RegisterResource response for urn %v", result.State.URN)
 		filtered := resource.PropertyMap{}

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -929,6 +929,10 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 
 	// Filter out partially-known values if the requestor does not support them.
 	outputs := result.State.Outputs
+	if !req.GetCustom() && !remote {
+		// Local ComponentResources may contain unresolved resource refs, so ignore those outputs.
+		outputs = resource.PropertyMap{}
+	}
 	if !req.GetSupportsPartialValues() {
 		logging.V(5).Infof("stripping unknowns from RegisterResource response for urn %v", result.State.URN)
 		filtered := resource.PropertyMap{}


### PR DESCRIPTION
Now that resources are serialized as refs, ComponentResources
may try to unmarshal local resource refs before they are
initialized during the RegisterResource step.

This change avoids that issue by skipping Output marshaling
for local ComponentResources during the RegisterResource step.
These Outputs will be handled instead during the
RegisterResourceOutputs step.

Fix https://github.com/pulumi/pulumi/issues/5940