### PR TITLE
[automation/dotnet] Fix GetConfigValueAsync failing to deserialize

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,3 +22,6 @@
   
 - [sdk/go] Use ioutil.ReadFile to avoid forcing 1.16 upgrade.
   [#6703](https://github.com/pulumi/pulumi/pull/6703)
+
+- [automation/dotnet] Fix GetConfigValueAsync failing to deserialize
+  [#6698](https://github.com/pulumi/pulumi/pull/6698)

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -195,6 +195,15 @@ namespace Pulumi.Automation.Tests
                 Assert.Equal("def", secretValue!.Value);
                 Assert.True(secretValue.IsSecret);
 
+                // Get individual configuration values
+                plainValue = await stack.GetConfigValueAsync(plainKey);
+                Assert.Equal("abc", plainValue!.Value);
+                Assert.False(plainValue.IsSecret);
+
+                secretValue = await stack.GetConfigValueAsync(secretKey);
+                Assert.Equal("def", secretValue!.Value);
+                Assert.True(secretValue.IsSecret);
+
                 await stack.RemoveConfigValueAsync("plain");
                 values = await stack.GetConfigAsync();
                 Assert.Single(values);

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -496,7 +496,7 @@ namespace Pulumi.Automation
         {
             await this.SelectStackAsync(stackName, cancellationToken).ConfigureAwait(false);
             var result = await this.RunCommandAsync(new[] { "config", "get", key, "--json" }, cancellationToken).ConfigureAwait(false);
-            return JsonSerializer.Deserialize<ConfigValue>(result.StandardOutput);
+            return this._serializer.DeserializeJson<ConfigValue>(result.StandardOutput);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Found this while working on something else. Basically `GetConfigValueAsync` was not working because the default JsonSerializer was unable to deserialize `ConfigValue` due to it not having a parameterless constructor.
