### PR TITLE
[automation/dotnet] Allow null environment variables

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,9 @@
 - [sdk/python] Ensure all async tasks are awaited prior to exit.
   [#6606](https://github.com/pulumi/pulumi/pull/6606)
 
+- [automation/dotnet] Allow null environment variables
+  [#6687](https://github.com/pulumi/pulumi/pull/6687)
+
 ### Bug Fixes
 
 - [sdk/nodejs] Fix error propagation in registerResource and other resource methods.

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Automation.Tests
         public async Task CheckVersionCommand()
         {
             var localCmd = new LocalPulumiCmd();
-            IDictionary<string,string> extraEnv = new Dictionary<string,string>();
+            IDictionary<string,string?> extraEnv = new Dictionary<string,string?>();
             IEnumerable<string> args = new string[]{ "version" };
 
             var stdoutLines = new List<string>();

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
@@ -14,7 +14,7 @@ namespace Pulumi.Automation.Tests
         public async Task CheckVersionCommand()
         {
             var localCmd = new LocalPulumiCmd();
-            IDictionary<string,string?> extraEnv = new Dictionary<string,string?>();
+            IDictionary<string, string?> extraEnv = new Dictionary<string, string?>();
             IEnumerable<string> args = new string[]{ "version" };
 
             var stdoutLines = new List<string>();

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -123,7 +123,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -160,7 +160,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -219,7 +219,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -257,7 +257,7 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -285,7 +285,7 @@ namespace Pulumi.Automation.Tests
             var workingDir = ResourcePath(Path.Combine("Data", "testproj"));
             using var stack = await LocalWorkspace.CreateStackAsync(new LocalProgramArgs(stackName, workingDir)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -360,7 +360,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_node";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -501,7 +501,7 @@ namespace Pulumi.Automation.Tests
             {
                 var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(project, stackName, program)
                 {
-                    EnvironmentVariables = new Dictionary<string, string>()
+                    EnvironmentVariables = new Dictionary<string, string?>()
                     {
                         ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                     }
@@ -528,7 +528,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_output";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -582,7 +582,7 @@ namespace Pulumi.Automation.Tests
             var stackName = $"inline_events{GetTestSuffix()}";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -668,7 +668,7 @@ namespace Pulumi.Automation.Tests
             var projectName = "inline_tstack_node";
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -734,7 +734,7 @@ namespace Pulumi.Automation.Tests
 
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -762,7 +762,7 @@ namespace Pulumi.Automation.Tests
 
             using var stack = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectName, stackName, program)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -827,7 +827,7 @@ namespace Pulumi.Automation.Tests
 
             using var stackOne = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectNameOne, stackNameOne, programOne)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }
@@ -835,7 +835,7 @@ namespace Pulumi.Automation.Tests
 
             using var stackTwo = await LocalWorkspace.CreateStackAsync(new InlineProgramArgs(projectNameTwo, stackNameTwo, programTwo)
             {
-                EnvironmentVariables = new Dictionary<string, string>()
+                EnvironmentVariables = new Dictionary<string, string?>()
                 {
                     ["PULUMI_CONFIG_PASSPHRASE"] = "test",
                 }

--- a/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/IPulumiCmd.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Automation.Commands
         Task<CommandResult> RunAsync(
             IEnumerable<string> args,
             string workingDir,
-            IDictionary<string, string> additionalEnv,
+            IDictionary<string, string?> additionalEnv,
             Action<string>? onStandardOutput = null,
             Action<string>? onStandardError = null,
             Action<EngineEvent>? onEngineEvent = null,

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -22,7 +22,7 @@ namespace Pulumi.Automation.Commands
         public async Task<CommandResult> RunAsync(
             IEnumerable<string> args,
             string workingDir,
-            IDictionary<string, string> additionalEnv,
+            IDictionary<string, string?> additionalEnv,
             Action<string>? onStandardOutput = null,
             Action<string>? onStandardError = null,
             Action<EngineEvent>? onEngineEvent = null,
@@ -49,7 +49,7 @@ namespace Pulumi.Automation.Commands
         private async Task<CommandResult> RunAsyncInner(
             IEnumerable<string> args,
             string workingDir,
-            IDictionary<string, string> additionalEnv,
+            IDictionary<string, string?> additionalEnv,
             Action<string>? onStandardOutput = null,
             Action<string>? onStandardError = null,
             EventLogFile? eventLogFile = null,
@@ -94,9 +94,9 @@ namespace Pulumi.Automation.Commands
             }
         }
 
-        private static IReadOnlyDictionary<string, string> PulumiEnvironment(IDictionary<string, string> additionalEnv, bool debugCommands)
+        private static IReadOnlyDictionary<string, string?> PulumiEnvironment(IDictionary<string, string?> additionalEnv, bool debugCommands)
         {
-            var env = new Dictionary<string, string>(additionalEnv);
+            var env = new Dictionary<string, string?>(additionalEnv);
 
             if (debugCommands)
             {

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -54,7 +54,7 @@ namespace Pulumi.Automation
         public override PulumiFn? Program { get; set; }
 
         /// <inheritdoc/>
-        public override IDictionary<string, string>? EnvironmentVariables { get; set; }
+        public override IDictionary<string, string?>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Creates a workspace using the specified options. Used for maximal control and
@@ -310,7 +310,7 @@ namespace Pulumi.Automation
                 this.SecretsProvider = options.SecretsProvider;
 
                 if (options.EnvironmentVariables != null)
-                    this.EnvironmentVariables = new Dictionary<string, string>(options.EnvironmentVariables);
+                    this.EnvironmentVariables = new Dictionary<string, string?>(options.EnvironmentVariables);
             }
 
             if (string.IsNullOrWhiteSpace(dir))

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspaceOptions.cs
@@ -38,7 +38,7 @@ namespace Pulumi.Automation
         /// Environment values scoped to the current workspace. These will be supplied to every
         /// Pulumi command.
         /// </summary>
-        public IDictionary<string, string>? EnvironmentVariables { get; set; }
+        public IDictionary<string, string?>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// The settings object for the current project.

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj
@@ -34,7 +34,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CliWrap" Version="3.3.1" />
+    <PackageReference Include="CliWrap" Version="3.3.2" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
     <PackageReference Include="YamlDotNet" Version="9.1.0" />
   </ItemGroup>

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -61,7 +61,7 @@ namespace Pulumi.Automation
         /// <summary>
         /// Environment values scoped to the current workspace. These will be supplied to every Pulumi command.
         /// </summary>
-        public abstract IDictionary<string, string>? EnvironmentVariables { get; set; }
+        public abstract IDictionary<string, string?>? EnvironmentVariables { get; set; }
 
         /// <summary>
         /// Returns project settings for the current project if any.
@@ -279,7 +279,7 @@ namespace Pulumi.Automation
             Action<EngineEvent>? onEngineEvent,
             CancellationToken cancellationToken)
         {
-            var env = new Dictionary<string, string>();
+            var env = new Dictionary<string, string?>();
             if (!string.IsNullOrWhiteSpace(this.PulumiHome))
                 env["PULUMI_HOME"] = this.PulumiHome;
 


### PR DESCRIPTION
This fixes #6499 

Based on https://github.com/pulumi/pulumi/pull/6680, only addition really is just updating CliWrap.