### PR TITLE
Fix python mock args

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes
 
+- [sdk/python] - Fix bug in MockResourceArgs.
+  [#6863](https://github.com/pulumi/pulumi/pull/6863)
 
 ### Misc.
 

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -15,7 +15,6 @@
 """
 Mocks for testing.
 """
-import asyncio
 import logging
 from abc import ABC, abstractmethod
 from typing import Dict, List, NamedTuple, Optional, Tuple, TYPE_CHECKING
@@ -45,11 +44,17 @@ class MockResourceArgs:
     typ: str
     name: str
     inputs: dict
-    provider: str
-    resource_id: str
-    custom: bool
+    provider: Optional[str] = None
+    resource_id: Optional[str] = None
+    custom: Optional[bool] = None
 
-    def __init__(self, typ: str, name: str, inputs: dict, provider: str, resource_id: str, custom: bool) -> None:
+    def __init__(self,
+                 typ: str,
+                 name: str,
+                 inputs: dict,
+                 provider: Optional[str] = None,
+                 resource_id: Optional[str] = None,
+                 custom: Optional[bool] = None) -> None:
         """
         :param str typ: The token that indicates which resource type is being constructed. This token is of the form "package:module:type".
         :param str name: The logical name of the resource instance.
@@ -64,6 +69,7 @@ class MockResourceArgs:
         self.provider = provider
         self.resource_id = resource_id
         self.custom = custom
+
 
 class MockCallArgs:
     """
@@ -167,8 +173,7 @@ class MockMonitor:
                                          name=request.name,
                                          inputs=state,
                                          provider=request.provider,
-                                         resource_id=request.id,
-                                         custom=request.custom or False)
+                                         resource_id=request.id)
         id_, state = self.mocks.new_resource(resource_args)
 
         props_proto = _sync_await(rpc.serialize_properties(state, {}))

--- a/sdk/python/lib/test_with_mocks/resources.py
+++ b/sdk/python/lib/test_with_mocks/resources.py
@@ -61,6 +61,8 @@ invoke_result = do_invoke()
 for x in range(5):
     MyCustom(f"mycustom{x}", {"instance": myinstance})
 
+dns_ref = pulumi.StackReference("dns")
+
 pulumi.export("hello", "world")
 pulumi.export("outprop", mycomponent.outprop)
 pulumi.export("public_ip", myinstance.public_ip)


### PR DESCRIPTION
The [refactor](https://github.com/pulumi/pulumi/pull/6672) to `MockResourceArgs` introduced a bug for `ReadResource` as the request does not include a `custom` attribute, leading to an error when mocking `StackReference`. 

This PR corrects the issue and adds a test for `StackReference`.

Fixes: #6861 