### PR TITLE
Omit non-primitive provider properties from code-gen

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1668,6 +1668,19 @@ func bindProvider(pkgName string, spec ResourceSpec, types *types) (*Resource, e
 	}
 	res.IsProvider = true
 
+	// Since non-primitive provider configuration is currently JSON serialized, we can't handle it without
+	// modifying the path by which it's looked up. As a temporary workaround to enable access to config which
+	// values which are primitives, we'll simply remove any properties for the provider resource which are not
+	// here, before we generate the provider code.
+	var primitiveProperties []*Property
+	for _, prop := range res.Properties {
+		if prop.Type != stringType {
+			continue
+		}
+		primitiveProperties = append(primitiveProperties, prop)
+	}
+	res.Properties = primitiveProperties
+
 	types.resources[res.Token] = &ResourceType{
 		Token:    res.Token,
 		Resource: res,


### PR DESCRIPTION
# Description

Following pulumi/pulumi-terraform-bridge#347, properties are generated for all provider config matching the inputs. Unfortunately this does not work for complex values generally (not only in bridged providers) since values are JSON serialized.

While a proper solution to this is designed, it's sufficient for now to stop generating non-primitive properties, which this commit does.

## Effect

Following pulumi/pulumi-terraform-bridge#347, the following schema diff is produced for `pulumi-aws`:

```diff
diff --git a/provider/cmd/pulumi-resource-aws/schema.json b/provider/cmd/pulumi-resource-aws/schema.json
index 4b9553258..72bdfca93 100644
--- a/provider/cmd/pulumi-resource-aws/schema.json
+++ b/provider/cmd/pulumi-resource-aws/schema.json
@@ -148781,6 +148781,93 @@
     },
     "provider": {
         "description": "The provider type for the aws package. By default, resources use package-wide configuration\nsettings, however an explicit `Provider` instance may be created and passed during resource\nconstruction to achieve fine-grained programmatic control over provider settings. See the\n[documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.\n",
+        "properties": {
+            "accessKey": {
+                "type": "string",
+                "description": "The access key for API operations. You can retrieve this from the 'Security \u0026 Credentials' section of the AWS console.\n"
+            },
+            "allowedAccountIds": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "assumeRole": {
+                "$ref": "#/types/aws:index/ProviderAssumeRole:ProviderAssumeRole"
+            },
+            "defaultTags": {
+                "$ref": "#/types/aws:index/ProviderDefaultTags:ProviderDefaultTags",
+                "description": "Configuration block with settings to default resource tags across all resources.\n"
+            },
+            "endpoints": {
+                "type": "array",
+                "items": {
+                    "$ref": "#/types/aws:index/ProviderEndpoint:ProviderEndpoint"
+                }
+            },
+            "forbiddenAccountIds": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "ignoreTags": {
+                "$ref": "#/types/aws:index/ProviderIgnoreTags:ProviderIgnoreTags",
+                "description": "Configuration block with settings to ignore resource tags across all resources.\n"
+            },
+            "insecure": {
+                "type": "boolean",
+                "description": "Explicitly allow the provider to perform \"insecure\" SSL requests. If omitted,default value is `false`\n"
+            },
+            "maxRetries": {
+                "type": "integer",
+                "description": "The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.\n"
+            },
+            "profile": {
+                "type": "string",
+                "description": "The profile for API operations. If not set, the default profile created with `aws configure` will be used.\n"
+            },
+            "region": {
+                "type": "string",
+                "$ref": "#/types/aws:index/region:Region",
+                "description": "The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.\n"
+            },
+            "s3ForcePathStyle": {
+                "type": "boolean",
+                "description": "Set this to true to force the request to use path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY. By\ndefault, the S3 client will use virtual hosted bucket addressing when possible (http://BUCKET.s3.amazonaws.com/KEY).\nSpecific to the Amazon S3 service.\n"
+            },
+            "secretKey": {
+                "type": "string",
+                "description": "The secret key for API operations. You can retrieve this from the 'Security \u0026 Credentials' section of the AWS console.\n"
+            },
+            "sharedCredentialsFile": {
+                "type": "string",
+                "description": "The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.\n"
+            },
+            "skipCredentialsValidation": {
+                "type": "boolean",
+                "description": "Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS\navailable/implemented.\n"
+            },
+            "skipGetEc2Platforms": {
+                "type": "boolean",
+                "description": "Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.\n"
+            },
+            "skipMetadataApiCheck": {
+                "type": "boolean"
+            },
+            "skipRegionValidation": {
+                "type": "boolean",
+                "description": "Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are\nnot public (yet).\n"
+            },
+            "skipRequestingAccountId": {
+                "type": "boolean",
+                "description": "Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.\n"
+            },
+            "token": {
+                "type": "string",
+                "description": "session token. A session token is only required if you are using temporary security credentials.\n"
+            }
+        },
         "inputProperties": {
             "accessKey": {
                 "type": "string",
```

With this commit included in the code generator, the following Go diff is produced:

```diff
diff --git a/sdk/go/aws/provider.go b/sdk/go/aws/provider.go
index 0cc0e0fe9..20a0326d0 100644
--- a/sdk/go/aws/provider.go
+++ b/sdk/go/aws/provider.go
@@ -16,6 +16,36 @@ import (
 // [documentation](https://www.pulumi.com/docs/reference/programming-model/#providers) for more information.
 type Provider struct {
 	pulumi.ProviderResourceState
+
+	// The access key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
+	AccessKey pulumi.StringPtrOutput `pulumi:"accessKey"`
+	// Explicitly allow the provider to perform "insecure" SSL requests. If omitted,default value is `false`
+	Insecure pulumi.BoolPtrOutput `pulumi:"insecure"`
+	// The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.
+	MaxRetries pulumi.IntPtrOutput `pulumi:"maxRetries"`
+	// The profile for API operations. If not set, the default profile created with `aws configure` will be used.
+	Profile pulumi.StringPtrOutput `pulumi:"profile"`
+	// Set this to true to force the request to use path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY. By
+	// default, the S3 client will use virtual hosted bucket addressing when possible (http://BUCKET.s3.amazonaws.com/KEY).
+	// Specific to the Amazon S3 service.
+	S3ForcePathStyle pulumi.BoolPtrOutput `pulumi:"s3ForcePathStyle"`
+	// The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
+	SecretKey pulumi.StringPtrOutput `pulumi:"secretKey"`
+	// The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.
+	SharedCredentialsFile pulumi.StringPtrOutput `pulumi:"sharedCredentialsFile"`
+	// Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
+	// available/implemented.
+	SkipCredentialsValidation pulumi.BoolPtrOutput `pulumi:"skipCredentialsValidation"`
+	// Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
+	SkipGetEc2Platforms  pulumi.BoolPtrOutput `pulumi:"skipGetEc2Platforms"`
+	SkipMetadataApiCheck pulumi.BoolPtrOutput `pulumi:"skipMetadataApiCheck"`
+	// Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
+	// not public (yet).
+	SkipRegionValidation pulumi.BoolPtrOutput `pulumi:"skipRegionValidation"`
+	// Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.
+	SkipRequestingAccountId pulumi.BoolPtrOutput `pulumi:"skipRequestingAccountId"`
+	// session token. A session token is only required if you are using temporary security credentials.
+	Token pulumi.StringPtrOutput `pulumi:"token"`
 }
 
 // NewProvider registers a new resource with the given unique name, arguments, and options.
```

For Node.js, there are other changes from recent commits, but still looks good:

```diff
diff --git a/sdk/nodejs/provider.ts b/sdk/nodejs/provider.ts
index 849a4503d..609f35dc6 100644
--- a/sdk/nodejs/provider.ts
+++ b/sdk/nodejs/provider.ts
@@ -28,6 +28,59 @@ export class Provider extends pulumi.ProviderResource {
         return obj['__pulumiType'] === Provider.__pulumiType;
     }
 
+    /**
+     * The access key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
+     */
+    public readonly accessKey!: pulumi.Output<string | undefined>;
+    /**
+     * Explicitly allow the provider to perform "insecure" SSL requests. If omitted,default value is `false`
+     */
+    public readonly insecure!: pulumi.Output<boolean | undefined>;
+    /**
+     * The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.
+     */
+    public readonly maxRetries!: pulumi.Output<number | undefined>;
+    /**
+     * The profile for API operations. If not set, the default profile created with `aws configure` will be used.
+     */
+    public readonly profile!: pulumi.Output<string | undefined>;
+    /**
+     * Set this to true to force the request to use path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY. By
+     * default, the S3 client will use virtual hosted bucket addressing when possible (http://BUCKET.s3.amazonaws.com/KEY).
+     * Specific to the Amazon S3 service.
+     */
+    public readonly s3ForcePathStyle!: pulumi.Output<boolean | undefined>;
+    /**
+     * The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
+     */
+    public readonly secretKey!: pulumi.Output<string | undefined>;
+    /**
+     * The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.
+     */
+    public readonly sharedCredentialsFile!: pulumi.Output<string | undefined>;
+    /**
+     * Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
+     * available/implemented.
+     */
+    public readonly skipCredentialsValidation!: pulumi.Output<boolean | undefined>;
+    /**
+     * Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
+     */
+    public readonly skipGetEc2Platforms!: pulumi.Output<boolean | undefined>;
+    public readonly skipMetadataApiCheck!: pulumi.Output<boolean | undefined>;
+    /**
+     * Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
+     * not public (yet).
+     */
+    public readonly skipRegionValidation!: pulumi.Output<boolean | undefined>;
+    /**
+     * Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.
+     */
+    public readonly skipRequestingAccountId!: pulumi.Output<boolean | undefined>;
+    /**
+     * session token. A session token is only required if you are using temporary security credentials.
+     */
+    public readonly token!: pulumi.Output<string | undefined>;
 
     /**
      * Create a Provider resource with the given unique name, arguments, and options.
@@ -75,70 +128,70 @@ export interface ProviderArgs {
     /**
      * The access key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
      */
-    readonly accessKey?: pulumi.Input<string>;
-    readonly allowedAccountIds?: pulumi.Input<pulumi.Input<string>[]>;
-    readonly assumeRole?: pulumi.Input<inputs.ProviderAssumeRole>;
+    accessKey?: pulumi.Input<string>;
+    allowedAccountIds?: pulumi.Input<pulumi.Input<string>[]>;
+    assumeRole?: pulumi.Input<inputs.ProviderAssumeRole>;
     /**
      * Configuration block with settings to default resource tags across all resources.
      */
-    readonly defaultTags?: pulumi.Input<inputs.ProviderDefaultTags>;
-    readonly endpoints?: pulumi.Input<pulumi.Input<inputs.ProviderEndpoint>[]>;
-    readonly forbiddenAccountIds?: pulumi.Input<pulumi.Input<string>[]>;
+    defaultTags?: pulumi.Input<inputs.ProviderDefaultTags>;
+    endpoints?: pulumi.Input<pulumi.Input<inputs.ProviderEndpoint>[]>;
+    forbiddenAccountIds?: pulumi.Input<pulumi.Input<string>[]>;
     /**
      * Configuration block with settings to ignore resource tags across all resources.
      */
-    readonly ignoreTags?: pulumi.Input<inputs.ProviderIgnoreTags>;
+    ignoreTags?: pulumi.Input<inputs.ProviderIgnoreTags>;
     /**
      * Explicitly allow the provider to perform "insecure" SSL requests. If omitted,default value is `false`
      */
-    readonly insecure?: pulumi.Input<boolean>;
+    insecure?: pulumi.Input<boolean>;
     /**
      * The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.
      */
-    readonly maxRetries?: pulumi.Input<number>;
+    maxRetries?: pulumi.Input<number>;
     /**
      * The profile for API operations. If not set, the default profile created with `aws configure` will be used.
      */
-    readonly profile?: pulumi.Input<string>;
+    profile?: pulumi.Input<string>;
     /**
      * The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.
      */
-    readonly region?: pulumi.Input<Region>;
+    region?: pulumi.Input<Region>;
     /**
      * Set this to true to force the request to use path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY. By
      * default, the S3 client will use virtual hosted bucket addressing when possible (http://BUCKET.s3.amazonaws.com/KEY).
      * Specific to the Amazon S3 service.
      */
-    readonly s3ForcePathStyle?: pulumi.Input<boolean>;
+    s3ForcePathStyle?: pulumi.Input<boolean>;
     /**
      * The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
      */
-    readonly secretKey?: pulumi.Input<string>;
+    secretKey?: pulumi.Input<string>;
     /**
      * The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.
      */
-    readonly sharedCredentialsFile?: pulumi.Input<string>;
+    sharedCredentialsFile?: pulumi.Input<string>;
     /**
      * Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
      * available/implemented.
      */
-    readonly skipCredentialsValidation?: pulumi.Input<boolean>;
+    skipCredentialsValidation?: pulumi.Input<boolean>;
     /**
      * Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
      */
-    readonly skipGetEc2Platforms?: pulumi.Input<boolean>;
-    readonly skipMetadataApiCheck?: pulumi.Input<boolean>;
+    skipGetEc2Platforms?: pulumi.Input<boolean>;
+    skipMetadataApiCheck?: pulumi.Input<boolean>;
     /**
      * Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
      * not public (yet).
      */
-    readonly skipRegionValidation?: pulumi.Input<boolean>;
+    skipRegionValidation?: pulumi.Input<boolean>;
     /**
      * Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.
      */
-    readonly skipRequestingAccountId?: pulumi.Input<boolean>;
+    skipRequestingAccountId?: pulumi.Input<boolean>;
     /**
      * session token. A session token is only required if you are using temporary security credentials.
      */
-    readonly token?: pulumi.Input<string>;
+    token?: pulumi.Input<string>;
 }
```

For Python, we get this diff:

```diff
diff --git a/sdk/python/pulumi_aws/provider.py b/sdk/python/pulumi_aws/provider.py
index e56f1542e..461ae62a4 100644
--- a/sdk/python/pulumi_aws/provider.py
+++ b/sdk/python/pulumi_aws/provider.py
@@ -490,3 +490,108 @@ class Provider(pulumi.ProviderResource):
             __props__,
             opts)
 
+    @property
+    @pulumi.getter(name="accessKey")
+    def access_key(self) -> pulumi.Output[Optional[str]]:
+        """
+        The access key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
+        """
+        return pulumi.get(self, "access_key")
+
+    @property
+    @pulumi.getter
+    def insecure(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Explicitly allow the provider to perform "insecure" SSL requests. If omitted,default value is `false`
+        """
+        return pulumi.get(self, "insecure")
+
+    @property
+    @pulumi.getter(name="maxRetries")
+    def max_retries(self) -> pulumi.Output[Optional[int]]:
+        """
+        The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.
+        """
+        return pulumi.get(self, "max_retries")
+
+    @property
+    @pulumi.getter
+    def profile(self) -> pulumi.Output[Optional[str]]:
+        """
+        The profile for API operations. If not set, the default profile created with `aws configure` will be used.
+        """
+        return pulumi.get(self, "profile")
+
+    @property
+    @pulumi.getter(name="s3ForcePathStyle")
+    def s3_force_path_style(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Set this to true to force the request to use path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY. By
+        default, the S3 client will use virtual hosted bucket addressing when possible (http://BUCKET.s3.amazonaws.com/KEY).
+        Specific to the Amazon S3 service.
+        """
+        return pulumi.get(self, "s3_force_path_style")
+
+    @property
+    @pulumi.getter(name="secretKey")
+    def secret_key(self) -> pulumi.Output[Optional[str]]:
+        """
+        The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
+        """
+        return pulumi.get(self, "secret_key")
+
+    @property
+    @pulumi.getter(name="sharedCredentialsFile")
+    def shared_credentials_file(self) -> pulumi.Output[Optional[str]]:
+        """
+        The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.
+        """
+        return pulumi.get(self, "shared_credentials_file")
+
+    @property
+    @pulumi.getter(name="skipCredentialsValidation")
+    def skip_credentials_validation(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
+        available/implemented.
+        """
+        return pulumi.get(self, "skip_credentials_validation")
+
+    @property
+    @pulumi.getter(name="skipGetEc2Platforms")
+    def skip_get_ec2_platforms(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
+        """
+        return pulumi.get(self, "skip_get_ec2_platforms")
+
+    @property
+    @pulumi.getter(name="skipMetadataApiCheck")
+    def skip_metadata_api_check(self) -> pulumi.Output[Optional[bool]]:
+        return pulumi.get(self, "skip_metadata_api_check")
+
+    @property
+    @pulumi.getter(name="skipRegionValidation")
+    def skip_region_validation(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
+        not public (yet).
+        """
+        return pulumi.get(self, "skip_region_validation")
+
+    @property
+    @pulumi.getter(name="skipRequestingAccountId")
+    def skip_requesting_account_id(self) -> pulumi.Output[Optional[bool]]:
+        """
+        Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.
+        """
+        return pulumi.get(self, "skip_requesting_account_id")
+
+    @property
+    @pulumi.getter
+    def token(self) -> pulumi.Output[Optional[str]]:
+        """
+        session token. A session token is only required if you are using temporary security credentials.
+        """
+        return pulumi.get(self, "token")
+
```

And finally for .NET, we get the following C# diff:

```diff
diff --git a/sdk/dotnet/Provider.cs b/sdk/dotnet/Provider.cs
index dd1b4ced3..df4fccdda 100644
--- a/sdk/dotnet/Provider.cs
+++ b/sdk/dotnet/Provider.cs
@@ -18,6 +18,86 @@ namespace Pulumi.Aws
     [AwsResourceType("pulumi:providers:aws")]
     public partial class Provider : Pulumi.ProviderResource
     {
+        /// <summary>
+        /// The access key for API operations. You can retrieve this from the 'Security &amp; Credentials' section of the AWS console.
+        /// </summary>
+        [Output("accessKey")]
+        public Output<string?> AccessKey { get; private set; } = null!;
+
+        /// <summary>
+        /// Explicitly allow the provider to perform "insecure" SSL requests. If omitted,default value is `false`
+        /// </summary>
+        [Output("insecure")]
+        public Output<bool?> Insecure { get; private set; } = null!;
+
+        /// <summary>
+        /// The maximum number of times an AWS API request is being executed. If the API request still fails, an error is thrown.
+        /// </summary>
+        [Output("maxRetries")]
+        public Output<int?> MaxRetries { get; private set; } = null!;
+
+        /// <summary>
+        /// The profile for API operations. If not set, the default profile created with `aws configure` will be used.
+        /// </summary>
+        [Output("profile")]
+        public Output<string?> Profile { get; private set; } = null!;
+
+        /// <summary>
+        /// Set this to true to force the request to use path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY. By
+        /// default, the S3 client will use virtual hosted bucket addressing when possible (http://BUCKET.s3.amazonaws.com/KEY).
+        /// Specific to the Amazon S3 service.
+        /// </summary>
+        [Output("s3ForcePathStyle")]
+        public Output<bool?> S3ForcePathStyle { get; private set; } = null!;
+
+        /// <summary>
+        /// The secret key for API operations. You can retrieve this from the 'Security &amp; Credentials' section of the AWS console.
+        /// </summary>
+        [Output("secretKey")]
+        public Output<string?> SecretKey { get; private set; } = null!;
+
+        /// <summary>
+        /// The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.
+        /// </summary>
+        [Output("sharedCredentialsFile")]
+        public Output<string?> SharedCredentialsFile { get; private set; } = null!;
+
+        /// <summary>
+        /// Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS
+        /// available/implemented.
+        /// </summary>
+        [Output("skipCredentialsValidation")]
+        public Output<bool?> SkipCredentialsValidation { get; private set; } = null!;
+
+        /// <summary>
+        /// Skip getting the supported EC2 platforms. Used by users that don't have ec2:DescribeAccountAttributes permissions.
+        /// </summary>
+        [Output("skipGetEc2Platforms")]
+        public Output<bool?> SkipGetEc2Platforms { get; private set; } = null!;
+
+        [Output("skipMetadataApiCheck")]
+        public Output<bool?> SkipMetadataApiCheck { get; private set; } = null!;
+
+        /// <summary>
+        /// Skip static validation of region name. Used by users of alternative AWS-like APIs or users w/ access to regions that are
+        /// not public (yet).
+        /// </summary>
+        [Output("skipRegionValidation")]
+        public Output<bool?> SkipRegionValidation { get; private set; } = null!;
+
+        /// <summary>
+        /// Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.
+        /// </summary>
+        [Output("skipRequestingAccountId")]
+        public Output<bool?> SkipRequestingAccountId { get; private set; } = null!;
+
+        /// <summary>
+        /// session token. A session token is only required if you are using temporary security credentials.
+        /// </summary>
+        [Output("token")]
+        public Output<string?> Token { get; private set; } = null!;
+
+
         /// <summary>
         /// Create a Provider resource with the given unique name, arguments, and options.
         /// </summary>
```


## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

No apparent test coverage existing for this, and it's a temporary fix until a proper solution is decided upon - see the code diffs above for indication that this works as expected.

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Not a user-facing change since generation has not been rolled out in the general case yet, and would be broken even if it had for non-primitives.