### PR TITLE
[codegen/python] Adopt improved key translation

### DIFF
--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 import pulumi_random
 
 __all__ = [

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/arg_function.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 import pulumi_random
 
 __all__ = [

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/cat.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/cat.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 from ._inputs import *
 import pulumi_random
 
@@ -102,11 +102,11 @@ class Cat(pulumi.CustomResource):
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
-            __props__ = dict()
+            __props__ = CatArgs.__new__(CatArgs)
 
-            __props__['age'] = age
-            __props__['pet'] = pet
-            __props__['name'] = None
+            __props__.__dict__['age'] = age
+            __props__.__dict__['pet'] = pet
+            __props__.__dict__['name'] = None
         super(Cat, __self__).__init__(
             'example::Cat',
             resource_name,
@@ -127,19 +127,13 @@ class Cat(pulumi.CustomResource):
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
-        __props__ = dict()
+        __props__ = CatArgs.__new__(CatArgs)
 
-        __props__["name"] = None
+        __props__.__dict__['name'] = None
         return Cat(resource_name, opts=opts, __props__=__props__)
 
     @property
     @pulumi.getter
     def name(self) -> pulumi.Output[Optional[str]]:
         return pulumi.get(self, "name")
-
-    def translate_output_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop):
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
 

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/cat.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/cat.py
@@ -104,9 +104,9 @@ class Cat(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = CatArgs.__new__(CatArgs)
 
-            __props__.__dict__['age'] = age
-            __props__.__dict__['pet'] = pet
-            __props__.__dict__['name'] = None
+            __props__.__dict__["age"] = age
+            __props__.__dict__["pet"] = pet
+            __props__.__dict__["name"] = None
         super(Cat, __self__).__init__(
             'example::Cat',
             resource_name,
@@ -129,7 +129,7 @@ class Cat(pulumi.CustomResource):
 
         __props__ = CatArgs.__new__(CatArgs)
 
-        __props__.__dict__['name'] = None
+        __props__.__dict__["name"] = None
         return Cat(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 import pulumi_aws
 import pulumi_kubernetes
 
@@ -88,12 +88,12 @@ class Component(pulumi.CustomResource):
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
-            __props__ = dict()
+            __props__ = ComponentArgs.__new__(ComponentArgs)
 
-            __props__['metadata'] = metadata
-            __props__['provider'] = None
-            __props__['security_group'] = None
-            __props__['storage_classes'] = None
+            __props__.__dict__['metadata'] = metadata
+            __props__.__dict__['provider'] = None
+            __props__.__dict__['security_group'] = None
+            __props__.__dict__['storage_classes'] = None
         super(Component, __self__).__init__(
             'example::Component',
             resource_name,
@@ -114,11 +114,11 @@ class Component(pulumi.CustomResource):
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
-        __props__ = dict()
+        __props__ = ComponentArgs.__new__(ComponentArgs)
 
-        __props__["provider"] = None
-        __props__["security_group"] = None
-        __props__["storage_classes"] = None
+        __props__.__dict__['provider'] = None
+        __props__.__dict__['security_group'] = None
+        __props__.__dict__['storage_classes'] = None
         return Component(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -135,10 +135,4 @@ class Component(pulumi.CustomResource):
     @pulumi.getter(name="storageClasses")
     def storage_classes(self) -> pulumi.Output[Optional[Mapping[str, 'pulumi_kubernetes.storage.v1.StorageClass']]]:
         return pulumi.get(self, "storage_classes")
-
-    def translate_output_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop):
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
 

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -90,10 +90,10 @@ class Component(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ComponentArgs.__new__(ComponentArgs)
 
-            __props__.__dict__['metadata'] = metadata
-            __props__.__dict__['provider'] = None
-            __props__.__dict__['security_group'] = None
-            __props__.__dict__['storage_classes'] = None
+            __props__.__dict__["metadata"] = metadata
+            __props__.__dict__["provider"] = None
+            __props__.__dict__["security_group"] = None
+            __props__.__dict__["storage_classes"] = None
         super(Component, __self__).__init__(
             'example::Component',
             resource_name,
@@ -116,9 +116,9 @@ class Component(pulumi.CustomResource):
 
         __props__ = ComponentArgs.__new__(ComponentArgs)
 
-        __props__.__dict__['provider'] = None
-        __props__.__dict__['security_group'] = None
-        __props__.__dict__['storage_classes'] = None
+        __props__.__dict__["provider"] = None
+        __props__.__dict__["security_group"] = None
+        __props__.__dict__["storage_classes"] = None
         return Component(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/workload.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/workload.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 import pulumi_kubernetes
 
 __all__ = ['WorkloadArgs', 'Workload']
@@ -74,9 +74,9 @@ class Workload(pulumi.CustomResource):
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
-            __props__ = dict()
+            __props__ = WorkloadArgs.__new__(WorkloadArgs)
 
-            __props__['pod'] = None
+            __props__.__dict__['pod'] = None
         super(Workload, __self__).__init__(
             'example::Workload',
             resource_name,
@@ -97,19 +97,13 @@ class Workload(pulumi.CustomResource):
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
-        __props__ = dict()
+        __props__ = WorkloadArgs.__new__(WorkloadArgs)
 
-        __props__["pod"] = None
+        __props__.__dict__['pod'] = None
         return Workload(resource_name, opts=opts, __props__=__props__)
 
     @property
     @pulumi.getter
     def pod(self) -> pulumi.Output[Optional['pulumi_kubernetes.core.v1.outputs.Pod']]:
         return pulumi.get(self, "pod")
-
-    def translate_output_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop):
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
 

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/workload.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/workload.py
@@ -76,7 +76,7 @@ class Workload(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = WorkloadArgs.__new__(WorkloadArgs)
 
-            __props__.__dict__['pod'] = None
+            __props__.__dict__["pod"] = None
         super(Workload, __self__).__init__(
             'example::Workload',
             resource_name,
@@ -99,7 +99,7 @@ class Workload(pulumi.CustomResource):
 
         __props__ = WorkloadArgs.__new__(WorkloadArgs)
 
-        __props__.__dict__['pod'] = None
+        __props__.__dict__["pod"] = None
         return Workload(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/_inputs.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/_inputs.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 from ._enums import *
 
 __all__ = [

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/outputs.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/outputs.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 from ._enums import *
 
 __all__ = [
@@ -49,8 +49,5 @@ class Container(dict):
     @pulumi.getter
     def material(self) -> Optional[str]:
         return pulumi.get(self, "material")
-
-    def _translate_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
 
 

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from ... import _utilities, _tables
+from ... import _utilities
 from ._enums import *
 
 __all__ = ['NurseryArgs', 'Nursery']
@@ -110,12 +110,12 @@ class Nursery(pulumi.CustomResource):
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
-            __props__ = dict()
+            __props__ = NurseryArgs.__new__(NurseryArgs)
 
-            __props__['sizes'] = sizes
+            __props__.__dict__['sizes'] = sizes
             if varieties is None and not opts.urn:
                 raise TypeError("Missing required property 'varieties'")
-            __props__['varieties'] = varieties
+            __props__.__dict__['varieties'] = varieties
         super(Nursery, __self__).__init__(
             'plant:tree/v1:Nursery',
             resource_name,
@@ -136,13 +136,7 @@ class Nursery(pulumi.CustomResource):
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
-        __props__ = dict()
+        __props__ = NurseryArgs.__new__(NurseryArgs)
 
         return Nursery(resource_name, opts=opts, __props__=__props__)
-
-    def translate_output_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop):
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
 

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -112,10 +112,10 @@ class Nursery(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = NurseryArgs.__new__(NurseryArgs)
 
-            __props__.__dict__['sizes'] = sizes
+            __props__.__dict__["sizes"] = sizes
             if varieties is None and not opts.urn:
                 raise TypeError("Missing required property 'varieties'")
-            __props__.__dict__['varieties'] = varieties
+            __props__.__dict__["varieties"] = varieties
         super(Nursery, __self__).__init__(
             'plant:tree/v1:Nursery',
             resource_name,

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from ... import _utilities, _tables
+from ... import _utilities
 from ... import _enums as _root_enums
 from ... import _inputs as _root_inputs
 from ... import outputs as _root_outputs
@@ -88,6 +88,28 @@ class RubberTreeArgs:
         pulumi.set(self, "size", value)
 
 
+@pulumi.input_type
+class _RubberTreeState:
+    def __init__(__self__, *,
+                 farm: Optional[pulumi.Input[Union['Farm', str]]] = None):
+        """
+        Input properties used for looking up and filtering RubberTree resources.
+        """
+        if farm is None:
+            farm = '(unknown)'
+        if farm is not None:
+            pulumi.set(__self__, "farm", farm)
+
+    @property
+    @pulumi.getter
+    def farm(self) -> Optional[pulumi.Input[Union['Farm', str]]]:
+        return pulumi.get(self, "farm")
+
+    @farm.setter
+    def farm(self, value: Optional[pulumi.Input[Union['Farm', str]]]):
+        pulumi.set(self, "farm", value)
+
+
 class RubberTree(pulumi.CustomResource):
     @overload
     def __init__(__self__,
@@ -152,25 +174,25 @@ class RubberTree(pulumi.CustomResource):
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
-            __props__ = dict()
+            __props__ = RubberTreeArgs.__new__(RubberTreeArgs)
 
-            __props__['container'] = container
+            __props__.__dict__['container'] = container
             if diameter is None:
                 diameter = 6
             if diameter is None and not opts.urn:
                 raise TypeError("Missing required property 'diameter'")
-            __props__['diameter'] = diameter
+            __props__.__dict__['diameter'] = diameter
             if farm is None:
                 farm = '(unknown)'
-            __props__['farm'] = farm
+            __props__.__dict__['farm'] = farm
             if size is None:
                 size = 'medium'
-            __props__['size'] = size
+            __props__.__dict__['size'] = size
             if type is None:
                 type = 'Burgundy'
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
-            __props__['type'] = type
+            __props__.__dict__['type'] = type
         super(RubberTree, __self__).__init__(
             'plant:tree/v1:RubberTree',
             resource_name,
@@ -192,13 +214,13 @@ class RubberTree(pulumi.CustomResource):
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
-        __props__ = dict()
+        __props__ = _RubberTreeState.__new__(_RubberTreeState)
 
-        __props__["farm"] = farm
-        __props__["container"] = None
-        __props__["diameter"] = None
-        __props__["size"] = None
-        __props__["type"] = None
+        __props__.__dict__['farm'] = farm
+        __props__.__dict__['container'] = None
+        __props__.__dict__['diameter'] = None
+        __props__.__dict__['size'] = None
+        __props__.__dict__['type'] = None
         return RubberTree(resource_name, opts=opts, __props__=__props__)
 
     @property
@@ -225,10 +247,4 @@ class RubberTree(pulumi.CustomResource):
     @pulumi.getter
     def type(self) -> pulumi.Output['RubberTreeVariety']:
         return pulumi.get(self, "type")
-
-    def translate_output_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop):
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
 

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -176,23 +176,23 @@ class RubberTree(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = RubberTreeArgs.__new__(RubberTreeArgs)
 
-            __props__.__dict__['container'] = container
+            __props__.__dict__["container"] = container
             if diameter is None:
                 diameter = 6
             if diameter is None and not opts.urn:
                 raise TypeError("Missing required property 'diameter'")
-            __props__.__dict__['diameter'] = diameter
+            __props__.__dict__["diameter"] = diameter
             if farm is None:
                 farm = '(unknown)'
-            __props__.__dict__['farm'] = farm
+            __props__.__dict__["farm"] = farm
             if size is None:
                 size = 'medium'
-            __props__.__dict__['size'] = size
+            __props__.__dict__["size"] = size
             if type is None:
                 type = 'Burgundy'
             if type is None and not opts.urn:
                 raise TypeError("Missing required property 'type'")
-            __props__.__dict__['type'] = type
+            __props__.__dict__["type"] = type
         super(RubberTree, __self__).__init__(
             'plant:tree/v1:RubberTree',
             resource_name,
@@ -216,11 +216,11 @@ class RubberTree(pulumi.CustomResource):
 
         __props__ = _RubberTreeState.__new__(_RubberTreeState)
 
-        __props__.__dict__['farm'] = farm
-        __props__.__dict__['container'] = None
-        __props__.__dict__['diameter'] = None
-        __props__.__dict__['size'] = None
-        __props__.__dict__['type'] = None
+        __props__.__dict__["farm"] = farm
+        __props__.__dict__["container"] = None
+        __props__.__dict__["diameter"] = None
+        __props__.__dict__["size"] = None
+        __props__.__dict__["type"] = None
         return RubberTree(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/_inputs.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 
 __all__ = [
     'FooArgs',

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 from . import outputs
 from ._inputs import *
 
@@ -171,21 +171,21 @@ class Component(pulumi.ComponentResource):
         else:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
-            __props__ = dict()
+            __props__ = ComponentArgs.__new__(ComponentArgs)
 
             if a is None and not opts.urn:
                 raise TypeError("Missing required property 'a'")
-            __props__['a'] = a
-            __props__['b'] = b
+            __props__.__dict__['a'] = a
+            __props__.__dict__['b'] = b
             if c is None and not opts.urn:
                 raise TypeError("Missing required property 'c'")
-            __props__['c'] = c
-            __props__['d'] = d
+            __props__.__dict__['c'] = c
+            __props__.__dict__['d'] = d
             if e is None and not opts.urn:
                 raise TypeError("Missing required property 'e'")
-            __props__['e'] = e
-            __props__['f'] = f
-            __props__['foo'] = foo
+            __props__.__dict__['e'] = e
+            __props__.__dict__['f'] = f
+            __props__.__dict__['foo'] = foo
         super(Component, __self__).__init__(
             'example::Component',
             resource_name,
@@ -227,10 +227,4 @@ class Component(pulumi.ComponentResource):
     @pulumi.getter
     def foo(self) -> pulumi.Output[Optional['outputs.Foo']]:
         return pulumi.get(self, "foo")
-
-    def translate_output_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop):
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
 

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -175,17 +175,17 @@ class Component(pulumi.ComponentResource):
 
             if a is None and not opts.urn:
                 raise TypeError("Missing required property 'a'")
-            __props__.__dict__['a'] = a
-            __props__.__dict__['b'] = b
+            __props__.__dict__["a"] = a
+            __props__.__dict__["b"] = b
             if c is None and not opts.urn:
                 raise TypeError("Missing required property 'c'")
-            __props__.__dict__['c'] = c
-            __props__.__dict__['d'] = d
+            __props__.__dict__["c"] = c
+            __props__.__dict__["d"] = d
             if e is None and not opts.urn:
                 raise TypeError("Missing required property 'e'")
-            __props__.__dict__['e'] = e
-            __props__.__dict__['f'] = f
-            __props__.__dict__['foo'] = foo
+            __props__.__dict__["e"] = e
+            __props__.__dict__["f"] = f
+            __props__.__dict__["foo"] = foo
         super(Component, __self__).__init__(
             'example::Component',
             resource_name,

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/outputs.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/outputs.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 
 __all__ = [
     'Foo',
@@ -60,8 +60,5 @@ class Foo(dict):
     @pulumi.getter
     def f(self) -> Optional[str]:
         return pulumi.get(self, "f")
-
-    def _translate_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
 
 

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/arg_function.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/arg_function.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 from .resource import Resource
 
 __all__ = [

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 from .resource import Resource
 
 __all__ = ['OtherResourceArgs', 'OtherResource']
@@ -89,9 +89,9 @@ class OtherResource(pulumi.ComponentResource):
         else:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
-            __props__ = dict()
+            __props__ = OtherResourceArgs.__new__(OtherResourceArgs)
 
-            __props__['foo'] = foo
+            __props__.__dict__['foo'] = foo
         super(OtherResource, __self__).__init__(
             'example::OtherResource',
             resource_name,
@@ -103,10 +103,4 @@ class OtherResource(pulumi.ComponentResource):
     @pulumi.getter
     def foo(self) -> pulumi.Output[Optional['Resource']]:
         return pulumi.get(self, "foo")
-
-    def translate_output_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop):
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
 

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -91,7 +91,7 @@ class OtherResource(pulumi.ComponentResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = OtherResourceArgs.__new__(OtherResourceArgs)
 
-            __props__.__dict__['foo'] = foo
+            __props__.__dict__["foo"] = foo
         super(OtherResource, __self__).__init__(
             'example::OtherResource',
             resource_name,

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
@@ -6,7 +6,7 @@ import warnings
 import pulumi
 import pulumi.runtime
 from typing import Any, Mapping, Optional, Sequence, Union, overload
-from . import _utilities, _tables
+from . import _utilities
 
 __all__ = ['ResourceArgs', 'Resource']
 
@@ -86,9 +86,9 @@ class Resource(pulumi.CustomResource):
         if opts.id is None:
             if __props__ is not None:
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
-            __props__ = dict()
+            __props__ = ResourceArgs.__new__(ResourceArgs)
 
-            __props__['bar'] = bar
+            __props__.__dict__['bar'] = bar
         super(Resource, __self__).__init__(
             'example::Resource',
             resource_name,
@@ -109,19 +109,13 @@ class Resource(pulumi.CustomResource):
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
-        __props__ = dict()
+        __props__ = ResourceArgs.__new__(ResourceArgs)
 
-        __props__["bar"] = None
+        __props__.__dict__['bar'] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @property
     @pulumi.getter
     def bar(self) -> pulumi.Output[Optional[str]]:
         return pulumi.get(self, "bar")
-
-    def translate_output_property(self, prop):
-        return _tables.CAMEL_TO_SNAKE_CASE_TABLE.get(prop) or prop
-
-    def translate_input_property(self, prop):
-        return _tables.SNAKE_TO_CAMEL_CASE_TABLE.get(prop) or prop
 

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
@@ -88,7 +88,7 @@ class Resource(pulumi.CustomResource):
                 raise TypeError('__props__ is only valid when passed in combination with a valid opts.id to get an existing resource')
             __props__ = ResourceArgs.__new__(ResourceArgs)
 
-            __props__.__dict__['bar'] = bar
+            __props__.__dict__["bar"] = bar
         super(Resource, __self__).__init__(
             'example::Resource',
             resource_name,
@@ -111,7 +111,7 @@ class Resource(pulumi.CustomResource):
 
         __props__ = ResourceArgs.__new__(ResourceArgs)
 
-        __props__.__dict__['bar'] = None
+        __props__.__dict__["bar"] = None
         return Resource(resource_name, opts=opts, __props__=__props__)
 
     @property

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1142,7 +1142,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		if res.IsProvider && !isStringType(prop.Type) {
 			arg = fmt.Sprintf("pulumi.Output.from_input(%s).apply(pulumi.runtime.to_json) if %s is not None else None", arg, arg)
 		}
-		fmt.Fprintf(w, "            __props__.__dict__['%s'] = %s\n", PyName(prop.Name), arg)
+		fmt.Fprintf(w, "            __props__.__dict__[%q] = %s\n", PyName(prop.Name), arg)
 
 		ins.Add(prop.Name)
 	}
@@ -1152,7 +1152,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		// Default any pure output properties to None.  This ensures they are available as properties, even if
 		// they don't ever get assigned a real value, and get documentation if available.
 		if !ins.Has(prop.Name) {
-			fmt.Fprintf(w, "            __props__.__dict__['%s'] = None\n", PyName(prop.Name))
+			fmt.Fprintf(w, "            __props__.__dict__[%q] = None\n", PyName(prop.Name))
 		}
 
 		if prop.Secret {
@@ -1235,12 +1235,12 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		if res.StateInputs != nil {
 			for _, prop := range res.StateInputs.Properties {
 				stateInputs.Add(prop.Name)
-				fmt.Fprintf(w, "        __props__.__dict__['%[1]s'] = %[1]s\n", PyName(prop.Name))
+				fmt.Fprintf(w, "        __props__.__dict__[%[1]q] = %[1]s\n", PyName(prop.Name))
 			}
 		}
 		for _, prop := range res.Properties {
 			if !stateInputs.Has(prop.Name) {
-				fmt.Fprintf(w, "        __props__.__dict__['%s'] = None\n", PyName(prop.Name))
+				fmt.Fprintf(w, "        __props__.__dict__[%q] = None\n", PyName(prop.Name))
 			}
 		}
 
@@ -2122,8 +2122,8 @@ func (mod *modContext) genType(w io.Writer, name, comment string, properties []*
 				if pname == prop.Name {
 					continue
 				}
-				fmt.Fprintf(w, "        %s key == \"%s\":\n", prefix, prop.Name)
-				fmt.Fprintf(w, "            suggest = \"%s\"\n", pname)
+				fmt.Fprintf(w, "        %s key == %q:\n", prefix, prop.Name)
+				fmt.Fprintf(w, "            suggest = %q\n", pname)
 				prefix = "elif"
 			}
 			fmt.Fprintf(w, "\n")


### PR DESCRIPTION
This change updates the Python SDK codegen to opt-in to the new casing
translation behavior, which will use the passed-in props type's property
name metadata for translations, rather than calling the resource's
`translate_input_property` and `translate_output_property` methods.

- FIX: Keys in user-defined dicts will no longer be unintentionally
  translated/modified.

- BREAKING: Dictionary keys in nested output classes are now
  consistently snake_case. If accessing camelCase keys from such output
  classes, move to accessing the values via the snake_case property
  getters (or snake_case keys). A warning will be logged when accessing
  camelCase keys.

When serializing inputs:

- If a value is a dict and the associated type is an input type, the
dict's keys will be translated based on the input type's property
name metadata.

- If a value is a dict and the associated type is a dict (or Mapping),
the dict's keys will _not_ be translated.

When resolving outputs:

- If a value is a dict and the associated type is an output type, the
dict's keys will be translated based on the output type's property
name metadata.

- If a value is a dict and the associated type is a dict (or Mapping),
the dict's keys will _not_ be translated.


Note: There is some additional codegen/docgen code related to generating the casing tables that can be deleted, but it can be removed in a follow-up change.

Part of https://github.com/pulumi/pulumi/issues/3151
Depends on SDK change: https://github.com/pulumi/pulumi/pull/6695