### PR TITLE
Don't return an error if DeleteAllAccounts failed because the creds file doesn't exist

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -28,6 +28,9 @@
 
 ### Bug Fixes
 
+- [cli] Handle non-existent creds file in `pulumi logout --all`
+  [#6741](https://github.com/pulumi/pulumi/pull/6741)
+
 - [sdk/nodejs] Explicitly create event log file for NodeJS Automation API.
   [#6730](https://github.com/pulumi/pulumi/pull/6730)
 

--- a/sdk/go/common/workspace/creds.go
+++ b/sdk/go/common/workspace/creds.go
@@ -81,7 +81,10 @@ func DeleteAllAccounts() error {
 		return err
 	}
 
-	return os.Remove(credsFile)
+	if err = os.Remove(credsFile); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
 }
 
 // StoreAccount saves the given account underneath the given key.

--- a/tests/login_test.go
+++ b/tests/login_test.go
@@ -1,0 +1,21 @@
+package tests
+
+import (
+	"github.com/pulumi/pulumi/pkg/v2/testing/integration"
+	ptesting "github.com/pulumi/pulumi/sdk/v2/go/common/testing"
+	"testing"
+)
+
+func TestLogin(t *testing.T) {
+
+	t.Run("RespectsEnvVar", func(t *testing.T) {
+		e := ptesting.NewEnvironment(t)
+		defer deleteIfNotFailed(e)
+
+		integration.CreateBasicPulumiRepo(e)
+
+		// Running pulumi logout --all twice shouldn't result in an error
+		e.RunCommand("pulumi", "logout", "--all")
+		e.RunCommand("pulumi", "logout", "--all")
+	})
+}


### PR DESCRIPTION
Currently, running `pulumi logout --all` will error out if the `credentials.json` file doesn't exist. With this change, the client won't complain if it fails to delete the creds file because it doesn't exist.