### PR TITLE
Distinguish between inputty and plain args types.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,3 +9,6 @@
 
 ### Bug Fixes
 
+
+- [codegen] Fix codegen for types that are used by both resources and functions.
+  [#6811](https://github.com/pulumi/pulumi/pull/6811)

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -50,12 +50,11 @@ func (ss stringSet) has(s string) bool {
 }
 
 type typeDetails struct {
-	outputType   bool
-	inputType    bool
-	stateType    bool
-	argsType     bool
-	plainType    bool
-	functionType bool
+	outputType bool
+	inputType  bool
+	stateType  bool
+	argsType   bool
+	plainType  bool
 }
 
 // Title converts the input string to a title case

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -424,9 +424,11 @@ type plainType struct {
 }
 
 func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent string) {
+	argsType := pt.args && !prop.IsPlain
+
 	wireName := prop.Name
 	propertyName := pt.mod.propertyName(prop)
-	propertyType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, true, pt.state, pt.args && !prop.IsPlain, pt.args && !prop.IsPlain, false, !prop.IsRequired)
+	propertyType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, true, pt.state, argsType, argsType, false, !prop.IsRequired)
 
 	// First generate the input attribute.
 	attributeArgs := ""
@@ -453,7 +455,7 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 	case *schema.ArrayType, *schema.MapType:
 		backingFieldName := "_" + prop.Name
 		requireInitializers := !pt.args
-		backingFieldType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, true, pt.state, pt.args && !prop.IsPlain, pt.args, requireInitializers, false)
+		backingFieldType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, true, pt.state, argsType, argsType, requireInitializers, false)
 
 		fmt.Fprintf(w, "%s[Input(\"%s\"%s)]\n", indent, wireName, attributeArgs)
 		fmt.Fprintf(w, "%sprivate %s? %s;\n", indent, backingFieldType, backingFieldName)

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/docs/component.md
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/docs/component.md
@@ -25,7 +25,7 @@ meta_desc: "Documentation for the example.Component resource with examples, inpu
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-              <span class="nx">metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMeta]</span> = None<span class="p">)</span>
+              <span class="nx">metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ComponentArgs]</a></span> = None<span class="p">,</span>
@@ -221,7 +221,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <a href="#metadata_python" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta</a></span>
+        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -15,7 +15,7 @@ __all__ = ['ComponentArgs', 'Component']
 @pulumi.input_type
 class ComponentArgs:
     def __init__(__self__, *,
-                 metadata: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMeta']] = None):
+                 metadata: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']] = None):
         """
         The set of arguments for constructing a Component resource.
         """
@@ -24,11 +24,11 @@ class ComponentArgs:
 
     @property
     @pulumi.getter
-    def metadata(self) -> Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMeta']]:
+    def metadata(self) -> Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]:
         return pulumi.get(self, "metadata")
 
     @metadata.setter
-    def metadata(self, value: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMeta']]):
+    def metadata(self, value: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
 
@@ -37,7 +37,7 @@ class Component(pulumi.CustomResource):
     def __init__(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMeta']]] = None,
+                 metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
                  __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
@@ -67,7 +67,7 @@ class Component(pulumi.CustomResource):
     def _internal_init(__self__,
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
-                 metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMeta']]] = None,
+                 metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
                  __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/docs/component.md
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/docs/component.md
@@ -27,6 +27,8 @@ meta_desc: "Documentation for the example.Component resource with examples, inpu
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
               <span class="nx">a</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
               <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
+              <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">,</span>
+              <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[Sequence[FooArgs]]</span> = None<span class="p">,</span>
               <span class="nx">c</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
               <span class="nx">d</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
               <span class="nx">e</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
@@ -219,6 +221,22 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
+        <span id="bar_csharp">
+<a href="#bar_csharp" style="color: inherit; text-decoration: inherit;">Bar</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="baz_csharp">
+<a href="#baz_csharp" style="color: inherit; text-decoration: inherit;">Baz</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#foo">List&lt;Foo<wbr>Args&gt;</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
         <span id="d_csharp">
 <a href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
@@ -276,6 +294,22 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="bar_go">
+<a href="#bar_go" style="color: inherit; text-decoration: inherit;">Bar</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#foo">Foo</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="baz_go">
+<a href="#baz_go" style="color: inherit; text-decoration: inherit;">Baz</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#foo">[]Foo</a></span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
@@ -339,6 +373,22 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
+        <span id="bar_nodejs">
+<a href="#bar_nodejs" style="color: inherit; text-decoration: inherit;">bar</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="baz_nodejs">
+<a href="#baz_nodejs" style="color: inherit; text-decoration: inherit;">baz</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#foo">Foo<wbr>Args[]</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
         <span id="d_nodejs">
 <a href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
@@ -396,6 +446,22 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">bool</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="bar_python">
+<a href="#bar_python" style="color: inherit; text-decoration: inherit;">bar</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#foo">Foo<wbr>Args</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="baz_python">
+<a href="#baz_python" style="color: inherit; text-decoration: inherit;">baz</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#foo">Sequence[Foo<wbr>Args]</a></span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Component.cs
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Component.cs
@@ -21,6 +21,9 @@ namespace Pulumi.Example
         [Output("bar")]
         public Output<Outputs.Foo?> Bar { get; private set; } = null!;
 
+        [Output("baz")]
+        public Output<ImmutableArray<Outputs.Foo>> Baz { get; private set; } = null!;
+
         [Output("c")]
         public Output<int> C { get; private set; } = null!;
 
@@ -72,6 +75,14 @@ namespace Pulumi.Example
 
         [Input("bar")]
         public Inputs.Foo? Bar { get; set; }
+
+        [Input("baz")]
+        private ImmutableArray<Inputs.Foo>? _baz;
+        public ImmutableArray<Inputs.Foo> Baz
+        {
+            get => _baz ?? (_baz = new ImmutableArray<Inputs.Foo>());
+            set => _baz = value;
+        }
 
         [Input("c", required: true)]
         public int C { get; set; } = null!;

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Component.cs
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Component.cs
@@ -18,6 +18,9 @@ namespace Pulumi.Example
         [Output("b")]
         public Output<bool?> B { get; private set; } = null!;
 
+        [Output("bar")]
+        public Output<Outputs.Foo?> Bar { get; private set; } = null!;
+
         [Output("c")]
         public Output<int> C { get; private set; } = null!;
 
@@ -66,6 +69,9 @@ namespace Pulumi.Example
 
         [Input("b")]
         public bool? B { get; set; }
+
+        [Input("bar")]
+        public Inputs.Foo? Bar { get; set; }
 
         [Input("c", required: true)]
         public int C { get; set; } = null!;

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Inputs/FooArgs.cs
@@ -34,4 +34,29 @@ namespace Pulumi.Example.Inputs
         {
         }
     }
+
+    public sealed class Foo : Pulumi.InvokeArgs
+    {
+        [Input("a", required: true)]
+        public bool A { get; set; }
+
+        [Input("b")]
+        public bool? B { get; set; }
+
+        [Input("c", required: true)]
+        public int C { get; set; }
+
+        [Input("d")]
+        public int? D { get; set; }
+
+        [Input("e", required: true)]
+        public string E { get; set; } = null!;
+
+        [Input("f")]
+        public string? F { get; set; }
+
+        public Foo()
+        {
+        }
+    }
 }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
@@ -17,6 +17,7 @@ type Component struct {
 	A   pulumi.BoolOutput      `pulumi:"a"`
 	B   pulumi.BoolPtrOutput   `pulumi:"b"`
 	Bar FooPtrOutput           `pulumi:"bar"`
+	Baz FooArrayOutput         `pulumi:"baz"`
 	C   pulumi.IntOutput       `pulumi:"c"`
 	D   pulumi.IntPtrOutput    `pulumi:"d"`
 	E   pulumi.StringOutput    `pulumi:"e"`
@@ -43,6 +44,7 @@ type componentArgs struct {
 	A   bool    `pulumi:"a"`
 	B   *bool   `pulumi:"b"`
 	Bar *Foo    `pulumi:"bar"`
+	Baz []Foo   `pulumi:"baz"`
 	C   int     `pulumi:"c"`
 	D   *int    `pulumi:"d"`
 	E   string  `pulumi:"e"`
@@ -55,6 +57,7 @@ type ComponentArgs struct {
 	A   bool
 	B   *bool
 	Bar *Foo
+	Baz []Foo
 	C   int
 	D   *int
 	E   string

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
@@ -16,6 +16,7 @@ type Component struct {
 
 	A   pulumi.BoolOutput      `pulumi:"a"`
 	B   pulumi.BoolPtrOutput   `pulumi:"b"`
+	Bar FooPtrOutput           `pulumi:"bar"`
 	C   pulumi.IntOutput       `pulumi:"c"`
 	D   pulumi.IntPtrOutput    `pulumi:"d"`
 	E   pulumi.StringOutput    `pulumi:"e"`
@@ -41,6 +42,7 @@ func NewComponent(ctx *pulumi.Context,
 type componentArgs struct {
 	A   bool    `pulumi:"a"`
 	B   *bool   `pulumi:"b"`
+	Bar *Foo    `pulumi:"bar"`
 	C   int     `pulumi:"c"`
 	D   *int    `pulumi:"d"`
 	E   string  `pulumi:"e"`
@@ -52,6 +54,7 @@ type componentArgs struct {
 type ComponentArgs struct {
 	A   bool
 	B   *bool
+	Bar *Foo
 	C   int
 	D   *int
 	E   string

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/pulumiTypes.go
@@ -92,6 +92,31 @@ func (i *fooPtrType) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput
 	return pulumi.ToOutputWithContext(ctx, i).(FooPtrOutput)
 }
 
+// FooArrayInput is an input type that accepts FooArray and FooArrayOutput values.
+// You can construct a concrete instance of `FooArrayInput` via:
+//
+//          FooArray{ FooArgs{...} }
+type FooArrayInput interface {
+	pulumi.Input
+
+	ToFooArrayOutput() FooArrayOutput
+	ToFooArrayOutputWithContext(context.Context) FooArrayOutput
+}
+
+type FooArray []FooInput
+
+func (FooArray) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]Foo)(nil)).Elem()
+}
+
+func (i FooArray) ToFooArrayOutput() FooArrayOutput {
+	return i.ToFooArrayOutputWithContext(context.Background())
+}
+
+func (i FooArray) ToFooArrayOutputWithContext(ctx context.Context) FooArrayOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(FooArrayOutput)
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -211,7 +236,28 @@ func (o FooPtrOutput) F() pulumi.StringPtrOutput {
 	}).(pulumi.StringPtrOutput)
 }
 
+type FooArrayOutput struct{ *pulumi.OutputState }
+
+func (FooArrayOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*[]Foo)(nil)).Elem()
+}
+
+func (o FooArrayOutput) ToFooArrayOutput() FooArrayOutput {
+	return o
+}
+
+func (o FooArrayOutput) ToFooArrayOutputWithContext(ctx context.Context) FooArrayOutput {
+	return o
+}
+
+func (o FooArrayOutput) Index(i pulumi.IntInput) FooOutput {
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Foo {
+		return vs[0].([]Foo)[vs[1].(int)]
+	}).(FooOutput)
+}
+
 func init() {
 	pulumi.RegisterOutputType(FooOutput{})
 	pulumi.RegisterOutputType(FooPtrOutput{})
+	pulumi.RegisterOutputType(FooArrayOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
@@ -23,6 +23,7 @@ export class Component extends pulumi.ComponentResource {
     public readonly a!: pulumi.Output<boolean>;
     public readonly b!: pulumi.Output<boolean | undefined>;
     public readonly bar!: pulumi.Output<outputs.Foo | undefined>;
+    public readonly baz!: pulumi.Output<outputs.Foo[] | undefined>;
     public readonly c!: pulumi.Output<number>;
     public readonly d!: pulumi.Output<number | undefined>;
     public readonly e!: pulumi.Output<string>;
@@ -52,6 +53,7 @@ export class Component extends pulumi.ComponentResource {
             inputs["a"] = args ? args.a : undefined;
             inputs["b"] = args ? args.b : undefined;
             inputs["bar"] = args ? args.bar : undefined;
+            inputs["baz"] = args ? args.baz : undefined;
             inputs["c"] = args ? args.c : undefined;
             inputs["d"] = args ? args.d : undefined;
             inputs["e"] = args ? args.e : undefined;
@@ -61,6 +63,7 @@ export class Component extends pulumi.ComponentResource {
             inputs["a"] = undefined /*out*/;
             inputs["b"] = undefined /*out*/;
             inputs["bar"] = undefined /*out*/;
+            inputs["baz"] = undefined /*out*/;
             inputs["c"] = undefined /*out*/;
             inputs["d"] = undefined /*out*/;
             inputs["e"] = undefined /*out*/;
@@ -81,6 +84,7 @@ export interface ComponentArgs {
     readonly a: boolean;
     readonly b?: boolean;
     readonly bar?: inputs.Foo;
+    readonly baz?: inputs.Foo[];
     readonly c: number;
     readonly d?: number;
     readonly e: string;

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
@@ -22,6 +22,7 @@ export class Component extends pulumi.ComponentResource {
 
     public readonly a!: pulumi.Output<boolean>;
     public readonly b!: pulumi.Output<boolean | undefined>;
+    public readonly bar!: pulumi.Output<outputs.Foo | undefined>;
     public readonly c!: pulumi.Output<number>;
     public readonly d!: pulumi.Output<number | undefined>;
     public readonly e!: pulumi.Output<string>;
@@ -50,6 +51,7 @@ export class Component extends pulumi.ComponentResource {
             }
             inputs["a"] = args ? args.a : undefined;
             inputs["b"] = args ? args.b : undefined;
+            inputs["bar"] = args ? args.bar : undefined;
             inputs["c"] = args ? args.c : undefined;
             inputs["d"] = args ? args.d : undefined;
             inputs["e"] = args ? args.e : undefined;
@@ -58,6 +60,7 @@ export class Component extends pulumi.ComponentResource {
         } else {
             inputs["a"] = undefined /*out*/;
             inputs["b"] = undefined /*out*/;
+            inputs["bar"] = undefined /*out*/;
             inputs["c"] = undefined /*out*/;
             inputs["d"] = undefined /*out*/;
             inputs["e"] = undefined /*out*/;
@@ -77,6 +80,7 @@ export class Component extends pulumi.ComponentResource {
 export interface ComponentArgs {
     readonly a: boolean;
     readonly b?: boolean;
+    readonly bar?: inputs.Foo;
     readonly c: number;
     readonly d?: number;
     readonly e: string;

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/types/input.ts
@@ -4,6 +4,14 @@
 import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "../types";
 
+export interface Foo {
+    a: boolean;
+    b?: boolean;
+    c: number;
+    d?: number;
+    e: string;
+    f?: string;
+}
 export interface FooArgs {
     a: boolean;
     b?: boolean;

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/_inputs.py
@@ -10,10 +10,85 @@ from . import _utilities
 
 __all__ = [
     'FooArgs',
+    'Foo',
 ]
 
 @pulumi.input_type
 class FooArgs:
+    def __init__(__self__, *,
+                 a: bool,
+                 c: int,
+                 e: str,
+                 b: Optional[bool] = None,
+                 d: Optional[int] = None,
+                 f: Optional[str] = None):
+        pulumi.set(__self__, "a", a)
+        pulumi.set(__self__, "c", c)
+        pulumi.set(__self__, "e", e)
+        if b is not None:
+            pulumi.set(__self__, "b", b)
+        if d is not None:
+            pulumi.set(__self__, "d", d)
+        if f is not None:
+            pulumi.set(__self__, "f", f)
+
+    @property
+    @pulumi.getter
+    def a(self) -> bool:
+        return pulumi.get(self, "a")
+
+    @a.setter
+    def a(self, value: bool):
+        pulumi.set(self, "a", value)
+
+    @property
+    @pulumi.getter
+    def c(self) -> int:
+        return pulumi.get(self, "c")
+
+    @c.setter
+    def c(self, value: int):
+        pulumi.set(self, "c", value)
+
+    @property
+    @pulumi.getter
+    def e(self) -> str:
+        return pulumi.get(self, "e")
+
+    @e.setter
+    def e(self, value: str):
+        pulumi.set(self, "e", value)
+
+    @property
+    @pulumi.getter
+    def b(self) -> Optional[bool]:
+        return pulumi.get(self, "b")
+
+    @b.setter
+    def b(self, value: Optional[bool]):
+        pulumi.set(self, "b", value)
+
+    @property
+    @pulumi.getter
+    def d(self) -> Optional[int]:
+        return pulumi.get(self, "d")
+
+    @d.setter
+    def d(self, value: Optional[int]):
+        pulumi.set(self, "d", value)
+
+    @property
+    @pulumi.getter
+    def f(self) -> Optional[str]:
+        return pulumi.get(self, "f")
+
+    @f.setter
+    def f(self, value: Optional[str]):
+        pulumi.set(self, "f", value)
+
+
+@pulumi.input_type
+class Foo:
     def __init__(__self__, *,
                  a: bool,
                  c: int,

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -20,6 +20,7 @@ class ComponentArgs:
                  e: str,
                  b: Optional[bool] = None,
                  bar: Optional['Foo'] = None,
+                 baz: Optional[Sequence['Foo']] = None,
                  d: Optional[int] = None,
                  f: Optional[str] = None,
                  foo: Optional[pulumi.Input['FooArgs']] = None):
@@ -33,6 +34,8 @@ class ComponentArgs:
             pulumi.set(__self__, "b", b)
         if bar is not None:
             pulumi.set(__self__, "bar", bar)
+        if baz is not None:
+            pulumi.set(__self__, "baz", baz)
         if d is not None:
             pulumi.set(__self__, "d", d)
         if f is not None:
@@ -87,6 +90,15 @@ class ComponentArgs:
 
     @property
     @pulumi.getter
+    def baz(self) -> Optional[Sequence['Foo']]:
+        return pulumi.get(self, "baz")
+
+    @baz.setter
+    def baz(self, value: Optional[Sequence['Foo']]):
+        pulumi.set(self, "baz", value)
+
+    @property
+    @pulumi.getter
     def d(self) -> Optional[int]:
         return pulumi.get(self, "d")
 
@@ -121,6 +133,7 @@ class Component(pulumi.ComponentResource):
                  a: Optional[bool] = None,
                  b: Optional[bool] = None,
                  bar: Optional[pulumi.InputType['Foo']] = None,
+                 baz: Optional[Sequence[pulumi.InputType['Foo']]] = None,
                  c: Optional[int] = None,
                  d: Optional[int] = None,
                  e: Optional[str] = None,
@@ -158,6 +171,7 @@ class Component(pulumi.ComponentResource):
                  a: Optional[bool] = None,
                  b: Optional[bool] = None,
                  bar: Optional[pulumi.InputType['Foo']] = None,
+                 baz: Optional[Sequence[pulumi.InputType['Foo']]] = None,
                  c: Optional[int] = None,
                  d: Optional[int] = None,
                  e: Optional[str] = None,
@@ -182,6 +196,7 @@ class Component(pulumi.ComponentResource):
             __props__.__dict__["a"] = a
             __props__.__dict__["b"] = b
             __props__.__dict__["bar"] = bar
+            __props__.__dict__["baz"] = baz
             if c is None and not opts.urn:
                 raise TypeError("Missing required property 'c'")
             __props__.__dict__["c"] = c
@@ -212,6 +227,11 @@ class Component(pulumi.ComponentResource):
     @pulumi.getter
     def bar(self) -> pulumi.Output[Optional['outputs.Foo']]:
         return pulumi.get(self, "bar")
+
+    @property
+    @pulumi.getter
+    def baz(self) -> pulumi.Output[Optional[Sequence['outputs.Foo']]]:
+        return pulumi.get(self, "baz")
 
     @property
     @pulumi.getter

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -19,6 +19,7 @@ class ComponentArgs:
                  c: int,
                  e: str,
                  b: Optional[bool] = None,
+                 bar: Optional['Foo'] = None,
                  d: Optional[int] = None,
                  f: Optional[str] = None,
                  foo: Optional[pulumi.Input['FooArgs']] = None):
@@ -30,6 +31,8 @@ class ComponentArgs:
         pulumi.set(__self__, "e", e)
         if b is not None:
             pulumi.set(__self__, "b", b)
+        if bar is not None:
+            pulumi.set(__self__, "bar", bar)
         if d is not None:
             pulumi.set(__self__, "d", d)
         if f is not None:
@@ -75,6 +78,15 @@ class ComponentArgs:
 
     @property
     @pulumi.getter
+    def bar(self) -> Optional['Foo']:
+        return pulumi.get(self, "bar")
+
+    @bar.setter
+    def bar(self, value: Optional['Foo']):
+        pulumi.set(self, "bar", value)
+
+    @property
+    @pulumi.getter
     def d(self) -> Optional[int]:
         return pulumi.get(self, "d")
 
@@ -108,6 +120,7 @@ class Component(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  a: Optional[bool] = None,
                  b: Optional[bool] = None,
+                 bar: Optional[pulumi.InputType['Foo']] = None,
                  c: Optional[int] = None,
                  d: Optional[int] = None,
                  e: Optional[str] = None,
@@ -144,6 +157,7 @@ class Component(pulumi.ComponentResource):
                  opts: Optional[pulumi.ResourceOptions] = None,
                  a: Optional[bool] = None,
                  b: Optional[bool] = None,
+                 bar: Optional[pulumi.InputType['Foo']] = None,
                  c: Optional[int] = None,
                  d: Optional[int] = None,
                  e: Optional[str] = None,
@@ -167,6 +181,7 @@ class Component(pulumi.ComponentResource):
                 raise TypeError("Missing required property 'a'")
             __props__.__dict__["a"] = a
             __props__.__dict__["b"] = b
+            __props__.__dict__["bar"] = bar
             if c is None and not opts.urn:
                 raise TypeError("Missing required property 'c'")
             __props__.__dict__["c"] = c
@@ -192,6 +207,11 @@ class Component(pulumi.ComponentResource):
     @pulumi.getter
     def b(self) -> pulumi.Output[Optional[bool]]:
         return pulumi.get(self, "b")
+
+    @property
+    @pulumi.getter
+    def bar(self) -> pulumi.Output[Optional['outputs.Foo']]:
+        return pulumi.get(self, "bar")
 
     @property
     @pulumi.getter

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/schema.json
@@ -52,6 +52,9 @@
         },
         "foo": {
           "$ref": "#/types/example::Foo"
+        },
+        "bar": {
+          "$ref": "#/types/example::Foo"
         }
       },
       "required": ["a", "c", "e"],
@@ -76,10 +79,13 @@
         },
         "foo": {
           "$ref": "#/types/example::Foo"
+        },
+        "bar": {
+          "$ref": "#/types/example::Foo"
         }
       },
       "requiredInputs": ["a", "c", "e"],
-      "plainInputs": ["a", "b", "c", "d", "e", "f"],
+      "plainInputs": ["a", "b", "c", "d", "e", "f", "bar"],
       "type": "object"
     }
   },

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/schema.json
@@ -55,6 +55,12 @@
         },
         "bar": {
           "$ref": "#/types/example::Foo"
+        },
+        "baz": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/example::Foo"
+          }
         }
       },
       "required": ["a", "c", "e"],
@@ -82,10 +88,16 @@
         },
         "bar": {
           "$ref": "#/types/example::Foo"
+        },
+        "baz": {
+          "type": "array",
+          "items": {
+            "$ref": "#/types/example::Foo"
+          }
         }
       },
       "requiredInputs": ["a", "c", "e"],
-      "plainInputs": ["a", "b", "c", "d", "e", "f", "bar"],
+      "plainInputs": ["a", "b", "c", "d", "e", "f", "bar", "baz"],
       "type": "object"
     }
   },

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1663,7 +1663,11 @@ func bindResources(specs map[string]ResourceSpec, types *types) ([]*Resource, ma
 		}
 		resourceTable[token] = res
 
-		if _, ok := types.resources[token]; !ok {
+		if rt, ok := types.resources[token]; ok {
+			if rt.Resource == nil {
+				rt.Resource = res
+			}
+		} else {
 			types.resources[token] = &ResourceType{
 				Token:    res.Token,
 				Resource: res,

--- a/pkg/codegen/utilities_types.go
+++ b/pkg/codegen/utilities_types.go
@@ -1,0 +1,46 @@
+package codegen
+
+import "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+type Type struct {
+	schema.Type
+
+	Plain    bool
+	Optional bool
+}
+
+func visitTypeClosure(t Type, visitor func(t Type), seen Set) {
+	if seen.Has(t) {
+		return
+	}
+	seen.Add(t)
+
+	visitor(t)
+
+	switch st := t.Type.(type) {
+	case *schema.ArrayType:
+		visitTypeClosure(Type{st.ElementType, t.Plain, t.Optional}, visitor, seen)
+	case *schema.MapType:
+		visitTypeClosure(Type{st.ElementType, t.Plain, t.Optional}, visitor, seen)
+	case *schema.ObjectType:
+		visitPropertyTypeClosure(t, st.Properties, visitor, seen)
+	case *schema.UnionType:
+		for _, e := range st.ElementTypes {
+			visitTypeClosure(Type{e, t.Plain, t.Optional}, visitor, seen)
+		}
+	}
+}
+
+func visitPropertyTypeClosure(root Type, properties []*schema.Property, visitor func(t Type), seen Set) {
+	for _, p := range properties {
+		visitTypeClosure(Type{
+			Type:     p.Type,
+			Plain:    root.Plain || p.IsPlain,
+			Optional: !p.IsRequired,
+		}, visitor, seen)
+	}
+}
+
+func VisitTypeClosure(properties []*schema.Property, visitor func(t Type)) {
+	visitPropertyTypeClosure(Type{}, properties, visitor, Set{})
+}


### PR DESCRIPTION
These changes fix a regression introduced by #6686 that caused the SDK
code generators for .NET, Python, and Typescript to omit definitions for
plain object types. This regression occurred because #6686 drew a
clearer line between types used as resource arguments and types used
as function arguments, but conflated "resource arguments" with "inputty
types". This caused the code generators to generate inputty types for
any types used as resource arguments, even those that are used for
plainly-typed properties.

Fixes #6796.