### PR TITLE
[sdk/go] Add config.SyncMap to support config concurrency

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,8 +3,8 @@
 
 ### Improvements
 
-- [cli] Improve diff displays during `pulumi refresh`
-  [#6568](https://github.com/pulumi/pulumi/pull/6568)
+- [sdk/go] Add config.SyncMap to support config concurrency.
+  [#6579](https://github.com/pulumi/pulumi/pull/6579)
 
 - [sdk/go] Cache loaded configuration files.
   [#6576](https://github.com/pulumi/pulumi/pull/6576)


### PR DESCRIPTION
Add a new config.SyncMap type that wraps the Map
type, which is used for Pulumi config values. SyncMap
overloads all Map methods but adds locking around the
method calls. This is not quite as performant as modifying
the Map type, but avoids the need for a breaking change.

Part of #6578 