### PR TITLE
Fix malformed resource value bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- [CLI] Fix malformed resource value bug.
+  [#6164](https://github.com/pulumi/pulumi/pull/6164)
 
 ## 2.18.1 (2021-01-21)
 

--- a/pkg/engine/events.go
+++ b/pkg/engine/events.go
@@ -417,7 +417,7 @@ func filterPropertyMap(propertyMap resource.PropertyMap, debug bool) resource.Pr
 		case resource.ResourceReference:
 			return resource.ResourceReference{
 				URN:            resource.URN(filterValue(string(t.URN)).(string)),
-				ID:             resource.ID(filterValue(string(t.ID)).(string)),
+				ID:             resource.PropertyValue{V: filterValue(t.ID.V)},
 				PackageVersion: filterValue(t.PackageVersion).(string),
 			}
 		}

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -1927,7 +1927,7 @@ func TestSingleComponentGetResourceDefaultProviderLifecycle(t *testing.T) {
 					URN: urn,
 					Outputs: resource.PropertyMap{
 						"foo": resource.NewStringProperty("bar"),
-						"res": resource.MakeResourceReference(urnB, idB, true, ""),
+						"res": resource.MakeCustomResourceReference(urnB, idB, ""),
 					},
 				}, nil
 			}
@@ -1953,7 +1953,7 @@ func TestSingleComponentGetResourceDefaultProviderLifecycle(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, resource.PropertyMap{
 			"foo": resource.NewStringProperty("bar"),
-			"res": resource.MakeResourceReference(urnB, idB, true, ""),
+			"res": resource.MakeCustomResourceReference(urnB, idB, ""),
 		}, state)
 
 		result, _, err := monitor.Invoke("pulumi:pulumi:getResource", resource.PropertyMap{

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -373,12 +373,15 @@ func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
 	// We serialize resource references using a map-based representation similar to assets, archives, and secrets.
 	if prop.IsResourceReference() {
 		ref := prop.ResourceReferenceValue()
-		return map[string]interface{}{
+		serialized := map[string]interface{}{
 			resource.SigKey:  resource.ResourceReferenceSig,
-			"urn":            ref.URN,
-			"id":             ref.ID,
+			"urn":            string(ref.URN),
 			"packageVersion": ref.PackageVersion,
-		}, nil
+		}
+		if id, hasID := ref.IDString(); hasID {
+			serialized["id"] = id
+		}
+		return serialized, nil
 	}
 
 	if prop.IsSecret() {
@@ -560,24 +563,52 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 						packageVersion, ok = packageVersionV.(string)
 						if !ok {
 							return resource.PropertyValue{},
-								errors.New("malformed resource value: packageVersion must be a string")
+								errors.New("malformed resource reference: packageVersion must be a string")
 						}
 					}
 
 					urnStr, ok := objmap["urn"].(string)
 					if !ok {
-						return resource.PropertyValue{}, errors.New("malformed resource value: missing urn")
+						return resource.PropertyValue{}, errors.New("malformed resource reference: missing urn")
 					}
 					urn := resource.URN(urnStr)
 
-					if idV, ok := objmap["id"]; ok {
-						id, ok := idV.(string)
+					// deserializeID handles two cases, one of which arose from a bug in a refactoring of resource.ResourceReference.
+					// This bug caused the raw ID PropertyValue to be serialized as a map[string]interface{}. In the normal case, the
+					// ID is serialized as a string.
+					deserializeID := func() (string, bool, error) {
+						idV, ok := objmap["id"]
 						if !ok {
-							return resource.PropertyValue{}, errors.New("malformed resource value: id must be a string")
+							return "", false, nil
 						}
-						return resource.MakeCustomResourceReference(urn, resource.ID(id), packageVersion), nil
+
+						switch idV := idV.(type) {
+						case string:
+							return idV, true, nil
+						case map[string]interface{}:
+							switch v := idV["V"].(type) {
+							case nil:
+								// This happens for component resource references, which do not have an associated ID.
+								return "", false, nil
+							case string:
+								// This happens for custom resource references, which do have an associated ID.
+								return v, true, nil
+							case map[string]interface{}:
+								// This happens for custom resource references with an unknown ID. In this case, the ID should be
+								// deserialized as the empty string.
+								return "", true, nil
+							}
+						}
+						return "", false, errors.New("malformed resource reference: id must be a string")
 					}
 
+					id, hasID, err := deserializeID()
+					if err != nil {
+						return resource.PropertyValue{}, err
+					}
+					if hasID {
+						return resource.MakeCustomResourceReference(urn, resource.ID(id), packageVersion), nil
+					}
 					return resource.MakeComponentResourceReference(urn, packageVersion), nil
 				default:
 					return resource.PropertyValue{}, errors.Errorf("unrecognized signature '%v' in property map", sig)

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -555,21 +555,6 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 					}
 					return prop, nil
 				case resource.ResourceReferenceSig:
-					urnStr, ok := objmap["urn"].(string)
-					if !ok {
-						return resource.PropertyValue{}, errors.New("malformed resource value: missing urn")
-					}
-					urn := resource.URN(urnStr)
-
-					id, hasID := resource.ID(""), false
-					if idV, ok := objmap["id"]; ok {
-						idStr, ok := idV.(string)
-						if !ok {
-							return resource.PropertyValue{}, errors.New("malformed resource value: id must be a string")
-						}
-						id, hasID = resource.ID(idStr), true
-					}
-
 					var packageVersion string
 					if packageVersionV, ok := objmap["packageVersion"]; ok {
 						packageVersion, ok = packageVersionV.(string)
@@ -579,7 +564,21 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 						}
 					}
 
-					return resource.MakeResourceReference(urn, id, hasID, packageVersion), nil
+					urnStr, ok := objmap["urn"].(string)
+					if !ok {
+						return resource.PropertyValue{}, errors.New("malformed resource value: missing urn")
+					}
+					urn := resource.URN(urnStr)
+
+					if idV, ok := objmap["id"]; ok {
+						id, ok := idV.(string)
+						if !ok {
+							return resource.PropertyValue{}, errors.New("malformed resource value: id must be a string")
+						}
+						return resource.MakeCustomResourceReference(urn, resource.ID(id), packageVersion), nil
+					}
+
+					return resource.MakeComponentResourceReference(urn, packageVersion), nil
 				default:
 					return resource.PropertyValue{}, errors.Errorf("unrecognized signature '%v' in property map", sig)
 				}

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -166,8 +166,8 @@ func MarshalPropertyValue(v resource.PropertyValue, opts MarshalOptions) (*struc
 		ref := v.ResourceReferenceValue()
 		if !opts.KeepResources {
 			val := string(ref.URN)
-			if ref.HasID {
-				val = string(ref.ID)
+			if !ref.ID.IsNull() {
+				return MarshalPropertyValue(ref.ID, opts)
 			}
 			logging.V(5).Infof("marshalling resource value as raw URN or ID as opts.KeepResources is false")
 			return MarshalString(val, opts), nil
@@ -176,8 +176,8 @@ func MarshalPropertyValue(v resource.PropertyValue, opts MarshalOptions) (*struc
 			resource.SigKey: resource.NewStringProperty(resource.ResourceReferenceSig),
 			"urn":           resource.NewStringProperty(string(ref.URN)),
 		}
-		if ref.HasID {
-			m["id"] = resource.NewStringProperty(string(ref.ID))
+		if id, hasID := ref.IDString(); hasID {
+			m["id"] = resource.NewStringProperty(id)
 		}
 		if ref.PackageVersion != "" {
 			m["packageVersion"] = resource.NewStringProperty(ref.PackageVersion)
@@ -398,15 +398,27 @@ func UnmarshalPropertyValue(v *structpb.Value, opts MarshalOptions) (*resource.P
 
 			if !opts.KeepResources {
 				value := urn.StringValue()
-				if id != "" {
+				if hasID {
+					isIDUnknown := id == ""
+					if isIDUnknown && opts.KeepUnknowns {
+						v := structpb.Value{
+							Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+						}
+						return UnmarshalPropertyValue(&v, opts)
+					}
 					value = id
 				}
 				r := resource.NewStringProperty(value)
 				return &r, nil
 			}
 
-			r := resource.MakeResourceReference(resource.URN(urn.StringValue()), resource.ID(id), hasID, packageVersion)
-			return &r, nil
+			var ref resource.PropertyValue
+			if hasID {
+				ref = resource.MakeCustomResourceReference(resource.URN(urn.StringValue()), resource.ID(id), packageVersion)
+			} else {
+				ref = resource.MakeComponentResourceReference(resource.URN(urn.StringValue()), packageVersion)
+			}
+			return &ref, nil
 		default:
 			return nil, errors.Errorf("unrecognized signature '%v' in property map", sig)
 		}

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -289,7 +289,7 @@ func TestSkipInternalKeys(t *testing.T) {
 func TestResourceReference(t *testing.T) {
 	// Test round-trip
 	opts := MarshalOptions{KeepResources: true}
-	rawProp := resource.MakeResourceReference("fakeURN", "fakeID", true, "fakeVersion")
+	rawProp := resource.MakeCustomResourceReference("fakeURN", "fakeID", "fakeVersion")
 	prop, err := MarshalPropertyValue(rawProp, opts)
 	assert.NoError(t, err)
 	actual, err := UnmarshalPropertyValue(prop, opts)
@@ -300,7 +300,7 @@ func TestResourceReference(t *testing.T) {
 	opts.KeepResources = false
 	actual, err = UnmarshalPropertyValue(prop, opts)
 	assert.NoError(t, err)
-	assert.Equal(t, resource.NewStringProperty(string(rawProp.ResourceReferenceValue().ID)), *actual)
+	assert.Equal(t, resource.NewStringProperty(rawProp.ResourceReferenceValue().ID.StringValue()), *actual)
 
 	// Test marshaling as an ID
 	prop, err = MarshalPropertyValue(rawProp, opts)
@@ -308,10 +308,10 @@ func TestResourceReference(t *testing.T) {
 	opts.KeepResources = true
 	actual, err = UnmarshalPropertyValue(prop, opts)
 	assert.NoError(t, err)
-	assert.Equal(t, resource.NewStringProperty(string(rawProp.ResourceReferenceValue().ID)), *actual)
+	assert.Equal(t, resource.NewStringProperty(rawProp.ResourceReferenceValue().ID.StringValue()), *actual)
 
 	// Test unmarshaling as a URN
-	rawProp = resource.MakeResourceReference("fakeURN", "", false, "fakeVersion")
+	rawProp = resource.MakeComponentResourceReference("fakeURN", "fakeVersion")
 	prop, err = MarshalPropertyValue(rawProp, opts)
 	assert.NoError(t, err)
 	opts.KeepResources = false

--- a/sdk/go/common/resource/properties_diff.go
+++ b/sdk/go/common/resource/properties_diff.go
@@ -331,7 +331,15 @@ func (v PropertyValue) DeepEquals(other PropertyValue) bool {
 		vr := v.ResourceReferenceValue()
 		or := other.ResourceReferenceValue()
 
-		return vr.URN == or.URN && vr.ID == or.ID
+		if vr.URN != or.URN {
+			return false
+		}
+
+		vid, oid := vr.ID, or.ID
+		if vid.IsComputed() && oid.IsComputed() {
+			return true
+		}
+		return vid.DeepEquals(oid)
 	}
 
 	// For all other cases, primitives are equal if their values are equal.

--- a/sdk/go/pulumi/resource_test.go
+++ b/sdk/go/pulumi/resource_test.go
@@ -4,7 +4,6 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,30 +17,6 @@ type testProv struct {
 	ProviderResourceState
 	// equality identifier used for testing
 	foo string
-}
-
-type testResourcePackage struct {
-	version semver.Version
-}
-
-func (rp *testResourcePackage) ConstructProvider(ctx *Context, name, typ, urn string) (ProviderResource, error) {
-	return &testProv{}, nil
-}
-
-func (rp *testResourcePackage) Version() semver.Version {
-	return rp.version
-}
-
-type testResourceModule struct {
-	version semver.Version
-}
-
-func (rm *testResourceModule) Construct(ctx *Context, name, typ, urn string) (Resource, error) {
-	return &testRes{}, nil
-}
-
-func (rm *testResourceModule) Version() semver.Version {
-	return rm.version
 }
 
 func TestResourceOptionMergingParent(t *testing.T) {

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -272,18 +272,17 @@ func marshalInputAndDetermineSecret(v interface{},
 			contract.Assert(known)
 			contract.Assert(!secretURN)
 
-			id, hasID := ID(""), false
 			if custom, ok := v.(CustomResource); ok {
-				resID, _, secretID, err := custom.ID().awaitID(context.Background())
+				id, _, secretID, err := custom.ID().awaitID(context.Background())
 				if err != nil {
 					return resource.PropertyValue{}, nil, false, err
 				}
 				contract.Assert(!secretID)
 
-				id, hasID = resID, true
+				return resource.MakeCustomResourceReference(resource.URN(urn), resource.ID(id), ""), deps, secret, nil
 			}
 
-			return resource.MakeResourceReference(resource.URN(urn), resource.ID(id), hasID, ""), deps, secret, nil
+			return resource.MakeComponentResourceReference(resource.URN(urn), ""), deps, secret, nil
 		}
 
 		contract.Assertf(valueType.AssignableTo(destType) || valueType.ConvertibleTo(destType),

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -392,6 +392,41 @@ func marshalInputAndDetermineSecret(v interface{},
 	}
 }
 
+func unmarshalResourceReference(ctx *Context, ref resource.ResourceReference) (Resource, error) {
+	version := nullVersion
+	if len(ref.PackageVersion) > 0 {
+		var err error
+		version, err = semver.ParseTolerant(ref.PackageVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse provider version: %s", ref.PackageVersion)
+		}
+	}
+
+	resName := ref.URN.Name().String()
+	resType := ref.URN.Type()
+
+	isProvider := tokens.Token(resType).HasModuleMember() && resType.Module() == "pulumi:providers"
+	if isProvider {
+		pkgName := resType.Name().String()
+		if resourcePackageV, ok := resourcePackages.Load(pkgName, version); ok {
+			resourcePackage := resourcePackageV.(ResourcePackage)
+			return resourcePackage.ConstructProvider(ctx, resName, string(resType), string(ref.URN))
+		}
+		id, _ := ref.IDString()
+		return newDependencyProviderResource(URN(ref.URN), ID(id)), nil
+	}
+
+	modName := resType.Module().String()
+	if resourceModuleV, ok := resourceModules.Load(modName, version); ok {
+		resourceModule := resourceModuleV.(ResourceModule)
+		return resourceModule.Construct(ctx, resName, string(resType), string(ref.URN))
+	}
+	if id, hasID := ref.IDString(); hasID {
+		return newDependencyCustomResource(URN(ref.URN), ID(id)), nil
+	}
+	return newDependencyResource(URN(ref.URN)), nil
+}
+
 func unmarshalPropertyValue(ctx *Context, v resource.PropertyValue) (interface{}, bool, error) {
 	switch {
 	case v.IsComputed() || v.IsOutput():
@@ -460,45 +495,7 @@ func unmarshalPropertyValue(ctx *Context, v resource.PropertyValue) (interface{}
 		}
 		return nil, false, errors.New("expected asset to be one of File, String, or Remote; got none")
 	case v.IsResourceReference():
-		ref := v.ResourceReferenceValue()
-
-		version := nullVersion
-		if len(ref.PackageVersion) > 0 {
-			var err error
-			version, err = semver.ParseTolerant(ref.PackageVersion)
-			if err != nil {
-				return nil, false, fmt.Errorf("failed to parse provider version: %s", ref.PackageVersion)
-			}
-		}
-
-		resName := ref.URN.Name().String()
-		resType := ref.URN.Type()
-
-		var resource Resource
-		var err error
-
-		isProvider := tokens.Token(resType).HasModuleMember() && resType.Module() == "pulumi:providers"
-		if isProvider {
-			pkgName := resType.Name().String()
-			resourcePackageV, ok := resourcePackages.Load(pkgName, version)
-			if !ok {
-				err := fmt.Errorf("unable to deserialize provider %v, no resource package is registered for %v",
-					ref.URN, pkgName)
-				return nil, false, err
-			}
-			resourcePackage := resourcePackageV.(ResourcePackage)
-			resource, err = resourcePackage.ConstructProvider(ctx, resName, string(resType), string(ref.URN))
-		} else {
-			pkgName := resType.Package().String()
-			modName := resType.Module().String()
-			resourceModuleV, ok := resourceModules.Load(moduleKey(pkgName, modName), version)
-			if !ok {
-				err := fmt.Errorf("unable to deserialize resource %v, no module is registered for %v", ref.URN, modName)
-				return nil, false, err
-			}
-			resourceModule := resourceModuleV.(ResourceModule)
-			resource, err = resourceModule.Construct(ctx, resName, string(resType), string(ref.URN))
-		}
+		resource, err := unmarshalResourceReference(ctx, v.ResourceReferenceValue())
 		if err != nil {
 			return nil, false, err
 		}
@@ -594,10 +591,19 @@ func unmarshalOutput(ctx *Context, v resource.PropertyValue, dest reflect.Value)
 		dest.SetFloat(v.NumberValue())
 		return false, nil
 	case reflect.String:
-		if !v.IsString() {
+		switch {
+		case v.IsString():
+			dest.SetString(v.StringValue())
+		case v.IsResourceReference():
+			ref := v.ResourceReferenceValue()
+			if id, hasID := ref.IDString(); hasID {
+				dest.SetString(id)
+			} else {
+				dest.SetString(string(ref.URN))
+			}
+		default:
 			return false, fmt.Errorf("expected a %v, got a %s", dest.Type(), v.TypeString())
 		}
-		dest.SetString(v.StringValue())
 		return false, nil
 	case reflect.Slice:
 		if !v.IsArray() {


### PR DESCRIPTION
PR #6125 introduced a bug by marshaling resource
ids as PropertyValues, but not handling that case on
the unmarshaling side. The previous code assumed
that the id was a simple string value. This bug prevents
any stack update operations (preview, update, destroy,
refresh). Since this change was already
released, we must now handle both cases in the
unmarshaling code.

Fix #6158 