### PR TITLE
Avoid toStringing Output in debuggablePromise

### DIFF
--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -74,7 +74,7 @@ export function transferProperties(onto: Resource, label: string, props: Inputs)
                 `transferIsStable(${label}, ${k}, ${propString})`),
             debuggablePromise(
                 new Promise<boolean>(resolve => resolveIsSecret = resolve),
-                `transferIsSecret(${label}, ${k}, ${props[k]})`),
+                `transferIsSecret(${label}, ${k}, ${propString})`),
             debuggablePromise(
                 new Promise<Resource[]>(resolve => resolveDeps = resolve),
                 `transferDeps(${label}, ${k}, ${propString})`));


### PR DESCRIPTION
Promise leak debugging was accidentally toStringing an Output, leading to a red herring for several users trying to understand what was causing promise leaks.

Related to #6153 and #5853.