### PR TITLE
[codegen/go] Fix Go resource registrations

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1724,11 +1724,12 @@ func (pkg *pkgContext) genResourceModule(w io.Writer) {
 
 			registrations.Add(tokenToModule(r.Token))
 			fmt.Fprintf(w, "\tcase %q:\n", r.Token)
-			fmt.Fprintf(w, "\t\tr, err = New%s(ctx, name, nil, pulumi.URN_(urn))\n", resourceName(r))
+			fmt.Fprintf(w, "\t\tr = &%s{}\n", resourceName(r))
 		}
 		fmt.Fprintf(w, "\tdefault:\n")
 		fmt.Fprintf(w, "\t\treturn nil, fmt.Errorf(\"unknown resource type: %%s\", typ)\n")
 		fmt.Fprintf(w, "\t}\n\n")
+		fmt.Fprintf(w, "\terr = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))\n")
 		fmt.Fprintf(w, "\treturn\n")
 		fmt.Fprintf(w, "}\n\n")
 	}
@@ -1746,7 +1747,9 @@ func (pkg *pkgContext) genResourceModule(w io.Writer) {
 		fmt.Fprintf(w, "\tif typ != \"pulumi:providers:%s\" {\n", pkg.pkg.Name)
 		fmt.Fprintf(w, "\t\treturn nil, fmt.Errorf(\"unknown provider type: %%s\", typ)\n")
 		fmt.Fprintf(w, "\t}\n\n")
-		fmt.Fprintf(w, "\treturn NewProvider(ctx, name, nil, pulumi.URN_(urn))\n")
+		fmt.Fprintf(w, "\tr := &Provider{}\n")
+		fmt.Fprintf(w, "\terr := ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))\n")
+		fmt.Fprintf(w, "\treturn r, err\n")
 		fmt.Fprintf(w, "}\n\n")
 	}
 

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/init.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/init.go
@@ -21,15 +21,16 @@ func (m *module) Version() semver.Version {
 func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi.Resource, err error) {
 	switch typ {
 	case "example::Cat":
-		r, err = NewCat(ctx, name, nil, pulumi.URN_(urn))
+		r = &Cat{}
 	case "example::Component":
-		r, err = NewComponent(ctx, name, nil, pulumi.URN_(urn))
+		r = &Component{}
 	case "example::Workload":
-		r, err = NewWorkload(ctx, name, nil, pulumi.URN_(urn))
+		r = &Workload{}
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", typ)
 	}
 
+	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
 	return
 }
 
@@ -46,7 +47,9 @@ func (p *pkg) ConstructProvider(ctx *pulumi.Context, name, typ, urn string) (pul
 		return nil, fmt.Errorf("unknown provider type: %s", typ)
 	}
 
-	return NewProvider(ctx, name, nil, pulumi.URN_(urn))
+	r := &Provider{}
+	err := ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
+	return r, err
 }
 
 func init() {

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/init.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/init.go
@@ -23,7 +23,9 @@ func (p *pkg) ConstructProvider(ctx *pulumi.Context, name, typ, urn string) (pul
 		return nil, fmt.Errorf("unknown provider type: %s", typ)
 	}
 
-	return NewProvider(ctx, name, nil, pulumi.URN_(urn))
+	r := &Provider{}
+	err := ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
+	return r, err
 }
 
 func init() {

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/init.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/init.go
@@ -22,13 +22,14 @@ func (m *module) Version() semver.Version {
 func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi.Resource, err error) {
 	switch typ {
 	case "plant:tree/v1:Nursery":
-		r, err = NewNursery(ctx, name, nil, pulumi.URN_(urn))
+		r = &Nursery{}
 	case "plant:tree/v1:RubberTree":
-		r, err = NewRubberTree(ctx, name, nil, pulumi.URN_(urn))
+		r = &RubberTree{}
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", typ)
 	}
 
+	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
 	return
 }
 

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/init.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/init.go
@@ -21,11 +21,12 @@ func (m *module) Version() semver.Version {
 func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi.Resource, err error) {
 	switch typ {
 	case "example::Component":
-		r, err = NewComponent(ctx, name, nil, pulumi.URN_(urn))
+		r = &Component{}
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", typ)
 	}
 
+	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
 	return
 }
 
@@ -42,7 +43,9 @@ func (p *pkg) ConstructProvider(ctx *pulumi.Context, name, typ, urn string) (pul
 		return nil, fmt.Errorf("unknown provider type: %s", typ)
 	}
 
-	return NewProvider(ctx, name, nil, pulumi.URN_(urn))
+	r := &Provider{}
+	err := ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
+	return r, err
 }
 
 func init() {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/init.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/init.go
@@ -21,13 +21,14 @@ func (m *module) Version() semver.Version {
 func (m *module) Construct(ctx *pulumi.Context, name, typ, urn string) (r pulumi.Resource, err error) {
 	switch typ {
 	case "example::OtherResource":
-		r, err = NewOtherResource(ctx, name, nil, pulumi.URN_(urn))
+		r = &OtherResource{}
 	case "example::Resource":
-		r, err = NewResource(ctx, name, nil, pulumi.URN_(urn))
+		r = &Resource{}
 	default:
 		return nil, fmt.Errorf("unknown resource type: %s", typ)
 	}
 
+	err = ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
 	return
 }
 
@@ -44,7 +45,9 @@ func (p *pkg) ConstructProvider(ctx *pulumi.Context, name, typ, urn string) (pul
 		return nil, fmt.Errorf("unknown provider type: %s", typ)
 	}
 
-	return NewProvider(ctx, name, nil, pulumi.URN_(urn))
+	r := &Provider{}
+	err := ctx.RegisterResource(typ, name, nil, r, pulumi.URN_(urn))
+	return r, err
 }
 
 func init() {


### PR DESCRIPTION
We've been emitting calls to `New<Resource>` for resource registrations in Go, passing `nil` for args. However, some of those `New<Resource>` functions actually check for `nil` args and return an error if the resource has required arguments.

At first, I was looking for a way to check inside `New<Resource>` if the `URN` option was specified and in that case not error on `nil` args (like we do in other languages), but we don't provide a way to access the resource option values outside the Go SDK), so I don't think there is a way to do it this way for Go.

So instead, this change updates the registration code to call `ctx.RegisterResource` directly instead of `New<Resource>`, where we can pass a `nil` args.

Fixes https://github.com/pulumi/pulumi-eks/issues/537