### PR TITLE
Remove annotations import

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         platform: [ ubuntu-latest, macos-latest ]
         go-version: [1.15.x]
-        python-version: [ 3.6.x ]
+        python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
         node-version: [ 14.x ]
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -105,7 +105,7 @@ jobs:
       matrix:
         go-version: [1.15.x]
         node-version: [14.x]
-        python-version: [3.6.x]
+        python-version: [3.9.x]
         dotnet: [3.1.x]
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: windows-latest

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         platform: [ ubuntu-latest, macos-latest ]
         go-version: [1.15.x]
-        python-version: [ 3.9.x ]
+        python-version: [ 3.6.x ]
         dotnet-version: [ 3.1.x ]
         node-version: [ 14.x ]
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
@@ -105,7 +105,7 @@ jobs:
       matrix:
         go-version: [1.15.x]
         node-version: [14.x]
-        python-version: [3.9.x]
+        python-version: [3.6.x]
         dotnet: [3.1.x]
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: windows-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
   
 - [automation/go] Set DryRun on previews so unknowns are identified correctly.
   [#6099](https://github.com/pulumi/pulumi/pull/6099)
+  
+- [sdk/python] Fix python 3.6 support by removing annotations import.
+  [#6109](https://github.com/pulumi/pulumi/pull/6109)
 
 ## 2.17.1 (2021-01-13)
 

--- a/sdk/python/lib/pulumi/x/automation/stack.py
+++ b/sdk/python/lib/pulumi/x/automation/stack.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import annotations
-
 import json
 import grpc
 from concurrent import futures


### PR DESCRIPTION
This import is only in v3.7 of python and isn't used in our code.

Fixes: https://github.com/pulumi/pulumi/issues/6108