### PR TITLE
[sdk/python] mypy was not found

### DIFF
--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -14,5 +14,5 @@ pyyaml = ">=5.3.1"
 
 [dev-packages]
 pylint = ">=2.1"
-mypy = "0.78"
+mypy = ">=0.78"
 pytest = "*"


### PR DESCRIPTION
I had actually some problems, if i try to build pulumi from the source.
Than mypi 0.78 was not found, which is https://pypi.org/project/mypy/#history somehow correct.

Thx in advance

meno