### PR TITLE
Ensure Old Secrets Provider Details Removed when Changing to Passphrase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ CHANGELOG
 - [sdk/go] Take a breaking change to remove unidiomatic numerical types and drastically improve build performance (binary size and compilation time).
   [#6143](https://github.com/pulumi/pulumi/pull/6143)
 
+- [cli] Ensure `pulumi stack change-secrets-provider` allows rotating the key from hashivault to passphrase provider
+  [#6210](https://github.com/pulumi/pulumi/pull/6210)
+
 ## 2.18.2 (2021-01-22)
 
 - [CLI] Fix malformed resource value bug.

--- a/pkg/cmd/pulumi/crypto_local.go
+++ b/pkg/cmd/pulumi/crypto_local.go
@@ -78,6 +78,14 @@ func newPassphraseSecretsManager(stackName tokens.QName, configFile string,
 		info.EncryptionSalt = ""
 	}
 
+	// We should check to see if any other secrets providers are actually set in this config
+	// if there are, then we should remove them as the passphrase provider deals only with
+	// encrytpionSalt not encryptionKey or secretsProvider
+	if info.EncryptedKey != "" || info.SecretsProvider != "" {
+		info.EncryptedKey = ""
+		info.SecretsProvider = ""
+	}
+
 	// If we have a salt, we can just use it.
 	if info.EncryptionSalt != "" {
 		for {

--- a/pkg/cmd/pulumi/crypto_local.go
+++ b/pkg/cmd/pulumi/crypto_local.go
@@ -78,9 +78,8 @@ func newPassphraseSecretsManager(stackName tokens.QName, configFile string,
 		info.EncryptionSalt = ""
 	}
 
-	// We should check to see if any other secrets providers are actually set in this config
-	// if there are, then we should remove them as the passphrase provider deals only with
-	// encrytpionSalt not encryptionKey or secretsProvider
+	// If there are any other secrets providers set in the config, remove them, as the passphrase
+	// provider deals only with EncryptionSalt, not EncryptedKey or SecretsProvider.
 	if info.EncryptedKey != "" || info.SecretsProvider != "" {
 		info.EncryptedKey = ""
 		info.SecretsProvider = ""


### PR DESCRIPTION
Fixes: #6208

When changing from a cloudsecrets provider to a passphrase secrets provider
ensure that cloud specific details are removed from the local workspace

```
▶ pulumi stack init my-stack --secrets-provider hashivault://my-stack
Created stack 'my-stack'

~/code/vault-test
▶ pulumi config set my-secret --secret Password1234!

~/code/vault-test
▶ cat Pulumi.my-stack.yaml
secretsprovider: hashivault://my-stack
encryptedkey: dmF1bHQ6djE6c1k3cnRtbExrTmsvYVJvV3Z1KzRJUncvWW5NaVVHd2VTWnBReU16UzR2bnZxcVk4L2dndkJUUzdNSTdSWWxNNEk5TmR1dVJ1UHJMOGQydUc=
config:
  vault-test:my-secret:
    secure: v1:QZTzjMyCabRLb3qF:6i00N2lYsAO0R3jOODDW89qJa5CTlLs3x0YroBg=

~/code/vault-test
▶ pulumi stack change-secrets-provider passphrase
Enter your new passphrase to protect config/secrets:
Re-enter your new passphrase to confirm:
Migrating old configuration and state to new secrets provider
Enter your passphrase to unlock config/secrets
    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember):

~/code/vault-test
▶ cat Pulumi.my-stack.yaml
encryptionsalt: v1:RMJFAiu8yyU=:v1:NhDBdi+YYKnnhx0q:l+mhKNIyREq47JDpMo96YF7064Nx8w==
config:
  vault-test:my-secret:
    secure: v1:SjKXzIICctu8i5UV:nOrSgmosDQv4+8TTO3O5wqwMRK0GpBv3Ti9OTSw=
```