### PR TITLE
[codegen/dotnet] Fixes to version.txt handling

### DIFF
--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -16,6 +16,7 @@
 package dotnet
 
 import (
+	"strings"
 	"text/template"
 
 	"github.com/pulumi/pulumi/pkg/v2/codegen/schema"
@@ -154,12 +155,12 @@ const csharpProjectFileTemplateText = `<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
     <EmbeddedResource Include="version.txt" />
-    <Content Include="version.txt" />
+    <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
   <ItemGroup>
     {{- range $package, $version := .PackageReferences}}
-    <PackageReference Include="{{$package}}" Version="{{$version}}" />
+    <PackageReference Include="{{$package}}" Version="{{$version}}"{{if ispulumipkg $package}} ExcludeAssets="contentFiles"{{end}} />
     {{- end}}
   </ItemGroup>
 
@@ -173,7 +174,16 @@ const csharpProjectFileTemplateText = `<Project Sdk="Microsoft.NET.Sdk">
 </Project>
 `
 
-var csharpProjectFileTemplate = template.Must(template.New("CSharpProject").Parse(csharpProjectFileTemplateText))
+var csharpProjectFileTemplate = template.Must(template.New("CSharpProject").Funcs(template.FuncMap{
+	// ispulumipkg is used in the template to conditionally emit `ExcludeAssets="contentFiles"`
+	// for `<PackageReference>`s that start with "Pulumi.", to prevent the references's contentFiles
+	// from being included in this project's package. Otherwise, if a reference has version.txt
+	// in its contentFiles, and we don't exclude contentFiles for the reference, the reference's
+	// version.txt will be used over this project's version.txt.
+	"ispulumipkg": func(s string) bool {
+		return strings.HasPrefix(s, "Pulumi.")
+	},
+}).Parse(csharpProjectFileTemplateText))
 
 type csharpProjectFileTemplateContext struct {
 	XMLDoc            string


### PR DESCRIPTION
We currently include `version.txt` in the package via `<Content Include="version.txt">`. This places the file in the NuGet package in two locations: the `content` directory and `contentFiles`.

We want the file to be in `content` because this is where the Pulumi .NET Language host looks for the file when determining a program's required plugins.

However, having the file in `contentFiles` is problematic. For packages that reference other Pulumi resource packages (e.g. for multi-lang components), referenced `contentFiles` are included in the package by default. This means another package's `version.txt` will be included and used over the current project's `version.txt`. For example, if a multi-lang component package `Pulumi.Xyz` references `Pulumi.Aws`, the `version.txt` from `Pulumi.Aws` will be included in `Pulumi.Xyz` package rather than the intended `version.txt` for `Pulumi.Xyz`.

To address this, stop including `version.txt` in `contentFiles`. We do this by changing the `<Content Include="version.txt" />` to `<None Include="version.txt" Pack="True" PackagePath="content" />` in the project file. This ensures the file will still be included in the package in the `content` dir (where the Pulumi .NET language host expects to find it), but doesn't include the file in `contentFiles` which would cause it to be used in other packages that reference the package.

Further, when generating `<PackageReference>`s for packages that start with "Pulumi.", include an additional `ExcludeAssets="contentFiles"` attribute to prevent the package's `contentFiles` from being included. This prevents the `version.txt` in `contentFiles` of referenced existing/older packages from being used by the package.

Part of https://github.com/pulumi/pulumi-eks/issues/529