### PR TITLE
[sdk/python] - Gracefully handle monitor shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@ CHANGELOG
 =========
 
 ## HEAD (Unreleased)
-_(none)_
+
+- [sdk/python] Gracefully handle monitor shutdown in the python runtime without exiting the process. 
+  [#6249](https://github.com/pulumi/pulumi/pull/6249)
 
 ## 2.20.0 (2021-02-03)
 

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -16,7 +16,6 @@
 Support for automatic stack components.
 """
 import asyncio
-import collections
 from inspect import isawaitable
 from typing import Callable, Any, Dict, List, TYPE_CHECKING
 
@@ -45,9 +44,10 @@ async def run_pulumi_func(func: Callable):
         # We await each RPC in turn so that this loop will actually block rather than busy-wait.
         while True:
             await asyncio.sleep(0)
-            if len(RPC_MANAGER.rpcs) == 0:
+            rpcs_remaining = len(RPC_MANAGER.rpcs)
+            if rpcs_remaining == 0:
                 break
-            log.debug(f"waiting for quiescence; {len(RPC_MANAGER.rpcs)} RPCs outstanding")
+            log.debug(f"waiting for quiescence; {rpcs_remaining} RPCs outstanding")
             await RPC_MANAGER.rpcs.pop()
 
         # Asyncio event loops require that all outstanding tasks be completed by the time that the

--- a/sdk/python/lib/pulumi/x/automation/stack.py
+++ b/sdk/python/lib/pulumi/x/automation/stack.py
@@ -22,7 +22,7 @@ from typing import List, Any, Mapping, MutableMapping, Optional
 from .cmd import CommandResult, _run_pulumi_cmd, OnOutput
 from .config import ConfigValue, ConfigMap, _SECRET_SENTINEL
 from .errors import StackAlreadyExistsError
-from .server import LanguageServer
+from ._server import LanguageServer
 from .workspace import Workspace, PulumiFn, Deployment
 from ...runtime.settings import _GRPC_CHANNEL_OPTIONS
 from ...runtime.proto import language_pb2_grpc

--- a/sdk/python/lib/pulumi/x/automation/workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/workspace.py
@@ -26,8 +26,7 @@ from .stack_settings import StackSettings
 from .project_settings import ProjectSettings
 from .config import ConfigMap, ConfigValue
 
-# TODO improve typing to encapsulate stack exports
-PulumiFn = Callable[[], Any]
+PulumiFn = Callable[[], None]
 
 
 class StackSummary:


### PR DESCRIPTION
The main goal of this PR is to fix all the areas where we were previously exiting the process when the monitor is unavailable and instead just absorb the grpc `UNAVAILABLE` message. There are more details on the exact behavior this was causing and the motivation behind the change in issue #6228. 

I've tested this manually against my initial program that was logging the asyncio warnings, but I'm  not really sure how to write automated tests for this - open to suggestions if there are any. The way to know that it works is that we don't see any asyncio warnings in the console when running a program that fails.

There are also a few misc. formatting corrections.

Fixes: #6228 