### PR TITLE
Changing the process for CHANGELOG entries

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,6 +4,7 @@ on:
       [ "master", "feature/**", "feature-**" ]
     paths-ignore:
       - 'CHANGELOG.md'
+      - 'CHANGELOG_PENDING.md'
       - 'README.md'
 
 env:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -4,6 +4,7 @@ on:
       - v*.*.*-**
     paths-ignore:
       - 'CHANGELOG.md'
+      - 'CHANGELOG_PENDING.md'
       - 'README.md'
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
       - v*.*.*
     paths-ignore:
       - 'CHANGELOG.md'
+      - 'CHANGELOG_PENDING.md'
       - 'README.md'
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
@@ -204,7 +205,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: -f .goreleaser.yml --rm-dist
+          args: -f .goreleaser.yml --rm-dist --release-notes=CHANGELOG_PENDING.md
   lint:
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -2,6 +2,9 @@ on:
   repository_dispatch:
     types: [ run-acceptance-tests-command ]
   pull_request:
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'CHANGELOG_PENDING.md'
 
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,8 +12,6 @@ blobs:
     - pulumi-unix
   provider: s3
   region: us-west-2
-changelog:
-  skip: true
 builds:
 # UNIX builds
 - id: pulumi-unix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 CHANGELOG
 =========
 
-## HEAD (Unreleased)
-_(none)_
-
 ## 2.21.2 (2021-02-22)
 
 ### Improvements

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,0 +1,7 @@
+### Features
+
+
+### Enhancements
+
+
+### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ is a pretty standard starting point during debugging that will show a fairly com
 ## Submitting a Pull Request
 
 For contributors we use the standard fork based workflow. Fork this repository, create a topic branch, and start hacking away.  When you're ready, make sure you've run the tests (`make travis_pull_request` will run the exact flow we run in CI) and open your PR.
+When adding a changelog entry, please be sure to use `CHANGELOG_PENDING.md` for the entry - we will then be able to ensure your PR gets into the next release.
 
 ## Getting Help
 


### PR DESCRIPTION
As part of our continued effort to make our releases more useful,
we will be adding our CHANGELOG entries to the GitHub Release.

To make this process smooth, we are going to change things a little:

1. All new changelog entries when submitting a PR for an upcoming
release will now need to get added to CHANGELOG_PENDING.md
This is the source of information for what will be delivered in the
release.

2. When a release is being made, the entries from CHANGELOG_PENDING
will be copied to a new version and dated section in CHANGLOG to
mark the release

3. The GH tags will continue as normal and Goreleaser will copy
the changelog entries to the release section in GH