### PR TITLE
Support package names with `-` in schema and NodeJS codegen

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -890,7 +890,7 @@ func (mod *modContext) getTypeImports(t schema.Type, recurse bool, externalImpor
 		// If it's from another package, add an import for the external package.
 		if t.Package != nil && t.Package != mod.pkg {
 			pkg := t.Package.Name
-			externalImports.Add(fmt.Sprintf("import * as %[1]s from \"@pulumi/%[1]s\";", pkg))
+			externalImports.Add(fmt.Sprintf("import * as %s from \"@pulumi/%s\";", makeValidIdentifier(pkg), pkg))
 			return false
 		}
 
@@ -902,7 +902,7 @@ func (mod *modContext) getTypeImports(t schema.Type, recurse bool, externalImpor
 		// If it's from another package, add an import for the external package.
 		if t.Resource != nil && t.Resource.Package != mod.pkg {
 			pkg := t.Resource.Package.Name
-			externalImports.Add(fmt.Sprintf("import * as %[1]s from \"@pulumi/%[1]s\";", pkg))
+			externalImports.Add(fmt.Sprintf("import * as %s from \"@pulumi/%s\";", makeValidIdentifier(pkg), pkg))
 			return false
 		}
 

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1025,7 +1025,7 @@ const (
 )
 
 // Regex used to parse external schema paths. This is declared at the package scope to avoid repeated recompilation.
-var refPathRegex = regexp.MustCompile(`^/?(?P<package>\w+)/(?P<version>v[^/]*)/schema\.json$`)
+var refPathRegex = regexp.MustCompile(`^/?(?P<package>[^/]+)/(?P<version>v[^/]*)/schema\.json$`)
 
 func (t *types) parseTypeSpecRef(ref string) (typeSpecRef, error) {
 	parsedURL, err := url.Parse(ref)


### PR DESCRIPTION
# Description

Fixes an issue unearthed during the Hackathon where package names with a `-` in them (like `azure-native`) didn't work with multi-language component schemas and codegen. Specifically, the schema parser now accepts `-` (and other non-alphabetic characters) as part of package names. The NodeJS codegen now generates valid `import * as [package_name] from [package_name]` and `pulumi.Output<[package_name]...>` statements.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
