### PR TITLE
[automation/dotnet] - Implement min version checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 **/.vs/
 **/.ionide/
 **/.idea/
+**/.DS_Store
 coverage.cov
 *.coverprofile
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,11 +9,12 @@
 - [sdk/go] Cache loaded configuration files.
   [#6576](https://github.com/pulumi/pulumi/pull/6576)
 
-- [automation/go,nodejs,python] Implement minimum version checking and add:
+- [automation/*] Implement minimum version checking and add:
   - Go: `LocalWorkspace.PulumiVersion()` - [#6577](https://github.com/pulumi/pulumi/pull/6577)
   - Nodejs: `LocalWorkspace.pulumiVersion` - [#6580](https://github.com/pulumi/pulumi/pull/6580)
   - Python: `LocalWorkspace.pulumi_version` - [#6589](https://github.com/pulumi/pulumi/pull/6589)
-
+  - Dotnet: `LocalWorkspace.PulumiVersion` - [#6590](https://github.com/pulumi/pulumi/pull/6590)
+  
 ### Bug Fixes
 
 - [automation/python] Fix Settings file save

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -848,12 +848,12 @@ namespace Pulumi.Automation.Tests
             var testCurrentVersion = SemVersion.Parse("2.21.1");
             if (errorExpected)
             {
-                Action act = () => LocalWorkspace.CheckVersionIsValid(minVersion, testCurrentVersion);
+                Action act = () => LocalWorkspace.ValidatePulumiVersion(minVersion, testCurrentVersion);
                 Assert.Throws<InvalidOperationException>(act);
             }
             else
             {
-                LocalWorkspace.CheckVersionIsValid(minVersion, testCurrentVersion);
+                LocalWorkspace.ValidatePulumiVersion(minVersion, testCurrentVersion);
             }
         }
     }

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -826,5 +826,12 @@ namespace Pulumi.Automation.Tests
                 Assert.True(expSecretValue.IsSecret);
             }
         }
+    
+        [Fact]
+        public async Task PulumiVersionTest()
+        {
+            using var workspace = await LocalWorkspace.CreateAsync();
+            Assert.Matches("(\\d+\\.)(\\d+\\.)(\\d+)(-.*)?", workspace.PulumiVersion.ToString());
+        }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -832,7 +832,7 @@ namespace Pulumi.Automation.Tests
         public async Task PulumiVersionTest()
         {
             using var workspace = await LocalWorkspace.CreateAsync();
-            Assert.Matches("(\\d+\\.)(\\d+\\.)(\\d+)(-.*)?", workspace.PulumiVersion.ToString());
+            Assert.Matches("(\\d+\\.)(\\d+\\.)(\\d+)(-.*)?", workspace.PulumiVersion);
         }
 
         [Theory]

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -838,22 +838,24 @@ namespace Pulumi.Automation.Tests
         [Theory]
         [InlineData("100.0.0", true)]
         [InlineData("1.0.0", true)]
-        [InlineData("2.22.0", true)]
-        [InlineData("2.1.0", false)]
-        [InlineData("2.21.2", true)]
+        [InlineData("2.22.0", false)]
+        [InlineData("2.1.0", true)]
+        [InlineData("2.21.2", false)]
         [InlineData("2.21.1", false)]
-        [InlineData("2.21.0", false)]
-        public void ValidVersionTheory(string minVersion, bool errorExpected)
+        [InlineData("2.21.0", true)]
+        // Note that prerelease < release so this case should error
+        [InlineData("2.21.1-alpha.1234", true)]
+        public void ValidVersionTheory(string currentVersion, bool errorExpected)
         {
-            var testCurrentVersion = SemVersion.Parse("2.21.1");
+            var testMinVersion = SemVersion.Parse("2.21.1");
             if (errorExpected)
             {
-                Action act = () => LocalWorkspace.ValidatePulumiVersion(minVersion, testCurrentVersion);
+                Action act = () => LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion);
                 Assert.Throws<InvalidOperationException>(act);
             }
             else
             {
-                LocalWorkspace.ValidatePulumiVersion(minVersion, testCurrentVersion);
+                LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion);
             }
         }
     }

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1,5 +1,6 @@
 // Copyright 2016-2021, Pulumi Corporation
 
+using Semver;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -832,6 +833,28 @@ namespace Pulumi.Automation.Tests
         {
             using var workspace = await LocalWorkspace.CreateAsync();
             Assert.Matches("(\\d+\\.)(\\d+\\.)(\\d+)(-.*)?", workspace.PulumiVersion.ToString());
+        }
+
+        [Theory]
+        [InlineData("100.0.0", true)]
+        [InlineData("1.0.0", true)]
+        [InlineData("2.22.0", true)]
+        [InlineData("2.1.0", false)]
+        [InlineData("2.21.2", true)]
+        [InlineData("2.21.1", false)]
+        [InlineData("2.21.0", false)]
+        public void ValidVersionTheory(string minVersion, bool errorExpected)
+        {
+            var testCurrentVersion = SemVersion.Parse("2.21.1");
+            if (errorExpected)
+            {
+                Action act = () => LocalWorkspace.CheckVersionIsValid(minVersion, testCurrentVersion);
+                Assert.Throws<InvalidOperationException>(act);
+            }
+            else
+            {
+                LocalWorkspace.CheckVersionIsValid(minVersion, testCurrentVersion);
+            }
         }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -369,9 +369,9 @@ namespace Pulumi.Automation
             this.pulumiVersion = version;
         }
 
-        private static void CheckVersionIsValid(SemVersion minVersion, SemVersion currentVersion)
+        public static void CheckVersionIsValid(SemVersion minVersion, SemVersion currentVersion)
         {
-            var err = new Exception($"Minimum version requirement failed. The minimum CLI version requirement is {minVersion}, your current CLI version is ${currentVersion}. Please update the Pulumi CLI.");
+            var err = new InvalidOperationException($"Minimum version requirement failed. The minimum CLI version requirement is {minVersion}, your current CLI version is ${currentVersion}. Please update the Pulumi CLI.");
             if (minVersion.Major != currentVersion.Major) {
                 throw err;
             }

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -45,13 +45,7 @@ namespace Pulumi.Automation
 
         private SemVersion? pulumiVersion;
         /// <inheritdoc/>
-        public override SemVersion PulumiVersion 
-        { 
-            get 
-            { 
-                return pulumiVersion!; 
-            }
-        }
+        public override SemVersion PulumiVersion => pulumiVersion ?? throw new InvalidOperationException("Failed to get Pulumi version.");
 
         /// <inheritdoc/>
         public override string? SecretsProvider { get; }
@@ -349,7 +343,7 @@ namespace Pulumi.Automation
 
         private static readonly string[] SettingsExtensions = new string[] { ".yaml", ".yml", ".json" };
 
-        private async Task PopulatePulumiVersionAsync(CancellationToken cancellationToken = default)
+        private async Task PopulatePulumiVersionAsync(CancellationToken cancellationToken)
         {
             var result = await this.RunCommandAsync(new[] { "version" }, cancellationToken).ConfigureAwait(false);
             var versionString = result.StandardOutput.Trim();
@@ -367,8 +361,8 @@ namespace Pulumi.Automation
             if (minVersion.Major < currentVersion.Major) {
                 throw new InvalidOperationException($"Major version mismatch. You are using Pulumi CLI version {currentVersion} with Automation SDK v{minVersion.Major}. Please update the SDK.");
             }
-            if (minVersion.CompareTo(currentVersion) == 1) {
-                throw new InvalidOperationException($"Minimum version requirement failed. The minimum CLI version requirement is {minVersion}, your current CLI version is ${currentVersion}. Please update the Pulumi CLI.");
+            if (minVersion > currentVersion) {
+                throw new InvalidOperationException($"Minimum version requirement failed. The minimum CLI version requirement is {minVersion}, your current CLI version is {currentVersion}. Please update the Pulumi CLI.");
             }
         }
 

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Automation
 
         private SemVersion? pulumiVersion;
         /// <inheritdoc/>
-        public override SemVersion PulumiVersion => pulumiVersion ?? throw new InvalidOperationException("Failed to get Pulumi version.");
+        public override string PulumiVersion => pulumiVersion is null ? throw new InvalidOperationException("Failed to get Pulumi version.") : pulumiVersion.ToString();
 
         /// <inheritdoc/>
         public override string? SecretsProvider { get; }

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Automation
 
         private SemVersion? pulumiVersion;
         /// <inheritdoc/>
-        public override string PulumiVersion => pulumiVersion is null ? throw new InvalidOperationException("Failed to get Pulumi version.") : pulumiVersion.ToString();
+        public override string PulumiVersion => pulumiVersion?.ToString() ?? throw new InvalidOperationException("Failed to get Pulumi version.");
 
         /// <inheritdoc/>
         public override string? SecretsProvider { get; }

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -314,6 +314,7 @@ override Pulumi.Automation.LocalWorkspace.SetConfigAsync(string stackName, Syste
 override Pulumi.Automation.LocalWorkspace.SetConfigValueAsync(string stackName, string key, Pulumi.Automation.ConfigValue value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 override Pulumi.Automation.LocalWorkspace.WhoAmIAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.WhoAmIResult>
 override Pulumi.Automation.LocalWorkspace.WorkDir.get -> string
+static Pulumi.Automation.LocalWorkspace.CheckVersionIsValid(Semver.SemVersion minVersion, Semver.SemVersion currentVersion) -> void
 static Pulumi.Automation.LocalWorkspace.CreateAsync(Pulumi.Automation.LocalWorkspaceOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.LocalWorkspace>
 static Pulumi.Automation.LocalWorkspace.CreateOrSelectStackAsync(Pulumi.Automation.InlineProgramArgs args) -> System.Threading.Tasks.Task<Pulumi.Automation.WorkspaceStack>
 static Pulumi.Automation.LocalWorkspace.CreateOrSelectStackAsync(Pulumi.Automation.InlineProgramArgs args, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Pulumi.Automation.WorkspaceStack>

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -269,7 +269,7 @@ abstract Pulumi.Automation.Workspace.PostCommandCallbackAsync(string stackName, 
 abstract Pulumi.Automation.Workspace.Program.get -> Pulumi.Automation.PulumiFn
 abstract Pulumi.Automation.Workspace.Program.set -> void
 abstract Pulumi.Automation.Workspace.PulumiHome.get -> string
-abstract Pulumi.Automation.Workspace.PulumiVersion.get -> Semver.SemVersion
+abstract Pulumi.Automation.Workspace.PulumiVersion.get -> string
 abstract Pulumi.Automation.Workspace.RefreshConfigAsync(string stackName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string, Pulumi.Automation.ConfigValue>>
 abstract Pulumi.Automation.Workspace.RemoveConfigAsync(string stackName, System.Collections.Generic.IEnumerable<string> keys, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 abstract Pulumi.Automation.Workspace.RemoveConfigValueAsync(string stackName, string key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
@@ -299,7 +299,7 @@ override Pulumi.Automation.LocalWorkspace.PostCommandCallbackAsync(string stackN
 override Pulumi.Automation.LocalWorkspace.Program.get -> Pulumi.Automation.PulumiFn
 override Pulumi.Automation.LocalWorkspace.Program.set -> void
 override Pulumi.Automation.LocalWorkspace.PulumiHome.get -> string
-override Pulumi.Automation.LocalWorkspace.PulumiVersion.get -> Semver.SemVersion
+override Pulumi.Automation.LocalWorkspace.PulumiVersion.get -> string
 override Pulumi.Automation.LocalWorkspace.RefreshConfigAsync(string stackName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string, Pulumi.Automation.ConfigValue>>
 override Pulumi.Automation.LocalWorkspace.RemoveConfigAsync(string stackName, System.Collections.Generic.IEnumerable<string> keys, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 override Pulumi.Automation.LocalWorkspace.RemoveConfigValueAsync(string stackName, string key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -314,7 +314,6 @@ override Pulumi.Automation.LocalWorkspace.SetConfigAsync(string stackName, Syste
 override Pulumi.Automation.LocalWorkspace.SetConfigValueAsync(string stackName, string key, Pulumi.Automation.ConfigValue value, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 override Pulumi.Automation.LocalWorkspace.WhoAmIAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.WhoAmIResult>
 override Pulumi.Automation.LocalWorkspace.WorkDir.get -> string
-static Pulumi.Automation.LocalWorkspace.CheckVersionIsValid(Semver.SemVersion minVersion, Semver.SemVersion currentVersion) -> void
 static Pulumi.Automation.LocalWorkspace.CreateAsync(Pulumi.Automation.LocalWorkspaceOptions options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.LocalWorkspace>
 static Pulumi.Automation.LocalWorkspace.CreateOrSelectStackAsync(Pulumi.Automation.InlineProgramArgs args) -> System.Threading.Tasks.Task<Pulumi.Automation.WorkspaceStack>
 static Pulumi.Automation.LocalWorkspace.CreateOrSelectStackAsync(Pulumi.Automation.InlineProgramArgs args, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Pulumi.Automation.WorkspaceStack>

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -269,6 +269,7 @@ abstract Pulumi.Automation.Workspace.PostCommandCallbackAsync(string stackName, 
 abstract Pulumi.Automation.Workspace.Program.get -> Pulumi.Automation.PulumiFn
 abstract Pulumi.Automation.Workspace.Program.set -> void
 abstract Pulumi.Automation.Workspace.PulumiHome.get -> string
+abstract Pulumi.Automation.Workspace.PulumiVersion.get -> Semver.SemVersion
 abstract Pulumi.Automation.Workspace.RefreshConfigAsync(string stackName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string, Pulumi.Automation.ConfigValue>>
 abstract Pulumi.Automation.Workspace.RemoveConfigAsync(string stackName, System.Collections.Generic.IEnumerable<string> keys, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 abstract Pulumi.Automation.Workspace.RemoveConfigValueAsync(string stackName, string key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
@@ -298,6 +299,7 @@ override Pulumi.Automation.LocalWorkspace.PostCommandCallbackAsync(string stackN
 override Pulumi.Automation.LocalWorkspace.Program.get -> Pulumi.Automation.PulumiFn
 override Pulumi.Automation.LocalWorkspace.Program.set -> void
 override Pulumi.Automation.LocalWorkspace.PulumiHome.get -> string
+override Pulumi.Automation.LocalWorkspace.PulumiVersion.get -> Semver.SemVersion
 override Pulumi.Automation.LocalWorkspace.RefreshConfigAsync(string stackName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string, Pulumi.Automation.ConfigValue>>
 override Pulumi.Automation.LocalWorkspace.RemoveConfigAsync(string stackName, System.Collections.Generic.IEnumerable<string> keys, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task
 override Pulumi.Automation.LocalWorkspace.RemoveConfigValueAsync(string stackName, string key, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -43,6 +43,9 @@
         <member name="P:Pulumi.Automation.LocalWorkspace.PulumiHome">
             <inheritdoc/>
         </member>
+        <member name="P:Pulumi.Automation.LocalWorkspace.PulumiVersion">
+            <inheritdoc/>
+        </member>
         <member name="P:Pulumi.Automation.LocalWorkspace.SecretsProvider">
             <inheritdoc/>
         </member>
@@ -537,6 +540,11 @@
             The directory override for CLI metadata if set.
             <para/>
             This customizes the location of $PULUMI_HOME where metadata is stored and plugins are installed.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Workspace.PulumiVersion">
+            <summary>
+            The version of the underlying Pulumi CLI/Engine.
             </summary>
         </member>
         <member name="P:Pulumi.Automation.Workspace.SecretsProvider">

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using Semver;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -37,6 +38,11 @@ namespace Pulumi.Automation
         /// This customizes the location of $PULUMI_HOME where metadata is stored and plugins are installed.
         /// </summary>
         public abstract string? PulumiHome { get; }
+
+        /// <summary>
+        /// The version of the underlying Pulumi CLI/Engine.
+        /// </summary>
+        public abstract SemVersion PulumiVersion { get; }
 
         /// <summary>
         /// The secrets provider to use for encryption and decryption of stack secrets.

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -42,7 +42,7 @@ namespace Pulumi.Automation
         /// <summary>
         /// The version of the underlying Pulumi CLI/Engine.
         /// </summary>
-        public abstract SemVersion PulumiVersion { get; }
+        public abstract string PulumiVersion { get; }
 
         /// <summary>
         /// The secrets provider to use for encryption and decryption of stack secrets.

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
-using Semver;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;


### PR DESCRIPTION
## Changes
* Added a `LocalWorkspace.PulumiVersion` field that returns the underlying Pulumi CLI version.
* `LocalWorkspace` constructor checks that the `PulumiVersion` >= `LocalWorkspace._minimumVersion` and raises an exception to update the CLI if the check fails.

Please let me know if there's a more idiomatic way to do this!

C# part of #6348 and #6419

Also see: https://github.com/pulumi/pulumi/pull/6577 for Go, https://github.com/pulumi/pulumi/pull/6580 for nodejs and https://github.com/pulumi/pulumi/pull/6589 for python