### PR TITLE
bump nodejs test timeout for automation api

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -42,7 +42,7 @@ install_plugin:: build
 install:: install_package install_plugin
 
 istanbul_tests:: build
-	./node_modules/.bin/istanbul test --print none _mocha -- --timeout 90000 'bin/tests/**/*.spec.js'
+	./node_modules/.bin/istanbul test --print none _mocha -- --timeout 120000 'bin/tests/**/*.spec.js'
 	./node_modules/.bin/istanbul report text-summary
 	./node_modules/.bin/istanbul report text
 	./node_modules/.bin/istanbul test --print none _mocha -- 'bin/tests_with_mocks/**/*.spec.js'


### PR DESCRIPTION
Bumping timeout as we've seen some related test failures recently. 