### PR TITLE
[Automation] Fix python nested config parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ CHANGELOG
 - [sdk/python] Define `__all__` in modules for better IDE autocomplete.
   [#6351](https://github.com/pulumi/pulumi/pull/6351)
 
+- [automation/python] Fix a bug in nested configuration parsing.
+  [#6349](https://github.com/pulumi/pulumi/pull/6349)
+
 ## 2.20.0 (2021-02-03)
 
 - [sdk/python] Fix `Output.from_input` to unwrap nested output values in input types (args classes), which addresses

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -1087,6 +1087,51 @@ func TestImportExportStack(t *testing.T) {
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
 }
 
+func TestNestedConfig(t *testing.T) {
+	ctx := context.Background()
+	stackName := FullyQualifiedStackName(pulumiOrg, "nested_config", "dev")
+
+	// initialize
+	pDir := filepath.Join(".", "test", "nested_config")
+	s, err := UpsertStackLocalSource(ctx, stackName, pDir)
+	if err != nil {
+		t.Errorf("failed to initialize stack, err: %v", err)
+		t.FailNow()
+	}
+
+	allConfig, err := s.GetAllConfig(ctx)
+	if err != nil {
+		t.Errorf("failed to get config, err: %v", err)
+		t.FailNow()
+	}
+
+	outerVal, ok := allConfig["nested_config:outer"]
+	assert.True(t, ok)
+	assert.True(t, outerVal.Secret)
+	assert.JSONEq(t, "{\"inner\":\"my_secret\", \"other\": \"something_else\"}", outerVal.Value)
+
+	listVal, ok := allConfig["nested_config:myList"]
+	assert.True(t, ok)
+	assert.False(t, listVal.Secret)
+	assert.JSONEq(t, "[\"one\",\"two\",\"three\"]", listVal.Value)
+
+	outer, err := s.GetConfig(ctx, "outer")
+	if err != nil {
+		t.Errorf("failed to get config, err: %v", err)
+		t.FailNow()
+	}
+	assert.True(t, outer.Secret)
+	assert.JSONEq(t, "{\"inner\":\"my_secret\", \"other\": \"something_else\"}", outer.Value)
+
+	list, err := s.GetConfig(ctx, "myList")
+	if err != nil {
+		t.Errorf("failed to get config, err: %v", err)
+		t.FailNow()
+	}
+	assert.False(t, list.Secret)
+	assert.JSONEq(t, "[\"one\",\"two\",\"three\"]", list.Value)
+}
+
 func getTestOrg() string {
 	testOrg := "pulumi-test"
 	if _, set := os.LookupEnv("PULUMI_TEST_ORG"); set {

--- a/sdk/go/x/auto/test/nested_config/Pulumi.dev.yaml
+++ b/sdk/go/x/auto/test/nested_config/Pulumi.dev.yaml
@@ -1,0 +1,12 @@
+config:
+  aws:region: us-west-2
+  nested_config:bar: 1234
+  nested_config:foo: aha
+  nested_config:myList:
+    - one
+    - two
+    - three
+  nested_config:outer:
+    inner:
+      secure: AAABADOd8UPayqGlunla+Lo6kSSYA4LffCNBe84ElLwv0kyz7oIcYAw=
+    other: something_else

--- a/sdk/go/x/auto/test/nested_config/Pulumi.yaml
+++ b/sdk/go/x/auto/test/nested_config/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: nested_config
+runtime: go
+description: A minimal Go Pulumi program

--- a/sdk/nodejs/tests/automation/data/nested_config/Pulumi.dev.yaml
+++ b/sdk/nodejs/tests/automation/data/nested_config/Pulumi.dev.yaml
@@ -1,0 +1,12 @@
+config:
+  aws:region: us-west-2
+  nested_config:bar: 1234
+  nested_config:foo: aha
+  nested_config:myList:
+    - one
+    - two
+    - three
+  nested_config:outer:
+    inner:
+      secure: AAABADOd8UPayqGlunla+Lo6kSSYA4LffCNBe84ElLwv0kyz7oIcYAw=
+    other: something_else

--- a/sdk/nodejs/tests/automation/data/nested_config/Pulumi.yaml
+++ b/sdk/nodejs/tests/automation/data/nested_config/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: nested_config
+runtime: go
+description: A minimal Go Pulumi program

--- a/sdk/python/lib/pulumi/x/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_local_workspace.py
@@ -152,7 +152,7 @@ class LocalWorkspace(Workspace):
         self.select_stack(stack_name)
         result = self._run_pulumi_cmd_sync(["config", "get", key, "--json"])
         val = json.loads(result.stdout)
-        return ConfigValue(**val)
+        return ConfigValue(value=val["value"], secret=val["secret"])
 
     def get_all_config(self, stack_name: str) -> ConfigMap:
         self.select_stack(stack_name)
@@ -160,7 +160,8 @@ class LocalWorkspace(Workspace):
         config_json = json.loads(result.stdout)
         config_map: ConfigMap = {}
         for key in config_json:
-            config_map[key] = ConfigValue(**config_json[key])
+            config_val_json = config_json[key]
+            config_map[key] = ConfigValue(value=config_val_json["value"], secret=config_val_json["secret"])
         return config_map
 
     def set_config(self, stack_name: str, key: str, value: ConfigValue) -> None:

--- a/sdk/python/lib/test/automation/data/nested_config/Pulumi.dev.yaml
+++ b/sdk/python/lib/test/automation/data/nested_config/Pulumi.dev.yaml
@@ -1,0 +1,12 @@
+config:
+  aws:region: us-west-2
+  nested_config:bar: 1234
+  nested_config:foo: aha
+  nested_config:myList:
+    - one
+    - two
+    - three
+  nested_config:outer:
+    inner:
+      secure: AAABADOd8UPayqGlunla+Lo6kSSYA4LffCNBe84ElLwv0kyz7oIcYAw=
+    other: something_else

--- a/sdk/python/lib/test/automation/data/nested_config/Pulumi.yaml
+++ b/sdk/python/lib/test/automation/data/nested_config/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: nested_config
+runtime: go
+description: A minimal Go Pulumi program


### PR DESCRIPTION
Also adds a test that parses nested configuration in each language.

To be clear, automation API reads lists and maps as json strings. For now, it is up to the user to de/reserialize the json. This PR is merely fixing the python implementation to match what is already happening in nodejs and go.