### PR TITLE
Ensure `Output.from_input({})` returns `{}` instead of `[]`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,4 +5,4 @@
 
 ### Bug Fixes
 
-
+- [sdk/python] - Fix regression in behaviour for `Output.from_input({})`

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -258,12 +258,12 @@ class Output(Generic[T]):
             o_typ: Output[typ] = Output.all(**val.__dict__).apply(lambda d: typ(**d)) # type:ignore
             return cast(Output[T], o_typ)
 
-        # Is a dict or list? Recurse into the values within them.
-        if isinstance(val, dict):
+        # Is a (non-empty) dict or list? Recurse into the values within them.
+        if val and isinstance(val, dict):
             o_dict: Output[dict] = Output.all(**val)
             return cast(Output[T], o_dict)
 
-        if isinstance(val, list):
+        if val and isinstance(val, list):
             o_list: Output[list] = Output.all(*val)
             return cast(Output[T], o_list)
 

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -55,6 +55,12 @@ class OutputSecretTests(unittest.TestCase):
 
 class OutputFromInputTests(unittest.TestCase):
     @pulumi_test
+    async def test_unwrap_empty_dict(self):
+        x = Output.from_input({})
+        x_val = await x.future()
+        self.assertEqual(x_val, {})
+
+    @pulumi_test
     async def test_unwrap_dict(self):
         x = Output.from_input({"hello": Output.from_input("world")})
         x_val = await x.future()
@@ -77,6 +83,12 @@ class OutputFromInputTests(unittest.TestCase):
         x = Output.from_input({"hello": ["foo", Output.from_input("bar")]})
         x_val = await x.future()
         self.assertEqual(x_val, {"hello": ["foo", "bar"]})
+
+    @pulumi_test
+    async def test_unwrap_empty_list(self):
+        x = Output.from_input([])
+        x_val = await x.future()
+        self.assertEqual(x_val, [])
 
     @pulumi_test
     async def test_unwrap_list(self):


### PR DESCRIPTION
Fixes #7252.

Subtly, `Output.all(**{})` by design returns `Output([])`, because the `all` function itself cannot distinguish between this and `Output.all()`.  So we must special case empty dicts to avoid calling `all` on them.

We were missing tests for empty arrays and dicts, so these have been added.  