### PR TITLE
make plugin metadata (size, install time) opt in for list operations

### DIFF
--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -42,7 +42,7 @@ func newPluginLsCmd() *cobra.Command {
 					return errors.Wrapf(err, "loading project plugins")
 				}
 			} else {
-				if plugins, err = workspace.GetPlugins(); err != nil {
+				if plugins, err = workspace.GetPluginsWithMetadata(); err != nil {
 					return errors.Wrapf(err, "loading plugins")
 				}
 			}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -533,17 +533,31 @@ func GetPluginDir() (string, error) {
 	return GetPulumiPath(PluginDir)
 }
 
-// GetPlugins returns a list of installed plugins.
+// GetPlugins returns a list of installed plugins without size info and last accessed metadata.
+// Plugin size requires recursively traversing the plugin directory, which can be extremely expensive with the introduction of
+// nodejs multilang components that have deeply nested node_modules folders.
 func GetPlugins() ([]PluginInfo, error) {
 	// To get the list of plugins, simply scan the directory in the usual place.
 	dir, err := GetPluginDir()
 	if err != nil {
 		return nil, err
 	}
-	return getPlugins(dir)
+	return getPlugins(dir /* skipMetadata */, true)
 }
 
-func getPlugins(dir string) ([]PluginInfo, error) {
+// GetPluginsWithMetadata returns a list of installed plugins with metadata about size, and last access (POOR RUNTIME PERF)
+// Plugin size requires recursively traversing the plugin directory, which can be extremely expensive with the introduction of
+// nodejs multilang components that have deeply nested node_modules folders.
+func GetPluginsWithMetadata() ([]PluginInfo, error) {
+	// To get the list of plugins, simply scan the directory in the usual place.
+	dir, err := GetPluginDir()
+	if err != nil {
+		return nil, err
+	}
+	return getPlugins(dir /* skipMetadata */, false)
+}
+
+func getPlugins(dir string, skipMetadata bool) ([]PluginInfo, error) {
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -569,8 +583,11 @@ func getPlugins(dir string) ([]PluginInfo, error) {
 			} else if !os.IsNotExist(err) {
 				return nil, err
 			}
-			if err = plugin.SetFileMetadata(path); err != nil {
-				return nil, err
+			// computing plugin sizes can be very expensive (nested node_modules)
+			if !skipMetadata {
+				if err = plugin.SetFileMetadata(path); err != nil {
+					return nil, err
+				}
 			}
 			plugins = append(plugins, plugin)
 		}


### PR DESCRIPTION
# Description

This change is a simple perf optimization to speed up the process of listing plugins by excluding some metadata like size by default. 

Our strategy for finding a plugin is to first look on the path, and then to iterate through all plugins in the plugin cache (a directory). We do this for each plugin that is loaded when `NewProvider` is called. Unfortunately, the codepath that gets all plugins is shared by `pulumi plugin ls` that needs to do things like display the total size of all plugins, the size of each plugin, and when the plugin was last installed/last used.

This means that any time a plugin is loaded, we are computing the size of all plugins by recursively enumerating all folder (including all of the node_modules directories of any installed node multi-lang plugins!). For my 5 gb of node plugins this translated to 10s of overhead each time a plugin was loaded. 

This change is a very simple fix. `pulumi plugin ls` is the only code path that uses size, so we create a dedicated code path `GetPluginsWithMetadata` that populates that info, excluding from the result of `GetPlugins` by default. 

This is the least invasive option I could come up with. This struct is public API (exposed via automation api), so removing these fields from the default PluginInfo struct would not be easy. 

Fixes https://github.com/pulumi/pulumi/issues/7149
Fixes https://github.com/pulumi/astro/issues/16 (for now)

## Checklist

No changelog required
Existing plugin tests (those that directly and indirectly exercise this path) are passing, however we have no e2e tests on `plugin ls`. Not going to take on adding those as a part of this change. 
