### PR TITLE
Revert "Allow environment variables to have a null value (#6520)"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -29,5 +29,3 @@
 
 - [automation/go,python,nodejs] Respect pre-existing Pulumi.yaml for inline programs.
   [#6655](https://github.com/pulumi/pulumi/pull/6655)
-
-  [automation/dotnet] Environment variable value type is now nullable. [#6520](https://github.com/pulumi/pulumi/pull/6520)

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -124,7 +124,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -161,7 +161,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -220,7 +220,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -258,7 +258,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -286,7 +286,7 @@ namespace Pulumi.Automation.Tests
             var workingDir = Path.Combine(_dataDirectory, "testproj");
             using var stack = await LocalWorkspace.CreateStackAsync(new LocalProgramArgs(stackName, workingDir)
             {
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -361,7 +361,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_node";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -529,7 +529,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_output";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -669,7 +669,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_tstack_node";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -735,7 +735,7 @@ namespace Pulumi.Automation.Tests
 
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -763,7 +763,7 @@ namespace Pulumi.Automation.Tests
 
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -828,7 +828,7 @@ namespace Pulumi.Automation.Tests
 
             using var stackOne = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectNameOne, stackNameOne, programOne)
             {
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -836,7 +836,7 @@ namespace Pulumi.Automation.Tests
 
             using var stackTwo = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectNameTwo, stackNameTwo, programTwo)
             {
-                EnvironmentVariables = new Dictionary<string, string?>()
+                EnvironmentVariables = new Dictionary<string, string>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }

--- a/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Automation.Commands
         Task<CommandResult> RunAsync(
             IEnumerable<string> args,
             string workingDir,
-            IDictionary<string, string?> additionalEnv,
+            IDictionary<string, string> additionalEnv,
             Action<string>? onStandardOutput = null,
             Action<string>? onStandardError = null,
             Action<EngineEvent>? onEngineEvent = null,

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -22,7 +22,7 @@ namespace Pulumi.Automation.Commands
         public async Task<CommandResult> RunAsync(
             IEnumerable<string> args,
             string workingDir,
-            IDictionary<string, string?> additionalEnv,
+            IDictionary<string, string> additionalEnv,
             Action<string>? onStandardOutput = null,
             Action<string>? onStandardError = null,
             Action<EngineEvent>? onEngineEvent = null,
@@ -96,7 +96,7 @@ namespace Pulumi.Automation.Commands
 
         private static IReadOnlyDictionary<string, string> PulumiEnvironment(IDictionary<string, string> additionalEnv, bool debugCommands)
         {
-            var env = new Dictionary<string, string?>();
+            var env = new Dictionary<string, string>();
 
             foreach (var element in Environment.GetEnvironmentVariables())
             {

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -54,7 +54,7 @@ namespace Pulumi.Automation
         public override PulumiFn? Program { get; set; }
 
         /// <inheritdoc/>
-        public override IDictionary<string, string?>? EnvironmentVariables { get; set; }
+        public override IDictionary<string, string>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Creates a workspace using the specified options. Used for maximal control and
@@ -310,7 +310,7 @@ namespace Pulumi.Automation
                 this.SecretsProvider = options.SecretsProvider;
 
                 if (options.EnvironmentVariables != null)
-                    this.EnvironmentVariables = new Dictionary<string, string?>(options.EnvironmentVariables);
+                    this.EnvironmentVariables = new Dictionary<string, string>(options.EnvironmentVariables);
             }
 
             if (string.IsNullOrWhiteSpace(dir))

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
@@ -38,7 +38,7 @@ namespace Pulumi.Automation
         /// Environment values scoped to the current workspace. These will be supplied to every
         /// Pulumi command.
         /// </summary>
-        public IDictionary<string, string?>? EnvironmentVariables { get; set; }
+        public IDictionary<string, string>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// The settings object for the current project.

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Automation
         /// <summary>
         /// Environment values scoped to the current workspace. These will be supplied to every Pulumi command.
         /// </summary>
-        public abstract IDictionary<string, string?>? EnvironmentVariables { get; set; }
+        public abstract IDictionary<string, string>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Returns project settings for the current project if any.
@@ -279,7 +279,7 @@ namespace Pulumi.Automation
             Action<EngineEvent>? onEngineEvent,
             CancellationToken cancellationToken)
         {
-            var env = new Dictionary<string, string?>();
+            var env = new Dictionary<string, string>();
             if (!string.IsNullOrWhiteSpace(this.PulumiHome))
                 env["PULUMI_HOME"] = this.PulumiHome;
 


### PR DESCRIPTION
This reverts commit 17d1ce509e5589ec7c6b495b7548e7ee1ad6671d.

This PR from a community memeber that I merged because it was approved is [breaking](https://github.com/pulumi/pulumi/runs/2242168751#step:17:47) master: https://github.com/pulumi/pulumi/pull/6520

Reverting until someone can take a closer look.