### PR TITLE
[python/sdk] - Correctly handle outputs with properties named "values"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ CHANGELOG
 - [sdk/python] Gracefully handle monitor shutdown in the python runtime without exiting the process. 
   [#6249](https://github.com/pulumi/pulumi/pull/6249)
 
+- [sdk/python] Fix a bug in `contains_unknowns` where outputs with a property named "values" failed with a TypeError.
+  [#6264](https://github.com/pulumi/pulumi/pull/6264)
+
 ## 2.20.0 (2021-02-03)
 
 - [sdk/python] Fix `Output.from_input` to unwrap nested output values in input types (args classes), which addresses

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -33,7 +33,7 @@ from .. import _types
 
 if TYPE_CHECKING:
     from ..output import Inputs, Input, Output
-    from ..resource import Resource, CustomResource, ProviderResource
+    from ..resource import Resource, ProviderResource
     from ..asset import FileAsset, RemoteAsset, StringAsset, FileArchive, RemoteArchive, AssetArchive
 
 UNKNOWN = "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
@@ -567,7 +567,7 @@ def contains_unknowns(val: Any) -> bool:
         if not any([x is val for x in stack]):
             stack.append(val)
             if isinstance(val, dict):
-                return any([impl(x, stack) for x in val.values()])
+                return any([impl(val[k], stack) for k in val])
             if isinstance(val, list):
                 return any([impl(x, stack) for x in val])
         return False

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -86,9 +86,9 @@ class MyOutputTypeDict(dict):
 
     # Property with empty body.
     @property
-    @pulumi.getter(name="firstValue")
+    @pulumi.getter
     def values(self) -> str:
-        """First value docstring."""
+        """Values docstring."""
         ...
 
 
@@ -1195,4 +1195,3 @@ class EnumSerializationTests(unittest.TestCase):
         one = FloatEnum.ZERO_POINT_ONE
         prop = await rpc.serialize_property(one, [])
         self.assertEqual(FloatEnum.ZERO_POINT_ONE, prop)
-


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi/issues/6000

The test case errors before the change and succeeds after.