### PR TITLE
Add ability to test downstream codegen and docsgen from PRs

### DIFF
--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -17,6 +17,32 @@ jobs:
           permission: write
           issue-type: pull-request
           repository: pulumi/pulumi
+  command-dispatch-for-docs-generation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Build
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: run-docs-gen
+          permission: write
+          issue-type: pull-request
+          repository: pulumi/pulumi
+  command-dispatch-for-downstream-codegen:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Build
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: run-codegen
+          permission: write
+          issue-type: pull-request
+          repository: pulumi/pulumi
   auto-rebase-command:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,4 +15,9 @@ jobs:
             PR is now waiting for a maintainer to run the acceptance tests.
 
             **Note for the maintainer:** To run the acceptance tests, please comment */run-acceptance-tests* on the PR
+
+            Further commands available:
+
+            * `/run-codegen` - used to test the Pull Request against downstream codegen
+            * `/run-docs-gen` - used to test the Pull Request against documentation generation
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -1,5 +1,7 @@
 name: Downstream Codegen Tests
 on:
+  repository_dispatch:
+    types: [ run-codegen-command ]
   pull_request:
     paths:
     - 'pkg/codegen/**'
@@ -8,11 +10,29 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
 
 jobs:
+  comment-notification:
+    if: github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+      - name: Update with Result
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          body: |
+            Please view the results of the Downstream Codegen Tests [Here][1]
+
+            [1]: ${{ steps.vars.outputs.run-url }}
   downstream-test:
     name: Test ${{ matrix.provider }} Downstream
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -36,9 +56,10 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
           repo: pulumi/pulumictl
-
       - name: Check out source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
       - name: Test Downstream
         uses: pulumi/action-test-provider-downstream@releases/v5
         env:

--- a/.github/workflows/run-docs-generation.yml
+++ b/.github/workflows/run-docs-generation.yml
@@ -1,5 +1,7 @@
 name: Downstream Resource Docs Test
 on:
+  repository_dispatch:
+    types: [ run-docs-gen-command ]
   pull_request:
     paths:
       - 'pkg/codegen/docs/**'
@@ -9,15 +11,33 @@ on:
 
 env:
   GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN }}
+  PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
 
 jobs:
+  comment-notification:
+    if: github.event_name == 'repository_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create URL to the run output
+        id: vars
+        run: echo ::set-output name=run-url::https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+      - name: Update with Result
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.event.client_payload.github.payload.repository.full_name }}
+          issue-number: ${{ github.event.client_payload.github.payload.issue.number }}
+          body: |
+            Please view the results of the Docs Generation Tests [Here][1]
+
+            [1]: ${{ steps.vars.outputs.run-url }}
   aws:
     name: Resource Docs
     # Verify that the event is not triggered by a fork since forks cannot
     # access secrets other than the default GITHUB_TOKEN. Specifically,
     # this workflow relies on the secret PULUMI_BOT_GH_PAT_DOCS to create a
     # draft PR in the docs repo.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     env:
       GOPATH: ${{ github.workspace }}
     runs-on: ubuntu-latest
@@ -45,21 +65,22 @@ jobs:
         with:
           repo: pulumi/pulumictl
       - name: Check out source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           path: pulumi
+          ref: ${{ env.PR_COMMIT_SHA }}
       - name: Check out pulumi-aws
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           repository: pulumi/pulumi-aws
           path: pulumi-aws
       - name: Check out pulumi-kubernetes
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           repository: pulumi/pulumi-kubernetes
           path: pulumi-kubernetes
       - name: Check out docs
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
         with:
           # Use the PAT and not the default GITHUB_TOKEN since we want to create a branch
           # in this workflow and push it to a remote that is NOT the current repo, i.e. pulumi/pulumi.


### PR DESCRIPTION
Fixes: #7099

PRs from maintainers will work as normal - PRs from the community
can now be triggered with command dispatch events