### PR TITLE
[sdk/go] Cache loaded configuration files

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 
 ### Improvements
 
+- [sdk/go] Cache loaded configuration files.
+  [#6576](https://github.com/pulumi/pulumi/pull/6576)
 
 ### Bug Fixes
 

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -63,11 +63,9 @@ func (singleton *projectLoader) load(path string) (*Project, error) {
 			return nil, fmt.Errorf("project path already set: %q, unexpected path: %q", singleton.path, path)
 		}
 
-		fmt.Println("Using Project singleton")
 		return singleton.internal, nil
 	}
 
-	fmt.Println("Initializing Project singleton")
 	marshaller, err := marshallerForPath(path)
 	if err != nil {
 		return nil, err
@@ -105,11 +103,9 @@ func (singleton *projectStackLoader) load(path string) (*ProjectStack, error) {
 	defer singleton.Unlock()
 
 	if v, ok := singleton.internal[path]; ok {
-		fmt.Println("Using ProjectStack singleton")
 		return v, nil
 	}
 
-	fmt.Println("Initializing ProjectStack singleton")
 	marshaler, err := marshallerForPath(path)
 	if err != nil {
 		return nil, err

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -1,0 +1,249 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workspace
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sync"
+
+	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/config"
+	"github.com/pulumi/pulumi/sdk/v2/go/common/util/contract"
+)
+
+// projectSingleton is a singleton instance of projectLoader, which controls a global instance of the Project config.
+var projectSingleton *projectLoader = &projectLoader{}
+
+// projectStackSingleton is a singleton instance of projectStackLoader, which controls a global map of instances of
+// ProjectStack configs (one per path).
+var projectStackSingleton *projectStackLoader = &projectStackLoader{
+	internal: map[string]*ProjectStack{},
+}
+
+// pluginProjectSingleton is a singleton instance of pluginProjectLoader, which controls a global map of instances of
+// PluginProject configs (one per path).
+var pluginProjectSingleton *pluginProjectLoader = &pluginProjectLoader{
+	internal: map[string]*PluginProject{},
+}
+
+// policyPackProjectSingleton is a singleton instance of policyPackProjectLoader, which controls a global map of
+// instances of PolicyPackProject configs (one per path).
+var policyPackProjectSingleton *policyPackProjectLoader = &policyPackProjectLoader{
+	internal: map[string]*PolicyPackProject{},
+}
+
+// projectLoader is used to load a single global instance of a Project config.
+type projectLoader struct {
+	sync.RWMutex
+	path     string
+	internal *Project
+}
+
+// Load a Project config file from the specified path. The configuration will be cached for subsequent loads.
+func (singleton *projectLoader) load(path string) (*Project, error) {
+	singleton.Lock()
+	defer singleton.Unlock()
+
+	if singleton.internal != nil {
+		// Currently, we only support a single Project.yaml per workspace, so return an error if another path is set.
+		if singleton.path != path {
+			return nil, fmt.Errorf("project path already set: %q, unexpected path: %q", singleton.path, path)
+		}
+
+		fmt.Println("Using Project singleton")
+		return singleton.internal, nil
+	}
+
+	fmt.Println("Initializing Project singleton")
+	marshaller, err := marshallerForPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var project Project
+	err = marshaller.Unmarshal(b, &project)
+	if err != nil {
+		return nil, err
+	}
+
+	err = project.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	singleton.internal, singleton.path = &project, path
+	return singleton.internal, nil
+}
+
+// projectStackLoader is used to load a single global instance of a ProjectStack config.
+type projectStackLoader struct {
+	sync.RWMutex
+	internal map[string]*ProjectStack
+}
+
+// Load a ProjectStack config file from the specified path. The configuration will be cached for subsequent loads.
+func (singleton *projectStackLoader) load(path string) (*ProjectStack, error) {
+	singleton.Lock()
+	defer singleton.Unlock()
+
+	if v, ok := singleton.internal[path]; ok {
+		fmt.Println("Using ProjectStack singleton")
+		return v, nil
+	}
+
+	fmt.Println("Initializing ProjectStack singleton")
+	marshaler, err := marshallerForPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var projectStack ProjectStack
+	b, err := ioutil.ReadFile(path)
+	if os.IsNotExist(err) {
+		projectStack = ProjectStack{
+			Config: make(config.Map),
+		}
+		singleton.internal[path] = &projectStack
+		return &projectStack, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	err = marshaler.Unmarshal(b, &projectStack)
+	if err != nil {
+		return nil, err
+	}
+
+	if projectStack.Config == nil {
+		projectStack.Config = make(config.Map)
+	}
+
+	singleton.internal[path] = &projectStack
+	return &projectStack, nil
+}
+
+// pluginProjectLoader is used to load a single global instance of a PluginProject config.
+type pluginProjectLoader struct {
+	sync.RWMutex
+	internal map[string]*PluginProject
+}
+
+// Load a PluginProject config file from the specified path. The configuration will be cached for subsequent loads.
+func (singleton *pluginProjectLoader) load(path string) (*PluginProject, error) {
+	singleton.Lock()
+	defer singleton.Unlock()
+
+	if result, ok := singleton.internal[path]; ok {
+		return result, nil
+	}
+
+	marshaller, err := marshallerForPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var pluginProject PluginProject
+	err = marshaller.Unmarshal(b, &pluginProject)
+	if err != nil {
+		return nil, err
+	}
+
+	err = pluginProject.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	singleton.internal[path] = &pluginProject
+	return &pluginProject, nil
+}
+
+// policyPackProjectLoader is used to load a single global instance of a PolicyPackProject config.
+type policyPackProjectLoader struct {
+	sync.RWMutex
+	internal map[string]*PolicyPackProject
+}
+
+// Load a PolicyPackProject config file from the specified path. The configuration will be cached for subsequent loads.
+func (singleton *policyPackProjectLoader) load(path string) (*PolicyPackProject, error) {
+	singleton.Lock()
+	defer singleton.Unlock()
+
+	if result, ok := singleton.internal[path]; ok {
+		return result, nil
+	}
+
+	marshaller, err := marshallerForPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var policyPackProject PolicyPackProject
+	err = marshaller.Unmarshal(b, &policyPackProject)
+	if err != nil {
+		return nil, err
+	}
+
+	err = policyPackProject.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	singleton.internal[path] = &policyPackProject
+	return &policyPackProject, nil
+}
+
+// LoadProject reads a project definition from a file.
+func LoadProject(path string) (*Project, error) {
+	contract.Require(path != "", "path")
+
+	return projectSingleton.load(path)
+}
+
+// LoadProjectStack reads a stack definition from a file.
+func LoadProjectStack(path string) (*ProjectStack, error) {
+	contract.Require(path != "", "path")
+
+	return projectStackSingleton.load(path)
+}
+
+// LoadPluginProject reads a plugin project definition from a file.
+func LoadPluginProject(path string) (*PluginProject, error) {
+	contract.Require(path != "", "path")
+
+	return pluginProjectSingleton.load(path)
+}
+
+// LoadPolicyPack reads a policy pack definition from a file.
+func LoadPolicyPack(path string) (*PolicyPackProject, error) {
+	contract.Require(path != "", "path")
+
+	return policyPackProjectSingleton.load(path)
+}

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-
 	"github.com/pulumi/pulumi/sdk/v2/go/common/encoding"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v2/go/common/tokens"
@@ -274,121 +273,6 @@ func (info *ProjectRuntimeInfo) UnmarshalYAML(unmarshal func(interface{}) error)
 	}
 
 	return errors.New("runtime section must be a string or an object with name and options attributes")
-}
-
-// LoadProject reads a project definition from a file.
-func LoadProject(path string) (*Project, error) {
-	contract.Require(path != "", "path")
-
-	m, err := marshallerForPath(path)
-	if err != nil {
-		return nil, err
-	}
-
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var proj Project
-	err = m.Unmarshal(b, &proj)
-	if err != nil {
-		return nil, err
-	}
-
-	err = proj.Validate()
-	if err != nil {
-		return nil, err
-	}
-
-	return &proj, err
-}
-
-// LoadPolicyPack reads a policy pack definition from a file.
-func LoadPolicyPack(path string) (*PolicyPackProject, error) {
-	contract.Require(path != "", "path")
-
-	m, err := marshallerForPath(path)
-	if err != nil {
-		return nil, err
-	}
-
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var proj PolicyPackProject
-	err = m.Unmarshal(b, &proj)
-	if err != nil {
-		return nil, err
-	}
-
-	err = proj.Validate()
-	if err != nil {
-		return nil, err
-	}
-
-	return &proj, err
-}
-
-// LoadPluginProject reads a plugin project definition from a file.
-func LoadPluginProject(path string) (*PluginProject, error) {
-	contract.Require(path != "", "path")
-
-	m, err := marshallerForPath(path)
-	if err != nil {
-		return nil, err
-	}
-
-	b, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-
-	var proj PluginProject
-	err = m.Unmarshal(b, &proj)
-	if err != nil {
-		return nil, err
-	}
-
-	err = proj.Validate()
-	if err != nil {
-		return nil, err
-	}
-
-	return &proj, err
-}
-
-// LoadProjectStack reads a stack definition from a file.
-func LoadProjectStack(path string) (*ProjectStack, error) {
-	contract.Require(path != "", "path")
-
-	m, err := marshallerForPath(path)
-	if err != nil {
-		return nil, err
-	}
-
-	b, err := ioutil.ReadFile(path)
-	if os.IsNotExist(err) {
-		return &ProjectStack{
-			Config: make(config.Map),
-		}, nil
-	} else if err != nil {
-		return nil, err
-	}
-
-	var ps ProjectStack
-	err = m.Unmarshal(b, &ps)
-	if err != nil {
-		return nil, err
-	}
-
-	if ps.Config == nil {
-		ps.Config = make(config.Map)
-	}
-
-	return &ps, err
 }
 
 func marshallerForPath(path string) (encoding.Marshaler, error) {


### PR DESCRIPTION
Previously, the CLI did not cache configuration files, which
required a read from disk + unmarshalling + validation each
time a consumer needed to read one of these configurations.
This change introduces global caches for each type of Pulumi
configuration file (Project, ProjectStack, PolicyPackProject, and
PluginProject). The configuration is cached after the first request
and the cached value will be used for any subsequent operations.

Important note: The global configurations are not thread safe,
but this same problem exists using the previous method of
reading/writing config files on disk. Synchronization
will be added in a follow up change to allow for thread safe config
operations.

Fix https://github.com/pulumi/pulumi/issues/6564

Here's an example `pulumi up` to show the new behavior:
```
Initializing Project singleton
Using Project singleton
Using Project singleton
Using Project singleton
Using Project singleton
Using Project singleton
Using Project singleton
Initializing ProjectStack singleton
Using Project singleton
Using ProjectStack singleton
Using Project singleton
Using ProjectStack singleton
```
Previously, each of these logs would have corresponded to a separate load from disk operation.