### PR TITLE
[automation/dotnet] Use Grpc.AspNetCore.Server package - without Grpc.Tools dependency

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -59,4 +59,7 @@
 - [sdk/go] Support defining remote components in Go.
   [#6403](https://github.com/pulumi/pulumi/pull/6403)
 
+- [automation/dotnet] Remove dependency on Gprc.Tools for F# / Paket compatibility
+  [#6793](https://github.com/pulumi/pulumi/pull/6793)  
+
 ### Bug Fixes

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj
@@ -35,7 +35,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="CliWrap" Version="3.3.2" />
-    <PackageReference Include="Grpc.AspNetCore" Version="2.34.0" />
+    <PackageReference Include="Grpc.AspNetCore.Server" version="2.34.0" />
     <PackageReference Include="YamlDotNet" Version="9.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes #6792 