### PR TITLE
Fix serializing bug if output contains 'items' property

### DIFF
--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -219,12 +219,13 @@ async def serialize_property(value: 'Input[Any]',
 
     if isinstance(value, abc.Mapping):
         obj = {}
-        for k, v in value.items():
+        # Don't use value.items() here, as it will error in the case of outputs with an `items` property.
+        for k in value:
             transformed_key = k
             if transform_keys and input_transformer is not None:
                 transformed_key = input_transformer(k)
                 log.debug(f"transforming input property: {k} -> {transformed_key}")
-            obj[transformed_key] = await serialize_property(v, deps, input_transformer)
+            obj[transformed_key] = await serialize_property(value[k], deps, input_transformer)
 
         return obj
 

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -81,14 +81,30 @@ class MyMocks(Mocks):
 @pulumi.output_type
 class MyOutputTypeDict(dict):
 
-    def __init__(self, values: list):
+    def __init__(self, values: list, items: list, keys: list):
         pulumi.set(self, "values", values)
+        pulumi.set(self, "items", items)
+        pulumi.set(self, "keys", keys)
 
     # Property with empty body.
     @property
     @pulumi.getter
     def values(self) -> str:
         """Values docstring."""
+        ...
+
+    # Property with empty body.
+    @property
+    @pulumi.getter
+    def items(self) -> str:
+        """Items docstring."""
+        ...
+
+    # Property with empty body.
+    @property
+    @pulumi.getter
+    def keys(self) -> str:
+        """Keys docstring."""
         ...
 
 
@@ -952,9 +968,15 @@ class NextSerializationTests(unittest.TestCase):
 
     @pulumi_test
     async def test_dangerous_prop_output(self):
-        out = self.create_output(MyOutputTypeDict(values=["foo", "bar"]), is_known=True)
+        out = self.create_output(MyOutputTypeDict(values=["foo", "bar"],
+                                                  items=["yellow", "purple"],
+                                                  keys=["yes", "no"]), is_known=True)
+        prop = await rpc.serialize_property(out, [])
 
         self.assertTrue(await out.is_known())
+        self.assertEqual(prop["values"], ["foo", "bar"])
+        self.assertEqual(prop["items"], ["yellow", "purple"])
+        self.assertEqual(prop["keys"], ["yes", "no"])
 
     @pulumi_test
     async def test_apply_unknown_output(self):


### PR DESCRIPTION
Follow-up from #6701

Marked as no-changelog-required because I added the changelog entry in #6701

Fixes: #6697 