### PR TITLE
Fix noisy nodejs runtime errors

### DIFF
--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -120,7 +120,7 @@ export function getResource(res: Resource, props: Inputs, custom: boolean, urn: 
         // Now run the operation, serializing the invocation if necessary.
         const opLabel = `monitor.getResource(${label})`;
         runAsyncResourceOp(opLabel, async () => {
-            let resp: any;
+            let resp: any = {};
             let err: Error | undefined;
             try {
                 if (monitor) {
@@ -226,7 +226,7 @@ export function readResource(res: Resource, t: string, name: string, props: Inpu
         // Now run the operation, serializing the invocation if necessary.
         const opLabel = `monitor.readResource(${label})`;
         runAsyncResourceOp(opLabel, async () => {
-            let resp: any;
+            let resp: any = {};
             let err: Error | undefined;
             try {
                 if (monitor) {
@@ -340,7 +340,7 @@ export function registerResource(res: Resource, t: string, name: string, custom:
         // Now run the operation, serializing the invocation if necessary.
         const opLabel = `monitor.registerResource(${label})`;
         runAsyncResourceOp(opLabel, async () => {
-            let resp: any;
+            let resp: any = {};
             let err: Error | undefined;
             try {
                 if (monitor) {


### PR DESCRIPTION


# Description

This change dedupes errors from two of the uncaught handlers in the nodejs runtime by consolidating the error cache from two handlers. In addition it fixes a null ref that occurs on registerResource rejection.

Fixes # https://github.com/pulumi/pulumi/issues/6992

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

I don't have any tests here. We don't have good test coverage in this area, and it would be fairly difficult to add. I manually verified that the 100+ line trace in the original issue is reduced down to the minimal set of information:

```
Diagnostics:
  pulumi:pulumi:Stack (astro-ts-localDemo):
    error: Error: this is intentional
        at /Users/evanboyle/.pulumi/plugins/resource-astro-containerApp-v0.0.1/node_modules/@pulumi/index.ts:99:19
        at /Users/evanboyle/.pulumi/plugins/resource-astro-containerApp-v0.0.1/node_modules/@pulumi/pulumi/output.js:250:35
        at Generator.next (<anonymous>)
        at /Users/evanboyle/.pulumi/plugins/resource-astro-containerApp-v0.0.1/node_modules/@pulumi/pulumi/output.js:21:71
        at new Promise (<anonymous>)
        at __awaiter (/Users/evanboyle/.pulumi/plugins/resource-astro-containerApp-v0.0.1/node_modules/@pulumi/pulumi/output.js:17:12)
        at applyHelperAsync (/Users/evanboyle/.pulumi/plugins/resource-astro-containerApp-v0.0.1/node_modules/@pulumi/pulumi/output.js:229:12)
        at /Users/evanboyle/.pulumi/plugins/resource-astro-containerApp-v0.0.1/node_modules/@pulumi/pulumi/output.js:183:65
        at processTicksAndRejections (node:internal/process/task_queues:94:5)
 
    Error: failed to register new resource api [astro-containerApp:index:ContainerApp]: Resource monitor is terminating
        at Object.registerResource (/opt/pulumi/node_modules/@pulumi/pulumi/runtime/resource.js:219:27)
        at new Resource (/opt/pulumi/node_modules/@pulumi/pulumi/resource.js:215:24)
        at new ComponentResource (/opt/pulumi/node_modules/@pulumi/pulumi/resource.js:386:9)
        at new ContainerApp (/Users/evanboyle/go/src/github.com/pulumi/astro/components/astro-containerApp/sdk/nodejs/containerApp.ts:80:9)
        at Object.<anonymous> (/Users/evanboyle/go/src/github.com/pulumi/astro/examples/todo-ts/pulumi/index.ts:10:13)
        at Module._compile (node:internal/modules/cjs/loader:1092:14)
        at Module.m._compile (/opt/pulumi/node_modules/@pulumi/pulumi/node_modules/ts-node/src/index.ts:439:23)
        at Module._extensions..js (node:internal/modules/cjs/loader:1121:10)
        at Object.require.extensions.<computed> [as .ts] (/opt/pulumi/node_modules/@pulumi/pulumi/node_modules/ts-node/src/index.ts:442:12)
        at Module.load (node:internal/modules/cjs/loader:972:32)
 
Resources:
    3 unchanged

Duration: 9s
```

There is probably more work to be done here. We have multiple uncaught handlers which doesn't feel quite right. My understanding of best practice here is to terminate execution as soon as an uncaught error handler is reached... But rearchitecting this approach safely is probably more than an afternoon's worth of work. 