### PR TITLE
[sdk/go] Use ioutil.ReadFile to avoid forcing 1.16 upgrade

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,3 +16,6 @@
 
 - [sdk/python] Fix serialization bug if output contains 'items' property.
   [#6701](https://github.com/pulumi/pulumi/pull/6701)
+  
+- [sdk/go] Use ioutil.ReadFile to avoid forcing 1.16 upgrade.
+  [#6703](https://github.com/pulumi/pulumi/pull/6703)

--- a/sdk/go/common/workspace/loaders.go
+++ b/sdk/go/common/workspace/loaders.go
@@ -15,6 +15,7 @@
 package workspace
 
 import (
+	"io/ioutil"
 	"os"
 	"sync"
 
@@ -46,9 +47,9 @@ var policyPackProjectSingleton *policyPackProjectLoader = &policyPackProjectLoad
 	internal: map[string]*PolicyPackProject{},
 }
 
-// readFileStripUTF8BOM wraps os.ReadFile and also strips the UTF-8 Byte-order Mark (BOM) if present.
+// readFileStripUTF8BOM wraps ioutil.ReadFile and also strips the UTF-8 Byte-order Mark (BOM) if present.
 func readFileStripUTF8BOM(path string) ([]byte, error) {
-	b, err := os.ReadFile(path)
+	b, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
#6636 inadvertently changed the minimum Go version
requirement to 1.16 since ReadFile was moved in that
version. Switch back to ioutil.ReadFile to avoid forcing
an upgrade at this time.