### PR TITLE
Respect the version option for provider resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Respect the `version` resource option for provider resources.
+  [#6055](https://github.com/pulumi/pulumi/pull/6055)
+
 - Allow `serializeFunction` to capture secrets.
   [#6013](https://github.com/pulumi/pulumi/pull/6013)
   

--- a/pkg/engine/lifeycletest/provider_test.go
+++ b/pkg/engine/lifeycletest/provider_test.go
@@ -659,3 +659,140 @@ func TestDefaultProviderDiffReplacement(t *testing.T) {
 		}
 	}
 }
+
+func TestProviderVersionOption(t *testing.T) {
+	version := ""
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			version = "1.0.0"
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.5.0"), func() (plugin.Provider, error) {
+			version = "1.5.0"
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, deploytest.ResourceOptions{
+			Version: "1.0.0",
+		})
+		assert.NoError(t, err)
+
+		if provID == "" {
+			provID = providers.UnknownID
+		}
+
+		provRef, err := providers.NewReference(provURN, provID)
+		assert.NoError(t, err)
+
+		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Provider: provRef.String(),
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+		Steps:   MakeBasicLifecycleSteps(t, 2),
+	}
+	p.Run(t, nil)
+
+	assert.Equal(t, "1.0.0", version)
+}
+
+func TestProviderVersionInput(t *testing.T) {
+	version := ""
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			version = "1.0.0"
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.5.0"), func() (plugin.Provider, error) {
+			version = "1.5.0"
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{
+				"version": resource.NewStringProperty("1.0.0"),
+			},
+		})
+		assert.NoError(t, err)
+
+		if provID == "" {
+			provID = providers.UnknownID
+		}
+
+		provRef, err := providers.NewReference(provURN, provID)
+		assert.NoError(t, err)
+
+		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Provider: provRef.String(),
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+		Steps:   MakeBasicLifecycleSteps(t, 2),
+	}
+	p.Run(t, nil)
+
+	assert.Equal(t, "1.0.0", version)
+}
+
+func TestProviderVersionInputAndOption(t *testing.T) {
+	version := ""
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			version = "1.0.0"
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.5.0"), func() (plugin.Provider, error) {
+			version = "1.5.0"
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, deploytest.ResourceOptions{
+			Inputs: resource.PropertyMap{
+				"version": resource.NewStringProperty("1.5.0"),
+			},
+			Version: "1.0.0",
+		})
+		assert.NoError(t, err)
+
+		if provID == "" {
+			provID = providers.UnknownID
+		}
+
+		provRef, err := providers.NewReference(provURN, provID)
+		assert.NoError(t, err)
+
+		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true, deploytest.ResourceOptions{
+			Provider: provRef.String(),
+		})
+		assert.NoError(t, err)
+
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+		Steps:   MakeBasicLifecycleSteps(t, 2),
+	}
+	p.Run(t, nil)
+
+	assert.Equal(t, "1.0.0", version)
+}

--- a/pkg/engine/lifeycletest/provider_test.go
+++ b/pkg/engine/lifeycletest/provider_test.go
@@ -1,3 +1,4 @@
+//nolint:goconst
 package lifecycletest
 
 import (
@@ -716,9 +717,10 @@ func TestProviderVersionOption(t *testing.T) {
 	}
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, deploytest.ResourceOptions{
-			Version: "1.0.0",
-		})
+		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true,
+			deploytest.ResourceOptions{
+				Version: "1.0.0",
+			})
 		assert.NoError(t, err)
 
 		if provID == "" {
@@ -760,11 +762,12 @@ func TestProviderVersionInput(t *testing.T) {
 	}
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, deploytest.ResourceOptions{
-			Inputs: resource.PropertyMap{
-				"version": resource.NewStringProperty("1.0.0"),
-			},
-		})
+		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true,
+			deploytest.ResourceOptions{
+				Inputs: resource.PropertyMap{
+					"version": resource.NewStringProperty("1.0.0"),
+				},
+			})
 		assert.NoError(t, err)
 
 		if provID == "" {
@@ -806,12 +809,13 @@ func TestProviderVersionInputAndOption(t *testing.T) {
 	}
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
-		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true, deploytest.ResourceOptions{
-			Inputs: resource.PropertyMap{
-				"version": resource.NewStringProperty("1.5.0"),
-			},
-			Version: "1.0.0",
-		})
+		provURN, provID, _, err := monitor.RegisterResource(providers.MakeProviderType("pkgA"), "provA", true,
+			deploytest.ResourceOptions{
+				Inputs: resource.PropertyMap{
+					"version": resource.NewStringProperty("1.5.0"),
+				},
+				Version: "1.0.0",
+			})
 		assert.NoError(t, err)
 
 		if provID == "" {

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -813,6 +813,9 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	if providers.IsProviderType(t) && req.GetVersion() != "" {
+		props["version"] = resource.NewStringProperty(req.GetVersion())
+	}
 
 	propertyDependencies := make(map[resource.PropertyKey][]resource.URN)
 	if len(req.GetPropertyDependencies()) == 0 {


### PR DESCRIPTION
Although raw provider resources accept an input that allows a user to
specifiy a provider version to use, this input is not reflected in
current SDK code generation. Furthermore, we already have a method to
specify the provider version that should be used for a resource: the
"version" resource option. These changes update the code that handles
provider resource registrations to autmoatically populate the version
input from the "version" resource option if the option is present.

Fixes https://github.com/pulumi/pulumi-azure/issues/803.