### PR TITLE
[sdk/go] Add To methods to convert array and map values to Inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,14 +112,6 @@ CHANGELOG
 - [automation/python] Fixed a bug in nested configuration parsing.
   [#6349](https://github.com/pulumi/pulumi/pull/6349)
 
-- [sdk/go] Return zero values instead of panicing in Index and Elem methods.
-  [#6338](https://github.com/pulumi/pulumi/pull/6338)
-
-
-- [sdk/go] Add helpers to convert raw Go maps and arrays to Pulumi Map and Array inputs.
-  [#6337](https://github.com/pulumi/pulumi/pull/6337)
-
-
 ## 2.20.0 (2021-02-03)
 
 - [sdk/python] Fix `Output.from_input` to unwrap nested output values in input types (args classes), which addresses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,10 @@ CHANGELOG
   [#6338](https://github.com/pulumi/pulumi/pull/6338)
 
 
+- [sdk/go] Add helpers to convert raw Go maps and arrays to Pulumi Map and Array inputs.
+  [#6337](https://github.com/pulumi/pulumi/pull/6337)
+
+
 ## 2.20.0 (2021-02-03)
 
 - [sdk/python] Fix `Output.from_input` to unwrap nested output values in input types (args classes), which addresses

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,11 @@
 
 ### Improvements
 
+- [sdk/go] Add helpers to convert raw Go maps and arrays to Pulumi `Map` and `Array` inputs.
+  [#6337](https://github.com/pulumi/pulumi/pull/6337)
+
+- [sdk/go] Return zero values instead of panicing in `Index` and `Elem` methods.
+  [#6338](https://github.com/pulumi/pulumi/pull/6338)
 
 ### Bug Fixes
 

--- a/sdk/go/pulumi/generate.go
+++ b/sdk/go/pulumi/generate.go
@@ -104,21 +104,21 @@ func (b builtin) MapIndexReturnType() string {
 }
 
 func (b builtin) IndexConversion() string {
-	if b.item.inputType != "" {
+	toType := b.item.Name
+	switch {
+	case b.item.inputType != "":
 		// No conversion necessary for types which are their own input type.
 		return ""
-	}
-	toType := b.item.Name
-	if toType == "Input" {
+	case toType == "Input":
 		// There is no direct conversion into `Input`, so special case to use `ToOutput`
 		return "ToOutput"
-	}
-	if b.item.item == nil {
+	case b.item.item == nil:
 		// The item type is a primitive - so use a direct conversion into the defined type (e.g. `String(...)`)
 		return toType
+	default:
+		// The item type is itself a container - so use one of the other code-generated `To<Type>` methods.
+		return "To" + toType
 	}
-	// The item type is itself a container - so use one of the other code-generated `To<Type>` methods.
-	return "To" + toType
 }
 
 func (b builtin) ElementType() string {

--- a/sdk/go/pulumi/generate.go
+++ b/sdk/go/pulumi/generate.go
@@ -142,6 +142,10 @@ func (b builtin) DefineToFunction() bool {
 	return b.DefineInputMethods()
 }
 
+func (b builtin) ItemExample() string {
+	return b.item.Example
+}
+
 func (b builtin) ElemExample() string {
 	if strings.HasSuffix(b.Name, "Map") {
 		return fmt.Sprintf("{\"baz\": %s}", b.item.ElemExample())

--- a/sdk/go/pulumi/generate.go
+++ b/sdk/go/pulumi/generate.go
@@ -38,6 +38,7 @@ type builtin struct {
 	item           *builtin
 	ItemType       string
 	Example        string
+	elemExample    string
 	GenerateConfig bool
 	DefaultConfig  string
 }
@@ -141,16 +142,29 @@ func (b builtin) DefineToFunction() bool {
 	return b.DefineInputMethods()
 }
 
+func (b builtin) ElemExample() string {
+	if strings.HasSuffix(b.Name, "Map") {
+		return fmt.Sprintf("{\"baz\": %s}", b.item.ElemExample())
+	}
+	if strings.HasSuffix(b.Name, "Array") {
+		return fmt.Sprintf("{%s}", b.item.ElemExample())
+	}
+	if b.elemExample != "" {
+		return b.elemExample
+	}
+	return b.Example
+}
+
 var builtins = makeBuiltins([]*builtin{
 	{Name: "Archive", Type: "Archive", inputType: "*archive", implements: []string{"AssetOrArchive"}, Example: "NewFileArchive(\"foo.zip\")"},
 	{Name: "Asset", Type: "Asset", inputType: "*asset", implements: []string{"AssetOrArchive"}, Example: "NewFileAsset(\"foo.txt\")"},
 	{Name: "AssetOrArchive", Type: "AssetOrArchive", Example: "NewFileArchive(\"foo.zip\")"},
-	{Name: "Bool", Type: "bool", Example: "Bool(true)", GenerateConfig: true, DefaultConfig: "false"},
-	{Name: "Float64", Type: "float64", Example: "Float64(999.9)", GenerateConfig: true, DefaultConfig: "0"},
+	{Name: "Bool", Type: "bool", Example: "Bool(true)", GenerateConfig: true, DefaultConfig: "false", elemExample: "true"},
+	{Name: "Float64", Type: "float64", Example: "Float64(999.9)", GenerateConfig: true, DefaultConfig: "0", elemExample: "999.9"},
 	{Name: "ID", Type: "ID", inputType: "ID", implements: []string{"String"}, Example: "ID(\"foo\")"},
 	{Name: "Input", Type: "interface{}", Example: "String(\"any\")"},
-	{Name: "Int", Type: "int", Example: "Int(42)", GenerateConfig: true, DefaultConfig: "0"},
-	{Name: "String", Type: "string", Example: "String(\"foo\")"},
+	{Name: "Int", Type: "int", Example: "Int(42)", GenerateConfig: true, DefaultConfig: "0", elemExample: "42"},
+	{Name: "String", Type: "string", Example: "String(\"foo\")", elemExample: "\"foo\""},
 	{Name: "URN", Type: "URN", inputType: "URN", implements: []string{"String"}, Example: "URN(\"foo\")"},
 })
 

--- a/sdk/go/pulumi/templates/types_builtins.go.template
+++ b/sdk/go/pulumi/templates/types_builtins.go.template
@@ -159,6 +159,16 @@ func (o {{.Name}}Output) Index(i IntInput) {{.IndexReturnType}}Output {
 		return ret
 	}).({{.IndexReturnType}}Output)
 }
+
+{{if .DefineToFunction}}
+func To{{.Name}}(in {{.ElementType}}) {{.Name}} {
+	a := make([]{{.ItemType}}, len(in))
+	for i, v := range in {
+		a[i] = {{.IndexConversion}}(v)
+	}
+	return {{.Name}}(a)
+}
+{{end}}
 {{end}}
 {{if .DefineMapIndex}}
 // MapIndex looks up the key k in the map.
@@ -167,6 +177,16 @@ func (o {{.Name}}Output) MapIndex(k StringInput) {{.MapIndexReturnType}}Output {
 		return vs[0].({{.ElementType}})[vs[1].(string)]
 	}).({{.MapIndexReturnType}}Output)
 }
+
+{{if .DefineToFunction}}
+func To{{.Name}}(in {{.ElementType}}) {{.Name}} {
+ 	m := make(map[string]{{.ItemType}})
+ 	for k, v := range in {
+ 		m[k] = {{.IndexConversion}}(v)
+ 	}
+ 	return {{.Name}}(m)
+}
+{{end}}
 {{end}}
 {{end}}
 {{end}}

--- a/sdk/go/pulumi/templates/types_builtins.go.template
+++ b/sdk/go/pulumi/templates/types_builtins.go.template
@@ -162,11 +162,19 @@ func (o {{.Name}}Output) Index(i IntInput) {{.IndexReturnType}}Output {
 
 {{if .DefineToFunction}}
 func To{{.Name}}(in {{.ElementType}}) {{.Name}} {
-	a := make([]{{.ItemType}}, len(in))
+	a := make({{.Name}}, len(in))
 	for i, v := range in {
 		a[i] = {{.IndexConversion}}(v)
 	}
-	return {{.Name}}(a)
+	return a
+}
+
+func To{{.Name}}Output(in []{{.IndexReturnType}}Output) {{.Name}}Output {
+	a := make({{.Name}}, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.To{{.Name}}Output()
 }
 {{end}}
 {{end}}
@@ -180,11 +188,19 @@ func (o {{.Name}}Output) MapIndex(k StringInput) {{.MapIndexReturnType}}Output {
 
 {{if .DefineToFunction}}
 func To{{.Name}}(in {{.ElementType}}) {{.Name}} {
- 	m := make(map[string]{{.ItemType}})
+ 	m := make({{.Name}})
  	for k, v := range in {
  		m[k] = {{.IndexConversion}}(v)
  	}
- 	return {{.Name}}(m)
+ 	return m
+}
+
+func To{{.Name}}Output(in map[string]{{.MapIndexReturnType}}Output) {{.Name}}Output {
+	m := make({{.Name}})
+ 	for k, v := range in {
+ 		m[k] = v
+ 	}
+ 	return m.To{{.Name}}Output()
 }
 {{end}}
 {{end}}

--- a/sdk/go/pulumi/templates/types_builtins_test.go.template
+++ b/sdk/go/pulumi/templates/types_builtins_test.go.template
@@ -417,6 +417,21 @@ func Test{{.Name}}Index(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
 }
+{{if .DefineToFunction}}
+func TestTo{{.Name}}(t *testing.T) {
+	out := To{{.Name}}([]{{.IndexElementType}}{{.ElemExample}}).To{{.Name}}Output()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]{{.IndexElementType}})[0], iv)
+}
+{{end}}
 {{end}}
 {{end}}
 
@@ -440,5 +455,20 @@ func Test{{.Name}}Index(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
 }
+{{if .DefineToFunction}}
+func TestTo{{.Name}}(t *testing.T) {
+	out := To{{.Name}}(map[string]{{.MapIndexElementType}}{{.ElemExample}}).To{{.Name}}Output()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]{{.MapIndexElementType}})["baz"], iv)
+}
+{{end}}
 {{end}}
 {{end}}

--- a/sdk/go/pulumi/templates/types_builtins_test.go.template
+++ b/sdk/go/pulumi/templates/types_builtins_test.go.template
@@ -431,6 +431,20 @@ func TestTo{{.Name}}(t *testing.T) {
 
 	assert.EqualValues(t, av.([]{{.IndexElementType}})[0], iv)
 }
+
+func TestTopLevelTo{{.Name}}Output(t *testing.T) {
+	out := To{{.Name}}Output([]{{.IndexReturnType}}Output{ ToOutput({{.ItemExample}}).({{.IndexReturnType}}Output) })
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]{{.IndexElementType}})[0], iv)
+}
 {{end}}
 {{end}}
 {{end}}
@@ -458,6 +472,20 @@ func Test{{.Name}}Index(t *testing.T) {
 {{if .DefineToFunction}}
 func TestTo{{.Name}}(t *testing.T) {
 	out := To{{.Name}}(map[string]{{.MapIndexElementType}}{{.ElemExample}}).To{{.Name}}Output()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]{{.MapIndexElementType}})["baz"], iv)
+}
+
+func TestTopLevelTo{{.Name}}Output(t *testing.T) {
+	out := To{{.Name}}Output(map[string]{{.MapIndexReturnType}}Output{"baz": ToOutput({{.ItemExample}}).({{.MapIndexReturnType}}Output)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)

--- a/sdk/go/pulumi/types_builtins.go
+++ b/sdk/go/pulumi/types_builtins.go
@@ -883,6 +883,14 @@ func (o ArchiveArrayOutput) Index(i IntInput) ArchiveOutput {
 	}).(ArchiveOutput)
 }
 
+func ToArchiveArray(in []Archive) ArchiveArray {
+	a := make([]ArchiveInput, len(in))
+	for i, v := range in {
+		a[i] = (v)
+	}
+	return ArchiveArray(a)
+}
+
 var archiveMapType = reflect.TypeOf((*map[string]Archive)(nil)).Elem()
 
 // ArchiveMapInput is an input type that accepts ArchiveMap and ArchiveMapOutput values.
@@ -932,6 +940,14 @@ func (o ArchiveMapOutput) MapIndex(k StringInput) ArchiveOutput {
 	}).(ArchiveOutput)
 }
 
+func ToArchiveMap(in map[string]Archive) ArchiveMap {
+	m := make(map[string]ArchiveInput)
+	for k, v := range in {
+		m[k] = (v)
+	}
+	return ArchiveMap(m)
+}
+
 var archiveArrayMapType = reflect.TypeOf((*map[string][]Archive)(nil)).Elem()
 
 // ArchiveArrayMapInput is an input type that accepts ArchiveArrayMap and ArchiveArrayMapOutput values.
@@ -979,6 +995,14 @@ func (o ArchiveArrayMapOutput) MapIndex(k StringInput) ArchiveArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []Archive {
 		return vs[0].(map[string][]Archive)[vs[1].(string)]
 	}).(ArchiveArrayOutput)
+}
+
+func ToArchiveArrayMap(in map[string][]Archive) ArchiveArrayMap {
+	m := make(map[string]ArchiveArrayInput)
+	for k, v := range in {
+		m[k] = ToArchiveArray(v)
+	}
+	return ArchiveArrayMap(m)
 }
 
 var archiveMapArrayType = reflect.TypeOf((*[]map[string]Archive)(nil)).Elem()
@@ -1037,6 +1061,14 @@ func (o ArchiveMapArrayOutput) Index(i IntInput) ArchiveMapOutput {
 	}).(ArchiveMapOutput)
 }
 
+func ToArchiveMapArray(in []map[string]Archive) ArchiveMapArray {
+	a := make([]ArchiveMapInput, len(in))
+	for i, v := range in {
+		a[i] = ToArchiveMap(v)
+	}
+	return ArchiveMapArray(a)
+}
+
 var archiveMapMapType = reflect.TypeOf((*map[string]map[string]Archive)(nil)).Elem()
 
 // ArchiveMapMapInput is an input type that accepts ArchiveMapMap and ArchiveMapMapOutput values.
@@ -1084,6 +1116,14 @@ func (o ArchiveMapMapOutput) MapIndex(k StringInput) ArchiveMapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]Archive {
 		return vs[0].(map[string]map[string]Archive)[vs[1].(string)]
 	}).(ArchiveMapOutput)
+}
+
+func ToArchiveMapMap(in map[string]map[string]Archive) ArchiveMapMap {
+	m := make(map[string]ArchiveMapInput)
+	for k, v := range in {
+		m[k] = ToArchiveMap(v)
+	}
+	return ArchiveMapMap(m)
 }
 
 var archiveArrayArrayType = reflect.TypeOf((*[][]Archive)(nil)).Elem()
@@ -1140,6 +1180,14 @@ func (o ArchiveArrayArrayOutput) Index(i IntInput) ArchiveArrayOutput {
 		}
 		return ret
 	}).(ArchiveArrayOutput)
+}
+
+func ToArchiveArrayArray(in [][]Archive) ArchiveArrayArray {
+	a := make([]ArchiveArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToArchiveArray(v)
+	}
+	return ArchiveArrayArray(a)
 }
 
 var assetType = reflect.TypeOf((*Asset)(nil)).Elem()
@@ -1255,6 +1303,14 @@ func (o AssetArrayOutput) Index(i IntInput) AssetOutput {
 	}).(AssetOutput)
 }
 
+func ToAssetArray(in []Asset) AssetArray {
+	a := make([]AssetInput, len(in))
+	for i, v := range in {
+		a[i] = (v)
+	}
+	return AssetArray(a)
+}
+
 var assetMapType = reflect.TypeOf((*map[string]Asset)(nil)).Elem()
 
 // AssetMapInput is an input type that accepts AssetMap and AssetMapOutput values.
@@ -1304,6 +1360,14 @@ func (o AssetMapOutput) MapIndex(k StringInput) AssetOutput {
 	}).(AssetOutput)
 }
 
+func ToAssetMap(in map[string]Asset) AssetMap {
+	m := make(map[string]AssetInput)
+	for k, v := range in {
+		m[k] = (v)
+	}
+	return AssetMap(m)
+}
+
 var assetArrayMapType = reflect.TypeOf((*map[string][]Asset)(nil)).Elem()
 
 // AssetArrayMapInput is an input type that accepts AssetArrayMap and AssetArrayMapOutput values.
@@ -1351,6 +1415,14 @@ func (o AssetArrayMapOutput) MapIndex(k StringInput) AssetArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []Asset {
 		return vs[0].(map[string][]Asset)[vs[1].(string)]
 	}).(AssetArrayOutput)
+}
+
+func ToAssetArrayMap(in map[string][]Asset) AssetArrayMap {
+	m := make(map[string]AssetArrayInput)
+	for k, v := range in {
+		m[k] = ToAssetArray(v)
+	}
+	return AssetArrayMap(m)
 }
 
 var assetMapArrayType = reflect.TypeOf((*[]map[string]Asset)(nil)).Elem()
@@ -1409,6 +1481,14 @@ func (o AssetMapArrayOutput) Index(i IntInput) AssetMapOutput {
 	}).(AssetMapOutput)
 }
 
+func ToAssetMapArray(in []map[string]Asset) AssetMapArray {
+	a := make([]AssetMapInput, len(in))
+	for i, v := range in {
+		a[i] = ToAssetMap(v)
+	}
+	return AssetMapArray(a)
+}
+
 var assetMapMapType = reflect.TypeOf((*map[string]map[string]Asset)(nil)).Elem()
 
 // AssetMapMapInput is an input type that accepts AssetMapMap and AssetMapMapOutput values.
@@ -1456,6 +1536,14 @@ func (o AssetMapMapOutput) MapIndex(k StringInput) AssetMapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]Asset {
 		return vs[0].(map[string]map[string]Asset)[vs[1].(string)]
 	}).(AssetMapOutput)
+}
+
+func ToAssetMapMap(in map[string]map[string]Asset) AssetMapMap {
+	m := make(map[string]AssetMapInput)
+	for k, v := range in {
+		m[k] = ToAssetMap(v)
+	}
+	return AssetMapMap(m)
 }
 
 var assetArrayArrayType = reflect.TypeOf((*[][]Asset)(nil)).Elem()
@@ -1512,6 +1600,14 @@ func (o AssetArrayArrayOutput) Index(i IntInput) AssetArrayOutput {
 		}
 		return ret
 	}).(AssetArrayOutput)
+}
+
+func ToAssetArrayArray(in [][]Asset) AssetArrayArray {
+	a := make([]AssetArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToAssetArray(v)
+	}
+	return AssetArrayArray(a)
 }
 
 var assetOrArchiveType = reflect.TypeOf((*AssetOrArchive)(nil)).Elem()
@@ -2031,6 +2127,14 @@ func (o BoolArrayOutput) Index(i IntInput) BoolOutput {
 	}).(BoolOutput)
 }
 
+func ToBoolArray(in []bool) BoolArray {
+	a := make([]BoolInput, len(in))
+	for i, v := range in {
+		a[i] = Bool(v)
+	}
+	return BoolArray(a)
+}
+
 var boolMapType = reflect.TypeOf((*map[string]bool)(nil)).Elem()
 
 // BoolMapInput is an input type that accepts BoolMap and BoolMapOutput values.
@@ -2080,6 +2184,14 @@ func (o BoolMapOutput) MapIndex(k StringInput) BoolOutput {
 	}).(BoolOutput)
 }
 
+func ToBoolMap(in map[string]bool) BoolMap {
+	m := make(map[string]BoolInput)
+	for k, v := range in {
+		m[k] = Bool(v)
+	}
+	return BoolMap(m)
+}
+
 var boolArrayMapType = reflect.TypeOf((*map[string][]bool)(nil)).Elem()
 
 // BoolArrayMapInput is an input type that accepts BoolArrayMap and BoolArrayMapOutput values.
@@ -2127,6 +2239,14 @@ func (o BoolArrayMapOutput) MapIndex(k StringInput) BoolArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []bool {
 		return vs[0].(map[string][]bool)[vs[1].(string)]
 	}).(BoolArrayOutput)
+}
+
+func ToBoolArrayMap(in map[string][]bool) BoolArrayMap {
+	m := make(map[string]BoolArrayInput)
+	for k, v := range in {
+		m[k] = ToBoolArray(v)
+	}
+	return BoolArrayMap(m)
 }
 
 var boolMapArrayType = reflect.TypeOf((*[]map[string]bool)(nil)).Elem()
@@ -2185,6 +2305,14 @@ func (o BoolMapArrayOutput) Index(i IntInput) BoolMapOutput {
 	}).(BoolMapOutput)
 }
 
+func ToBoolMapArray(in []map[string]bool) BoolMapArray {
+	a := make([]BoolMapInput, len(in))
+	for i, v := range in {
+		a[i] = ToBoolMap(v)
+	}
+	return BoolMapArray(a)
+}
+
 var boolMapMapType = reflect.TypeOf((*map[string]map[string]bool)(nil)).Elem()
 
 // BoolMapMapInput is an input type that accepts BoolMapMap and BoolMapMapOutput values.
@@ -2232,6 +2360,14 @@ func (o BoolMapMapOutput) MapIndex(k StringInput) BoolMapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]bool {
 		return vs[0].(map[string]map[string]bool)[vs[1].(string)]
 	}).(BoolMapOutput)
+}
+
+func ToBoolMapMap(in map[string]map[string]bool) BoolMapMap {
+	m := make(map[string]BoolMapInput)
+	for k, v := range in {
+		m[k] = ToBoolMap(v)
+	}
+	return BoolMapMap(m)
 }
 
 var boolArrayArrayType = reflect.TypeOf((*[][]bool)(nil)).Elem()
@@ -2288,6 +2424,14 @@ func (o BoolArrayArrayOutput) Index(i IntInput) BoolArrayOutput {
 		}
 		return ret
 	}).(BoolArrayOutput)
+}
+
+func ToBoolArrayArray(in [][]bool) BoolArrayArray {
+	a := make([]BoolArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToBoolArray(v)
+	}
+	return BoolArrayArray(a)
 }
 
 var float64Type = reflect.TypeOf((*float64)(nil)).Elem()
@@ -2466,6 +2610,14 @@ func (o Float64ArrayOutput) Index(i IntInput) Float64Output {
 	}).(Float64Output)
 }
 
+func ToFloat64Array(in []float64) Float64Array {
+	a := make([]Float64Input, len(in))
+	for i, v := range in {
+		a[i] = Float64(v)
+	}
+	return Float64Array(a)
+}
+
 var float64MapType = reflect.TypeOf((*map[string]float64)(nil)).Elem()
 
 // Float64MapInput is an input type that accepts Float64Map and Float64MapOutput values.
@@ -2515,6 +2667,14 @@ func (o Float64MapOutput) MapIndex(k StringInput) Float64Output {
 	}).(Float64Output)
 }
 
+func ToFloat64Map(in map[string]float64) Float64Map {
+	m := make(map[string]Float64Input)
+	for k, v := range in {
+		m[k] = Float64(v)
+	}
+	return Float64Map(m)
+}
+
 var float64ArrayMapType = reflect.TypeOf((*map[string][]float64)(nil)).Elem()
 
 // Float64ArrayMapInput is an input type that accepts Float64ArrayMap and Float64ArrayMapOutput values.
@@ -2562,6 +2722,14 @@ func (o Float64ArrayMapOutput) MapIndex(k StringInput) Float64ArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []float64 {
 		return vs[0].(map[string][]float64)[vs[1].(string)]
 	}).(Float64ArrayOutput)
+}
+
+func ToFloat64ArrayMap(in map[string][]float64) Float64ArrayMap {
+	m := make(map[string]Float64ArrayInput)
+	for k, v := range in {
+		m[k] = ToFloat64Array(v)
+	}
+	return Float64ArrayMap(m)
 }
 
 var float64MapArrayType = reflect.TypeOf((*[]map[string]float64)(nil)).Elem()
@@ -2620,6 +2788,14 @@ func (o Float64MapArrayOutput) Index(i IntInput) Float64MapOutput {
 	}).(Float64MapOutput)
 }
 
+func ToFloat64MapArray(in []map[string]float64) Float64MapArray {
+	a := make([]Float64MapInput, len(in))
+	for i, v := range in {
+		a[i] = ToFloat64Map(v)
+	}
+	return Float64MapArray(a)
+}
+
 var float64MapMapType = reflect.TypeOf((*map[string]map[string]float64)(nil)).Elem()
 
 // Float64MapMapInput is an input type that accepts Float64MapMap and Float64MapMapOutput values.
@@ -2667,6 +2843,14 @@ func (o Float64MapMapOutput) MapIndex(k StringInput) Float64MapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]float64 {
 		return vs[0].(map[string]map[string]float64)[vs[1].(string)]
 	}).(Float64MapOutput)
+}
+
+func ToFloat64MapMap(in map[string]map[string]float64) Float64MapMap {
+	m := make(map[string]Float64MapInput)
+	for k, v := range in {
+		m[k] = ToFloat64Map(v)
+	}
+	return Float64MapMap(m)
 }
 
 var float64ArrayArrayType = reflect.TypeOf((*[][]float64)(nil)).Elem()
@@ -2723,6 +2907,14 @@ func (o Float64ArrayArrayOutput) Index(i IntInput) Float64ArrayOutput {
 		}
 		return ret
 	}).(Float64ArrayOutput)
+}
+
+func ToFloat64ArrayArray(in [][]float64) Float64ArrayArray {
+	a := make([]Float64ArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToFloat64Array(v)
+	}
+	return Float64ArrayArray(a)
 }
 
 var idType = reflect.TypeOf((*ID)(nil)).Elem()
@@ -2916,6 +3108,14 @@ func (o IDArrayOutput) Index(i IntInput) IDOutput {
 	}).(IDOutput)
 }
 
+func ToIDArray(in []ID) IDArray {
+	a := make([]IDInput, len(in))
+	for i, v := range in {
+		a[i] = (v)
+	}
+	return IDArray(a)
+}
+
 var iDMapType = reflect.TypeOf((*map[string]ID)(nil)).Elem()
 
 // IDMapInput is an input type that accepts IDMap and IDMapOutput values.
@@ -2965,6 +3165,14 @@ func (o IDMapOutput) MapIndex(k StringInput) IDOutput {
 	}).(IDOutput)
 }
 
+func ToIDMap(in map[string]ID) IDMap {
+	m := make(map[string]IDInput)
+	for k, v := range in {
+		m[k] = (v)
+	}
+	return IDMap(m)
+}
+
 var iDArrayMapType = reflect.TypeOf((*map[string][]ID)(nil)).Elem()
 
 // IDArrayMapInput is an input type that accepts IDArrayMap and IDArrayMapOutput values.
@@ -3012,6 +3220,14 @@ func (o IDArrayMapOutput) MapIndex(k StringInput) IDArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []ID {
 		return vs[0].(map[string][]ID)[vs[1].(string)]
 	}).(IDArrayOutput)
+}
+
+func ToIDArrayMap(in map[string][]ID) IDArrayMap {
+	m := make(map[string]IDArrayInput)
+	for k, v := range in {
+		m[k] = ToIDArray(v)
+	}
+	return IDArrayMap(m)
 }
 
 var iDMapArrayType = reflect.TypeOf((*[]map[string]ID)(nil)).Elem()
@@ -3070,6 +3286,14 @@ func (o IDMapArrayOutput) Index(i IntInput) IDMapOutput {
 	}).(IDMapOutput)
 }
 
+func ToIDMapArray(in []map[string]ID) IDMapArray {
+	a := make([]IDMapInput, len(in))
+	for i, v := range in {
+		a[i] = ToIDMap(v)
+	}
+	return IDMapArray(a)
+}
+
 var iDMapMapType = reflect.TypeOf((*map[string]map[string]ID)(nil)).Elem()
 
 // IDMapMapInput is an input type that accepts IDMapMap and IDMapMapOutput values.
@@ -3117,6 +3341,14 @@ func (o IDMapMapOutput) MapIndex(k StringInput) IDMapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]ID {
 		return vs[0].(map[string]map[string]ID)[vs[1].(string)]
 	}).(IDMapOutput)
+}
+
+func ToIDMapMap(in map[string]map[string]ID) IDMapMap {
+	m := make(map[string]IDMapInput)
+	for k, v := range in {
+		m[k] = ToIDMap(v)
+	}
+	return IDMapMap(m)
 }
 
 var iDArrayArrayType = reflect.TypeOf((*[][]ID)(nil)).Elem()
@@ -3175,6 +3407,14 @@ func (o IDArrayArrayOutput) Index(i IntInput) IDArrayOutput {
 	}).(IDArrayOutput)
 }
 
+func ToIDArrayArray(in [][]ID) IDArrayArray {
+	a := make([]IDArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToIDArray(v)
+	}
+	return IDArrayArray(a)
+}
+
 var arrayType = reflect.TypeOf((*[]interface{})(nil)).Elem()
 
 // ArrayInput is an input type that accepts Array and ArrayOutput values.
@@ -3231,6 +3471,14 @@ func (o ArrayOutput) Index(i IntInput) Output {
 	}).(Output)
 }
 
+func ToArray(in []interface{}) Array {
+	a := make([]Input, len(in))
+	for i, v := range in {
+		a[i] = ToOutput(v)
+	}
+	return Array(a)
+}
+
 var mapType = reflect.TypeOf((*map[string]interface{})(nil)).Elem()
 
 // MapInput is an input type that accepts Map and MapOutput values.
@@ -3280,6 +3528,14 @@ func (o MapOutput) MapIndex(k StringInput) Output {
 	}).(Output)
 }
 
+func ToMap(in map[string]interface{}) Map {
+	m := make(map[string]Input)
+	for k, v := range in {
+		m[k] = ToOutput(v)
+	}
+	return Map(m)
+}
+
 var arrayMapType = reflect.TypeOf((*map[string][]interface{})(nil)).Elem()
 
 // ArrayMapInput is an input type that accepts ArrayMap and ArrayMapOutput values.
@@ -3327,6 +3583,14 @@ func (o ArrayMapOutput) MapIndex(k StringInput) ArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []interface{} {
 		return vs[0].(map[string][]interface{})[vs[1].(string)]
 	}).(ArrayOutput)
+}
+
+func ToArrayMap(in map[string][]interface{}) ArrayMap {
+	m := make(map[string]ArrayInput)
+	for k, v := range in {
+		m[k] = ToArray(v)
+	}
+	return ArrayMap(m)
 }
 
 var mapArrayType = reflect.TypeOf((*[]map[string]interface{})(nil)).Elem()
@@ -3385,6 +3649,14 @@ func (o MapArrayOutput) Index(i IntInput) MapOutput {
 	}).(MapOutput)
 }
 
+func ToMapArray(in []map[string]interface{}) MapArray {
+	a := make([]MapInput, len(in))
+	for i, v := range in {
+		a[i] = ToMap(v)
+	}
+	return MapArray(a)
+}
+
 var mapMapType = reflect.TypeOf((*map[string]map[string]interface{})(nil)).Elem()
 
 // MapMapInput is an input type that accepts MapMap and MapMapOutput values.
@@ -3432,6 +3704,14 @@ func (o MapMapOutput) MapIndex(k StringInput) MapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]interface{} {
 		return vs[0].(map[string]map[string]interface{})[vs[1].(string)]
 	}).(MapOutput)
+}
+
+func ToMapMap(in map[string]map[string]interface{}) MapMap {
+	m := make(map[string]MapInput)
+	for k, v := range in {
+		m[k] = ToMap(v)
+	}
+	return MapMap(m)
 }
 
 var arrayArrayType = reflect.TypeOf((*[][]interface{})(nil)).Elem()
@@ -3488,6 +3768,14 @@ func (o ArrayArrayOutput) Index(i IntInput) ArrayOutput {
 		}
 		return ret
 	}).(ArrayOutput)
+}
+
+func ToArrayArray(in [][]interface{}) ArrayArray {
+	a := make([]ArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToArray(v)
+	}
+	return ArrayArray(a)
 }
 
 var intType = reflect.TypeOf((*int)(nil)).Elem()
@@ -3666,6 +3954,14 @@ func (o IntArrayOutput) Index(i IntInput) IntOutput {
 	}).(IntOutput)
 }
 
+func ToIntArray(in []int) IntArray {
+	a := make([]IntInput, len(in))
+	for i, v := range in {
+		a[i] = Int(v)
+	}
+	return IntArray(a)
+}
+
 var intMapType = reflect.TypeOf((*map[string]int)(nil)).Elem()
 
 // IntMapInput is an input type that accepts IntMap and IntMapOutput values.
@@ -3715,6 +4011,14 @@ func (o IntMapOutput) MapIndex(k StringInput) IntOutput {
 	}).(IntOutput)
 }
 
+func ToIntMap(in map[string]int) IntMap {
+	m := make(map[string]IntInput)
+	for k, v := range in {
+		m[k] = Int(v)
+	}
+	return IntMap(m)
+}
+
 var intArrayMapType = reflect.TypeOf((*map[string][]int)(nil)).Elem()
 
 // IntArrayMapInput is an input type that accepts IntArrayMap and IntArrayMapOutput values.
@@ -3762,6 +4066,14 @@ func (o IntArrayMapOutput) MapIndex(k StringInput) IntArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []int {
 		return vs[0].(map[string][]int)[vs[1].(string)]
 	}).(IntArrayOutput)
+}
+
+func ToIntArrayMap(in map[string][]int) IntArrayMap {
+	m := make(map[string]IntArrayInput)
+	for k, v := range in {
+		m[k] = ToIntArray(v)
+	}
+	return IntArrayMap(m)
 }
 
 var intMapArrayType = reflect.TypeOf((*[]map[string]int)(nil)).Elem()
@@ -3820,6 +4132,14 @@ func (o IntMapArrayOutput) Index(i IntInput) IntMapOutput {
 	}).(IntMapOutput)
 }
 
+func ToIntMapArray(in []map[string]int) IntMapArray {
+	a := make([]IntMapInput, len(in))
+	for i, v := range in {
+		a[i] = ToIntMap(v)
+	}
+	return IntMapArray(a)
+}
+
 var intMapMapType = reflect.TypeOf((*map[string]map[string]int)(nil)).Elem()
 
 // IntMapMapInput is an input type that accepts IntMapMap and IntMapMapOutput values.
@@ -3867,6 +4187,14 @@ func (o IntMapMapOutput) MapIndex(k StringInput) IntMapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]int {
 		return vs[0].(map[string]map[string]int)[vs[1].(string)]
 	}).(IntMapOutput)
+}
+
+func ToIntMapMap(in map[string]map[string]int) IntMapMap {
+	m := make(map[string]IntMapInput)
+	for k, v := range in {
+		m[k] = ToIntMap(v)
+	}
+	return IntMapMap(m)
 }
 
 var intArrayArrayType = reflect.TypeOf((*[][]int)(nil)).Elem()
@@ -3923,6 +4251,14 @@ func (o IntArrayArrayOutput) Index(i IntInput) IntArrayOutput {
 		}
 		return ret
 	}).(IntArrayOutput)
+}
+
+func ToIntArrayArray(in [][]int) IntArrayArray {
+	a := make([]IntArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToIntArray(v)
+	}
+	return IntArrayArray(a)
 }
 
 var stringType = reflect.TypeOf((*string)(nil)).Elem()
@@ -4101,6 +4437,14 @@ func (o StringArrayOutput) Index(i IntInput) StringOutput {
 	}).(StringOutput)
 }
 
+func ToStringArray(in []string) StringArray {
+	a := make([]StringInput, len(in))
+	for i, v := range in {
+		a[i] = String(v)
+	}
+	return StringArray(a)
+}
+
 var stringMapType = reflect.TypeOf((*map[string]string)(nil)).Elem()
 
 // StringMapInput is an input type that accepts StringMap and StringMapOutput values.
@@ -4150,6 +4494,14 @@ func (o StringMapOutput) MapIndex(k StringInput) StringOutput {
 	}).(StringOutput)
 }
 
+func ToStringMap(in map[string]string) StringMap {
+	m := make(map[string]StringInput)
+	for k, v := range in {
+		m[k] = String(v)
+	}
+	return StringMap(m)
+}
+
 var stringArrayMapType = reflect.TypeOf((*map[string][]string)(nil)).Elem()
 
 // StringArrayMapInput is an input type that accepts StringArrayMap and StringArrayMapOutput values.
@@ -4197,6 +4549,14 @@ func (o StringArrayMapOutput) MapIndex(k StringInput) StringArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []string {
 		return vs[0].(map[string][]string)[vs[1].(string)]
 	}).(StringArrayOutput)
+}
+
+func ToStringArrayMap(in map[string][]string) StringArrayMap {
+	m := make(map[string]StringArrayInput)
+	for k, v := range in {
+		m[k] = ToStringArray(v)
+	}
+	return StringArrayMap(m)
 }
 
 var stringMapArrayType = reflect.TypeOf((*[]map[string]string)(nil)).Elem()
@@ -4255,6 +4615,14 @@ func (o StringMapArrayOutput) Index(i IntInput) StringMapOutput {
 	}).(StringMapOutput)
 }
 
+func ToStringMapArray(in []map[string]string) StringMapArray {
+	a := make([]StringMapInput, len(in))
+	for i, v := range in {
+		a[i] = ToStringMap(v)
+	}
+	return StringMapArray(a)
+}
+
 var stringMapMapType = reflect.TypeOf((*map[string]map[string]string)(nil)).Elem()
 
 // StringMapMapInput is an input type that accepts StringMapMap and StringMapMapOutput values.
@@ -4302,6 +4670,14 @@ func (o StringMapMapOutput) MapIndex(k StringInput) StringMapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]string {
 		return vs[0].(map[string]map[string]string)[vs[1].(string)]
 	}).(StringMapOutput)
+}
+
+func ToStringMapMap(in map[string]map[string]string) StringMapMap {
+	m := make(map[string]StringMapInput)
+	for k, v := range in {
+		m[k] = ToStringMap(v)
+	}
+	return StringMapMap(m)
 }
 
 var stringArrayArrayType = reflect.TypeOf((*[][]string)(nil)).Elem()
@@ -4358,6 +4734,14 @@ func (o StringArrayArrayOutput) Index(i IntInput) StringArrayOutput {
 		}
 		return ret
 	}).(StringArrayOutput)
+}
+
+func ToStringArrayArray(in [][]string) StringArrayArray {
+	a := make([]StringArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToStringArray(v)
+	}
+	return StringArrayArray(a)
 }
 
 var urnType = reflect.TypeOf((*URN)(nil)).Elem()
@@ -4551,6 +4935,14 @@ func (o URNArrayOutput) Index(i IntInput) URNOutput {
 	}).(URNOutput)
 }
 
+func ToURNArray(in []URN) URNArray {
+	a := make([]URNInput, len(in))
+	for i, v := range in {
+		a[i] = (v)
+	}
+	return URNArray(a)
+}
+
 var uRNMapType = reflect.TypeOf((*map[string]URN)(nil)).Elem()
 
 // URNMapInput is an input type that accepts URNMap and URNMapOutput values.
@@ -4600,6 +4992,14 @@ func (o URNMapOutput) MapIndex(k StringInput) URNOutput {
 	}).(URNOutput)
 }
 
+func ToURNMap(in map[string]URN) URNMap {
+	m := make(map[string]URNInput)
+	for k, v := range in {
+		m[k] = (v)
+	}
+	return URNMap(m)
+}
+
 var uRNArrayMapType = reflect.TypeOf((*map[string][]URN)(nil)).Elem()
 
 // URNArrayMapInput is an input type that accepts URNArrayMap and URNArrayMapOutput values.
@@ -4647,6 +5047,14 @@ func (o URNArrayMapOutput) MapIndex(k StringInput) URNArrayOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) []URN {
 		return vs[0].(map[string][]URN)[vs[1].(string)]
 	}).(URNArrayOutput)
+}
+
+func ToURNArrayMap(in map[string][]URN) URNArrayMap {
+	m := make(map[string]URNArrayInput)
+	for k, v := range in {
+		m[k] = ToURNArray(v)
+	}
+	return URNArrayMap(m)
 }
 
 var uRNMapArrayType = reflect.TypeOf((*[]map[string]URN)(nil)).Elem()
@@ -4705,6 +5113,14 @@ func (o URNMapArrayOutput) Index(i IntInput) URNMapOutput {
 	}).(URNMapOutput)
 }
 
+func ToURNMapArray(in []map[string]URN) URNMapArray {
+	a := make([]URNMapInput, len(in))
+	for i, v := range in {
+		a[i] = ToURNMap(v)
+	}
+	return URNMapArray(a)
+}
+
 var uRNMapMapType = reflect.TypeOf((*map[string]map[string]URN)(nil)).Elem()
 
 // URNMapMapInput is an input type that accepts URNMapMap and URNMapMapOutput values.
@@ -4752,6 +5168,14 @@ func (o URNMapMapOutput) MapIndex(k StringInput) URNMapOutput {
 	return All(o, k).ApplyT(func(vs []interface{}) map[string]URN {
 		return vs[0].(map[string]map[string]URN)[vs[1].(string)]
 	}).(URNMapOutput)
+}
+
+func ToURNMapMap(in map[string]map[string]URN) URNMapMap {
+	m := make(map[string]URNMapInput)
+	for k, v := range in {
+		m[k] = ToURNMap(v)
+	}
+	return URNMapMap(m)
 }
 
 var uRNArrayArrayType = reflect.TypeOf((*[][]URN)(nil)).Elem()
@@ -4808,6 +5232,14 @@ func (o URNArrayArrayOutput) Index(i IntInput) URNArrayOutput {
 		}
 		return ret
 	}).(URNArrayOutput)
+}
+
+func ToURNArrayArray(in [][]URN) URNArrayArray {
+	a := make([]URNArrayInput, len(in))
+	for i, v := range in {
+		a[i] = ToURNArray(v)
+	}
+	return URNArrayArray(a)
 }
 
 func getResolvedValue(input Input) (reflect.Value, bool) {

--- a/sdk/go/pulumi/types_builtins.go
+++ b/sdk/go/pulumi/types_builtins.go
@@ -884,11 +884,19 @@ func (o ArchiveArrayOutput) Index(i IntInput) ArchiveOutput {
 }
 
 func ToArchiveArray(in []Archive) ArchiveArray {
-	a := make([]ArchiveInput, len(in))
+	a := make(ArchiveArray, len(in))
 	for i, v := range in {
 		a[i] = (v)
 	}
-	return ArchiveArray(a)
+	return a
+}
+
+func ToArchiveArrayOutput(in []ArchiveOutput) ArchiveArrayOutput {
+	a := make(ArchiveArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToArchiveArrayOutput()
 }
 
 var archiveMapType = reflect.TypeOf((*map[string]Archive)(nil)).Elem()
@@ -941,11 +949,19 @@ func (o ArchiveMapOutput) MapIndex(k StringInput) ArchiveOutput {
 }
 
 func ToArchiveMap(in map[string]Archive) ArchiveMap {
-	m := make(map[string]ArchiveInput)
+	m := make(ArchiveMap)
 	for k, v := range in {
 		m[k] = (v)
 	}
-	return ArchiveMap(m)
+	return m
+}
+
+func ToArchiveMapOutput(in map[string]ArchiveOutput) ArchiveMapOutput {
+	m := make(ArchiveMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToArchiveMapOutput()
 }
 
 var archiveArrayMapType = reflect.TypeOf((*map[string][]Archive)(nil)).Elem()
@@ -998,11 +1014,19 @@ func (o ArchiveArrayMapOutput) MapIndex(k StringInput) ArchiveArrayOutput {
 }
 
 func ToArchiveArrayMap(in map[string][]Archive) ArchiveArrayMap {
-	m := make(map[string]ArchiveArrayInput)
+	m := make(ArchiveArrayMap)
 	for k, v := range in {
 		m[k] = ToArchiveArray(v)
 	}
-	return ArchiveArrayMap(m)
+	return m
+}
+
+func ToArchiveArrayMapOutput(in map[string]ArchiveArrayOutput) ArchiveArrayMapOutput {
+	m := make(ArchiveArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToArchiveArrayMapOutput()
 }
 
 var archiveMapArrayType = reflect.TypeOf((*[]map[string]Archive)(nil)).Elem()
@@ -1062,11 +1086,19 @@ func (o ArchiveMapArrayOutput) Index(i IntInput) ArchiveMapOutput {
 }
 
 func ToArchiveMapArray(in []map[string]Archive) ArchiveMapArray {
-	a := make([]ArchiveMapInput, len(in))
+	a := make(ArchiveMapArray, len(in))
 	for i, v := range in {
 		a[i] = ToArchiveMap(v)
 	}
-	return ArchiveMapArray(a)
+	return a
+}
+
+func ToArchiveMapArrayOutput(in []ArchiveMapOutput) ArchiveMapArrayOutput {
+	a := make(ArchiveMapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToArchiveMapArrayOutput()
 }
 
 var archiveMapMapType = reflect.TypeOf((*map[string]map[string]Archive)(nil)).Elem()
@@ -1119,11 +1151,19 @@ func (o ArchiveMapMapOutput) MapIndex(k StringInput) ArchiveMapOutput {
 }
 
 func ToArchiveMapMap(in map[string]map[string]Archive) ArchiveMapMap {
-	m := make(map[string]ArchiveMapInput)
+	m := make(ArchiveMapMap)
 	for k, v := range in {
 		m[k] = ToArchiveMap(v)
 	}
-	return ArchiveMapMap(m)
+	return m
+}
+
+func ToArchiveMapMapOutput(in map[string]ArchiveMapOutput) ArchiveMapMapOutput {
+	m := make(ArchiveMapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToArchiveMapMapOutput()
 }
 
 var archiveArrayArrayType = reflect.TypeOf((*[][]Archive)(nil)).Elem()
@@ -1183,11 +1223,19 @@ func (o ArchiveArrayArrayOutput) Index(i IntInput) ArchiveArrayOutput {
 }
 
 func ToArchiveArrayArray(in [][]Archive) ArchiveArrayArray {
-	a := make([]ArchiveArrayInput, len(in))
+	a := make(ArchiveArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToArchiveArray(v)
 	}
-	return ArchiveArrayArray(a)
+	return a
+}
+
+func ToArchiveArrayArrayOutput(in []ArchiveArrayOutput) ArchiveArrayArrayOutput {
+	a := make(ArchiveArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToArchiveArrayArrayOutput()
 }
 
 var assetType = reflect.TypeOf((*Asset)(nil)).Elem()
@@ -1304,11 +1352,19 @@ func (o AssetArrayOutput) Index(i IntInput) AssetOutput {
 }
 
 func ToAssetArray(in []Asset) AssetArray {
-	a := make([]AssetInput, len(in))
+	a := make(AssetArray, len(in))
 	for i, v := range in {
 		a[i] = (v)
 	}
-	return AssetArray(a)
+	return a
+}
+
+func ToAssetArrayOutput(in []AssetOutput) AssetArrayOutput {
+	a := make(AssetArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToAssetArrayOutput()
 }
 
 var assetMapType = reflect.TypeOf((*map[string]Asset)(nil)).Elem()
@@ -1361,11 +1417,19 @@ func (o AssetMapOutput) MapIndex(k StringInput) AssetOutput {
 }
 
 func ToAssetMap(in map[string]Asset) AssetMap {
-	m := make(map[string]AssetInput)
+	m := make(AssetMap)
 	for k, v := range in {
 		m[k] = (v)
 	}
-	return AssetMap(m)
+	return m
+}
+
+func ToAssetMapOutput(in map[string]AssetOutput) AssetMapOutput {
+	m := make(AssetMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToAssetMapOutput()
 }
 
 var assetArrayMapType = reflect.TypeOf((*map[string][]Asset)(nil)).Elem()
@@ -1418,11 +1482,19 @@ func (o AssetArrayMapOutput) MapIndex(k StringInput) AssetArrayOutput {
 }
 
 func ToAssetArrayMap(in map[string][]Asset) AssetArrayMap {
-	m := make(map[string]AssetArrayInput)
+	m := make(AssetArrayMap)
 	for k, v := range in {
 		m[k] = ToAssetArray(v)
 	}
-	return AssetArrayMap(m)
+	return m
+}
+
+func ToAssetArrayMapOutput(in map[string]AssetArrayOutput) AssetArrayMapOutput {
+	m := make(AssetArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToAssetArrayMapOutput()
 }
 
 var assetMapArrayType = reflect.TypeOf((*[]map[string]Asset)(nil)).Elem()
@@ -1482,11 +1554,19 @@ func (o AssetMapArrayOutput) Index(i IntInput) AssetMapOutput {
 }
 
 func ToAssetMapArray(in []map[string]Asset) AssetMapArray {
-	a := make([]AssetMapInput, len(in))
+	a := make(AssetMapArray, len(in))
 	for i, v := range in {
 		a[i] = ToAssetMap(v)
 	}
-	return AssetMapArray(a)
+	return a
+}
+
+func ToAssetMapArrayOutput(in []AssetMapOutput) AssetMapArrayOutput {
+	a := make(AssetMapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToAssetMapArrayOutput()
 }
 
 var assetMapMapType = reflect.TypeOf((*map[string]map[string]Asset)(nil)).Elem()
@@ -1539,11 +1619,19 @@ func (o AssetMapMapOutput) MapIndex(k StringInput) AssetMapOutput {
 }
 
 func ToAssetMapMap(in map[string]map[string]Asset) AssetMapMap {
-	m := make(map[string]AssetMapInput)
+	m := make(AssetMapMap)
 	for k, v := range in {
 		m[k] = ToAssetMap(v)
 	}
-	return AssetMapMap(m)
+	return m
+}
+
+func ToAssetMapMapOutput(in map[string]AssetMapOutput) AssetMapMapOutput {
+	m := make(AssetMapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToAssetMapMapOutput()
 }
 
 var assetArrayArrayType = reflect.TypeOf((*[][]Asset)(nil)).Elem()
@@ -1603,11 +1691,19 @@ func (o AssetArrayArrayOutput) Index(i IntInput) AssetArrayOutput {
 }
 
 func ToAssetArrayArray(in [][]Asset) AssetArrayArray {
-	a := make([]AssetArrayInput, len(in))
+	a := make(AssetArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToAssetArray(v)
 	}
-	return AssetArrayArray(a)
+	return a
+}
+
+func ToAssetArrayArrayOutput(in []AssetArrayOutput) AssetArrayArrayOutput {
+	a := make(AssetArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToAssetArrayArrayOutput()
 }
 
 var assetOrArchiveType = reflect.TypeOf((*AssetOrArchive)(nil)).Elem()
@@ -2128,11 +2224,19 @@ func (o BoolArrayOutput) Index(i IntInput) BoolOutput {
 }
 
 func ToBoolArray(in []bool) BoolArray {
-	a := make([]BoolInput, len(in))
+	a := make(BoolArray, len(in))
 	for i, v := range in {
 		a[i] = Bool(v)
 	}
-	return BoolArray(a)
+	return a
+}
+
+func ToBoolArrayOutput(in []BoolOutput) BoolArrayOutput {
+	a := make(BoolArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToBoolArrayOutput()
 }
 
 var boolMapType = reflect.TypeOf((*map[string]bool)(nil)).Elem()
@@ -2185,11 +2289,19 @@ func (o BoolMapOutput) MapIndex(k StringInput) BoolOutput {
 }
 
 func ToBoolMap(in map[string]bool) BoolMap {
-	m := make(map[string]BoolInput)
+	m := make(BoolMap)
 	for k, v := range in {
 		m[k] = Bool(v)
 	}
-	return BoolMap(m)
+	return m
+}
+
+func ToBoolMapOutput(in map[string]BoolOutput) BoolMapOutput {
+	m := make(BoolMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToBoolMapOutput()
 }
 
 var boolArrayMapType = reflect.TypeOf((*map[string][]bool)(nil)).Elem()
@@ -2242,11 +2354,19 @@ func (o BoolArrayMapOutput) MapIndex(k StringInput) BoolArrayOutput {
 }
 
 func ToBoolArrayMap(in map[string][]bool) BoolArrayMap {
-	m := make(map[string]BoolArrayInput)
+	m := make(BoolArrayMap)
 	for k, v := range in {
 		m[k] = ToBoolArray(v)
 	}
-	return BoolArrayMap(m)
+	return m
+}
+
+func ToBoolArrayMapOutput(in map[string]BoolArrayOutput) BoolArrayMapOutput {
+	m := make(BoolArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToBoolArrayMapOutput()
 }
 
 var boolMapArrayType = reflect.TypeOf((*[]map[string]bool)(nil)).Elem()
@@ -2306,11 +2426,19 @@ func (o BoolMapArrayOutput) Index(i IntInput) BoolMapOutput {
 }
 
 func ToBoolMapArray(in []map[string]bool) BoolMapArray {
-	a := make([]BoolMapInput, len(in))
+	a := make(BoolMapArray, len(in))
 	for i, v := range in {
 		a[i] = ToBoolMap(v)
 	}
-	return BoolMapArray(a)
+	return a
+}
+
+func ToBoolMapArrayOutput(in []BoolMapOutput) BoolMapArrayOutput {
+	a := make(BoolMapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToBoolMapArrayOutput()
 }
 
 var boolMapMapType = reflect.TypeOf((*map[string]map[string]bool)(nil)).Elem()
@@ -2363,11 +2491,19 @@ func (o BoolMapMapOutput) MapIndex(k StringInput) BoolMapOutput {
 }
 
 func ToBoolMapMap(in map[string]map[string]bool) BoolMapMap {
-	m := make(map[string]BoolMapInput)
+	m := make(BoolMapMap)
 	for k, v := range in {
 		m[k] = ToBoolMap(v)
 	}
-	return BoolMapMap(m)
+	return m
+}
+
+func ToBoolMapMapOutput(in map[string]BoolMapOutput) BoolMapMapOutput {
+	m := make(BoolMapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToBoolMapMapOutput()
 }
 
 var boolArrayArrayType = reflect.TypeOf((*[][]bool)(nil)).Elem()
@@ -2427,11 +2563,19 @@ func (o BoolArrayArrayOutput) Index(i IntInput) BoolArrayOutput {
 }
 
 func ToBoolArrayArray(in [][]bool) BoolArrayArray {
-	a := make([]BoolArrayInput, len(in))
+	a := make(BoolArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToBoolArray(v)
 	}
-	return BoolArrayArray(a)
+	return a
+}
+
+func ToBoolArrayArrayOutput(in []BoolArrayOutput) BoolArrayArrayOutput {
+	a := make(BoolArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToBoolArrayArrayOutput()
 }
 
 var float64Type = reflect.TypeOf((*float64)(nil)).Elem()
@@ -2611,11 +2755,19 @@ func (o Float64ArrayOutput) Index(i IntInput) Float64Output {
 }
 
 func ToFloat64Array(in []float64) Float64Array {
-	a := make([]Float64Input, len(in))
+	a := make(Float64Array, len(in))
 	for i, v := range in {
 		a[i] = Float64(v)
 	}
-	return Float64Array(a)
+	return a
+}
+
+func ToFloat64ArrayOutput(in []Float64Output) Float64ArrayOutput {
+	a := make(Float64Array, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToFloat64ArrayOutput()
 }
 
 var float64MapType = reflect.TypeOf((*map[string]float64)(nil)).Elem()
@@ -2668,11 +2820,19 @@ func (o Float64MapOutput) MapIndex(k StringInput) Float64Output {
 }
 
 func ToFloat64Map(in map[string]float64) Float64Map {
-	m := make(map[string]Float64Input)
+	m := make(Float64Map)
 	for k, v := range in {
 		m[k] = Float64(v)
 	}
-	return Float64Map(m)
+	return m
+}
+
+func ToFloat64MapOutput(in map[string]Float64Output) Float64MapOutput {
+	m := make(Float64Map)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToFloat64MapOutput()
 }
 
 var float64ArrayMapType = reflect.TypeOf((*map[string][]float64)(nil)).Elem()
@@ -2725,11 +2885,19 @@ func (o Float64ArrayMapOutput) MapIndex(k StringInput) Float64ArrayOutput {
 }
 
 func ToFloat64ArrayMap(in map[string][]float64) Float64ArrayMap {
-	m := make(map[string]Float64ArrayInput)
+	m := make(Float64ArrayMap)
 	for k, v := range in {
 		m[k] = ToFloat64Array(v)
 	}
-	return Float64ArrayMap(m)
+	return m
+}
+
+func ToFloat64ArrayMapOutput(in map[string]Float64ArrayOutput) Float64ArrayMapOutput {
+	m := make(Float64ArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToFloat64ArrayMapOutput()
 }
 
 var float64MapArrayType = reflect.TypeOf((*[]map[string]float64)(nil)).Elem()
@@ -2789,11 +2957,19 @@ func (o Float64MapArrayOutput) Index(i IntInput) Float64MapOutput {
 }
 
 func ToFloat64MapArray(in []map[string]float64) Float64MapArray {
-	a := make([]Float64MapInput, len(in))
+	a := make(Float64MapArray, len(in))
 	for i, v := range in {
 		a[i] = ToFloat64Map(v)
 	}
-	return Float64MapArray(a)
+	return a
+}
+
+func ToFloat64MapArrayOutput(in []Float64MapOutput) Float64MapArrayOutput {
+	a := make(Float64MapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToFloat64MapArrayOutput()
 }
 
 var float64MapMapType = reflect.TypeOf((*map[string]map[string]float64)(nil)).Elem()
@@ -2846,11 +3022,19 @@ func (o Float64MapMapOutput) MapIndex(k StringInput) Float64MapOutput {
 }
 
 func ToFloat64MapMap(in map[string]map[string]float64) Float64MapMap {
-	m := make(map[string]Float64MapInput)
+	m := make(Float64MapMap)
 	for k, v := range in {
 		m[k] = ToFloat64Map(v)
 	}
-	return Float64MapMap(m)
+	return m
+}
+
+func ToFloat64MapMapOutput(in map[string]Float64MapOutput) Float64MapMapOutput {
+	m := make(Float64MapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToFloat64MapMapOutput()
 }
 
 var float64ArrayArrayType = reflect.TypeOf((*[][]float64)(nil)).Elem()
@@ -2910,11 +3094,19 @@ func (o Float64ArrayArrayOutput) Index(i IntInput) Float64ArrayOutput {
 }
 
 func ToFloat64ArrayArray(in [][]float64) Float64ArrayArray {
-	a := make([]Float64ArrayInput, len(in))
+	a := make(Float64ArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToFloat64Array(v)
 	}
-	return Float64ArrayArray(a)
+	return a
+}
+
+func ToFloat64ArrayArrayOutput(in []Float64ArrayOutput) Float64ArrayArrayOutput {
+	a := make(Float64ArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToFloat64ArrayArrayOutput()
 }
 
 var idType = reflect.TypeOf((*ID)(nil)).Elem()
@@ -3109,11 +3301,19 @@ func (o IDArrayOutput) Index(i IntInput) IDOutput {
 }
 
 func ToIDArray(in []ID) IDArray {
-	a := make([]IDInput, len(in))
+	a := make(IDArray, len(in))
 	for i, v := range in {
 		a[i] = (v)
 	}
-	return IDArray(a)
+	return a
+}
+
+func ToIDArrayOutput(in []IDOutput) IDArrayOutput {
+	a := make(IDArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToIDArrayOutput()
 }
 
 var iDMapType = reflect.TypeOf((*map[string]ID)(nil)).Elem()
@@ -3166,11 +3366,19 @@ func (o IDMapOutput) MapIndex(k StringInput) IDOutput {
 }
 
 func ToIDMap(in map[string]ID) IDMap {
-	m := make(map[string]IDInput)
+	m := make(IDMap)
 	for k, v := range in {
 		m[k] = (v)
 	}
-	return IDMap(m)
+	return m
+}
+
+func ToIDMapOutput(in map[string]IDOutput) IDMapOutput {
+	m := make(IDMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToIDMapOutput()
 }
 
 var iDArrayMapType = reflect.TypeOf((*map[string][]ID)(nil)).Elem()
@@ -3223,11 +3431,19 @@ func (o IDArrayMapOutput) MapIndex(k StringInput) IDArrayOutput {
 }
 
 func ToIDArrayMap(in map[string][]ID) IDArrayMap {
-	m := make(map[string]IDArrayInput)
+	m := make(IDArrayMap)
 	for k, v := range in {
 		m[k] = ToIDArray(v)
 	}
-	return IDArrayMap(m)
+	return m
+}
+
+func ToIDArrayMapOutput(in map[string]IDArrayOutput) IDArrayMapOutput {
+	m := make(IDArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToIDArrayMapOutput()
 }
 
 var iDMapArrayType = reflect.TypeOf((*[]map[string]ID)(nil)).Elem()
@@ -3287,11 +3503,19 @@ func (o IDMapArrayOutput) Index(i IntInput) IDMapOutput {
 }
 
 func ToIDMapArray(in []map[string]ID) IDMapArray {
-	a := make([]IDMapInput, len(in))
+	a := make(IDMapArray, len(in))
 	for i, v := range in {
 		a[i] = ToIDMap(v)
 	}
-	return IDMapArray(a)
+	return a
+}
+
+func ToIDMapArrayOutput(in []IDMapOutput) IDMapArrayOutput {
+	a := make(IDMapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToIDMapArrayOutput()
 }
 
 var iDMapMapType = reflect.TypeOf((*map[string]map[string]ID)(nil)).Elem()
@@ -3344,11 +3568,19 @@ func (o IDMapMapOutput) MapIndex(k StringInput) IDMapOutput {
 }
 
 func ToIDMapMap(in map[string]map[string]ID) IDMapMap {
-	m := make(map[string]IDMapInput)
+	m := make(IDMapMap)
 	for k, v := range in {
 		m[k] = ToIDMap(v)
 	}
-	return IDMapMap(m)
+	return m
+}
+
+func ToIDMapMapOutput(in map[string]IDMapOutput) IDMapMapOutput {
+	m := make(IDMapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToIDMapMapOutput()
 }
 
 var iDArrayArrayType = reflect.TypeOf((*[][]ID)(nil)).Elem()
@@ -3408,11 +3640,19 @@ func (o IDArrayArrayOutput) Index(i IntInput) IDArrayOutput {
 }
 
 func ToIDArrayArray(in [][]ID) IDArrayArray {
-	a := make([]IDArrayInput, len(in))
+	a := make(IDArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToIDArray(v)
 	}
-	return IDArrayArray(a)
+	return a
+}
+
+func ToIDArrayArrayOutput(in []IDArrayOutput) IDArrayArrayOutput {
+	a := make(IDArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToIDArrayArrayOutput()
 }
 
 var arrayType = reflect.TypeOf((*[]interface{})(nil)).Elem()
@@ -3472,11 +3712,19 @@ func (o ArrayOutput) Index(i IntInput) Output {
 }
 
 func ToArray(in []interface{}) Array {
-	a := make([]Input, len(in))
+	a := make(Array, len(in))
 	for i, v := range in {
 		a[i] = ToOutput(v)
 	}
-	return Array(a)
+	return a
+}
+
+func ToArrayOutput(in []Output) ArrayOutput {
+	a := make(Array, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToArrayOutput()
 }
 
 var mapType = reflect.TypeOf((*map[string]interface{})(nil)).Elem()
@@ -3529,11 +3777,19 @@ func (o MapOutput) MapIndex(k StringInput) Output {
 }
 
 func ToMap(in map[string]interface{}) Map {
-	m := make(map[string]Input)
+	m := make(Map)
 	for k, v := range in {
 		m[k] = ToOutput(v)
 	}
-	return Map(m)
+	return m
+}
+
+func ToMapOutput(in map[string]Output) MapOutput {
+	m := make(Map)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToMapOutput()
 }
 
 var arrayMapType = reflect.TypeOf((*map[string][]interface{})(nil)).Elem()
@@ -3586,11 +3842,19 @@ func (o ArrayMapOutput) MapIndex(k StringInput) ArrayOutput {
 }
 
 func ToArrayMap(in map[string][]interface{}) ArrayMap {
-	m := make(map[string]ArrayInput)
+	m := make(ArrayMap)
 	for k, v := range in {
 		m[k] = ToArray(v)
 	}
-	return ArrayMap(m)
+	return m
+}
+
+func ToArrayMapOutput(in map[string]ArrayOutput) ArrayMapOutput {
+	m := make(ArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToArrayMapOutput()
 }
 
 var mapArrayType = reflect.TypeOf((*[]map[string]interface{})(nil)).Elem()
@@ -3650,11 +3914,19 @@ func (o MapArrayOutput) Index(i IntInput) MapOutput {
 }
 
 func ToMapArray(in []map[string]interface{}) MapArray {
-	a := make([]MapInput, len(in))
+	a := make(MapArray, len(in))
 	for i, v := range in {
 		a[i] = ToMap(v)
 	}
-	return MapArray(a)
+	return a
+}
+
+func ToMapArrayOutput(in []MapOutput) MapArrayOutput {
+	a := make(MapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToMapArrayOutput()
 }
 
 var mapMapType = reflect.TypeOf((*map[string]map[string]interface{})(nil)).Elem()
@@ -3707,11 +3979,19 @@ func (o MapMapOutput) MapIndex(k StringInput) MapOutput {
 }
 
 func ToMapMap(in map[string]map[string]interface{}) MapMap {
-	m := make(map[string]MapInput)
+	m := make(MapMap)
 	for k, v := range in {
 		m[k] = ToMap(v)
 	}
-	return MapMap(m)
+	return m
+}
+
+func ToMapMapOutput(in map[string]MapOutput) MapMapOutput {
+	m := make(MapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToMapMapOutput()
 }
 
 var arrayArrayType = reflect.TypeOf((*[][]interface{})(nil)).Elem()
@@ -3771,11 +4051,19 @@ func (o ArrayArrayOutput) Index(i IntInput) ArrayOutput {
 }
 
 func ToArrayArray(in [][]interface{}) ArrayArray {
-	a := make([]ArrayInput, len(in))
+	a := make(ArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToArray(v)
 	}
-	return ArrayArray(a)
+	return a
+}
+
+func ToArrayArrayOutput(in []ArrayOutput) ArrayArrayOutput {
+	a := make(ArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToArrayArrayOutput()
 }
 
 var intType = reflect.TypeOf((*int)(nil)).Elem()
@@ -3955,11 +4243,19 @@ func (o IntArrayOutput) Index(i IntInput) IntOutput {
 }
 
 func ToIntArray(in []int) IntArray {
-	a := make([]IntInput, len(in))
+	a := make(IntArray, len(in))
 	for i, v := range in {
 		a[i] = Int(v)
 	}
-	return IntArray(a)
+	return a
+}
+
+func ToIntArrayOutput(in []IntOutput) IntArrayOutput {
+	a := make(IntArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToIntArrayOutput()
 }
 
 var intMapType = reflect.TypeOf((*map[string]int)(nil)).Elem()
@@ -4012,11 +4308,19 @@ func (o IntMapOutput) MapIndex(k StringInput) IntOutput {
 }
 
 func ToIntMap(in map[string]int) IntMap {
-	m := make(map[string]IntInput)
+	m := make(IntMap)
 	for k, v := range in {
 		m[k] = Int(v)
 	}
-	return IntMap(m)
+	return m
+}
+
+func ToIntMapOutput(in map[string]IntOutput) IntMapOutput {
+	m := make(IntMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToIntMapOutput()
 }
 
 var intArrayMapType = reflect.TypeOf((*map[string][]int)(nil)).Elem()
@@ -4069,11 +4373,19 @@ func (o IntArrayMapOutput) MapIndex(k StringInput) IntArrayOutput {
 }
 
 func ToIntArrayMap(in map[string][]int) IntArrayMap {
-	m := make(map[string]IntArrayInput)
+	m := make(IntArrayMap)
 	for k, v := range in {
 		m[k] = ToIntArray(v)
 	}
-	return IntArrayMap(m)
+	return m
+}
+
+func ToIntArrayMapOutput(in map[string]IntArrayOutput) IntArrayMapOutput {
+	m := make(IntArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToIntArrayMapOutput()
 }
 
 var intMapArrayType = reflect.TypeOf((*[]map[string]int)(nil)).Elem()
@@ -4133,11 +4445,19 @@ func (o IntMapArrayOutput) Index(i IntInput) IntMapOutput {
 }
 
 func ToIntMapArray(in []map[string]int) IntMapArray {
-	a := make([]IntMapInput, len(in))
+	a := make(IntMapArray, len(in))
 	for i, v := range in {
 		a[i] = ToIntMap(v)
 	}
-	return IntMapArray(a)
+	return a
+}
+
+func ToIntMapArrayOutput(in []IntMapOutput) IntMapArrayOutput {
+	a := make(IntMapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToIntMapArrayOutput()
 }
 
 var intMapMapType = reflect.TypeOf((*map[string]map[string]int)(nil)).Elem()
@@ -4190,11 +4510,19 @@ func (o IntMapMapOutput) MapIndex(k StringInput) IntMapOutput {
 }
 
 func ToIntMapMap(in map[string]map[string]int) IntMapMap {
-	m := make(map[string]IntMapInput)
+	m := make(IntMapMap)
 	for k, v := range in {
 		m[k] = ToIntMap(v)
 	}
-	return IntMapMap(m)
+	return m
+}
+
+func ToIntMapMapOutput(in map[string]IntMapOutput) IntMapMapOutput {
+	m := make(IntMapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToIntMapMapOutput()
 }
 
 var intArrayArrayType = reflect.TypeOf((*[][]int)(nil)).Elem()
@@ -4254,11 +4582,19 @@ func (o IntArrayArrayOutput) Index(i IntInput) IntArrayOutput {
 }
 
 func ToIntArrayArray(in [][]int) IntArrayArray {
-	a := make([]IntArrayInput, len(in))
+	a := make(IntArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToIntArray(v)
 	}
-	return IntArrayArray(a)
+	return a
+}
+
+func ToIntArrayArrayOutput(in []IntArrayOutput) IntArrayArrayOutput {
+	a := make(IntArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToIntArrayArrayOutput()
 }
 
 var stringType = reflect.TypeOf((*string)(nil)).Elem()
@@ -4438,11 +4774,19 @@ func (o StringArrayOutput) Index(i IntInput) StringOutput {
 }
 
 func ToStringArray(in []string) StringArray {
-	a := make([]StringInput, len(in))
+	a := make(StringArray, len(in))
 	for i, v := range in {
 		a[i] = String(v)
 	}
-	return StringArray(a)
+	return a
+}
+
+func ToStringArrayOutput(in []StringOutput) StringArrayOutput {
+	a := make(StringArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToStringArrayOutput()
 }
 
 var stringMapType = reflect.TypeOf((*map[string]string)(nil)).Elem()
@@ -4495,11 +4839,19 @@ func (o StringMapOutput) MapIndex(k StringInput) StringOutput {
 }
 
 func ToStringMap(in map[string]string) StringMap {
-	m := make(map[string]StringInput)
+	m := make(StringMap)
 	for k, v := range in {
 		m[k] = String(v)
 	}
-	return StringMap(m)
+	return m
+}
+
+func ToStringMapOutput(in map[string]StringOutput) StringMapOutput {
+	m := make(StringMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToStringMapOutput()
 }
 
 var stringArrayMapType = reflect.TypeOf((*map[string][]string)(nil)).Elem()
@@ -4552,11 +4904,19 @@ func (o StringArrayMapOutput) MapIndex(k StringInput) StringArrayOutput {
 }
 
 func ToStringArrayMap(in map[string][]string) StringArrayMap {
-	m := make(map[string]StringArrayInput)
+	m := make(StringArrayMap)
 	for k, v := range in {
 		m[k] = ToStringArray(v)
 	}
-	return StringArrayMap(m)
+	return m
+}
+
+func ToStringArrayMapOutput(in map[string]StringArrayOutput) StringArrayMapOutput {
+	m := make(StringArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToStringArrayMapOutput()
 }
 
 var stringMapArrayType = reflect.TypeOf((*[]map[string]string)(nil)).Elem()
@@ -4616,11 +4976,19 @@ func (o StringMapArrayOutput) Index(i IntInput) StringMapOutput {
 }
 
 func ToStringMapArray(in []map[string]string) StringMapArray {
-	a := make([]StringMapInput, len(in))
+	a := make(StringMapArray, len(in))
 	for i, v := range in {
 		a[i] = ToStringMap(v)
 	}
-	return StringMapArray(a)
+	return a
+}
+
+func ToStringMapArrayOutput(in []StringMapOutput) StringMapArrayOutput {
+	a := make(StringMapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToStringMapArrayOutput()
 }
 
 var stringMapMapType = reflect.TypeOf((*map[string]map[string]string)(nil)).Elem()
@@ -4673,11 +5041,19 @@ func (o StringMapMapOutput) MapIndex(k StringInput) StringMapOutput {
 }
 
 func ToStringMapMap(in map[string]map[string]string) StringMapMap {
-	m := make(map[string]StringMapInput)
+	m := make(StringMapMap)
 	for k, v := range in {
 		m[k] = ToStringMap(v)
 	}
-	return StringMapMap(m)
+	return m
+}
+
+func ToStringMapMapOutput(in map[string]StringMapOutput) StringMapMapOutput {
+	m := make(StringMapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToStringMapMapOutput()
 }
 
 var stringArrayArrayType = reflect.TypeOf((*[][]string)(nil)).Elem()
@@ -4737,11 +5113,19 @@ func (o StringArrayArrayOutput) Index(i IntInput) StringArrayOutput {
 }
 
 func ToStringArrayArray(in [][]string) StringArrayArray {
-	a := make([]StringArrayInput, len(in))
+	a := make(StringArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToStringArray(v)
 	}
-	return StringArrayArray(a)
+	return a
+}
+
+func ToStringArrayArrayOutput(in []StringArrayOutput) StringArrayArrayOutput {
+	a := make(StringArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToStringArrayArrayOutput()
 }
 
 var urnType = reflect.TypeOf((*URN)(nil)).Elem()
@@ -4936,11 +5320,19 @@ func (o URNArrayOutput) Index(i IntInput) URNOutput {
 }
 
 func ToURNArray(in []URN) URNArray {
-	a := make([]URNInput, len(in))
+	a := make(URNArray, len(in))
 	for i, v := range in {
 		a[i] = (v)
 	}
-	return URNArray(a)
+	return a
+}
+
+func ToURNArrayOutput(in []URNOutput) URNArrayOutput {
+	a := make(URNArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToURNArrayOutput()
 }
 
 var uRNMapType = reflect.TypeOf((*map[string]URN)(nil)).Elem()
@@ -4993,11 +5385,19 @@ func (o URNMapOutput) MapIndex(k StringInput) URNOutput {
 }
 
 func ToURNMap(in map[string]URN) URNMap {
-	m := make(map[string]URNInput)
+	m := make(URNMap)
 	for k, v := range in {
 		m[k] = (v)
 	}
-	return URNMap(m)
+	return m
+}
+
+func ToURNMapOutput(in map[string]URNOutput) URNMapOutput {
+	m := make(URNMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToURNMapOutput()
 }
 
 var uRNArrayMapType = reflect.TypeOf((*map[string][]URN)(nil)).Elem()
@@ -5050,11 +5450,19 @@ func (o URNArrayMapOutput) MapIndex(k StringInput) URNArrayOutput {
 }
 
 func ToURNArrayMap(in map[string][]URN) URNArrayMap {
-	m := make(map[string]URNArrayInput)
+	m := make(URNArrayMap)
 	for k, v := range in {
 		m[k] = ToURNArray(v)
 	}
-	return URNArrayMap(m)
+	return m
+}
+
+func ToURNArrayMapOutput(in map[string]URNArrayOutput) URNArrayMapOutput {
+	m := make(URNArrayMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToURNArrayMapOutput()
 }
 
 var uRNMapArrayType = reflect.TypeOf((*[]map[string]URN)(nil)).Elem()
@@ -5114,11 +5522,19 @@ func (o URNMapArrayOutput) Index(i IntInput) URNMapOutput {
 }
 
 func ToURNMapArray(in []map[string]URN) URNMapArray {
-	a := make([]URNMapInput, len(in))
+	a := make(URNMapArray, len(in))
 	for i, v := range in {
 		a[i] = ToURNMap(v)
 	}
-	return URNMapArray(a)
+	return a
+}
+
+func ToURNMapArrayOutput(in []URNMapOutput) URNMapArrayOutput {
+	a := make(URNMapArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToURNMapArrayOutput()
 }
 
 var uRNMapMapType = reflect.TypeOf((*map[string]map[string]URN)(nil)).Elem()
@@ -5171,11 +5587,19 @@ func (o URNMapMapOutput) MapIndex(k StringInput) URNMapOutput {
 }
 
 func ToURNMapMap(in map[string]map[string]URN) URNMapMap {
-	m := make(map[string]URNMapInput)
+	m := make(URNMapMap)
 	for k, v := range in {
 		m[k] = ToURNMap(v)
 	}
-	return URNMapMap(m)
+	return m
+}
+
+func ToURNMapMapOutput(in map[string]URNMapOutput) URNMapMapOutput {
+	m := make(URNMapMap)
+	for k, v := range in {
+		m[k] = v
+	}
+	return m.ToURNMapMapOutput()
 }
 
 var uRNArrayArrayType = reflect.TypeOf((*[][]URN)(nil)).Elem()
@@ -5235,11 +5659,19 @@ func (o URNArrayArrayOutput) Index(i IntInput) URNArrayOutput {
 }
 
 func ToURNArrayArray(in [][]URN) URNArrayArray {
-	a := make([]URNArrayInput, len(in))
+	a := make(URNArrayArray, len(in))
 	for i, v := range in {
 		a[i] = ToURNArray(v)
 	}
-	return URNArrayArray(a)
+	return a
+}
+
+func ToURNArrayArrayOutput(in []URNArrayOutput) URNArrayArrayOutput {
+	a := make(URNArrayArray, len(in))
+	for i, v := range in {
+		a[i] = v
+	}
+	return a.ToURNArrayArrayOutput()
 }
 
 func getResolvedValue(input Input) (reflect.Value, bool) {

--- a/sdk/go/pulumi/types_builtins_test.go
+++ b/sdk/go/pulumi/types_builtins_test.go
@@ -5163,6 +5163,20 @@ func TestToArchiveArray(t *testing.T) {
 	assert.EqualValues(t, av.([]Archive)[0], iv)
 }
 
+func TestTopLevelToArchiveArrayOutput(t *testing.T) {
+	out := ToArchiveArrayOutput([]ArchiveOutput{ToOutput(NewFileArchive("foo.zip")).(ArchiveOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]Archive)[0], iv)
+}
+
 func TestArchiveMapArrayIndex(t *testing.T) {
 	out := (ArchiveMapArray{ArchiveMap{"baz": NewFileArchive("foo.zip")}}).ToArchiveMapArrayOutput()
 
@@ -5183,6 +5197,20 @@ func TestArchiveMapArrayIndex(t *testing.T) {
 
 func TestToArchiveMapArray(t *testing.T) {
 	out := ToArchiveMapArray([]map[string]Archive{{"baz": NewFileArchive("foo.zip")}}).ToArchiveMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]Archive)[0], iv)
+}
+
+func TestTopLevelToArchiveMapArrayOutput(t *testing.T) {
+	out := ToArchiveMapArrayOutput([]ArchiveMapOutput{ToOutput(ArchiveMap{"baz": NewFileArchive("foo.zip")}).(ArchiveMapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5227,6 +5255,20 @@ func TestToArchiveArrayArray(t *testing.T) {
 	assert.EqualValues(t, av.([][]Archive)[0], iv)
 }
 
+func TestTopLevelToArchiveArrayArrayOutput(t *testing.T) {
+	out := ToArchiveArrayArrayOutput([]ArchiveArrayOutput{ToOutput(ArchiveArray{NewFileArchive("foo.zip")}).(ArchiveArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]Archive)[0], iv)
+}
+
 func TestAssetArrayIndex(t *testing.T) {
 	out := (AssetArray{NewFileAsset("foo.txt")}).ToAssetArrayOutput()
 
@@ -5247,6 +5289,20 @@ func TestAssetArrayIndex(t *testing.T) {
 
 func TestToAssetArray(t *testing.T) {
 	out := ToAssetArray([]Asset{NewFileAsset("foo.txt")}).ToAssetArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]Asset)[0], iv)
+}
+
+func TestTopLevelToAssetArrayOutput(t *testing.T) {
+	out := ToAssetArrayOutput([]AssetOutput{ToOutput(NewFileAsset("foo.txt")).(AssetOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5291,6 +5347,20 @@ func TestToAssetMapArray(t *testing.T) {
 	assert.EqualValues(t, av.([]map[string]Asset)[0], iv)
 }
 
+func TestTopLevelToAssetMapArrayOutput(t *testing.T) {
+	out := ToAssetMapArrayOutput([]AssetMapOutput{ToOutput(AssetMap{"baz": NewFileAsset("foo.txt")}).(AssetMapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]Asset)[0], iv)
+}
+
 func TestAssetArrayArrayIndex(t *testing.T) {
 	out := (AssetArrayArray{AssetArray{NewFileAsset("foo.txt")}}).ToAssetArrayArrayOutput()
 
@@ -5311,6 +5381,20 @@ func TestAssetArrayArrayIndex(t *testing.T) {
 
 func TestToAssetArrayArray(t *testing.T) {
 	out := ToAssetArrayArray([][]Asset{{NewFileAsset("foo.txt")}}).ToAssetArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]Asset)[0], iv)
+}
+
+func TestTopLevelToAssetArrayArrayOutput(t *testing.T) {
+	out := ToAssetArrayArrayOutput([]AssetArrayOutput{ToOutput(AssetArray{NewFileAsset("foo.txt")}).(AssetArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5409,6 +5493,20 @@ func TestToBoolArray(t *testing.T) {
 	assert.EqualValues(t, av.([]bool)[0], iv)
 }
 
+func TestTopLevelToBoolArrayOutput(t *testing.T) {
+	out := ToBoolArrayOutput([]BoolOutput{ToOutput(Bool(true)).(BoolOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]bool)[0], iv)
+}
+
 func TestBoolMapArrayIndex(t *testing.T) {
 	out := (BoolMapArray{BoolMap{"baz": Bool(true)}}).ToBoolMapArrayOutput()
 
@@ -5429,6 +5527,20 @@ func TestBoolMapArrayIndex(t *testing.T) {
 
 func TestToBoolMapArray(t *testing.T) {
 	out := ToBoolMapArray([]map[string]bool{{"baz": true}}).ToBoolMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]bool)[0], iv)
+}
+
+func TestTopLevelToBoolMapArrayOutput(t *testing.T) {
+	out := ToBoolMapArrayOutput([]BoolMapOutput{ToOutput(BoolMap{"baz": Bool(true)}).(BoolMapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5473,6 +5585,20 @@ func TestToBoolArrayArray(t *testing.T) {
 	assert.EqualValues(t, av.([][]bool)[0], iv)
 }
 
+func TestTopLevelToBoolArrayArrayOutput(t *testing.T) {
+	out := ToBoolArrayArrayOutput([]BoolArrayOutput{ToOutput(BoolArray{Bool(true)}).(BoolArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]bool)[0], iv)
+}
+
 func TestFloat64ArrayIndex(t *testing.T) {
 	out := (Float64Array{Float64(999.9)}).ToFloat64ArrayOutput()
 
@@ -5493,6 +5619,20 @@ func TestFloat64ArrayIndex(t *testing.T) {
 
 func TestToFloat64Array(t *testing.T) {
 	out := ToFloat64Array([]float64{999.9}).ToFloat64ArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]float64)[0], iv)
+}
+
+func TestTopLevelToFloat64ArrayOutput(t *testing.T) {
+	out := ToFloat64ArrayOutput([]Float64Output{ToOutput(Float64(999.9)).(Float64Output)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5537,6 +5677,20 @@ func TestToFloat64MapArray(t *testing.T) {
 	assert.EqualValues(t, av.([]map[string]float64)[0], iv)
 }
 
+func TestTopLevelToFloat64MapArrayOutput(t *testing.T) {
+	out := ToFloat64MapArrayOutput([]Float64MapOutput{ToOutput(Float64Map{"baz": Float64(999.9)}).(Float64MapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]float64)[0], iv)
+}
+
 func TestFloat64ArrayArrayIndex(t *testing.T) {
 	out := (Float64ArrayArray{Float64Array{Float64(999.9)}}).ToFloat64ArrayArrayOutput()
 
@@ -5557,6 +5711,20 @@ func TestFloat64ArrayArrayIndex(t *testing.T) {
 
 func TestToFloat64ArrayArray(t *testing.T) {
 	out := ToFloat64ArrayArray([][]float64{{999.9}}).ToFloat64ArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]float64)[0], iv)
+}
+
+func TestTopLevelToFloat64ArrayArrayOutput(t *testing.T) {
+	out := ToFloat64ArrayArrayOutput([]Float64ArrayOutput{ToOutput(Float64Array{Float64(999.9)}).(Float64ArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5601,6 +5769,20 @@ func TestToIDArray(t *testing.T) {
 	assert.EqualValues(t, av.([]ID)[0], iv)
 }
 
+func TestTopLevelToIDArrayOutput(t *testing.T) {
+	out := ToIDArrayOutput([]IDOutput{ToOutput(ID("foo")).(IDOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]ID)[0], iv)
+}
+
 func TestIDMapArrayIndex(t *testing.T) {
 	out := (IDMapArray{IDMap{"baz": ID("foo")}}).ToIDMapArrayOutput()
 
@@ -5621,6 +5803,20 @@ func TestIDMapArrayIndex(t *testing.T) {
 
 func TestToIDMapArray(t *testing.T) {
 	out := ToIDMapArray([]map[string]ID{{"baz": ID("foo")}}).ToIDMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]ID)[0], iv)
+}
+
+func TestTopLevelToIDMapArrayOutput(t *testing.T) {
+	out := ToIDMapArrayOutput([]IDMapOutput{ToOutput(IDMap{"baz": ID("foo")}).(IDMapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5665,6 +5861,20 @@ func TestToIDArrayArray(t *testing.T) {
 	assert.EqualValues(t, av.([][]ID)[0], iv)
 }
 
+func TestTopLevelToIDArrayArrayOutput(t *testing.T) {
+	out := ToIDArrayArrayOutput([]IDArrayOutput{ToOutput(IDArray{ID("foo")}).(IDArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]ID)[0], iv)
+}
+
 func TestArrayIndex(t *testing.T) {
 	out := (Array{String("any")}).ToArrayOutput()
 
@@ -5685,6 +5895,20 @@ func TestArrayIndex(t *testing.T) {
 
 func TestToArray(t *testing.T) {
 	out := ToArray([]interface{}{String("any")}).ToArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]interface{})[0], iv)
+}
+
+func TestTopLevelToArrayOutput(t *testing.T) {
+	out := ToArrayOutput([]Output{ToOutput(String("any")).(Output)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5729,6 +5953,20 @@ func TestToMapArray(t *testing.T) {
 	assert.EqualValues(t, av.([]map[string]interface{})[0], iv)
 }
 
+func TestTopLevelToMapArrayOutput(t *testing.T) {
+	out := ToMapArrayOutput([]MapOutput{ToOutput(Map{"baz": String("any")}).(MapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]interface{})[0], iv)
+}
+
 func TestArrayArrayIndex(t *testing.T) {
 	out := (ArrayArray{Array{String("any")}}).ToArrayArrayOutput()
 
@@ -5749,6 +5987,20 @@ func TestArrayArrayIndex(t *testing.T) {
 
 func TestToArrayArray(t *testing.T) {
 	out := ToArrayArray([][]interface{}{{String("any")}}).ToArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]interface{})[0], iv)
+}
+
+func TestTopLevelToArrayArrayOutput(t *testing.T) {
+	out := ToArrayArrayOutput([]ArrayOutput{ToOutput(Array{String("any")}).(ArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5793,6 +6045,20 @@ func TestToIntArray(t *testing.T) {
 	assert.EqualValues(t, av.([]int)[0], iv)
 }
 
+func TestTopLevelToIntArrayOutput(t *testing.T) {
+	out := ToIntArrayOutput([]IntOutput{ToOutput(Int(42)).(IntOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]int)[0], iv)
+}
+
 func TestIntMapArrayIndex(t *testing.T) {
 	out := (IntMapArray{IntMap{"baz": Int(42)}}).ToIntMapArrayOutput()
 
@@ -5813,6 +6079,20 @@ func TestIntMapArrayIndex(t *testing.T) {
 
 func TestToIntMapArray(t *testing.T) {
 	out := ToIntMapArray([]map[string]int{{"baz": 42}}).ToIntMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]int)[0], iv)
+}
+
+func TestTopLevelToIntMapArrayOutput(t *testing.T) {
+	out := ToIntMapArrayOutput([]IntMapOutput{ToOutput(IntMap{"baz": Int(42)}).(IntMapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5857,6 +6137,20 @@ func TestToIntArrayArray(t *testing.T) {
 	assert.EqualValues(t, av.([][]int)[0], iv)
 }
 
+func TestTopLevelToIntArrayArrayOutput(t *testing.T) {
+	out := ToIntArrayArrayOutput([]IntArrayOutput{ToOutput(IntArray{Int(42)}).(IntArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]int)[0], iv)
+}
+
 func TestStringArrayIndex(t *testing.T) {
 	out := (StringArray{String("foo")}).ToStringArrayOutput()
 
@@ -5877,6 +6171,20 @@ func TestStringArrayIndex(t *testing.T) {
 
 func TestToStringArray(t *testing.T) {
 	out := ToStringArray([]string{"foo"}).ToStringArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]string)[0], iv)
+}
+
+func TestTopLevelToStringArrayOutput(t *testing.T) {
+	out := ToStringArrayOutput([]StringOutput{ToOutput(String("foo")).(StringOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5921,6 +6229,20 @@ func TestToStringMapArray(t *testing.T) {
 	assert.EqualValues(t, av.([]map[string]string)[0], iv)
 }
 
+func TestTopLevelToStringMapArrayOutput(t *testing.T) {
+	out := ToStringMapArrayOutput([]StringMapOutput{ToOutput(StringMap{"baz": String("foo")}).(StringMapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]string)[0], iv)
+}
+
 func TestStringArrayArrayIndex(t *testing.T) {
 	out := (StringArrayArray{StringArray{String("foo")}}).ToStringArrayArrayOutput()
 
@@ -5941,6 +6263,20 @@ func TestStringArrayArrayIndex(t *testing.T) {
 
 func TestToStringArrayArray(t *testing.T) {
 	out := ToStringArrayArray([][]string{{"foo"}}).ToStringArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]string)[0], iv)
+}
+
+func TestTopLevelToStringArrayArrayOutput(t *testing.T) {
+	out := ToStringArrayArrayOutput([]StringArrayOutput{ToOutput(StringArray{String("foo")}).(StringArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -5985,6 +6321,20 @@ func TestToURNArray(t *testing.T) {
 	assert.EqualValues(t, av.([]URN)[0], iv)
 }
 
+func TestTopLevelToURNArrayOutput(t *testing.T) {
+	out := ToURNArrayOutput([]URNOutput{ToOutput(URN("foo")).(URNOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]URN)[0], iv)
+}
+
 func TestURNMapArrayIndex(t *testing.T) {
 	out := (URNMapArray{URNMap{"baz": URN("foo")}}).ToURNMapArrayOutput()
 
@@ -6017,6 +6367,20 @@ func TestToURNMapArray(t *testing.T) {
 	assert.EqualValues(t, av.([]map[string]URN)[0], iv)
 }
 
+func TestTopLevelToURNMapArrayOutput(t *testing.T) {
+	out := ToURNMapArrayOutput([]URNMapOutput{ToOutput(URNMap{"baz": URN("foo")}).(URNMapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]URN)[0], iv)
+}
+
 func TestURNArrayArrayIndex(t *testing.T) {
 	out := (URNArrayArray{URNArray{URN("foo")}}).ToURNArrayArrayOutput()
 
@@ -6037,6 +6401,20 @@ func TestURNArrayArrayIndex(t *testing.T) {
 
 func TestToURNArrayArray(t *testing.T) {
 	out := ToURNArrayArray([][]URN{{URN("foo")}}).ToURNArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]URN)[0], iv)
+}
+
+func TestTopLevelToURNArrayArrayOutput(t *testing.T) {
+	out := ToURNArrayArrayOutput([]URNArrayOutput{ToOutput(URNArray{URN("foo")}).(URNArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6083,6 +6461,20 @@ func TestToArchiveMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]Archive)["baz"], iv)
 }
 
+func TestTopLevelToArchiveMapOutput(t *testing.T) {
+	out := ToArchiveMapOutput(map[string]ArchiveOutput{"baz": ToOutput(NewFileArchive("foo.zip")).(ArchiveOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]Archive)["baz"], iv)
+}
+
 func TestArchiveArrayMapIndex(t *testing.T) {
 	out := (ArchiveArrayMap{"baz": ArchiveArray{NewFileArchive("foo.zip")}}).ToArchiveArrayMapOutput()
 
@@ -6103,6 +6495,20 @@ func TestArchiveArrayMapIndex(t *testing.T) {
 
 func TestToArchiveArrayMap(t *testing.T) {
 	out := ToArchiveArrayMap(map[string][]Archive{"baz": {NewFileArchive("foo.zip")}}).ToArchiveArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]Archive)["baz"], iv)
+}
+
+func TestTopLevelToArchiveArrayMapOutput(t *testing.T) {
+	out := ToArchiveArrayMapOutput(map[string]ArchiveArrayOutput{"baz": ToOutput(ArchiveArray{NewFileArchive("foo.zip")}).(ArchiveArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6147,6 +6553,20 @@ func TestToArchiveMapMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]map[string]Archive)["baz"], iv)
 }
 
+func TestTopLevelToArchiveMapMapOutput(t *testing.T) {
+	out := ToArchiveMapMapOutput(map[string]ArchiveMapOutput{"baz": ToOutput(ArchiveMap{"baz": NewFileArchive("foo.zip")}).(ArchiveMapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]Archive)["baz"], iv)
+}
+
 func TestAssetMapIndex(t *testing.T) {
 	out := (AssetMap{"baz": NewFileAsset("foo.txt")}).ToAssetMapOutput()
 
@@ -6167,6 +6587,20 @@ func TestAssetMapIndex(t *testing.T) {
 
 func TestToAssetMap(t *testing.T) {
 	out := ToAssetMap(map[string]Asset{"baz": NewFileAsset("foo.txt")}).ToAssetMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]Asset)["baz"], iv)
+}
+
+func TestTopLevelToAssetMapOutput(t *testing.T) {
+	out := ToAssetMapOutput(map[string]AssetOutput{"baz": ToOutput(NewFileAsset("foo.txt")).(AssetOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6211,6 +6645,20 @@ func TestToAssetArrayMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string][]Asset)["baz"], iv)
 }
 
+func TestTopLevelToAssetArrayMapOutput(t *testing.T) {
+	out := ToAssetArrayMapOutput(map[string]AssetArrayOutput{"baz": ToOutput(AssetArray{NewFileAsset("foo.txt")}).(AssetArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]Asset)["baz"], iv)
+}
+
 func TestAssetMapMapIndex(t *testing.T) {
 	out := (AssetMapMap{"baz": AssetMap{"baz": NewFileAsset("foo.txt")}}).ToAssetMapMapOutput()
 
@@ -6231,6 +6679,20 @@ func TestAssetMapMapIndex(t *testing.T) {
 
 func TestToAssetMapMap(t *testing.T) {
 	out := ToAssetMapMap(map[string]map[string]Asset{"baz": {"baz": NewFileAsset("foo.txt")}}).ToAssetMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]Asset)["baz"], iv)
+}
+
+func TestTopLevelToAssetMapMapOutput(t *testing.T) {
+	out := ToAssetMapMapOutput(map[string]AssetMapOutput{"baz": ToOutput(AssetMap{"baz": NewFileAsset("foo.txt")}).(AssetMapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6329,6 +6791,20 @@ func TestToBoolMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]bool)["baz"], iv)
 }
 
+func TestTopLevelToBoolMapOutput(t *testing.T) {
+	out := ToBoolMapOutput(map[string]BoolOutput{"baz": ToOutput(Bool(true)).(BoolOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]bool)["baz"], iv)
+}
+
 func TestBoolArrayMapIndex(t *testing.T) {
 	out := (BoolArrayMap{"baz": BoolArray{Bool(true)}}).ToBoolArrayMapOutput()
 
@@ -6349,6 +6825,20 @@ func TestBoolArrayMapIndex(t *testing.T) {
 
 func TestToBoolArrayMap(t *testing.T) {
 	out := ToBoolArrayMap(map[string][]bool{"baz": {true}}).ToBoolArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]bool)["baz"], iv)
+}
+
+func TestTopLevelToBoolArrayMapOutput(t *testing.T) {
+	out := ToBoolArrayMapOutput(map[string]BoolArrayOutput{"baz": ToOutput(BoolArray{Bool(true)}).(BoolArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6393,6 +6883,20 @@ func TestToBoolMapMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]map[string]bool)["baz"], iv)
 }
 
+func TestTopLevelToBoolMapMapOutput(t *testing.T) {
+	out := ToBoolMapMapOutput(map[string]BoolMapOutput{"baz": ToOutput(BoolMap{"baz": Bool(true)}).(BoolMapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]bool)["baz"], iv)
+}
+
 func TestFloat64MapIndex(t *testing.T) {
 	out := (Float64Map{"baz": Float64(999.9)}).ToFloat64MapOutput()
 
@@ -6413,6 +6917,20 @@ func TestFloat64MapIndex(t *testing.T) {
 
 func TestToFloat64Map(t *testing.T) {
 	out := ToFloat64Map(map[string]float64{"baz": 999.9}).ToFloat64MapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]float64)["baz"], iv)
+}
+
+func TestTopLevelToFloat64MapOutput(t *testing.T) {
+	out := ToFloat64MapOutput(map[string]Float64Output{"baz": ToOutput(Float64(999.9)).(Float64Output)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6457,6 +6975,20 @@ func TestToFloat64ArrayMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string][]float64)["baz"], iv)
 }
 
+func TestTopLevelToFloat64ArrayMapOutput(t *testing.T) {
+	out := ToFloat64ArrayMapOutput(map[string]Float64ArrayOutput{"baz": ToOutput(Float64Array{Float64(999.9)}).(Float64ArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]float64)["baz"], iv)
+}
+
 func TestFloat64MapMapIndex(t *testing.T) {
 	out := (Float64MapMap{"baz": Float64Map{"baz": Float64(999.9)}}).ToFloat64MapMapOutput()
 
@@ -6477,6 +7009,20 @@ func TestFloat64MapMapIndex(t *testing.T) {
 
 func TestToFloat64MapMap(t *testing.T) {
 	out := ToFloat64MapMap(map[string]map[string]float64{"baz": {"baz": 999.9}}).ToFloat64MapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]float64)["baz"], iv)
+}
+
+func TestTopLevelToFloat64MapMapOutput(t *testing.T) {
+	out := ToFloat64MapMapOutput(map[string]Float64MapOutput{"baz": ToOutput(Float64Map{"baz": Float64(999.9)}).(Float64MapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6521,6 +7067,20 @@ func TestToIDMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]ID)["baz"], iv)
 }
 
+func TestTopLevelToIDMapOutput(t *testing.T) {
+	out := ToIDMapOutput(map[string]IDOutput{"baz": ToOutput(ID("foo")).(IDOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]ID)["baz"], iv)
+}
+
 func TestIDArrayMapIndex(t *testing.T) {
 	out := (IDArrayMap{"baz": IDArray{ID("foo")}}).ToIDArrayMapOutput()
 
@@ -6541,6 +7101,20 @@ func TestIDArrayMapIndex(t *testing.T) {
 
 func TestToIDArrayMap(t *testing.T) {
 	out := ToIDArrayMap(map[string][]ID{"baz": {ID("foo")}}).ToIDArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]ID)["baz"], iv)
+}
+
+func TestTopLevelToIDArrayMapOutput(t *testing.T) {
+	out := ToIDArrayMapOutput(map[string]IDArrayOutput{"baz": ToOutput(IDArray{ID("foo")}).(IDArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6585,6 +7159,20 @@ func TestToIDMapMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]map[string]ID)["baz"], iv)
 }
 
+func TestTopLevelToIDMapMapOutput(t *testing.T) {
+	out := ToIDMapMapOutput(map[string]IDMapOutput{"baz": ToOutput(IDMap{"baz": ID("foo")}).(IDMapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]ID)["baz"], iv)
+}
+
 func TestMapIndex(t *testing.T) {
 	out := (Map{"baz": String("any")}).ToMapOutput()
 
@@ -6605,6 +7193,20 @@ func TestMapIndex(t *testing.T) {
 
 func TestToMap(t *testing.T) {
 	out := ToMap(map[string]interface{}{"baz": String("any")}).ToMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]interface{})["baz"], iv)
+}
+
+func TestTopLevelToMapOutput(t *testing.T) {
+	out := ToMapOutput(map[string]Output{"baz": ToOutput(String("any")).(Output)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6649,6 +7251,20 @@ func TestToArrayMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string][]interface{})["baz"], iv)
 }
 
+func TestTopLevelToArrayMapOutput(t *testing.T) {
+	out := ToArrayMapOutput(map[string]ArrayOutput{"baz": ToOutput(Array{String("any")}).(ArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]interface{})["baz"], iv)
+}
+
 func TestMapMapIndex(t *testing.T) {
 	out := (MapMap{"baz": Map{"baz": String("any")}}).ToMapMapOutput()
 
@@ -6669,6 +7285,20 @@ func TestMapMapIndex(t *testing.T) {
 
 func TestToMapMap(t *testing.T) {
 	out := ToMapMap(map[string]map[string]interface{}{"baz": {"baz": String("any")}}).ToMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]interface{})["baz"], iv)
+}
+
+func TestTopLevelToMapMapOutput(t *testing.T) {
+	out := ToMapMapOutput(map[string]MapOutput{"baz": ToOutput(Map{"baz": String("any")}).(MapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6713,6 +7343,20 @@ func TestToIntMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]int)["baz"], iv)
 }
 
+func TestTopLevelToIntMapOutput(t *testing.T) {
+	out := ToIntMapOutput(map[string]IntOutput{"baz": ToOutput(Int(42)).(IntOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]int)["baz"], iv)
+}
+
 func TestIntArrayMapIndex(t *testing.T) {
 	out := (IntArrayMap{"baz": IntArray{Int(42)}}).ToIntArrayMapOutput()
 
@@ -6733,6 +7377,20 @@ func TestIntArrayMapIndex(t *testing.T) {
 
 func TestToIntArrayMap(t *testing.T) {
 	out := ToIntArrayMap(map[string][]int{"baz": {42}}).ToIntArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]int)["baz"], iv)
+}
+
+func TestTopLevelToIntArrayMapOutput(t *testing.T) {
+	out := ToIntArrayMapOutput(map[string]IntArrayOutput{"baz": ToOutput(IntArray{Int(42)}).(IntArrayOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6777,6 +7435,20 @@ func TestToIntMapMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]map[string]int)["baz"], iv)
 }
 
+func TestTopLevelToIntMapMapOutput(t *testing.T) {
+	out := ToIntMapMapOutput(map[string]IntMapOutput{"baz": ToOutput(IntMap{"baz": Int(42)}).(IntMapOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]int)["baz"], iv)
+}
+
 func TestStringMapIndex(t *testing.T) {
 	out := (StringMap{"baz": String("foo")}).ToStringMapOutput()
 
@@ -6797,6 +7469,20 @@ func TestStringMapIndex(t *testing.T) {
 
 func TestToStringMap(t *testing.T) {
 	out := ToStringMap(map[string]string{"baz": "foo"}).ToStringMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]string)["baz"], iv)
+}
+
+func TestTopLevelToStringMapOutput(t *testing.T) {
+	out := ToStringMapOutput(map[string]StringOutput{"baz": ToOutput(String("foo")).(StringOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6841,6 +7527,20 @@ func TestToStringArrayMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string][]string)["baz"], iv)
 }
 
+func TestTopLevelToStringArrayMapOutput(t *testing.T) {
+	out := ToStringArrayMapOutput(map[string]StringArrayOutput{"baz": ToOutput(StringArray{String("foo")}).(StringArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]string)["baz"], iv)
+}
+
 func TestStringMapMapIndex(t *testing.T) {
 	out := (StringMapMap{"baz": StringMap{"baz": String("foo")}}).ToStringMapMapOutput()
 
@@ -6861,6 +7561,20 @@ func TestStringMapMapIndex(t *testing.T) {
 
 func TestToStringMapMap(t *testing.T) {
 	out := ToStringMapMap(map[string]map[string]string{"baz": {"baz": "foo"}}).ToStringMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]string)["baz"], iv)
+}
+
+func TestTopLevelToStringMapMapOutput(t *testing.T) {
+	out := ToStringMapMapOutput(map[string]StringMapOutput{"baz": ToOutput(StringMap{"baz": String("foo")}).(StringMapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)
@@ -6905,6 +7619,20 @@ func TestToURNMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string]URN)["baz"], iv)
 }
 
+func TestTopLevelToURNMapOutput(t *testing.T) {
+	out := ToURNMapOutput(map[string]URNOutput{"baz": ToOutput(URN("foo")).(URNOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]URN)["baz"], iv)
+}
+
 func TestURNArrayMapIndex(t *testing.T) {
 	out := (URNArrayMap{"baz": URNArray{URN("foo")}}).ToURNArrayMapOutput()
 
@@ -6937,6 +7665,20 @@ func TestToURNArrayMap(t *testing.T) {
 	assert.EqualValues(t, av.(map[string][]URN)["baz"], iv)
 }
 
+func TestTopLevelToURNArrayMapOutput(t *testing.T) {
+	out := ToURNArrayMapOutput(map[string]URNArrayOutput{"baz": ToOutput(URNArray{URN("foo")}).(URNArrayOutput)})
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]URN)["baz"], iv)
+}
+
 func TestURNMapMapIndex(t *testing.T) {
 	out := (URNMapMap{"baz": URNMap{"baz": URN("foo")}}).ToURNMapMapOutput()
 
@@ -6957,6 +7699,20 @@ func TestURNMapMapIndex(t *testing.T) {
 
 func TestToURNMapMap(t *testing.T) {
 	out := ToURNMapMap(map[string]map[string]URN{"baz": {"baz": URN("foo")}}).ToURNMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]URN)["baz"], iv)
+}
+
+func TestTopLevelToURNMapMapOutput(t *testing.T) {
+	out := ToURNMapMapOutput(map[string]URNMapOutput{"baz": ToOutput(URNMap{"baz": URN("foo")}).(URNMapOutput)})
 
 	av, known, _, _, err := await(out)
 	assert.True(t, known)

--- a/sdk/go/pulumi/types_builtins_test.go
+++ b/sdk/go/pulumi/types_builtins_test.go
@@ -5149,6 +5149,20 @@ func TestArchiveArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToArchiveArray(t *testing.T) {
+	out := ToArchiveArray([]Archive{NewFileArchive("foo.zip")}).ToArchiveArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]Archive)[0], iv)
+}
+
 func TestArchiveMapArrayIndex(t *testing.T) {
 	out := (ArchiveMapArray{ArchiveMap{"baz": NewFileArchive("foo.zip")}}).ToArchiveMapArrayOutput()
 
@@ -5165,6 +5179,20 @@ func TestArchiveMapArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToArchiveMapArray(t *testing.T) {
+	out := ToArchiveMapArray([]map[string]Archive{{"baz": NewFileArchive("foo.zip")}}).ToArchiveMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]Archive)[0], iv)
 }
 
 func TestArchiveArrayArrayIndex(t *testing.T) {
@@ -5185,6 +5213,20 @@ func TestArchiveArrayArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToArchiveArrayArray(t *testing.T) {
+	out := ToArchiveArrayArray([][]Archive{{NewFileArchive("foo.zip")}}).ToArchiveArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]Archive)[0], iv)
+}
+
 func TestAssetArrayIndex(t *testing.T) {
 	out := (AssetArray{NewFileAsset("foo.txt")}).ToAssetArrayOutput()
 
@@ -5201,6 +5243,20 @@ func TestAssetArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToAssetArray(t *testing.T) {
+	out := ToAssetArray([]Asset{NewFileAsset("foo.txt")}).ToAssetArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]Asset)[0], iv)
 }
 
 func TestAssetMapArrayIndex(t *testing.T) {
@@ -5221,6 +5277,20 @@ func TestAssetMapArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToAssetMapArray(t *testing.T) {
+	out := ToAssetMapArray([]map[string]Asset{{"baz": NewFileAsset("foo.txt")}}).ToAssetMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]Asset)[0], iv)
+}
+
 func TestAssetArrayArrayIndex(t *testing.T) {
 	out := (AssetArrayArray{AssetArray{NewFileAsset("foo.txt")}}).ToAssetArrayArrayOutput()
 
@@ -5237,6 +5307,20 @@ func TestAssetArrayArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToAssetArrayArray(t *testing.T) {
+	out := ToAssetArrayArray([][]Asset{{NewFileAsset("foo.txt")}}).ToAssetArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]Asset)[0], iv)
 }
 
 func TestAssetOrArchiveArrayIndex(t *testing.T) {
@@ -5311,6 +5395,20 @@ func TestBoolArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToBoolArray(t *testing.T) {
+	out := ToBoolArray([]bool{true}).ToBoolArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]bool)[0], iv)
+}
+
 func TestBoolMapArrayIndex(t *testing.T) {
 	out := (BoolMapArray{BoolMap{"baz": Bool(true)}}).ToBoolMapArrayOutput()
 
@@ -5327,6 +5425,20 @@ func TestBoolMapArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToBoolMapArray(t *testing.T) {
+	out := ToBoolMapArray([]map[string]bool{{"baz": true}}).ToBoolMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]bool)[0], iv)
 }
 
 func TestBoolArrayArrayIndex(t *testing.T) {
@@ -5347,6 +5459,20 @@ func TestBoolArrayArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToBoolArrayArray(t *testing.T) {
+	out := ToBoolArrayArray([][]bool{{true}}).ToBoolArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]bool)[0], iv)
+}
+
 func TestFloat64ArrayIndex(t *testing.T) {
 	out := (Float64Array{Float64(999.9)}).ToFloat64ArrayOutput()
 
@@ -5363,6 +5489,20 @@ func TestFloat64ArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToFloat64Array(t *testing.T) {
+	out := ToFloat64Array([]float64{999.9}).ToFloat64ArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]float64)[0], iv)
 }
 
 func TestFloat64MapArrayIndex(t *testing.T) {
@@ -5383,6 +5523,20 @@ func TestFloat64MapArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToFloat64MapArray(t *testing.T) {
+	out := ToFloat64MapArray([]map[string]float64{{"baz": 999.9}}).ToFloat64MapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]float64)[0], iv)
+}
+
 func TestFloat64ArrayArrayIndex(t *testing.T) {
 	out := (Float64ArrayArray{Float64Array{Float64(999.9)}}).ToFloat64ArrayArrayOutput()
 
@@ -5399,6 +5553,20 @@ func TestFloat64ArrayArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToFloat64ArrayArray(t *testing.T) {
+	out := ToFloat64ArrayArray([][]float64{{999.9}}).ToFloat64ArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]float64)[0], iv)
 }
 
 func TestIDArrayIndex(t *testing.T) {
@@ -5419,6 +5587,20 @@ func TestIDArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToIDArray(t *testing.T) {
+	out := ToIDArray([]ID{ID("foo")}).ToIDArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]ID)[0], iv)
+}
+
 func TestIDMapArrayIndex(t *testing.T) {
 	out := (IDMapArray{IDMap{"baz": ID("foo")}}).ToIDMapArrayOutput()
 
@@ -5435,6 +5617,20 @@ func TestIDMapArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToIDMapArray(t *testing.T) {
+	out := ToIDMapArray([]map[string]ID{{"baz": ID("foo")}}).ToIDMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]ID)[0], iv)
 }
 
 func TestIDArrayArrayIndex(t *testing.T) {
@@ -5455,6 +5651,20 @@ func TestIDArrayArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToIDArrayArray(t *testing.T) {
+	out := ToIDArrayArray([][]ID{{ID("foo")}}).ToIDArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]ID)[0], iv)
+}
+
 func TestArrayIndex(t *testing.T) {
 	out := (Array{String("any")}).ToArrayOutput()
 
@@ -5471,6 +5681,20 @@ func TestArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToArray(t *testing.T) {
+	out := ToArray([]interface{}{String("any")}).ToArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]interface{})[0], iv)
 }
 
 func TestMapArrayIndex(t *testing.T) {
@@ -5491,6 +5715,20 @@ func TestMapArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToMapArray(t *testing.T) {
+	out := ToMapArray([]map[string]interface{}{{"baz": String("any")}}).ToMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]interface{})[0], iv)
+}
+
 func TestArrayArrayIndex(t *testing.T) {
 	out := (ArrayArray{Array{String("any")}}).ToArrayArrayOutput()
 
@@ -5507,6 +5745,20 @@ func TestArrayArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToArrayArray(t *testing.T) {
+	out := ToArrayArray([][]interface{}{{String("any")}}).ToArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]interface{})[0], iv)
 }
 
 func TestIntArrayIndex(t *testing.T) {
@@ -5527,6 +5779,20 @@ func TestIntArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToIntArray(t *testing.T) {
+	out := ToIntArray([]int{42}).ToIntArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]int)[0], iv)
+}
+
 func TestIntMapArrayIndex(t *testing.T) {
 	out := (IntMapArray{IntMap{"baz": Int(42)}}).ToIntMapArrayOutput()
 
@@ -5543,6 +5809,20 @@ func TestIntMapArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToIntMapArray(t *testing.T) {
+	out := ToIntMapArray([]map[string]int{{"baz": 42}}).ToIntMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]int)[0], iv)
 }
 
 func TestIntArrayArrayIndex(t *testing.T) {
@@ -5563,6 +5843,20 @@ func TestIntArrayArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToIntArrayArray(t *testing.T) {
+	out := ToIntArrayArray([][]int{{42}}).ToIntArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]int)[0], iv)
+}
+
 func TestStringArrayIndex(t *testing.T) {
 	out := (StringArray{String("foo")}).ToStringArrayOutput()
 
@@ -5579,6 +5873,20 @@ func TestStringArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToStringArray(t *testing.T) {
+	out := ToStringArray([]string{"foo"}).ToStringArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]string)[0], iv)
 }
 
 func TestStringMapArrayIndex(t *testing.T) {
@@ -5599,6 +5907,20 @@ func TestStringMapArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToStringMapArray(t *testing.T) {
+	out := ToStringMapArray([]map[string]string{{"baz": "foo"}}).ToStringMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]string)[0], iv)
+}
+
 func TestStringArrayArrayIndex(t *testing.T) {
 	out := (StringArrayArray{StringArray{String("foo")}}).ToStringArrayArrayOutput()
 
@@ -5615,6 +5937,20 @@ func TestStringArrayArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToStringArrayArray(t *testing.T) {
+	out := ToStringArrayArray([][]string{{"foo"}}).ToStringArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]string)[0], iv)
 }
 
 func TestURNArrayIndex(t *testing.T) {
@@ -5635,6 +5971,20 @@ func TestURNArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToURNArray(t *testing.T) {
+	out := ToURNArray([]URN{URN("foo")}).ToURNArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]URN)[0], iv)
+}
+
 func TestURNMapArrayIndex(t *testing.T) {
 	out := (URNMapArray{URNMap{"baz": URN("foo")}}).ToURNMapArrayOutput()
 
@@ -5653,6 +6003,20 @@ func TestURNMapArrayIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToURNMapArray(t *testing.T) {
+	out := ToURNMapArray([]map[string]URN{{"baz": URN("foo")}}).ToURNMapArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([]map[string]URN)[0], iv)
+}
+
 func TestURNArrayArrayIndex(t *testing.T) {
 	out := (URNArrayArray{URNArray{URN("foo")}}).ToURNArrayArrayOutput()
 
@@ -5669,6 +6033,20 @@ func TestURNArrayArrayIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToURNArrayArray(t *testing.T) {
+	out := ToURNArrayArray([][]URN{{URN("foo")}}).ToURNArrayArrayOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.Index(Int(0)))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.([][]URN)[0], iv)
 }
 
 // Test map indexers.
@@ -5691,6 +6069,20 @@ func TestArchiveMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToArchiveMap(t *testing.T) {
+	out := ToArchiveMap(map[string]Archive{"baz": NewFileArchive("foo.zip")}).ToArchiveMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]Archive)["baz"], iv)
+}
+
 func TestArchiveArrayMapIndex(t *testing.T) {
 	out := (ArchiveArrayMap{"baz": ArchiveArray{NewFileArchive("foo.zip")}}).ToArchiveArrayMapOutput()
 
@@ -5707,6 +6099,20 @@ func TestArchiveArrayMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToArchiveArrayMap(t *testing.T) {
+	out := ToArchiveArrayMap(map[string][]Archive{"baz": {NewFileArchive("foo.zip")}}).ToArchiveArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]Archive)["baz"], iv)
 }
 
 func TestArchiveMapMapIndex(t *testing.T) {
@@ -5727,6 +6133,20 @@ func TestArchiveMapMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToArchiveMapMap(t *testing.T) {
+	out := ToArchiveMapMap(map[string]map[string]Archive{"baz": {"baz": NewFileArchive("foo.zip")}}).ToArchiveMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]Archive)["baz"], iv)
+}
+
 func TestAssetMapIndex(t *testing.T) {
 	out := (AssetMap{"baz": NewFileAsset("foo.txt")}).ToAssetMapOutput()
 
@@ -5743,6 +6163,20 @@ func TestAssetMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToAssetMap(t *testing.T) {
+	out := ToAssetMap(map[string]Asset{"baz": NewFileAsset("foo.txt")}).ToAssetMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]Asset)["baz"], iv)
 }
 
 func TestAssetArrayMapIndex(t *testing.T) {
@@ -5763,6 +6197,20 @@ func TestAssetArrayMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToAssetArrayMap(t *testing.T) {
+	out := ToAssetArrayMap(map[string][]Asset{"baz": {NewFileAsset("foo.txt")}}).ToAssetArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]Asset)["baz"], iv)
+}
+
 func TestAssetMapMapIndex(t *testing.T) {
 	out := (AssetMapMap{"baz": AssetMap{"baz": NewFileAsset("foo.txt")}}).ToAssetMapMapOutput()
 
@@ -5779,6 +6227,20 @@ func TestAssetMapMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToAssetMapMap(t *testing.T) {
+	out := ToAssetMapMap(map[string]map[string]Asset{"baz": {"baz": NewFileAsset("foo.txt")}}).ToAssetMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]Asset)["baz"], iv)
 }
 
 func TestAssetOrArchiveMapIndex(t *testing.T) {
@@ -5853,6 +6315,20 @@ func TestBoolMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToBoolMap(t *testing.T) {
+	out := ToBoolMap(map[string]bool{"baz": true}).ToBoolMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]bool)["baz"], iv)
+}
+
 func TestBoolArrayMapIndex(t *testing.T) {
 	out := (BoolArrayMap{"baz": BoolArray{Bool(true)}}).ToBoolArrayMapOutput()
 
@@ -5869,6 +6345,20 @@ func TestBoolArrayMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToBoolArrayMap(t *testing.T) {
+	out := ToBoolArrayMap(map[string][]bool{"baz": {true}}).ToBoolArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]bool)["baz"], iv)
 }
 
 func TestBoolMapMapIndex(t *testing.T) {
@@ -5889,6 +6379,20 @@ func TestBoolMapMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToBoolMapMap(t *testing.T) {
+	out := ToBoolMapMap(map[string]map[string]bool{"baz": {"baz": true}}).ToBoolMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]bool)["baz"], iv)
+}
+
 func TestFloat64MapIndex(t *testing.T) {
 	out := (Float64Map{"baz": Float64(999.9)}).ToFloat64MapOutput()
 
@@ -5905,6 +6409,20 @@ func TestFloat64MapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToFloat64Map(t *testing.T) {
+	out := ToFloat64Map(map[string]float64{"baz": 999.9}).ToFloat64MapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]float64)["baz"], iv)
 }
 
 func TestFloat64ArrayMapIndex(t *testing.T) {
@@ -5925,6 +6443,20 @@ func TestFloat64ArrayMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToFloat64ArrayMap(t *testing.T) {
+	out := ToFloat64ArrayMap(map[string][]float64{"baz": {999.9}}).ToFloat64ArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]float64)["baz"], iv)
+}
+
 func TestFloat64MapMapIndex(t *testing.T) {
 	out := (Float64MapMap{"baz": Float64Map{"baz": Float64(999.9)}}).ToFloat64MapMapOutput()
 
@@ -5941,6 +6473,20 @@ func TestFloat64MapMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToFloat64MapMap(t *testing.T) {
+	out := ToFloat64MapMap(map[string]map[string]float64{"baz": {"baz": 999.9}}).ToFloat64MapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]float64)["baz"], iv)
 }
 
 func TestIDMapIndex(t *testing.T) {
@@ -5961,6 +6507,20 @@ func TestIDMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToIDMap(t *testing.T) {
+	out := ToIDMap(map[string]ID{"baz": ID("foo")}).ToIDMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]ID)["baz"], iv)
+}
+
 func TestIDArrayMapIndex(t *testing.T) {
 	out := (IDArrayMap{"baz": IDArray{ID("foo")}}).ToIDArrayMapOutput()
 
@@ -5977,6 +6537,20 @@ func TestIDArrayMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToIDArrayMap(t *testing.T) {
+	out := ToIDArrayMap(map[string][]ID{"baz": {ID("foo")}}).ToIDArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]ID)["baz"], iv)
 }
 
 func TestIDMapMapIndex(t *testing.T) {
@@ -5997,6 +6571,20 @@ func TestIDMapMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToIDMapMap(t *testing.T) {
+	out := ToIDMapMap(map[string]map[string]ID{"baz": {"baz": ID("foo")}}).ToIDMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]ID)["baz"], iv)
+}
+
 func TestMapIndex(t *testing.T) {
 	out := (Map{"baz": String("any")}).ToMapOutput()
 
@@ -6013,6 +6601,20 @@ func TestMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToMap(t *testing.T) {
+	out := ToMap(map[string]interface{}{"baz": String("any")}).ToMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]interface{})["baz"], iv)
 }
 
 func TestArrayMapIndex(t *testing.T) {
@@ -6033,6 +6635,20 @@ func TestArrayMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToArrayMap(t *testing.T) {
+	out := ToArrayMap(map[string][]interface{}{"baz": {String("any")}}).ToArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]interface{})["baz"], iv)
+}
+
 func TestMapMapIndex(t *testing.T) {
 	out := (MapMap{"baz": Map{"baz": String("any")}}).ToMapMapOutput()
 
@@ -6049,6 +6665,20 @@ func TestMapMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToMapMap(t *testing.T) {
+	out := ToMapMap(map[string]map[string]interface{}{"baz": {"baz": String("any")}}).ToMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]interface{})["baz"], iv)
 }
 
 func TestIntMapIndex(t *testing.T) {
@@ -6069,6 +6699,20 @@ func TestIntMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToIntMap(t *testing.T) {
+	out := ToIntMap(map[string]int{"baz": 42}).ToIntMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]int)["baz"], iv)
+}
+
 func TestIntArrayMapIndex(t *testing.T) {
 	out := (IntArrayMap{"baz": IntArray{Int(42)}}).ToIntArrayMapOutput()
 
@@ -6085,6 +6729,20 @@ func TestIntArrayMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToIntArrayMap(t *testing.T) {
+	out := ToIntArrayMap(map[string][]int{"baz": {42}}).ToIntArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]int)["baz"], iv)
 }
 
 func TestIntMapMapIndex(t *testing.T) {
@@ -6105,6 +6763,20 @@ func TestIntMapMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToIntMapMap(t *testing.T) {
+	out := ToIntMapMap(map[string]map[string]int{"baz": {"baz": 42}}).ToIntMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]int)["baz"], iv)
+}
+
 func TestStringMapIndex(t *testing.T) {
 	out := (StringMap{"baz": String("foo")}).ToStringMapOutput()
 
@@ -6121,6 +6793,20 @@ func TestStringMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToStringMap(t *testing.T) {
+	out := ToStringMap(map[string]string{"baz": "foo"}).ToStringMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]string)["baz"], iv)
 }
 
 func TestStringArrayMapIndex(t *testing.T) {
@@ -6141,6 +6827,20 @@ func TestStringArrayMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToStringArrayMap(t *testing.T) {
+	out := ToStringArrayMap(map[string][]string{"baz": {"foo"}}).ToStringArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]string)["baz"], iv)
+}
+
 func TestStringMapMapIndex(t *testing.T) {
 	out := (StringMapMap{"baz": StringMap{"baz": String("foo")}}).ToStringMapMapOutput()
 
@@ -6157,6 +6857,20 @@ func TestStringMapMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToStringMapMap(t *testing.T) {
+	out := ToStringMapMap(map[string]map[string]string{"baz": {"baz": "foo"}}).ToStringMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]string)["baz"], iv)
 }
 
 func TestURNMapIndex(t *testing.T) {
@@ -6177,6 +6891,20 @@ func TestURNMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToURNMap(t *testing.T) {
+	out := ToURNMap(map[string]URN{"baz": URN("foo")}).ToURNMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]URN)["baz"], iv)
+}
+
 func TestURNArrayMapIndex(t *testing.T) {
 	out := (URNArrayMap{"baz": URNArray{URN("foo")}}).ToURNArrayMapOutput()
 
@@ -6195,6 +6923,20 @@ func TestURNArrayMapIndex(t *testing.T) {
 	assert.Zero(t, iv)
 }
 
+func TestToURNArrayMap(t *testing.T) {
+	out := ToURNArrayMap(map[string][]URN{"baz": {URN("foo")}}).ToURNArrayMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string][]URN)["baz"], iv)
+}
+
 func TestURNMapMapIndex(t *testing.T) {
 	out := (URNMapMap{"baz": URNMap{"baz": URN("foo")}}).ToURNMapMapOutput()
 
@@ -6211,4 +6953,18 @@ func TestURNMapMapIndex(t *testing.T) {
 	assert.True(t, known)
 	assert.NoError(t, err)
 	assert.Zero(t, iv)
+}
+
+func TestToURNMapMap(t *testing.T) {
+	out := ToURNMapMap(map[string]map[string]URN{"baz": {"baz": URN("foo")}}).ToURNMapMapOutput()
+
+	av, known, _, _, err := await(out)
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	iv, known, _, _, err := await(out.MapIndex(String("baz")))
+	assert.True(t, known)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, av.(map[string]map[string]URN)["baz"], iv)
 }


### PR DESCRIPTION
Adds two new methods for every Array and Map type:

```go
func ToStringArray(in []string) StringArray 
func ToStringArrayOutput(in []StringOutput) StringArrayOutput
```

These make it easier to take raw arrays of underlying values and project them into `*Array` instances of the lifted Pulumi type.

This addresses most of the cases in #3861, but does not handle cross-casting between things like `[]ID` and `[]string`.  Conversions like that always require writing a `for` loop in Go, and I believe it's reasonable to say that they require a for loop in an Apply in the Pulumi Go programming model.

It could be argued that we don't even need the helpers added here along similar grounds - but in this case, the Pulumi Go programming model itself is the one forcing a type projection that wouldn't have been necessary in plain Go, so it feels more justified to try and make this possible without writing a for loop manually.  Though notably, these conversion functions are all quite simple (much simpler than the implementations suggested in #3861), and it could be argued that Go idiom would be to just write these conversions inline in code that needed it. But to avoid the difficulty discovering the simple implementations of these functions as encountered in #3861 and elsewhere, this feels like a reasonable addition.

This does *not* introduce all the various intermediate combinations for the `ArrayArray`/`ArrayMap`/`MapArray`/`MapMap` types.  For example, we generate `func ToStringArrayArray(in [][]string) StringArrayArray` and `func ToStringArrayArrayOutput(in []StringArrayOutput) StringArrayArrayOutput` but do not generate any method that takes `[][]StringOutput` as input.  We could in theory add this later - but it's unclear what name to give it.  

Fixes #3861.