### PR TITLE
Reduce the number of methods on output

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -765,7 +765,7 @@ func makeResourceState(t, name string, resourceV Resource, providers map[string]
 			fieldV.Set(reflect.ValueOf(output))
 
 			if tag == "" && field.Type != mapOutputType {
-				output.reject(fmt.Errorf("the field %v must be a MapOutput or its tag must be non-empty", field.Name))
+				output.getState().reject(fmt.Errorf("the field %v must be a MapOutput or its tag must be non-empty", field.Name))
 			}
 
 			state.outputs[tag] = output
@@ -821,7 +821,7 @@ func (state *resourceState) resolve(ctx *Context, dryrun bool, err error, inputs
 	if err != nil {
 		// If there was an error, we must reject everything.
 		for _, output := range state.outputs {
-			output.reject(err)
+			output.getState().reject(err)
 		}
 		return
 	}
@@ -866,9 +866,9 @@ func (state *resourceState) resolve(ctx *Context, dryrun bool, err error, inputs
 		dest := reflect.New(output.ElementType()).Elem()
 		secret, err := unmarshalOutput(ctx, v, dest)
 		if err != nil {
-			output.reject(err)
+			output.getState().reject(err)
 		} else {
-			output.resolve(dest.Interface(), known, secret, deps[k])
+			output.getState().resolve(dest.Interface(), known, secret, deps[k])
 		}
 	}
 }

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -217,7 +217,7 @@ func marshalInputAndDetermineSecret(v interface{},
 				}
 
 				// Await the output.
-				ov, known, outputSecret, outputDeps, err := output.await(context.TODO())
+				ov, known, outputSecret, outputDeps, err := output.getState().await(context.TODO())
 				if err != nil {
 					return resource.PropertyValue{}, nil, false, err
 				}

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -624,7 +624,7 @@ func (UntypedArgs) ElementType() reflect.Type {
 func TestMapInputMarhsalling(t *testing.T) {
 	var theResource simpleCustomResource
 	out := newOutput(reflect.TypeOf((*StringOutput)(nil)).Elem(), &theResource)
-	out.resolve("outputty", true, false, nil)
+	out.getState().resolve("outputty", true, false, nil)
 
 	inputs1 := Map(map[string]Input{
 		"prop": out,

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func await(out Output) (interface{}, bool, bool, []Resource, error) {
-	return out.await(context.Background())
+	return out.getState().await(context.Background())
 }
 
 func assertApplied(t *testing.T, out Output) {


### PR DESCRIPTION
These methods were getting promoted onto every struct that implemented
the Output interface, and are not necessary.

On a real world program, this saves 4% in binary size overall, and
15% of remaining binary size if `Apply<TypeName>` functions are
removed (https://github.com/pulumi/pulumi/issues/6592).