### PR TITLE
[codegen/go] Fix emitted type of resources and types

### DIFF
--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -62,7 +62,12 @@ func TestGeneratePackage(t *testing.T) {
 				filepath.Join(testDir, tt.schemaDir, "schema.json"), GeneratePackage)
 			assert.NoError(t, err)
 
-			expectedFiles, err := test.LoadFiles(filepath.Join(testDir, tt.schemaDir), "dotnet", tt.expectedFiles)
+			dir := filepath.Join(testDir, tt.schemaDir)
+			lang := "dotnet"
+
+			test.RewriteFilesWhenPulumiAccept(t, dir, lang, files)
+
+			expectedFiles, err := test.LoadFiles(filepath.Join(testDir, tt.schemaDir), lang, tt.expectedFiles)
 			assert.NoError(t, err)
 
 			test.ValidateFileEquality(t, files, expectedFiles)

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -910,7 +910,7 @@ func (pkg *pkgContext) genOutputTypes(w io.Writer, t *schema.ObjectType, details
 			outputType, applyType := pkg.outputType(p.Type, true), pkg.plainType(p.Type, true)
 			deref := ""
 			// If the property was required, but the type it needs to return is an explicit pointer type, then we need
-			// to derference it, unless it is a resource type which should remain a pointer.
+			// to dereference it, unless it is a resource type which should remain a pointer.
 			_, isResourceType := p.Type.(*schema.ResourceType)
 			if p.IsRequired && applyType[0] == '*' && !isResourceType {
 				deref = "&"

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -146,7 +146,12 @@ func TestGeneratePackage(t *testing.T) {
 				})
 			assert.NoError(t, err)
 
-			expectedFiles, err := test.LoadFiles(filepath.Join(testDir, tt.schemaDir), "go", tt.expectedFiles)
+			dir := filepath.Join(testDir, tt.schemaDir)
+			lang := "go"
+
+			test.RewriteFilesWhenPulumiAccept(t, dir, lang, files)
+
+			expectedFiles, err := test.LoadFiles(filepath.Join(testDir, tt.schemaDir), lang, tt.expectedFiles)
 			assert.NoError(t, err)
 			test.ValidateFileEquality(t, files, expectedFiles)
 			test.CheckAllFilesGenerated(t, files, expectedFiles)

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/docs/cat.md
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/docs/cat.md
@@ -333,7 +333,31 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <h4 id="pet">Pet</h4>
 
 {{% choosable language csharp %}}
-<dl class="resources-properties"><dt class="property-optional"
+<dl class="resources-properties"><dt class="property-required"
+            title="Required">
+        <span id="requiredname_csharp">
+<a href="#requiredname_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requirednamearray_csharp">
+<a href="#requirednamearray_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">List&lt;Pulumi.<wbr>Random.<wbr>Random<wbr>Pet&gt;</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requirednamemap_csharp">
+<a href="#requirednamemap_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Random.<wbr>Random<wbr>Pet&gt;</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="age_csharp">
 <a href="#age_csharp" style="color: inherit; text-decoration: inherit;">Age</a>
@@ -349,11 +373,51 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Random.<wbr>Random<wbr>Pet</span>
     </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="namearray_csharp">
+<a href="#namearray_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">List&lt;Pulumi.<wbr>Random.<wbr>Random<wbr>Pet&gt;</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="namemap_csharp">
+<a href="#namemap_csharp" style="color: inherit; text-decoration: inherit;">Name<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Random.<wbr>Random<wbr>Pet&gt;</span>
+    </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language go %}}
-<dl class="resources-properties"><dt class="property-optional"
+<dl class="resources-properties"><dt class="property-required"
+            title="Required">
+        <span id="requiredname_go">
+<a href="#requiredname_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requirednamearray_go">
+<a href="#requirednamearray_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requirednamemap_go">
+<a href="#requirednamemap_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Name<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="age_go">
 <a href="#age_go" style="color: inherit; text-decoration: inherit;">Age</a>
@@ -369,11 +433,51 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
     </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="namearray_go">
+<a href="#namearray_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="namemap_go">
+<a href="#namemap_go" style="color: inherit; text-decoration: inherit;">Name<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet</span>
+    </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language nodejs %}}
-<dl class="resources-properties"><dt class="property-optional"
+<dl class="resources-properties"><dt class="property-required"
+            title="Required">
+        <span id="requiredname_nodejs">
+<a href="#requiredname_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">random<wbr>Random<wbr>Pet</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requirednamearray_nodejs">
+<a href="#requirednamearray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">random<wbr>Random<wbr>Pet[]</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requirednamemap_nodejs">
+<a href="#requirednamemap_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">{[key: string]: random<wbr>Random<wbr>Pet}</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="age_nodejs">
 <a href="#age_nodejs" style="color: inherit; text-decoration: inherit;">age</a>
@@ -389,11 +493,51 @@ All [input](#inputs) properties are implicitly available as output properties. A
         <span class="property-indicator"></span>
         <span class="property-type">random<wbr>Random<wbr>Pet</span>
     </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="namearray_nodejs">
+<a href="#namearray_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">random<wbr>Random<wbr>Pet[]</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="namemap_nodejs">
+<a href="#namemap_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">{[key: string]: random<wbr>Random<wbr>Pet}</span>
+    </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language python %}}
-<dl class="resources-properties"><dt class="property-optional"
+<dl class="resources-properties"><dt class="property-required"
+            title="Required">
+        <span id="required_name_python">
+<a href="#required_name_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="required_name_array_python">
+<a href="#required_name_array_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name_<wbr>array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet]</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="required_name_map_python">
+<a href="#required_name_map_python" style="color: inherit; text-decoration: inherit;">required_<wbr>name_<wbr>map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet]</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="age_python">
 <a href="#age_python" style="color: inherit; text-decoration: inherit;">age</a>
@@ -408,6 +552,22 @@ All [input](#inputs) properties are implicitly available as output properties. A
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Random<wbr>Pet</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="name_array_python">
+<a href="#name_array_python" style="color: inherit; text-decoration: inherit;">name_<wbr>array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet]</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="name_map_python">
+<a href="#name_map_python" style="color: inherit; text-decoration: inherit;">name_<wbr>map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Random<wbr>Pet]</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/docs/component.md
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/docs/component.md
@@ -18,26 +18,31 @@ meta_desc: "Documentation for the example.Component resource with examples, inpu
 
 
 {{% choosable language nodejs %}}
-<div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">new </span><span class="nx">Component</span><span class="p">(</span><span class="nx">name</span><span class="p">:</span> <span class="nx">string</span><span class="p">,</span> <span class="nx">args</span><span class="p">?:</span> <span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">,</span> <span class="nx">opts</span><span class="p">?:</span> <span class="nx"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions">CustomResourceOptions</a></span><span class="p">);</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-typescript" data-lang="typescript"><span class="k">new </span><span class="nx">Component</span><span class="p">(</span><span class="nx">name</span><span class="p">:</span> <span class="nx">string</span><span class="p">,</span> <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">,</span> <span class="nx">opts</span><span class="p">?:</span> <span class="nx"><a href="/docs/reference/pkg/nodejs/pulumi/pulumi/#CustomResourceOptions">CustomResourceOptions</a></span><span class="p">);</span></code></pre></div>
 {{% /choosable %}}
 
 {{% choosable language python %}}
 <div class="highlight"><pre class="chroma"><code class="language-python" data-lang="python"><span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">,</span>
-              <span class="nx">metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">)</span>
+              <span class="nx">metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">,</span>
+              <span class="nx">metadata_array</span><span class="p">:</span> <span class="nx">Optional[Sequence[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
+              <span class="nx">metadata_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
+              <span class="nx">required_metadata</span><span class="p">:</span> <span class="nx">Optional[pulumi_kubernetes.meta.v1.ObjectMetaArgs]</span> = None<span class="p">,</span>
+              <span class="nx">required_metadata_array</span><span class="p">:</span> <span class="nx">Optional[Sequence[pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">,</span>
+              <span class="nx">required_metadata_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, pulumi_kubernetes.meta.v1.ObjectMetaArgs]]</span> = None<span class="p">)</span>
 <span class=nd>@overload</span>
 <span class="k">def </span><span class="nx">Component</span><span class="p">(</span><span class="nx">resource_name</span><span class="p">:</span> <span class="nx">str</span><span class="p">,</span>
-              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">Optional[ComponentArgs]</a></span> = None<span class="p">,</span>
+              <span class="nx">args</span><span class="p">:</span> <span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">,</span>
               <span class="nx">opts</span><span class="p">:</span> <span class="nx"><a href="/docs/reference/pkg/python/pulumi/#pulumi.ResourceOptions">Optional[ResourceOptions]</a></span> = None<span class="p">)</span></code></pre></div>
 {{% /choosable %}}
 
 {{% choosable language go %}}
-<div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span><span class="nx">NewComponent</span><span class="p">(</span><span class="nx">ctx</span><span class="p"> *</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#Context">Context</a></span><span class="p">,</span> <span class="nx">name</span><span class="p"> </span><span class="nx">string</span><span class="p">,</span> <span class="nx">args</span><span class="p"> *</span><span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">,</span> <span class="nx">opts</span><span class="p"> ...</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#ResourceOption">ResourceOption</a></span><span class="p">) (*<span class="nx">Component</span>, error)</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-go" data-lang="go"><span class="k">func </span><span class="nx">NewComponent</span><span class="p">(</span><span class="nx">ctx</span><span class="p"> *</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#Context">Context</a></span><span class="p">,</span> <span class="nx">name</span><span class="p"> </span><span class="nx">string</span><span class="p">,</span> <span class="nx">args</span><span class="p"> </span><span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">,</span> <span class="nx">opts</span><span class="p"> ...</span><span class="nx"><a href="https://pkg.go.dev/github.com/pulumi/pulumi/sdk/go/pulumi?tab=doc#ResourceOption">ResourceOption</a></span><span class="p">) (*<span class="nx">Component</span>, error)</span></code></pre></div>
 {{% /choosable %}}
 
 {{% choosable language csharp %}}
-<div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public </span><span class="nx">Component</span><span class="p">(</span><span class="nx">string</span><span class="p"> </span><span class="nx">name<span class="p">,</span> <span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p">? </span><span class="nx">args = null<span class="p">,</span> <span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.CustomResourceOptions.html">CustomResourceOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span></code></pre></div>
+<div class="highlight"><pre class="chroma"><code class="language-csharp" data-lang="csharp"><span class="k">public </span><span class="nx">Component</span><span class="p">(</span><span class="nx">string</span><span class="p"> </span><span class="nx">name<span class="p">,</span> <span class="nx"><a href="#inputs">ComponentArgs</a></span><span class="p"> </span><span class="nx">args<span class="p">,</span> <span class="nx"><a href="/docs/reference/pkg/dotnet/Pulumi/Pulumi.CustomResourceOptions.html">CustomResourceOptions</a></span><span class="p">? </span><span class="nx">opts = null<span class="p">)</span></code></pre></div>
 {{% /choosable %}}
 
 {{% choosable language nodejs %}}
@@ -49,7 +54,7 @@ meta_desc: "Documentation for the example.Component resource with examples, inpu
         <span class="property-type">string</span>
     </dt>
     <dd>The unique name of the resource.</dd><dt
-        class="property-optional" title="Optional">
+        class="property-required" title="Required">
         <span>args</span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#inputs">ComponentArgs</a></span>
@@ -73,7 +78,7 @@ meta_desc: "Documentation for the example.Component resource with examples, inpu
         <span class="property-type">str</span>
     </dt>
     <dd>The unique name of the resource.</dd><dt
-        class="property-optional" title="Optional">
+        class="property-required" title="Required">
         <span>args</span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#inputs">ComponentArgs</a></span>
@@ -103,7 +108,7 @@ meta_desc: "Documentation for the example.Component resource with examples, inpu
         <span class="property-type">string</span>
     </dt>
     <dd>The unique name of the resource.</dd><dt
-        class="property-optional" title="Optional">
+        class="property-required" title="Required">
         <span>args</span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#inputs">ComponentArgs</a></span>
@@ -127,7 +132,7 @@ meta_desc: "Documentation for the example.Component resource with examples, inpu
         <span class="property-type">string</span>
     </dt>
     <dd>The unique name of the resource.</dd><dt
-        class="property-optional" title="Optional">
+        class="property-required" title="Required">
         <span>args</span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#inputs">ComponentArgs</a></span>
@@ -153,7 +158,31 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 
 
 {{% choosable language csharp %}}
-<dl class="resources-properties"><dt class="property-optional"
+<dl class="resources-properties"><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadata_csharp">
+<a href="#requiredmetadata_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadataarray_csharp">
+<a href="#requiredmetadataarray_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">List&lt;Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadatamap_csharp">
+<a href="#requiredmetadatamap_csharp" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_csharp">
 <a href="#metadata_csharp" style="color: inherit; text-decoration: inherit;">Metadata</a>
@@ -161,11 +190,51 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args</a></span>
     </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="metadataarray_csharp">
+<a href="#metadataarray_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">List&lt;Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="metadatamap_csharp">
+<a href="#metadatamap_csharp" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Dictionary&lt;string, Pulumi.<wbr>Kubernetes.<wbr>Types.<wbr>Inputs.<wbr>Meta.<wbr>V1.<wbr>Object<wbr>Meta<wbr>Args&gt;</span>
+    </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language go %}}
-<dl class="resources-properties"><dt class="property-optional"
+<dl class="resources-properties"><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadata_go">
+<a href="#requiredmetadata_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadataarray_go">
+<a href="#requiredmetadataarray_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadatamap_go">
+<a href="#requiredmetadatamap_go" style="color: inherit; text-decoration: inherit;">Required<wbr>Metadata<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Object<wbr>Meta</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_go">
 <a href="#metadata_go" style="color: inherit; text-decoration: inherit;">Metadata</a>
@@ -173,11 +242,51 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta</a></span>
     </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="metadataarray_go">
+<a href="#metadataarray_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="metadatamap_go">
+<a href="#metadatamap_go" style="color: inherit; text-decoration: inherit;">Metadata<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Object<wbr>Meta</span>
+    </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language nodejs %}}
-<dl class="resources-properties"><dt class="property-optional"
+<dl class="resources-properties"><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadata_nodejs">
+<a href="#requiredmetadata_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadataarray_nodejs">
+<a href="#requiredmetadataarray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args[]</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="requiredmetadatamap_nodejs">
+<a href="#requiredmetadatamap_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">{[key: string]: kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args}</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_nodejs">
 <a href="#metadata_nodejs" style="color: inherit; text-decoration: inherit;">metadata</a>
@@ -185,17 +294,73 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args</a></span>
     </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="metadataarray_nodejs">
+<a href="#metadataarray_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args[]</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="metadatamap_nodejs">
+<a href="#metadatamap_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">{[key: string]: kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args}</span>
+    </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
 
 {{% choosable language python %}}
-<dl class="resources-properties"><dt class="property-optional"
+<dl class="resources-properties"><dt class="property-required"
+            title="Required">
+        <span id="required_metadata_python">
+<a href="#required_metadata_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="required_metadata_array_python">
+<a href="#required_metadata_array_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata_<wbr>array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args]</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
+            title="Required">
+        <span id="required_metadata_map_python">
+<a href="#required_metadata_map_python" style="color: inherit; text-decoration: inherit;">required_<wbr>metadata_<wbr>map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Object<wbr>Meta<wbr>Args]</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
         <span id="metadata_python">
 <a href="#metadata_python" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="metadata_array_python">
+<a href="#metadata_array_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>array</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type"><a href="#objectmeta">Object<wbr>Meta<wbr>Args]</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="metadata_map_python">
+<a href="#metadata_map_python" style="color: inherit; text-decoration: inherit;">metadata_<wbr>map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Object<wbr>Meta<wbr>Args]</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
@@ -218,19 +383,19 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
-        <span id="provider_csharp">
-<a href="#provider_csharp" style="color: inherit; text-decoration: inherit;">Provider</a>
-</span>
-        <span class="property-indicator"></span>
-        <span class="property-type">Pulumi.<wbr>Kubernetes.<wbr>Provider</span>
-    </dt>
-    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
-            title="">
         <span id="securitygroup_csharp">
 <a href="#securitygroup_csharp" style="color: inherit; text-decoration: inherit;">Security<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Pulumi.<wbr>Aws.<wbr>Ec2.<wbr>Security<wbr>Group</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
+            title="">
+        <span id="provider_csharp">
+<a href="#provider_csharp" style="color: inherit; text-decoration: inherit;">Provider</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Pulumi.<wbr>Kubernetes.<wbr>Provider</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
@@ -254,19 +419,19 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
-        <span id="provider_go">
-<a href="#provider_go" style="color: inherit; text-decoration: inherit;">Provider</a>
-</span>
-        <span class="property-indicator"></span>
-        <span class="property-type">Provider</span>
-    </dt>
-    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
-            title="">
         <span id="securitygroup_go">
 <a href="#securitygroup_go" style="color: inherit; text-decoration: inherit;">Security<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Security<wbr>Group</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
+            title="">
+        <span id="provider_go">
+<a href="#provider_go" style="color: inherit; text-decoration: inherit;">Provider</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Provider</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
@@ -290,19 +455,19 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
-        <span id="provider_nodejs">
-<a href="#provider_nodejs" style="color: inherit; text-decoration: inherit;">provider</a>
-</span>
-        <span class="property-indicator"></span>
-        <span class="property-type">kubernetes<wbr>Provider</span>
-    </dt>
-    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
-            title="">
         <span id="securitygroup_nodejs">
 <a href="#securitygroup_nodejs" style="color: inherit; text-decoration: inherit;">security<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">awsec2Security<wbr>Group</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
+            title="">
+        <span id="provider_nodejs">
+<a href="#provider_nodejs" style="color: inherit; text-decoration: inherit;">provider</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">kubernetes<wbr>Provider</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
@@ -326,19 +491,19 @@ All [input](#inputs) properties are implicitly available as output properties. A
     </dt>
     <dd>{{% md %}}The provider-assigned unique ID for this managed resource.{{% /md %}}</dd><dt class="property-"
             title="">
-        <span id="provider_python">
-<a href="#provider_python" style="color: inherit; text-decoration: inherit;">provider</a>
-</span>
-        <span class="property-indicator"></span>
-        <span class="property-type">Provider</span>
-    </dt>
-    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
-            title="">
         <span id="security_group_python">
 <a href="#security_group_python" style="color: inherit; text-decoration: inherit;">security_<wbr>group</a>
 </span>
         <span class="property-indicator"></span>
         <span class="property-type">Security<wbr>Group</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
+            title="">
+        <span id="provider_python">
+<a href="#provider_python" style="color: inherit; text-decoration: inherit;">provider</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Provider</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Component.cs
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Component.cs
@@ -16,7 +16,7 @@ namespace Pulumi.Example
         public Output<Pulumi.Kubernetes.Provider?> Provider { get; private set; } = null!;
 
         [Output("securityGroup")]
-        public Output<Pulumi.Aws.Ec2.SecurityGroup?> SecurityGroup { get; private set; } = null!;
+        public Output<Pulumi.Aws.Ec2.SecurityGroup> SecurityGroup { get; private set; } = null!;
 
         [Output("storageClasses")]
         public Output<ImmutableDictionary<string, Pulumi.Kubernetes.Storage.V1.StorageClass>?> StorageClasses { get; private set; } = null!;
@@ -29,7 +29,7 @@ namespace Pulumi.Example
         /// <param name="name">The unique name of the resource</param>
         /// <param name="args">The arguments used to populate this resource's properties</param>
         /// <param name="options">A bag of options that control this resource's behavior</param>
-        public Component(string name, ComponentArgs? args = null, CustomResourceOptions? options = null)
+        public Component(string name, ComponentArgs args, CustomResourceOptions? options = null)
             : base("example::Component", name, args ?? new ComponentArgs(), MakeResourceOptions(options, ""))
         {
         }
@@ -68,6 +68,41 @@ namespace Pulumi.Example
     {
         [Input("metadata")]
         public Input<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? Metadata { get; set; }
+
+        [Input("metadataArray")]
+        private InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? _metadataArray;
+        public InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs> MetadataArray
+        {
+            get => _metadataArray ?? (_metadataArray = new InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>());
+            set => _metadataArray = value;
+        }
+
+        [Input("metadataMap")]
+        private InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? _metadataMap;
+        public InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs> MetadataMap
+        {
+            get => _metadataMap ?? (_metadataMap = new InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>());
+            set => _metadataMap = value;
+        }
+
+        [Input("requiredMetadata", required: true)]
+        public Input<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs> RequiredMetadata { get; set; } = null!;
+
+        [Input("requiredMetadataArray", required: true)]
+        private InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? _requiredMetadataArray;
+        public InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs> RequiredMetadataArray
+        {
+            get => _requiredMetadataArray ?? (_requiredMetadataArray = new InputList<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>());
+            set => _requiredMetadataArray = value;
+        }
+
+        [Input("requiredMetadataMap", required: true)]
+        private InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>? _requiredMetadataMap;
+        public InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs> RequiredMetadataMap
+        {
+            get => _requiredMetadataMap ?? (_requiredMetadataMap = new InputMap<Pulumi.Kubernetes.Types.Inputs.Meta.V1.ObjectMetaArgs>());
+            set => _requiredMetadataMap = value;
+        }
 
         public ComponentArgs()
         {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Inputs/PetArgs.cs
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Inputs/PetArgs.cs
@@ -18,6 +18,41 @@ namespace Pulumi.Example.Inputs
         [Input("name")]
         public Input<Pulumi.Random.RandomPet>? Name { get; set; }
 
+        [Input("nameArray")]
+        private InputList<Pulumi.Random.RandomPet>? _nameArray;
+        public InputList<Pulumi.Random.RandomPet> NameArray
+        {
+            get => _nameArray ?? (_nameArray = new InputList<Pulumi.Random.RandomPet>());
+            set => _nameArray = value;
+        }
+
+        [Input("nameMap")]
+        private InputMap<Pulumi.Random.RandomPet>? _nameMap;
+        public InputMap<Pulumi.Random.RandomPet> NameMap
+        {
+            get => _nameMap ?? (_nameMap = new InputMap<Pulumi.Random.RandomPet>());
+            set => _nameMap = value;
+        }
+
+        [Input("requiredName", required: true)]
+        public Input<Pulumi.Random.RandomPet> RequiredName { get; set; } = null!;
+
+        [Input("requiredNameArray", required: true)]
+        private InputList<Pulumi.Random.RandomPet>? _requiredNameArray;
+        public InputList<Pulumi.Random.RandomPet> RequiredNameArray
+        {
+            get => _requiredNameArray ?? (_requiredNameArray = new InputList<Pulumi.Random.RandomPet>());
+            set => _requiredNameArray = value;
+        }
+
+        [Input("requiredNameMap", required: true)]
+        private InputMap<Pulumi.Random.RandomPet>? _requiredNameMap;
+        public InputMap<Pulumi.Random.RandomPet> RequiredNameMap
+        {
+            get => _requiredNameMap ?? (_requiredNameMap = new InputMap<Pulumi.Random.RandomPet>());
+            set => _requiredNameMap = value;
+        }
+
         public PetArgs()
         {
         }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"reflect"
 
+	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi-aws/sdk/v3/go/aws/ec2"
 	"github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes"
 	metav1 "github.com/pulumi/pulumi-kubernetes/sdk/v2/go/kubernetes/meta/v1"
@@ -26,9 +27,18 @@ type Component struct {
 func NewComponent(ctx *pulumi.Context,
 	name string, args *ComponentArgs, opts ...pulumi.ResourceOption) (*Component, error) {
 	if args == nil {
-		args = &ComponentArgs{}
+		return nil, errors.New("missing one or more required arguments")
 	}
 
+	if args.RequiredMetadata == nil {
+		return nil, errors.New("invalid value for required argument 'RequiredMetadata'")
+	}
+	if args.RequiredMetadataArray == nil {
+		return nil, errors.New("invalid value for required argument 'RequiredMetadataArray'")
+	}
+	if args.RequiredMetadataMap == nil {
+		return nil, errors.New("invalid value for required argument 'RequiredMetadataMap'")
+	}
 	var resource Component
 	err := ctx.RegisterResource("example::Component", name, args, &resource, opts...)
 	if err != nil {
@@ -67,12 +77,22 @@ func (ComponentState) ElementType() reflect.Type {
 }
 
 type componentArgs struct {
-	Metadata *metav1.ObjectMeta `pulumi:"metadata"`
+	Metadata              *metav1.ObjectMeta           `pulumi:"metadata"`
+	MetadataArray         []metav1.ObjectMeta          `pulumi:"metadataArray"`
+	MetadataMap           map[string]metav1.ObjectMeta `pulumi:"metadataMap"`
+	RequiredMetadata      metav1.ObjectMeta            `pulumi:"requiredMetadata"`
+	RequiredMetadataArray []metav1.ObjectMeta          `pulumi:"requiredMetadataArray"`
+	RequiredMetadataMap   map[string]metav1.ObjectMeta `pulumi:"requiredMetadataMap"`
 }
 
 // The set of arguments for constructing a Component resource.
 type ComponentArgs struct {
-	Metadata metav1.ObjectMetaPtrInput
+	Metadata              metav1.ObjectMetaPtrInput
+	MetadataArray         metav1.ObjectMetaArrayInput
+	MetadataMap           metav1.ObjectMetaMapInput
+	RequiredMetadata      metav1.ObjectMetaInput
+	RequiredMetadataArray metav1.ObjectMetaArrayInput
+	RequiredMetadataMap   metav1.ObjectMetaMapInput
 }
 
 func (ComponentArgs) ElementType() reflect.Type {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/pulumiTypes.go
@@ -12,8 +12,13 @@ import (
 )
 
 type Pet struct {
-	Age  *int              `pulumi:"age"`
-	Name *random.RandomPet `pulumi:"name"`
+	Age               *int                         `pulumi:"age"`
+	Name              *random.RandomPet            `pulumi:"name"`
+	NameArray         []*random.RandomPet          `pulumi:"nameArray"`
+	NameMap           map[string]*random.RandomPet `pulumi:"nameMap"`
+	RequiredName      *random.RandomPet            `pulumi:"requiredName"`
+	RequiredNameArray []*random.RandomPet          `pulumi:"requiredNameArray"`
+	RequiredNameMap   map[string]*random.RandomPet `pulumi:"requiredNameMap"`
 }
 
 // PetInput is an input type that accepts PetArgs and PetOutput values.
@@ -28,8 +33,13 @@ type PetInput interface {
 }
 
 type PetArgs struct {
-	Age  pulumi.IntPtrInput    `pulumi:"age"`
-	Name random.RandomPetInput `pulumi:"name"`
+	Age               pulumi.IntPtrInput         `pulumi:"age"`
+	Name              random.RandomPetInput      `pulumi:"name"`
+	NameArray         random.RandomPetArrayInput `pulumi:"nameArray"`
+	NameMap           random.RandomPetMapInput   `pulumi:"nameMap"`
+	RequiredName      random.RandomPetInput      `pulumi:"requiredName"`
+	RequiredNameArray random.RandomPetArrayInput `pulumi:"requiredNameArray"`
+	RequiredNameMap   random.RandomPetMapInput   `pulumi:"requiredNameMap"`
 }
 
 func (PetArgs) ElementType() reflect.Type {
@@ -116,6 +126,26 @@ func (o PetOutput) Name() random.RandomPetOutput {
 	return o.ApplyT(func(v Pet) *random.RandomPet { return v.Name }).(random.RandomPetOutput)
 }
 
+func (o PetOutput) NameArray() random.RandomPetArrayOutput {
+	return o.ApplyT(func(v Pet) []*random.RandomPet { return v.NameArray }).(random.RandomPetArrayOutput)
+}
+
+func (o PetOutput) NameMap() random.RandomPetMapOutput {
+	return o.ApplyT(func(v Pet) map[string]*random.RandomPet { return v.NameMap }).(random.RandomPetMapOutput)
+}
+
+func (o PetOutput) RequiredName() random.RandomPetOutput {
+	return o.ApplyT(func(v Pet) *random.RandomPet { return v.RequiredName }).(random.RandomPetOutput)
+}
+
+func (o PetOutput) RequiredNameArray() random.RandomPetArrayOutput {
+	return o.ApplyT(func(v Pet) []*random.RandomPet { return v.RequiredNameArray }).(random.RandomPetArrayOutput)
+}
+
+func (o PetOutput) RequiredNameMap() random.RandomPetMapOutput {
+	return o.ApplyT(func(v Pet) map[string]*random.RandomPet { return v.RequiredNameMap }).(random.RandomPetMapOutput)
+}
+
 type PetPtrOutput struct{ *pulumi.OutputState }
 
 func (PetPtrOutput) ElementType() reflect.Type {
@@ -150,6 +180,51 @@ func (o PetPtrOutput) Name() random.RandomPetOutput {
 		}
 		return v.Name
 	}).(random.RandomPetOutput)
+}
+
+func (o PetPtrOutput) NameArray() random.RandomPetArrayOutput {
+	return o.ApplyT(func(v *Pet) []*random.RandomPet {
+		if v == nil {
+			return nil
+		}
+		return v.NameArray
+	}).(random.RandomPetArrayOutput)
+}
+
+func (o PetPtrOutput) NameMap() random.RandomPetMapOutput {
+	return o.ApplyT(func(v *Pet) map[string]*random.RandomPet {
+		if v == nil {
+			return nil
+		}
+		return v.NameMap
+	}).(random.RandomPetMapOutput)
+}
+
+func (o PetPtrOutput) RequiredName() random.RandomPetOutput {
+	return o.ApplyT(func(v *Pet) *random.RandomPet {
+		if v == nil {
+			return nil
+		}
+		return v.RequiredName
+	}).(random.RandomPetOutput)
+}
+
+func (o PetPtrOutput) RequiredNameArray() random.RandomPetArrayOutput {
+	return o.ApplyT(func(v *Pet) []*random.RandomPet {
+		if v == nil {
+			return nil
+		}
+		return v.RequiredNameArray
+	}).(random.RandomPetArrayOutput)
+}
+
+func (o PetPtrOutput) RequiredNameMap() random.RandomPetMapOutput {
+	return o.ApplyT(func(v *Pet) map[string]*random.RandomPet {
+		if v == nil {
+			return nil
+		}
+		return v.RequiredNameMap
+	}).(random.RandomPetMapOutput)
 }
 
 func init() {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/component.ts
@@ -35,7 +35,7 @@ export class Component extends pulumi.CustomResource {
     }
 
     public /*out*/ readonly provider!: pulumi.Output<kubernetes.Provider | undefined>;
-    public /*out*/ readonly securityGroup!: pulumi.Output<aws.ec2.SecurityGroup | undefined>;
+    public /*out*/ readonly securityGroup!: pulumi.Output<aws.ec2.SecurityGroup>;
     public /*out*/ readonly storageClasses!: pulumi.Output<{[key: string]: kubernetes.storage.v1.StorageClass} | undefined>;
 
     /**
@@ -45,11 +45,25 @@ export class Component extends pulumi.CustomResource {
      * @param args The arguments to use to populate this resource's properties.
      * @param opts A bag of options that control this resource's behavior.
      */
-    constructor(name: string, args?: ComponentArgs, opts?: pulumi.CustomResourceOptions) {
+    constructor(name: string, args: ComponentArgs, opts?: pulumi.CustomResourceOptions) {
         let inputs: pulumi.Inputs = {};
         opts = opts || {};
         if (!opts.id) {
+            if ((!args || args.requiredMetadata === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'requiredMetadata'");
+            }
+            if ((!args || args.requiredMetadataArray === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'requiredMetadataArray'");
+            }
+            if ((!args || args.requiredMetadataMap === undefined) && !opts.urn) {
+                throw new Error("Missing required property 'requiredMetadataMap'");
+            }
             inputs["metadata"] = args ? args.metadata : undefined;
+            inputs["metadataArray"] = args ? args.metadataArray : undefined;
+            inputs["metadataMap"] = args ? args.metadataMap : undefined;
+            inputs["requiredMetadata"] = args ? args.requiredMetadata : undefined;
+            inputs["requiredMetadataArray"] = args ? args.requiredMetadataArray : undefined;
+            inputs["requiredMetadataMap"] = args ? args.requiredMetadataMap : undefined;
             inputs["provider"] = undefined /*out*/;
             inputs["securityGroup"] = undefined /*out*/;
             inputs["storageClasses"] = undefined /*out*/;
@@ -70,4 +84,9 @@ export class Component extends pulumi.CustomResource {
  */
 export interface ComponentArgs {
     metadata?: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>;
+    metadataArray?: pulumi.Input<pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>[]>;
+    metadataMap?: pulumi.Input<{[key: string]: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>}>;
+    requiredMetadata: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>;
+    requiredMetadataArray: pulumi.Input<pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>[]>;
+    requiredMetadataMap: pulumi.Input<{[key: string]: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>}>;
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/types/input.ts
@@ -9,4 +9,9 @@ import * as random from "@pulumi/random";
 export interface PetArgs {
     age?: pulumi.Input<number>;
     name?: pulumi.Input<random.RandomPet>;
+    nameArray?: pulumi.Input<pulumi.Input<random.RandomPet>[]>;
+    nameMap?: pulumi.Input<{[key: string]: pulumi.Input<random.RandomPet>}>;
+    requiredName: pulumi.Input<random.RandomPet>;
+    requiredNameArray: pulumi.Input<pulumi.Input<random.RandomPet>[]>;
+    requiredNameMap: pulumi.Input<{[key: string]: pulumi.Input<random.RandomPet>}>;
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/_inputs.py
@@ -16,12 +16,51 @@ __all__ = [
 @pulumi.input_type
 class PetArgs:
     def __init__(__self__, *,
+                 required_name: pulumi.Input['pulumi_random.RandomPet'],
+                 required_name_array: pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]],
+                 required_name_map: pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]],
                  age: Optional[pulumi.Input[int]] = None,
-                 name: Optional[pulumi.Input['pulumi_random.RandomPet']] = None):
+                 name: Optional[pulumi.Input['pulumi_random.RandomPet']] = None,
+                 name_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]] = None,
+                 name_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]] = None):
+        pulumi.set(__self__, "required_name", required_name)
+        pulumi.set(__self__, "required_name_array", required_name_array)
+        pulumi.set(__self__, "required_name_map", required_name_map)
         if age is not None:
             pulumi.set(__self__, "age", age)
         if name is not None:
             pulumi.set(__self__, "name", name)
+        if name_array is not None:
+            pulumi.set(__self__, "name_array", name_array)
+        if name_map is not None:
+            pulumi.set(__self__, "name_map", name_map)
+
+    @property
+    @pulumi.getter(name="requiredName")
+    def required_name(self) -> pulumi.Input['pulumi_random.RandomPet']:
+        return pulumi.get(self, "required_name")
+
+    @required_name.setter
+    def required_name(self, value: pulumi.Input['pulumi_random.RandomPet']):
+        pulumi.set(self, "required_name", value)
+
+    @property
+    @pulumi.getter(name="requiredNameArray")
+    def required_name_array(self) -> pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]:
+        return pulumi.get(self, "required_name_array")
+
+    @required_name_array.setter
+    def required_name_array(self, value: pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]):
+        pulumi.set(self, "required_name_array", value)
+
+    @property
+    @pulumi.getter(name="requiredNameMap")
+    def required_name_map(self) -> pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]:
+        return pulumi.get(self, "required_name_map")
+
+    @required_name_map.setter
+    def required_name_map(self, value: pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]):
+        pulumi.set(self, "required_name_map", value)
 
     @property
     @pulumi.getter
@@ -40,5 +79,23 @@ class PetArgs:
     @name.setter
     def name(self, value: Optional[pulumi.Input['pulumi_random.RandomPet']]):
         pulumi.set(self, "name", value)
+
+    @property
+    @pulumi.getter(name="nameArray")
+    def name_array(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]]:
+        return pulumi.get(self, "name_array")
+
+    @name_array.setter
+    def name_array(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_random.RandomPet']]]]):
+        pulumi.set(self, "name_array", value)
+
+    @property
+    @pulumi.getter(name="nameMap")
+    def name_map(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]]:
+        return pulumi.get(self, "name_map")
+
+    @name_map.setter
+    def name_map(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_random.RandomPet']]]]):
+        pulumi.set(self, "name_map", value)
 
 

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/component.py
@@ -15,12 +15,51 @@ __all__ = ['ComponentArgs', 'Component']
 @pulumi.input_type
 class ComponentArgs:
     def __init__(__self__, *,
-                 metadata: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']] = None):
+                 required_metadata: pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs'],
+                 required_metadata_array: pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]],
+                 required_metadata_map: pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]],
+                 metadata: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']] = None,
+                 metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None,
+                 metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]] = None):
         """
         The set of arguments for constructing a Component resource.
         """
+        pulumi.set(__self__, "required_metadata", required_metadata)
+        pulumi.set(__self__, "required_metadata_array", required_metadata_array)
+        pulumi.set(__self__, "required_metadata_map", required_metadata_map)
         if metadata is not None:
             pulumi.set(__self__, "metadata", metadata)
+        if metadata_array is not None:
+            pulumi.set(__self__, "metadata_array", metadata_array)
+        if metadata_map is not None:
+            pulumi.set(__self__, "metadata_map", metadata_map)
+
+    @property
+    @pulumi.getter(name="requiredMetadata")
+    def required_metadata(self) -> pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']:
+        return pulumi.get(self, "required_metadata")
+
+    @required_metadata.setter
+    def required_metadata(self, value: pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']):
+        pulumi.set(self, "required_metadata", value)
+
+    @property
+    @pulumi.getter(name="requiredMetadataArray")
+    def required_metadata_array(self) -> pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]:
+        return pulumi.get(self, "required_metadata_array")
+
+    @required_metadata_array.setter
+    def required_metadata_array(self, value: pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]):
+        pulumi.set(self, "required_metadata_array", value)
+
+    @property
+    @pulumi.getter(name="requiredMetadataMap")
+    def required_metadata_map(self) -> pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]:
+        return pulumi.get(self, "required_metadata_map")
+
+    @required_metadata_map.setter
+    def required_metadata_map(self, value: pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]):
+        pulumi.set(self, "required_metadata_map", value)
 
     @property
     @pulumi.getter
@@ -31,6 +70,24 @@ class ComponentArgs:
     def metadata(self, value: Optional[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]):
         pulumi.set(self, "metadata", value)
 
+    @property
+    @pulumi.getter(name="metadataArray")
+    def metadata_array(self) -> Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]:
+        return pulumi.get(self, "metadata_array")
+
+    @metadata_array.setter
+    def metadata_array(self, value: Optional[pulumi.Input[Sequence[pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]):
+        pulumi.set(self, "metadata_array", value)
+
+    @property
+    @pulumi.getter(name="metadataMap")
+    def metadata_map(self) -> Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]:
+        return pulumi.get(self, "metadata_map")
+
+    @metadata_map.setter
+    def metadata_map(self, value: Optional[pulumi.Input[Mapping[str, pulumi.Input['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]):
+        pulumi.set(self, "metadata_map", value)
+
 
 class Component(pulumi.CustomResource):
     @overload
@@ -38,6 +95,11 @@ class Component(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
+                 metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 required_metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
+                 required_metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 required_metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
                  __props__=None):
         """
         Create a Component resource with the given unique name, props, and options.
@@ -48,7 +110,7 @@ class Component(pulumi.CustomResource):
     @overload
     def __init__(__self__,
                  resource_name: str,
-                 args: Optional[ComponentArgs] = None,
+                 args: ComponentArgs,
                  opts: Optional[pulumi.ResourceOptions] = None):
         """
         Create a Component resource with the given unique name, props, and options.
@@ -68,6 +130,11 @@ class Component(pulumi.CustomResource):
                  resource_name: str,
                  opts: Optional[pulumi.ResourceOptions] = None,
                  metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
+                 metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 required_metadata: Optional[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]] = None,
+                 required_metadata_array: Optional[pulumi.Input[Sequence[pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
+                 required_metadata_map: Optional[pulumi.Input[Mapping[str, pulumi.Input[pulumi.InputType['pulumi_kubernetes.meta.v1.ObjectMetaArgs']]]]] = None,
                  __props__=None):
         if opts is None:
             opts = pulumi.ResourceOptions()
@@ -81,6 +148,17 @@ class Component(pulumi.CustomResource):
             __props__ = ComponentArgs.__new__(ComponentArgs)
 
             __props__.__dict__["metadata"] = metadata
+            __props__.__dict__["metadata_array"] = metadata_array
+            __props__.__dict__["metadata_map"] = metadata_map
+            if required_metadata is None and not opts.urn:
+                raise TypeError("Missing required property 'required_metadata'")
+            __props__.__dict__["required_metadata"] = required_metadata
+            if required_metadata_array is None and not opts.urn:
+                raise TypeError("Missing required property 'required_metadata_array'")
+            __props__.__dict__["required_metadata_array"] = required_metadata_array
+            if required_metadata_map is None and not opts.urn:
+                raise TypeError("Missing required property 'required_metadata_map'")
+            __props__.__dict__["required_metadata_map"] = required_metadata_map
             __props__.__dict__["provider"] = None
             __props__.__dict__["security_group"] = None
             __props__.__dict__["storage_classes"] = None
@@ -118,7 +196,7 @@ class Component(pulumi.CustomResource):
 
     @property
     @pulumi.getter(name="securityGroup")
-    def security_group(self) -> pulumi.Output[Optional['pulumi_aws.ec2.SecurityGroup']]:
+    def security_group(self) -> pulumi.Output['pulumi_aws.ec2.SecurityGroup']:
         return pulumi.get(self, "security_group")
 
     @property

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/schema.json
@@ -7,10 +7,38 @@
         "name": {
           "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
         },
+        "requiredName": {
+          "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+        },
+        "nameArray": {
+          "type": "array",
+          "items": {
+            "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+          }
+        },
+        "requiredNameArray": {
+          "type": "array",
+          "items": {
+            "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+          }
+        },
+        "nameMap": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+          }
+        },
+        "requiredNameMap": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+          }
+        },
         "age": {
           "type": "integer"
         }
       },
+      "required": ["requiredName", "requiredNameArray", "requiredNameMap"],
       "type": "object"
     }
   },
@@ -57,8 +85,37 @@
       "inputProperties": {
         "metadata": {
           "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta%2Fv1:ObjectMeta"
+        },
+        "requiredMetadata": {
+          "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta%2Fv1:ObjectMeta"
+        },
+        "metadataArray": {
+          "type": "array",
+          "items": {
+            "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta%2Fv1:ObjectMeta"
+          }
+        },
+        "requiredMetadataArray": {
+          "type": "array",
+          "items": {
+            "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta%2Fv1:ObjectMeta"
+          }
+        },
+        "metadataMap": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta%2Fv1:ObjectMeta"
+          }
+        },
+        "requiredMetadataMap": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta%2Fv1:ObjectMeta"
+          }
         }
-      }
+      },
+      "required": ["securityGroup"],
+      "requiredInputs": ["requiredMetadata", "requiredMetadataArray", "requiredMetadataMap"]
     }
   },
   "functions": {

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -73,7 +73,12 @@ func TestGeneratePackage(t *testing.T) {
 				filepath.Join(testDir, tt.schemaDir, "schema.json"), GeneratePackage)
 			assert.NoError(t, err)
 
-			expectedFiles, err := test.LoadFiles(filepath.Join(testDir, tt.schemaDir), "nodejs", tt.expectedFiles)
+			dir := filepath.Join(testDir, tt.schemaDir)
+			lang := "nodejs"
+
+			test.RewriteFilesWhenPulumiAccept(t, dir, lang, files)
+
+			expectedFiles, err := test.LoadFiles(filepath.Join(testDir, tt.schemaDir), lang, tt.expectedFiles)
 			assert.NoError(t, err)
 
 			test.ValidateFileEquality(t, files, expectedFiles)


### PR DESCRIPTION
In Go, resource types are modeled as pointers, but there were cases where the type was not being emitted as a pointer, leading to marshaling errors in programs. Additionally, array and map values that are external references were being emitted as pointers, but only _resources_ should be pointers (not external types), regardless of whether the resource type is external or local.

This fixes the underlying Go marshaling issues with https://github.com/pulumi/pulumi-eks/issues/566 and @lblackstone's repro in https://github.com/pulumi/pulumi-eks/issues/577

Part of https://github.com/pulumi/pulumi-eks/issues/566
Part of https://github.com/pulumi/pulumi-eks/issues/577