### PR TITLE
Assertion fix in config key generation

### DIFF
--- a/pkg/cmd/pulumi/config_test.go
+++ b/pkg/cmd/pulumi/config_test.go
@@ -32,6 +32,7 @@ func TestPrettyKeyForProject(t *testing.T) {
 
 	assert.Equal(t, "foo", prettyKeyForProject(config.MustMakeKey("test-package", "foo"), proj))
 	assert.Equal(t, "other-package:bar", prettyKeyForProject(config.MustMakeKey("other-package", "bar"), proj))
+	assert.Panics(t, func() { config.MustMakeKey("other:package", "bar") })
 }
 
 func TestSecretDetection(t *testing.T) {

--- a/sdk/go/common/resource/config/key.go
+++ b/sdk/go/common/resource/config/key.go
@@ -31,7 +31,7 @@ type Key struct {
 
 // MustMakeKey constructs a config.Key for a given namespace and name. The namespace may not contain a `:`
 func MustMakeKey(namespace string, name string) Key {
-	contract.Requiref(!strings.Contains(":", namespace), "namespace", "may not contain a colon")
+	contract.Requiref(!strings.Contains(namespace, ":"), "namespace", "may not contain a colon")
 	return Key{namespace: namespace, name: name}
 }
 


### PR DESCRIPTION
Turns out the assertion check would only fail if the namespace was ":" or "".