### PR TITLE
[auto/dotnet] - plugin acquisition for inline programs

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
+Pulumi.Automation.PulumiFn.DiscoveryAssembly.get -> System.Reflection.Assembly
+Pulumi.Automation.PulumiFn.DiscoveryAssembly.set -> void
 abstract Pulumi.Automation.Workspace.GetStackOutputsAsync(string stackName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string, Pulumi.Automation.OutputValue>>
 override Pulumi.Automation.LocalWorkspace.GetStackOutputsAsync(string stackName, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.Collections.Immutable.ImmutableDictionary<string, Pulumi.Automation.OutputValue>>

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -724,6 +724,11 @@
             A Pulumi program as an inline function (in process).
             </summary>
         </member>
+        <member name="P:Pulumi.Automation.PulumiFn.DiscoveryAssembly">
+            <summary>
+            Get or set the assembly that will be used for required plugin discovery.
+            </summary>
+        </member>
         <member name="M:Pulumi.Automation.PulumiFn.Create(System.Func{System.Threading.CancellationToken,System.Threading.Tasks.Task{System.Collections.Generic.IDictionary{System.String,System.Object}}})">
             <summary>
             Creates an asynchronous inline (in process) pulumi program.

--- a/sdk/dotnet/Pulumi.Automation/PulumiFn.Inline.cs
+++ b/sdk/dotnet/Pulumi.Automation/PulumiFn.Inline.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
-
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,6 +16,7 @@ namespace Pulumi.Automation
         public PulumiFnInline(Func<CancellationToken, Task<IDictionary<string, object?>>> program)
         {
             this._program = program;
+            this.DiscoveryAssembly = Assembly.GetEntryAssembly();
         }
 
         internal override async Task<ExceptionDispatchInfo?> InvokeAsync(IRunner runner, CancellationToken cancellationToken)

--- a/sdk/dotnet/Pulumi.Automation/PulumiFn.TStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/PulumiFn.TStack.cs
@@ -15,6 +15,7 @@ namespace Pulumi.Automation
         public PulumiFn(Func<TStack> stackFactory)
         {
             this._stackFactory = stackFactory;
+            this.DiscoveryAssembly = typeof(TStack).Assembly;
         }
 
         internal override async Task<ExceptionDispatchInfo?> InvokeAsync(IRunner runner, CancellationToken cancellationToken)

--- a/sdk/dotnet/Pulumi.Automation/PulumiFn.cs
+++ b/sdk/dotnet/Pulumi.Automation/PulumiFn.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -14,6 +15,11 @@ namespace Pulumi.Automation
     /// </summary>
     public abstract class PulumiFn
     {
+        /// <summary>
+        /// Get or set the assembly that will be used for required plugin discovery.
+        /// </summary>
+        public Assembly? DiscoveryAssembly { get; set; }
+
         internal PulumiFn()
         {
         }

--- a/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
+++ b/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
@@ -33,7 +33,7 @@ namespace Pulumi.Automation
             if (assembly is null)
                 return response;
 
-            var pulumiAssemblyNames = assembly.GetReferencedAssemblies().Where(x => x.Name != null && x.Name.StartsWith("Pulumi.")).ToArray();
+            var pulumiAssemblyNames = assembly.GetReferencedAssemblies().Where(x => x.Name != null && x.Name.StartsWith("Pulumi.", StringComparison.Ordinal)).ToArray();
             foreach (var assemblyName in pulumiAssemblyNames)
             {
                 var pulumiAssembly = Assembly.Load(assemblyName);
@@ -43,7 +43,7 @@ namespace Pulumi.Automation
                 // instead of using the embedded version.txt resource
                 // pulumiAssembly.GetCustomAttribute<ResourcePluginAttribute>();
                 var resources = pulumiAssembly.GetManifestResourceNames();
-                var versionResource = resources.FirstOrDefault(x => x.EndsWith("version.txt"));
+                var versionResource = resources.FirstOrDefault(x => x.EndsWith("version.txt", StringComparison.Ordinal));
                 if (versionResource is null)
                 {
                     // no version.txt so is not resource plugin
@@ -61,7 +61,7 @@ namespace Pulumi.Automation
                 var versionText = await versionReader.ReadToEndAsync().ConfigureAwait(false);
 
                 // ToLower() everything after "Pulumi." to determine plugin name
-                var pluginName = assemblyName.Name!.Substring("Pulumi.".Length).ToLower();
+                var pluginName = assemblyName.Name!.Substring("Pulumi.".Length).ToLowerInvariant();
                 var version = versionText.Trim();
                 var parts = versionText.Split('\n', StringSplitOptions.RemoveEmptyEntries)
                     .Select(x => x.Trim())

--- a/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
+++ b/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
 using System;
-using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,10 +24,69 @@ namespace Pulumi.Automation
             this._callerContext = callerContext;
         }
 
-        public override Task<GetRequiredPluginsResponse> GetRequiredPlugins(GetRequiredPluginsRequest request, ServerCallContext context)
+        public override async Task<GetRequiredPluginsResponse> GetRequiredPlugins(GetRequiredPluginsRequest request, ServerCallContext context)
         {
             var response = new GetRequiredPluginsResponse();
-            return Task.FromResult(response);
+            var assembly = this._callerContext.Program.DiscoveryAssembly;
+
+            // if discovery assembly is null, assuming consumer installed plugins manually
+            if (assembly is null)
+                return response;
+
+            var pulumiAssemblyNames = assembly.GetReferencedAssemblies().Where(x => x.Name != null && x.Name.StartsWith("Pulumi.")).ToArray();
+            foreach (var assemblyName in pulumiAssemblyNames)
+            {
+                var pulumiAssembly = Assembly.Load(assemblyName);
+
+                // get version.txt
+                // this part would probably be less error prone if there was an assembly attribute available
+                // instead of using the embedded version.txt resource
+                // pulumiAssembly.GetCustomAttribute<ResourcePluginAttribute>();
+                var resources = pulumiAssembly.GetManifestResourceNames();
+                var versionResource = resources.FirstOrDefault(x => x.EndsWith("version.txt"));
+                if (versionResource is null)
+                {
+                    // no version.txt so is not resource plugin
+                    continue;
+                }
+
+                using var versionStream = pulumiAssembly.GetManifestResourceStream(versionResource);
+                if (versionStream is null)
+                {
+                    // we've already verified that version.txt should be present so throw here?
+                    throw new ApplicationException($"Unable to load version.txt from {assemblyName.FullName}");
+                }
+
+                var versionReader = new StreamReader(versionStream);
+                var versionText = await versionReader.ReadToEndAsync().ConfigureAwait(false);
+
+                // ToLower() everything after "Pulumi." to determine plugin name
+                var pluginName = assemblyName.Name!.Substring("Pulumi.".Length).ToLower();
+                var version = versionText.Trim();
+                var parts = versionText.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                    .Select(x => x.Trim())
+                    .ToArray();
+
+                // if version.txt is 2 lines than it is specifying plugin name explicitly
+                if (parts.Length is 2)
+                {
+                    pluginName = parts[0];
+                    version = parts[1];
+                }
+
+                // pre-pend 'v' if it isn't present on version string
+                if (!version.StartsWith('v'))
+                    version = $"v{version}";
+
+                response.Plugins.Add(new PluginDependency
+                {
+                    Name = pluginName,
+                    Version = version,
+                    Kind = "resource",
+                });
+            }
+
+            return response;
         }
 
         public override async Task<RunResponse> Run(RunRequest request, ServerCallContext context)


### PR DESCRIPTION
For the .NET portion of #5448

Looking for thoughts/criticism on this approach. I will do a review and leave some questions that I am looking for specific thoughts on.

Any suggestions on how we want to unit test this? Since it means manipulating the referenced assemblies for whatever we pass in to `DiscoveryAssembly` - so not sure how to best approach that. I was testing in a console app (lol) where I could reference and de-reference resource providers as I worked.

@EvanBoyle @komalali @t0yv0 any thoughts welcome :)
