### PR TITLE
Fix tests that used to be skipped on missing async lib

### DIFF
--- a/sdk/python/lib/test/provider/test_server.py
+++ b/sdk/python/lib/test/provider/test_server.py
@@ -14,34 +14,32 @@
 
 from typing import Dict, Any
 
+import os
 import pytest
 
-from pulumi.runtime.proto.provider_pb2 import ConstructRequest
 from pulumi.provider.server import ProviderServicer
 from pulumi.runtime import proto, rpc
+from pulumi.runtime.proto.provider_pb2 import ConstructRequest
 import google.protobuf.struct_pb2 as struct_pb2
+import pulumi.output
 
 
-@pytest.mark.asyncio
-async def test_construct_inputs_parses_request():
+def test_construct_inputs_parses_request():
     value = 'foobar'
     inputs = _as_struct({'echo': value})
     req = ConstructRequest(inputs=inputs)
     inputs = ProviderServicer._construct_inputs(req)
     assert len(inputs) == 1
-    fut_v = await inputs['echo'].future()
-    assert fut_v == value
+    assert inputs['echo'] == value
 
 
-@pytest.mark.asyncio
-async def test_construct_inputs_preserves_unknowns():
+def test_construct_inputs_preserves_unknowns():
     unknown = '04da6b54-80e4-46f7-96ec-b56ff0331ba9'
     inputs = _as_struct({'echo': unknown})
     req = ConstructRequest(inputs=inputs)
     inputs = ProviderServicer._construct_inputs(req)
     assert len(inputs) == 1
-    fut_v = await inputs['echo'].future()
-    assert fut_v is None
+    assert isinstance(inputs['echo'], pulumi.output.Unknown)
 
 
 def _as_struct(key_values: Dict[str, Any]) -> struct_pb2.Struct:


### PR DESCRIPTION
The test changed since it was broken; after changes the async modifier is not even needed. We did not detect test breakage before since it was not running as it was missing the extra async pytest dependency.

# Description

Fixes skipped/broken python unit test.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have labelled my PR with the relevant change type
- [x] I have updated the [CHANGELOG-PENDING]