### PR TITLE
[kind/bug] [automation/go]: Look in workspace options for version optout

### DIFF
--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -579,7 +579,7 @@ func NewLocalWorkspace(ctx context.Context, opts ...LocalWorkspaceOption) (Works
 	}
 	l.pulumiVersion = v
 	optOut := os.Getenv(skipVersionCheckVar) != ""
-	if val, ok := l.GetEnvVars()[skipVersionCheckVar]; ok {
+	if val, ok := lwOpts.EnvVars[skipVersionCheckVar]; ok {
 		optOut = optOut || val != ""
 	}
 


### PR DESCRIPTION
# Description

When calling l.GetEnvVars() to evaluate whether version checking should be skipped because of variables passed into the workspace, they have not yet been set. This commit modifies the logic to look at the environment variables in the options instead of in the workspace.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

Test coverage is at the level of the function called currently.

- [ ] I have labelled my PR with the relevant change type

Labelling pull requests requires write access to the repository.

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Since the original functionality  has not yet been released, I do not believe it warrants a CHANGELOG entry.