### PR TITLE
[automation] - Remove summary from PreviewResult

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,7 @@
 
 
 ### Bug Fixes
+
+- [automation/python,nodejs,dotnet] - BREAKING - Remove `summary` property from `PreviewResult`.
+  The `summary` property on `PreviewResult` returns a result that is always incorrect and is being removed.
+  [#6405](https://github.com/pulumi/pulumi/pull/6405)

--- a/sdk/dotnet/Pulumi.Automation/PreviewResult.cs
+++ b/sdk/dotnet/Pulumi.Automation/PreviewResult.cs
@@ -1,0 +1,19 @@
+// Copyright 2016-2021, Pulumi Corporation
+
+namespace Pulumi.Automation
+{
+    public class PreviewResult
+    {
+        public string StandardOutput { get; }
+
+        public string StandardError { get; }
+
+        internal PreviewResult(
+            string standardOutput,
+            string standardError)
+        {
+            this.StandardOutput = standardOutput;
+            this.StandardError = standardError;
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -78,6 +78,9 @@ Pulumi.Automation.PreviewOptions.Replace.get -> System.Collections.Generic.List<
 Pulumi.Automation.PreviewOptions.Replace.set -> void
 Pulumi.Automation.PreviewOptions.TargetDependents.get -> bool?
 Pulumi.Automation.PreviewOptions.TargetDependents.set -> void
+Pulumi.Automation.PreviewResult
+Pulumi.Automation.PreviewResult.StandardError.get -> string
+Pulumi.Automation.PreviewResult.StandardOutput.get -> string
 Pulumi.Automation.ProjectBackend
 Pulumi.Automation.ProjectBackend.ProjectBackend() -> void
 Pulumi.Automation.ProjectBackend.Url.get -> string
@@ -233,7 +236,7 @@ Pulumi.Automation.WorkspaceStack.GetConfigValueAsync(string key, System.Threadin
 Pulumi.Automation.WorkspaceStack.GetHistoryAsync(Pulumi.Automation.HistoryOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableList<Pulumi.Automation.UpdateSummary>>
 Pulumi.Automation.WorkspaceStack.GetInfoAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.UpdateSummary>
 Pulumi.Automation.WorkspaceStack.Name.get -> string
-Pulumi.Automation.WorkspaceStack.PreviewAsync(Pulumi.Automation.PreviewOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.UpdateResult>
+Pulumi.Automation.WorkspaceStack.PreviewAsync(Pulumi.Automation.PreviewOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.PreviewResult>
 Pulumi.Automation.WorkspaceStack.RefreshAsync(Pulumi.Automation.RefreshOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.UpdateResult>
 Pulumi.Automation.WorkspaceStack.RefreshConfigAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string, Pulumi.Automation.ConfigValue>>
 Pulumi.Automation.WorkspaceStack.RemoveConfigAsync(System.Collections.Generic.IEnumerable<string> keys, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -300,7 +300,7 @@ namespace Pulumi.Automation
         /// </summary>
         /// <param name="options">Options to customize the behavior of the update.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
-        public async Task<UpdateResult> PreviewAsync(
+        public async Task<PreviewResult> PreviewAsync(
             PreviewOptions? options = null,
             CancellationToken cancellationToken = default)
         {
@@ -370,11 +370,9 @@ namespace Pulumi.Automation
                 if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
                     exceptionInfo.Throw();
 
-                var summary = await this.GetInfoAsync(cancellationToken).ConfigureAwait(false);
-                return new UpdateResult(
+                return new PreviewResult(
                     upResult.StandardOutput,
-                    upResult.StandardError,
-                    summary!);
+                    upResult.StandardError);
             }
             finally
             {

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -177,8 +177,7 @@ export class Stack {
         } finally {
             onExit();
         }
-        
-        
+
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
         const outputs = await this.outputs();
         const summary = await this.info();
@@ -263,11 +262,9 @@ export class Stack {
         } finally {
             onExit();
         }
-        const summary = await this.info();
         return {
             stdout: preResult.stdout,
             stderr: preResult.stderr,
-            summary: summary!,
         };
     }
     /**
@@ -419,12 +416,12 @@ export class Stack {
         const args = ["history", "--json", "--show-secrets"];
         if (pageSize) {
             if (!page || page < 1) {
-                page = 1
+                page = 1;
             }
-            args.push("--page-size", Math.floor(pageSize).toString(), "--page", Math.floor(page).toString())
+            args.push("--page-size", Math.floor(pageSize).toString(), "--page", Math.floor(page).toString());
         }
         const result = await this.runPulumiCmd(args);
-      
+
         return JSON.parse(result.stdout, (key, value) => {
             if (key === "startTime" || key === "endTime") {
                 return new Date(value);
@@ -565,7 +562,6 @@ export interface UpResult {
 export interface PreviewResult {
     stdout: string;
     stderr: string;
-    summary: UpdateSummary;
 }
 
 /**

--- a/sdk/python/lib/pulumi/x/automation/_stack.py
+++ b/sdk/python/lib/pulumi/x/automation/_stack.py
@@ -107,39 +107,51 @@ class UpdateSummary:
 class BaseResult:
     stdout: str
     stderr: str
-    summary: UpdateSummary
 
-    def __init__(self, stdout: str, stderr: str, summary: UpdateSummary):
+    def __init__(self, stdout: str, stderr: str):
         self.stdout = stdout
         self.stderr = stderr
-        self.summary = summary
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(summary={self.summary!r}, stdout={self.stdout!r}, stderr={self.stderr!r})"
-
-
-class UpResult(BaseResult):
-    outputs: OutputMap
-
-    def __init__(self, stdout: str, stderr: str, summary: UpdateSummary, outputs: OutputMap):
-        super().__init__(stdout, stderr, summary)
-        self.outputs = outputs
-
-    def __repr__(self):
-        return f"{self.__class__.__name__}(outputs={self.outputs!r}, summary={self.summary!r}, " \
-               f"stdout={self.stdout!r}, stderr={self.stderr!r})"
+        return f"{self.__class__.__name__}(stdout={self.stdout!r}, stderr={self.stderr!r})"
 
 
 class PreviewResult(BaseResult):
     pass
 
 
+class UpResult(BaseResult):
+    outputs: OutputMap
+    summary: UpdateSummary
+
+    def __init__(self, stdout: str, stderr: str, summary: UpdateSummary, outputs: OutputMap):
+        super().__init__(stdout, stderr)
+        self.outputs = outputs
+        self.summary = summary
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(outputs={self.outputs!r}, summary={self.summary!r}, " \
+               f"stdout={self.stdout!r}, stderr={self.stderr!r})"
+
+
 class RefreshResult(BaseResult):
-    pass
+    def __init__(self, stdout: str, stderr: str, summary: UpdateSummary):
+        super().__init__(stdout, stderr)
+        self.summary = summary
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(summary={self.summary!r}, " \
+               f"stdout={self.stdout!r}, stderr={self.stderr!r})"
 
 
 class DestroyResult(BaseResult):
-    pass
+    def __init__(self, stdout: str, stderr: str, summary: UpdateSummary):
+        super().__init__(stdout, stderr)
+        self.summary = summary
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(summary={self.summary!r}, " \
+               f"stdout={self.stdout!r}, stderr={self.stderr!r})"
 
 
 class Stack:
@@ -330,9 +342,7 @@ class Stack:
 
         try:
             preview_result = self._run_pulumi_cmd_sync(args)
-            summary = self.info()
-            assert (summary is not None)
-            return PreviewResult(stdout=preview_result.stdout, stderr=preview_result.stderr, summary=summary)
+            return PreviewResult(stdout=preview_result.stdout, stderr=preview_result.stderr)
         finally:
             if on_exit is not None:
                 on_exit()


### PR DESCRIPTION
The current implementation in nodejs, python and dotnet attempts to get an action summary for `preview` by running `pulumi history --page-size 1`. However, `preview` summaries are not pushed to `history` because (you guessed it!) it's just a preview and not an actually executed command. As a result, the `summary` ends up being either nothing (before an `up` has ever been run) or the summary of the last executed command of `up/refresh/destroy`. In either case, it is an incorrect result.

This PR removes the `summary` property from `PreviewResult`. 

Notes:
* It might be preferable to wait until structured output is implemented and we can access the preview summary and use that here rather than removing the summary property.
* Go will be handled in a separate PR as it has a different implementation and a [separate issue](https://github.com/pulumi/pulumi/issues/6308) relating to it.

Fixes: https://github.com/pulumi/pulumi/issues/5630