### PR TITLE
[codegen/dotnet] Stop generating nested unions

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -288,11 +288,6 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			typ = ns + "." + typ
 		}
 	case *schema.UnionType:
-		unionT := "Union"
-		if wrapInput {
-			unionT = "InputUnion"
-		}
-
 		elementTypeSet := stringSet{}
 		var elementTypes []string
 		for _, e := range t.ElementTypes {
@@ -309,18 +304,19 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			}
 		}
 
-		if len(elementTypes) == 1 {
+		switch len(elementTypes) {
+		case 1:
 			return mod.typeString(t.ElementTypes[0], qualifier, input, state, wrapInput, requireInitializers, optional)
+		case 2:
+			unionT := "Union"
+			if wrapInput {
+				unionT = "InputUnion"
+			}
+			typ = fmt.Sprintf("%s<%s>", unionT, strings.Join(elementTypes, ", "))
+			wrapInput = false
+		default:
+			typ = "object"
 		}
-
-		for _, e := range elementTypes[:len(elementTypes)-1] {
-			typ = fmt.Sprintf("%s%s<%s, ", typ, unionT, e)
-		}
-		last := elementTypes[len(elementTypes)-1]
-		term := strings.Repeat(">", len(elementTypes)-1)
-
-		wrapInput = false
-		typ += last + term
 	default:
 		switch t {
 		case schema.BoolType:


### PR DESCRIPTION
The current .NET codegen implementation generates nested union types for multi-case `oneOf` properties. The number of cases varies between 3 and 93 in the Azure NextGen provider. Nested union types in our C# SDK turn out to be highly problematic, see https://github.com/pulumi/pulumi-azure-nextgen/issues/19

This PR keeps `Union<T0, T1>` type for two-case unions but falls back to plain `object` for any multi-case property. While we lose some type "safety", the user experience actually becomes simpler.

I considered more advanced alternative but they seem non-trivial:

- Support inheritance in schema (including multi-level hierarchies). Possibly doable but is disruptive for all languages.
- Support `Union3<T0, T1, T2>`, `Union4...` types. The `OneOf` library that we rely on has types up to 9 generic parameters. Azure NextGEn has 100+ properties with more than 9 type parameters. OneOf's extended version has up to 32 that still doesn't cover all the cases. We likely need to generate our types and serialization/deserialization code.

We may want to do one or both of the above at some point. For now, I think the simple fallback to `object` is an improvement. FWIW, the Go SDK uses `interface{}` for similar cases.

AFAIK, no other providers are affected.