### PR TITLE
[cli] Disable permalinks to the update details page when using self-managed backends (S3, Azure, GCS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ CHANGELOG
 
 - [sdk/dotnet] F# API to specify stack options.
   [#5077](https://github.com/pulumi/pulumi/pull/5077)
+
+- [cli] Disable permalinks to the update details page when using self-managed backends (S3, Azure, GCS). Should the user 
+  want to get permalinks when using a self backend, they can pass a flag:  
+      `pulumi up --suppress-permalink false`.  
+  Permalinks for these self-managed backends will be suppressed on `update`, `preview`, `destroy`, `import` and `refresh` 
+  operations.
+  [#6251](https://github.com/pulumi/pulumi/pull/6251)
   
 ## 2.21.1 (2021-02-18)
 
@@ -56,7 +63,7 @@ CHANGELOG
 
 - [sdk/python] Fixed a bug in `contains_unknowns` where outputs with a property named "values" failed with a TypeError.
   [#6264](https://github.com/pulumi/pulumi/pull/6264)
-
+  
 - [sdk/python] Allowed keyword args in Output.all() to create a dict.
   [#6269](https://github.com/pulumi/pulumi/pull/6269)
   
@@ -65,7 +72,6 @@ CHANGELOG
 
 - [automation/python] Fixed a bug in nested configuration parsing.
   [#6349](https://github.com/pulumi/pulumi/pull/6349)
-
 
 ## 2.20.0 (2021-02-03)
 

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -599,18 +599,25 @@ func (b *localBackend) apply(
 		} else {
 			link, err = b.bucket.SignedURL(context.TODO(), b.stackPath(stackName), nil)
 			if err != nil {
+				// set link to be empty to when there is an error to hide use of Permalinks
+				link = ""
+
 				// we log a warning here rather then returning an error to avoid exiting
 				// pulumi with an error code.
 				// printing a statefile perma link happens after all the providers have finished
 				// deploying the infrastructure, failing the pulumi update because there was a
 				// problem printing a statefile perma link can be missleading in automated CI environments.
-				cmdutil.Diag().Warningf(diag.Message("", "Could not get signed url for stack location: %v"), err)
+				cmdutil.Diag().Warningf(diag.Message("", "Unable to create signed url for current backend to "+
+					"create a Permalink. Please visit https://www.pulumi.com/docs/troubleshooting/ "+
+					"for more information\n"))
 			}
 		}
 
-		fmt.Printf(op.Opts.Display.Color.Colorize(
-			colors.SpecHeadline+"Permalink: "+
-				colors.Underline+colors.BrightBlue+"%s"+colors.Reset+"\n"), link)
+		if link != "" {
+			fmt.Printf(op.Opts.Display.Color.Colorize(
+				colors.SpecHeadline+"Permalink: "+
+					colors.Underline+colors.BrightBlue+"%s"+colors.Reset+"\n"), link)
+		}
 	}
 
 	return changes, nil

--- a/pkg/backend/filestate/gcpauth.go
+++ b/pkg/backend/filestate/gcpauth.go
@@ -5,9 +5,6 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/pulumi/pulumi/sdk/v2/go/common/diag"
-	"github.com/pulumi/pulumi/sdk/v2/go/common/util/cmdutil"
-
 	"golang.org/x/oauth2/google"
 
 	"gocloud.dev/blob/gcsblob"
@@ -68,11 +65,6 @@ func GoogleCredentialsMux(ctx context.Context) (*blob.URLMux, error) {
 	if err == nil && account.ClientEmail != "" && account.PrivateKey != "" {
 		options.GoogleAccessID = account.ClientEmail
 		options.PrivateKey = []byte(account.PrivateKey)
-	} else {
-		cmdutil.Diag().Warningf(diag.Message("",
-			"Pulumi will not be able to print a statefile permalink using these credentials. "+
-				"Neither a GoogleAccessID or PrivateKey are available. "+
-				"Try using a GCP Service Account."))
 	}
 
 	blobmux := &blob.URLMux{}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -44,7 +44,7 @@ func newRefreshCmd() *cobra.Command {
 	var showSames bool
 	var skipPreview bool
 	var suppressOutputs bool
-	var suppressPermaLink bool
+	var suppressPermaLink string
 	var yes bool
 	var targets *[]string
 
@@ -84,11 +84,29 @@ func newRefreshCmd() *cobra.Command {
 				ShowReplacementSteps: showReplacementSteps,
 				ShowSameResources:    showSames,
 				SuppressOutputs:      suppressOutputs,
-				SuppressPermaLink:    suppressPermaLink,
 				IsInteractive:        interactive,
 				Type:                 displayType,
 				EventLogPath:         eventLogPath,
 				Debug:                debug,
+			}
+
+			// we only suppress permalinks if the user passes true. the default is an empty string
+			// which we pass as 'false'
+			if suppressPermaLink == "true" {
+				opts.Display.SuppressPermaLink = true
+			} else {
+				opts.Display.SuppressPermaLink = false
+			}
+
+			filestateBackend, err := isFilestateBackend(opts.Display)
+			if err != nil {
+				return result.FromError(err)
+			}
+
+			// by default, we are going to suppress the permalink when using self-managed backends
+			// this can be re-enabled by explicitly passing "false" to the `supppress-permalink` flag
+			if suppressPermaLink != "false" && filestateBackend {
+				opts.Display.SuppressPermaLink = true
 			}
 
 			s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
@@ -193,9 +211,10 @@ func newRefreshCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
-	cmd.PersistentFlags().BoolVar(
-		&suppressPermaLink, "suppress-permalink", false,
+	cmd.PersistentFlags().StringVar(
+		&suppressPermaLink, "suppress-permalink", "",
 		"Suppress display of the state permalink")
+	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the refresh after previewing it")

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -66,7 +66,7 @@ func newUpCmd() *cobra.Command {
 	var showReads bool
 	var skipPreview bool
 	var suppressOutputs bool
-	var suppressPermaLink bool
+	var suppressPermaLink string
 	var yes bool
 	var secretsProvider string
 	var targets []string
@@ -364,11 +364,29 @@ func newUpCmd() *cobra.Command {
 				ShowSameResources:    showSames,
 				ShowReads:            showReads,
 				SuppressOutputs:      suppressOutputs,
-				SuppressPermaLink:    suppressPermaLink,
 				IsInteractive:        interactive,
 				Type:                 displayType,
 				EventLogPath:         eventLogPath,
 				Debug:                debug,
+			}
+
+			// we only suppress permalinks if the user passes true. the default is an empty string
+			// which we pass as 'false'
+			if suppressPermaLink == "true" {
+				opts.Display.SuppressPermaLink = true
+			} else {
+				opts.Display.SuppressPermaLink = false
+			}
+
+			filestateBackend, err := isFilestateBackend(opts.Display)
+			if err != nil {
+				return result.FromError(err)
+			}
+
+			// by default, we are going to suppress the permalink when using self-managed backends
+			// this can be re-enabled by explicitly passing "false" to the `supppress-permalink` flag
+			if suppressPermaLink != "false" && filestateBackend {
+				opts.Display.SuppressPermaLink = true
 			}
 
 			if len(args) > 0 {
@@ -461,9 +479,10 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
-	cmd.PersistentFlags().BoolVar(
-		&suppressPermaLink, "suppress-permalink", false,
+	cmd.PersistentFlags().StringVar(
+		&suppressPermaLink, "suppress-permalink", "",
 		"Suppress display of the state permalink")
+	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
 	cmd.PersistentFlags().BoolVarP(
 		&yes, "yes", "y", false,
 		"Automatically approve and perform the update after previewing it")

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -88,6 +88,19 @@ func skipConfirmations() bool {
 // backendInstance is used to inject a backend mock from tests.
 var backendInstance backend.Backend
 
+func isFilestateBackend(opts display.Options) (bool, error) {
+	if backendInstance != nil {
+		return false, nil
+	}
+
+	url, err := workspace.GetCurrentCloudURL()
+	if err != nil {
+		return false, errors.Wrapf(err, "could not get cloud url")
+	}
+
+	return filestate.IsFileStateBackendURL(url), nil
+}
+
 func currentBackend(opts display.Options) (backend.Backend, error) {
 	if backendInstance != nil {
 		return backendInstance, nil


### PR DESCRIPTION
Fixes: #4029
Fixes: #3537

Should the user want to get permalinks when using a self-managed backend, they can pass a flag:

```
$ pulumi up --suppress-permalink false
```

Permalinks for these self-managed backends will be suppressed on `update`, `preview`, `destroy`,
`import` and `refresh` operations.

A view of the functionality:

### self-managed backend

```
$ pulumi whoami -v
User: stack72
Backend URL: file://~


$ PULUMI_CONFIG_PASSPHRASE=password pulumi up
Previewing update (pphrase-2):
     Type                 Name                       Plan
     pulumi:pulumi:Stack  testing-pphrase-2
Resources:
    2 unchanged


$ PULUMI_CONFIG_PASSPHRASE=password pulumi up --suppress-permalink false
Previewing update (pphrase-2):
     Type                 Name                       Plan
     pulumi:pulumi:Stack  testing-pphrase-2
Resources:
    2 unchanged

Permalink: file:///Users/stack72/.pulumi/stacks/pphrase-2.json
```

### Using the SaaS

```
$ pulumi whoami -v
User: stack72
Backend URL: https://app.pulumi.com/stack72


$ pulumi up
Previewing update (dev4)
View Live: https://app.pulumi.com/stack72/testing/dev4/previews/11d3539a-93be-4272-8070-190875b8697f
     Type                          Name                  Plan
 +   pulumi:pulumi:Stack           testing-dev4          create
 +   └─ random:index:RandomString  test                  create
Resources:
    + 2 to create


$ pulumi up --suppress-permalink false
Previewing update (dev4)
View Live: https://app.pulumi.com/stack72/testing/dev4/previews/416a8023-ddcd-4ed1-8d48-5744831b836d
     Type                          Name                  Plan
 +   pulumi:pulumi:Stack           testing-dev4          create
 +   └─ random:index:RandomString  test                  create
Resources:
    + 2 to create


$ pulumi up --suppress-permalink true
Previewing update (dev4)
     Type                          Name                  Plan
 +   pulumi:pulumi:Stack           testing-dev4          create
 +   └─ random:index:RandomString  test                  create
Resources:
    + 2 to create
```

