### PR TITLE
remove erroneous global promise rejection handler

### DIFF
--- a/sdk/nodejs/runtime/debuggable.ts
+++ b/sdk/nodejs/runtime/debuggable.ts
@@ -114,12 +114,6 @@ export function debuggablePromise<T>(p: Promise<T>, ctx: any): Promise<T> {
     });
 }
 
-process.on("unhandledRejection", err => {
-    if (err && (<any>err).promise) {
-        console.log(`unhandled rejection: ${promiseDebugString((<any>err).promise)}`);
-    }
-});
-
 /**
  * errorString produces a string from an error, conditionally including additional diagnostics.
  * @internal


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/6815

It appears this rejection handler was left over was not meant to ship in the nodejs SDK. It seems to be interfering with error handling in some cases. 