### PR TITLE
Temporarily disable config secrets warning

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,3 +16,6 @@
 
 - [auto/dotnet] - Fix deserialization of CancelEvent in .NET 5
   [#7051](https://github.com/pulumi/pulumi/pull/7051)
+
+- Temporarily disable warning when a secret config is read as a non-secret
+  [#7129](https://github.com/pulumi/pulumi/pull/7129)

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -783,7 +783,8 @@ namespace Pulumi.Automation.Tests
             }
         }
 
-        [Fact]
+        // TODO[pulumi/pulumi#7127]: Re-enable the warning.
+        [Fact(Skip="Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")]
         public async Task ConfigSecretWarnings()
         {
             var program = PulumiFn.Create(() =>

--- a/sdk/dotnet/Pulumi/Config.cs
+++ b/sdk/dotnet/Pulumi/Config.cs
@@ -59,11 +59,12 @@ namespace Pulumi
         private string? GetImpl(string key, string? use = null, [CallerMemberName] string? insteadOf = null)
         {
             var fullKey = FullKey(key);
-            if (use != null && Deployment.InternalInstance.IsConfigSecret(fullKey))
-            {
-                Debug.Assert(insteadOf != null);
-                Log.Warn($"Configuration '{fullKey}' value is a secret; use `{use}` instead of `{insteadOf}`");
-            }
+            // TODO[pulumi/pulumi#7127]: Re-enable the warning.
+            // if (use != null && Deployment.InternalInstance.IsConfigSecret(fullKey))
+            // {
+            //     Debug.Assert(insteadOf != null);
+            //     Log.Warn($"Configuration '{fullKey}' value is a secret; use `{use}` instead of `{insteadOf}`");
+            // }
             return Deployment.InternalInstance.GetConfig(fullKey);
         }
 

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1574,6 +1574,8 @@ func TestSaveStackSettings(t *testing.T) {
 }
 
 func TestConfigSecretWarnings(t *testing.T) {
+	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+	t.Skip("Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")
 	ctx := context.Background()
 	sName := fmt.Sprintf("int_test%d", rangeIn(10000000, 99999999))
 	stackName := FullyQualifiedStackName(pulumiOrg, pName, sName)

--- a/sdk/go/pulumi/config/get.go
+++ b/sdk/go/pulumi/config/get.go
@@ -16,12 +16,10 @@ package config
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cast"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -35,12 +33,13 @@ func ensureKey(ctx *pulumi.Context, key string) string {
 func get(ctx *pulumi.Context, key, use, insteadOf string) (string, bool) {
 	key = ensureKey(ctx, key)
 	v, ok := ctx.GetConfig(key)
-	if use != "" && ctx.IsConfigSecret(key) {
-		contract.Assert(insteadOf != "")
-		warning := fmt.Sprintf("Configuration '%s' value is a secret; use `%s` instead of `%s`", key, use, insteadOf)
-		err := ctx.Log.Warn(warning, nil)
-		contract.IgnoreError(err)
-	}
+	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+	// if use != "" && ctx.IsConfigSecret(key) {
+	// 	contract.Assert(insteadOf != "")
+	// 	warning := fmt.Sprintf("Configuration '%s' value is a secret; use `%s` instead of `%s`", key, use, insteadOf)
+	// 	err := ctx.Log.Warn(warning, nil)
+	// 	contract.IgnoreError(err)
+	// }
 	return v, ok
 }
 

--- a/sdk/go/pulumi/templates/config-get.go.template
+++ b/sdk/go/pulumi/templates/config-get.go.template
@@ -17,11 +17,9 @@ package config
 import (
 	"encoding/json"
 	"strings"
-	"fmt"
 
 	"github.com/spf13/cast"
 
-	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -35,12 +33,13 @@ func ensureKey(ctx *pulumi.Context, key string) string {
 func get(ctx *pulumi.Context, key, use, insteadOf string) (string, bool) {
 	key = ensureKey(ctx, key)
 	v, ok := ctx.GetConfig(key)
-	if use != "" && ctx.IsConfigSecret(key) {
-		contract.Assert(insteadOf != "")
-		warning := fmt.Sprintf("Configuration '%s' value is a secret; use `%s` instead of `%s`", key, use, insteadOf)
-		err := ctx.Log.Warn(warning, nil)
-		contract.IgnoreError(err)
-	}
+	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+	// if use != "" && ctx.IsConfigSecret(key) {
+	// 	contract.Assert(insteadOf != "")
+	// 	warning := fmt.Sprintf("Configuration '%s' value is a secret; use `%s` instead of `%s`", key, use, insteadOf)
+	// 	err := ctx.Log.Warn(warning, nil)
+	// 	contract.IgnoreError(err)
+	// }
 	return v, ok
 }
 

--- a/sdk/nodejs/config.ts
+++ b/sdk/nodejs/config.ts
@@ -66,10 +66,12 @@ export class Config {
         if (v === undefined) {
             return undefined;
         }
-        if (use && insteadOf && isConfigSecret(fullKey)) {
-            log.warn(`Configuration '${fullKey}' value is a secret; ` +
-                `use \`${use.name}\` instead of \`${insteadOf.name}\``);
-        }
+        // TODO[pulumi/pulumi#7127]: Re-enable the warning.
+        // Temporarily disabling the new warning.
+        // if (use && insteadOf && isConfigSecret(fullKey)) {
+        //     log.warn(`Configuration '${fullKey}' value is a secret; ` +
+        //         `use \`${use.name}\` instead of \`${insteadOf.name}\``);
+        // }
         if (opts) {
             // SAFETY: if allowedValues != null, verifying v ∈ K[]
             if (opts.allowedValues !== undefined && opts.allowedValues.indexOf(v as any) === -1) {

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -340,7 +340,9 @@ describe("LocalWorkspace", () => {
 
         await stack.workspace.removeStack(stackName);
     }));
-    it(`has secret config warnings`, asyncTest(async () => {
+    // TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+    // Temporarily skipping test until we've re-enabled the warning.
+    it.skip(`has secret config warnings`, asyncTest(async () => {
         const program = async () => {
             const config = new Config();
 

--- a/sdk/python/lib/pulumi/config.py
+++ b/sdk/python/lib/pulumi/config.py
@@ -49,13 +49,15 @@ class Config:
             raise TypeError('Expected name to be a string')
         self.name = name
 
+    # pylint: disable=unused-argument
     def _get(self, key: str, use: Optional[Callable] = None, instead_of: Optional[Callable] = None) -> Optional[str]:
         full_key = self.full_key(key)
-        if use is not None and is_config_secret(full_key):
-            assert instead_of is not None
-            log.warn(
-                f"Configuration '{full_key}' value is a secret; " +
-                f"use `{use.__name__}` instead of `{instead_of.__name__}`")
+        # TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+        # if use is not None and is_config_secret(full_key):
+        #     assert instead_of is not None
+        #     log.warn(
+        #         f"Configuration '{full_key}' value is a secret; " +
+        #         f"use `{use.__name__}` instead of `{instead_of.__name__}`")
         return get_config(full_key)
 
     def get(self, key: str) -> Optional[str]:

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -528,6 +528,8 @@ class TestLocalWorkspace(unittest.TestCase):
         finally:
             stack.workspace.remove_stack(stack_name)
 
+    # TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+    @unittest.skip("Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")
     def test_secret_config_warnings(self):
         def program():
             config = Config()

--- a/tests/integration/integration_dotnet_test.go
+++ b/tests/integration/integration_dotnet_test.go
@@ -123,6 +123,8 @@ func TestConfigBasicDotNet(t *testing.T) {
 
 // Tests that accessing config secrets using non-secret APIs results in warnings being logged.
 func TestConfigSecretsWarnDotNet(t *testing.T) {
+	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+	t.Skip("Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          filepath.Join("config_secrets_warn", "dotnet"),
 		Dependencies: []string{"Pulumi"},

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -80,6 +80,8 @@ func TestConfigBasicGo(t *testing.T) {
 
 // Tests that accessing config secrets using non-secret APIs results in warnings being logged.
 func TestConfigSecretsWarnGo(t *testing.T) {
+	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+	t.Skip("Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: filepath.Join("config_secrets_warn", "go"),
 		Dependencies: []string{

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -398,6 +398,8 @@ func TestConfigCaptureNodeJS(t *testing.T) {
 
 // Tests that accessing config secrets using non-secret APIs results in warnings being logged.
 func TestConfigSecretsWarnNodeJS(t *testing.T) {
+	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+	t.Skip("Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          filepath.Join("config_secrets_warn", "nodejs"),
 		Dependencies: []string{"@pulumi/pulumi"},

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -91,6 +91,8 @@ func TestConfigBasicPython(t *testing.T) {
 
 // Tests that accessing config secrets using non-secret APIs results in warnings being logged.
 func TestConfigSecretsWarnPython(t *testing.T) {
+	// TODO[pulumi/pulumi#7127]: Re-enabled the warning.
+	t.Skip("Temporarily skipping test until we've re-enabled the warning - pulumi/pulumi#7127")
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: filepath.Join("config_secrets_warn", "python"),
 		Dependencies: []string{


### PR DESCRIPTION
Temporarily disable the new config secret warning to avoid unactionable warnings from provider `config` modules. We'll re-enable the warning when we've addressed that issue.

Fixes #7126