### PR TITLE
[BREAKING] - Standardize stack select behavior

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,7 @@ on:
       [ "master", "feature/**", "feature-**" ]
     paths-ignore:
       - 'CHANGELOG.md'
+      - 'CHANGELOG_PENDING.md'
       - 'README.md'
 
 env:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,7 @@ on:
       - v*.*.*-**
     paths-ignore:
       - 'CHANGELOG.md'
+      - 'CHANGELOG_PENDING.md'
       - 'README.md'
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
       - v*.*.*
     paths-ignore:
       - 'CHANGELOG.md'
+      - 'CHANGELOG_PENDING.md'
       - 'README.md'
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
@@ -204,7 +205,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: -f .goreleaser.yml --rm-dist
+          args: -f .goreleaser.yml --rm-dist --release-notes=CHANGELOG_PENDING.md
   lint:
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -2,6 +2,9 @@ on:
   repository_dispatch:
     types: [ run-acceptance-tests-command ]
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'CHANGELOG_PENDING.md'
 
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,6 @@ blobs:
     - pulumi-unix
   provider: s3
   region: us-west-2
-changelog:
-  skip: true
 builds:
 # UNIX builds
 - id: pulumi-unix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 CHANGELOG
 =========
 
-## HEAD (Unreleased)
-_(none)_
-
 ## 2.21.2 (2021-02-22)
 
 ### Improvements

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,10 @@
+### Breaking Changes
+- [CLI] Standardize the `--stack` flag to *not* set the stack as current (i.e. setStack=false) across CLI commands.
+  [#6300](https://github.com/pulumi/pulumi/pull/6300)
+
+- [Automation/*] All operations use `--stack` to specify the stack instead of running `select stack` before the operation.
+  [#6300](https://github.com/pulumi/pulumi/pull/6300)
+
 ### Features
 
 
@@ -5,3 +12,9 @@
 
 
 ### Bug Fixes
+
+
+
+
+
+

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,0 +1,7 @@
+### Features
+
+
+### Enhancements
+
+
+### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ is a pretty standard starting point during debugging that will show a fairly com
 ## Submitting a Pull Request
 
 For contributors we use the standard fork based workflow. Fork this repository, create a topic branch, and start hacking away.  When you're ready, make sure you've run the tests (`make travis_pull_request` will run the exact flow we run in CI) and open your PR.
+When adding a changelog entry, please be sure to use `CHANGELOG_PENDING.md` for the entry - we will then be able to ensure your PR gets into the next release.
 
 ## Getting Help
 

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -56,7 +56,7 @@ func newCancelCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -390,7 +390,7 @@ func newConfigRefreshCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(*stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -113,7 +113,7 @@ func newDestroyCmd() *cobra.Command {
 				opts.Display.SuppressPermaLink = true
 			}
 
-			s, err := requireStack(stack, false, opts.Display, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -432,7 +432,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack.
-			s, err := requireStack(stack, false, opts.Display, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -56,7 +56,7 @@ func newLogsCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -114,7 +114,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(stack, true, displayOpts, true /*setCurrent*/)
+			s, err := requireStack(stack, true, displayOpts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -109,7 +109,7 @@ func newRefreshCmd() *cobra.Command {
 				opts.Display.SuppressPermaLink = true
 			}
 
-			s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
+			s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -43,7 +43,7 @@ func newStackCmd() *cobra.Command {
 		Short: "Manage stacks",
 		Long: "Manage stacks\n" +
 			"\n" +
-			"An stack is a named update target, and a single project may have many of them.\n" +
+			"A stack is a named update target, and a single project may have many of them.\n" +
 			"Each stack has a configuration and update history associated with it, stored in\n" +
 			"the workspace, in addition to a full checkpoint of the last known good update.\n",
 		Args: cmdutil.NoArgs,
@@ -52,7 +52,7 @@ func newStackCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stackName, true, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, true, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -51,7 +51,7 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and export its deployment
-			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -57,7 +57,7 @@ func newStackGraphCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -50,7 +50,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and import a deployment.
-			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -46,7 +46,7 @@ func newStackOutputCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and its output properties.
-			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -52,7 +52,7 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Look up the stack to be moved, and find the path to the project file's location.
-			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -59,7 +59,7 @@ func newStackRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -64,7 +64,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(*stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -132,7 +132,7 @@ func runTotalStateEdit(
 	opts := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
 	}
-	s, err := requireStack(stackName, true, opts, true /*setCurrent*/)
+	s, err := requireStack(stackName, true, opts, false /*setCurrent*/)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -76,7 +76,7 @@ func newUpCmd() *cobra.Command {
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(opts backend.UpdateOptions) result.Result {
-		s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
+		s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
 		if err != nil {
 			return result.FromError(err)
 		}

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -83,7 +83,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
+			s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -205,7 +205,6 @@ namespace Pulumi.Automation
             UpOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            await this.Workspace.SelectStackAsync(this.Name, cancellationToken).ConfigureAwait(false);
             var execKind = ExecKind.Local;
             var program = this.Workspace.Program;
             var args = new List<string>()
@@ -213,6 +212,8 @@ namespace Pulumi.Automation
                 "up",
                 "--yes",
                 "--skip-preview",
+                "--stack",
+                this.Name,
             };
 
             if (options != null)
@@ -304,10 +305,9 @@ namespace Pulumi.Automation
             PreviewOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            await this.Workspace.SelectStackAsync(this.Name, cancellationToken).ConfigureAwait(false);
             var execKind = ExecKind.Local;
             var program = this.Workspace.Program;
-            var args = new List<string>() { "preview" };
+            var args = new List<string>() { "preview", "--stack", this.Name };
 
             if (options != null)
             {
@@ -395,12 +395,13 @@ namespace Pulumi.Automation
             RefreshOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            await this.Workspace.SelectStackAsync(this.Name, cancellationToken).ConfigureAwait(false);
             var args = new List<string>()
             {
                 "refresh",
                 "--yes",
                 "--skip-preview",
+                "--stack",
+                this.Name
             };
 
             if (options != null)
@@ -447,12 +448,13 @@ namespace Pulumi.Automation
             DestroyOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            await this.Workspace.SelectStackAsync(this.Name, cancellationToken).ConfigureAwait(false);
             var args = new List<string>()
             {
                 "destroy",
                 "--yes",
                 "--skip-preview",
+                "--stack",
+                this.Name
             };
 
             if (options != null)
@@ -495,11 +497,9 @@ namespace Pulumi.Automation
         /// </summary>
         private async Task<ImmutableDictionary<string, OutputValue>> GetOutputAsync(CancellationToken cancellationToken)
         {
-            await this.Workspace.SelectStackAsync(this.Name).ConfigureAwait(false);
-
             // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
-            var maskedResult = await this.RunCommandAsync(new[] { "stack", "output", "--json" }, null, cancellationToken).ConfigureAwait(false);
-            var plaintextResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--show-secrets" }, null, cancellationToken).ConfigureAwait(false);
+            var maskedResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--stack", this.Name }, null, cancellationToken).ConfigureAwait(false);
+            var plaintextResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--show-secrets", "--stack", this.Name }, null, cancellationToken).ConfigureAwait(false);
             var jsonOptions = LocalSerializer.BuildJsonSerializerOptions();
             var maskedOutput = JsonSerializer.Deserialize<Dictionary<string, object>>(maskedResult.StandardOutput, jsonOptions);
             var plaintextOutput = JsonSerializer.Deserialize<Dictionary<string, object>>(plaintextResult.StandardOutput, jsonOptions);

--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -129,11 +129,7 @@ func (l *LocalWorkspace) PostCommandCallback(ctx context.Context, stackName stri
 // scoped to the current workspace. LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
 func (l *LocalWorkspace) GetConfig(ctx context.Context, stackName string, key string) (ConfigValue, error) {
 	var val ConfigValue
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return val, errors.Wrapf(err, "could not get config, unable to select stack %s", stackName)
-	}
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "get", key, "--json")
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "get", key, "--json", "--stack", stackName)
 	if err != nil {
 		return val, newAutoError(errors.Wrap(err, "unable to read config"), stdout, stderr, errCode)
 	}
@@ -148,13 +144,9 @@ func (l *LocalWorkspace) GetConfig(ctx context.Context, stackName string, key st
 // LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
 func (l *LocalWorkspace) GetAllConfig(ctx context.Context, stackName string) (ConfigMap, error) {
 	var val ConfigMap
-	err := l.SelectStack(ctx, stackName)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "--show-secrets", "--json", "--stack", stackName)
 	if err != nil {
-		return val, errors.Wrapf(err, "could not get config, unable to select stack %s", stackName)
-	}
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "--show-secrets", "--json")
-	if err != nil {
-		return val, newAutoError(errors.Wrap(err, "unable read config"), stdout, stderr, errCode)
+		return val, newAutoError(errors.Wrap(err, "unable to read config"), stdout, stderr, errCode)
 	}
 	err = json.Unmarshal([]byte(stdout), &val)
 	if err != nil {
@@ -166,19 +158,14 @@ func (l *LocalWorkspace) GetAllConfig(ctx context.Context, stackName string) (Co
 // SetConfig sets the specified key-value pair on the provided stack name.
 // LocalWorkspace writes this value to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) SetConfig(ctx context.Context, stackName string, key string, val ConfigValue) error {
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return errors.Wrapf(err, "could not set config, unable to select stack %s", stackName)
-	}
-
 	secretArg := "--plaintext"
 	if val.Secret {
 		secretArg = "--secret"
 	}
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "set", key, val.Value, secretArg)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "set", key, val.Value, secretArg, "--stack", stackName)
 	if err != nil {
-		return newAutoError(errors.Wrap(err, "unable set config"), stdout, stderr, errCode)
+		return newAutoError(errors.Wrap(err, "unable to set config"), stdout, stderr, errCode)
 	}
 	return nil
 }
@@ -206,12 +193,7 @@ func (l *LocalWorkspace) SetAllConfig(ctx context.Context, stackName string, con
 // RemoveConfig removes the specified key-value pair on the provided stack name.
 // It will remove any matching values in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) RemoveConfig(ctx context.Context, stackName string, key string) error {
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return errors.Wrapf(err, "could not remove config, unable to select stack %s", stackName)
-	}
-
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "rm", key)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "rm", key, "--stack", stackName)
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "could not remove config"), stdout, stderr, errCode)
 	}
@@ -233,12 +215,7 @@ func (l *LocalWorkspace) RemoveAllConfig(ctx context.Context, stackName string, 
 // RefreshConfig gets and sets the config map used with the last Update for Stack matching stack name.
 // It will overwrite all configuration in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) RefreshConfig(ctx context.Context, stackName string) (ConfigMap, error) {
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not refresh config, unable to select stack %s", stackName)
-	}
-
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "refresh", "--force")
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "refresh", "--force", "--stack", stackName)
 	if err != nil {
 		return nil, newAutoError(errors.Wrap(err, "could not refresh config"), stdout, stderr, errCode)
 	}
@@ -427,12 +404,8 @@ func (l *LocalWorkspace) SetProgram(fn pulumi.RunFunc) {
 // This can be combined with ImportStack to edit a stack's state (such as recovery from failed deployments).
 func (l *LocalWorkspace) ExportStack(ctx context.Context, stackName string) (apitype.UntypedDeployment, error) {
 	var state apitype.UntypedDeployment
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return state, errors.Wrapf(err, "could not export stack, unable to select stack %s.", stackName)
-	}
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "export", "--show-secrets")
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "export", "--show-secrets", "--stack", stackName)
 	if err != nil {
 		return state, newAutoError(errors.Wrap(err, "could not export stack."), stdout, stderr, errCode)
 	}
@@ -450,11 +423,6 @@ func (l *LocalWorkspace) ExportStack(ctx context.Context, stackName string) (api
 // ImportStack imports the specified deployment state into a pre-existing stack.
 // This can be combined with ExportStack to edit a stack's state (such as recovery from failed deployments).
 func (l *LocalWorkspace) ImportStack(ctx context.Context, stackName string, state apitype.UntypedDeployment) error {
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return errors.Wrapf(err, "could not import stack, failed to select stack %s.", stackName)
-	}
-
 	f, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		return errors.Wrap(err, "could not import stack. failed to allocate temp file.")
@@ -471,7 +439,7 @@ func (l *LocalWorkspace) ImportStack(ctx context.Context, stackName string, stat
 		return errors.Wrap(err, "could not import stack. failed to write out stack intermediate.")
 	}
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "import", "--file", f.Name())
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "import", "--file", f.Name(), "--stack", stackName)
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "could not import stack."), stdout, stderr, errCode)
 	}
@@ -899,7 +867,7 @@ func SelectStackInlineSource(
 	if err != nil {
 		return stack, errors.Wrap(err, "failed to select stack")
 	}
-	// as we implictly create project on behalf of the user, prepend to opts in case the user specifies one
+	// as we implicitly create project on behalf of the user, prepend to opts in case the user specifies one
 	opts = append([]LocalWorkspaceOption{Project(proj)}, opts...)
 	w, err := NewLocalWorkspace(ctx, opts...)
 	if err != nil {

--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -163,7 +163,8 @@ func (l *LocalWorkspace) SetConfig(ctx context.Context, stackName string, key st
 		secretArg = "--secret"
 	}
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "set", key, val.Value, secretArg, "--stack", stackName)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx,
+		"config", "set", key, val.Value, secretArg, "--stack", stackName)
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "unable to set config"), stdout, stderr, errCode)
 	}

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -574,7 +574,10 @@ func (s *Stack) Info(ctx context.Context) (StackSummary, error) {
 // if a resource operation was pending when the update was canceled.
 // This command is not supported for local backends.
 func (s *Stack) Cancel(ctx context.Context) error {
-	stdout, stderr, errCode, err := s.runPulumiCmdSync(ctx, nil /* additionalOutput */, "cancel", "--yes", "--stack", s.Name())
+	stdout, stderr, errCode, err := s.runPulumiCmdSync(
+		ctx,
+		nil, /* additionalOutput */
+		"cancel", "--yes", "--stack", s.Name())
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "failed to cancel update"), stdout, stderr, errCode)
 	}

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -153,8 +153,7 @@ func NewStack(ctx context.Context, stackName string, ws Workspace) (Stack, error
 }
 
 // SelectStack selects stack using the given workspace, and stack name.
-// It returns an error if the given Stack does not exist. All LocalWorkspace operations will call SelectStack()
-// before running.
+// It returns an error if the given Stack does not exist.
 func SelectStack(ctx context.Context, stackName string, ws Workspace) (Stack, error) {
 	var s Stack
 	s = Stack{
@@ -207,11 +206,6 @@ func (s *Stack) Workspace() Workspace {
 func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (PreviewResult, error) {
 	var res PreviewResult
 
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return res, errors.Wrap(err, "failed to run preview")
-	}
-
 	preOpts := &optpreview.Options{}
 	for _, o := range opts {
 		o.ApplyOption(preOpts)
@@ -239,7 +233,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", preOpts.Parallel))
 	}
 
-	kind, args := constant.ExecKindAutoLocal, []string{"preview", "--json"}
+	kind, args := constant.ExecKindAutoLocal, []string{"preview", "--json", "--stack", s.Name()}
 	if program := s.Workspace().Program(); program != nil {
 		server, err := startLanguageRuntimeServer(program)
 		if err != nil {
@@ -269,10 +263,6 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 // https://www.pulumi.com/docs/reference/cli/pulumi_up/
 func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) {
 	var res UpResult
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return res, errors.Wrap(err, "failed to run update")
-	}
 
 	upOpts := &optup.Options{}
 	for _, o := range opts {
@@ -301,7 +291,7 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", upOpts.Parallel))
 	}
 
-	kind, args := constant.ExecKindAutoLocal, []string{"up", "--yes", "--skip-preview"}
+	kind, args := constant.ExecKindAutoLocal, []string{"up", "--yes", "--skip-preview", "--stack", s.Name()}
 	if program := s.Workspace().Program(); program != nil {
 		server, err := startLanguageRuntimeServer(program)
 		if err != nil {
@@ -347,11 +337,6 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (RefreshResult, error) {
 	var res RefreshResult
 
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return res, errors.Wrap(err, "failed to refresh stack")
-	}
-
 	refreshOpts := &optrefresh.Options{}
 	for _, o := range opts {
 		o.ApplyOption(refreshOpts)
@@ -360,7 +345,7 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 	var args []string
 
 	args = debug.AddArgs(&refreshOpts.DebugLogOpts, args)
-	args = append(args, "refresh", "--yes", "--skip-preview")
+	args = append(args, "refresh", "--yes", "--skip-preview", "--stack", s.Name())
 	if refreshOpts.Message != "" {
 		args = append(args, fmt.Sprintf("--message=%q", refreshOpts.Message))
 	}
@@ -407,11 +392,6 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (DestroyResult, error) {
 	var res DestroyResult
 
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return res, errors.Wrap(err, "failed to destroy stack")
-	}
-
 	destroyOpts := &optdestroy.Options{}
 	for _, o := range opts {
 		o.ApplyOption(destroyOpts)
@@ -420,7 +400,7 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 	var args []string
 
 	args = debug.AddArgs(&destroyOpts.DebugLogOpts, args)
-	args = append(args, "destroy", "--yes", "--skip-preview")
+	args = append(args, "destroy", "--yes", "--skip-preview", "--stack", s.Name())
 	if destroyOpts.Message != "" {
 		args = append(args, fmt.Sprintf("--message=%q", destroyOpts.Message))
 	}
@@ -465,14 +445,9 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 
 // Outputs get the current set of Stack outputs from the last Stack.Up().
 func (s *Stack) Outputs(ctx context.Context) (OutputMap, error) {
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get stack outputs")
-	}
-
 	// standard outputs
 	outStdout, outStderr, code, err := s.runPulumiCmdSync(ctx, nil, /* additionalOutputs */
-		"stack", "output", "--json",
+		"stack", "output", "--json", "--stack", s.Name(),
 	)
 	if err != nil {
 		return nil, newAutoError(errors.Wrap(err, "could not get outputs"), outStdout, outStderr, code)
@@ -480,7 +455,7 @@ func (s *Stack) Outputs(ctx context.Context) (OutputMap, error) {
 
 	// secret outputs
 	secretStdout, secretStderr, code, err := s.runPulumiCmdSync(ctx, nil, /* additionalOutputs */
-		"stack", "output", "--json", "--show-secrets",
+		"stack", "output", "--json", "--show-secrets", "--stack", s.Name(),
 	)
 	if err != nil {
 		return nil, newAutoError(errors.Wrap(err, "could not get secret outputs"), outStdout, outStderr, code)
@@ -516,7 +491,7 @@ func (s *Stack) History(ctx context.Context, pageSize int, page int) ([]UpdateSu
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get stack history")
 	}
-	args := []string{"history", "--json", "--show-secrets"}
+	args := []string{"history", "--json", "--show-secrets", "--stack", s.Name()}
 	if pageSize > 0 {
 		// default page=1 if unset when pageSize is set
 		if page < 1 {
@@ -599,12 +574,7 @@ func (s *Stack) Info(ctx context.Context) (StackSummary, error) {
 // if a resource operation was pending when the update was canceled.
 // This command is not supported for local backends.
 func (s *Stack) Cancel(ctx context.Context) error {
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return errors.Wrap(err, "failed to cancel update")
-	}
-
-	stdout, stderr, errCode, err := s.runPulumiCmdSync(ctx, nil /* additionalOutput */, "cancel", "--yes")
+	stdout, stderr, errCode, err := s.runPulumiCmdSync(ctx, nil /* additionalOutput */, "cancel", "--yes", "--stack", s.Name())
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "failed to cancel update"), stdout, stderr, errCode)
 	}

--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -346,8 +346,7 @@ export class LocalWorkspace implements Workspace {
      * @param key The key to use for the config lookup
      */
     async getConfig(stackName: string, key: string): Promise<ConfigValue> {
-        await this.selectStack(stackName);
-        const result = await this.runPulumiCmd(["config", "get", key, "--json"]);
+        const result = await this.runPulumiCmd(["config", "get", key, "--json", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
     /**
@@ -357,8 +356,7 @@ export class LocalWorkspace implements Workspace {
      * @param stackName The stack to read config from
      */
     async getAllConfig(stackName: string): Promise<ConfigMap> {
-        await this.selectStack(stackName);
-        const result = await this.runPulumiCmd(["config", "--show-secrets", "--json"]);
+        const result = await this.runPulumiCmd(["config", "--show-secrets", "--json", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
     /**
@@ -370,9 +368,8 @@ export class LocalWorkspace implements Workspace {
      * @param value The value to set
      */
     async setConfig(stackName: string, key: string, value: ConfigValue): Promise<void> {
-        await this.selectStack(stackName);
         const secretArg = value.secret ? "--secret" : "--plaintext";
-        await this.runPulumiCmd(["config", "set", key, value.value, secretArg]);
+        await this.runPulumiCmd(["config", "set", key, value.value, secretArg, "--stack", stackName]);
     }
     /**
      * Sets all values in the provided config map for the specified stack name.
@@ -398,8 +395,7 @@ export class LocalWorkspace implements Workspace {
      * @param key The config key to remove
      */
     async removeConfig(stackName: string, key: string): Promise<void> {
-        await this.selectStack(stackName);
-        await this.runPulumiCmd(["config", "rm", key]);
+        await this.runPulumiCmd(["config", "rm", key, "--stack", stackName]);
     }
     /**
      *
@@ -419,8 +415,7 @@ export class LocalWorkspace implements Workspace {
      * @param stackName The stack to refresh
      */
     async refreshConfig(stackName: string): Promise<ConfigMap> {
-        await this.selectStack(stackName);
-        await this.runPulumiCmd(["config", "refresh", "--force"]);
+        await this.runPulumiCmd(["config", "refresh", "--force", "--stack", stackName]);
         return this.getAllConfig(stackName);
     }
     /**
@@ -498,8 +493,7 @@ export class LocalWorkspace implements Workspace {
      * @param stackName the name of the stack.
      */
     async exportStack(stackName: string): Promise<Deployment> {
-        await this.selectStack(stackName);
-        const result = await this.runPulumiCmd(["stack", "export", "--show-secrets"]);
+        const result = await this.runPulumiCmd(["stack", "export", "--show-secrets", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
     /**
@@ -510,12 +504,11 @@ export class LocalWorkspace implements Workspace {
      * @param state the stack state to import.
      */
     async importStack(stackName: string, state: Deployment): Promise<void> {
-        await this.selectStack(stackName);
         const randomSuffix = Math.floor(100000 + Math.random() * 900000);
         const filepath = upath.joinSafe(os.tmpdir(), `automation-${randomSuffix}`);
         const contents = JSON.stringify(state, null, 4);
         fs.writeFileSync(filepath, contents);
-        await this.runPulumiCmd(["stack", "import", "--file", filepath]);
+        await this.runPulumiCmd(["stack", "import", "--file", filepath, "--stack", stackName]);
         fs.unlinkSync(filepath);
     }
     /**

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -56,8 +56,7 @@ export class Stack {
     }
     /**
      * Selects stack using the given workspace, and stack name.
-     * It returns an error if the given Stack does not exist. All LocalWorkspace operations will call `select`
-     * before running.
+     * It returns an error if the given Stack does not exist.
      *
      * @param name The name identifying the Stack.
      * @param workspace The Workspace the Stack was created from.
@@ -111,10 +110,9 @@ export class Stack {
      * @param opts Options to customize the behavior of the update.
      */
     async up(opts?: UpOptions): Promise<UpResult> {
-        const args = ["up", "--yes", "--skip-preview"];
+        const args = ["up", "--yes", "--skip-preview", "--stack", this.name];
         let kind = execKind.local;
         let program = this.workspace.program;
-        await this.workspace.selectStack(this.name);
 
         if (opts) {
             if (opts.program) {
@@ -177,8 +175,7 @@ export class Stack {
         } finally {
             onExit();
         }
-        
-        
+
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
         const outputs = await this.outputs();
         const summary = await this.info();
@@ -197,10 +194,9 @@ export class Stack {
      */
     async preview(opts?: PreviewOptions): Promise<PreviewResult> {
         // TODO JSON
-        const args = ["preview"];
+        const args = ["preview", "--stack", this.name];
         let kind = execKind.local;
         let program = this.workspace.program;
-        await this.workspace.selectStack(this.name);
 
         if (opts) {
             if (opts.program) {
@@ -277,8 +273,7 @@ export class Stack {
      * @param opts Options to customize the behavior of the refresh.
      */
     async refresh(opts?: RefreshOptions): Promise<RefreshResult> {
-        const args = ["refresh", "--yes", "--skip-preview"];
-        await this.workspace.selectStack(this.name);
+        const args = ["refresh", "--yes", "--skip-preview", "--stack", this.name];
 
         if (opts) {
             if (opts.message) {
@@ -311,8 +306,7 @@ export class Stack {
      * @param opts Options to customize the behavior of the destroy.
      */
     async destroy(opts?: DestroyOptions): Promise<DestroyResult> {
-        const args = ["destroy", "--yes", "--skip-preview"];
-        await this.workspace.selectStack(this.name);
+        const args = ["destroy", "--yes", "--skip-preview", "--stack", this.name];
 
         if (opts) {
             if (opts.message) {
@@ -396,10 +390,9 @@ export class Stack {
      * Gets the current set of Stack outputs from the last Stack.up().
      */
     async outputs(): Promise<OutputMap> {
-        await this.workspace.selectStack(this.name);
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
-        const maskedResult = await this.runPulumiCmd(["stack", "output", "--json"]);
-        const plaintextResult = await this.runPulumiCmd(["stack", "output", "--json", "--show-secrets"]);
+        const maskedResult = await this.runPulumiCmd(["stack", "output", "--json", "--stack", this.name]);
+        const plaintextResult = await this.runPulumiCmd(["stack", "output", "--json", "--show-secrets", "--stack", this.name]);
         const maskedOuts = JSON.parse(maskedResult.stdout);
         const plaintextOuts = JSON.parse(plaintextResult.stdout);
         const outputs: OutputMap = {};
@@ -446,8 +439,7 @@ export class Stack {
      * This command is not supported for local backends.
      */
     async cancel(): Promise<void> {
-        await this.workspace.selectStack(this.name);
-        await this.runPulumiCmd(["cancel", "--yes"]);
+        await this.runPulumiCmd(["cancel", "--yes", "--stack", this.name]);
     }
 
     /**

--- a/sdk/python/lib/pulumi/x/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_local_workspace.py
@@ -149,14 +149,12 @@ class LocalWorkspace(Workspace):
         return
 
     def get_config(self, stack_name: str, key: str) -> ConfigValue:
-        self.select_stack(stack_name)
-        result = self._run_pulumi_cmd_sync(["config", "get", key, "--json"])
+        result = self._run_pulumi_cmd_sync(["config", "get", key, "--json", "-s", stack_name])
         val = json.loads(result.stdout)
         return ConfigValue(value=val["value"], secret=val["secret"])
 
     def get_all_config(self, stack_name: str) -> ConfigMap:
-        self.select_stack(stack_name)
-        result = self._run_pulumi_cmd_sync(["config", "--show-secrets", "--json"])
+        result = self._run_pulumi_cmd_sync(["config", "--show-secrets", "--json", "-s", stack_name])
         config_json = json.loads(result.stdout)
         config_map: ConfigMap = {}
         for key in config_json:
@@ -165,9 +163,8 @@ class LocalWorkspace(Workspace):
         return config_map
 
     def set_config(self, stack_name: str, key: str, value: ConfigValue) -> None:
-        self.select_stack(stack_name)
         secret_arg = "--secret" if value.secret else "--plaintext"
-        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg])
+        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg, "-s", stack_name])
 
     def set_all_config(self, stack_name: str, config: ConfigMap) -> None:
         args = ["config", "set-all", "--stack", stack_name]
@@ -179,8 +176,7 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(args)
 
     def remove_config(self, stack_name: str, key: str) -> None:
-        self.select_stack(stack_name)
-        self._run_pulumi_cmd_sync(["config", "rm", key])
+        self._run_pulumi_cmd_sync(["config", "rm", key, "-s", stack_name])
 
     def remove_all_config(self, stack_name: str, keys: List[str]) -> None:
         args = ["config", "rm-all", "--stack", stack_name]
@@ -188,8 +184,7 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(args)
 
     def refresh_config(self, stack_name: str) -> None:
-        self.select_stack(stack_name)
-        self._run_pulumi_cmd_sync(["config", "refresh", "--force"])
+        self._run_pulumi_cmd_sync(["config", "refresh", "--force", "-s", stack_name])
         self.get_all_config(stack_name)
 
     def who_am_i(self) -> WhoAmIResult:
@@ -262,17 +257,15 @@ class LocalWorkspace(Workspace):
         return plugin_list
 
     def export_stack(self, stack_name: str) -> Deployment:
-        self.select_stack(stack_name)
-        result = self._run_pulumi_cmd_sync(["stack", "export", "--show-secrets"])
+        result = self._run_pulumi_cmd_sync(["stack", "export", "--show-secrets", "-s", stack_name])
         state_json = json.loads(result.stdout)
         return Deployment(**state_json)
 
     def import_stack(self, stack_name: str, state: Deployment) -> None:
-        self.select_stack(stack_name)
         file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         json.dump(state.__dict__, file, indent=4)
         file.close()
-        self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name])
+        self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name, "-s", stack_name])
         os.remove(file.name)
 
     def _run_pulumi_cmd_sync(self, args: List[str], on_output: Optional[OnOutput] = None) -> CommandResult:

--- a/sdk/python/lib/pulumi/x/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_local_workspace.py
@@ -149,12 +149,12 @@ class LocalWorkspace(Workspace):
         return
 
     def get_config(self, stack_name: str, key: str) -> ConfigValue:
-        result = self._run_pulumi_cmd_sync(["config", "get", key, "--json", "-s", stack_name])
+        result = self._run_pulumi_cmd_sync(["config", "get", key, "--json", "--stack", stack_name])
         val = json.loads(result.stdout)
         return ConfigValue(value=val["value"], secret=val["secret"])
 
     def get_all_config(self, stack_name: str) -> ConfigMap:
-        result = self._run_pulumi_cmd_sync(["config", "--show-secrets", "--json", "-s", stack_name])
+        result = self._run_pulumi_cmd_sync(["config", "--show-secrets", "--json", "--stack", stack_name])
         config_json = json.loads(result.stdout)
         config_map: ConfigMap = {}
         for key in config_json:
@@ -164,7 +164,7 @@ class LocalWorkspace(Workspace):
 
     def set_config(self, stack_name: str, key: str, value: ConfigValue) -> None:
         secret_arg = "--secret" if value.secret else "--plaintext"
-        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg, "-s", stack_name])
+        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg, "--stack", stack_name])
 
     def set_all_config(self, stack_name: str, config: ConfigMap) -> None:
         args = ["config", "set-all", "--stack", stack_name]
@@ -176,7 +176,7 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(args)
 
     def remove_config(self, stack_name: str, key: str) -> None:
-        self._run_pulumi_cmd_sync(["config", "rm", key, "-s", stack_name])
+        self._run_pulumi_cmd_sync(["config", "rm", key, "--stack", stack_name])
 
     def remove_all_config(self, stack_name: str, keys: List[str]) -> None:
         args = ["config", "rm-all", "--stack", stack_name]
@@ -184,7 +184,7 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(args)
 
     def refresh_config(self, stack_name: str) -> None:
-        self._run_pulumi_cmd_sync(["config", "refresh", "--force", "-s", stack_name])
+        self._run_pulumi_cmd_sync(["config", "refresh", "--force", "--stack", stack_name])
         self.get_all_config(stack_name)
 
     def who_am_i(self) -> WhoAmIResult:
@@ -257,7 +257,7 @@ class LocalWorkspace(Workspace):
         return plugin_list
 
     def export_stack(self, stack_name: str) -> Deployment:
-        result = self._run_pulumi_cmd_sync(["stack", "export", "--show-secrets", "-s", stack_name])
+        result = self._run_pulumi_cmd_sync(["stack", "export", "--show-secrets", "--stack", stack_name])
         state_json = json.loads(result.stdout)
         return Deployment(**state_json)
 
@@ -265,7 +265,7 @@ class LocalWorkspace(Workspace):
         file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         json.dump(state.__dict__, file, indent=4)
         file.close()
-        self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name, "-s", stack_name])
+        self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name, "--stack", stack_name])
         os.remove(file.name)
 
     def _run_pulumi_cmd_sync(self, args: List[str], on_output: Optional[OnOutput] = None) -> CommandResult:

--- a/sdk/python/lib/pulumi/x/automation/_stack.py
+++ b/sdk/python/lib/pulumi/x/automation/_stack.py
@@ -165,8 +165,7 @@ class Stack:
     def select(cls, stack_name: str, workspace: Workspace) -> 'Stack':
         """
         Selects stack using the given workspace, and stack name.
-        It returns an error if the given Stack does not exist. All LocalWorkspace operations will call `select` before
-        running.
+        It returns an error if the given Stack does not exist.
 
         :param stack_name: The name identifying the Stack
         :param workspace: The Workspace the Stack was created from.
@@ -247,10 +246,9 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["up", "--yes", "--skip-preview"]
+        args = ["up", "--yes", "--skip-preview", "-s", self.name]
         args.extend(extra_args)
 
-        self.workspace.select_stack(self.name)
         kind = ExecKind.LOCAL.value
         on_exit = None
 
@@ -305,10 +303,9 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["preview"]
+        args = ["preview", "-s", self.name]
         args.extend(extra_args)
 
-        self.workspace.select_stack(self.name)
         kind = ExecKind.LOCAL.value
         on_exit = None
 
@@ -356,10 +353,9 @@ class Stack:
         :returns: RefreshResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["refresh", "--yes", "--skip-preview"]
+        args = ["refresh", "--yes", "--skip-preview", "-s", self.name]
         args.extend(extra_args)
 
-        self.workspace.select_stack(self.name)
         refresh_result = self._run_pulumi_cmd_sync(args, on_output)
         summary = self.info()
         assert(summary is not None)
@@ -383,10 +379,9 @@ class Stack:
         :returns: DestroyResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["destroy", "--yes", "--skip-preview"]
+        args = ["destroy", "--yes", "--skip-preview", "-s", self.name]
         args.extend(extra_args)
 
-        self.workspace.select_stack(self.name)
         destroy_result = self._run_pulumi_cmd_sync(args, on_output)
         summary = self.info()
         assert(summary is not None)
@@ -452,10 +447,8 @@ class Stack:
 
         :returns: OutputMap
         """
-        self.workspace.select_stack(self.name)
-
-        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json"])
-        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets"])
+        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "-s", self.name])
+        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets", "-s", self.name])
         masked_outputs = json.loads(masked_result.stdout)
         plaintext_outputs = json.loads(plaintext_result.stdout)
         outputs: OutputMap = {}
@@ -476,7 +469,7 @@ class Stack:
 
         :returns: List[UpdateSummary]
         """
-        args = ["history", "--json", "--show-secrets"]
+        args = ["history", "--json", "--show-secrets", "-s", self.name]
         if page_size is not None:
             # default page=1 when page_size is set
             if page is None:
@@ -518,8 +511,7 @@ class Stack:
         if a resource operation was pending when the update was canceled.
         This command is not supported for local backends.
         """
-        self.workspace.select_stack(self.name)
-        self._run_pulumi_cmd_sync(["cancel", "--yes"])
+        self._run_pulumi_cmd_sync(["cancel", "--yes", "-s", self.name])
 
     def export_stack(self) -> Deployment:
         """

--- a/sdk/python/lib/pulumi/x/automation/_stack.py
+++ b/sdk/python/lib/pulumi/x/automation/_stack.py
@@ -246,7 +246,7 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["up", "--yes", "--skip-preview", "-s", self.name]
+        args = ["up", "--yes", "--skip-preview", "--stack", self.name]
         args.extend(extra_args)
 
         kind = ExecKind.LOCAL.value
@@ -303,7 +303,7 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["preview", "-s", self.name]
+        args = ["preview", "--stack", self.name]
         args.extend(extra_args)
 
         kind = ExecKind.LOCAL.value
@@ -353,7 +353,7 @@ class Stack:
         :returns: RefreshResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["refresh", "--yes", "--skip-preview", "-s", self.name]
+        args = ["refresh", "--yes", "--skip-preview", "--stack", self.name]
         args.extend(extra_args)
 
         refresh_result = self._run_pulumi_cmd_sync(args, on_output)
@@ -379,7 +379,7 @@ class Stack:
         :returns: DestroyResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["destroy", "--yes", "--skip-preview", "-s", self.name]
+        args = ["destroy", "--yes", "--skip-preview", "--stack", self.name]
         args.extend(extra_args)
 
         destroy_result = self._run_pulumi_cmd_sync(args, on_output)
@@ -447,8 +447,8 @@ class Stack:
 
         :returns: OutputMap
         """
-        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "-s", self.name])
-        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets", "-s", self.name])
+        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--stack", self.name])
+        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets", "--stack", self.name])
         masked_outputs = json.loads(masked_result.stdout)
         plaintext_outputs = json.loads(plaintext_result.stdout)
         outputs: OutputMap = {}
@@ -469,7 +469,7 @@ class Stack:
 
         :returns: List[UpdateSummary]
         """
-        args = ["history", "--json", "--show-secrets", "-s", self.name]
+        args = ["history", "--json", "--show-secrets", "--stack", self.name]
         if page_size is not None:
             # default page=1 when page_size is set
             if page is None:
@@ -511,7 +511,7 @@ class Stack:
         if a resource operation was pending when the update was canceled.
         This command is not supported for local backends.
         """
-        self._run_pulumi_cmd_sync(["cancel", "--yes", "-s", self.name])
+        self._run_pulumi_cmd_sync(["cancel", "--yes", "--stack", self.name])
 
     def export_stack(self) -> Deployment:
         """


### PR DESCRIPTION
This PR has 2 purposes:

1. Standardize the `--stack` flag in the CLI to `setCurrent=False` (this is a breaking change and we will keep it in a 3.0 branch)
2. Change the automation API implementation in each language to use the `--stack` flag for stack operations rather than first running `selectStack`, followed by the operation in question.

**Note:** I would like to get this PR reviewed but will hold off on merging this until we have our 3.0 branch figured out.

Fixes: https://github.com/pulumi/pulumi/issues/5257 and https://github.com/pulumi/pulumi/issues/6062