### PR TITLE
Disabling the use of pulumi watch on darwin/arm64 architecture

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,7 +15,8 @@
 - [build] Updating Pulumi to use Go 1.16
   [#6470](https://github.com/pulumi/pulumi/pull/6470)
 
-- [build] Adding a Pulumi arm64 binary for use on new macOS hardware
+- [build] Adding a Pulumi arm64 binary for use on new macOS hardware.  
+  Please note that `pulumi watch` will not be supported on darwin/arm64 builds.
   [#6492](https://github.com/pulumi/pulumi/pull/6492)
 
 ### Bug Fixes

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -1,3 +1,5 @@
+// +build !darwin !arm64
+
 // Copyright 2016-2019, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/backend/watch_darwin_arm64.go
+++ b/pkg/backend/watch_darwin_arm64.go
@@ -1,0 +1,26 @@
+// Copyright 2016-2019, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"errors"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/result"
+)
+
+func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, apply Applier) result.Result {
+	return result.FromError(errors.New("pulumi watch is not currently supported on darwin/arm64"))
+}


### PR DESCRIPTION
The underlying library for pulumi watch uses CGO which stops
cross compilation. As as our CI vendor does't have the new mac
hardware, we cannot compile our binaries on darwin arm64 hardware

This means, that in order to release the arm64 binaries, we are
going to remove support for pulumi watch as that is the functionality
using the library in question

This functionality will be returning in a future release