### PR TITLE
Fix 2 small release issues with regards to uploading binaries to S3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
       - 'README.md'
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
   PULUMI_TEST_OWNER: "moolumi"
   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,6 +10,7 @@ blobs:
   folder: releases/sdk/
   ids:
     - pulumi-unix
+    - pulumi-windows
   provider: s3
   region: us-west-2
 builds:


### PR DESCRIPTION
The Windows binary didn't upload to S3 during the release. We had to
ask our ops team to do this - this fixes that issue