### PR TITLE
[codegen/python] Emit pulumiplugin.json in the correct dir

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -2449,7 +2449,7 @@ func GeneratePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 		if err != nil {
 			return nil, err
 		}
-		files.add("pulumiplugin.json", plugin)
+		files.add(filepath.Join(pyPack(pkg.Name), "pulumiplugin.json"), plugin)
 	}
 
 	// Finally emit the package metadata (setup.py).


### PR DESCRIPTION
This [new](https://github.com/pulumi/pulumi/pull/5787) optional file can be used to include additional metadata about the provider plugin (such as version and custom server URL), which the [Python language host will use](https://github.com/pulumi/pulumi/blob/5ab051cd974a619ab4c31e423b5813df0df4b3a2/sdk/python/cmd/pulumi-language-python/main.go#L338-L343) when determining a program's required plugins.

This change fixes the codegen to emit the file in the correct location (inside the package dir). Note: Providers need to opt-in to emitting this file via a schema option (because it requires some Makefile changes to insert the version in the file) and we haven't done that with any of our providers yet.