### PR TITLE
Various fixes to go codegen to address SDK compilation problems

### DIFF
--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
@@ -65,6 +65,56 @@ func (o ObjectOutput) Foo() ResourceOutput {
 	return o.ApplyT(func(v Object) *Resource { return v.Foo }).(ResourceOutput)
 }
 
+type OtherResourceOutputType struct {
+	Foo *string `pulumi:"foo"`
+}
+
+// OtherResourceOutputTypeInput is an input type that accepts OtherResourceOutputTypeArgs and OtherResourceOutputTypeOutput values.
+// You can construct a concrete instance of `OtherResourceOutputTypeInput` via:
+//
+//          OtherResourceOutputTypeArgs{...}
+type OtherResourceOutputTypeInput interface {
+	pulumi.Input
+
+	ToOtherResourceOutputTypeOutput() OtherResourceOutputTypeOutput
+	ToOtherResourceOutputTypeOutputWithContext(context.Context) OtherResourceOutputTypeOutput
+}
+
+type OtherResourceOutputTypeArgs struct {
+	Foo pulumi.StringPtrInput `pulumi:"foo"`
+}
+
+func (OtherResourceOutputTypeArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*OtherResourceOutputType)(nil)).Elem()
+}
+
+func (i OtherResourceOutputTypeArgs) ToOtherResourceOutputTypeOutput() OtherResourceOutputTypeOutput {
+	return i.ToOtherResourceOutputTypeOutputWithContext(context.Background())
+}
+
+func (i OtherResourceOutputTypeArgs) ToOtherResourceOutputTypeOutputWithContext(ctx context.Context) OtherResourceOutputTypeOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutputTypeOutput)
+}
+
+type OtherResourceOutputTypeOutput struct{ *pulumi.OutputState }
+
+func (OtherResourceOutputTypeOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*OtherResourceOutputType)(nil)).Elem()
+}
+
+func (o OtherResourceOutputTypeOutput) ToOtherResourceOutputTypeOutput() OtherResourceOutputTypeOutput {
+	return o
+}
+
+func (o OtherResourceOutputTypeOutput) ToOtherResourceOutputTypeOutputWithContext(ctx context.Context) OtherResourceOutputTypeOutput {
+	return o
+}
+
+func (o OtherResourceOutputTypeOutput) Foo() pulumi.StringPtrOutput {
+	return o.ApplyT(func(v OtherResourceOutputType) *string { return v.Foo }).(pulumi.StringPtrOutput)
+}
+
 func init() {
 	pulumi.RegisterOutputType(ObjectOutput{})
+	pulumi.RegisterOutputType(OtherResourceOutputTypeOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/schema.json
@@ -12,6 +12,14 @@
         }
       },
       "type": "object"
+    },
+    "example::OtherResourceOutput": {
+      "properties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "type": "object"
     }
   },
   "resources": {


### PR DESCRIPTION
Multiple fixes to compilation problems in various generated Go SDKs.
Fixes https://github.com/pulumi/pulumi-aws/issues/1321 among other issues.

This follows up from https://github.com/pulumi/pulumi/pull/6179 

Having run on some major SDKs, the last set of compilation issues are due to:
1. Lack of Array and Map input/output variants generated for enum types
2. Name collisions among input/output variants of types and other synonymous types.
These are being addressed in a separate PR.