### PR TITLE
Fix bug in semver usage by enabling typechecking

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,10 +7,13 @@
   [#6795](https://github.com/pulumi/pulumi/pull/6795)
 
 - [automation/dotnet] Remove dependency on Gprc.Tools for F# / Paket compatibility
-  [#6793](https://github.com/pulumi/pulumi/pull/6793)  
+  [#6793](https://github.com/pulumi/pulumi/pull/6793)
 
 ### Bug Fixes
 
 
 - [codegen] Fix codegen for types that are used by both resources and functions.
   [#6811](https://github.com/pulumi/pulumi/pull/6811)
+
+- [sdk/python] Fix bug in `get_resource_module` affecting resource hydration.
+  [#6833](https://github.com/pulumi/pulumi/pull/6833)

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -24,7 +24,7 @@ from typing import List, Any, Callable, Dict, Mapping, Optional, Sequence, Set, 
 from enum import Enum
 
 from google.protobuf import struct_pb2
-from semver import VersionInfo as Version  # type:ignore
+from semver import VersionInfo as Version
 import six
 from . import known_types, settings
 from .. import log
@@ -777,7 +777,7 @@ def same_version(a: Optional[Version], b: Optional[Version]) -> bool:
 def check_version(want: Optional[Version], have: Optional[Version]) -> bool:
     if want is None or have is None:
         return True
-    return have.major == want.major() and have.minor() >= want.minor() and have.patch() >= want.patch()
+    return have.major == want.major and have.minor >= want.minor and have.patch >= want.patch
 
 
 class ResourcePackage(ABC):

--- a/sdk/python/mypy.ini
+++ b/sdk/python/mypy.ini
@@ -10,9 +10,6 @@ ignore_missing_imports = True
 [mypy-google.protobuf.pyext._message]
 ignore_missing_imports = True
 
-[mypy-semver]
-ignore_missing_imports = True
-
 # grpc generated
 [mypy-pulumi.runtime.proto.*]
 ignore_errors = True

--- a/sdk/python/stubs/semver/__init__.pyi
+++ b/sdk/python/stubs/semver/__init__.pyi
@@ -1,0 +1,11 @@
+class VersionInfo:
+    major: int
+    minor: int
+    patch: int
+
+    def compare(self, other: VersionInfo) -> int:
+        ...
+
+    @staticmethod
+    def parse(version: str) -> VersionInfo:
+        ...


### PR DESCRIPTION
This bug actually prevents resources from hydrating that is:

```
get_resource_module('azure-native', 'authorization', '1.0.0')
```

Is broken..