### PR TITLE
Illustrate ignoreChanges diffing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ CHANGELOG
 ## HEAD (Unreleased)
 _(none)_
 
+- Fix an issue in the `ignoreChanges` diffing logic which prevented deep matching properties
+  which used a period in their path keys.
+
 ## 2.16.2 (2020-12-23)
 
 - Fix a bug in the core engine that could cause previews to fail if a resource with changes had

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -902,23 +902,23 @@ func TestSingleResourceIgnoreChanges(t *testing.T) {
 	snap := updateProgramWithProps(nil, resource.NewPropertyMapFromMap(map[string]interface{}{
 		"a": 1,
 		"b": map[string]interface{}{
-			"c": "foo",
+			"c.d": "foo",
 		},
-	}), []string{"a", "b.c"}, []deploy.StepOp{deploy.OpCreate})
+	}), []string{"a", "b.c.d"}, []deploy.StepOp{deploy.OpCreate})
 
 	// Ensure that a change to an ignored property results in an OpSame
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
 		"a": 2,
 		"b": map[string]interface{}{
-			"c": "bar",
+			"c.d": "bar",
 		},
-	}), []string{"a", "b.c"}, []deploy.StepOp{deploy.OpSame})
+	}), []string{"a", "b.c.d"}, []deploy.StepOp{deploy.OpSame})
 
 	// Ensure that a change to an un-ignored property results in an OpUpdate
 	snap = updateProgramWithProps(snap, resource.NewPropertyMapFromMap(map[string]interface{}{
 		"a": 3,
 		"b": map[string]interface{}{
-			"c": "qux",
+			"c.d": "qux",
 		},
 	}), nil, []deploy.StepOp{deploy.OpUpdate})
 


### PR DESCRIPTION
I'm not well-versed enough in the codebase to be able to fix the issue, but at least I should be able to illustrate it by modifying the existing unit tests a bit.

Currently it's either impossible to properly match deep structures in `ignoreChanges`, or the syntax for doing so is undocumented or at the very least hard to find. I was able to ignore properties just fine to the point where some key contains the same character as pulumi uses for separating nested props.

I would propose adding some syntax to escape this behavior for scenarios where the path separator is supposed to be a part of the key identifier. Alternatively the `ignoreChanges` syntax could be a nested structure in itself, rather than a string.

### This is pull request does not attempt to fix the issue, just illustrate it via tests

Related issue: #2663
Related PR: #3005