### PR TITLE
Add gzip compression in filestate backend

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 - [cli] Fix a regression caused by [#6893](https://github.com/pulumi/pulumi/pull/6893) that stopped stacks created
   with empty passphrases from completing successful pulumi commands when loading the passphrase secrets provider.
   [#6976](https://github.com/pulumi/pulumi/pull/6976)
+- [backend] Add gzip compression to filestate backend.
+  Compression can be disabled via `PULUMI_SELF_MANAGED_STATE_NO_GZIP`.
+  [7086](https://github.com/pulumi/pulumi/pull/7086)

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -77,6 +77,8 @@ type localBackend struct {
 	mutex  sync.Mutex
 
 	lockID string
+
+	gzip bool
 }
 
 type localBackendReference struct {
@@ -157,6 +159,7 @@ func New(d diag.Sink, originalURL string) (Backend, error) {
 		url:         u,
 		bucket:      &wrappedBucket{bucket: bucket},
 		lockID:      lockID.String(),
+		gzip:        true,
 	}, nil
 }
 
@@ -848,6 +851,12 @@ func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
 		// Skip files without valid extensions (e.g., *.bak files).
 		stackfn := objectName(file)
 		ext := filepath.Ext(stackfn)
+		// But accept gzip compression
+		if ext == ".gz" {
+			stackfn = strings.TrimSuffix(stackfn, ".gz")
+			ext = filepath.Ext(stackfn)
+		}
+
 		if _, has := encoding.Marshalers[ext]; !has {
 			continue
 		}

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -58,6 +58,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+// PulumiFilestateNoGzipEnvVar is an env var that must be truthy to disable gzip compression when using a filestate backend.
+const PulumiFilestateNoGzipEnvVar = "PULUMI_SELF_MANAGED_STATE_NO_GZIP"
+
 // Backend extends the base backend interface with specific information about local backends.
 type Backend interface {
 	backend.Backend
@@ -153,13 +156,15 @@ func New(d diag.Sink, originalURL string) (Backend, error) {
 		return nil, err
 	}
 
+	disableGzipCompression := cmdutil.IsTruthy(os.Getenv(PulumiFilestateNoGzipEnvVar))
+
 	return &localBackend{
 		d:           d,
 		originalURL: originalURL,
 		url:         u,
 		bucket:      &wrappedBucket{bucket: bucket},
 		lockID:      lockID.String(),
-		gzip:        true,
+		gzip:        !disableGzipCompression,
 	}, nil
 }
 

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -197,6 +197,8 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 		if err != nil {
 			return "", errors.Wrap(err, "An IO error occurred while compressing the checkpoint")
 		}
+	} else {
+		file = strings.TrimSuffix(file, ".gz")
 	}
 
 	// Try to back up the existing file if it already exists,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Add gzip compression in the filestate backend.
Compression can be turned off by setting `gzip` to `false` in the `localBackend` `struct` (default is `true`).
Fixes 
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #5469

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
