### PR TITLE
Use `beforeEach` in NodeJS tests.

### DIFF
--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -645,6 +645,11 @@ export interface ResourcePackage {
 
 const resourcePackages = new Map<string, ResourcePackage[]>();
 
+/** @internal Used only for testing purposes. */
+export function _resetResourcePackages() {
+    resourcePackages.clear();
+}
+
 /**
  * registerResourcePackage registers a resource package that will be used to construct providers for any URNs matching
  * the package name and version that are deserialized by the current instance of the Pulumi JavaScript SDK.
@@ -669,6 +674,11 @@ const resourceModules = new Map<string, ResourceModule[]>();
 
 function moduleKey(pkg: string, mod: string): string {
     return `${pkg}:${mod}`;
+}
+
+/** @internal Used only for testing purposes. */
+export function _resetResourceModules() {
+    resourceModules.clear();
 }
 
 /**

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -17,6 +17,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { ComponentResource, URN } from "../resource";
 import { debuggablePromise } from "./debuggable";
+import { _resetResourceModules, _resetResourcePackages } from "./rpc";
 
 const engrpc = require("../proto/engine_grpc_pb.js");
 const engproto = require("../proto/engine_pb.js");
@@ -118,6 +119,8 @@ export function _reset() {
     rpcDone = Promise.resolve();
     featureSupport = {};
     options = {};
+    _resetResourcePackages();
+    _resetResourceModules();
 }
 
 /** @internal Used only for testing purposes */

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -17,7 +17,6 @@ import * as fs from "fs";
 import * as path from "path";
 import { ComponentResource, URN } from "../resource";
 import { debuggablePromise } from "./debuggable";
-import { _resetResourceModules, _resetResourcePackages } from "./rpc";
 
 const engrpc = require("../proto/engine_grpc_pb.js");
 const engproto = require("../proto/engine_pb.js");
@@ -119,8 +118,6 @@ export function _reset() {
     rpcDone = Promise.resolve();
     featureSupport = {};
     options = {};
-    _resetResourcePackages();
-    _resetResourceModules();
 }
 
 /** @internal Used only for testing purposes */

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -112,6 +112,8 @@ interface TestInputs {
 }
 
 describe("runtime", () => {
+    beforeEach(runtime._reset);
+
     describe("transferProperties", () => {
         it("marshals basic properties correctly", asyncTest(async () => {
             const inputs: TestInputs = {
@@ -164,13 +166,12 @@ describe("runtime", () => {
             transfer = gstruct.Struct.fromJavaScript(
                 await runtime.serializeProperties("test", inputs));
             result = runtime.deserializeProperties(transfer);
+            assert.ok(!runtime.isRpcSecret(result.secret1));
+            assert.ok(!runtime.isRpcSecret(result.secret2));
             assert.strictEqual(result.secret1, 1);
             assert.strictEqual(result.secret2, undefined);
-
-            runtime._setTestModeEnabled(false);
         }));
         it("marshals resource references correctly during preview", asyncTest(async () => {
-            runtime._setTestModeEnabled(false);
             runtime._setIsDryRun(true);
             runtime.setMocks(new TestMocks());
 
@@ -210,8 +211,6 @@ describe("runtime", () => {
         }));
 
         it("marshals resource references correctly during update", asyncTest(async () => {
-            runtime._setTestModeEnabled(false);
-            runtime._setIsDryRun(false);
             runtime.setMocks(new TestMocks());
 
             const component = new TestComponentResource("test");
@@ -309,8 +308,6 @@ describe("runtime", () => {
             assert.strictEqual(result.listWithMap.value[0].secret, "a secret value");
         });
         it("deserializes resource references properly during preview", asyncTest(async () => {
-            runtime._setIsDryRun(false);
-
             runtime.setMocks(new TestMocks());
             runtime._setFeatureSupport("resourceReferences", true);
             runtime.registerResourceModule("test", "index", new TestResourceModule());

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -112,7 +112,11 @@ interface TestInputs {
 }
 
 describe("runtime", () => {
-    beforeEach(runtime._reset);
+    beforeEach(() => {
+        runtime._reset();
+        runtime._resetResourcePackages();
+        runtime._resetResourceModules();
+    });
 
     describe("transferProperties", () => {
         it("marshals basic properties correctly", asyncTest(async () => {


### PR DESCRIPTION
Call `runtime._reset` prior to each test to ensure that the runtime is
in a consistent state.