### PR TITLE
Improve nodejs automation api inline error handling

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -272,6 +272,25 @@ describe("LocalWorkspace", () => {
             await stack.workspace.removeStack(stackName);
         }
     }));
+    it(`runs an inline program that rejects a promise and exits gracefully`, asyncTest(async () => {
+        const program = async () => {
+            Promise.reject(new Error());
+            return {};
+        };
+        const stackName = `int_test${getTestSuffix()}`;
+        const projectName = "inline_node";
+        const stack = await LocalWorkspace.createStack({ stackName, projectName, program });
+
+        // pulumi up        
+        await assert.rejects(stack.up())
+
+        // pulumi destroy
+        const destroyRes = await stack.destroy();
+        assert.strictEqual(destroyRes.summary.kind, "destroy");
+        assert.strictEqual(destroyRes.summary.result, "succeeded");
+
+        await stack.workspace.removeStack(stackName);
+    }));
 });
 
 const getTestSuffix = () => {

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -144,7 +144,7 @@ export class Stack {
             }
         }
 
-        let onExit = (code: number) => { return; };
+        let onExit = () => { return; };
 
         if (program) {
             kind = execKind.inline;
@@ -163,16 +163,23 @@ export class Stack {
                 });
             });
             server.start();
-            onExit = (code: number) => {
-                languageServer.onPulumiExit(code, false /* preview */);
+            onExit = () => {
+                languageServer.onPulumiExit();
                 server.forceShutdown();
             };
             args.push(`--client=127.0.0.1:${port}`);
         }
 
         args.push("--exec-kind", kind);
-        const upResult = await this.runPulumiCmd(args, opts?.onOutput);
-        onExit(upResult.code);
+        let upResult;
+        try {
+            upResult = await this.runPulumiCmd(args, opts?.onOutput);
+            onExit();
+        } finally {
+            onExit()
+        }
+        
+        
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
         const outputs = await this.outputs();
         const summary = await this.info();
@@ -224,7 +231,7 @@ export class Stack {
             }
         }
 
-        let onExit = (code: number) => { return; };
+        let onExit = () => { return; };
 
         if (program) {
             kind = execKind.inline;
@@ -243,16 +250,20 @@ export class Stack {
                 });
             });
             server.start();
-            onExit = (code: number) => {
-                languageServer.onPulumiExit(code, false /* preview */);
+            onExit = () => {
+                languageServer.onPulumiExit();
                 server.forceShutdown();
             };
             args.push(`--client=127.0.0.1:${port}`);
         }
 
         args.push("--exec-kind", kind);
-        const preResult = await this.runPulumiCmd(args);
-        onExit(preResult.code);
+        let preResult;
+        try {
+            preResult = await this.runPulumiCmd(args);
+        } finally {
+            onExit();
+        }
         const summary = await this.info();
         return {
             stdout: preResult.stdout,

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -174,7 +174,6 @@ export class Stack {
         let upResult;
         try {
             upResult = await this.runPulumiCmd(args, opts?.onOutput);
-            onExit();
         } finally {
             onExit()
         }

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -175,7 +175,7 @@ export class Stack {
         try {
             upResult = await this.runPulumiCmd(args, opts?.onOutput);
         } finally {
-            onExit()
+            onExit();
         }
         
         


### PR DESCRIPTION
This changeset adds several improvements to our error handling for nodejs inline programs run via Automation API. Along the way, I also cleaned up a bunch of unused functionality from `server.ts` (exposing a `result` promise, providing an unused CLI exit code, etc). Summary of fixes: 

1. Run user code in a try/finally to ensure the gRPC `LanguageServer` is always torn down cleanly (otherwise causes failed programs to hang)
2. Run the leaked promise detector after the CLI has exited, this is more consistent with the behavior of CLI programs (detector normally runs as late as possible when the process exits). This fixes the erroneous messages observed in https://github.com/pulumi/pulumi/issues/6153 https://github.com/pulumi/pulumi/issues/5853
2. Ensure that all kinds of `Error` are handled properly, even if user code throws an error without any details, exception message, etc.
4. `LanguageServer.Run` should respond with errors via calling the `callback` function https://avi.im/grpc-errors/#node

Fixes https://github.com/pulumi/pulumi/issues/6153
Fixes https://github.com/pulumi/pulumi/issues/5853
Fixes https://github.com/pulumi/pulumi/issues/6057