### PR TITLE
Fix MarshalProperties handling of list-nested unknowns

### DIFF
--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -115,7 +115,9 @@ func MarshalPropertyValue(v resource.PropertyValue, opts MarshalOptions) (*struc
 			if err != nil {
 				return nil, err
 			}
-			elems = append(elems, e)
+			if e != nil {
+				elems = append(elems, e)
+			}
 		}
 		return &structpb.Value{
 			Kind: &structpb.Value_ListValue{

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -327,3 +327,98 @@ func TestResourceReference(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, resource.NewStringProperty(string(rawProp.ResourceReferenceValue().URN)), *actual)
 }
+
+func TestMarshalPropertiesDiscardsListNestedUnknowns(t *testing.T) {
+	proto := pbStruct("resources", pbList(pbString(UnknownStringValue)))
+
+	propsWithUnknowns, err := UnmarshalProperties(proto, MarshalOptions{KeepUnknowns: true})
+	if err != nil {
+		t.Errorf("UnmarhsalProperties failed: %w", err)
+	}
+
+	protobufStruct, err := MarshalProperties(propsWithUnknowns, MarshalOptions{KeepUnknowns: false})
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	protobufValue := &structpb.Value{
+		Kind: &structpb.Value_StructValue{
+			StructValue: protobufStruct,
+		},
+	}
+
+	assertValidProtobufValue(t, protobufValue)
+}
+
+func pbString(s string) *structpb.Value {
+	return &structpb.Value{
+		Kind: &structpb.Value_StringValue{
+			StringValue: s,
+		},
+	}
+}
+
+func pbStruct(name string, value *structpb.Value) *structpb.Struct {
+	return &structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			name: value,
+		},
+	}
+}
+
+func pbList(elems ...*structpb.Value) *structpb.Value {
+	return &structpb.Value{
+		Kind: &structpb.Value_ListValue{
+			ListValue: &structpb.ListValue{Values: elems},
+		},
+	}
+}
+
+func assertValidProtobufValue(t *testing.T, value *structpb.Value) {
+	err := walkValueSelfWithDescendants(value, "", func(path string, v *structpb.Value) error {
+		return nil
+	})
+	if err != nil {
+		t.Errorf("This is not a valid *structpb.Value: %v\n%w", value, err)
+	}
+}
+
+func walkValueSelfWithDescendants(v *structpb.Value, path string, visit func(path string, v *structpb.Value) error) error {
+	if v == nil {
+		return fmt.Errorf("Bad *structpb.Value nil at %s", path)
+	}
+	err := visit(path, v)
+	if err != nil {
+		return err
+	}
+	switch v.Kind.(type) {
+	case *structpb.Value_ListValue:
+		values := v.GetListValue().GetValues()
+		for i, v := range values {
+			err = walkValueSelfWithDescendants(v, fmt.Sprintf("%s[%d]", path, i), visit)
+			if err != nil {
+				return err
+			}
+		}
+	case *structpb.Value_StructValue:
+		s := v.GetStructValue()
+		for fn, fv := range s.Fields {
+			err = walkValueSelfWithDescendants(fv, fmt.Sprintf(`%s["%s"]`, path, fn), visit)
+			if err != nil {
+				return err
+			}
+		}
+	case *structpb.Value_NumberValue:
+		return nil
+	case *structpb.Value_StringValue:
+		return nil
+	case *structpb.Value_BoolValue:
+		return nil
+	case *structpb.Value_NullValue:
+		return nil
+	default:
+		return fmt.Errorf("Bad *structpb.Value of unknown type at %s: %v", path, v)
+	}
+	return nil
+}

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -384,7 +384,11 @@ func assertValidProtobufValue(t *testing.T, value *structpb.Value) {
 	}
 }
 
-func walkValueSelfWithDescendants(v *structpb.Value, path string, visit func(path string, v *structpb.Value) error) error {
+func walkValueSelfWithDescendants(
+	v *structpb.Value,
+	path string,
+	visit func(path string, v *structpb.Value) error) error {
+
 	if v == nil {
 		return fmt.Errorf("Bad *structpb.Value nil at %s", path)
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

Fixes #7132 

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and 
context. -->

MarshalPropertyValue code says:

```
		return nil, nil // return nil and the caller will ignore it.
```

But this particular call site does not ignore `nil`. This has caused panics far away from the source of the problem.

The fix ignores the nil inside the list context.

If this is against the spirit of removing unknowns, we should fail loudly instead.

I don't as of today have a valid Pulumi user program that hits this; the example I was going off is not valid.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
