### PR TITLE
[sdk/python] Don't error when dict input value has a mismatched type

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -45,6 +45,9 @@
 - [sdk/python] Fix type-related regression on Python 3.6.
   [#6942](https://github.com/pulumi/pulumi/pull/6942)
 
+- [sdk/python] Don't error when a dict input value has a mismatched type annotation.
+  [#6949](https://github.com/pulumi/pulumi/pull/6949)
+
 ### Misc.
 
 - [auto/dotnet] Bump YamlDotNet to 11.1.1

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -300,7 +300,15 @@ async def serialize_property(value: 'Input[Any]',
                         get_type = lambda k: args[1]
                         translate = None
                 else:
-                    raise AssertionError(f"Unexpected type. Expected 'dict' got '{typ}'")
+                    translate = None
+                    # Note: Alternatively, we could assert here that we expected a dict type but got some other type,
+                    # but there are cases where we've historically allowed a user-defined dict value to be passed even
+                    # though the type annotation isn't a dict type (e.g. the `aws.s3.BucketPolicy.policy` input property
+                    # is currently typed as `pulumi.Input[str]`, but we've allowed a dict to be passed, which will
+                    # "magically" work at runtime because the provider will convert the dict value to a JSON string).
+                    # Ideally, we'd update the type annotations for such cases to reflect that a dict could be passed,
+                    # but we haven't done that yet and want these existing cases to continue to work as they have
+                    # before.
 
         obj = {}
         # Don't use value.items() here, as it will error in the case of outputs with an `items` property.

--- a/sdk/python/lib/test/langhost/input_type_mismatch/__init__.py
+++ b/sdk/python/lib/test/langhost/input_type_mismatch/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/input_type_mismatch/__main__.py
+++ b/sdk/python/lib/test/langhost/input_type_mismatch/__main__.py
@@ -1,0 +1,46 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pulumi
+
+@pulumi.input_type
+class MyResourceArgs:
+    def __init__(self, policy: pulumi.Input[str]):
+        pulumi.set(self, "policy", policy)
+
+    @property
+    @pulumi.getter
+    def policy(self) -> pulumi.Input[str]:
+        return pulumi.get(self, "policy")
+
+class MyResource(pulumi.CustomResource):
+    def __init__(self, name, args: MyResourceArgs):
+        super().__init__("test:index:MyResource", name, args)
+
+    @property
+    @pulumi.getter
+    def policy(self) -> pulumi.Output[str]:
+        return pulumi.get(self, "policy")
+
+r1 = MyResource("testResource", MyResourceArgs(policy='{"hello": "world"}'))
+
+# We have cases where an input is typed as `Input[str]` but passing a dict still works despite
+# the type annotation not saying that it accepts a dict (e.g. aws.s3.BucketPolicy.policy, which
+# is typed as `Input[str]` but passing a dict works because the provider will convert the dict
+# to a JSON string). We need to fix the type annotations in these cases, but in the meantime such
+# cases should continue to work as before without an error being raised by the SDK.
+r2 = MyResource("testResource", MyResourceArgs(policy={"hello": "world"}))
+
+pulumi.export("r1.policy", r1.policy)
+pulumi.export("r2.policy", r2.policy)

--- a/sdk/python/lib/test/langhost/input_type_mismatch/test_input_type_mismatch.py
+++ b/sdk/python/lib/test/langhost/input_type_mismatch/test_input_type_mismatch.py
@@ -1,0 +1,46 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from os import path
+from ..util import LanghostTest
+
+
+class InputTypeMismatchTest(LanghostTest):
+    def test_input_type_mismatch(self):
+        self.run_test(
+            program=path.join(self.base_path(), "input_type_mismatch"),
+            expected_resource_count=2)
+
+    def register_resource(self, ctx, dry_run, ty, name, _resource,
+                          _dependencies, _parent, _custom, _protect, _provider, _property_deps, _delete_before_replace,
+                          _ignore_changes, _version):
+        self.assertEqual("test:index:MyResource", ty)
+
+        policy = _resource["policy"]
+        if isinstance(policy, dict):
+            policy = json.dumps(policy)
+
+        return {
+            "urn": self.make_urn(ty, name),
+            "id": name,
+            "object": {"policy": policy},
+        }
+
+    def register_resource_outputs(self, _ctx, _dry_run, _urn, ty, _name, _resource, outputs):
+        self.assertEqual("pulumi:pulumi:Stack", ty)
+        self.assertEqual({
+            "r1.policy": '{"hello": "world"}',
+            "r2.policy": '{"hello": "world"}',
+        }, outputs)


### PR DESCRIPTION
Pulumi 3.0 raises an error when a dict value is passed as an input but the type annotation does not accept a dict. Unfortunately, this prevents historical cases where a dict value is allowed but the type annotation doesn't match. We need to fix the type annotations, but in the meantime, we should not raise an error in the SDK for such cases as it breaks existing programs.

Fixes #6818
Fixes https://github.com/pulumi/pulumi-kubernetes/issues/1541