### PR TITLE
Setting the minimum version of the CLI to be 3.0.0-rc.1 for the automation API

### DIFF
--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -35,7 +35,7 @@ namespace Pulumi.Automation
         private readonly LocalSerializer _serializer = new LocalSerializer();
         private readonly bool _ownsWorkingDir;
         private readonly Task _readyTask;
-        private static readonly SemVersion _minimumVersion = SemVersion.Parse("3.0.0-alpha.0");
+        private static readonly SemVersion _minimumVersion = SemVersion.Parse("3.0.0-rc.1");
 
         /// <inheritdoc/>
         public override string WorkDir { get; }

--- a/sdk/go/auto/minimum_version.go
+++ b/sdk/go/auto/minimum_version.go
@@ -19,6 +19,6 @@ import "github.com/blang/semver"
 var minimumVersion = calculateMinVersion()
 
 func calculateMinVersion() semver.Version {
-	v, _ := semver.ParseTolerant("3.0.0-alpha.0")
+	v, _ := semver.ParseTolerant("3.0.0-rc.1")
 	return v
 }

--- a/sdk/nodejs/automation/minimumVersion.ts
+++ b/sdk/nodejs/automation/minimumVersion.ts
@@ -14,4 +14,4 @@
 
 import * as semver from "semver";
 
-export const minimumVersion = new semver.SemVer("v3.0.0-alpha.0");
+export const minimumVersion = new semver.SemVer("v3.0.0-rc.1");

--- a/sdk/python/lib/pulumi/automation/_minimum_version.py
+++ b/sdk/python/lib/pulumi/automation/_minimum_version.py
@@ -14,4 +14,4 @@
 
 from semver import VersionInfo
 
-_MINIMUM_VERSION = VersionInfo.parse("3.0.0-alpha.0")
+_MINIMUM_VERSION = VersionInfo.parse("3.0.0-rc.1")


### PR DESCRIPTION
No changelog needed as this will be in the main release tomorrow - this is just remembering to not allow the alphas or betas