### PR TITLE
Reproducing 7132

### DIFF
--- a/sdk/go/common/resource/plugin/regression_test.go
+++ b/sdk/go/common/resource/plugin/regression_test.go
@@ -10,6 +10,19 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
+/*
+   In the wild the 7132 situation looked like this:
+
+   - Python provider calling monitor.Invoke
+   - func (rm *resmon) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
+   - plugin.UnmarshalProperties(req.GetArgs(), MarshalOptions{KeepUnknowns/Secrets/Resources: true}
+   - func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (resource.PropertyMap, []CheckFailure, error)
+   - MarshalProperties(args, MarshalOptions{})
+   - Network hop to AWS provider
+   - Invoke(), UnmarshalProperties fails
+
+   This test reproduces the sequence from the gRPC request.
+*/
 func Test7132(t *testing.T) {
 	reqStr := "Cithd3M6aWFtL2dldFBvbGljeURvY3VtZW50OmdldFBvbGljeURvY3VtZW50En8KfQoKc3RhdGVtZW50cxJvMm0KayppCjcKCXJlc291cmNlcxIqMigKJhokMDRkYTZiNTQtODBlNC00NmY3LTk2ZWMtYjU2ZmYwMzMxYmE5Ci4KB2FjdGlvbnMSIzIhCh8aHXNlY3JldHNtYW5hZ2VyOkdldFNlY3JldFZhbHVlKAE="
 	req := readRequest(t, reqStr)

--- a/sdk/go/common/resource/plugin/regression_test.go
+++ b/sdk/go/common/resource/plugin/regression_test.go
@@ -1,0 +1,96 @@
+package plugin
+
+import (
+	b64 "encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	proto "github.com/golang/protobuf/proto"
+	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+)
+
+func Test7132(t *testing.T) {
+	reqStr := "Cithd3M6aWFtL2dldFBvbGljeURvY3VtZW50OmdldFBvbGljeURvY3VtZW50En8KfQoKc3RhdGVtZW50cxJvMm0KayppCjcKCXJlc291cmNlcxIqMigKJhokMDRkYTZiNTQtODBlNC00NmY3LTk2ZWMtYjU2ZmYwMzMxYmE5Ci4KB2FjdGlvbnMSIzIhCh8aHXNlY3JldHNtYW5hZ2VyOkdldFNlY3JldFZhbHVlKAE="
+	req := readRequest(t, reqStr)
+
+	fmt.Printf("req.GetArgs(): ")
+	spew.Dump(req.GetArgs())
+
+	propertyMap1, err := UnmarshalProperties(req.GetArgs(),
+		MarshalOptions{
+			Label:         "label",
+			KeepUnknowns:  true,
+			KeepSecrets:   true,
+			KeepResources: true,
+		})
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	fmt.Printf("propertyMap1: ")
+	spew.Dump(propertyMap1)
+
+	args2, err := MarshalProperties(propertyMap1, MarshalOptions{
+		Label: "label",
+	})
+	if err != nil {
+		t.Error(err)
+	}
+
+	fmt.Printf("args2: ")
+	spew.Dump(args2)
+
+	args3 := imitateNetworkPass(t, &pulumirpc.InvokeRequest{
+		Tok:             req.Tok,
+		Args:            args2,
+		AcceptResources: req.AcceptResources,
+	}).GetArgs()
+
+	fmt.Printf("args3: ")
+	spew.Dump(args3)
+
+	propertyMap2, err := UnmarshalProperties(args3,
+		MarshalOptions{
+			Label:         "label",
+			KeepUnknowns:  true,
+			KeepSecrets:   true,
+			KeepResources: true,
+		})
+
+	fmt.Printf("propertyMap2: ")
+	spew.Dump(propertyMap2)
+
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func imitateNetworkPass(t *testing.T, req *pulumirpc.InvokeRequest) *pulumirpc.InvokeRequest {
+	reqBytes, err := proto.Marshal(req)
+	if err != nil {
+		t.Error(err)
+		return nil
+	}
+	ir := new(pulumirpc.InvokeRequest)
+	if err := proto.Unmarshal(reqBytes, ir); err != nil {
+		t.Error(err)
+		return nil
+	}
+	return ir
+
+}
+
+func readRequest(t *testing.T, base64 string) *pulumirpc.InvokeRequest {
+	reqBytes, err := b64.StdEncoding.DecodeString(base64)
+	if err != nil {
+		t.Error(err)
+	}
+
+	ir := new(pulumirpc.InvokeRequest)
+	if err := proto.Unmarshal(reqBytes, ir); err != nil {
+		t.Error(err)
+	}
+	return ir
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

```
[nix-shell:~/pulumi3]$ (cd sdk/go/common/resource/plugin/ && go test -run Test7132)
(cd sdk/go/common/resource/plugin/ && go test -run Test7132)
req.GetArgs(): (*structpb.Struct)(0xc000271c80)(fields:{key:"statements" value:{list_value:{values:{struct_value:{fields:{key:"actions" value:{list_value:{values:{string_value:"secretsmanager:GetSecretValue"}}}} fields:{key:"resources" value:{list_value:{values:{string_value:"04da6b54-80e4-46f7-96ec-b56ff0331ba9"}}}}}}}}})
propertyMap1: (resource.PropertyMap) (len=1) {
 (resource.PropertyKey) (len=10) "statements": (resource.PropertyValue) {[{map[actions:{[{secretsmanager:GetSecretValue}]} resources:{[output<string>{}]}]}]}
}
args2: (*structpb.Struct)(0xc0003e4930)(fields:{key:"statements" value:{list_value:{values:{struct_value:{fields:{key:"actions" value:{list_value:{values:{string_value:"secretsmanager:GetSecretValue"}}}} fields:{key:"resources" value:{list_value:{values:{}}}}}}}}})
args3: (*structpb.Struct)(0xc0003e4b10)(fields:{key:"statements" value:{list_value:{values:{struct_value:{fields:{key:"actions" value:{list_value:{values:{string_value:"secretsmanager:GetSecretValue"}}}} fields:{key:"resources" value:{list_value:{values:{}}}}}}}}})
--- FAIL: Test7132 (0.00s)
panic: fatal: A failure has occurred: Unrecognized structpb value kind in RPC[label]: <nil> [recovered]
	panic: fatal: A failure has occurred: Unrecognized structpb value kind in RPC[label]: <nil>

```

Note how `resources` list gets wrapped in `output<string>` and then disappears/breaks the RPC layer.

Relates to #7132 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
