### PR TITLE
Use local backend for concurrency test

### DIFF
--- a/sdk/nodejs/tests/automation/data/tcfg/Pulumi.yaml
+++ b/sdk/nodejs/tests/automation/data/tcfg/Pulumi.yaml
@@ -1,3 +1,4 @@
-name: tcfg
+name: concurrent-config
 runtime: nodejs
-description: A minimal TypeScript Pulumi program
+backend:
+  url: 'file://~'

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -458,7 +458,17 @@ describe("LocalWorkspace", () => {
         const dones = [];
         const stacks = [ "dev", "dev2", "dev3", "dev4", "dev5" ];
         const workDir = upath.joinSafe(__dirname, "data", "tcfg");
-        const ws = await LocalWorkspace.create({ workDir });
+        const ws = await LocalWorkspace.create({
+            workDir,
+            projectSettings: {
+                name: "concurrent-config",
+                runtime: "nodejs",
+                backend: { url: "file://~" },
+            },
+            envVars: {
+                "PULUMI_CONFIG_PASSPHRASE": "test",
+            },
+        });
         for (let i = 0; i < stacks.length; i++) {
             const x = i;
             const s = stacks[i];


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes a flakey test by using a local file backend to avoid interop in the service.

Fixes https://github.com/pulumi/pulumi/issues/6945

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
