### PR TITLE
Update Pulumi python docker image to python 3.9

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,9 @@
 
 ### Improvements
 
+- [automation/python] Update pulumi python docker image to python 3.9
+  [#6706](https://github.com/pulumi/pulumi/pull/6706)
+
 - [sdk/nodejs] Add program side caching for dynamic provider serialization behind env var
   [#6673](https://github.com/pulumi/pulumi/pull/6673)
 

--- a/docker/python/Dockerfile
+++ b/docker/python/Dockerfile
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 # Must be defined first
 ARG PULUMI_VERSION=latest
-ARG RUNTIME_VERSION=3.7.7
+ARG RUNTIME_VERSION=3.9
 ARG PULUMI_IMAGE=pulumi/pulumi-base
 FROM ${PULUMI_IMAGE}:${PULUMI_VERSION} as pulumi
 

--- a/docker/python/Dockerfile.alpine
+++ b/docker/python/Dockerfile.alpine
@@ -2,7 +2,7 @@
 # Interim container so we can copy pulumi binaries
 # Must be defined first
 ARG PULUMI_VERSION=latest
-ARG RUNTIME_VERSION=3.8.3
+ARG RUNTIME_VERSION=3.9
 ARG PULUMI_IMAGE=pulumi/pulumi-base
 FROM ${PULUMI_IMAGE}:${PULUMI_VERSION}-alpine as pulumi
 


### PR DESCRIPTION
Latest stable image is 3.9.4.