### PR TITLE
Exposing the version in the UpdateSummary struct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- [automation/go] Exposing the version in the UpdateSummary struct.
+  [#6339](https://github.com/pulumi/pulumi/pull/6339)
+
 - [CLI] Add pagination options to `pulumi stack history` (`--page`, `--page-size`). These replace the `--limit` flag.
   [#6292](https://github.com/pulumi/pulumi/pull/6292)
 

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -758,6 +758,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	assert.True(t, res.Outputs["exp_secret"].Secret)
 	assert.Equal(t, "update", res.Summary.Kind)
 	assert.Equal(t, "succeeded", res.Summary.Result)
+	assert.Greater(t, res.Summary.Version, 0)
 
 	// -- pulumi preview --
 

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -626,6 +626,7 @@ func (s *Stack) Import(ctx context.Context, state apitype.UntypedDeployment) err
 
 // UpdateSummary provides a summary of a Stack lifecycle operation (up/preview/refresh/destroy).
 type UpdateSummary struct {
+	Version     int               `json:"version"`
 	Kind        string            `json:"kind"`
 	StartTime   string            `json:"startTime"`
 	Message     string            `json:"message"`


### PR DESCRIPTION
TL;DR After running `stack.Up(...)` via the Automation API, I want access to the update `version` number for the stack.

A resource type integration in [Concourse](https://concourse-ci.org) expects that after an "update" (semantic specific to the resource type implementation) that an identifier for this new version is returned to Concourse. 

For the [Pulumi Concourse CI](https://github.com/ringods/pulumi-resource) integration, I am using the `version` field to model the series of Pulumi deployments. After running `stack.Up(...)` via the Automation API, I would like access to the `version` field from the result JSON so I can return it to Concourse:

https://github.com/ringods/pulumi-resource/blob/c122a20c802fc200f69c303d525c6f83e28ed83b/pkg/out/out.go#L45-L49

/cc @EvanBoyle 
