### PR TITLE
Ensure a user has access to the secret manager before trying to decrypt checkpoint

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -58,3 +58,7 @@ type PreviewResult struct {
 
 - [automation/dotnet] Add ReadDiscard OperationType
   [#6493](https://github.com/pulumi/pulumi/pull/6493)
+
+- [cli] Ensure the user has the correct access to the secrets manager before using it as part of
+  `pulumi stack export --show-secrets`.
+  [#6215](https://github.com/pulumi/pulumi/pull/6210)

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -90,6 +90,13 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			if showSecrets {
+				// Currently, the stack.DefaultSecretsProvider is cached so adding a call to getStackSecretsManager
+				// will ensure that the user has the correct credentials to decrypt the stack deployment
+				_, err := getStackSecretsManager(s)
+				if err != nil {
+					return errors.Wrap(err, "getting secrets manager")
+				}
+
 				snap, err := stack.DeserializeUntypedDeployment(deployment, stack.DefaultSecretsProvider)
 				if err != nil {
 					return checkDeploymentVersionError(err, stackName)


### PR DESCRIPTION
Fixes: #6195

Before:

```
▶ pulumi stack export --show-secrets
error: could not deserialize deployment: decrypting secret value: failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the correct passphrase
```

Notice that it doesn't even ask for the passphrase

After adding a simple check to get the secrets manager we can now
ensure that the user has access to the correct credentials before
we even use the secrets manager

```
pulumi stack export --show-secrets
Enter your passphrase to unlock config/secrets
    (set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE to remember):
{
    "version": 3,
    "deployment": {
        "manifest": {
            "time": "2021-01-27T14:21:23.197301Z",
            "magic": "72fc43d05bda7c857308a563548faa323639f314a8d27c0ce550589753311fad",
            "version": "v2.19.0-alpha.1611602537+g0f06e0393.dirty"
        },
        "secrets_providers": {
            "type": "passphrase",
            "state": {
                "salt": "v1:BW++rEnZJd4=:v1:KS0AGrKyxgf6cpWW:Lw27W/I/sGUV1mvuywjZY/LG3xdEEA=="
            }
        },
        "resources": [
            {
                "urn": "urn:pulumi:password::passphrase-err::pulumi:pulumi:Stack::passphrase-err-password",
                "custom": false,
                "type": "pulumi:pulumi:Stack",
                "outputs": {
                    "x": {
                        "4dabf18193072939515e22adb298388d": "1b47061264138c4ac30d75fd1eb44270",
                        "plaintext": "\"Password1234!\""
                    }
                }
            }
        ]
    }
}
```