### PR TITLE
Add resource ref unit tests for the Go SDK.

### DIFF
--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,30 +17,6 @@ type testProv struct {
 	ProviderResourceState
 	// equality identifier used for testing
 	foo string
-}
-
-type testResourcePackage struct {
-	version semver.Version
-}
-
-func (rp *testResourcePackage) ConstructProvider(ctx *Context, name, typ, urn string) (ProviderResource, error) {
-	return &testProv{}, nil
-}
-
-func (rp *testResourcePackage) Version() semver.Version {
-	return rp.version
-}
-
-type testResourceModule struct {
-	version semver.Version
-}
-
-func (rm *testResourceModule) Construct(ctx *Context, name, typ, urn string) (Resource, error) {
-	return &testRes{}, nil
-}
-
-func (rm *testResourceModule) Version() semver.Version {
-	return rm.version
 }
 
 func TestResourceOptionMergingParent(t *testing.T) {

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -393,6 +393,40 @@ func marshalInputAndDetermineSecret(v interface{},
 	}
 }
 
+func unmarshalResourceReference(ctx *Context, ref resource.ResourceReference) (Resource, error) {
+	version := nullVersion
+	if len(ref.PackageVersion) > 0 {
+		var err error
+		version, err = semver.ParseTolerant(ref.PackageVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse provider version: %s", ref.PackageVersion)
+		}
+	}
+
+	resName := ref.URN.Name().String()
+	resType := ref.URN.Type()
+
+	isProvider := tokens.Token(resType).HasModuleMember() && resType.Module() == "pulumi:providers"
+	if isProvider {
+		pkgName := resType.Name().String()
+		if resourcePackageV, ok := resourcePackages.Load(pkgName, version); ok {
+			resourcePackage := resourcePackageV.(ResourcePackage)
+			return resourcePackage.ConstructProvider(ctx, resName, string(resType), string(ref.URN))
+		}
+		return newDependencyProviderResource(URN(ref.URN), ID(ref.ID)), nil
+	}
+
+	modName := resType.Module().String()
+	if resourceModuleV, ok := resourceModules.Load(modName, version); ok {
+		resourceModule := resourceModuleV.(ResourceModule)
+		return resourceModule.Construct(ctx, resName, string(resType), string(ref.URN))
+	}
+	if ref.HasID {
+		return newDependencyCustomResource(URN(ref.URN), ID(ref.ID)), nil
+	}
+	return newDependencyResource(URN(ref.URN)), nil
+}
+
 func unmarshalPropertyValue(ctx *Context, v resource.PropertyValue) (interface{}, bool, error) {
 	switch {
 	case v.IsComputed() || v.IsOutput():
@@ -461,45 +495,7 @@ func unmarshalPropertyValue(ctx *Context, v resource.PropertyValue) (interface{}
 		}
 		return nil, false, errors.New("expected asset to be one of File, String, or Remote; got none")
 	case v.IsResourceReference():
-		ref := v.ResourceReferenceValue()
-
-		version := nullVersion
-		if len(ref.PackageVersion) > 0 {
-			var err error
-			version, err = semver.ParseTolerant(ref.PackageVersion)
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse provider version: %s", ref.PackageVersion)
-			}
-		}
-
-		resName := ref.URN.Name().String()
-		resType := ref.URN.Type()
-
-		var resource Resource
-		var err error
-
-		isProvider := tokens.Token(resType).HasModuleMember() && resType.Module() == "pulumi:providers"
-		if isProvider {
-			pkgName := resType.Name().String()
-			resourcePackageV, ok := resourcePackages.Load(pkgName, version)
-			if !ok {
-				err := fmt.Errorf("unable to deserialize provider %v, no resource package is registered for %v",
-					ref.URN, pkgName)
-				return nil, false, err
-			}
-			resourcePackage := resourcePackageV.(ResourcePackage)
-			resource, err = resourcePackage.ConstructProvider(ctx, resName, string(resType), string(ref.URN))
-		} else {
-			pkgName := resType.Package().String()
-			modName := resType.Module().String()
-			resourceModuleV, ok := resourceModules.Load(moduleKey(pkgName, modName), version)
-			if !ok {
-				err := fmt.Errorf("unable to deserialize resource %v, no module is registered for %v", ref.URN, modName)
-				return nil, false, err
-			}
-			resourceModule := resourceModuleV.(ResourceModule)
-			resource, err = resourceModule.Construct(ctx, resName, string(resType), string(ref.URN))
-		}
+		resource, err := unmarshalResourceReference(ctx, v.ResourceReferenceValue())
 		if err != nil {
 			return nil, false, err
 		}
@@ -595,10 +591,19 @@ func unmarshalOutput(ctx *Context, v resource.PropertyValue, dest reflect.Value)
 		dest.SetFloat(v.NumberValue())
 		return false, nil
 	case reflect.String:
-		if !v.IsString() {
+		switch {
+		case v.IsString():
+			dest.SetString(v.StringValue())
+		case v.IsResourceReference():
+			ref := v.ResourceReferenceValue()
+			if ref.HasID {
+				dest.SetString(string(ref.ID))
+			} else {
+				dest.SetString(string(ref.URN))
+			}
+		default:
 			return false, fmt.Errorf("expected a %v, got a %s", dest.Type(), v.TypeString())
 		}
-		dest.SetString(v.StringValue())
 		return false, nil
 	case reflect.Slice:
 		if !v.IsArray() {

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -639,6 +639,8 @@ func TestMarshalRoundtripNestedSecret(t *testing.T) {
 	assert.Nil(t, err)
 
 	if assert.Nil(t, err) {
+		// The value we marshaled above omits the 10 Resource-typed fields, so we don't expect those fields to appear
+		// in the unmarshaled value.
 		const resourceFields = 10
 		assert.Equal(t, reflect.TypeOf(inputs).NumField()-resourceFields, len(resolved))
 		assert.Equal(t, 0, len(deps))

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -17,6 +17,7 @@ package pulumi
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -26,40 +27,140 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type simpleComponentResource struct {
+	ResourceState
+}
+
+func newSimpleComponentResource(urn URN) ComponentResource {
+	var res simpleComponentResource
+	res.urn.OutputState = newOutputState(res.urn.ElementType(), &res)
+	res.urn.resolve(urn, true, false, nil)
+	return &res
+}
+
+type simpleCustomResource struct {
+	CustomResourceState
+}
+
+func newSimpleCustomResource(urn URN, id ID) CustomResource {
+	var res simpleCustomResource
+	res.urn.OutputState = newOutputState(res.urn.ElementType(), &res)
+	res.id.OutputState = newOutputState(res.id.ElementType(), &res)
+	res.urn.resolve(urn, true, false, nil)
+	res.id.resolve(id, id != "", false, nil)
+	return &res
+}
+
+type simpleProviderResource struct {
+	ProviderResourceState
+}
+
+func newSimpleProviderResource(urn URN, id ID) ProviderResource {
+	var res simpleProviderResource
+	res.urn.OutputState = newOutputState(res.urn.ElementType(), &res)
+	res.id.OutputState = newOutputState(res.id.ElementType(), &res)
+	res.urn.resolve(urn, true, false, nil)
+	res.id.resolve(id, id != "", false, nil)
+	res.pkg = string(resource.URN(urn).Type().Name())
+	return &res
+}
+
+type testResourcePackage struct {
+	version semver.Version
+}
+
+func (rp *testResourcePackage) ConstructProvider(ctx *Context, name, typ, urn string) (ProviderResource, error) {
+	if typ != "pulumi:providers:test" {
+		return nil, fmt.Errorf("unknown provider type %v", typ)
+	}
+	id := "id"
+	if resource.URN(urn).Name() == "preview" {
+		id = ""
+	}
+	return newSimpleProviderResource(URN(urn), ID(id)), nil
+}
+
+func (rp *testResourcePackage) Version() semver.Version {
+	return rp.version
+}
+
+type testResourceModule struct {
+	version semver.Version
+}
+
+func (rm *testResourceModule) Construct(ctx *Context, name, typ, urn string) (Resource, error) {
+	switch typ {
+	case "test:index:custom":
+		id := "id"
+		if resource.URN(urn).Name() == "preview" {
+			id = ""
+		}
+		return newSimpleCustomResource(URN(urn), ID(id)), nil
+	case "test:index:component":
+		return newSimpleComponentResource(URN(urn)), nil
+	default:
+		return nil, fmt.Errorf("unknown resource type %v", typ)
+	}
+}
+
+func (rm *testResourceModule) Version() semver.Version {
+	return rm.version
+}
+
 type test struct {
-	S             string                 `pulumi:"s"`
-	A             bool                   `pulumi:"a"`
-	B             int                    `pulumi:"b"`
-	StringAsset   Asset                  `pulumi:"cStringAsset"`
-	FileAsset     Asset                  `pulumi:"cFileAsset"`
-	RemoteAsset   Asset                  `pulumi:"cRemoteAsset"`
-	AssetArchive  Archive                `pulumi:"dAssetArchive"`
-	FileArchive   Archive                `pulumi:"dFileArchive"`
-	RemoteArchive Archive                `pulumi:"dRemoteArchive"`
-	E             interface{}            `pulumi:"e"`
-	Array         []interface{}          `pulumi:"fArray"`
-	Map           map[string]interface{} `pulumi:"fMap"`
-	G             string                 `pulumi:"g"`
-	H             string                 `pulumi:"h"`
-	I             string                 `pulumi:"i"`
+	S                              string                 `pulumi:"s"`
+	A                              bool                   `pulumi:"a"`
+	B                              int                    `pulumi:"b"`
+	StringAsset                    Asset                  `pulumi:"cStringAsset"`
+	FileAsset                      Asset                  `pulumi:"cFileAsset"`
+	RemoteAsset                    Asset                  `pulumi:"cRemoteAsset"`
+	AssetArchive                   Archive                `pulumi:"dAssetArchive"`
+	FileArchive                    Archive                `pulumi:"dFileArchive"`
+	RemoteArchive                  Archive                `pulumi:"dRemoteArchive"`
+	E                              interface{}            `pulumi:"e"`
+	Array                          []interface{}          `pulumi:"fArray"`
+	Map                            map[string]interface{} `pulumi:"fMap"`
+	G                              string                 `pulumi:"g"`
+	H                              string                 `pulumi:"h"`
+	I                              string                 `pulumi:"i"`
+	CustomResource                 CustomResource         `pulumi:"jCustomResource"`
+	ComponentResource              ComponentResource      `pulumi:"jComponentResource"`
+	ProviderResource               ProviderResource       `pulumi:"jProviderResource"`
+	PreviewCustomResource          CustomResource         `pulumi:"jPreviewCustomResource"`
+	PreviewProviderResource        ProviderResource       `pulumi:"jPreviewProviderResource"`
+	MissingCustomResource          CustomResource         `pulumi:"kCustomResource"`
+	MissingComponentResource       ComponentResource      `pulumi:"kComponentResource"`
+	MissingProviderResource        ProviderResource       `pulumi:"kProviderResource"`
+	MissingPreviewCustomResource   CustomResource         `pulumi:"kPreviewCustomResource"`
+	MissingPreviewProviderResource ProviderResource       `pulumi:"kPreviewProviderResource"`
 }
 
 type testInputs struct {
-	S             StringInput
-	A             BoolInput
-	B             IntInput
-	StringAsset   AssetInput
-	FileAsset     AssetInput
-	RemoteAsset   AssetInput
-	AssetArchive  ArchiveInput
-	FileArchive   ArchiveInput
-	RemoteArchive ArchiveInput
-	E             Input
-	Array         ArrayInput
-	Map           MapInput
-	G             StringInput
-	H             StringInput
-	I             StringInput
+	S                              StringInput
+	A                              BoolInput
+	B                              IntInput
+	StringAsset                    AssetInput
+	FileAsset                      AssetInput
+	RemoteAsset                    AssetInput
+	AssetArchive                   ArchiveInput
+	FileArchive                    ArchiveInput
+	RemoteArchive                  ArchiveInput
+	E                              Input
+	Array                          ArrayInput
+	Map                            MapInput
+	G                              StringInput
+	H                              StringInput
+	I                              StringInput
+	CustomResource                 CustomResource
+	ComponentResource              ComponentResource
+	ProviderResource               ProviderResource
+	PreviewCustomResource          CustomResource
+	PreviewProviderResource        ProviderResource
+	MissingCustomResource          CustomResource
+	MissingComponentResource       ComponentResource
+	MissingProviderResource        ProviderResource
+	MissingPreviewCustomResource   CustomResource
+	MissingPreviewProviderResource ProviderResource
 }
 
 func (testInputs) ElementType() reflect.Type {
@@ -71,6 +172,21 @@ func TestMarshalRoundtrip(t *testing.T) {
 	// Create interesting inputs.
 	ctx, err := NewContext(context.Background(), RunInfo{})
 	assert.Nil(t, err)
+
+	customURN := resource.NewURN("stack", "project", "", "test:index:custom", "test")
+	componentURN := resource.NewURN("stack", "project", "", "test:index:component", "test")
+	providerURN := resource.NewURN("stack", "project", "", "pulumi:providers:test", "test")
+	previewCustomURN := resource.NewURN("stack", "project", "", "test:index:custom", "preview")
+	previewProviderURN := resource.NewURN("stack", "project", "", "pulumi:providers:test", "preview")
+
+	missingCustomURN := resource.NewURN("stack", "project", "", "missing:index:custom", "test")
+	missingComponentURN := resource.NewURN("stack", "project", "", "missing:index:component", "test")
+	missingProviderURN := resource.NewURN("stack", "project", "", "pulumi:providers:missing", "test")
+	missingPreviewCustomURN := resource.NewURN("stack", "project", "", "missing:index:custom", "preview")
+	missingPreviewProviderURN := resource.NewURN("stack", "project", "", "pulumi:providers:missing", "preview")
+
+	RegisterResourcePackage("test", &testResourcePackage{})
+	RegisterResourceModule("test", "index", &testResourceModule{})
 
 	out, resolve, _ := NewOutput()
 	resolve("outputty")
@@ -96,9 +212,19 @@ func TestMarshalRoundtrip(t *testing.T) {
 			"y": Float64(999.9),
 			"z": Bool(false),
 		},
-		G: StringOutput{out2},
-		H: URN("foo"),
-		I: StringOutput{},
+		G:                              StringOutput{out2},
+		H:                              URN("foo"),
+		I:                              StringOutput{},
+		CustomResource:                 newSimpleCustomResource(URN(customURN), "id"),
+		ComponentResource:              newDependencyResource(URN(componentURN)),
+		ProviderResource:               newSimpleProviderResource(URN(providerURN), "id"),
+		PreviewCustomResource:          newSimpleCustomResource(URN(previewCustomURN), ""),
+		PreviewProviderResource:        newSimpleProviderResource(URN(previewProviderURN), ""),
+		MissingCustomResource:          newSimpleCustomResource(URN(missingCustomURN), "id"),
+		MissingComponentResource:       newDependencyResource(URN(missingComponentURN)),
+		MissingProviderResource:        newSimpleProviderResource(URN(missingProviderURN), "id"),
+		MissingPreviewCustomResource:   newSimpleCustomResource(URN(missingPreviewCustomURN), ""),
+		MissingPreviewProviderResource: newSimpleProviderResource(URN(missingPreviewProviderURN), ""),
 	}
 
 	// Marshal those inputs.
@@ -107,8 +233,8 @@ func TestMarshalRoundtrip(t *testing.T) {
 
 	if assert.Nil(t, err) {
 		assert.Equal(t, reflect.TypeOf(inputs).NumField(), len(resolved))
-		assert.Equal(t, 0, len(deps))
-		assert.Equal(t, 0, len(pdeps))
+		assert.Equal(t, 10, len(deps))
+		assert.Equal(t, 10, len(pdeps))
 
 		// Now just unmarshal and ensure the resulting map matches.
 		resV, secret, err := unmarshalPropertyValue(ctx, resource.NewObjectProperty(resolved))
@@ -144,6 +270,52 @@ func TestMarshalRoundtrip(t *testing.T) {
 				assert.Equal(t, nil, res["g"])
 				assert.Equal(t, "foo", res["h"])
 				assert.Equal(t, nil, res["i"])
+				custom := res["jCustomResource"].(*simpleCustomResource)
+				urn, _, _, _ := custom.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(customURN), urn)
+				id, _, _, _ := custom.ID().awaitID(context.Background())
+				assert.Equal(t, ID("id"), id)
+				component := res["jComponentResource"].(*simpleComponentResource)
+				urn, _, _, _ = component.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(componentURN), urn)
+				provider := res["jProviderResource"].(*simpleProviderResource)
+				urn, _, _, _ = provider.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(providerURN), urn)
+				id, _, _, _ = provider.ID().awaitID(context.Background())
+				assert.Equal(t, ID("id"), id)
+				previewCustom := res["jPreviewCustomResource"].(*simpleCustomResource)
+				urn, _, _, _ = previewCustom.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(previewCustomURN), urn)
+				_, known, _, _ := previewCustom.ID().awaitID(context.Background())
+				assert.False(t, known)
+				previewProvider := res["jPreviewProviderResource"].(*simpleProviderResource)
+				urn, _, _, _ = previewProvider.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(previewProviderURN), urn)
+				_, known, _, _ = previewProvider.ID().awaitID(context.Background())
+				assert.False(t, known)
+				missingCustom := res["kCustomResource"].(CustomResource)
+				urn, _, _, _ = missingCustom.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(missingCustomURN), urn)
+				id, _, _, _ = missingCustom.ID().awaitID(context.Background())
+				assert.Equal(t, ID("id"), id)
+				missingComponent := res["kComponentResource"].(ComponentResource)
+				urn, _, _, _ = missingComponent.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(missingComponentURN), urn)
+				missingProvider := res["kProviderResource"].(ProviderResource)
+				urn, _, _, _ = missingProvider.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(missingProviderURN), urn)
+				id, _, _, _ = missingProvider.ID().awaitID(context.Background())
+				assert.Equal(t, ID("id"), id)
+				missingPreviewCustom := res["kPreviewCustomResource"].(CustomResource)
+				urn, _, _, _ = missingPreviewCustom.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(missingPreviewCustomURN), urn)
+				_, known, _, _ = missingPreviewCustom.ID().awaitID(context.Background())
+				assert.False(t, known)
+				missingPreviewProvider := res["kPreviewProviderResource"].(ProviderResource)
+				urn, _, _, _ = missingPreviewProvider.URN().awaitURN(context.Background())
+				assert.Equal(t, URN(missingPreviewProviderURN), urn)
+				_, known, _, _ = missingPreviewProvider.ID().awaitID(context.Background())
+				assert.False(t, known)
 			}
 		}
 	}
@@ -467,7 +639,8 @@ func TestMarshalRoundtripNestedSecret(t *testing.T) {
 	assert.Nil(t, err)
 
 	if assert.Nil(t, err) {
-		assert.Equal(t, reflect.TypeOf(inputs).NumField(), len(resolved))
+		const resourceFields = 10
+		assert.Equal(t, reflect.TypeOf(inputs).NumField()-resourceFields, len(resolved))
 		assert.Equal(t, 0, len(deps))
 		assert.Equal(t, 0, len(pdeps))
 
@@ -510,10 +683,6 @@ func TestMarshalRoundtripNestedSecret(t *testing.T) {
 	}
 }
 
-type simpleResource struct {
-	CustomResourceState
-}
-
 type UntypedArgs map[string]interface{}
 
 func (UntypedArgs) ElementType() reflect.Type {
@@ -521,7 +690,7 @@ func (UntypedArgs) ElementType() reflect.Type {
 }
 
 func TestMapInputMarhsalling(t *testing.T) {
-	var theResource simpleResource
+	var theResource simpleCustomResource
 	out := newOutput(reflect.TypeOf((*StringOutput)(nil)).Elem(), &theResource)
 	out.resolve("outputty", true, false, nil)
 
@@ -640,7 +809,7 @@ func TestVersionedMap(t *testing.T) {
 }
 
 func TestRegisterResourcePackage(t *testing.T) {
-	pkg := "test"
+	pkg := "testPkg"
 
 	tests := []struct {
 		name            string


### PR DESCRIPTION
- Add tests that deserialize known custom and component resources
- Add tests that deserialize missing custom and component resources

These changes also add support for deserializing resources with missing
modules/packages. Such resources are deserialized as generic component,
custom, or provider resources as appropriate.

Contributes to #5943.