### PR TITLE
[codegen/dotnet]: Fix bugs referencing external resources/types

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -239,14 +239,16 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 	case *schema.ObjectType:
 		namingCtx := mod
 		if t.Package != mod.pkg {
-			// If object type belongs to another package, we apply naming convensions from that package,
+			// If object type belongs to another package, we apply naming conventions from that package,
 			// including namespace naming and compatibility mode.
+			extPkg := t.Package
 			var info CSharpPackageInfo
+			contract.AssertNoError(extPkg.ImportLanguages(map[string]schema.Language{"csharp": Importer}))
 			if v, ok := t.Package.Language["csharp"].(CSharpPackageInfo); ok {
 				info = v
 			}
 			namingCtx = &modContext{
-				pkg:           t.Package,
+				pkg:           extPkg,
 				namespaces:    info.Namespaces,
 				compatibility: info.Compatibility,
 			}
@@ -272,7 +274,23 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 			pkgName := strings.TrimPrefix(t.Token, "pulumi:providers:")
 			typ = fmt.Sprintf("Pulumi.%s.Provider", namespaceName(mod.namespaces, pkgName))
 		} else {
-			typ = mod.tokenToNamespace(t.Token, "")
+			namingCtx := mod
+			if t.Resource != nil && t.Resource.Package != mod.pkg {
+				// If resource type belongs to another package, we apply naming conventions from that package,
+				// including namespace naming and compatibility mode.
+				extPkg := t.Resource.Package
+				var info CSharpPackageInfo
+				contract.AssertNoError(extPkg.ImportLanguages(map[string]schema.Language{"csharp": Importer}))
+				if v, ok := t.Resource.Package.Language["csharp"].(CSharpPackageInfo); ok {
+					info = v
+				}
+				namingCtx = &modContext{
+					pkg:           extPkg,
+					namespaces:    info.Namespaces,
+					compatibility: info.Compatibility,
+				}
+			}
+			typ = namingCtx.tokenToNamespace(t.Token, "")
 			if typ != "" {
 				typ += "."
 			}
@@ -1260,6 +1278,12 @@ func (mod *modContext) getTypeImports(t schema.Type, recurse bool, imports map[s
 		}
 		return
 	case *schema.ResourceType:
+		// If it's an external resource, we'll be using fully-qualified type names, so there's no need
+		// for an import.
+		if t.Resource != nil && t.Resource.Package != mod.pkg {
+			return
+		}
+
 		modName, name, modPath := mod.pkg.TokenToModule(t.Token), tokenToName(t.Token), ""
 		if modName != mod.mod {
 			mp, err := filepath.Rel(mod.mod, modName)
@@ -1770,7 +1794,11 @@ func generateModuleContextMap(tool string, pkg *schema.Package) (map[string]*mod
 				parent.children = append(parent.children, mod)
 			}
 
-			modules[modName] = mod
+			// Save the module only if it's for the current package.
+			// This way, modules for external packages are not saved.
+			if p == pkg {
+				modules[modName] = mod
+			}
 		}
 		return mod
 	}

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Component.cs
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Component.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Pulumi.Serialization;
-using SecurityGroup;
-using StorageClass;
 
 namespace Pulumi.Example
 {
@@ -18,10 +16,10 @@ namespace Pulumi.Example
         public Output<Pulumi.Kubernetes.Provider?> Provider { get; private set; } = null!;
 
         [Output("securityGroup")]
-        public Output<Pulumi.Aws.Ec2/securityGroup.SecurityGroup?> SecurityGroup { get; private set; } = null!;
+        public Output<Pulumi.Aws.Ec2.SecurityGroup?> SecurityGroup { get; private set; } = null!;
 
         [Output("storageClasses")]
-        public Output<ImmutableDictionary<string, Pulumi.Kubernetes.Storage.k8s.io/v1.StorageClass>?> StorageClasses { get; private set; } = null!;
+        public Output<ImmutableDictionary<string, Pulumi.Kubernetes.Storage.V1.StorageClass>?> StorageClasses { get; private set; } = null!;
 
 
         /// <summary>


### PR DESCRIPTION
- Avoids problematic `using` statements.
- Fixes fully qualified names of external resources.
- Avoids emitting directories with README.md files for external modules.

This change will allow us to remove the [workarounds](https://github.com/pulumi/pulumi-eks/blob/e92395d0148d0ea3016a0212a2c9532561a3d5be/provider/cmd/pulumi-gen-eks/main.go#L1519-L1557) for .NET in EKS.