### PR TITLE
Simplify env var propagation

### DIFF
--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -96,7 +96,7 @@ namespace Pulumi.Automation.Commands
 
         private static IReadOnlyDictionary<string, string> PulumiEnvironment(IDictionary<string, string> additionalEnv, bool debugCommands)
         {
-            var env = new Dictionary<string, string>(additonalEnv);
+            var env = new Dictionary<string, string>(additionalEnv);
 
             if (debugCommands)
             {

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -96,19 +96,7 @@ namespace Pulumi.Automation.Commands
 
         private static IReadOnlyDictionary<string, string> PulumiEnvironment(IDictionary<string, string> additionalEnv, bool debugCommands)
         {
-            var env = new Dictionary<string, string>();
-
-            foreach (var element in Environment.GetEnvironmentVariables())
-            {
-                if (element is KeyValuePair<string, object> pair
-                    && pair.Value is string valueStr)
-                    env[pair.Key] = valueStr;
-            }
-
-            foreach (var pair in additionalEnv)
-            {
-                env[pair.Key] = pair.Value;
-            }
+            var env = new Dictionary<string, string>(additonalEnv);
 
             if (debugCommands)
             {


### PR DESCRIPTION
This change should not result in visible behavior difference but simplifies the code. It turns out CliWrap treats the envVar arg as modifications on top of existing system environment, which it propagates already. We do not need to do it therefore.