### PR TITLE
Fix looking up empty version in ResourcePackages.TryGetResourceType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ CHANGELOG
   determine if an output has a secret within the output.
   [#6092](https://github.com/pulumi/pulumi/pull/6092)
 
+- [sdk/dotnet] Fix looking up empty version in `ResourcePackages.TryGetResourceType`.
+  [#6084](https://github.com/pulumi/pulumi/pull/6084)
+
 ## 2.17.0 (2021-01-06)
 
 - Respect the `version` resource option for provider resources.

--- a/sdk/dotnet/Pulumi.Tests/Serialization/ResourcePackagesTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/ResourcePackagesTests.cs
@@ -13,6 +13,10 @@ namespace Pulumi.Tests.Serialization
             {
                 Assert.True(false, "Unknown resource found");
             }
+            if (ResourcePackages.TryGetResourceType("test:index/UnknownResource", "", out _))
+            {
+                Assert.True(false, "Unknown resource found");
+            }
             if (ResourcePackages.TryGetResourceType("unknown:index/TestResource", "0.0.1", out _))
             {
                 Assert.True(false, "Unknown resource found");
@@ -22,9 +26,9 @@ namespace Pulumi.Tests.Serialization
                 Assert.True(false, "Resource with non-matching assembly version found");
             }
         }
-        
+
         [Fact]
-        public void BlankReturnsHighestVersion()
+        public void NullReturnsHighestVersion()
         {
             if (ResourcePackages.TryGetResourceType("test:index/TestResource", null, out var type))
             {
@@ -35,7 +39,20 @@ namespace Pulumi.Tests.Serialization
                 Assert.True(false, "Test resource not found");
             }
         }
-        
+
+        [Fact]
+        public void BlankReturnsHighestVersion()
+        {
+            if (ResourcePackages.TryGetResourceType("test:index/TestResource", "", out var type))
+            {
+                Assert.Equal(typeof(Version202TestResource), type);
+            }
+            else
+            {
+                Assert.True(false, "Test resource not found");
+            }
+        }
+
         [Fact]
         public void MajorVersionRespected()
         {
@@ -48,7 +65,7 @@ namespace Pulumi.Tests.Serialization
                 Assert.True(false, "Test resource not found");
             }
         }
-        
+
         [Fact]
         public void WildcardSelectedIfOthersDontMatch()
         {
@@ -69,7 +86,7 @@ namespace Pulumi.Tests.Serialization
             {
             }
         }
-        
+
         [ResourceType("test:index/TestResource", "1.0.2")]
         private class Version102TestResource : CustomResource
         {
@@ -77,7 +94,7 @@ namespace Pulumi.Tests.Serialization
             {
             }
         }
-        
+
         [ResourceType("test:index/TestResource", "2.0.2")]
         private class Version202TestResource : CustomResource
         {
@@ -85,7 +102,7 @@ namespace Pulumi.Tests.Serialization
             {
             }
         }
-        
+
         [ResourceType("test:index/TestResource", null)]
         private class WildcardTestResource : CustomResource
         {
@@ -93,7 +110,7 @@ namespace Pulumi.Tests.Serialization
             {
             }
         }
-        
+
         [ResourceType("test:index/UnrelatedResource", "1.0.3")]
         private class OtherResource : CustomResource
         {

--- a/sdk/dotnet/Pulumi/Serialization/ResourcePackages.cs
+++ b/sdk/dotnet/Pulumi/Serialization/ResourcePackages.cs
@@ -47,7 +47,7 @@ namespace Pulumi
                     from vt in types
                     let resourceVersion = !string.IsNullOrEmpty(vt.Item1) ? SemVersion.Parse(vt.Item1) : minimalVersion
                     where resourceVersion >= minimalVersion
-                    where (version == null || vt.Item1 == null || minimalVersion.Major == resourceVersion.Major)
+                    where (string.IsNullOrEmpty(version) || vt.Item1 == null || minimalVersion.Major == resourceVersion.Major)
                     orderby resourceVersion descending
                     select vt.Item2;
             


### PR DESCRIPTION
When a resource reference is deserialized, it may not have a version in which case `version` will be an empty string:

https://github.com/pulumi/pulumi/blob/9fbdc51fcd38cd6e805652928583eba4ce6a5b5b/sdk/dotnet/Pulumi/Serialization/Deserializer.cs#L227-L230

This change fixes `TryGetResourceType` to work correctly when an empty version is passed.

Fixes https://github.com/pulumi/pulumi/issues/6088