### PR TITLE
Fix docstring on node log.error and other SDK equivalents

### DIFF
--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Logger.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Logger.cs
@@ -66,10 +66,8 @@ namespace Pulumi
             }
 
             /// <summary>
-            /// Logs a fatal condition. Calling ErrorAsync does not by
-            /// itself stop processing resource operations. To stop
-            /// programs should raise unhandled exceptions after
-            /// calling ErrorAsync.
+            /// Logs a fatal condition. Consider raising an exception
+            /// after calling this method to stop the Pulumi program.
             /// </summary>
             Task ILogger.ErrorAsync(string message, Resource? resource, int? streamId, bool? ephemeral)
                 => ErrorAsync(message, resource, streamId, ephemeral);

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.Logger.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.Logger.cs
@@ -66,8 +66,10 @@ namespace Pulumi
             }
 
             /// <summary>
-            /// Error logs a fatal error to indicate that the tool should stop processing resource
-            /// operations immediately.
+            /// Logs a fatal condition. Calling ErrorAsync does not by
+            /// itself stop processing resource operations. To stop
+            /// programs should raise unhandled exceptions after
+            /// calling ErrorAsync.
             /// </summary>
             Task ILogger.ErrorAsync(string message, Resource? resource, int? streamId, bool? ephemeral)
                 => ErrorAsync(message, resource, streamId, ephemeral);

--- a/sdk/dotnet/Pulumi/Log.cs
+++ b/sdk/dotnet/Pulumi/Log.cs
@@ -31,17 +31,15 @@ namespace Pulumi
             => Deployment.InternalInstance.Logger.WarnAsync(message, resource, streamId, ephemeral);
 
         /// <summary>
-        /// Logs a fatal condition. Calling Error does not by itself
-        /// stop processing resource operations. To stop programs
-        /// should raise unhandled exceptions after calling Error.
+        /// Logs a fatal condition. Consider raising an exception
+        /// after calling Error to stop the Pulumi program.
         /// </summary>
         public static void Error(string message, Resource? resource = null, int? streamId = null, bool? ephemeral = null)
             => Deployment.InternalInstance.Logger.ErrorAsync(message, resource, streamId, ephemeral);
 
         /// <summary>
-        /// Logs an exception. Calling Exception does not by itself
-        /// stop processing resource operations. To stop programs
-        /// should raise unhandled exceptions after calling Exception.
+        /// Logs an exception. Consider raising the exception after
+        /// calling this method to stop the Pulumi program.
         /// </summary>
         public static void Exception(Exception exception, Resource? resource = null, int? streamId = null, bool? ephemeral = null)
             => Error(exception.ToString(), resource, streamId, ephemeral);

--- a/sdk/dotnet/Pulumi/Log.cs
+++ b/sdk/dotnet/Pulumi/Log.cs
@@ -31,15 +31,17 @@ namespace Pulumi
             => Deployment.InternalInstance.Logger.WarnAsync(message, resource, streamId, ephemeral);
 
         /// <summary>
-        /// Logs a fatal error to indicate that the tool should stop processing resource
-        /// operations immediately.
+        /// Logs a fatal condition. Calling Error does not by itself
+        /// stop processing resource operations. To stop programs
+        /// should raise unhandled exceptions after calling Error.
         /// </summary>
         public static void Error(string message, Resource? resource = null, int? streamId = null, bool? ephemeral = null)
             => Deployment.InternalInstance.Logger.ErrorAsync(message, resource, streamId, ephemeral);
 
         /// <summary>
-        /// Logs a fatal exception to indicate that the tool should stop processing resource
-        /// operations immediately.
+        /// Logs an exception. Calling Exception does not by itself
+        /// stop processing resource operations. To stop programs
+        /// should raise unhandled exceptions after calling Exception.
         /// </summary>
         public static void Exception(Exception exception, Resource? resource = null, int? streamId = null, bool? ephemeral = null)
             => Error(exception.ToString(), resource, streamId, ephemeral);

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -69,9 +69,8 @@ func (log *logState) Warn(msg string, args *LogArgs) error {
 	return _log(log.ctx, log.engine, pulumirpc.LogSeverity_WARNING, msg, args)
 }
 
-// Logs a fatal condition. Calling Error does not by itself stop
-// processing resource operations. To stop programs should panic or
-// explicitly return a non-nil error object early after calling Error.
+// Logs a fatal condition. Consider returning a non-nil error object
+// after calling Error to stop the Pulumi program.
 func (log *logState) Error(msg string, args *LogArgs) error {
 	return _log(log.ctx, log.engine, pulumirpc.LogSeverity_ERROR, msg, args)
 }

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -69,7 +69,9 @@ func (log *logState) Warn(msg string, args *LogArgs) error {
 	return _log(log.ctx, log.engine, pulumirpc.LogSeverity_WARNING, msg, args)
 }
 
-// Logs a fatal error to indicate that the tool should stop processing resource
+// Logs a fatal condition. Calling Error does not by itself stop
+// processing resource operations. To stop programs should panic or
+// explicitly return a non-nil error object early after calling Error.
 func (log *logState) Error(msg string, args *LogArgs) error {
 	return _log(log.ctx, log.engine, pulumirpc.LogSeverity_ERROR, msg, args)
 }

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -70,9 +70,7 @@ export function warn(msg: string, resource?: resourceTypes.Resource, streamId?: 
 }
 
 /**
- * error logs a fatal condition. Calling error does not by itself stop
- * processing resource operations. To stop programs should raise
- * unhandled exceptions after calling error.
+ * error logs a fatal condition. Consider raising an exception after calling error to stop the Pulumi program.
  */
 export function error(msg: string, resource?: resourceTypes.Resource, streamId?: number, ephemeral?: boolean) {
     errcnt++; // remember the error so we can suppress leaks.

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -70,7 +70,9 @@ export function warn(msg: string, resource?: resourceTypes.Resource, streamId?: 
 }
 
 /**
- * error logs a fatal error to indicate that the tool should stop processing resource operations immediately.
+ * error logs a fatal condition. Calling error does not by itself stop
+ * processing resource operations. To stop programs should raise
+ * unhandled exceptions after calling error.
  */
 export function error(msg: string, resource?: resourceTypes.Resource, streamId?: number, ephemeral?: boolean) {
     errcnt++; // remember the error so we can suppress leaks.

--- a/sdk/python/lib/pulumi/log.py
+++ b/sdk/python/lib/pulumi/log.py
@@ -74,12 +74,17 @@ def warn(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[in
 
 def error(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[int] = None, ephemeral: Optional[bool] = None):
     """
-    Logs a message to the Pulumi CLI's error channel, associating it with a resource
-    and stream_id if provided.
+    Logs a message to the Pulumi CLI's error channel, associating it
+    with a resource and stream_id if provided.
+
+    Calling error does not by itself stop processing resource
+    operations. To stop programs should raise unhandled errors after
+    calling this function.
 
     :param str msg: The message to send to the Pulumi CLI.
     :param Optional[Resource] resource: If provided, associate this message with the given resource in the Pulumi CLI.
     :param Optional[int] stream_id: If provided, associate this message with a stream of other messages.
+
     """
     engine = get_engine()
     if engine is not None:

--- a/sdk/python/lib/pulumi/log.py
+++ b/sdk/python/lib/pulumi/log.py
@@ -77,9 +77,7 @@ def error(msg: str, resource: Optional['Resource'] = None, stream_id: Optional[i
     Logs a message to the Pulumi CLI's error channel, associating it
     with a resource and stream_id if provided.
 
-    Calling error does not by itself stop processing resource
-    operations. To stop programs should raise unhandled errors after
-    calling this function.
+    Consider raising an exception after calling error to stop the Pulumi program.
 
     :param str msg: The message to send to the Pulumi CLI.
     :param Optional[Resource] resource: If provided, associate this message with the given resource in the Pulumi CLI.


### PR DESCRIPTION
Resolves https://github.com/pulumi/pulumi/issues/6090 by updating docs to reflect current non-terminating behavior of log.error and equivalents.

- [x] node SDK
- [x] golang SDK
- [x] dotnet SDK
- [x] python SDK
