### PR TITLE
Allow null env vars and treat null/empty as deletions

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Automation.Tests
         public async Task CheckVersionCommand()
         {
             var localCmd = new LocalPulumiCmd();
-            IDictionary<string,string> extraEnv = new Dictionary<string,string>();
+            IDictionary<string,string?> extraEnv = new Dictionary<string,string?>();
             IEnumerable<string> args = new string[]{ "version" };
 
             var stdoutLines = new List<string>();

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -124,7 +124,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -161,7 +161,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -220,7 +220,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -258,7 +258,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -286,7 +286,7 @@ namespace Pulumi.Automation.Tests
             var workingDir = Path.Combine(_dataDirectory, "testproj");
             using var stack = await LocalWorkspace.CreateStackAsync(new LocalProgramArgs(stackName, workingDir)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -361,7 +361,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_node";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -502,7 +502,7 @@ namespace Pulumi.Automation.Tests
             {
                 var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(project, stackName, program)
                 {
-                    EnvironmentVariables = new Dictionary<string, string>()
+                    EnvironmentVariables = new Dictionary<string, string?>()
                     {
                         ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                     }
@@ -529,7 +529,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_output";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -583,7 +583,7 @@ namespace Pulumi.Automation.Tests
             var stackName = $"inline_events{GetTestSuffix()}";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -669,7 +669,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_tstack_node";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -735,7 +735,7 @@ namespace Pulumi.Automation.Tests
 
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -763,7 +763,7 @@ namespace Pulumi.Automation.Tests
 
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -828,7 +828,7 @@ namespace Pulumi.Automation.Tests
 
             using var stackOne = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectNameOne, stackNameOne, programOne)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -836,7 +836,7 @@ namespace Pulumi.Automation.Tests
 
             using var stackTwo = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectNameTwo, stackNameTwo, programTwo)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -908,7 +908,7 @@ namespace Pulumi.Automation.Tests
                 Assert.True(expSecretValue.IsSecret);
             }
         }
-    
+
         [Fact]
         public async Task PulumiVersionTest()
         {

--- a/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Automation.Commands
         Task<CommandResult> RunAsync(
             IEnumerable<string> args,
             string workingDir,
-            IDictionary<string, string> additionalEnv,
+            IDictionary<string, string?> additionalEnv,
             Action<string>? onStandardOutput = null,
             Action<string>? onStandardError = null,
             Action<EngineEvent>? onEngineEvent = null,

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -54,7 +54,7 @@ namespace Pulumi.Automation
         public override PulumiFn? Program { get; set; }
 
         /// <inheritdoc/>
-        public override IDictionary<string, string>? EnvironmentVariables { get; set; }
+        public override IDictionary<string, string?>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Creates a workspace using the specified options. Used for maximal control and
@@ -310,7 +310,7 @@ namespace Pulumi.Automation
                 this.SecretsProvider = options.SecretsProvider;
 
                 if (options.EnvironmentVariables != null)
-                    this.EnvironmentVariables = new Dictionary<string, string>(options.EnvironmentVariables);
+                    this.EnvironmentVariables = new Dictionary<string, string?>(options.EnvironmentVariables);
             }
 
             if (string.IsNullOrWhiteSpace(dir))
@@ -499,7 +499,7 @@ namespace Pulumi.Automation
         public override async Task SetConfigAsync(string stackName, IDictionary<string, ConfigValue> configMap, CancellationToken cancellationToken = default)
         {
             var args = new List<string>{"config", "set-all", "--stack", stackName};
-            foreach (var (key, value) in configMap) 
+            foreach (var (key, value) in configMap)
             {
                 var secretArg = value.IsSecret ? "--secret" : "--plaintext";
                 args.Add(secretArg);
@@ -574,7 +574,7 @@ namespace Pulumi.Automation
             var result = await this.RunCommandAsync(new[] { "stack", "ls", "--json" }, cancellationToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(result.StandardOutput))
                 return ImmutableList<StackSummary>.Empty;
-            
+
             var stacks = this._serializer.DeserializeJson<List<StackSummary>>(result.StandardOutput);
             return stacks.ToImmutableList();
         }

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
@@ -38,7 +38,7 @@ namespace Pulumi.Automation
         /// Environment values scoped to the current workspace. These will be supplied to every
         /// Pulumi command.
         /// </summary>
-        public IDictionary<string, string>? EnvironmentVariables { get; set; }
+        public IDictionary<string, string?>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// The settings object for the current project.

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Automation
         /// <summary>
         /// Environment values scoped to the current workspace. These will be supplied to every Pulumi command.
         /// </summary>
-        public abstract IDictionary<string, string>? EnvironmentVariables { get; set; }
+        public abstract IDictionary<string, string?>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Returns project settings for the current project if any.
@@ -279,7 +279,7 @@ namespace Pulumi.Automation
             Action<EngineEvent>? onEngineEvent,
             CancellationToken cancellationToken)
         {
-            var env = new Dictionary<string, string>();
+            var env = new Dictionary<string, string?>();
             if (!string.IsNullOrWhiteSpace(this.PulumiHome))
                 env["PULUMI_HOME"] = this.PulumiHome;
 


### PR DESCRIPTION
Continuing with https://github.com/pulumi/pulumi/issues/6499 which is the reverted work of @orionstudt reconciled with CliWrap, plus we are adding a new meaning to empty/null strings as "deleting" environment variables, similar to how dotnet BCL does it.