### PR TITLE
[automation/dotnet] Add ability to capture stderr

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -24,6 +24,11 @@ type PreviewResult struct {
 }
 ```
 
+- [automation/dotnet] Add ability to capture stderr
+  [#6513](https://github.com/pulumi/pulumi/pull/6513)
+
+This change is marked breaking because it also renames `OnOutput` to `OnStandardOutput`.
+
 ### Improvements
 
 - [sdk/go] Add helpers to convert raw Go maps and arrays to Pulumi `Map` and `Array` inputs.
@@ -41,13 +46,13 @@ type PreviewResult struct {
 - [build] Updating Pulumi to use Go 1.16
   [#6470](https://github.com/pulumi/pulumi/pull/6470)
 
-- [build] Adding a Pulumi arm64 binary for use on new macOS hardware.  
+- [build] Adding a Pulumi arm64 binary for use on new macOS hardware.
   Please note that `pulumi watch` will not be supported on darwin/arm64 builds.
   [#6492](https://github.com/pulumi/pulumi/pull/6492)
 
 - [automation/nodejs] - Expose structured logging for Stack.up/preview/refresh/destroy.
   [#6454](https://github.com/pulumi/pulumi/pull/6454)
-  
+
 - [automation/nodejs] - Add `onOutput` event handler to `PreviewOptions`.
   [#6507](https://github.com/pulumi/pulumi/pull/6507)
 

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2021, Pulumi Corporation
+// Copyright 2016-2021, Pulumi Corporation
 
 using System;
 using System.Collections.Generic;
@@ -512,7 +512,14 @@ namespace Pulumi.Automation.Tests
 
             var outputCalled = false;
 
+            // pulumi preview
+            outputCalled = false;
+            var previewResult = await stack.PreviewAsync(new PreviewOptions { OnOutput = (str) => outputCalled = true });
+            Assert.False(string.IsNullOrEmpty(previewResult.StandardOutput));
+            Assert.True(outputCalled);
+
             // pulumi up
+            outputCalled = false;
             var upResult = await stack.UpAsync(new UpOptions { OnOutput = (str) => outputCalled = true });
             Assert.False(string.IsNullOrEmpty(upResult.StandardOutput));
             Assert.True(outputCalled);

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -514,25 +514,25 @@ namespace Pulumi.Automation.Tests
 
             // pulumi preview
             outputCalled = false;
-            var previewResult = await stack.PreviewAsync(new PreviewOptions { OnOutput = (str) => outputCalled = true });
+            var previewResult = await stack.PreviewAsync(new PreviewOptions { OnStandardOutput = (str) => outputCalled = true });
             Assert.False(string.IsNullOrEmpty(previewResult.StandardOutput));
             Assert.True(outputCalled);
 
             // pulumi up
             outputCalled = false;
-            var upResult = await stack.UpAsync(new UpOptions { OnOutput = (str) => outputCalled = true });
+            var upResult = await stack.UpAsync(new UpOptions { OnStandardOutput = (str) => outputCalled = true });
             Assert.False(string.IsNullOrEmpty(upResult.StandardOutput));
             Assert.True(outputCalled);
 
             // pulumi refresh
             outputCalled = false;
-            var refreshResult = await stack.RefreshAsync(new RefreshOptions { OnOutput = (str) => outputCalled = true });
+            var refreshResult = await stack.RefreshAsync(new RefreshOptions { OnStandardOutput = (str) => outputCalled = true });
             Assert.False(string.IsNullOrEmpty(refreshResult.StandardOutput));
             Assert.True(outputCalled);
 
             // pulumi destroy
             outputCalled = false;
-            var destroyResult = await stack.DestroyAsync(new DestroyOptions { OnOutput = (str) => outputCalled = true });
+            var destroyResult = await stack.DestroyAsync(new DestroyOptions { OnStandardOutput = (str) => outputCalled = true });
             Assert.False(string.IsNullOrEmpty(destroyResult.StandardOutput));
             Assert.True(outputCalled);
         }

--- a/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
@@ -13,8 +13,8 @@ namespace Pulumi.Automation.Commands
             IEnumerable<string> args,
             string workingDir,
             IDictionary<string, string> additionalEnv,
-            Action<string>? onOutput = null,
-            Action<string>? onError = null,
+            Action<string>? onStandardOutput = null,
+            Action<string>? onStandardError = null,
             CancellationToken cancellationToken = default);
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
@@ -14,6 +14,7 @@ namespace Pulumi.Automation.Commands
             string workingDir,
             IDictionary<string, string> additionalEnv,
             Action<string>? onOutput = null,
+            Action<string>? onStdErr = null,
             CancellationToken cancellationToken = default);
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Automation.Commands
             string workingDir,
             IDictionary<string, string> additionalEnv,
             Action<string>? onOutput = null,
-            Action<string>? onStdErr = null,
+            Action<string>? onError = null,
             CancellationToken cancellationToken = default);
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -18,6 +18,7 @@ namespace Pulumi.Automation.Commands
             string workingDir,
             IDictionary<string, string> additionalEnv,
             Action<string>? onOutput = null,
+            Action<string>? onStdErr = null,
             CancellationToken cancellationToken = default)
         {
             // all commands should be run in non-interactive mode.
@@ -62,7 +63,17 @@ namespace Pulumi.Automation.Commands
                 {
                     standardOutputBuilder.AppendLine(@event.Data);
                     onOutput?.Invoke(@event.Data);
-                }  
+                }
+            };
+
+            var standardErrorBuilder = new StringBuilder();
+            proc.ErrorDataReceived += (_, @event) =>
+            {
+                if (@event.Data != null)
+                {
+                    standardErrorBuilder.AppendLine(@event.Data);
+                    onStdErr?.Invoke(@event.Data);
+                }
             };
 
             var tcs = new TaskCompletionSource<CommandResult>();
@@ -88,12 +99,11 @@ namespace Pulumi.Automation.Commands
                 }
             });
 
-            proc.Exited += async (_, @event) =>
+            proc.Exited += (_, @event) =>
             {
                 var code = proc.ExitCode;
-                var stdErr = await proc.StandardError.ReadToEndAsync().ConfigureAwait(false);
 
-                var result = new CommandResult(code, standardOutputBuilder.ToString(), stdErr);
+                var result = new CommandResult(code, standardOutputBuilder.ToString(), standardErrorBuilder.ToString());
                 if (code != 0)
                 {
                     var ex = CommandException.CreateFromResult(result);
@@ -107,6 +117,7 @@ namespace Pulumi.Automation.Commands
 
             proc.Start();
             proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
             return await tcs.Task.ConfigureAwait(false);
         }
     }

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -18,7 +18,7 @@ namespace Pulumi.Automation.Commands
             string workingDir,
             IDictionary<string, string> additionalEnv,
             Action<string>? onOutput = null,
-            Action<string>? onStdErr = null,
+            Action<string>? onError = null,
             CancellationToken cancellationToken = default)
         {
             // all commands should be run in non-interactive mode.
@@ -72,7 +72,7 @@ namespace Pulumi.Automation.Commands
                 if (@event.Data != null)
                 {
                     standardErrorBuilder.AppendLine(@event.Data);
-                    onStdErr?.Invoke(@event.Data);
+                    onError?.Invoke(@event.Data);
                 }
             };
 

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -17,8 +17,8 @@ namespace Pulumi.Automation.Commands
             IEnumerable<string> args,
             string workingDir,
             IDictionary<string, string> additionalEnv,
-            Action<string>? onOutput = null,
-            Action<string>? onError = null,
+            Action<string>? onStandardOutput = null,
+            Action<string>? onStandardError = null,
             CancellationToken cancellationToken = default)
         {
             // all commands should be run in non-interactive mode.
@@ -62,7 +62,7 @@ namespace Pulumi.Automation.Commands
                 if (@event.Data != null)
                 {
                     standardOutputBuilder.AppendLine(@event.Data);
-                    onOutput?.Invoke(@event.Data);
+                    onStandardOutput?.Invoke(@event.Data);
                 }
             };
 
@@ -72,7 +72,7 @@ namespace Pulumi.Automation.Commands
                 if (@event.Data != null)
                 {
                     standardErrorBuilder.AppendLine(@event.Data);
-                    onError?.Invoke(@event.Data);
+                    onStandardError?.Invoke(@event.Data);
                 }
             };
 

--- a/sdk/dotnet/Pulumi.Automation/DestroyOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/DestroyOptions.cs
@@ -10,7 +10,5 @@ namespace Pulumi.Automation
     public sealed class DestroyOptions : UpdateOptions
     {
         public bool? TargetDependents { get; set; }
-
-        public Action<string>? OnOutput { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -11,8 +11,6 @@ Pulumi.Automation.ConfigValue.Value.get -> string
 Pulumi.Automation.ConfigValue.Value.set -> void
 Pulumi.Automation.DestroyOptions
 Pulumi.Automation.DestroyOptions.DestroyOptions() -> void
-Pulumi.Automation.DestroyOptions.OnOutput.get -> System.Action<string>
-Pulumi.Automation.DestroyOptions.OnOutput.set -> void
 Pulumi.Automation.DestroyOptions.TargetDependents.get -> bool?
 Pulumi.Automation.DestroyOptions.TargetDependents.set -> void
 Pulumi.Automation.HistoryOptions
@@ -159,8 +157,6 @@ Pulumi.Automation.PulumiFn
 Pulumi.Automation.RefreshOptions
 Pulumi.Automation.RefreshOptions.ExpectNoChanges.get -> bool?
 Pulumi.Automation.RefreshOptions.ExpectNoChanges.set -> void
-Pulumi.Automation.RefreshOptions.OnOutput.get -> System.Action<string>
-Pulumi.Automation.RefreshOptions.OnOutput.set -> void
 Pulumi.Automation.RefreshOptions.RefreshOptions() -> void
 Pulumi.Automation.StackSettings
 Pulumi.Automation.StackSettings.Config.get -> System.Collections.Generic.IDictionary<string, Pulumi.Automation.StackSettingsConfigValue>
@@ -188,8 +184,6 @@ Pulumi.Automation.UpOptions.ExpectNoChanges.get -> bool?
 Pulumi.Automation.UpOptions.ExpectNoChanges.set -> void
 Pulumi.Automation.UpOptions.Diff.get -> bool?
 Pulumi.Automation.UpOptions.Diff.set -> void
-Pulumi.Automation.UpOptions.OnOutput.get -> System.Action<string>
-Pulumi.Automation.UpOptions.OnOutput.set -> void
 Pulumi.Automation.UpOptions.Program.get -> Pulumi.Automation.PulumiFn
 Pulumi.Automation.UpOptions.Program.set -> void
 Pulumi.Automation.UpOptions.Replace.get -> System.Collections.Generic.List<string>
@@ -209,6 +203,10 @@ Pulumi.Automation.UpdateKind.Update = 0 -> Pulumi.Automation.UpdateKind
 Pulumi.Automation.UpdateOptions
 Pulumi.Automation.UpdateOptions.Message.get -> string
 Pulumi.Automation.UpdateOptions.Message.set -> void
+Pulumi.Automation.UpdateOptions.OnOutput.get -> System.Action<string>
+Pulumi.Automation.UpdateOptions.OnOutput.set -> void
+Pulumi.Automation.UpdateOptions.OnStdErr.get -> System.Action<string>
+Pulumi.Automation.UpdateOptions.OnStdErr.set -> void
 Pulumi.Automation.UpdateOptions.Parallel.get -> int?
 Pulumi.Automation.UpdateOptions.Parallel.set -> void
 Pulumi.Automation.UpdateOptions.Target.get -> System.Collections.Generic.List<string>

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -203,10 +203,10 @@ Pulumi.Automation.UpdateKind.Update = 0 -> Pulumi.Automation.UpdateKind
 Pulumi.Automation.UpdateOptions
 Pulumi.Automation.UpdateOptions.Message.get -> string
 Pulumi.Automation.UpdateOptions.Message.set -> void
+Pulumi.Automation.UpdateOptions.OnError.get -> System.Action<string>
+Pulumi.Automation.UpdateOptions.OnError.set -> void
 Pulumi.Automation.UpdateOptions.OnOutput.get -> System.Action<string>
 Pulumi.Automation.UpdateOptions.OnOutput.set -> void
-Pulumi.Automation.UpdateOptions.OnStdErr.get -> System.Action<string>
-Pulumi.Automation.UpdateOptions.OnStdErr.set -> void
 Pulumi.Automation.UpdateOptions.Parallel.get -> int?
 Pulumi.Automation.UpdateOptions.Parallel.set -> void
 Pulumi.Automation.UpdateOptions.Target.get -> System.Collections.Generic.List<string>

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -203,10 +203,10 @@ Pulumi.Automation.UpdateKind.Update = 0 -> Pulumi.Automation.UpdateKind
 Pulumi.Automation.UpdateOptions
 Pulumi.Automation.UpdateOptions.Message.get -> string
 Pulumi.Automation.UpdateOptions.Message.set -> void
-Pulumi.Automation.UpdateOptions.OnError.get -> System.Action<string>
-Pulumi.Automation.UpdateOptions.OnError.set -> void
-Pulumi.Automation.UpdateOptions.OnOutput.get -> System.Action<string>
-Pulumi.Automation.UpdateOptions.OnOutput.set -> void
+Pulumi.Automation.UpdateOptions.OnStandardError.get -> System.Action<string>
+Pulumi.Automation.UpdateOptions.OnStandardError.set -> void
+Pulumi.Automation.UpdateOptions.OnStandardOutput.get -> System.Action<string>
+Pulumi.Automation.UpdateOptions.OnStandardOutput.set -> void
 Pulumi.Automation.UpdateOptions.Parallel.get -> int?
 Pulumi.Automation.UpdateOptions.Parallel.set -> void
 Pulumi.Automation.UpdateOptions.Target.get -> System.Collections.Generic.List<string>

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -504,6 +504,16 @@
             against an instance of <see cref="T:Pulumi.Automation.WorkspaceStack"/>.
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.UpdateOptions.OnStandardOutput">
+            <summary>
+            Optional callback which is invoked whenever StandardOutput is written into
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.UpdateOptions.OnStandardError">
+            <summary>
+            Optional callback which is invoked whenever StandardError is written into
+            </summary>
+        </member>
         <member name="T:Pulumi.Automation.UpOptions">
             <summary>
             Options controlling the behavior of an <see cref="M:Pulumi.Automation.WorkspaceStack.UpAsync(Pulumi.Automation.UpOptions,System.Threading.CancellationToken)"/> operation.

--- a/sdk/dotnet/Pulumi.Automation/RefreshOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/RefreshOptions.cs
@@ -10,7 +10,5 @@ namespace Pulumi.Automation
     public sealed class RefreshOptions : UpdateOptions
     {
         public bool? ExpectNoChanges { get; set; }
-
-        public Action<string>? OnOutput { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/UpOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/UpOptions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
-using System;
 using System.Collections.Generic;
 
 namespace Pulumi.Automation
@@ -11,14 +10,12 @@ namespace Pulumi.Automation
     public sealed class UpOptions : UpdateOptions
     {
         public bool? ExpectNoChanges { get; set; }
-        
+
         public bool? Diff { get; set; }
 
         public List<string>? Replace { get; set; }
 
         public bool? TargetDependents { get; set; }
-
-        public Action<string>? OnOutput { get; set; }
 
         public PulumiFn? Program { get; set; }
     }

--- a/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
@@ -17,8 +17,14 @@ namespace Pulumi.Automation
 
         public List<string>? Target { get; set; }
 
+        /// <summary>
+        /// Optional callback which is invoked whenever StandardOutput is written into
+        /// </summary>
         public Action<string>? OnOutput { get; set; }
 
-        public Action<string>? OnStdErr { get; set; }
+        /// <summary>
+        /// Optional callback which is invoked whenever StandardError is written into
+        /// </summary>
+        public Action<string>? OnError { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using System;
 using System.Collections.Generic;
 
 namespace Pulumi.Automation
@@ -15,5 +16,9 @@ namespace Pulumi.Automation
         public string? Message { get; set; }
 
         public List<string>? Target { get; set; }
+
+        public Action<string>? OnOutput { get; set; }
+
+        public Action<string>? OnStdErr { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/UpdateOptions.cs
@@ -20,11 +20,11 @@ namespace Pulumi.Automation
         /// <summary>
         /// Optional callback which is invoked whenever StandardOutput is written into
         /// </summary>
-        public Action<string>? OnOutput { get; set; }
+        public Action<string>? OnStandardOutput { get; set; }
 
         /// <summary>
         /// Optional callback which is invoked whenever StandardError is written into
         /// </summary>
-        public Action<string>? OnError { get; set; }
+        public Action<string>? OnStandardError { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -249,13 +249,13 @@ namespace Pulumi.Automation
             string stackName,
             IEnumerable<string> args,
             Action<string>? onOutput,
-            Action<string>? onStdErr,
+            Action<string>? onError,
             CancellationToken cancellationToken)
         {
             var additionalArgs = await this.SerializeArgsForOpAsync(stackName, cancellationToken).ConfigureAwait(false);
             var completeArgs = args.Concat(additionalArgs).ToList();
 
-            var result = await this.RunCommandAsync(completeArgs, onOutput, onStdErr, cancellationToken).ConfigureAwait(false);
+            var result = await this.RunCommandAsync(completeArgs, onOutput, onError, cancellationToken).ConfigureAwait(false);
             await this.PostCommandCallbackAsync(stackName, cancellationToken).ConfigureAwait(false);
             return result;
         }
@@ -263,12 +263,12 @@ namespace Pulumi.Automation
         internal Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
             CancellationToken cancellationToken)
-            => this.RunCommandAsync(args, onOutput: null, onStdErr: null, cancellationToken);
+            => this.RunCommandAsync(args, onOutput: null, onError: null, cancellationToken);
 
         internal Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
             Action<string>? onOutput,
-            Action<string>? onStdErr,
+            Action<string>? onError,
             CancellationToken cancellationToken)
         {
             var env = new Dictionary<string, string>();
@@ -281,7 +281,7 @@ namespace Pulumi.Automation
                     env[pair.Key] = pair.Value;
             }
 
-            return this._cmd.RunAsync(args, this.WorkDir, env, onOutput, onStdErr, cancellationToken);
+            return this._cmd.RunAsync(args, this.WorkDir, env, onOutput, onError, cancellationToken);
         }
 
         public virtual void Dispose()

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -249,12 +249,13 @@ namespace Pulumi.Automation
             string stackName,
             IEnumerable<string> args,
             Action<string>? onOutput,
+            Action<string>? onStdErr,
             CancellationToken cancellationToken)
         {
             var additionalArgs = await this.SerializeArgsForOpAsync(stackName, cancellationToken).ConfigureAwait(false);
             var completeArgs = args.Concat(additionalArgs).ToList();
 
-            var result = await this.RunCommandAsync(completeArgs, onOutput, cancellationToken).ConfigureAwait(false);
+            var result = await this.RunCommandAsync(completeArgs, onOutput, onStdErr, cancellationToken).ConfigureAwait(false);
             await this.PostCommandCallbackAsync(stackName, cancellationToken).ConfigureAwait(false);
             return result;
         }
@@ -262,11 +263,12 @@ namespace Pulumi.Automation
         internal Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
             CancellationToken cancellationToken)
-            => this.RunCommandAsync(args, null, cancellationToken);
+            => this.RunCommandAsync(args, onOutput: null, onStdErr: null, cancellationToken);
 
         internal Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
             Action<string>? onOutput,
+            Action<string>? onStdErr,
             CancellationToken cancellationToken)
         {
             var env = new Dictionary<string, string>();
@@ -279,7 +281,7 @@ namespace Pulumi.Automation
                     env[pair.Key] = pair.Value;
             }
 
-            return this._cmd.RunAsync(args, this.WorkDir, env, onOutput, cancellationToken);
+            return this._cmd.RunAsync(args, this.WorkDir, env, onOutput, onStdErr, cancellationToken);
         }
 
         public virtual void Dispose()

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -248,14 +248,14 @@ namespace Pulumi.Automation
         internal async Task<CommandResult> RunStackCommandAsync(
             string stackName,
             IEnumerable<string> args,
-            Action<string>? onOutput,
-            Action<string>? onError,
+            Action<string>? onStandardOutput,
+            Action<string>? onStandardError,
             CancellationToken cancellationToken)
         {
             var additionalArgs = await this.SerializeArgsForOpAsync(stackName, cancellationToken).ConfigureAwait(false);
             var completeArgs = args.Concat(additionalArgs).ToList();
 
-            var result = await this.RunCommandAsync(completeArgs, onOutput, onError, cancellationToken).ConfigureAwait(false);
+            var result = await this.RunCommandAsync(completeArgs, onStandardOutput, onStandardError, cancellationToken).ConfigureAwait(false);
             await this.PostCommandCallbackAsync(stackName, cancellationToken).ConfigureAwait(false);
             return result;
         }
@@ -263,12 +263,12 @@ namespace Pulumi.Automation
         internal Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
             CancellationToken cancellationToken)
-            => this.RunCommandAsync(args, onOutput: null, onError: null, cancellationToken);
+            => this.RunCommandAsync(args, onStandardOutput: null, onStandardError: null, cancellationToken);
 
         internal Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
-            Action<string>? onOutput,
-            Action<string>? onError,
+            Action<string>? onStandardOutput,
+            Action<string>? onStandardError,
             CancellationToken cancellationToken)
         {
             var env = new Dictionary<string, string>();
@@ -281,7 +281,7 @@ namespace Pulumi.Automation
                     env[pair.Key] = pair.Value;
             }
 
-            return this._cmd.RunAsync(args, this.WorkDir, env, onOutput, onError, cancellationToken);
+            return this._cmd.RunAsync(args, this.WorkDir, env, onStandardOutput, onStandardError, cancellationToken);
         }
 
         public virtual void Dispose()

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -275,7 +275,7 @@ namespace Pulumi.Automation
                 args.Add("--exec-kind");
                 args.Add(execKind);
 
-                var upResult = await this.RunCommandAsync(args, options?.OnOutput, options?.OnStdErr, cancellationToken).ConfigureAwait(false);
+                var upResult = await this.RunCommandAsync(args, options?.OnOutput, options?.OnError, cancellationToken).ConfigureAwait(false);
                 if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
                     exceptionInfo.Throw();
 
@@ -372,7 +372,7 @@ namespace Pulumi.Automation
                 args.Add("--exec-kind");
                 args.Add(execKind);
 
-                var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnStdErr, cancellationToken).ConfigureAwait(false);
+                var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnError, cancellationToken).ConfigureAwait(false);
                 if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
                     exceptionInfo.Throw();
 
@@ -434,7 +434,7 @@ namespace Pulumi.Automation
                 }
             }
 
-            var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnStdErr, cancellationToken).ConfigureAwait(false);
+            var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnError, cancellationToken).ConfigureAwait(false);
             var summary = await this.GetInfoAsync(cancellationToken).ConfigureAwait(false);
             return new UpdateResult(
                 result.StandardOutput,
@@ -486,7 +486,7 @@ namespace Pulumi.Automation
                 }
             }
 
-            var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnStdErr, cancellationToken).ConfigureAwait(false);
+            var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnError, cancellationToken).ConfigureAwait(false);
             var summary = await this.GetInfoAsync(cancellationToken).ConfigureAwait(false);
             return new UpdateResult(
                 result.StandardOutput,
@@ -570,9 +570,9 @@ namespace Pulumi.Automation
         private Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
             Action<string>? onOutput,
-            Action<string>? onStdErr,
+            Action<string>? onError,
             CancellationToken cancellationToken)
-            => this.Workspace.RunStackCommandAsync(this.Name, args, onOutput, onStdErr, cancellationToken);
+            => this.Workspace.RunStackCommandAsync(this.Name, args, onOutput, onError, cancellationToken);
 
         public void Dispose()
             => this.Workspace.Dispose();

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -275,7 +275,7 @@ namespace Pulumi.Automation
                 args.Add("--exec-kind");
                 args.Add(execKind);
 
-                var upResult = await this.RunCommandAsync(args, options?.OnOutput, options?.OnError, cancellationToken).ConfigureAwait(false);
+                var upResult = await this.RunCommandAsync(args, options?.OnStandardOutput, options?.OnStandardError, cancellationToken).ConfigureAwait(false);
                 if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
                     exceptionInfo.Throw();
 
@@ -372,7 +372,7 @@ namespace Pulumi.Automation
                 args.Add("--exec-kind");
                 args.Add(execKind);
 
-                var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnError, cancellationToken).ConfigureAwait(false);
+                var result = await this.RunCommandAsync(args, options?.OnStandardOutput, options?.OnStandardError, cancellationToken).ConfigureAwait(false);
                 if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
                     exceptionInfo.Throw();
 
@@ -434,7 +434,7 @@ namespace Pulumi.Automation
                 }
             }
 
-            var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnError, cancellationToken).ConfigureAwait(false);
+            var result = await this.RunCommandAsync(args, options?.OnStandardOutput, options?.OnStandardError, cancellationToken).ConfigureAwait(false);
             var summary = await this.GetInfoAsync(cancellationToken).ConfigureAwait(false);
             return new UpdateResult(
                 result.StandardOutput,
@@ -486,7 +486,7 @@ namespace Pulumi.Automation
                 }
             }
 
-            var result = await this.RunCommandAsync(args, options?.OnOutput, options?.OnError, cancellationToken).ConfigureAwait(false);
+            var result = await this.RunCommandAsync(args, options?.OnStandardOutput, options?.OnStandardError, cancellationToken).ConfigureAwait(false);
             var summary = await this.GetInfoAsync(cancellationToken).ConfigureAwait(false);
             return new UpdateResult(
                 result.StandardOutput,
@@ -569,10 +569,10 @@ namespace Pulumi.Automation
 
         private Task<CommandResult> RunCommandAsync(
             IEnumerable<string> args,
-            Action<string>? onOutput,
-            Action<string>? onError,
+            Action<string>? onStandardOutput,
+            Action<string>? onStandardError,
             CancellationToken cancellationToken)
-            => this.Workspace.RunStackCommandAsync(this.Name, args, onOutput, onError, cancellationToken);
+            => this.Workspace.RunStackCommandAsync(this.Name, args, onStandardOutput, onStandardError, cancellationToken);
 
         public void Dispose()
             => this.Workspace.Dispose();


### PR DESCRIPTION
Dotnet support for #6511 and also fixes #6483 

NOTE: I did move the `OnOutput` and added the new `OnStdErr` action to the options base class `UpdateOptions` instead of duplicating them for each option type.

I tried to figure out a way to test that the StdErr action would be called, but I did not seem to find a way to get data written to the standard error stream. Even logging with `Log.Warn` or `Log.Error` would end up being written to the standard output stream.