### PR TITLE
Fix package names for generated imports

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,7 +6,10 @@
 - [sdk/python] - Generated SDKs may now be installed from in-tree source.
   [#7097](https://github.com/pulumi/pulumi/pull/7097)
 
+- [codegen/go] - Root package naming is now respected in nested packages
+
 ### Bug Fixes
 
 - [auto/dotnet] Fix deserialization of CancelEvent in .NET 5
   [#7051](https://github.com/pulumi/pulumi/pull/7051)
+

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1815,7 +1815,7 @@ func (pkg *pkgContext) genResourceModule(w io.Writer) {
 	}
 	topLevelModule := pkg.mod == ""
 	if !topLevelModule {
-		imports[basePath] = ""
+		imports[basePath] = pkg.rootPackageName
 	}
 
 	pkg.genHeader(w, []string{"fmt"}, imports)
@@ -1877,8 +1877,11 @@ func (pkg *pkgContext) genResourceModule(w io.Writer) {
 	if topLevelModule {
 		fmt.Fprintf(w, "\tversion, err := PkgVersion()\n")
 	} else {
-		// Some package names contain '-' characters, so grab the name from the base path.
-		pkgName := basePath[strings.LastIndex(basePath, "/")+1:]
+		// Some package names contain '-' characters, so grab the name from the base path unless we have an override.
+		pkgName := pkg.rootPackageName
+		if pkgName == "" {
+			pkgName = basePath[strings.LastIndex(basePath, "/")+1:]
+		}
 		fmt.Fprintf(w, "\tversion, err := %s.PkgVersion()\n", pkgName)
 	}
 	fmt.Fprintf(w, "\tif err != nil {\n")


### PR DESCRIPTION
# Description

This commit respects the rootPackageName option in more places in generated Go code.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

No test coverage of nested Go module generation.

- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change