### PR TITLE
[codegen/docs] Add environment variable info to Provider inputs

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -760,7 +760,7 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 				// Create a map to hold the per-language properties of this object.
 				props := make(map[string][]property)
 				for _, lang := range supportedLanguages {
-					props[lang] = mod.getProperties(typ.Properties, lang, true, true)
+					props[lang] = mod.getProperties(typ.Properties, lang, true, true, false)
 				}
 
 				name := strings.Title(tokenToName(typ.Token))
@@ -816,7 +816,8 @@ func (mod *modContext) genNestedTypes(member interface{}, resourceType bool) []d
 
 // getProperties returns a slice of properties that can be rendered for docs for
 // the provided slice of properties in the schema.
-func (mod *modContext) getProperties(properties []*schema.Property, lang string, input, nested bool) []property {
+func (mod *modContext) getProperties(properties []*schema.Property, lang string, input, nested, isProvider bool,
+) []property {
 	if len(properties) == 0 {
 		return nil
 	}
@@ -856,11 +857,27 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 			propTypes = append(propTypes, mod.typeString(prop.Type, lang, characteristics, true))
 		}
 
+		comment := prop.Comment
+		// Default values for Provider inputs correspond to environment variables, so add that info to the docs.
+		if isProvider && input && prop.DefaultValue != nil && len(prop.DefaultValue.Environment) > 0 {
+			suffix := ""
+			if len(prop.DefaultValue.Environment) > 1 {
+				suffix = "s"
+			}
+			comment += fmt.Sprintf(" It can also be sourced from the following environment variable%s: ", suffix)
+			for i, v := range prop.DefaultValue.Environment {
+				comment += fmt.Sprintf("`%s`", v)
+				if i != len(prop.DefaultValue.Environment)-1 {
+					comment += ", "
+				}
+			}
+		}
+
 		docProperties = append(docProperties, property{
 			ID:                 propID,
 			DisplayName:        wbr(propLangName),
 			Name:               propLangName,
-			Comment:            prop.Comment,
+			Comment:            comment,
 			DeprecationMessage: prop.DeprecationMessage,
 			IsRequired:         prop.IsRequired,
 			IsInput:            input,
@@ -1241,13 +1258,13 @@ func (mod *modContext) genResource(r *schema.Resource) resourceDocArgs {
 	})
 
 	for _, lang := range supportedLanguages {
-		inputProps[lang] = mod.getProperties(r.InputProperties, lang, true, false)
-		outputProps[lang] = mod.getProperties(filteredOutputProps, lang, false, false)
+		inputProps[lang] = mod.getProperties(r.InputProperties, lang, true, false, r.IsProvider)
+		outputProps[lang] = mod.getProperties(filteredOutputProps, lang, false, false, r.IsProvider)
 		if r.IsProvider {
 			continue
 		}
 		if r.StateInputs != nil {
-			stateProps := mod.getProperties(r.StateInputs.Properties, lang, true, false)
+			stateProps := mod.getProperties(r.StateInputs.Properties, lang, true, false, r.IsProvider)
 			for i := 0; i < len(stateProps); i++ {
 				id := "state_" + stateProps[i].ID
 				stateProps[i].ID = id

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -860,7 +860,7 @@ func (mod *modContext) getProperties(properties []*schema.Property, lang string,
 		comment := prop.Comment
 		// Default values for Provider inputs correspond to environment variables, so add that info to the docs.
 		if isProvider && input && prop.DefaultValue != nil && len(prop.DefaultValue.Environment) > 0 {
-			suffix := ""
+			var suffix string
 			if len(prop.DefaultValue.Environment) > 1 {
 				suffix = "s"
 			}

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -303,10 +303,10 @@ func (mod *modContext) genFunction(f *schema.Function) functionDocArgs {
 	outputProps := make(map[string][]property)
 	for _, lang := range supportedLanguages {
 		if f.Inputs != nil {
-			inputProps[lang] = mod.getProperties(f.Inputs.Properties, lang, true, false)
+			inputProps[lang] = mod.getProperties(f.Inputs.Properties, lang, true, false, false)
 		}
 		if f.Outputs != nil {
-			outputProps[lang] = mod.getProperties(f.Outputs.Properties, lang, false, false)
+			outputProps[lang] = mod.getProperties(f.Outputs.Properties, lang, false, false, false)
 		}
 	}
 


### PR DESCRIPTION
The schema specifies supported environment variables
for Provider inputs, but these are not currently reflected
in the generated docs. This change adds any supported
environment variables to the input property comment
field on Provider resources.

Here's an example of the rendered docs with this change:
![Screen Shot 2021-02-12 at 4 50 07 PM](https://user-images.githubusercontent.com/9253463/107834059-6db11600-6d52-11eb-9a65-f63e96ea1abd.png)
