### PR TITLE
Debugging why windows builds are being marked as dirty

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -294,6 +294,7 @@ jobs:
         run: |
           cd src\github.com\${{ github.repository }}
           dotnet msbuild /t:Publish /v:Detailed build.proj /p:PulumiRoot="D:\\Pulumi"
+      - run: git status
   verify-containers:
     name: Run Container Tests
     needs: [publish-binaries, publish-sdks]


### PR DESCRIPTION
temporary debugging - will be removed