### PR TITLE
[docgen] Fix horizontal scroll in python resource docs

### DIFF
--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -237,6 +237,9 @@ func (mod *modContext) genFunctionArgs(f *schema.Function, funcNameMap map[strin
 		)
 		b := &bytes.Buffer{}
 
+		paramSeparatorTemplate := "param_separator"
+		ps := paramSeparator{}
+
 		switch lang {
 		case "nodejs":
 			params = mod.genFunctionTS(f, funcNameMap["nodejs"])
@@ -250,6 +253,11 @@ func (mod *modContext) genFunctionArgs(f *schema.Function, funcNameMap map[strin
 		case "python":
 			params = mod.genFunctionPython(f, funcNameMap["python"])
 			paramTemplate = "py_formal_param"
+			paramSeparatorTemplate = "py_param_separator"
+
+			docHelper := getLanguageDocHelper(lang)
+			funcName := docHelper.GetFunctionName(mod.mod, f)
+			ps = paramSeparator{Indent: strings.Repeat(" ", len("def (")+len(funcName))}
 		}
 
 		n := len(params)
@@ -262,7 +270,7 @@ func (mod *modContext) genFunctionArgs(f *schema.Function, funcNameMap map[strin
 				panic(err)
 			}
 			if i != n-1 {
-				if err := templates.ExecuteTemplate(b, "param_separator", nil); err != nil {
+				if err := templates.ExecuteTemplate(b, paramSeparatorTemplate, ps); err != nil {
 					panic(err)
 				}
 			}

--- a/pkg/codegen/docs/templates/constructor_args.tmpl
+++ b/pkg/codegen/docs/templates/constructor_args.tmpl
@@ -7,7 +7,7 @@
         {{- end }}>
         <span>{{- htmlSafe .Name -}}</span>
         <span class="property-indicator"></span>
-        <span class="property-type">{{- if eq .Type.Link "#" "" -}}{{- htmlSafe .Type.Name -}}{{- else -}}{{ template "linkify" .Type }}{{- end -}}</span>
+        <span class="property-type">{{- if eq .Type.Link "#" "" -}}{{- htmlSafe .Type.Name -}}{{- else -}}{{ template "linkify_constructor_args" .Type }}{{- end -}}</span>
     </dt>
     <dd>
       {{ .Comment }}

--- a/pkg/codegen/docs/templates/constructor_params.tmpl
+++ b/pkg/codegen/docs/templates/constructor_params.tmpl
@@ -1,4 +1,7 @@
-{{ define "param_separator" }}<span class="p">, </span>{{ end }}
+{{ define "param_separator" }}<span class="p">,</span> {{ end }}
+
+{{ define "py_param_separator" }}<span class="p">,</span>
+{{ .Indent }}{{ end }}
 
 {{ define "go_formal_param" }}<span class="nx">{{ .Name }}</span><span class="p"> {{ .OptionalFlag }}</span>{{ template "linkify_param" .Type }}{{ end }}
 

--- a/pkg/codegen/docs/templates/resource.tmpl
+++ b/pkg/codegen/docs/templates/resource.tmpl
@@ -31,7 +31,10 @@
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language python %}}" }}
-<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class="k">def </span>{{ template "linkify_param" .ConstructorResource.python }}<span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">, </span>{{ htmlSafe .ConstructorParams.python }}<span class="p">)</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
+<span class="k">def </span>{{ template "linkify_param" .ConstructorResource.python }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.python }}<span class="p">)</span>
+<span class=nd>@overload</span>
+<span class="k">def </span>{{ template "linkify_param" .ConstructorResource.python }}<span class="p">(</span>{{ htmlSafe .ConstructorParams.pythonargs }}<span class="p">)</span></code></pre></div>
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language go %}}" }}
@@ -47,26 +50,7 @@
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language python %}}" }}
-{{/*
-    Constructing resources in python uses a different approach, which is why
-    we don't use the "constructor_args" and just hard-code two params here.
-*/}}
-<dl class="resources-properties">
-    <dt class="property-required" title="Required">
-        <span>resource_name</span>
-        <span class="property-indicator"></span>
-        <span class="property-type">str</span>
-    </dt>
-    <dd>The unique name of the resource.</dd>
-    <dt class="property-optional" title="Optional">
-        <span>opts</span>
-        <span class="property-indicator"></span>
-        <span class="property-type">
-            <a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">ResourceOptions</a>
-        </span>
-    </dt>
-    <dd>A bag of options that control this resource's behavior.</dd>
-</dl>
+{{ template "constructor_args" .ConstructorParamsTyped.pythonargs }}
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language go %}}" }}
@@ -112,7 +96,10 @@ Get an existing {{.Header.Title}} resource's state with the given name, ID, and 
 
 {{ htmlSafe "{{% choosable language python %}}" }}
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@staticmethod</span>
-<span class="k">def </span><span class="nf">get</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">, </span><span class="nx">id</span><span class="p">:</span> <span class="nx">str</span><span class="p">, </span><span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">, </span>{{ htmlSafe .LookupParams.python }}<span class="p">) -&gt;</span> {{ .ConstructorResource.python.Name }}</code></pre></div>
+<span class="k">def </span><span class="nf">get</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
+        <span class="nx">id</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
+        <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
+        {{ htmlSafe .LookupParams.python }}<span class="p">) -&gt;</span> {{ .ConstructorResource.python.Name }}</code></pre></div>
 {{ htmlSafe "{{% /choosable %}}" }}
 
 {{ htmlSafe "{{% choosable language go %}}" }}

--- a/pkg/codegen/docs/templates/utils.tmpl
+++ b/pkg/codegen/docs/templates/utils.tmpl
@@ -8,6 +8,9 @@
 to avoid double-encoding html characters, which is typical of properties type names. -->
 {{ define "linkify" }}<a href="{{ .Link }}">{{ if ne .DisplayName "" }}{{ htmlSafe .DisplayName }}{{ else }}{{ htmlSafe .Name }}{{ end }}</a>{{ end }}
 
+<!-- linkify_constructor_args is like linkify, but will display the DescriptionName if it's present -->
+{{ define "linkify_constructor_args" }}<a href="{{ .Link }}">{{ if ne .DescriptionName "" }}{{ htmlSafe .DescriptionName }}{{ else if ne .DisplayName "" }}{{ htmlSafe .DisplayName }}{{ else }}{{ htmlSafe .Name }}{{ end }}</a>{{ end }}
+
 <!-- linkify_wo_style an wraps a propertyType with an anchor tag but retains parent styling. The display name/name is rendered as-is by
 passing it through the htmlSafe function
 to avoid double-encoding html characters, which is typical of properties type names. -->


### PR DESCRIPTION
Add line breaks and whitespace to avoid long horizontal scrolls for Python constructor/function arguments. Also, include the new ResourceArgs constructor overload.

## Before

<img width="816" alt="Screen Shot 2021-04-17 at 12 07 17 PM" src="https://user-images.githubusercontent.com/710598/115124302-4a832c80-9f76-11eb-81bf-ed58fb89d1d9.png">

## After

<img width="819" alt="Screen Shot 2021-04-17 at 12 07 33 PM" src="https://user-images.githubusercontent.com/710598/115124310-51aa3a80-9f76-11eb-9c84-3f7dfacecc62.png">

Fixes https://github.com/pulumi/docs/issues/5365