### PR TITLE
Enable absolute and relative parent paths for pulumi main

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,9 @@
 
 ### Improvements
 
+- [cli] Enable absolute and relative parent paths for pulumi main
+  [#6734](https://github.com/pulumi/pulumi/pull/6734)
+
 - [automation/python] Update pulumi python docker image to python 3.9
   [#6706](https://github.com/pulumi/pulumi/pull/6706)
 

--- a/pkg/engine/project.go
+++ b/pkg/engine/project.go
@@ -16,7 +16,6 @@ package engine
 
 import (
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -51,7 +50,7 @@ func getPwdMain(root, main string) (string, string, error) {
 	} else {
 
 		// The path can be relative from the package root.
-		if !path.IsAbs(main) {
+		if !filepath.IsAbs(main) {
 			cleanPwd := filepath.Clean(pwd)
 			main = filepath.Clean(filepath.Join(cleanPwd, main))
 		}

--- a/pkg/engine/project.go
+++ b/pkg/engine/project.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -50,16 +49,11 @@ func getPwdMain(root, main string) (string, string, error) {
 	if main == "" {
 		main = "."
 	} else {
-		// The path must be relative from the package root.
-		if path.IsAbs(main) {
-			return "", "", errors.New("project 'main' must be a relative path")
-		}
 
-		// Check that main is a subdirectory.
-		cleanPwd := filepath.Clean(pwd)
-		main = filepath.Clean(filepath.Join(cleanPwd, main))
-		if !strings.HasPrefix(main, cleanPwd) {
-			return "", "", errors.New("project 'main' must be a subfolder")
+		// The path can be relative from the package root.
+		if !path.IsAbs(main) {
+			cleanPwd := filepath.Clean(pwd)
+			main = filepath.Clean(filepath.Join(cleanPwd, main))
 		}
 
 		// So that any relative paths inside of the program are correct, we still need to pass the pwd

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -102,7 +102,7 @@ func TestProjectMain(t *testing.T) {
 		e.ImportDirectory("project_main_abs")
 
 		// write a new Pulumi.yaml using the absolute path of the environment as "main"
-		yamlPath := filepath.Join(e.RootPath, "Pulumi.Yaml")
+		yamlPath := filepath.Join(e.RootPath, "Pulumi.yaml")
 		absYamlContents := fmt.Sprintf(
 			"name: project_main_abs\ndescription: A program with an absolute entry point\nruntime: nodejs\nmain: %s\n",
 			e.RootPath,

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -111,6 +111,7 @@ func TestProjectMain(t *testing.T) {
 			t.Error(err)
 			return
 		}
+
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
 		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", "main-abs")
@@ -129,19 +130,8 @@ func TestProjectMain(t *testing.T) {
 
 		// yarn link first
 		e.RunCommand("yarn", "link", "@pulumi/pulumi")
-		// then virtually change directory
+		// then virtually change directory to the location of the nested Pulumi.yaml
 		e.CWD = filepath.Join(e.RootPath, "foo", "bar")
-
-		// files, err := os.ReadDir(filepath.Join(e.RootPath, ".."))
-		// if err != nil {
-		// 	t.Error(err)
-		// 	return
-		// }
-
-		// for _, file := range files {
-		// 	t.Logf(file.Name())
-		// }
-		// t.Logf(e.RootPath)
 
 		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", "main-parent")

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -92,7 +92,7 @@ func TestProjectMain(t *testing.T) {
 	}
 	integration.ProgramTest(t, &test)
 
-	t.Run("Error_AbsolutePath", func(t *testing.T) {
+	t.Run("AbsolutePath", func(t *testing.T) {
 		e := ptesting.NewEnvironment(t)
 		defer func() {
 			if !t.Failed() {
@@ -100,15 +100,25 @@ func TestProjectMain(t *testing.T) {
 			}
 		}()
 		e.ImportDirectory("project_main_abs")
+
+		// write a new Pulumi.yaml using the absolute path of the environment as "main"
+		yamlPath := filepath.Join(e.RootPath, "Pulumi.Yaml")
+		absYamlContents := fmt.Sprintf(
+			"name: project_main_abs\ndescription: A program with an absolute entry point\nruntime: nodejs\nmain: %s\n",
+			e.RootPath,
+		)
+		if err := os.WriteFile(yamlPath, []byte(absYamlContents), 0644); err != nil {
+			t.Error(err)
+			return
+		}
+		e.RunCommand("yarn", "link", "@pulumi/pulumi")
 		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", "main-abs")
-		stdout, stderr := e.RunCommandExpectError("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
-		assert.Equal(t, "Updating (main-abs):\n \n", stdout)
-		assert.Contains(t, stderr, "project 'main' must be a relative path")
+		e.RunCommand("pulumi", "preview")
 		e.RunCommand("pulumi", "stack", "rm", "--yes")
 	})
 
-	t.Run("Error_ParentFolder", func(t *testing.T) {
+	t.Run("ParentFolder", func(t *testing.T) {
 		e := ptesting.NewEnvironment(t)
 		defer func() {
 			if !t.Failed() {
@@ -116,11 +126,26 @@ func TestProjectMain(t *testing.T) {
 			}
 		}()
 		e.ImportDirectory("project_main_parent")
+
+		// yarn link first
+		e.RunCommand("yarn", "link", "@pulumi/pulumi")
+		// then virtually change directory
+		e.CWD = filepath.Join(e.RootPath, "foo", "bar")
+
+		// files, err := os.ReadDir(filepath.Join(e.RootPath, ".."))
+		// if err != nil {
+		// 	t.Error(err)
+		// 	return
+		// }
+
+		// for _, file := range files {
+		// 	t.Logf(file.Name())
+		// }
+		// t.Logf(e.RootPath)
+
 		e.RunCommand("pulumi", "login", "--cloud-url", e.LocalURL())
 		e.RunCommand("pulumi", "stack", "init", "main-parent")
-		stdout, stderr := e.RunCommandExpectError("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
-		assert.Equal(t, "Updating (main-parent):\n \n", stdout)
-		assert.Contains(t, stderr, "project 'main' must be a subfolder")
+		e.RunCommand("pulumi", "preview")
 		e.RunCommand("pulumi", "stack", "rm", "--yes")
 	})
 }

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -107,6 +107,7 @@ func TestProjectMain(t *testing.T) {
 			"name: project_main_abs\ndescription: A program with an absolute entry point\nruntime: nodejs\nmain: %s\n",
 			e.RootPath,
 		)
+		t.Logf("writing new Pulumi.yaml: \npath: %s\ncontents:%s", yamlPath, absYamlContents)
 		if err := os.WriteFile(yamlPath, []byte(absYamlContents), 0644); err != nil {
 			t.Error(err)
 			return

--- a/tests/integration/project_main_abs/.gitignore
+++ b/tests/integration/project_main_abs/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/node_modules/
+

--- a/tests/integration/project_main_abs/Pulumi.yaml
+++ b/tests/integration/project_main_abs/Pulumi.yaml
@@ -1,5 +1,0 @@
-name: project_main_abs
-description: A program with an absolute entry point (should fail)
-runtime: nodejs
-main: /user/bin
-

--- a/tests/integration/project_main_abs/index.ts
+++ b/tests/integration/project_main_abs/index.ts
@@ -1,0 +1,3 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+console.log("So much abs main");

--- a/tests/integration/project_main_abs/package.json
+++ b/tests/integration/project_main_abs/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "project_main",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    }
+}

--- a/tests/integration/project_main_parent/Pulumi.yaml
+++ b/tests/integration/project_main_parent/Pulumi.yaml
@@ -1,4 +1,0 @@
-name: project_main_parent
-description: A program with an entry point in a parent folder (should fail)
-runtime: nodejs
-main: ./foo/../../bar

--- a/tests/integration/project_main_parent/foo/.gitignore
+++ b/tests/integration/project_main_parent/foo/.gitignore
@@ -1,0 +1,3 @@
+/bin/
+/node_modules/
+

--- a/tests/integration/project_main_parent/foo/bar/Pulumi.yaml
+++ b/tests/integration/project_main_parent/foo/bar/Pulumi.yaml
@@ -1,0 +1,4 @@
+name: project_main_parent
+description: A program with an entry point in a parent folder
+runtime: nodejs
+main: ../../foo

--- a/tests/integration/project_main_parent/foo/index.ts
+++ b/tests/integration/project_main_parent/foo/index.ts
@@ -1,0 +1,3 @@
+// Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+
+console.log("So much abs main");

--- a/tests/integration/project_main_parent/foo/package.json
+++ b/tests/integration/project_main_parent/foo/package.json
@@ -1,0 +1,7 @@
+{
+    "name": "project_main",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^2.5.3"
+    }
+}


### PR DESCRIPTION
Required to fix https://github.com/pulumi/pulumi/issues/5578

See previous discussion in prototype PR here: https://github.com/pulumi/pulumi/pull/6247

TLDR; this change relaxes constraints on the `main` field in a pulumi project (pulumi.yaml) to accept absolute paths and relative paths that point to a parent directory. These are old constraints from PPC that are no longer relevant. Relaxing these constraints will allow us to fix bugs around file assets, closure serialization, and dynamic providers for automation API inline programs. 