### PR TITLE
Generate old type names in k8s compat mode.

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -213,7 +213,7 @@ func (mod *modContext) typeName(t *schema.ObjectType, state, input, args bool) s
 	if state {
 		return name + "GetArgs"
 	}
-	if !mod.isTFCompatMode() {
+	if !mod.isTFCompatMode() && !mod.isK8sCompatMode() {
 		if args {
 			return name + "Args"
 		}
@@ -1648,7 +1648,7 @@ func (mod *modContext) gen(fs fs) error {
 			fmt.Fprintf(buffer, "}\n")
 
 			suffix := ""
-			if mod.isTFCompatMode() && mod.details(t).functionType {
+			if (mod.isTFCompatMode() || mod.isK8sCompatMode()) && mod.details(t).functionType {
 				suffix = "Result"
 			}
 

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -158,7 +158,7 @@ func (mod *modContext) objectType(pkg *schema.Package, tok string, input, args, 
 		return "enums." + modName + title(name)
 	}
 
-	if args && mod.compatibility != tfbridge20 {
+	if args && mod.compatibility != tfbridge20 && mod.compatibility != kubernetes20 {
 		name += "Args"
 	}
 	return pkgName + root + modName + title(name)
@@ -850,7 +850,7 @@ func (mod *modContext) genType(w io.Writer, obj *schema.ObjectType, input bool, 
 	}
 
 	name := tokenToName(obj.Token)
-	if mod.compatibility == tfbridge20 {
+	if mod.compatibility == tfbridge20 || mod.compatibility == kubernetes20 {
 		wrapInput := input && !mod.details(obj).functionType
 		mod.genPlainType(w, name, obj.Comment, properties, input, wrapInput, false, level)
 		return

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -138,7 +138,7 @@ func (mod *modContext) modNameAndName(tok string, pkg *schema.Package) (modName 
 func (mod *modContext) unqualifiedObjectTypeName(t *schema.ObjectType, input, args bool) string {
 	name := tokenToName(t.Token)
 
-	if mod.compatibility != tfbridge20 {
+	if mod.compatibility != tfbridge20 && mod.compatibility != kubernetes20 {
 		if args {
 			return name + "Args"
 		}


### PR DESCRIPTION
This avoids unintentional breaking changes. Ideally we would use a
different knob, but we only have one compat field at the moment.