### PR TITLE
[build] ensure downstream codegen tests run go mod tidy

### DIFF
--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -61,7 +61,7 @@ jobs:
         with:
           ref: ${{ env.PR_COMMIT_SHA }}
       - name: Test Downstream
-        uses: pulumi/action-test-provider-downstream@releases/v6
+        uses: pulumi/action-test-provider-downstream@releases/v7
         env:
           GOPROXY: "https://proxy.golang.org"
         with:


### PR DESCRIPTION
Fixes: #7218

Changes that propagated from the pulumi codebase to the providers
conflicted with dep versions already in place - the provider tests
needed to have a `go mod tidy` command rather than a `go mod download`

This will clean the unused dependencies that were causing the conflict
and thus the build failure

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
