### PR TITLE
[codegen/python] - Fix python .get() codegen

### DIFF
--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/cat.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/cat.py
@@ -69,6 +69,7 @@ class Cat(pulumi.CustomResource):
 
         __props__ = dict()
 
+        __props__["name"] = None
         return Cat(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -69,6 +69,9 @@ class Component(pulumi.CustomResource):
 
         __props__ = dict()
 
+        __props__["provider"] = None
+        __props__["security_group"] = None
+        __props__["storage_classes"] = None
         return Component(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/workload.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/workload.py
@@ -64,6 +64,7 @@ class Workload(pulumi.CustomResource):
 
         __props__ = dict()
 
+        __props__["pod"] = None
         return Workload(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Tree/V1/RubberTree.cs
@@ -40,8 +40,8 @@ namespace Pulumi.Plant.Tree.V1
         {
         }
 
-        private RubberTree(string name, Input<string> id, CustomResourceOptions? options = null)
-            : base("plant:tree/v1:RubberTree", name, null, MakeResourceOptions(options, id))
+        private RubberTree(string name, Input<string> id, RubberTreeState? state = null, CustomResourceOptions? options = null)
+            : base("plant:tree/v1:RubberTree", name, state, MakeResourceOptions(options, id))
         {
         }
 
@@ -63,10 +63,11 @@ namespace Pulumi.Plant.Tree.V1
         ///
         /// <param name="name">The unique name of the resulting resource.</param>
         /// <param name="id">The unique provider ID of the resource to lookup.</param>
+        /// <param name="state">Any extra arguments used during the lookup.</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public static RubberTree Get(string name, Input<string> id, CustomResourceOptions? options = null)
+        public static RubberTree Get(string name, Input<string> id, RubberTreeState? state = null, CustomResourceOptions? options = null)
         {
-            return new RubberTree(name, id, options);
+            return new RubberTree(name, id, state, options);
         }
     }
 
@@ -93,6 +94,17 @@ namespace Pulumi.Plant.Tree.V1
             Farm = "(unknown)";
             Size = Pulumi.Plant.Tree.V1.TreeSize.Medium;
             Type = Pulumi.Plant.Tree.V1.RubberTreeVariety.Burgundy;
+        }
+    }
+
+    public sealed class RubberTreeState : Pulumi.ResourceArgs
+    {
+        [Input("farm")]
+        public InputUnion<Pulumi.Plant.Tree.V1.Farm, string>? Farm { get; set; }
+
+        public RubberTreeState()
+        {
+            Farm = "(unknown)";
         }
     }
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
@@ -12,10 +12,11 @@ export class RubberTree extends pulumi.CustomResource {
      *
      * @param name The _unique_ name of the resulting resource.
      * @param id The _unique_ provider ID of the resource to lookup.
+     * @param state Any extra arguments used during the lookup.
      * @param opts Optional settings to control the behavior of the CustomResource.
      */
-    public static get(name: string, id: pulumi.Input<pulumi.ID>, opts?: pulumi.CustomResourceOptions): RubberTree {
-        return new RubberTree(name, undefined as any, { ...opts, id: id });
+    public static get(name: string, id: pulumi.Input<pulumi.ID>, state?: RubberTreeState, opts?: pulumi.CustomResourceOptions): RubberTree {
+        return new RubberTree(name, <any>state, { ...opts, id: id });
     }
 
     /** @internal */
@@ -45,10 +46,15 @@ export class RubberTree extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args: RubberTreeArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args: RubberTreeArgs, opts?: pulumi.CustomResourceOptions)
+    constructor(name: string, argsOrState?: RubberTreeArgs | RubberTreeState, opts?: pulumi.CustomResourceOptions) {
         let inputs: pulumi.Inputs = {};
         opts = opts || {};
-        if (!opts.id) {
+        if (opts.id) {
+            const state = argsOrState as RubberTreeState | undefined;
+            inputs["farm"] = state ? state.farm : undefined;
+        } else {
+            const args = argsOrState as RubberTreeArgs | undefined;
             if ((!args || args.diameter === undefined) && !opts.urn) {
                 throw new Error("Missing required property 'diameter'");
             }
@@ -60,18 +66,16 @@ export class RubberTree extends pulumi.CustomResource {
             inputs["farm"] = (args ? args.farm : undefined) || "(unknown)";
             inputs["size"] = (args ? args.size : undefined) || "medium";
             inputs["type"] = (args ? args.type : undefined) || "Burgundy";
-        } else {
-            inputs["container"] = undefined /*out*/;
-            inputs["diameter"] = undefined /*out*/;
-            inputs["farm"] = undefined /*out*/;
-            inputs["size"] = undefined /*out*/;
-            inputs["type"] = undefined /*out*/;
         }
         if (!opts.version) {
             opts = pulumi.mergeOptions(opts, { version: utilities.getVersion()});
         }
         super(RubberTree.__pulumiType, name, inputs, opts);
     }
+}
+
+export interface RubberTreeState {
+    readonly farm?: pulumi.Input<enums.tree.v1.Farm | string>;
 }
 
 /**

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -75,7 +75,8 @@ class RubberTree(pulumi.CustomResource):
     @staticmethod
     def get(resource_name: str,
             id: pulumi.Input[str],
-            opts: Optional[pulumi.ResourceOptions] = None) -> 'RubberTree':
+            opts: Optional[pulumi.ResourceOptions] = None,
+            farm: Optional[pulumi.Input[Union['Farm', str]]] = None) -> 'RubberTree':
         """
         Get an existing RubberTree resource's state with the given name, id, and optional extra
         properties used to qualify the lookup.
@@ -88,6 +89,11 @@ class RubberTree(pulumi.CustomResource):
 
         __props__ = dict()
 
+        __props__["farm"] = farm
+        __props__["container"] = None
+        __props__["diameter"] = None
+        __props__["size"] = None
+        __props__["type"] = None
         return RubberTree(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/schema.json
@@ -46,6 +46,17 @@
           "default": 6
         }
       },
+      "stateInputs": {
+        "properties": {
+          "farm": {
+            "oneOf": [
+              {"$ref": "#/types/plant:tree/v1:Farm"},
+              {"type": "string"}
+            ],
+            "default": "(unknown)"
+          }
+        }
+      },
       "properties": {
         "container": {
           "$ref": "#/types/plant::Container"

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
@@ -64,6 +64,7 @@ class Resource(pulumi.CustomResource):
 
         __props__ = dict()
 
+        __props__["bar"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @property


### PR DESCRIPTION
The python implementation of the `Resource.get()` function doesn't account for output properties that are not also represented in the `stateInputs`. This PR corrects this oversight.

From the codegen tests and how this error has manifested, this appears to only affect non-TF providers.

Fixes: https://github.com/pulumi/pulumi-kubernetes/issues/1479