### PR TITLE
Set main for default projects in Automation API

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -28,6 +28,9 @@
 
 ### Bug Fixes
 
+- [automation] Set default value for 'main' for inline programs to support relative paths, assets, and closure serialization.
+  [#6743](https://github.com/pulumi/pulumi/pull/6743)
+
 - [sdk/nodejs] Explicitly create event log file for NodeJS Automation API.
   [#6730](https://github.com/pulumi/pulumi/pull/6730)
 

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -35,7 +35,7 @@ namespace Pulumi.Automation
         private readonly LocalSerializer _serializer = new LocalSerializer();
         private readonly bool _ownsWorkingDir;
         private readonly Task _readyTask;
-        private static readonly SemVersion _minimumVersion = SemVersion.Parse("2.25.0");
+        private static readonly SemVersion _minimumVersion = SemVersion.Parse("2.25.0-alpha");
 
         /// <inheritdoc/>
         public override string WorkDir { get; }

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -35,7 +35,7 @@ namespace Pulumi.Automation
         private readonly LocalSerializer _serializer = new LocalSerializer();
         private readonly bool _ownsWorkingDir;
         private readonly Task _readyTask;
-        private static readonly SemVersion _minimumVersion = SemVersion.Parse("2.21.0");
+        private static readonly SemVersion _minimumVersion = SemVersion.Parse("2.25.0");
 
         /// <inheritdoc/>
         public override string WorkDir { get; }

--- a/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
+++ b/sdk/dotnet/Pulumi.Automation/ProjectSettings.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 
 namespace Pulumi.Automation
 {
@@ -47,8 +48,11 @@ namespace Pulumi.Automation
         {
         }
 
-        internal static ProjectSettings Default(string name)
-            => new ProjectSettings(name, new ProjectRuntime(ProjectRuntimeName.NodeJS));
+        internal static ProjectSettings Default(string name) {
+            var defaultSettings = new ProjectSettings(name, new ProjectRuntime(ProjectRuntimeName.Dotnet));
+            defaultSettings.Main = Directory.GetCurrentDirectory();
+            return defaultSettings;
+        }
 
         internal bool IsDefault
         {

--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -958,7 +958,7 @@ func defaultInlineProject(projectName string) (workspace.Project, error) {
 	proj = workspace.Project{
 		Name:    tokens.PackageName(projectName),
 		Runtime: workspace.NewProjectRuntimeInfo("go", nil),
-		Main: cwd
+		Main:    cwd,
 	}
 
 	return proj, nil

--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -951,9 +951,14 @@ func SelectStackInlineSource(
 
 func defaultInlineProject(projectName string) (workspace.Project, error) {
 	var proj workspace.Project
+	cwd, err := os.Getwd()
+	if err != nil {
+		return proj, err
+	}
 	proj = workspace.Project{
 		Name:    tokens.PackageName(projectName),
 		Runtime: workspace.NewProjectRuntimeInfo("go", nil),
+		Main: cwd
 	}
 
 	return proj, nil

--- a/sdk/go/x/auto/minimum_version.go
+++ b/sdk/go/x/auto/minimum_version.go
@@ -20,4 +20,10 @@ var minimumVersion = semver.Version{
 	Major: 2,
 	Minor: 25,
 	Patch: 0,
+	Pre: []semver.PRVersion{
+		{
+			VersionStr: "alpha",
+			IsNum:      false,
+		},
+	},
 }

--- a/sdk/go/x/auto/minimum_version.go
+++ b/sdk/go/x/auto/minimum_version.go
@@ -18,6 +18,6 @@ import "github.com/blang/semver"
 
 var minimumVersion = semver.Version{
 	Major: 2,
-	Minor: 21,
+	Minor: 25,
 	Patch: 0,
 }

--- a/sdk/nodejs/x/automation/localWorkspace.ts
+++ b/sdk/nodejs/x/automation/localWorkspace.ts
@@ -663,7 +663,7 @@ function getStackSettingsName(name: string): string {
 type StackInitializer = (name: string, workspace: Workspace) => Promise<Stack>;
 
 function defaultProject(projectName: string) {
-    const settings: ProjectSettings = { name: projectName, runtime: "nodejs" };
+    const settings: ProjectSettings = { name: projectName, runtime: "nodejs", main: process.cwd() };
     return settings;
 }
 

--- a/sdk/nodejs/x/automation/minimumVersion.ts
+++ b/sdk/nodejs/x/automation/minimumVersion.ts
@@ -14,4 +14,4 @@
 
 import * as semver from "semver";
 
-export const minimumVersion = new semver.SemVer("v2.21.0");
+export const minimumVersion = new semver.SemVer("v2.25.0");

--- a/sdk/nodejs/x/automation/minimumVersion.ts
+++ b/sdk/nodejs/x/automation/minimumVersion.ts
@@ -14,4 +14,4 @@
 
 import * as semver from "semver";
 
-export const minimumVersion = new semver.SemVer("v2.25.0");
+export const minimumVersion = new semver.SemVer("v2.25.0-alpha");

--- a/sdk/python/lib/pulumi/x/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/x/automation/_local_workspace.py
@@ -458,7 +458,7 @@ def _local_source_stack_helper(stack_name: str,
 
 
 def default_project(project_name: str) -> ProjectSettings:
-    return ProjectSettings(name=project_name, runtime="python")
+    return ProjectSettings(name=project_name, runtime="python", main=os.getcwd())
 
 
 def get_stack_settings_name(name: str) -> str:

--- a/sdk/python/lib/pulumi/x/automation/_minimum_version.py
+++ b/sdk/python/lib/pulumi/x/automation/_minimum_version.py
@@ -14,4 +14,4 @@
 
 from semver import VersionInfo
 
-_MINIMUM_VERSION = VersionInfo.parse("2.25.0")
+_MINIMUM_VERSION = VersionInfo.parse("2.25.0-alpha")

--- a/sdk/python/lib/pulumi/x/automation/_minimum_version.py
+++ b/sdk/python/lib/pulumi/x/automation/_minimum_version.py
@@ -14,4 +14,4 @@
 
 from semver import VersionInfo
 
-_MINIMUM_VERSION = VersionInfo.parse("2.21.0")
+_MINIMUM_VERSION = VersionInfo.parse("2.25.0")


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/5578

This sets the `main` property when create default projects for inline programs so that relative paths properly resolve. This allows many utilities to function as expected such as assets, archives, closure serialization, magic functions, and dynamic providers. 

Writing tests for this proved to be challenging. Assets were the first thing I thought to reach for, but they don't wail when pointing at an invalid path so that was effectively useless: https://github.com/pulumi/pulumi/issues/5577

I did try to write a dynamic provider test, and couldn't get it to pass inside of our existing test infrastructure (the defaults are designed for situations where you have /index.ts and /node_modules as siblings). 

I did manually verify this with an inline program that uses a dynamic provider and everything worked as expected (and failed without the change applied as expected):

```ts
import { InlineProgramArgs, LocalWorkspace } from "@pulumi/pulumi/x/automation";
import * as pulumi from "@pulumi/pulumi";

const process = require('process');

const args = process.argv.slice(2);
let destroy = false;
if (args.length > 0 && args[0]) {
    destroy = args[0] === "destroy";
}

const run = async () => {
    // This is our pulumi program in "inline function" form
    const pulumiProgram = async () => {
        
        const myProvider: pulumi.dynamic.ResourceProvider = {
            async create(inputs: any) {
        
                return { id: "foo", outs: { "abc": "def"} };
            },
        }
        class MyResource extends pulumi.dynamic.Resource {
            constructor(name: string, props: {}, opts?: any) {
                super(myProvider, name, props, opts);
            }
        }


       const res = new MyResource("foo", {});

        return {
            res,
        };
    };

    // Create our stack 
    const args: InlineProgramArgs = {
        stackName: "dev22",
        projectName: "inlineNode",
        program: pulumiProgram
    };

    // create (or select if one already exists) a stack that uses our inline program
    const stack = await LocalWorkspace.createOrSelectStack(args);

    console.info("successfully initialized stack");
    console.info("installing plugins...");
    await stack.workspace.installPlugin("aws", "v3.6.1");
    console.info("plugins installed");
    console.info("setting up config");
    await stack.setConfig("aws:region", { value: "us-west-2" });
    console.info("config set");
    console.info("refreshing stack...");
    await stack.refresh({ onOutput: console.info });
    console.info("refresh complete");

    if (destroy) {
        console.info("destroying stack...");
        await stack.destroy({ onOutput: console.info });
        console.info("stack destroy complete");
        process.exit(0);
    }

    console.info("updating stack...");
    const upRes = await stack.up({ onOutput: console.info });
    console.log(`update summary: \n${JSON.stringify(upRes.summary.resourceChanges, null, 4)}`);
    console.log(`res : ${upRes.outputs.res.value}`);
};

run().catch(err => console.log(err));
```