### PR TITLE
Improve default formatting of auto.autoError

### DIFF
--- a/sdk/go/auto/errors.go
+++ b/sdk/go/auto/errors.go
@@ -15,10 +15,9 @@
 package auto
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 type autoError struct {
@@ -38,7 +37,7 @@ func newAutoError(err error, stdout, stderr string, code int) autoError {
 }
 
 func (ae autoError) Error() string {
-	return errors.Wrapf(ae.err, "code: %d\n, stdout: %s\n, stderr: %s\n", ae.code, ae.stdout, ae.stderr).Error()
+	return fmt.Sprintf("%s\ncode: %d\nstdout: %s\nstderr: %s\n", ae.err.Error(), ae.code, ae.stdout, ae.stderr)
 }
 
 // IsConcurrentUpdateError returns true if the error was a result of a conflicting update locking the stack.


### PR DESCRIPTION
This commit changes the `error` interface for `auto.autoError` such that the formatting does not contain punctuation at the start of lines. Previously the formatting for an error was similar to this:

```
code: 255
, stdout: Created stack 'ateststack-90f37904'
, stderr: error: no Pulumi project found in the current working directory
: failed to create stack: exit status 255
```

After this change, the same error would be formatted:

```
failed to create stack: exit status 255
code: 255
stdout: Created stack 'ateststack-90f37904'
stderr: error: no Pulumi project found in the current working directory
```

The implementation no longer relies on `github.com/pkg/errors`, instead just using `fmt.Sprintf` since the error contract returns a plain string.