### PR TITLE
Add user agent to the CLI, Go and Nodejs Automation API SDKs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,6 +18,8 @@
 - [codegen/python] Lazy module import to improve CLI startup performance
   [#6827](https://github.com/pulumi/pulumi/pull/6827)
 
+- [auto/go,nodejs] Add UserAgent to update/pre/refresh/destroy options.
+  [#6935](https://github.com/pulumi/pulumi/pull/6935)
 
 ### Bug Fixes
 

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -89,7 +89,7 @@ const (
 	// ExecutionKind indicates how the update was executed. One of "cli", "auto.local", or "auto.inline".
 	ExecutionKind = "exec.kind"
 	// ExecutionAgent indicates the user agent of the updater for automated scenarios (GHA, Kubernetes Operator).
-	ExecutionAgent = "exec.kind"
+	ExecutionAgent = "exec.agent"
 )
 
 // UpdateInfo describes a previous update.

--- a/pkg/backend/updates.go
+++ b/pkg/backend/updates.go
@@ -88,6 +88,8 @@ const (
 
 	// ExecutionKind indicates how the update was executed. One of "cli", "auto.local", or "auto.inline".
 	ExecutionKind = "exec.kind"
+	// ExecutionAgent indicates the user agent of the updater for automated scenarios (GHA, Kubernetes Operator).
+	ExecutionAgent = "exec.kind"
 )
 
 // UpdateInfo describes a previous update.

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -35,6 +35,7 @@ func newDestroyCmd() *cobra.Command {
 
 	var message string
 	var execKind string
+	var execAgent string
 
 	// Flags for engine.UpdateOptions.
 	var diffDisplay bool
@@ -122,7 +123,7 @@ func newDestroyCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind)
+			m, err := getUpdateMetadata(message, root, execKind, execAgent)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
@@ -235,10 +236,13 @@ func newDestroyCmd() *cobra.Command {
 			"Log events to a file at this path")
 	}
 
-	// internal flag
+	// internal flags
 	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
 	// ignore err, only happens if flag does not exist
 	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+	cmd.PersistentFlags().StringVar(&execAgent, "exec-agent", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-agent")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -262,6 +262,7 @@ func newImportCmd() *cobra.Command {
 	var message string
 	var stack string
 	var execKind string
+	var execAgent string
 
 	// Flags for engine.UpdateOptions.
 	var diffDisplay bool
@@ -437,7 +438,7 @@ func newImportCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind)
+			m, err := getUpdateMetadata(message, root, execKind, execAgent)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
@@ -576,10 +577,13 @@ func newImportCmd() *cobra.Command {
 			"Log events to a file at this path")
 	}
 
-	// internal flag
+	// internal flags
 	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
 	// ignore err, only happens if flag does not exist
 	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+	cmd.PersistentFlags().StringVar(&execAgent, "exec-agent", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-agent")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -31,6 +31,7 @@ func newPreviewCmd() *cobra.Command {
 	var expectNop bool
 	var message string
 	var execKind string
+	var execAgent string
 	var stack string
 	var configArray []string
 	var configPath bool
@@ -129,7 +130,7 @@ func newPreviewCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind)
+			m, err := getUpdateMetadata(message, root, execKind, execAgent)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
@@ -285,10 +286,13 @@ func newPreviewCmd() *cobra.Command {
 			"Log events to a file at this path")
 	}
 
-	// internal flag
+	// internal flags
 	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
 	// ignore err, only happens if flag does not exist
 	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+	cmd.PersistentFlags().StringVar(&execAgent, "exec-agent", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-agent")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -33,6 +33,7 @@ func newRefreshCmd() *cobra.Command {
 	var expectNop bool
 	var message string
 	var execKind string
+	var execAgent string
 	var stack string
 
 	// Flags for engine.UpdateOptions.
@@ -119,7 +120,7 @@ func newRefreshCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind)
+			m, err := getUpdateMetadata(message, root, execKind, execAgent)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}
@@ -225,10 +226,13 @@ func newRefreshCmd() *cobra.Command {
 			"Log events to a file at this path")
 	}
 
-	// internal flag
+	// internal flags
 	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
 	// ignore err, only happens if flag does not exist
 	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+	cmd.PersistentFlags().StringVar(&execAgent, "exec-agent", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-agent")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -48,6 +48,7 @@ func newUpCmd() *cobra.Command {
 	var expectNop bool
 	var message string
 	var execKind string
+	var execAgent string
 	var stack string
 	var configArray []string
 	var path bool
@@ -91,7 +92,7 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(err)
 		}
 
-		m, err := getUpdateMetadata(message, root, execKind)
+		m, err := getUpdateMetadata(message, root, execKind, execAgent)
 		if err != nil {
 			return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 		}
@@ -270,7 +271,7 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(err)
 		}
 
-		m, err := getUpdateMetadata(message, root, execKind)
+		m, err := getUpdateMetadata(message, root, execKind, execAgent)
 		if err != nil {
 			return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 		}
@@ -493,10 +494,13 @@ func newUpCmd() *cobra.Command {
 			"Log events to a file at this path")
 	}
 
-	// internal flag
+	// internal flags
 	cmd.PersistentFlags().StringVar(&execKind, "exec-kind", "", "")
 	// ignore err, only happens if flag does not exist
 	_ = cmd.PersistentFlags().MarkHidden("exec-kind")
+	cmd.PersistentFlags().StringVar(&execAgent, "exec-agent", "", "")
+	// ignore err, only happens if flag does not exist
+	_ = cmd.PersistentFlags().MarkHidden("exec-agent")
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -530,7 +530,7 @@ func isGitWorkTreeDirty(repoRoot string) (bool, error) {
 
 // getUpdateMetadata returns an UpdateMetadata object, with optional data about the environment
 // performing the update.
-func getUpdateMetadata(msg, root, execKind string) (*backend.UpdateMetadata, error) {
+func getUpdateMetadata(msg, root, execKind, execAgent string) (*backend.UpdateMetadata, error) {
 	m := &backend.UpdateMetadata{
 		Message:     msg,
 		Environment: make(map[string]string),
@@ -542,7 +542,7 @@ func getUpdateMetadata(msg, root, execKind string) (*backend.UpdateMetadata, err
 
 	addCIMetadataToEnvironment(m.Environment)
 
-	addExecutionMetadataToEnvironment(m.Environment, execKind)
+	addExecutionMetadataToEnvironment(m.Environment, execKind, execAgent)
 
 	return m, nil
 }
@@ -695,7 +695,7 @@ func addCIMetadataToEnvironment(env map[string]string) {
 }
 
 // addExecutionMetadataToEnvironment populates the environment metadata bag with execution-related values.
-func addExecutionMetadataToEnvironment(env map[string]string, execKind string) {
+func addExecutionMetadataToEnvironment(env map[string]string, execKind, execAgent string) {
 	// this comes from a hidden flag, so we restrict the set of allowed values
 	switch execKind {
 	case constant.ExecKindAutoInline:
@@ -708,6 +708,9 @@ func addExecutionMetadataToEnvironment(env map[string]string, execKind string) {
 		execKind = constant.ExecKindCLI
 	}
 	env[backend.ExecutionKind] = execKind
+	if execAgent != "" {
+		env[backend.ExecutionAgent] = execAgent
+	}
 }
 
 type cancellationScope struct {

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -98,7 +98,7 @@ func newWatchCmd() *cobra.Command {
 				return result.FromError(err)
 			}
 
-			m, err := getUpdateMetadata(message, root, execKind)
+			m, err := getUpdateMetadata(message, root, execKind, "" /* execAgent */)
 			if err != nil {
 				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
 			}

--- a/sdk/go/auto/debug/debuglogging.go
+++ b/sdk/go/auto/debug/debuglogging.go
@@ -3,7 +3,7 @@ package debug
 import "fmt"
 
 type LoggingOptions struct {
-	// LogLevel - choose verbosity level between 1 (least verbose) to 9 (most verbose).
+	// LogLevel - choose verbosity level of at least 1 (least verbose).
 	// If not specified, reverts to default log level.
 	// Note - These logs may include sensitive information that is provided from your
 	// execution environment to your cloud provider (and which Pulumi may not even
@@ -21,9 +21,6 @@ func AddArgs(debugLogOpts *LoggingOptions, sharedArgs []string) []string {
 		sharedArgs = append(sharedArgs, "--logtostderr")
 	}
 	if debugLogOpts.LogLevel != nil {
-		if *debugLogOpts.LogLevel > 9 {
-			*debugLogOpts.LogLevel = 9
-		}
 		if *debugLogOpts.LogLevel == 0 {
 			*debugLogOpts.LogLevel = 1
 		}

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -45,6 +45,7 @@ import (
 var pulumiOrg = getTestOrg()
 
 const pName = "testproj"
+const agent = "pulumi/pulumi/test"
 
 func TestWorkspaceSecretsProvider(t *testing.T) {
 	ctx := context.Background()
@@ -171,7 +172,7 @@ func TestNewStackLocalSource(t *testing.T) {
 	assert.NotNil(t, envvars, "failed to get environment values after unsetting.")
 
 	// -- pulumi up --
-	res, err := s.Up(ctx)
+	res, err := s.Up(ctx, optup.UserAgent(agent))
 	if err != nil {
 		t.Errorf("up failed, err: %v", err)
 		t.FailNow()
@@ -198,7 +199,7 @@ func TestNewStackLocalSource(t *testing.T) {
 	var previewEvents []events.EngineEvent
 	prevCh := make(chan events.EngineEvent)
 	go collectEvents(prevCh, &previewEvents)
-	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh), optpreview.UserAgent(agent))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
@@ -209,7 +210,7 @@ func TestNewStackLocalSource(t *testing.T) {
 
 	// -- pulumi refresh --
 
-	ref, err := s.Refresh(ctx)
+	ref, err := s.Refresh(ctx, optrefresh.UserAgent(agent))
 
 	if err != nil {
 		t.Errorf("refresh failed, err: %v", err)
@@ -220,7 +221,7 @@ func TestNewStackLocalSource(t *testing.T) {
 
 	// -- pulumi destroy --
 
-	dRes, err := s.Destroy(ctx)
+	dRes, err := s.Destroy(ctx, optdestroy.UserAgent(agent))
 	if err != nil {
 		t.Errorf("destroy failed, err: %v", err)
 		t.FailNow()
@@ -772,7 +773,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	}
 
 	// -- pulumi up --
-	res, err := s.Up(ctx)
+	res, err := s.Up(ctx, optup.UserAgent(agent))
 	if err != nil {
 		t.Errorf("up failed, err: %v", err)
 		t.FailNow()
@@ -794,7 +795,7 @@ func TestNewStackInlineSource(t *testing.T) {
 	var previewEvents []events.EngineEvent
 	prevCh := make(chan events.EngineEvent)
 	go collectEvents(prevCh, &previewEvents)
-	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh))
+	prev, err := s.Preview(ctx, optpreview.EventStreams(prevCh), optpreview.UserAgent(agent))
 	if err != nil {
 		t.Errorf("preview failed, err: %v", err)
 		t.FailNow()
@@ -805,7 +806,7 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi refresh --
 
-	ref, err := s.Refresh(ctx)
+	ref, err := s.Refresh(ctx, optrefresh.UserAgent(agent))
 
 	if err != nil {
 		t.Errorf("refresh failed, err: %v", err)
@@ -816,7 +817,7 @@ func TestNewStackInlineSource(t *testing.T) {
 
 	// -- pulumi destroy --
 
-	dRes, err := s.Destroy(ctx)
+	dRes, err := s.Destroy(ctx, optdestroy.UserAgent(agent))
 	if err != nil {
 		t.Errorf("destroy failed, err: %v", err)
 		t.FailNow()

--- a/sdk/go/auto/minimum_version.go
+++ b/sdk/go/auto/minimum_version.go
@@ -19,6 +19,6 @@ import "github.com/blang/semver"
 var minimumVersion = calculateMinVersion()
 
 func calculateMinVersion() semver.Version {
-	v, _ := semver.ParseTolerant("3.1.0-alpha")
+	v, _ := semver.ParseTolerant("3.2.0-alpha")
 	return v
 }

--- a/sdk/go/auto/minimum_version.go
+++ b/sdk/go/auto/minimum_version.go
@@ -19,6 +19,6 @@ import "github.com/blang/semver"
 var minimumVersion = calculateMinVersion()
 
 func calculateMinVersion() semver.Version {
-	v, _ := semver.ParseTolerant("3.1.0")
+	v, _ := semver.ParseTolerant("3.1.0-alpha")
 	return v
 }

--- a/sdk/go/auto/optdestroy/optdestroy.go
+++ b/sdk/go/auto/optdestroy/optdestroy.go
@@ -66,9 +66,17 @@ func EventStreams(channels ...chan<- events.EngineEvent) Option {
 	})
 }
 
+// DebugLogging provides options for verbose logging to standard error, and enabling plugin logs.
 func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	return optionFunc(func(opts *Options) {
 		opts.DebugLogOpts = debugOpts
+	})
+}
+
+// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"
+func UserAgent(agent string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.UserAgent = agent
 	})
 }
 
@@ -96,6 +104,8 @@ type Options struct {
 	EventStreams []chan<- events.EngineEvent
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
+	// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"
+	UserAgent string
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optpreview/optpreview.go
+++ b/sdk/go/auto/optpreview/optpreview.go
@@ -73,6 +73,7 @@ func TargetDependents() Option {
 	})
 }
 
+// DebugLogging provides options for verbose logging to standard error, and enabling plugin logs.
 func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	return optionFunc(func(opts *Options) {
 		opts.DebugLogOpts = debugOpts
@@ -90,6 +91,13 @@ func ProgressStreams(writers ...io.Writer) Option {
 func EventStreams(channels ...chan<- events.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
 		opts.EventStreams = channels
+	})
+}
+
+// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"
+func UserAgent(agent string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.UserAgent = agent
 	})
 }
 
@@ -123,6 +131,8 @@ type Options struct {
 	ProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
 	EventStreams []chan<- events.EngineEvent
+	// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"
+	UserAgent string
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optrefresh/optrefresh.go
+++ b/sdk/go/auto/optrefresh/optrefresh.go
@@ -66,9 +66,17 @@ func EventStreams(channels ...chan<- events.EngineEvent) Option {
 	})
 }
 
+// DebugLogging provides options for verbose logging to standard error, and enabling plugin logs.
 func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	return optionFunc(func(opts *Options) {
 		opts.DebugLogOpts = debugOpts
+	})
+}
+
+// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"
+func UserAgent(agent string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.UserAgent = agent
 	})
 }
 
@@ -96,6 +104,8 @@ type Options struct {
 	EventStreams []chan<- events.EngineEvent
 	// DebugLogOpts specifies additional settings for debug logging
 	DebugLogOpts debug.LoggingOptions
+	// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"
+	UserAgent string
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/optup/optup.go
+++ b/sdk/go/auto/optup/optup.go
@@ -80,6 +80,7 @@ func ProgressStreams(writers ...io.Writer) Option {
 	})
 }
 
+// DebugLogging provides options for verbose logging to standard error, and enabling plugin logs.
 func DebugLogging(debugOpts debug.LoggingOptions) Option {
 	return optionFunc(func(opts *Options) {
 		opts.DebugLogOpts = debugOpts
@@ -90,6 +91,13 @@ func DebugLogging(debugOpts debug.LoggingOptions) Option {
 func EventStreams(channels ...chan<- events.EngineEvent) Option {
 	return optionFunc(func(opts *Options) {
 		opts.EventStreams = channels
+	})
+}
+
+// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"
+func UserAgent(agent string) Option {
+	return optionFunc(func(opts *Options) {
+		opts.UserAgent = agent
 	})
 }
 
@@ -123,6 +131,8 @@ type Options struct {
 	ProgressStreams []io.Writer
 	// EventStreams allows specifying one or more channels to receive the Pulumi event stream
 	EventStreams []chan<- events.EngineEvent
+	// UserAgent specifies the agent responsible for the update, stored in backends as "environment.exec.agent"
+	UserAgent string
 }
 
 type optionFunc func(*Options)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -238,6 +238,9 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 	if preOpts.Parallel > 0 {
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", preOpts.Parallel))
 	}
+	if preOpts.UserAgent != "" {
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--exec-agent=%s", preOpts.UserAgent))
+	}
 
 	kind, args := constant.ExecKindAutoLocal, []string{"preview"}
 	if program := s.Workspace().Program(); program != nil {
@@ -330,6 +333,9 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 	if upOpts.Parallel > 0 {
 		sharedArgs = append(sharedArgs, fmt.Sprintf("--parallel=%d", upOpts.Parallel))
 	}
+	if upOpts.UserAgent != "" {
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--exec-agent=%s", upOpts.UserAgent))
+	}
 
 	kind, args := constant.ExecKindAutoLocal, []string{"up", "--yes", "--skip-preview"}
 	if program := s.Workspace().Program(); program != nil {
@@ -408,6 +414,9 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 	if refreshOpts.Parallel > 0 {
 		args = append(args, fmt.Sprintf("--parallel=%d", refreshOpts.Parallel))
 	}
+	if refreshOpts.UserAgent != "" {
+		args = append(args, fmt.Sprintf("--exec-agent=%s", refreshOpts.UserAgent))
+	}
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {
 		execKind = constant.ExecKindAutoInline
@@ -472,6 +481,9 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 	}
 	if destroyOpts.Parallel > 0 {
 		args = append(args, fmt.Sprintf("--parallel=%d", destroyOpts.Parallel))
+	}
+	if destroyOpts.UserAgent != "" {
+		args = append(args, fmt.Sprintf("--exec-agent=%s", destroyOpts.UserAgent))
 	}
 	execKind := constant.ExecKindAutoLocal
 	if s.Workspace().Program() != nil {

--- a/sdk/nodejs/automation/minimumVersion.ts
+++ b/sdk/nodejs/automation/minimumVersion.ts
@@ -14,4 +14,4 @@
 
 import * as semver from "semver";
 
-export const minimumVersion = new semver.SemVer("v3.1.0");
+export const minimumVersion = new semver.SemVer("v3.2.0-alpha");

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -164,6 +164,9 @@ export class Stack {
             if (opts.parallel) {
                 args.push("--parallel", opts.parallel.toString());
             }
+            if (opts.userAgent) {
+                args.push("--exec-agent", opts.userAgent);
+            }
         }
 
         let onExit = (hasError: boolean) => { return; };
@@ -272,6 +275,9 @@ export class Stack {
             if (opts.parallel) {
                 args.push("--parallel", opts.parallel.toString());
             }
+            if (opts.userAgent) {
+                args.push("--exec-agent", opts.userAgent);
+            }
         }
 
         let onExit = (hasError: boolean) => { return; };
@@ -364,6 +370,9 @@ export class Stack {
             if (opts.parallel) {
                 args.push("--parallel", opts.parallel.toString());
             }
+            if (opts.userAgent) {
+                args.push("--exec-agent", opts.userAgent);
+            }
         }
 
         let logPromise: Promise<TailFile> | undefined;
@@ -415,6 +424,9 @@ export class Stack {
             }
             if (opts.parallel) {
                 args.push("--parallel", opts.parallel.toString());
+            }
+            if (opts.userAgent) {
+                args.push("--exec-agent", opts.userAgent);
             }
         }
 
@@ -705,6 +717,7 @@ export interface UpOptions {
     replace?: string[];
     target?: string[];
     targetDependents?: boolean;
+    userAgent?: string;
     onOutput?: (out: string) => void;
     onEvent?: (event: EngineEvent) => void;
     program?: PulumiFn;
@@ -721,6 +734,7 @@ export interface PreviewOptions {
     replace?: string[];
     target?: string[];
     targetDependents?: boolean;
+    userAgent?: string;
     program?: PulumiFn;
     onOutput?: (out: string) => void;
     onEvent?: (event: EngineEvent) => void;
@@ -734,6 +748,7 @@ export interface RefreshOptions {
     message?: string;
     expectNoChanges?: boolean;
     target?: string[];
+    userAgent?: string;
     onOutput?: (out: string) => void;
     onEvent?: (event: EngineEvent) => void;
 }
@@ -746,6 +761,7 @@ export interface DestroyOptions {
     message?: string;
     target?: string[];
     targetDependents?: boolean;
+    userAgent?: string;
     onOutput?: (out: string) => void;
     onEvent?: (event: EngineEvent) => void;
 }

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -30,6 +30,7 @@ import { Config } from "../../index";
 import { asyncTest } from "../util";
 
 const versionRegex = /(\d+\.)(\d+\.)(\d+)(-.*)?/;
+const userAgent = "pulumi/pulumi/test";
 
 describe("LocalWorkspace", () => {
     it(`projectSettings from yaml/yml/json`, asyncTest(async () => {
@@ -198,7 +199,7 @@ describe("LocalWorkspace", () => {
         await stack.setAllConfig(config);
 
         // pulumi up
-        const upRes = await stack.up();
+        const upRes = await stack.up({ userAgent });
         assert.strictEqual(Object.keys(upRes.outputs).length, 3);
         assert.strictEqual(upRes.outputs["exp_static"].value, "foo");
         assert.strictEqual(upRes.outputs["exp_static"].secret, false);
@@ -210,16 +211,16 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(upRes.summary.result, "succeeded");
 
         // pulumi preview
-        const preRes = await stack.preview();
+        const preRes = await stack.preview({ userAgent });
         assert.strictEqual(preRes.changeSummary.same, 1);
 
         // pulumi refresh
-        const refRes = await stack.refresh();
+        const refRes = await stack.refresh({ userAgent });
         assert.strictEqual(refRes.summary.kind, "refresh");
         assert.strictEqual(refRes.summary.result, "succeeded");
 
         // pulumi destroy
-        const destroyRes = await stack.destroy();
+        const destroyRes = await stack.destroy({ userAgent });
         assert.strictEqual(destroyRes.summary.kind, "destroy");
         assert.strictEqual(destroyRes.summary.result, "succeeded");
 
@@ -245,7 +246,7 @@ describe("LocalWorkspace", () => {
         await stack.setAllConfig(stackConfig);
 
         // pulumi up
-        const upRes = await stack.up();
+        const upRes = await stack.up({ userAgent });
         assert.strictEqual(Object.keys(upRes.outputs).length, 3);
         assert.strictEqual(upRes.outputs["exp_static"].value, "foo");
         assert.strictEqual(upRes.outputs["exp_static"].secret, false);
@@ -257,16 +258,16 @@ describe("LocalWorkspace", () => {
         assert.strictEqual(upRes.summary.result, "succeeded");
 
         // pulumi preview
-        const preRes = await stack.preview();
+        const preRes = await stack.preview({ userAgent });
         assert.strictEqual(preRes.changeSummary.same, 1);
 
         // pulumi refresh
-        const refRes = await stack.refresh();
+        const refRes = await stack.refresh({ userAgent });
         assert.strictEqual(refRes.summary.kind, "refresh");
         assert.strictEqual(refRes.summary.result, "succeeded");
 
         // pulumi destroy
-        const destroyRes = await stack.destroy();
+        const destroyRes = await stack.destroy({ userAgent });
         assert.strictEqual(destroyRes.summary.kind, "destroy");
         assert.strictEqual(destroyRes.summary.result, "succeeded");
 


### PR DESCRIPTION
# Description

Adds CLI support, and automation API support for the nodejs and Go SDKs for specifying a user agent at update time. 

This user agent is stored with the update and can be displayed in various backends so that users can distinguish between human driven activity, CLI activity, and activity driven by automation like the Kubernetes Operator or the Pulumi GHA. 

Leaving this as a hidden flag in the CLI for now. We can eventually open and up, and add documentation so users can use this via the CLI but I will leave that as a later exercise. For now the current implementation with a hidden flag suits the desired use case. 

Contributes to https://github.com/pulumi/pulumi/issues/6503 for CLI, Go, and Node. Required for https://github.com/pulumi/home/issues/1375

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
Please label your PR with the change type. Relevant labels are:
- [kind/bug] if this is a bug fix (non-breaking change which fixes an issue)
- [kind/enhancement] if this is a new feature (non-breaking change which adds functionality)
- [impact/breaking] if this is a breaking change (fix or feature that would cause existing functionality to not work as expected)
-->
- [x] I have labelled my PR with the relevant change type
<!--- 
User-facing changes require a CHANGELOG entry. Please add the [impact/no-changelog-required] label if the checkbox below is to be left unchecked.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
