### PR TITLE
[auto/go] Fix stack settings save/load typo and add tests

### DIFF
--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -73,7 +73,7 @@ func (l *LocalWorkspace) SaveProjectSettings(ctx context.Context, settings *work
 func (l *LocalWorkspace) StackSettings(ctx context.Context, stackName string) (*workspace.ProjectStack, error) {
 	name := getStackSettingsName(stackName)
 	for _, ext := range settingsExtensions {
-		stackPath := filepath.Join(l.WorkDir(), fmt.Sprintf("pulumi.%s%s", name, ext))
+		stackPath := filepath.Join(l.WorkDir(), fmt.Sprintf("Pulumi.%s%s", name, ext))
 		if _, err := os.Stat(stackPath); err != nil {
 			proj, err := workspace.LoadProjectStack(stackPath)
 			if err != nil {
@@ -93,7 +93,7 @@ func (l *LocalWorkspace) SaveStackSettings(
 	settings *workspace.ProjectStack,
 ) error {
 	name := getStackSettingsName(stackName)
-	stackYamlPath := filepath.Join(l.WorkDir(), fmt.Sprintf("pulumi.%s.yaml:", name))
+	stackYamlPath := filepath.Join(l.WorkDir(), fmt.Sprintf("Pulumi.%s.yaml", name))
 	err := settings.Save(stackYamlPath)
 	if err != nil {
 		return errors.Wrapf(err, "failed to save stack setttings for %s", stackName)

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"github.com/stretchr/testify/require"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -1482,6 +1483,65 @@ func TestProjectSettingsRespected(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, projectSettings.Name, tokens.PackageName("correct_project"))
 	assert.Equal(t, *projectSettings.Description, "This is a description")
+}
+
+func TestSaveStackSettings(t *testing.T) {
+	ctx := context.Background()
+	sName := fmt.Sprintf("int_test%d", rangeIn(10000000, 99999999))
+	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)
+
+	opts := []LocalWorkspaceOption{
+		SecretsProvider("passphrase"),
+		EnvVars(map[string]string{
+			"PULUMI_CONFIG_PASSPHRASE": "password",
+		}),
+	}
+
+	// initialize
+	s, err := NewStackInlineSource(ctx, stackName, pName, func(ctx *pulumi.Context) error {
+		c := config.New(ctx, "")
+		ctx.Export("exp_static", pulumi.String("foo"))
+		ctx.Export("exp_cfg", pulumi.String(c.Get("bar")))
+		ctx.Export("exp_secret", c.GetSecret("buzz"))
+		return nil
+	}, opts...)
+	require.NoError(t, err, "failed to initialize stack, err: %v", err)
+
+	defer func() {
+		// -- pulumi stack rm --
+		err = s.Workspace().RemoveStack(ctx, s.Name())
+		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
+	}()
+
+	// first load settings for created stack
+	stackConfig, err := s.Workspace().StackSettings(ctx, stackName)
+	require.NoError(t, err)
+	stackConfig.SecretsProvider = "passphrase"
+	assert.NoError(t, s.Workspace().SaveStackSettings(ctx, stackName, stackConfig))
+
+	// -- pulumi up --
+
+	res, err := s.Up(ctx)
+	if err != nil {
+		t.Errorf("up failed, err: %v", err)
+		t.FailNow()
+	}
+	assert.Equal(t, "update", res.Summary.Kind)
+	assert.Equal(t, "succeeded", res.Summary.Result)
+
+	reloaded, err := s.workspace.StackSettings(ctx, stackName)
+	assert.NoError(t, err)
+	assert.Equal(t, stackConfig, reloaded)
+
+	// -- pulumi destroy --
+
+	dRes, err := s.Destroy(ctx)
+	if err != nil {
+		t.Errorf("destroy failed, err: %v", err)
+		t.FailNow()
+	}
+	assert.Equal(t, "destroy", dRes.Summary.Kind)
+	assert.Equal(t, "succeeded", dRes.Summary.Result)
 }
 
 func BenchmarkBulkSetConfigMixed(b *testing.B) {


### PR DESCRIPTION
Helps with #5432 

Test demonstrates a panic without the fixes. Also - on case-sensitive filesystems the use of `pulumi.xxx.yaml` vs. `Pulumi.xxx.yaml` matters.