### PR TITLE
Make .old and .new nullable on StateEventMetadata

### DIFF
--- a/sdk/nodejs/x/automation/events.ts
+++ b/sdk/nodejs/x/automation/events.ts
@@ -109,9 +109,9 @@ export interface StepEventMetadata {
     type: string;
 
     // Old is the state of the resource before performing the step.
-    old: StepEventStateMetadata;
+    old?: StepEventStateMetadata;
     // New is the state of the resource after performing the step.
-    new: StepEventStateMetadata;
+    new?: StepEventStateMetadata;
 
     // Keys causing a replacement (only applicable for "create" and "replace" Ops).
     keys?: string[];


### PR DESCRIPTION
Go model seems to have these optional:

```
// StepEventMetadata describes a "step" within the Pulumi engine, which is any concrete action
// to migrate a set of cloud resources from one state to another.
type StepEventMetadata struct {
	// Op is the operation being performed.
	Op   OpType `json:"op"`
	URN  string `json:"urn"`
	Type string `json:"type"`

	// Old is the state of the resource before performing the step.
	Old *StepEventStateMetadata `json:"old"`
	// New is the state of the resource after performing the step.
	New *StepEventStateMetadata `json:"new"`
	// Omitted from the type sent to the Pulumi Service is "Res", which may be either Old or New.
```

The emerging C# model treats them optional also. 

Should they be optional/nullable in TypeScript?