### PR TITLE
bump GHA workflows to node 16.x

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,7 @@ jobs:
         go-version: [ 1.16.x ]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
         language: [ "nodejs", "python", "dotnet" ]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -136,7 +136,7 @@ jobs:
         go-version: [1.16.x]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -206,7 +206,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x]
-        node-version: [14.x]
+        node-version: [16.x]
         python-version: [3.9.x]
         dotnet: [3.1.x]
     runs-on: windows-latest
@@ -296,7 +296,7 @@ jobs:
         go-version: [1.16.x]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -27,7 +27,7 @@ jobs:
         go-version: [ 1.16.x ]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
         language: [ "nodejs", "python", "dotnet" ]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -135,7 +135,7 @@ jobs:
         go-version: [1.16.x]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -205,7 +205,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ 1.16.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
         python-version: [ 3.9.x ]
         dotnet: [ 3.1.x ]
     runs-on: windows-latest
@@ -291,7 +291,7 @@ jobs:
         go-version: [1.16.x]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,7 @@ jobs:
         go-version: [ 1.16.x ]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
         language: [ "nodejs", "python", "dotnet" ]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -243,7 +243,7 @@ jobs:
         go-version: [1.16.x]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -313,7 +313,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x]
-        node-version: [14.x]
+        node-version: [16.x]
         python-version: [3.9.x]
         dotnet: [3.1.x]
     runs-on: windows-latest
@@ -399,7 +399,7 @@ jobs:
         go-version: [1.16.x]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go ${{ matrix.go-version }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -110,7 +110,7 @@ jobs:
         go-version: [1.16.x]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.platform }}
     steps:
@@ -182,7 +182,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x]
-        node-version: [14.x]
+        node-version: [16.x]
         python-version: [3.9.x]
         dotnet: [3.1.x]
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install Python
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/run-docs-generation.yml
+++ b/.github/workflows/run-docs-generation.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         go-version: [ 1.16.x ]
-        node-version: [ 14.x ]
+        node-version: [ 16.x ]
     steps:
       - name: Install Go
         uses: actions/setup-go@v1


### PR DESCRIPTION
Draft PR to run our test suite against node 16.x.