### PR TITLE
fix nodejs resource functions (ie registerResource) to properly propagate errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,4 +8,5 @@
 
 ### Bug Fixes
 
-
+- [sdk/nodejs] Fix error propagation in registerResource and other resource methods.
+  [#6644](https://github.com/pulumi/pulumi/pull/6644)

--- a/sdk/nodejs/tests/runtime/props.spec.ts
+++ b/sdk/nodejs/tests/runtime/props.spec.ts
@@ -67,6 +67,7 @@ class TestMocks implements runtime.Mocks {
                     state: {},
                 };
             case "error":
+                throw new Error("this is an intentional error");
             default:
                 throw new Error(`unknown resource type ${type}`);
         }
@@ -366,7 +367,7 @@ describe("runtime", () => {
                 const customURN = await errResource.urn.promise();
                 const customID = await errResource.id.promise();
             }, (err: Error) => {
-                const containsMessage = err.stack!.indexOf("unknown resource type error") >= 0;
+                const containsMessage = err.stack!.indexOf("this is an intentional error") >= 0;
                 const containsRegisterResource = err.stack!.indexOf("registerResource") >= 0;
                 return containsMessage && containsRegisterResource;
             });


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/6643

More detail in the issues above, but TLDR is that we were swallowing errors in registerResource. This change fixes `prepareResource` to set up reject handlers on ID and URN promises to appropriately propagate the errors. 