### PR TITLE
[automation/nodejs] - Only log, don't error on unparsed events

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,5 @@
 ### Improvements
 
-
-  
 - [codegen] - Encrypt input args for secret properties.
   [#7128](https://github.com/pulumi/pulumi/pull/7128)
 
@@ -10,3 +8,6 @@
 - [cli] - Send plugin install output to stderr, so that it doesn't
   clutter up --json, automation API scenarios, and so on.
   [#7115](https://github.com/pulumi/pulumi/pull/7115)
+
+- [auto/nodejs] - Emit warning instead of breaking on parsing JSON events for automation API.
+  [#7162](https://github.com/pulumi/pulumi/pull/7162)

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -354,13 +354,13 @@ Event: ${line}\n${e.toString()}`);
         }
 
         if (!summaryEvent) {
-            throw new Error("No summary of changes.");
+            log.warn("Failed to parse summary event, but preview succeeded. PreviewResult `changeSummary` will be empty.");
         }
 
         return {
             stdout: preResult.stdout,
             stderr: preResult.stderr,
-            changeSummary: summaryEvent.resourceChanges,
+            changeSummary: summaryEvent?.resourceChanges || {},
         };
     }
     /**
@@ -678,7 +678,7 @@ export type OpType = "same"
  * A map of operation types and their corresponding counts.
  */
 export type OpMap = {
-    [key in OpType]: number;
+    [key in OpType]?: number;
 };
 
 /**

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -126,11 +126,14 @@ export class Stack {
             let event: EngineEvent;
             try {
                 event = JSON.parse(line);
+                callback(event);
             } catch (e) {
-                log.error(`failed to parse engine event\nevent: ${line}\n${e.toString()}`);
-                throw e;
+                log.warn(`Failed to parse engine event
+If you're seeing this warning, please comment on https://github.com/pulumi/pulumi/issues/6768 with the event and any
+details about your environment.
+
+Event: ${line}\n${e.toString()}`);
             }
-            callback(event);
         });
 
         return {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
I had thought this issue was resolved, but alas it is not.

In the absence of a repro, I've decided to remove the error on this line and change it to a warning. In most cases all we need is the summary event from the preview (when a user hasn’t provided an onEvent callback), and it seems more reasonable to only error if we are unable to get the summary rather than if we are unable to read any random event. Hopefully this warning will allow us to gather more data on the issue if it continues to pop up, but at the very least folks who are not using `onEvent` will be able to let their programs complete without error.

Related to: https://github.com/pulumi/pulumi/issues/6768

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
