### PR TITLE
[CLI] Allow pulumi console to accept a stack name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
 
 - Parallelize bulk operations in NodeJS Automation API.
   [#6022](https://github.com/pulumi/pulumi/pull/6022)
+  
+- [CLI] Allow `pulumi console` to accept a stack name
+  [#6031](https://github.com/pulumi/pulumi/pull/6031)
 
 ## 2.16.2 (2020-12-23)
 


### PR DESCRIPTION
Fixes: #5854

If a stackname is not passed as an argument then it will use the
currently selected stack