### PR TITLE
Avoid overriding dotnet proj settings accidentally

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,10 @@
 
 - [automation/python] Fix passing of additional environment variables.
   [#6639](https://github.com/pulumi/pulumi/pull/6639)
-  
+
 - [sdk/python] Make exceptions raised by calls to provider functions (e.g. data sources) catchable.
   [#6504](https://github.com/pulumi/pulumi/pull/6504)
+
+- [sdk/dotnet] Avoid overwriting existing Pulumi.yaml, introduce
+  ProjectSettingsConflictException.
+  [6670](https://github.com/pulumi/pulumi/pull/6670)

--- a/sdk/dotnet/Pulumi.Automation.Tests/Data/correct_project/Pulumi.yaml
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Data/correct_project/Pulumi.yaml
@@ -1,0 +1,3 @@
+description: This is a description
+name: correct_project
+runtime: dotnet

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -908,7 +908,7 @@ namespace Pulumi.Automation.Tests
                 Assert.True(expSecretValue.IsSecret);
             }
         }
-    
+
         [Fact]
         public async Task PulumiVersionTest()
         {
@@ -938,6 +938,22 @@ namespace Pulumi.Automation.Tests
             {
                 LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion);
             }
+        }
+
+        [Fact]
+        public async Task RespectsProjectSettingsTest()
+        {
+            var program = PulumiFn.Create<ValidStack>();
+
+            var stackName = $"{RandomStackName()}";
+            var projectName = "project_was_overwritten";
+            var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
+            {
+                WorkDir = Path.Combine(_dataDirectory, "correct_project")
+            });
+            var settings = await stack.Workspace.GetProjectSettingsAsync();
+            Assert.Equal("correct_project", settings!.Name);
+            Assert.Equal("This is a description", settings.Description);
         }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Pulumi.Automation.Commands.Exceptions;
@@ -16,9 +17,6 @@ namespace Pulumi.Automation.Tests
 {
     public class LocalWorkspaceTests
     {
-        private static readonly string _dataDirectory =
-            Path.Combine(new FileInfo(Assembly.GetExecutingAssembly().Location).DirectoryName, "Data");
-
         private static readonly string _pulumiOrg = GetTestOrg();
 
         private static string GetTestSuffix()
@@ -55,7 +53,7 @@ namespace Pulumi.Automation.Tests
         [InlineData("json")]
         public async Task GetProjectSettings(string extension)
         {
-            var workingDir = Path.Combine(_dataDirectory, extension);
+            var workingDir = ResourcePath(Path.Combine("Data", extension));
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 WorkDir = workingDir,
@@ -74,7 +72,7 @@ namespace Pulumi.Automation.Tests
         [InlineData("json")]
         public async Task GetStackSettings(string extension)
         {
-            var workingDir = Path.Combine(_dataDirectory, extension);
+            var workingDir = ResourcePath(Path.Combine("Data", extension));
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 WorkDir = workingDir,
@@ -283,7 +281,7 @@ namespace Pulumi.Automation.Tests
         public async Task StackLifecycleLocalProgram()
         {
             var stackName = $"{RandomStackName()}";
-            var workingDir = Path.Combine(_dataDirectory, "testproj");
+            var workingDir = ResourcePath(Path.Combine("Data", "testproj"));
             using var stack = await LocalWorkspace.CreateStackAsync(new LocalProgramArgs(stackName, workingDir)
             {
                 EnvironmentVariables = new Dictionary<string, string>()
@@ -622,7 +620,7 @@ namespace Pulumi.Automation.Tests
             }
 
             static async Task<T> RunCommand<T, TOptions>(Func<TOptions, CancellationToken, Task<T>> func, string command)
-                where TOptions: UpdateOptions, new()
+                where TOptions : UpdateOptions, new()
             {
                 var events = new List<EngineEvent>();
 
@@ -947,13 +945,24 @@ namespace Pulumi.Automation.Tests
 
             var stackName = $"{RandomStackName()}";
             var projectName = "project_was_overwritten";
-            var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
-            {
-                WorkDir = Path.Combine(_dataDirectory, "correct_project")
-            });
+
+            var workdir = ResourcePath(Path.Combine("Data", "correct_project"));
+
+            var stack = await LocalWorkspace.CreateStackAsync(
+                new InlineProgramArgs(projectName, stackName, program)
+                {
+                    WorkDir = workdir
+                });
+
             var settings = await stack.Workspace.GetProjectSettingsAsync();
             Assert.Equal("correct_project", settings!.Name);
             Assert.Equal("This is a description", settings.Description);
+        }
+
+        private string ResourcePath(string path, [CallerFilePath] string pathBase = "LocalWorkspaceTests.cs")
+        {
+            var dir = Path.GetDirectoryName(pathBase) ?? ".";
+            return Path.Combine(dir, path);
         }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/Collections/DictionaryContentsComparer.cs
+++ b/sdk/dotnet/Pulumi.Automation/Collections/DictionaryContentsComparer.cs
@@ -2,7 +2,7 @@
 
 using System.Collections.Generic;
 
-namespace Pulumi.Automation
+namespace Pulumi.Automation.Collections
 {
     /// Compares two dictionaries for equality by content, as F# maps would.
     internal sealed class DictionaryContentsComparer<K, V> : IEqualityComparer<IDictionary<K, V>> where K : notnull

--- a/sdk/dotnet/Pulumi.Automation/DictionaryContentsComparer.cs
+++ b/sdk/dotnet/Pulumi.Automation/DictionaryContentsComparer.cs
@@ -26,6 +26,10 @@ namespace Pulumi.Automation
             {
                 return x == null;
             }
+            if (ReferenceEquals(x, y))
+            {
+                return true;
+            }
             if (x.Count != y.Count)
             {
                 return false;

--- a/sdk/dotnet/Pulumi.Automation/DictionaryContentsComparer.cs
+++ b/sdk/dotnet/Pulumi.Automation/DictionaryContentsComparer.cs
@@ -1,0 +1,54 @@
+// Copyright 2016-2019, Pulumi Corporation
+
+using System.Collections.Generic;
+
+namespace Pulumi.Automation
+{
+    /// Compares two dictionaries for equality by content, as F# maps would.
+    internal sealed class DictionaryContentsComparer<K, V> : IEqualityComparer<IDictionary<K, V>> where K : notnull
+    {
+        private IEqualityComparer<K> _keyComparer;
+        private IEqualityComparer<V> _valueComparer;
+
+        public DictionaryContentsComparer(IEqualityComparer<K> keyComparer, IEqualityComparer<V> valueComparer)
+        {
+            this._keyComparer = keyComparer;
+            this._valueComparer = valueComparer;
+        }
+
+        bool IEqualityComparer<IDictionary<K, V>>.Equals(IDictionary<K, V>? x, IDictionary<K, V>? y)
+        {
+            if (x == null)
+            {
+                return y == null;
+            }
+            if (y == null)
+            {
+                return x == null;
+            }
+            if (x.Count != y.Count)
+            {
+                return false;
+            }
+            var y2 = new Dictionary<K, V>(y, this._keyComparer);
+            foreach (var pair in x)
+            {
+                if (!y2.ContainsKey(pair.Key))
+                {
+                    return false;
+                }
+
+                if (!this._valueComparer.Equals(pair.Value, y2[pair.Key]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        int IEqualityComparer<IDictionary<K, V>>.GetHashCode(IDictionary<K, V> obj)
+        {
+            return 0; // inefficient but correct
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/DictionaryContentsComparer.cs
+++ b/sdk/dotnet/Pulumi.Automation/DictionaryContentsComparer.cs
@@ -7,8 +7,8 @@ namespace Pulumi.Automation
     /// Compares two dictionaries for equality by content, as F# maps would.
     internal sealed class DictionaryContentsComparer<K, V> : IEqualityComparer<IDictionary<K, V>> where K : notnull
     {
-        private IEqualityComparer<K> _keyComparer;
-        private IEqualityComparer<V> _valueComparer;
+        private readonly IEqualityComparer<K> _keyComparer;
+        private readonly IEqualityComparer<V> _valueComparer;
 
         public DictionaryContentsComparer(IEqualityComparer<K> keyComparer, IEqualityComparer<V> valueComparer)
         {

--- a/sdk/dotnet/Pulumi.Automation/Exceptions/ProjectSettingsConflictException.cs
+++ b/sdk/dotnet/Pulumi.Automation/Exceptions/ProjectSettingsConflictException.cs
@@ -4,7 +4,22 @@ using System;
 
 namespace Pulumi.Automation.Exceptions
 {
-    internal class ProjectSettingsConflictException : Exception
+    /// <summary>
+    ///
+    /// Thrown when creating a Workspace detects a conflict between
+    /// project settings found on disk (such as Pulumi.yaml) and a
+    /// ProjectSettings object passed to the Create API.
+    ///
+    /// There are two resolutions:
+    ///
+    /// (A) to use the ProjectSettings, delete the Pulumi.yaml file
+    ///     from WorkDir or use a different WorkDir
+    ///
+    /// (B) to use the exiting Pulumi.yaml from WorkDir, avoid
+    ///     customizing the ProjectSettings
+    ///
+    /// </summary>
+    public class ProjectSettingsConflictException : Exception
     {
         internal string SettingsFileLocation { get; }
 

--- a/sdk/dotnet/Pulumi.Automation/Exceptions/ProjectSettingsConflictException.cs
+++ b/sdk/dotnet/Pulumi.Automation/Exceptions/ProjectSettingsConflictException.cs
@@ -1,0 +1,24 @@
+// Copyright 2016-2021, Pulumi Corporation
+
+using System;
+
+namespace Pulumi.Automation.Exceptions
+{
+    internal class ProjectSettingsConflictException : Exception
+    {
+        internal string SettingsFileLocation { get; }
+
+        internal ProjectSettingsConflictException(string settingsFileLocation)
+            : base(ErrMsg(settingsFileLocation))
+        {
+            SettingsFileLocation = settingsFileLocation;
+        }
+
+        private static string ErrMsg(string settingsFileLocation)
+        {
+            return String.Format(
+                "Custom ProjectSettings passed in code conflict with settings found on disk: {0}",
+                settingsFileLocation);
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/Exceptions/ProjectSettingsConflictException.cs
+++ b/sdk/dotnet/Pulumi.Automation/Exceptions/ProjectSettingsConflictException.cs
@@ -21,19 +21,19 @@ namespace Pulumi.Automation.Exceptions
     /// </summary>
     public class ProjectSettingsConflictException : Exception
     {
-        internal string SettingsFileLocation { get; }
+
+        /// <summary>
+        ///
+        /// FullPath of the Pulumi.yaml (or Pulumi.yml, Pulumi.json)
+        /// settings file found on disk.
+        ///
+        /// </summary>
+        public string SettingsFileLocation { get; }
 
         internal ProjectSettingsConflictException(string settingsFileLocation)
-            : base(ErrMsg(settingsFileLocation))
+            : base($"Custom {nameof(ProjectSettings)} passed in code conflict with settings found on disk: {settingsFileLocation}")
         {
             SettingsFileLocation = settingsFileLocation;
-        }
-
-        private static string ErrMsg(string settingsFileLocation)
-        {
-            return String.Format(
-                "Custom ProjectSettings passed in code conflict with settings found on disk: {0}",
-                settingsFileLocation);
         }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -354,13 +354,11 @@ namespace Pulumi.Automation
             {
                 await this.SaveProjectSettingsAsync(projectSettings, cancellationToken);
             }
-            else
+            else if (!projectSettings.IsDefault &&
+                     !ProjectSettings.Comparer.Equals(projectSettings, existingSettings))
             {
-                if (!projectSettings.IsDefault)
-                {
-                    var path = this.FindSettingsFile();
-                    throw new Exceptions.ProjectSettingsConflictException(path);
-                }
+                var path = this.FindSettingsFile();
+                throw new Exceptions.ProjectSettingsConflictException(path);
             }
         }
 

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -400,19 +400,16 @@ namespace Pulumi.Automation
             {
                 return null;
             }
+            var content = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
+            if (isJson)
+            {
+                return this._serializer.DeserializeJson<ProjectSettings>(content);
+            }
             else
             {
-                var content = await File.ReadAllTextAsync(path, cancellationToken).ConfigureAwait(false);
-                if (isJson)
-                {
-                    return this._serializer.DeserializeJson<ProjectSettings>(content);
-                }
-                else
-                {
 
-                    var model = this._serializer.DeserializeYaml<ProjectSettingsModel>(content);
-                    return model.Convert();
-                }
+                var model = this._serializer.DeserializeYaml<ProjectSettingsModel>(content);
+                return model.Convert();
             }
         }
 

--- a/sdk/dotnet/Pulumi.Automation/ProjectBackend.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectBackend.cs
@@ -10,9 +10,9 @@ namespace Pulumi.Automation
     /// </summary>
     public class ProjectBackend
     {
-        public string? Url { get; set; }
-
         internal static IEqualityComparer<ProjectBackend> Comparer { get; } = new ProjectBackendComparer();
+
+        public string? Url { get; set; }
 
         private sealed class ProjectBackendComparer : IEqualityComparer<ProjectBackend>
         {

--- a/sdk/dotnet/Pulumi.Automation/ProjectBackend.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectBackend.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using System;
+using System.Collections.Generic;
+
 namespace Pulumi.Automation
 {
     /// <summary>
@@ -8,5 +11,32 @@ namespace Pulumi.Automation
     public class ProjectBackend
     {
         public string? Url { get; set; }
+
+        internal static IEqualityComparer<ProjectBackend> Comparer { get; } = new ProjectBackendComparer();
+
+        private sealed class ProjectBackendComparer : IEqualityComparer<ProjectBackend>
+        {
+            bool IEqualityComparer<ProjectBackend>.Equals(ProjectBackend? x, ProjectBackend? y)
+            {
+                if (x == null)
+                {
+                    return y == null;
+                }
+
+                if (y == null)
+                {
+                    return x == null;
+                }
+
+                return x.Url == y.Url;
+            }
+
+            int IEqualityComparer<ProjectBackend>.GetHashCode(ProjectBackend obj)
+            {
+                var hash = new HashCode();
+                hash.Add(obj.Url);
+                return hash.ToHashCode();
+            }
+        }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/ProjectBackend.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectBackend.cs
@@ -28,6 +28,11 @@ namespace Pulumi.Automation
                     return x == null;
                 }
 
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
                 return x.Url == y.Url;
             }
 

--- a/sdk/dotnet/Pulumi.Automation/ProjectBackend.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectBackend.cs
@@ -33,9 +33,7 @@ namespace Pulumi.Automation
 
             int IEqualityComparer<ProjectBackend>.GetHashCode(ProjectBackend obj)
             {
-                var hash = new HashCode();
-                hash.Add(obj.Url);
-                return hash.ToHashCode();
+                return HashCode.Combine(obj.Url);
             }
         }
     }

--- a/sdk/dotnet/Pulumi.Automation/ProjectRuntime.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectRuntime.cs
@@ -35,6 +35,11 @@ namespace Pulumi.Automation
                     return x == null;
                 }
 
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
                 return x.Name == y.Name && ProjectRuntimeOptions.Comparer.Equals(x.Options, y.Options);
             }
 

--- a/sdk/dotnet/Pulumi.Automation/ProjectRuntime.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectRuntime.cs
@@ -40,15 +40,11 @@ namespace Pulumi.Automation
 
             int IEqualityComparer<ProjectRuntime>.GetHashCode(ProjectRuntime obj)
             {
-                var hash = new HashCode();
-                hash.Add(obj.Name);                
-                if (obj.Options != null)
-                {
-                    hash.Add(ProjectRuntimeOptions.Comparer.GetHashCode(obj.Options));
-                }
-                return hash.ToHashCode();
+                return HashCode.Combine(
+                    obj.Name,
+                    obj.Options != null ? ProjectRuntimeOptions.Comparer.GetHashCode(obj.Options) : 0
+                );
             }
         }
     }
 }
-

--- a/sdk/dotnet/Pulumi.Automation/ProjectRuntime.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectRuntime.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using System;
+using System.Collections.Generic;
+
 namespace Pulumi.Automation
 {
     /// <summary>
@@ -15,5 +18,37 @@ namespace Pulumi.Automation
         {
             this.Name = name;
         }
+
+        internal static IEqualityComparer<ProjectRuntime> Comparer { get; } = new ProjectRuntimeComparer();
+
+        private sealed class ProjectRuntimeComparer : IEqualityComparer<ProjectRuntime>
+        {
+            bool IEqualityComparer<ProjectRuntime>.Equals(ProjectRuntime? x, ProjectRuntime? y)
+            {
+                if (x == null)
+                {
+                    return y == null;
+                }
+
+                if (y == null)
+                {
+                    return x == null;
+                }
+
+                return x.Name == y.Name && ProjectRuntimeOptions.Comparer.Equals(x.Options, y.Options);
+            }
+
+            int IEqualityComparer<ProjectRuntime>.GetHashCode(ProjectRuntime obj)
+            {
+                var hash = new HashCode();
+                hash.Add(obj.Name);                
+                if (obj.Options != null)
+                {
+                    hash.Add(ProjectRuntimeOptions.Comparer.GetHashCode(obj.Options));
+                }
+                return hash.ToHashCode();
+            }
+        }
     }
 }
+

--- a/sdk/dotnet/Pulumi.Automation/ProjectRuntime.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectRuntime.cs
@@ -10,6 +10,8 @@ namespace Pulumi.Automation
     /// </summary>
     public class ProjectRuntime
     {
+        internal static IEqualityComparer<ProjectRuntime> Comparer { get; } = new ProjectRuntimeComparer();
+
         public ProjectRuntimeName Name { get; set; }
 
         public ProjectRuntimeOptions? Options { get; set; }
@@ -18,8 +20,6 @@ namespace Pulumi.Automation
         {
             this.Name = name;
         }
-
-        internal static IEqualityComparer<ProjectRuntime> Comparer { get; } = new ProjectRuntimeComparer();
 
         private sealed class ProjectRuntimeComparer : IEqualityComparer<ProjectRuntime>
         {

--- a/sdk/dotnet/Pulumi.Automation/ProjectRuntimeOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectRuntimeOptions.cs
@@ -10,6 +10,8 @@ namespace Pulumi.Automation
     /// </summary>
     public class ProjectRuntimeOptions
     {
+        internal static IEqualityComparer<ProjectRuntimeOptions> Comparer { get; } = new ProjectRuntimeOptionsComparer();
+
         /// <summary>
         /// Applies to NodeJS projects only.
         /// <para/>
@@ -32,8 +34,6 @@ namespace Pulumi.Automation
         /// A string that specifies the path to a virtual environment to use when running the program.
         /// </summary>
         public string? VirtualEnv { get; set; }
-
-        internal static IEqualityComparer<ProjectRuntimeOptions> Comparer { get; } = new ProjectRuntimeOptionsComparer();
 
         private sealed class ProjectRuntimeOptionsComparer : IEqualityComparer<ProjectRuntimeOptions>
         {

--- a/sdk/dotnet/Pulumi.Automation/ProjectRuntimeOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectRuntimeOptions.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using System;
+using System.Collections.Generic;
+
 namespace Pulumi.Automation
 {
     /// <summary>
@@ -29,5 +32,34 @@ namespace Pulumi.Automation
         /// A string that specifies the path to a virtual environment to use when running the program.
         /// </summary>
         public string? VirtualEnv { get; set; }
+
+        internal static IEqualityComparer<ProjectRuntimeOptions> Comparer { get; } = new ProjectRuntimeOptionsComparer();
+
+        private sealed class ProjectRuntimeOptionsComparer : IEqualityComparer<ProjectRuntimeOptions>
+        {
+            bool IEqualityComparer<ProjectRuntimeOptions>.Equals(ProjectRuntimeOptions? x, ProjectRuntimeOptions? y)
+            {
+                if (x == null)
+                {
+                    return y == null;
+                }
+
+                if (y == null)
+                {
+                    return x == null;
+                }
+
+                return x.TypeScript == y.TypeScript && x.Binary == y.Binary && x.VirtualEnv == y.VirtualEnv;
+            }
+
+            int IEqualityComparer<ProjectRuntimeOptions>.GetHashCode(ProjectRuntimeOptions obj)
+            {
+                var hash = new HashCode();
+                hash.Add(obj.TypeScript);
+                hash.Add(obj.Binary);
+                hash.Add(obj.VirtualEnv);
+                return hash.ToHashCode();
+            }
+        }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/ProjectRuntimeOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectRuntimeOptions.cs
@@ -54,11 +54,7 @@ namespace Pulumi.Automation
 
             int IEqualityComparer<ProjectRuntimeOptions>.GetHashCode(ProjectRuntimeOptions obj)
             {
-                var hash = new HashCode();
-                hash.Add(obj.TypeScript);
-                hash.Add(obj.Binary);
-                hash.Add(obj.VirtualEnv);
-                return hash.ToHashCode();
+                return HashCode.Combine(obj.TypeScript, obj.Binary, obj.VirtualEnv);
             }
         }
     }

--- a/sdk/dotnet/Pulumi.Automation/ProjectRuntimeOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectRuntimeOptions.cs
@@ -49,6 +49,11 @@ namespace Pulumi.Automation
                     return x == null;
                 }
 
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
                 return x.TypeScript == y.TypeScript && x.Binary == y.Binary && x.VirtualEnv == y.VirtualEnv;
             }
 

--- a/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
@@ -86,17 +86,17 @@ namespace Pulumi.Automation
 
             int IEqualityComparer<ProjectSettings>.GetHashCode(ProjectSettings obj)
             {
-                var hash = new HashCode();
-                hash.Add(obj.Name);
-                hash.Add(obj.Main);
-                hash.Add(obj.Description);
-                hash.Add(obj.Author);
-                hash.Add(obj.Website);
-                hash.Add(obj.License);
-                hash.Add(obj.Config);
-                hash.Add(obj.Backend);
                 // fields with custom Comparer skipped for efficiency
-                return hash.ToHashCode();
+                return HashCode.Combine(
+                    obj.Name,
+                    obj.Main,
+                    obj.Description,
+                    obj.Author,
+                    obj.Website,
+                    obj.License,
+                    obj.Config,
+                    obj.Backend
+                );
             }
         }
     }

--- a/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using System;
+using System.Collections.Generic;
+
 namespace Pulumi.Automation
 {
     /// <summary>
@@ -44,5 +47,57 @@ namespace Pulumi.Automation
 
         internal static ProjectSettings Default(string name)
             => new ProjectSettings(name, new ProjectRuntime(ProjectRuntimeName.NodeJS));
+
+        internal bool IsDefault
+        {
+            get
+            {
+                return ProjectSettings.Comparer.Equals(this, ProjectSettings.Default(this.Name));
+            }
+        }
+
+        internal static IEqualityComparer<ProjectSettings> Comparer { get; } = new ProjectSettingsComparer();
+
+        private sealed class ProjectSettingsComparer : IEqualityComparer<ProjectSettings>
+        {
+            bool IEqualityComparer<ProjectSettings>.Equals(ProjectSettings? x, ProjectSettings? y)
+            {
+                if (x == null)
+                {
+                    return y == null;
+                }
+
+                if (y == null)
+                {
+                    return x == null;
+                }
+
+                return x.Name == y.Name &&
+                        ProjectRuntime.Comparer.Equals(x.Runtime, y.Runtime) &&
+                        x.Main == y.Main &&
+                        x.Description == y.Description &&
+                        x.Author == y.Author &&
+                        x.Website == y.Website &&
+                        x.License == y.License &&
+                        x.Config == y.Config &&
+                        ProjectTemplate.Comparer.Equals(x.Template, y.Template) &&
+                        ProjectBackend.Comparer.Equals(x.Backend, y.Backend);
+            }
+
+            int IEqualityComparer<ProjectSettings>.GetHashCode(ProjectSettings obj)
+            {
+                var hash = new HashCode();
+                hash.Add(obj.Name);
+                hash.Add(obj.Main);
+                hash.Add(obj.Description);
+                hash.Add(obj.Author);
+                hash.Add(obj.Website);
+                hash.Add(obj.License);
+                hash.Add(obj.Config);
+                hash.Add(obj.Backend);
+                // fields with custom Comparer skipped for efficiency
+                return hash.ToHashCode();
+            }
+        }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
@@ -72,6 +72,11 @@ namespace Pulumi.Automation
                     return x == null;
                 }
 
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
                 return x.Name == y.Name &&
                         ProjectRuntime.Comparer.Equals(x.Runtime, y.Runtime) &&
                         x.Main == y.Main &&

--- a/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
@@ -10,6 +10,8 @@ namespace Pulumi.Automation
     /// </summary>
     public class ProjectSettings
     {
+        internal static IEqualityComparer<ProjectSettings> Comparer { get; } = new ProjectSettingsComparer();
+
         public string Name { get; set; }
 
         public ProjectRuntime Runtime { get; set; }
@@ -55,8 +57,6 @@ namespace Pulumi.Automation
                 return ProjectSettings.Comparer.Equals(this, ProjectSettings.Default(this.Name));
             }
         }
-
-        internal static IEqualityComparer<ProjectSettings> Comparer { get; } = new ProjectSettingsComparer();
 
         private sealed class ProjectSettingsComparer : IEqualityComparer<ProjectSettings>
         {

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using Pulumi.Automation.Collections;
 
 namespace Pulumi.Automation
 {

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
@@ -10,6 +10,8 @@ namespace Pulumi.Automation
     /// </summary>
     public class ProjectTemplate
     {
+        internal static IEqualityComparer<ProjectTemplate> Comparer { get; } = new ProjectTemplateComparer();
+
         public string? Description { get; set; }
 
         public string? QuickStart { get; set; }
@@ -17,8 +19,6 @@ namespace Pulumi.Automation
         public IDictionary<string, ProjectTemplateConfigValue>? Config { get; set; }
 
         public bool? Important { get; set; }
-
-        internal static IEqualityComparer<ProjectTemplate> Comparer { get; } = new ProjectTemplateComparer();
 
         private sealed class ProjectTemplateComparer : IEqualityComparer<ProjectTemplate>
         {

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
@@ -48,12 +48,8 @@ namespace Pulumi.Automation
 
             int IEqualityComparer<ProjectTemplate>.GetHashCode(ProjectTemplate obj)
             {
-                var hash = new HashCode();
-                hash.Add(obj.Description);
-                hash.Add(obj.QuickStart);
-                hash.Add(obj.Important);
                 // omit hashing Config dict for efficiency
-                return hash.ToHashCode();
+                return HashCode.Combine(obj.Description, obj.QuickStart, obj.Important);
             }
         }
     }

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using System;
 using System.Collections.Generic;
 
 namespace Pulumi.Automation
@@ -16,5 +17,44 @@ namespace Pulumi.Automation
         public IDictionary<string, ProjectTemplateConfigValue>? Config { get; set; }
 
         public bool? Important { get; set; }
+
+        internal static IEqualityComparer<ProjectTemplate> Comparer { get; } = new ProjectTemplateComparer();
+
+        private sealed class ProjectTemplateComparer : IEqualityComparer<ProjectTemplate>
+        {
+
+            private IEqualityComparer<IDictionary<string, ProjectTemplateConfigValue>> _configComparer =
+                new DictionaryContentsComparer<string, ProjectTemplateConfigValue>(
+                    EqualityComparer<string>.Default,
+                    ProjectTemplateConfigValue.Comparer);
+
+            bool IEqualityComparer<ProjectTemplate>.Equals(ProjectTemplate? x, ProjectTemplate? y)
+            {
+                if (x == null)
+                {
+                    return y == null;
+                }
+
+                if (y == null)
+                {
+                    return x == null;
+                }
+
+                return x.Description == y.Description
+                    && x.QuickStart == y.QuickStart
+                    && x.Important == y.Important
+                    && _configComparer.Equals(x.Config, y.Config);
+            }
+
+            int IEqualityComparer<ProjectTemplate>.GetHashCode(ProjectTemplate obj)
+            {
+                var hash = new HashCode();
+                hash.Add(obj.Description);
+                hash.Add(obj.QuickStart);
+                hash.Add(obj.Important);
+                // omit hashing Config dict for efficiency
+                return hash.ToHashCode();
+            }
+        }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplate.cs
@@ -40,6 +40,11 @@ namespace Pulumi.Automation
                     return x == null;
                 }
 
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
                 return x.Description == y.Description
                     && x.QuickStart == y.QuickStart
                     && x.Important == y.Important

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplateConfigValue.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplateConfigValue.cs
@@ -37,11 +37,7 @@ namespace Pulumi.Automation
 
             int IEqualityComparer<ProjectTemplateConfigValue>.GetHashCode(ProjectTemplateConfigValue obj)
             {
-                var hash = new HashCode();
-                hash.Add(obj.Description);
-                hash.Add(obj.Default);
-                hash.Add(obj.Secret);
-                return hash.ToHashCode();
+                return HashCode.Combine(obj.Description, obj.Default, obj.Secret);
             }
         }
     }

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplateConfigValue.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplateConfigValue.cs
@@ -10,13 +10,13 @@ namespace Pulumi.Automation
     /// </summary>
     public class ProjectTemplateConfigValue
     {
+        internal static IEqualityComparer<ProjectTemplateConfigValue> Comparer { get; } = new ProjectTemplateConfigValueComparer();
+
         public string? Description { get; set; }
 
         public string? Default { get; set; }
 
         public bool? Secret { get; set; }
-
-        internal static IEqualityComparer<ProjectTemplateConfigValue> Comparer { get; } = new ProjectTemplateConfigValueComparer();
 
         private sealed class ProjectTemplateConfigValueComparer : IEqualityComparer<ProjectTemplateConfigValue>
         {

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplateConfigValue.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplateConfigValue.cs
@@ -32,6 +32,11 @@ namespace Pulumi.Automation
                     return x == null;
                 }
 
+                if (ReferenceEquals(x, y))
+                {
+                    return true;
+                }
+
                 return x.Description == y.Description && x.Default == y.Default && x.Secret == y.Secret;
             }
 

--- a/sdk/dotnet/Pulumi.Automation/ProjectTemplateConfigValue.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectTemplateConfigValue.cs
@@ -1,5 +1,8 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using System;
+using System.Collections.Generic;
+
 namespace Pulumi.Automation
 {
     /// <summary>
@@ -12,5 +15,34 @@ namespace Pulumi.Automation
         public string? Default { get; set; }
 
         public bool? Secret { get; set; }
+
+        internal static IEqualityComparer<ProjectTemplateConfigValue> Comparer { get; } = new ProjectTemplateConfigValueComparer();
+
+        private sealed class ProjectTemplateConfigValueComparer : IEqualityComparer<ProjectTemplateConfigValue>
+        {
+            bool IEqualityComparer<ProjectTemplateConfigValue>.Equals(ProjectTemplateConfigValue? x, ProjectTemplateConfigValue? y)
+            {
+                if (x == null)
+                {
+                    return y == null;
+                }
+
+                if (y == null)
+                {
+                    return x == null;
+                }
+
+                return x.Description == y.Description && x.Default == y.Default && x.Secret == y.Secret;
+            }
+
+            int IEqualityComparer<ProjectTemplateConfigValue>.GetHashCode(ProjectTemplateConfigValue obj)
+            {
+                var hash = new HashCode();
+                hash.Add(obj.Description);
+                hash.Add(obj.Default);
+                hash.Add(obj.Secret);
+                return hash.ToHashCode();
+            }
+        }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -429,3 +429,4 @@ static Pulumi.Automation.WorkspaceStack.CreateOrSelectAsync(string name, Pulumi.
 static Pulumi.Automation.WorkspaceStack.SelectAsync(string name, Pulumi.Automation.Workspace workspace, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.WorkspaceStack>
 virtual Pulumi.Automation.Workspace.Dispose() -> void
 virtual Pulumi.Automation.Workspace.GetStackAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.StackSummary>
+Pulumi.Automation.Exceptions.ProjectSettingsConflictException

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -430,3 +430,4 @@ static Pulumi.Automation.WorkspaceStack.SelectAsync(string name, Pulumi.Automati
 virtual Pulumi.Automation.Workspace.Dispose() -> void
 virtual Pulumi.Automation.Workspace.GetStackAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Pulumi.Automation.StackSummary>
 Pulumi.Automation.Exceptions.ProjectSettingsConflictException
+Pulumi.Automation.Exceptions.ProjectSettingsConflictException.SettingsFileLocation.get -> string

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -277,6 +277,23 @@
             PolicyPacks run during update. Maps PolicyPackName -> version.
             </summary>
         </member>
+        <member name="T:Pulumi.Automation.Exceptions.ProjectSettingsConflictException">
+             <summary>
+            
+             Thrown when creating a Workspace detects a conflict between
+             project settings found on disk (such as Pulumi.yaml) and a
+             ProjectSettings object passed to the Create API.
+            
+             There are two resolutions:
+            
+             (A) to use the ProjectSettings, delete the Pulumi.yaml file
+                 from WorkDir or use a different WorkDir
+            
+             (B) to use the exiting Pulumi.yaml from WorkDir, avoid
+                 customizing the ProjectSettings
+            
+             </summary>
+        </member>
         <member name="T:Pulumi.Automation.HistoryOptions">
             <summary>
             Options controlling the behavior of a <see cref="M:Pulumi.Automation.WorkspaceStack.GetHistoryAsync(Pulumi.Automation.HistoryOptions,System.Threading.CancellationToken)"/> operation.

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -9,6 +9,9 @@
             Options controlling the behavior of an <see cref="M:Pulumi.Automation.WorkspaceStack.DestroyAsync(Pulumi.Automation.DestroyOptions,System.Threading.CancellationToken)"/> operation.
             </summary>
         </member>
+        <member name="T:Pulumi.Automation.DictionaryContentsComparer`2">
+            Compares two dictionaries for equality by content, as F# maps would.
+        </member>
         <member name="T:Pulumi.Automation.Events.CancelEvent">
             <summary>
             <see cref="T:Pulumi.Automation.Events.CancelEvent"/> is emitted when the user initiates a cancellation of the update in progress, or

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -294,6 +294,14 @@
             
              </summary>
         </member>
+        <member name="P:Pulumi.Automation.Exceptions.ProjectSettingsConflictException.SettingsFileLocation">
+             <summary>
+            
+             FullPath of the Pulumi.yaml (or Pulumi.yml, Pulumi.json)
+             settings file found on disk.
+            
+             </summary>
+        </member>
         <member name="T:Pulumi.Automation.HistoryOptions">
             <summary>
             Options controlling the behavior of a <see cref="M:Pulumi.Automation.WorkspaceStack.GetHistoryAsync(Pulumi.Automation.HistoryOptions,System.Threading.CancellationToken)"/> operation.

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -4,13 +4,13 @@
         <name>Pulumi.Automation</name>
     </assembly>
     <members>
+        <member name="T:Pulumi.Automation.Collections.DictionaryContentsComparer`2">
+            Compares two dictionaries for equality by content, as F# maps would.
+        </member>
         <member name="T:Pulumi.Automation.DestroyOptions">
             <summary>
             Options controlling the behavior of an <see cref="M:Pulumi.Automation.WorkspaceStack.DestroyAsync(Pulumi.Automation.DestroyOptions,System.Threading.CancellationToken)"/> operation.
             </summary>
-        </member>
-        <member name="T:Pulumi.Automation.DictionaryContentsComparer`2">
-            Compares two dictionaries for equality by content, as F# maps would.
         </member>
         <member name="T:Pulumi.Automation.Events.CancelEvent">
             <summary>

--- a/sdk/dotnet/README.md
+++ b/sdk/dotnet/README.md
@@ -77,3 +77,23 @@ $ pulumi config set aws:region us-west-2
 ```
 
 And finally, preview and update as you would any other Pulumi project.
+
+
+## Public API Changes
+
+When making changes to the code you may get the following compilation
+error:
+
+```
+error RS0016: Symbol XYZ' is not part of the declared API.
+```
+
+This indicates a change in public API. If you are developing a change
+and this is intentional, add the new API elements to
+`PublicAPI.Unshipped.txt` corresponding to your project (some IDEs
+will do this automatically for you, but manual additions are fine as
+well).
+
+Project maintainers will move API elements from
+`PublicAPI.Unshipped.txt` to `PublicAPI.Shipped.txt` when cutting a
+release.


### PR DESCRIPTION
It's been a while since I did .NET (mostly F# background) so appreciate comments on what's C#-idiomatic, is the IEqualityComparer thing over the top? IN F# we take for granted auto-gen value equality on maps etc.