### PR TITLE
Create stacks serially before setting config concurrently

### DIFF
--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -478,12 +478,14 @@ describe("LocalWorkspace", () => {
             },
         });
         for (let i = 0; i < stacks.length; i++) {
+            await Stack.create(stacks[i], ws);
+        }
+        for (let i = 0; i < stacks.length; i++) {
             const x = i;
             const s = stacks[i];
             dones.push((async () => {
-                const stack = await Stack.createOrSelect(s, ws);
                 for (let j = 0; j < 20; j++) {
-                    await stack.setConfig("var-" + j, { value: ((x*20)+j).toString() });
+                    await ws.setConfig(s, "var-" + j, { value: ((x*20)+j).toString()});
                 }
             })());
         }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The test in question was running `Stack.createOrSelect` concurrently which modifies global state by setting each stack [as current](https://github.com/pulumi/pulumi/blob/73a66f48ead301bacf1d7d2833c016cf803b57c1/pkg/cmd/pulumi/stack_init.go#L120) which can cause issues. This PR moves the stack creation out of the promise and sets config via the `ws` to avoid the global state corruption cause by `createStack` and `selectStack`.

Fixes https://github.com/pulumi/pulumi/issues/7026

If the test stops being flakey this PR has been successful. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
