### PR TITLE
Relax readonly requirement for generated nodejs resource args

### DIFF
--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/argFunction.ts
@@ -22,7 +22,7 @@ export function argFunction(args?: ArgFunctionArgs, opts?: pulumi.InvokeOptions)
 }
 
 export interface ArgFunctionArgs {
-    readonly name?: random.RandomPet;
+    name?: random.RandomPet;
 }
 
 export interface ArgFunctionResult {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/cat.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/cat.ts
@@ -64,6 +64,6 @@ export class Cat extends pulumi.CustomResource {
  * The set of arguments for constructing a Cat resource.
  */
 export interface CatArgs {
-    readonly age?: pulumi.Input<number>;
-    readonly pet?: pulumi.Input<inputs.PetArgs>;
+    age?: pulumi.Input<number>;
+    pet?: pulumi.Input<inputs.PetArgs>;
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/component.ts
@@ -69,5 +69,5 @@ export class Component extends pulumi.CustomResource {
  * The set of arguments for constructing a Component resource.
  */
 export interface ComponentArgs {
-    readonly metadata?: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>;
+    metadata?: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/nursery.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/nursery.ts
@@ -65,9 +65,9 @@ export interface NurseryArgs {
     /**
      * The sizes of trees available
      */
-    readonly sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>}>;
+    sizes?: pulumi.Input<{[key: string]: pulumi.Input<enums.tree.v1.TreeSize>}>;
     /**
      * The varieties available
      */
-    readonly varieties: pulumi.Input<pulumi.Input<enums.tree.v1.RubberTreeVariety>[]>;
+    varieties: pulumi.Input<pulumi.Input<enums.tree.v1.RubberTreeVariety>[]>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
@@ -75,7 +75,7 @@ export class RubberTree extends pulumi.CustomResource {
 }
 
 export interface RubberTreeState {
-    readonly farm?: pulumi.Input<enums.tree.v1.Farm | string>;
+    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
 }
 
 /**

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/nodejs/tree/v1/rubberTree.ts
@@ -82,9 +82,9 @@ export interface RubberTreeState {
  * The set of arguments for constructing a RubberTree resource.
  */
 export interface RubberTreeArgs {
-    readonly container?: pulumi.Input<inputs.ContainerArgs>;
-    readonly diameter: pulumi.Input<enums.tree.v1.Diameter>;
-    readonly farm?: pulumi.Input<enums.tree.v1.Farm | string>;
-    readonly size?: pulumi.Input<enums.tree.v1.TreeSize>;
-    readonly type: pulumi.Input<enums.tree.v1.RubberTreeVariety>;
+    container?: pulumi.Input<inputs.ContainerArgs>;
+    diameter: pulumi.Input<enums.tree.v1.Diameter>;
+    farm?: pulumi.Input<enums.tree.v1.Farm | string>;
+    size?: pulumi.Input<enums.tree.v1.TreeSize>;
+    type: pulumi.Input<enums.tree.v1.RubberTreeVariety>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
@@ -81,13 +81,13 @@ export class Component extends pulumi.ComponentResource {
  * The set of arguments for constructing a Component resource.
  */
 export interface ComponentArgs {
-    readonly a: boolean;
-    readonly b?: boolean;
-    readonly bar?: inputs.Foo;
-    readonly baz?: inputs.Foo[];
-    readonly c: number;
-    readonly d?: number;
-    readonly e: string;
-    readonly f?: string;
-    readonly foo?: pulumi.Input<inputs.FooArgs>;
+    a: boolean;
+    b?: boolean;
+    bar?: inputs.Foo;
+    baz?: inputs.Foo[];
+    c: number;
+    d?: number;
+    e: string;
+    f?: string;
+    foo?: pulumi.Input<inputs.FooArgs>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/argFunction.ts
@@ -22,7 +22,7 @@ export function argFunction(args?: ArgFunctionArgs, opts?: pulumi.InvokeOptions)
 }
 
 export interface ArgFunctionArgs {
-    readonly arg1?: Resource;
+    arg1?: Resource;
 }
 
 export interface ArgFunctionResult {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/otherResource.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/otherResource.ts
@@ -49,5 +49,5 @@ export class OtherResource extends pulumi.ComponentResource {
  * The set of arguments for constructing a OtherResource resource.
  */
 export interface OtherResourceArgs {
-    readonly foo?: pulumi.Input<Resource>;
+    foo?: pulumi.Input<Resource>;
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/resource.ts
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/nodejs/resource.ts
@@ -59,5 +59,5 @@ export class Resource extends pulumi.CustomResource {
  * The set of arguments for constructing a Resource resource.
  */
 export interface ResourceArgs {
-    readonly bar?: pulumi.Input<string>;
+    bar?: pulumi.Input<string>;
 }

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -716,7 +716,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	// Emit the state type for get methods.
 	if r.StateInputs != nil {
 		fmt.Fprintf(w, "\n")
-		mod.genPlainType(w, stateType, r.StateInputs.Comment, r.StateInputs.Properties, true, true, true, 0)
+		mod.genPlainType(w, stateType, r.StateInputs.Comment, r.StateInputs.Properties, true, true, false, 0)
 	}
 
 	// Emit the argument type for construction.

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -722,7 +722,7 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 	// Emit the argument type for construction.
 	fmt.Fprintf(w, "\n")
 	argsComment := fmt.Sprintf("The set of arguments for constructing a %s resource.", name)
-	mod.genPlainType(w, argsType, argsComment, r.InputProperties, true, true, true, 0)
+	mod.genPlainType(w, argsType, argsComment, r.InputProperties, true, true, false, 0)
 
 	return nil
 }
@@ -793,7 +793,7 @@ func (mod *modContext) genFunction(w io.Writer, fun *schema.Function) {
 	// If there are argument and/or return types, emit them.
 	if fun.Inputs != nil {
 		fmt.Fprintf(w, "\n")
-		mod.genPlainType(w, title(name)+"Args", fun.Inputs.Comment, fun.Inputs.Properties, true, false, true, 0)
+		mod.genPlainType(w, title(name)+"Args", fun.Inputs.Comment, fun.Inputs.Properties, true, false, false, 0)
 	}
 	if fun.Outputs != nil {
 		fmt.Fprintf(w, "\n")


### PR DESCRIPTION
# Description

This change removes the `readonly` requirement for nodejs resource and function input args. The readonly requirement makes it unnecessarily difficult to do simple things like conditional argument construction:

```ts
let args: ResourceArgs = { someProp: "someValue" }
if (something) {
  args.someOtherProp = "someOtherValue"
}
```

I can't think of any way that this would impact or break users. Just seems like we're being overly-conservative here.

Fixes https://github.com/pulumi/pulumi/issues/6106

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

(no changelog as this shouldn't impact users at all)