### PR TITLE
Add provider side caching for dynamic provider deserialization

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 
 ### Improvements
 
+- [sdk/nodejs] Add provider side caching for dynamic provider deserialization
+  [#6657](https://github.com/pulumi/pulumi/pull/6657)
+
 - [automation/dotnet] Expose structured logging
   [#6572](https://github.com/pulumi/pulumi/pull/6572)
 

--- a/sdk/nodejs/cmd/dynamic-provider/index.ts
+++ b/sdk/nodejs/cmd/dynamic-provider/index.ts
@@ -57,9 +57,18 @@ process.on("exit", (code: number) => {
     }
 });
 
+const providerCache: { [key: string]: dynamic.ResourceProvider } = {};
+
 function getProvider(props: any): dynamic.ResourceProvider {
+    const providerString = props[providerKey];
+    let provider: any = providerCache[providerString];
+    if (!provider) {
+        provider = requireFromString(providerString).handler();
+        providerCache[providerString] = provider;
+    }
+
     // TODO[pulumi/pulumi#414]: investigate replacing requireFromString with eval
-    return requireFromString(props[providerKey]).handler();
+    return provider;
 }
 
 // Each of the *RPC functions below implements a single method of the resource provider gRPC interface. The CRUD


### PR DESCRIPTION
Contributes to https://github.com/pulumi/pulumi/issues/6645
Closes https://github.com/pulumi/customer-support/issues/360

I went ahead and broke out the non-breaking portion of https://github.com/pulumi/pulumi/pull/6646 into a separate PR. 

This change caches deserialized dynamic providers, so we don't have to repeatedly call `requireFromString` for each diff, check, etc call when many of the same dynamic resource are created. That library ultimately bottoms out on `vm.createContext` https://nodejs.org/api/vm.html#vm_what_does_it_mean_to_contextify_an_object

There was a perf regression in node v12 on this method that exacerbates the issue for our users on that version: https://github.com/nodejs/node/issues/29842