### PR TITLE
[auto/go] - Provide GetPermalink for all results

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,9 @@
 
 ### Enhancements
 
+- [auto/go] - Provide GetPermalink for all results
+  [#6875](https://github.com/pulumi/pulumi/pull/6875)
+
 - [automation/*] Add support for getting stack outputs using Workspace
   [#6859](https://github.com/pulumi/pulumi/pull/6859)
 

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -666,6 +666,9 @@ func (ur *UpResult) GetPermalink() (string, error) {
 	return GetPermalink(ur.StdOut)
 }
 
+// ErrParsePermalinkFailed occurs when the the generated permalink URL can't be found in the op result
+var ErrParsePermalinkFailed = errors.New("failed to get permalink")
+
 // GetPermalink returns the permalink URL in the Pulumi Console for the update
 // or refresh operation. This will error for alternate, local backends.
 func GetPermalink(stdout string) (string, error) {
@@ -676,14 +679,14 @@ func GetPermalink(stdout string) (string, error) {
 	// Find the start of the permalink in the output.
 	start := startRegex.FindStringIndex(stdout)
 	if start == nil {
-		return "", errors.New(fmt.Sprintf("failed to get permalink for update"))
+		return "", ErrParsePermalinkFailed
 	}
 	permalinkStart := stdout[start[1]:]
 
 	// Find the end of the permalink.
 	end := endRegex.FindStringIndex(permalinkStart)
 	if end == nil {
-		return "", errors.New(fmt.Sprintf("failed to get permalink for update"))
+		return "", ErrParsePermalinkFailed
 	}
 	permalink := permalinkStart[:end[1]-1]
 	return permalink, nil
@@ -727,6 +730,11 @@ type PreviewResult struct {
 	ChangeSummary map[apitype.OpType]int
 }
 
+// GetPermalink returns the permalink URL in the Pulumi Console for the preview operation.
+func (pr *PreviewResult) GetPermalink() (string, error) {
+	return GetPermalink(pr.StdOut)
+}
+
 // RefreshResult is the output of a successful Stack.Refresh operation
 type RefreshResult struct {
 	StdOut  string
@@ -734,11 +742,21 @@ type RefreshResult struct {
 	Summary UpdateSummary
 }
 
+// GetPermalink returns the permalink URL in the Pulumi Console for the refresh operation.
+func (rr *RefreshResult) GetPermalink() (string, error) {
+	return GetPermalink(rr.StdOut)
+}
+
 // DestroyResult is the output of a successful Stack.Destroy operation
 type DestroyResult struct {
 	StdOut  string
 	StdErr  string
 	Summary UpdateSummary
+}
+
+// GetPermalink returns the permalink URL in the Pulumi Console for the destroy operation.
+func (dr *DestroyResult) GetPermalink() (string, error) {
+	return GetPermalink(dr.StdOut)
 }
 
 // secretSentinel represents the CLI response for an output marked as "secret"

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -1,3 +1,17 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package auto
 
 import (

--- a/sdk/go/auto/stack_test.go
+++ b/sdk/go/auto/stack_test.go
@@ -1,0 +1,35 @@
+package auto
+
+import (
+	"fmt"
+	"testing"
+)
+
+const testPermalink = "Permalink: https://gotest"
+
+func TestGetPermalink(t *testing.T) {
+	tests := map[string]struct {
+		testee string
+		want   string
+		err    error
+	}{
+		"successful parsing": {testee: fmt.Sprintf("%s\n", testPermalink), want: "https://gotest"},
+		"failed parsing":     {testee: testPermalink, err: ErrParsePermalinkFailed},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := GetPermalink(test.testee)
+			if err != nil {
+				if test.err == nil || test.err != err {
+					t.Errorf("got '%v', want '%v'", err, test.err)
+				}
+			}
+
+			if got != test.want {
+				t.Errorf("got '%s', want '%s'", got, test.want)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Adds missing receiver funcs for GetPermalink to PreviewResult,RefreshResult,DestroyResult
Add simple test case
Update Changelog

Fix #6778