### PR TITLE
Fix virtual env path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- Fix regression in `venv` creation for python policy packs.
+  [#5992](https://github.com/pulumi/pulumi/pull/5992)
 
 ## 2.16.0 (2020-12-21)
 
-- Do not read plugins and policy packs into memory prior to exctraction, as doing so can exhaust
+- Do not read plugins and policy packs into memory prior to extraction, as doing so can exhaust
   the available memory on lower-end systems.
   [#5983](https://github.com/pulumi/pulumi/pull/5983)
 

--- a/sdk/python/python.go
+++ b/sdk/python/python.go
@@ -213,6 +213,7 @@ func InstallDependenciesWithWriters(root, venvDir string, showOutput bool, infoW
 	print("Creating virtual environment...")
 
 	// Create the virtual environment by running `python -m venv <venvDir>`.
+	venvDir = filepath.Join(root, venvDir)
 	cmd, err := Command("-m", "venv", venvDir)
 	if err != nil {
 		return err


### PR DESCRIPTION
There was a [regression](https://github.com/pulumi/pulumi/pull/5787/files#diff-4a0aed9481c8b2728775fb1fd8bf00087e85c56b10002168c675e4c4c32f2325L147-L148) introduced in #5787 that causes the `venv` for the policy pack to not be created correctly. This PR fixes the regression.

Fixes: https://github.com/pulumi/pulumi-policy/issues/262