### PR TITLE
[codegen/python] Update Python codegen to use a non-conflicting property name

### DIFF
--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1193,7 +1193,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 
 		if hasStateInputs {
 			for _, prop := range res.StateInputs.Properties {
-				pname := PyName(prop.Name)
+				pname := InitParamName(prop.Name)
 				ty := mod.typeString(prop.Type, true, true, true, true /*optional*/, true /*acceptMapping*/)
 				fmt.Fprintf(w, ",\n            %s: %s = None", pname, ty)
 			}
@@ -1215,7 +1215,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		if res.StateInputs != nil {
 			for _, prop := range res.StateInputs.Properties {
 				stateInputs.Add(prop.Name)
-				fmt.Fprintf(w, "        __props__.__dict__[%[1]q] = %[1]s\n", PyName(prop.Name))
+				fmt.Fprintf(w, "        __props__.__dict__[%q] = %s\n", PyName(prop.Name), InitParamName(prop.Name))
 			}
 		}
 		for _, prop := range res.Properties {
@@ -1818,7 +1818,7 @@ func (mod *modContext) genGetDocstring(w io.Writer, res *schema.Resource) {
 	fmt.Fprintln(b, ":param pulumi.ResourceOptions opts: Options for the resource.")
 	if res.StateInputs != nil {
 		for _, prop := range res.StateInputs.Properties {
-			mod.genPropDocstring(b, PyName(prop.Name), prop, true /*wrapInput*/, true /*acceptMapping*/)
+			mod.genPropDocstring(b, InitParamName(prop.Name), prop, true /*wrapInput*/, true /*acceptMapping*/)
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/pulumi/pulumi-aws/issues/1519

There is a realistic change that a mapped property is called `resource_name` and
this would conflict with the internal property `resource_name`.

Mypy reports an sdk error here:

```
dk/python/pulumi_aws/servicecatalog/tag_option_resource_association.py:277: error: Duplicate argument 'resource_name' in function definition
Found 1 error in 1 file (errors prevented further checking)
```

It's better to move the python internal property to something that
won't conflict, `resource_name_` in this case

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
