### PR TITLE
[cli] Provide user feedback when protected resources can't be deleted

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,6 +2,9 @@
 
 ### Improvements
 
+- [cli] - Provide user information when protected resources are not able to be deleted
+  [#7055](https://github.com/pulumi/pulumi/pull/7055)
+
 - [auto/dotnet] - Provide PulumiFn implementation that allows runtime stack type
   [#6910](https://github.com/pulumi/pulumi/pull/6910)
 

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -326,7 +326,10 @@ func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	// Refuse to delete protected resources.
 	if s.old.Protect {
 		return resource.StatusOK, nil,
-			errors.Errorf("refusing to delete protected resource '%s'", s.old.URN)
+			errors.Errorf("unable to delete resource %q\n"+
+				"as it is currently marked for protection. To unprotect the resource, "+
+				"either remove the `protect` flag from the resource in your Pulumi program or use the command:\n"+
+				"`pulumi state unprotect %s`", s.old.URN, s.old.URN)
 	}
 
 	// Deleting an External resource is a no-op, since Pulumi does not own the lifecycle.


### PR DESCRIPTION
Fixes: #4662

Before:

```
Diagnostics:
  random:index:RandomPassword (test):
    error: Preview failed: refusing to delete protected resource 'urn:pulumi:dev::test-protected-resource::random:index/randomPassword:RandomPassword::test'

  pulumi:pulumi:Stack (test-protected-resource-dev):
    error: preview failed
```

After:

```
Diagnostics:
  pulumi:pulumi:Stack (test-protected-resource-dev):
    error: preview failed

  random:index:RandomPassword (test):
    error: Preview failed: unable to delete resource "urn:pulumi:dev::test-protected-resource::random:index/randomPassword:RandomPassword::test"
    as it is currently marked for protection. To unprotect the resource, either remove the protection bit from your Pulumi application or use the command:
    `pulumi state unprotect urn:pulumi:dev::test-protected-resource::random:index/randomPassword:RandomPassword::test`


```