### PR TITLE
[sdk/python] - Don't log if debug and no engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- Fix an issue where python debug messages print unexpectedly.
+  [#6967](https://github.com/pulumi/pulumi/pull/6067)
+  
 - [CLI] Add `version` to the stack history output to be able to
   correlate events back to the Pulumi SaaS
   [#6063](https://github.com/pulumi/pulumi/pull/6063)

--- a/sdk/python/lib/pulumi/log.py
+++ b/sdk/python/lib/pulumi/log.py
@@ -38,8 +38,6 @@ def debug(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[i
     engine = get_engine()
     if engine is not None:
         _log(engine, engine_pb2.DEBUG, msg, resource, stream_id, ephemeral)
-    else:
-        print("debug: " + msg, file=sys.stderr)
 
 
 def info(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None, ephemeral: Optional[bool] = None) -> None:


### PR DESCRIPTION
Fixes: #6066 