### PR TITLE
[auto/nodejs] - Reimplement JSON event parsing with Readline

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,5 +11,8 @@
 
 ### Bug Fixes
 
-- [auto/dotnet] Fix deserialization of CancelEvent in .NET 5
+- [auto/nodejs] - Fix an intermittent bug in parsing JSON events 
+  [#7032](https://github.com/pulumi/pulumi/pull/7032) 
+
+- [auto/dotnet] - Fix deserialization of CancelEvent in .NET 5
   [#7051](https://github.com/pulumi/pulumi/pull/7051)

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -794,7 +794,8 @@ const cleanUp = async (tail?: TailFile, logFile?: string) => {
     if (tail) {
         await tail.quit();
     }
-    if (logFile) {
-        fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
-    }
+    // TODO: Undo this. Not deleting the logfile for debugging purposes.
+    // if (logFile) {
+    //     fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
+    // }
 };

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -111,8 +111,7 @@ export class Stack {
         }
     }
     private async readLines(logPath: string, callback: (event: EngineEvent) => void): Promise<TailFile> {
-        const eventLogTail = new TailFile(logPath, { startPos: 0 });
-        await eventLogTail.start();
+        const eventLogTail = new TailFile(logPath, { startPos: 0, pollFileIntervalMs: 200 });
         eventLogTail
             .on("tail_error", (err) => {
                 throw err;
@@ -128,6 +127,7 @@ export class Stack {
                 }
                 callback(event);
             });
+        await eventLogTail.start();
 
         return eventLogTail;
     }

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -21,6 +21,7 @@ import * as grpc from "@grpc/grpc-js";
 import * as TailFile from "@logdna/tail-file";
 import * as split2 from "split2";
 
+import * as log from "../log";
 import { CommandResult, runPulumiCmd } from "./cmd";
 import { ConfigMap, ConfigValue } from "./config";
 import { StackAlreadyExistsError } from "./errors";
@@ -118,7 +119,13 @@ export class Stack {
             })
             .pipe(split2())
             .on("data", (line: string) => {
-                const event: EngineEvent = JSON.parse(line);
+                let event: EngineEvent;
+                try {
+                    event = JSON.parse(line);
+                } catch (e) {
+                    log.info(`failed to parse engine event\nevent: ${line}\n${e.toString()}`);
+                    return;
+                }
                 callback(event);
             });
 

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -123,7 +123,7 @@ export class Stack {
                 try {
                     event = JSON.parse(line);
                 } catch (e) {
-                    log.info(`failed to parse engine event\nevent: ${line}\n${e.toString()}`);
+                    log.info(`failed to parse engine event\nlogfile: ${logPath}\nevent: ${line}\n${e.toString()}`);
                     return;
                 }
                 callback(event);

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { read } from "fs";
 import * as fs from "fs";
 import * as os from "os";
+import * as path from "path";
 import * as readline from "readline";
 import * as upath from "upath";
 
@@ -127,8 +127,8 @@ export class Stack {
             try {
                 event = JSON.parse(line);
             } catch (e) {
-                log.info(`failed to parse engine event\nlogfile: ${logPath}\nevent: ${line}\n${e.toString()}`);
-                return;
+                log.error(`failed to parse engine event\nevent: ${line}\n${e.toString()}`);
+                throw e;
             }
             callback(event);
         });
@@ -799,11 +799,13 @@ const createLogFile = (command: string) => {
 
 const cleanUp = async (logFile?: string, rl?: ReadlineResult) => {
     if (rl) {
+        // stop tailing
         await rl.tail.quit();
+        // close the readline interface
         rl.rl.close();
     }
-    // TODO: Undo this. Not deleting the logfile for debugging purposes.
-    // if (logFile) {
-    //     fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
-    // }
+    if (logFile) {
+        // remove the logfile
+        fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
+    }
 };

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -21,7 +21,6 @@
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",
         "source-map-support": "^0.4.16",
-        "split2": "^3.2.2",
         "ts-node": "^7.0.1",
         "typescript": "~3.7.3",
         "upath": "^1.1.0"


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
A few users have reported a failure when running `Stack.preview()` due to JSON failing to parse. Unfortunately, the error message wasn't really telling us what the actual issue was, but we were able to get some more details by adding debugging logging and getting some help from users.

I traced this issue back to the split2 library, where incomplete lines might be dropped. This could happen if the logfile is polled when a message is being written, resulting in a half-formed JSON line. I've replaced it using [Readline](https://nodejs.org/docs/latest-v14.x/api/readline.html#readline_readline). I've also added additional error logging in case we see these errors again.

Fixes: https://github.com/pulumi/pulumi/issues/6768

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

This error is difficult to test as it is intermittent, but the existing tests for parsing events continue to succeed. We'll keep an eye on this to see if we see any more reports.