### PR TITLE
Allow editable installs of dev Python packages

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,8 @@
   [#7079](https://github.com/pulumi/pulumi/pull/7079)
   [#7080](https://github.com/pulumi/pulumi/pull/7080)
 
+- [sdk/python] - Generated SDKs may now be installed from in-tree source.
+
 - [sdk/nodejs|python] - Add GetSchema support to providers
   [#6892](https://github.com/pulumi/pulumi/pull/6892)
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1556,8 +1556,11 @@ func genPackageMetadata(
 	// Generate a readme method which will load README.rst, we use this to fill out the
 	// long_description field in the setup call.
 	fmt.Fprintf(w, "def readme():\n")
-	fmt.Fprintf(w, "    with open('README.md', encoding='utf-8') as f:\n")
-	fmt.Fprintf(w, "        return f.read()\n")
+	fmt.Fprintf(w, "    try:\n")
+	fmt.Fprintf(w, "        with open('README.md', encoding='utf-8') as f:\n")
+	fmt.Fprintf(w, "            return f.read()\n")
+	fmt.Fprintf(w, "    except FileNotFoundError:\n")
+	fmt.Fprintf(w, "            return \"%s Pulumi Package - Development Version\"\n", pkg.Name)
 	fmt.Fprintf(w, "\n\n")
 
 	// Finally, the actual setup part.


### PR DESCRIPTION
# Description

This commit adds a fallback for the README definition in the generated setup.py files for Python SDKs, thus allowing editable installs of packages which not yet been built.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

Codegen tests do not appear to test setup.py generation.

- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
