### PR TITLE
[cli] Prevent regression in loading passphrase secrets provider from state

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,3 +6,6 @@
   
 ### Bug Fixes
 
+- [cli] Fix a regression caused by [#6893](https://github.com/pulumi/pulumi/pull/6893) that stopped stacks created
+  with empty passphrases from completing successful pulumi commands when loading the passphrase secrets provider.
+  [#6976](https://github.com/pulumi/pulumi/pull/6976)


### PR DESCRIPTION
Fixes: #6974

Passphrase Environment variables were set before loading the
secrets provider from state

Unfortunately, it seems that some users are using empty passphrases
and thus this newly introduced logic has broken their usecases

We now check that the environment variables are set - it doesn't
matter if they are set as empty, but the existance of an empty
environment variabe still suggests that it is an intentional
empty passphrase