### PR TITLE
Move linting check into command-dispatch job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,16 +16,3 @@ jobs:
 
             **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  lint:
-    container: golangci/golangci-lint:latest
-    name: Lint ${{ matrix.directory }}
-    strategy:
-      matrix:
-        directory: [ sdk, pkg, tests ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v2
-      - name: Lint ${{ matrix.directory }}
-        run: |
-          cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -30,6 +30,19 @@ jobs:
             Please view the results of the PR Build + Acceptance Tests Run [Here][1]
 
             [1]: ${{ steps.vars.outputs.run-url }}
+  lint:
+    container: golangci/golangci-lint:latest
+    name: Lint ${{ matrix.directory }}
+    strategy:
+      matrix:
+        directory: [ sdk, pkg, tests ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Lint ${{ matrix.directory }}
+        run: |
+          cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
   build_and_test:
     name: Build & Test
     strategy:


### PR DESCRIPTION
This fixes not picking up linting issues when sending a PR as
the PR job uses `pull_request_target` which in turn only checks out
from master which is a security measure