### PR TITLE
Ignore Pipfile.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ coverage.cov
 # By default, we don't check in yarn.lock files
 **/yarn.lock
 
+# By default, we don't check in Pipfile.lock files
+**/Pipfile.lock
+
 # Turning on MyPy in VSCode creates this workspace local folder
 .mypy_cache
 


### PR DESCRIPTION
We removed the `Pipfile.lock` file from source control as part of #6424 because we require different dependencies based on platform. This PR adds `Pipfile.lock` to `.gitignore`.