### PR TITLE
[automation/nodejs] - Implement min version checking

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,9 @@
 
 - [sdk/go] Cache loaded configuration files.
   [#6576](https://github.com/pulumi/pulumi/pull/6576)
+
+- [automation/nodejs] Implement minimum version checking and add `LocalWorkspace.pulumiVersion`.
+  [#6580](https://github.com/pulumi/pulumi/pull/6580)
   
 ### Bug Fixes
 

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -18,13 +18,13 @@ import * as upath from "upath";
 
 import { Config } from "../../index";
 import {
-    checkVersionIsValid,
     ConfigMap,
     EngineEvent,
     fullyQualifiedStackName,
     LocalWorkspace,
     ProjectSettings,
     Stack,
+    validatePulumiVersion,
 } from "../../x/automation";
 import { asyncTest } from "../util";
 
@@ -436,9 +436,13 @@ describe(`checkVersionIsValid`, () => {
             const minVersion = new semver.SemVer(test.minVersion);
 
             if (test.expectError) {
-                assert.throws(() => checkVersionIsValid(minVersion, currentVersion), /Minimum version requirement failed. The minimum CLI version requirement is/);
+                if (minVersion.major < currentVersion.major) {
+                    assert.throws(() => validatePulumiVersion(minVersion, currentVersion), /Major version mismatch./);
+                } else {
+                    assert.throws(() => validatePulumiVersion(minVersion, currentVersion), /Minimum version requirement failed./);
+                }
             } else {
-                assert.doesNotThrow(() => checkVersionIsValid(minVersion, currentVersion));
+                assert.doesNotThrow(() => validatePulumiVersion(minVersion, currentVersion));
             }
         });
     });

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -28,7 +28,7 @@ import {
 } from "../../x/automation";
 import { asyncTest } from "../util";
 
-const versionRegex = /v(\d+\.)(\d+\.)(\d+)(-.*)?/;
+const versionRegex = /(\d+\.)(\d+\.)(\d+)(-.*)?/;
 
 describe("LocalWorkspace", () => {
     it(`projectSettings from yaml/yml/json`, asyncTest(async () => {
@@ -433,11 +433,10 @@ describe(`checkVersionIsValid`, () => {
 
     versionTests.forEach(test => {
         it(`validates ${test.minVersion}`, () => {
-            assert(true);
             const minVersion = new semver.SemVer(test.minVersion);
 
             if (test.expectError) {
-                assert.throws(() => checkVersionIsValid(minVersion, currentVersion));
+                assert.throws(() => checkVersionIsValid(minVersion, currentVersion), /Minimum version requirement failed. The minimum CLI version requirement is/);
             } else {
                 assert.doesNotThrow(() => checkVersionIsValid(minVersion, currentVersion));
             }

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as assert from "assert";
+import * as semver from "semver";
 import * as upath from "upath";
 
 import { Config } from "../../index";
@@ -24,7 +25,6 @@ import {
     LocalWorkspace,
     ProjectSettings,
     Stack,
-    Version,
 } from "../../x/automation";
 import { asyncTest } from "../util";
 
@@ -429,12 +429,12 @@ describe(`checkVersionIsValid`, () => {
             expectError: false,
         },
     ];
-    const currentVersion = new Version("v2.21.1");
+    const currentVersion = new semver.SemVer("v2.21.1");
 
     versionTests.forEach(test => {
         it(`validates ${test.minVersion}`, () => {
             assert(true);
-            const minVersion = new Version(test.minVersion);
+            const minVersion = new semver.SemVer(test.minVersion);
 
             if (test.expectError) {
                 assert.throws(() => checkVersionIsValid(minVersion, currentVersion));

--- a/sdk/nodejs/tsconfig.json
+++ b/sdk/nodejs/tsconfig.json
@@ -72,6 +72,7 @@
         "x/automation/cmd.ts",
         "x/automation/config.ts",
         "x/automation/localWorkspace.ts",
+        "x/automation/minimumVersion.ts",
         "x/automation/projectSettings.ts",
         "x/automation/stackSettings.ts",
         "x/automation/server.ts",

--- a/sdk/nodejs/x/automation/index.ts
+++ b/sdk/nodejs/x/automation/index.ts
@@ -21,5 +21,3 @@ export * from "./projectSettings";
 export * from "./localWorkspace";
 export * from "./workspace";
 export * from "./events";
-import { Version } from "./workspace";
-export { Version };

--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -55,10 +55,6 @@ export class LocalWorkspace implements Workspace {
      */
     readonly secretsProvider?: string;
     /**
-     * The version of the underlying Pulumi CLI/Engine.
-     */
-    pulumiVersion?: semver.SemVer;
-    /**
      *  The inline program `PulumiFn` to be used for Preview/Update operations if any.
      *  If none is specified, the stack will refer to ProjectSettings for this information.
      */
@@ -67,6 +63,16 @@ export class LocalWorkspace implements Workspace {
      * Environment values scoped to the current workspace. These will be supplied to every Pulumi command.
      */
     envVars: { [key: string]: string };
+    private _pulumiVersion?: semver.SemVer;
+    /**
+     * The version of the underlying Pulumi CLI/Engine.
+     */
+    public get pulumiVersion(): semver.SemVer {
+        if (!this._pulumiVersion) {
+            throw new Error("Failed to get pulumi version.");
+        }
+        return this._pulumiVersion;
+    }
     private ready: Promise<any[]>;
     /**
      * Creates a workspace using the specified options. Used for maximal control and customization
@@ -547,7 +553,7 @@ export class LocalWorkspace implements Workspace {
         const result = await this.runPulumiCmd(["version"]);
         const version = new semver.SemVer(result.stdout.trim());
         checkVersionIsValid(minVersion, version);
-        this.pulumiVersion = version;
+        this._pulumiVersion = version;
     }
     private async runPulumiCmd(
         args: string[],

--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -15,6 +15,7 @@
 import * as fs from "fs";
 import * as yaml from "js-yaml";
 import * as os from "os";
+import * as semver from "semver";
 import * as upath from "upath";
 
 import { CommandResult, runPulumiCmd } from "./cmd";
@@ -23,7 +24,7 @@ import { minimumVersion } from "./minimumVersion";
 import { ProjectSettings } from "./projectSettings";
 import { Stack } from "./stack";
 import { StackSettings } from "./stackSettings";
-import { Deployment, PluginInfo, PulumiFn, StackSummary, Version, WhoAmIResult, Workspace } from "./workspace";
+import { Deployment, PluginInfo, PulumiFn, StackSummary, WhoAmIResult, Workspace } from "./workspace";
 
 /**
  * LocalWorkspace is a default implementation of the Workspace interface.
@@ -56,7 +57,7 @@ export class LocalWorkspace implements Workspace {
     /**
      * The version of the underlying Pulumi CLI/Engine.
      */
-    pulumiVersion?: Version;
+    pulumiVersion?: semver.SemVer;
     /**
      *  The inline program `PulumiFn` to be used for Preview/Update operations if any.
      *  If none is specified, the stack will refer to ProjectSettings for this information.
@@ -542,9 +543,9 @@ export class LocalWorkspace implements Workspace {
         // LocalWorkspace does not utilize this extensibility point.
         return;
     }
-    private async getPulumiVersion(minVersion: Version) {
+    private async getPulumiVersion(minVersion: semver.SemVer) {
         const result = await this.runPulumiCmd(["version"]);
-        const version = new Version(result.stdout.trim());
+        const version = new semver.SemVer(result.stdout.trim());
         checkVersionIsValid(minVersion, version);
         this.pulumiVersion = version;
     }
@@ -659,7 +660,7 @@ function defaultProject(projectName: string) {
     return settings;
 }
 
-export function checkVersionIsValid(minVersion: Version, currentVersion: Version) {
+export function checkVersionIsValid(minVersion: semver.SemVer, currentVersion: semver.SemVer) {
     const err = new Error(`Minimum version requirement failed. The minimum CLI version requirement is ${minimumVersion.toString()}, your current CLI version is ${currentVersion.toString()}. Please update the Pulumi CLI.`);
     if (minVersion.major !== currentVersion.major) {
         throw err;

--- a/sdk/nodejs/x/automation/minimumVersion.ts
+++ b/sdk/nodejs/x/automation/minimumVersion.ts
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-import { Version } from "./workspace";
 
-export const minimumVersion = new Version("v2.21.0");
+import * as semver from "semver";
+
+export const minimumVersion = new semver.SemVer("v2.21.0");

--- a/sdk/nodejs/x/automation/minimumVersion.ts
+++ b/sdk/nodejs/x/automation/minimumVersion.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,15 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
-export * from "./cmd";
-export * from "./config";
-export * from "./errors";
-export * from "./stack";
-export * from "./stackSettings";
-export * from "./projectSettings";
-export * from "./localWorkspace";
-export * from "./workspace";
-export * from "./events";
 import { Version } from "./workspace";
-export { Version };
+
+export const minimumVersion = new Version("v2.21.0");

--- a/sdk/nodejs/x/automation/workspace.ts
+++ b/sdk/nodejs/x/automation/workspace.ts
@@ -39,6 +39,10 @@ export interface Workspace {
      */
     readonly secretsProvider?: string;
     /**
+     * The version of the underlying Pulumi CLI/Engine.
+     */
+    pulumiVersion?: Version;
+    /**
      *  The inline program `PulumiFn` to be used for Preview/Update operations if any.
      *  If none is specified, the stack will refer to ProjectSettings for this information.
      */
@@ -255,3 +259,37 @@ export interface PluginInfo {
 }
 
 export type PluginKind = "analyzer" | "language" | "resource";
+
+export class Version {
+    readonly major: number;
+    readonly minor: number;
+    readonly patch: number;
+    readonly suffix?: string;
+
+    public constructor(version: string) {
+        let splitVersion = version.split("-", 2);
+        if (splitVersion.length > 1) {
+            this.suffix = splitVersion[1];
+        }
+        splitVersion = splitVersion[0].split(".");
+        if (splitVersion.length !== 3) {
+            throw new Error("invalid version");
+        }
+        let majorString = splitVersion[0];
+        // `pulumi version` may or may not start with a `v` depending on platform
+        if (majorString[0] === "v") {
+            majorString = majorString.replace("v", "");
+        }
+        this.major = parseInt(majorString, 10);
+        this.minor = parseInt(splitVersion[1], 10);
+        this.patch = parseInt(splitVersion[2], 10);
+    }
+
+    public toString(): string {
+        const version = `v${this.major}.${this.minor}.${this.patch}`;
+        if (this.suffix) {
+            return `${version}-${this.suffix}`;
+        }
+        return version;
+    }
+}

--- a/sdk/nodejs/x/automation/workspace.ts
+++ b/sdk/nodejs/x/automation/workspace.ts
@@ -43,7 +43,7 @@ export interface Workspace {
     /**
      * The version of the underlying Pulumi CLI/Engine.
      */
-    pulumiVersion?: semver.SemVer;
+    readonly pulumiVersion: semver.SemVer;
     /**
      *  The inline program `PulumiFn` to be used for Preview/Update operations if any.
      *  If none is specified, the stack will refer to ProjectSettings for this information.

--- a/sdk/nodejs/x/automation/workspace.ts
+++ b/sdk/nodejs/x/automation/workspace.ts
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import * as semver from "semver";
+
 import { ConfigMap, ConfigValue } from "./config";
 import { ProjectSettings } from "./projectSettings";
 import { StackSettings } from "./stackSettings";
@@ -41,7 +43,7 @@ export interface Workspace {
     /**
      * The version of the underlying Pulumi CLI/Engine.
      */
-    pulumiVersion?: Version;
+    pulumiVersion?: semver.SemVer;
     /**
      *  The inline program `PulumiFn` to be used for Preview/Update operations if any.
      *  If none is specified, the stack will refer to ProjectSettings for this information.
@@ -259,37 +261,3 @@ export interface PluginInfo {
 }
 
 export type PluginKind = "analyzer" | "language" | "resource";
-
-export class Version {
-    readonly major: number;
-    readonly minor: number;
-    readonly patch: number;
-    readonly suffix?: string;
-
-    public constructor(version: string) {
-        let splitVersion = version.split("-", 2);
-        if (splitVersion.length > 1) {
-            this.suffix = splitVersion[1];
-        }
-        splitVersion = splitVersion[0].split(".");
-        if (splitVersion.length !== 3) {
-            throw new Error("invalid version");
-        }
-        let majorString = splitVersion[0];
-        // `pulumi version` may or may not start with a `v` depending on platform
-        if (majorString[0] === "v") {
-            majorString = majorString.replace("v", "");
-        }
-        this.major = parseInt(majorString, 10);
-        this.minor = parseInt(splitVersion[1], 10);
-        this.patch = parseInt(splitVersion[2], 10);
-    }
-
-    public toString(): string {
-        const version = `v${this.major}.${this.minor}.${this.patch}`;
-        if (this.suffix) {
-            return `${version}-${this.suffix}`;
-        }
-        return version;
-    }
-}


### PR DESCRIPTION
## Changes
* Added a `LocalWorkspace.pulumiVersion` property that returns the underlying Pulumi CLI version.
* `LocalWorkspace` constructor checks that the `pulumiVersion` >= the minimum version set in `minimumVersion.ts` and returns an error to update the CLI if the check fails.

Nodejs part of #6348 and #6419

Also see: https://github.com/pulumi/pulumi/pull/6577 for Go