### PR TITLE
Include props which have underlying strings on Go SDK providers

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,8 @@
 - [codegen] - Encrypt input args for secret properties.
   [#7128](https://github.com/pulumi/pulumi/pull/7128)
 
+- [codegen] - Include properties with an underlying type of string on Go provider instances.
+
 ### Bug Fixes
 
 - [cli] - Send plugin install output to stderr, so that it doesn't

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1671,15 +1671,22 @@ func bindProvider(pkgName string, spec ResourceSpec, types *types) (*Resource, e
 	// Since non-primitive provider configuration is currently JSON serialized, we can't handle it without
 	// modifying the path by which it's looked up. As a temporary workaround to enable access to config which
 	// values which are primitives, we'll simply remove any properties for the provider resource which are not
-	// here, before we generate the provider code.
-	var primitiveProperties []*Property
+	// strings, or types with an underlying type of string, before we generate the provider code.
+	var stringProperties []*Property
 	for _, prop := range res.Properties {
-		if prop.Type != stringType {
-			continue
+		if tokenType, isTokenType := prop.Type.(*TokenType); isTokenType {
+			if tokenType.UnderlyingType != stringType {
+				continue
+			}
+		} else {
+			if prop.Type != stringType {
+				continue
+			}
 		}
-		primitiveProperties = append(primitiveProperties, prop)
+
+		stringProperties = append(stringProperties, prop)
 	}
-	res.Properties = primitiveProperties
+	res.Properties = stringProperties
 
 	types.resources[res.Token] = &ResourceType{
 		Token:    res.Token,


### PR DESCRIPTION
## Description

This commit modifies the work in #7058 to permit properties which do not pass the test of being strings directly, but which have an underlying type of string.

When applied to `pulumi-aws`, this results in the following diff:

```diff
diff --git a/sdk/go/aws/provider.go b/sdk/go/aws/provider.go
index c32ad2367..8b4c9fd0a 100644
--- a/sdk/go/aws/provider.go
+++ b/sdk/go/aws/provider.go
@@ -21,6 +21,8 @@ type Provider struct {
 	AccessKey pulumi.StringPtrOutput `pulumi:"accessKey"`
 	// The profile for API operations. If not set, the default profile created with `aws configure` will be used.
 	Profile pulumi.StringPtrOutput `pulumi:"profile"`
+	// The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.
+	Region pulumi.StringPtrOutput `pulumi:"region"`
 	// The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
 	SecretKey pulumi.StringPtrOutput `pulumi:"secretKey"`
 	// The path to the shared credentials file. If not set this defaults to ~/.aws/credentials.
```

The primary purpose this is desirable is to expose Region from instances of the AWS provider.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

Code-gen diff included in PR text.

- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
