### PR TITLE
Ensure ubi container installs correct dotnet sdk version

### DIFF
--- a/.github/workflows/trigger-container-build-event.yml
+++ b/.github/workflows/trigger-container-build-event.yml
@@ -176,7 +176,7 @@ jobs:
           dockerfile: docker/${{ matrix.sdk }}/Dockerfile.${{ matrix.os }}
           additional-tags: ${{ env.VERSION }}-${{ matrix.os }}
           build-args: PULUMI_VERSION=${{ env.VERSION }}
-          tag-latest: true
+          tag-latest: false
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,13 +38,14 @@ pulumi/pulumi-base:<PULUMI_VERSION>
 Images with the SDK runtimes are generated in the following format:
 
 ```
-pulumi/pulumi-<PULUM_SDK>:<PULUMI_VERSION>-<OS>
+pulumi/pulumi-<PULUMI_SDK>:<PULUMI_VERSION>-<OS>
 ```
 
-The default image without the OS is based on Debian Buster, and can be used like so:
+The default image without the OS suffix is based on Debian Buster, and can be used like so:
 
 ```
-pulumi/pulumi-base-<PULUMI_SDK>:<PULUMI_VERSION>
+pulumi/pulumi-<PULUMI_SDK>:<PULUMI_VERSION>
+pulumi/pulumi-<PULUMI_SDK>:latest
 ```
 
 ### Image Size

--- a/docker/dotnet/Dockerfile.ubi
+++ b/docker/dotnet/Dockerfile.ubi
@@ -14,7 +14,7 @@ RUN --mount=target=/var/cache/yum,type=cache \
     microdnf install -y \
     ca-certificates \
     tar \
-    dotnet \
+    dotnet-sdk-${RUNTIME_VERSION} \
     git
 
 # Uses the workdir, copies from pulumi interim container


### PR DESCRIPTION
Fixes: #6185

This PR also addresses the fact that we create an image of
pulumi-nodejs:latest and then the ubi and debian builds override
that pulumi-nodejs:latest with their versions

this overwrite is actually last container wins. Therefore, we will
not be tagging the ubi and debian builds with latest to ensure that
latest is *actually* deterministic