### PR TITLE
Add suport to use pipenv in pulumi/actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ CHANGELOG
   give the user some information on how to resolve the problem
   [#6044](https://github.com/pulumi/pulumi/pull/6044)
 
+- Add suport for pipenv on the github action
+  [6019](https://github.com/pulumi/pulumi/pull/6019)
+
 ## 2.16.2 (2020-12-23)
 
 - Fix a bug in the core engine that could cause previews to fail if a resource with changes had

--- a/docker/actions/Dockerfile
+++ b/docker/actions/Dockerfile
@@ -18,6 +18,8 @@ LABEL "homepage"="https://pulumi.com/docs/reference/cd-github-actions/"
 RUN apt-get update -y && \
   apt-get install -y jq
 
+RUN pip install pipenv
+
 # Copy the entrypoint script.
 COPY ./entrypoint.sh /usr/bin/pulumi-action
 

--- a/docker/actions/entrypoint.sh
+++ b/docker/actions/entrypoint.sh
@@ -129,12 +129,15 @@ if [ -e requirements.txt ]; then
         $PULUMI_VENV/bin/python -m pip install --upgrade pip setuptools wheel
         $PULUMI_VENV/bin/python -m pip install -r requirements.txt
     fi
+elif [ -e Pipfile.lock ]; then
+    pipenv install
+    PULUMI_PREFIX="pipenv run"
 fi
 
 # Now just pass along all arguments to the Pulumi CLI, sending the output to a file for
 # later use. Note that we exit immediately on failure (under set -e), so we `tee` stdout, but
 # allow errors to be surfaced in the Actions log.
-PULUMI_COMMAND="pulumi $*"
+PULUMI_COMMAND="$PULUMI_PREFIX pulumi $*"
 OUTPUT_FILE=$(mktemp)
 echo "#### :tropical_drink: \`$PULUMI_COMMAND\`"
 bash -c "$PULUMI_COMMAND" | tee $OUTPUT_FILE


### PR DESCRIPTION
Fixes #6018 

About the PULUMI_PREFIX, we could also define PULUMI_COMMAND earlier, and overwrite it in the if.

I was not sure which approach was better. But open to suggestion, and can change it.