### PR TITLE
Fix flaky test that fails on unrelated PRs

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1067,7 +1067,8 @@ namespace Pulumi.Automation.Tests
             {
                 WorkDir = workingDir
             });
-            var stackName = "teststack";
+            var stackName = $"{RandomStackName()}";
+
             var stack = await WorkspaceStack.CreateAsync(stackName, workspace);
             try
             {


### PR DESCRIPTION
# Description

Flaky test fix. Sometimes failing "Stack already exists".
