### PR TITLE
Fix resource-ref-as-ID marshaling.

### DIFF
--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -417,7 +417,7 @@ func filterPropertyMap(propertyMap resource.PropertyMap, debug bool) resource.Pr
 		case resource.ResourceReference:
 			return resource.ResourceReference{
 				URN:            resource.URN(filterValue(string(t.URN)).(string)),
-				ID:             resource.ID(filterValue(string(t.ID)).(string)),
+				ID:             resource.PropertyValue{V: filterValue(t.ID.V)},
 				PackageVersion: filterValue(t.PackageVersion).(string),
 			}
 		}

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -1927,7 +1927,7 @@ func TestSingleComponentGetResourceDefaultProviderLifecycle(t *testing.T) {
 					URN: urn,
 					Outputs: resource.PropertyMap{
 						"foo": resource.NewStringProperty("bar"),
-						"res": resource.MakeResourceReference(urnB, idB, true, ""),
+						"res": resource.MakeCustomResourceReference(urnB, idB, ""),
 					},
 				}, nil
 			}
@@ -1953,7 +1953,7 @@ func TestSingleComponentGetResourceDefaultProviderLifecycle(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
 			"foo": resource.NewStringProperty("bar"),
-			"res": resource.MakeResourceReference(urnB, idB, true, ""),
+			"res": resource.MakeCustomResourceReference(urnB, idB, ""),
 		}, state)
 
 		result, _, err := monitor.Invoke("pulumi:pulumi:getResource", resource.PropertyMap{

--- a/pkg/engine/lifeycletest/resource_reference_test.go
+++ b/pkg/engine/lifeycletest/resource_reference_test.go
@@ -135,10 +135,12 @@ func TestResourceReferences_DownlevelSDK(t *testing.T) {
 		_, _, props, err := monitor.RegisterResource("pkgA:m:typA", "resC", true, opts)
 		assert.NoError(t, err)
 
-		assert.True(t, props.DeepEquals(resource.PropertyMap{
-			"resA": resource.NewStringProperty(string(urnA)),
-			"resB": resource.NewStringProperty(string(idB)),
-		}))
+		assert.Equal(t, resource.NewStringProperty(string(urnA)), props["resA"])
+		if idB != "" {
+			assert.Equal(t, resource.NewStringProperty(string(idB)), props["resB"])
+		} else {
+			assert.True(t, props["resB"].IsComputed())
+		}
 		return nil
 	})
 	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
@@ -155,7 +157,7 @@ func TestResourceReferences_DownlevelSDK(t *testing.T) {
 func TestResourceReferences_DownlevelEngine(t *testing.T) {
 	var urnA resource.URN
 	var urnB resource.URN
-	var idB resource.ID
+	var idB resource.PropertyValue
 
 	loaders := []*deploytest.ProviderLoader{
 		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
@@ -171,7 +173,7 @@ func TestResourceReferences_DownlevelEngine(t *testing.T) {
 					// If we have resource references here, the engine has not properly disabled them.
 					if urn.Name() == "resC" {
 						assert.Equal(t, resource.NewStringProperty(string(urnA)), news["resA"])
-						assert.Equal(t, resource.NewStringProperty(string(idB)), news["resB"])
+						assert.Equal(t, idB, news["resB"])
 					}
 
 					return resource.ID(id), news, resource.StatusOK, nil
@@ -193,21 +195,29 @@ func TestResourceReferences_DownlevelEngine(t *testing.T) {
 		err = monitor.RegisterResourceOutputs(urnA, resource.PropertyMap{})
 		assert.NoError(t, err)
 
-		urnB, idB, _, err = monitor.RegisterResource("pkgA:m:typA", "resB", true)
+		var idBString resource.ID
+		urnB, idBString, _, err = monitor.RegisterResource("pkgA:m:typA", "resB", true)
 		assert.NoError(t, err)
+
+		idB = resource.NewStringProperty(string(idBString))
+		if idBString == "" {
+			idB = resource.MakeComputed(resource.NewStringProperty(""))
+		}
 
 		_, _, props, err := monitor.RegisterResource("pkgA:m:typA", "resC", true, deploytest.ResourceOptions{
 			Inputs: resource.PropertyMap{
 				"resA": resource.MakeResourceReference(urnA, "", false, ""),
-				"resB": resource.MakeResourceReference(urnB, idB, true, ""),
+				"resB": resource.MakeResourceReference(urnB, idBString, true, ""),
 			},
 		})
 		assert.NoError(t, err)
 
-		assert.True(t, props.DeepEquals(resource.PropertyMap{
-			"resA": resource.NewStringProperty(string(urnA)),
-			"resB": resource.NewStringProperty(string(idB)),
-		}))
+		assert.Equal(t, resource.NewStringProperty(string(urnA)), props["resA"])
+		if idBString != "" {
+			assert.Equal(t, resource.NewStringProperty(string(idBString)), props["resB"])
+		} else {
+			assert.True(t, props["resB"].IsComputed())
+		}
 		return nil
 	})
 

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -555,21 +555,6 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 					}
 					return prop, nil
 				case resource.ResourceReferenceSig:
-					urnStr, ok := objmap["urn"].(string)
-					if !ok {
-						return resource.PropertyValue{}, errors.New("malformed resource value: missing urn")
-					}
-					urn := resource.URN(urnStr)
-
-					id, hasID := resource.ID(""), false
-					if idV, ok := objmap["id"]; ok {
-						idStr, ok := idV.(string)
-						if !ok {
-							return resource.PropertyValue{}, errors.New("malformed resource value: id must be a string")
-						}
-						id, hasID = resource.ID(idStr), true
-					}
-
 					var packageVersion string
 					if packageVersionV, ok := objmap["packageVersion"]; ok {
 						packageVersion, ok = packageVersionV.(string)
@@ -579,7 +564,21 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 						}
 					}
 
-					return resource.MakeResourceReference(urn, id, hasID, packageVersion), nil
+					urnStr, ok := objmap["urn"].(string)
+					if !ok {
+						return resource.PropertyValue{}, errors.New("malformed resource value: missing urn")
+					}
+					urn := resource.URN(urnStr)
+
+					if idV, ok := objmap["id"]; ok {
+						id, ok := idV.(string)
+						if !ok {
+							return resource.PropertyValue{}, errors.New("malformed resource value: id must be a string")
+						}
+						return resource.MakeCustomResourceReference(urn, resource.ID(id), packageVersion), nil
+					}
+
+					return resource.MakeComponentResourceReference(urn, packageVersion), nil
 				default:
 					return resource.PropertyValue{}, errors.Errorf("unrecognized signature '%v' in property map", sig)
 				}

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -289,7 +289,7 @@ func TestSkipInternalKeys(t *testing.T) {
 func TestResourceReference(t *testing.T) {
 	// Test round-trip
 	opts := MarshalOptions{KeepResources: true}
-	rawProp := resource.MakeResourceReference("fakeURN", "fakeID", true, "fakeVersion")
+	rawProp := resource.MakeCustomResourceReference("fakeURN", "fakeID", "fakeVersion")
 	prop, err := MarshalPropertyValue(rawProp, opts)
 	assert.NoError(t, err)
 	actual, err := UnmarshalPropertyValue(prop, opts)
@@ -300,7 +300,7 @@ func TestResourceReference(t *testing.T) {
 	opts.KeepResources = false
 	actual, err = UnmarshalPropertyValue(prop, opts)
 	assert.NoError(t, err)
-	assert.Equal(t, resource.NewStringProperty(string(rawProp.ResourceReferenceValue().ID)), *actual)
+	assert.Equal(t, resource.NewStringProperty(rawProp.ResourceReferenceValue().ID.StringValue()), *actual)
 
 	// Test marshaling as an ID
 	prop, err = MarshalPropertyValue(rawProp, opts)
@@ -308,10 +308,10 @@ func TestResourceReference(t *testing.T) {
 	opts.KeepResources = true
 	actual, err = UnmarshalPropertyValue(prop, opts)
 	assert.NoError(t, err)
-	assert.Equal(t, resource.NewStringProperty(string(rawProp.ResourceReferenceValue().ID)), *actual)
+	assert.Equal(t, resource.NewStringProperty(rawProp.ResourceReferenceValue().ID.StringValue()), *actual)
 
 	// Test unmarshaling as a URN
-	rawProp = resource.MakeResourceReference("fakeURN", "", false, "fakeVersion")
+	rawProp = resource.MakeComponentResourceReference("fakeURN", "fakeVersion")
 	prop, err = MarshalPropertyValue(rawProp, opts)
 	assert.NoError(t, err)
 	opts.KeepResources = false

--- a/sdk/go/common/resource/properties_diff.go
+++ b/sdk/go/common/resource/properties_diff.go
@@ -331,7 +331,15 @@ func (v PropertyValue) DeepEquals(other PropertyValue) bool {
 		vr := v.ResourceReferenceValue()
 		or := other.ResourceReferenceValue()
 
-		return vr.URN == or.URN && vr.ID == or.ID
+		if vr.URN != or.URN {
+			return false
+		}
+
+		vid, oid := vr.ID, or.ID
+		if vid.IsComputed() && oid.IsComputed() {
+			return true
+		}
+		return vid.DeepEquals(oid)
 	}
 
 	// For all other cases, primitives are equal if their values are equal.

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -272,18 +272,17 @@ func marshalInputAndDetermineSecret(v interface{},
 			contract.Assert(known)
 			contract.Assert(!secretURN)
 
-			id, hasID := ID(""), false
 			if custom, ok := v.(CustomResource); ok {
-				resID, _, secretID, err := custom.ID().awaitID(context.Background())
+				id, _, secretID, err := custom.ID().awaitID(context.Background())
 				if err != nil {
 					return resource.PropertyValue{}, nil, false, err
 				}
 				contract.Assert(!secretID)
 
-				id, hasID = resID, true
+				return resource.MakeCustomResourceReference(resource.URN(urn), resource.ID(id), ""), deps, secret, nil
 			}
 
-			return resource.MakeResourceReference(resource.URN(urn), resource.ID(id), hasID, ""), deps, secret, nil
+			return resource.MakeComponentResourceReference(resource.URN(urn), ""), deps, secret, nil
 		}
 
 		contract.Assertf(valueType.AssignableTo(destType) || valueType.ConvertibleTo(destType),


### PR DESCRIPTION
When marshaling a resource reference as its ID (i.e. when
opts.KeepResources is false, as it will be in the case of downlevel SDKs
and resource providers), we must take care to marshal/unmarshal an empty
ID as the unknown property value.

Fixes #5939.