### PR TITLE
[cli] Strip Byte-order Mark (BOM) from YAML configs during load

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,7 +4,7 @@
 ### Improvements
 
 - [cli] Strip Byte-order Mark (BOM) from YAML configs during load.
-  [#6635](https://github.com/pulumi/pulumi/pull/6635)
+  [#6636](https://github.com/pulumi/pulumi/pull/6636)
 
 ### Bug Fixes
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 
 ### Improvements
 
+- [cli] Strip Byte-order Mark (BOM) from YAML configs during load.
+  [#6635](https://github.com/pulumi/pulumi/pull/6635)
 
 ### Bug Fixes
 

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -46,14 +46,14 @@ var policyPackProjectSingleton *policyPackProjectLoader = &policyPackProjectLoad
 	internal: map[string]*PolicyPackProject{},
 }
 
-// readFile wraps os.ReadFile and also strips the Byte-order Mark (BOM) if present.
+// readFile wraps os.ReadFile and also strips the UTF-8 Byte-order Mark (BOM) if present.
 func readFile(path string) ([]byte, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	// Strip BOM bytes if present to avoid problems with downstream parsing.
+	// Strip UTF-8 BOM bytes if present to avoid problems with downstream parsing.
 	// References:
 	//   https://github.com/spkg/bom
 	//   https://en.wikipedia.org/wiki/Byte_order_mark

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -46,8 +46,8 @@ var policyPackProjectSingleton *policyPackProjectLoader = &policyPackProjectLoad
 	internal: map[string]*PolicyPackProject{},
 }
 
-// readFile wraps os.ReadFile and also strips the UTF-8 Byte-order Mark (BOM) if present.
-func readFile(path string) ([]byte, error) {
+// readFileStripUTF8BOM wraps os.ReadFile and also strips the UTF-8 Byte-order Mark (BOM) if present.
+func readFileStripUTF8BOM(path string) ([]byte, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (singleton *projectLoader) load(path string) (*Project, error) {
 		return nil, err
 	}
 
-	b, err := readFile(path)
+	b, err := readFileStripUTF8BOM(path)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (singleton *projectStackLoader) load(path string) (*ProjectStack, error) {
 	}
 
 	var projectStack ProjectStack
-	b, err := readFile(path)
+	b, err := readFileStripUTF8BOM(path)
 	if os.IsNotExist(err) {
 		projectStack = ProjectStack{
 			Config: make(config.Map),
@@ -172,7 +172,7 @@ func (singleton *pluginProjectLoader) load(path string) (*PluginProject, error) 
 		return nil, err
 	}
 
-	b, err := readFile(path)
+	b, err := readFileStripUTF8BOM(path)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +212,7 @@ func (singleton *policyPackProjectLoader) load(path string) (*PolicyPackProject,
 		return nil, err
 	}
 
-	b, err := readFile(path)
+	b, err := readFileStripUTF8BOM(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Some YAML parsers don't correctly handle Byte-order Marks,
so automatically strip it off during load.

Related to #423