### PR TITLE
Pin version of pip on Windows for Python tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -227,8 +227,11 @@ jobs:
         run: dotnet nuget locals all --clear
       - name: Install Python Deps
         run: |
-          pip3 install pyenv-win
-          pip3 install pipenv
+          pip install --upgrade pip==20.3.3
+          pip install pyenv-win==2.64.3
+          pip install pipenv
+          pip install virtualenv
+      - run: pip -V
       - name: Set Build Env Vars
         shell: bash
         run: |
@@ -269,6 +272,8 @@ jobs:
         run: |
           cd src\github.com\${{ github.repository }}
           dotnet msbuild /t:Build /v:Detailed build.proj /p:PulumiRoot="D:\\Pulumi"
+      - run: dir D:\a\pulumi\pulumi\src\github.com\pulumi\pulumi\sdk\python\env\src
+      - run: pip install -e D:\a\pulumi\pulumi\src\github.com\pulumi\pulumi\sdk\python\env\src
       - name: Run Pulumi Tests
         run: |
           cd src\github.com\${{ github.repository }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -226,8 +226,11 @@ jobs:
         run: dotnet nuget locals all --clear
       - name: Install Python Deps
         run: |
-          pip3 install pyenv-win
-          pip3 install pipenv
+          pip install --upgrade pip==20.3.3
+          pip install pyenv-win==2.64.3
+          pip install pipenv
+          pip install virtualenv
+      - run: pip -V
       - name: Set Build Env Vars
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,8 +322,11 @@ jobs:
         run: dotnet nuget locals all --clear
       - name: Install Python Deps
         run: |
-          pip3 install pyenv-win
-          pip3 install pipenv
+          pip install --upgrade pip==20.3.3
+          pip install pyenv-win==2.64.3
+          pip install pipenv
+          pip install virtualenv
+      - run: pip -V
       - name: Set Build Env Vars
         shell: bash
         run: |

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -145,8 +145,11 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Python Deps
         run: |
-          pip3 install pyenv-win
-          pip3 install pipenv
+          pip install --upgrade pip==20.3.3
+          pip install pyenv-win==2.64.3
+          pip install pipenv
+          pip install virtualenv
+      - run: pip -V
       - name: Set Build Env Vars
         shell: bash
         run: |
@@ -185,6 +188,8 @@ jobs:
         run: |
           cd src\github.com\${{ github.repository }}
           dotnet msbuild /t:Build /v:Detailed build.proj /p:PulumiRoot="D:\\Pulumi"
+      - run: dir D:\a\pulumi\pulumi\src\github.com\pulumi\pulumi\sdk\python\env\src
+      - run: pip install -e D:\a\pulumi\pulumi\src\github.com\pulumi\pulumi\sdk\python\env\src
       - name: Run Pulumi Tests
         run: |
           cd src\github.com\${{ github.repository }}


### PR DESCRIPTION
Fixes: #6268

On Feb 1st 2021, GHA upgraded the windows build runner to set the
pip version to be 21.0.1 which broke our python tests on windows

This PR sets the version back to 20.3.3 so we can have time to
understand why we were broken by that upgrade