### PR TITLE
[dotnet] Fix InputList implicit conversion with default ImmutableArray

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,6 @@
 
 - [cli] Fix a bug where a version wasn't passed to go install commands as part of `make brew` installs from homebrew
   [#6566](https://github.com/pulumi/pulumi/pull/6566)
+
+- [dotnet] Fix InputList implicit conversion with default ImmutableArray
+  [#6544](https://github.com/pulumi/pulumi/pull/6544)

--- a/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
@@ -21,6 +21,7 @@ namespace Pulumi.Tests.Core
                 await AssertCanConvert((ImmutableArray<bool>) default);
                 await AssertCanConvert((ImmutableArray<Input<bool>>) default);
                 await AssertCanConvert((ImmutableArray<Output<bool>>) default);
+                await AssertCanConvert(Output.Create((ImmutableArray<bool>) default));
 
                 static async Task AssertCanConvert(InputList<bool> inputList)
                 {

--- a/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
@@ -13,6 +13,45 @@ namespace Pulumi.Tests.Core
     public class InputTests : PulumiTest
     {
         [Fact]
+        public Task ConvertDefaultSimpleImmutableArray()
+            => RunInPreview(async () =>
+            {
+                ImmutableArray<bool> defaultArray = default;
+
+                InputList<bool> inputList= defaultArray;
+
+                var data = await inputList.ToOutput().DataTask.ConfigureAwait(false);
+
+                Assert.Empty(data.Value);
+            });
+
+        [Fact]
+        public Task ConvertDefaultInputImmutableArray()
+            => RunInPreview(async () =>
+            {
+                ImmutableArray<Input<bool>> defaultArray = default;
+
+                InputList<bool> inputList= defaultArray;
+
+                var data = await inputList.ToOutput().DataTask.ConfigureAwait(false);
+
+                Assert.Empty(data.Value);
+            });
+
+        [Fact]
+        public Task ConvertDefaultOutputImmutableArray()
+            => RunInPreview(async () =>
+            {
+                ImmutableArray<Output<bool>> defaultArray = default;
+
+                InputList<bool> inputList= defaultArray;
+
+                var data = await inputList.ToOutput().DataTask.ConfigureAwait(false);
+
+                Assert.Empty(data.Value);
+            });
+
+        [Fact]
         public Task MergeInputMaps()
             => RunInPreview(async () =>
             {
@@ -61,7 +100,7 @@ namespace Pulumi.Tests.Core
                 Assert.True(data.Value.ContainsValue("testValue"));
                 Assert.True(data.Value.ContainsValue(123));
             });
-        
+
         [Fact]
         public Task InputListUnionInitializer()
             => RunInPreview(async () =>

--- a/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
@@ -13,42 +13,21 @@ namespace Pulumi.Tests.Core
     public class InputTests : PulumiTest
     {
         [Fact]
-        public Task ConvertDefaultSimpleImmutableArray()
+        public Task InputListImplicitConversionFromDefaultImmutableArray()
             => RunInPreview(async () =>
             {
-                ImmutableArray<bool> defaultArray = default;
+                // Using explicit cast for the default value which then
+                // ends up being implicitly converted to InputList
+                await AssertCanConvert((ImmutableArray<bool>) default);
+                await AssertCanConvert((ImmutableArray<Input<bool>>) default);
+                await AssertCanConvert((ImmutableArray<Output<bool>>) default);
 
-                InputList<bool> inputList= defaultArray;
+                static async Task AssertCanConvert(InputList<bool> inputList)
+                {
+                    var data = await inputList.ToOutput().DataTask.ConfigureAwait(false);
 
-                var data = await inputList.ToOutput().DataTask.ConfigureAwait(false);
-
-                Assert.Empty(data.Value);
-            });
-
-        [Fact]
-        public Task ConvertDefaultInputImmutableArray()
-            => RunInPreview(async () =>
-            {
-                ImmutableArray<Input<bool>> defaultArray = default;
-
-                InputList<bool> inputList= defaultArray;
-
-                var data = await inputList.ToOutput().DataTask.ConfigureAwait(false);
-
-                Assert.Empty(data.Value);
-            });
-
-        [Fact]
-        public Task ConvertDefaultOutputImmutableArray()
-            => RunInPreview(async () =>
-            {
-                ImmutableArray<Output<bool>> defaultArray = default;
-
-                InputList<bool> inputList= defaultArray;
-
-                var data = await inputList.ToOutput().DataTask.ConfigureAwait(false);
-
-                Assert.Empty(data.Value);
+                    Assert.Empty(data.Value);
+                }
             });
 
         [Fact]

--- a/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
@@ -25,7 +25,6 @@ namespace Pulumi.Tests.Core
                 static async Task AssertCanConvert(InputList<bool> inputList)
                 {
                     var data = await inputList.ToOutput().DataTask.ConfigureAwait(false);
-
                     Assert.Empty(data.Value);
                 }
             });

--- a/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
@@ -247,7 +247,7 @@ namespace Pulumi.Tests.Core
                     Assert.False(data.IsSecret);
                     Assert.Null(data.Value);
                 });
-            
+
             [Fact]
             public Task AllParamsOutputs()
                 => RunInPreview(async () =>
@@ -258,7 +258,7 @@ namespace Pulumi.Tests.Core
                     var data = await o3.DataTask.ConfigureAwait(false);
                     Assert.Equal(new[] { 1, 2 }, data.Value);
                 });
-            
+
             [Fact]
             public Task AllEnumerableOutputs()
                 => RunInPreview(async () =>
@@ -281,7 +281,7 @@ namespace Pulumi.Tests.Core
                     var data = await o.DataTask.ConfigureAwait(false);
                     Assert.Equal(new[] { 1, 2 }, data.Value);
                 });
-            
+
             [Fact]
             public Task AllEnumerableInputs()
                 => RunInPreview(async () =>
@@ -293,7 +293,7 @@ namespace Pulumi.Tests.Core
                     var data = await o.DataTask.ConfigureAwait(false);
                     Assert.Equal(new[] { 1, 2 }, data.Value);
                 });
-            
+
             [Fact]
             public Task IsSecretAsyncOnKnownOutput()
                 => RunInPreview(async () =>
@@ -305,7 +305,7 @@ namespace Pulumi.Tests.Core
                     Assert.True(isSecret1);
                     Assert.False(isSecret2);
                 });
-            
+
             [Fact]
             public Task IsSecretAsyncOnAwaitableOutput()
                 => RunInPreview(async () =>
@@ -317,7 +317,7 @@ namespace Pulumi.Tests.Core
                     Assert.True(isSecret1);
                     Assert.False(isSecret2);
                 });
-            
+
             [Fact]
             public Task UnsecretOnKnownSecretValue()
                 => RunInPreview(async () =>
@@ -328,7 +328,7 @@ namespace Pulumi.Tests.Core
                     Assert.False(notSecretData.IsSecret);
                     Assert.Equal(1, notSecretData.Value);
                 });
-            
+
             [Fact]
             public Task UnsecretOnAwaitableSecretValue()
                 => RunInPreview(async () =>
@@ -339,7 +339,7 @@ namespace Pulumi.Tests.Core
                     Assert.False(notSecretData.IsSecret);
                     Assert.Equal("inner", notSecretData.Value);
                 });
-            
+
             [Fact]
             public Task UnsecretOnNonSecretValue()
                 => RunInPreview(async () =>
@@ -349,6 +349,32 @@ namespace Pulumi.Tests.Core
                     var notSecretData = await notSecret.DataTask.ConfigureAwait(false);
                     Assert.False(notSecretData.IsSecret);
                     Assert.Equal(2, notSecretData.Value);
+                });
+
+            [Fact]
+            public Task OutputAllInputImmutableArrayDefault()
+                => RunInPreview(async () =>
+                {
+                    ImmutableArray<Input<bool>> defaultArray = default;
+
+                    var output = Output.All(defaultArray);
+
+                    var result = await output.DataTask.ConfigureAwait(false);
+
+                    Assert.Empty(result.Value);
+                });
+
+            [Fact]
+            public Task OutputAllOutputImmutableArrayDefault()
+                => RunInPreview(async () =>
+                {
+                    ImmutableArray<Output<bool>> defaultArray = default;
+
+                    var output = Output.All(defaultArray);
+
+                    var result = await output.DataTask.ConfigureAwait(false);
+
+                    Assert.Empty(result.Value);
                 });
         }
 

--- a/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2016-2019, Pulumi Corporation
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
@@ -353,16 +354,10 @@ namespace Pulumi.Tests.Core
 
             [Fact]
             public Task OutputAllDefaultImmutableArray()
-                => RunInPreview(async () =>
+                => RunInPreview(() =>
                 {
-                    await AssertEmpty(Output.All((ImmutableArray<Input<bool>>) default));
-                    await AssertEmpty(Output.All((ImmutableArray<Output<bool>>) default));
-
-                    static async Task AssertEmpty(Output<ImmutableArray<bool>> output)
-                    {
-                        var result = await output.DataTask.ConfigureAwait(false);
-                        Assert.Empty(result.Value);
-                    }
+                    Assert.Throws<InvalidOperationException>(() => Output.All((ImmutableArray<Input<bool>>) default));
+                    Assert.Throws<InvalidOperationException>(() => Output.All((ImmutableArray<Output<bool>>) default));
                 });
         }
 

--- a/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/OutputTests.cs
@@ -352,29 +352,17 @@ namespace Pulumi.Tests.Core
                 });
 
             [Fact]
-            public Task OutputAllInputImmutableArrayDefault()
+            public Task OutputAllDefaultImmutableArray()
                 => RunInPreview(async () =>
                 {
-                    ImmutableArray<Input<bool>> defaultArray = default;
+                    await AssertEmpty(Output.All((ImmutableArray<Input<bool>>) default));
+                    await AssertEmpty(Output.All((ImmutableArray<Output<bool>>) default));
 
-                    var output = Output.All(defaultArray);
-
-                    var result = await output.DataTask.ConfigureAwait(false);
-
-                    Assert.Empty(result.Value);
-                });
-
-            [Fact]
-            public Task OutputAllOutputImmutableArrayDefault()
-                => RunInPreview(async () =>
-                {
-                    ImmutableArray<Output<bool>> defaultArray = default;
-
-                    var output = Output.All(defaultArray);
-
-                    var result = await output.DataTask.ConfigureAwait(false);
-
-                    Assert.Empty(result.Value);
+                    static async Task AssertEmpty(Output<ImmutableArray<bool>> output)
+                    {
+                        var result = await output.DataTask.ConfigureAwait(false);
+                        Assert.Empty(result.Value);
+                    }
                 });
         }
 

--- a/sdk/dotnet/Pulumi/Core/InputList.cs
+++ b/sdk/dotnet/Pulumi/Core/InputList.cs
@@ -120,7 +120,7 @@ namespace Pulumi
             => values.EnsureNotDefault().SelectAsArray(v => (Input<T>)v);
 
         public static implicit operator InputList<T>(ImmutableArray<Input<T>> values)
-            => Output.All(values);
+            => Output.All(values.EnsureNotDefault());
 
         #endregion
 
@@ -136,7 +136,7 @@ namespace Pulumi
             => values.Apply(a => ImmutableArray.CreateRange(a));
 
         public static implicit operator InputList<T>(Output<ImmutableArray<T>> values)
-            => new InputList<T>(values);
+            => new InputList<T>(values.Apply(v => v.EnsureNotDefault()));
 
         #endregion
 

--- a/sdk/dotnet/Pulumi/Core/InputList.cs
+++ b/sdk/dotnet/Pulumi/Core/InputList.cs
@@ -114,10 +114,10 @@ namespace Pulumi
         #region construct from immutable array
 
         public static implicit operator InputList<T>(ImmutableArray<T> values)
-            => values.SelectAsArray(v => (Input<T>)v);
+            => values.EnsureNotDefault().SelectAsArray(v => (Input<T>)v);
 
         public static implicit operator InputList<T>(ImmutableArray<Output<T>> values)
-            => values.SelectAsArray(v => (Input<T>)v);
+            => values.EnsureNotDefault().SelectAsArray(v => (Input<T>)v);
 
         public static implicit operator InputList<T>(ImmutableArray<Input<T>> values)
             => Output.All(values);

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -58,7 +58,13 @@ namespace Pulumi
         /// </summary>
         public static Output<ImmutableArray<T>> All<T>(IEnumerable<Input<T>> inputs)
             => Output<T>.All(ImmutableArray.CreateRange(inputs));
-        
+
+        /// <summary>
+        /// <see cref="All{T}(Input{T}[])"/> for more details.
+        /// </summary>
+        public static Output<ImmutableArray<T>> All<T>(ImmutableArray<Input<T>> inputs)
+            => Output<T>.All(ImmutableArray.CreateRange(inputs.EnsureNotDefault()));
+
         /// <summary>
         /// Combines all the <see cref="Output{T}"/> values in <paramref name="outputs"/>
         /// into a single <see cref="Output{T}"/> with an <see cref="ImmutableArray{T}"/>
@@ -74,6 +80,12 @@ namespace Pulumi
         /// </summary>
         public static Output<ImmutableArray<T>> All<T>(IEnumerable<Output<T>> outputs)
             => Output<T>.All(ImmutableArray.CreateRange(outputs.Select(o => (Input<T>)o)));
+
+        /// <summary>
+        /// <see cref="All{T}(Output{T}[])"/> for more details.
+        /// </summary>
+        public static Output<ImmutableArray<T>> All<T>(ImmutableArray<Output<T>> outputs)
+            => Output<T>.All(ImmutableArray.CreateRange(outputs.EnsureNotDefault().Select(o => (Input<T>)o)));
 
         /// <summary>
         /// Takes in a <see cref="FormattableString"/> with potential <see cref="Input{T}"/>s or

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -57,13 +57,10 @@ namespace Pulumi
         /// <see cref="All{T}(Input{T}[])"/> for more details.
         /// </summary>
         public static Output<ImmutableArray<T>> All<T>(IEnumerable<Input<T>> inputs)
-            => Output<T>.All(ImmutableArray.CreateRange(inputs));
-
-        /// <summary>
-        /// <see cref="All{T}(Input{T}[])"/> for more details.
-        /// </summary>
-        public static Output<ImmutableArray<T>> All<T>(ImmutableArray<Input<T>> inputs)
-            => Output<T>.All(ImmutableArray.CreateRange(inputs.EnsureNotDefault()));
+            => Output<T>.All(ImmutableArray.CreateRange(inputs switch {
+                   ImmutableArray<Input<T>> immutable => immutable.EnsureNotDefault(),
+                   _ => inputs,
+               }));
 
         /// <summary>
         /// Combines all the <see cref="Output{T}"/> values in <paramref name="outputs"/>
@@ -79,13 +76,10 @@ namespace Pulumi
         /// <see cref="All{T}(Output{T}[])"/> for more details.
         /// </summary>
         public static Output<ImmutableArray<T>> All<T>(IEnumerable<Output<T>> outputs)
-            => Output<T>.All(ImmutableArray.CreateRange(outputs.Select(o => (Input<T>)o)));
-
-        /// <summary>
-        /// <see cref="All{T}(Output{T}[])"/> for more details.
-        /// </summary>
-        public static Output<ImmutableArray<T>> All<T>(ImmutableArray<Output<T>> outputs)
-            => Output<T>.All(ImmutableArray.CreateRange(outputs.EnsureNotDefault().Select(o => (Input<T>)o)));
+            => Output<T>.All(ImmutableArray.CreateRange((outputs switch {
+                   ImmutableArray<Output<T>> immutable => immutable.EnsureNotDefault(),
+                   _ => outputs,
+               }).Select(o => (Input<T>)o)));
 
         /// <summary>
         /// Takes in a <see cref="FormattableString"/> with potential <see cref="Input{T}"/>s or

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -57,10 +57,7 @@ namespace Pulumi
         /// <see cref="All{T}(Input{T}[])"/> for more details.
         /// </summary>
         public static Output<ImmutableArray<T>> All<T>(IEnumerable<Input<T>> inputs)
-            => Output<T>.All(ImmutableArray.CreateRange(inputs switch {
-                   ImmutableArray<Input<T>> immutable => immutable.EnsureNotDefault(),
-                   _ => inputs,
-               }));
+            => Output<T>.All(ImmutableArray.CreateRange(inputs));
 
         /// <summary>
         /// Combines all the <see cref="Output{T}"/> values in <paramref name="outputs"/>
@@ -76,10 +73,7 @@ namespace Pulumi
         /// <see cref="All{T}(Output{T}[])"/> for more details.
         /// </summary>
         public static Output<ImmutableArray<T>> All<T>(IEnumerable<Output<T>> outputs)
-            => Output<T>.All(ImmutableArray.CreateRange((outputs switch {
-                   ImmutableArray<Output<T>> immutable => immutable.EnsureNotDefault(),
-                   _ => outputs,
-               }).Select(o => (Input<T>)o)));
+            => Output<T>.All(ImmutableArray.CreateRange(outputs.Select(o => (Input<T>)o)));
 
         /// <summary>
         /// Takes in a <see cref="FormattableString"/> with potential <see cref="Input{T}"/>s or

--- a/sdk/dotnet/Pulumi/Extensions.cs
+++ b/sdk/dotnet/Pulumi/Extensions.cs
@@ -27,6 +27,7 @@ namespace Pulumi
             value = pair.Value;
         }
 
+
         public static Output<object?> ToObjectOutput(this object? obj)
         {
             var output = obj is IInput input ? input.ToOutput() : obj as IOutput;
@@ -34,6 +35,9 @@ namespace Pulumi
                 ? new Output<object?>(output.GetDataAsync())
                 : Output.Create(obj);
         }
+
+        public static ImmutableArray<TItem> EnsureNotDefault<TItem>(this ImmutableArray<TItem> items)
+            => items.IsDefault ? ImmutableArray<TItem>.Empty : items;
 
         public static ImmutableArray<TResult> SelectAsArray<TItem, TResult>(this ImmutableArray<TItem> items, Func<TItem, TResult> map)
             => ImmutableArray.CreateRange(items, map);

--- a/sdk/dotnet/Pulumi/Extensions.cs
+++ b/sdk/dotnet/Pulumi/Extensions.cs
@@ -27,7 +27,6 @@ namespace Pulumi
             value = pair.Value;
         }
 
-
         public static Output<object?> ToObjectOutput(this object? obj)
         {
             var output = obj is IInput input ? input.ToOutput() : obj as IOutput;

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -295,8 +295,6 @@ static Pulumi.Log.Info(string message, Pulumi.Resource resource = null, int? str
 static Pulumi.Log.Warn(string message, Pulumi.Resource resource = null, int? streamId = null, bool? ephemeral = null) -> void
 static Pulumi.Output.All<T>(System.Collections.Generic.IEnumerable<Pulumi.Input<T>> inputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
 static Pulumi.Output.All<T>(System.Collections.Generic.IEnumerable<Pulumi.Output<T>> outputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
-static Pulumi.Output.All<T>(System.Collections.Immutable.ImmutableArray<Pulumi.Input<T>> inputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
-static Pulumi.Output.All<T>(System.Collections.Immutable.ImmutableArray<Pulumi.Output<T>> outputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
 static Pulumi.Output.All<T>(params Pulumi.Input<T>[] inputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
 static Pulumi.Output.All<T>(params Pulumi.Output<T>[] outputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
 static Pulumi.Output.Create<T>(System.Threading.Tasks.Task<T> value) -> Pulumi.Output<T>

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -295,6 +295,8 @@ static Pulumi.Log.Info(string message, Pulumi.Resource resource = null, int? str
 static Pulumi.Log.Warn(string message, Pulumi.Resource resource = null, int? streamId = null, bool? ephemeral = null) -> void
 static Pulumi.Output.All<T>(System.Collections.Generic.IEnumerable<Pulumi.Input<T>> inputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
 static Pulumi.Output.All<T>(System.Collections.Generic.IEnumerable<Pulumi.Output<T>> outputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
+static Pulumi.Output.All<T>(System.Collections.Immutable.ImmutableArray<Pulumi.Input<T>> inputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
+static Pulumi.Output.All<T>(System.Collections.Immutable.ImmutableArray<Pulumi.Output<T>> outputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
 static Pulumi.Output.All<T>(params Pulumi.Input<T>[] inputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
 static Pulumi.Output.All<T>(params Pulumi.Output<T>[] outputs) -> Pulumi.Output<System.Collections.Immutable.ImmutableArray<T>>
 static Pulumi.Output.Create<T>(System.Threading.Tasks.Task<T> value) -> Pulumi.Output<T>


### PR DESCRIPTION
I discovered an issue with `Pulumi.Kubernetes.Helm.V3.Charts` pulumi/pulumi-kubernetes#1496
when trying to write unit tests in C# for a stack using Helm charts.

After looking at the problem, I think the problem can be solved inside the core Pulumi SDK.

The problem occurs when an InputList is initialized from a default `ImmutableArray` using the
implicit conversion operator. The conversion operator eventually calls `ImmutableArray.CreateRange`,
which ends up failing due to accessing an uninitialized array.

This PR now adds some extra safeguards to both `InputList` and `Output` types against
`ImmutableArray` values which have `IsDefault` true.

The `InputList` fix is necessary, as implicit conversion operations should not fail.
So when given an array with `IsDefault` `true`, we return `ImmutableArray<T>.Empty` instead.

I also applied same logic to `Output.All` overloads.