### PR TITLE
skip installing dev dependencies for nodejs plugin setup

### DIFF
--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -311,7 +311,7 @@ func installRequiredPolicy(finalDir string, tgz io.ReadCloser) error {
 }
 
 func completeNodeJSInstall(finalDir string) error {
-	if bin, err := npm.Install(finalDir, nil, os.Stderr); err != nil {
+	if bin, err := npm.Install(finalDir, false /*production*/, nil, os.Stderr); err != nil {
 		return errors.Wrapf(
 			err,
 			"failed to install dependencies of policy pack; you may need to re-run `%s install` "+

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -599,7 +599,7 @@ func nodeInstallDependencies() (string, error) {
 	fmt.Println("Installing dependencies...")
 	fmt.Println()
 
-	bin, err := npm.Install("", os.Stdout, os.Stderr)
+	bin, err := npm.Install("", false /*production*/, os.Stdout, os.Stderr)
 	if err != nil {
 		return bin, err
 	}

--- a/sdk/go/common/workspace/plugins.go
+++ b/sdk/go/common/workspace/plugins.go
@@ -383,7 +383,7 @@ func (info PluginInfo) Install(tgz io.ReadCloser) error {
 		switch runtime {
 		case "nodejs":
 			var b bytes.Buffer
-			if _, err := npm.Install(finalDir, &b, &b); err != nil {
+			if _, err := npm.Install(finalDir, true /* production */, &b, &b); err != nil {
 				os.Stderr.Write(b.Bytes())
 				return errors.Wrap(err, "installing plugin dependencies")
 			}

--- a/sdk/nodejs/npm/npm.go
+++ b/sdk/nodejs/npm/npm.go
@@ -36,7 +36,7 @@ import (
 // generate useful data. If the `PULUMI_PREFER_YARN` environment variable is set, `yarn pack` is run
 // instead of `npm pack`.
 func Pack(dir string, stderr io.Writer) ([]byte, error) {
-	c, npm, bin, err := getCmd("pack")
+	c, npm, bin, err := getCmd("pack", false /*production*/)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +83,8 @@ func Pack(dir string, stderr io.Writer) ([]byte, error) {
 // Install runs `npm install` in the given directory, installing the dependencies for the Node.js
 // app located there. If the `PULUMI_PREFER_YARN` environment variable is set, `yarn install` is used
 // instead of `npm install`.
-func Install(dir string, stdout, stderr io.Writer) (string, error) {
-	c, npm, bin, err := getCmd("install")
+func Install(dir string, production bool, stdout, stderr io.Writer) (string, error) {
+	c, npm, bin, err := getCmd("install", production)
 	if err != nil {
 		return bin, err
 	}
@@ -107,12 +107,16 @@ func Install(dir string, stdout, stderr io.Writer) (string, error) {
 // getCmd returns the exec.Cmd used to install NPM dependencies. It will either use `npm` or `yarn` depending
 // on what is available on the current path, and if `PULUMI_PREFER_YARN` is truthy.
 // The boolean return parameter indicates if `npm` is chosen or not (instead of `yarn`).
-func getCmd(command string) (*exec.Cmd, bool, string, error) {
+func getCmd(command string, production bool) (*exec.Cmd, bool, string, error) {
+	args := []string{command}
+	if production {
+		args = append(args, "--production")
+	}
 	if preferYarn() {
 		const file = "yarn"
 		yarnPath, err := exec.LookPath(file)
 		if err == nil {
-			return exec.Command(yarnPath, command), false, file, nil
+			return exec.Command(yarnPath, args...), false, file, nil
 		}
 		logging.Warningf("could not find yarn on the $PATH, trying npm instead: %v", err)
 	}
@@ -125,7 +129,8 @@ func getCmd(command string) (*exec.Cmd, bool, string, error) {
 	}
 	// We pass `--loglevel=error` to prevent `npm` from printing warnings about missing
 	// `description`, `repository`, and `license` fields in the package.json file.
-	return exec.Command(npmPath, command, "--loglevel=error"), true, file, nil
+	args = append(args, "--loglevel=error")
+	return exec.Command(npmPath, args...), true, file, nil
 }
 
 // runCmd handles hooking up `stdout` and `stderr` and then runs the command.

--- a/sdk/nodejs/npm/npm_test.go
+++ b/sdk/nodejs/npm/npm_test.go
@@ -24,15 +24,17 @@ import (
 )
 
 func TestNPMInstall(t *testing.T) {
-	testInstall(t, "npm")
+	testInstall(t, "npm", false /*production*/)
+	testInstall(t, "npm", true /*production*/)
 }
 
 func TestYarnInstall(t *testing.T) {
 	os.Setenv("PULUMI_PREFER_YARN", "true")
-	testInstall(t, "yarn")
+	testInstall(t, "yarn", false /*production*/)
+	testInstall(t, "yarn", true /*production*/)
 }
 
-func testInstall(t *testing.T, expectedBin string) {
+func testInstall(t *testing.T, expectedBin string, production bool) {
 	// Skip during short test runs since this test involves downloading dependencies.
 	if testing.Short() {
 		t.Skip("Skipped in short test run")
@@ -59,7 +61,7 @@ func testInstall(t *testing.T, expectedBin string) {
 
 	// Install dependencies, passing nil for stdout and stderr, which connects
 	// them to the file descriptor for the null device (os.DevNull).
-	bin, err := Install(pkgdir, nil, nil)
+	bin, err := Install(pkgdir, production, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedBin, bin)
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This change skips installation of `devDependencies` by running  `yarn install --production` or `npm install --production` when installing pulumi plugins that specify the `nodejs` runtime via `PulumiPlugin.yaml`. 

In my tests, this results in a 35% reduction in size (my plugins include typescript as a dev dep) from `230MB` -> `150MB`. 

Contributes to https://github.com/pulumi/pulumi/issues/7182

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Not a user facing features, simply an optimization. 
