### PR TITLE
[sdk/go] Support prompt values in `Construct`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ test_build:: $(SUB_PROJECTS:%=%_install)
 	cd tests/integration/construct_component/testcomponent-go && go build -o pulumi-resource-testcomponent
 	cd tests/integration/construct_component_slow/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_plain/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
+	cd tests/integration/construct_component_plain/testcomponent-go && go build -o pulumi-resource-testcomponent
 
 test_all:: build test_build $(SUB_PROJECTS:%=%_install)
 	cd pkg && $(GO_TEST) ${PROJECT_PKGS}

--- a/build.proj
+++ b/build.proj
@@ -295,6 +295,7 @@
     <Exec Command="go build -o pulumi-resource-testcomponent.exe" WorkingDirectory="$(TestsDirectory)\integration\construct_component\testcomponent-go" />
     <Exec Command="yarn run tsc" WorkingDirectory="$(TestsDirectory)\integration\construct_component_slow\testcomponent" />
     <Exec Command="yarn run tsc" WorkingDirectory="$(TestsDirectory)\integration\construct_component_plain\testcomponent" />
+    <Exec Command="go build -o pulumi-resource-testcomponent.exe" WorkingDirectory="$(TestsDirectory)\integration\construct_component_plain\testcomponent-go" />
 
     <!-- Install pulumi SDK into the venv managed by pipenv. -->
     <Exec Command="pipenv run pip install -e ."

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -192,8 +192,8 @@ func constructInputsMap(ctx *Context, inputs map[string]interface{}) (Map, error
 	return result, nil
 }
 
-// constructInputsSetArgs sets the inputs on the given args struct.
-func constructInputsSetArgs(ctx *Context, inputs map[string]interface{}, args interface{}) error {
+// constructInputsCopyTo sets the inputs on the given args struct.
+func constructInputsCopyTo(ctx *Context, inputs map[string]interface{}, args interface{}) error {
 	if args == nil {
 		return errors.New("args must not be nil")
 	}

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -59,7 +60,7 @@ func construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 		return nil, errors.Wrap(err, "unmarshaling inputs")
 	}
 	inputs := make(map[string]interface{}, len(deserializedInputs))
-	for key, input := range deserializedInputs {
+	for key, value := range deserializedInputs {
 		k := string(key)
 		var deps []Resource
 		if inputDeps, ok := inputDependencies[k]; ok {
@@ -69,15 +70,9 @@ func construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 			}
 		}
 
-		val, secret, err := unmarshalPropertyValue(pulumiCtx, input)
-		if err != nil {
-			return nil, errors.Wrapf(err, "unmarshaling input %s", k)
-		}
-
 		inputs[k] = &constructInput{
-			value:  val,
-			secret: secret,
-			deps:   deps,
+			value: value,
+			deps:  deps,
 		}
 	}
 
@@ -170,25 +165,35 @@ func construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 }
 
 type constructInput struct {
-	value  interface{}
-	secret bool
-	deps   []Resource
+	value resource.PropertyValue
+	deps  []Resource
 }
 
 // constructInputsMap returns the inputs as a Map.
-func constructInputsMap(inputs map[string]interface{}) Map {
+func constructInputsMap(ctx *Context, inputs map[string]interface{}) (Map, error) {
 	result := make(Map, len(inputs))
 	for k, v := range inputs {
-		val := v.(*constructInput)
-		output := newOutput(anyOutputType, val.deps...)
-		output.getState().resolve(val.value, true /*known*/, val.secret, nil)
+		ci := v.(*constructInput)
+
+		value, secret, err := unmarshalPropertyValue(ctx, ci.value)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unmarshaling input %s", k)
+		}
+
+		resultType := anyOutputType
+		if ot, ok := concreteTypeToOutputType.Load(reflect.TypeOf(value)); ok {
+			resultType = ot.(reflect.Type)
+		}
+
+		output := newOutput(resultType, ci.deps...)
+		output.getState().resolve(value, true /*known*/, secret, nil)
 		result[k] = output
 	}
-	return result
+	return result, nil
 }
 
 // constructInputsSetArgs sets the inputs on the given args struct.
-func constructInputsSetArgs(inputs map[string]interface{}, args interface{}) error {
+func constructInputsSetArgs(ctx *Context, inputs map[string]interface{}, args interface{}) error {
 	if args == nil {
 		return errors.New("args must not be nil")
 	}
@@ -200,7 +205,7 @@ func constructInputsSetArgs(inputs map[string]interface{}, args interface{}) err
 	argsV, typ = argsV.Elem(), typ.Elem()
 
 	for k, v := range inputs {
-		val := v.(*constructInput)
+		ci := v.(*constructInput)
 		for i := 0; i < typ.NumField(); i++ {
 			fieldV := argsV.Field(i)
 			if !fieldV.CanSet() {
@@ -212,28 +217,46 @@ func constructInputsSetArgs(inputs map[string]interface{}, args interface{}) err
 				continue
 			}
 
-			if !field.Type.Implements(reflect.TypeOf((*Input)(nil)).Elem()) {
+			if field.Type.Implements(outputType) || field.Type.Implements(inputType) {
+				resultType := anyOutputType
+				if field.Type.Implements(outputType) {
+					resultType = field.Type
+				} else if field.Type.Implements(inputType) {
+					toOutputMethodName := "To" + strings.TrimSuffix(field.Type.Name(), "Input") + "Output"
+					if toOutputMethod, found := field.Type.MethodByName(toOutputMethodName); found {
+						mt := toOutputMethod.Type
+						if mt.NumIn() == 0 && mt.NumOut() == 1 && mt.Out(0).Implements(outputType) {
+							resultType = mt.Out(0)
+						}
+					}
+				}
+				output := newOutput(resultType, ci.deps...)
+				dest := reflect.New(output.ElementType()).Elem()
+				secret, err := unmarshalOutput(ctx, ci.value, dest)
+				if err != nil {
+					return err
+				}
+				output.getState().resolve(dest.Interface(), true /*known*/, secret, nil)
+				fieldV.Set(reflect.ValueOf(output))
 				continue
 			}
 
-			outputType := anyOutputType
-
-			toOutputMethodName := "To" + strings.TrimSuffix(field.Type.Name(), "Input") + "Output"
-			toOutputMethod, found := field.Type.MethodByName(toOutputMethodName)
-			if found {
-				mt := toOutputMethod.Type
-				if mt.NumIn() != 0 || mt.NumOut() != 1 {
-					continue
-				}
-				outputType = mt.Out(0)
-				if !outputType.Implements(reflect.TypeOf((*Output)(nil)).Elem()) {
-					continue
-				}
+			if len(ci.deps) > 0 {
+				return errors.Errorf(
+					"%s.%s is typed as %v but must be typed as Input or Output for input %q with dependencies",
+					typ, field.Name, field.Type, k)
 			}
-
-			output := newOutput(outputType, val.deps...)
-			output.getState().resolve(val.value, true /*known*/, val.secret, nil)
-			fieldV.Set(reflect.ValueOf(output))
+			dest := reflect.New(field.Type).Elem()
+			secret, err := unmarshalOutput(ctx, ci.value, dest)
+			if err != nil {
+				return errors.Wrapf(err, "unmarshaling input %s", k)
+			}
+			if secret {
+				return errors.Errorf(
+					"%s.%s is typed as %v but must be typed as Input or Output for secret input %q",
+					typ, field.Name, field.Type, k)
+			}
+			fieldV.Set(reflect.ValueOf(dest.Interface()))
 		}
 	}
 
@@ -256,6 +279,9 @@ func newConstructResult(resource ComponentResource) (URNInput, Input, error) {
 	state := make(Map)
 	for i := 0; i < typ.NumField(); i++ {
 		fieldV := resourceV.Field(i)
+		if !fieldV.CanInterface() {
+			continue
+		}
 		field := typ.Field(i)
 		tag, has := field.Tag.Lookup("pulumi")
 		if !has {
@@ -264,6 +290,8 @@ func newConstructResult(resource ComponentResource) (URNInput, Input, error) {
 		val := fieldV.Interface()
 		if v, ok := val.(Input); ok {
 			state[tag] = v
+		} else {
+			state[tag] = ToOutput(val)
 		}
 	}
 

--- a/sdk/go/pulumi/provider/provider.go
+++ b/sdk/go/pulumi/provider/provider.go
@@ -54,9 +54,9 @@ func (inputs ConstructInputs) Map() (pulumi.Map, error) {
 	return linkedConstructInputsMap(inputs.ctx, inputs.inputs)
 }
 
-// SetArgs sets the inputs on the given args struct.
-func (inputs ConstructInputs) SetArgs(args interface{}) error {
-	return linkedConstructInputsSetArgs(inputs.ctx, inputs.inputs, args)
+// CopyTo sets the inputs on the given args struct.
+func (inputs ConstructInputs) CopyTo(args interface{}) error {
+	return linkedConstructInputsCopyTo(inputs.ctx, inputs.inputs, args)
 }
 
 // ConstructResult is the result of a call to Construct.
@@ -87,8 +87,8 @@ func linkedConstruct(ctx context.Context, req *pulumirpc.ConstructRequest, engin
 // linkedConstructInputsMap is made available here from ../provider_linked.go via go:linkname.
 func linkedConstructInputsMap(ctx *pulumi.Context, inputs map[string]interface{}) (pulumi.Map, error)
 
-// linkedConstructInputsSetArgs is made available here from ../provider_linked.go via go:linkname.
-func linkedConstructInputsSetArgs(ctx *pulumi.Context, inputs map[string]interface{}, args interface{}) error
+// linkedConstructInputsCopyTo is made available here from ../provider_linked.go via go:linkname.
+func linkedConstructInputsCopyTo(ctx *pulumi.Context, inputs map[string]interface{}, args interface{}) error
 
 // linkedNewConstructResult is made available here from ../provider_linked.go via go:linkname.
 func linkedNewConstructResult(resource pulumi.ComponentResource) (pulumi.URNInput, pulumi.Input, error)

--- a/sdk/go/pulumi/provider/provider.go
+++ b/sdk/go/pulumi/provider/provider.go
@@ -34,7 +34,8 @@ func Construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 	construct ConstructFunc) (*pulumirpc.ConstructResponse, error) {
 	return linkedConstruct(ctx, req, engineConn, func(pulumiCtx *pulumi.Context, typ, name string,
 		inputs map[string]interface{}, options pulumi.ResourceOption) (pulumi.URNInput, pulumi.Input, error) {
-		result, err := construct(pulumiCtx, typ, name, ConstructInputs{inputs: inputs}, options)
+		ci := ConstructInputs{ctx: pulumiCtx, inputs: inputs}
+		result, err := construct(pulumiCtx, typ, name, ci, options)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -44,17 +45,18 @@ func Construct(ctx context.Context, req *pulumirpc.ConstructRequest, engineConn 
 
 // ConstructInputs represents the inputs associated with a call to Construct.
 type ConstructInputs struct {
+	ctx    *pulumi.Context
 	inputs map[string]interface{}
 }
 
 // Map returns the inputs as a Map.
-func (inputs ConstructInputs) Map() pulumi.Map {
-	return linkedConstructInputsMap(inputs.inputs)
+func (inputs ConstructInputs) Map() (pulumi.Map, error) {
+	return linkedConstructInputsMap(inputs.ctx, inputs.inputs)
 }
 
 // SetArgs sets the inputs on the given args struct.
 func (inputs ConstructInputs) SetArgs(args interface{}) error {
-	return linkedConstructInputsSetArgs(inputs.inputs, args)
+	return linkedConstructInputsSetArgs(inputs.ctx, inputs.inputs, args)
 }
 
 // ConstructResult is the result of a call to Construct.
@@ -83,10 +85,10 @@ func linkedConstruct(ctx context.Context, req *pulumirpc.ConstructRequest, engin
 	constructF constructFunc) (*pulumirpc.ConstructResponse, error)
 
 // linkedConstructInputsMap is made available here from ../provider_linked.go via go:linkname.
-func linkedConstructInputsMap(inputs map[string]interface{}) pulumi.Map
+func linkedConstructInputsMap(ctx *pulumi.Context, inputs map[string]interface{}) (pulumi.Map, error)
 
 // linkedConstructInputsSetArgs is made available here from ../provider_linked.go via go:linkname.
-func linkedConstructInputsSetArgs(inputs map[string]interface{}, args interface{}) error
+func linkedConstructInputsSetArgs(ctx *pulumi.Context, inputs map[string]interface{}, args interface{}) error
 
 // linkedNewConstructResult is made available here from ../provider_linked.go via go:linkname.
 func linkedNewConstructResult(resource pulumi.ComponentResource) (pulumi.URNInput, pulumi.Input, error)

--- a/sdk/go/pulumi/provider_linked.go
+++ b/sdk/go/pulumi/provider_linked.go
@@ -35,13 +35,13 @@ func linkedConstruct(ctx context.Context, req *pulumirpc.ConstructRequest, engin
 }
 
 //go:linkname linkedConstructInputsMap github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider.linkedConstructInputsMap
-func linkedConstructInputsMap(inputs map[string]interface{}) Map {
-	return constructInputsMap(inputs)
+func linkedConstructInputsMap(ctx *Context, inputs map[string]interface{}) (Map, error) {
+	return constructInputsMap(ctx, inputs)
 }
 
 //go:linkname linkedConstructInputsSetArgs github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider.linkedConstructInputsSetArgs
-func linkedConstructInputsSetArgs(inputs map[string]interface{}, args interface{}) error {
-	return constructInputsSetArgs(inputs, args)
+func linkedConstructInputsSetArgs(ctx *Context, inputs map[string]interface{}, args interface{}) error {
+	return constructInputsSetArgs(ctx, inputs, args)
 }
 
 //go:linkname linkedNewConstructResult github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider.linkedNewConstructResult

--- a/sdk/go/pulumi/provider_linked.go
+++ b/sdk/go/pulumi/provider_linked.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:deadcode,lll
+//nolint:deadcode
 package pulumi
 
 import (
@@ -39,9 +39,9 @@ func linkedConstructInputsMap(ctx *Context, inputs map[string]interface{}) (Map,
 	return constructInputsMap(ctx, inputs)
 }
 
-//go:linkname linkedConstructInputsSetArgs github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider.linkedConstructInputsSetArgs
-func linkedConstructInputsSetArgs(ctx *Context, inputs map[string]interface{}, args interface{}) error {
-	return constructInputsSetArgs(ctx, inputs, args)
+//go:linkname linkedConstructInputsCopyTo github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider.linkedConstructInputsCopyTo
+func linkedConstructInputsCopyTo(ctx *Context, inputs map[string]interface{}, args interface{}) error {
+	return constructInputsCopyTo(ctx, inputs, args)
 }
 
 //go:linkname linkedNewConstructResult github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider.linkedNewConstructResult

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -130,7 +130,7 @@ type NestedMapArgs struct {
 	Value map[string]Nested `pulumi:"value"`
 }
 
-func TestSetArgs(t *testing.T) {
+func TestConstructInputsCopyTo(t *testing.T) {
 	bar := "bar"
 	dep := newDependencyResource(URN(resource.NewURN("stack", "project", "", "test:index:custom", "test")))
 	tests := []struct {
@@ -346,7 +346,7 @@ func TestSetArgs(t *testing.T) {
 			inputs := map[string]interface{}{
 				"value": &constructInput{value: test.input, deps: test.deps},
 			}
-			err = constructInputsSetArgs(ctx, inputs, test.args)
+			err = constructInputsCopyTo(ctx, inputs, test.args)
 			assert.NoError(t, err)
 
 			result := reflect.ValueOf(test.args).Elem().FieldByName("Value").Interface()
@@ -371,7 +371,7 @@ func TestSetArgs(t *testing.T) {
 	}
 }
 
-func TestSetArgsError(t *testing.T) {
+func TestConstructInputsCopyToError(t *testing.T) {
 	tests := []struct {
 		input         resource.PropertyValue
 		deps          []Resource
@@ -421,7 +421,7 @@ func TestSetArgsError(t *testing.T) {
 			inputs := map[string]interface{}{
 				"value": &constructInput{value: test.input, deps: test.deps},
 			}
-			err = constructInputsSetArgs(ctx, inputs, test.args)
+			err = constructInputsCopyTo(ctx, inputs, test.args)
 			if assert.Error(t, err) {
 				assert.Equal(t, test.expectedError, err.Error())
 			}

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -1,0 +1,461 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+type StringInputArgs struct {
+	Value StringInput `pulumi:"value"`
+}
+
+type StringPtrInputArgs struct {
+	Value StringPtrInput `pulumi:"value"`
+}
+
+type StringArrayInputArgs struct {
+	Value StringArrayInput `pulumi:"value"`
+}
+
+type StringMapInputArgs struct {
+	Value StringMapInput `pulumi:"value"`
+}
+
+type NestedOutputArgs struct {
+	Value NestedOutput `pulumi:"value"`
+}
+
+type NestedPtrOutputArgs struct {
+	Value NestedPtrOutput `pulumi:"value"`
+}
+
+type NestedArrayOutputArgs struct {
+	Value NestedArrayOutput `pulumi:"value"`
+}
+
+type NestedMapOutputArgs struct {
+	Value NestedMapOutput `pulumi:"value"`
+}
+
+type Nested struct {
+	Foo string `pulumi:"foo"`
+	Bar int    `pulumi:"bar"`
+}
+
+type NestedOutput struct {
+	*OutputState
+}
+
+func (NestedOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*Nested)(nil)).Elem()
+}
+
+type NestedPtrOutput struct {
+	*OutputState
+}
+
+func (NestedPtrOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((**Nested)(nil)).Elem()
+}
+
+type NestedArrayOutput struct {
+	*OutputState
+}
+
+func (NestedArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]Nested)(nil)).Elem()
+}
+
+type NestedMapOutput struct {
+	*OutputState
+}
+
+func (NestedMapOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]Nested)(nil)).Elem()
+}
+
+type StringArgs struct {
+	Value string `pulumi:"value"`
+}
+
+type StringPtrArgs struct {
+	Value *string `pulumi:"value"`
+}
+
+type StringArrayArgs struct {
+	Value []string `pulumi:"value"`
+}
+
+type StringMapArgs struct {
+	Value map[string]string `pulumi:"value"`
+}
+
+type IntArgs struct {
+	Value int `pulumi:"value"`
+}
+
+type NestedArgs struct {
+	Value Nested `pulumi:"value"`
+}
+
+type NestedPtrArgs struct {
+	Value *Nested `pulumi:"value"`
+}
+
+type NestedArrayArgs struct {
+	Value []Nested `pulumi:"value"`
+}
+
+type NestedMapArgs struct {
+	Value map[string]Nested `pulumi:"value"`
+}
+
+func TestSetArgs(t *testing.T) {
+	bar := "bar"
+	dep := newDependencyResource(URN(resource.NewURN("stack", "project", "", "test:index:custom", "test")))
+	tests := []struct {
+		input          resource.PropertyValue
+		deps           []Resource
+		args           interface{}
+		expectedType   interface{}
+		expectedValue  interface{}
+		expectedSecret bool
+		expectedDeps   []Resource
+	}{
+		{
+			input:         resource.NewStringProperty("foo"),
+			args:          &StringInputArgs{},
+			expectedType:  StringOutput{},
+			expectedValue: "foo",
+		},
+		{
+			input:          resource.MakeSecret(resource.NewStringProperty("foo")),
+			args:           &StringInputArgs{},
+			expectedType:   StringOutput{},
+			expectedValue:  "foo",
+			expectedSecret: true,
+		},
+		{
+			input:         resource.NewStringProperty("foo"),
+			deps:          []Resource{dep},
+			args:          &StringInputArgs{},
+			expectedType:  StringOutput{},
+			expectedValue: "foo",
+			expectedDeps:  []Resource{dep},
+		},
+		{
+			input:         resource.NewStringProperty("bar"),
+			args:          &StringPtrInputArgs{},
+			expectedType:  StringPtrOutput{},
+			expectedValue: &bar,
+		},
+		{
+			input: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("hello"),
+				resource.NewStringProperty("world"),
+			}),
+			args:          &StringArrayInputArgs{},
+			expectedType:  StringArrayOutput{},
+			expectedValue: []string{"hello", "world"},
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "hello",
+				"bar": "world",
+			})),
+			args:         &StringMapInputArgs{},
+			expectedType: StringMapOutput{},
+			expectedValue: map[string]string{
+				"foo": "hello",
+				"bar": "world",
+			},
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "hello",
+				"bar": 42,
+			})),
+			args:          &NestedOutputArgs{},
+			expectedType:  NestedOutput{},
+			expectedValue: Nested{Foo: "hello", Bar: 42},
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "world",
+				"bar": 100,
+			})),
+			args:          &NestedPtrOutputArgs{},
+			expectedType:  NestedPtrOutput{},
+			expectedValue: &Nested{Foo: "world", Bar: 100},
+		},
+		{
+			input: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+					"foo": "a",
+					"bar": 1,
+				})),
+				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+					"foo": "b",
+					"bar": 2,
+				})),
+			}),
+			args:         &NestedArrayOutputArgs{},
+			expectedType: NestedArrayOutput{},
+			expectedValue: []Nested{
+				{Foo: "a", Bar: 1},
+				{Foo: "b", Bar: 2},
+			},
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"a": map[string]interface{}{
+					"foo": "c",
+					"bar": 3,
+				},
+				"b": map[string]interface{}{
+					"foo": "d",
+					"bar": 4,
+				},
+			})),
+			args:         &NestedMapOutputArgs{},
+			expectedType: NestedMapOutput{},
+			expectedValue: map[string]Nested{
+				"a": {Foo: "c", Bar: 3},
+				"b": {Foo: "d", Bar: 4},
+			},
+		},
+		{
+			input:         resource.NewStringProperty("foo"),
+			args:          &StringArgs{},
+			expectedType:  string(""),
+			expectedValue: "foo",
+		},
+		{
+			input:         resource.NewStringProperty("bar"),
+			args:          &StringPtrArgs{},
+			expectedType:  &bar,
+			expectedValue: &bar,
+		},
+		{
+			input: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewStringProperty("hello"),
+				resource.NewStringProperty("world"),
+			}),
+			args:          &StringArrayArgs{},
+			expectedType:  []string{},
+			expectedValue: []string{"hello", "world"},
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "hello",
+				"bar": "world",
+			})),
+			args:         &StringMapArgs{},
+			expectedType: map[string]string{},
+			expectedValue: map[string]string{
+				"foo": "hello",
+				"bar": "world",
+			},
+		},
+		{
+			input:         resource.NewNumberProperty(42),
+			args:          &IntArgs{},
+			expectedType:  int(0),
+			expectedValue: 42,
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "hi",
+				"bar": 7,
+			})),
+			args:          &NestedArgs{},
+			expectedType:  Nested{},
+			expectedValue: Nested{Foo: "hi", Bar: 7},
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "pointer",
+				"bar": 2,
+			})),
+			args:          &NestedPtrArgs{},
+			expectedType:  &Nested{},
+			expectedValue: &Nested{Foo: "pointer", Bar: 2},
+		},
+		{
+			input: resource.NewArrayProperty([]resource.PropertyValue{
+				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+					"foo": "1",
+					"bar": 1,
+				})),
+				resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+					"foo": "2",
+					"bar": 2,
+				})),
+			}),
+			args:         &NestedArrayArgs{},
+			expectedType: []Nested{},
+			expectedValue: []Nested{
+				{Foo: "1", Bar: 1},
+				{Foo: "2", Bar: 2},
+			},
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"a": map[string]interface{}{
+					"foo": "3",
+					"bar": 3,
+				},
+				"b": map[string]interface{}{
+					"foo": "4",
+					"bar": 4,
+				},
+			})),
+			args:         &NestedMapArgs{},
+			expectedType: map[string]Nested{},
+			expectedValue: map[string]Nested{
+				"a": {Foo: "3", Bar: 3},
+				"b": {Foo: "4", Bar: 4},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%T-%v-%T", test.args, test.input, test.expectedType), func(t *testing.T) {
+			ctx, err := NewContext(context.Background(), RunInfo{})
+			assert.NoError(t, err)
+
+			inputs := map[string]interface{}{
+				"value": &constructInput{value: test.input, deps: test.deps},
+			}
+			err = constructInputsSetArgs(ctx, inputs, test.args)
+			assert.NoError(t, err)
+
+			result := reflect.ValueOf(test.args).Elem().FieldByName("Value").Interface()
+			assert.IsType(t, test.expectedType, result)
+
+			if _, ok := test.expectedType.(Output); ok {
+				value, known, secret, deps, err := await(result.(Output))
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedValue, value)
+				assert.True(t, known)
+				assert.Equal(t, test.expectedSecret, secret)
+				assert.Equal(t, test.expectedDeps, deps)
+			} else {
+				if test.expectedValue == nil {
+					assert.Nil(t, result)
+					assert.True(t, false)
+				} else {
+					assert.Equal(t, test.expectedValue, result)
+				}
+			}
+		})
+	}
+}
+
+func TestSetArgsError(t *testing.T) {
+	tests := []struct {
+		input         resource.PropertyValue
+		deps          []Resource
+		args          interface{}
+		expectedError string
+	}{
+		{
+			input:         resource.NewStringProperty("foo"),
+			args:          &IntArgs{},
+			expectedError: "unmarshaling input value: expected an int, got a string",
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": 500,
+				"bar": 42,
+			})),
+			args:          &NestedArgs{},
+			expectedError: "unmarshaling input value: expected a string, got a number",
+		},
+		{
+			input: resource.MakeSecret(resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "hello",
+				"bar": 42,
+			}))),
+			args: &NestedArgs{},
+			expectedError: "pulumi.NestedArgs.Value is typed as pulumi.Nested but must be typed as Input or " +
+				"Output for secret input \"value\"",
+		},
+		{
+			input: resource.NewObjectProperty(resource.NewPropertyMapFromMap(map[string]interface{}{
+				"foo": "hello",
+				"bar": 42,
+			})),
+			deps: []Resource{
+				newDependencyResource(URN(resource.NewURN("stack", "project", "", "test:index:custom", "test"))),
+			},
+			args: &NestedArgs{},
+			expectedError: "pulumi.NestedArgs.Value is typed as pulumi.Nested but must be typed as Input or " +
+				"Output for input \"value\" with dependencies",
+		},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%T-%v", test.args, test.input), func(t *testing.T) {
+			ctx, err := NewContext(context.Background(), RunInfo{})
+			assert.NoError(t, err)
+
+			inputs := map[string]interface{}{
+				"value": &constructInput{value: test.input, deps: test.deps},
+			}
+			err = constructInputsSetArgs(ctx, inputs, test.args)
+			if assert.Error(t, err) {
+				assert.Equal(t, test.expectedError, err.Error())
+			}
+		})
+	}
+}
+
+type MyComponent struct {
+	ResourceState
+
+	Foo        string       `pulumi:"foo"`
+	SomeValue  StringOutput `pulumi:"someValue"`
+	Nope       StringOutput
+	unexported StringOutput `pulumi:"unexported"`
+}
+
+func TestConstructResult(t *testing.T) {
+	someOutput := String("something").ToStringOutput()
+
+	component := &MyComponent{
+		Foo:        "hi",
+		SomeValue:  someOutput,
+		Nope:       String("nope").ToStringOutput(),
+		unexported: String("nope").ToStringOutput(),
+	}
+
+	_, state, err := newConstructResult(component)
+	assert.NoError(t, err)
+
+	resolvedProps, _, _, err := marshalInputs(state)
+	assert.NoError(t, err)
+
+	assert.Equal(t, resource.NewPropertyMapFromMap(map[string]interface{}{
+		"foo":       "hi",
+		"someValue": "something",
+	}), resolvedProps)
+}

--- a/tests/integration/construct_component/testcomponent-go/main.go
+++ b/tests/integration/construct_component/testcomponent-go/main.go
@@ -138,7 +138,7 @@ func (p *testcomponentProvider) Construct(ctx context.Context,
 		}
 
 		args := &ComponentArgs{}
-		if err := inputs.SetArgs(args); err != nil {
+		if err := inputs.CopyTo(args); err != nil {
 			return nil, errors.Wrap(err, "setting args")
 		}
 

--- a/tests/integration/construct_component_plain/testcomponent-go/.gitignore
+++ b/tests/integration/construct_component_plain/testcomponent-go/.gitignore
@@ -1,0 +1,2 @@
+pulumi-resource-testcomponent
+pulumi-resource-testcomponent.exe

--- a/tests/integration/integration_dotnet_test.go
+++ b/tests/integration/integration_dotnet_test.go
@@ -300,32 +300,55 @@ func TestConstructSlowDotnet(t *testing.T) {
 
 // Test remote component construction with prompt inputs.
 func TestConstructPlainDotnet(t *testing.T) {
-	runtimeVenv := pulumiRuntimeVirtualEnv(t, filepath.Join("..", ".."))
+	tests := []struct {
+		componentDir          string
+		expectedResourceCount int
+		env                   []string
+	}{
+		{
+			componentDir:          "testcomponent",
+			expectedResourceCount: 9,
+			// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
+			// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
+			// module to run `yarn install && yarn link @pulumi/pulumi` in the Go program's directory, allowing
+			// the Node.js dynamic provider plugin to load.
+			// When the underlying issue has been fixed, the use of this environment variable inside the integration
+			// test module should be removed.
+			env: []string{"PULUMI_TEST_YARN_LINK_PULUMI=true"},
+		},
+		{
+			componentDir:          "testcomponent-python",
+			expectedResourceCount: 9,
+			env:                   []string{pulumiRuntimeVirtualEnv(t, filepath.Join("..", ".."))},
+		},
+		{
+			componentDir:          "testcomponent-go",
+			expectedResourceCount: 8, // One less because no dynamic provider.
+		},
+	}
 
-	// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-	// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-	// module to run `yarn install && yarn link @pulumi/pulumi` in the .NET program's directory, allowing
-	// the Node.js dynamic provider plugin to load.
-	// When the underlying issue has been fixed, the use of this environment variable inside the integration
-	// test module should be removed.
-	const testYarnLinkPulumiEnv = "PULUMI_TEST_YARN_LINK_PULUMI=true"
+	for _, test := range tests {
+		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := componentPathEnv(t, "construct_component_plain", test.componentDir)
+			integration.ProgramTest(t,
+				optsForConstructPlainDotnet(t, test.expectedResourceCount, append(test.env, pathEnv)...))
+		})
+	}
+}
 
-	opts := &integration.ProgramTestOptions{
-		Env:          []string{testYarnLinkPulumiEnv, runtimeVenv},
+func optsForConstructPlainDotnet(t *testing.T, expectedResourceCount int,
+	env ...string) *integration.ProgramTestOptions {
+	return &integration.ProgramTestOptions{
+		Env:          env,
 		Dir:          filepath.Join("construct_component_plain", "dotnet"),
 		Dependencies: []string{"Pulumi"},
 		NoParallel:   true, // avoid contention for Dir
 		Quick:        true,
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Deployment)
-			assert.Equal(t, 9, len(stackInfo.Deployment.Resources))
+			assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources))
 		},
 	}
-
-	runProgramSubTests(t, opts, map[string]string{
-		"WithNodeProvider":   componentPathEnv(t, "construct_component_plain", "testcomponent"),
-		"WithPythonProvider": componentPathEnv(t, "construct_component_plain", "testcomponent-python"),
-	})
 }
 
 func TestGetResourceDotnet(t *testing.T) {

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -489,19 +489,46 @@ func TestConstructSlowPython(t *testing.T) {
 
 // Test remote component construction with prompt inputs.
 func TestConstructPlainPython(t *testing.T) {
+	tests := []struct {
+		componentDir          string
+		expectedResourceCount int
+		env                   []string
+	}{
+		{
+			componentDir:          "testcomponent",
+			expectedResourceCount: 9,
+			// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
+			// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
+			// module to run `yarn install && yarn link @pulumi/pulumi` in the Go program's directory, allowing
+			// the Node.js dynamic provider plugin to load.
+			// When the underlying issue has been fixed, the use of this environment variable inside the integration
+			// test module should be removed.
+			env: []string{"PULUMI_TEST_YARN_LINK_PULUMI=true"},
+		},
+		{
+			componentDir:          "testcomponent-python",
+			expectedResourceCount: 9,
+			env:                   []string{pulumiRuntimeVirtualEnv(t, filepath.Join("..", ".."))},
+		},
+		{
+			componentDir:          "testcomponent-go",
+			expectedResourceCount: 8, // One less because no dynamic provider.
+		},
+	}
 
-	// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-	// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-	// module to run `yarn install && yarn link @pulumi/pulumi` in the Python program's directory, allowing
-	// the Node.js dynamic provider plugin to load.
-	// When the underlying issue has been fixed, the use of this environment variable inside the integration
-	// test module should be removed.
-	const testYarnLinkPulumiEnv = "PULUMI_TEST_YARN_LINK_PULUMI=true"
+	for _, test := range tests {
+		t.Run(test.componentDir, func(t *testing.T) {
+			pathEnv := componentPathEnv(t, "construct_component_plain", test.componentDir)
+			integration.ProgramTest(t,
+				optsForConstructPlainPython(t, test.expectedResourceCount, append(test.env, pathEnv)...))
+		})
+	}
+}
 
-	runtimeVenv := pulumiRuntimeVirtualEnv(t, filepath.Join("..", ".."))
-
-	opts := &integration.ProgramTestOptions{
-		Env: []string{testYarnLinkPulumiEnv, runtimeVenv},
+func optsForConstructPlainPython(t *testing.T, expectedResourceCount int,
+	env ...string) *integration.ProgramTestOptions {
+	return &integration.ProgramTestOptions{
+		Env: env,
 		Dir: filepath.Join("construct_component_plain", "python"),
 		Dependencies: []string{
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
@@ -510,14 +537,9 @@ func TestConstructPlainPython(t *testing.T) {
 		NoParallel: true, // avoid contention for Dir
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Deployment)
-			assert.Equal(t, 9, len(stackInfo.Deployment.Resources))
+			assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources))
 		},
 	}
-
-	runProgramSubTests(t, opts, map[string]string{
-		"WithNodeProvider":   componentPathEnv(t, "construct_component_plain", "testcomponent"),
-		"WithPythonProvider": componentPathEnv(t, "construct_component_plain", "testcomponent-python"),
-	})
 }
 
 func TestGetResourcePython(t *testing.T) {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -625,17 +625,3 @@ func pulumiRuntimeVirtualEnv(t *testing.T, pulumiRepoRootDir string) string {
 	r := fmt.Sprintf("PULUMI_RUNTIME_VIRTUALENV=%s", venvFolder)
 	return r
 }
-
-// nolint: unused,deadcode
-func runProgramSubTests(t *testing.T, opts *integration.ProgramTestOptions, envExtensions map[string]string) {
-	extend := func(extraEnv string, opts integration.ProgramTestOptions) integration.ProgramTestOptions {
-		opts.Env = append(opts.Env, extraEnv)
-		return opts
-	}
-	for subTestName, extraEnv := range envExtensions {
-		t.Run(subTestName, func(t *testing.T) {
-			subTestOpts := extend(extraEnv, *opts)
-			integration.ProgramTest(t, &subTestOpts)
-		})
-	}
-}


### PR DESCRIPTION
- Adds support for prompt values.
- Renames `ConstructInputs.SetArgs` => `ConstructInputs.CopyTo` (improved name, IMO)

Fixes #6425