### PR TITLE
[codegen] Add support for default values in enum properties

### DIFF
--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Inputs/ContainerArgs.cs
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Inputs/ContainerArgs.cs
@@ -26,6 +26,7 @@ namespace Pulumi.PlantProvider.Inputs
 
         public ContainerArgs()
         {
+            Brightness = Pulumi.PlantProvider.ContainerBrightness.One;
         }
     }
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
@@ -77,6 +77,7 @@ namespace Pulumi.PlantProvider.Tree.V1
 
         public RubberTreeArgs()
         {
+            Farm = "(unknown)";
         }
     }
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -27,6 +27,9 @@ func NewRubberTree(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Farm == nil {
+		args.Farm = pulumi.StringPtr("(unknown)")
+	}
 	var resource RubberTree
 	err := ctx.RegisterResource("plant-provider:tree/v1:RubberTree", name, args, &resource, opts...)
 	if err != nil {

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
@@ -50,7 +50,7 @@ export class RubberTree extends pulumi.CustomResource {
                 throw new Error("Missing required property 'type'");
             }
             inputs["container"] = args ? args.container : undefined;
-            inputs["farm"] = args ? args.farm : undefined;
+            inputs["farm"] = (args ? args.farm : undefined) || "(unknown)";
             inputs["type"] = args ? args.type : undefined;
         } else {
             inputs["container"] = undefined /*out*/;

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant_provider/_inputs.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant_provider/_inputs.py
@@ -21,6 +21,8 @@ class ContainerArgs:
                  color: Optional[pulumi.Input[Union['ContainerColor', str]]] = None,
                  material: Optional[pulumi.Input[str]] = None):
         pulumi.set(__self__, "size", size)
+        if brightness is None:
+            brightness = 1
         if brightness is not None:
             pulumi.set(__self__, "brightness", brightness)
         if color is not None:

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant_provider/outputs.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant_provider/outputs.py
@@ -21,6 +21,8 @@ class Container(dict):
                  color: Optional[str] = None,
                  material: Optional[str] = None):
         pulumi.set(__self__, "size", size)
+        if brightness is None:
+            brightness = 1
         if brightness is not None:
             pulumi.set(__self__, "brightness", brightness)
         if color is not None:

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant_provider/tree/v1/rubber_tree.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant_provider/tree/v1/rubber_tree.py
@@ -48,6 +48,8 @@ class RubberTree(pulumi.CustomResource):
             __props__ = dict()
 
             __props__['container'] = container
+            if farm is None:
+                farm = '(unknown)'
             __props__['farm'] = farm
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/schema.json
@@ -14,7 +14,8 @@
           "oneOf": [
             {"$ref": "#/types/plant-provider:tree/v1:Farm"},
             {"type": "string"}
-          ]
+          ],
+          "default": "(unknown)"
         }
       },
       "properties": {
@@ -52,7 +53,8 @@
           ]
         },
         "brightness": {
-          "$ref": "#/types/plant-provider::ContainerBrightness"
+          "$ref": "#/types/plant-provider::ContainerBrightness",
+          "default": 1.0
         }
       },
       "required": ["size"]

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1534,21 +1534,17 @@ func bindTypes(pkg *Package, complexTypes map[string]ComplexTypeSpec, loader Loa
 			typ := &EnumType{Token: token}
 			typs.enums[token] = typ
 			typs.named[token] = typ
+
+			// Bind enums before object types because object type generation depends on enum values to be present.
+			if err := typs.bindEnumTypeDetails(typs.enums[token], token, spec); err != nil {
+				return nil, errors.Wrapf(err, "failed to bind type %s", token)
+			}
 		}
 	}
 
 	// Process resources.
 	for _, r := range pkg.Resources {
 		typs.resources[r.Token] = &ResourceType{Token: r.Token}
-	}
-
-	// Process enums.
-	for token, spec := range complexTypes {
-		if len(spec.Enum) > 0 {
-			if err := typs.bindEnumTypeDetails(typs.enums[token], token, spec); err != nil {
-				return nil, errors.Wrapf(err, "failed to bind type %s", token)
-			}
-		}
 	}
 
 	// Process object types.


### PR DESCRIPTION
While trying to implement https://github.com/pulumi/pulumi-azure-nextgen/issues/183 I noticed that schema binding fails for enum properties if they have a default value.

This PR binds the default value to the underlying type of the enum, both strict and "relaxed" (union-based).

It also adjusts the .NET codegen to set the default value to a strict enum in constructors.