### PR TITLE
[sdk/python] Improved dict key translation support

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -10,6 +10,7 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULUMI_TEST_OWNER: "moolumi"
+  VERSION_PREFIX: "3.0.0"
 
 jobs:
   comment-notification:

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,6 +27,9 @@
 - [Automation/go] Moving go automation API package from sdk/v2/go/x/auto -> sdk/v2/go/auto
   [#6518](https://github.com/pulumi/pulumi/pull/6518)
 
+- [sdk/python] Improved dict key translation support (3.0-based providers will opt-in to the improved behavior)
+  [#6695](https://github.com/pulumi/pulumi/pull/6695)
+
 ### Enhancements
 
 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -15,18 +15,13 @@
 """The Resource module, containing all resource-related definitions."""
 
 import asyncio
-
-from typing import Optional, List, Any, Mapping, Union, Callable, TYPE_CHECKING, cast
-
 import copy
-
+from typing import Optional, List, Any, Mapping, Union, Callable, TYPE_CHECKING, cast
+from . import _types
+from .metadata import get_project, get_stack
 from .runtime import known_types
 from .runtime.resource import get_resource, register_resource, register_resource_outputs, read_resource
 from .runtime.settings import get_root_resource
-
-from .metadata import get_project, get_stack
-
-from . import _types
 
 if TYPE_CHECKING:
     from .output import Input, Inputs, Output

--- a/sdk/python/lib/test/test_types_input_type_types.py
+++ b/sdk/python/lib/test/test_types_input_type_types.py
@@ -1,0 +1,127 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from typing import Optional
+
+from pulumi._types import input_type_types
+import pulumi
+
+
+@pulumi.input_type
+class Foo:
+    @property
+    @pulumi.getter()
+    def bar(self) -> pulumi.Input[str]:
+        ...
+
+
+@pulumi.input_type
+class MySimpleInputType:
+    a: str
+    b: Optional[str]
+    c: pulumi.Input[str]
+    d: Optional[pulumi.Input[str]]
+    e: Foo
+    f: Optional[Foo]
+    g: pulumi.Input[Foo]
+    h: Optional[pulumi.Input[Foo]]
+    i: pulumi.InputType[Foo]
+    j: Optional[pulumi.InputType[Foo]]
+    k: pulumi.Input[pulumi.InputType[Foo]]
+    l: Optional[pulumi.Input[pulumi.InputType[Foo]]]
+
+
+@pulumi.input_type
+class MyPropertiesInputType:
+    @property
+    @pulumi.getter()
+    def a(self) -> str:
+        ...
+
+    @property
+    @pulumi.getter()
+    def b(self) -> Optional[str]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def c(self) -> pulumi.Input[str]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def d(self) -> Optional[pulumi.Input[str]]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def e(self) -> Foo:
+        ...
+
+    @property
+    @pulumi.getter()
+    def f(self) -> Optional[Foo]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def g(self) -> pulumi.Input[Foo]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def h(self) -> Optional[pulumi.Input[Foo]]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def i(self) -> pulumi.InputType[Foo]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def j(self) -> Optional[pulumi.InputType[Foo]]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def k(self) -> pulumi.Input[pulumi.InputType[Foo]]:
+        ...
+
+    @property
+    @pulumi.getter()
+    def l(self) -> Optional[pulumi.Input[pulumi.InputType[Foo]]]:
+        ...
+
+
+class InputTypeTypesTests(unittest.TestCase):
+    def test_input_type_types(self):
+        expected = {
+            "a": str,
+            "b": str,
+            "c": str,
+            "d": str,
+            "e": Foo,
+            "f": Foo,
+            "g": Foo,
+            "h": Foo,
+            "i": Foo,
+            "j": Foo,
+            "k": Foo,
+            "l": Foo,
+        }
+        self.assertEqual(expected, input_type_types(MySimpleInputType))
+        self.assertEqual(expected, input_type_types(MyPropertiesInputType))

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -740,3 +740,14 @@ func TestPythonAwaitOutputs(t *testing.T) {
 		})
 	})
 }
+
+// Test dict key translations.
+func TestPythonTranslation(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join("python", "translation"),
+		Dependencies: []string{
+			filepath.Join("..", "..", "sdk", "python", "env", "src"),
+		},
+		Quick: true,
+	})
+}

--- a/tests/integration/python/translation/.gitignore
+++ b/tests/integration/python/translation/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info
+venv/

--- a/tests/integration/python/translation/Pulumi.yaml
+++ b/tests/integration/python/translation/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: pylint
+description: A Python program that tests dict key translation.
+runtime: python

--- a/tests/integration/python/translation/__main__.py
+++ b/tests/integration/python/translation/__main__.py
@@ -1,0 +1,611 @@
+# Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import pulumi
+
+from typing import Mapping, Optional, Sequence
+
+
+CAMEL_TO_SNAKE_CASE_TABLE = {
+    "anotherValue": "another_value",
+    "listOfNestedValues": "list_of_nested_values",
+    "nestedValue": "nested_value",
+    "serviceName": "service_name",
+    "somethingElse": "something_else",
+    "someValue": "some_value",
+}
+
+SNAKE_TO_CAMEL_CASE_TABLE = {
+    "another_value": "anotherValue",
+    "list_of_nested_values": "listOfNestedValues",
+    "nested_value": "nestedValue",
+    "service_name": "serviceName",
+    "something_else": "somethingElse",
+    "some_value": "someValue",
+}
+
+
+@pulumi.input_type
+class NestedArgs:
+    def __init__(self,
+                 foo_bar: pulumi.Input[str],
+                 some_value: pulumi.Input[int]):
+        pulumi.set(self, "foo_bar", foo_bar)
+        pulumi.set(self, "some_value", some_value)
+
+    @property
+    @pulumi.getter(name="fooBar")
+    def foo_bar(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "foo_bar")
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> pulumi.Input[int]:
+        return pulumi.get(self, "some_value")
+
+
+@pulumi.output_type
+class NestedOldOutput(dict):
+    def __init__(self,
+                 foo_bar: str,
+                 some_value: int):
+        pulumi.set(self, "foo_bar", foo_bar)
+        pulumi.set(self, "some_value", some_value)
+
+    @property
+    @pulumi.getter(name="fooBar")
+    def foo_bar(self) -> str:
+        return pulumi.get(self, "foo_bar")
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> int:
+        return pulumi.get(self, "some_value")
+
+    def _translate_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+
+class OldBehavior(pulumi.CustomResource):
+    def __init__(self,
+                 resource_name: str,
+                 service_name: pulumi.Input[str],
+                 some_value: Optional[pulumi.Input[str]] = None,
+                 another_value: Optional[pulumi.Input[str]] = None,
+                 nested_value: Optional[pulumi.Input[pulumi.InputType[NestedArgs]]] = None,
+                 list_of_nested_values: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType[NestedArgs]]]]] = None,
+                 tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 items: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 keys: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 values: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 get: Optional[pulumi.Input[str]] = None,
+                 opts: Optional[pulumi.ResourceOptions] = None):
+        if opts is None:
+            opts = pulumi.ResourceOptions()
+        __props__ = dict()
+        __props__["service_name"] = service_name
+        __props__["some_value"] = some_value
+        __props__["another_value"] = another_value
+        __props__["nested_value"] = nested_value
+        __props__["list_of_nested_values"] = list_of_nested_values
+        __props__["tags"] = tags
+        __props__["items"] = items
+        __props__["keys"] = keys
+        __props__["values"] = values
+        __props__["get"] = get
+        __props__["something_else"] = None
+        super().__init__("test::OldBehavior", resource_name, __props__, opts)
+
+    @property
+    @pulumi.getter(name="serviceName")
+    def service_name(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "service_name")
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "some_value")
+
+    @property
+    @pulumi.getter(name="anotherValue")
+    def another_value(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "another_value")
+
+    @property
+    @pulumi.getter(name="nestedValue")
+    def nested_value(self) -> pulumi.Output[Optional[NestedOldOutput]]:
+        return pulumi.get(self, "nested_value")
+
+    @property
+    @pulumi.getter(name="listOfNestedValues")
+    def list_of_nested_values(self) -> pulumi.Output[Optional[Sequence[NestedOldOutput]]]:
+        return pulumi.get(self, "list_of_nested_values")
+
+    @property
+    @pulumi.getter
+    def tags(self) -> pulumi.Output[Optional[Mapping[str, str]]]:
+        return pulumi.get(self, "tags")
+
+    @property
+    @pulumi.getter
+    def items(self) -> pulumi.Output[Optional[Mapping[str, str]]]:
+        return pulumi.get(self, "items")
+
+    @property
+    @pulumi.getter
+    def keys(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        return pulumi.get(self, "keys")
+
+    @property
+    @pulumi.getter
+    def values(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        return pulumi.get(self, "values")
+
+    @property
+    @pulumi.getter
+    def get(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "get")
+
+    @property
+    @pulumi.getter(name="somethingElse")
+    def something_else(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "something_else")
+
+    def translate_output_property(self, prop):
+        return CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
+
+    def translate_input_property(self, prop):
+        return SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
+
+
+# NestedNewOutput doesn't have a _translate_property method.
+@pulumi.output_type
+class NestedNewOutput(dict):
+    def __init__(self,
+                 foo_bar: str,
+                 some_value: int):
+        pulumi.set(self, "foo_bar", foo_bar)
+        pulumi.set(self, "some_value", some_value)
+
+    @property
+    @pulumi.getter(name="fooBar")
+    def foo_bar(self) -> str:
+        return pulumi.get(self, "foo_bar")
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> int:
+        return pulumi.get(self, "some_value")
+
+
+# The <Resource>Args class that is passed-through. Since this is an @input_type, its type/name
+# metadata will be used for translations.
+@pulumi.input_type
+class NewBehaviorArgs:
+    def __init__(self,
+                 service_name: pulumi.Input[str],
+                 some_value: Optional[pulumi.Input[str]] = None,
+                 another_value: Optional[pulumi.Input[str]] = None,
+                 nested_value: Optional[pulumi.Input[pulumi.InputType[NestedArgs]]] = None,
+                 list_of_nested_values: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType[NestedArgs]]]]] = None,
+                 tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 items: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 keys: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 values: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 get: Optional[pulumi.Input[str]] = None):
+        pulumi.set(self, "service_name", service_name)
+        pulumi.set(self, "some_value", some_value)
+        pulumi.set(self, "another_value", another_value)
+        pulumi.set(self, "nested_value", nested_value)
+        pulumi.set(self, "list_of_nested_values", list_of_nested_values)
+        pulumi.set(self, "tags", tags)
+        pulumi.set(self, "items", items)
+        pulumi.set(self, "keys", keys)
+        pulumi.set(self, "values", values)
+        pulumi.set(self, "get", get)
+
+    @property
+    @pulumi.getter(name="serviceName")
+    def service_name(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "service_name")
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "some_value")
+
+    @property
+    @pulumi.getter(name="anotherValue")
+    def another_value(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "another_value")
+
+    @property
+    @pulumi.getter(name="nestedValue")
+    def nested_value(self) -> Optional[pulumi.Input[pulumi.InputType[NestedArgs]]]:
+        return pulumi.get(self, "nested_value")
+
+    @property
+    @pulumi.getter(name="listOfNestedValues")
+    def list_of_nested_values(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType[NestedArgs]]]]]:
+        return pulumi.get(self, "list_of_nested_values")
+
+    @property
+    @pulumi.getter
+    def tags(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+        return pulumi.get(self, "tags")
+
+    @property
+    @pulumi.getter
+    def items(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+        return pulumi.get(self, "items")
+
+    @property
+    @pulumi.getter
+    def keys(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        return pulumi.get(self, "keys")
+
+    @property
+    @pulumi.getter
+    def values(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        return pulumi.get(self, "values")
+
+    @property
+    @pulumi.getter
+    def get(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "get")
+
+# This resource opts-in to the new translation behavior, by passing its <Resource>Args type.
+# It's written in the same manner that our codegen is emitted.
+# The class includes overrides of `translate_output_property` and `translate_input_property`
+# that raise exceptions, to ensure they aren't called.
+class NewBehavior(pulumi.CustomResource):
+    def __init__(self,
+                 resource_name: str,
+                 service_name: pulumi.Input[str],
+                 some_value: Optional[pulumi.Input[str]] = None,
+                 another_value: Optional[pulumi.Input[str]] = None,
+                 nested_value: Optional[pulumi.Input[pulumi.InputType[NestedArgs]]] = None,
+                 list_of_nested_values: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType[NestedArgs]]]]] = None,
+                 tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 items: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 keys: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 values: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 get: Optional[pulumi.Input[str]] = None,
+                 opts: Optional[pulumi.ResourceOptions] = None):
+        if opts is None:
+            opts = pulumi.ResourceOptions()
+        # This is how our codegen creates the props to pass to super's `__init__`.
+        __props__ = NewBehaviorArgs.__new__(NewBehaviorArgs)
+        __props__.__dict__["service_name"] = service_name
+        __props__.__dict__["some_value"] = some_value
+        __props__.__dict__["another_value"] = another_value
+        __props__.__dict__["nested_value"] = nested_value
+        __props__.__dict__["list_of_nested_values"] = list_of_nested_values
+        __props__.__dict__["tags"] = tags
+        __props__.__dict__["items"] = items
+        __props__.__dict__["keys"] = keys
+        __props__.__dict__["values"] = values
+        __props__.__dict__["get"] = get
+        __props__.__dict__["something_else"] = None
+        super().__init__("test::NewBehavior", resource_name, __props__, opts)
+
+    @property
+    @pulumi.getter(name="serviceName")
+    def service_name(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "service_name")
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "some_value")
+
+    @property
+    @pulumi.getter(name="anotherValue")
+    def another_value(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "another_value")
+
+    @property
+    @pulumi.getter(name="nestedValue")
+    def nested_value(self) -> pulumi.Output[Optional[NestedNewOutput]]:
+        return pulumi.get(self, "nested_value")
+
+    @property
+    @pulumi.getter(name="listOfNestedValues")
+    def list_of_nested_values(self) -> pulumi.Output[Optional[Sequence[NestedNewOutput]]]:
+        return pulumi.get(self, "list_of_nested_values")
+
+    @property
+    @pulumi.getter
+    def tags(self) -> pulumi.Output[Optional[Mapping[str, str]]]:
+        return pulumi.get(self, "tags")
+
+    @property
+    @pulumi.getter
+    def items(self) -> pulumi.Output[Optional[Mapping[str, str]]]:
+        return pulumi.get(self, "items")
+
+    @property
+    @pulumi.getter
+    def keys(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        return pulumi.get(self, "keys")
+
+    @property
+    @pulumi.getter
+    def values(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        return pulumi.get(self, "values")
+
+    @property
+    @pulumi.getter
+    def get(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "get")
+
+    @property
+    @pulumi.getter(name="somethingElse")
+    def something_else(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "something_else")
+
+    def translate_output_property(self, prop):
+        raise Exception("Unexpected call to translate_output_property")
+
+    def translate_input_property(self, prop):
+        raise Exception("Unexpected call to translate_input_property")
+
+
+# Variant where the <Resource>Args class is a subclass of dict.
+@pulumi.input_type
+class NewBehaviorDictArgs(dict):
+    def __init__(self,
+                 service_name: pulumi.Input[str],
+                 some_value: Optional[pulumi.Input[str]] = None,
+                 another_value: Optional[pulumi.Input[str]] = None,
+                 nested_value: Optional[pulumi.Input[pulumi.InputType[NestedArgs]]] = None,
+                 list_of_nested_values: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType[NestedArgs]]]]] = None,
+                 tags: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 items: Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]] = None,
+                 keys: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 values: Optional[pulumi.Input[Sequence[pulumi.Input[str]]]] = None,
+                 get: Optional[pulumi.Input[str]] = None):
+        pulumi.set(self, "service_name", service_name)
+        pulumi.set(self, "some_value", some_value)
+        pulumi.set(self, "another_value", another_value)
+        pulumi.set(self, "nested_value", nested_value)
+        pulumi.set(self, "list_of_nested_values", list_of_nested_values)
+        pulumi.set(self, "tags", tags)
+        pulumi.set(self, "items", items)
+        pulumi.set(self, "keys", keys)
+        pulumi.set(self, "values", values)
+        pulumi.set(self, "get", get)
+
+    @property
+    @pulumi.getter(name="serviceName")
+    def service_name(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "service_name")
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "some_value")
+
+    @property
+    @pulumi.getter(name="anotherValue")
+    def another_value(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "another_value")
+
+    @property
+    @pulumi.getter(name="nestedValue")
+    def nested_value(self) -> Optional[pulumi.Input[pulumi.InputType[NestedArgs]]]:
+        return pulumi.get(self, "nested_value")
+
+    @property
+    @pulumi.getter(name="listOfNestedValues")
+    def list_of_nested_values(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType[NestedArgs]]]]]:
+        return pulumi.get(self, "list_of_nested_values")
+
+    @property
+    @pulumi.getter
+    def tags(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+        return pulumi.get(self, "tags")
+
+    @property
+    @pulumi.getter
+    def items(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input[str]]]]:
+        return pulumi.get(self, "items")
+
+    @property
+    @pulumi.getter
+    def keys(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        return pulumi.get(self, "keys")
+
+    @property
+    @pulumi.getter
+    def values(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[str]]]]:
+        return pulumi.get(self, "values")
+
+    @property
+    @pulumi.getter
+    def get(self) -> Optional[pulumi.Input[str]]:
+        return pulumi.get(self, "get")
+
+
+# Passes the <Resource>Args class (that's a subclass of dict) through.
+class NewBehaviorDict(pulumi.CustomResource):
+    def __init__(self,
+                 resource_name: str,
+                 args: NewBehaviorDictArgs,
+                 opts: Optional[pulumi.ResourceOptions] = None):
+        if opts is None:
+            opts = pulumi.ResourceOptions()
+
+        # Include the additional output and pass args directly to super's `__init__`.
+        args["something_else"] = None
+        super().__init__("test::NewBehaviorDict", resource_name, args, opts)
+
+    @property
+    @pulumi.getter(name="serviceName")
+    def service_name(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "service_name")
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "some_value")
+
+    @property
+    @pulumi.getter(name="anotherValue")
+    def another_value(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "another_value")
+
+    @property
+    @pulumi.getter(name="nestedValue")
+    def nested_value(self) -> pulumi.Output[Optional[NestedNewOutput]]:
+        return pulumi.get(self, "nested_value")
+
+    @property
+    @pulumi.getter(name="listOfNestedValues")
+    def list_of_nested_values(self) -> pulumi.Output[Optional[Sequence[NestedNewOutput]]]:
+        return pulumi.get(self, "list_of_nested_values")
+
+    @property
+    @pulumi.getter
+    def tags(self) -> pulumi.Output[Optional[Mapping[str, str]]]:
+        return pulumi.get(self, "tags")
+
+    @property
+    @pulumi.getter
+    def items(self) -> pulumi.Output[Optional[Mapping[str, str]]]:
+        return pulumi.get(self, "items")
+
+    @property
+    @pulumi.getter
+    def keys(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        return pulumi.get(self, "keys")
+
+    @property
+    @pulumi.getter
+    def values(self) -> pulumi.Output[Optional[Sequence[str]]]:
+        return pulumi.get(self, "values")
+
+    @property
+    @pulumi.getter
+    def get(self) -> pulumi.Output[Optional[str]]:
+        return pulumi.get(self, "get")
+
+    @property
+    @pulumi.getter(name="somethingElse")
+    def something_else(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "something_else")
+
+    def translate_output_property(self, prop):
+        raise Exception("Unexpected call to translate_output_property")
+
+    def translate_input_property(self, prop):
+        raise Exception("Unexpected call to translate_input_property")
+
+
+class MyMocks(pulumi.runtime.Mocks):
+    def call(self, token, args, provider):
+        return {}
+    def new_resource(self, type_, name, inputs, provider, id_):
+        if name == "o1":
+            assert inputs == {"serviceName": "hello"}
+        elif name == "o2":
+            assert inputs == {"serviceName": "hi", "nestedValue": {"fooBar": "foo bar", "someValue": 42}}
+        elif name == "o3":
+            assert inputs == {"serviceName": "bye", "nestedValue": {"fooBar": "bar foo", "someValue": 24}}
+        elif name == "o4":
+            # The "service_name" key in the user-defined tags dict is translated to "serviceName"
+            # due to it being in the case tables.
+            assert inputs == {"serviceName": "sn", "tags": {"serviceName": "my-service"}}
+        elif name == "o5":
+            assert inputs == {"serviceName": "o5sn", "listOfNestedValues": [{"fooBar": "f", "someValue": 1}]}
+        elif name == "o6":
+            assert inputs == {"serviceName": "o6sn", "listOfNestedValues": [{"fooBar": "b", "someValue": 2}]}
+        elif name == "n1":
+            assert inputs == {"serviceName": "hi new", "nestedValue": {"fooBar": "noo nar", "someValue": 100}}
+        elif name == "n2":
+            assert inputs == {"serviceName": "hello new", "nestedValue": {"fooBar": "2", "someValue": 3}}
+        elif name == "n3":
+            # service_name correctly isn't translated, because the tags dict is a user-defined dict.
+            assert inputs == {"serviceName": "sn", "tags": {"service_name": "a-service"}}
+        elif name == "n4":
+            assert inputs == {"serviceName": "a", "items": {"foo": "bar"}, "keys": ["foo"], "values": ["bar"], "get": "bar"}
+        elif name == "d1":
+            assert inputs == {"serviceName": "b", "items": {"hello": "world"}, "keys": ["hello"], "values": ["world"], "get": "world"}
+        return [name + '_id', {**inputs, "somethingElse": "hehe"}]
+
+pulumi.runtime.set_mocks(MyMocks())
+
+o1 = OldBehavior("o1", service_name="hello")
+
+o2 = OldBehavior("o2", service_name="hi", nested_value=NestedArgs(foo_bar="foo bar", some_value=42))
+def o2checks(v: NestedOldOutput):
+    assert v.foo_bar == "foo bar"
+    assert v["fooBar"] == "foo bar" # key remains camelCase because it's not in casing table.
+    assert v.some_value == 42
+    assert v["some_value"] == 42
+    return v
+pulumi.export("o2", o2.nested_value.apply(o2checks))
+
+# "foo_bar" isn't in the casing table, so it must be specified as "fooBar", but "some_value" is,
+# so it could be snake_case in the dict.
+o3 = OldBehavior("o3", service_name="bye", nested_value={"fooBar": "bar foo", "some_value": 24})
+def o3checks(v: NestedOldOutput):
+    assert v.foo_bar == "bar foo"
+    assert v["fooBar"] == "bar foo" # key remains camelCase because it's not in casing table.
+    assert v.some_value == 24
+    assert v["some_value"] == 24
+    return v
+pulumi.export("o3", o3.nested_value.apply(o3checks))
+
+o4 = OldBehavior("o4", service_name="sn", tags={"service_name": "my-service"})
+def o4checks(v: Mapping[str, str]):
+    assert v == {"service_name": "my-service"}
+    return v
+pulumi.export("o4", o4.tags.apply(o4checks))
+
+o5 = OldBehavior("o5", service_name="o5sn", list_of_nested_values=[NestedArgs(foo_bar="f", some_value=1)])
+def o5checks(v: Sequence[NestedOldOutput]):
+    assert v[0].foo_bar == "f"
+    assert v[0]["fooBar"] == "f" # key remains camelCase because it's not in casing table.
+    assert v[0].some_value == 1
+    assert v[0]["some_value"] == 1
+    return v
+pulumi.export("o5", o5.list_of_nested_values.apply(o5checks))
+
+o6 = OldBehavior("o6", service_name="o6sn", list_of_nested_values=[{"fooBar": "b", "some_value": 2}])
+def o6checks(v: Sequence[NestedOldOutput]):
+    assert v[0].foo_bar == "b"
+    assert v[0]["fooBar"] == "b" # key remains camelCase because it's not in casing table.
+    assert v[0].some_value == 2
+    assert v[0]["some_value"] == 2
+    return v
+pulumi.export("o6", o6.list_of_nested_values.apply(o6checks))
+
+
+n1 = NewBehavior("n1", service_name="hi new", nested_value=NestedArgs(foo_bar="noo nar", some_value=100))
+def n1checks(v: NestedNewOutput):
+    assert v.foo_bar == "noo nar"
+    assert v["foo_bar"] == "noo nar" # key consistently snake_case
+    assert v.some_value == 100
+    assert v["some_value"] == 100
+    return v
+pulumi.export("n1", n1.nested_value.apply(n1checks))
+
+n2 = NewBehavior("n2", service_name="hello new", nested_value={"foo_bar": "2", "some_value": 3})
+def n2checks(v: NestedNewOutput):
+    assert v.foo_bar == "2"
+    assert v["foo_bar"] == "2" # key consistently snake_case
+    assert v.some_value == 3
+    assert v["some_value"] == 3
+    return v
+pulumi.export("n2", n2.nested_value.apply(n2checks))
+
+n3 = NewBehavior("n3", service_name="sn", tags={"service_name": "a-service"})
+def n3checks(v: Mapping[str, str]):
+    assert v == {"service_name": "a-service"}
+    return v
+pulumi.export("n3", n3.tags.apply(n3checks))
+
+n4 = NewBehavior("n4", service_name="a", items={"foo": "bar"}, keys=["foo"], values=["bar"], get="bar")
+
+d1 = NewBehaviorDict("d1", NewBehaviorDictArgs(
+    service_name="b", items={"hello": "world"}, keys=["hello"], values=["world"], get="world"))


### PR DESCRIPTION
This change addresses Python dictionary key translation issues. When the
type of `props` passed to the resource is decorated with `@input_type`,
the type's and resource's property name metadata will be used for dict
key translations instead of the resource's `translate_input_property`
and `translate_output_property` methods.

The generated provider SDKs will be updated to opt-in to this new
behavior:

- FIX: Keys in user-defined dicts will no longer be unintentionally
  translated/modified.

- BREAKING: Dictionary keys in nested output classes are now
  consistently snake_case. If accessing camelCase keys from such output
  classes, move to accessing the values via the snake_case property
  getters (or snake_case keys). Generated SDKs will log a warning
  when accessing camelCase keys.

When serializing inputs:

  - If a value is a dict and the associated type is an input type, the
    dict's keys will be translated based on the input type's property
    name metadata.

  - If a value is a dict and the associated type is a dict (or Mapping),
    the dict's keys will _not_ be translated.

When resolving outputs:

  - If a value is a dict and the associated type is an output type, the
    dict's keys will be translated based on the output type's property
    name metadata.

  - If a value is a dict and the associated type is a dict (or Mapping),
    the dict's keys will _not_ be translated.


---

Example of opting-in to the new behavior:

```python
# A <Resource>Args class decorated with `@input_type` with type/name metadata for the resource's
# top-level inputs.
@pulumi.input_type
class FooArgs:
    def __init__(self, some_value: pulumi.Input[str]):
        pulumi.set(self, "some_value", some_value)

    @property
    @pulumi.getter(name="someValue")
    def some_value(self) -> pulumi.Input[str]:
        return pulumi.get(self, "some_value")

class Foo(pulumi.CustomResource):
    def __init__(__self__, resource_name: str, args: FooArgs, opts: pulumi.ResourceOptions):
        # An instance of <Resource>Args is passed for `props`. Since it is decorated with
        # `@input_type` this opts-in to using the input type and the resource's
        # type/name metadata for dict key translations, rather than calling
        # `translate_input_property` and `translate_output_property`.
        super().__init__(__self__, "example::Foo", args, opts)
```

Part of https://github.com/pulumi/pulumi/issues/3151
Codegen change: https://github.com/pulumi/pulumi/pull/6696