### PR TITLE
[codegen/dotnet] - Fix enum naming for k8s

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -187,7 +187,9 @@ func (mod *modContext) tokenToNamespace(tok string, qualifier string) string {
 	pkg, nsName := "Pulumi."+namespaceName(mod.namespaces, components[0]), mod.pkg.TokenToModule(tok)
 
 	if mod.isK8sCompatMode() {
-		return pkg + ".Types." + qualifier + "." + namespaceName(mod.namespaces, nsName)
+		if qualifier != "" {
+			return pkg + ".Types." + qualifier + "." + namespaceName(mod.namespaces, nsName)
+		}
 	}
 
 	typ := pkg


### PR DESCRIPTION
Fixes the enum typestring from `Pulumi.Kubernetes.Types..Core.V1.ServiceSpecType` to `Pulumi.Kubernetes.Core.V1.ServiceSpecType`