### PR TITLE
[auto/dotnet] Fix deserialization of CancelEvent in .NET 5

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,9 @@
 - [auto/dotnet] - Disable Language Server Host logging and checking appsettings.json config
   [#7023](https://github.com/pulumi/pulumi/pull/7023)
 
+- [auto/dotnet] Fix deserialization of CancelEvent in .NET 5
+  [#7051](https://github.com/pulumi/pulumi/pull/7051)
+
 - [auto/python] - Export missing `ProjectBackend` type
   [#6984](https://github.com/pulumi/pulumi/pull/6984)
 

--- a/sdk/dotnet/Pulumi.Automation/Serialization/CancelEventModel.cs
+++ b/sdk/dotnet/Pulumi.Automation/Serialization/CancelEventModel.cs
@@ -1,0 +1,15 @@
+// Copyright 2016-2021, Pulumi Corporation
+
+using Pulumi.Automation.Events;
+using Pulumi.Automation.Serialization.Json;
+
+// NOTE: The classes in this file are intended to align with the serialized
+// JSON types defined and versioned in sdk/go/common/apitype/events.go
+namespace Pulumi.Automation.Serialization
+{
+    internal class CancelEventModel : IJsonModel<CancelEvent>
+    {
+        public CancelEvent Convert()
+            => new CancelEvent();
+    }
+}

--- a/sdk/dotnet/Pulumi.Automation/Serialization/EngineEventModel.cs
+++ b/sdk/dotnet/Pulumi.Automation/Serialization/EngineEventModel.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Automation.Serialization
 
         public int Timestamp { get; set; }
 
-        public CancelEvent? CancelEvent { get; set; }
+        public CancelEventModel? CancelEvent { get; set; }
         public StandardOutputEngineEventModel? StdoutEvent { get; set; }
         public DiagnosticEventModel? DiagnosticEvent { get; set; }
         public PreludeEventModel? PreludeEvent { get; set; }
@@ -27,7 +27,7 @@ namespace Pulumi.Automation.Serialization
             new EngineEvent(
                 this.Sequence,
                 this.Timestamp,
-                this.CancelEvent,
+                this.CancelEvent?.Convert(),
                 this.StdoutEvent?.Convert(),
                 this.DiagnosticEvent?.Convert(),
                 this.PreludeEvent?.Convert(),


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #7047 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works

Unfortunately the problem only happens when using .NET 5 so writing a suitable test currently is not possible afaik. I verified the change locally by using a minimal .NET 5 program and then calling `PreviewAsync` with the provided `OnEvent`-callback. Without the change the same error occurs as described in #7047. With the change the deserialization works as expected.

<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
