### PR TITLE
Ensure only latest nuget packages are locally installed

### DIFF
--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -35,6 +35,7 @@ build::
 	# following:
 	#
 	#     -alpha: Alpha release, typically used for work-in-progress and experimentation
+	dotnet clean
 	dotnet build dotnet.sln /p:VersionPrefix=${VERSION_PREFIX} /p:VersionSuffix=${VERSION_SUFFIX}
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v2/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
 
@@ -44,7 +45,8 @@ install_plugin::
 install:: build install_plugin
 	echo "Copying NuGet packages to ${PULUMI_NUGET}"
 	[ ! -e "$(PULUMI_NUGET)" ] || rm -rf "$(PULUMI_NUGET)/*"
-	find . -name '*.nupkg' -exec cp -p {} ${PULUMI_NUGET} \;
+	rm -f $(PULUMI_NUGET)/*.nupkg
+	find . -name '*${VERSION_PREFIX}-*.nupkg' -exec cp -p {} ${PULUMI_NUGET} \;
 
 dotnet_test:: install
 	# include the version prefix/suffix to avoid generating a separate nupkg file


### PR DESCRIPTION
Fixes: #3882

This will clean the old packages as well as only "installing" the
latest built package

This ensures old packages are not "installed"

This will only affect local builds / installs