### PR TITLE
[automation/python] - Use TemporaryFile and seek()

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,3 +10,6 @@
 - [automation/python,nodejs,dotnet] - BREAKING - Remove `summary` property from `PreviewResult`.
   The `summary` property on `PreviewResult` returns a result that is always incorrect and is being removed.
   [#6405](https://github.com/pulumi/pulumi/pull/6405)
+  
+- [automation/python] - Fix Windows error caused by use of NamedTemporaryFile in automation api.
+  [#6421](https://github.com/pulumi/pulumi/pull/6421)

--- a/sdk/python/lib/pulumi/x/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/x/automation/_cmd.py
@@ -50,7 +50,7 @@ def _run_pulumi_cmd(args: List[str],
     cmd = ["pulumi"]
     cmd.extend(args)
 
-    stderr_file = tempfile.NamedTemporaryFile(delete=False)
+    stderr_file = tempfile.TemporaryFile()
     stdout_chunks: List[str] = []
 
     with subprocess.Popen(cmd,
@@ -70,9 +70,9 @@ def _run_pulumi_cmd(args: List[str],
 
         code = process.returncode
 
-    with open(stderr_file.name) as stderr:
-        stderr_contents = stderr.read()
-    os.remove(stderr_file.name)
+    stderr_file.seek(0)
+    stderr_contents = stderr_file.read().decode("utf-8")
+    stderr_file.close()
 
     result = CommandResult(stderr=stderr_contents, stdout='\n'.join(stdout_chunks), code=code)
     if code != 0:


### PR DESCRIPTION
This PR fixes the usage of `TemporaryFile` in python automation API. Particularly in Windows, `NamedTemporaryFile` [cannot be reopened](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile:~:text=Whether%20the%20name%20can%20be%20used,cannot%20on%20Windows%20NT%20or%20later) while it is already open, which was leading to errors. We don't need a `NamedTemporaryFile` nor did we need to reopen it, we just needed `seek` to get back to the beginning of the file before we read it.

We don't run SDK unit tests in our Windows build which is why this wasn't caught, but I've opened an [issue](https://github.com/pulumi/pulumi/issues/6417) to track that work.

https://github.com/pulumi/pulumi/pull/6424 has an example of the [repro](https://github.com/pulumi/pulumi/pull/6424/checks?check_run_id=1974871868#step:14:215) and a rerun with this change included that [passes](https://github.com/pulumi/pulumi/pull/6424/checks?check_run_id=1975009417#step:14:489).

Fixes: #6402 