### PR TITLE
Support using pre-signed URLs for Azure Storage issued by the Pulumi Service

### DIFF
--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -616,10 +616,8 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 		return "", errors.Wrapf(err, "Failed to upload compressed PolicyPack")
 	}
 
-	if resp.RequiredHeaders != nil {
-		for k := range resp.RequiredHeaders {
-			putReq.Header.Add(k, resp.RequiredHeaders[k])
-		}
+	for k := range resp.RequiredHeaders {
+		putReq.Header.Add(k, resp.RequiredHeaders[k])
 	}
 
 	_, err = http.DefaultClient.Do(putReq)

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -616,8 +616,8 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 		return "", errors.Wrapf(err, "Failed to upload compressed PolicyPack")
 	}
 
-	for k := range resp.RequiredHeaders {
-		putReq.Header.Add(k, resp.RequiredHeaders[k])
+	for k, v := range resp.RequiredHeaders {
+		putReq.Header.Add(k, v)
 	}
 
 	_, err = http.DefaultClient.Do(putReq)

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -616,10 +616,11 @@ func (pc *Client) PublishPolicyPack(ctx context.Context, orgName string,
 		return "", errors.Wrapf(err, "Failed to upload compressed PolicyPack")
 	}
 
-	// Add a custom header for Azure Storage so that if the pre-signed URL is for their
-	// storage service, the request doesn't fail due to it being required.
-	// See x-ms-blob-type on https://docs.microsoft.com/en-us/rest/api/storageservices/put-blob
-	putReq.Header.Add("x-ms-blob-type", "BlockBlob")
+	if resp.RequiredHeaders != nil {
+		for k := range resp.RequiredHeaders {
+			putReq.Header.Add(k, resp.RequiredHeaders[k])
+		}
+	}
 
 	_, err = http.DefaultClient.Do(putReq)
 	if err != nil {

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -46,6 +46,9 @@ type CreatePolicyPackRequest struct {
 type CreatePolicyPackResponse struct {
 	Version   int    `json:"version"`
 	UploadURI string `json:"uploadURI"`
+	// RequiredHeaders represent any headers that the CLI must set in order
+	// for the upload to succeed.
+	RequiredHeaders map[string]string `json:"headers,omitempty"`
 }
 
 // RequiredPolicy is the information regarding a particular Policy that is required

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -48,7 +48,7 @@ type CreatePolicyPackResponse struct {
 	UploadURI string `json:"uploadURI"`
 	// RequiredHeaders represents headers that the CLI must set in order
 	// for the upload to succeed.
-	RequiredHeaders map[string]string `json:"headers,omitempty"`
+	RequiredHeaders map[string]string `json:"requiredHeaders,omitempty"`
 }
 
 // RequiredPolicy is the information regarding a particular Policy that is required

--- a/sdk/go/common/apitype/policy.go
+++ b/sdk/go/common/apitype/policy.go
@@ -46,7 +46,7 @@ type CreatePolicyPackRequest struct {
 type CreatePolicyPackResponse struct {
 	Version   int    `json:"version"`
 	UploadURI string `json:"uploadURI"`
-	// RequiredHeaders represent any headers that the CLI must set in order
+	// RequiredHeaders represents headers that the CLI must set in order
 	// for the upload to succeed.
 	RequiredHeaders map[string]string `json:"headers,omitempty"`
 }


### PR DESCRIPTION
# Description

As you know Pulumi Service supports [self-hosted](https://www.pulumi.com/docs/guides/self-hosted/) options. This means a customer can self-host Pulumi Service on Azure. For policy pack publishing to work with Azure Storage, the signed URL retrieved from the service must have a header called `x-ms-blob-type` that is set to `BlockBlob`. This is an exception with Azure Storage only. Since the header is a custom header only used by Azure Storage service, it is safe to include it for all of them.

Fixes `N/A`

## Checklist

~~- [ ] I have added tests that prove my fix is effective or that my feature works~~ I have not added a test to this repo but we do have a test in the service that exercises this for signed URLs.
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
