### PR TITLE
[cli] Ensure the user has set PULUMI_CONFIG_PASSPHRASE or PULUMI_CONFIG_PASSPHRASE_FILE

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,10 @@
 
 ### Bug Fixes
 
+- [cli] Return an appropriate error when a user has not set `PULUMI_CONFIG_PASSPHRASE` nor `PULUMI_CONFIG_PASSPHRASE_FILE`
+  when trying to access the Passphrase Secrets Manager
+  [#6893](https://github.com/pulumi/pulumi/pull/6893)
+
 - [sdk/python] - Fix bug in MockResourceArgs.
   [#6863](https://github.com/pulumi/pulumi/pull/6863)
 

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -90,13 +90,6 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			if showSecrets {
-				// Currently, the stack.DefaultSecretsProvider is cached so adding a call to getStackSecretsManager
-				// will ensure that the user has the correct credentials to decrypt the stack deployment
-				_, err := getStackSecretsManager(s)
-				if err != nil {
-					return errors.Wrap(err, "getting secrets manager")
-				}
-
 				snap, err := stack.DeserializeUntypedDeployment(deployment, stack.DefaultSecretsProvider)
 				if err != nil {
 					return checkDeploymentVersionError(err, stackName)

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -18,7 +18,9 @@ package passphrase
 import (
 	"encoding/base64"
 	"encoding/json"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 
@@ -151,7 +153,35 @@ func NewPassphaseSecretsManagerFromState(state json.RawMessage) (secrets.Manager
 	// This is not ideal, but we don't have a great way to prompt the user in this case, since this may be
 	// called during an update when trying to read stack outputs as part servicing a StackReference request
 	// (since we need to decrypt the deployment)
-	phrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
+	phrase := ""
+	passphrase, isOk := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE")
+	if isOk {
+		phrase = passphrase
+	}
+	phraseFile, isOk := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE_FILE")
+	if isOk {
+		phraseFilePath, err := filepath.Abs(phraseFile)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to detect passphrase path")
+		}
+
+		phraseDetails, err := ioutil.ReadFile(phraseFilePath)
+		if err != nil {
+			return nil, errors.Wrap(err, "unable to read PULUMI_CONFIG_PASSPHRASE_FILE")
+		}
+
+		phrase = strings.TrimSpace(string(phraseDetails))
+	}
+
+	// At this point, we don't know if it's an incorrect passphrase. We only know if there is a passphrase or there is
+	// not. Ideally, we would prompt the user for the passphrase at this point but we can't do that in the CLI is in an
+	// update operation, so we should at least error out with an appropriate message here to ensure that the user
+	// understands why the operation fails unexpectedly.
+	if phrase == "" {
+		return nil, errors.New("unable to find either `PULUMI_CONFIG_PASSPHRASE` nor " +
+			"`PULUMI_CONFIG_PASSPHRASE_FILE` when trying to access the Passphrase Secrets Manager; please ensure one " +
+			"of these environment variables is set to allow the operation to continue")
+	}
 
 	sm, err := NewPassphaseSecretsManager(phrase, s.Salt)
 	switch {
@@ -180,10 +210,10 @@ type errorCrypter struct{}
 
 func (ec *errorCrypter) EncryptValue(v string) (string, error) {
 	return "", errors.New("failed to encrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
-		"correct passphrase")
+		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }
 
 func (ec *errorCrypter) DecryptValue(v string) (string, error) {
 	return "", errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
-		"correct passphrase")
+		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -1,0 +1,88 @@
+package passphrase
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"strings"
+	"testing"
+)
+
+const (
+	state = `
+    {"salt": "v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}
+`
+	brokenState = `
+    {"salt": "fozI5u6B030=:v1:F+6ZduL:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="}
+`
+)
+
+func setIncorrectPassphraseTestEnvVars() func() {
+	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
+	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
+	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password123")
+	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
+	return func() {
+		os.Setenv("PULUMI_CONFIG_PASSPHRASE", oldPassphrase)
+		os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", oldPassphraseFile)
+	}
+}
+
+func TestPassphraseManagerIncorrectPassphraseReturnsErrorCrypter(t *testing.T) {
+	setupEnv := setIncorrectPassphraseTestEnvVars()
+	defer setupEnv()
+
+	manager, err := NewPassphaseSecretsManagerFromState([]byte(state))
+	assert.NoError(t, err) // even if we pass the wrong provider, we should get a lockedPassphraseProvider
+
+	assert.Equal(t, manager, &localSecretsManager{
+		state:   localSecretsManagerState{Salt: "v1:fozI5u6B030=:v1:F+6ZduKKd8G0/V7L:PGMFeIzwobWRKmEAzUdaQHqC5mMRIQ=="},
+		crypter: &errorCrypter{},
+	})
+}
+
+func setCorrectPassphraseTestEnvVars() func() {
+	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
+	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
+	os.Setenv("PULUMI_CONFIG_PASSPHRASE", "password")
+	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
+	return func() {
+		os.Setenv("PULUMI_CONFIG_PASSPHRASE", oldPassphrase)
+		os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", oldPassphraseFile)
+	}
+}
+
+func TestPassphraseManagerIncorrectStateReturnsError(t *testing.T) {
+	setupEnv := setCorrectPassphraseTestEnvVars()
+	defer setupEnv()
+
+	_, err := NewPassphaseSecretsManagerFromState([]byte(brokenState))
+	assert.Error(t, err)
+}
+
+func TestPassphraseManagerCorrectPassphraseReturnsSecretsManager(t *testing.T) {
+	setupEnv := setCorrectPassphraseTestEnvVars()
+	defer setupEnv()
+
+	sm, _ := NewPassphaseSecretsManagerFromState([]byte(state))
+	assert.NotNil(t, sm)
+}
+
+func unsetAllPassphraseEnvVars() func() {
+	oldPassphrase := os.Getenv("PULUMI_CONFIG_PASSPHRASE")
+	oldPassphraseFile := os.Getenv("PULUMI_CONFIG_PASSPHRASE_FILE")
+	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
+	os.Unsetenv("PULUMI_CONFIG_PASSPHRASE_FILE")
+	return func() {
+		os.Setenv("PULUMI_CONFIG_PASSPHRASE", oldPassphrase)
+		os.Setenv("PULUMI_CONFIG_PASSPHRASE_FILE", oldPassphraseFile)
+	}
+}
+
+func TestPassphraseManagerNoEnvironmentVariablesReturnsError(t *testing.T) {
+	setupEnv := unsetAllPassphraseEnvVars()
+	defer setupEnv()
+
+	_, err := NewPassphaseSecretsManagerFromState([]byte(state))
+	assert.NotNil(t, err, strings.Contains(err.Error(), "unable to find either `PULUMI_CONFIG_PASSPHRASE` nor "+
+		"`PULUMI_CONFIG_PASSPHRASE_FILE`"))
+}

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -232,6 +232,7 @@ func TestStackCommands(t *testing.T) {
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
+		os.Setenv("PULUMI_CONFIG_PASSPHRASE", "correct horse battery staple")
 		snap, err := stack.DeserializeUntypedDeployment(&deployment, stack.DefaultSecretsProvider)
 		if !assert.NoError(t, err) {
 			t.FailNow()
@@ -260,6 +261,7 @@ func TestStackCommands(t *testing.T) {
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
+		os.Unsetenv("PULUMI_CONFIG_PASSPHRASE")
 		_, stderr := e.RunCommand("pulumi", "stack", "import", "--file", "stack.json")
 		assert.Contains(t, stderr, fmt.Sprintf("removing pending operation 'deleting' on '%s'", res.URN))
 		// The engine should be happy now that there are no invalid resources.


### PR DESCRIPTION
Fixes: #6286

When a user is using the passphrase provider and unsets the environment
variables that let them interact with the secrets provider, then would
get an error as follows:

```
▶ pulumi up -y -f
error: decrypting secret value: failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the correct passphrase
```

We are oging to change this error message to make it more obvious
to a user what the error is and how they need to fix it

```
▶ pulumi up -y -f
error: constructing secrets manager of type "passphrase": unable to find either `PULUMI_CONFIG_PASSPHRASE` nor `PULUMI_CONFIG_PASSPHRASE_FILE` when trying to access the Passphrase Secrets Manager. Please ensure one of these values are set to allow the operation to continue
```

Ideally, we would like to prompt the user for the passphrase at this
point rather than error, but the CLI could be in the middle of an
update operation as the same codepath is used for reading stackreference
values