### PR TITLE
[codegen/dotnet] Fix plain properties

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,9 @@
 - [sdk/python] Improve performance of `Output.from_input` and `Output.all` on nested objects.
   [#7175](https://github.com/pulumi/pulumi/pull/7175)
 
+- [codegen/dotnet] Fix plain properties
+  [#7180](https://github.com/pulumi/pulumi/pull/7180)
+
 ### Misc
 - Update version of go-cloud used by Pulumi to `0.23.0`.
   [#7204](https://github.com/pulumi/pulumi/pull/7204)

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -461,7 +461,7 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 	// complex types like lists and maps need a backing field. Secret properties also require a backing field.
 	if needsBackingField {
 		backingFieldName := "_" + prop.Name
-		requireInitializers := !pt.args
+		requireInitializers := !pt.args || prop.IsPlain
 		backingFieldType := pt.mod.typeString(prop.Type, pt.propertyTypeQualifier, true, pt.state, argsType, argsType, requireInitializers, false)
 
 		fmt.Fprintf(w, "%s[Input(\"%s\"%s)]\n", indent, wireName, attributeArgs)
@@ -510,7 +510,7 @@ func (pt *plainType) genInputProperty(w io.Writer, prop *schema.Property, indent
 		fmt.Fprintf(w, "%s}\n", indent)
 	} else {
 		initializer := ""
-		if prop.IsRequired && (!isValueType(prop.Type) || pt.args) {
+		if prop.IsRequired && (!isValueType(prop.Type) || (pt.args && !prop.IsPlain)) {
 			initializer = " = null!;"
 		}
 

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/docs/component.md
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/docs/component.md
@@ -29,6 +29,7 @@ meta_desc: "Documentation for the example.Component resource with examples, inpu
               <span class="nx">b</span><span class="p">:</span> <span class="nx">Optional[bool]</span> = None<span class="p">,</span>
               <span class="nx">bar</span><span class="p">:</span> <span class="nx">Optional[FooArgs]</span> = None<span class="p">,</span>
               <span class="nx">baz</span><span class="p">:</span> <span class="nx">Optional[Sequence[FooArgs]]</span> = None<span class="p">,</span>
+              <span class="nx">baz_map</span><span class="p">:</span> <span class="nx">Optional[Mapping[str, FooArgs]]</span> = None<span class="p">,</span>
               <span class="nx">c</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
               <span class="nx">d</span><span class="p">:</span> <span class="nx">Optional[int]</span> = None<span class="p">,</span>
               <span class="nx">e</span><span class="p">:</span> <span class="nx">Optional[str]</span> = None<span class="p">,</span>
@@ -211,6 +212,14 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
+        <span id="bazmap_csharp">
+<a href="#bazmap_csharp" style="color: inherit; text-decoration: inherit;">Baz<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Dictionary&lt;string, Foo<wbr>Args&gt;</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
         <span id="d_csharp">
 <a href="#d_csharp" style="color: inherit; text-decoration: inherit;">D</a>
 </span>
@@ -284,6 +293,14 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">[]Foo</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="bazmap_go">
+<a href="#bazmap_go" style="color: inherit; text-decoration: inherit;">Baz<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">map[string]Foo</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
@@ -363,6 +380,14 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
+        <span id="bazmap_nodejs">
+<a href="#bazmap_nodejs" style="color: inherit; text-decoration: inherit;">baz<wbr>Map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">{[key: string]: Foo<wbr>Args}</span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
         <span id="d_nodejs">
 <a href="#d_nodejs" style="color: inherit; text-decoration: inherit;">d</a>
 </span>
@@ -436,6 +461,14 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 </span>
         <span class="property-indicator"></span>
         <span class="property-type"><a href="#foo">Sequence[Foo<wbr>Args]</a></span>
+    </dt>
+    <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
+            title="Optional">
+        <span id="baz_map_python">
+<a href="#baz_map_python" style="color: inherit; text-decoration: inherit;">baz_<wbr>map</a>
+</span>
+        <span class="property-indicator"></span>
+        <span class="property-type">Mapping[str, Foo<wbr>Args]</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Component.cs
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Component.cs
@@ -68,7 +68,7 @@ namespace Pulumi.Example
     public sealed class ComponentArgs : Pulumi.ResourceArgs
     {
         [Input("a", required: true)]
-        public bool A { get; set; } = null!;
+        public bool A { get; set; }
 
         [Input("b")]
         public bool? B { get; set; }
@@ -77,15 +77,23 @@ namespace Pulumi.Example
         public Inputs.Foo? Bar { get; set; }
 
         [Input("baz")]
-        private ImmutableArray<Inputs.Foo>? _baz;
-        public ImmutableArray<Inputs.Foo> Baz
+        private List<Inputs.Foo>? _baz;
+        public List<Inputs.Foo> Baz
         {
-            get => _baz ?? (_baz = new ImmutableArray<Inputs.Foo>());
+            get => _baz ?? (_baz = new List<Inputs.Foo>());
             set => _baz = value;
         }
 
+        [Input("bazMap")]
+        private Dictionary<string, Inputs.Foo>? _bazMap;
+        public Dictionary<string, Inputs.Foo> BazMap
+        {
+            get => _bazMap ?? (_bazMap = new Dictionary<string, Inputs.Foo>());
+            set => _bazMap = value;
+        }
+
         [Input("c", required: true)]
-        public int C { get; set; } = null!;
+        public int C { get; set; }
 
         [Input("d")]
         public int? D { get; set; }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Inputs/FooArgs.cs
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Inputs/FooArgs.cs
@@ -13,13 +13,13 @@ namespace Pulumi.Example.Inputs
     public sealed class FooArgs : Pulumi.ResourceArgs
     {
         [Input("a", required: true)]
-        public bool A { get; set; } = null!;
+        public bool A { get; set; }
 
         [Input("b")]
         public bool? B { get; set; }
 
         [Input("c", required: true)]
-        public int C { get; set; } = null!;
+        public int C { get; set; }
 
         [Input("d")]
         public int? D { get; set; }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
@@ -41,28 +41,30 @@ func NewComponent(ctx *pulumi.Context,
 }
 
 type componentArgs struct {
-	A   bool    `pulumi:"a"`
-	B   *bool   `pulumi:"b"`
-	Bar *Foo    `pulumi:"bar"`
-	Baz []Foo   `pulumi:"baz"`
-	C   int     `pulumi:"c"`
-	D   *int    `pulumi:"d"`
-	E   string  `pulumi:"e"`
-	F   *string `pulumi:"f"`
-	Foo *Foo    `pulumi:"foo"`
+	A      bool           `pulumi:"a"`
+	B      *bool          `pulumi:"b"`
+	Bar    *Foo           `pulumi:"bar"`
+	Baz    []Foo          `pulumi:"baz"`
+	BazMap map[string]Foo `pulumi:"bazMap"`
+	C      int            `pulumi:"c"`
+	D      *int           `pulumi:"d"`
+	E      string         `pulumi:"e"`
+	F      *string        `pulumi:"f"`
+	Foo    *Foo           `pulumi:"foo"`
 }
 
 // The set of arguments for constructing a Component resource.
 type ComponentArgs struct {
-	A   bool
-	B   *bool
-	Bar *Foo
-	Baz []Foo
-	C   int
-	D   *int
-	E   string
-	F   *string
-	Foo FooPtrInput
+	A      bool
+	B      *bool
+	Bar    *Foo
+	Baz    []Foo
+	BazMap map[string]Foo
+	C      int
+	D      *int
+	E      string
+	F      *string
+	Foo    FooPtrInput
 }
 
 func (ComponentArgs) ElementType() reflect.Type {

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/pulumiTypes.go
@@ -117,6 +117,31 @@ func (i FooArray) ToFooArrayOutputWithContext(ctx context.Context) FooArrayOutpu
 	return pulumi.ToOutputWithContext(ctx, i).(FooArrayOutput)
 }
 
+// FooMapInput is an input type that accepts FooMap and FooMapOutput values.
+// You can construct a concrete instance of `FooMapInput` via:
+//
+//          FooMap{ "key": FooArgs{...} }
+type FooMapInput interface {
+	pulumi.Input
+
+	ToFooMapOutput() FooMapOutput
+	ToFooMapOutputWithContext(context.Context) FooMapOutput
+}
+
+type FooMap map[string]FooInput
+
+func (FooMap) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]Foo)(nil)).Elem()
+}
+
+func (i FooMap) ToFooMapOutput() FooMapOutput {
+	return i.ToFooMapOutputWithContext(context.Background())
+}
+
+func (i FooMap) ToFooMapOutputWithContext(ctx context.Context) FooMapOutput {
+	return pulumi.ToOutputWithContext(ctx, i).(FooMapOutput)
+}
+
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
@@ -256,8 +281,29 @@ func (o FooArrayOutput) Index(i pulumi.IntInput) FooOutput {
 	}).(FooOutput)
 }
 
+type FooMapOutput struct{ *pulumi.OutputState }
+
+func (FooMapOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*map[string]Foo)(nil)).Elem()
+}
+
+func (o FooMapOutput) ToFooMapOutput() FooMapOutput {
+	return o
+}
+
+func (o FooMapOutput) ToFooMapOutputWithContext(ctx context.Context) FooMapOutput {
+	return o
+}
+
+func (o FooMapOutput) MapIndex(k pulumi.StringInput) FooOutput {
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Foo {
+		return vs[0].(map[string]Foo)[vs[1].(string)]
+	}).(FooOutput)
+}
+
 func init() {
 	pulumi.RegisterOutputType(FooOutput{})
 	pulumi.RegisterOutputType(FooPtrOutput{})
 	pulumi.RegisterOutputType(FooArrayOutput{})
+	pulumi.RegisterOutputType(FooMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/nodejs/component.ts
@@ -54,6 +54,7 @@ export class Component extends pulumi.ComponentResource {
             inputs["b"] = args ? args.b : undefined;
             inputs["bar"] = args ? args.bar : undefined;
             inputs["baz"] = args ? args.baz : undefined;
+            inputs["bazMap"] = args ? args.bazMap : undefined;
             inputs["c"] = args ? args.c : undefined;
             inputs["d"] = args ? args.d : undefined;
             inputs["e"] = args ? args.e : undefined;
@@ -85,6 +86,7 @@ export interface ComponentArgs {
     b?: boolean;
     bar?: inputs.Foo;
     baz?: inputs.Foo[];
+    bazMap?: {[key: string]: inputs.Foo};
     c: number;
     d?: number;
     e: string;

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/component.py
@@ -21,6 +21,7 @@ class ComponentArgs:
                  b: Optional[bool] = None,
                  bar: Optional['Foo'] = None,
                  baz: Optional[Sequence['Foo']] = None,
+                 baz_map: Optional[Mapping[str, 'Foo']] = None,
                  d: Optional[int] = None,
                  f: Optional[str] = None,
                  foo: Optional[pulumi.Input['FooArgs']] = None):
@@ -36,6 +37,8 @@ class ComponentArgs:
             pulumi.set(__self__, "bar", bar)
         if baz is not None:
             pulumi.set(__self__, "baz", baz)
+        if baz_map is not None:
+            pulumi.set(__self__, "baz_map", baz_map)
         if d is not None:
             pulumi.set(__self__, "d", d)
         if f is not None:
@@ -98,6 +101,15 @@ class ComponentArgs:
         pulumi.set(self, "baz", value)
 
     @property
+    @pulumi.getter(name="bazMap")
+    def baz_map(self) -> Optional[Mapping[str, 'Foo']]:
+        return pulumi.get(self, "baz_map")
+
+    @baz_map.setter
+    def baz_map(self, value: Optional[Mapping[str, 'Foo']]):
+        pulumi.set(self, "baz_map", value)
+
+    @property
     @pulumi.getter
     def d(self) -> Optional[int]:
         return pulumi.get(self, "d")
@@ -134,6 +146,7 @@ class Component(pulumi.ComponentResource):
                  b: Optional[bool] = None,
                  bar: Optional[pulumi.InputType['Foo']] = None,
                  baz: Optional[Sequence[pulumi.InputType['Foo']]] = None,
+                 baz_map: Optional[Mapping[str, pulumi.InputType['Foo']]] = None,
                  c: Optional[int] = None,
                  d: Optional[int] = None,
                  e: Optional[str] = None,
@@ -172,6 +185,7 @@ class Component(pulumi.ComponentResource):
                  b: Optional[bool] = None,
                  bar: Optional[pulumi.InputType['Foo']] = None,
                  baz: Optional[Sequence[pulumi.InputType['Foo']]] = None,
+                 baz_map: Optional[Mapping[str, pulumi.InputType['Foo']]] = None,
                  c: Optional[int] = None,
                  d: Optional[int] = None,
                  e: Optional[str] = None,
@@ -197,6 +211,7 @@ class Component(pulumi.ComponentResource):
             __props__.__dict__["b"] = b
             __props__.__dict__["bar"] = bar
             __props__.__dict__["baz"] = baz
+            __props__.__dict__["baz_map"] = baz_map
             if c is None and not opts.urn:
                 raise TypeError("Missing required property 'c'")
             __props__.__dict__["c"] = c

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/schema.json
@@ -94,10 +94,16 @@
           "items": {
             "$ref": "#/types/example::Foo"
           }
+        },
+        "bazMap": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/types/example::Foo"
+          }
         }
       },
       "requiredInputs": ["a", "c", "e"],
-      "plainInputs": ["a", "b", "c", "d", "e", "f", "bar", "baz"],
+      "plainInputs": ["a", "b", "c", "d", "e", "f", "bar", "baz", "bazMap"],
       "type": "object"
     }
   },


### PR DESCRIPTION
Fix the generated C# code for plain properties:

- Value types should not be initialized with `= null!`
- Arrays and maps should be `List<T>` and `Dictionary<string, TValue>`

Fixes #6813
Fixes #7092