### PR TITLE
[cli] Protect against panic when using incorrect token type in pulumi import

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,9 @@
 - [cli] - Send plugin install output to stderr, so that it doesn't
   clutter up --json, automation API scenarios, and so on.
   [#7115](https://github.com/pulumi/pulumi/pull/7115)
+  
+- [cli] Protect against panics when using the wrong resource type with `pulumi import`
+  [#7202](https://github.com/pulumi/pulumi/pull/7202)
 
 - [auto/nodejs] - Emit warning instead of breaking on parsing JSON events for automation API.
   [#7162](https://github.com/pulumi/pulumi/pull/7162)

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -16,6 +16,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -25,6 +26,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/fsutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
@@ -173,6 +175,12 @@ func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions
 		}
 		for i := range opts.imports {
 			imp := &opts.imports[i]
+			_, err := tokens.ParseTypeToken(imp.Type.String())
+			if err != nil {
+				return nil, errors.New(fmt.Sprintf("import type %q is not a valid resource type token. "+
+					"Type tokens must be of the format <package>:<module>:<type> - "+
+					"refer to the import section of the provider resource documentation.", imp.Type.String()))
+			}
 			if imp.Provider == "" && imp.Version == nil {
 				imp.Version = defaultProviderVersions[imp.Type.Package()]
 			}


### PR DESCRIPTION
Fixes: #6990

Previously:

```
pulumi import aws:ec2/instance/Instance id-12345 test-instance
Previewing import (dev)

================================================================================
The Pulumi CLI encountered a fatal error. This is a bug!
We would appreciate a report: https://github.com/pulumi/pulumi/issues/
Please provide all of the below text in your report.
================================================================================
Pulumi Version:   3.4.0-alpha.1622658772+dbea8058.dirty
Go Version:       go1.16.4
Go Compiler:      gc
Architecture:     amd64
Operating System: darwin
Panic:            fatal: An assertion has failed: Module member token 'aws:ec2/instance/Instance' missing module member delimiter
```

After:

```
pulumi import aws:ec2/instance/Instance id-12345 test-instance
Previewing import (dev)

error: import type "aws:ec2/instance/Instance" is not a valid resource type - refer to the import section of the provider resource documentation.
```