### PR TITLE
[sdk/python] Avoid 'referenced before assignment' error

### DIFF
--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -152,6 +152,7 @@ class Output(Generic[T_co]):
 
         # The "run" coroutine actually runs the apply.
         async def run() -> U:
+            resources: Set['Resource'] = set()
             try:
                 # Await this output's details.
                 resources = await self._resources


### PR DESCRIPTION
We have seen cases where a lot of errors like this are reported:

```
UnboundLocalError: local variable 'resources' referenced before assignment
```

This change prevents this failure mode, which might be a symptom of some other issue, but currently obscures it in the error path.
