### PR TITLE
[sdk/nodejs] Mark an internal function as internal

### DIFF
--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -663,6 +663,7 @@ function defaultProject(projectName: string) {
     return settings;
 }
 
+/** @internal */
 export function validatePulumiVersion(minVersion: semver.SemVer, currentVersion: semver.SemVer) {
     if (minVersion.major < currentVersion.major) {
         throw new Error(`Major version mismatch. You are using Pulumi CLI version ${currentVersion.toString()} with Automation SDK v${minVersion.major}. Please update the SDK.`);


### PR DESCRIPTION
That way it doesn't show up in the public API signature, which is causing build breaks due to missing definitions for semver types.

Fixes #6614