### PR TITLE
Migrating to smoke-test-cli repository_dispatch event in examples repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
           repo: pulumi/pulumictl
       - name: Repository Dispatch
         run: |
-          pulumictl dispatch -r pulumi/examples -c trigger-cron $(pulumictl get version --language generic -o)
+          pulumictl dispatch -r pulumi/examples -c smoke-test-cli $(pulumictl get version --language generic -o)
         env:
           GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN}}
   chocolatey:


### PR DESCRIPTION
This is a specific repository dispatch event that can be used for
updating and testing a CLI version