### PR TITLE
[auto/*] - Bump min version

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,3 +9,7 @@
 ### Bug Fixes
 
 
+### Misc.
+
+- [auto/*] - Bump minimum version to v3.1.0.
+  [#6852](https://github.com/pulumi/pulumi/pull/6852)

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -35,7 +35,7 @@ namespace Pulumi.Automation
         private readonly LocalSerializer _serializer = new LocalSerializer();
         private readonly bool _ownsWorkingDir;
         private readonly Task _readyTask;
-        private static readonly SemVersion _minimumVersion = SemVersion.Parse("3.0.0");
+        private static readonly SemVersion _minimumVersion = SemVersion.Parse("3.1.0");
 
         /// <inheritdoc/>
         public override string WorkDir { get; }

--- a/sdk/go/auto/minimum_version.go
+++ b/sdk/go/auto/minimum_version.go
@@ -19,6 +19,6 @@ import "github.com/blang/semver"
 var minimumVersion = calculateMinVersion()
 
 func calculateMinVersion() semver.Version {
-	v, _ := semver.ParseTolerant("3.0.0")
+	v, _ := semver.ParseTolerant("3.1.0")
 	return v
 }

--- a/sdk/nodejs/automation/minimumVersion.ts
+++ b/sdk/nodejs/automation/minimumVersion.ts
@@ -14,4 +14,4 @@
 
 import * as semver from "semver";
 
-export const minimumVersion = new semver.SemVer("v3.0.0");
+export const minimumVersion = new semver.SemVer("v3.1.0");

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -457,14 +457,12 @@ describe("LocalWorkspace", () => {
         const dones = [];
         const stacks = [ "dev", "dev2", "dev3", "dev4", "dev5" ];
         const workDir = upath.joinSafe(__dirname, "data", "tcfg");
+        const ws = await LocalWorkspace.create({ workDir });
         for (let i = 0; i < stacks.length; i++) {
             const x = i;
             const s = stacks[i];
             dones.push((async () => {
-                const stack = await LocalWorkspace.createOrSelectStack({
-                    stackName: s,
-                    workDir,
-                });
+                const stack = await Stack.createOrSelect(s, ws);
                 for (let j = 0; j < 20; j++) {
                     await stack.setConfig("var-" + j, { value: ((x*20)+j).toString() });
                 }

--- a/sdk/python/lib/pulumi/automation/_minimum_version.py
+++ b/sdk/python/lib/pulumi/automation/_minimum_version.py
@@ -14,4 +14,4 @@
 
 from semver import VersionInfo
 
-_MINIMUM_VERSION = VersionInfo.parse("3.0.0")
+_MINIMUM_VERSION = VersionInfo.parse("3.1.0")


### PR DESCRIPTION
We need to bump the minimum version because the stack select changes require CLI-SDK alignment.