### PR TITLE
[automation/go,nodejs,python] - Don't roundtrip project settings if file already exists.

### DIFF
--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -876,7 +876,9 @@ func NewStackInlineSource(
 	if err != nil {
 		return stack, err
 	}
-	opts = append(opts, Project(*proj))
+	if proj != nil {
+		opts = append(opts, Project(*proj))
+	}
 
 	w, err := NewLocalWorkspace(ctx, opts...)
 	if err != nil {
@@ -905,7 +907,9 @@ func UpsertStackInlineSource(
 	if err != nil {
 		return stack, err
 	}
-	opts = append(opts, Project(*proj))
+	if proj != nil {
+		opts = append(opts, Project(*proj))
+	}
 
 	w, err := NewLocalWorkspace(ctx, opts...)
 	if err != nil {
@@ -933,7 +937,9 @@ func SelectStackInlineSource(
 	if err != nil {
 		return stack, err
 	}
-	opts = append(opts, Project(*proj))
+	if proj != nil {
+		opts = append(opts, Project(*proj))
+	}
 
 	w, err := NewLocalWorkspace(ctx, opts...)
 	if err != nil {
@@ -998,9 +1004,9 @@ func getProjectSettings(
 	// If WorkDir is specified, try to read any existing project settings before resorting to
 	// creating a default project.
 	if optsBag.WorkDir != "" {
-		proj, err := readProjectSettingsFromDir(ctx, optsBag.WorkDir)
+		_, err := readProjectSettingsFromDir(ctx, optsBag.WorkDir)
 		if err == nil {
-			return proj, nil
+			return nil, nil
 		}
 
 		if err.Error() == "unable to find project settings in workspace" {

--- a/sdk/go/x/auto/local_workspace_test.go
+++ b/sdk/go/x/auto/local_workspace_test.go
@@ -1374,6 +1374,13 @@ func TestProjectSettingsRespected(t *testing.T) {
 	stack, err := NewStackInlineSource(ctx, stackName, badProjectName, func(ctx *pulumi.Context) error {
 		return nil
 	}, WorkDir(filepath.Join(".", "test", pName)))
+
+	defer func() {
+		// -- pulumi stack rm --
+		err = stack.Workspace().RemoveStack(ctx, stack.Name())
+		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
+	}()
+
 	assert.Nil(t, err)
 	projectSettings, err := stack.workspace.ProjectSettings(ctx)
 	assert.Nil(t, err)

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -399,6 +399,7 @@ describe("LocalWorkspace", () => {
         const projectSettings = await stack.workspace.projectSettings();
         assert.strictEqual(projectSettings.name, "correct_project");
         assert.strictEqual(projectSettings.description, "This is a description");
+        await stack.workspace.removeStack(stackName);
     }));
 });
 

--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -188,8 +188,10 @@ export class LocalWorkspace implements Workspace {
         if (!wsOpts.projectSettings) {
             if (!!wsOpts.workDir) {
                 try {
-                    wsOpts.projectSettings = loadProjectSettings(wsOpts.workDir);
+                    // Try to load the project settings.
+                    loadProjectSettings(wsOpts.workDir);
                 } catch (e) {
+                    // If it failed to find the project settings file, set a default project.
                     if (e.toString().includes("failed to find project settings")) {
                         wsOpts.projectSettings = defaultProject(args.projectName);
                     } else {

--- a/sdk/python/lib/pulumi/x/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_local_workspace.py
@@ -428,13 +428,11 @@ def _inline_source_stack_helper(stack_name: str,
         work_dir = workspace_options.work_dir
         if work_dir:
             try:
-                project_settings = _load_project_settings(work_dir)
+                _load_project_settings(work_dir)
             except FileNotFoundError:
-                project_settings = default_project(project_name)
+                workspace_options.project_settings = default_project(project_name)
         else:
-            project_settings = default_project(project_name)
-
-        workspace_options.project_settings = project_settings
+            workspace_options.project_settings = default_project(project_name)
 
     ws = LocalWorkspace(**workspace_options.__dict__)
     return init_fn(stack_name, ws)

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -396,6 +396,7 @@ class TestLocalWorkspace(unittest.TestCase):
         project_settings = stack.workspace.project_settings()
         self.assertEqual(project_settings.name, "correct_project")
         self.assertEqual(project_settings.description, "This is a description")
+        stack.workspace.remove_stack(stack_name)
 
 
 def pulumi_program():


### PR DESCRIPTION
Follow-up from #6655 