### PR TITLE
Improve resource ref unit tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fix a bug in the core engine that could cause resources references to marshal improperly
+  during preview.
+  [#5960](https://github.com/pulumi/pulumi/pull/5960)
+
 - [sdk/dotnet] Add collection initializers for smooth support of Union<T, U> as element type
   [#5938](https://github.com/pulumi/pulumi/pull/5938)
 

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -123,13 +123,14 @@ func newDestroyCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				Parallel:               parallel,
-				Debug:                  debug,
-				Refresh:                refresh,
-				DestroyTargets:         targetUrns,
-				TargetDependents:       targetDependents,
-				UseLegacyDiff:          useLegacyDiff(),
-				DisableProviderPreview: disableProviderPreview(),
+				Parallel:                  parallel,
+				Debug:                     debug,
+				Refresh:                   refresh,
+				DestroyTargets:            targetUrns,
+				TargetDependents:          targetDependents,
+				UseLegacyDiff:             useLegacyDiff(),
+				DisableProviderPreview:    disableProviderPreview(),
+				DisableResourceReferences: disableResourceReferences(),
 			}
 
 			_, res := s.Destroy(commandContext(), backend.UpdateOperation{

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -144,15 +144,16 @@ func newPreviewCmd() *cobra.Command {
 
 			opts := backend.UpdateOptions{
 				Engine: engine.UpdateOptions{
-					LocalPolicyPacks:       engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
-					Parallel:               parallel,
-					Debug:                  debug,
-					Refresh:                refresh,
-					ReplaceTargets:         replaceURNs,
-					UseLegacyDiff:          useLegacyDiff(),
-					DisableProviderPreview: disableProviderPreview(),
-					UpdateTargets:          targetURNs,
-					TargetDependents:       targetDependents,
+					LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
+					Parallel:                  parallel,
+					Debug:                     debug,
+					Refresh:                   refresh,
+					ReplaceTargets:            replaceURNs,
+					UseLegacyDiff:             useLegacyDiff(),
+					DisableProviderPreview:    disableProviderPreview(),
+					DisableResourceReferences: disableResourceReferences(),
+					UpdateTargets:             targetURNs,
+					TargetDependents:          targetDependents,
 				},
 				Display: displayOpts,
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -122,11 +122,12 @@ func newRefreshCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				Parallel:               parallel,
-				Debug:                  debug,
-				UseLegacyDiff:          useLegacyDiff(),
-				DisableProviderPreview: disableProviderPreview(),
-				RefreshTargets:         targetUrns,
+				Parallel:                  parallel,
+				Debug:                     debug,
+				UseLegacyDiff:             useLegacyDiff(),
+				DisableProviderPreview:    disableProviderPreview(),
+				DisableResourceReferences: disableResourceReferences(),
+				RefreshTargets:            targetUrns,
 			}
 
 			changes, res := s.Refresh(commandContext(), backend.UpdateOperation{

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -122,16 +122,17 @@ func newUpCmd() *cobra.Command {
 		}
 
 		opts.Engine = engine.UpdateOptions{
-			LocalPolicyPacks:       engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
-			Parallel:               parallel,
-			Debug:                  debug,
-			Refresh:                refresh,
-			RefreshTargets:         targetURNs,
-			ReplaceTargets:         replaceURNs,
-			UseLegacyDiff:          useLegacyDiff(),
-			DisableProviderPreview: disableProviderPreview(),
-			UpdateTargets:          targetURNs,
-			TargetDependents:       targetDependents,
+			LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
+			Parallel:                  parallel,
+			Debug:                     debug,
+			Refresh:                   refresh,
+			RefreshTargets:            targetURNs,
+			ReplaceTargets:            replaceURNs,
+			UseLegacyDiff:             useLegacyDiff(),
+			DisableProviderPreview:    disableProviderPreview(),
+			DisableResourceReferences: disableResourceReferences(),
+			UpdateTargets:             targetURNs,
+			TargetDependents:          targetDependents,
 		}
 
 		changes, res := s.Update(commandContext(), backend.UpdateOperation{

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -72,13 +72,10 @@ func disableProviderPreview() bool {
 }
 
 func disableResourceReferences() bool {
-	// TODO: Temporarily disabling resource ref support (https://github.com/pulumi/pulumi-kubernetes/issues/1405)
-
-	// Allow the resource reference feature to be disabled by explicitly setting an env var.
-	//	if v, ok := os.LookupEnv("PULUMI_DISABLE_RESOURCE_REFERENCES"); ok && cmdutil.IsTruthy(v) {
-	//		hasSupport = false
-	//	}
-
+	// Allow the resource reference feature to be enabled by explicitly setting an env var.
+	if v, ok := os.LookupEnv("PULUMI_ENABLE_RESOURCE_REFERENCES"); ok && cmdutil.IsTruthy(v) {
+		return false
+	}
 	return true
 }
 

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -71,6 +71,17 @@ func disableProviderPreview() bool {
 	return cmdutil.IsTruthy(os.Getenv("PULUMI_DISABLE_PROVIDER_PREVIEW"))
 }
 
+func disableResourceReferences() bool {
+	// TODO: Temporarily disabling resource ref support (https://github.com/pulumi/pulumi-kubernetes/issues/1405)
+
+	// Allow the resource reference feature to be disabled by explicitly setting an env var.
+	//	if v, ok := os.LookupEnv("PULUMI_DISABLE_RESOURCE_REFERENCES"); ok && cmdutil.IsTruthy(v) {
+	//		hasSupport = false
+	//	}
+
+	return true
+}
+
 // skipConfirmations returns whether or not confirmation prompts should
 // be skipped. This should be used by pass any requirement that a --yes
 // parameter has been set for non-interactive scenarios.

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -114,12 +114,13 @@ func newWatchCmd() *cobra.Command {
 			}
 
 			opts.Engine = engine.UpdateOptions{
-				LocalPolicyPacks:       engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
-				Parallel:               parallel,
-				Debug:                  debug,
-				Refresh:                refresh,
-				UseLegacyDiff:          useLegacyDiff(),
-				DisableProviderPreview: disableProviderPreview(),
+				LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
+				Parallel:                  parallel,
+				Debug:                     debug,
+				Refresh:                   refresh,
+				UseLegacyDiff:             useLegacyDiff(),
+				DisableProviderPreview:    disableProviderPreview(),
+				DisableResourceReferences: disableResourceReferences(),
 			}
 
 			res := s.Watch(commandContext(), backend.UpdateOperation{

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -236,17 +236,18 @@ func (deployment *deployment) run(cancelCtx *Context, actions runActions, policy
 	var walkResult result.Result
 	go func() {
 		opts := deploy.Options{
-			Events:            actions,
-			Parallel:          deployment.Options.Parallel,
-			Refresh:           deployment.Options.Refresh,
-			RefreshOnly:       deployment.Options.isRefresh,
-			RefreshTargets:    deployment.Options.RefreshTargets,
-			ReplaceTargets:    deployment.Options.ReplaceTargets,
-			DestroyTargets:    deployment.Options.DestroyTargets,
-			UpdateTargets:     deployment.Options.UpdateTargets,
-			TargetDependents:  deployment.Options.TargetDependents,
-			TrustDependencies: deployment.Options.trustDependencies,
-			UseLegacyDiff:     deployment.Options.UseLegacyDiff,
+			Events:                    actions,
+			Parallel:                  deployment.Options.Parallel,
+			Refresh:                   deployment.Options.Refresh,
+			RefreshOnly:               deployment.Options.isRefresh,
+			RefreshTargets:            deployment.Options.RefreshTargets,
+			ReplaceTargets:            deployment.Options.ReplaceTargets,
+			DestroyTargets:            deployment.Options.DestroyTargets,
+			UpdateTargets:             deployment.Options.UpdateTargets,
+			TargetDependents:          deployment.Options.TargetDependents,
+			TrustDependencies:         deployment.Options.trustDependencies,
+			UseLegacyDiff:             deployment.Options.UseLegacyDiff,
+			DisableResourceReferences: deployment.Options.DisableResourceReferences,
 		}
 		walkResult = deployment.Deployment.Execute(ctx, opts, preview)
 		close(done)

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -1689,57 +1689,6 @@ func TestSingleComponentDefaultProviderLifecycle(t *testing.T) {
 	p.Run(t, nil)
 }
 
-func TestResourceReferences(t *testing.T) {
-	var urnA resource.URN
-	var idA resource.ID
-
-	loaders := []*deploytest.ProviderLoader{
-		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
-			v := &deploytest.Provider{
-				CreateF: func(urn resource.URN, news resource.PropertyMap,
-					timeout float64, preview bool) (resource.ID, resource.PropertyMap, resource.Status, error) {
-
-					if urn.Name() == "resB" {
-						propA, ok := news["resA"]
-						assert.True(t, ok)
-						assert.Equal(t, resource.MakeResourceReference(urnA, idA, true, ""), propA)
-					}
-
-					return "created-id", news, resource.StatusOK, nil
-				},
-				ReadF: func(urn resource.URN, id resource.ID,
-					inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error) {
-					return plugin.ReadResult{Inputs: inputs, Outputs: state}, resource.StatusOK, nil
-				},
-			}
-			return v, nil
-		}),
-	}
-
-	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		var err error
-		urnA, idA, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true)
-		assert.NoError(t, err)
-
-		ins := resource.PropertyMap{
-			"resA": resource.MakeResourceReference(urnA, idA, true, ""),
-		}
-		_, _, props, err := monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
-			Inputs: ins,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, ins, props)
-		return nil
-	})
-	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
-
-	p := &TestPlan{
-		Options: UpdateOptions{Host: host},
-		Steps:   MakeBasicLifecycleSteps(t, 3),
-	}
-	p.Run(t, nil)
-}
-
 type updateContext struct {
 	*deploytest.ResourceMonitor
 

--- a/pkg/engine/lifeycletest/resource_reference_test.go
+++ b/pkg/engine/lifeycletest/resource_reference_test.go
@@ -1,0 +1,221 @@
+//nolint:goconst
+package lifecycletest
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/pulumi/pulumi/pkg/v2/engine"
+	"github.com/pulumi/pulumi/pkg/v2/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/plugin"
+)
+
+// TestResourceReferences tests that resource references can be marshaled between the engine, language host,
+// resource providers, and statefile if each entity supports resource references.
+func TestResourceReferences(t *testing.T) {
+	var urnA resource.URN
+	var urnB resource.URN
+	var idB resource.ID
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			v := &deploytest.Provider{
+				CreateF: func(urn resource.URN, news resource.PropertyMap,
+					timeout float64, preview bool) (resource.ID, resource.PropertyMap, resource.Status, error) {
+
+					id := "created-id"
+					if preview {
+						id = ""
+					}
+
+					if urn.Name() == "resC" {
+						assert.True(t, news.DeepEquals(resource.PropertyMap{
+							"resA": resource.MakeResourceReference(urnA, "", false, ""),
+							"resB": resource.MakeResourceReference(urnB, idB, true, ""),
+						}))
+					}
+
+					return resource.ID(id), news, resource.StatusOK, nil
+				},
+				ReadF: func(urn resource.URN, id resource.ID,
+					inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error) {
+					return plugin.ReadResult{Inputs: inputs, Outputs: state}, resource.StatusOK, nil
+				},
+			}
+			return v, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		var err error
+		urnA, _, _, err = monitor.RegisterResource("component", "resA", false)
+		assert.NoError(t, err)
+
+		err = monitor.RegisterResourceOutputs(urnA, resource.PropertyMap{})
+		assert.NoError(t, err)
+
+		urnB, idB, _, err = monitor.RegisterResource("pkgA:m:typA", "resB", true)
+		assert.NoError(t, err)
+
+		_, _, props, err := monitor.RegisterResource("pkgA:m:typA", "resC", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{
+				"resA": resource.MakeResourceReference(urnA, "", false, ""),
+				"resB": resource.MakeResourceReference(urnB, idB, true, ""),
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.True(t, props.DeepEquals(resource.PropertyMap{
+			"resA": resource.MakeResourceReference(urnA, "", false, ""),
+			"resB": resource.MakeResourceReference(urnB, idB, true, ""),
+		}))
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+		Steps:   MakeBasicLifecycleSteps(t, 4),
+	}
+	p.Run(t, nil)
+}
+
+// TestResourceReferences_DownlevelSDK tests that resource references are properly marshaled as URNs (for references to
+// component resources) or IDs (for references to custom resources) if the SDK does not support resource references.
+func TestResourceReferences_DownlevelSDK(t *testing.T) {
+	var urnA resource.URN
+	var urnB resource.URN
+	var idB resource.ID
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			v := &deploytest.Provider{
+				CreateF: func(urn resource.URN, news resource.PropertyMap,
+					timeout float64, preview bool) (resource.ID, resource.PropertyMap, resource.Status, error) {
+
+					id := "created-id"
+					if preview {
+						id = ""
+					}
+
+					state := resource.PropertyMap{}
+					if urn.Name() == "resC" {
+						state = resource.PropertyMap{
+							"resA": resource.MakeResourceReference(urnA, "", false, ""),
+							"resB": resource.MakeResourceReference(urnB, idB, true, ""),
+						}
+					}
+
+					return resource.ID(id), state, resource.StatusOK, nil
+				},
+				ReadF: func(urn resource.URN, id resource.ID,
+					inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error) {
+					return plugin.ReadResult{Inputs: inputs, Outputs: state}, resource.StatusOK, nil
+				},
+			}
+			return v, nil
+		}),
+	}
+
+	opts := deploytest.ResourceOptions{DisableResourceReferences: true}
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		var err error
+		urnA, _, _, err = monitor.RegisterResource("component", "resA", false, opts)
+		assert.NoError(t, err)
+
+		err = monitor.RegisterResourceOutputs(urnA, resource.PropertyMap{})
+		assert.NoError(t, err)
+
+		urnB, idB, _, err = monitor.RegisterResource("pkgA:m:typA", "resB", true, opts)
+		assert.NoError(t, err)
+
+		_, _, props, err := monitor.RegisterResource("pkgA:m:typA", "resC", true, opts)
+		assert.NoError(t, err)
+
+		assert.True(t, props.DeepEquals(resource.PropertyMap{
+			"resA": resource.NewStringProperty(string(urnA)),
+			"resB": resource.NewStringProperty(string(idB)),
+		}))
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+		Steps:   MakeBasicLifecycleSteps(t, 4),
+	}
+	p.Run(t, nil)
+}
+
+// TestResourceReferences_DownlevelEngine tests an SDK that supports resource references communicating with an engine
+// that does not.
+func TestResourceReferences_DownlevelEngine(t *testing.T) {
+	var urnA resource.URN
+	var urnB resource.URN
+	var idB resource.ID
+
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			v := &deploytest.Provider{
+				CreateF: func(urn resource.URN, news resource.PropertyMap,
+					timeout float64, preview bool) (resource.ID, resource.PropertyMap, resource.Status, error) {
+
+					id := "created-id"
+					if preview {
+						id = ""
+					}
+
+					// If we have resource references here, the engine has not properly disabled them.
+					if urn.Name() == "resC" {
+						assert.Equal(t, resource.NewStringProperty(string(urnA)), news["resA"])
+						assert.Equal(t, resource.NewStringProperty(string(idB)), news["resB"])
+					}
+
+					return resource.ID(id), news, resource.StatusOK, nil
+				},
+				ReadF: func(urn resource.URN, id resource.ID,
+					inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error) {
+					return plugin.ReadResult{Inputs: inputs, Outputs: state}, resource.StatusOK, nil
+				},
+			}
+			return v, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		var err error
+		urnA, _, _, err = monitor.RegisterResource("component", "resA", false)
+		assert.NoError(t, err)
+
+		err = monitor.RegisterResourceOutputs(urnA, resource.PropertyMap{})
+		assert.NoError(t, err)
+
+		urnB, idB, _, err = monitor.RegisterResource("pkgA:m:typA", "resB", true)
+		assert.NoError(t, err)
+
+		_, _, props, err := monitor.RegisterResource("pkgA:m:typA", "resC", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{
+				"resA": resource.MakeResourceReference(urnA, "", false, ""),
+				"resB": resource.MakeResourceReference(urnB, idB, true, ""),
+			},
+		})
+		assert.NoError(t, err)
+
+		assert.True(t, props.DeepEquals(resource.PropertyMap{
+			"resA": resource.NewStringProperty(string(urnA)),
+			"resB": resource.NewStringProperty(string(idB)),
+		}))
+		return nil
+	})
+
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host, DisableResourceReferences: true},
+		Steps:   MakeBasicLifecycleSteps(t, 4),
+	}
+	p.Run(t, nil)
+}

--- a/pkg/engine/update.go
+++ b/pkg/engine/update.go
@@ -134,6 +134,9 @@ type UpdateOptions struct {
 	// true if the engine should disable provider previews.
 	DisableProviderPreview bool
 
+	// true if the engine should disable resource reference support.
+	DisableResourceReferences bool
+
 	// true if we should report events for steps that involve default providers.
 	reportDefaultProviderSteps bool
 

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -49,17 +49,18 @@ type BackendClient interface {
 
 // Options controls the deployment process.
 type Options struct {
-	Events            Events         // an optional events callback interface.
-	Parallel          int            // the degree of parallelism for resource operations (<=1 for serial).
-	Refresh           bool           // whether or not to refresh before executing the deployment.
-	RefreshOnly       bool           // whether or not to exit after refreshing.
-	RefreshTargets    []resource.URN // The specific resources to refresh during a refresh op.
-	ReplaceTargets    []resource.URN // Specific resources to replace.
-	DestroyTargets    []resource.URN // Specific resources to destroy.
-	UpdateTargets     []resource.URN // Specific resources to update.
-	TargetDependents  bool           // true if we're allowing things to proceed, even with unspecified targets
-	TrustDependencies bool           // whether or not to trust the resource dependency graph.
-	UseLegacyDiff     bool           // whether or not to use legacy diffing behavior.
+	Events                    Events         // an optional events callback interface.
+	Parallel                  int            // the degree of parallelism for resource operations (<=1 for serial).
+	Refresh                   bool           // whether or not to refresh before executing the deployment.
+	RefreshOnly               bool           // whether or not to exit after refreshing.
+	RefreshTargets            []resource.URN // The specific resources to refresh during a refresh op.
+	ReplaceTargets            []resource.URN // Specific resources to replace.
+	DestroyTargets            []resource.URN // Specific resources to destroy.
+	UpdateTargets             []resource.URN // Specific resources to update.
+	TargetDependents          bool           // true if we're allowing things to proceed, even with unspecified targets
+	TrustDependencies         bool           // whether or not to trust the resource dependency graph.
+	UseLegacyDiff             bool           // whether or not to use legacy diffing behavior.
+	DisableResourceReferences bool           // true to disable resource reference support.
 }
 
 // DegreeOfParallelism returns the degree of parallelism that should be used during the

--- a/pkg/resource/deploy/deploytest/languageruntime.go
+++ b/pkg/resource/deploy/deploytest/languageruntime.go
@@ -15,6 +15,8 @@
 package deploytest
 
 import (
+	"context"
+
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/workspace"
@@ -43,7 +45,7 @@ func (p *languageRuntime) GetRequiredPlugins(info plugin.ProgInfo) ([]workspace.
 }
 
 func (p *languageRuntime) Run(info plugin.RunInfo) (string, bool, error) {
-	monitor, err := dialMonitor(info.MonitorAddress)
+	monitor, err := dialMonitor(context.Background(), info.MonitorAddress)
 	if err != nil {
 		return "", false, err
 	}

--- a/pkg/resource/deploy/deploytest/provider.go
+++ b/pkg/resource/deploy/deploytest/provider.go
@@ -15,6 +15,7 @@
 package deploytest
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/blang/semver"
@@ -176,7 +177,7 @@ func (prov *Provider) Construct(info plugin.ConstructInfo, typ tokens.Type, name
 	if prov.ConstructF == nil {
 		return plugin.ConstructResult{}, nil
 	}
-	monitor, err := dialMonitor(info.MonitorAddress)
+	monitor, err := dialMonitor(context.Background(), info.MonitorAddress)
 	if err != nil {
 		return plugin.ConstructResult{}, err
 	}

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -166,7 +166,7 @@ func MarshalPropertyValue(v resource.PropertyValue, opts MarshalOptions) (*struc
 		ref := v.ResourceReferenceValue()
 		if !opts.KeepResources {
 			val := string(ref.URN)
-			if ref.ID != "" {
+			if ref.HasID {
 				val = string(ref.ID)
 			}
 			logging.V(5).Infof("marshalling resource value as raw URN or ID as opts.KeepResources is false")


### PR DESCRIPTION
- Add component ref coverage to the existing test
- Add coverage for a downlevel SDK communicating with an engine that
  supports resource refs
- Add coverage for a downlevel engine communicating with an SDK that
  supports resource refs

As part of improving coverage, these changes add a knob to explicitly
disable resource refs in the engine without the use of the environment
variable. The environment variable is now only read by the CLI.

I believe that these changes also fix #5939, which I needed to
address in order for the tests to pass.

Contributes to #5943.