### PR TITLE
Clean the template dir if the remote has changed

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -53,3 +53,6 @@
   [#6771](https://github.com/pulumi/pulumi/pull/6771)
 
 ### Bug Fixes
+
+- [CLI] Clean the template cache if the repo remote has changed.
+  [#6784](https://github.com/pulumi/pulumi/pull/6784)


### PR DESCRIPTION
If the remote of the `~/.pulumi/templates` repo is different than the remote provided through the `workspace.pulumiTemplateGitRepository`, remove that directory. Without this change, if the user has templates cached locally (extremely likely), the client will attempt to clone the directory in `~/.pulumi`; when that fails because the dir already exists, it will drop into the `templates` dir and do a pull. This results in the client continuing to use the previous templates source, instead of the new one set by `pulumiTemplateGitRepository`.

This change makes https://github.com/pulumi/pulumi/pull/6545 usable.