### PR TITLE
Respect baseImportPath in codegen'd Go SDKs

### DIFF
--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/pulumiUtilities.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/pulumiUtilities.go
@@ -65,7 +65,7 @@ func getEnvOrDefault(def interface{}, parser envParser, vars ...string) interfac
 func PkgVersion() (semver.Version, error) {
 	type sentinal struct{}
 	pkgPath := reflect.TypeOf(sentinal{}).PkgPath()
-	re := regexp.MustCompile("^.*/pulumi-example/sdk(/v\\d+)?")
+	re := regexp.MustCompile("^github.com/pulumi/pulumi/pkg/v3/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/example(/v\\d+)?")
 	if match := re.FindStringSubmatch(pkgPath); match != nil {
 		vStr := match[1]
 		if len(vStr) == 0 { // If the version capture group was empty, default to v1.


### PR DESCRIPTION
If `rootPackageName` is set, we can look for the version in the `baseImportPath` rather than at a location based on the package name - which currently fails if every component is not named `pulumi-*`. To err on the side of caution, this method is only used for packages where `rootPackageName` is set, meaning existing SDKs retain their current behavior.

The new behavior is confirmed via the test added in #6862.

_Note that this PR requires #6862 to apply cleanly - that commit is included here so it builds. Apparently stacked PRs don't work across forks - or I can't work out how to make it so to target #6862! The actual new work of this PR is in `a73dd60`._