### PR TITLE
Fix base import path handling in go programgen

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -283,7 +283,7 @@ func (g *generator) getPulumiImport(pkg, vPath, mod string) string {
 
 	// All providers don't follow the sdk/go/<package> scheme. Allow ImportBasePath as
 	// a means to override this assumption.
-	if info.ImportBasePath != "" {
+	if info.ImportBasePath != "" && mod != "" {
 		imp = fmt.Sprintf("%s/%s", info.ImportBasePath, mod)
 	}
 


### PR DESCRIPTION
Needed for https://github.com/pulumi/pulumi-terraform-bridge/issues/320

Without this go programgen produces malformed input.