### PR TITLE
[sdk/nodejs] Improve handling of log related errors 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,6 +11,9 @@
 
 ### Bug Fixes
 
+- [sdk/nodejs] Fix error handling for failed logging statements
+  [#6714](https://github.com/pulumi/pulumi/pull/6714)
+
 - [automation/dotnet] Environment variable value type is now nullable.
   [#6520](https://github.com/pulumi/pulumi/pull/6520)
 

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -21,6 +21,13 @@ const engproto = require("../proto/engine_pb.js");
 let errcnt = 0;
 let lastLog: Promise<any> = Promise.resolve();
 
+const messageLevels = {
+    [engproto.LogSeverity.DEBUG]: "debug",
+    [engproto.LogSeverity.INFO]: "info",
+    [engproto.LogSeverity.WARNING]: "warn",
+    [engproto.LogSeverity.ERROR]: "error",
+};
+
 /**
  * hasErrors returns true if any errors have occurred in the program.
  */
@@ -118,5 +125,13 @@ function log(
         });
     });
 
-    return lastLog.catch(() => undefined);
+    return lastLog.catch((err) => {
+        // debug messages never go to stdout/err
+        if (sev !== engproto.LogSeverity.DEBUG) {
+            // if we're unable to deliver the log message, deliver to stderr instead
+            console.error(`failed to deliver log message. \nerror: ${err} \noriginal message: ${msg}\n message severity: ${messageLevels[sev]}`)
+        }
+        // we still need to free up the outstanding promise chain, whether or not delivery succeeded.
+        keepAlive();
+    });
 }

--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -129,7 +129,7 @@ function log(
         // debug messages never go to stdout/err
         if (sev !== engproto.LogSeverity.DEBUG) {
             // if we're unable to deliver the log message, deliver to stderr instead
-            console.error(`failed to deliver log message. \nerror: ${err} \noriginal message: ${msg}\n message severity: ${messageLevels[sev]}`)
+            console.error(`failed to deliver log message. \nerror: ${err} \noriginal message: ${msg}\n message severity: ${messageLevels[sev]}`);
         }
         // we still need to free up the outstanding promise chain, whether or not delivery succeeded.
         keepAlive();


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/6713

Logging-related errors in nodejs are currently getting swallowed and holding up the RPCKeepAlive chain ultimately causing promise leaks. 

Incidentally contributes towards https://github.com/pulumi/pulumi/issues/6712

For #6712, this approach bubbles up log messages impacted to stderr which seems like a good compromise here. 