### PR TITLE
Enable nodejs dynamic provider caching by default on program side

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Breaking Changes
 
+- [sdk/nodejs] Enable nodejs dynamic provider caching by default on program side.
+  [#6704](https://github.com/pulumi/pulumi/pull/6704)
+
 - [CLI] Standardize the `--stack` flag to *not* set the stack as current (i.e. setStack=false) across CLI commands.
   [#6300](https://github.com/pulumi/pulumi/pull/6300)
 

--- a/sdk/nodejs/dynamic/index.ts
+++ b/sdk/nodejs/dynamic/index.ts
@@ -165,6 +165,7 @@ const providerCache = new WeakMap<ResourceProvider, Promise<string>>();
 
 function serializeProvider(provider: ResourceProvider): Promise<string> {
     let result: Promise<string>;
+    // caching is enabled by default as of 3.0
     if (runtime.cacheDynamicProviders()) {
         const cachedProvider = providerCache.get(provider);
         if (cachedProvider) {

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -174,7 +174,7 @@ export function isLegacyApplyEnabled(): boolean {
 }
 
 /**
- * Returns true true if we will cache serialized dynamic providers on the program side
+ * Returns true (default) if we will cache serialized dynamic providers on the program side
  */
 export function cacheDynamicProviders(): boolean {
     return options().cacheDynamicProviders === true;
@@ -353,7 +353,7 @@ function options(): Options {
         monitorAddr: process.env[nodeEnvKeys.monitorAddr],
         engineAddr: process.env[nodeEnvKeys.engineAddr],
         syncDir: process.env[nodeEnvKeys.syncDir],
-        cacheDynamicProviders: (process.env[nodeEnvKeys.cacheDynamicProviders] === "true"),
+        cacheDynamicProviders: process.env[nodeEnvKeys.cacheDynamicProviders] !== "false", // true by default
         // pulumi specific
         testModeEnabled: (process.env[pulumiEnvKeys.testMode] === "true"),
         legacyApply: (process.env[pulumiEnvKeys.legacyApply] === "true"),

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -16,7 +16,6 @@ import * as assert from "assert";
 import * as semver from "semver";
 import * as upath from "upath";
 
-import { Config } from "../../index";
 import {
     ConfigMap,
     EngineEvent,
@@ -26,6 +25,7 @@ import {
     Stack,
     validatePulumiVersion,
 } from "../../automation";
+import { Config } from "../../index";
 import { asyncTest } from "../util";
 
 const versionRegex = /(\d+\.)(\d+\.)(\d+)(-.*)?/;

--- a/sdk/nodejs/tests/runtime/settings.spec.ts
+++ b/sdk/nodejs/tests/runtime/settings.spec.ts
@@ -45,7 +45,7 @@ describe("settings", () => {
         assert.strictEqual(runtime.isDryRun(), isDryRun);
         assert.strictEqual(runtime.isQueryMode(), isQueryMode);
         assert.strictEqual(runtime.getConfig(key), val);
-        assert.strictEqual(runtime.cacheDynamicProviders(), false);
+        assert.strictEqual(runtime.cacheDynamicProviders(), true);
 
         assert.strictEqual(testProject, process.env["PULUMI_NODEJS_PROJECT"]);
         assert.strictEqual(testStack, process.env["PULUMI_NODEJS_STACK"]);


### PR DESCRIPTION
The full description and motivation of this change is outlined here: https://github.com/pulumi/pulumi/pull/6673

TLDR; this change enables caching by default for dynamic providers serialized as a part of executing a program via nodejs. This decreases memory usage and increases runtime significantly for programs making heavy use of dynamic providers. 

This is technically a breaking change as we are now caching dynamic providers based on object equality. It is technically true (but unlikely in practice) that a dynamic provider could rely on some global state, or that in-between resource creation operations that individual methods of the provider (diff/check/create/etc) could be mutated. 

Due to this, users should treat dynamic resource providers as immutable and opt to create singleton instances to get access to these performance benefits. This behavior can be disabled by setting `PULUMI_NODEJS_CACHE_DYNAMIC_PROVIDERS=false`.