### PR TITLE
Allow outputs in dictionary resource args

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/Resources/DictionaryResourceArgsTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Resources/DictionaryResourceArgsTests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright 2016-2021, Pulumi Corporation
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Pulumi.Tests.Resources
+{
+    public class DictionaryResourceArgsTests
+    {
+        [Fact]
+        public void ConstructorValidValues()
+        {
+            var dict = new Dictionary<string, object?>
+            {
+                { "null", null },
+                { "string", "foo" },
+                { "int", 123 },
+                { "dictionary", new Dictionary<string, object?> { {"foo", "bar"} }.ToImmutableDictionary() },
+                { "output", Output.CreateSecret("secret") },
+            };
+            new DictionaryResourceArgs(dict.ToImmutableDictionary());
+        }
+
+        [Fact]
+        public void ConstructorInvalidValue()
+        {
+            var dict = new Dictionary<string, object?>
+            {
+                { "arbitrary", new { Foo = "bar" } },
+            };
+            Assert.Throws<InvalidOperationException>(() =>
+                new DictionaryResourceArgs(dict.ToImmutableDictionary()));
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Resources/DictionaryResourceArgs.cs
+++ b/sdk/dotnet/Pulumi/Resources/DictionaryResourceArgs.cs
@@ -13,7 +13,7 @@ namespace Pulumi
     /// since it's too low-level and provides low safety. Its target scenario are
     /// resources with a very dynamic shape of inputs.
     /// The input dictionary may only contain objects that are serializable by
-    /// Pulumi, i.e only the following types are allowed:
+    /// Pulumi, i.e only the following types (or pulumi.Output of those types) are allowed:
     /// <list type="bullet">
     /// <item><description>Primitive types: <see cref="string"/>, <see cref="double"/>,
     /// <see cref="int"/>, <see cref="bool"/></description></item>
@@ -29,7 +29,7 @@ namespace Pulumi
     public sealed class DictionaryResourceArgs : ResourceArgs
     {
         private readonly ImmutableDictionary<string, object?> _dictionary;
-        
+
         /// <summary>
         /// Constructs an instance of <see cref="DictionaryResourceArgs"/> from
         /// a dictionary of input objects.
@@ -53,7 +53,7 @@ namespace Pulumi
                         targetType = type.GenericTypeArguments[0];
                     }
                 }
-                
+
                 Converter.CheckTargetType(nameof(dictionary), targetType, seenTypes);
             }
 

--- a/sdk/dotnet/Pulumi/Resources/DictionaryResourceArgs.cs
+++ b/sdk/dotnet/Pulumi/Resources/DictionaryResourceArgs.cs
@@ -42,8 +42,19 @@ namespace Pulumi
             var seenTypes = new HashSet<Type>();
             foreach (var value in dictionary.Values)
             {
-                if (value != null)
-                    Converter.CheckTargetType(nameof(dictionary), value.GetType(), seenTypes);
+                if (value == null) continue;
+
+                var targetType = value.GetType();
+                if (value is IOutput)
+                {
+                    var type = value.GetType();
+                    if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Output<>))
+                    {
+                        targetType = type.GenericTypeArguments[0];
+                    }
+                }
+                
+                Converter.CheckTargetType(nameof(dictionary), targetType, seenTypes);
             }
 
             _dictionary = dictionary;


### PR DESCRIPTION
@lblackstone this should prevent the exception that you are getting from the Kubernetes secret wrapping. I haven't tested it end-to-end though because your original commit doesn't seem to exist anymore. There's a chance something would go wrong at a later stage. I'm happy to collaborate further on that one.