### PR TITLE
[codegen/go] @viveklak Add a rename mapping to package info to control collision renames

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -145,8 +145,8 @@ func (pkg *pkgContext) tokenToType(tok string) string {
 
 	if ok {
 		renamed := false
-		// First determine if there is an existing rename required for the pkg+type
-		if renames, ok := modPkg.typeRenameMappings[pkg.pkg.Name]; ok {
+		// First determine if there is an existing rename required for the module+type
+		if renames, ok := modPkg.typeRenameMappings[mod]; ok {
 			if newName, ok := renames[name]; ok {
 				name = newName
 				renamed = true
@@ -1669,7 +1669,7 @@ func generatePackageContextMap(tool string, pkg *schema.Package, goInfo GoPackag
 				modToPkg:           goInfo.ModuleToPackage,
 				pkgImportAliases:   goInfo.PackageImportAliases,
 				packages:           packages,
-				typeRenameMappings: goInfo.PackageToTypeRenameMapping,
+				typeRenameMappings: goInfo.ModuleToTypeRenameMapping,
 			}
 			packages[mod] = pack
 		}

--- a/pkg/codegen/go/importer.go
+++ b/pkg/codegen/go/importer.go
@@ -42,7 +42,13 @@ type GoPackageInfo struct {
 	// Generate container types (arrays, maps, pointer output types etc.) for each resource.
 	// These are typically used to support external references.
 	GenerateResourceContainerTypes bool `json:"generateResourceContainerTypes,omitempty"`
+
+	// An optional mapping keyed by package name, storing a nested map keyed by schema types
+	// and the corresponding renamed version.
+	PackageToTypeRenameMapping map[string]TypeRenameMapping `json:"packageToTypeRenameMapping,omitempty"`
 }
+
+type TypeRenameMapping map[string]string
 
 // Importer implements schema.Language for Go.
 var Importer schema.Language = importer(0)

--- a/pkg/codegen/go/importer.go
+++ b/pkg/codegen/go/importer.go
@@ -43,9 +43,9 @@ type GoPackageInfo struct {
 	// These are typically used to support external references.
 	GenerateResourceContainerTypes bool `json:"generateResourceContainerTypes,omitempty"`
 
-	// An optional mapping keyed by package name, storing a nested map keyed by schema types
+	// An optional mapping keyed by module name, storing a nested map keyed by schema types
 	// and the corresponding renamed version.
-	PackageToTypeRenameMapping map[string]TypeRenameMapping `json:"packageToTypeRenameMapping,omitempty"`
+	ModuleToTypeRenameMapping map[string]TypeRenameMapping `json:"moduleToTypeRenameMapping,omitempty"`
 }
 
 type TypeRenameMapping map[string]string

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
@@ -65,6 +65,56 @@ func (o ObjectOutput) Foo() ResourceOutput {
 	return o.ApplyT(func(v Object) *Resource { return v.Foo }).(ResourceOutput)
 }
 
+type RenamedResourceOutput struct {
+	Foo *string `pulumi:"foo"`
+}
+
+// RenamedResourceOutputInput is an input type that accepts RenamedResourceOutputArgs and RenamedResourceOutputOutput values.
+// You can construct a concrete instance of `RenamedResourceOutputInput` via:
+//
+//          RenamedResourceOutputArgs{...}
+type RenamedResourceOutputInput interface {
+	pulumi.Input
+
+	ToRenamedResourceOutputOutput() RenamedResourceOutputOutput
+	ToRenamedResourceOutputOutputWithContext(context.Context) RenamedResourceOutputOutput
+}
+
+type RenamedResourceOutputArgs struct {
+	Foo pulumi.StringPtrInput `pulumi:"foo"`
+}
+
+func (RenamedResourceOutputArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*RenamedResourceOutput)(nil)).Elem()
+}
+
+func (i RenamedResourceOutputArgs) ToRenamedResourceOutputOutput() RenamedResourceOutputOutput {
+	return i.ToRenamedResourceOutputOutputWithContext(context.Background())
+}
+
+func (i RenamedResourceOutputArgs) ToRenamedResourceOutputOutputWithContext(ctx context.Context) RenamedResourceOutputOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(RenamedResourceOutputOutput)
+}
+
+type RenamedResourceOutputOutput struct{ *pulumi.OutputState }
+
+func (RenamedResourceOutputOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*RenamedResourceOutput)(nil)).Elem()
+}
+
+func (o RenamedResourceOutputOutput) ToRenamedResourceOutputOutput() RenamedResourceOutputOutput {
+	return o
+}
+
+func (o RenamedResourceOutputOutput) ToRenamedResourceOutputOutputWithContext(ctx context.Context) RenamedResourceOutputOutput {
+	return o
+}
+
+func (o RenamedResourceOutputOutput) Foo() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v RenamedResourceOutput) *string { return v.Foo }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterOutputType(ObjectOutput{})
+	pulumi.RegisterOutputType(RenamedResourceOutputOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/schema.json
@@ -73,8 +73,8 @@
     "csharp": {},
     "go": {
       "importBasePath": "github.com/pulumi/pulumi/pkg/v2/codegen/internal/test/testdata/simple-resource-schema/go/example",
-      "packageToTypeRenameMapping": {
-        "example": {
+      "moduleToTypeRenameMapping": {
+        "": {
           "OtherResourceOutput": "RenamedResourceOutput"
         }
       }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/schema.json
@@ -12,6 +12,14 @@
         }
       },
       "type": "object"
+    },
+    "example::OtherResourceOutput": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "resources": {
@@ -64,7 +72,12 @@
   "language": {
     "csharp": {},
     "go": {
-      "importBasePath": "github.com/pulumi/pulumi/pkg/v2/codegen/internal/test/testdata/simple-resource-schema/go/example"
+      "importBasePath": "github.com/pulumi/pulumi/pkg/v2/codegen/internal/test/testdata/simple-resource-schema/go/example",
+      "packageToTypeRenameMapping": {
+        "example": {
+          "OtherResourceOutput": "RenamedResourceOutput"
+        }
+      }
     },
     "nodejs": {},
     "python": {}


### PR DESCRIPTION
Fix for https://github.com/pulumi/pulumi-azure-nextgen/issues/137.

This is a targeted addition to allow an escape hatch to handle fallout from our poor name collision handling. The proper long term fix is tracked in https://github.com/pulumi/pulumi/issues/6170
