### PR TITLE
Allow VERSION to be set explicitly

### DIFF
--- a/scripts/get-version
+++ b/scripts/get-version
@@ -7,7 +7,7 @@ if [ $# -eq 0 ]; then
 fi
 
 # Allow version to be set manually when building outside of git repo
-if [ ! -z ${PULUMI_VERSION+x} ]; then
+if [ -n ${PULUMI_VERSION+x} ]; then
     echo "${PULUMI_VERSION}"
     exit 0
 fi

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -7,7 +7,7 @@ if [ $# -eq 0 ]; then
 fi
 
 # Allow version to be set manually when building outside of git repo
-if [ -n ${PULUMI_VERSION+x} ]; then
+if [ -n "${PULUMI_VERSION+x}" ]; then
     echo "${PULUMI_VERSION}"
     exit 0
 fi

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -6,6 +6,12 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
+# Allow version to be set manually when building outside of git repo
+if [ ! -z ${PULUMI_VERSION+x} ]; then
+    echo "v${PULUMI_VERSION}"
+    exit 0
+fi
+
 COMMITISH=$1
 DIRTY_TAG=""
 EXACT=0

--- a/scripts/get-version
+++ b/scripts/get-version
@@ -8,7 +8,7 @@ fi
 
 # Allow version to be set manually when building outside of git repo
 if [ ! -z ${PULUMI_VERSION+x} ]; then
-    echo "v${PULUMI_VERSION}"
+    echo "${PULUMI_VERSION}"
     exit 0
 fi
 


### PR DESCRIPTION
When building for alpine aports we download the pulumi source from a
github archive (e.g.
https://github.com/pulumi/pulumi/archive/v2.16.0.tar.gz) but this
doesn't include the .git information to allow scripts/get-version to
work.

This patch, which is currently applied on top of the base pulumi
code as part of the alpine build (see [1]), simply allows the alpine
build script to explicitly set the version used. In the alpine build
script this always matches the source code archive version to download.

[1] https://gitlab.alpinelinux.org/alpine/aports/-/merge_requests/16281