### PR TITLE
[automation/go] - Expose structured logging

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -40,7 +40,7 @@ type PreviewResult struct {
   StdOut        string
   StdErr        string
   ChangeSummary map[string]int
-  EventLog      []apitype.EngineEvent
+  EventLog      []events.EngineEvent
 }
 ```
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,28 +21,28 @@
 
 - [automation/go] - BREAKING - Expose structured logging for Stack.Up/Preview/Refresh/Destroy.
   [#6436](https://github.com/pulumi/pulumi/pull/6436)
-
-  This change is marked breaking because it changes the shape of the PreviewResult struct.
   
-  Before:
-  
-  ```go
-  type PreviewResult struct {
-    Steps         []PreviewStep  `json:"steps"`
-    ChangeSummary map[string]int `json:"changeSummary"`
-  }
-  ```
+This change is marked breaking because it changes the shape of the `PreviewResult` struct.
 
-  After:
+**Before**
 
-  ```go
-  type PreviewResult struct {
-    StdOut        string
-    StdErr        string
-    ChangeSummary map[string]int
-    EventLog      []apitype.EngineEvent
-  }```
-  
+```go
+type PreviewResult struct {
+  Steps         []PreviewStep  `json:"steps"`
+  ChangeSummary map[string]int `json:"changeSummary"`
+}
+```
+
+**After**
+
+```go
+type PreviewResult struct {
+  StdOut        string
+  StdErr        string
+  ChangeSummary map[string]int
+  EventLog      []apitype.EngineEvent
+}
+```
 
 ### Bug Fixes
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,6 +19,31 @@
   Please note that `pulumi watch` will not be supported on darwin/arm64 builds.
   [#6492](https://github.com/pulumi/pulumi/pull/6492)
 
+- [automation/go] - BREAKING - Expose structured logging for Stack.Up/Preview/Refresh/Destroy.
+  [#6436](https://github.com/pulumi/pulumi/pull/6436)
+
+  This change is marked breaking because it changes the shape of the PreviewResult struct.
+  
+  Before:
+  
+  ```go
+  type PreviewResult struct {
+    Steps         []PreviewStep  `json:"steps"`
+    ChangeSummary map[string]int `json:"changeSummary"`
+  }
+  ```
+
+  After:
+
+  ```go
+  type PreviewResult struct {
+    StdOut        string
+    StdErr        string
+    ChangeSummary map[string]int
+    EventLog      []apitype.EngineEvent
+  }```
+  
+
 ### Bug Fixes
 
 - [sdk/python] Fix mocks issue when passing a resource more than once.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -40,7 +40,6 @@ type PreviewResult struct {
   StdOut        string
   StdErr        string
   ChangeSummary map[string]int
-  EventLog      []events.EngineEvent
 }
 ```
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -39,7 +39,7 @@ type PreviewResult struct {
 type PreviewResult struct {
   StdOut        string
   StdErr        string
-  ChangeSummary map[string]int
+  ChangeSummary map[apitype.OpType]int
 }
 ```
 

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -87,9 +87,9 @@ func ConvertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
 			return apiEvent, eventTypePayloadMismatch
 		}
 		// Convert the resource changes.
-		changes := make(map[string]int)
+		changes := make(map[apitype.OpType]int)
 		for op, count := range p.ResourceChanges {
-			changes[string(op)] = count
+			changes[apitype.OpType(op)] = count
 		}
 		apiEvent.SummaryEvent = &apitype.SummaryEvent{
 			MaybeCorrupt:    p.MaybeCorrupt,
@@ -174,7 +174,7 @@ func convertStepEventMetadata(md engine.StepEventMetadata) apitype.StepEventMeta
 	}
 
 	return apitype.StepEventMetadata{
-		Op:   string(md.Op),
+		Op:   apitype.OpType(md.Op),
 		URN:  string(md.URN),
 		Type: string(md.Type),
 

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -539,6 +539,7 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -1067,6 +1068,7 @@ gopkg.in/src-d/go-git-fixtures.v3 v3.5.0 h1:ivZFOIltbce2Mo8IjzUHAFoq/IylO9WHhNOA
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.13.1 h1:SRtFyV8Kxc0UP7aCHcijOMQGPxHSmMOPrzulQWolkYE=
 gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/scripts/go.sum
+++ b/scripts/go.sum
@@ -73,6 +73,7 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjr
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
@@ -185,6 +186,7 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opentracing/basictracer-go v1.0.0 h1:YyUAhaEfjoWXclZVJ9sGoNct7j4TVk7lZWlQw5UXuoo=
@@ -337,6 +339,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -406,6 +409,7 @@ gopkg.in/src-d/go-git-fixtures.v3 v3.5.0 h1:ivZFOIltbce2Mo8IjzUHAFoq/IylO9WHhNOA
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.13.1 h1:SRtFyV8Kxc0UP7aCHcijOMQGPxHSmMOPrzulQWolkYE=
 gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -17,14 +17,15 @@ require (
 	github.com/google/go-cmp v0.4.1 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/mitchellh/go-ps v1.0.0
+	github.com/nxadm/tail v1.4.8
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.9.1
+	github.com/ryboe/q v1.0.13
 	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cast v1.3.1

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-cmp v0.4.1 // indirect
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-runewidth v0.0.8 // indirect
@@ -25,7 +26,6 @@ require (
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pkg/errors v0.9.1
-	github.com/ryboe/q v1.0.13
 	github.com/sabhiram/go-gitignore v0.0.0-20180611051255-d3107576ba94
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/spf13/cast v1.3.1

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -73,6 +73,8 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjr
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.2.2 h1:6zsha5zo/TWhRhwqCD3+EarCAgZ2yN28ipRnGPnwkI0=
@@ -185,6 +187,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opentracing/basictracer-go v1.0.0 h1:YyUAhaEfjoWXclZVJ9sGoNct7j4TVk7lZWlQw5UXuoo=
@@ -337,6 +341,7 @@ golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -406,6 +411,8 @@ gopkg.in/src-d/go-git-fixtures.v3 v3.5.0 h1:ivZFOIltbce2Mo8IjzUHAFoq/IylO9WHhNOA
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.13.1 h1:SRtFyV8Kxc0UP7aCHcijOMQGPxHSmMOPrzulQWolkYE=
 gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/sdk/go/common/apitype/events.go
+++ b/sdk/go/common/apitype/events.go
@@ -72,9 +72,8 @@ type SummaryEvent struct {
 	MaybeCorrupt bool `json:"maybeCorrupt"`
 	// Duration is the number of seconds the update was executing.
 	DurationSeconds int `json:"durationSeconds"`
-	// ResourceChanges contains the count for resource change by type. The keys are deploy.StepOp,
-	// which is not exported in this package.
-	ResourceChanges map[string]int `json:"resourceChanges"`
+	// ResourceChanges contains the count for resource change by type.
+	ResourceChanges map[OpType]int `json:"resourceChanges"`
 	// PolicyPacks run during update. Maps PolicyPackName -> version.
 	// Note: When this field was initially added, we forgot to add the JSON tag
 	// and are now locked into to using PascalCase for this field to maintain backwards
@@ -112,8 +111,8 @@ type PropertyDiff struct {
 // StepEventMetadata describes a "step" within the Pulumi engine, which is any concrete action
 // to migrate a set of cloud resources from one state to another.
 type StepEventMetadata struct {
-	// Op is the operation being performed, a deploy.StepOp.
-	Op   string `json:"op"`
+	// Op is the operation being performed.
+	Op   OpType `json:"op"`
 	URN  string `json:"urn"`
 	Type string `json:"type"`
 

--- a/sdk/go/common/apitype/history.go
+++ b/sdk/go/common/apitype/history.go
@@ -77,6 +77,22 @@ const (
 	OpCreateReplacement OpType = "create-replacement"
 	// OpDeleteReplaced indicates an existing resource was deleted after replacement.
 	OpDeleteReplaced OpType = "delete-replaced"
+	// OpRead indicates reading an existing resource.
+	OpRead OpType = "read"
+	// OpReadReplacement indicates reading an existing resource for a replacement.
+	OpReadReplacement OpType = "read-replacement"
+	// OpRefresh indicates refreshing an existing resource.
+	OpRefresh OpType = "refresh" // refreshing an existing resource.
+	// OpReadDiscard indicates removing a resource that was read.
+	OpReadDiscard OpType = "discard"
+	// OpDiscardReplaced indicates discarding a read resource that was replaced.
+	OpDiscardReplaced OpType = "discard-replaced"
+	// OpRemovePendingReplace indicates removing a pending replace resource.
+	OpRemovePendingReplace OpType = "remove-pending-replace"
+	// OpImport indicates importing an existing resource.
+	OpImport OpType = "import"
+	// OpImportReplacement indicates replacement of an existing resource with an imported resource.
+	OpImportReplacement OpType = "import-replacement"
 )
 
 // UpdateInfo describes a previous update.

--- a/sdk/go/x/auto/events/events.go
+++ b/sdk/go/x/auto/events/events.go
@@ -1,0 +1,8 @@
+package events
+
+import "github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
+
+type EngineEvent struct {
+	apitype.EngineEvent
+	Error error
+}

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -1208,6 +1208,7 @@ func TestStructuredOutput(t *testing.T) {
 	assert.True(t, res.Outputs["exp_secret"].Secret)
 	assert.Equal(t, "update", res.Summary.Kind)
 	assert.Equal(t, "succeeded", res.Summary.Result)
+	assert.True(t, containsSummary(res.EventLog))
 
 	// -- pulumi preview --
 	prev, err := s.Preview(ctx, optpreview.ProgressStreams(os.Stdout))
@@ -1219,6 +1220,7 @@ func TestStructuredOutput(t *testing.T) {
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
 	steps := countSteps(prev.EventLog)
 	assert.Equal(t, 1, steps)
+	assert.True(t, containsSummary(prev.EventLog))
 
 	// -- pulumi refresh --
 	ref, err := s.Refresh(ctx, optrefresh.ProgressStreams(os.Stdout))
@@ -1229,6 +1231,7 @@ func TestStructuredOutput(t *testing.T) {
 
 	assert.Equal(t, "refresh", ref.Summary.Kind)
 	assert.Equal(t, "succeeded", ref.Summary.Result)
+	assert.True(t, containsSummary(ref.EventLog))
 
 	// -- pulumi destroy --
 	dRes, err := s.Destroy(ctx, optdestroy.ProgressStreams(os.Stdout))
@@ -1239,6 +1242,7 @@ func TestStructuredOutput(t *testing.T) {
 
 	assert.Equal(t, "destroy", dRes.Summary.Kind)
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
+	assert.True(t, containsSummary(dRes.EventLog))
 }
 
 func BenchmarkBulkSetConfigMixed(b *testing.B) {
@@ -1458,4 +1462,14 @@ func countSteps(log []apitype.EngineEvent) int {
 		}
 	}
 	return steps
+}
+
+func containsSummary(log []apitype.EngineEvent) bool {
+	hasSummary := false
+	for _, e := range log {
+		if e.SummaryEvent != nil {
+			hasSummary = true
+		}
+	}
+	return hasSummary
 }

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optpreview"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -273,7 +274,8 @@ func TestUpsertStackLocalSource(t *testing.T) {
 	assert.NotNil(t, envvars, "failed to get environment values after unsetting.")
 
 	// -- pulumi up --
-	res, err := s.Up(ctx)
+	var upBuf bytes.Buffer
+	res, err := s.Up(ctx, optup.ProgressStreams(os.Stdout), optup.EventStreams(&upBuf))
 	if err != nil {
 		t.Errorf("up failed, err: %v", err)
 		t.FailNow()
@@ -290,29 +292,30 @@ func TestUpsertStackLocalSource(t *testing.T) {
 	assert.Equal(t, "succeeded", res.Summary.Result)
 
 	// -- pulumi preview --
-
-	prev, err := s.Preview(ctx)
+	var prevBuf bytes.Buffer
+	prev, err := s.Preview(ctx, optpreview.ProgressStreams(os.Stdout), optpreview.EventStreams(&prevBuf))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
+
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
 	assert.Equal(t, 1, len(prev.Steps))
 
 	// -- pulumi refresh --
-
-	ref, err := s.Refresh(ctx)
-
+	var refBuf bytes.Buffer
+	ref, err := s.Refresh(ctx, optrefresh.ProgressStreams(os.Stdout), optrefresh.EventStreams(&refBuf))
 	if err != nil {
 		t.Errorf("refresh failed, err: %v", err)
 		t.FailNow()
 	}
+
 	assert.Equal(t, "refresh", ref.Summary.Kind)
 	assert.Equal(t, "succeeded", ref.Summary.Result)
 
 	// -- pulumi destroy --
-
-	dRes, err := s.Destroy(ctx)
+	var desBuf bytes.Buffer
+	dRes, err := s.Destroy(ctx, optdestroy.ProgressStreams(os.Stdout), optdestroy.EventStreams(&desBuf))
 	if err != nil {
 		t.Errorf("destroy failed, err: %v", err)
 		t.FailNow()

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi/config"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/events"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optdestroy"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optrefresh"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optup"
 	"github.com/stretchr/testify/assert"
@@ -190,13 +191,16 @@ func TestNewStackLocalSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
 	// -- pulumi refresh --
@@ -292,14 +296,18 @@ func TestUpsertStackLocalSource(t *testing.T) {
 	assert.Equal(t, "succeeded", res.Summary.Result)
 
 	// -- pulumi preview --
-	prev, err := s.Preview(ctx)
+
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
 	// -- pulumi refresh --
@@ -385,13 +393,16 @@ func TestNewStackRemoteSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
 	// -- pulumi refresh --
@@ -474,13 +485,16 @@ func TestUpsertStackRemoteSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
 	// -- pulumi refresh --
@@ -575,13 +589,16 @@ func TestNewStackRemoteSourceWithSetup(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
 	// -- pulumi refresh --
@@ -676,13 +693,16 @@ func TestUpsertStackRemoteSourceWithSetup(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
 	// -- pulumi refresh --
@@ -767,13 +787,16 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
 	// -- pulumi refresh --
@@ -857,13 +880,16 @@ func TestUpsertStackInlineSource(t *testing.T) {
 
 	// -- pulumi preview --
 
-	prev, err := s.Preview(ctx)
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
 	// -- pulumi refresh --
@@ -1192,7 +1218,10 @@ func TestStructuredOutput(t *testing.T) {
 	assert.NotNil(t, envvars, "failed to get environment values after unsetting.")
 
 	// -- pulumi up --
-	res, err := s.Up(ctx)
+	var upEvents []events.EngineEvent
+	upCh := make(chan events.EngineEvent)
+	go collectEvents(upCh, &upEvents)
+	res, err := s.Up(ctx, optup.EventStreams(upCh))
 	if err != nil {
 		t.Errorf("up failed, err: %v", err)
 		t.FailNow()
@@ -1207,22 +1236,28 @@ func TestStructuredOutput(t *testing.T) {
 	assert.True(t, res.Outputs["exp_secret"].Secret)
 	assert.Equal(t, "update", res.Summary.Kind)
 	assert.Equal(t, "succeeded", res.Summary.Result)
-	assert.True(t, containsSummary(res.EventLog))
+	assert.True(t, containsSummary(upEvents))
 
 	// -- pulumi preview --
-	prev, err := s.Preview(ctx)
+	var previewEvents []events.EngineEvent
+	prevCh := make(chan events.EngineEvent)
+	go collectEvents(prevCh, &previewEvents)
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
 
 	assert.Equal(t, 1, prev.ChangeSummary["same"])
-	steps := countSteps(prev.EventLog)
+	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
-	assert.True(t, containsSummary(prev.EventLog))
+	assert.True(t, containsSummary(previewEvents))
 
 	// -- pulumi refresh --
-	ref, err := s.Refresh(ctx)
+	var refreshEvents []events.EngineEvent
+	refCh := make(chan events.EngineEvent)
+	go collectEvents(refCh, &refreshEvents)
+	ref, err := s.Refresh(ctx, optrefresh.EventStreams(refCh))
 	if err != nil {
 		t.Errorf("refresh failed, err: %v", err)
 		t.FailNow()
@@ -1230,10 +1265,13 @@ func TestStructuredOutput(t *testing.T) {
 
 	assert.Equal(t, "refresh", ref.Summary.Kind)
 	assert.Equal(t, "succeeded", ref.Summary.Result)
-	assert.True(t, containsSummary(ref.EventLog))
+	assert.True(t, containsSummary(refreshEvents))
 
 	// -- pulumi destroy --
-	dRes, err := s.Destroy(ctx)
+	var destroyEvents []events.EngineEvent
+	desCh := make(chan events.EngineEvent)
+	go collectEvents(desCh, &destroyEvents)
+	dRes, err := s.Destroy(ctx, optdestroy.EventStreams(desCh))
 	if err != nil {
 		t.Errorf("destroy failed, err: %v", err)
 		t.FailNow()
@@ -1241,7 +1279,7 @@ func TestStructuredOutput(t *testing.T) {
 
 	assert.Equal(t, "destroy", dRes.Summary.Kind)
 	assert.Equal(t, "succeeded", dRes.Summary.Result)
-	assert.True(t, containsSummary(dRes.EventLog))
+	assert.True(t, containsSummary(destroyEvents))
 }
 
 func BenchmarkBulkSetConfigMixed(b *testing.B) {
@@ -1471,4 +1509,14 @@ func containsSummary(log []events.EngineEvent) bool {
 		}
 	}
 	return hasSummary
+}
+
+func collectEvents(eventChannel <-chan events.EngineEvent, events *[]events.EngineEvent) {
+	for {
+		event, ok := <-eventChannel
+		if !ok {
+			return
+		}
+		*events = append(*events, event)
+	}
 }

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -26,13 +26,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi/config"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/events"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optdestroy"
-	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optpreview"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optrefresh"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/optup"
 	"github.com/stretchr/testify/assert"
@@ -1193,7 +1192,7 @@ func TestStructuredOutput(t *testing.T) {
 	assert.NotNil(t, envvars, "failed to get environment values after unsetting.")
 
 	// -- pulumi up --
-	res, err := s.Up(ctx, optup.ProgressStreams(os.Stdout))
+	res, err := s.Up(ctx)
 	if err != nil {
 		t.Errorf("up failed, err: %v", err)
 		t.FailNow()
@@ -1211,7 +1210,7 @@ func TestStructuredOutput(t *testing.T) {
 	assert.True(t, containsSummary(res.EventLog))
 
 	// -- pulumi preview --
-	prev, err := s.Preview(ctx, optpreview.ProgressStreams(os.Stdout))
+	prev, err := s.Preview(ctx)
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
@@ -1223,7 +1222,7 @@ func TestStructuredOutput(t *testing.T) {
 	assert.True(t, containsSummary(prev.EventLog))
 
 	// -- pulumi refresh --
-	ref, err := s.Refresh(ctx, optrefresh.ProgressStreams(os.Stdout))
+	ref, err := s.Refresh(ctx)
 	if err != nil {
 		t.Errorf("refresh failed, err: %v", err)
 		t.FailNow()
@@ -1234,7 +1233,7 @@ func TestStructuredOutput(t *testing.T) {
 	assert.True(t, containsSummary(ref.EventLog))
 
 	// -- pulumi destroy --
-	dRes, err := s.Destroy(ctx, optdestroy.ProgressStreams(os.Stdout))
+	dRes, err := s.Destroy(ctx)
 	if err != nil {
 		t.Errorf("destroy failed, err: %v", err)
 		t.FailNow()
@@ -1454,7 +1453,7 @@ func getTestOrg() string {
 	return testOrg
 }
 
-func countSteps(log []apitype.EngineEvent) int {
+func countSteps(log []events.EngineEvent) int {
 	steps := 0
 	for _, e := range log {
 		if e.ResourcePreEvent != nil {
@@ -1464,7 +1463,7 @@ func countSteps(log []apitype.EngineEvent) int {
 	return steps
 }
 
-func containsSummary(log []apitype.EngineEvent) bool {
+func containsSummary(log []events.EngineEvent) bool {
 	hasSummary := false
 	for _, e := range log {
 		if e.SummaryEvent != nil {

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/workspace"
 	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
@@ -199,7 +200,7 @@ func TestNewStackLocalSource(t *testing.T) {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
@@ -306,7 +307,7 @@ func TestUpsertStackLocalSource(t *testing.T) {
 		t.FailNow()
 	}
 
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
@@ -401,7 +402,7 @@ func TestNewStackRemoteSource(t *testing.T) {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
@@ -493,7 +494,7 @@ func TestUpsertStackRemoteSource(t *testing.T) {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
@@ -597,7 +598,7 @@ func TestNewStackRemoteSourceWithSetup(t *testing.T) {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
@@ -701,7 +702,7 @@ func TestUpsertStackRemoteSourceWithSetup(t *testing.T) {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
@@ -795,7 +796,7 @@ func TestNewStackInlineSource(t *testing.T) {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
@@ -888,7 +889,7 @@ func TestUpsertStackInlineSource(t *testing.T) {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
 	}
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 
@@ -1248,7 +1249,7 @@ func TestStructuredOutput(t *testing.T) {
 		t.FailNow()
 	}
 
-	assert.Equal(t, 1, prev.ChangeSummary["same"])
+	assert.Equal(t, 1, prev.ChangeSummary[apitype.OpSame])
 	steps := countSteps(previewEvents)
 	assert.Equal(t, 1, steps)
 	assert.True(t, containsSummary(previewEvents))

--- a/sdk/go/x/auto/optdestroy/optdestroy.go
+++ b/sdk/go/x/auto/optdestroy/optdestroy.go
@@ -57,6 +57,13 @@ func ProgressStreams(writers ...io.Writer) Option {
 	})
 }
 
+// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
+func EventStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.EventStreams = writers
+	})
+}
+
 func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	return optionFunc(func(opts *Options) {
 		opts.DebugLogOpts = debugOpts
@@ -83,6 +90,8 @@ type Options struct {
 	TargetDependents bool
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy output
 	ProgressStreams []io.Writer
+	// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
+	EventStreams []io.Writer
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 }

--- a/sdk/go/x/auto/optdestroy/optdestroy.go
+++ b/sdk/go/x/auto/optdestroy/optdestroy.go
@@ -19,8 +19,8 @@ package optdestroy
 import (
 	"io"
 
-	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/events"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the destroy
@@ -60,7 +60,7 @@ func ProgressStreams(writers ...io.Writer) Option {
 }
 
 // EventStreams allows specifying one or more channels to receive the Pulumi event stream
-func EventStreams(channels ...chan<- apitype.EngineEvent) Option {
+func EventStreams(channels ...chan<- events.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
 		opts.EventStreams = channels
 	})
@@ -93,7 +93,7 @@ type Options struct {
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy output
 	ProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
-	EventStreams []chan<- apitype.EngineEvent
+	EventStreams []chan<- events.EngineEvent
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 }

--- a/sdk/go/x/auto/optdestroy/optdestroy.go
+++ b/sdk/go/x/auto/optdestroy/optdestroy.go
@@ -17,8 +17,10 @@
 package optdestroy
 
 import (
-	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 	"io"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the destroy
@@ -57,10 +59,10 @@ func ProgressStreams(writers ...io.Writer) Option {
 	})
 }
 
-// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
-func EventStreams(writers ...io.Writer) Option {
+// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+func EventStreams(channels ...chan<- apitype.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
-		opts.EventStreams = writers
+		opts.EventStreams = channels
 	})
 }
 
@@ -90,8 +92,8 @@ type Options struct {
 	TargetDependents bool
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental destroy output
 	ProgressStreams []io.Writer
-	// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
-	EventStreams []io.Writer
+	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+	EventStreams []chan<- apitype.EngineEvent
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 }

--- a/sdk/go/x/auto/optpreview/optpreview.go
+++ b/sdk/go/x/auto/optpreview/optpreview.go
@@ -19,8 +19,8 @@ package optpreview
 import (
 	"io"
 
-	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/events"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the update
@@ -87,7 +87,7 @@ func ProgressStreams(writers ...io.Writer) Option {
 }
 
 // EventStreams allows specifying one or more channels to receive the Pulumi event stream
-func EventStreams(channels ...chan<- apitype.EngineEvent) Option {
+func EventStreams(channels ...chan<- events.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
 		opts.EventStreams = channels
 	})
@@ -122,7 +122,7 @@ type Options struct {
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview output
 	ProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
-	EventStreams []chan<- apitype.EngineEvent
+	EventStreams []chan<- events.EngineEvent
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/x/auto/optpreview/optpreview.go
+++ b/sdk/go/x/auto/optpreview/optpreview.go
@@ -18,6 +18,7 @@ package optpreview
 
 import (
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
+	"io"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the update
@@ -76,6 +77,20 @@ func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	})
 }
 
+// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
+func ProgressStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.ProgressStreams = writers
+	})
+}
+
+// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
+func EventStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.EventStreams = writers
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Preview() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -102,6 +117,10 @@ type Options struct {
 	TargetDependents bool
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
+	ProgressStreams []io.Writer
+	// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
+	EventStreams []io.Writer
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/x/auto/optpreview/optpreview.go
+++ b/sdk/go/x/auto/optpreview/optpreview.go
@@ -17,8 +17,10 @@
 package optpreview
 
 import (
-	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 	"io"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the update
@@ -77,17 +79,17 @@ func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	})
 }
 
-// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
+// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview output
 func ProgressStreams(writers ...io.Writer) Option {
 	return optionFunc(func(opts *Options) {
 		opts.ProgressStreams = writers
 	})
 }
 
-// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
-func EventStreams(writers ...io.Writer) Option {
+// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+func EventStreams(channels ...chan<- apitype.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
-		opts.EventStreams = writers
+		opts.EventStreams = channels
 	})
 }
 
@@ -117,10 +119,10 @@ type Options struct {
 	TargetDependents bool
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
-	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental preview output
 	ProgressStreams []io.Writer
-	// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
-	EventStreams []io.Writer
+	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+	EventStreams []chan<- apitype.EngineEvent
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/x/auto/optrefresh/optrefresh.go
+++ b/sdk/go/x/auto/optrefresh/optrefresh.go
@@ -57,6 +57,13 @@ func ProgressStreams(writers ...io.Writer) Option {
 	})
 }
 
+// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
+func EventStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.EventStreams = writers
+	})
+}
+
 func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	return optionFunc(func(opts *Options) {
 		opts.DebugLogOpts = debugOpts
@@ -83,6 +90,8 @@ type Options struct {
 	Target []string
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh output
 	ProgressStreams []io.Writer
+	// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
+	EventStreams []io.Writer
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 }

--- a/sdk/go/x/auto/optrefresh/optrefresh.go
+++ b/sdk/go/x/auto/optrefresh/optrefresh.go
@@ -17,8 +17,10 @@
 package optrefresh
 
 import (
-	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 	"io"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the refresh
@@ -57,10 +59,10 @@ func ProgressStreams(writers ...io.Writer) Option {
 	})
 }
 
-// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
-func EventStreams(writers ...io.Writer) Option {
+// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+func EventStreams(channels ...chan<- apitype.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
-		opts.EventStreams = writers
+		opts.EventStreams = channels
 	})
 }
 
@@ -90,8 +92,8 @@ type Options struct {
 	Target []string
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh output
 	ProgressStreams []io.Writer
-	// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
-	EventStreams []io.Writer
+	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+	EventStreams []chan<- apitype.EngineEvent
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 }

--- a/sdk/go/x/auto/optrefresh/optrefresh.go
+++ b/sdk/go/x/auto/optrefresh/optrefresh.go
@@ -19,8 +19,8 @@ package optrefresh
 import (
 	"io"
 
-	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/events"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the refresh
@@ -60,7 +60,7 @@ func ProgressStreams(writers ...io.Writer) Option {
 }
 
 // EventStreams allows specifying one or more channels to receive the Pulumi event stream
-func EventStreams(channels ...chan<- apitype.EngineEvent) Option {
+func EventStreams(channels ...chan<- events.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
 		opts.EventStreams = channels
 	})
@@ -93,7 +93,7 @@ type Options struct {
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental refresh output
 	ProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
-	EventStreams []chan<- apitype.EngineEvent
+	EventStreams []chan<- events.EngineEvent
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
 }

--- a/sdk/go/x/auto/optup/optup.go
+++ b/sdk/go/x/auto/optup/optup.go
@@ -17,8 +17,10 @@
 package optup
 
 import (
-	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 	"io"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the update
@@ -84,10 +86,10 @@ func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	})
 }
 
-// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
-func EventStreams(writers ...io.Writer) Option {
+// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+func EventStreams(channels ...chan<- apitype.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
-		opts.EventStreams = writers
+		opts.EventStreams = channels
 	})
 }
 
@@ -119,8 +121,8 @@ type Options struct {
 	DebugLogOpts debug.LoggingOptions
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
 	ProgressStreams []io.Writer
-	// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
-	EventStreams []io.Writer
+	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
+	EventStreams []chan<- apitype.EngineEvent
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/x/auto/optup/optup.go
+++ b/sdk/go/x/auto/optup/optup.go
@@ -19,8 +19,8 @@ package optup
 import (
 	"io"
 
-	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/debug"
+	"github.com/pulumi/pulumi/sdk/v2/go/x/auto/events"
 )
 
 // Parallel is the number of resource operations to run in parallel at once during the update
@@ -87,7 +87,7 @@ func DebugLogging(debugOpts debug.LoggingOptions) Option {
 }
 
 // EventStreams allows specifying one or more channels to receive the Pulumi event stream
-func EventStreams(channels ...chan<- apitype.EngineEvent) Option {
+func EventStreams(channels ...chan<- events.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
 		opts.EventStreams = channels
 	})
@@ -122,7 +122,7 @@ type Options struct {
 	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
 	ProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
-	EventStreams []chan<- apitype.EngineEvent
+	EventStreams []chan<- events.EngineEvent
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/x/auto/optup/optup.go
+++ b/sdk/go/x/auto/optup/optup.go
@@ -84,6 +84,13 @@ func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	})
 }
 
+// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
+func EventStreams(writers ...io.Writer) Option {
+	return optionFunc(func(opts *Options) {
+		opts.EventStreams = writers
+	})
+}
+
 // Option is a parameter to be applied to a Stack.Up() operation
 type Option interface {
 	ApplyOption(*Options)
@@ -108,10 +115,12 @@ type Options struct {
 	Target []string
 	// Allows updating of dependent targets discovered but not specified in the Target list
 	TargetDependents bool
-	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
-	ProgressStreams []io.Writer
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
+	// ProgressStreams allows specifying one or more io.Writers to redirect incremental update output
+	ProgressStreams []io.Writer
+	// EventStreams allows specifying one or more io.Writers to redirect the Pulumi event stream
+	EventStreams []io.Writer
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/x/auto/stack.go
+++ b/sdk/go/x/auto/stack.go
@@ -788,7 +788,7 @@ type PropertyDiff struct {
 type PreviewResult struct {
 	StdOut        string
 	StdErr        string
-	ChangeSummary map[string]int
+	ChangeSummary map[apitype.OpType]int
 }
 
 // RefreshResult is the output of a successful Stack.Refresh operation
@@ -991,7 +991,7 @@ func (s *languageRuntimeServer) GetPluginInfo(ctx context.Context, req *pbempty.
 }
 
 func tailLogs(command string, receivers []chan<- events.EngineEvent) (*tail.Tail, error) {
-	logDir, err := ioutil.TempDir(os.TempDir(), fmt.Sprintf("automation-logs-%s-", command))
+	logDir, err := ioutil.TempDir("", fmt.Sprintf("automation-logs-%s-", command))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create logdir")
 	}
@@ -1006,7 +1006,9 @@ func tailLogs(command string, receivers []chan<- events.EngineEvent) (*tail.Tail
 }
 
 func cleanup(t *tail.Tail, channels []chan<- events.EngineEvent) {
+	logDir := filepath.Dir(t.Filename)
 	t.Cleanup()
+	os.RemoveAll(logDir)
 	for _, ch := range channels {
 		close(ch)
 	}

--- a/sdk/go/x/auto/watcher.go
+++ b/sdk/go/x/auto/watcher.go
@@ -14,9 +14,10 @@
 package auto
 
 import (
-	"github.com/nxadm/tail"
-	"github.com/ryboe/q"
+	"fmt"
 	"io"
+
+	"github.com/nxadm/tail"
 )
 
 func watchFile(path string, streams []io.Writer) (*tail.Tail, error) {
@@ -25,18 +26,13 @@ func watchFile(path string, streams []io.Writer) (*tail.Tail, error) {
 		Logger: tail.DiscardingLogger,
 	})
 	if err != nil {
-		q.Q("could not tail file")
 		return nil, err
 	}
 	go func(tailedLog *tail.Tail) {
 		for line := range tailedLog.Lines {
 			for _, s := range streams {
-				_, err = io.WriteString(s, line.Text)
-				if err != nil {
-					q.Q(err)
-				}
+				_, err = io.WriteString(s, fmt.Sprintf("%s\n", line.Text))
 			}
-			q.Q(line.Text)
 		}
 	}(t)
 	return t, nil

--- a/sdk/go/x/auto/watcher.go
+++ b/sdk/go/x/auto/watcher.go
@@ -1,0 +1,43 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package auto
+
+import (
+	"github.com/nxadm/tail"
+	"github.com/ryboe/q"
+	"io"
+)
+
+func watchFile(path string, streams []io.Writer) (*tail.Tail, error) {
+	t, err := tail.TailFile(path, tail.Config{
+		Follow: true,
+		Logger: tail.DiscardingLogger,
+	})
+	if err != nil {
+		q.Q("could not tail file")
+		return nil, err
+	}
+	go func(tailedLog *tail.Tail) {
+		for line := range tailedLog.Lines {
+			for _, s := range streams {
+				_, err = io.WriteString(s, line.Text)
+				if err != nil {
+					q.Q(err)
+				}
+			}
+			q.Q(line.Text)
+		}
+	}(t)
+	return t, nil
+}

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -540,6 +540,7 @@ github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d h1:AREM5mwr4u1
 github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d/go.mod h1:o96djdrsSGy3AWPyBgZMAGfxZNfgntdJG+11KU4QvbU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -1070,6 +1071,7 @@ gopkg.in/src-d/go-git-fixtures.v3 v3.5.0 h1:ivZFOIltbce2Mo8IjzUHAFoq/IylO9WHhNOA
 gopkg.in/src-d/go-git-fixtures.v3 v3.5.0/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
 gopkg.in/src-d/go-git.v4 v4.13.1 h1:SRtFyV8Kxc0UP7aCHcijOMQGPxHSmMOPrzulQWolkYE=
 gopkg.in/src-d/go-git.v4 v4.13.1/go.mod h1:nx5NYcxdKxq5fpltdHnPa2Exj4Sx0EclMWZQbYDu2z8=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2 h1:wFXVbFY8DY5/xOe1ECiWdKCzZlxgshcYVNkBHstARME=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=


### PR DESCRIPTION
See also: https://github.com/pulumi/pulumi/pull/6454 for the nodejs implementation.


### Changes

Adds the ability to pass in channels to receive raw events from the Pulumi event stream via an option passed to the `Preview`, `Up`, `Refresh` and `Destroy` commands.

This change is marked **breaking** because it changes the shape of the `PreviewResult` struct.

Before:
```go
type PreviewResult struct {
	Steps         []PreviewStep  `json:"steps"`
	ChangeSummary map[string]int `json:"changeSummary"`
}
```

After:
```go
type PreviewResult struct {
	StdOut        string
	StdErr        string
	ChangeSummary map[apitype.OpType]int
}
```

Fixes: #6441, #6308 