### PR TITLE
Update resource-docs templates to adjust for Hugo upgrade

### DIFF
--- a/pkg/codegen/docs/templates/constructor_args.tmpl
+++ b/pkg/codegen/docs/templates/constructor_args.tmpl
@@ -1,6 +1,6 @@
 {{ define "constructor_args" }}
 <dl class="resources-properties">
-  {{ range $params := . }}
+  {{- range $params := . -}}
     <dt
         {{ if .OptionalFlag -}}class="property-optional" title="Optional"
         {{- else -}}class="property-required" title="Required"
@@ -12,7 +12,6 @@
     <dd>
       {{ .Comment }}
     </dd>
-  {{ end }}
-
+  {{- end -}}
 </dl>
 {{ end }}

--- a/pkg/codegen/docs/templates/enums.tmpl
+++ b/pkg/codegen/docs/templates/enums.tmpl
@@ -3,7 +3,8 @@
 {{- range $lang, $enums := . }}
 
 {{ print "{{% choosable language" }} {{ print $lang }} {{ print "%}}" }}
-<dl class="tabular">{{ range . }}
+<dl class="tabular">
+{{- range . -}}
     <dt>
         {{- htmlSafe .DisplayName -}}
     </dt>
@@ -12,7 +13,7 @@
         {{- if .Comment }}{{ print "{{% md %}}" -}}{{- htmlSafe .Comment -}}{{- print "{{% /md %}}" }}{{ end -}}
         {{- if .DeprecationMessage }}<p class="property-message">Deprecated: {{ print "{{% md %}}" -}}{{- htmlSafe .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>{{- end -}}
     </dd>
-{{- end }}
+{{- end -}}
 </dl>
 {{ print "{{% /choosable %}}" }}
 

--- a/pkg/codegen/docs/templates/examples.tmpl
+++ b/pkg/codegen/docs/templates/examples.tmpl
@@ -1,19 +1,24 @@
 {{ define "examples" -}}
 {{ print "{{% examples %}}" }}
+
 ## Example Usage
 
 {{ htmlSafe "{{< chooser language \"typescript,python,go,csharp\" / >}}" }}
 
-{{- range . }}
+{{ range . }}
 {{ .Title }}
 
-{{- range $key, $val := .Snippets }}
-{{ print "{{% example " }}{{ $key }}{{ print " %}}" }}
+{{ range $key, $val := .Snippets }}
+{{ htmlSafe "{{< example " }}{{ $key }}{{ htmlSafe " >}}" }}
+
 {{ htmlSafe $val }}
-{{ print "{{% /example %}}" }}
+
+{{ htmlSafe "{{< /example >}}" }}
+
 {{ end }}
 
-{{- end }}
+{{ end }}
+
 {{ print "{{% /examples %}}" }}
 
-{{- end }}
+{{ end }}

--- a/pkg/codegen/docs/templates/package_details.tmpl
+++ b/pkg/codegen/docs/templates/package_details.tmpl
@@ -7,7 +7,7 @@
 	<dd>{{ htmlSafe .License }}</dd>
     {{- if ne .Notes "" }}
 	<dt>Notes</dt>
-	<dd>{{ htmlSafe .Notes }}</dd>
+	<dd>{{ print "{{% md %}}" -}}{{ htmlSafe .Notes }}{{- print "{{% /md %}}" -}}</dd>
 	{{- end }}
 	{{- if ne .Version "" }}
 	<dt>Version</dt>

--- a/pkg/codegen/docs/templates/properties.tmpl
+++ b/pkg/codegen/docs/templates/properties.tmpl
@@ -4,7 +4,7 @@
 
 {{ print "{{% choosable language" }} {{ print $lang }} {{ print "%}}" }}
 <dl class="resources-properties">
-{{ range . }}
+{{- range . -}}
     <dt class="property-{{- if .IsInput -}}{{- if .IsRequired -}}required{{- else -}}optional{{- end -}}{{- end -}}{{ if .DeprecationMessage }} property-deprecated{{- end -}}"
             title="{{ if .IsInput -}}{{- if .IsRequired -}}Required{{- else -}}Optional{{- end -}}{{- end -}}{{- if .DeprecationMessage -}}, Deprecated{{- end -}}">
         <span id="{{ htmlSafe .ID }}">{{ template "linkify_wo_style" . }}</span>
@@ -20,7 +20,7 @@
         {{- print "{{% md %}}" -}}{{- htmlSafe .Comment -}}{{- print "{{% /md %}}" -}}
         {{- if .DeprecationMessage -}}<p class="property-message">Deprecated: {{ print "{{% md %}}" -}}{{- .DeprecationMessage -}}{{- print "{{% /md %}}" -}}</p>{{- end -}}
     </dd>
-{{- end }}
+{{- end -}}
 </dl>
 {{ print "{{% /choosable %}}" }}
 


### PR DESCRIPTION
https://github.com/pulumi/docs/pull/5418 upgrades pulumi/docs to use Hugo 0.81, whose new(ish) Markdown renderer functions a little bit differently. This change updates our doc-gen templates accordingly.

⚠️ Don't merge this change until the PR above is merged into pulumi/docs. 