### PR TITLE
[sdk/dotnet] RegisterResourceOutputs: Check for resource ref support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ CHANGELOG
 - [CLI] Fix malformed resource value bug.
   [#6164](https://github.com/pulumi/pulumi/pull/6164)
 
+- [sdk/dotnet] Fix `RegisterResourceOutputs` to serialize resources as resource references
+  only when the monitor reports that resource references are supported.
+  [#6172](https://github.com/pulumi/pulumi/pull/6172)
+
 ## 2.18.1 (2021-01-21)
 
 - Revert [#6125](https://github.com/pulumi/pulumi/pull/6125) as it caused a which introduced a bug with serializing resource IDs

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResourceOutputs.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResourceOutputs.cs
@@ -29,7 +29,8 @@ namespace Pulumi
             var urn = await resource.Urn.GetValueAsync().ConfigureAwait(false);
             var props = await outputs.GetValueAsync().ConfigureAwait(false);
 
-            var serialized = await SerializeAllPropertiesAsync(opLabel, props, true).ConfigureAwait(false);
+            var serialized = await SerializeAllPropertiesAsync(
+                opLabel, props, await MonitorSupportsResourceReferences().ConfigureAwait(false)).ConfigureAwait(false);
             Log.Debug($"RegisterResourceOutputs RPC prepared: urn={urn}" +
                 (_excessiveDebugOutput ? $", outputs ={JsonFormatter.Default.Format(serialized)}" : ""));
 


### PR DESCRIPTION
.NET's implementation of `RegisterResourceOutputs` was always serializing resources as resource references, regardless of the monitor's reported support. This change fixes .NET to check if the monitor supports resource references, which is consistent with all the other languages, and with serialization code elsewhere in the .NET SDK ([here](https://github.com/pulumi/pulumi/blob/45d81f4eb4bba3d7989c4ba072a21c5d9d36b355/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs#L37) and [here](https://github.com/pulumi/pulumi/blob/45d81f4eb4bba3d7989c4ba072a21c5d9d36b355/sdk/dotnet/Pulumi/Deployment/Deployment_Invoke.cs#L45)).

Fixes #6171