### PR TITLE
Change nodejs codegen to use coalescing operator when when default values are present

### DIFF
--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
@@ -62,10 +62,10 @@ export class RubberTree extends pulumi.CustomResource {
                 throw new Error("Missing required property 'type'");
             }
             inputs["container"] = args ? args.container : undefined;
-            inputs["diameter"] = (args ? args.diameter : undefined) || 6;
-            inputs["farm"] = (args ? args.farm : undefined) || "(unknown)";
-            inputs["size"] = (args ? args.size : undefined) || "medium";
-            inputs["type"] = (args ? args.type : undefined) || "Burgundy";
+            inputs["diameter"] = (args ? args.diameter : undefined) ?? 6;
+            inputs["farm"] = (args ? args.farm : undefined) ?? "(unknown)";
+            inputs["size"] = (args ? args.size : undefined) ?? "medium";
+            inputs["type"] = (args ? args.type : undefined) ?? "Burgundy";
         }
         if (!opts.version) {
             opts = pulumi.mergeOptions(opts, { version: utilities.getVersion()});

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -583,13 +583,8 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 					if err != nil {
 						return err
 					}
-					// Note: this logic isn't quite correct, but already exists in all of the TF-based providers.
-					// Specifically, this doesn't work right if the first value is set to false but the default value
-					// is true. The Kubernetes provider didn't include this logic, so use the correct ?? operator there.
-					arg = fmt.Sprintf("(%s) || %s", arg, dv)
-					if mod.compatibility == kubernetes20 {
-						arg = fmt.Sprintf("(%s) ?? %s", arg, dv)
-					}
+
+					arg = fmt.Sprintf("(%s) ?? %s", arg, dv)
 				}
 
 				// provider properties must be marshaled as JSON strings.


### PR DESCRIPTION
Before this change, any changes to provider defaults were not picked up:

```
const prov = new aws.Provider("named-provider", {
    region: "us-west-2",
    skipMetadataApiCheck: false,
    skipGetEc2Platforms: false,
});
```

the false values were overriding the defaults but they were not being picked up by the provider:

```
I0310 18:51:52.873680   49300 rpc.go:72] Marshaling property for RPC[ResourceMonitor.RegisterResource(pulumi:providers:aws,named-provider)]: skipCredentialsValidation={true}
I0310 18:51:52.873691   49300 rpc.go:72] Marshaling property for RPC[ResourceMonitor.RegisterResource(pulumi:providers:aws,named-provider)]: skipGetEc2Platforms={true}
I0310 18:51:52.873700   49300 rpc.go:72] Marshaling property for RPC[ResourceMonitor.RegisterResource(pulumi:providers:aws,named-provider)]: skipMetadataApiCheck={true}
I0310 18:51:52.873709   49300 rpc.go:72] Marshaling property for RPC[ResourceMonitor.RegisterResource(pulumi:providers:aws,named-provider)]: skipRegionValidation={true}
```

With this codegen change, we can see they are picked up:

```
18:47
I0310 18:45:39.469090   48726 rpc.go:72] Marshaling property for RPC[ResourceMonitor.RegisterResource(pulumi:providers:aws,named-provider)]: skipCredentialsValidation={true}
I0310 18:45:39.469101   48726 rpc.go:72] Marshaling property for RPC[ResourceMonitor.RegisterResource(pulumi:providers:aws,named-provider)]: skipGetEc2Platforms={false}
I0310 18:45:39.469111   48726 rpc.go:72] Marshaling property for RPC[ResourceMonitor.RegisterResource(pulumi:providers:aws,named-provider)]: skipMetadataApiCheck={false}
I0310 18:45:39.469143   48726 rpc.go:72] Marshaling property for RPC[ResourceMonitor.RegisterResource(pulumi:providers:aws,named-provider)]: skipRegionValidation={true}
```

And we can see that we also get provider level diffs now:

```
     Type                     Name            Plan       Info
     pulumi:pulumi:Stack      test-aws-dev
 ~   └─ pulumi:providers:aws  named-provider  update     [diff: ~skipGetEc2Platforms,skipMetadataApiCheck]
```