### PR TITLE
Keep unknown fix

### DIFF
--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1172,6 +1172,7 @@ func (p *provider) Invoke(tok tokens.ModuleMember, args resource.PropertyMap) (r
 		Label:         fmt.Sprintf("%s.args", label),
 		KeepSecrets:   p.acceptSecrets,
 		KeepResources: p.acceptResources,
+		KeepUnknowns:  true,
 	})
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION

Isolating a panic from #7132.

- during discussion it came up that 7132 is not a valid program (not well typed; invoke should not accept Output that can be unknown)

- as far as I can tell from static code analysis, callers of this function (such as resmon.Invoke), marshal with KeepUnknowns = true

- if we believe that invoke should never have unknowns, should we instead do RejectUnknowns = true to fail fast?

- there may be a separate issue with list-nested unknown removal




# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
