### PR TITLE
Relax the diff path check to avoid panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ CHANGELOG
   only when the monitor reports that resource references are supported.
   [#6172](https://github.com/pulumi/pulumi/pull/6172)
 
+- [CLI] Avoid panic for diffs with invalid property paths.
+  [#6159](https://github.com/pulumi/pulumi/pull/6159)
+
 ## 2.18.1 (2021-01-21)
 
 - Revert [#6125](https://github.com/pulumi/pulumi/pull/6125) as it caused a which introduced a bug with serializing resource IDs

--- a/pkg/backend/display/detailedDiff.go
+++ b/pkg/backend/display/detailedDiff.go
@@ -142,7 +142,9 @@ func translateDetailedDiff(step engine.StepEventMetadata) *resource.ObjectDiff {
 	var diff resource.ValueDiff
 	for path, pdiff := range step.DetailedDiff {
 		elements, err := resource.ParsePropertyPath(path)
-		contract.Assert(err == nil)
+		if err != nil {
+			elements = []interface{}{path}
+		}
 
 		olds := resource.NewObjectProperty(step.Old.Outputs)
 		if pdiff.InputDiff {

--- a/pkg/backend/display/detailedDiff_test.go
+++ b/pkg/backend/display/detailedDiff_test.go
@@ -708,6 +708,21 @@ func TestTranslateDetailedDiff(t *testing.T) {
 				},
 			},
 		},
+		{
+			state:  map[string]interface{}{},
+			inputs: map[string]interface{}{},
+			detailedDiff: map[string]plugin.PropertyDiff{
+				"foo[something.wonky]probably/miscalculated.by.provider": U,
+			},
+			expected: &resource.ObjectDiff{
+				Adds:    resource.PropertyMap{},
+				Deletes: resource.PropertyMap{},
+				Sames:   resource.PropertyMap{},
+				Updates: map[resource.PropertyKey]resource.ValueDiff{
+					"foo[something.wonky]probably/miscalculated.by.provider": {},
+				},
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/6135

The cause is probably the Azure NextGen provider that returns the diff in tags as if tags are a typed object rather than an untyped map with arbitrary keys. In the case of panic, there is a tag that contains `[Something]` which fails to parse as a valid path.

However, my point in this PR is that the diff comes from a semi-trusted source (an arbitrary provider, could be 3rd party, eventually), so it's not worth panicking. Rather, we can assume a reasonable default.  In this case, the diff shows as 
![image](https://user-images.githubusercontent.com/1454008/105364048-fda0eb80-5bfc-11eb-856f-94fe742a7e62.png)
which isn't perfect but probably way better than panic.