### PR TITLE
Allow optional inputs to be Input<T | undefined>

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,9 @@
 ### Improvements
 
+- [sdk/nodejs] - Type optional input properties as `Input<T | undefined> | undefined` instead of
+  `Input<T> | undefined`. This allows users to pass `Output<T | undefined>` for optional input
+  properties.
+  [#6323](https://github.com/pulumi/pulumi/pull/6323)
 
 ### Bug Fixes
 

--- a/pkg/codegen/internal/test/testdata/dash-named-schema/nodejs/submodule1/moduleResource.ts
+++ b/pkg/codegen/internal/test/testdata/dash-named-schema/nodejs/submodule1/moduleResource.ts
@@ -58,5 +58,5 @@ export class ModuleResource extends pulumi.CustomResource {
  * The set of arguments for constructing a ModuleResource resource.
  */
 export interface ModuleResourceArgs {
-    thing?: pulumi.Input<inputs.TopLevelArgs>;
+    thing?: pulumi.Input<inputs.TopLevelArgs | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/dash-named-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/dash-named-schema/nodejs/types/input.ts
@@ -5,5 +5,5 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "../types";
 
 export interface TopLevelArgs {
-    buzz?: pulumi.Input<string>;
+    buzz?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/nodejs/tree/v1/nursery.ts
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/nodejs/tree/v1/nursery.ts
@@ -63,7 +63,7 @@ export interface NurseryArgs {
     /**
      * The sizes of trees available
      */
-    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>}>;
+    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>} | undefined>;
     /**
      * The varieties available
      */

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/nodejs/tree/v1/rubberTree.ts
@@ -73,16 +73,16 @@ export class RubberTree extends pulumi.CustomResource {
 }
 
 export interface RubberTreeState {
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
+    farm?: pulumi.Input<enums.tree.v1.Farm | string | undefined>;
 }
 
 /**
  * The set of arguments for constructing a RubberTree resource.
  */
 export interface RubberTreeArgs {
-    container?: pulumi.Input<inputs.ContainerArgs>;
+    container?: pulumi.Input<inputs.ContainerArgs | undefined>;
     diameter: pulumi.Input<enums.tree.v1.Diameter>;
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
-    size?: pulumi.Input<enums.tree.v1.TreeSize>;
+    farm?: pulumi.Input<enums.tree.v1.Farm | string | undefined>;
+    size?: pulumi.Input<enums.tree.v1.TreeSize | undefined>;
     type: pulumi.Input<enums.tree.v1.RubberTreeVariety>;
 }

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/nodejs/types/input.ts
@@ -7,9 +7,9 @@ import { input as inputs, output as outputs, enums } from "../types";
 import * as utilities from "../utilities";
 
 export interface ContainerArgs {
-    brightness?: pulumi.Input<enums.ContainerBrightness>;
-    color?: pulumi.Input<enums.ContainerColor | string>;
-    material?: pulumi.Input<string>;
+    brightness?: pulumi.Input<enums.ContainerBrightness | undefined>;
+    color?: pulumi.Input<enums.ContainerColor | string | undefined>;
+    material?: pulumi.Input<string | undefined>;
     size: pulumi.Input<enums.ContainerSize>;
 }
 /**

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/argFunction.ts
@@ -31,5 +31,5 @@ export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.In
 }
 
 export interface ArgFunctionOutputArgs {
-    name?: pulumi.Input<pulumiRandom.RandomPet>;
+    name?: pulumi.Input<pulumiRandom.RandomPet | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/cat.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/cat.ts
@@ -62,6 +62,6 @@ export class Cat extends pulumi.CustomResource {
  * The set of arguments for constructing a Cat resource.
  */
 export interface CatArgs {
-    age?: pulumi.Input<number>;
-    pet?: pulumi.Input<inputs.PetArgs>;
+    age?: pulumi.Input<number | undefined>;
+    pet?: pulumi.Input<inputs.PetArgs | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/component.ts
@@ -81,9 +81,9 @@ export class Component extends pulumi.CustomResource {
  * The set of arguments for constructing a Component resource.
  */
 export interface ComponentArgs {
-    metadata?: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>;
-    metadataArray?: pulumi.Input<pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>[]>;
-    metadataMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>}>;
+    metadata?: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs | undefined>;
+    metadataArray?: pulumi.Input<pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>[] | undefined>;
+    metadataMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>} | undefined>;
     requiredMetadata: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>;
     requiredMetadataArray: pulumi.Input<pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>[]>;
     requiredMetadataMap: pulumi.Input<{[key: string]: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>}>;

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/types/input.ts
@@ -7,10 +7,10 @@ import { input as inputs, output as outputs } from "../types";
 import * as pulumiRandom from "@pulumi/random";
 
 export interface PetArgs {
-    age?: pulumi.Input<number>;
-    name?: pulumi.Input<pulumiRandom.RandomPet>;
-    nameArray?: pulumi.Input<pulumi.Input<pulumiRandom.RandomPet>[]>;
-    nameMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiRandom.RandomPet>}>;
+    age?: pulumi.Input<number | undefined>;
+    name?: pulumi.Input<pulumiRandom.RandomPet | undefined>;
+    nameArray?: pulumi.Input<pulumi.Input<pulumiRandom.RandomPet>[] | undefined>;
+    nameMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiRandom.RandomPet>} | undefined>;
     requiredName: pulumi.Input<pulumiRandom.RandomPet>;
     requiredNameArray: pulumi.Input<pulumi.Input<pulumiRandom.RandomPet>[]>;
     requiredNameMap: pulumi.Input<{[key: string]: pulumi.Input<pulumiRandom.RandomPet>}>;

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/nodejs/deeply/nested/module/resource.ts
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/nodejs/deeply/nested/module/resource.ts
@@ -59,5 +59,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    baz?: pulumi.Input<string>;
+    baz?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/nested-module/nodejs/nested/module/resource.ts
+++ b/pkg/codegen/internal/test/testdata/nested-module/nodejs/nested/module/resource.ts
@@ -59,5 +59,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/nodejs/listConfigurations.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/nodejs/listConfigurations.ts
@@ -63,9 +63,9 @@ export interface ListConfigurationsOutputArgs {
     /**
      * Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
      */
-    customerSubscriptionDetails?: pulumi.Input<inputs.CustomerSubscriptionDetailsArgs>;
+    customerSubscriptionDetails?: pulumi.Input<inputs.CustomerSubscriptionDetailsArgs | undefined>;
     /**
      * $skipToken is supported on list of configurations, which provides the next page in the list of configurations.
      */
-    skipToken?: pulumi.Input<string>;
+    skipToken?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/nodejs/listProductFamilies.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/nodejs/listProductFamilies.ts
@@ -64,11 +64,11 @@ export interface ListProductFamiliesOutputArgs {
     /**
      * Customer subscription properties. Clients can display available products to unregistered customers by explicitly passing subscription details
      */
-    customerSubscriptionDetails?: pulumi.Input<inputs.CustomerSubscriptionDetailsArgs>;
+    customerSubscriptionDetails?: pulumi.Input<inputs.CustomerSubscriptionDetailsArgs | undefined>;
     /**
      * $expand is supported on configurations parameter for product, which provides details on the configurations for the product.
      */
-    expand?: pulumi.Input<string>;
+    expand?: pulumi.Input<string | undefined>;
     /**
      * Dictionary of filterable properties on product family.
      */
@@ -76,5 +76,5 @@ export interface ListProductFamiliesOutputArgs {
     /**
      * $skipToken is supported on list of product families, which provides the next page in the list of product families.
      */
-    skipToken?: pulumi.Input<string>;
+    skipToken?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/nodejs/types/input.ts
@@ -11,7 +11,7 @@ export interface ConfigurationFiltersArgs {
     /**
      * Filters specific to product
      */
-    filterableProperty?: pulumi.Input<pulumi.Input<inputs.FilterablePropertyArgs>[]>;
+    filterableProperty?: pulumi.Input<pulumi.Input<inputs.FilterablePropertyArgs>[] | undefined>;
     /**
      * Product hierarchy information
      */
@@ -57,7 +57,7 @@ export interface CustomerSubscriptionDetailsArgs {
     /**
      * Location placement Id of a subscription
      */
-    locationPlacementId?: pulumi.Input<string>;
+    locationPlacementId?: pulumi.Input<string | undefined>;
     /**
      * Quota ID of a subscription
      */
@@ -65,7 +65,7 @@ export interface CustomerSubscriptionDetailsArgs {
     /**
      * List of registered feature flags for subscription
      */
-    registeredFeatures?: pulumi.Input<pulumi.Input<inputs.CustomerSubscriptionRegisteredFeaturesArgs>[]>;
+    registeredFeatures?: pulumi.Input<pulumi.Input<inputs.CustomerSubscriptionRegisteredFeaturesArgs>[] | undefined>;
 }
 
 /**
@@ -89,11 +89,11 @@ export interface CustomerSubscriptionRegisteredFeaturesArgs {
     /**
      * Name of subscription registered feature
      */
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
     /**
      * State of subscription registered feature
      */
-    state?: pulumi.Input<string>;
+    state?: pulumi.Input<string | undefined>;
 }
 
 /**
@@ -153,18 +153,18 @@ export interface HierarchyInformationArgs {
     /**
      * Represents configuration name that uniquely identifies configuration
      */
-    configurationName?: pulumi.Input<string>;
+    configurationName?: pulumi.Input<string | undefined>;
     /**
      * Represents product family name that uniquely identifies product family
      */
-    productFamilyName?: pulumi.Input<string>;
+    productFamilyName?: pulumi.Input<string | undefined>;
     /**
      * Represents product line name that uniquely identifies product line
      */
-    productLineName?: pulumi.Input<string>;
+    productLineName?: pulumi.Input<string | undefined>;
     /**
      * Represents product name that uniquely identifies product
      */
-    productName?: pulumi.Input<string>;
+    productName?: pulumi.Input<string | undefined>;
 }
 

--- a/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/nodejs/getAmiIds.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/nodejs/getAmiIds.ts
@@ -86,13 +86,13 @@ export interface GetAmiIdsOutputArgs {
      * Limit search to users with *explicit* launch
      * permission on  the image. Valid items are the numeric account ID or `self`.
      */
-    executableUsers?: pulumi.Input<pulumi.Input<string>[]>;
+    executableUsers?: pulumi.Input<pulumi.Input<string>[] | undefined>;
     /**
      * One or more name/value pairs to filter off of. There
      * are several valid keys, for a full reference, check out
      * [describe-images in the AWS CLI reference][1].
      */
-    filters?: pulumi.Input<pulumi.Input<inputs.GetAmiIdsFilterArgs>[]>;
+    filters?: pulumi.Input<pulumi.Input<inputs.GetAmiIdsFilterArgs>[] | undefined>;
     /**
      * A regex string to apply to the AMI list returned
      * by AWS. This allows more advanced filtering not supported from the AWS API.
@@ -100,7 +100,7 @@ export interface GetAmiIdsOutputArgs {
      * impact if the result is large. It is recommended to combine this with other
      * options to narrow down the list AWS returns.
      */
-    nameRegex?: pulumi.Input<string>;
+    nameRegex?: pulumi.Input<string | undefined>;
     /**
      * List of AMI owners to limit search. At least 1 value must be specified. Valid values: an AWS account ID, `self` (the current account), or an AWS owner alias (e.g. `amazon`, `aws-marketplace`, `microsoft`).
      */
@@ -108,5 +108,5 @@ export interface GetAmiIdsOutputArgs {
     /**
      * Used to sort AMIs by creation time.
      */
-    sortAscending?: pulumi.Input<boolean>;
+    sortAscending?: pulumi.Input<boolean | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/nodejs/listStorageAccountKeys.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/nodejs/listStorageAccountKeys.ts
@@ -59,7 +59,7 @@ export interface ListStorageAccountKeysOutputArgs {
     /**
      * Specifies type of the key to be listed. Possible value is kerb.
      */
-    expand?: pulumi.Input<string>;
+    expand?: pulumi.Input<string | undefined>;
     /**
      * The name of the resource group within the user's subscription. The name is case insensitive.
      */

--- a/pkg/codegen/internal/test/testdata/output-funcs/nodejs/funcWithAllOptionalInputs.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs/nodejs/funcWithAllOptionalInputs.ts
@@ -43,9 +43,9 @@ export interface FuncWithAllOptionalInputsOutputArgs {
     /**
      * Property A
      */
-    a?: pulumi.Input<string>;
+    a?: pulumi.Input<string | undefined>;
     /**
      * Property B
      */
-    b?: pulumi.Input<string>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs/nodejs/funcWithDefaultValue.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs/nodejs/funcWithDefaultValue.ts
@@ -34,5 +34,5 @@ export function funcWithDefaultValueOutput(args: FuncWithDefaultValueOutputArgs,
 
 export interface FuncWithDefaultValueOutputArgs {
     a: pulumi.Input<string>;
-    b?: pulumi.Input<string>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs/nodejs/funcWithDictParam.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs/nodejs/funcWithDictParam.ts
@@ -34,6 +34,6 @@ export function funcWithDictParamOutput(args?: FuncWithDictParamOutputArgs, opts
 }
 
 export interface FuncWithDictParamOutputArgs {
-    a?: pulumi.Input<{[key: string]: pulumi.Input<string>}>;
-    b?: pulumi.Input<string>;
+    a?: pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs/nodejs/funcWithListParam.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs/nodejs/funcWithListParam.ts
@@ -34,6 +34,6 @@ export function funcWithListParamOutput(args?: FuncWithListParamOutputArgs, opts
 }
 
 export interface FuncWithListParamOutputArgs {
-    a?: pulumi.Input<pulumi.Input<string>[]>;
-    b?: pulumi.Input<string>;
+    a?: pulumi.Input<pulumi.Input<string>[] | undefined>;
+    b?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs/nodejs/getBastionShareableLink.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs/nodejs/getBastionShareableLink.ts
@@ -63,5 +63,5 @@ export interface GetBastionShareableLinkOutputArgs {
     /**
      * List of VM references.
      */
-    vms?: pulumi.Input<pulumi.Input<inputs.BastionShareableLinkArgs>[]>;
+    vms?: pulumi.Input<pulumi.Input<inputs.BastionShareableLinkArgs>[] | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs/nodejs/getIntegrationRuntimeObjectMetadatum.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs/nodejs/getIntegrationRuntimeObjectMetadatum.ts
@@ -72,7 +72,7 @@ export interface GetIntegrationRuntimeObjectMetadatumOutputArgs {
     /**
      * Metadata path.
      */
-    metadataPath?: pulumi.Input<string>;
+    metadataPath?: pulumi.Input<string | undefined>;
     /**
      * The resource group name.
      */

--- a/pkg/codegen/internal/test/testdata/output-funcs/nodejs/listStorageAccountKeys.ts
+++ b/pkg/codegen/internal/test/testdata/output-funcs/nodejs/listStorageAccountKeys.ts
@@ -59,7 +59,7 @@ export interface ListStorageAccountKeysOutputArgs {
     /**
      * Specifies type of the key to be listed. Possible value is kerb.
      */
-    expand?: pulumi.Input<string>;
+    expand?: pulumi.Input<string | undefined>;
     /**
      * The name of the resource group within the user's subscription. The name is case insensitive.
      */

--- a/pkg/codegen/internal/test/testdata/plain-and-default/nodejs/moduleResource.ts
+++ b/pkg/codegen/internal/test/testdata/plain-and-default/nodejs/moduleResource.ts
@@ -96,11 +96,11 @@ export class ModuleResource extends pulumi.CustomResource {
  * The set of arguments for constructing a ModuleResource resource.
  */
 export interface ModuleResourceArgs {
-    optional_bool?: pulumi.Input<boolean>;
-    optional_const?: pulumi.Input<"val">;
-    optional_enum?: pulumi.Input<enums.EnumThing>;
-    optional_number?: pulumi.Input<number>;
-    optional_string?: pulumi.Input<string>;
+    optional_bool?: pulumi.Input<boolean | undefined>;
+    optional_const?: pulumi.Input<"val" | undefined>;
+    optional_enum?: pulumi.Input<enums.EnumThing | undefined>;
+    optional_number?: pulumi.Input<number | undefined>;
+    optional_string?: pulumi.Input<string | undefined>;
     plain_optional_bool?: boolean;
     plain_optional_const?: "val";
     plain_optional_number?: number;

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/nodejs/types/input.ts
@@ -5,5 +5,5 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "../types";
 
 export interface FooArgs {
-    a?: pulumi.Input<boolean>;
+    a?: pulumi.Input<boolean | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/nodejs/provider.ts
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/nodejs/provider.ts
@@ -46,5 +46,5 @@ export interface ProviderArgs {
     /**
      * this is a relaxed string enum which can also be set via env var
      */
-    favoriteColor?: pulumi.Input<string | enums.Color>;
+    favoriteColor?: pulumi.Input<string | enums.Color | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/nodejs/person.ts
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/nodejs/person.ts
@@ -61,6 +61,6 @@ export class Person extends pulumi.CustomResource {
  * The set of arguments for constructing a Person resource.
  */
 export interface PersonArgs {
-    name?: pulumi.Input<string>;
-    pets?: pulumi.Input<pulumi.Input<inputs.PetArgs>[]>;
+    name?: pulumi.Input<string | undefined>;
+    pets?: pulumi.Input<pulumi.Input<inputs.PetArgs>[] | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/nodejs/pet.ts
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/nodejs/pet.ts
@@ -57,5 +57,5 @@ export class Pet extends pulumi.CustomResource {
  * The set of arguments for constructing a Pet resource.
  */
 export interface PetArgs {
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/nodejs/types/input.ts
@@ -5,5 +5,5 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "../types";
 
 export interface PetArgs {
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/nodejs/person.ts
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/nodejs/person.ts
@@ -61,6 +61,6 @@ export class Person extends pulumi.CustomResource {
  * The set of arguments for constructing a Person resource.
  */
 export interface PersonArgs {
-    name?: pulumi.Input<string>;
-    pets?: pulumi.Input<pulumi.Input<inputs.PetArgs>[]>;
+    name?: pulumi.Input<string | undefined>;
+    pets?: pulumi.Input<pulumi.Input<inputs.PetArgs>[] | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/nodejs/pet.ts
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/nodejs/pet.ts
@@ -57,5 +57,5 @@ export class Pet extends pulumi.CustomResource {
  * The set of arguments for constructing a Pet resource.
  */
 export interface PetArgs {
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/nodejs/types/input.ts
@@ -5,5 +5,5 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "../types";
 
 export interface PetArgs {
-    name?: pulumi.Input<string>;
+    name?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/nursery.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/nursery.ts
@@ -63,7 +63,7 @@ export interface NurseryArgs {
     /**
      * The sizes of trees available
      */
-    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>}>;
+    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>} | undefined>;
     /**
      * The varieties available
      */

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
@@ -73,16 +73,16 @@ export class RubberTree extends pulumi.CustomResource {
 }
 
 export interface RubberTreeState {
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
+    farm?: pulumi.Input<enums.tree.v1.Farm | string | undefined>;
 }
 
 /**
  * The set of arguments for constructing a RubberTree resource.
  */
 export interface RubberTreeArgs {
-    container?: pulumi.Input<inputs.ContainerArgs>;
+    container?: pulumi.Input<inputs.ContainerArgs | undefined>;
     diameter: pulumi.Input<enums.tree.v1.Diameter>;
-    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
-    size?: pulumi.Input<enums.tree.v1.TreeSize>;
+    farm?: pulumi.Input<enums.tree.v1.Farm | string | undefined>;
+    size?: pulumi.Input<enums.tree.v1.TreeSize | undefined>;
     type: pulumi.Input<enums.tree.v1.RubberTreeVariety>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/types/input.ts
@@ -7,9 +7,9 @@ import { input as inputs, output as outputs, enums } from "../types";
 import * as utilities from "../utilities";
 
 export interface ContainerArgs {
-    brightness?: pulumi.Input<enums.ContainerBrightness>;
-    color?: pulumi.Input<enums.ContainerColor | string>;
-    material?: pulumi.Input<string>;
+    brightness?: pulumi.Input<enums.ContainerBrightness | undefined>;
+    color?: pulumi.Input<enums.ContainerColor | string | undefined>;
+    material?: pulumi.Input<string | undefined>;
     size: pulumi.Input<enums.ContainerSize>;
 }
 /**

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/nodejs/foo.ts
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/nodejs/foo.ts
@@ -59,8 +59,8 @@ export namespace Foo {
      * The set of arguments for the Foo.getKubeconfig method.
      */
     export interface GetKubeconfigArgs {
-        profileName?: pulumi.Input<string>;
-        roleArn?: pulumi.Input<string>;
+        profileName?: pulumi.Input<string | undefined>;
+        roleArn?: pulumi.Input<string | undefined>;
     }
 
     /**

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/nodejs/foo.ts
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/nodejs/foo.ts
@@ -89,16 +89,16 @@ export namespace Foo {
      * The set of arguments for the Foo.bar method.
      */
     export interface BarArgs {
-        baz?: pulumi.Input<inputs.nested.BazArgs>;
+        baz?: pulumi.Input<inputs.nested.BazArgs | undefined>;
         bazPlain?: inputs.nested.BazArgs;
         bazRequired: pulumi.Input<inputs.nested.BazArgs>;
-        boolValue?: pulumi.Input<boolean>;
+        boolValue?: pulumi.Input<boolean | undefined>;
         boolValuePlain?: boolean;
         boolValueRequired: pulumi.Input<boolean>;
-        name?: pulumi.Input<pulumiRandom.RandomPet>;
+        name?: pulumi.Input<pulumiRandom.RandomPet | undefined>;
         namePlain?: pulumiRandom.RandomPet;
         nameRequired: pulumi.Input<pulumiRandom.RandomPet>;
-        stringValue?: pulumi.Input<string>;
+        stringValue?: pulumi.Input<string | undefined>;
         stringValuePlain?: string;
         stringValueRequired: pulumi.Input<string>;
     }

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/nodejs/types/input.ts
@@ -11,7 +11,7 @@ export namespace nested {
     }
 
     export interface BazArgs {
-        hello?: pulumi.Input<string>;
-        world?: pulumi.Input<string>;
+        hello?: pulumi.Input<string | undefined>;
+        world?: pulumi.Input<string | undefined>;
     }
 }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/nodejs/component.ts
@@ -87,5 +87,5 @@ export interface ComponentArgs {
     d?: number;
     e: string;
     f?: string;
-    foo?: pulumi.Input<inputs.FooArgs>;
+    foo?: pulumi.Input<inputs.FooArgs | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
@@ -89,5 +89,5 @@ export interface ComponentArgs {
     d?: number;
     e: string;
     f?: string;
-    foo?: pulumi.Input<inputs.FooArgs>;
+    foo?: pulumi.Input<inputs.FooArgs | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/argFunction.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/argFunction.ts
@@ -31,5 +31,5 @@ export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.In
 }
 
 export interface ArgFunctionOutputArgs {
-    arg1?: pulumi.Input<Resource>;
+    arg1?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/otherResource.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/otherResource.ts
@@ -47,5 +47,5 @@ export class OtherResource extends pulumi.ComponentResource {
  * The set of arguments for constructing a OtherResource resource.
  */
 export interface OtherResourceArgs {
-    foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/resource.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/nodejs/resource.ts
@@ -57,5 +57,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/argFunction.ts
@@ -31,5 +31,5 @@ export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.In
 }
 
 export interface ArgFunctionOutputArgs {
-    arg1?: pulumi.Input<Resource>;
+    arg1?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/otherResource.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/otherResource.ts
@@ -47,5 +47,5 @@ export class OtherResource extends pulumi.ComponentResource {
  * The set of arguments for constructing a OtherResource resource.
  */
 export interface OtherResourceArgs {
-    foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/resource.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/resource.ts
@@ -59,5 +59,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/typeUses.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/typeUses.ts
@@ -66,7 +66,7 @@ export class TypeUses extends pulumi.CustomResource {
  * The set of arguments for constructing a TypeUses resource.
  */
 export interface TypeUsesArgs {
-    bar?: pulumi.Input<inputs.SomeOtherObjectArgs>;
-    baz?: pulumi.Input<inputs.ObjectWithNodeOptionalInputsArgs>;
-    foo?: pulumi.Input<inputs.ObjectArgs>;
+    bar?: pulumi.Input<inputs.SomeOtherObjectArgs | undefined>;
+    baz?: pulumi.Input<inputs.ObjectWithNodeOptionalInputsArgs | undefined>;
+    foo?: pulumi.Input<inputs.ObjectArgs | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/types/input.ts
@@ -7,28 +7,28 @@ import { input as inputs, output as outputs } from "../types";
 import {Resource} from "..";
 
 export interface ConfigMapArgs {
-    config?: pulumi.Input<string>;
+    config?: pulumi.Input<string | undefined>;
 }
 
 export interface ObjectArgs {
-    bar?: pulumi.Input<string>;
-    configs?: pulumi.Input<pulumi.Input<inputs.ConfigMapArgs>[]>;
-    foo?: pulumi.Input<Resource>;
+    bar?: pulumi.Input<string | undefined>;
+    configs?: pulumi.Input<pulumi.Input<inputs.ConfigMapArgs>[] | undefined>;
+    foo?: pulumi.Input<Resource | undefined>;
     /**
      * List of lists of other objects
      */
-    others?: pulumi.Input<pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>[]>;
+    others?: pulumi.Input<pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>[] | undefined>;
     /**
      * Mapping from string to list of some other object
      */
-    stillOthers?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>}>;
+    stillOthers?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>} | undefined>;
 }
 
 export interface ObjectWithNodeOptionalInputsArgs {
-    bar?: pulumi.Input<number>;
-    foo?: pulumi.Input<string>;
+    bar?: pulumi.Input<number | undefined>;
+    foo?: pulumi.Input<string | undefined>;
 }
 
 export interface SomeOtherObjectArgs {
-    baz?: pulumi.Input<string>;
+    baz?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/argFunction.ts
@@ -31,5 +31,5 @@ export function argFunctionOutput(args?: ArgFunctionOutputArgs, opts?: pulumi.In
 }
 
 export interface ArgFunctionOutputArgs {
-    arg1?: pulumi.Input<Resource>;
+    arg1?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/otherResource.ts
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/otherResource.ts
@@ -49,5 +49,5 @@ export class OtherResource extends pulumi.ComponentResource {
  */
 export interface OtherResourceArgs {
     bar?: pulumi.Input<string>[];
-    foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/resource.ts
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/resource.ts
@@ -59,5 +59,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/typeUses.ts
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/typeUses.ts
@@ -81,8 +81,8 @@ export class TypeUses extends pulumi.CustomResource {
  * The set of arguments for constructing a TypeUses resource.
  */
 export interface TypeUsesArgs {
-    bar?: pulumi.Input<inputs.SomeOtherObjectArgs>;
-    baz?: pulumi.Input<inputs.ObjectWithNodeOptionalInputsArgs>;
-    foo?: pulumi.Input<inputs.ObjectArgs>;
-    qux?: pulumi.Input<enums.RubberTreeVariety>;
+    bar?: pulumi.Input<inputs.SomeOtherObjectArgs | undefined>;
+    baz?: pulumi.Input<inputs.ObjectWithNodeOptionalInputsArgs | undefined>;
+    foo?: pulumi.Input<inputs.ObjectArgs | undefined>;
+    qux?: pulumi.Input<enums.RubberTreeVariety | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/nodejs/types/input.ts
@@ -7,28 +7,28 @@ import { input as inputs, output as outputs, enums } from "../types";
 import {Resource} from "..";
 
 export interface ConfigMapArgs {
-    config?: pulumi.Input<string>;
+    config?: pulumi.Input<string | undefined>;
 }
 
 export interface ObjectArgs {
-    bar?: pulumi.Input<string>;
-    configs?: pulumi.Input<pulumi.Input<inputs.ConfigMapArgs>[]>;
-    foo?: pulumi.Input<Resource>;
+    bar?: pulumi.Input<string | undefined>;
+    configs?: pulumi.Input<pulumi.Input<inputs.ConfigMapArgs>[] | undefined>;
+    foo?: pulumi.Input<Resource | undefined>;
     /**
      * List of lists of other objects
      */
-    others?: pulumi.Input<pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>[]>;
+    others?: pulumi.Input<pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>[] | undefined>;
     /**
      * Mapping from string to list of some other object
      */
-    stillOthers?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>}>;
+    stillOthers?: pulumi.Input<{[key: string]: pulumi.Input<pulumi.Input<inputs.SomeOtherObjectArgs>[]>} | undefined>;
 }
 
 export interface ObjectWithNodeOptionalInputsArgs {
-    bar?: pulumi.Input<number>;
-    foo?: pulumi.Input<string>;
+    bar?: pulumi.Input<number | undefined>;
+    foo?: pulumi.Input<string | undefined>;
 }
 
 export interface SomeOtherObjectArgs {
-    baz?: pulumi.Input<string>;
+    baz?: pulumi.Input<string | undefined>;
 }

--- a/pkg/codegen/internal/test/testdata/types.json
+++ b/pkg/codegen/internal/test/testdata/types.json
@@ -58,7 +58,7 @@
                   "plain": "map[string]string"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<{[key: string]: pulumi.Input<string>}> | undefined",
+                  "input": "pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined> | undefined",
                   "plain": "{[key: string]: string} | undefined"
                 },
                 "python": {
@@ -114,7 +114,7 @@
                   "plain": "pulumi.Archive"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<pulumi.asset.Archive> | undefined",
+                  "input": "pulumi.Input<pulumi.asset.Archive | undefined> | undefined",
                   "plain": "pulumi.asset.Archive | undefined"
                 },
                 "python": {
@@ -139,7 +139,7 @@
                   "plain": "pulumi.AssetOrArchive"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive> | undefined",
+                  "input": "pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive | undefined> | undefined",
                   "plain": "pulumi.asset.Asset | pulumi.asset.Archive | undefined"
                 },
                 "python": {
@@ -164,7 +164,7 @@
                   "plain": "*bool"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<boolean> | undefined",
+                  "input": "pulumi.Input<boolean | undefined> | undefined",
                   "plain": "boolean | undefined"
                 },
                 "python": {
@@ -189,7 +189,7 @@
                   "plain": "*int"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<number> | undefined",
+                  "input": "pulumi.Input<number | undefined> | undefined",
                   "plain": "number | undefined"
                 },
                 "python": {
@@ -239,7 +239,7 @@
                   "plain": "*float64"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<number> | undefined",
+                  "input": "pulumi.Input<number | undefined> | undefined",
                   "plain": "number | undefined"
                 },
                 "python": {
@@ -464,7 +464,7 @@
                   "plain": "*string"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<string> | undefined",
+                  "input": "pulumi.Input<string | undefined> | undefined",
                   "plain": "string | undefined"
                 },
                 "python": {
@@ -508,7 +508,7 @@
                   "plain": "map[string]string"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<{[key: string]: pulumi.Input<string>}> | undefined",
+                  "input": "pulumi.Input<{[key: string]: pulumi.Input<string>} | undefined> | undefined",
                   "plain": "{[key: string]: string} | undefined"
                 },
                 "python": {
@@ -549,7 +549,7 @@
                   "plain": "interface{}"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<outputs.ObjectArgs | any[]> | undefined",
+                  "input": "pulumi.Input<outputs.ObjectArgs | any[] | undefined> | undefined",
                   "plain": "outputs.Object | any[] | undefined"
                 },
                 "python": {

--- a/pkg/codegen/internal/tstypes/tstypes.go
+++ b/pkg/codegen/internal/tstypes/tstypes.go
@@ -39,6 +39,14 @@ func Identifier(id string) TypeAst {
 	return &idType{id}
 }
 
+// IsIdentifier returns true if the AST node is an identifier.
+func IsIdentifier(t TypeAst) (string, bool) {
+	if i, ok := t.(*idType); ok {
+		return i.id, true
+	}
+	return "", false
+}
+
 // Builds a `T[]` type from a `T` type.
 func Array(t TypeAst) TypeAst {
 	return &arrayType{t}

--- a/pkg/codegen/internal/tstypes/tstypes.go
+++ b/pkg/codegen/internal/tstypes/tstypes.go
@@ -68,6 +68,14 @@ func Union(t ...TypeAst) TypeAst {
 	return &unionType{t[0], t[1], t[2:]}
 }
 
+// IsUnion returns true if the AST node is a union.
+func IsUnion(t TypeAst) ([]TypeAst, bool) {
+	if union, ok := t.(*unionType); ok {
+		return union.all(), true
+	}
+	return nil, false
+}
+
 // Normalizes by unnesting unions `A | (B | C) => A | B | C`.
 func Normalize(ast TypeAst) TypeAst {
 	return transform(ast, func(t TypeAst) TypeAst {

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 import * as assert from "assert";
-import { ComponentResource, CustomResource, DependencyResource, Inputs, Output, Resource, ResourceOptions, runtime,
-    secret } from "../../index";
+import { ComponentResource, CustomResource, DependencyResource, Input, Inputs, Output, Resource, ResourceOptions,
+    output, runtime, secret } from "../../index";
 import { asyncTest } from "../util";
 
 const gstruct = require("google-protobuf/google/protobuf/struct_pb.js");
@@ -114,7 +114,9 @@ type TestBoolEnum = (typeof TestBoolEnum)[keyof typeof TestBoolEnum];
 interface TestInputs {
     aNum: number;
     bStr: string;
+    bStrInput: Input<string>;
     cUnd: undefined;
+    cUndInput: Input<undefined>;
     dArr: Promise<Array<any>>;
     id: string;
     urn: string;
@@ -207,16 +209,18 @@ describe("runtime", () => {
 
         it("marshals basic properties correctly", asyncTest(async () => {
             const inputs: TestInputs = {
-                "aNum": 42,
-                "bStr": "a string",
-                "cUnd": undefined,
-                "dArr": Promise.resolve([ "x", 42, Promise.resolve(true), Promise.resolve(undefined) ]),
-                "id": "foo",
-                "urn": "bar",
-                "strEnum": TestStrEnum.Foo,
-                "intEnum": TestIntEnum.One,
-                "numEnum": TestNumEnum.One,
-                "boolEnum": TestBoolEnum.One,
+                aNum: 42,
+                bStr: "a string",
+                bStrInput: output("a string"),
+                cUnd: undefined,
+                cUndInput: output(undefined),
+                dArr: Promise.resolve([ "x", 42, Promise.resolve(true), Promise.resolve(undefined) ]),
+                id: "foo",
+                urn: "bar",
+                strEnum: TestStrEnum.Foo,
+                intEnum: TestIntEnum.One,
+                numEnum: TestNumEnum.One,
+                boolEnum: TestBoolEnum.One,
             };
             // Serialize and then deserialize all the properties, checking that they round-trip as expected.
             const transfer = gstruct.Struct.fromJavaScript(
@@ -224,7 +228,9 @@ describe("runtime", () => {
             const result = runtime.deserializeProperties(transfer);
             assert.strictEqual(result.aNum, 42);
             assert.strictEqual(result.bStr, "a string");
+            assert.strictEqual(result.bStrInput, "a string");
             assert.strictEqual(result.cUnd, undefined);
+            assert.strictEqual(result.cUndInput, undefined);
             assert.deepStrictEqual(result.dArr, [ "x", 42, true, null ]);
             assert.strictEqual(result.id, "foo");
             assert.strictEqual(result.urn, "bar");


### PR DESCRIPTION
The Node.js runtime accepts `Output<undefined>` values as inputs to optional parameters, but the TypeScript typing currently does not allow these.  This extends the TypeScript typings to allow `Output<undefined>` values as inputs to optional input properties.

I cannot think of any way in which this is breaking or would regress any aspect of the TypeScript experience, other than making the `.d.ts` files a little "noisier".

Fixes #6175