### PR TITLE
[automation/dotnet] Import & Export support

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,9 @@
 - [automation/dotnet] Expose WorkspaceStack.GetOutputsAsync
   [#6699](https://github.com/pulumi/pulumi/pull/6699)
 
+- [automation/dotnet] Import & Export support
+  [#6727](https://github.com/pulumi/pulumi/pull/6727)
+
 ### Bug Fixes
 
 - [sdk/nodejs] Fix error handling for failed logging statements

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -584,6 +584,12 @@
         <member name="M:Pulumi.Automation.LocalWorkspace.ListStacksAsync(System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
+        <member name="M:Pulumi.Automation.LocalWorkspace.ExportStackAsync(System.String,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Pulumi.Automation.LocalWorkspace.ImportStackAsync(System.String,Pulumi.Automation.Types.VersionedDeployment,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
         <member name="M:Pulumi.Automation.LocalWorkspace.InstallPluginAsync(System.String,System.String,Pulumi.Automation.PluginKind,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
@@ -792,6 +798,206 @@
         <member name="P:Pulumi.Automation.StackSettings.Config">
             <summary>
             This is an optional configuration bag.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.Types.EngineOperationType">
+            <summary>
+            <see cref="T:Pulumi.Automation.Types.EngineOperationType"/> is the type of an operation initiated by the engine. Its value indicates the type of operation
+            that the engine initiated.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Automation.Types.EngineOperationType.Creating">
+            <summary>
+            Creating is the state of resources that are being created.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Automation.Types.EngineOperationType.Updating">
+            <summary>
+            Updating is the state of resources that are being updated.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Automation.Types.EngineOperationType.Deleting">
+            <summary>
+            Deleting is the state of resources that are being deleted.
+            </summary>
+        </member>
+        <member name="F:Pulumi.Automation.Types.EngineOperationType.Reading">
+            <summary>
+            Reading is the state of resources that are being read.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.Types.ManifestV1">
+            <summary>
+            <see cref="T:Pulumi.Automation.Types.ManifestV1"/> captures meta-information about this checkpoint file, such as versions of binaries, etc.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ManifestV1.Time">
+            <summary>
+            Time of the update.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ManifestV1.Magic">
+            <summary>
+            Magic number, used to identify integrity of the checkpoint.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ManifestV1.Version">
+            <summary>
+            Version of the Pulumi engine used to render the checkpoint.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ManifestV1.Plugins">
+            <summary>
+            Plugins contains the binary version info of plug-ins used.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.Types.PluginInfoV1">
+            <summary>
+            <see cref="T:Pulumi.Automation.Types.PluginInfoV1"/> captures the version and information about a plugin.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.Types.OperationV2">
+            <summary>
+            <see cref="T:Pulumi.Automation.Types.OperationV2"/> represents an operation that the engine is performing. It consists of a Resource, which is the state
+            that the engine used to initiate the operation, and a Type, which represents the operation that the engine initiated.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.OperationV2.Resource">
+            <summary>
+            Resource is the state that the engine used to initiate this operation.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.OperationV2.Type">
+            <summary>
+            Type represents the operation that the engine is performing.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.Types.DeploymentV3">
+            <summary>
+            <see cref="T:Pulumi.Automation.Types.DeploymentV3"/> is the third version of the Deployment. It contains newer versions of the
+            Resource and Operation API types and a placeholder for a stack's secrets configuration.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.DeploymentV3.Manifest">
+            <summary>
+            Manifest contains metadata about this deployment.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.DeploymentV3.SecretsProviders">
+            <summary>
+            SecretsProviders is a placeholder for secret provider configuration.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.DeploymentV3.Resources">
+            <summary>
+            Resources contains all resources that are currently part of this stack after this deployment has finished.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.DeploymentV3.PendingOperations">
+            <summary>
+            PendingOperations are all operations that were known by the engine to be currently executing.
+            </summary>
+        </member>
+        <member name="T:Pulumi.Automation.Types.ResourceV3">
+            <summary>
+            <see cref="T:Pulumi.Automation.Types.ResourceV3"/> is the third version of the Resource API type
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Urn">
+            <summary>
+            URN uniquely identifying this resource.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Custom">
+            <summary>
+            Custom is true when it is managed by a plugin.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Delete">
+            <summary>
+            Delete is true when the resource should be deleted during the next update.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Id">
+            <summary>
+            ID is the provider-assigned resource, if any, for custom resources.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Type">
+            <summary>
+            Type is the resource's full type token.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Inputs">
+            <summary>
+            Inputs are the input properties supplied to the provider.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Outputs">
+            <summary>
+            Outputs are the output properties returned by the provider after provisioning.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Parent">
+            <summary>
+            Parent is an optional parent URN if this resource is a child of it.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Protect">
+            <summary>
+            Protect is set to true when this resource is "protected" and may not be deleted.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.External">
+            <summary>
+            External is set to true when the lifecycle of this resource is not managed by Pulumi.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Dependencies">
+            <summary>
+            Dependencies contains the dependency edges to other resources that this depends on.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.InitErrors">
+            <summary>
+            InitErrors is the set of errors encountered in the process of initializing resource (i.e.,
+            during create or update).
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Provider">
+            <summary>
+            Provider is a reference to the provider that is associated with this resource.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.PropertyDependencies">
+            <summary>
+            PropertyDependencies maps from an input property name to the set of resources that property depends on.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.PendingReplacement">
+            <summary>
+            PendingReplacement is used to track delete-before-replace resources that have been deleted but not yet
+            recreated.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.AdditionalSecretOutputs">
+            <summary>
+            AdditionalSecretOutputs is a list of outputs that were explicitly marked as secret when the resource was created.
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.Aliases">
+            <summary>
+            Aliases is a list of previous URNs that this resource may have had in previous deployments
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.CustomTimeouts">
+            <summary>
+            CustomTimeouts is a configuration block that can be used to control timeouts of CRUD operations
+            </summary>
+        </member>
+        <member name="P:Pulumi.Automation.Types.ResourceV3.ImportId">
+            <summary>
+            ImportID is the import input used for imported resources.
             </summary>
         </member>
         <member name="T:Pulumi.Automation.UpdateOptions">
@@ -1016,6 +1222,23 @@
             <param name="stackName">The stack to remove.</param>
             <param name="cancellationToken">A cancellation token.</param>
         </member>
+        <member name="M:Pulumi.Automation.Workspace.ExportStackAsync(System.String,System.Threading.CancellationToken)">
+            <summary>
+            <see cref="M:Pulumi.Automation.Workspace.ExportStackAsync(System.String,System.Threading.CancellationToken)"/> exports the deployment state of the stack.
+            This can be combined with <see cref="M:Pulumi.Automation.Workspace.ImportStackAsync(System.String,Pulumi.Automation.Types.VersionedDeployment,System.Threading.CancellationToken)"/> to edit a stack's state (such as recovery from failed deployments).
+            </summary>
+            <param name="stackName">The stack to export.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.Workspace.ImportStackAsync(System.String,Pulumi.Automation.Types.VersionedDeployment,System.Threading.CancellationToken)">
+            <summary>
+            <see cref="M:Pulumi.Automation.Workspace.ImportStackAsync(System.String,Pulumi.Automation.Types.VersionedDeployment,System.Threading.CancellationToken)"/> imports the specified deployment state into a pre-existing stack.
+            This can be combined with <see cref="M:Pulumi.Automation.Workspace.ExportStackAsync(System.String,System.Threading.CancellationToken)"/> to edit a stack's state (such as recovery from failed deployments).
+            </summary>
+            <param name="stackName">The stack to import to.</param>
+            <param name="state">The stack state to import.</param>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
         <member name="M:Pulumi.Automation.Workspace.ListStacksAsync(System.Threading.CancellationToken)">
             <summary>
             Returns all stacks created under the current project.
@@ -1146,6 +1369,21 @@
             <summary>
             Gets and sets the config map used with the last update.
             </summary>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.WorkspaceStack.ExportStackAsync(System.Threading.CancellationToken)">
+            <summary>
+            <see cref="M:Pulumi.Automation.WorkspaceStack.ExportStackAsync(System.Threading.CancellationToken)"/> exports the deployment state of the stack.
+            This can be combined with <see cref="M:Pulumi.Automation.WorkspaceStack.ImportStackAsync(Pulumi.Automation.Types.VersionedDeployment,System.Threading.CancellationToken)"/> to edit a stack's state (such as recovery from failed deployments).
+            </summary>
+            <param name="cancellationToken">A cancellation token.</param>
+        </member>
+        <member name="M:Pulumi.Automation.WorkspaceStack.ImportStackAsync(Pulumi.Automation.Types.VersionedDeployment,System.Threading.CancellationToken)">
+            <summary>
+            <see cref="M:Pulumi.Automation.WorkspaceStack.ImportStackAsync(Pulumi.Automation.Types.VersionedDeployment,System.Threading.CancellationToken)"/> imports the specified deployment state into a pre-existing stack.
+            This can be combined with <see cref="M:Pulumi.Automation.WorkspaceStack.ExportStackAsync(System.Threading.CancellationToken)"/> to edit a stack's state (such as recovery from failed deployments).
+            </summary>
+            <param name="state">The stack state to import.</param>
             <param name="cancellationToken">A cancellation token.</param>
         </member>
         <member name="M:Pulumi.Automation.WorkspaceStack.UpAsync(Pulumi.Automation.UpOptions,System.Threading.CancellationToken)">

--- a/sdk/dotnet/Pulumi.Automation/Types/ExportTypes.cs
+++ b/sdk/dotnet/Pulumi.Automation/Types/ExportTypes.cs
@@ -1,0 +1,252 @@
+// Copyright 2016-2021, Pulumi Corporation
+// NOTE: The classes in this file are intended to align with the serialized
+// JSON types defined and versioned in sdk/go/common/apitype/core.go
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+// TODO(vipentti): Select proper namespace
+namespace Pulumi.Automation.Types
+{
+    // TODO(vipentti): internal -> public
+    // TODO(vipentti): Split into file per class
+    // TODO(vipentti): Separate JSON models & public types?
+
+    internal class VersionedDeployment
+    {
+        public int? Version { get; set; }
+
+        public DeploymentV3 Deployment { get; set; } = null!;
+    }
+
+    /// <summary>
+    /// <see cref="EngineOperationType"/> is the type of an operation initiated by the engine. Its value indicates the type of operation
+    /// that the engine initiated.
+    /// </summary>
+    internal enum EngineOperationType
+    {
+        /// <summary>
+        /// Creating is the state of resources that are being created.
+        /// </summary>
+        Creating,
+
+        /// <summary>
+	    /// Updating is the state of resources that are being updated.
+        /// </summary>
+        Updating,
+
+        /// <summary>
+        /// Deleting is the state of resources that are being deleted.
+        /// </summary>
+        Deleting,
+
+        /// <summary>
+        /// Reading is the state of resources that are being read.
+        /// </summary>
+        Reading,
+    }
+
+    internal class CustomTimeouts
+    {
+        public string Create { get; set; } = null!;
+
+        public string Update { get; set; } = null!;
+
+        public string Delete { get; set; } = null!;
+    }
+
+    /// <summary>
+    /// <see cref="ManifestV1"/> captures meta-information about this checkpoint file, such as versions of binaries, etc.
+    /// </summary>
+    internal class ManifestV1
+    {
+        /// <summary>
+        /// Time of the update.
+        /// </summary>
+        public DateTime Time { get; set; }
+
+        /// <summary>
+        /// Magic number, used to identify integrity of the checkpoint.
+        /// </summary>
+        public string Magic { get; set; } = null!;
+
+        /// <summary>
+        /// Version of the Pulumi engine used to render the checkpoint.
+        /// </summary>
+        public string Version { get; set; } = null!;
+
+        /// <summary>
+        /// Plugins contains the binary version info of plug-ins used.
+        /// </summary>
+        public List<PluginInfoV1>? Plugins { get; set; } = null!;
+    }
+
+    /// <summary>
+    /// <see cref="PluginInfoV1"/> captures the version and information about a plugin.
+    /// </summary>
+    internal class PluginInfoV1
+    {
+        public string Name { get; set; } = null!;
+        public string Path { get; set; } = null!;
+        public PluginKind Type { get; set; }
+        public string Version { get; set; } = null!;
+    }
+
+    internal class SecretsProvidersV1
+    {
+        public string Type { get; set; } = null!;
+
+        // TODO(vipentti): Verify type
+        public object? State { get; set; } = null!;
+    }
+
+    /// <summary>
+    /// <see cref="OperationV2"/> represents an operation that the engine is performing. It consists of a Resource, which is the state
+    /// that the engine used to initiate the operation, and a Type, which represents the operation that the engine initiated.
+    /// </summary>
+    internal class OperationV2
+    {
+        /// <summary>
+        /// Resource is the state that the engine used to initiate this operation.
+        /// </summary>
+        public ResourceV3 Resource { get; set; } = null!;
+
+        /// <summary>
+        /// Type represents the operation that the engine is performing.
+        /// </summary>
+        public EngineOperationType Type { get; set; }
+    }
+
+    /// <summary>
+    /// <see cref="DeploymentV3"/> is the third version of the Deployment. It contains newer versions of the
+    /// Resource and Operation API types and a placeholder for a stack's secrets configuration.
+    /// </summary>
+    internal class DeploymentV3
+    {
+        /// <summary>
+        /// Manifest contains metadata about this deployment.
+        /// </summary>
+        public ManifestV1 Manifest { get; set; } = null!;
+
+        /// <summary>
+        /// SecretsProviders is a placeholder for secret provider configuration.
+        /// </summary>
+        [JsonPropertyName("secrets_providers")]
+        public SecretsProvidersV1? SecretsProviders { get; set; }
+
+        /// <summary>
+        /// Resources contains all resources that are currently part of this stack after this deployment has finished.
+        /// </summary>
+        public List<ResourceV3>? Resources { get; set; }
+
+        /// <summary>
+        /// PendingOperations are all operations that were known by the engine to be currently executing.
+        /// </summary>
+        [JsonPropertyName("pending_operations")]
+        public List<OperationV2>? PendingOperations { get; set; }
+    }
+
+    /// <summary>
+    /// <see cref="ResourceV3"/> is the third version of the Resource API type
+    /// </summary>
+    internal class ResourceV3
+    {
+        /// <summary>
+        /// URN uniquely identifying this resource.
+        /// </summary>
+        public string Urn { get; set; } = null!;
+
+        /// <summary>
+        /// Custom is true when it is managed by a plugin.
+        /// </summary>
+        public bool Custom { get; set; }
+
+        /// <summary>
+        /// Delete is true when the resource should be deleted during the next update.
+        /// </summary>
+        public bool? Delete { get; set; }
+
+        /// <summary>
+        /// ID is the provider-assigned resource, if any, for custom resources.
+        /// </summary>
+        public string? Id { get; set; } = null!;
+
+        /// <summary>
+        /// Type is the resource's full type token.
+        /// </summary>
+        public string Type { get; set; } = null!;
+
+        /// <summary>
+        /// Inputs are the input properties supplied to the provider.
+        /// </summary>
+        public Dictionary<string, object>? Inputs { get; set; } = null!;
+
+        /// <summary>
+        /// Outputs are the output properties returned by the provider after provisioning.
+        /// </summary>
+        public Dictionary<string, object>? Outputs { get; set; } = null!;
+
+        /// <summary>
+        /// Parent is an optional parent URN if this resource is a child of it.
+        /// </summary>
+        public string? Parent { get; set; } = null!;
+
+        /// <summary>
+        /// Protect is set to true when this resource is "protected" and may not be deleted.
+        /// </summary>
+        public bool? Protect { get; set; }
+
+        /// <summary>
+        /// External is set to true when the lifecycle of this resource is not managed by Pulumi.
+        /// </summary>
+        public bool? External { get; set; }
+
+        /// <summary>
+        /// Dependencies contains the dependency edges to other resources that this depends on.
+        /// </summary>
+        public List<string>? Dependencies { get; set; } = null!;
+
+        /// <summary>
+        /// InitErrors is the set of errors encountered in the process of initializing resource (i.e.,
+        /// during create or update).
+        /// </summary>
+        public List<string>? InitErrors { get; set; } = null!;
+
+        /// <summary>
+        /// Provider is a reference to the provider that is associated with this resource.
+        /// </summary>
+        public string? Provider { get; set; } = null!;
+
+        /// <summary>
+        /// PropertyDependencies maps from an input property name to the set of resources that property depends on.
+        /// </summary>
+        public Dictionary<string, string?>? PropertyDependencies { get; set; } = null!;
+
+        /// <summary>
+        /// PendingReplacement is used to track delete-before-replace resources that have been deleted but not yet
+        /// recreated.
+        /// </summary>
+        public bool? PendingReplacement { get; set; }
+
+        /// <summary>
+        /// AdditionalSecretOutputs is a list of outputs that were explicitly marked as secret when the resource was created.
+        /// </summary>
+        public List<string>? AdditionalSecretOutputs { get; set; }
+
+        /// <summary>
+        /// Aliases is a list of previous URNs that this resource may have had in previous deployments
+        /// </summary>
+        public List<string>? Aliases { get; set; }
+
+        /// <summary>
+        /// CustomTimeouts is a configuration block that can be used to control timeouts of CRUD operations
+        /// </summary>
+        public CustomTimeouts? CustomTimeouts { get; set; }
+
+        /// <summary>
+        /// ImportID is the import input used for imported resources.
+        /// </summary>
+        public string? ImportId { get; set; }
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/Workspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/Workspace.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using Pulumi.Automation.Commands;
 using Pulumi.Automation.Commands.Exceptions;
 using Pulumi.Automation.Events;
+using Pulumi.Automation.Types;
 
 namespace Pulumi.Automation
 {
@@ -220,6 +221,25 @@ namespace Pulumi.Automation
         /// <param name="stackName">The stack to remove.</param>
         /// <param name="cancellationToken">A cancellation token.</param>
         public abstract Task RemoveStackAsync(string stackName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <see cref="ExportStackAsync"/> exports the deployment state of the stack.
+        /// This can be combined with <see cref="ImportStackAsync(string, VersionedDeployment, CancellationToken)"/> to edit a stack's state (such as recovery from failed deployments).
+        /// </summary>
+        /// <param name="stackName">The stack to export.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        // TODO(vipentti): internal -> public
+        internal abstract Task<VersionedDeployment> ExportStackAsync(string stackName, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// <see cref="ImportStackAsync(string, VersionedDeployment, CancellationToken)"/> imports the specified deployment state into a pre-existing stack.
+        /// This can be combined with <see cref="ExportStackAsync(string, CancellationToken)"/> to edit a stack's state (such as recovery from failed deployments).
+        /// </summary>
+        /// <param name="stackName">The stack to import to.</param>
+        /// <param name="state">The stack state to import.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        // TODO(vipentti): internal -> public
+        internal abstract Task ImportStackAsync(string stackName, VersionedDeployment state, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Returns all stacks created under the current project.

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2021, Pulumi Corporation
+// Copyright 2016-2021, Pulumi Corporation
 
 using System;
 using System.Collections.Generic;
@@ -24,6 +24,7 @@ using Pulumi.Automation.Commands.Exceptions;
 using Pulumi.Automation.Events;
 using Pulumi.Automation.Exceptions;
 using Pulumi.Automation.Serialization;
+using Pulumi.Automation.Types;
 
 namespace Pulumi.Automation
 {
@@ -196,6 +197,25 @@ namespace Pulumi.Automation
         /// <param name="cancellationToken">A cancellation token.</param>
         public Task<ImmutableDictionary<string, ConfigValue>> RefreshConfigAsync(CancellationToken cancellationToken = default)
             => this.Workspace.RefreshConfigAsync(this.Name, cancellationToken);
+
+        /// <summary>
+        /// <see cref="ExportStackAsync(CancellationToken)"/> exports the deployment state of the stack.
+        /// This can be combined with <see cref="ImportStackAsync(VersionedDeployment, CancellationToken)"/> to edit a stack's state (such as recovery from failed deployments).
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        // TODO(vipentti): internal -> public
+        internal Task<VersionedDeployment> ExportStackAsync(CancellationToken cancellationToken = default)
+            => this.Workspace.ExportStackAsync(this.Name, cancellationToken);
+
+        /// <summary>
+        /// <see cref="ImportStackAsync(VersionedDeployment, CancellationToken)"/> imports the specified deployment state into a pre-existing stack.
+        /// This can be combined with <see cref="ExportStackAsync(CancellationToken)"/> to edit a stack's state (such as recovery from failed deployments).
+        /// </summary>
+        /// <param name="state">The stack state to import.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        // TODO(vipentti): internal -> public
+        internal Task ImportStackAsync(VersionedDeployment state, CancellationToken cancellationToken = default)
+            => this.Workspace.ImportStackAsync(this.Name, state, cancellationToken);
 
         /// <summary>
         /// Creates or updates the resources in a stack by executing the program in the Workspace.


### PR DESCRIPTION
This is currently WIP, but since the basic functionality is working, at least based on the simple test (which is based on the one in the nodejs automation API), I'd like to get some feedback on what kind of API we want to have for managing the deployment resources.

Some questions I have:

- What kind of problems or other reasons usually require editing the exported json?
- Should we support older versions of the types (e.g. ResourceV1, ResourceV2 etc)?

Some notes:

- Currently all the import/export types have public getters and setters, which I'm not a huge fan of, it makes the implementation simple, but do we want users to be able to create deployments manually via constructing resources with all of their properties?

- Currently the types for import/export are in a separate namespace `Pulumi.Automation.Types` and the namings for the resources include the version e.g. `ResourceV3` to match the types in apitype/core.go. Maybe the types should be in the top-level `Pulumi.Automation` namespace? or some more descriptive namespace.

- By default System.Text.Json encodes certain characters when serializing such as `+` gets encoded as `\u002B`, this affects the serialized output which is used when importing. I believe according to JSON-specification these should be treated as identical, but something worth nothing. This can be changed by specifying an encoder for the [JsonSerializerOptions](https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-character-encoding#serialize-all-characters).

  > The default encoder escapes non-ASCII characters, HTML-sensitive characters within the ASCII-range, and characters that must be escaped according to the RFC 8259 JSON spec.

  Source: https://docs.microsoft.com/en-us/dotnet/standard/serialization/system-text-json-how-to?pivots=dotnet-core-3-1#serialization-behavior

- Currently everything is intentionally marked as `internal` while working on this to avoid having to keep `PublicAPI.Unshipped.txt` in sync

- Currently all the types used by import/export are in a single file for simplicity during development, the types will be split into separate files when they are ready

TODO:

- [ ] Serialization tests
- [ ] Additional import & export tests with edits
- [ ] Ensure all the types, methods and properties which should be public are public and updated in `PublicAPI.Unshipped.txt`