### PR TITLE
[Automation API] - resolve stack manipulation test assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
+- [sdk/dotnet] Resolve automation api stack manipulation test issue with existing stacks.
+  [#6382](https://github.com/pulumi/pulumi/pull/6382)
+
 - [sdk/dotnet] C# Automation API.
   [#5761](https://github.com/pulumi/pulumi/pull/5761)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,6 @@ CHANGELOG
 
 ## HEAD (Unreleased)
 
-- [sdk/dotnet] Resolve automation api stack manipulation test issue with existing stacks.
-  [#6382](https://github.com/pulumi/pulumi/pull/6382)
-
 - [sdk/dotnet] C# Automation API.
   [#5761](https://github.com/pulumi/pulumi/pull/5761)
 

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -101,7 +101,7 @@ namespace Pulumi.Automation.Tests
             Assert.DoesNotContain(plugins, p => p.Name == "aws" && p.Version == "3.0.0");
         }
 
-        [Fact(Skip = "Failing due to workspace already existing with some stacks from previous runs")]
+        [Fact]
         public async Task CreateSelectRemoveStack()
         {
             var projectSettings = new ProjectSettings("node_test", ProjectRuntimeName.NodeJS);
@@ -117,7 +117,12 @@ namespace Pulumi.Automation.Tests
             var stackName = $"int_test{GetTestSuffix()}";
 
             var stacks = await workspace.ListStacksAsync();
-            Assert.Empty(stacks);
+            if (stacks.Any(s => s.Name == stackName))
+            {
+                await workspace.RemoveStackAsync(stackName);
+                stacks = await workspace.ListStacksAsync();
+                Assert.DoesNotContain(stacks, s => s.Name == stackName);
+            }
 
             await workspace.CreateStackAsync(stackName);
             stacks = await workspace.ListStacksAsync();
@@ -128,7 +133,7 @@ namespace Pulumi.Automation.Tests
             await workspace.SelectStackAsync(stackName);
             await workspace.RemoveStackAsync(stackName);
             stacks = await workspace.ListStacksAsync();
-            Assert.Empty(stacks);
+            Assert.DoesNotContain(stacks, s => s.Name == stackName);
         }
 
         [Fact]


### PR DESCRIPTION
By just not making assertions about the entire collection, as that will break if there are existing stacks.

Fix https://github.com/pulumi/pulumi/issues/6378