### PR TITLE
cache serialized/deserialized dynamic providers in nodejs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 
 ### Improvements
 
+- [sdk/nodejs] Improve performance of dynamic providers by caching serlialized/deserialized providers.
+  [#6646](https://github.com/pulumi/pulumi/pull/6646)
+
 - [cli] Support full fidelity YAML round-tripping
   - Strip Byte-order Mark (BOM) from YAML configs during load. - [#6636](https://github.com/pulumi/pulumi/pull/6636)
   - Swap out YAML parser library - [#6642](https://github.com/pulumi/pulumi/pull/6642)

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -59,28 +59,14 @@ process.on("exit", (code: number) => {
 
 const providerCache: { [key: string]: dynamic.ResourceProvider} = {};
 
-const hashCode = (str: string) => {
-    let hash = 0;
-    let i: number;
-    let chr: number;
-    if (str.length === 0) return hash;
-    for (i = 0; i < str.length; i++) {
-        chr = str.charCodeAt(i);
-        hash = ((hash << 5) - hash) + chr;
-        hash |= 0; // Convert to 32bit integer
-    }
-    return hash;
-};
-
 function getProvider(props: any): dynamic.ResourceProvider {
     const providerString = props[providerKey];
-    const providerHash = hashCode(providerString);
     let provider: any;
-    if(providerCache[providerHash]) {
-        provider = providerCache[providerHash];
+    if(providerCache[providerString]) {
+        provider = providerCache[providerString];
     } else {
         provider = requireFromString(props[providerKey]).handler();
-        providerCache[providerHash] = provider;
+        providerCache[providerString] = provider;
     }
     
     // TODO[pulumi/pulumi#414]: investigate replacing requireFromString with eval

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -57,9 +57,34 @@ process.on("exit", (code: number) => {
     }
 });
 
+const providerCache: { [key: string]: dynamic.ResourceProvider} = {};
+
+const hashCode = (str: string) => {
+    let hash = 0;
+    let i: number;
+    let chr: number;
+    if (str.length === 0) return hash;
+    for (i = 0; i < str.length; i++) {
+        chr = str.charCodeAt(i);
+        hash = ((hash << 5) - hash) + chr;
+        hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+};
+
 function getProvider(props: any): dynamic.ResourceProvider {
+    const providerString = props[providerKey];
+    const providerHash = hashCode(providerString);
+    let provider: any;
+    if(providerCache[providerHash]) {
+        provider = providerCache[providerHash];
+    } else {
+        provider = requireFromString(props[providerKey]).handler();
+        providerCache[providerHash] = provider;
+    }
+    
     // TODO[pulumi/pulumi#414]: investigate replacing requireFromString with eval
-    return requireFromString(props[providerKey]).handler();
+    return provider
 }
 
 // Each of the *RPC functions below implements a single method of the resource provider gRPC interface. The CRUD


### PR DESCRIPTION
This fix was done as a part of investigating https://github.com/pulumi/pulumi/issues/6645

On the user program side, every instance of a dynamic resource individually serializes its provider. On the dynamic provider side, every call to check, diff, etc, deserialized the dynamic provider in the payload. This change does two things:

1. Add program level caching of serialized dynamic providers
2. Add dynamic provider level caching of deserialized dynamic providers

(1) alone cuts memory usage in the linked repro by 2/3 from 1.5Gb to 500Mb. The repro program also runs in 1/5th the time (100s -> 20s) after this change. 

Unfortunately, the failures in the linked issue still happen although with seemingly lower frequency. 

As for the implementation, both of these rely on globals caches. This is OK, as the caching mechanism is tolerant to multiple provider processes or instances of the SDK. 

We should consider porting this change to python as well. 