### PR TITLE
Filestate backend gzip compression

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,3 +6,5 @@
 - [cli] - Send plugin install output to stderr, so that it doesn't
   clutter up --json, automation API scenarios, and so on.
   [#7115](https://github.com/pulumi/pulumi/pull/7115)
+- [backend] Add gzip compression to filestate backend.
+  Compression can be enabled via `PULUMI_SELF_MANAGED_STATE_GZIP=true`.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -58,6 +58,10 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+// PulumiFilestateGzipEnvVar is an env var that must be truthy
+//  to ensable gzip compression when using the filestate backend.
+const PulumiFilestateGzipEnvVar = "PULUMI_SELF_MANAGED_STATE_GZIP"
+
 // Backend extends the base backend interface with specific information about local backends.
 type Backend interface {
 	backend.Backend
@@ -77,6 +81,8 @@ type localBackend struct {
 	mutex  sync.Mutex
 
 	lockID string
+
+	gzip bool
 }
 
 type localBackendReference struct {
@@ -151,12 +157,15 @@ func New(d diag.Sink, originalURL string) (Backend, error) {
 		return nil, err
 	}
 
+	gzipCompression := cmdutil.IsTruthy(os.Getenv(PulumiFilestateGzipEnvVar))
+
 	return &localBackend{
 		d:           d,
 		originalURL: originalURL,
 		url:         u,
 		bucket:      &wrappedBucket{bucket: bucket},
 		lockID:      lockID.String(),
+		gzip:        gzipCompression,
 	}, nil
 }
 
@@ -848,6 +857,12 @@ func (b *localBackend) getLocalStacks() ([]tokens.QName, error) {
 		// Skip files without valid extensions (e.g., *.bak files).
 		stackfn := objectName(file)
 		ext := filepath.Ext(stackfn)
+		// But accept gzip compression
+		if ext == ".gz" {
+			stackfn = strings.TrimSuffix(stackfn, ".gz")
+			ext = filepath.Ext(stackfn)
+		}
+
 		if _, has := encoding.Marshalers[ext]; !has {
 			continue
 		}

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -163,7 +163,7 @@ func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.Checkpoin
 	if err != nil {
 		return nil, err
 	}
-	bytes, err = inflateBytes(bytes)
+	bytes, err = maybeInflateBytes(bytes)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func (b *localBackend) backupStack(name tokens.QName) error {
 	if err != nil {
 		return err
 	}
-	byts, err = inflateBytes(byts)
+	byts, err = maybeInflateBytes(byts)
 	if err != nil {
 		return err
 	}
@@ -419,7 +419,7 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 		if err != nil {
 			return nil, errors.Wrapf(err, "reading history file %s", filepath)
 		}
-		b, err = inflateBytes(b)
+		b, err = maybeInflateBytes(b)
 		if err != nil {
 			return nil, err
 		}
@@ -504,12 +504,17 @@ func (b *localBackend) addToHistory(name tokens.QName, update backend.UpdateInfo
 	return b.bucket.Copy(context.TODO(), checkpointFile, b.stackPath(name), nil)
 }
 
-// return plain data from gziped (or plain) data
-func inflateBytes(data []byte) ([]byte, error) {
+// friendly wrapper for inflateBytes
+func maybeInflateBytes(data []byte) ([]byte, error) {
 	if data[0] != 31 || data[1] != 139 {
-		// not gzip
+		// not gzip (doesn't have bagic bytes), don't do anything
 		return data, nil
 	}
+	return inflateBytes(data)
+}
+
+// return plain data from gziped data
+func inflateBytes(data []byte) ([]byte, error) {
 	buf := bytes.NewBuffer(data)
 	reader, err := gzip.NewReader(buf)
 	if err != nil {
@@ -528,10 +533,6 @@ func inflateBytes(data []byte) ([]byte, error) {
 
 // return gziped data from plain data
 func deflateBytes(data []byte) ([]byte, error) {
-	if data[0] == 31 && data[1] == 139 {
-		// already gziped
-		return nil, errors.New("trying to compress already gziped data")
-	}
 	var buf bytes.Buffer
 	writer := gzip.NewWriter(&buf)
 	defer writer.Close()

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -15,9 +15,12 @@
 package filestate
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -160,6 +163,10 @@ func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.Checkpoin
 	if err != nil {
 		return nil, err
 	}
+	bytes, err = inflateBytes(bytes)
+	if err != nil {
+		return nil, err
+	}
 
 	return stack.UnmarshalVersionedCheckpointToLatestCheckpoint(bytes)
 }
@@ -167,7 +174,7 @@ func (b *localBackend) getCheckpoint(stackName tokens.QName) (*apitype.Checkpoin
 func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm secrets.Manager) (string, error) {
 	// Make a serializable stack and then use the encoder to encode it.
 	file := b.stackPath(name)
-	m, ext := encoding.Detect(file)
+	m, ext := encoding.Detect(strings.TrimSuffix(file, ".gz"))
 	if m == nil {
 		return "", errors.Errorf("resource serialization failed; illegal markup extension: '%v'", ext)
 	}
@@ -182,9 +189,25 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 	if err != nil {
 		return "", errors.Wrap(err, "An IO error occurred while marshalling the checkpoint")
 	}
+	if b.gzip {
+		if filepath.Ext(file) != ".gz" {
+			file = file + ".gz"
+		}
+		byts, err = deflateBytes(byts)
+		if err != nil {
+			return "", errors.Wrap(err, "An IO error occurred while compressing the checkpoint")
+		}
+	} else {
+		file = strings.TrimSuffix(file, ".gz")
+	}
 
-	// Back up the existing file if it already exists.
-	bck := backupTarget(b.bucket, file)
+	// Try to back up the existing file if it already exists,
+	// whether it's compressed or not
+	filePlain := strings.TrimSuffix(file, ".gz")
+	fileGzip := filePlain + ".gz"
+	bckPlain := backupTarget(b.bucket, filePlain)
+	bckGzip := backupTarget(b.bucket, fileGzip)
+	bck := fmt.Sprintf("[%s, %s]", bckPlain, bckGzip)
 
 	// And now write out the new snapshot file, overwriting that location.
 	if err = b.bucket.WriteAll(context.TODO(), file, byts, nil); err != nil {
@@ -260,7 +283,9 @@ func (b *localBackend) removeStack(name tokens.QName) error {
 func backupTarget(bucket Bucket, file string) string {
 	contract.Require(file != "", "file")
 	bck := file + ".bak"
-	err := renameObject(bucket, file, bck)
+	err := bucket.Delete(context.TODO(), bck)
+	contract.IgnoreError(err)
+	err = renameObject(bucket, file, bck)
 	contract.IgnoreError(err) // ignore errors.
 	// IDEA: consider multiple backups (.bak.bak.bak...etc).
 	return bck
@@ -281,6 +306,10 @@ func (b *localBackend) backupStack(name tokens.QName) error {
 	if err != nil {
 		return err
 	}
+	byts, err = inflateBytes(byts)
+	if err != nil {
+		return err
+	}
 
 	// Get the backup directory.
 	backupDir := b.backupDirectory(name)
@@ -288,6 +317,10 @@ func (b *localBackend) backupStack(name tokens.QName) error {
 	// Write out the new backup checkpoint file.
 	stackFile := filepath.Base(stackPath)
 	ext := filepath.Ext(stackFile)
+	if ext == ".gz" {
+		// store .json.gz in ext
+		ext = filepath.Ext(strings.TrimSuffix(stackFile, ext)) + ".gz"
+	}
 	base := strings.TrimSuffix(stackFile, ext)
 	backupFile := fmt.Sprintf("%s.%v%s", base, time.Now().UnixNano(), ext)
 	return b.bucket.WriteAll(context.TODO(), filepath.Join(backupDir, backupFile), byts, nil)
@@ -296,9 +329,24 @@ func (b *localBackend) backupStack(name tokens.QName) error {
 func (b *localBackend) stackPath(stack tokens.QName) string {
 	path := filepath.Join(b.StateDir(), workspace.StackDir)
 	if stack != "" {
-		path = filepath.Join(path, fsutil.QnamePath(stack)+".json")
+		allObjs, err := listBucket(b.bucket, path)
+		path = filepath.Join(path, fsutil.QnamePath(stack)) + ".json"
+		if err == nil {
+			gzipedPath := path + ".gz"
+			var plainObj *blob.ListObject
+			for _, obj := range allObjs {
+				// plainObj will always come out first since allObjs is sorted by Key
+				if obj.Key == path {
+					plainObj = obj
+				} else if obj.Key == gzipedPath {
+					if plainObj != nil && plainObj.ModTime.After(obj.ModTime) {
+						return path
+					}
+					return gzipedPath
+				}
+			}
+		}
 	}
-
 	return path
 }
 
@@ -339,7 +387,8 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 		filepath := file.Key
 
 		// ignore checkpoints
-		if !strings.HasSuffix(filepath, ".history.json") {
+		if !strings.HasSuffix(filepath, ".history.json") &&
+			!strings.HasSuffix(filepath, ".history.json.gz") {
 			continue
 		}
 
@@ -369,6 +418,10 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 		b, err := b.bucket.ReadAll(context.TODO(), filepath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "reading history file %s", filepath)
+		}
+		b, err = inflateBytes(b)
+		if err != nil {
+			return nil, err
 		}
 		err = json.Unmarshal(b, &update)
 		if err != nil {
@@ -425,19 +478,69 @@ func (b *localBackend) addToHistory(name tokens.QName, update backend.UpdateInfo
 
 	// Prefix for the update and checkpoint files.
 	pathPrefix := path.Join(dir, fmt.Sprintf("%s-%d", name, time.Now().UnixNano()))
+	// Add extra extension to file (like ".gz")
+	fileExtraExt := ""
 
 	// Save the history file.
 	byts, err := json.MarshalIndent(&update, "", "    ")
 	if err != nil {
 		return err
 	}
+	if b.gzip {
+		fileExtraExt = ".gz"
+		byts, err = deflateBytes(byts)
+		if err != nil {
+			return err
+		}
+	}
 
-	historyFile := fmt.Sprintf("%s.history.json", pathPrefix)
+	historyFile := fmt.Sprintf("%s.history.json%s", pathPrefix, fileExtraExt)
 	if err = b.bucket.WriteAll(context.TODO(), historyFile, byts, nil); err != nil {
 		return err
 	}
 
 	// Make a copy of the checkpoint file. (Assuming it already exists.)
-	checkpointFile := fmt.Sprintf("%s.checkpoint.json", pathPrefix)
+	checkpointFile := fmt.Sprintf("%s.checkpoint.json%s", pathPrefix, fileExtraExt)
 	return b.bucket.Copy(context.TODO(), checkpointFile, b.stackPath(name), nil)
+}
+
+// return plain data from gziped (or plain) data
+func inflateBytes(data []byte) ([]byte, error) {
+	if data[0] != 31 || data[1] != 139 {
+		// not gzip
+		return data, nil
+	}
+	buf := bytes.NewBuffer(data)
+	reader, err := gzip.NewReader(buf)
+	if err != nil {
+		return nil, err
+	}
+	defer reader.Close()
+	inflated, err := ioutil.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	if err := reader.Close(); err != nil {
+		return nil, err
+	}
+	return inflated, nil
+}
+
+// return gziped data from plain data
+func deflateBytes(data []byte) ([]byte, error) {
+	if data[0] == 31 && data[1] == 139 {
+		// already gziped
+		return nil, errors.New("trying to compress already gziped data")
+	}
+	var buf bytes.Buffer
+	writer := gzip.NewWriter(&buf)
+	defer writer.Close()
+	_, err := writer.Write(data)
+	if err != nil {
+		return nil, err
+	}
+	if err := writer.Close(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -451,6 +451,84 @@ func TestLocalStateLocking(t *testing.T) {
 
 }
 
+func TestLocalStateGzip(t *testing.T) {
+	e := ptesting.NewEnvironment(t)
+	defer func() {
+		if !t.Failed() {
+			e.DeleteEnvironment()
+		}
+	}()
+	stackName := addRandomSuffix("gzip-state")
+	integration.CreateBasicPulumiRepo(e)
+	e.ImportDirectory("integration/stack_dependencies")
+	e.SetBackend(e.LocalURL())
+	e.RunCommand("pulumi", "stack", "init", stackName)
+	e.RunCommand("yarn", "install")
+	e.RunCommand("yarn", "link", "@pulumi/pulumi")
+	e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
+
+	stacksDir := ".pulumi/stacks"
+	pathStack := stacksDir + "/" + stackName + ".json"
+	pathStackGzip := pathStack + ".gz"
+	pathStackBak := pathStack + ".bak"
+	pathStackBakGzip := pathStack + ".gz.bak"
+	sizeGzip := int64(-1)
+	sizeJson := int64(-1)
+
+	assertStackFilesOk := func(gzip bool) {
+		oneBackupExists := e.PathExists(pathStackBak) != e.PathExists(pathStackBakGzip)
+		gzipStackInfo, err := os.Stat(e.CWD + "/" + pathStackGzip)
+		if err == nil {
+			sizeGzip = gzipStackInfo.Size()
+		}
+		jsonStackInfo, err := os.Stat(e.CWD + "/" + pathStack)
+		if err == nil {
+			sizeJson = jsonStackInfo.Size()
+		}
+
+		ok := true
+		ok = ok && assert.Equal(t, !gzip, e.PathExists(pathStack), "Raw json stack file missing")
+		ok = ok && assert.Equal(t, gzip, e.PathExists(pathStackGzip), "gzip stack file missing")
+		ok = ok && assert.Equal(t, true, oneBackupExists, "One and only one backup shall exist, gzip or not")
+		if sizeGzip != -1 && sizeJson != -1 {
+			ok = ok && assert.Greater(t, sizeJson, sizeGzip, "Json file smaller than gzip")
+		}
+		if !ok {
+			fmt.Printf("Stacks dir state at time of failure (gzip: %t):\n", gzip)
+			files, _ := ioutil.ReadDir(e.CWD + "/" + stacksDir)
+			for _, file := range files {
+				fmt.Println(file.Name(), file.Size())
+			}
+		}
+	}
+
+	// Test "pulumi up" with gzip compression on and off.
+	// Running "pulumi up" 2 times is important because normaly, first the
+	//   `.json` becomes `.json.gz`, then the `.json.bak` becomes `.json.gz.bak`.
+	// Default is no gzip compression
+	assertStackFilesOk(false)
+	// Enable Gzip compression
+	e.SetEnvVars([]string{fmt.Sprintf("%s=1", filestate.PulumiFilestateGzipEnvVar)})
+	e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
+	assertStackFilesOk(true)
+	e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
+	assertStackFilesOk(true)
+	// Disable Gzip compression
+	e.SetEnvVars([]string{fmt.Sprintf("%s=0", filestate.PulumiFilestateGzipEnvVar)})
+	e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
+	assertStackFilesOk(false)
+	e.RunCommand("pulumi", "up", "--non-interactive", "--yes", "--skip-preview")
+	assertStackFilesOk(false)
+
+	// Check stack history is still good even with mixed gzip / json files
+	rawHistory, _ := e.RunCommand("pulumi", "stack", "history", "--json")
+	var history []interface{}
+	if err := json.Unmarshal([]byte(rawHistory), &history); err != nil {
+		t.Fatalf("Can't unmarshall history json")
+	}
+	assert.Equal(t, 5, len(history), "Stack history doesn't match reality")
+}
+
 func getFileNames(infos []os.FileInfo) []string {
 	var result []string
 	for _, i := range infos {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Replacement for #7086.
Fixes #5469
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Motivation:
Stack file size explosion with lots of k8s resources (helm charts are the worst offender): we've got stacks above 30MB ! (from 16MB in the linked issue). Pulumi becomes a real chore to use when it spends so much time transferring files.

Solution:
Enable compressed (gzip) files reading and add an environment var to write compressed files.
The default behavior is still to write plain json, so backwards compatibility is assured. The default behavior could then change in a later (breaking) update.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
