### PR TITLE
Seal internal members of Resource to prevent accidental inherit/override

### DIFF
--- a/sdk/dotnet/Pulumi/Resources/Resource.cs
+++ b/sdk/dotnet/Pulumi/Resources/Resource.cs
@@ -25,33 +25,33 @@ namespace Pulumi
         /// The child resources of this resource.  We use these (only from a ComponentResource) to
         /// allow code to dependOn a ComponentResource and have that effectively mean that it is
         /// depending on all the CustomResource children of that component.
-        /// 
+        ///
         /// Important!  We only walk through ComponentResources.They're the only resources that
         /// serve as an aggregation of other primitive(i.e.custom) resources.While a custom resource
         /// can be a parent of other resources, we don't want to ever depend on those child
         /// resource.  If we do, it's simple to end up in a situation where we end up depending on a
         /// child resource that has a data cycle dependency due to the data passed into it. An
         /// example of how this would be bad is:
-        /// 
+        ///
         /// <c>
         ///     var c1 = new CustomResource("c1");
         ///     var c2 = new CustomResource("c2", { parentId = c1.id }, { parent = c1 });
         ///     var c3 = new CustomResource("c3", { parentId = c1.id }, { parent = c1 });
         /// </c>
-        /// 
+        ///
         /// The problem here is that 'c2' has a data dependency on 'c1'.  If it tries to wait on
         /// 'c1' it will walk to the children and wait on them.This will mean it will wait on 'c3'.
         /// But 'c3' will be waiting in the same manner on 'c2', and a cycle forms. This normally
         /// does not happen with ComponentResources as they do not have any data flowing into
         /// them.The only way you would be able to have a problem is if you had this sort of coding
         /// pattern:
-        /// 
+        ///
         /// <c>
         ///     var c1 = new ComponentResource("c1");
         ///     var c2 = new CustomResource("c2", { parentId = c1.urn }, { parent: c1 });
         ///     var c3 = new CustomResource("c3", { parentId = c1.urn }, { parent: c1 });
         /// </c>
-        /// 
+        ///
         /// However, this would be pretty nonsensical as there is zero need for a custom resource to
         /// ever need to reference the urn of a component resource.  So it's acceptable if that sort
         /// of pattern failed in practice.
@@ -64,7 +64,7 @@ namespace Pulumi
         /// </summary>
         // Set using reflection, so we silence the NRT warnings with `null!`.
         [Output(Constants.UrnPropertyName)]
-        public Output<string> Urn { get; private protected set; } = null!;
+        public sealed Output<string> Urn { get; private protected set; } = null!;
 
         /// <summary>
         /// When set to true, protect ensures this resource cannot be deleted.
@@ -85,13 +85,13 @@ namespace Pulumi
         /// The type assigned to the resource at construction.
         /// </summary>
         // This is a method and not a property to not collide with potential subclass property names.
-        public string GetResourceType() => _type;
+        public sealed string GetResourceType() => _type;
 
         /// <summary>
         /// The name assigned to the resource at construction.
         /// </summary>
         // This is a method and not a property to not collide with potential subclass property names.
-        public string GetResourceName() => _name;
+        public sealed string GetResourceName() => _name;
 
         /// <summary>
         /// The set of providers to use for child resources. Keyed by package name (e.g. "aws").


### PR DESCRIPTION
Seal members of Resource class to prevent accidental inherit+override bugs as in https://github.com/pulumi/examples/issues/1017

I expect this is incomplete as we'd need to modify codegen also to rename things like `Urn` property correct?

Is there an easy way to trigger tests of downstream codegen impacts, like I sometimes see automatically happen on codegen PRs..



# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
