### PR TITLE
[automation/python] - Fix passing of extra environment variables

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,4 +6,5 @@
 
 ### Bug Fixes
 
-
+- [automation/python] Fix passing of additional environment variables.
+  [#6639](https://github.com/pulumi/pulumi/pull/6639)

--- a/sdk/python/lib/pulumi/x/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/x/automation/_cmd.py
@@ -46,7 +46,7 @@ def _run_pulumi_cmd(args: List[str],
     # All commands should be run in non-interactive mode.
     # This causes commands to fail rather than prompting for input (and thus hanging indefinitely).
     args.append("--non-interactive")
-    env = os.environ.copy().update(additional_env)
+    env = {**os.environ, **additional_env}
     cmd = ["pulumi"]
     cmd.extend(args)
 


### PR DESCRIPTION
The previous implementation did not correctly pass forward the environment variables and `env` ended up as `None`. 

This isn't entirely straightforward to test in isolation but it is used by https://github.com/pulumi/pulumi/pull/6527 and I was able to test that it works as expected because the `PULUMI_DEBUG_COMMANDS` env var is successfully passed through and the tests don't fail with `unknown flag --event-log`.