### PR TITLE
[automation/*] - Optionally skip Automation API version check

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,11 @@
 
 - [automation/*] Add support for getting stack outputs using Workspace
   [#6859](https://github.com/pulumi/pulumi/pull/6859)
+  
+- [automation/go] Optionally skip Automation API version check
+  [#6882](https://github.com/pulumi/pulumi/pull/6882)
+  
+  The version check can be skipped by passing a non-empty value to the `PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK` environment variable.
 
 ### Bug Fixes
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,7 +10,7 @@
 - [automation/*] Add support for getting stack outputs using Workspace
   [#6859](https://github.com/pulumi/pulumi/pull/6859)
   
-- [automation/go] Optionally skip Automation API version check
+- [automation/*] Optionally skip Automation API version check
   [#6882](https://github.com/pulumi/pulumi/pull/6882)
   
   The version check can be skipped by passing a non-empty value to the `PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK` environment variable.

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1135,22 +1135,14 @@ namespace Pulumi.Automation.Tests
         public void ValidVersionTheory(string currentVersion, bool errorExpected, bool optOut)
         {
             var testMinVersion = SemVersion.Parse("2.21.1");
-            if (optOut)
-            {
-                Environment.SetEnvironmentVariable("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK", "1");
-            }
             if (errorExpected)
             {
-                Action act = () => LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion);
+                Action act = () => LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion, optOut);
                 Assert.Throws<InvalidOperationException>(act);
             }
             else
             {
-                LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion);
-            }
-            if (optOut)
-            {
-                Environment.SetEnvironmentVariable("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK", null);
+                LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion, optOut);
             }
         }
 

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1121,18 +1121,24 @@ namespace Pulumi.Automation.Tests
         }
 
         [Theory]
-        [InlineData("100.0.0", true)]
-        [InlineData("1.0.0", true)]
-        [InlineData("2.22.0", false)]
-        [InlineData("2.1.0", true)]
-        [InlineData("2.21.2", false)]
-        [InlineData("2.21.1", false)]
-        [InlineData("2.21.0", true)]
+        [InlineData("100.0.0", true, false)]
+        [InlineData("1.0.0", true, false)]
+        [InlineData("2.22.0", false, false)]
+        [InlineData("2.1.0", true, false)]
+        [InlineData("2.21.2", false, false)]
+        [InlineData("2.21.1", false, false)]
+        [InlineData("2.21.0", true, false)]
         // Note that prerelease < release so this case should error
-        [InlineData("2.21.1-alpha.1234", true)]
-        public void ValidVersionTheory(string currentVersion, bool errorExpected)
+        [InlineData("2.21.1-alpha.1234", true, false)]
+        [InlineData("2.20.0", false, true)]
+        [InlineData("2.22.0", false, true)]
+        public void ValidVersionTheory(string currentVersion, bool errorExpected, bool optOut)
         {
             var testMinVersion = SemVersion.Parse("2.21.1");
+            if (optOut)
+            {
+                Environment.SetEnvironmentVariable("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK", "1");
+            }
             if (errorExpected)
             {
                 Action act = () => LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion);
@@ -1141,6 +1147,10 @@ namespace Pulumi.Automation.Tests
             else
             {
                 LocalWorkspace.ValidatePulumiVersion(testMinVersion, currentVersion);
+            }
+            if (optOut)
+            {
+                Environment.SetEnvironmentVariable("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK", null);
             }
         }
 

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -373,13 +373,16 @@ namespace Pulumi.Automation
             {
                 throw new InvalidOperationException("Failed to get Pulumi version.");
             }
-            LocalWorkspace.ValidatePulumiVersion(LocalWorkspace._minimumVersion, version);
+            var skipVersionCheckVar = "PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK";
+            var hasSkipEnvVar = this.EnvironmentVariables?.ContainsKey(skipVersionCheckVar) ?? false;
+            var optOut = hasSkipEnvVar || Environment.GetEnvironmentVariable(skipVersionCheckVar) != null;
+            LocalWorkspace.ValidatePulumiVersion(LocalWorkspace._minimumVersion, version, optOut);
             this.pulumiVersion = version;
         }
 
-        internal static void ValidatePulumiVersion(SemVersion minVersion, SemVersion currentVersion)
+        internal static void ValidatePulumiVersion(SemVersion minVersion, SemVersion currentVersion, bool optOut)
         {
-            if (Environment.GetEnvironmentVariable("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK") != null)
+            if (optOut)
             {
                 return;
             }

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -379,6 +379,10 @@ namespace Pulumi.Automation
 
         internal static void ValidatePulumiVersion(SemVersion minVersion, SemVersion currentVersion)
         {
+            if (Environment.GetEnvironmentVariable("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK") != null)
+            {
+                return;
+            }
             if (minVersion.Major < currentVersion.Major)
             {
                 throw new InvalidOperationException($"Major version mismatch. You are using Pulumi CLI version {currentVersion} with Automation SDK v{minVersion.Major}. Please update the SDK.");

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -599,7 +599,7 @@
         <member name="M:Pulumi.Automation.LocalWorkspace.ListPluginsAsync(System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
-        <member name="M:Pulumi.Automation.LocalWorkspace.GetOutputsAsync(System.String,System.Threading.CancellationToken)">
+        <member name="M:Pulumi.Automation.LocalWorkspace.GetStackOutputsAsync(System.String,System.Threading.CancellationToken)">
             <inheritdoc/>
         </member>
         <member name="T:Pulumi.Automation.LocalWorkspaceOptions">
@@ -1092,7 +1092,7 @@
             Returns a list of all plugins installed in the Workspace.
             </summary>
         </member>
-        <member name="M:Pulumi.Automation.Workspace.GetOutputsAsync(System.String,System.Threading.CancellationToken)">
+        <member name="M:Pulumi.Automation.Workspace.GetStackOutputsAsync(System.String,System.Threading.CancellationToken)">
             <summary>
             Gets the current set of Stack outputs from the last <see cref="M:Pulumi.Automation.WorkspaceStack.UpAsync(Pulumi.Automation.UpOptions,System.Threading.CancellationToken)"/>.
             </summary>

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -53,6 +53,8 @@ type LocalWorkspace struct {
 
 var settingsExtensions = []string{".yaml", ".yml", ".json"}
 
+var skipVersionCheckVar = "PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK"
+
 // ProjectSettings returns the settings object for the current project if any
 // LocalWorkspace reads settings from the Pulumi.yaml in the workspace.
 // A workspace can contain only a single project at a time.
@@ -498,8 +500,8 @@ func (l *LocalWorkspace) getPulumiVersion(ctx context.Context) (semver.Version, 
 }
 
 //nolint:lll
-func validatePulumiVersion(minVersion semver.Version, currentVersion semver.Version) error {
-	if os.Getenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK") != "" {
+func validatePulumiVersion(minVersion semver.Version, currentVersion semver.Version, optOut bool) error {
+	if optOut {
 		return nil
 	}
 	if minVersion.Major < currentVersion.Major {
@@ -576,8 +578,12 @@ func NewLocalWorkspace(ctx context.Context, opts ...LocalWorkspaceOption) (Works
 		return nil, errors.Wrap(err, "failed to create workspace, unable to get pulumi version")
 	}
 	l.pulumiVersion = v
+	optOut := os.Getenv(skipVersionCheckVar) != ""
+	if val, ok := l.GetEnvVars()[skipVersionCheckVar]; ok {
+		optOut = optOut || val != ""
+	}
 
-	if err = validatePulumiVersion(minimumVersion, l.pulumiVersion); err != nil {
+	if err = validatePulumiVersion(minimumVersion, l.pulumiVersion, optOut); err != nil {
 		return nil, err
 	}
 

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -499,6 +499,9 @@ func (l *LocalWorkspace) getPulumiVersion(ctx context.Context) (semver.Version, 
 
 //nolint:lll
 func validatePulumiVersion(minVersion semver.Version, currentVersion semver.Version) error {
+	if os.Getenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK") != "" {
+		return nil
+	}
 	if minVersion.Major < currentVersion.Major {
 		return errors.New(fmt.Sprintf("Major version mismatch. You are using Pulumi CLI version %s with Automation SDK v%v. Please update the SDK.", currentVersion, minVersion.Major))
 	}

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1468,13 +1468,7 @@ func TestMinimumVersion(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			minVersion := semver.Version{Major: 2, Minor: 21, Patch: 1}
 
-			if tt.optOut {
-				assert.NoError(t, os.Setenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK", "1"))
-			}
-			err := validatePulumiVersion(minVersion, tt.currentVersion)
-			if tt.optOut {
-				assert.NoError(t, os.Unsetenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK"))
-			}
+			err := validatePulumiVersion(minVersion, tt.currentVersion, tt.optOut)
 
 			if tt.expectError {
 				assert.Error(t, err)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1457,7 +1457,7 @@ var minVersionTests = []struct {
 	},
 	{
 		"opt_out_of_check_would_succeed_otherwise",
-		semver.Version{Major: 3, Minor: 0, Patch: 0},
+		semver.Version{Major: 2, Minor: 22, Patch: 0},
 		false,
 		true,
 	},

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1397,47 +1397,68 @@ var minVersionTests = []struct {
 	name           string
 	currentVersion semver.Version
 	expectError    bool
+	optOut         bool
 }{
 	{
 		"higher_major",
 		semver.Version{Major: 100, Minor: 0, Patch: 0},
 		true,
+		false,
 	},
 	{
 		"lower_major",
 		semver.Version{Major: 1, Minor: 0, Patch: 0},
 		true,
+		false,
 	},
 	{
 		"higher_minor",
 		semver.Version{Major: 2, Minor: 22, Patch: 0},
+		false,
 		false,
 	},
 	{
 		"lower_minor",
 		semver.Version{Major: 2, Minor: 1, Patch: 0},
 		true,
+		false,
 	},
 	{
 		"equal_minor_higher_patch",
 		semver.Version{Major: 2, Minor: 21, Patch: 2},
+		false,
 		false,
 	},
 	{
 		"equal_minor_equal_patch",
 		semver.Version{Major: 2, Minor: 21, Patch: 1},
 		false,
+		false,
 	},
 	{
 		"equal_minor_lower_patch",
 		semver.Version{Major: 2, Minor: 21, Patch: 0},
 		true,
+		false,
 	},
 	{
 		"equal_minor_equal_patch_prerelease",
 		// Note that prerelease < release so this case will error
 		semver.Version{Major: 2, Minor: 21, Patch: 1,
 			Pre: []semver.PRVersion{{VersionStr: "alpha"}, {VersionNum: 1234, IsNum: true}}},
+		true,
+		false,
+	},
+	{
+		"opt_out_of_check_would_fail_otherwise",
+		semver.Version{Major: 2, Minor: 20, Patch: 0},
+		false,
+		true,
+	},
+	{
+		"opt_out_of_check_would_succeed_otherwise",
+		semver.Version{Major: 3, Minor: 0, Patch: 0},
+		false,
 		true,
 	},
 }
@@ -1446,7 +1467,15 @@ func TestMinimumVersion(t *testing.T) {
 	for _, tt := range minVersionTests {
 		t.Run(tt.name, func(t *testing.T) {
 			minVersion := semver.Version{Major: 2, Minor: 21, Patch: 1}
+
+			if tt.optOut {
+				assert.NoError(t, os.Setenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK", "1"))
+			}
 			err := validatePulumiVersion(minVersion, tt.currentVersion)
+			if tt.optOut {
+				assert.NoError(t, os.Unsetenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK"))
+			}
+
 			if tt.expectError {
 				assert.Error(t, err)
 				if minVersion.Major < tt.currentVersion.Major {

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -716,6 +716,9 @@ function loadProjectSettings(workDir: string) {
 
 /** @internal */
 export function validatePulumiVersion(minVersion: semver.SemVer, currentVersion: semver.SemVer) {
+    if (process.env.PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK !== undefined) {
+        return;
+    }
     if (minVersion.major < currentVersion.major) {
         throw new Error(`Major version mismatch. You are using Pulumi CLI version ${currentVersion.toString()} with Automation SDK v${minVersion.major}. Please update the SDK.`);
     }

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -488,42 +488,62 @@ describe(`checkVersionIsValid`, () => {
             name: "higher_major",
             currentVersion: "100.0.0",
             expectError: true,
+            optOut: false,
         },
         {
             name: "lower_major",
             currentVersion: "1.0.0",
             expectError: true,
+            optOut: false,
         },
         {
             name: "higher_minor",
             currentVersion: "v2.22.0",
             expectError: false,
+            optOut: false,
         },
         {
             name: "lower_minor",
             currentVersion: "v2.1.0",
             expectError: true,
+            optOut: false,
         },
         {
             name: "equal_minor_higher_patch",
             currentVersion: "v2.21.2",
             expectError: false,
+            optOut: false,
         },
         {
             name: "equal_minor_equal_patch",
             currentVersion: "v2.21.1",
             expectError: false,
+            optOut: false,
         },
         {
             name: "equal_minor_lower_patch",
             currentVersion: "v2.21.0",
             expectError: true,
+            optOut: false,
         },
         {
             name: "equal_minor_equal_patch_prerelease",
             // Note that prerelease < release so this case will error
             currentVersion: "v2.21.1-alpha.1234",
             expectError: true,
+            optOut: false,
+        },
+        {
+            name: "opt_out_of_check_would_fail_otherwise",
+            currentVersion: "v2.20.0",
+            expectError: false,
+            optOut: true,
+        },
+        {
+            name: "opt_out_of_check_would_succeed_otherwise",
+            currentVersion: "v2.22.0",
+            expectError: false,
+            optOut: true,
         },
     ];
     const minVersion = new semver.SemVer("v2.21.1");
@@ -532,6 +552,9 @@ describe(`checkVersionIsValid`, () => {
         it(`validates ${test.currentVersion}`, () => {
             const currentVersion = new semver.SemVer(test.currentVersion);
 
+            if (test.optOut) {
+                process.env.PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK = "1";
+            }
             if (test.expectError) {
                 if (minVersion.major < currentVersion.major) {
                     assert.throws(() => validatePulumiVersion(minVersion, currentVersion), /Major version mismatch./);
@@ -540,6 +563,9 @@ describe(`checkVersionIsValid`, () => {
                 }
             } else {
                 assert.doesNotThrow(() => validatePulumiVersion(minVersion, currentVersion));
+            }
+            if (test.optOut) {
+                delete process.env.PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK;
             }
         });
     });

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -552,20 +552,14 @@ describe(`checkVersionIsValid`, () => {
         it(`validates ${test.currentVersion}`, () => {
             const currentVersion = new semver.SemVer(test.currentVersion);
 
-            if (test.optOut) {
-                process.env.PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK = "1";
-            }
             if (test.expectError) {
                 if (minVersion.major < currentVersion.major) {
-                    assert.throws(() => validatePulumiVersion(minVersion, currentVersion), /Major version mismatch./);
+                    assert.throws(() => validatePulumiVersion(minVersion, currentVersion, test.optOut), /Major version mismatch./);
                 } else {
-                    assert.throws(() => validatePulumiVersion(minVersion, currentVersion), /Minimum version requirement failed./);
+                    assert.throws(() => validatePulumiVersion(minVersion, currentVersion, test.optOut), /Minimum version requirement failed./);
                 }
             } else {
-                assert.doesNotThrow(() => validatePulumiVersion(minVersion, currentVersion));
-            }
-            if (test.optOut) {
-                delete process.env.PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK;
+                assert.doesNotThrow(() => validatePulumiVersion(minVersion, currentVersion, test.optOut));
             }
         });
     });

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -469,6 +469,8 @@ def get_stack_settings_name(name: str) -> str:
 
 
 def _validate_pulumi_version(min_version: VersionInfo, current_version: VersionInfo):
+    if os.getenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK") is not None:
+        return
     if min_version.major < current_version.major:
         raise InvalidVersionError(f"Major version mismatch. You are using Pulumi CLI version {current_version} with "
                                   f"Automation SDK v{min_version.major}. Please update the SDK.")

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -443,8 +443,6 @@ class TestLocalWorkspace(unittest.TestCase):
         for current_version, expect_error, opt_out in version_tests:
             with self.subTest():
                 current_version = VersionInfo.parse(current_version)
-                if opt_out:
-                    os.environ["PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK"] = "1"
                 if expect_error:
                     error_regex = "Major version mismatch." \
                         if test_min_version.major < current_version.major \
@@ -454,11 +452,9 @@ class TestLocalWorkspace(unittest.TestCase):
                             error_regex,
                             msg=f"min_version:{test_min_version}, current_version:{current_version}"
                     ):
-                        _validate_pulumi_version(test_min_version, current_version)
+                        _validate_pulumi_version(test_min_version, current_version, opt_out)
                 else:
-                    self.assertIsNone(_validate_pulumi_version(test_min_version, current_version))
-                if opt_out:
-                    os.unsetenv("PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK")
+                    self.assertIsNone(_validate_pulumi_version(test_min_version, current_version, opt_out))
 
     def test_project_settings_respected(self):
         stack_name = stack_namer()


### PR DESCRIPTION
This PR adds an option to skip the minimal CLI version check for Automation API . If `PULUMI_AUTOMATION_API_SKIP_VERSION_CHECK` has a non-empty value, the check is skipped.

Docs PR: https://github.com/pulumi/pulumi-hugo/pull/154

Fixes: #6711 