### PR TITLE
Optionally skip Go automation API version check

### DIFF
--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -499,6 +499,9 @@ func (l *LocalWorkspace) getPulumiVersion(ctx context.Context) (semver.Version, 
 
 //nolint:lll
 func validatePulumiVersion(minVersion semver.Version, currentVersion semver.Version) error {
+	if os.Getenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK") != "" {
+		return nil
+	}
 	if minVersion.Major < currentVersion.Major {
 		return errors.New(fmt.Sprintf("Major version mismatch. You are using Pulumi CLI version %s with Automation SDK v%v. Please update the SDK.", currentVersion, minVersion.Major))
 	}

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1397,47 +1397,68 @@ var minVersionTests = []struct {
 	name           string
 	currentVersion semver.Version
 	expectError    bool
+	optOut         bool
 }{
 	{
 		"higher_major",
 		semver.Version{Major: 100, Minor: 0, Patch: 0},
 		true,
+		false,
 	},
 	{
 		"lower_major",
 		semver.Version{Major: 1, Minor: 0, Patch: 0},
 		true,
+		false,
 	},
 	{
 		"higher_minor",
 		semver.Version{Major: 2, Minor: 22, Patch: 0},
+		false,
 		false,
 	},
 	{
 		"lower_minor",
 		semver.Version{Major: 2, Minor: 1, Patch: 0},
 		true,
+		false,
 	},
 	{
 		"equal_minor_higher_patch",
 		semver.Version{Major: 2, Minor: 21, Patch: 2},
+		false,
 		false,
 	},
 	{
 		"equal_minor_equal_patch",
 		semver.Version{Major: 2, Minor: 21, Patch: 1},
 		false,
+		false,
 	},
 	{
 		"equal_minor_lower_patch",
 		semver.Version{Major: 2, Minor: 21, Patch: 0},
 		true,
+		false,
 	},
 	{
 		"equal_minor_equal_patch_prerelease",
 		// Note that prerelease < release so this case will error
 		semver.Version{Major: 2, Minor: 21, Patch: 1,
 			Pre: []semver.PRVersion{{VersionStr: "alpha"}, {VersionNum: 1234, IsNum: true}}},
+		true,
+		false,
+	},
+	{
+		"opt_out_of_check_would_fail_otherwise",
+		semver.Version{Major: 2, Minor: 20, Patch: 0},
+		false,
+		true,
+	},
+	{
+		"opt_out_of_check_would_succeed_otherwise",
+		semver.Version{Major: 3, Minor: 0, Patch: 0},
+		false,
 		true,
 	},
 }
@@ -1446,7 +1467,15 @@ func TestMinimumVersion(t *testing.T) {
 	for _, tt := range minVersionTests {
 		t.Run(tt.name, func(t *testing.T) {
 			minVersion := semver.Version{Major: 2, Minor: 21, Patch: 1}
+
+			if tt.optOut {
+				assert.NoError(t, os.Setenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK", "1"))
+			}
 			err := validatePulumiVersion(minVersion, tt.currentVersion)
+			if tt.optOut {
+				assert.NoError(t, os.Unsetenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK"))
+			}
+
 			if tt.expectError {
 				assert.Error(t, err)
 				if minVersion.Major < tt.currentVersion.Major {


### PR DESCRIPTION
This commit adds an option to skip the minimal CLI version check for the automation API in Go. If `PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK` has a non-empty value, the check is skipped.

Fixes #6711 for Go only.