### PR TITLE
Ensure ResourceReference is included in printPropertyValue

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -26,6 +26,9 @@
 - [cli] Return an appropriate error when a user has not set `PULUMI_CONFIG_PASSPHRASE` nor `PULUMI_CONFIG_PASSPHRASE_FILE`
   when trying to access the Passphrase Secrets Manager
   [#6893](https://github.com/pulumi/pulumi/pull/6893)
+  
+- [cli] Prevent against panic when using a ResourceReference as a program output
+  [#6962](https://github.com/pulumi/pulumi/pull/6962)
 
 - [sdk/python] - Fix bug in MockResourceArgs.
   [#6863](https://github.com/pulumi/pulumi/pull/6863)

--- a/pkg/engine/diff.go
+++ b/pkg/engine/diff.go
@@ -232,6 +232,18 @@ func PrintObject(
 	}
 }
 
+func PrintResourceReference(
+	b *bytes.Buffer, resRef resource.ResourceReference, planning bool,
+	indent int, op deploy.StepOp, prefix bool, debug bool) {
+
+	printPropertyTitle(b, "URN", 3, indent, op, prefix)
+	write(b, op, "%q\n", resRef.URN)
+	printPropertyTitle(b, "ID", 3, indent, op, prefix)
+	printPropertyValue(b, resRef.ID, planning, indent, op, prefix, debug)
+	printPropertyTitle(b, "PackageVersion", 3, indent, op, prefix)
+	write(b, op, "%q\n", resRef.PackageVersion)
+}
+
 func massageStackPreviewAdd(p resource.PropertyValue) resource.PropertyValue {
 	switch {
 	case p.IsArray():
@@ -453,9 +465,10 @@ func printPropertyValue(
 	b *bytes.Buffer, v resource.PropertyValue, planning bool,
 	indent int, op deploy.StepOp, prefix bool, debug bool) {
 
-	if isPrimitive(v) {
+	switch {
+	case isPrimitive(v) || v.IsSecret():
 		printPrimitivePropertyValue(b, v, planning, op)
-	} else if v.IsArray() {
+	case v.IsArray():
 		arr := v.ArrayValue()
 		if len(arr) == 0 {
 			writeVerbatim(b, op, "[]")
@@ -467,7 +480,7 @@ func printPropertyValue(
 			}
 			writeWithIndentNoPrefix(b, indent, op, "]")
 		}
-	} else if v.IsAsset() {
+	case v.IsAsset():
 		a := v.AssetValue()
 		if a.IsText() {
 			write(b, op, "asset(text:%s) {\n", shortHash(a.Hash))
@@ -488,7 +501,7 @@ func printPropertyValue(
 			contract.Assert(a.IsURI())
 			write(b, op, "asset(uri:%s) { %s }", shortHash(a.Hash), a.URI)
 		}
-	} else if v.IsArchive() {
+	case v.IsArchive():
 		a := v.ArchiveValue()
 		if assets, has := a.GetAssets(); has {
 			write(b, op, "archive(assets:%s) {\n", shortHash(a.Hash))
@@ -507,8 +520,7 @@ func printPropertyValue(
 			contract.Assert(a.IsURI())
 			write(b, op, "archive(uri:%s) { %v }", shortHash(a.Hash), a.URI)
 		}
-	} else {
-		contract.Assert(v.IsObject())
+	case v.IsObject():
 		obj := v.ObjectValue()
 		if len(obj) == 0 {
 			writeVerbatim(b, op, "{}")
@@ -517,6 +529,13 @@ func printPropertyValue(
 			PrintObject(b, obj, planning, indent+1, op, prefix, debug)
 			writeWithIndentNoPrefix(b, indent, op, "}")
 		}
+	case v.IsResourceReference():
+		resRef := v.ResourceReferenceValue()
+		writeVerbatim(b, op, "{\n")
+		PrintResourceReference(b, resRef, planning, indent+1, op, prefix, debug)
+		writeWithIndentNoPrefix(b, indent, op, "}")
+	default:
+		contract.Failf("Unknown PropertyValue type %v", v)
 	}
 	writeVerbatim(b, op, "\n")
 }
@@ -710,7 +729,7 @@ func printPrimitivePropertyValue(b io.StringWriter, v resource.PropertyValue, pl
 			write(b, op, "undefined")
 		}
 	} else {
-		contract.Failf("Unexpected property value kind")
+		contract.Failf("Unexpected property value kind '%v'", v)
 	}
 }
 


### PR DESCRIPTION
Fixes: #6934

With this snippet of code:

```
func main() {
	pulumi.Run(func(ctx *pulumi.Context) error {
		// Create an AWS resource (S3 Bucket)
		vpc, err := ec2.NewVpc(ctx, "main", &ec2.VpcArgs{
			CidrBlock: pulumi.String("10.0.0.0/16"),
		})
		if err != nil {
			return err
		}

		rt, err := ec2.NewRouteTable(ctx, "example", &ec2.RouteTableArgs{
			VpcId: vpc.ID(),
		})

		// Export the name of the bucket
		ctx.Export("rt", rt)
		return nil
	})
}
```

the CLI would panic on the diff as follows:

```
panic: fatal: An assertion has failed

goroutine 249 [running]:
github.com/pulumi/pulumi/sdk/v3/go/common/util/contract.failfast(...)
	/private/tmp/pulumi-20210422-70582-1bpvlru/sdk/go/common/util/contract/failfast.go:23
github.com/pulumi/pulumi/sdk/v3/go/common/util/contract.Assert(...)
	/private/tmp/pulumi-20210422-70582-1bpvlru/sdk/go/common/util/contract/assert.go:26
github.com/pulumi/pulumi/pkg/v3/engine.printPropertyValue(0xc0005d41b0, 0x57cce00, 0xc001da9050, 0x0, 0x1, 0x5932853, 0x4, 0x0)
	/private/tmp/pulumi-20210422-70582-1bpvlru/pkg/engine/diff.go:511 +0x1485
```

This was due to the entire object being added to the output and
the property being a ResourceReference

On the changing of the code to use a switch statement, we can
now include the ResourceReference and ensure that we catch any
missing case statements with a panic as default

This means the same piece of code now outputs to the CLI as
follows:

```
Outputs:
    rt: {
        URN: "urn:pulumi:dev::testing-new-engine-diff::aws:ec2/routeTable:RouteTable::example"
        ID : "rtb-09b37608ec34f3b49"
        PackageVersion: ""
    }

Resources:
    3 unchanged

Duration: 2s
```