### PR TITLE
[codegen/python] - Generate accessors for provider resource properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - [sdk/python] Gracefully handle monitor shutdown in the python runtime without exiting the process. 
   [#6249](https://github.com/pulumi/pulumi/pull/6249)
 
+- [codegen/python] Generate accessors for provider resource properties.
+  [#6249](https://github.com/pulumi/pulumi/pull/6260)
+
 ## 2.20.0 (2021-02-03)
 
 - [sdk/python] Fix `Output.from_input` to unwrap nested output values in input types (args classes), which addresses

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1117,6 +1117,14 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		return fmt.Sprintf("pulumi.Output[%s]", ty)
 	})
 
+	// Write out Python property getters for all inputs if this is a provider resource because all inputs are implicitly outputs.
+	if res.IsProvider {
+		mod.genProperties(w, res.InputProperties, false /*setters*/, func(prop *schema.Property) string {
+			ty := mod.typeString(prop.Type, false /*input*/, false /*wrapInput*/, !prop.IsRequired, false /*acceptMapping*/)
+			return fmt.Sprintf("pulumi.Output[%s]", ty)
+		})
+	}
+
 	// Override translate_{input|output}_property on each resource to translate between snake case and
 	// camel case when interacting with tfbridge.
 	fmt.Fprintf(w,


### PR DESCRIPTION
@justinvp I'm not sure if something different needs to happen here since these are provider properties. Should the resource also have a `get` method? Is there anything that needs to happen with respect to the camelCase <-> snake_case conversion in the getter functions?

Fixes: https://github.com/pulumi/pulumi/issues/6259