### PR TITLE
Add the ability to pulumi.unsecret an existing output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ CHANGELOG
 - [automation/go] Set DryRun on previews so unknowns are identified correctly.
   [#6099](https://github.com/pulumi/pulumi/pull/6099)
 
+- [sdk/nodejs] Added `pulumi.unsecret` which will take an existing secret output and
+  create a non-secret variant with an unwrapped secret value. Also adds,
+  `pulumi.isSecret` which will take an existing output and
+  determine if an output has a secret within the output.
+  [#6086](https://github.com/pulumi/pulumi/pull/6086)
+
 ## 2.17.1 (2021-01-13)
 
 - Fix an issue with go sdk generation where optional strict enum values
@@ -30,7 +36,7 @@ CHANGELOG
 - [sdk/dotnet] Moved urn value retrieval into if statement
   for MockMonitor
   [#6081](https://github.com/pulumi/pulumi/pull/6081)
-
+  
 - [sdk/dotnet] Added `Pulumi.Output.Unsecret` which will
   take an existing secret output and
   create a non-secret variant with an unwrapped secret value.

--- a/sdk/nodejs/tests/output.spec.ts
+++ b/sdk/nodejs/tests/output.spec.ts
@@ -15,7 +15,7 @@
 // tslint:disable
 
 import * as assert from "assert";
-import { Output, all, concat, interpolate, output, unknown } from "../output";
+import { Output, all, concat, interpolate, output, unknown, secret, unsecret, isSecret } from "../output";
 import { Resource } from "../resource";
 import * as runtime from "../runtime";
 import { asyncTest } from "./util";
@@ -858,6 +858,21 @@ describe("output", () => {
             const result = interpolate `http://${output("a")}:${80}/`;
             assert.strictEqual(await result.promise(), "http://a:80/");
         }));
+    });
+
+    describe("secret operations", () => {
+       it("ensure secret", asyncTest(async () => {
+           const sec = secret("foo");
+           assert.strictEqual(await sec.isSecret, true)
+       }));
+       it("ensure that a secret can be unwrapped", asyncTest(async () => {
+           const sec = secret("foo");
+           assert.strictEqual(await isSecret(sec), true)
+
+           const unsec = unsecret(sec);
+           assert.strictEqual(await isSecret(unsec), false)
+           assert.strictEqual(await unsec.promise(), "foo")
+       }));
     });
 
     describe("lifted operations", () => {


### PR DESCRIPTION
Related: #5653

This will take an existing output and then unwrap the secret, and
return a new output

```
import * as pulumi from "@pulumi/pulumi";

const x = pulumi.secret("test")
export const xVal = x;

const y = pulumi.unsecret(x);
export const yVal = y;
```

```
▶ pulumi stack output
Current stack outputs (3):
    OUTPUT         VALUE
    xVal           [secret]
    yVal           test
```

Also adds the ability to check if an output is as secret:

```
import * as pulumi from "@pulumi/pulumi";

const x = pulumi.secret("test")
const isSecret = pulumi.isSecret(x);

export const isSecretDeets = isSecret;
```