### PR TITLE
Populate package.json version to match provider version

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1603,7 +1603,7 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 	// Create info that will get serialized into an NPM package.json.
 	npminfo := npmPackage{
 		Name:        packageName,
-		Version:     "${VERSION}",
+		Version:     pkg.Version.String(),
 		Description: info.PackageDescription,
 		Keywords:    pkg.Keywords,
 		Homepage:    pkg.Homepage,


### PR DESCRIPTION
As the version is hardcoded, whenever I rebuild I get:

```
Diagnostics:
  pulumi:providers:tsb (tsb):
    error: pulumi:providers:tsb resource 'tsb's property 'version' value {${VERSION}} has a problem: could not parse provider version: Invalid character(s) found in major number "${VERSION}"
```

Is there any reason we can't just populate this with the provider version?
