### PR TITLE
docs: Update Github logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <a href="https://www.pulumi.com?utm_campaign=pulumi-pulumi-github-repo&utm_source=github.com&utm_medium=top-logo" title="Pulumi - Modern Infrastructure as Code - AWS Azure Kubernetes Containers Serverless">
-    <img src="https://www.pulumi.com/images/logo/logo.svg?" width="350">
+    <img src="https://www.pulumi.com/images/logo/logo-on-white-box.svg?" width="350">
 </a>
 
 [![Slack](http://www.pulumi.com/images/docs/badges/slack.svg)](https://slack.pulumi.com?utm_campaign=pulumi-pulumi-github-repo&utm_source=github.com&utm_medium=slack-badge)


### PR DESCRIPTION
For us who are using dark mode on Github, the Pulumi logo is not showing. I've taken the liberty to play around with a few options to fix it.

### Considered options

#### ~~With drop shadow~~

~~This option mimics the information boxes from the Pulumi website.~~


- ~~Dark mode: https://user-images.githubusercontent.com/3726815/115958917-ca2a7180-a509-11eb-8680-7ea2da401b3b.jpg~~
- ~~Light mode: https://user-images.githubusercontent.com/3726815/115958922-d0205280-a509-11eb-88e9-aea7dd346a58.jpg~~

#### Without drop shadow (my personal favourite)

This option is just a box with rounded corners in white with the logo on top.

<img src="https://raw.githubusercontent.com/pulumi/pulumi-hugo/master/themes/default/static/images/logo/logo-on-white-box.svg" width="350">

**Screenshots of the README**:

- Dark mode: https://user-images.githubusercontent.com/3726815/115958887-ab2bdf80-a509-11eb-9b29-ecb469c6d1a8.jpg
- Light mode: https://user-images.githubusercontent.com/3726815/115958907-b717a180-a509-11eb-944c-e98d73966860.jpg


Requires pulumi/pulumi-hugo#140 to be merged. ~~← Has both of the options!~~

**Edit**: See comment from @susanev in pulumi/pulumi-hugo#140. The shadow option has been removed from that pull request. 