### PR TITLE
[automation/dotnet,nodejs,python] Specify exec-kind for refresh & destroy

### DIFF
--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -434,6 +434,10 @@ namespace Pulumi.Automation
                 }
             }
 
+            var execKind = Workspace.Program is null ? ExecKind.Local : ExecKind.Inline;
+            args.Add("--exec-kind");
+            args.Add(execKind);
+
             var result = await this.RunCommandAsync(args, options?.OnStandardOutput, options?.OnStandardError, cancellationToken).ConfigureAwait(false);
             var summary = await this.GetInfoAsync(cancellationToken).ConfigureAwait(false);
             return new UpdateResult(
@@ -485,6 +489,10 @@ namespace Pulumi.Automation
                     args.Add(options.Parallel.Value.ToString());
                 }
             }
+
+            var execKind = Workspace.Program is null ? ExecKind.Local : ExecKind.Inline;
+            args.Add("--exec-kind");
+            args.Add(execKind);
 
             var result = await this.RunCommandAsync(args, options?.OnStandardOutput, options?.OnStandardError, cancellationToken).ConfigureAwait(false);
             var summary = await this.GetInfoAsync(cancellationToken).ConfigureAwait(false);

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -389,6 +389,9 @@ export class Stack {
             });
         }
 
+        const kind = this.workspace.program ? execKind.inline : execKind.local;
+        args.push("--exec-kind", kind);
+
         const refPromise = this.runPulumiCmd(args, opts?.onOutput);
         const [refResult, tail] = await Promise.all([refPromise, logPromise]);
         await cleanUp(tail, logFile);
@@ -438,6 +441,9 @@ export class Stack {
                 onEvent(event);
             });
         }
+
+        const kind = this.workspace.program ? execKind.inline : execKind.local;
+        args.push("--exec-kind", kind);
 
         const desPromise = this.runPulumiCmd(args, opts?.onOutput);
         const [desResult, tail] = await Promise.all([desPromise, logPromise]);

--- a/sdk/python/lib/pulumi/x/automation/_stack.py
+++ b/sdk/python/lib/pulumi/x/automation/_stack.py
@@ -375,6 +375,9 @@ class Stack:
         args = ["refresh", "--yes", "--skip-preview"]
         args.extend(extra_args)
 
+        kind = ExecKind.INLINE.value if self.workspace.program else ExecKind.LOCAL.value
+        args.extend(["--exec-kind", kind])
+
         self.workspace.select_stack(self.name)
         refresh_result = self._run_pulumi_cmd_sync(args, on_output)
         summary = self.info()
@@ -401,6 +404,9 @@ class Stack:
         extra_args = _parse_extra_args(**locals())
         args = ["destroy", "--yes", "--skip-preview"]
         args.extend(extra_args)
+
+        kind = ExecKind.INLINE.value if self.workspace.program else ExecKind.LOCAL.value
+        args.extend(["--exec-kind", kind])
 
         self.workspace.select_stack(self.name)
         destroy_result = self._run_pulumi_cmd_sync(args, on_output)


### PR DESCRIPTION
dotnet, nodejs and python automation APIs did not specify exec-kind for
refresh or destroy operations. This is now added following the same
logic from the go automation API.