### PR TITLE
[sdk/dotnet] - refactor automation tests to be less prone to existing state errors

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -264,7 +264,7 @@ namespace Pulumi.Automation.Tests
             });
 
             var stackName = $"stack_status_test{GetTestSuffix()}";
-            var stack = await WorkspaceStack.CreateAsync(stackName, workspace);
+            var stack = await WorkspaceStack.CreateOrSelectAsync(stackName, workspace);
             try
             {
                 var history = await stack.GetHistoryAsync();


### PR DESCRIPTION
mostly by isolating the tests more by giving them each their own stack name prefix