### PR TITLE
[codegen/go]Handle arrays/maps of external refs as pointers

### DIFF
--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
@@ -51,9 +51,9 @@ func GetComponent(ctx *pulumi.Context,
 
 // Input properties used for looking up and filtering Component resources.
 type componentState struct {
-	Provider       *kubernetes.Provider              `pulumi:"provider"`
-	SecurityGroup  *ec2.SecurityGroup                `pulumi:"securityGroup"`
-	StorageClasses map[string]storagev1.StorageClass `pulumi:"storageClasses"`
+	Provider       *kubernetes.Provider               `pulumi:"provider"`
+	SecurityGroup  *ec2.SecurityGroup                 `pulumi:"securityGroup"`
+	StorageClasses map[string]*storagev1.StorageClass `pulumi:"storageClasses"`
 }
 
 type ComponentState struct {


### PR DESCRIPTION
Avoid serialization failures for inputs with arrays/maps of external references.

Without this the array and maps input types in `Args` structs don't match their corresponding `Input` variants' element type resulting in errors such as this:
`marshaling properties: awaiting input property instanceRoles: cannot marshal an input of type iam.RoleArray with element type []*iam.Role as a value of type []iam.Role`