### PR TITLE
[cli] prevent panic in pulumi python applications when apply is used incorrectly

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,6 +13,9 @@
   
 - [cli] Protect against panics when using the wrong resource type with `pulumi import`
   [#7202](https://github.com/pulumi/pulumi/pull/7202)
+  
+- [cli] Prevent a panic in python programs when incorrect use of `apply` is included in pulumi program
+  [#7210](https://github.com/pulumi/pulumi/pull/7210)
 
 - [auto/nodejs] - Emit warning instead of breaking on parsing JSON events for automation API.
   [#7162](https://github.com/pulumi/pulumi/pull/7162)


### PR DESCRIPTION
Fixes: #5236

This bug *only* affected Python - as other language runtimes caught the
incorrect use of apply at compile time. Given the following Pulumi program:

```
from pulumi_aws import iam, s3
my_bucket = s3.Bucket(
    "simple-bucket",
    force_destroy=True,
    acl="private",
    versioning=s3.BucketVersioningArgs(enabled=True),
)
policy_document = iam.get_policy_document(
    statements=[
        iam.GetPolicyDocumentStatementArgs(
            sid="",
            effect="Allow",
            actions=["s3:GetObject"],
            resources=[my_bucket.arn.apply(lambda arn: f"{arn}/*")],
        ),
    ]
)
```

The apply is incorrect here as the Invoke should be run as part of the apply. This
application will produce a panic message similar to the following:

```
pulumi:pulumi:Stack (my-stack-dev):
    panic: fatal: A failure has occurred: Unrecognized structpb value kind in RPC[tf.Provider[aws].Invoke(aws:iam/getPolicyDocument:getPolicyDocument).args]: <nil>
    goroutine 114 [running]:
    github.com/pulumi/pulumi/sdk/v2/go/common/util/contract.failfast(...)
    	/home/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v2@v2.9.1-0.20200825190708-910aa96016cd/go/common/util/contract/failfast.go:23
    github.com/pulumi/pulumi/sdk/v2/go/common/util/contract.Failf(0x6bc984f, 0x2f, 0xc0010daec8, 0x2, 0x2)
```

In order to help the user, we are able to detect if the error is due to an Invoke and point
them in the direction of the `apply` docs:

```
    Exception: invoke of aws:iam/getPolicyDocument:getPolicyDocument failed: invocation of aws:iam/getPolicyDocument:getPolicyDocument returned an error:
    Incorrect use of `apply`. Please refer to https://www.pulumi.com/docs/intro/concepts/inputs-outputs/#apply for further details on how to use `apply`
    error: an unhandled error occurred: Program exited with non-zero exit code: 1
```

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
