### PR TITLE
Add ignoreChanges preprocessing in `ImportStep`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fix a bug in the core engine that caused `ignoreChanges` to fail for resources being imported.
+  [#5976](https://github.com/pulumi/pulumi/pull/5976)
+
 - Fix a bug in the core engine that could cause resources references to marshal improperly
   during preview.
   [#5960](https://github.com/pulumi/pulumi/pull/5960)

--- a/pkg/engine/lifeycletest/import_test.go
+++ b/pkg/engine/lifeycletest/import_test.go
@@ -428,7 +428,7 @@ const importSchema = `{
   }
 }`
 
-func TestImport(t *testing.T) {
+func TestImportPlan(t *testing.T) {
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
 			return &deploytest.Provider{
@@ -495,4 +495,63 @@ func TestImport(t *testing.T) {
 
 	assert.Nil(t, res)
 	assert.Len(t, snap.Resources, 4)
+}
+
+func TestImportIgnoreChanges(t *testing.T) {
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				DiffF: func(urn resource.URN, id resource.ID,
+					olds, news resource.PropertyMap, ignoreChanges []string) (plugin.DiffResult, error) {
+
+					if olds["foo"].DeepEquals(news["foo"]) {
+						return plugin.DiffResult{Changes: plugin.DiffNone}, nil
+					}
+
+					return plugin.DiffResult{
+						Changes: plugin.DiffSome,
+						DetailedDiff: map[string]plugin.PropertyDiff{
+							"foo": {Kind: plugin.DiffUpdate},
+						},
+					}, nil
+				},
+				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+					preview bool) (resource.ID, resource.PropertyMap, resource.Status, error) {
+
+					return "created-id", news, resource.StatusOK, nil
+				},
+				ReadF: func(urn resource.URN, id resource.ID,
+					inputs, state resource.PropertyMap) (plugin.ReadResult, resource.Status, error) {
+
+					return plugin.ReadResult{
+						Inputs: resource.PropertyMap{
+							"foo": resource.NewStringProperty("bar"),
+						},
+						Outputs: resource.PropertyMap{
+							"foo": resource.NewStringProperty("bar"),
+						},
+					}, resource.StatusOK, nil
+				},
+			}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Inputs:        resource.PropertyMap{"foo": resource.NewStringProperty("foo")},
+			ImportID:      "import-id",
+			IgnoreChanges: []string{"foo"},
+		})
+		assert.NoError(t, err)
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+	}
+
+	project := p.GetProject()
+	_, res := TestOp(Update).Run(project, p.GetTarget(nil), p.Options, false, p.BackendClient, nil)
+	assert.Nil(t, res)
 }

--- a/pkg/engine/lifeycletest/import_test.go
+++ b/pkg/engine/lifeycletest/import_test.go
@@ -552,6 +552,9 @@ func TestImportIgnoreChanges(t *testing.T) {
 	}
 
 	project := p.GetProject()
-	_, res := TestOp(Update).Run(project, p.GetTarget(nil), p.Options, false, p.BackendClient, nil)
+	snap, res := TestOp(Update).Run(project, p.GetTarget(nil), p.Options, false, p.BackendClient, nil)
 	assert.Nil(t, res)
+
+	assert.Len(t, snap.Resources, 2)
+	assert.Equal(t, resource.NewStringProperty("bar"), snap.Resources[1].Outputs["foo"])
 }

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -921,6 +921,13 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 				s.new.Inputs[k] = s.old.Inputs[k]
 			}
 		}
+	} else {
+		// Set inputs back to their old values (if any) for any "ignored" properties
+		processedInputs, res := processIgnoreChanges(s.new.Inputs, s.old.Inputs, s.ignoreChanges)
+		if res != nil {
+			return resource.StatusOK, nil, res.Error()
+		}
+		s.new.Inputs = processedInputs
 	}
 
 	// Check the inputs using the provider inputs for defaults.


### PR DESCRIPTION
The step generator applies `ignoreChanges` pre-processing for all
resources by copying old input values to the new goal for any properties
mentioned in the `ignoreChanges` list. However, this pre-processing
depends on the existence of prior inputs, which by definition does not
exist for a resource being imported prior to the issuance of the
`ImportStep`. These changes add this processing to the implementation of
`ImportStep`, using the inputs read from the provider as the prior
inputs.