### PR TITLE
Fixes to support non-pulumi backends in kubernetes operator

### DIFF
--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -16,9 +16,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v2/backend"
@@ -193,6 +195,52 @@ func TestCreatingProjectWithDefaultName(t *testing.T) {
 
 	proj := loadProject(t, tempdir)
 	assert.Equal(t, defaultProjectName, proj.Name.String())
+}
+
+func TestCreatingProjectWithPulumiBackendURL(t *testing.T) {
+	skipIfShortOrNoPulumiAccessToken(t)
+
+	b, err := currentBackend(display.Options{})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(b.URL(), "https://app.pulumi.com"))
+
+	fileStateDir, _ := ioutil.TempDir("", "local-state-dir")
+	defer os.RemoveAll(fileStateDir)
+
+	// Now override to local filesystem backend
+	backendURL := "file://" + fileStateDir
+	_ = os.Setenv("PULUMI_CONFIG_PASSPHRASE", "how now brown cow")
+	_ = os.Setenv(workspace.PulumiBackendURLEnvVar, backendURL)
+	defer func() {
+		_ = os.Unsetenv(workspace.PulumiBackendURLEnvVar)
+		_ = os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
+	}()
+
+	backendInstance = nil
+	tempdir, _ := ioutil.TempDir("", "test-env-local")
+	defer os.RemoveAll(tempdir)
+	assert.NoError(t, os.Chdir(tempdir))
+	defaultProjectName := filepath.Base(tempdir)
+
+	var args = newArgs{
+		interactive:       true,
+		prompt:            promptForValue,
+		secretsProvider:   "default",
+		stack:             stackName,
+		templateNameOrURL: "typescript",
+		yes:               true,
+	}
+
+	assert.NoError(t, runNew(args))
+	proj := loadProject(t, tempdir)
+	assert.Equal(t, defaultProjectName, proj.Name.String())
+	// Expect the stack directory to have a checkpoint file for the stack.
+	_, err = os.Stat(filepath.Join(fileStateDir, workspace.BookkeepingDir, workspace.StackDir, stackName+".json"))
+	assert.NoError(t, err)
+
+	b, err = currentBackend(display.Options{})
+	require.NoError(t, err)
+	assert.Equal(t, backendURL, b.URL())
 }
 
 func TestCreatingProjectWithArgsSpecifiedName(t *testing.T) {

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -425,6 +425,7 @@ github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7q
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -131,7 +131,8 @@ func getCredsFilePath() (string, error) {
 }
 
 // GetCurrentCloudURL returns the URL of the cloud we are currently connected to. This may be empty if we
-// have not logged in.
+// have not logged in. Note if PULUMI_BACKEND_URL is set, the corresponding value is returned
+// instead irrespective of the backend for current project or stored credentials.
 func GetCurrentCloudURL() (string, error) {
 	// Allow PULUMI_BACKEND_URL to override the current cloud URL selection
 	if backend := os.Getenv(PulumiBackendURLEnvVar); backend != "" {

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -133,13 +133,12 @@ func getCredsFilePath() (string, error) {
 // GetCurrentCloudURL returns the URL of the cloud we are currently connected to. This may be empty if we
 // have not logged in.
 func GetCurrentCloudURL() (string, error) {
-	var url string
-
 	// Allow PULUMI_BACKEND_URL to override the current cloud URL selection
 	if backend := os.Getenv(PulumiBackendURLEnvVar); backend != "" {
-		url = backend
+		return backend, nil
 	}
 
+	var url string
 	// Try detecting backend from config
 	projPath, err := DetectProjectPath()
 	if err == nil && projPath != "" {

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -646,7 +646,7 @@ func (ur *UpResult) GetPermalink() (string, error) {
 func GetPermalink(stdout string) (string, error) {
 	const permalinkSearchStr = "View Live: |Permalink: "
 	startRegex := regexp.MustCompile(permalinkSearchStr)
-	var endRegex = regexp.MustCompile("\n")
+	endRegex := regexp.MustCompile("\n")
 
 	// Find the start of the permalink in the output.
 	start := startRegex.FindStringIndex(stdout)

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -644,8 +644,8 @@ func (ur *UpResult) GetPermalink() (string, error) {
 // GetPermalink returns the permalink URL in the Pulumi Console for the update
 // or refresh operation. This will error for alternate, local backends.
 func GetPermalink(stdout string) (string, error) {
-	const permalinkSearchStr = "View Live: "
-	var startRegex = regexp.MustCompile(permalinkSearchStr)
+	const permalinkSearchStr = "View Live: |Permalink: "
+	startRegex := regexp.MustCompile(permalinkSearchStr)
 	var endRegex = regexp.MustCompile("\n")
 
 	// Find the start of the permalink in the output.


### PR DESCRIPTION
Couple of quick but necessary fixes for Kubernetes operator to support backends other than app.pulumi.com.
