### PR TITLE
Fix `pulumi refresh` diffs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 
 ### Improvements
 
+- [cli] Improve diff displays during `pulumi refresh`
+  [#6568](https://github.com/pulumi/pulumi/pull/6568)
 
 ### Bug Fixes
 

--- a/pkg/backend/display/rows.go
+++ b/pkg/backend/display/rows.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dustin/go-humanize/english"
 	"github.com/pulumi/pulumi/pkg/v2/engine"
 	"github.com/pulumi/pulumi/pkg/v2/resource/deploy"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource"
@@ -342,7 +343,7 @@ func (data *resourceRowData) getInfoColumn() string {
 		diagMsg += msg
 	}
 
-	changes := getDiffInfo(step)
+	changes := getDiffInfo(step, data.display.action)
 	if colors.Never.Colorize(changes) != "" {
 		appendDiagMessage("[" + changes + "]")
 	}
@@ -397,8 +398,8 @@ func (data *resourceRowData) getInfoColumn() string {
 	return diagMsg
 }
 
-func getDiffInfo(step engine.StepEventMetadata) string {
-	diffOutputs := step.Op == deploy.OpRefresh
+func getDiffInfo(step engine.StepEventMetadata, action apitype.UpdateKind) string {
+	diffOutputs := action == apitype.RefreshUpdate
 	changesBuf := &bytes.Buffer{}
 	if step.Old != nil && step.New != nil {
 		var diff *resource.ObjectDiff


### PR DESCRIPTION
Refresh diffs should be diffs of *outputs* not *inputs*.  The code was previously attempting to do this - but was not correct because OpRefresh transmogrifies itself into OpUpdate, OpSame or OpDelete as it is processed, and so those resulting operations (which were what shows the diff) would render their input diff as normal.

Instead, decide whether to render refresh-based output diffs based on whether the action being performed is a `pulumi refresh` instead of using the Op kind.

**Before:**

```
     Type                                   Name                                   Plan       Info
     pulumi:pulumi:Stack                    refresh-test-luke-dev                             
     ├─ aws:s3:Bucket                       b                                                 
     │  ├─ aws:s3:BucketEventSubscription   newObj                                            
     │  │  ├─ aws:iam:Policy                newObj-LambdaFullAccess                           
     │  │  ├─ aws:iam:RolePolicyAttachment  newObj-lambdaFullAccessCopyAttachment             [diff: -__defaults]
 ~   │  │  ├─ aws:iam:Role                  newObj                                 update     [diff: ~assumeRolePolicy]
     │  │  ├─ aws:lambda:Permission         newObj                                            
 ~   │  │  └─ aws:lambda:Function           newObj                                 update     [diff: ~code]
     │  └─ aws:s3:BucketNotification        newObj                                            [diff: -__defaults~lambdaFunctions]
     ├─ aws:ec2:SecurityGroup               web-secgrp                                        [diff: ~ingress]
     └─ aws:ec2:Instance                    web-server-www                                    [diff: ~tags]
 
Resources:
    ~ 2 to update
    9 unchanged
```

**After:**

```
     Type                                   Name                                   Plan       Info
     pulumi:pulumi:Stack                    refresh-test-luke-dev                             
     ├─ aws:s3:Bucket                       b                                                 
     │  ├─ aws:s3:BucketEventSubscription   newObj                                            
     │  │  ├─ aws:iam:Policy                newObj-LambdaFullAccess                           
 ~   │  │  ├─ aws:iam:Role                  newObj                                 update     [diff: ~managedPolicyArns]
     │  │  ├─ aws:iam:RolePolicyAttachment  newObj-lambdaFullAccessCopyAttachment             
     │  │  ├─ aws:lambda:Permission         newObj                                            
 ~   │  │  └─ aws:lambda:Function           newObj                                 update     [diff: ~code,lastModified]
     │  └─ aws:s3:BucketNotification        newObj                                            
     ├─ aws:ec2:SecurityGroup               web-secgrp                                        
     └─ aws:ec2:Instance                    web-server-www                                    
 
Resources:
    ~ 2 to update
    9 unchanged
```

The after above captures what is actually changed (module the `~code` diff, which is due to https://github.com/pulumi/pulumi/issues/6235).

Related to #6243, #5713, #5816 and possibly others.