### PR TITLE
Add a flag to stack history to print full dates

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- [cli] Add option to print absolute rather than relative dates in stack history
+  [#6742](https://github.com/pulumi/pulumi/pull/6742)
+
 - [sdk/dotnet] Thread-safe concurrency-friendly global state
   [#6139](https://github.com/pulumi/pulumi/pull/6139)
 

--- a/pkg/cmd/pulumi/history.go
+++ b/pkg/cmd/pulumi/history.go
@@ -68,7 +68,7 @@ func newHistoryCmd() *cobra.Command {
 				return displayUpdatesJSON(updates, decrypter)
 			}
 
-			return displayUpdatesConsole(updates, page, opts)
+			return displayUpdatesConsole(updates, page, opts, false)
 		}),
 	}
 	cmd.PersistentFlags().StringVarP(


### PR DESCRIPTION
Adds the flag `pulumi stack history --full-dates` will print the full dates of updates, instead of the relative `6 hours ago` (or whatever amount).

Ex, `Updated 2021-02-04 10:38:15 -0800 PST took 46s` instead of `Updated 2 months ago took 46s`

rdar://76424838 (pulumi stack history should show full dates instead of relative dates)