### PR TITLE
[sdk/python] - Allow Output.all with no inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ CHANGELOG
 
 - [sdk/dotnet] F# API to specify stack options.
   [#5077](https://github.com/pulumi/pulumi/pull/5077)
+  
+- [sdk/python] Fixed a change to `Output.all()` that raised an error if no inputs are passed in.
+  [#6381](https://github.com/pulumi/pulumi/pull/6381)
 
 ## 2.21.0 (2021-02-17)
 

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -384,15 +384,13 @@ class Output(Generic[T]):
             return await _gather_from_dict(value_futures_dict)
         from_input = cast(Callable[[Union[T, Awaitable[T], Output[T]]], Output[T]], Output.from_input)
 
-        if not args and not kwargs:
-            raise ValueError("Output.all() was supplied no inputs")
         if args and kwargs:
             raise ValueError("Output.all() was supplied a mix of named and unnamed inputs")
         # First, map all inputs to outputs using `from_input`.
-        if args:
-            all_outputs: Union[list, dict] = [from_input(x) for x in args]
-        else:
+        if kwargs:
             all_outputs = {k: from_input(v) for k, v in kwargs.items()}
+        else:
+            all_outputs: Union[list, dict] = [from_input(x) for x in args]
 
         # Aggregate the list or dict of futures into a future of list or dict.
         value_futures = asyncio.ensure_future(gather_futures(all_outputs))

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -304,9 +304,11 @@ class NextSerializationTests(unittest.TestCase):
         self.assertEqual({"out": 42, "other": 99}, prop_dict)
 
     @pulumi_test
-    async def test_output_all_failure_no_inputs(self):
-        self.assertRaises(ValueError, Output.all)
-        self.assertRaisesRegex(ValueError, "Output.all() was supplied no inputs")
+    async def test_output_all_no_inputs(self):
+        empty_all = Output.all()
+        deps = []
+        prop = await rpc.serialize_property(empty_all, deps)
+        self.assertEqual([], prop)
 
     @pulumi_test
     async def test_output_all_failure_mixed_inputs(self):


### PR DESCRIPTION
We added a check to `Output.all()` that raises an error if no inputs are provided. This is a breaking change as both internal and user code depends on `Output.all()` to handle empty inputs. 

This PR corrects the function to once again handle `Output.all()` with empty inputs.

Fixes: https://github.com/pulumi/pulumi/issues/6380