### PR TITLE
Move comment in python SDK

### DIFF
--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -324,10 +324,10 @@ class Output(Generic[T]):
         is_secret.set_result(True)
         return Output(o._resources, o._future, o._is_known, is_secret)
 
-    @overload
-    @staticmethod
     # According to mypy these overloads unsafely overlap, so we ignore the type check.
     # https://mypy.readthedocs.io/en/stable/more_types.html#type-checking-the-variants:~:text=considered%20unsafely%20overlapping
+    @overload
+    @staticmethod
     def all(*args: Input[T]) -> 'Output[List[T]]':  # type: ignore
         ...
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

For some reason, when using the pulumi docker image, `mypy` doesn't like that there is a comment between the overload decorator and the function and throws this error:

```
LINT:
MYPYPATH=./stubs pipenv run mypy ./lib/pulumi --config-file=mypy.ini
lib/pulumi/output.py:329: error: Overloaded function signatures 1 and 2 overlap with incompatible return types
Found 1 error in 1 file (checked 63 source files)
Makefile:30: recipe for target 'lint' failed
make: *** [lint] Error 1
```

@gitfool noticed this when using a devcontainer https://github.com/pulumi/pulumi/issues/6952#issuecomment-839271952

After the change, there is no error:
```
LINT:
MYPYPATH=./stubs pipenv run mypy ./lib/pulumi --config-file=mypy.ini
Success: no issues found in 63 source files
pipenv run pylint ./lib/pulumi --rcfile=.pylintrc

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```