### PR TITLE
[automation/go] - Remove --json flag from preview

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,12 +1,21 @@
+### Breaking changes
+
+Note: Breaking changes should be expected outside of major version changes while Automation API is in preview.
+
+- [automation/python,nodejs,dotnet] - Remove `summary` property from `PreviewResult`.
+  The `summary` property on `PreviewResult` returns a result that is always incorrect and is being removed.
+  [#6405](https://github.com/pulumi/pulumi/pull/6405)
+  
+- [automation/go] - Add a `ProgressStreams` option to Stack.Preview().
+  This is a breaking change as it changes the shape of `PreviewResult`.
+  [#6308](https://github.com/pulumi/pulumi/pull/6308)
+
 ### Features
 
 
 ### Enhancements
 
-- [#6410](https://github.com/pulumi/pulumi/pull/6410) Add `diff` option to Automation API's `preview` and `up`
+- Add `diff` option to Automation API's `preview` and `up`.
+  [#6410](https://github.com/pulumi/pulumi/pull/6410)
 
 ### Bug Fixes
-
-- [automation/python,nodejs,dotnet] - BREAKING - Remove `summary` property from `PreviewResult`.
-  The `summary` property on `PreviewResult` returns a result that is always incorrect and is being removed.
-  [#6405](https://github.com/pulumi/pulumi/pull/6405)

--- a/sdk/go/x/auto/example_test.go
+++ b/sdk/go/x/auto/example_test.go
@@ -669,12 +669,10 @@ func ExampleStack() {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		// Handle failure previewing stack.
 	}
-	// no changes after the update
-	fmt.Println(prev.ChangeSummary["same"])
 
 	// -- pulumi refresh --
 

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -189,13 +189,11 @@ func TestNewStackLocalSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
 
@@ -291,13 +289,11 @@ func TestUpsertStackLocalSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
 
@@ -384,13 +380,11 @@ func TestNewStackRemoteSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
 
@@ -472,13 +466,11 @@ func TestUpsertStackRemoteSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
 
@@ -572,13 +564,11 @@ func TestNewStackRemoteSourceWithSetup(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
 
@@ -672,13 +662,11 @@ func TestUpsertStackRemoteSourceWithSetup(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
 
@@ -762,13 +750,11 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
 
@@ -851,13 +837,11 @@ func TestUpsertStackInlineSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	_, err = s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
 

--- a/sdk/go/x/auto/optpreview/optpreview.go
+++ b/sdk/go/x/auto/optpreview/optpreview.go
@@ -17,6 +17,8 @@
 package optpreview
 
 import (
+	"io"
+
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 )
 
@@ -70,6 +72,13 @@ func TargetDependents() Option {
 	})
 }
 
+// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview output
+func ProgressStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ProgressStreams = writers
+	})
+}
+
 func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	return optionFunc(func(opts *Options) {
 		opts.DebugLogOpts = debugOpts
@@ -100,6 +109,8 @@ type Options struct {
 	Target []string
 	// Allows updating of dependent targets discovered but not specified in the Target list
 	TargetDependents bool
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview output
+	ProgressStreams []io.Writer
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 }

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -242,7 +242,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", preOpts.Parallel))
 	}
 
-	kind, args := constant.ExecKindAutoLocal, []string{"preview", "--json"}
+	kind, args := constant.ExecKindAutoLocal, []string{"preview"}
 	if program := s.Workspace().Program(); program != nil {
 		server, err := startLanguageRuntimeServer(program)
 		if err != nil {
@@ -255,7 +255,7 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 
 	args = append(args, fmt.Sprintf("--exec-kind=%s", kind))
 	args = append(args, sharedArgs...)
-	stdout, stderr, code, err := s.runPulumiCmdSync(ctx, nil /* additionalOutput */, args...)
+	stdout, stderr, code, err := s.runPulumiCmdSync(ctx, preOpts.ProgressStreams, args...)
 	if err != nil {
 		return res, newAutoError(errors.Wrap(err, "failed to run preview"), stdout, stderr, code)
 	}
@@ -722,8 +722,8 @@ type PropertyDiff struct {
 
 // PreviewResult is the output of Stack.Preview() describing the expected set of changes from the next Stack.Up()
 type PreviewResult struct {
-	Steps         []PreviewStep  `json:"steps"`
-	ChangeSummary map[string]int `json:"changeSummary"`
+	StdOut string
+	StdErr string
 }
 
 // RefreshResult is the output of a successful Stack.Refresh operation

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -715,7 +715,7 @@ type PropertyDiff struct {
 	InputDiff bool `json:"inputDiff"`
 }
 
-// PreviewResult is the output of Stack.Preview() describing the expected set of changes from the next Stack.Up()
+// PreviewResult is the output of Stack.Preview
 type PreviewResult struct {
 	StdOut string
 	StdErr string

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -260,11 +260,6 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		return res, newAutoError(errors.Wrap(err, "failed to run preview"), stdout, stderr, code)
 	}
 
-	err = json.Unmarshal([]byte(stdout), &res)
-	if err != nil {
-		return res, newAutoError(errors.Wrap(err, "unable to unmarshal preview result"), stdout, stderr, code)
-	}
-
 	return res, nil
 }
 


### PR DESCRIPTION
The `--json` flag prevents us from being able to stream incremental updates via `ProgressStreams` for Stack.Preview(), so we are removing it and changing the shape of the `PreviewResult` to match the other language implementations and the other commands.

This is a breaking change because we are changing the shape of `PreviewResult`, but this is to be expected while automation api is in preview.

Fixes: #6308 