### PR TITLE
Add Python resource ref unit tests.

### DIFF
--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -55,7 +55,7 @@ class Mocks(ABC):
         return {}
 
     @abstractmethod
-    def new_resource(self, type_: str, name: str, inputs: dict, provider: Optional[str], id_: Optional[str]) -> Tuple[str, dict]:
+    def new_resource(self, type_: str, name: str, inputs: dict, provider: Optional[str], id_: Optional[str]) -> Tuple[Optional[str], dict]:
         """
         new_resource mocks resource construction calls. This function should return the physical identifier and the output properties
         for the resource being constructed.

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -114,7 +114,6 @@ async def serialize_property(value: 'Input[Any]',
 
     if known_types.is_resource(value):
         resource = cast('Resource', value)
-        deps.append(resource)
 
         is_custom = known_types.is_custom_resource(value)
         resource_id = cast('CustomResource', value).id if is_custom else None


### PR DESCRIPTION
- Improve the existing coverage to use real resources and mocks
- Add tests for deserialization as well as serialization
- Add tests that serialize custom resources during preview

Contributes to #5943.