### PR TITLE
put nodejs resource registration logs behind excessiveDebugOutput flag

### DIFF
--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -631,7 +631,9 @@ export function register<T extends { readonly version?: string }>(source: Map<st
                 // In this case, we might legitimately get mutliple registrations of the same resource.  It should not
                 // matter which we use, so we can just skip re-registering.  De-serialized resources will always be
                 // instances of classes from the first registered package.
-                log.debug(`skip re-registering already registered ${registrationType} ${key}@${item.version}.`);
+                if (excessiveDebugOutput) {
+                    log.debug(`skip re-registering already registered ${registrationType} ${key}@${item.version}.`);
+                }
                 return false;
             }
         }
@@ -640,7 +642,9 @@ export function register<T extends { readonly version?: string }>(source: Map<st
         source.set(key, items);
     }
 
-    log.debug(`registering ${registrationType} ${key}@${item.version}`);
+    if (excessiveDebugOutput) {
+        log.debug(`skip re-registering already registered ${registrationType} ${key}@${item.version}.`);
+    }
     items.push(item);
     return true;
 }

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -643,7 +643,7 @@ export function register<T extends { readonly version?: string }>(source: Map<st
     }
 
     if (excessiveDebugOutput) {
-        log.debug(`skip re-registering already registered ${registrationType} ${key}@${item.version}.`);
+        log.debug(`registering ${registrationType} ${key}@${item.version}`);
     }
     items.push(item);
     return true;


### PR DESCRIPTION
I was looking at some program traces and noticed hundreds of calls to `/pulumirpc.Engine/Log`. When I remove debug logs for duplicate resource registrations, this basic program cuts it's runtime from 10s down to 3s.

```ts
import * as aws from "@pulumi/aws";
import * as kubernetes from "@pulumi/kubernetes";

console.log(aws);
console.log(kubernetes);

export const foo = {};
```

Looking at the traces, there are ~800 logging calls for duplicate registrations, each of which is an RPC request to the engine. This change puts those specific logging calls behind the excessive debug flag. Perhaps in theory this shouldn't be a problem, and we should be able to handle these logging requests but it does appear to be creating perf problems for the most basic of programs. 

Fixes # (issue)

## Checklist

No tests or changelog here. No behavior change, just hiding some logs behind the debug flag.