### PR TITLE
Revert "Revert "[sdk/nodejs] Add multiple VM contexts support to closure serialization"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Breaking Changes
 
+- [sdk/nodejs] Drop support for NodeJS < v11.x
+
 - [cli] Set pagination defaults for `pulumi stack history` to 10 entries.
   [#6739](https://github.com/pulumi/pulumi/pull/6739)
 
@@ -41,5 +43,7 @@
 
 ### Enhancements
 
+- [sdk/nodejs] Add support for multiple V8 VM contexts in closure serialization.
+  [#6648](https://github.com/pulumi/pulumi/pull/6648)
 
 ### Bug Fixes


### PR DESCRIPTION
…ure serialization (#6648)" (#6759)"

This reverts commit fd9f2710b6027d36990a6705fe41e10d9d820c3b.

This reapplies the VM context change that requires node v11+. I added a breaking entry in the changelog indicating that we are dropping support for node < v11.x. 

cc @DSoko2 this change will be available in the upcoming 3.0 release. 