### PR TITLE
[sdk/dotnet] Allow automation api consumer to provide custom logger implementation for inline program

### DIFF
--- a/sdk/dotnet/Pulumi.Automation/PreviewOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/PreviewOptions.cs
@@ -18,5 +18,7 @@ namespace Pulumi.Automation
         public bool? TargetDependents { get; set; }
 
         public PulumiFn? Program { get; set; }
+
+        public IDeploymentLogger? Logger { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/PreviewOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/PreviewOptions.cs
@@ -19,6 +19,10 @@ namespace Pulumi.Automation
 
         public PulumiFn? Program { get; set; }
 
+        /// <summary>
+        /// A custom logger implementation that will be used for the action. Note that it will only be used
+        /// if <see cref="Program"/> is also provided.
+        /// </summary>
         public IDeploymentLogger? Logger { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi.Automation/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+Pulumi.Automation.PreviewOptions.Logger.get -> Pulumi.IDeploymentLogger
+Pulumi.Automation.PreviewOptions.Logger.set -> void
+Pulumi.Automation.UpOptions.Logger.get -> Pulumi.IDeploymentLogger
+Pulumi.Automation.UpOptions.Logger.set -> void

--- a/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
+++ b/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
@@ -44,11 +44,12 @@ namespace Pulumi.Automation
                 engineAddr,
                 request.MonitorAddress,
                 request.Config,
+                request.ConfigSecretKeys,
                 request.Project,
                 request.Stack,
                 request.Parallel,
                 request.DryRun,
-                request.ConfigSecretKeys);
+                this._callerContext.Logger);
 
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(
                 this._callerContext.CancellationToken,
@@ -68,14 +69,18 @@ namespace Pulumi.Automation
 
             public CancellationToken CancellationToken { get; }
 
+            public IDeploymentLogger? Logger { get; }
+
             public ExceptionDispatchInfo? ExceptionDispatchInfo { get; set; }
 
             public CallerContext(
                 PulumiFn program,
-                CancellationToken cancellationToken)
+                CancellationToken cancellationToken,
+                IDeploymentLogger? logger)
             {
                 this.Program = program;
                 this.CancellationToken = cancellationToken;
+                this.Logger = logger;
             }
         }
     }

--- a/sdk/dotnet/Pulumi.Automation/UpOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/UpOptions.cs
@@ -18,5 +18,7 @@ namespace Pulumi.Automation
         public bool? TargetDependents { get; set; }
 
         public PulumiFn? Program { get; set; }
+
+        public IDeploymentLogger? Logger { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/UpOptions.cs
+++ b/sdk/dotnet/Pulumi.Automation/UpOptions.cs
@@ -19,6 +19,10 @@ namespace Pulumi.Automation
 
         public PulumiFn? Program { get; set; }
 
+        /// <summary>
+        /// A custom logger implementation that will be used for the action. Note that it will only be used
+        /// if <see cref="Program"/> is also provided.
+        /// </summary>
         public IDeploymentLogger? Logger { get; set; }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -270,7 +270,7 @@ namespace Pulumi.Automation
                 if (program != null)
                 {
                     execKind = ExecKind.Inline;
-                    inlineHost = new InlineLanguageHost(program, cancellationToken);
+                    inlineHost = new InlineLanguageHost(program, cancellationToken, options?.Logger);
                     await inlineHost.StartAsync().ConfigureAwait(false);
                     var port = await inlineHost.GetPortAsync().ConfigureAwait(false);
                     args.Add($"--client=127.0.0.1:{port}");
@@ -381,7 +381,7 @@ namespace Pulumi.Automation
                 if (program != null)
                 {
                     execKind = ExecKind.Inline;
-                    inlineHost = new InlineLanguageHost(program, cancellationToken);
+                    inlineHost = new InlineLanguageHost(program, cancellationToken, options?.Logger);
                     await inlineHost.StartAsync().ConfigureAwait(false);
                     var port = await inlineHost.GetPortAsync().ConfigureAwait(false);
                     args.Add($"--client=127.0.0.1:{port}");
@@ -652,7 +652,8 @@ namespace Pulumi.Automation
 
             public InlineLanguageHost(
                 PulumiFn program,
-                CancellationToken cancellationToken)
+                CancellationToken cancellationToken,
+                IDeploymentLogger? logger)
             {
                 this._cancelToken = cancellationToken;
                 this._host = Host.CreateDefaultBuilder()
@@ -680,7 +681,7 @@ namespace Pulumi.Automation
                             .ConfigureServices(services =>
                             {
                                 // to be injected into LanguageRuntimeService
-                                var callerContext = new LanguageRuntimeService.CallerContext(program, cancellationToken);
+                                var callerContext = new LanguageRuntimeService.CallerContext(program, cancellationToken, logger);
                                 services.AddSingleton(callerContext);
 
                                 services.AddGrpc(grpcOptions =>

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Inline.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Inline.cs
@@ -26,18 +26,18 @@ namespace Pulumi
                 throw new InvalidOperationException("Inline execution was not provided the necessary parameters to run the Pulumi engine.");
             }
 
-            InitSerilogger();
+            var deploymentLogger = settings.Logger ?? SerilogDeploymentLogger.Create();
 
-            _serilogger.Debug("Creating Deployment Engine.");
+            deploymentLogger.Debug("Creating Deployment Engine.");
             Engine = new GrpcEngine(settings.EngineAddr);
-            _serilogger.Debug("Created Deployment Engine.");
+            deploymentLogger.Debug("Created Deployment Engine.");
 
-            _serilogger.Debug("Creating Deployment Monitor.");
+            deploymentLogger.Debug("Creating Deployment Monitor.");
             Monitor = new GrpcMonitor(settings.MonitorAddr);
-            _serilogger.Debug("Created Deployment Monitor.");
+            deploymentLogger.Debug("Created Deployment Monitor.");
 
-            _runner = new Runner(this);
-            _logger = new Logger(this, Engine);
+            _runner = new Runner(this, deploymentLogger);
+            _logger = new EngineLogger(this, deploymentLogger, Engine);
         }
 
         internal static async Task<ExceptionDispatchInfo?> RunInlineAsync(InlineDeploymentSettings settings, Func<IRunner, Task<ExceptionDispatchInfo?>> func)

--- a/sdk/dotnet/Pulumi/Deployment/IDeploymentInternal.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IDeploymentInternal.cs
@@ -12,8 +12,8 @@ namespace Pulumi
 
         Stack Stack { get; set; }
 
-        Serilog.ILogger Serilogger { get; }
-        ILogger Logger { get; }
+        IEngineLogger Logger { get; }
+
         IRunner Runner { get; }
 
         void ReadOrRegisterResource(

--- a/sdk/dotnet/Pulumi/Deployment/IDeploymentLogger.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IDeploymentLogger.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2016-2019, Pulumi Corporation
+
+using System;
+
+namespace Pulumi
+{
+    public interface IDeploymentLogger
+    {
+        void Debug(string message);
+
+        void Info(string message);
+
+        void Warn(string message);
+
+        void Error(string message);
+
+        void Error(Exception exception, string message);
+    }
+}

--- a/sdk/dotnet/Pulumi/Deployment/IEngineLogger.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IEngineLogger.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 
 namespace Pulumi
 {
-    internal interface ILogger
+    internal interface IEngineLogger
     {
         bool LoggedErrors { get; }
 

--- a/sdk/dotnet/Pulumi/Deployment/InlineDeploymentSettings.cs
+++ b/sdk/dotnet/Pulumi/Deployment/InlineDeploymentSettings.cs
@@ -19,25 +19,29 @@ namespace Pulumi
         public int Parallel { get; }
 
         public bool IsDryRun { get; }
+        
+        public IDeploymentLogger? Logger { get; }
 
         public InlineDeploymentSettings(
             string engineAddr,
             string monitorAddr,
             IDictionary<string, string> config,
+            IEnumerable<string>? configSecretKeys,
             string project,
             string stack,
             int parallel,
             bool isDryRun,
-            IEnumerable<string>? configSecretKeys = null)
+            IDeploymentLogger? logger)
         {
             EngineAddr = engineAddr;
             MonitorAddr = monitorAddr;
             Config = config;
+            ConfigSecretKeys = configSecretKeys;
             Project = project;
             Stack = stack;
             Parallel = parallel;
             IsDryRun = isDryRun;
-            ConfigSecretKeys = configSecretKeys;
+            Logger = logger;
         }
     }
 }

--- a/sdk/dotnet/Pulumi/Deployment/SerilogDeploymentLogger.cs
+++ b/sdk/dotnet/Pulumi/Deployment/SerilogDeploymentLogger.cs
@@ -1,0 +1,50 @@
+﻿// Copyright 2016-2019, Pulumi Corporation
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using Serilog.Events;
+
+namespace Pulumi
+{
+    internal class SerilogDeploymentLogger : IDeploymentLogger
+    {
+        private readonly ILogger _logger;
+
+        private SerilogDeploymentLogger(ILogger logger)
+            => _logger = logger;
+
+        public void Debug(string message)
+            => _logger.Debug(message);
+
+        public void Error(string message)
+            => _logger.Error(message);
+
+        public void Error(Exception exception, string message)
+            => _logger.Error(exception, message);
+
+        public void Info(string message)
+            => _logger.Information(message);
+
+        public void Warn(string message)
+            => _logger.Warning(message);
+
+        public static IDeploymentLogger Create()
+        {
+            var verboseLogging = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("PULUMI_DOTNET_LOG_VERBOSE"));
+
+            var configRoot = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
+
+            var logger = new LoggerConfiguration()
+                .MinimumLevel.Is(verboseLogging ? LogEventLevel.Verbose : LogEventLevel.Fatal)
+                .ReadFrom.Configuration(configRoot)
+                .WriteTo.Console()
+                .CreateLogger()
+                .ForContext<Deployment>();
+
+            return new SerilogDeploymentLogger(logger);
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -1,0 +1,6 @@
+Pulumi.IDeploymentLogger
+Pulumi.IDeploymentLogger.Debug(string message) -> void
+Pulumi.IDeploymentLogger.Error(System.Exception exception, string message) -> void
+Pulumi.IDeploymentLogger.Error(string message) -> void
+Pulumi.IDeploymentLogger.Info(string message) -> void
+Pulumi.IDeploymentLogger.Warn(string message) -> void


### PR DESCRIPTION
# Description

Fixes #7116

Allows consumer of dotnet Automation API to provide a custom deployment logger implementation so that Automation API logs can be sent to whatever logging provider the consumer uses with whatever config they desire.

## Checklist

- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
