### PR TITLE
JSON does not admit trailing commas

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/Serialization/GeneralJsonConverterTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Serialization/GeneralJsonConverterTests.cs
@@ -18,11 +18,11 @@ namespace Pulumi.Automation.Tests.Serialization
 {
     ""aws:region"": {
         ""value"": ""us-east-1"",
-        ""secret"": false,
+        ""secret"": false
     },
     ""project:name"": {
         ""value"": ""test"",
-        ""secret"": true,
+        ""secret"": true
     }
 }
 ";


### PR DESCRIPTION
When running `make`:

```
X Pulumi.Automation.Tests.Serialization.GeneralJsonConverterTests.CanDeserializeConfigValue [1ms]
  Error Message:
   System.Text.Json.JsonException : The JSON object contains a trailing comma at the end which is not supported in this mode. Change the reader options. Path: $.secret | LineNumber: 3 | BytePositionInLine: 4.
---- System.Text.Json.JsonReaderException : The JSON object contains a trailing comma at the end which is not supported in this mode. Change the reader options. LineNumber: 3 | BytePositionInLine: 4.
  Stack Trace:
     at System.Text.Json.ThrowHelper.ReThrowWithPath(ReadStack& readStack, JsonReaderException ex)
   at System.Text.Json.JsonSerializer.ReadCore(JsonSerializerOptions options, Utf8JsonReader& reader, ReadStack& readStack)
   at System.Text.Json.JsonSerializer.ReadValueCore(JsonSerializerOptions options, Utf8JsonReader& reader, ReadStack& readStack)
   at System.Text.Json.JsonSerializer.ReadValueCore(Utf8JsonReader& reader, Type returnType, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.Deserialize[TValue](Utf8JsonReader& reader, JsonSerializerOptions options)
   at Pulumi.Automation.Serialization.Json.MapToModelJsonConverter`2.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options) in /Users/anton/pulumi/sdk/dotnet/Pulumi.Automation/Serialization/Json/MapToModelJsonConverter.cs:line 16
   at System.Text.Json.JsonPropertyInfoNotNullable`4.OnReadEnumerable(ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.JsonPropertyInfo.ReadEnumerable(JsonTokenType tokenType, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.JsonPropertyInfo.Read(JsonTokenType tokenType, ReadStack& state, Utf8JsonReader& reader)
   at System.Text.Json.JsonSerializer.ReadCore(JsonSerializerOptions options, Utf8JsonReader& reader, ReadStack& readStack)
   at System.Text.Json.JsonSerializer.ReadCore(Type returnType, JsonSerializerOptions options, Utf8JsonReader& reader)
   at System.Text.Json.JsonSerializer.Deserialize(String json, Type returnType, JsonSerializerOptions options)
   at System.Text.Json.JsonSerializer.Deserialize[TValue](String json, JsonSerializerOptions options)
   at Pulumi.Automation.Serialization.LocalSerializer.DeserializeJson[T](String content) in /Users/anton/pulumi/sdk/dotnet/Pulumi.Automation/Serialization/LocalSerializer.cs:line 29
   at Pulumi.Automation.Tests.Serialization.GeneralJsonConverterTests.CanDeserializeConfigValue() in /Users/anton/pulumi/sdk/dotnet/Pulumi.Automation.Tests/Serialization/GeneralJsonConverterTests.cs:line 30
----- Inner Stack Trace -----
   at System.Text.Json.ThrowHelper.ThrowJsonReaderException(Utf8JsonReader& json, ExceptionResource resource, Byte nextByte, ReadOnlySpan`1 bytes)
   at System.Text.Json.Utf8JsonReader.ConsumeNextToken(Byte marker)
   at System.Text.Json.Utf8JsonReader.ConsumeNextTokenOrRollback(Byte marker)
   at System.Text.Json.Utf8JsonReader.ReadSingleSegment()
   at System.Text.Json.Utf8JsonReader.Read()
   at System.Text.Json.JsonSerializer.ReadCore(JsonSerializerOptions options, Utf8JsonReader& reader, ReadStack& readStack)
```

I do not think we intentionally tested trailing commas? The JSON standard grammar does not admit them.