### PR TITLE
[codegen/pcl] Add a urnName resource option.

### DIFF
--- a/pkg/codegen/dotnet/gen_program.go
+++ b/pkg/codegen/dotnet/gen_program.go
@@ -435,8 +435,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		input.Value = g.lowerExpression(input.Value, destType.(model.Type))
 	}
 
-	name := r.Name()
-	variableName := makeValidIdentifier(name)
+	variableName := makeValidIdentifier(r.Name())
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))
 	for _, l := range r.Definition.Tokens.GetLabels(nil) {
@@ -477,7 +476,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 			g.Fgenf(w, "%s{\n", g.Indent)
 		}
 
-		resName := g.makeResourceName(name, "range."+resKey)
+		resName := g.makeResourceName(r.URNName(), "range."+resKey)
 		g.Indented(func() {
 			g.Fgenf(w, "%s%s.Add(", g.Indent, variableName)
 			instantiate(resName)
@@ -486,7 +485,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		g.Fgenf(w, "%s}\n", g.Indent)
 	} else {
 		g.Fgenf(w, "%svar %s = ", g.Indent, variableName)
-		instantiate(g.makeResourceName(name, ""))
+		instantiate(g.makeResourceName(r.URNName(), ""))
 		g.Fgenf(w, ";\n")
 	}
 

--- a/pkg/codegen/hcl2/binder_resource.go
+++ b/pkg/codegen/hcl2/binder_resource.go
@@ -313,11 +313,19 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 				case "ignoreChanges":
 					t = model.NewListType(ResourcePropertyType)
 					resourceOptions.IgnoreChanges = item.Value
+				case "urnName":
+					lit, ok := model.IsQuotedStringLiteral(item.Value)
+					if !ok {
+						diagnostics = append(diagnostics, urnNameMustBeStringLiteral(item.Value))
+					} else {
+						resourceOptions.URNName = lit
+					}
+					continue
 				default:
 					diagnostics = append(diagnostics, unsupportedAttribute(item.Name, item.Syntax.NameRange))
 					continue
 				}
-				if model.InputType(t).ConversionFrom(item.Value.Type()) == model.NoConversion {
+				if !model.InputType(t).ConversionFrom(item.Value.Type()).Exists() {
 					diagnostics = append(diagnostics, model.ExprNotConvertible(model.InputType(t), item.Value))
 				}
 			case *model.Block:

--- a/pkg/codegen/hcl2/diagnostics.go
+++ b/pkg/codegen/hcl2/diagnostics.go
@@ -68,3 +68,7 @@ func tokenMustBeStringLiteral(tokenExpr model.Expression) *hcl.Diagnostic {
 func duplicateBlock(blockType string, typeRange hcl.Range) *hcl.Diagnostic {
 	return errorf(typeRange, "duplicate block of type '%v'", blockType)
 }
+
+func urnNameMustBeStringLiteral(urnNameExpr model.Expression) *hcl.Diagnostic {
+	return errorf(urnNameExpr.SyntaxNode().Range(), "urnName must be a string literal")
+}

--- a/pkg/codegen/hcl2/invoke.go
+++ b/pkg/codegen/hcl2/invoke.go
@@ -64,12 +64,8 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return signature, nil
 	}
 
-	template, ok := args[0].(*model.TemplateExpression)
-	if !ok || len(template.Parts) != 1 {
-		return signature, hcl.Diagnostics{tokenMustBeStringLiteral(args[0])}
-	}
-	lit, ok := template.Parts[0].(*model.LiteralValueExpression)
-	if !ok || lit.Type() != model.StringType {
+	lit, ok := model.IsQuotedStringLiteral(args[0])
+	if !ok {
 		return signature, hcl.Diagnostics{tokenMustBeStringLiteral(args[0])}
 	}
 

--- a/pkg/codegen/hcl2/model/utilities.go
+++ b/pkg/codegen/hcl2/model/utilities.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
 
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
@@ -72,4 +73,25 @@ func ConstantReference(c *Constant) *ScopeTraversalExpression {
 	diags := x.Typecheck(false)
 	contract.Assert(len(diags) == 0)
 	return x
+}
+
+func NewQuotedStringLiteral(s string) *TemplateExpression {
+	return &TemplateExpression{
+		Parts: []Expression{&LiteralValueExpression{
+			Tokens: syntax.NewLiteralValueTokens(cty.StringVal(s)),
+			Value:  cty.StringVal(s),
+		}},
+	}
+}
+
+func IsQuotedStringLiteral(x Expression) (*LiteralValueExpression, bool) {
+	template, ok := x.(*TemplateExpression)
+	if !ok || len(template.Parts) != 1 {
+		return nil, false
+	}
+	lit, ok := template.Parts[0].(*LiteralValueExpression)
+	if !ok || lit.Type() != StringType {
+		return nil, false
+	}
+	return lit, true
 }

--- a/pkg/codegen/hcl2/resource.go
+++ b/pkg/codegen/hcl2/resource.go
@@ -39,6 +39,8 @@ type ResourceOptions struct {
 	Protect model.Expression
 	// A list of properties that are not considered when diffing the resource.
 	IgnoreChanges model.Expression
+	// An optional override for the "name" portion of the resource's URN.
+	URNName *model.LiteralValueExpression
 }
 
 // Resource represents a resource instantiation inside of a program or component.
@@ -92,6 +94,14 @@ func (r *Resource) Traverse(traverser hcl.Traverser) (model.Traversable, hcl.Dia
 // Name returns the name of the resource.
 func (r *Resource) Name() string {
 	return r.Definition.Labels[0]
+}
+
+// URNName returns the URN name of the resource
+func (r *Resource) URNName() string {
+	if r.Options != nil && r.Options.URNName != nil {
+		return r.Options.URNName.Value.AsString()
+	}
+	return r.Name()
 }
 
 // DecomposeToken attempts to decompose the resource's type token into its package, module, and type. If decomposition

--- a/pkg/codegen/hcl2/rewrite_convert.go
+++ b/pkg/codegen/hcl2/rewrite_convert.go
@@ -188,11 +188,7 @@ func convertPrimitiveValues(from model.Expression, to model.Type) (model.Express
 		}
 	case to.AssignableFrom(model.StringType):
 		if stringValue, ok := convertLiteralToString(from); ok {
-			expression = &model.TemplateExpression{
-				Parts: []model.Expression{&model.LiteralValueExpression{
-					Value: cty.StringVal(stringValue),
-				}},
-			}
+			expression = model.NewQuotedStringLiteral(stringValue)
 		}
 	}
 	if expression == nil {
@@ -210,12 +206,8 @@ func convertPrimitiveValues(from model.Expression, to model.Type) (model.Express
 // extractStringValue returns a string if the given expression is a template expression containing a single string
 // literal value.
 func extractStringValue(arg model.Expression) (string, bool) {
-	template, ok := arg.(*model.TemplateExpression)
-	if !ok || len(template.Parts) != 1 {
-		return "", false
-	}
-	lit, ok := template.Parts[0].(*model.LiteralValueExpression)
-	if !ok || lit.Type() != model.StringType {
+	lit, ok := model.IsQuotedStringLiteral(arg)
+	if !ok {
 		return "", false
 	}
 	return lit.Value.AsString(), true

--- a/pkg/codegen/hcl2/rewrite_properties.go
+++ b/pkg/codegen/hcl2/rewrite_properties.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/model"
-	"github.com/pulumi/pulumi/pkg/v2/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -47,15 +46,8 @@ func RewritePropertyReferences(expr model.Expression) model.Expression {
 
 		// TODO: transfer internal trivia
 
-		propertyPath := cty.StringVal(buffer.String())
-		value := &model.TemplateExpression{
-			Parts: []model.Expression{
-				&model.LiteralValueExpression{
-					Tokens: syntax.NewLiteralValueTokens(propertyPath),
-					Value:  propertyPath,
-				},
-			},
-		}
+		propertyPath := buffer.String()
+		value := model.NewQuotedStringLiteral(propertyPath)
 		value.SetLeadingTrivia(expr.GetLeadingTrivia())
 		value.SetTrailingTrivia(expr.GetTrailingTrivia())
 		diags := value.Typecheck(false)

--- a/pkg/codegen/importer/hcl2.go
+++ b/pkg/codegen/importer/hcl2.go
@@ -145,6 +145,8 @@ func makeResourceOptions(state *resource.State, names NameTable) (*model.Block, 
 			Value:  cty.True,
 		})
 	}
+	resourceOptions = appendResourceOption(resourceOptions, "urnName",
+		model.NewQuotedStringLiteral(string(state.URN.Name())))
 	return resourceOptions, nil
 }
 
@@ -462,13 +464,7 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 			Args: []model.Expression{arg},
 		}, nil
 	case value.IsString():
-		return &model.TemplateExpression{
-			Parts: []model.Expression{
-				&model.LiteralValueExpression{
-					Value: cty.StringVal(value.StringValue()),
-				},
-			},
-		}, nil
+		return model.NewQuotedStringLiteral(value.StringValue()), nil
 	default:
 		contract.Failf("unexpected property value %v", value)
 		return nil, nil

--- a/pkg/codegen/internal/test/testdata/resource-options.pp
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp
@@ -1,5 +1,9 @@
 resource provider "pulumi:providers:aws" {
 	region = "us-west-2"
+
+	options {
+		urnName = "bucket"
+	}
 }
 
 resource bucket1 "aws:s3:Bucket" {
@@ -8,5 +12,6 @@ resource bucket1 "aws:s3:Bucket" {
 		dependsOn = [provider]
 		protect = true
 		ignoreChanges = [bucket, lifecycleRules[0]]
+		urnName = "bucket"
 	}
 }

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.cs
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.cs
@@ -5,11 +5,11 @@ class MyStack : Stack
 {
     public MyStack()
     {
-        var provider = new Aws.Provider("provider", new Aws.ProviderArgs
+        var provider = new Aws.Provider("bucket", new Aws.ProviderArgs
         {
             Region = "us-west-2",
         });
-        var bucket1 = new Aws.S3.Bucket("bucket1", new Aws.S3.BucketArgs
+        var bucket1 = new Aws.S3.Bucket("bucket", new Aws.S3.BucketArgs
         {
         }, new CustomResourceOptions
         {

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.go
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.go
@@ -8,13 +8,13 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		provider, err := providers.Newaws(ctx, "provider", &providers.awsArgs{
+		provider, err := providers.Newaws(ctx, "bucket", &providers.awsArgs{
 			Region: pulumi.String("us-west-2"),
 		})
 		if err != nil {
 			return err
 		}
-		_, err = s3.NewBucket(ctx, "bucket1", nil, pulumi.Provider(provider), pulumi.DependsOn([]pulumi.Resource{
+		_, err = s3.NewBucket(ctx, "bucket", nil, pulumi.Provider(provider), pulumi.DependsOn([]pulumi.Resource{
 			provider,
 		}), pulumi.Protect(true), pulumi.IgnoreChanges([]string{
 			"bucket",

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.py
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.py
@@ -2,8 +2,8 @@ import pulumi
 import pulumi_aws as aws
 import pulumi_pulumi as pulumi
 
-provider = pulumi.providers.Aws("provider", region="us-west-2")
-bucket1 = aws.s3.Bucket("bucket1", opts=pulumi.ResourceOptions(provider=provider,
+provider = pulumi.providers.Aws("bucket", region="us-west-2")
+bucket1 = aws.s3.Bucket("bucket", opts=pulumi.ResourceOptions(provider=provider,
     depends_on=[provider],
     protect=True,
     ignore_changes=[

--- a/pkg/codegen/internal/test/testdata/resource-options.pp.ts
+++ b/pkg/codegen/internal/test/testdata/resource-options.pp.ts
@@ -1,8 +1,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as aws from "@pulumi/aws";
 
-const provider = new aws.Provider("provider", {region: "us-west-2"});
-const bucket1 = new aws.s3.Bucket("bucket1", {}, {
+const provider = new aws.Provider("bucket", {region: "us-west-2"});
+const bucket1 = new aws.s3.Bucket("bucket", {}, {
     provider: provider,
     dependsOn: [provider],
     protect: true,

--- a/pkg/codegen/nodejs/gen_program.go
+++ b/pkg/codegen/nodejs/gen_program.go
@@ -305,8 +305,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 	optionsBag := g.genResourceOptions(r.Options)
 
-	name := r.Name()
-	variableName := makeValidIdentifier(name)
+	variableName := makeValidIdentifier(r.Name())
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))
 	for _, l := range r.Definition.Tokens.GetLabels(nil) {
@@ -349,7 +348,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 			g.Fgenf(w, "%sif (%.v) {\n", g.Indent, rangeExpr)
 			g.Indented(func() {
 				g.Fgenf(w, "%s%s = ", g.Indent, variableName)
-				instantiate(g.makeResourceName(name, ""))
+				instantiate(g.makeResourceName(r.URNName(), ""))
 				g.Fgenf(w, ";\n")
 			})
 			g.Fgenf(w, "%s}\n", g.Indent)
@@ -368,7 +367,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 				g.Fgenf(w, "%sfor (const range of %.v) {\n", g.Indent, rangeExpr)
 			}
 
-			resName := g.makeResourceName(name, "range."+resKey)
+			resName := g.makeResourceName(r.URNName(), "range."+resKey)
 			g.Indented(func() {
 				g.Fgenf(w, "%s%s.push(", g.Indent, variableName)
 				instantiate(resName)
@@ -378,7 +377,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 		}
 	} else {
 		g.Fgenf(w, "%sconst %s = ", g.Indent, variableName)
-		instantiate(g.makeResourceName(name, ""))
+		instantiate(g.makeResourceName(r.URNName(), ""))
 		g.Fgenf(w, ";\n")
 	}
 

--- a/pkg/codegen/python/gen_program.go
+++ b/pkg/codegen/python/gen_program.go
@@ -338,7 +338,7 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 
 	optionsBag, temps := g.lowerResourceOptions(r.Options)
 
-	name := PyName(r.Name())
+	variableName := PyName(r.Name())
 
 	g.genTrivia(w, r.Definition.Tokens.GetType(""))
 	for _, l := range r.Definition.Tokens.Labels {
@@ -381,15 +381,15 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 	if r.Options != nil && r.Options.Range != nil {
 		rangeExpr := r.Options.Range
 		if model.InputType(model.BoolType).ConversionFrom(r.Options.Range.Type()) == model.SafeConversion {
-			g.Fgenf(w, "%s%s = None\n", g.Indent, name)
+			g.Fgenf(w, "%s%s = None\n", g.Indent, variableName)
 			g.Fgenf(w, "%sif %.v:\n", g.Indent, rangeExpr)
 			g.Indented(func() {
-				g.Fprintf(w, "%s%s = ", g.Indent, name)
-				instantiate(g.makeResourceName(r.Name(), ""))
+				g.Fprintf(w, "%s%s = ", g.Indent, variableName)
+				instantiate(g.makeResourceName(r.URNName(), ""))
 				g.Fprint(w, "\n")
 			})
 		} else {
-			g.Fgenf(w, "%s%s = []\n", g.Indent, name)
+			g.Fgenf(w, "%s%s = []\n", g.Indent, variableName)
 
 			resKey := "key"
 			if model.InputType(model.NumberType).ConversionFrom(rangeExpr.Type()) != model.NoConversion {
@@ -399,16 +399,16 @@ func (g *generator) genResource(w io.Writer, r *hcl2.Resource) {
 				g.Fgenf(w, "%sfor range in [{\"key\": k, \"value\": v} for [k, v] in enumerate(%.v)]:\n", g.Indent, rangeExpr)
 			}
 
-			resName := g.makeResourceName(r.Name(), fmt.Sprintf("range['%s']", resKey))
+			resName := g.makeResourceName(r.URNName(), fmt.Sprintf("range['%s']", resKey))
 			g.Indented(func() {
-				g.Fgenf(w, "%s%s.append(", g.Indent, name)
+				g.Fgenf(w, "%s%s.append(", g.Indent, variableName)
 				instantiate(resName)
 				g.Fprint(w, ")\n")
 			})
 		}
 	} else {
-		g.Fgenf(w, "%s%s = ", g.Indent, name)
-		instantiate(g.makeResourceName(r.Name(), ""))
+		g.Fgenf(w, "%s%s = ", g.Indent, variableName)
+		instantiate(g.makeResourceName(r.URNName(), ""))
 		g.Fprint(w, "\n")
 	}
 


### PR DESCRIPTION
This resource option controls the "name" portion of the resource's URN.
It is intended for use by the import code generator, which may need to
generate code for multiple resources that share the "name" portion of
the URN, but must still generate unique names for the PCL resource
declarations.

This is the backend half of the fix for #6032. The frontend half of the
fix will ensure that names for PCL resource declarations are unique.