### PR TITLE
explicitly create event log file for nodejs automation api

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,9 @@
 
 ### Bug Fixes
 
+- [sdk/nodejs] Explicitly create event log file for NodeJS Automation API.
+  [#6730](https://github.com/pulumi/pulumi/pull/6730)
+
 - [sdk/nodejs] Fix error handling for failed logging statements
   [#6714](https://github.com/pulumi/pulumi/pull/6714)
 

--- a/sdk/nodejs/x/automation/stack.ts
+++ b/sdk/nodejs/x/automation/stack.ts
@@ -786,7 +786,10 @@ const delay = (duration: number) => new Promise(resolve => setTimeout(resolve, d
 
 const createLogFile = (command: string) => {
     const logDir = fs.mkdtempSync(upath.joinSafe(os.tmpdir(), `automation-logs-${command}-`));
-    return upath.joinSafe(logDir, "eventlog.txt");
+    const logFile = upath.joinSafe(logDir, "eventlog.txt");
+    // just open/close the file to make sure it exists when we start polling.
+    fs.closeSync(fs.openSync(logFile, "w"));
+    return logFile;
 };
 
 const cleanUp = async (tail?: TailFile, logFile?: string) => {


### PR DESCRIPTION
An attempt at fixing https://github.com/pulumi/actions/issues/163

The current implementation just creates a temp dir and waits for the CLI to start writing to that file. If that process is delayed by more than 10s we fail. This change tries to be resilient to that case. 