### PR TITLE
[codegen/python] Remove deprecated __name__ and __opts__ args

### DIFF
--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/cat.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/cat.py
@@ -51,9 +51,7 @@ class Cat(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  age: Optional[pulumi.Input[int]] = None,
                  pet: Optional[pulumi.Input[pulumi.InputType['PetArgs']]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
+                 __props__=None):
         """
         Create a Cat resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
@@ -84,15 +82,7 @@ class Cat(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  age: Optional[pulumi.Input[int]] = None,
                  pet: Optional[pulumi.Input[pulumi.InputType['PetArgs']]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
-        if __name__ is not None:
-            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
-            resource_name = __name__
-        if __opts__ is not None:
-            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
-            opts = __opts__
+                 __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -38,9 +38,7 @@ class Component(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
+                 __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
@@ -70,15 +68,7 @@ class Component(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
-        if __name__ is not None:
-            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
-            resource_name = __name__
-        if __opts__ is not None:
-            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
-            opts = __opts__
+                 __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/workload.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/workload.py
@@ -25,9 +25,7 @@ class Workload(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
+                 __props__=None):
         """
         Create a Workload resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
@@ -56,15 +54,7 @@ class Workload(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
-        if __name__ is not None:
-            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
-            resource_name = __name__
-        if __opts__ is not None:
-            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
-            opts = __opts__
+                 __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/nursery.py
@@ -57,9 +57,7 @@ class Nursery(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
+                 __props__=None):
         """
         Create a Nursery resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
@@ -92,15 +90,7 @@ class Nursery(pulumi.CustomResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  sizes: Optional[pulumi.Input[Mapping[str, pulumi.Input['TreeSize']]]] = None,
                  varieties: Optional[pulumi.Input[Sequence[pulumi.Input['RubberTreeVariety']]]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
-        if __name__ is not None:
-            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
-            resource_name = __name__
-        if __opts__ is not None:
-            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
-            opts = __opts__
+                 __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/v1/rubber_tree.py
@@ -120,9 +120,7 @@ class RubberTree(pulumi.CustomResource):
                  farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
                  size: Optional[pulumi.Input['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
+                 __props__=None):
         """
         Create a RubberTree resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
@@ -156,15 +154,7 @@ class RubberTree(pulumi.CustomResource):
                  farm: Optional[pulumi.Input[Union['Farm', str]]] = None,
                  size: Optional[pulumi.Input['TreeSize']] = None,
                  type: Optional[pulumi.Input['RubberTreeVariety']] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
-        if __name__ is not None:
-            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
-            resource_name = __name__
-        if __opts__ is not None:
-            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
-            opts = __opts__
+                 __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -113,9 +113,7 @@ class Component(pulumi.ComponentResource):
                  e: Optional[str] = None,
                  f: Optional[str] = None,
                  foo: Optional[pulumi.Input[pulumi.InputType['FooArgs']]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
+                 __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
@@ -151,15 +149,7 @@ class Component(pulumi.ComponentResource):
                  e: Optional[str] = None,
                  f: Optional[str] = None,
                  foo: Optional[pulumi.Input[pulumi.InputType['FooArgs']]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
-        if __name__ is not None:
-            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
-            resource_name = __name__
-        if __opts__ is not None:
-            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
-            opts = __opts__
+                 __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/other_resource.py
@@ -37,9 +37,7 @@ class OtherResource(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  foo: Optional[pulumi.Input['Resource']] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
+                 __props__=None):
         """
         Create a OtherResource resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
@@ -69,15 +67,7 @@ class OtherResource(pulumi.ComponentResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  foo: Optional[pulumi.Input['Resource']] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
-        if __name__ is not None:
-            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
-            resource_name = __name__
-        if __opts__ is not None:
-            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
-            opts = __opts__
+                 __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/resource.py
@@ -36,9 +36,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bar: Optional[pulumi.Input[str]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
+                 __props__=None):
         """
         Create a Resource resource with the given unique name, props, and options.
         :param str resource_name: The name of the resource.
@@ -68,15 +66,7 @@ class Resource(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  bar: Optional[pulumi.Input[str]] = None,
-                 __props__=None,
-                 __name__=None,
-                 __opts__=None):
-        if __name__ is not None:
-            warnings.warn("explicit use of __name__ is deprecated", DeprecationWarning)
-            resource_name = __name__
-        if __opts__ is not None:
-            warnings.warn("explicit use of __opts__ is deprecated, use 'opts' instead", DeprecationWarning)
-            opts = __opts__
+                 __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
         if not isinstance(opts, pulumi.ResourceOptions):

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1026,11 +1026,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 			fmt.Fprintf(w, ",\n                 %s: %s = None", InitParamName(prop.Name), ty)
 		}
 
-		// Old versions of TFGen emitted parameters named __name__ and __opts__. In order to preserve backwards
-		// compatibility, we still emit them, but we don't emit documentation for them.
-		fmt.Fprintf(w, ",\n                 __props__=None")
-		fmt.Fprintf(w, ",\n                 __name__=None")
-		fmt.Fprintf(w, ",\n                 __opts__=None):\n")
+		fmt.Fprintf(w, ",\n                 __props__=None):\n")
 	}
 
 	// Emit an __init__ overload that accepts the resource's inputs as function arguments.
@@ -1067,12 +1063,6 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 	if res.DeprecationMessage != "" && mod.compatibility != kubernetes20 {
 		fmt.Fprintf(w, "        pulumi.log.warn(\"\"\"%s is deprecated: %s\"\"\")\n", name, res.DeprecationMessage)
 	}
-	fmt.Fprintf(w, "        if __name__ is not None:\n")
-	fmt.Fprintf(w, "            warnings.warn(\"explicit use of __name__ is deprecated\", DeprecationWarning)\n")
-	fmt.Fprintf(w, "            resource_name = __name__\n")
-	fmt.Fprintf(w, "        if __opts__ is not None:\n")
-	fmt.Fprintf(w, "            warnings.warn(\"explicit use of __opts__ is deprecated, use 'opts' instead\", DeprecationWarning)\n")
-	fmt.Fprintf(w, "            opts = __opts__\n")
 	fmt.Fprintf(w, "        if opts is None:\n")
 	fmt.Fprintf(w, "            opts = pulumi.ResourceOptions()\n")
 	fmt.Fprintf(w, "        if not isinstance(opts, pulumi.ResourceOptions):\n")


### PR DESCRIPTION
These have been deprecated for a very long time and it's a trivial change to remove them from the generated code. Let's clean this up for the 3.0-based providers.