### PR TITLE
Send plugin install output to stderr

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 
 ### Bug Fixes
 
+- [cli] - Send plugin install output to stderr, so that it doesn't
+  clutter up --json, automation API scenarios, and so on.
+  [#7115](https://github.com/pulumi/pulumi/pull/7115)

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -16,6 +16,7 @@ package engine
 
 import (
 	"fmt"
+	"os"
 	"sort"
 
 	"github.com/blang/semver"
@@ -176,7 +177,7 @@ func installPlugin(plugin workspace.PluginInfo) error {
 		return err
 	}
 
-	fmt.Printf("[%s plugin %s-%s] installing\n", plugin.Kind, plugin.Name, plugin.Version)
+	fmt.Fprintf(os.Stderr, "[%s plugin %s-%s] installing\n", plugin.Kind, plugin.Name, plugin.Version)
 	stream = workspace.ReadCloserProgressBar(stream, size, "Downloading plugin", cmdutil.GetGlobalColorization())
 
 	logging.V(preparePluginVerboseLog).Infof(

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -767,6 +767,7 @@ func ReadCloserProgressBar(
 
 	// If we know the length of the download, show a progress bar.
 	bar := pb.New(int(size))
+	bar.Output = os.Stderr
 	bar.Prefix(colorization.Colorize(colors.SpecUnimportant + message + ":"))
 	bar.Postfix(colorization.Colorize(colors.Reset))
 	bar.SetMaxWidth(80)


### PR DESCRIPTION
We currently send plugin install output to stdout. This interferes
with --json (#5747), automation API scenarios, and in general is bad
CLI hygiene. This change sends plugin output to stdout instead.

Two questions:

1. Is there a reason this isn't the preferred fix? I can easily believe
  so, since we were exploring alternative ideas in the linked issue.

2. How should I test this? Where are the current plugin installation
  test cases? I clearly can't add a dependency on AWS here -- is
  there a "simpler" plugin that I can install for test purposes?