### PR TITLE
Set defaults for `pulumi stack history`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Breaking Changes
 
+- [cli] Set pagination defaults for `pulumi stack history` to 10 entries. 
+  [#6739](https://github.com/pulumi/pulumi/pull/6739)
+
 - [sdk/nodejs] Enable nodejs dynamic provider caching by default on program side.
   [#6704](https://github.com/pulumi/pulumi/pull/6704)
 

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -74,9 +74,9 @@ This command displays data about previous updates for a stack.`,
 	cmd.PersistentFlags().BoolVarP(
 		&jsonOut, "json", "j", false, "Emit output as JSON")
 	cmd.PersistentFlags().IntVar(
-		&pageSize, "page-size", 0, "Used with 'page' to control number of results returned")
+		&pageSize, "page-size", 10, "Used with 'page' to control number of results returned")
 	cmd.PersistentFlags().IntVar(
-		&page, "page", 0, "Used with 'page-size' to paginate results")
+		&page, "page", 1, "Used with 'page-size' to paginate results")
 	return cmd
 }
 


### PR DESCRIPTION
fixes https://github.com/pulumi/pulumi/issues/6737

Set a default limit of 10 entries for `pulumi stack history`. It isn't uncommon for a stack to have hundreds of history entries, in which case accidentally running this command can cause hangs for several seconds. 