### PR TITLE
[sdk/python] - Fix python lint errors

### DIFF
--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -265,9 +265,8 @@ class LocalWorkspace(Workspace):
         return Deployment(**state_json)
 
     def import_stack(self, stack_name: str, state: Deployment) -> None:
-        file = tempfile.NamedTemporaryFile(mode="w", delete=False)
-        json.dump(state.__dict__, file, indent=4)
-        file.close()
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as file:
+            json.dump(state.__dict__, file, indent=4)
         self._run_pulumi_cmd_sync(["stack", "import", "--file", file.name, "--stack", stack_name])
         os.remove(file.name)
 

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -665,12 +665,12 @@ def fully_qualified_stack_name(org: str, project: str, stack: str) -> str:
 
 
 def _create_log_file(command: str) -> Tuple[str, tempfile.TemporaryDirectory]:
-    log_dir = tempfile.TemporaryDirectory(prefix=f"automation-logs-{command}-")
+    log_dir = tempfile.TemporaryDirectory(prefix=f"automation-logs-{command}-")  # pylint: disable=consider-using-with
     filepath = os.path.join(log_dir.name, "eventlog.txt")
 
     # Open and close the file to ensure it exists before we start polling for logs
-    f = open(filepath, "w+")
-    f.close()
+    with open(filepath, "w+"):
+        pass
     return filepath, log_dir
 
 

--- a/sdk/python/lib/setup.py
+++ b/sdk/python/lib/setup.py
@@ -39,7 +39,7 @@ setup(name='pulumi',
       install_requires=[
           'protobuf>=3.6.0',
           'dill>=0.3.0',
-          'grpcio>=1.9.1,!=1.30.0',
+          'grpcio>=1.33.2',
           'six>=1.12.0',
           'semver>=2.8.1',
           'pyyaml>=5.3.1'


### PR DESCRIPTION
* Fixes a number of pylint errors for [consider-using-with](http://pylint.pycqa.org/en/latest/whatsnew/2.8.html?highlight=consider-using-with#new-checkers:~:text=New%20refactoring%20message%20consider%2Dusing%2Dwith.%20This%20message,are%20called%20without%20a%20with%20block.)
* Updates the grpcio requirement in `setup.py` to mirror the [Pipfile](https://github.com/pulumi/pulumi/blob/master/sdk/python/Pipfile#L9)