### PR TITLE
Adding `pulumi.IsSecret` and `pulumi.Unsecret` to the Go SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ CHANGELOG
 - [CLI] Add the ability to log out of all Pulumi backends at once.
   [#6101](https://github.com/pulumi/pulumi/pull/6101)
 
+- [sdk/go] Added `pulumi.Unsecret` which will take an existing secret output and
+  create a non-secret variant with an unwrapped secret value. Also adds,
+  `pulumi.IsSecret` which will take an existing output and
+  determine if an output has a secret within the output.
+  [#6085](https://github.com/pulumi/pulumi/pull/6085)
+
 ## 2.17.2 (2021-01-14)
 
 - .NET: Allow `IMock.NewResourceAsync` to return a null ID for component resources.
@@ -55,7 +61,7 @@ CHANGELOG
 - [sdk/dotnet] Moved urn value retrieval into if statement
   for MockMonitor
   [#6081](https://github.com/pulumi/pulumi/pull/6081)
-
+  
 - [sdk/dotnet] Added `Pulumi.Output.Unsecret` which will
   take an existing secret output and
   create a non-secret variant with an unwrapped secret value.

--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -45,7 +45,7 @@ type Output interface {
 	resolve(value interface{}, known, secret bool, deps []Resource)
 	reject(err error)
 	await(ctx context.Context) (interface{}, bool, bool, []Resource, error)
-	isSecret() bool
+	IsSecret() bool
 }
 
 var outputType = reflect.TypeOf((*Output)(nil)).Elem()
@@ -419,9 +419,24 @@ func (o *OutputState) ApplyTWithContext(ctx context.Context, applier interface{}
 	return result
 }
 
-// isSecret returns a bool representing the secretness of the Output
-func (o *OutputState) isSecret() bool {
+// IsSecret returns a bool representing the secretness of the Output
+func (o *OutputState) IsSecret() bool {
 	return o.getState().secret
+}
+
+// Unsecret will unwrap a secret output as a new output with a resolved value and no secretness
+func Unsecret(input Output) Output {
+	return UnsecretWithContext(context.Background(), input)
+}
+
+// UnsecretWithContext will unwrap a secret output as a new output with a resolved value and no secretness
+func UnsecretWithContext(ctx context.Context, input Output) Output {
+	var x bool
+	x = false
+	o := toOutputWithContext(ctx, input, &x)
+	// set immediate secretness ahead of resolution/fufillment
+	o.getState().secret = false
+	return o
 }
 
 // ToSecret wraps the input in an Output marked as secret
@@ -433,7 +448,9 @@ func ToSecret(input interface{}) Output {
 // ToSecretWithContext wraps the input in an Output marked as secret
 // that will resolve when all Inputs contained in the given value have resolved.
 func ToSecretWithContext(ctx context.Context, input interface{}) Output {
-	o := toOutputWithContext(ctx, input, true)
+	var x bool
+	x = true
+	o := toOutputWithContext(ctx, input, &x)
 	// set immediate secretness ahead of resolution/fufillment
 	o.getState().secret = true
 	return o
@@ -738,10 +755,10 @@ func ToOutput(v interface{}) Output {
 // ToOutputWithContext returns an Output that will resolve when all Outputs contained in the given value have
 // resolved.
 func ToOutputWithContext(ctx context.Context, v interface{}) Output {
-	return toOutputWithContext(ctx, v, false)
+	return toOutputWithContext(ctx, v, nil)
 }
 
-func toOutputWithContext(ctx context.Context, v interface{}, forceSecret bool) Output {
+func toOutputWithContext(ctx context.Context, v interface{}, forceSecretVal *bool) Output {
 	resolvedType := reflect.TypeOf(v)
 	if input, ok := v.(Input); ok {
 		resolvedType = input.ElementType()
@@ -762,7 +779,9 @@ func toOutputWithContext(ctx context.Context, v interface{}, forceSecret bool) O
 		element := reflect.New(resolvedType).Elem()
 
 		known, secret, deps, err := awaitInputs(ctx, reflect.ValueOf(v), element)
-		secret = secret || forceSecret
+		if forceSecretVal != nil {
+			secret = *forceSecretVal
+		}
 		if err != nil || !known {
 			result.fulfill(nil, known, secret, deps, err)
 			return


### PR DESCRIPTION
Related: #5653

There are situations where we need to ensure we understand if an
Output contains secrets and for the ability to take an Output that
contains a secret and creates the unsecret version

```
secretString := ToSecret(String("foo"))

unSecretString := Unsecret(secretString)
```