### PR TITLE
Do not specify a specific version of Python on Windows

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -200,7 +200,7 @@
 
   <Target Name="PythonDependencies">
     <MakeDir Directories="$(PythonSdkDirectory)\env\src"/>
-    <Exec Command="pipenv --python 3.7 install --dev"
+    <Exec Command="pipenv install --dev"
           WorkingDirectory="$(PythonSdkDirectory)\env\src" />
   </Target>
   

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1770,14 +1770,7 @@ func (pt *ProgramTester) preparePythonProjectWithPipenv(cwd string) error {
 	// Create a new Pipenv environment. This bootstraps a new virtual environment containing the version of Python that
 	// we requested. Note that this version of Python is sourced from the machine, so you must first install the version
 	// of Python that you are requesting on the host machine before building a virtualenv for it.
-	pythonVersion := "3"
-	if runtime.GOOS == windowsOS {
-		// Due to https://bugs.python.org/issue34679, Python Dynamic Providers on Windows do not
-		// work on Python 3.8.0 (but are fixed in 3.8.1).  For now we will force Windows to use 3.7
-		// to avoid this bug, until 3.8.1 is available in all our CI systems.
-		pythonVersion = "3.7"
-	}
-	if err := pt.runPipenvCommand("pipenv-new", []string{"--python", pythonVersion}, cwd); err != nil {
+	if err := pt.runPipenvCommand("pipenv-new", []string{"--python", "3"}, cwd); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
We install the version of Python we need in the CI environment (e.g. 3.9.x).