### PR TITLE
[sdk/python] Avoid exponential complexity for `from_input`/`all`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,3 +11,6 @@
 
 - [auto/nodejs] - Emit warning instead of breaking on parsing JSON events for automation API.
   [#7162](https://github.com/pulumi/pulumi/pull/7162)
+
+- [sdk/python] Improve performance of `Output.from_input` and `Output.all` on nested objects.
+  [#7175](https://github.com/pulumi/pulumi/pull/7175)

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -96,6 +96,14 @@ class OutputFromInputTests(unittest.TestCase):
         x_val = await x.future()
         self.assertEqual(x_val, ["hello", {"foo": "bar"}])
 
+    @pulumi_test
+    async def test_deeply_nested_objects(self):
+        o1 = {"a": {"a": {"a": {"a": {"a": {"a": {"a": {"a": {"a": {"a": {"a": Output.from_input("a")}}}}}}}}}}}
+        o2 = {"a": {"a": {"a": {"a": {"a": {"a": {"a": {"a": {"a": {"a": {"a": "a"}}}}}}}}}}}
+        x = Output.from_input(o1)
+        x_val = await x.future()
+        self.assertEqual(x_val, o2)
+
     @pulumi.input_type
     class FooArgs:
         def __init__(self, *,


### PR DESCRIPTION
These mutually recursive functions unintentionally had exponential complexity in nesting depth of objects, arg types and most likely arrays.

Remove the exponential complexity by avoiding direct recursion of `from_input` on itself, and relying on mutual recursion with `all` alone to reduce nested substructure.

Also simplify the implementation to aid readability.

Fixes pulumi/pulumi-kubernetes#1597.
Fixes pulumi/pulumi-kubernetes#1425.
Fixes pulumi/pulumi-kubernetes#1372.
Fixes #3987.
