### PR TITLE
[CLI] Provider better user error when Pulumi credentials file is corrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ CHANGELOG
 - [CLI] Allow `pulumi console` to accept a stack name
   [#6031](https://github.com/pulumi/pulumi/pull/6031)
 
+- [CLI] Ensure errors with the Pulumi credentials file
+  give the user some information on how to resolve the problem
+  [#6044](https://github.com/pulumi/pulumi/pull/6044)
+
 ## 2.16.2 (2020-12-23)
 
 - Fix a bug in the core engine that could cause previews to fail if a resource with changes had

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -181,7 +181,8 @@ func GetStoredCredentials() (Credentials, error) {
 
 	var creds Credentials
 	if err = json.Unmarshal(c, &creds); err != nil {
-		return Credentials{}, errors.Wrapf(err, "unmarshalling credentials file")
+		return Credentials{}, errors.Wrapf(err, "failed to read Pulumi credentials file. Please re-run "+
+			"`pulumi login` to reset your credentials file")
 	}
 
 	var secrets []string


### PR DESCRIPTION
Fixes: #2779
Fixes: #5963