### PR TITLE
Add .NET resource ref unit tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- .NET: Allow `IMock.NewResourceAsync` to return a null ID for component resources.
+  Note that this may require mocks written in C# to be updated to account for the
+  change in nullability.
+  [#6104](https://github.com/pulumi/pulumi/pull/6104)
+
 - [automation/go] Add debug logging settings for common automation API operations
   [#6095](https://github.com/pulumi/pulumi/pull/6095)
   

--- a/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
@@ -17,16 +17,16 @@ namespace Pulumi.Tests.Mocks
             return Task.FromResult<object>(args);
         }
 
-        public Task<(string id, object state)> NewResourceAsync(string type, string name, ImmutableDictionary<string, object> inputs, string? provider, string? id)
+        public Task<(string? id, object state)> NewResourceAsync(string type, string name, ImmutableDictionary<string, object> inputs, string? provider, string? id)
         {
             switch (type)
             {
                 case "aws:ec2/instance:Instance":
-                    return Task.FromResult<(string, object)>(("i-1234567890abcdef0", new Dictionary<string, object> {
+                    return Task.FromResult<(string?, object)>(("i-1234567890abcdef0", new Dictionary<string, object> {
                         { "publicIp", "203.0.113.12" },
                     }));
                 case "pkg:index:MyCustom":
-                    return Task.FromResult<(string, object)>((name + "_id", inputs));
+                    return Task.FromResult<(string?, object)>((name + "_id", inputs));
                 default:
                     throw new Exception($"Unknown resource {type}");
             }

--- a/sdk/dotnet/Pulumi.Tests/Serialization/ConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/ConverterTests.cs
@@ -28,11 +28,17 @@ namespace Pulumi.Tests.Serialization
             => new Output<T>(Task.FromResult(new OutputData<T>(
                 ImmutableHashSet<Resource>.Empty, value, isKnown: false, isSecret: false)));
 
-        protected async Task<Value> SerializeToValueAsync(object? value)
+        protected async Task<Value> SerializeToValueAsync(object? value, bool keepResources = true)
         {
             var serializer = new Serializer(excessiveDebugOutput: false);
             return Serializer.CreateValue(
-                await serializer.SerializeAsync(ctx: "", value, true).ConfigureAwait(false));
+                await serializer.SerializeAsync(ctx: "", value, keepResources).ConfigureAwait(false));
+        }
+
+        protected static T DeserializeValue<T>(Value value)
+        {
+            var v = Deserializer.Deserialize(value).Value;
+            return v == null ? default! : (T)v;
         }
     }
 }

--- a/sdk/dotnet/Pulumi.Tests/Serialization/ResourceRefPropertyTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/ResourceRefPropertyTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation
+// Copyright 2016-2021, Pulumi Corporation
 
 using System;
 using System.Collections.Generic;

--- a/sdk/dotnet/Pulumi.Tests/Serialization/ResourceRefPropertyTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/ResourceRefPropertyTests.cs
@@ -1,0 +1,324 @@
+// Copyright 2016-2020, Pulumi Corporation
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Google.Protobuf.WellKnownTypes;
+using Pulumi.Serialization;
+using Pulumi.Testing;
+using Xunit;
+
+namespace Pulumi.Tests.Serialization
+{
+    public class ResourceRefPropertyTests : ConverterTests
+    {
+        public sealed class MyArgs : Pulumi.ResourceArgs
+        {
+        }
+
+        [ResourceType("test:index:resource", null)]
+        private class MyCustomResource : CustomResource
+        {
+            public MyCustomResource(string name, MyArgs? args, CustomResourceOptions? options = null) : base("test:index:resource", name, args ?? new MyArgs(), options)
+            {
+            }
+        }
+
+        [ResourceType("test:index:component", null)]
+        private class MyComponentResource : ComponentResource
+        {
+            public MyComponentResource(string name, MyArgs? args, ComponentResourceOptions? options = null) : base("test:index:component", name, args ?? new MyArgs(), options)
+            {
+            }
+        }
+
+        private class MissingCustomResource : CustomResource
+        {
+            public MissingCustomResource(string name, MyArgs? args, CustomResourceOptions? options = null) : base("test:missing:resource", name, args ?? new MyArgs(), options)
+            {
+            }
+        }
+
+        private class MissingComponentResource : ComponentResource
+        {
+            public MissingComponentResource(string name, MyArgs? args, ComponentResourceOptions? options = null) : base("test:missing:component", name, args ?? new MyArgs(), options)
+            {
+            }
+        }
+
+        public class MyStack : Stack
+        {
+            public MyStack()
+            {
+                var customResource = new MyCustomResource("test", null, null);
+                var componentResource = new MyComponentResource("test", null, null);
+            }
+        }
+
+        class MyMocks : IMocks
+        {
+            bool isPreview;
+
+            public MyMocks(bool isPreview)
+            {
+                this.isPreview = isPreview;
+            }
+
+            public Task<object> CallAsync(string token, ImmutableDictionary<string, object> args, string? provider)
+            {
+                throw new Exception($"Unknown function {token}");
+            }
+
+            public Task<(string? id, object state)> NewResourceAsync(string type, string name, ImmutableDictionary<string, object> inputs, string? provider, string? id)
+            {
+                switch (type)
+                {
+                    case "test:index:resource":
+                    case "test:missing:resource":
+                        return Task.FromResult<(string?, object)>((this.isPreview ? null : "id", new Dictionary<string, object> {}));
+                    case "test:index:component":
+                    case "test:missing:component":
+                        return Task.FromResult<(string?, object)>((null, new Dictionary<string, object> {}));
+                    default:
+                        throw new Exception($"Unknown resource {type}");
+                }
+            }
+        }
+
+        static Task<ImmutableArray<Resource>> RunAsync<T>(bool isPreview) where T : Stack, new()
+        {
+            return Deployment.TestAsync<T>(new MyMocks(isPreview), new TestOptions { IsPreview = isPreview });
+        }
+
+        static Value CreateCustomResourceReference(string urn, string id)
+            => new Value
+            {
+                StructValue = new Struct
+                {
+                    Fields =
+                    {
+                        { Constants.SpecialSigKey, new Value { StringValue = Constants.SpecialResourceSig } },
+                        { "urn", new Value { StringValue = urn } },
+                        { "id", new Value { StringValue = id } },
+                    }
+                }
+            };
+
+        static Value CreateComponentResourceReference(string urn)
+            => new Value
+            {
+                StructValue = new Struct
+                {
+                    Fields =
+                    {
+                        { Constants.SpecialSigKey, new Value { StringValue = Constants.SpecialResourceSig } },
+                        { "urn", new Value { StringValue = urn } },
+                    }
+                }
+            };
+
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SerializeCustomResource(bool isPreview)
+        {
+            var resources = await RunAsync<MyStack>(isPreview);
+            var res = resources.OfType<MyCustomResource>().FirstOrDefault();
+            Assert.NotNull(res);
+
+            var urn = (await res.Urn.DataTask).Value;
+            var id = (await res.Id.DataTask).Value;
+
+            var v = await SerializeToValueAsync(res);
+            Assert.Equal(CreateCustomResourceReference(urn, id), v);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SerializeCustomResourceDownlevel(bool isPreview)
+        {
+            var resources = await RunAsync<MyStack>(isPreview);
+            var res = resources.OfType<MyCustomResource>().FirstOrDefault();
+            Assert.NotNull(res);
+
+            var id = await SerializeToValueAsync(res.Id);
+
+            var v = await SerializeToValueAsync(res, false);
+            Assert.Equal(id, v);
+        }
+
+        public class DeserializeCustomResourceStack : Stack
+        {
+            [Output("values")]
+            public Output<ImmutableDictionary<string, string>> Values { get; private set; } = null!;
+
+            public DeserializeCustomResourceStack()
+            {
+                var res = new MyCustomResource("test", null, null);
+
+                var urn = res.Urn.DataTask.Result.Value;
+                var id = res.Id.DataTask.Result.Value;
+
+                var v = DeserializeValue<MyCustomResource>(CreateCustomResourceReference(urn, ""));
+
+                this.Values = Output.Create(new Dictionary<string, string> {
+                    { "expectedUrn", urn },
+                    { "expectedId", id },
+                    { "actualUrn", v.Urn.DataTask.Result.Value },
+                    { "actualId", v.Id.DataTask.Result.Value },
+                }.ToImmutableDictionary());
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DeserializeCustomResource(bool isPreview)
+        {
+            var resources = await RunAsync<DeserializeCustomResourceStack>(isPreview);
+
+            var stack = resources.OfType<DeserializeCustomResourceStack>().FirstOrDefault();
+            Assert.NotNull(stack);
+
+            var values = (await stack.Values.DataTask).Value;
+            Assert.Equal(values["expectedUrn"], values["actualUrn"]);
+            Assert.Equal(values["expectedId"], values["actualId"]);
+        }
+
+        public class DeserializeMissingCustomResourceStack : Stack
+        {
+            [Output("values")]
+            public Output<ImmutableDictionary<string, string>> Values { get; private set; } = null!;
+
+            public DeserializeMissingCustomResourceStack()
+            {
+                var res = new MissingCustomResource("test", null, null);
+
+                var urn = res.Urn.DataTask.Result.Value;
+
+                var v = DeserializeValue<Resource>(CreateCustomResourceReference(urn, ""));
+
+                this.Values = Output.Create(new Dictionary<string, string> {
+                    { "expectedUrn", urn },
+                    { "actualUrn", v.Urn.DataTask.Result.Value },
+                }.ToImmutableDictionary());
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DeserializeMissingCustomResource(bool isPreview)
+        {
+            var resources = await RunAsync<DeserializeMissingCustomResourceStack>(isPreview);
+
+            var stack = resources.OfType<DeserializeMissingCustomResourceStack>().FirstOrDefault();
+            Assert.NotNull(stack);
+
+            var values = (await stack.Values.DataTask).Value;
+            Assert.Equal(values["expectedUrn"], values["actualUrn"]);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SerializeComponentResource(bool isPreview)
+        {
+            var resources = await RunAsync<MyStack>(isPreview);
+            var res = resources.OfType<MyComponentResource>().FirstOrDefault();
+            Assert.NotNull(res);
+
+            var urn = (await res.Urn.DataTask).Value;
+
+            var v = await SerializeToValueAsync(res);
+            Assert.Equal(CreateComponentResourceReference(urn), v);
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task SerializeComponentResourceDownlevel(bool isPreview)
+        {
+            var resources = await RunAsync<MyStack>(isPreview);
+            var res = resources.OfType<MyComponentResource>().FirstOrDefault();
+            Assert.NotNull(res);
+
+            var urn = await SerializeToValueAsync(res.Urn);
+
+            var v = await SerializeToValueAsync(res, false);
+            Assert.Equal(urn, v);
+        }
+
+        public class DeserializeComponentResourceStack : Stack
+        {
+            [Output("values")]
+            public Output<ImmutableDictionary<string, string>> Values { get; private set; } = null!;
+
+            public DeserializeComponentResourceStack()
+            {
+                var res = new MyComponentResource("test", null, null);
+
+                var urn = res.Urn.DataTask.Result.Value;
+
+                var v = DeserializeValue<MyComponentResource>(CreateComponentResourceReference(urn));
+
+                this.Values = Output.Create(new Dictionary<string, string> {
+                    { "expectedUrn", urn },
+                    { "actualUrn", v.Urn.DataTask.Result.Value },
+                }.ToImmutableDictionary());
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DeserializeComponentResource(bool isPreview)
+        {
+            var resources = await RunAsync<DeserializeComponentResourceStack>(isPreview);
+
+            var stack = resources.OfType<DeserializeComponentResourceStack>().FirstOrDefault();
+            Assert.NotNull(stack);
+
+            var values = (await stack.Values.DataTask).Value;
+            Assert.Equal(values["expectedUrn"], values["actualUrn"]);
+        }
+
+        public class DeserializeMissingComponentResourceStack : Stack
+        {
+            [Output("values")]
+            public Output<ImmutableDictionary<string, string>> Values { get; private set; } = null!;
+
+            public DeserializeMissingComponentResourceStack()
+            {
+                var res = new MissingComponentResource("test", null, null);
+
+                var urn = res.Urn.DataTask.Result.Value;
+
+                var v = DeserializeValue<Resource>(CreateComponentResourceReference(urn));
+
+                this.Values = Output.Create(new Dictionary<string, string> {
+                    { "expectedUrn", urn },
+                    { "actualUrn", v.Urn.DataTask.Result.Value },
+                }.ToImmutableDictionary());
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task DeserializeMissingComponentResource(bool isPreview)
+        {
+            var resources = await RunAsync<DeserializeMissingComponentResourceStack>(isPreview);
+
+            var stack = resources.OfType<DeserializeMissingComponentResourceStack>().FirstOrDefault();
+            Assert.NotNull(stack);
+
+            var values = (await stack.Values.DataTask).Value;
+            Assert.Equal(values["expectedUrn"], values["actualUrn"]);
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Serialization/Constants.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Constants.cs
@@ -43,6 +43,7 @@ namespace Pulumi.Serialization
         public const string AssetOrArchiveUriName = "uri";
 
         public const string ResourceUrnName = "urn";
+        public const string ResourceIdName = "id";
         public const string ResourceVersionName = "packageVersion";
 
         public const string IdPropertyName = "id";

--- a/sdk/dotnet/Pulumi/Serialization/Deserializer.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Deserializer.cs
@@ -234,7 +234,11 @@ namespace Pulumi.Serialization
             var qualifiedTypeParts = qualifiedType.Split('$');
             var type = qualifiedTypeParts[^1];
 
-            resource = ResourcePackages.Construct(type, version, urn);
+            if (ResourcePackages.TryConstruct(type, version, urn, out resource)) {
+                return true;
+            }
+
+            resource = new DependencyResource(urn);
             return true;
         }
 

--- a/sdk/dotnet/Pulumi/Serialization/Serializer.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Serializer.cs
@@ -167,15 +167,18 @@ $"Tasks are not allowed inside ResourceArgs. Please wrap your Task in an Output:
                 }
 
                 this.DependentResources.Add(customResource);
+
+                var id = await SerializeAsync($"{ctx}.id", customResource.Id, keepResources).ConfigureAwait(false);
                 if (keepResources)
                 {
                     var urn = await SerializeAsync($"{ctx}.urn", customResource.Urn, keepResources).ConfigureAwait(false);
                     var builder = ImmutableDictionary.CreateBuilder<string, object?>();
                     builder.Add(Constants.SpecialSigKey, Constants.SpecialResourceSig);
                     builder.Add(Constants.ResourceUrnName, urn);
+                    builder.Add(Constants.ResourceIdName, id as string == Constants.UnknownValue ? "" : id);
                     return builder.ToImmutable();
                 }
-                return await SerializeAsync($"{ctx}.id", customResource.Id, keepResources).ConfigureAwait(false);
+                return id;
             }
 
             if (prop is ComponentResource componentResource)

--- a/sdk/dotnet/Pulumi/Testing/IMocks.cs
+++ b/sdk/dotnet/Pulumi/Testing/IMocks.cs
@@ -19,8 +19,8 @@ namespace Pulumi.Testing
         /// <param name="provider">Provider.</param>
         /// <param name="id">Resource identifier.</param>
         /// <returns>A tuple of a resource identifier and resource state. State can be either a POCO
-        /// or a dictionary bag.</returns>
-        Task<(string id, object state)> NewResourceAsync(string type, string name,
+        /// or a dictionary bag. The returned ID may be null for component resources.</returns>
+        Task<(string? id, object state)> NewResourceAsync(string type, string name,
             ImmutableDictionary<string, object> inputs, string? provider, string? id);
 
         /// <summary>

--- a/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
@@ -65,7 +65,8 @@ namespace Pulumi.Testing
             {
                 var builder = ImmutableDictionary.CreateBuilder<string, object>();
                 builder.Add("urn", urn);
-                if (id != null) {
+                if (id != null)
+                {
                     builder.Add("id", id);
                 }
                 builder.Add("state", serializedState);

--- a/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
@@ -65,7 +65,9 @@ namespace Pulumi.Testing
             {
                 var builder = ImmutableDictionary.CreateBuilder<string, object>();
                 builder.Add("urn", urn);
-                builder.Add("id", id);
+                if (id != null) {
+                    builder.Add("id", id);
+                }
                 builder.Add("state", serializedState);
                 _registeredResources[urn] = builder.ToImmutable();
             }


### PR DESCRIPTION
- Add tests that serialize custom and component resources for targets
  that support resource references
- Add tests that serialize custom and component resources for downlevel
  targets
- Add tests that deserialize known custom and component resources
- Add tests that deserialize missing custom and component resources

These changes also fix a few bugs that were encountered during testing:
- Component resource construction was not supported
- Resources with missing packages could not be deserialized

In the latter case, a missing resource is deserialized as a generic
DependencyResource.

These changes also update the signature of IMocks.NewResourceAsync to
allow the returned ID to be null. This is technically a C# breaking change
with respect to nullability.

Contributes to #5943.