### PR TITLE
Re-add - Set pagination defaults for `pulumi stack history` to 10 entries (#6739)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Breaking Changes
 
+- [cli] Set pagination defaults for `pulumi stack history` to 10 entries.
+  [#6841](https://github.com/pulumi/pulumi/pull/6841)
 
 ### Enhancements
 
@@ -10,7 +12,6 @@
   [#6793](https://github.com/pulumi/pulumi/pull/6793)
 
 ### Bug Fixes
-
 
 - [codegen] Fix codegen for types that are used by both resources and functions.
   [#6811](https://github.com/pulumi/pulumi/pull/6811)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,8 @@
 ### Breaking Changes
 
 - [cli] Set pagination defaults for `pulumi stack history` to 10 entries.
+  This change was originally intended for the 3.0 release but was unfortunately left out of the initial release.
+  We apologize for any confusion or inconvenience this may have caused and have now correctly added the behavior.
   [#6841](https://github.com/pulumi/pulumi/pull/6841)
 
 ### Enhancements

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -77,9 +77,9 @@ This command displays data about previous updates for a stack.`,
 	cmd.PersistentFlags().BoolVar(
 		&showFullDates, "full-dates", false, "Show full dates, instead of relative dates")
 	cmd.PersistentFlags().IntVar(
-		&pageSize, "page-size", 0, "Used with 'page' to control number of results returned")
+		&pageSize, "page-size", 10, "Used with 'page' to control number of results returned")
 	cmd.PersistentFlags().IntVar(
-		&page, "page", 0, "Used with 'page-size' to paginate results")
+		&page, "page", 1, "Used with 'page-size' to paginate results")
 	return cmd
 }
 


### PR DESCRIPTION
Readding #6739 since it was lost during the 3.0 release

Also not sure what to say in the CHANGELOG