### PR TITLE
[CLI] Handle providers field for RegisterResourceRequest

### DIFF
--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -786,7 +786,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 			return nil, err
 		}
 
-		providerRefs = make(map[string]string)
+		providerRefs = make(map[string]string, len(req.GetProviders()))
 		for name, provider := range req.GetProviders() {
 			ref, err := getProviderReference(rm.defaultProviders, providerReq, provider)
 			if err != nil {


### PR DESCRIPTION
Update the RegisterResource method in the ResourceMonitor
to unmarshal the providers field added in d297db3 and then resolve
any provider references so that they can be set on the Construct call.

Related to https://github.com/pulumi/pulumi-eks/issues/555