### PR TITLE
Watch Command - Added `--path` Argument

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,4 +2,9 @@
 
 ### Improvements
 
+- [cli] - Added support for passing custom paths that need
+  to be watched by the `pulumi watch` command.
+  [#7115](https://github.com/pulumi/pulumi/pull/7247)
+
+
 ### Bug Fixes

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -164,7 +164,7 @@ type Backend interface {
 	// Destroy destroys all of this stack's resources.
 	Destroy(ctx context.Context, stack Stack, op UpdateOperation) (engine.ResourceChanges, result.Result)
 	// Watch watches the project's working directory for changes and automatically updates the active stack.
-	Watch(ctx context.Context, stack Stack, op UpdateOperation) result.Result
+	Watch(ctx context.Context, stack Stack, op UpdateOperation, paths []string) result.Result
 
 	// Query against the resource outputs in a stack's state checkpoint.
 	Query(ctx context.Context, op QueryOperation) result.Result

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -245,6 +245,9 @@ type UpdateOptions struct {
 	AutoApprove bool
 	// SkipPreview, when true, causes the preview step to be skipped.
 	SkipPreview bool
+
+	// WatchPaths, allows specifying paths that need to be watched (instead of the whole project).
+	WatchPaths []string
 }
 
 // QueryOptions configures a query to operate against a backend and the engine.

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -245,9 +245,6 @@ type UpdateOptions struct {
 	AutoApprove bool
 	// SkipPreview, when true, causes the preview step to be skipped.
 	SkipPreview bool
-
-	// WatchPaths, allows specifying paths that need to be watched (instead of the whole project).
-	WatchPaths []string
 }
 
 // QueryOptions configures a query to operate against a backend and the engine.

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -534,8 +534,8 @@ func (b *localBackend) Query(ctx context.Context, op backend.QueryOperation) res
 }
 
 func (b *localBackend) Watch(ctx context.Context, stack backend.Stack,
-	op backend.UpdateOperation) result.Result {
-	return backend.Watch(ctx, b, stack, op, b.apply)
+	op backend.UpdateOperation, paths []string) result.Result {
+	return backend.Watch(ctx, b, stack, op, b.apply, paths)
 }
 
 // apply actually performs the provided type of update on a locally hosted stack.

--- a/pkg/backend/filestate/stack.go
+++ b/pkg/backend/filestate/stack.go
@@ -85,8 +85,8 @@ func (s *localStack) Destroy(ctx context.Context, op backend.UpdateOperation) (e
 	return backend.DestroyStack(ctx, s, op)
 }
 
-func (s *localStack) Watch(ctx context.Context, op backend.UpdateOperation) result.Result {
-	return backend.WatchStack(ctx, s, op)
+func (s *localStack) Watch(ctx context.Context, op backend.UpdateOperation, paths []string) result.Result {
+	return backend.WatchStack(ctx, s, op, paths)
 }
 
 func (s *localStack) GetLogs(ctx context.Context, cfg backend.StackConfiguration,

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -853,8 +853,8 @@ func (b *cloudBackend) Destroy(ctx context.Context, stack backend.Stack,
 }
 
 func (b *cloudBackend) Watch(ctx context.Context, stack backend.Stack,
-	op backend.UpdateOperation) result.Result {
-	return backend.Watch(ctx, b, stack, op, b.apply)
+	op backend.UpdateOperation, paths []string) result.Result {
+	return backend.Watch(ctx, b, stack, op, b.apply, paths)
 }
 
 func (b *cloudBackend) Query(ctx context.Context, op backend.QueryOperation) result.Result {

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -161,8 +161,8 @@ func (s *cloudStack) Destroy(ctx context.Context, op backend.UpdateOperation) (e
 	return backend.DestroyStack(ctx, s, op)
 }
 
-func (s *cloudStack) Watch(ctx context.Context, op backend.UpdateOperation) result.Result {
-	return backend.WatchStack(ctx, s, op)
+func (s *cloudStack) Watch(ctx context.Context, op backend.UpdateOperation, paths []string) result.Result {
+	return backend.WatchStack(ctx, s, op, paths)
 }
 
 func (s *cloudStack) GetLogs(ctx context.Context, cfg backend.StackConfiguration,

--- a/pkg/backend/mock.go
+++ b/pkg/backend/mock.go
@@ -66,7 +66,7 @@ type MockBackend struct {
 	DestroyF func(context.Context, Stack,
 		UpdateOperation) (engine.ResourceChanges, result.Result)
 	WatchF func(context.Context, Stack,
-		UpdateOperation) result.Result
+		UpdateOperation, []string) result.Result
 	GetLogsF func(context.Context, Stack, StackConfiguration,
 		operations.LogQuery) ([]operations.LogEntry, error)
 }
@@ -221,10 +221,10 @@ func (be *MockBackend) Destroy(ctx context.Context, stack Stack,
 }
 
 func (be *MockBackend) Watch(ctx context.Context, stack Stack,
-	op UpdateOperation) result.Result {
+	op UpdateOperation, paths []string) result.Result {
 
 	if be.WatchF != nil {
-		return be.WatchF(ctx, stack, op)
+		return be.WatchF(ctx, stack, op, paths)
 	}
 	panic("not implemented")
 }
@@ -337,7 +337,7 @@ type MockStack struct {
 		imports []deploy.Import) (engine.ResourceChanges, result.Result)
 	RefreshF func(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, result.Result)
 	DestroyF func(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, result.Result)
-	WatchF   func(ctx context.Context, op UpdateOperation) result.Result
+	WatchF   func(ctx context.Context, op UpdateOperation, paths []string) result.Result
 	QueryF   func(ctx context.Context, op UpdateOperation) result.Result
 	RemoveF  func(ctx context.Context, force bool) (bool, error)
 	RenameF  func(ctx context.Context, newName tokens.QName) (StackReference, error)
@@ -413,9 +413,9 @@ func (ms *MockStack) Destroy(ctx context.Context, op UpdateOperation) (engine.Re
 	panic("not implemented")
 }
 
-func (ms *MockStack) Watch(ctx context.Context, op UpdateOperation) result.Result {
+func (ms *MockStack) Watch(ctx context.Context, op UpdateOperation, paths []string) result.Result {
 	if ms.WatchF != nil {
-		return ms.WatchF(ctx, op)
+		return ms.WatchF(ctx, op, paths)
 	}
 	panic("not implemented")
 }

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -50,7 +50,7 @@ type Stack interface {
 	// Destroy this stack's resources.
 	Destroy(ctx context.Context, op UpdateOperation) (engine.ResourceChanges, result.Result)
 	// Watch this stack.
-	Watch(ctx context.Context, op UpdateOperation) result.Result
+	Watch(ctx context.Context, op UpdateOperation, paths []string) result.Result
 
 	// remove this stack.
 	Remove(ctx context.Context, force bool) (bool, error)
@@ -103,8 +103,8 @@ func DestroyStack(ctx context.Context, s Stack, op UpdateOperation) (engine.Reso
 
 // WatchStack watches the projects working directory for changes and automatically updates the
 // active stack.
-func WatchStack(ctx context.Context, s Stack, op UpdateOperation) result.Result {
-	return s.Backend().Watch(ctx, s, op)
+func WatchStack(ctx context.Context, s Stack, op UpdateOperation, paths []string) result.Result {
+	return s.Backend().Watch(ctx, s, op, paths)
 }
 
 // GetLatestConfiguration returns the configuration for the most recent deployment of the stack.

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -69,9 +69,19 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, appl
 	}()
 
 	events := make(chan notify.EventInfo, 1)
-	if err := notify.Watch(path.Join(op.Root, "..."), events, notify.All); err != nil {
-		return result.FromError(err)
+
+	if len(op.Opts.WatchPaths) > 0 {
+		for _, element := range op.Opts.WatchPaths {
+			if err := notify.Watch(path.Join(op.Root, element, "..."), events, notify.All); err != nil {
+				return result.FromError(err)
+			}
+		}
+	} else {
+		if err := notify.Watch(path.Join(op.Root, "..."), events, notify.All); err != nil {
+			return result.FromError(err)
+		}
 	}
+
 	defer notify.Stop(events)
 
 	fmt.Printf(op.Opts.Display.Color.Colorize(

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -70,8 +70,8 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, appl
 
 	events := make(chan notify.EventInfo, 1)
 
-	for _, element := range op.Opts.WatchPaths {
-		if err := notify.Watch(path.Join(op.Root, element, "..."), events, notify.All); err != nil {
+	for _, currentPath := range paths {
+		if err := notify.Watch(path.Join(op.Root, currentPath, "..."), events, notify.All); err != nil {
 			return result.FromError(err)
 		}
 	}

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -70,14 +70,8 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, appl
 
 	events := make(chan notify.EventInfo, 1)
 
-	if len(op.Opts.WatchPaths) > 0 {
-		for _, element := range op.Opts.WatchPaths {
-			if err := notify.Watch(path.Join(op.Root, element, "..."), events, notify.All); err != nil {
-				return result.FromError(err)
-			}
-		}
-	} else {
-		if err := notify.Watch(path.Join(op.Root, "..."), events, notify.All); err != nil {
+	for _, element := range op.Opts.WatchPaths {
+		if err := notify.Watch(path.Join(op.Root, element, "..."), events, notify.All); err != nil {
 			return result.FromError(err)
 		}
 	}

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -35,7 +35,7 @@ import (
 
 // Watch watches the project's working directory for changes and automatically updates the active
 // stack.
-func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, apply Applier) result.Result {
+func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, apply Applier, paths []string) result.Result {
 
 	opts := ApplierOptions{
 		DryRun:   false,

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -35,7 +35,8 @@ import (
 
 // Watch watches the project's working directory for changes and automatically updates the active
 // stack.
-func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, apply Applier, paths []string) result.Result {
+func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation,
+	apply Applier, paths []string) result.Result {
 
 	opts := ApplierOptions{
 		DryRun:   false,

--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -70,8 +70,16 @@ func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, appl
 
 	events := make(chan notify.EventInfo, 1)
 
-	for _, currentPath := range paths {
-		if err := notify.Watch(path.Join(op.Root, currentPath, "..."), events, notify.All); err != nil {
+	for _, p := range paths {
+		// Provided paths can be both relative and absolute.
+		watchPath := ""
+		if path.IsAbs(p) {
+			watchPath = path.Join(p, "...")
+		} else {
+			watchPath = path.Join(op.Root, p, "...")
+		}
+
+		if err := notify.Watch(watchPath, events, notify.All); err != nil {
 			return result.FromError(err)
 		}
 	}

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -124,8 +124,6 @@ func newWatchCmd() *cobra.Command {
 				DisableResourceReferences: disableResourceReferences(),
 			}
 
-			opts.WatchPaths = pathArray
-
 			res := s.Watch(commandContext(), backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
@@ -134,7 +132,8 @@ func newWatchCmd() *cobra.Command {
 				StackConfiguration: cfg,
 				SecretsManager:     sm,
 				Scopes:             cancellationScopes,
-			})
+			}, pathArray)
+
 			switch {
 			case res != nil && res.Error() == context.Canceled:
 				return result.FromError(errors.New("update cancelled"))

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -35,6 +35,7 @@ func newWatchCmd() *cobra.Command {
 	var execKind string
 	var stack string
 	var configArray []string
+	var pathArray []string
 	var configPath bool
 
 	// Flags for engine.UpdateOptions.
@@ -123,6 +124,8 @@ func newWatchCmd() *cobra.Command {
 				DisableResourceReferences: disableResourceReferences(),
 			}
 
+			opts.WatchPaths = pathArray
+
 			res := s.Watch(commandContext(), backend.UpdateOperation{
 				Proj:               proj,
 				Root:               root,
@@ -143,6 +146,9 @@ func newWatchCmd() *cobra.Command {
 		}),
 	}
 
+	cmd.PersistentFlags().StringArrayVarP(
+		&pathArray, "path", "", []string{},
+		"Specify one or more paths that need to be watched. Defaults to working directory")
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,
 		"Print detailed debugging output during resource operations")

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -54,7 +54,7 @@ func newWatchCmd() *cobra.Command {
 		Short:      "[PREVIEW] Continuously update the resources in a stack",
 		Long: "Continuously update the resources in a stack.\n" +
 			"\n" +
-			"This command watches the working directory for the current project and updates the active stack whenever\n" +
+			"This command watches the working directory or specified paths for the current project and updates the active stack whenever\n" +
 			"the project changes.  In parallel, logs are collected for all resources in the stack and displayed along\n" +
 			"with update progress.\n" +
 			"\n" +
@@ -147,7 +147,7 @@ func newWatchCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringArrayVarP(
 		&pathArray, "path", "", []string{""},
-		"Specify one or more paths that need to be watched. Defaults to working directory")
+		"Specify one or more relative or absolute paths that need to be watched. A path can point to a folder or a file. Defaults to working directory")
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,
 		"Print detailed debugging output during resource operations")

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -54,9 +54,9 @@ func newWatchCmd() *cobra.Command {
 		Short:      "[PREVIEW] Continuously update the resources in a stack",
 		Long: "Continuously update the resources in a stack.\n" +
 			"\n" +
-			"This command watches the working directory or specified paths for the current project and updates the active stack whenever\n" +
-			"the project changes.  In parallel, logs are collected for all resources in the stack and displayed along\n" +
-			"with update progress.\n" +
+			"This command watches the working directory or specified paths for the current project and updates\n" +
+			"the active stack whenever the project changes.  In parallel, logs are collected for all resources\n" +
+			"in the stack and displayed along with update progress.\n" +
 			"\n" +
 			"The program to watch is loaded from the project in the current directory by default. Use the `-C` or\n" +
 			"`--cwd` flag to use a different directory.",
@@ -147,7 +147,8 @@ func newWatchCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringArrayVarP(
 		&pathArray, "path", "", []string{""},
-		"Specify one or more relative or absolute paths that need to be watched. A path can point to a folder or a file. Defaults to working directory")
+		"Specify one or more relative or absolute paths that need to be watched. "+
+			"A path can point to a folder or a file. Defaults to working directory")
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,
 		"Print detailed debugging output during resource operations")

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -147,7 +147,7 @@ func newWatchCmd() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringArrayVarP(
-		&pathArray, "path", "", []string{},
+		&pathArray, "path", "", []string{""},
 		"Specify one or more paths that need to be watched. Defaults to working directory")
 	cmd.PersistentFlags().BoolVarP(
 		&debug, "debug", "d", false,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Closes https://github.com/pulumi/pulumi/issues/6620

As mentioned in the linked issue, currently, the `pulumi watch` command watches the entire Pulumi project directory (recursively). With this PR, developers will be able to specify the exact paths that need to be watched.

The main motivation for this came from the fact that in our project, the application code (so, not infrastructure code) folder is located within the Pulumi project folder. Now, this wouldn't be a problem if we didn't bundle our application code with Webpack.  

This means that, while writing application code, the re-deploy process gets triggered by the `watch` command twice:

1. once for the change that the developer made in the source application code
2. once after Webpack has actually built the change, and stored the new code in a separate `code/build` folder (so, also stored within the Pulumi project folder)

For reference, I'm pasting an image I pasted in the original issue:
![image](https://user-images.githubusercontent.com/5121148/121244905-b8294600-c89f-11eb-960d-d22545a942cb.png)

In our specific case, ideally, we'd only want Pulumi to process a re-deployment once a change has been detected in `code/build` and  `pulumi` (this is where cloud infra code is located) folders.

So, with this PR, developers will be able to run the following:

```bash
pulumi watch --path code/build --path pulumi
```

If no `--path` arguments were passed, the `watch` command acts as usual - watches the whole Pulumi project folder.

Fixes #6620

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
