### PR TITLE
prototype fix for auto api relative paths

### DIFF
--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -176,8 +176,12 @@ export class LocalWorkspace implements Workspace {
             wsOpts = { ...opts, program: args.program };
         }
 
+        if(!wsOpts.workDir) {
+            wsOpts.workDir = fs.mkdtempSync(upath.joinSafe(os.tmpdir(), "automation-"));
+        }
+
         if (!wsOpts.projectSettings) {
-            wsOpts.projectSettings = defaultProject(args.projectName);
+            wsOpts.projectSettings = defaultProject(args.projectName, wsOpts.workDir);
         }
 
         const ws = new LocalWorkspace(wsOpts);
@@ -643,7 +647,8 @@ function getStackSettingsName(name: string): string {
 
 type StackInitializer = (name: string, workspace: Workspace) => Promise<Stack>;
 
-function defaultProject(projectName: string) {
-    const settings: ProjectSettings = { name: projectName, runtime: "nodejs" };
+function defaultProject(projectName: string, workDir: string) {
+
+    const settings: ProjectSettings = { name: projectName, runtime: "nodejs", main: process.cwd() };
     return settings;
 }


### PR DESCRIPTION
Prototypes a fix for https://github.com/pulumi/pulumi/issues/5578 by wiring up the `main` field for the generated default `pulumi.yaml` for inline programs in nodejs.

A few things that need to be completed before this can ship:

1. update some of the engine tests that block main being an absolute path, and enforcing main is subdir of root
2. For cases where the user is authoring an `index.ts` that gets compiled into a `/bin/index.js` or other location, do we need convenience util to allow the user to configure this as it impacts relative paths? Like an `auto API build root`? Otherwise they have to specify the entire `ProjectSettings` object, and know to specify the `main` folder. Not making any suggestions here, but something we need to think through documenting at the least.
3. Update other languages. Compiled languages will have to deal with (2) as well. 

Regarding (1), I believe this is safe to do and is a holdover of PPC constraints that are no longer relevant. Would be good to check with @chrsmith to verify. I've summarized my findings in a comment on the relevant code:

https://github.com/pulumi/pulumi/blob/c8c3db0197845fed9bfdde27ad165fc5563e8983/pkg/engine/project.go#L52-L60

I tested this with an S3 bucket object:

```ts
        // write our index.html into the site bucket
        let object = new s3.BucketObject("index", {
            bucket: siteBucket,
            source: new pulumi.asset.FileAsset("./README.md"),
            contentType: "text/html; charset=utf-8",
            key: "index.html"
        });
```
|
Before this change, no object gets uploaded. After the change, it works as expected. 