### PR TITLE
Add ability to skip installation (npm, venv, etc) step when installing plugins

### DIFF
--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -374,7 +374,7 @@ func (info PluginInfo) Install(tgz io.ReadCloser) error {
 	if err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "loading PulumiPlugin.yaml")
 	}
-	if proj != nil {
+	if proj != nil && !proj.SkipInstall {
 		runtime := strings.ToLower(proj.Runtime.Name())
 		// For now, we only do this for Node.js and Python. For Go, the expectation is the binary is
 		// already built. For .NET, similarly, a single self-contained binary could be used, but

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -157,6 +157,8 @@ func (proj *PolicyPackProject) Save(path string) error {
 type PluginProject struct {
 	// Runtime is a required runtime that executes code.
 	Runtime ProjectRuntimeInfo `json:"runtime" yaml:"runtime"`
+	// skips installation of runtime depenencies
+	SkipInstall bool `json:"skipInstall" yaml:"skipInstall"`
 }
 
 func (proj *PluginProject) Validate() error {


### PR DESCRIPTION
This change allows plugins to opt out of `npm install`, `venv`, and other installation/setup steps. This allows for instance, a single `index.js` file to be compiled and run by node as per an `ncc` build configuration: https://github.com/pulumi/pulumi/issues/7182#issuecomment-852420810