### PR TITLE
[sdk/dotnet] Moved urn value retrieval into if statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CHANGELOG
   correlate events back to the Pulumi SaaS
   [#6063](https://github.com/pulumi/pulumi/pull/6063)
 
+- [sdk/dotnet] Moved urn value retrieval into if statement for MockMonitor
+  [#6081](https://github.com/pulumi/pulumi/pull/6081)
+
 ## 2.17.0 (2021-01-06)
 
 - Respect the `version` resource option for provider resources.

--- a/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
@@ -33,10 +33,10 @@ namespace Pulumi.Testing
         public async Task<InvokeResponse> InvokeAsync(InvokeRequest request)
         {
             var args = ToDictionary(request.Args);
-            var urn = (string)args["urn"];
 
             if (request.Tok == "pulumi:pulumi:getResource")
             {
+                var urn = (string)args["urn"];
                 object? registeredResource;
                 lock (_registeredResources)
                 {


### PR DESCRIPTION
Fixes #6080

For more details check #6080 
The problem is that if the urn is not present in the given args, then the unit tests will fail. 
