### PR TITLE
[sdk/python] Address issues when using resource subclasses

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,6 +21,9 @@
 - [automation/dotnet] Use stackName in ImportStack
   [#6858](https://github.com/pulumi/pulumi/pull/6858)
 
+- [sdk/python] Address issues when using resource subclasses.
+  [#6890](https://github.com/pulumi/pulumi/pull/6890)
+
 ### Misc.
 
 - [auto/*] - Bump minimum version to v3.1.0.

--- a/sdk/python/lib/test/langhost/inheritance_translation/__init__.py
+++ b/sdk/python/lib/test/langhost/inheritance_translation/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/inheritance_translation/__main__.py
+++ b/sdk/python/lib/test/langhost/inheritance_translation/__main__.py
@@ -1,0 +1,118 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+
+
+class MyResource(pulumi.CustomResource):
+    def __init__(self, name):
+        # Pass a @pulumi.input_type to opt-in to new translation behavior.
+        @pulumi.input_type
+        class Args:
+            pass
+        props = Args()
+        props.__dict__["some_value"] = None
+        props.__dict__["another_value"] = None
+        super().__init__("test:index:MyResource", name, props)
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "some_value")
+
+    @property
+    @pulumi.getter(name="anotherValue")
+    def another_value(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "another_value")
+
+
+class MyResourceSubclass(MyResource):
+    combined_values: pulumi.Output[str]
+    def __init__(self, name):
+        super().__init__(name)
+        self.combined_values = pulumi.Output.concat(self.some_value, " ", self.another_value)
+
+
+class MyResourceSubclassSubclass(MyResourceSubclass):
+    new_value: pulumi.Output[str]
+    def __init__(self, name):
+        super().__init__(name)
+        self.new_value = pulumi.Output.concat(self.combined_values, "!")
+
+
+class MyLegacyTranslationResource(pulumi.CustomResource):
+    def __init__(self, name):
+        # Pass a regular dict to use the old translation behavior.
+        props = dict()
+        props["some_value"] = None
+        props["another_value"] = None
+        super().__init__("test:index:MyResource", name, props)
+
+    def translate_output_property(self, prop: str) -> str:
+        return {
+            "someValue": "some_value",
+            "anotherValue": "another_value",
+        }.get(prop) or prop
+
+    def translate_input_property(self, prop: str) -> str:
+        return {
+            "some_value": "someValue",
+            "another_value": "anotherValue",
+        }.get(prop) or prop
+
+    @property
+    @pulumi.getter(name="someValue")
+    def some_value(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "some_value")
+
+    @property
+    @pulumi.getter(name="anotherValue")
+    def another_value(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "another_value")
+
+
+class MyLegacyTranslationResourceSubclass(MyLegacyTranslationResource):
+    combined_values: pulumi.Output[str]
+    def __init__(self, name):
+        super().__init__(name)
+        self.combined_values = pulumi.Output.concat(self.some_value, " ", self.another_value)
+
+
+class MyLegacyTranslationResourceSubclassSubclass(MyLegacyTranslationResourceSubclass):
+    new_value: pulumi.Output[str]
+    def __init__(self, name):
+        super().__init__(name)
+        self.new_value = pulumi.Output.concat(self.combined_values, "!")
+
+
+r1 = MyResourceSubclass("testResource")
+r2 = MyResourceSubclassSubclass("testResource")
+pulumi.export("r1.some_value", r1.some_value)
+pulumi.export("r1.another_value", r1.another_value)
+pulumi.export("r1.combined_values", r1.combined_values)
+pulumi.export("r2.some_value", r2.some_value)
+pulumi.export("r2.another_value", r2.another_value)
+pulumi.export("r2.combined_values", r2.combined_values)
+pulumi.export("r2.new_value", r2.new_value)
+
+
+r3 = MyLegacyTranslationResourceSubclass("testResource")
+r4 = MyLegacyTranslationResourceSubclassSubclass("testResource")
+pulumi.export("r3.some_value", r3.some_value)
+pulumi.export("r3.another_value", r3.another_value)
+pulumi.export("r3.combined_values", r3.combined_values)
+pulumi.export("r4.some_value", r4.some_value)
+pulumi.export("r4.another_value", r4.another_value)
+pulumi.export("r4.combined_values", r4.combined_values)
+pulumi.export("r4.new_value", r4.new_value)

--- a/sdk/python/lib/test/langhost/inheritance_translation/inheritance_translation.py
+++ b/sdk/python/lib/test/langhost/inheritance_translation/inheritance_translation.py
@@ -1,0 +1,51 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class InheritanceTranslationTest(LanghostTest):
+    def test_inheritance_translation(self):
+        self.run_test(
+            program=path.join(self.base_path(), "inheritance_translation"),
+            expected_resource_count=4)
+
+    def register_resource(self, ctx, dry_run, ty, name, _resource,
+                          _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
+                          _ignore_changes, _version):
+        self.assertEqual("test:index:MyResource", ty)
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": {"someValue": "hello", "anotherValue": "world"},
+        }
+
+    def register_resource_outputs(self, _ctx, _dry_run, _urn, ty, _name, _resource, outputs):
+        self.assertEqual("pulumi:pulumi:Stack", ty)
+        self.assertEqual({
+            "r1.some_value": "hello",
+            "r1.another_value": "world",
+            "r1.combined_values": "hello world",
+            "r2.some_value": "hello",
+            "r2.another_value": "world",
+            "r2.combined_values": "hello world",
+            "r2.new_value": "hello world!",
+            "r3.some_value": "hello",
+            "r3.another_value": "world",
+            "r3.combined_values": "hello world",
+            "r4.some_value": "hello",
+            "r4.another_value": "world",
+            "r4.combined_values": "hello world",
+            "r4.new_value": "hello world!",
+        }, outputs)

--- a/sdk/python/lib/test/langhost/inheritance_types/__init__.py
+++ b/sdk/python/lib/test/langhost/inheritance_types/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/inheritance_types/__main__.py
+++ b/sdk/python/lib/test/langhost/inheritance_types/__main__.py
@@ -1,0 +1,28 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+
+import pulumi_pkg
+
+
+class MyResourceSubclass(pulumi_pkg.mod.MyResource):
+    combined_values: pulumi.Output[str]
+    def __init__(self, name):
+        super().__init__(name)
+        self.combined_values = self.foo.apply(lambda f: f"{f.bar} {f.baz}")
+
+
+r = MyResourceSubclass("testResource")
+pulumi.export("combined_values", r.combined_values)

--- a/sdk/python/lib/test/langhost/inheritance_types/inheritance_types.py
+++ b/sdk/python/lib/test/langhost/inheritance_types/inheritance_types.py
@@ -1,0 +1,36 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+from ..util import LanghostTest
+
+
+class InheritanceTypesTest(LanghostTest):
+    def test_inheritance_types(self):
+        self.run_test(
+            program=path.join(self.base_path(), "inheritance_types"),
+            expected_resource_count=1)
+
+    def register_resource(self, ctx, dry_run, ty, name, _resource,
+                          _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
+                          _ignore_changes, _version):
+        self.assertEqual("test:index:MyResource", ty)
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": {"foo": {"bar": "hello", "baz": "world"}},
+        }
+
+    def register_resource_outputs(self, _ctx, _dry_run, _urn, ty, _name, _resource, outputs):
+        self.assertEqual("pulumi:pulumi:Stack", ty)
+        self.assertEqual({"combined_values": "hello world"}, outputs)

--- a/sdk/python/lib/test/langhost/inheritance_types/pulumi_pkg/__init__.py
+++ b/sdk/python/lib/test/langhost/inheritance_types/pulumi_pkg/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from . import mod

--- a/sdk/python/lib/test/langhost/inheritance_types/pulumi_pkg/mod/__init__.py
+++ b/sdk/python/lib/test/langhost/inheritance_types/pulumi_pkg/mod/__init__.py
@@ -1,0 +1,16 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .resource import *
+from . import outputs

--- a/sdk/python/lib/test/langhost/inheritance_types/pulumi_pkg/mod/outputs.py
+++ b/sdk/python/lib/test/langhost/inheritance_types/pulumi_pkg/mod/outputs.py
@@ -1,0 +1,31 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+
+@pulumi.output_type
+class MyResourceFoo(dict):
+    def __init__(self, *, bar: str, baz: str):
+        pulumi.set(self, "bar", bar)
+        pulumi.set(self, "baz", baz)
+
+    @property
+    @pulumi.getter
+    def bar(self) -> str:
+        return pulumi.get(self, "bar")
+
+    @property
+    @pulumi.getter
+    def baz(self) -> str:
+        return pulumi.get(self, "baz")

--- a/sdk/python/lib/test/langhost/inheritance_types/pulumi_pkg/mod/resource.py
+++ b/sdk/python/lib/test/langhost/inheritance_types/pulumi_pkg/mod/resource.py
@@ -1,0 +1,33 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+
+from . import outputs
+
+
+class MyResource(pulumi.CustomResource):
+    def __init__(self, name):
+        @pulumi.input_type
+        class Args:
+            pass
+        props = Args()
+        props.__dict__["foo"] = None
+        super().__init__("test:index:MyResource", name, props)
+
+    @property
+    @pulumi.getter
+    def foo(self) -> pulumi.Output['outputs.MyResourceFoo']:
+        return pulumi.get(self, "foo")
+


### PR DESCRIPTION
We were only looking at the current resource class's type/name metadata for camelCase <=> snake_case property name translations which prevented it from working correctly when using a subclass of a resource. This change addresses this by looking at metadata of the current class and any base classes.

Additionally, to help resolve forward references when getting type hints, we'd pass along the current resource class's globals, which doesn't work correctly when using a subclass of a resource. This change also addresses this, by using the globals of the current class and any base classes.

Fixes #6850