### PR TITLE
Fixes #6775: Duplicated Go modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,9 @@ CHANGELOG
 
 ### Bug Fixes
 
+- [sdk/go] Fix wrongly named Go modules
+  [#6775](https://github.com/pulumi/pulumi/issues/6775)
+
 - [cli] Handle non-existent creds file in `pulumi logout --all`
   [#6741](https://github.com/pulumi/pulumi/pull/6741)
 

--- a/sdk/dotnet/Pulumi.Automation.Tests/Data/testproj/go.mod
+++ b/sdk/dotnet/Pulumi.Automation.Tests/Data/testproj/go.mod
@@ -1,4 +1,4 @@
-module testproj
+module github.com/pulumi/pulumi/sdk/v3/dotnet/Pulumi.Automation.Tests/Data/testproj
 
 go 1.16
 

--- a/sdk/go/auto/test/errors/compilation_error/go/go.mod
+++ b/sdk/go/auto/test/errors/compilation_error/go/go.mod
@@ -1,4 +1,4 @@
-module compilation_error
+module github.com/pulumi/pulumi/sdk/v3/go/auto/test/errors/compilation_error
 
 go 1.16
 

--- a/sdk/go/auto/test/errors/conflict_error/go.mod
+++ b/sdk/go/auto/test/errors/conflict_error/go.mod
@@ -1,4 +1,4 @@
-module testproj
+module github.com/pulumi/pulumi/sdk/v3/go/auto/test/errors/conflict_error
 
 go 1.16
 

--- a/sdk/go/auto/test/errors/runtime_error/go/go.mod
+++ b/sdk/go/auto/test/errors/runtime_error/go/go.mod
@@ -1,4 +1,4 @@
-module lkjljlj
+module github.com/pulumi/pulumi/sdk/v3/go/auto/test/errors/runtime_error/go
 
 go 1.16
 

--- a/sdk/go/auto/test/testproj/go.mod
+++ b/sdk/go/auto/test/testproj/go.mod
@@ -1,4 +1,4 @@
-module testproj
+module github.com/pulumi/pulumi/sdk/v3/go/auto/test/testproj
 
 go 1.16
 

--- a/sdk/nodejs/tests/automation/data/testproj/go.mod
+++ b/sdk/nodejs/tests/automation/data/testproj/go.mod
@@ -1,4 +1,4 @@
-module testproj
+module github.com/pulumi/pulumi/sdk/v3/nodejs/tests/automation/data/testproj
 
 go 1.16
 

--- a/sdk/python/lib/test/automation/data/testproj/go.mod
+++ b/sdk/python/lib/test/automation/data/testproj/go.mod
@@ -1,5 +1,4 @@
-module testproj
-
+module github.com/pulumi/pulumi/sdk/v3/python/lib/test/automation/data/testproj
 go 1.16
 
 require github.com/pulumi/pulumi/sdk/v3 v3.0.0-20210322210933-10a6a2caf014

--- a/sdk/python/lib/test/automation/errors/conflict_error/go.mod
+++ b/sdk/python/lib/test/automation/errors/conflict_error/go.mod
@@ -1,4 +1,4 @@
-module testproj
+module github.com/pulumi/pulumi/sdk/v3/python/lib/test/automation/errors/conflict_error
 
 go 1.16
 

--- a/sdk/python/lib/test/automation/errors/runtime_error/go/go.mod
+++ b/sdk/python/lib/test/automation/errors/runtime_error/go/go.mod
@@ -1,4 +1,4 @@
-module lkjljlj
+module github.com/pulumi/pulumi/sdk/v3/python/lib/test/automation/errors/runtime_error
 
 go 1.16
 


### PR DESCRIPTION
Fixes the problems that `gopls` language server reports regarding same module names being overused within the project.

Closes #6775 