### PR TITLE
Fully-automate development setup with Gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,10 @@
+FROM gitpod/workspace-full
+USER gitpod
+
+ENV PATH="/opt/pulumi:/opt/pulumi/bin:$PATH"
+
+# Install .NET Core 3.1 SDK binaries on Ubuntu 20.04
+# Source: https://dev.to/carlos487/installing-dotnet-core-in-ubuntu-20-04-6jh
+RUN mkdir -p /home/gitpod/dotnet && curl -fsSL https://download.visualstudio.microsoft.com/download/pr/f65a8eb0-4537-4e69-8ff3-1a80a80d9341/cc0ca9ff8b9634f3d9780ec5915c1c66/dotnet-sdk-3.1.201-linux-x64.tar.gz | tar xz -C /home/gitpod/dotnet
+ENV DOTNET_ROOT=/home/gitpod/dotnet
+ENV PATH=$PATH:/home/gitpod/dotnet

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,21 @@
+image:
+  file: .gitpod.Dockerfile
+
+# See: https://www.gitpod.io/docs/config-start-tasks/
+tasks:
+  - before: >
+      mkdir -p /workspace/opt-pulumi &&
+      sudo ln -s /workspace/opt-pulumi /opt/pulumi
+    init: >
+      make ensure &&
+      make install
+    command: pulumi version
+
+# See: https://www.gitpod.io/docs/prebuilds/#configure-the-github-app
+github:
+  prebuilds:
+    master: true
+    branches: true
+    pullRequests: true
+    pullRequestsFromForks: true
+    addCheck: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,12 @@ brew install --HEAD -s dotnet-sdk.rb
 rm dotnet-sdk.rb
 ```
 
+## Hacking on Pulumi in Gitpod
+
+If you have a web browser, you can get a fully pre-configured Pulumi development environment in one click:
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/pulumi/pulumi)
+
 ## Make build system
 
 We use `make` as our build system, so you'll want to install that as well, if you don't have it already. We have extremely limited support for doing development on Windows (the bare minimum for us to get Windows validation of `pulumi`) so if you're on windows, we recommend that you use the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). We'd like to [make this better](https://github.com/pulumi/pulumi/issues/208) so feel free to pitch in if you can.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![NuGet version](https://badge.fury.io/nu/pulumi.svg)](https://badge.fury.io/nu/pulumi)
 [![GoDoc](https://godoc.org/github.com/pulumi/pulumi?status.svg)](https://godoc.org/github.com/pulumi/pulumi)
 [![License](https://img.shields.io/npm/l/%40pulumi%2Fpulumi.svg)](https://github.com/pulumi/pulumi/blob/master/LICENSE)
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/pulumi/pulumi)
 
 <a href="https://www.pulumi.com/docs/get-started/?utm_campaign=pulumi-pulumi-github-repo&utm_source=github.com&utm_medium=get-started-button" title="Get Started">
     <img src="https://www.pulumi.com/images/get-started.svg" align="right" width="120">


### PR DESCRIPTION
Hi Pulumi team! 👋

As discussed with @jaxxstorm, here is a PR that fully-automates the dev setup of Pulumi with Gitpod, providing anyone with a pre-built, browser-based Pulumi dev environment in one click:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/pulumi)
<img width="1552" alt="Screenshot 2021-02-26 at 18 31 57" src="https://user-images.githubusercontent.com/599268/109334403-f6ef3f00-7860-11eb-926f-5ac94a221649.png">

### What it does

- Comes with all Pulumi dependencies pre-installed (including Go, Node.js, Python, and .NET Core 3.1)
- Runs `make ensure && make install` ahead-of-time (so you don't need to wait)
- Gives anyone immediate access to the pre-compiled `pulumi` CLI, and allows to easily edit & rebuild the code

I hope this can make life easier for Pulumi contributors, and for Pulumi maintainers who need to review many PRs (hint: you can already [open this PR in Gitpod](https://gitpod.io/from-referrer/) to easily review & test it without messing up your local checkout).

### Notes & caveats

You may need to set up a `PULUMI_ACCESS_TOKEN` for certain actions to work (or let `pulumi login` guide you interactively).

I tried to get the tests to pass in Gitpod, but running just `make` revealed a few errors in "LINT" and "TEST FAST", which I attempted to "fix":
- Fixed JSON format in a test fixture (https://github.com/jankeromnes/pulumi/commit/8cad1e9dd3e29bc6e7aadfe960959ece7a653e1d)
- Fixed `tslint` problems in `sdk/nodejs/` (https://github.com/jankeromnes/pulumi/commit/3e05e81663a8d4d08f4d714ef4d6a6022add9615)
- Disabled 2 tests (https://github.com/jankeromnes/pulumi/commit/58da8e9a2d969afc5bd84fa58253ed23f05b270e and https://github.com/jankeromnes/pulumi/commit/6cb68ced84091cc7cb373d1ebbbd49206a90b56b) due to "no language plugin 'go' found in the workspace or on your $PATH"(?)
- Disabled another test due to "Organization 'pulumi-test' not found" (https://github.com/jankeromnes/pulumi/commit/d0004f6c0756cccc9dc32234ab2ef1141155d81f)
- And disabled yet another test (https://github.com/jankeromnes/pulumi/commit/9e1cdf05c1019173223043484c025fdcffe6ee7c) due to:

```
System.Collections.Generic.KeyNotFoundException: The given key 'System.Runtime.CompilerServices.AsyncTaskMethodBuilder`1+AsyncStateMachineBox`1[System.Threading.Tasks.VoidTaskResult,Pulumi.Deployment+<RegisterResourceOutputsAsync>d__77]' was not present in the dictionary
```

I'm not sure if these problems are due to the Gitpod setup or the Pulumi tests, so these commits live on a separate branch in my fork for now. Also, since @jaxxstorm told me that `sdk/*` is auto-generated, the fixes are probably not in the right place anyway.

Please let me know if I should open issues for these & how they can be fixed (e.g. in the generator).

And I'm looking forward to your feedback on this PR! 🚀 