### PR TITLE
Checkout for command dispatch events was using master

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -10,6 +10,7 @@ env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PULUMI_TEST_OWNER: "moolumi"
+  PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
 
 jobs:
   comment-notification:
@@ -40,6 +41,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
       - name: Lint ${{ matrix.directory }}
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
@@ -75,6 +78,8 @@ jobs:
           echo "${{ runner.temp }}/opt/pulumi/bin" >> $GITHUB_PATH
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
@@ -137,6 +142,8 @@ jobs:
           echo "${{ runner.temp }}/opt/pulumi/bin" >> $GITHUB_PATH
       - name: Checkout Repo
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
@@ -220,6 +227,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./src/github.com/${{ github.repository }}
+          ref: ${{ env.PR_COMMIT_SHA }}
       - name: Fetch Tags
         run: |
           cd ./src/github.com/${{ github.repository }} && git fetch --quiet --prune --unshallow --tags


### PR DESCRIPTION
We should ensure that when a command dispatch event comes from a
user contribution, that we are running CI against their code