### PR TITLE
Respect provider aliases while diffing resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+## HEAD (Unreleased)
+
+- [cli] Respect provider aliases while diffing resources.
+  [#6453](https://github.com/pulumi/pulumi/pull/6453)
+
 ## 2.21.2 (2021-02-22)
 
 ### Improvements

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -965,6 +965,12 @@ func (sg *stepGenerator) providerChanged(urn resource.URN, old, new *resource.St
 		return false, err
 	}
 
+	if alias, ok := sg.aliased[oldRef.URN()]; ok && alias == newRef.URN() {
+		logging.V(stepExecutorLogLevel).Infof(
+			"sg.diffProvider(%s, ...): observed an aliased provider from %q to %q", urn, oldRef.URN(), newRef.URN())
+		return false, nil
+	}
+
 	// If one or both of these providers are not default providers, we will need to accept the diff and replace
 	// everything. This might not be strictly necessary, but it is conservatively correct.
 	if !providers.IsDefaultProvider(oldRef.URN()) || !providers.IsDefaultProvider(newRef.URN()) {


### PR DESCRIPTION
The engine-side fix for https://github.com/pulumi/pulumi-azure-native/issues/617

If an explicit provider is aliased, the difference must not require replacements for resources defined with this provider.

After the fix and aliasing the provider, I'm only seeing this diff in the scenario of https://github.com/pulumi/pulumi-azure-native/issues/617

```
     Type                              Name                  Plan       Info
     pulumi:pulumi:Stack               azure-nextgen-cs-dev             
 ~   └─ pulumi:providers:azure-native  p1                    update     [diff: ~version]
 ```