### PR TITLE
Fix non-deterministic ordering of generated Python code

### DIFF
--- a/pkg/codegen/python/gen_resource_mappings.go
+++ b/pkg/codegen/python/gen_resource_mappings.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 )
 
 // Generates code to build and regsiter ResourceModule and
@@ -79,6 +80,12 @@ type resourceModuleInfo struct {
 	Classes map[string]string `json:"classes"`
 }
 
+type resourceModuleInfoByFqn []resourceModuleInfo
+
+func (a resourceModuleInfoByFqn) Len() int           { return len(a) }
+func (a resourceModuleInfoByFqn) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a resourceModuleInfoByFqn) Less(i, j int) bool { return a[i].Fqn < a[j].Fqn }
+
 func makeResourceModuleInfo(pkg, mod, fqn string) resourceModuleInfo {
 	return resourceModuleInfo{pkg, mod, fqn, make(map[string]string)}
 }
@@ -88,6 +95,7 @@ func allResourceModuleInfos(root *modContext) []resourceModuleInfo {
 	for _, mctx := range root.walkSelfWithDescendants() {
 		result = append(result, collectResourceModuleInfos(mctx)...)
 	}
+	sort.Sort(resourceModuleInfoByFqn(result))
 	return result
 }
 
@@ -136,11 +144,18 @@ type resourcePackageInfo struct {
 	Class string `json:"class"`
 }
 
+type resourcePackageInfoByFqn []resourcePackageInfo
+
+func (a resourcePackageInfoByFqn) Len() int           { return len(a) }
+func (a resourcePackageInfoByFqn) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a resourcePackageInfoByFqn) Less(i, j int) bool { return a[i].Fqn < a[j].Fqn }
+
 func allResourcePackageInfos(root *modContext) []resourcePackageInfo {
 	var result []resourcePackageInfo
 	for _, mctx := range root.walkSelfWithDescendants() {
 		result = append(result, collectResourcePackageInfos(mctx)...)
 	}
+	sort.Sort(resourcePackageInfoByFqn(result))
 	return result
 }
 

--- a/pkg/codegen/python/gen_resource_mappings.go
+++ b/pkg/codegen/python/gen_resource_mappings.go
@@ -80,11 +80,9 @@ type resourceModuleInfo struct {
 	Classes map[string]string `json:"classes"`
 }
 
-type resourceModuleInfoByFqn []resourceModuleInfo
-
-func (a resourceModuleInfoByFqn) Len() int           { return len(a) }
-func (a resourceModuleInfoByFqn) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a resourceModuleInfoByFqn) Less(i, j int) bool { return a[i].Fqn < a[j].Fqn }
+func (rmi *resourceModuleInfo) Token() string {
+	return fmt.Sprintf("%s:%s", rmi.Pkg, rmi.Mod)
+}
 
 func makeResourceModuleInfo(pkg, mod, fqn string) resourceModuleInfo {
 	return resourceModuleInfo{pkg, mod, fqn, make(map[string]string)}
@@ -95,7 +93,9 @@ func allResourceModuleInfos(root *modContext) []resourceModuleInfo {
 	for _, mctx := range root.walkSelfWithDescendants() {
 		result = append(result, collectResourceModuleInfos(mctx)...)
 	}
-	sort.Sort(resourceModuleInfoByFqn(result))
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].Token() < result[j].Token()
+	})
 	return result
 }
 
@@ -144,18 +144,14 @@ type resourcePackageInfo struct {
 	Class string `json:"class"`
 }
 
-type resourcePackageInfoByFqn []resourcePackageInfo
-
-func (a resourcePackageInfoByFqn) Len() int           { return len(a) }
-func (a resourcePackageInfoByFqn) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a resourcePackageInfoByFqn) Less(i, j int) bool { return a[i].Fqn < a[j].Fqn }
-
 func allResourcePackageInfos(root *modContext) []resourcePackageInfo {
 	var result []resourcePackageInfo
 	for _, mctx := range root.walkSelfWithDescendants() {
 		result = append(result, collectResourcePackageInfos(mctx)...)
 	}
-	sort.Sort(resourcePackageInfoByFqn(result))
+	sort.Slice(result, func(i int, j int) bool {
+		return result[i].Token < result[j].Token
+	})
 	return result
 }
 

--- a/pkg/codegen/python/gen_resource_mappings_test.go
+++ b/pkg/codegen/python/gen_resource_mappings_test.go
@@ -1,0 +1,64 @@
+package python
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
+
+// Regress a problem of non-deterministic codegen (due to reordering).
+// The schema is taken from `pulumi-aws` and minified to the smallest
+// example that still reproduced the issue.
+func TestGenResourceMappingsIsDeterministic(t *testing.T) {
+	minimalSchema := `
+        {
+            "name": "aws",
+            "meta": {
+                "moduleFormat": "(.*)(?:/[^/]*)"
+            },
+            "resources": {
+                "aws:acm/certificateValidation:CertificateValidation": {},
+                "aws:acm/certificate:Certificate": {}
+            },
+            "language": {
+                "python": {
+                    "readme": ".."
+                }
+            }
+        }`
+
+	var pkgSpec schema.PackageSpec
+	err := json.Unmarshal([]byte(minimalSchema), &pkgSpec)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	generateInitHash := func() string {
+		pkg, err := schema.ImportSpec(pkgSpec, nil)
+		if err != nil {
+			t.Error(err)
+			return ""
+		}
+
+		files, err := GeneratePackage("tool", pkg, nil)
+
+		file, haveFile := files["pulumi_aws/__init__.py"]
+		if !haveFile {
+			t.Error("Cannot find pulumi_aws/__init__.py in the generated files")
+			return ""
+		}
+
+		return fmt.Sprintf("%x", md5.Sum(file))
+	}
+
+	h1 := generateInitHash()
+	for i := 0; i < 16; i++ {
+		assert.Equal(t, h1, generateInitHash())
+	}
+}

--- a/pkg/codegen/python/gen_resource_mappings_test.go
+++ b/pkg/codegen/python/gen_resource_mappings_test.go
@@ -1,7 +1,7 @@
 package python
 
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint: gosec
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -47,6 +47,10 @@ func TestGenResourceMappingsIsDeterministic(t *testing.T) {
 		}
 
 		files, err := GeneratePackage("tool", pkg, nil)
+		if err != nil {
+			t.Error(err)
+			return ""
+		}
 
 		file, haveFile := files["pulumi_aws/__init__.py"]
 		if !haveFile {
@@ -54,7 +58,7 @@ func TestGenResourceMappingsIsDeterministic(t *testing.T) {
 			return ""
 		}
 
-		return fmt.Sprintf("%x", md5.Sum(file))
+		return fmt.Sprintf("%x", md5.Sum(file)) //nolint: gosec
 	}
 
 	h1 := generateInitHash()


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Currently the JSON literals generated for Python codegen do not have consistent ordering of list elements. This is unfortunate for our CI as repeat builds generate code diffs. The fix sorts the data before splicing it into JSON.


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
