### PR TITLE
Ensure changes to pkg/codegen/docs run PR build

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -2,8 +2,6 @@ on:
   repository_dispatch:
     types: [ run-acceptance-tests-command ]
   pull_request:
-    paths-ignore:
-      - 'pkg/codegen/docs/**'
 
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}


### PR DESCRIPTION
@komalali tagging you for review here as you originally added this line - not sure if it was intended to be left there though

Basically, with that line in place, we never ran any linting / building or testing on a PR run when changes to codegen happened and that meant that #6336 to fix a broken build so hoping we can add this

P.