### PR TITLE
Improve meta tags on documentation

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1356,9 +1356,9 @@ func (mod *modContext) genResourceHeader(r *schema.Resource) header {
 			"lookup functions, and supporting types.", resourceName, packageName)
 		titleTag = fmt.Sprintf("Resource %s | Package %s", resourceName, packageName)
 	} else {
-		baseDescription = fmt.Sprintf("Explore the %s resource of the %s module, "+
-			"including examples, input properties, output properties, "+
-			"lookup functions, and supporting types.", resourceName, mod.mod)
+		baseDescription = fmt.Sprintf("Documentation for the %s.%s.%s resource "+
+			"with examples, input properties, output properties, "+
+			"lookup functions, and supporting types.", mod.pkg.Name, mod.mod, resourceName)
 		titleTag = fmt.Sprintf("%s.%s.%s", mod.pkg.Name, mod.mod, resourceName)
 	}
 

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -1348,15 +1348,16 @@ func filterOutputProperties(inputProps []*schema.Property, props []*schema.Prope
 func (mod *modContext) genResourceHeader(r *schema.Resource) header {
 	packageName := formatTitleText(mod.pkg.Name)
 	resourceName := resourceName(r)
-	var baseDescription string
+	var metaDescription string
 	var titleTag string
 	if mod.mod == "" {
-		baseDescription = fmt.Sprintf("Explore the %s resource of the %s package, "+
+		metaDescription = fmt.Sprintf("Explore the %s resource of the %s package, "+
 			"including examples, input properties, output properties, "+
-			"lookup functions, and supporting types.", resourceName, packageName)
+			"lookup functions, and supporting types.", resourceName, packageName) + " " +
+			metaDescriptionRegexp.FindString(r.Comment)
 		titleTag = fmt.Sprintf("Resource %s | Package %s", resourceName, packageName)
 	} else {
-		baseDescription = fmt.Sprintf("Documentation for the %s.%s.%s resource "+
+		metaDescription = fmt.Sprintf("Documentation for the %s.%s.%s resource "+
 			"with examples, input properties, output properties, "+
 			"lookup functions, and supporting types.", mod.pkg.Name, mod.mod, resourceName)
 		titleTag = fmt.Sprintf("%s.%s.%s", mod.pkg.Name, mod.mod, resourceName)
@@ -1365,7 +1366,7 @@ func (mod *modContext) genResourceHeader(r *schema.Resource) header {
 	return header{
 		Title:    resourceName,
 		TitleTag: titleTag,
-		MetaDesc: baseDescription + " " + metaDescriptionRegexp.FindString(r.Comment),
+		MetaDesc: metaDescription,
 	}
 }
 

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -365,6 +365,7 @@ func TestResourceDocHeader(t *testing.T) {
 		ExpectedTitleTag string
 		ResourceName     string
 		ModuleName       string
+		ExpectedMetaDesc string
 	}{
 		{
 			Name:         "PackageLevelResourceHeader",
@@ -372,12 +373,14 @@ func TestResourceDocHeader(t *testing.T) {
 			// Empty string indicates the package-level root module.
 			ModuleName:       "",
 			ExpectedTitleTag: "Resource PackageLevelResource | Package prov",
+			ExpectedMetaDesc: "Explore the PackageLevelResource resource of the prov package, including examples, input properties, output properties, lookup functions, and supporting types. This is a package-level resource.",
 		},
 		{
 			Name:             "ModuleLevelResourceHeader",
 			ResourceName:     "Resource",
 			ModuleName:       "module",
 			ExpectedTitleTag: "prov.module.Resource",
+			ExpectedMetaDesc: "Documentation for the prov.module.Resource resource with examples, input properties, output properties, lookup functions, and supporting types.",
 		},
 	}
 
@@ -395,6 +398,7 @@ func TestResourceDocHeader(t *testing.T) {
 			}
 			h := mod.genResourceHeader(r)
 			assert.Equal(t, test.ExpectedTitleTag, h.TitleTag)
+			assert.Equal(t, test.ExpectedMetaDesc, h.MetaDesc)
 		})
 	}
 }


### PR DESCRIPTION
@zchase I went with the suggestion you had in the issue but happy to adjust as needed. Note the difference between the Package level and Resource level tags... both for the title tag and the meta description. Let me know if we want to bring those in alignment.

Fixes: https://github.com/pulumi/docs/issues/4799