### PR TITLE
[BREAKING] - Standardize stack select behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+## 3.0.0 (Unreleased)
+
+- [CLI] Standardize the `--stack` flag to *not* set the stack as current (i.e. setStack=false) across CLI commands.
+  [#6300](https://github.com/pulumi/pulumi/pull/6300)
+  
+- [Automation/*] All operations use `--stack` to specify the stack instead of running `select stack` before the operation.
+  [#6300](https://github.com/pulumi/pulumi/pull/6300)
+
 ## HEAD (Unreleased)
 _(none)_  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,6 @@
 CHANGELOG
 =========
 
-## 3.0.0 (Unreleased)
-
-- [CLI] Standardize the `--stack` flag to *not* set the stack as current (i.e. setStack=false) across CLI commands.
-  [#6300](https://github.com/pulumi/pulumi/pull/6300)
-  
-- [Automation/*] All operations use `--stack` to specify the stack instead of running `select stack` before the operation.
-  [#6300](https://github.com/pulumi/pulumi/pull/6300)
-
-## HEAD (Unreleased)
-_(none)_  
-
 ## 2.21.2 (2021-02-22)
 
 ### Improvements

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,10 @@
 ### Breaking Changes
 
+- [CLI] Standardize the `--stack` flag to *not* set the stack as current (i.e. setStack=false) across CLI commands.
+  [#6300](https://github.com/pulumi/pulumi/pull/6300)
+
+- [Automation/*] All operations use `--stack` to specify the stack instead of running `select stack` before the operation.
+  [#6300](https://github.com/pulumi/pulumi/pull/6300)
 
 ### Features
 

--- a/pkg/cmd/pulumi/cancel.go
+++ b/pkg/cmd/pulumi/cancel.go
@@ -56,7 +56,7 @@ func newCancelCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -390,7 +390,7 @@ func newConfigRefreshCmd(stack *string) *cobra.Command {
 			}
 
 			// Ensure the stack exists.
-			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(*stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -113,7 +113,7 @@ func newDestroyCmd() *cobra.Command {
 				opts.Display.SuppressPermaLink = true
 			}
 
-			s, err := requireStack(stack, false, opts.Display, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -432,7 +432,7 @@ func newImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack.
-			s, err := requireStack(stack, false, opts.Display, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -56,7 +56,7 @@ func newLogsCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -114,7 +114,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(stack, true, displayOpts, true /*setCurrent*/)
+			s, err := requireStack(stack, true, displayOpts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -109,7 +109,7 @@ func newRefreshCmd() *cobra.Command {
 				opts.Display.SuppressPermaLink = true
 			}
 
-			s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
+			s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -43,7 +43,7 @@ func newStackCmd() *cobra.Command {
 		Short: "Manage stacks",
 		Long: "Manage stacks\n" +
 			"\n" +
-			"An stack is a named update target, and a single project may have many of them.\n" +
+			"A stack is a named update target, and a single project may have many of them.\n" +
 			"Each stack has a configuration and update history associated with it, stored in\n" +
 			"the workspace, in addition to a full checkpoint of the last known good update.\n",
 		Args: cmdutil.NoArgs,
@@ -52,7 +52,7 @@ func newStackCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stackName, true, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, true, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -51,7 +51,7 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and export its deployment
-			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -57,7 +57,7 @@ func newStackGraphCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -50,7 +50,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and import a deployment.
-			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -46,7 +46,7 @@ func newStackOutputCmd() *cobra.Command {
 			}
 
 			// Fetch the current stack and its output properties.
-			s, err := requireStack(stackName, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stackName, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -52,7 +52,7 @@ func newStackRenameCmd() *cobra.Command {
 			}
 
 			// Look up the stack to be moved, and find the path to the project file's location.
-			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/stack_rm.go
+++ b/pkg/cmd/pulumi/stack_rm.go
@@ -59,7 +59,7 @@ func newStackRmCmd() *cobra.Command {
 				Color: cmdutil.GetGlobalColorization(),
 			}
 
-			s, err := requireStack(stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -64,7 +64,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
 			}
-			s, err := requireStack(*stack, false, opts, true /*setCurrent*/)
+			s, err := requireStack(*stack, false, opts, false /*setCurrent*/)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -132,7 +132,7 @@ func runTotalStateEdit(
 	opts := display.Options{
 		Color: cmdutil.GetGlobalColorization(),
 	}
-	s, err := requireStack(stackName, true, opts, true /*setCurrent*/)
+	s, err := requireStack(stackName, true, opts, false /*setCurrent*/)
 	if err != nil {
 		return result.FromError(err)
 	}

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -76,7 +76,7 @@ func newUpCmd() *cobra.Command {
 
 	// up implementation used when the source of the Pulumi program is in the current working directory.
 	upWorkingDirectory := func(opts backend.UpdateOptions) result.Result {
-		s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
+		s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
 		if err != nil {
 			return result.FromError(err)
 		}

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -83,7 +83,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			s, err := requireStack(stack, true, opts.Display, true /*setCurrent*/)
+			s, err := requireStack(stack, true, opts.Display, false /*setCurrent*/)
 			if err != nil {
 				return result.FromError(err)
 			}

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -205,7 +205,6 @@ namespace Pulumi.Automation
             UpOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            await this.Workspace.SelectStackAsync(this.Name, cancellationToken).ConfigureAwait(false);
             var execKind = ExecKind.Local;
             var program = this.Workspace.Program;
             var args = new List<string>()
@@ -213,6 +212,8 @@ namespace Pulumi.Automation
                 "up",
                 "--yes",
                 "--skip-preview",
+                "--stack",
+                this.Name,
             };
 
             if (options != null)
@@ -307,10 +308,9 @@ namespace Pulumi.Automation
             PreviewOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            await this.Workspace.SelectStackAsync(this.Name, cancellationToken).ConfigureAwait(false);
             var execKind = ExecKind.Local;
             var program = this.Workspace.Program;
-            var args = new List<string>() { "preview" };
+            var args = new List<string>() { "preview", "--stack", this.Name };
 
             if (options != null)
             {
@@ -399,12 +399,13 @@ namespace Pulumi.Automation
             RefreshOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            await this.Workspace.SelectStackAsync(this.Name, cancellationToken).ConfigureAwait(false);
             var args = new List<string>()
             {
                 "refresh",
                 "--yes",
                 "--skip-preview",
+                "--stack",
+                this.Name
             };
 
             if (options != null)
@@ -451,12 +452,13 @@ namespace Pulumi.Automation
             DestroyOptions? options = null,
             CancellationToken cancellationToken = default)
         {
-            await this.Workspace.SelectStackAsync(this.Name, cancellationToken).ConfigureAwait(false);
             var args = new List<string>()
             {
                 "destroy",
                 "--yes",
                 "--skip-preview",
+                "--stack",
+                this.Name
             };
 
             if (options != null)
@@ -499,11 +501,9 @@ namespace Pulumi.Automation
         /// </summary>
         private async Task<ImmutableDictionary<string, OutputValue>> GetOutputAsync(CancellationToken cancellationToken)
         {
-            await this.Workspace.SelectStackAsync(this.Name).ConfigureAwait(false);
-
             // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
-            var maskedResult = await this.RunCommandAsync(new[] { "stack", "output", "--json" }, null, cancellationToken).ConfigureAwait(false);
-            var plaintextResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--show-secrets" }, null, cancellationToken).ConfigureAwait(false);
+            var maskedResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--stack", this.Name }, null, cancellationToken).ConfigureAwait(false);
+            var plaintextResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--show-secrets", "--stack", this.Name }, null, cancellationToken).ConfigureAwait(false);
             var jsonOptions = LocalSerializer.BuildJsonSerializerOptions();
             var maskedOutput = JsonSerializer.Deserialize<Dictionary<string, object>>(maskedResult.StandardOutput, jsonOptions);
             var plaintextOutput = JsonSerializer.Deserialize<Dictionary<string, object>>(plaintextResult.StandardOutput, jsonOptions);

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -212,8 +212,6 @@ namespace Pulumi.Automation
                 "up",
                 "--yes",
                 "--skip-preview",
-                "--stack",
-                this.Name,
             };
 
             if (options != null)
@@ -310,7 +308,7 @@ namespace Pulumi.Automation
         {
             var execKind = ExecKind.Local;
             var program = this.Workspace.Program;
-            var args = new List<string>() { "preview", "--stack", this.Name };
+            var args = new List<string>() { "preview" };
 
             if (options != null)
             {
@@ -404,8 +402,6 @@ namespace Pulumi.Automation
                 "refresh",
                 "--yes",
                 "--skip-preview",
-                "--stack",
-                this.Name
             };
 
             if (options != null)
@@ -457,8 +453,6 @@ namespace Pulumi.Automation
                 "destroy",
                 "--yes",
                 "--skip-preview",
-                "--stack",
-                this.Name
             };
 
             if (options != null)
@@ -502,8 +496,8 @@ namespace Pulumi.Automation
         private async Task<ImmutableDictionary<string, OutputValue>> GetOutputAsync(CancellationToken cancellationToken)
         {
             // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
-            var maskedResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--stack", this.Name }, null, cancellationToken).ConfigureAwait(false);
-            var plaintextResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--show-secrets", "--stack", this.Name }, null, cancellationToken).ConfigureAwait(false);
+            var maskedResult = await this.RunCommandAsync(new[] { "stack", "output", "--json" }, null, cancellationToken).ConfigureAwait(false);
+            var plaintextResult = await this.RunCommandAsync(new[] { "stack", "output", "--json", "--show-secrets" }, null, cancellationToken).ConfigureAwait(false);
             var jsonOptions = LocalSerializer.BuildJsonSerializerOptions();
             var maskedOutput = JsonSerializer.Deserialize<Dictionary<string, object>>(maskedResult.StandardOutput, jsonOptions);
             var plaintextOutput = JsonSerializer.Deserialize<Dictionary<string, object>>(plaintextResult.StandardOutput, jsonOptions);
@@ -570,9 +564,13 @@ namespace Pulumi.Automation
         private Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
             Action<string>? onOutput,
-            CancellationToken cancellationToken)
-            => this.Workspace.RunStackCommandAsync(this.Name, args, onOutput, cancellationToken);
-
+            CancellationToken cancellationToken) 
+            {
+                var argsList = args.ToList();
+                argsList.AddRange(new List<string>(){"--stack", this.Name});
+                return this.Workspace.RunStackCommandAsync(this.Name, args, onOutput, cancellationToken);
+            }
+            
         public void Dispose()
             => this.Workspace.Dispose();
 

--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -129,11 +129,7 @@ func (l *LocalWorkspace) PostCommandCallback(ctx context.Context, stackName stri
 // scoped to the current workspace. LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
 func (l *LocalWorkspace) GetConfig(ctx context.Context, stackName string, key string) (ConfigValue, error) {
 	var val ConfigValue
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return val, errors.Wrapf(err, "could not get config, unable to select stack %s", stackName)
-	}
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "get", key, "--json")
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "get", key, "--json", "--stack", stackName)
 	if err != nil {
 		return val, newAutoError(errors.Wrap(err, "unable to read config"), stdout, stderr, errCode)
 	}
@@ -148,13 +144,9 @@ func (l *LocalWorkspace) GetConfig(ctx context.Context, stackName string, key st
 // LocalWorkspace reads this config from the matching Pulumi.stack.yaml file.
 func (l *LocalWorkspace) GetAllConfig(ctx context.Context, stackName string) (ConfigMap, error) {
 	var val ConfigMap
-	err := l.SelectStack(ctx, stackName)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "--show-secrets", "--json", "--stack", stackName)
 	if err != nil {
-		return val, errors.Wrapf(err, "could not get config, unable to select stack %s", stackName)
-	}
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "--show-secrets", "--json")
-	if err != nil {
-		return val, newAutoError(errors.Wrap(err, "unable read config"), stdout, stderr, errCode)
+		return val, newAutoError(errors.Wrap(err, "unable to read config"), stdout, stderr, errCode)
 	}
 	err = json.Unmarshal([]byte(stdout), &val)
 	if err != nil {
@@ -166,19 +158,14 @@ func (l *LocalWorkspace) GetAllConfig(ctx context.Context, stackName string) (Co
 // SetConfig sets the specified key-value pair on the provided stack name.
 // LocalWorkspace writes this value to the matching Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) SetConfig(ctx context.Context, stackName string, key string, val ConfigValue) error {
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return errors.Wrapf(err, "could not set config, unable to select stack %s", stackName)
-	}
-
 	secretArg := "--plaintext"
 	if val.Secret {
 		secretArg = "--secret"
 	}
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "set", key, val.Value, secretArg)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "set", key, val.Value, secretArg, "--stack", stackName)
 	if err != nil {
-		return newAutoError(errors.Wrap(err, "unable set config"), stdout, stderr, errCode)
+		return newAutoError(errors.Wrap(err, "unable to set config"), stdout, stderr, errCode)
 	}
 	return nil
 }
@@ -206,12 +193,7 @@ func (l *LocalWorkspace) SetAllConfig(ctx context.Context, stackName string, con
 // RemoveConfig removes the specified key-value pair on the provided stack name.
 // It will remove any matching values in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) RemoveConfig(ctx context.Context, stackName string, key string) error {
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return errors.Wrapf(err, "could not remove config, unable to select stack %s", stackName)
-	}
-
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "rm", key)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "rm", key, "--stack", stackName)
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "could not remove config"), stdout, stderr, errCode)
 	}
@@ -233,12 +215,7 @@ func (l *LocalWorkspace) RemoveAllConfig(ctx context.Context, stackName string, 
 // RefreshConfig gets and sets the config map used with the last Update for Stack matching stack name.
 // It will overwrite all configuration in the Pulumi.<stack>.yaml file in Workspace.WorkDir().
 func (l *LocalWorkspace) RefreshConfig(ctx context.Context, stackName string) (ConfigMap, error) {
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not refresh config, unable to select stack %s", stackName)
-	}
-
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "refresh", "--force")
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "refresh", "--force", "--stack", stackName)
 	if err != nil {
 		return nil, newAutoError(errors.Wrap(err, "could not refresh config"), stdout, stderr, errCode)
 	}
@@ -427,12 +404,8 @@ func (l *LocalWorkspace) SetProgram(fn pulumi.RunFunc) {
 // This can be combined with ImportStack to edit a stack's state (such as recovery from failed deployments).
 func (l *LocalWorkspace) ExportStack(ctx context.Context, stackName string) (apitype.UntypedDeployment, error) {
 	var state apitype.UntypedDeployment
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return state, errors.Wrapf(err, "could not export stack, unable to select stack %s.", stackName)
-	}
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "export", "--show-secrets")
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "export", "--show-secrets", "--stack", stackName)
 	if err != nil {
 		return state, newAutoError(errors.Wrap(err, "could not export stack."), stdout, stderr, errCode)
 	}
@@ -450,11 +423,6 @@ func (l *LocalWorkspace) ExportStack(ctx context.Context, stackName string) (api
 // ImportStack imports the specified deployment state into a pre-existing stack.
 // This can be combined with ExportStack to edit a stack's state (such as recovery from failed deployments).
 func (l *LocalWorkspace) ImportStack(ctx context.Context, stackName string, state apitype.UntypedDeployment) error {
-	err := l.SelectStack(ctx, stackName)
-	if err != nil {
-		return errors.Wrapf(err, "could not import stack, failed to select stack %s.", stackName)
-	}
-
 	f, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
 		return errors.Wrap(err, "could not import stack. failed to allocate temp file.")
@@ -471,7 +439,7 @@ func (l *LocalWorkspace) ImportStack(ctx context.Context, stackName string, stat
 		return errors.Wrap(err, "could not import stack. failed to write out stack intermediate.")
 	}
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "import", "--file", f.Name())
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "import", "--file", f.Name(), "--stack", stackName)
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "could not import stack."), stdout, stderr, errCode)
 	}
@@ -899,7 +867,7 @@ func SelectStackInlineSource(
 	if err != nil {
 		return stack, errors.Wrap(err, "failed to select stack")
 	}
-	// as we implictly create project on behalf of the user, prepend to opts in case the user specifies one
+	// as we implicitly create project on behalf of the user, prepend to opts in case the user specifies one
 	opts = append([]LocalWorkspaceOption{Project(proj)}, opts...)
 	w, err := NewLocalWorkspace(ctx, opts...)
 	if err != nil {

--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -163,7 +163,8 @@ func (l *LocalWorkspace) SetConfig(ctx context.Context, stackName string, key st
 		secretArg = "--secret"
 	}
 
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "config", "set", key, val.Value, secretArg, "--stack", stackName)
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx,
+		"config", "set", key, val.Value, secretArg, "--stack", stackName)
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "unable to set config"), stdout, stderr, errCode)
 	}

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -236,7 +236,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", preOpts.Parallel))
 	}
 
-	kind, args := constant.ExecKindAutoLocal, []string{"preview", "--json", "--stack", s.Name()}
+	kind, args := constant.ExecKindAutoLocal, []string{"preview", "--json"}
 	if program := s.Workspace().Program(); program != nil {
 		server, err := startLanguageRuntimeServer(program)
 		if err != nil {
@@ -297,7 +297,7 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", upOpts.Parallel))
 	}
 
-	kind, args := constant.ExecKindAutoLocal, []string{"up", "--yes", "--skip-preview", "--stack", s.Name()}
+	kind, args := constant.ExecKindAutoLocal, []string{"up", "--yes", "--skip-preview"}
 	if program := s.Workspace().Program(); program != nil {
 		server, err := startLanguageRuntimeServer(program)
 		if err != nil {
@@ -351,7 +351,7 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 	var args []string
 
 	args = debug.AddArgs(&refreshOpts.DebugLogOpts, args)
-	args = append(args, "refresh", "--yes", "--skip-preview", "--stack", s.Name())
+	args = append(args, "refresh", "--yes", "--skip-preview")
 	if refreshOpts.Message != "" {
 		args = append(args, fmt.Sprintf("--message=%q", refreshOpts.Message))
 	}
@@ -406,7 +406,7 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 	var args []string
 
 	args = debug.AddArgs(&destroyOpts.DebugLogOpts, args)
-	args = append(args, "destroy", "--yes", "--skip-preview", "--stack", s.Name())
+	args = append(args, "destroy", "--yes", "--skip-preview")
 	if destroyOpts.Message != "" {
 		args = append(args, fmt.Sprintf("--message=%q", destroyOpts.Message))
 	}
@@ -453,7 +453,7 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 func (s *Stack) Outputs(ctx context.Context) (OutputMap, error) {
 	// standard outputs
 	outStdout, outStderr, code, err := s.runPulumiCmdSync(ctx, nil, /* additionalOutputs */
-		"stack", "output", "--json", "--stack", s.Name(),
+		"stack", "output", "--json",
 	)
 	if err != nil {
 		return nil, newAutoError(errors.Wrap(err, "could not get outputs"), outStdout, outStderr, code)
@@ -461,7 +461,7 @@ func (s *Stack) Outputs(ctx context.Context) (OutputMap, error) {
 
 	// secret outputs
 	secretStdout, secretStderr, code, err := s.runPulumiCmdSync(ctx, nil, /* additionalOutputs */
-		"stack", "output", "--json", "--show-secrets", "--stack", s.Name(),
+		"stack", "output", "--json", "--show-secrets",
 	)
 	if err != nil {
 		return nil, newAutoError(errors.Wrap(err, "could not get secret outputs"), outStdout, outStderr, code)
@@ -497,7 +497,7 @@ func (s *Stack) History(ctx context.Context, pageSize int, page int) ([]UpdateSu
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get stack history")
 	}
-	args := []string{"history", "--json", "--show-secrets", "--stack", s.Name()}
+	args := []string{"history", "--json", "--show-secrets"}
 	if pageSize > 0 {
 		// default page=1 if unset when pageSize is set
 		if page < 1 {
@@ -583,7 +583,7 @@ func (s *Stack) Cancel(ctx context.Context) error {
 	stdout, stderr, errCode, err := s.runPulumiCmdSync(
 		ctx,
 		nil, /* additionalOutput */
-		"cancel", "--yes", "--stack", s.Name())
+		"cancel", "--yes")
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "failed to cancel update"), stdout, stderr, errCode)
 	}
@@ -739,6 +739,8 @@ func (s *Stack) runPulumiCmdSync(
 		return "", "", -1, errors.Wrap(err, "failed to exec command, error getting additional args")
 	}
 	args = append(args, additionalArgs...)
+	args = append(args, "--stack", s.Name())
+
 	stdout, stderr, errCode, err := runPulumiCommandSync(ctx, s.Workspace().WorkDir(), additionalOutput, env, args...)
 	if err != nil {
 		return stdout, stderr, errCode, err

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -580,7 +580,10 @@ func (s *Stack) Info(ctx context.Context) (StackSummary, error) {
 // if a resource operation was pending when the update was canceled.
 // This command is not supported for local backends.
 func (s *Stack) Cancel(ctx context.Context) error {
-	stdout, stderr, errCode, err := s.runPulumiCmdSync(ctx, nil /* additionalOutput */, "cancel", "--yes", "--stack", s.Name())
+	stdout, stderr, errCode, err := s.runPulumiCmdSync(
+		ctx,
+		nil, /* additionalOutput */
+		"cancel", "--yes", "--stack", s.Name())
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "failed to cancel update"), stdout, stderr, errCode)
 	}

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -153,8 +153,7 @@ func NewStack(ctx context.Context, stackName string, ws Workspace) (Stack, error
 }
 
 // SelectStack selects stack using the given workspace, and stack name.
-// It returns an error if the given Stack does not exist. All LocalWorkspace operations will call SelectStack()
-// before running.
+// It returns an error if the given Stack does not exist.
 func SelectStack(ctx context.Context, stackName string, ws Workspace) (Stack, error) {
 	var s Stack
 	s = Stack{
@@ -207,11 +206,6 @@ func (s *Stack) Workspace() Workspace {
 func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (PreviewResult, error) {
 	var res PreviewResult
 
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return res, errors.Wrap(err, "failed to run preview")
-	}
-
 	preOpts := &optpreview.Options{}
 	for _, o := range opts {
 		o.ApplyOption(preOpts)
@@ -242,7 +236,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", preOpts.Parallel))
 	}
 
-	kind, args := constant.ExecKindAutoLocal, []string{"preview", "--json"}
+	kind, args := constant.ExecKindAutoLocal, []string{"preview", "--json", "--stack", s.Name()}
 	if program := s.Workspace().Program(); program != nil {
 		server, err := startLanguageRuntimeServer(program)
 		if err != nil {
@@ -272,10 +266,6 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 // https://www.pulumi.com/docs/reference/cli/pulumi_up/
 func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) {
 	var res UpResult
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return res, errors.Wrap(err, "failed to run update")
-	}
 
 	upOpts := &optup.Options{}
 	for _, o := range opts {
@@ -307,7 +297,7 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", upOpts.Parallel))
 	}
 
-	kind, args := constant.ExecKindAutoLocal, []string{"up", "--yes", "--skip-preview"}
+	kind, args := constant.ExecKindAutoLocal, []string{"up", "--yes", "--skip-preview", "--stack", s.Name()}
 	if program := s.Workspace().Program(); program != nil {
 		server, err := startLanguageRuntimeServer(program)
 		if err != nil {
@@ -353,11 +343,6 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (RefreshResult, error) {
 	var res RefreshResult
 
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return res, errors.Wrap(err, "failed to refresh stack")
-	}
-
 	refreshOpts := &optrefresh.Options{}
 	for _, o := range opts {
 		o.ApplyOption(refreshOpts)
@@ -366,7 +351,7 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 	var args []string
 
 	args = debug.AddArgs(&refreshOpts.DebugLogOpts, args)
-	args = append(args, "refresh", "--yes", "--skip-preview")
+	args = append(args, "refresh", "--yes", "--skip-preview", "--stack", s.Name())
 	if refreshOpts.Message != "" {
 		args = append(args, fmt.Sprintf("--message=%q", refreshOpts.Message))
 	}
@@ -413,11 +398,6 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (DestroyResult, error) {
 	var res DestroyResult
 
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return res, errors.Wrap(err, "failed to destroy stack")
-	}
-
 	destroyOpts := &optdestroy.Options{}
 	for _, o := range opts {
 		o.ApplyOption(destroyOpts)
@@ -426,7 +406,7 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 	var args []string
 
 	args = debug.AddArgs(&destroyOpts.DebugLogOpts, args)
-	args = append(args, "destroy", "--yes", "--skip-preview")
+	args = append(args, "destroy", "--yes", "--skip-preview", "--stack", s.Name())
 	if destroyOpts.Message != "" {
 		args = append(args, fmt.Sprintf("--message=%q", destroyOpts.Message))
 	}
@@ -471,14 +451,9 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 
 // Outputs get the current set of Stack outputs from the last Stack.Up().
 func (s *Stack) Outputs(ctx context.Context) (OutputMap, error) {
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get stack outputs")
-	}
-
 	// standard outputs
 	outStdout, outStderr, code, err := s.runPulumiCmdSync(ctx, nil, /* additionalOutputs */
-		"stack", "output", "--json",
+		"stack", "output", "--json", "--stack", s.Name(),
 	)
 	if err != nil {
 		return nil, newAutoError(errors.Wrap(err, "could not get outputs"), outStdout, outStderr, code)
@@ -486,7 +461,7 @@ func (s *Stack) Outputs(ctx context.Context) (OutputMap, error) {
 
 	// secret outputs
 	secretStdout, secretStderr, code, err := s.runPulumiCmdSync(ctx, nil, /* additionalOutputs */
-		"stack", "output", "--json", "--show-secrets",
+		"stack", "output", "--json", "--show-secrets", "--stack", s.Name(),
 	)
 	if err != nil {
 		return nil, newAutoError(errors.Wrap(err, "could not get secret outputs"), outStdout, outStderr, code)
@@ -522,7 +497,7 @@ func (s *Stack) History(ctx context.Context, pageSize int, page int) ([]UpdateSu
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get stack history")
 	}
-	args := []string{"history", "--json", "--show-secrets"}
+	args := []string{"history", "--json", "--show-secrets", "--stack", s.Name()}
 	if pageSize > 0 {
 		// default page=1 if unset when pageSize is set
 		if page < 1 {
@@ -605,12 +580,7 @@ func (s *Stack) Info(ctx context.Context) (StackSummary, error) {
 // if a resource operation was pending when the update was canceled.
 // This command is not supported for local backends.
 func (s *Stack) Cancel(ctx context.Context) error {
-	err := s.Workspace().SelectStack(ctx, s.Name())
-	if err != nil {
-		return errors.Wrap(err, "failed to cancel update")
-	}
-
-	stdout, stderr, errCode, err := s.runPulumiCmdSync(ctx, nil /* additionalOutput */, "cancel", "--yes")
+	stdout, stderr, errCode, err := s.runPulumiCmdSync(ctx, nil /* additionalOutput */, "cancel", "--yes", "--stack", s.Name())
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "failed to cancel update"), stdout, stderr, errCode)
 	}

--- a/sdk/nodejs/tests/automation/data/tcfg/.gitignore
+++ b/sdk/nodejs/tests/automation/data/tcfg/.gitignore
@@ -1,0 +1,2 @@
+/bin/
+/node_modules/

--- a/sdk/nodejs/tests/automation/data/tcfg/Pulumi.yaml
+++ b/sdk/nodejs/tests/automation/data/tcfg/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: tcfg
+runtime: nodejs
+description: A minimal TypeScript Pulumi program

--- a/sdk/nodejs/tests/automation/data/tcfg/index.ts
+++ b/sdk/nodejs/tests/automation/data/tcfg/index.ts
@@ -1,0 +1,1 @@
+import * as pulumi from "@pulumi/pulumi";

--- a/sdk/nodejs/tests/automation/data/tcfg/package-lock.json
+++ b/sdk/nodejs/tests/automation/data/tcfg/package-lock.json
@@ -1,0 +1,867 @@
+{
+    "name": "tcfg",
+    "requires": true,
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@grpc/grpc-js": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.8.tgz",
+            "integrity": "sha512-9C1xiCbnYe/3OFpSuRqz2JgFSOxv6+SlqFhXgRC1nHfXYbLnXvtmsI/NpaMs6k9ZNyV4gyaOOh5Z4McfegQGew==",
+            "requires": {
+                "@types/node": ">=12.12.47",
+                "google-auth-library": "^6.1.1",
+                "semver": "^6.2.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "14.14.31",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.31.tgz",
+                    "integrity": "sha512-vFHy/ezP5qI0rFgJ7aQnjDXwAMrG0KqqIH7tQG5PPv3BWBayOPIQNBjVc/P6hhdZfMx51REc6tfDNXHUio893g=="
+                }
+            }
+        },
+        "@protobufjs/aspromise": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+            "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
+        },
+        "@protobufjs/base64": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+            "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+        },
+        "@protobufjs/codegen": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+        },
+        "@protobufjs/eventemitter": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+            "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
+        },
+        "@protobufjs/fetch": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+            "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.0"
+            }
+        },
+        "@protobufjs/float": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+            "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
+        },
+        "@protobufjs/inquire": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+            "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
+        },
+        "@protobufjs/path": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+            "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
+        },
+        "@protobufjs/pool": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+            "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
+        },
+        "@protobufjs/utf8": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+            "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
+        },
+        "@pulumi/pulumi": {
+            "version": "2.21.2",
+            "resolved": "https://registry.npmjs.org/@pulumi/pulumi/-/pulumi-2.21.2.tgz",
+            "integrity": "sha512-XrOPxI55ktMJekmBLidYmlyvJuycNdGNmx733GHqfFVdytgfKwBp7CWLCQbPgtDV+klnG/wR2xsOLBGRBtFeTQ==",
+            "requires": {
+                "@grpc/grpc-js": "^1.2.7",
+                "@pulumi/query": "^0.3.0",
+                "google-protobuf": "^3.5.0",
+                "js-yaml": "^3.14.0",
+                "minimist": "^1.2.0",
+                "normalize-package-data": "^2.4.0",
+                "protobufjs": "^6.8.6",
+                "read-package-tree": "^5.3.1",
+                "require-from-string": "^2.0.1",
+                "semver": "^6.1.0",
+                "source-map-support": "^0.4.16",
+                "ts-node": "^7.0.1",
+                "typescript": "~3.7.3",
+                "upath": "^1.1.0"
+            }
+        },
+        "@pulumi/query": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@pulumi/query/-/query-0.3.0.tgz",
+            "integrity": "sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w=="
+        },
+        "@types/long": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+            "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
+        },
+        "@types/node": {
+            "version": "10.17.54",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.54.tgz",
+            "integrity": "sha512-c8Lm7+hXdSPmWH4B9z/P/xIXhFK3mCQin4yCYMd2p1qpMG5AfgyJuYZ+3q2dT7qLiMMMGMd5dnkFpdqJARlvtQ==",
+            "dev": true
+        },
+        "abort-controller": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+            "requires": {
+                "event-target-shim": "^5.0.0"
+            }
+        },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "requires": {
+                "debug": "4"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "requires": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "arrify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+            "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        },
+        "asap": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+        },
+        "base64-js": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+        },
+        "bignumber.js": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+            "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "call-bind": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2"
+            }
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+        },
+        "debug": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "requires": {
+                "ms": "2.1.2"
+            }
+        },
+        "debuglog": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+            "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
+        },
+        "dezalgo": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
+            "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
+            "requires": {
+                "asap": "^2.0.0",
+                "wrappy": "1"
+            }
+        },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
+        },
+        "ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "es-abstract": {
+            "version": "1.18.0-next.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.2.tgz",
+            "integrity": "sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "es-to-primitive": "^1.2.1",
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.2",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1",
+                "is-callable": "^1.2.2",
+                "is-negative-zero": "^2.0.1",
+                "is-regex": "^1.1.1",
+                "object-inspect": "^1.9.0",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.2",
+                "string.prototype.trimend": "^1.0.3",
+                "string.prototype.trimstart": "^1.0.3"
+            }
+        },
+        "es-to-primitive": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+            "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+            "requires": {
+                "is-callable": "^1.1.4",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.2"
+            }
+        },
+        "esprima": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+        },
+        "event-target-shim": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+        },
+        "extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+        },
+        "fast-text-encoding": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+            "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+        },
+        "gaxios": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+            "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+            "requires": {
+                "abort-controller": "^3.0.0",
+                "extend": "^3.0.2",
+                "https-proxy-agent": "^5.0.0",
+                "is-stream": "^2.0.0",
+                "node-fetch": "^2.3.0"
+            }
+        },
+        "gcp-metadata": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+            "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
+            "requires": {
+                "gaxios": "^4.0.0",
+                "json-bigint": "^1.0.0"
+            }
+        },
+        "get-intrinsic": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+            "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "glob": {
+            "version": "7.1.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+            "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+            "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            }
+        },
+        "google-auth-library": {
+            "version": "6.1.6",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+            "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
+            "requires": {
+                "arrify": "^2.0.0",
+                "base64-js": "^1.3.0",
+                "ecdsa-sig-formatter": "^1.0.11",
+                "fast-text-encoding": "^1.0.0",
+                "gaxios": "^4.0.0",
+                "gcp-metadata": "^4.2.0",
+                "gtoken": "^5.0.4",
+                "jws": "^4.0.0",
+                "lru-cache": "^6.0.0"
+            }
+        },
+        "google-p12-pem": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+            "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
+            "requires": {
+                "node-forge": "^0.10.0"
+            }
+        },
+        "google-protobuf": {
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.2.tgz",
+            "integrity": "sha512-HU67XsVFarxjHceJgrX0K75zzUFS+95LTArAncQ1BI156oEZR+fWXgk6Fxn4fNIpmrB0fwklwjXhMB0DQe0YNg=="
+        },
+        "graceful-fs": {
+            "version": "4.2.6",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+        },
+        "gtoken": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+            "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
+            "requires": {
+                "gaxios": "^4.0.0",
+                "google-p12-pem": "^3.0.3",
+                "jws": "^4.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "requires": {
+                "function-bind": "^1.1.1"
+            }
+        },
+        "has-symbols": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+        },
+        "hosted-git-info": {
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+            "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+        },
+        "https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            }
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "is-callable": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
+        },
+        "is-core-module": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+            "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+            "requires": {
+                "has": "^1.0.3"
+            }
+        },
+        "is-date-object": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+            "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
+        },
+        "is-negative-zero": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+            "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+        },
+        "is-regex": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.2.tgz",
+            "integrity": "sha512-axvdhb5pdhEVThqJzYXwMlVuZwC+FF2DpcOhTS+y/8jVq4trxyPgfcwIxIKiyeuLlSQYKkmUaPQJ8ZE4yNKXDg==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "is-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+            "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+        },
+        "is-symbol": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+            "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+            "requires": {
+                "has-symbols": "^1.0.1"
+            }
+        },
+        "js-yaml": {
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+            "requires": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            }
+        },
+        "json-bigint": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+            "requires": {
+                "bignumber.js": "^9.0.0"
+            }
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+        },
+        "jwa": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+            "requires": {
+                "buffer-equal-constant-time": "1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "jws": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+            "requires": {
+                "jwa": "^2.0.0",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "long": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+        },
+        "lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "requires": {
+                "yallist": "^4.0.0"
+            }
+        },
+        "make-error": {
+            "version": "1.3.6",
+            "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+            "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "requires": {
+                "brace-expansion": "^1.1.7"
+            }
+        },
+        "minimist": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+        },
+        "mkdirp": {
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+            "requires": {
+                "minimist": "^1.2.5"
+            }
+        },
+        "ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node-fetch": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        },
+        "node-forge": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+        },
+        "normalize-package-data": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+            "requires": {
+                "hosted-git-info": "^2.1.4",
+                "resolve": "^1.10.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
+            }
+        },
+        "npm-normalize-package-bin": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+            "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+        },
+        "object-inspect": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.9.0.tgz",
+            "integrity": "sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw=="
+        },
+        "object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+        },
+        "object.assign": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+            "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+            "requires": {
+                "call-bind": "^1.0.0",
+                "define-properties": "^1.1.3",
+                "has-symbols": "^1.0.1",
+                "object-keys": "^1.1.1"
+            }
+        },
+        "object.getownpropertydescriptors": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz",
+            "integrity": "sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0-next.2"
+            }
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "requires": {
+                "wrappy": "1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+        },
+        "path-parse": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+        },
+        "protobufjs": {
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
+            "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+            "requires": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.4",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.0",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.0",
+                "@types/long": "^4.0.1",
+                "@types/node": "^13.7.0",
+                "long": "^4.0.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "13.13.45",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.45.tgz",
+                    "integrity": "sha512-703YTEp8AwQeapI0PTXDOj+Bs/mtdV/k9VcTP7z/de+lx6XjFMKdB+JhKnK+6PZ5za7omgZ3V6qm/dNkMj/Zow=="
+                }
+            }
+        },
+        "read-package-json": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+            "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+            "requires": {
+                "glob": "^7.1.1",
+                "json-parse-even-better-errors": "^2.3.0",
+                "normalize-package-data": "^2.0.0",
+                "npm-normalize-package-bin": "^1.0.0"
+            }
+        },
+        "read-package-tree": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.3.1.tgz",
+            "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
+            "requires": {
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "util-promisify": "^2.1.0"
+            }
+        },
+        "readdir-scoped-modules": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+            "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+            "requires": {
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
+            }
+        },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+        },
+        "resolve": {
+            "version": "1.20.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "requires": {
+                "is-core-module": "^2.2.0",
+                "path-parse": "^1.0.6"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        },
+        "semver": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+        },
+        "source-map-support": {
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+            "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+            "requires": {
+                "source-map": "^0.5.6"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+            "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+            "requires": {
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+            "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+            "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+            "requires": {
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ=="
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+        },
+        "string.prototype.trimend": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+            "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+            "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3"
+            }
+        },
+        "ts-node": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+            "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+            "requires": {
+                "arrify": "^1.0.0",
+                "buffer-from": "^1.1.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^2.0.0"
+            },
+            "dependencies": {
+                "arrify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                },
+                "source-map-support": {
+                    "version": "0.5.19",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                }
+            }
+        },
+        "typescript": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.7.tgz",
+            "integrity": "sha512-MmQdgo/XenfZPvVLtKZOq9jQQvzaUAUpcKW8Z43x9B2fOm4S5g//tPtMweZUIP+SoBqrVPEIm+dJeQ9dfO0QdA=="
+        },
+        "upath": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+        },
+        "util-promisify": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/util-promisify/-/util-promisify-2.1.0.tgz",
+            "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
+            "requires": {
+                "object.getownpropertydescriptors": "^2.0.3"
+            }
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+            "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+            "requires": {
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
+            }
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "yallist": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        },
+        "yn": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+            "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
+        }
+    }
+}

--- a/sdk/nodejs/tests/automation/data/tcfg/package.json
+++ b/sdk/nodejs/tests/automation/data/tcfg/package.json
@@ -1,0 +1,9 @@
+{
+    "name": "tcfg",
+    "devDependencies": {
+        "@types/node": "^10.0.0"
+    },
+    "dependencies": {
+        "@pulumi/pulumi": "^2.0.0"
+    }
+}

--- a/sdk/nodejs/tests/automation/data/tcfg/tsconfig.json
+++ b/sdk/nodejs/tests/automation/data/tcfg/tsconfig.json
@@ -1,0 +1,18 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "sourceMap": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts"
+    ]
+}

--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -346,8 +346,7 @@ export class LocalWorkspace implements Workspace {
      * @param key The key to use for the config lookup
      */
     async getConfig(stackName: string, key: string): Promise<ConfigValue> {
-        await this.selectStack(stackName);
-        const result = await this.runPulumiCmd(["config", "get", key, "--json"]);
+        const result = await this.runPulumiCmd(["config", "get", key, "--json", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
     /**
@@ -357,8 +356,7 @@ export class LocalWorkspace implements Workspace {
      * @param stackName The stack to read config from
      */
     async getAllConfig(stackName: string): Promise<ConfigMap> {
-        await this.selectStack(stackName);
-        const result = await this.runPulumiCmd(["config", "--show-secrets", "--json"]);
+        const result = await this.runPulumiCmd(["config", "--show-secrets", "--json", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
     /**
@@ -370,9 +368,8 @@ export class LocalWorkspace implements Workspace {
      * @param value The value to set
      */
     async setConfig(stackName: string, key: string, value: ConfigValue): Promise<void> {
-        await this.selectStack(stackName);
         const secretArg = value.secret ? "--secret" : "--plaintext";
-        await this.runPulumiCmd(["config", "set", key, value.value, secretArg]);
+        await this.runPulumiCmd(["config", "set", key, value.value, secretArg, "--stack", stackName]);
     }
     /**
      * Sets all values in the provided config map for the specified stack name.
@@ -398,8 +395,7 @@ export class LocalWorkspace implements Workspace {
      * @param key The config key to remove
      */
     async removeConfig(stackName: string, key: string): Promise<void> {
-        await this.selectStack(stackName);
-        await this.runPulumiCmd(["config", "rm", key]);
+        await this.runPulumiCmd(["config", "rm", key, "--stack", stackName]);
     }
     /**
      *
@@ -419,8 +415,7 @@ export class LocalWorkspace implements Workspace {
      * @param stackName The stack to refresh
      */
     async refreshConfig(stackName: string): Promise<ConfigMap> {
-        await this.selectStack(stackName);
-        await this.runPulumiCmd(["config", "refresh", "--force"]);
+        await this.runPulumiCmd(["config", "refresh", "--force", "--stack", stackName]);
         return this.getAllConfig(stackName);
     }
     /**
@@ -498,8 +493,7 @@ export class LocalWorkspace implements Workspace {
      * @param stackName the name of the stack.
      */
     async exportStack(stackName: string): Promise<Deployment> {
-        await this.selectStack(stackName);
-        const result = await this.runPulumiCmd(["stack", "export", "--show-secrets"]);
+        const result = await this.runPulumiCmd(["stack", "export", "--show-secrets", "--stack", stackName]);
         return JSON.parse(result.stdout);
     }
     /**
@@ -510,12 +504,11 @@ export class LocalWorkspace implements Workspace {
      * @param state the stack state to import.
      */
     async importStack(stackName: string, state: Deployment): Promise<void> {
-        await this.selectStack(stackName);
         const randomSuffix = Math.floor(100000 + Math.random() * 900000);
         const filepath = upath.joinSafe(os.tmpdir(), `automation-${randomSuffix}`);
         const contents = JSON.stringify(state, null, 4);
         fs.writeFileSync(filepath, contents);
-        await this.runPulumiCmd(["stack", "import", "--file", filepath]);
+        await this.runPulumiCmd(["stack", "import", "--file", filepath, "--stack", stackName]);
         fs.unlinkSync(filepath);
     }
     /**

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -110,7 +110,7 @@ export class Stack {
      * @param opts Options to customize the behavior of the update.
      */
     async up(opts?: UpOptions): Promise<UpResult> {
-        const args = ["up", "--yes", "--skip-preview", "--stack", this.name];
+        const args = ["up", "--yes", "--skip-preview"];
         let kind = execKind.local;
         let program = this.workspace.program;
 
@@ -197,7 +197,7 @@ export class Stack {
      */
     async preview(opts?: PreviewOptions): Promise<PreviewResult> {
         // TODO JSON
-        const args = ["preview", "--stack", this.name];
+        const args = ["preview"];
         let kind = execKind.local;
         let program = this.workspace.program;
 
@@ -277,7 +277,7 @@ export class Stack {
      * @param opts Options to customize the behavior of the refresh.
      */
     async refresh(opts?: RefreshOptions): Promise<RefreshResult> {
-        const args = ["refresh", "--yes", "--skip-preview", "--stack", this.name];
+        const args = ["refresh", "--yes", "--skip-preview"];
 
         if (opts) {
             if (opts.message) {
@@ -310,7 +310,7 @@ export class Stack {
      * @param opts Options to customize the behavior of the destroy.
      */
     async destroy(opts?: DestroyOptions): Promise<DestroyResult> {
-        const args = ["destroy", "--yes", "--skip-preview", "--stack", this.name];
+        const args = ["destroy", "--yes", "--skip-preview"];
 
         if (opts) {
             if (opts.message) {
@@ -395,8 +395,8 @@ export class Stack {
      */
     async outputs(): Promise<OutputMap> {
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
-        const maskedResult = await this.runPulumiCmd(["stack", "output", "--json", "--stack", this.name]);
-        const plaintextResult = await this.runPulumiCmd(["stack", "output", "--json", "--show-secrets", "--stack", this.name]);
+        const maskedResult = await this.runPulumiCmd(["stack", "output", "--json"]);
+        const plaintextResult = await this.runPulumiCmd(["stack", "output", "--json", "--show-secrets"]);
         const maskedOuts = JSON.parse(maskedResult.stdout);
         const plaintextOuts = JSON.parse(plaintextResult.stdout);
         const outputs: OutputMap = {};
@@ -443,7 +443,7 @@ export class Stack {
      * This command is not supported for local backends.
      */
     async cancel(): Promise<void> {
-        await this.runPulumiCmd(["cancel", "--yes", "--stack", this.name]);
+        await this.runPulumiCmd(["cancel", "--yes"]);
     }
 
     /**
@@ -472,7 +472,7 @@ export class Stack {
         }
         envs = { ...envs, ...this.workspace.envVars };
         const additionalArgs = await this.workspace.serializeArgsForOp(this.name);
-        args = [...args, ...additionalArgs];
+        args = [...args, "--stack", this.name, ...additionalArgs];
         const result = await runPulumiCmd(args, this.workspace.workDir, envs, onOutput);
         await this.workspace.postCommandCallback(this.name);
         return result;

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -56,8 +56,7 @@ export class Stack {
     }
     /**
      * Selects stack using the given workspace, and stack name.
-     * It returns an error if the given Stack does not exist. All LocalWorkspace operations will call `select`
-     * before running.
+     * It returns an error if the given Stack does not exist.
      *
      * @param name The name identifying the Stack.
      * @param workspace The Workspace the Stack was created from.
@@ -111,10 +110,9 @@ export class Stack {
      * @param opts Options to customize the behavior of the update.
      */
     async up(opts?: UpOptions): Promise<UpResult> {
-        const args = ["up", "--yes", "--skip-preview"];
+        const args = ["up", "--yes", "--skip-preview", "--stack", this.name];
         let kind = execKind.local;
         let program = this.workspace.program;
-        await this.workspace.selectStack(this.name);
 
         if (opts) {
             if (opts.program) {
@@ -180,8 +178,7 @@ export class Stack {
         } finally {
             onExit();
         }
-        
-        
+
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
         const outputs = await this.outputs();
         const summary = await this.info();
@@ -200,10 +197,9 @@ export class Stack {
      */
     async preview(opts?: PreviewOptions): Promise<PreviewResult> {
         // TODO JSON
-        const args = ["preview"];
+        const args = ["preview", "--stack", this.name];
         let kind = execKind.local;
         let program = this.workspace.program;
-        await this.workspace.selectStack(this.name);
 
         if (opts) {
             if (opts.program) {
@@ -281,8 +277,7 @@ export class Stack {
      * @param opts Options to customize the behavior of the refresh.
      */
     async refresh(opts?: RefreshOptions): Promise<RefreshResult> {
-        const args = ["refresh", "--yes", "--skip-preview"];
-        await this.workspace.selectStack(this.name);
+        const args = ["refresh", "--yes", "--skip-preview", "--stack", this.name];
 
         if (opts) {
             if (opts.message) {
@@ -315,8 +310,7 @@ export class Stack {
      * @param opts Options to customize the behavior of the destroy.
      */
     async destroy(opts?: DestroyOptions): Promise<DestroyResult> {
-        const args = ["destroy", "--yes", "--skip-preview"];
-        await this.workspace.selectStack(this.name);
+        const args = ["destroy", "--yes", "--skip-preview", "--stack", this.name];
 
         if (opts) {
             if (opts.message) {
@@ -400,10 +394,9 @@ export class Stack {
      * Gets the current set of Stack outputs from the last Stack.up().
      */
     async outputs(): Promise<OutputMap> {
-        await this.workspace.selectStack(this.name);
         // TODO: do this in parallel after this is fixed https://github.com/pulumi/pulumi/issues/6050
-        const maskedResult = await this.runPulumiCmd(["stack", "output", "--json"]);
-        const plaintextResult = await this.runPulumiCmd(["stack", "output", "--json", "--show-secrets"]);
+        const maskedResult = await this.runPulumiCmd(["stack", "output", "--json", "--stack", this.name]);
+        const plaintextResult = await this.runPulumiCmd(["stack", "output", "--json", "--show-secrets", "--stack", this.name]);
         const maskedOuts = JSON.parse(maskedResult.stdout);
         const plaintextOuts = JSON.parse(plaintextResult.stdout);
         const outputs: OutputMap = {};
@@ -450,8 +443,7 @@ export class Stack {
      * This command is not supported for local backends.
      */
     async cancel(): Promise<void> {
-        await this.workspace.selectStack(this.name);
-        await this.runPulumiCmd(["cancel", "--yes"]);
+        await this.runPulumiCmd(["cancel", "--yes", "--stack", this.name]);
     }
 
     /**

--- a/sdk/python/lib/pulumi/x/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_local_workspace.py
@@ -149,14 +149,12 @@ class LocalWorkspace(Workspace):
         return
 
     def get_config(self, stack_name: str, key: str) -> ConfigValue:
-        self.select_stack(stack_name)
-        result = self._run_pulumi_cmd_sync(["config", "get", key, "--json"])
+        result = self._run_pulumi_cmd_sync(["config", "get", key, "--json", "-s", stack_name])
         val = json.loads(result.stdout)
         return ConfigValue(value=val["value"], secret=val["secret"])
 
     def get_all_config(self, stack_name: str) -> ConfigMap:
-        self.select_stack(stack_name)
-        result = self._run_pulumi_cmd_sync(["config", "--show-secrets", "--json"])
+        result = self._run_pulumi_cmd_sync(["config", "--show-secrets", "--json", "-s", stack_name])
         config_json = json.loads(result.stdout)
         config_map: ConfigMap = {}
         for key in config_json:
@@ -165,9 +163,8 @@ class LocalWorkspace(Workspace):
         return config_map
 
     def set_config(self, stack_name: str, key: str, value: ConfigValue) -> None:
-        self.select_stack(stack_name)
         secret_arg = "--secret" if value.secret else "--plaintext"
-        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg])
+        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg, "-s", stack_name])
 
     def set_all_config(self, stack_name: str, config: ConfigMap) -> None:
         args = ["config", "set-all", "--stack", stack_name]
@@ -179,8 +176,7 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(args)
 
     def remove_config(self, stack_name: str, key: str) -> None:
-        self.select_stack(stack_name)
-        self._run_pulumi_cmd_sync(["config", "rm", key])
+        self._run_pulumi_cmd_sync(["config", "rm", key, "-s", stack_name])
 
     def remove_all_config(self, stack_name: str, keys: List[str]) -> None:
         args = ["config", "rm-all", "--stack", stack_name]
@@ -188,8 +184,7 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(args)
 
     def refresh_config(self, stack_name: str) -> None:
-        self.select_stack(stack_name)
-        self._run_pulumi_cmd_sync(["config", "refresh", "--force"])
+        self._run_pulumi_cmd_sync(["config", "refresh", "--force", "-s", stack_name])
         self.get_all_config(stack_name)
 
     def who_am_i(self) -> WhoAmIResult:
@@ -262,17 +257,15 @@ class LocalWorkspace(Workspace):
         return plugin_list
 
     def export_stack(self, stack_name: str) -> Deployment:
-        self.select_stack(stack_name)
-        result = self._run_pulumi_cmd_sync(["stack", "export", "--show-secrets"])
+        result = self._run_pulumi_cmd_sync(["stack", "export", "--show-secrets", "-s", stack_name])
         state_json = json.loads(result.stdout)
         return Deployment(**state_json)
 
     def import_stack(self, stack_name: str, state: Deployment) -> None:
-        self.select_stack(stack_name)
         file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         json.dump(state.__dict__, file, indent=4)
         file.close()
-        self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name])
+        self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name, "-s", stack_name])
         os.remove(file.name)
 
     def _run_pulumi_cmd_sync(self, args: List[str], on_output: Optional[OnOutput] = None) -> CommandResult:

--- a/sdk/python/lib/pulumi/x/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_local_workspace.py
@@ -149,12 +149,12 @@ class LocalWorkspace(Workspace):
         return
 
     def get_config(self, stack_name: str, key: str) -> ConfigValue:
-        result = self._run_pulumi_cmd_sync(["config", "get", key, "--json", "-s", stack_name])
+        result = self._run_pulumi_cmd_sync(["config", "get", key, "--json", "--stack", stack_name])
         val = json.loads(result.stdout)
         return ConfigValue(value=val["value"], secret=val["secret"])
 
     def get_all_config(self, stack_name: str) -> ConfigMap:
-        result = self._run_pulumi_cmd_sync(["config", "--show-secrets", "--json", "-s", stack_name])
+        result = self._run_pulumi_cmd_sync(["config", "--show-secrets", "--json", "--stack", stack_name])
         config_json = json.loads(result.stdout)
         config_map: ConfigMap = {}
         for key in config_json:
@@ -164,7 +164,7 @@ class LocalWorkspace(Workspace):
 
     def set_config(self, stack_name: str, key: str, value: ConfigValue) -> None:
         secret_arg = "--secret" if value.secret else "--plaintext"
-        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg, "-s", stack_name])
+        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg, "--stack", stack_name])
 
     def set_all_config(self, stack_name: str, config: ConfigMap) -> None:
         args = ["config", "set-all", "--stack", stack_name]
@@ -176,7 +176,7 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(args)
 
     def remove_config(self, stack_name: str, key: str) -> None:
-        self._run_pulumi_cmd_sync(["config", "rm", key, "-s", stack_name])
+        self._run_pulumi_cmd_sync(["config", "rm", key, "--stack", stack_name])
 
     def remove_all_config(self, stack_name: str, keys: List[str]) -> None:
         args = ["config", "rm-all", "--stack", stack_name]
@@ -184,7 +184,7 @@ class LocalWorkspace(Workspace):
         self._run_pulumi_cmd_sync(args)
 
     def refresh_config(self, stack_name: str) -> None:
-        self._run_pulumi_cmd_sync(["config", "refresh", "--force", "-s", stack_name])
+        self._run_pulumi_cmd_sync(["config", "refresh", "--force", "--stack", stack_name])
         self.get_all_config(stack_name)
 
     def who_am_i(self) -> WhoAmIResult:
@@ -257,7 +257,7 @@ class LocalWorkspace(Workspace):
         return plugin_list
 
     def export_stack(self, stack_name: str) -> Deployment:
-        result = self._run_pulumi_cmd_sync(["stack", "export", "--show-secrets", "-s", stack_name])
+        result = self._run_pulumi_cmd_sync(["stack", "export", "--show-secrets", "--stack", stack_name])
         state_json = json.loads(result.stdout)
         return Deployment(**state_json)
 
@@ -265,7 +265,7 @@ class LocalWorkspace(Workspace):
         file = tempfile.NamedTemporaryFile(mode="w", delete=False)
         json.dump(state.__dict__, file, indent=4)
         file.close()
-        self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name, "-s", stack_name])
+        self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name, "--stack", stack_name])
         os.remove(file.name)
 
     def _run_pulumi_cmd_sync(self, args: List[str], on_output: Optional[OnOutput] = None) -> CommandResult:

--- a/sdk/python/lib/pulumi/x/automation/_stack.py
+++ b/sdk/python/lib/pulumi/x/automation/_stack.py
@@ -177,8 +177,7 @@ class Stack:
     def select(cls, stack_name: str, workspace: Workspace) -> 'Stack':
         """
         Selects stack using the given workspace, and stack name.
-        It returns an error if the given Stack does not exist. All LocalWorkspace operations will call `select` before
-        running.
+        It returns an error if the given Stack does not exist.
 
         :param stack_name: The name identifying the Stack
         :param workspace: The Workspace the Stack was created from.
@@ -259,10 +258,9 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["up", "--yes", "--skip-preview"]
+        args = ["up", "--yes", "--skip-preview", "-s", self.name]
         args.extend(extra_args)
 
-        self.workspace.select_stack(self.name)
         kind = ExecKind.LOCAL.value
         on_exit = None
 
@@ -319,10 +317,9 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["preview"]
+        args = ["preview", "-s", self.name]
         args.extend(extra_args)
 
-        self.workspace.select_stack(self.name)
         kind = ExecKind.LOCAL.value
         on_exit = None
 
@@ -368,10 +365,9 @@ class Stack:
         :returns: RefreshResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["refresh", "--yes", "--skip-preview"]
+        args = ["refresh", "--yes", "--skip-preview", "-s", self.name]
         args.extend(extra_args)
 
-        self.workspace.select_stack(self.name)
         refresh_result = self._run_pulumi_cmd_sync(args, on_output)
         summary = self.info()
         assert(summary is not None)
@@ -395,10 +391,9 @@ class Stack:
         :returns: DestroyResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["destroy", "--yes", "--skip-preview"]
+        args = ["destroy", "--yes", "--skip-preview", "-s", self.name]
         args.extend(extra_args)
 
-        self.workspace.select_stack(self.name)
         destroy_result = self._run_pulumi_cmd_sync(args, on_output)
         summary = self.info()
         assert(summary is not None)
@@ -464,10 +459,8 @@ class Stack:
 
         :returns: OutputMap
         """
-        self.workspace.select_stack(self.name)
-
-        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json"])
-        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets"])
+        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "-s", self.name])
+        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets", "-s", self.name])
         masked_outputs = json.loads(masked_result.stdout)
         plaintext_outputs = json.loads(plaintext_result.stdout)
         outputs: OutputMap = {}
@@ -488,7 +481,7 @@ class Stack:
 
         :returns: List[UpdateSummary]
         """
-        args = ["history", "--json", "--show-secrets"]
+        args = ["history", "--json", "--show-secrets", "-s", self.name]
         if page_size is not None:
             # default page=1 when page_size is set
             if page is None:
@@ -530,8 +523,7 @@ class Stack:
         if a resource operation was pending when the update was canceled.
         This command is not supported for local backends.
         """
-        self.workspace.select_stack(self.name)
-        self._run_pulumi_cmd_sync(["cancel", "--yes"])
+        self._run_pulumi_cmd_sync(["cancel", "--yes", "-s", self.name])
 
     def export_stack(self) -> Deployment:
         """

--- a/sdk/python/lib/pulumi/x/automation/_stack.py
+++ b/sdk/python/lib/pulumi/x/automation/_stack.py
@@ -258,7 +258,7 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["up", "--yes", "--skip-preview", "--stack", self.name]
+        args = ["up", "--yes", "--skip-preview"]
         args.extend(extra_args)
 
         kind = ExecKind.LOCAL.value
@@ -317,7 +317,7 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["preview", "--stack", self.name]
+        args = ["preview"]
         args.extend(extra_args)
 
         kind = ExecKind.LOCAL.value
@@ -365,7 +365,7 @@ class Stack:
         :returns: RefreshResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["refresh", "--yes", "--skip-preview", "--stack", self.name]
+        args = ["refresh", "--yes", "--skip-preview"]
         args.extend(extra_args)
 
         refresh_result = self._run_pulumi_cmd_sync(args, on_output)
@@ -391,7 +391,7 @@ class Stack:
         :returns: DestroyResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["destroy", "--yes", "--skip-preview", "--stack", self.name]
+        args = ["destroy", "--yes", "--skip-preview"]
         args.extend(extra_args)
 
         destroy_result = self._run_pulumi_cmd_sync(args, on_output)
@@ -459,8 +459,8 @@ class Stack:
 
         :returns: OutputMap
         """
-        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--stack", self.name])
-        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets", "--stack", self.name])
+        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json"])
+        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets"])
         masked_outputs = json.loads(masked_result.stdout)
         plaintext_outputs = json.loads(plaintext_result.stdout)
         outputs: OutputMap = {}
@@ -481,7 +481,7 @@ class Stack:
 
         :returns: List[UpdateSummary]
         """
-        args = ["history", "--json", "--show-secrets", "--stack", self.name]
+        args = ["history", "--json", "--show-secrets"]
         if page_size is not None:
             # default page=1 when page_size is set
             if page is None:
@@ -523,7 +523,7 @@ class Stack:
         if a resource operation was pending when the update was canceled.
         This command is not supported for local backends.
         """
-        self._run_pulumi_cmd_sync(["cancel", "--yes", "--stack", self.name])
+        self._run_pulumi_cmd_sync(["cancel", "--yes"])
 
     def export_stack(self) -> Deployment:
         """
@@ -551,7 +551,7 @@ class Stack:
 
         additional_args = self.workspace.serialize_args_for_op(self.name)
         args.extend(additional_args)
-
+        args.extend(["--stack", self.name])
         result = _run_pulumi_cmd(args, self.workspace.work_dir, envs, on_output)
         self.workspace.post_command_callback(self.name)
         return result

--- a/sdk/python/lib/pulumi/x/automation/_stack.py
+++ b/sdk/python/lib/pulumi/x/automation/_stack.py
@@ -258,7 +258,7 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["up", "--yes", "--skip-preview", "-s", self.name]
+        args = ["up", "--yes", "--skip-preview", "--stack", self.name]
         args.extend(extra_args)
 
         kind = ExecKind.LOCAL.value
@@ -317,7 +317,7 @@ class Stack:
         """
         program = program or self.workspace.program
         extra_args = _parse_extra_args(**locals())
-        args = ["preview", "-s", self.name]
+        args = ["preview", "--stack", self.name]
         args.extend(extra_args)
 
         kind = ExecKind.LOCAL.value
@@ -365,7 +365,7 @@ class Stack:
         :returns: RefreshResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["refresh", "--yes", "--skip-preview", "-s", self.name]
+        args = ["refresh", "--yes", "--skip-preview", "--stack", self.name]
         args.extend(extra_args)
 
         refresh_result = self._run_pulumi_cmd_sync(args, on_output)
@@ -391,7 +391,7 @@ class Stack:
         :returns: DestroyResult
         """
         extra_args = _parse_extra_args(**locals())
-        args = ["destroy", "--yes", "--skip-preview", "-s", self.name]
+        args = ["destroy", "--yes", "--skip-preview", "--stack", self.name]
         args.extend(extra_args)
 
         destroy_result = self._run_pulumi_cmd_sync(args, on_output)
@@ -459,8 +459,8 @@ class Stack:
 
         :returns: OutputMap
         """
-        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "-s", self.name])
-        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets", "-s", self.name])
+        masked_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--stack", self.name])
+        plaintext_result = self._run_pulumi_cmd_sync(["stack", "output", "--json", "--show-secrets", "--stack", self.name])
         masked_outputs = json.loads(masked_result.stdout)
         plaintext_outputs = json.loads(plaintext_result.stdout)
         outputs: OutputMap = {}
@@ -481,7 +481,7 @@ class Stack:
 
         :returns: List[UpdateSummary]
         """
-        args = ["history", "--json", "--show-secrets", "-s", self.name]
+        args = ["history", "--json", "--show-secrets", "--stack", self.name]
         if page_size is not None:
             # default page=1 when page_size is set
             if page is None:
@@ -523,7 +523,7 @@ class Stack:
         if a resource operation was pending when the update was canceled.
         This command is not supported for local backends.
         """
-        self._run_pulumi_cmd_sync(["cancel", "--yes", "-s", self.name])
+        self._run_pulumi_cmd_sync(["cancel", "--yes", "--stack", self.name])
 
     def export_stack(self) -> Deployment:
         """


### PR DESCRIPTION
This PR has 2 purposes:

* Standardize the `--stack` flag in the CLI to `setCurrent=False` (this is a breaking change and we will keep it in a 3.0 branch)
* Change the automation API implementation in each language to use the `--stack` flag for stack operations rather than first running `selectStack`, followed by the operation in question.

Also added a test that previously failed to correctly set config values across stacks asyncronously in nodejs.

Fixes: #5257 and #6062