### PR TITLE
[automation/python] - Implement min version checking

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,15 +5,12 @@
 
 - [cli] Improve diff displays during `pulumi refresh`
   [#6568](https://github.com/pulumi/pulumi/pull/6568)
-  
-- [automation/go] Implement minimum version checking and add `LocalWorkspace.PulumiVersion()`.
-  [#6577](https://github.com/pulumi/pulumi/pull/6577)
 
 - [sdk/go] Cache loaded configuration files.
   [#6576](https://github.com/pulumi/pulumi/pull/6576)
 
-- [automation/nodejs] Implement minimum version checking and add `LocalWorkspace.pulumiVersion`.
-  [#6580](https://github.com/pulumi/pulumi/pull/6580)
+- [automation/go,nodejs,python] Implement minimum version checking and add `LocalWorkspace.PulumiVersion()`.
+  [#6577](https://github.com/pulumi/pulumi/pull/6577), [#6580](https://github.com/pulumi/pulumi/pull/6580), [#6589](https://github.com/pulumi/pulumi/pull/6589)
   
 ### Bug Fixes
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,8 +9,10 @@
 - [sdk/go] Cache loaded configuration files.
   [#6576](https://github.com/pulumi/pulumi/pull/6576)
 
-- [automation/go,nodejs,python] Implement minimum version checking and add `LocalWorkspace.PulumiVersion()`.
-  [#6577](https://github.com/pulumi/pulumi/pull/6577), [#6580](https://github.com/pulumi/pulumi/pull/6580), [#6589](https://github.com/pulumi/pulumi/pull/6589)
+- [automation/go,nodejs,python] Implement minimum version checking and add:
+  - Go: `LocalWorkspace.PulumiVersion()` - [#6577](https://github.com/pulumi/pulumi/pull/6577)
+  - Nodejs: `LocalWorkspace.pulumiVersion` - [#6580](https://github.com/pulumi/pulumi/pull/6580)
+  - Python: `LocalWorkspace.pulumi_version` - [#6589](https://github.com/pulumi/pulumi/pull/6589)
   
 ### Bug Fixes
 

--- a/sdk/python/lib/pulumi/x/automation/__init__.py
+++ b/sdk/python/lib/pulumi/x/automation/__init__.py
@@ -106,7 +106,8 @@ from .errors import (
     ConcurrentUpdateError,
     InlineSourceRuntimeError,
     RuntimeError,
-    CompilationError
+    CompilationError,
+    InvalidVersionError
 )
 
 from ._local_workspace import (
@@ -162,6 +163,7 @@ __all__ = [
     "InlineSourceRuntimeError",
     "RuntimeError",
     "CompilationError",
+    "InvalidVersionError",
 
     # _local_workspace
     "LocalWorkspace",

--- a/sdk/python/lib/pulumi/x/automation/_minimum_version.py
+++ b/sdk/python/lib/pulumi/x/automation/_minimum_version.py
@@ -1,0 +1,17 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from semver import VersionInfo
+
+_MINIMUM_VERSION = VersionInfo.parse("2.21.0")

--- a/sdk/python/lib/pulumi/x/automation/_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_workspace.py
@@ -14,6 +14,7 @@
 
 from abc import ABC, abstractmethod
 from datetime import datetime
+from semver import VersionInfo
 from typing import (
     Callable,
     Mapping,
@@ -129,6 +130,11 @@ class Workspace(ABC):
     env_vars: Mapping[str, str] = {}
     """
     Environment values scoped to the current workspace. These will be supplied to every Pulumi command.
+    """
+
+    pulumi_version: VersionInfo
+    """
+    The version of the underlying Pulumi CLI/Engine.
     """
 
     @abstractmethod

--- a/sdk/python/lib/pulumi/x/automation/errors.py
+++ b/sdk/python/lib/pulumi/x/automation/errors.py
@@ -61,6 +61,10 @@ class CompilationError(CommandError):
         self.name = "CompilationError"
 
 
+class InvalidVersionError(Exception):
+    pass
+
+
 not_found_regex = re.compile("no stack named.*found")
 already_exists_regex = re.compile("stack.*already exists")
 conflict_text = "[409] Conflict: Another update is currently in progress."


### PR DESCRIPTION
## Changes
* Added a `LocalWorkspace.pulumi_version` attribute that returns the underlying Pulumi CLI version.
* `LocalWorkspace` constructor checks that the `pulumi_version` >= the minimum version set in `_minimum_version.py` and raises an exception to update the CLI if the check fails.

Python part of #6348 and #6419

Also see: https://github.com/pulumi/pulumi/pull/6577 for Go and https://github.com/pulumi/pulumi/pull/6580 for nodejs