### PR TITLE
[automation/python] Fix Settings file save

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,3 +16,5 @@
   
 ### Bug Fixes
 
+- [automation/python] Fix Settings file save
+  [#6605](https://github.com/pulumi/pulumi/pull/6605)

--- a/sdk/python/lib/pulumi/x/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_local_workspace.py
@@ -118,7 +118,8 @@ class LocalWorkspace(Workspace):
                 break
         path = os.path.join(self.work_dir, f"Pulumi{found_ext}")
         with open(path, "w") as file:
-            json.dump(settings, file, indent=4) if found_ext == ".json" else yaml.dump(settings, stream=file)
+            json.dump(settings.__dict__, file, indent=4) if found_ext == ".json" else yaml.dump(
+                settings.__dict__, stream=file)
 
     def stack_settings(self, stack_name: str) -> StackSettings:
         stack_settings_name = get_stack_settings_name(stack_name)
@@ -145,7 +146,8 @@ class LocalWorkspace(Workspace):
                 break
         path = os.path.join(self.work_dir, f"Pulumi.{stack_settings_name}{found_ext}")
         with open(path, "w") as file:
-            json.dump(settings, file, indent=4) if found_ext == ".json" else yaml.dump(settings, stream=file)
+            json.dump(settings.__dict__, file, indent=4) if found_ext == ".json" else yaml.dump(
+                settings.__dict__, stream=file)
 
     def serialize_args_for_op(self, stack_name: str) -> List[str]:
         # Not used by LocalWorkspace


### PR DESCRIPTION
The Project and Stack save routines were erroneously
dumping the Python objects rather than the `__dict__`
property, which resulted in some extra annotations
in the resulting YAML files. Some parsers don't handle
these annotations correctly, and consider the resulting
YAML file to be invalid.

Here's an example of the previous `Pulumi.yaml` file:
```yaml
!!python/object:pulumi.x.automation._project_settings.ProjectSettings
author: null
backend: null
config: null
description: null
license: null
main: null
name: inline_runtime_error_python
runtime: python
template: null
website: null
```