### PR TITLE
Add pagination to `pulumi stack history`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-- [CLI] Add pagination options to `pulumi stack history` (`--page`, `--pageSize`). These replace the `--limit` flag.
+- [CLI] Add pagination options to `pulumi stack history` (`--page`, `--page-size`). These replace the `--limit` flag.
   [#6292](https://github.com/pulumi/pulumi/pull/6292)
 
 - [CLI, automation/*] Add `--limit` flag to `pulumi stack history` command and consume this from Automation API SDKs to improve performance of stack updates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- [CLI] Add pagination options to `pulumi stack history` (`--page`, `--pageSize`). These replace the `--limit` flag.
+  [#6292](https://github.com/pulumi/pulumi/pull/6292)
+
 - [CLI, automation/*] Add `--limit` flag to `pulumi stack history` command and consume this from Automation API SDKs to improve performance of stack updates.
   [#6257](https://github.com/pulumi/pulumi/pull/6257)
 

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -171,7 +171,7 @@ type Backend interface {
 
 	// GetHistory returns all updates for the stack. The returned UpdateInfo slice will be in
 	// descending order (newest first).
-	GetHistory(ctx context.Context, stackRef StackReference, limit int) ([]UpdateInfo, error)
+	GetHistory(ctx context.Context, stackRef StackReference, pageSize int, page int) ([]UpdateInfo, error)
 	// GetLogs fetches a list of log entries for the given stack, with optional filtering/querying.
 	GetLogs(ctx context.Context, stack Stack, cfg StackConfiguration,
 		query operations.LogQuery) ([]operations.LogEntry, error)

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -399,7 +399,7 @@ func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 func (b *localBackend) GetLatestConfiguration(ctx context.Context,
 	stack backend.Stack) (config.Map, error) {
 
-	hist, err := b.GetHistory(ctx, stack.Ref(), 1 /*limit*/)
+	hist, err := b.GetHistory(ctx, stack.Ref(), 1 /*pageSize*/, 1 /*page*/)
 	if err != nil {
 		return nil, err
 	}
@@ -626,9 +626,10 @@ func (b *localBackend) query(ctx context.Context, op backend.QueryOperation,
 func (b *localBackend) GetHistory(
 	ctx context.Context,
 	stackRef backend.StackReference,
-	limit int) ([]backend.UpdateInfo, error) {
+	pageSize int,
+	page int) ([]backend.UpdateInfo, error) {
 	stackName := stackRef.Name()
-	updates, err := b.getHistory(stackName, limit)
+	updates, err := b.getHistory(stackName, pageSize, page)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -1100,13 +1100,15 @@ func (b *cloudBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend
 
 func (b *cloudBackend) GetHistory(
 	ctx context.Context,
-	stackRef backend.StackReference, limit int) ([]backend.UpdateInfo, error) {
+	stackRef backend.StackReference,
+	pageSize int,
+	page int) ([]backend.UpdateInfo, error) {
 	stack, err := b.getCloudStackIdentifier(stackRef)
 	if err != nil {
 		return nil, err
 	}
 
-	updates, err := b.client.GetStackUpdates(ctx, stack, limit)
+	updates, err := b.client.GetStackUpdates(ctx, stack, pageSize, page)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -376,11 +376,15 @@ func (pc *Client) DecryptValue(ctx context.Context, stack StackIdentifier, ciphe
 func (pc *Client) GetStackUpdates(
 	ctx context.Context,
 	stack StackIdentifier,
-	pageSize int) ([]apitype.UpdateInfo, error) {
+	pageSize int,
+	page int) ([]apitype.UpdateInfo, error) {
 	var response apitype.GetHistoryResponse
 	path := getStackPath(stack, "updates")
 	if pageSize > 0 {
-		path += fmt.Sprintf("?pageSize=%d&page=1", pageSize)
+		if page < 1 {
+			page = 1
+		}
+		path += fmt.Sprintf("?pageSize=%d&page=%d", pageSize, page)
 	}
 	if err := pc.restCall(ctx, "GET", path, nil, nil, &response); err != nil {
 		return nil, err

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -47,7 +47,7 @@ type MockBackend struct {
 	GetStackCrypterF        func(StackReference) (config.Crypter, error)
 	QueryF                  func(context.Context, QueryOperation) result.Result
 	GetLatestConfigurationF func(context.Context, Stack) (config.Map, error)
-	GetHistoryF             func(context.Context, StackReference, int) ([]UpdateInfo, error)
+	GetHistoryF             func(context.Context, StackReference, int, int) ([]UpdateInfo, error)
 	GetStackTagsF           func(context.Context, Stack) (map[apitype.StackTagName]string, error)
 	UpdateStackTagsF        func(context.Context, Stack, map[apitype.StackTagName]string) error
 	ExportDeploymentF       func(context.Context, Stack) (*apitype.UntypedDeployment, error)
@@ -237,9 +237,12 @@ func (be *MockBackend) Query(ctx context.Context, op QueryOperation) result.Resu
 	panic("not implemented")
 }
 
-func (be *MockBackend) GetHistory(ctx context.Context, stackRef StackReference, limit int) ([]UpdateInfo, error) {
+func (be *MockBackend) GetHistory(ctx context.Context,
+	stackRef StackReference,
+	pageSize int,
+	page int) ([]UpdateInfo, error) {
 	if be.GetHistoryF != nil {
-		return be.GetHistoryF(ctx, stackRef, limit)
+		return be.GetHistoryF(ctx, stackRef, pageSize, page)
 	}
 	panic("not implemented")
 }

--- a/pkg/cmd/pulumi/history.go
+++ b/pkg/cmd/pulumi/history.go
@@ -80,8 +80,8 @@ func newHistoryCmd() *cobra.Command {
 	cmd.PersistentFlags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")
 	cmd.PersistentFlags().IntVar(
-		&pageSize, "pageSize", 0, "Used with 'page' to control number of results returned")
+		&pageSize, "page-size", 0, "Used with 'page' to control number of results returned")
 	cmd.PersistentFlags().IntVar(
-		&page, "page", 0, "Used with 'pageSize' to paginate results")
+		&page, "page", 0, "Used with 'page-size' to paginate results")
 	return cmd
 }

--- a/pkg/cmd/pulumi/history.go
+++ b/pkg/cmd/pulumi/history.go
@@ -28,7 +28,8 @@ func newHistoryCmd() *cobra.Command {
 	var stack string
 	var jsonOut bool
 	var showSecrets bool
-	var limit int
+	var pageSize int
+	var page int
 	var cmd = &cobra.Command{
 		Use:        "history",
 		Aliases:    []string{"hist"},
@@ -50,7 +51,7 @@ func newHistoryCmd() *cobra.Command {
 			}
 
 			b := s.Backend()
-			updates, err := b.GetHistory(commandContext(), s.Ref(), limit)
+			updates, err := b.GetHistory(commandContext(), s.Ref(), pageSize, page)
 			if err != nil {
 				return errors.Wrap(err, "getting history")
 			}
@@ -67,7 +68,7 @@ func newHistoryCmd() *cobra.Command {
 				return displayUpdatesJSON(updates, decrypter)
 			}
 
-			return displayUpdatesConsole(updates, opts)
+			return displayUpdatesConsole(updates, page, opts)
 		}),
 	}
 	cmd.PersistentFlags().StringVarP(
@@ -78,7 +79,9 @@ func newHistoryCmd() *cobra.Command {
 		"Show secret values when listing config instead of displaying blinded values")
 	cmd.PersistentFlags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")
-	cmd.PersistentFlags().IntVarP(
-		&limit, "limit", "l", 0, "Limit the number of entries returned, defaults to all")
+	cmd.PersistentFlags().IntVar(
+		&pageSize, "pageSize", 0, "Used with 'page' to control number of results returned")
+	cmd.PersistentFlags().IntVar(
+		&page, "page", 0, "Used with 'pageSize' to paginate results")
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -74,9 +74,9 @@ This command displays data about previous updates for a stack.`,
 	cmd.PersistentFlags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")
 	cmd.PersistentFlags().IntVar(
-		&pageSize, "pageSize", 0, "Used with 'page' to control number of results returned")
+		&pageSize, "page-size", 0, "Used with 'page' to control number of results returned")
 	cmd.PersistentFlags().IntVar(
-		&page, "page", 0, "Used with 'pageSize' to paginate results")
+		&page, "page", 0, "Used with 'page-size' to paginate results")
 	return cmd
 }
 

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -24,7 +24,8 @@ func newStackHistoryCmd() *cobra.Command {
 	var stack string
 	var jsonOut bool
 	var showSecrets bool
-	var limit int
+	var pageSize int
+	var page int
 
 	cmd := &cobra.Command{
 		Use:        "history",
@@ -43,7 +44,7 @@ This command displays data about previous updates for a stack.`,
 				return err
 			}
 			b := s.Backend()
-			updates, err := b.GetHistory(commandContext(), s.Ref(), limit)
+			updates, err := b.GetHistory(commandContext(), s.Ref(), pageSize, page)
 			if err != nil {
 				return errors.Wrap(err, "getting history")
 			}
@@ -60,7 +61,7 @@ This command displays data about previous updates for a stack.`,
 				return displayUpdatesJSON(updates, decrypter)
 			}
 
-			return displayUpdatesConsole(updates, opts)
+			return displayUpdatesConsole(updates, page, opts)
 		}),
 	}
 
@@ -72,8 +73,10 @@ This command displays data about previous updates for a stack.`,
 		"Show secret values when listing config instead of displaying blinded values")
 	cmd.PersistentFlags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")
-	cmd.PersistentFlags().IntVarP(
-		&limit, "limit", "l", 0, "Limit the number of entries returned, defaults to all")
+	cmd.PersistentFlags().IntVar(
+		&pageSize, "pageSize", 0, "Used with 'page' to control number of results returned")
+	cmd.PersistentFlags().IntVar(
+		&page, "page", 0, "Used with 'pageSize' to paginate results")
 	return cmd
 }
 
@@ -148,8 +151,12 @@ func displayUpdatesJSON(updates []backend.UpdateInfo, decrypter config.Decrypter
 	return printJSON(updatesJSON)
 }
 
-func displayUpdatesConsole(updates []backend.UpdateInfo, opts display.Options) error {
+func displayUpdatesConsole(updates []backend.UpdateInfo, page int, opts display.Options) error {
 	if len(updates) == 0 {
+		if page > 1 {
+			fmt.Printf("No stack updates found on page '%d'\n", page)
+			return nil
+		}
 		fmt.Println("Stack has never been updated")
 		return nil
 	}

--- a/sdk/go/x/auto/example_test.go
+++ b/sdk/go/x/auto/example_test.go
@@ -1034,8 +1034,9 @@ func ExampleStack_History() {
 	ctx := context.Background()
 	stackName := FullyQualifiedStackName("org", "project", "stack")
 	stack, _ := SelectStackLocalSource(ctx, stackName, filepath.Join(".", "program"))
-	limit := 0 // fetch all history entries
-	hist, _ := stack.History(ctx, limit)
+	pageSize := 0 // fetch all history entries, don't paginate
+	page := 0     // fetch all history entries, don't paginate
+	hist, _ := stack.History(ctx, pageSize, page)
 	// last operation start time
 	fmt.Println(hist[0].StartTime)
 }

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -522,7 +522,7 @@ func (s *Stack) History(ctx context.Context, pageSize int, page int) ([]UpdateSu
 		if page < 1 {
 			page = 1
 		}
-		args = append(args, "--pageSize", fmt.Sprintf("%d", pageSize), "--page", fmt.Sprintf("%d", page))
+		args = append(args, "--page-size", fmt.Sprintf("%d", pageSize), "--page", fmt.Sprintf("%d", page))
 	}
 
 	stdout, stderr, errCode, err := s.runPulumiCmdSync(ctx, nil /* additionalOutputs */, args...)

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -415,10 +415,13 @@ export class Stack {
      * Returns a list summarizing all previous and current results from Stack lifecycle operations
      * (up/preview/refresh/destroy).
      */
-    async history(limit?: number): Promise<UpdateSummary[]> {
+    async history(pageSize?: number, page?: number): Promise<UpdateSummary[]> {
         const args = ["history", "--json", "--show-secrets"];
-        if (limit) {
-            args.push("--limit", Math.floor(limit).toString())
+        if (pageSize) {
+            if (!page || page < 1) {
+                page = 1
+            }
+            args.push("--pageSize", Math.floor(pageSize).toString(), "--page", Math.floor(page).toString())
         }
         const result = await this.runPulumiCmd(args);
       
@@ -430,7 +433,7 @@ export class Stack {
         });
     }
     async info(): Promise<UpdateSummary | undefined> {
-        const history = await this.history(1 /*limit*/);
+        const history = await this.history(1 /*pageSize*/);
         if (!history || history.length === 0) {
             return undefined;
         }

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -421,7 +421,7 @@ export class Stack {
             if (!page || page < 1) {
                 page = 1
             }
-            args.push("--pageSize", Math.floor(pageSize).toString(), "--page", Math.floor(page).toString())
+            args.push("--page-size", Math.floor(pageSize).toString(), "--page", Math.floor(page).toString())
         }
         const result = await this.runPulumiCmd(args);
       

--- a/sdk/python/lib/pulumi/x/automation/stack.py
+++ b/sdk/python/lib/pulumi/x/automation/stack.py
@@ -465,23 +465,23 @@ class Stack:
         return outputs
 
     def history(self,
-        pageSize: Optional[int] = None,
+        page_size: Optional[int] = None,
         page: Optional[int] = None) -> List[UpdateSummary]:
         """
         Returns a list summarizing all previous and current results from Stack lifecycle operations
         (up/preview/refresh/destroy).
 
-        :param pageSize: Paginate history entries (used in combination with page), defaults to all.
-        :param page: Paginate history entries (used in combination with pageSize), defaults to all.
+        :param page_size: Paginate history entries (used in combination with page), defaults to all.
+        :param page: Paginate history entries (used in combination with page_size), defaults to all.
 
         :returns: List[UpdateSummary]
         """
         args = ["history", "--json", "--show-secrets"]
-        if pageSize is not None:
-            # default page=1 when pageSize is set
+        if page_size is not None:
+            # default page=1 when page_size is set
             if page is None:
                 page = 1
-            args.extend(["--page-size", str(pageSize), "--page", str(page)])
+            args.extend(["--page-size", str(page_size), "--page", str(page)])
         result = self._run_pulumi_cmd_sync(args)
         summary_list = json.loads(result.stdout)
 
@@ -506,7 +506,7 @@ class Stack:
 
         :returns: Optional[UpdateSummary]
         """
-        history = self.history(pageSize=1)
+        history = self.history(page_size=1)
         if not len(history):
             return None
         return history[0]

--- a/sdk/python/lib/pulumi/x/automation/stack.py
+++ b/sdk/python/lib/pulumi/x/automation/stack.py
@@ -481,7 +481,7 @@ class Stack:
             # default page=1 when pageSize is set
             if page is None:
                 page = 1
-            args.extend(["--pageSize", str(pageSize), "--page", str(page)])
+            args.extend(["--page-size", str(pageSize), "--page", str(page)])
         result = self._run_pulumi_cmd_sync(args)
         summary_list = json.loads(result.stdout)
 

--- a/sdk/python/lib/pulumi/x/automation/stack.py
+++ b/sdk/python/lib/pulumi/x/automation/stack.py
@@ -465,18 +465,23 @@ class Stack:
         return outputs
 
     def history(self,
-        limit: Optional[int] = None) -> List[UpdateSummary]:
+        pageSize: Optional[int] = None,
+        page: Optional[int] = None) -> List[UpdateSummary]:
         """
         Returns a list summarizing all previous and current results from Stack lifecycle operations
         (up/preview/refresh/destroy).
 
-        :param limit: Limit the number of history entires to retrieve, defaults to all.
+        :param pageSize: Paginate history entries (used in combination with page), defaults to all.
+        :param page: Paginate history entries (used in combination with pageSize), defaults to all.
 
         :returns: List[UpdateSummary]
         """
         args = ["history", "--json", "--show-secrets"]
-        if limit is not None:
-            args.extend(["--limit", str(limit)])
+        if pageSize is not None:
+            # default page=1 when pageSize is set
+            if page is None:
+                page = 1
+            args.extend(["--pageSize", str(pageSize), "--page", str(page)])
         result = self._run_pulumi_cmd_sync(args)
         summary_list = json.loads(result.stdout)
 
@@ -501,7 +506,7 @@ class Stack:
 
         :returns: Optional[UpdateSummary]
         """
-        history = self.history(limit=1)
+        history = self.history(pageSize=1)
         if not len(history):
             return None
         return history[0]

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -42,7 +42,7 @@ func assertHasNoHistory(e *ptesting.Environment) {
 // updates in the given pagination window
 func assertNoResultsOnPage(e *ptesting.Environment) {
 	// NOTE: pulumi returns with exit code 0 in this scenario.
-	out, err := e.RunCommand("pulumi", "history", "--pageSize", "1", "--page", "10000000")
+	out, err := e.RunCommand("pulumi", "history", "--page-size", "1", "--page", "10000000")
 	assert.Equal(e.T, "", err)
 	assert.Equal(e.T, "No stack updates found on page '10000000'\n", out)
 }
@@ -87,7 +87,7 @@ func TestHistoryCommand(t *testing.T) {
 		assert.Equal(t, "", err)
 		assert.Contains(t, out, "this is an updated stack")
 		// Confirm we see the update message in thie history output, with pagination.
-		out, err = e.RunCommand("pulumi", "history", "--pageSize", "1")
+		out, err = e.RunCommand("pulumi", "history", "--page-size", "1")
 		assert.Equal(t, "", err)
 		assert.Contains(t, out, "this is an updated stack")
 		// Get an error message when we page too far

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -37,6 +37,15 @@ func assertHasNoHistory(e *ptesting.Environment) {
 	assert.Equal(e.T, "", err)
 	assert.Equal(e.T, "Stack has never been updated\n", out)
 }
+
+// assertNoResultsOnPage runs `pulumi history` and confirms an error that the stack has no
+// updates in the given pagination window
+func assertNoResultsOnPage(e *ptesting.Environment) {
+	// NOTE: pulumi returns with exit code 0 in this scenario.
+	out, err := e.RunCommand("pulumi", "history", "--pageSize", "1", "--page", "10000000")
+	assert.Equal(e.T, "", err)
+	assert.Equal(e.T, "No stack updates found on page '10000000'\n", out)
+}
 func TestHistoryCommand(t *testing.T) {
 	// We fail if no stack is selected.
 	t.Run("NoStackSelected", func(t *testing.T) {
@@ -77,6 +86,12 @@ func TestHistoryCommand(t *testing.T) {
 		out, err := e.RunCommand("pulumi", "history")
 		assert.Equal(t, "", err)
 		assert.Contains(t, out, "this is an updated stack")
+		// Confirm we see the update message in thie history output, with pagination.
+		out, err = e.RunCommand("pulumi", "history", "--pageSize", "1")
+		assert.Equal(t, "", err)
+		assert.Contains(t, out, "this is an updated stack")
+		// Get an error message when we page too far
+		assertNoResultsOnPage(e)
 		// Change stack and confirm the history command honors the selected stack.
 		e.RunCommand("pulumi", "stack", "select", "stack-without-updates")
 		assertHasNoHistory(e)


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/6168.

Replaces the `--limit` flag added in https://github.com/pulumi/pulumi/pull/6257.

Found that we have some integration tests that cover the history command, so I made some updates to add some coverage over the new parameters (In addition to the same set of manual testing I did on both the SaaS and filestate backends for #6257)