### PR TITLE
[sdk/go] Support maps in Invoke outputs and Read inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ CHANGELOG
   give the user some information on how to resolve the problem
   [#6044](https://github.com/pulumi/pulumi/pull/6044)
 
+- [sdk/go] Support maps in Invoke outputs and Read inputs
+  [#6014](https://github.com/pulumi/pulumi/pull/6014)
+
 ## 2.16.2 (2020-12-23)
 
 - Fix a bug in the core engine that could cause previews to fail if a resource with changes had

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -172,7 +172,8 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 
 	resultV := reflect.ValueOf(result)
 	if !(resultV.Kind() == reflect.Ptr &&
-		(resultV.Elem().Kind() == reflect.Struct || resultV.Elem().Kind() == reflect.Map)) {
+		(resultV.Elem().Kind() == reflect.Struct ||
+			(resultV.Elem().Kind() == reflect.Map && resultV.Elem().Type().Key().Kind() == reflect.String))) {
 		return errors.New("result must be a pointer to a struct or map value")
 	}
 

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -171,8 +171,9 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 	}
 
 	resultV := reflect.ValueOf(result)
-	if resultV.Kind() != reflect.Ptr || resultV.Elem().Kind() != reflect.Struct {
-		return errors.New("result must be a pointer to a struct value")
+	if !(resultV.Kind() == reflect.Ptr &&
+		(resultV.Elem().Kind() == reflect.Struct || resultV.Elem().Kind() == reflect.Map)) {
+		return errors.New("result must be a pointer to a struct or map value")
 	}
 
 	options := &invokeOptions{}
@@ -305,8 +306,9 @@ func (ctx *Context) ReadResource(
 		if propsType.Kind() == reflect.Ptr {
 			propsType = propsType.Elem()
 		}
-		if propsType.Kind() != reflect.Struct {
-			return errors.New("props must be a struct or a pointer to a struct")
+		if !(propsType.Kind() == reflect.Struct ||
+			(propsType.Kind() == reflect.Map && propsType.Key().Kind() == reflect.String)) {
+			return errors.New("props must be a struct or map or a pointer to a struct or map")
 		}
 	}
 


### PR DESCRIPTION
These are already supported by the implementation, but were prevented by overzealous input validation in Invoke and ReadResource.

Follow-up to #4522 and #4521.