### PR TITLE
[plugins] Allow opt out of loading plugins on PATH

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,6 +21,8 @@
 - [auto/go,nodejs] Add UserAgent to update/pre/refresh/destroy options.
   [#6935](https://github.com/pulumi/pulumi/pull/6935)
 
+- [plugins] - It is now possible to opt out of loading plugins present on PATH but not installed explicitly, by setting the `PULUMI_IGNORE_AMBIENT_PLUGINS` environment variable to any non-empty value.
+
 ### Bug Fixes
 
 - [cli] Return an appropriate error when a user has not set `PULUMI_CONFIG_PASSPHRASE` nor `PULUMI_CONFIG_PASSPHRASE_FILE`

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -580,13 +580,19 @@ func getPlugins(dir string) ([]PluginInfo, error) {
 
 // GetPluginPath finds a plugin's path by its kind, name, and optional version.  It will match the latest version that
 // is >= the version specified.  If no version is supplied, the latest plugin for that given kind/name pair is loaded,
-// using standard semver sorting rules.  A plugin may be overridden entirely by placing it on your $PATH.
+// using standard semver sorting rules.  A plugin may be overridden entirely by placing it on your $PATH, though it is
+// possible to opt out of this behavior by setting PULUMI_IGNORE_AMBIENT_PLUGINS to any non-empty value.
 func GetPluginPath(kind PluginKind, name string, version *semver.Version) (string, string, error) {
-	// If we have a version of the plugin on its $PATH, use it.  This supports development scenarios.
-	filename := (&PluginInfo{Kind: kind, Name: name, Version: version}).FilePrefix()
-	if path, err := exec.LookPath(filename); err == nil {
-		logging.V(6).Infof("GetPluginPath(%s, %s, %v): found on $PATH %s", kind, name, version, path)
-		return "", path, nil
+	var filename string
+
+	// If we have a version of the plugin on its $PATH, use it, unless we have opted out of this behavior explicitly.
+	// This supports development scenarios.
+	if os.Getenv("PULUMI_IGNORE_AMBIENT_PLUGINS") != "" {
+		filename = (&PluginInfo{Kind: kind, Name: name, Version: version}).FilePrefix()
+		if path, err := exec.LookPath(filename); err == nil {
+			logging.V(6).Infof("GetPluginPath(%s, %s, %v): found on $PATH %s", kind, name, version, path)
+			return "", path, nil
+		}
 	}
 
 	// At some point in the future, language plugins will be located in the plugin cache, just like regular plugins


### PR DESCRIPTION
# Description

This commit makes it possible to opt out of loading plugins from `PATH` by setting `PULUMI_IGNORE_AMBIENT_PLUGINS` to any non-empty value. This is useful when automatic IDE tooling may build remote component plugins into `GOBIN` unbeknownst to the user, and a resulting stale version of the plugin is loaded in place of newer versions - even those , explicitly installed.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

No existing test coverage of plugin loading as far as I can tell.

- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
