### PR TITLE
Ensuring dotnet package sources are correct for local packages

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -147,6 +147,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -212,6 +213,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -226,6 +228,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Clean
         run: dotnet nuget locals all --clear
+      - name: Create Local Nuget
+        run: mkdir -p "D:\\Pulumi\\nuget"
+        shell: bash
       - name: Install Python Deps
         run: |
           pip3 install pyenv-win

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -146,6 +146,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -211,6 +212,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -225,6 +227,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Clean
         run: dotnet nuget locals all --clear
+      - name: Create Local Nuget
+        run: mkdir -p "D:\\Pulumi\\nuget"
+        shell: bash
       - name: Install Python Deps
         run: |
           pip3 install pyenv-win

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -242,6 +242,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -307,6 +308,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -321,6 +323,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Clean
         run: dotnet nuget locals all --clear
+      - name: Create Local Nuget
+        run: mkdir -p "D:\\Pulumi\\nuget"
+        shell: bash
       - name: Install Python Deps
         run: |
           pip3 install pyenv-win

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -68,6 +68,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -107,8 +108,7 @@ jobs:
           PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Test
-        run: |
-          make test_all
+        run: make test_all
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
           PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
@@ -148,6 +148,7 @@ jobs:
         run: |
           pip3 install pyenv-win
           pip3 install pipenv
+      - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Set Build Env Vars
         shell: bash
         run: |
@@ -163,6 +164,9 @@ jobs:
           cd ./src/github.com/${{ github.repository }} && git fetch --quiet --prune --unshallow --tags
       - name: Clean
         run: dotnet nuget locals all --clear
+      - name: Create Local Nuget
+        run: mkdir -p "D:\\Pulumi\\nuget"
+        shell: bash
       - name: Get dependencies
         run: |
           cd src\github.com\${{ github.repository }}
@@ -190,5 +194,3 @@ jobs:
         run: |
           cd src\github.com\${{ github.repository }}
           dotnet msbuild /t:Tests /v:Detailed build.proj /p:PulumiRoot="D:\\Pulumi"
-
-

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1990,7 +1990,7 @@ func (pt *ProgramTester) prepareDotNetProject(projinfo *engine.Projinfo) error {
 		version := r.Replace(file)
 
 		err = pt.runCommand("dotnet-add-package",
-			[]string{dotNetBin, "add", "package", dep, "-s", localNuget, "-v", version}, cwd)
+			[]string{dotNetBin, "add", "package", dep, "-v", version}, cwd)
 		if err != nil {
 			return errors.Wrapf(err, "failed to add dependency on %s", dep)
 		}

--- a/tests/integration/get_resource/dotnet/GetResource.csproj
+++ b/tests/integration/get_resource/dotnet/GetResource.csproj
@@ -6,9 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Pulumi.Random" Version="2.*" />
   </ItemGroup>
 

--- a/tests/integration/transformations/dotnet/simple/Transformations.csproj
+++ b/tests/integration/transformations/dotnet/simple/Transformations.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pulumi.Random" Version="1.6.0-preview" />
+    <PackageReference Include="Pulumi.Random" Version="2.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When passing a package source as part of a `dotnet add package` in
our acceptance testing framework, dotnet was then trying to use that
package source for the restoration of other packages in the csproj
file.

We have removed passing the source to `dotnet add package` add
and replaced it with adding a machine level package source via
`dotnet nuget add source` command

this is the more correct way to work and will allow us to be able
to search multiple locations as part of the `dotnet restore` command