### PR TITLE
[sdk/dotnet] - automation api OnOutput not called fix

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,9 @@
 
 ### Bug Fixes
 
+- [automation/dotnet] - resolve issue with OnOutput delegate not being called properly during pulumi process execution.
+  [#6435](https://github.com/pulumi/pulumi/pull/6435)
+
 - [automation/python,nodejs,dotnet] - BREAKING - Remove `summary` property from `PreviewResult`.
   The `summary` property on `PreviewResult` returns a result that is always incorrect and is being removed.
   [#6405](https://github.com/pulumi/pulumi/pull/6405)


### PR DESCRIPTION
Resolve issue with the `UpdateOptions.OnOutput` delegate not being called because we were reading from the Standard Output stream on the `Process` incorrectly in `LocalPulumiCmd`.