### PR TITLE
[auto/dotnet] - disable language server host logging and appsettings.json check

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,7 +13,7 @@
 ### Bug Fixes
 
  - [auto/dotnet] - Disable Language Server Host logging and checking appsettings.json config
-   [#6023](https://github.com/pulumi/pulumi/pull/7023)
+   [#7023](https://github.com/pulumi/pulumi/pull/7023)
 
  - [auto/python] - Export missing `ProjectBackend` type
    [#6984](https://github.com/pulumi/pulumi/pull/6984)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,9 @@
   
 ### Bug Fixes
 
+ - [auto/dotnet] - Disable Language Server Host logging and checking appsettings.json config
+   [#6023](https://github.com/pulumi/pulumi/pull/7023)
+
  - [auto/python] - Export missing `ProjectBackend` type
    [#6984](https://github.com/pulumi/pulumi/pull/6984)
 

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Pulumi.Automation.Commands;
 using Pulumi.Automation.Commands.Exceptions;
 using Pulumi.Automation.Events;
@@ -658,18 +659,23 @@ namespace Pulumi.Automation
                     .ConfigureWebHostDefaults(webBuilder =>
                     {
                         webBuilder
-                            .ConfigureAppConfiguration((context, config) =>
-                            {
-                                // clear so we don't read appsettings.json
-                                // note that we also won't read environment variables for config
-                                config.Sources.Clear();
-                            })
                             .ConfigureKestrel(kestrelOptions =>
                             {
                                 kestrelOptions.Listen(IPAddress.Any, 0, listenOptions =>
                                 {
                                     listenOptions.Protocols = HttpProtocols.Http2;
                                 });
+                            })
+                            .ConfigureAppConfiguration((context, config) =>
+                            {
+                                // clear so we don't read appsettings.json
+                                // note that we also won't read environment variables for config
+                                config.Sources.Clear();
+                            })
+                            .ConfigureLogging(loggingBuilder =>
+                            {
+                                // disable default logging
+                                loggingBuilder.ClearProviders();
                             })
                             .ConfigureServices(services =>
                             {

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -658,6 +658,12 @@ namespace Pulumi.Automation
                     .ConfigureWebHostDefaults(webBuilder =>
                     {
                         webBuilder
+                            .ConfigureAppConfiguration((context, config) =>
+                            {
+                                // clear so we don't read appsettings.json
+                                // note that we also won't read environment variables for config
+                                config.Sources.Clear();
+                            })
                             .ConfigureKestrel(kestrelOptions =>
                             {
                                 kestrelOptions.Listen(IPAddress.Any, 0, listenOptions =>
@@ -667,8 +673,6 @@ namespace Pulumi.Automation
                             })
                             .ConfigureServices(services =>
                             {
-                                services.AddLogging();
-
                                 // to be injected into LanguageRuntimeService
                                 var callerContext = new LanguageRuntimeService.CallerContext(program, cancellationToken);
                                 services.AddSingleton(callerContext);


### PR DESCRIPTION
## Description

This is a nuclear option for the issue of the internal language server web host:
1. Reading `appsettings.json` and causing collision issues if referenced by an ASPNET API
2. Logging ASPNET logs

If we want to include some configuration of the internal web host, such as environment variables, or if we want to conditionally enable the logging or something, we can do that.

Fixes #7020 #6780
