### PR TITLE
Updating doc links to align with changes in docs #4707

### DIFF
--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -358,7 +358,7 @@ func WelcomeUser(opts display.Options) {
 
   %s Resources you create with Pulumi are given unique names (a randomly
   generated suffix) by default. To learn more about auto-naming or customizing resource
-  names see https://www.pulumi.com/docs/intro/concepts/programming-model/#autonaming.
+  names see https://www.pulumi.com/docs/intro/concepts/resources/#autonaming.
 
 
 `,

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -79,7 +79,7 @@
 
 ## {{ .Header.Title }} Resource Properties {#properties}
 
-To learn more about resource properties and how to use them, see [Inputs and Outputs]({{ htmlSafe "{{< relref \"/docs/intro/concepts/inputs-outputs\" >}}" }}) in the Programming Model docs.
+To learn more about resource properties and how to use them, see [Inputs and Outputs]({{ htmlSafe "{{< relref \"/docs/intro/concepts/inputs-outputs\" >}}" }}) in the Architecture and Concepts docs.
 
 ### Inputs
 


### PR DESCRIPTION
Per the title, the programming model topic is being refactored, split up, and merged with existing content in pulumi/docs#4707.

This PR updates the boilerplate doc links from within our autogen'ed ref pages. The docs PR has redirects in place so the current link doesn't 404 after the PR merged and pushed live.

Once the docs PR is live, we can merge this in when it makes sense to do so. 