### PR TITLE
Bump the Pulumi Service API version header to 7

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,3 +16,11 @@ Fixes # (issue)
 User-facing changes require a CHANGELOG entry.
 -->
 - [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
+<!--
+If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
+then the service should honor older versions of the CLI where this change would not exist.
+You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
+it to the service.
+-->
+- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
+  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -171,7 +171,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 	userAgent := fmt.Sprintf("pulumi-cli/1 (%s; %s)", version.Version, runtime.GOOS)
 	req.Header.Set("User-Agent", userAgent)
 	// Specify the specific API version we accept.
-	req.Header.Set("Accept", "application/vnd.pulumi+6")
+	req.Header.Set("Accept", "application/vnd.pulumi+7")
 
 	// Apply credentials if provided.
 	if tok.String() != "" {


### PR DESCRIPTION
# Description

It ensures users are using a CLI version that supports publishing policy packs to Azure Storage.

Fixes # `N/A`

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~ Bumping the service API version.
~~- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change~~
- [x] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version