### PR TITLE
Plumb context through RPC interface to support resource construction

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -257,7 +257,7 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 	}
 
 	// fail if there are secrets returned from the invoke
-	hasSecret, err := unmarshalOutput(resource.NewObjectProperty(outProps), resultV.Elem())
+	hasSecret, err := unmarshalOutput(ctx, resource.NewObjectProperty(outProps), resultV.Elem())
 	if err != nil {
 		return err
 	}
@@ -350,7 +350,7 @@ func (ctx *Context) ReadResource(
 		var state *structpb.Struct
 		var err error
 		defer func() {
-			res.resolve(ctx.DryRun(), err, inputs, urn, resID, state, nil)
+			res.resolve(ctx, ctx.DryRun(), err, inputs, urn, resID, state, nil)
 			ctx.endRPC(err)
 		}()
 
@@ -529,7 +529,7 @@ func (ctx *Context) registerResource(
 		deps := make(map[string][]Resource)
 		var err error
 		defer func() {
-			resState.resolve(ctx.DryRun(), err, inputs, urn, resID, state, deps)
+			resState.resolve(ctx, ctx.DryRun(), err, inputs, urn, resID, state, deps)
 			ctx.endRPC(err)
 		}()
 
@@ -803,7 +803,7 @@ func makeResourceState(t, name string, resourceV Resource, providers map[string]
 }
 
 // resolve resolves the resource outputs using the given error and/or values.
-func (state *resourceState) resolve(dryrun bool, err error, inputs *resourceInputs, urn, id string,
+func (state *resourceState) resolve(ctx *Context, dryrun bool, err error, inputs *resourceInputs, urn, id string,
 	result *structpb.Struct, deps map[string][]Resource) {
 
 	var inprops resource.PropertyMap
@@ -864,7 +864,7 @@ func (state *resourceState) resolve(dryrun bool, err error, inputs *resourceInpu
 
 		// Allocate storage for the unmarshalled output.
 		dest := reflect.New(output.ElementType()).Elem()
-		secret, err := unmarshalOutput(v, dest)
+		secret, err := unmarshalOutput(ctx, v, dest)
 		if err != nil {
 			output.reject(err)
 		} else {

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -24,7 +24,7 @@ type testResourcePackage struct {
 	version semver.Version
 }
 
-func (rp *testResourcePackage) ConstructProvider(name, typ string, urn string) (ProviderResource, error) {
+func (rp *testResourcePackage) ConstructProvider(ctx *Context, name, typ, urn string) (ProviderResource, error) {
 	return &testProv{}, nil
 }
 
@@ -36,7 +36,7 @@ type testResourceModule struct {
 	version semver.Version
 }
 
-func (rm *testResourceModule) Construct(name, typ string, urn string) (Resource, error) {
+func (rm *testResourceModule) Construct(ctx *Context, name, typ, urn string) (Resource, error) {
 	return &testRes{}, nil
 }
 


### PR DESCRIPTION
In order to support resource construction in the Go SDK, the
engine context needs to be available in the RPC unmarshaling
code. This change adds a context parameter to the Construct and
ConstructProvider functions, and plumbs the engine context through
to the relevant calls to these functions.

Related to #5801 