### PR TITLE
[codegen/go] Fix default value handling for enums

### DIFF
--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Tree/V1/Enums.cs
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Tree/V1/Enums.cs
@@ -8,6 +8,34 @@ using Pulumi;
 namespace Pulumi.Plant.Tree.V1
 {
     [EnumType]
+    public readonly struct Diameter : IEquatable<Diameter>
+    {
+        private readonly double _value;
+
+        private Diameter(double value)
+        {
+            _value = value;
+        }
+
+        public static Diameter Sixinch { get; } = new Diameter(6);
+        public static Diameter Twelveinch { get; } = new Diameter(12);
+
+        public static bool operator ==(Diameter left, Diameter right) => left.Equals(right);
+        public static bool operator !=(Diameter left, Diameter right) => !left.Equals(right);
+
+        public static explicit operator double(Diameter value) => value._value;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) => obj is Diameter other && Equals(other);
+        public bool Equals(Diameter other) => _value == other._value;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value.GetHashCode();
+
+        public override string ToString() => _value.ToString();
+    }
+
+    [EnumType]
     public readonly struct Farm : IEquatable<Farm>
     {
         private readonly string _value;
@@ -69,6 +97,35 @@ namespace Pulumi.Plant.Tree.V1
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override bool Equals(object? obj) => obj is RubberTreeVariety other && Equals(other);
         public bool Equals(RubberTreeVariety other) => string.Equals(_value, other._value, StringComparison.Ordinal);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => _value?.GetHashCode() ?? 0;
+
+        public override string ToString() => _value;
+    }
+
+    [EnumType]
+    public readonly struct TreeSize : IEquatable<TreeSize>
+    {
+        private readonly string _value;
+
+        private TreeSize(string value)
+        {
+            _value = value ?? throw new ArgumentNullException(nameof(value));
+        }
+
+        public static TreeSize Small { get; } = new TreeSize("small");
+        public static TreeSize Medium { get; } = new TreeSize("medium");
+        public static TreeSize Large { get; } = new TreeSize("large");
+
+        public static bool operator ==(TreeSize left, TreeSize right) => left.Equals(right);
+        public static bool operator !=(TreeSize left, TreeSize right) => !left.Equals(right);
+
+        public static explicit operator string(TreeSize value) => value._value;
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object? obj) => obj is TreeSize other && Equals(other);
+        public bool Equals(TreeSize other) => string.Equals(_value, other._value, StringComparison.Ordinal);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode() => _value?.GetHashCode() ?? 0;

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
@@ -15,8 +15,14 @@ namespace Pulumi.Plant.Tree.V1
         [Output("container")]
         public Output<Pulumi.Plant.Outputs.Container?> Container { get; private set; } = null!;
 
+        [Output("diameter")]
+        public Output<Pulumi.Plant.Tree.V1.Diameter> Diameter { get; private set; } = null!;
+
         [Output("farm")]
         public Output<string?> Farm { get; private set; } = null!;
+
+        [Output("size")]
+        public Output<Pulumi.Plant.Tree.V1.TreeSize?> Size { get; private set; } = null!;
 
         [Output("type")]
         public Output<Pulumi.Plant.Tree.V1.RubberTreeVariety> Type { get; private set; } = null!;
@@ -69,15 +75,24 @@ namespace Pulumi.Plant.Tree.V1
         [Input("container")]
         public Input<Pulumi.Plant.Inputs.ContainerArgs>? Container { get; set; }
 
+        [Input("diameter", required: true)]
+        public Input<Pulumi.Plant.Tree.V1.Diameter> Diameter { get; set; } = null!;
+
         [Input("farm")]
         public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }
+
+        [Input("size")]
+        public Input<Pulumi.Plant.Tree.V1.TreeSize>? Size { get; set; }
 
         [Input("type", required: true)]
         public Input<Pulumi.Plant.Tree.V1.RubberTreeVariety> Type { get; set; } = null!;
 
         public RubberTreeArgs()
         {
+            Diameter = Pulumi.Plant.Tree.V1.Diameter.Sixinch;
             Farm = "(unknown)";
+            Size = Pulumi.Plant.Tree.V1.TreeSize.Medium;
+            Type = Pulumi.Plant.Tree.V1.RubberTreeVariety.Burgundy;
         }
     }
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/pulumiEnums.go
@@ -10,6 +10,33 @@ import (
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 )
 
+type Diameter pulumi.Float64
+
+const (
+	DiameterSixinch    = Diameter(6)
+	DiameterTwelveinch = Diameter(12)
+)
+
+func (Diameter) ElementType() reflect.Type {
+	return reflect.TypeOf((*pulumi.Float64)(nil)).Elem()
+}
+
+func (e Diameter) ToFloat64Output() pulumi.Float64Output {
+	return pulumi.ToOutput(pulumi.Float64(e)).(pulumi.Float64Output)
+}
+
+func (e Diameter) ToFloat64OutputWithContext(ctx context.Context) pulumi.Float64Output {
+	return pulumi.ToOutputWithContext(ctx, pulumi.Float64(e)).(pulumi.Float64Output)
+}
+
+func (e Diameter) ToFloat64PtrOutput() pulumi.Float64PtrOutput {
+	return pulumi.Float64(e).ToFloat64PtrOutputWithContext(context.Background())
+}
+
+func (e Diameter) ToFloat64PtrOutputWithContext(ctx context.Context) pulumi.Float64PtrOutput {
+	return pulumi.Float64(e).ToFloat64OutputWithContext(ctx).ToFloat64PtrOutputWithContext(ctx)
+}
+
 type Farm pulumi.String
 
 const (
@@ -66,5 +93,33 @@ func (e RubberTreeVariety) ToStringPtrOutput() pulumi.StringPtrOutput {
 }
 
 func (e RubberTreeVariety) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
+	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
+}
+
+type TreeSize pulumi.String
+
+const (
+	TreeSizeSmall  = TreeSize("small")
+	TreeSizeMedium = TreeSize("medium")
+	TreeSizeLarge  = TreeSize("large")
+)
+
+func (TreeSize) ElementType() reflect.Type {
+	return reflect.TypeOf((*pulumi.String)(nil)).Elem()
+}
+
+func (e TreeSize) ToStringOutput() pulumi.StringOutput {
+	return pulumi.ToOutput(pulumi.String(e)).(pulumi.StringOutput)
+}
+
+func (e TreeSize) ToStringOutputWithContext(ctx context.Context) pulumi.StringOutput {
+	return pulumi.ToOutputWithContext(ctx, pulumi.String(e)).(pulumi.StringOutput)
+}
+
+func (e TreeSize) ToStringPtrOutput() pulumi.StringPtrOutput {
+	return pulumi.String(e).ToStringPtrOutputWithContext(context.Background())
+}
+
+func (e TreeSize) ToStringPtrOutputWithContext(ctx context.Context) pulumi.StringPtrOutput {
 	return pulumi.String(e).ToStringOutputWithContext(ctx).ToStringPtrOutputWithContext(ctx)
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -16,7 +16,9 @@ type RubberTree struct {
 	pulumi.CustomResourceState
 
 	Container plant.ContainerPtrOutput `pulumi:"container"`
+	Diameter  pulumi.Float64Output     `pulumi:"diameter"`
 	Farm      pulumi.StringPtrOutput   `pulumi:"farm"`
+	Size      pulumi.StringPtrOutput   `pulumi:"size"`
 	Type      pulumi.StringOutput      `pulumi:"type"`
 }
 
@@ -27,8 +29,18 @@ func NewRubberTree(ctx *pulumi.Context,
 		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.Diameter == 0 {
+		args.Diameter = Diameter(6)
+	}
 	if args.Farm == nil {
 		args.Farm = pulumi.StringPtr("(unknown)")
+	}
+	if args.Size == nil {
+		e := TreeSize("medium")
+		args.Size = &e
+	}
+	if args.Type == "" {
+		args.Type = RubberTreeVariety("Burgundy")
 	}
 	var resource RubberTree
 	err := ctx.RegisterResource("plant:tree/v1:RubberTree", name, args, &resource, opts...)
@@ -53,13 +65,17 @@ func GetRubberTree(ctx *pulumi.Context,
 // Input properties used for looking up and filtering RubberTree resources.
 type rubberTreeState struct {
 	Container *plant.Container `pulumi:"container"`
+	Diameter  *float64         `pulumi:"diameter"`
 	Farm      *string          `pulumi:"farm"`
+	Size      *string          `pulumi:"size"`
 	Type      *string          `pulumi:"type"`
 }
 
 type RubberTreeState struct {
 	Container plant.ContainerPtrInput
+	Diameter  *Diameter
 	Farm      pulumi.StringPtrInput
+	Size      *TreeSize
 	Type      *RubberTreeVariety
 }
 
@@ -69,14 +85,18 @@ func (RubberTreeState) ElementType() reflect.Type {
 
 type rubberTreeArgs struct {
 	Container *plant.Container `pulumi:"container"`
+	Diameter  float64          `pulumi:"diameter"`
 	Farm      *string          `pulumi:"farm"`
+	Size      *string          `pulumi:"size"`
 	Type      string           `pulumi:"type"`
 }
 
 // The set of arguments for constructing a RubberTree resource.
 type RubberTreeArgs struct {
 	Container plant.ContainerPtrInput
+	Diameter  Diameter
 	Farm      pulumi.StringPtrInput
+	Size      *TreeSize
 	Type      RubberTreeVariety
 }
 

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
@@ -33,7 +33,9 @@ export class RubberTree extends pulumi.CustomResource {
     }
 
     public readonly container!: pulumi.Output<outputs.Container | undefined>;
+    public readonly diameter!: pulumi.Output<enums.tree.v1.Diameter>;
     public readonly farm!: pulumi.Output<enums.tree.v1.Farm | string | undefined>;
+    public readonly size!: pulumi.Output<enums.tree.v1.TreeSize | undefined>;
     public readonly type!: pulumi.Output<enums.tree.v1.RubberTreeVariety>;
 
     /**
@@ -46,15 +48,22 @@ export class RubberTree extends pulumi.CustomResource {
     constructor(name: string, args: RubberTreeArgs, opts?: pulumi.CustomResourceOptions) {
         let inputs: pulumi.Inputs = {};
         if (!(opts && opts.id)) {
+            if ((!args || args.diameter === undefined) && !(opts && opts.urn)) {
+                throw new Error("Missing required property 'diameter'");
+            }
             if ((!args || args.type === undefined) && !(opts && opts.urn)) {
                 throw new Error("Missing required property 'type'");
             }
             inputs["container"] = args ? args.container : undefined;
+            inputs["diameter"] = (args ? args.diameter : undefined) || 6;
             inputs["farm"] = (args ? args.farm : undefined) || "(unknown)";
-            inputs["type"] = args ? args.type : undefined;
+            inputs["size"] = (args ? args.size : undefined) || "medium";
+            inputs["type"] = (args ? args.type : undefined) || "Burgundy";
         } else {
             inputs["container"] = undefined /*out*/;
+            inputs["diameter"] = undefined /*out*/;
             inputs["farm"] = undefined /*out*/;
+            inputs["size"] = undefined /*out*/;
             inputs["type"] = undefined /*out*/;
         }
         if (!opts) {
@@ -73,6 +82,8 @@ export class RubberTree extends pulumi.CustomResource {
  */
 export interface RubberTreeArgs {
     readonly container?: pulumi.Input<inputs.Container>;
+    readonly diameter: pulumi.Input<enums.tree.v1.Diameter>;
     readonly farm?: pulumi.Input<enums.tree.v1.Farm | string>;
+    readonly size?: pulumi.Input<enums.tree.v1.TreeSize>;
     readonly type: pulumi.Input<enums.tree.v1.RubberTreeVariety>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/types/enums/tree/v1/index.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/types/enums/tree/v1/index.ts
@@ -2,6 +2,13 @@
 // *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 
+export const Diameter = {
+    Sixinch: 6,
+    Twelveinch: 12,
+} as const;
+
+export type Diameter = (typeof Diameter)[keyof typeof Diameter];
+
 export const Farm = {
     Pulumi_Planters_Inc_: "Pulumi Planters Inc.",
     Plants_R_Us: "Plants'R'Us",
@@ -28,3 +35,11 @@ export const RubberTreeVariety = {
  * types of rubber trees
  */
 export type RubberTreeVariety = (typeof RubberTreeVariety)[keyof typeof RubberTreeVariety];
+
+export const TreeSize = {
+    Small: "small",
+    Medium: "medium",
+    Large: "large",
+} as const;
+
+export type TreeSize = (typeof TreeSize)[keyof typeof TreeSize];

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/_enums.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/_enums.py
@@ -5,9 +5,16 @@
 from enum import Enum
 
 __all__ = [
+    'Diameter',
     'Farm',
     'RubberTreeVariety',
+    'TreeSize',
 ]
+
+
+class Diameter(float, Enum):
+    SIXINCH = 6
+    TWELVEINCH = 12
 
 
 class Farm(str, Enum):
@@ -22,3 +29,9 @@ class RubberTreeVariety(str, Enum):
     BURGUNDY = "Burgundy"
     RUBY = "Ruby"
     TINEKE = "Tineke"
+
+
+class TreeSize(str, Enum):
+    SMALL = "small"
+    MEDIUM = "medium"
+    LARGE = "large"

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -20,7 +20,9 @@ class RubberTree(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  container: Optional[pulumi.Input[pulumi.InputType['_root_inputs.ContainerArgs']]] = None,
+                 diameter: Optional[pulumi.Input['Diameter']] = None,
                  farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
+                 size: Optional[pulumi.Input['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
                  __props__=None,
                  __name__=None,
@@ -48,9 +50,19 @@ class RubberTree(pulumi.CustomResource):
             __props__ = dict()
 
             __props__['container'] = container
+            if diameter is None:
+                diameter = 6
+            if diameter is None and not opts.urn:
+                raise TypeError("Missing required property 'diameter'")
+            __props__['diameter'] = diameter
             if farm is None:
                 farm = '(unknown)'
             __props__['farm'] = farm
+            if size is None:
+                size = 'medium'
+            __props__['size'] = size
+            if type is None:
+                type = 'Burgundy'
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
             __props__['type'] = type
@@ -85,8 +97,18 @@ class RubberTree(pulumi.CustomResource):
 
     @property
     @pulumi.getter
+    def diameter(self) -> pulumi.Output['Diameter']:
+        return pulumi.get(self, "diameter")
+
+    @property
+    @pulumi.getter
     def farm(self) -> pulumi.Output[Optional[str]]:
         return pulumi.get(self, "farm")
+
+    @property
+    @pulumi.getter
+    def size(self) -> pulumi.Output[Optional['TreeSize']]:
+        return pulumi.get(self, "size")
 
     @property
     @pulumi.getter

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/schema.json
@@ -8,7 +8,8 @@
           "$ref": "#/types/plant::Container"
         },
         "type": {
-          "$ref": "#/types/plant:tree/v1:RubberTreeVariety"
+          "$ref": "#/types/plant:tree/v1:RubberTreeVariety",
+          "default": "Burgundy"
         },
         "farm": {
           "oneOf": [
@@ -16,6 +17,14 @@
             {"type": "string"}
           ],
           "default": "(unknown)"
+        },
+        "size": {
+          "$ref": "#/types/plant:tree/v1:TreeSize",
+          "default": "medium"
+        },
+        "diameter": {
+          "$ref": "#/types/plant:tree/v1:Diameter",
+          "default": 6
         }
       },
       "properties": {
@@ -30,10 +39,18 @@
             {"$ref": "#/types/plant:tree/v1:Farm"},
             {"type": "string"}
           ]
+        },
+        "size": {
+          "$ref": "#/types/plant:tree/v1:TreeSize",
+          "default": "medium"
+        },
+        "diameter": {
+          "$ref": "#/types/plant:tree/v1:Diameter",
+          "default": 6
         }
       },
-      "required": ["type"],
-      "requiredInputs": ["type"]
+      "required": ["type", "diameter"],
+      "requiredInputs": ["type", "diameter"]
     }
   },
   "types": {
@@ -132,6 +149,33 @@
         },
         {
           "value": "Plants'R'Us"
+        }
+      ]
+    },
+    "plant:tree/v1:TreeSize": {
+      "type": "string",
+      "enum": [
+        {
+          "value": "small"
+        },
+        {
+          "value": "medium"
+        },
+        {
+          "value": "large"
+        }
+      ]
+    },
+    "plant:tree/v1:Diameter": {
+      "type": "number",
+      "enum": [
+        {
+          "name": "sixinch",
+          "value": 6
+        },
+        {
+          "name": "twelveinch",
+          "value": 12
         }
       ]
     }


### PR DESCRIPTION
Fixes a couple of bugs in go codegen for enums - specifically around setting defaults correctly.
Updated tests with improved coverage for the above.

The PR is split in 2 commits, the first implements the core Go changes and adds the relevant go test data. The latter updates testdata for other languages due to the test schema update. 