### PR TITLE
[cli/import] - Handle panic during import codegen

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,7 +8,7 @@
 
 - [codegen] - Include properties with an underlying type of string on Go provider instances.
 
-- [cli] - Provide a more useful error instead of panicking when codegen fails during import.
+- [cli] - Provide a more helpful error instead of panicking when codegen fails during import.
   [#7265](https://github.com/pulumi/pulumi/pull/7265)
 
 ### Bug Fixes

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,9 @@
 
 - [codegen] - Include properties with an underlying type of string on Go provider instances.
 
+- [cli] - Provide a more useful error instead of panicking when codegen fails during import.
+  [#7265](https://github.com/pulumi/pulumi/pull/7265)
+
 ### Bug Fixes
 
 - [sdk/python] - Fix regression in behaviour for `Output.from_input({})`


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This PR is to handle a panic that is caused by a failure during go codegen when using the `pulumi import` command. Unfortunately, `import` is impossible to write tests for since it is dependent on a resource existing in a provider. The [original PR](https://github.com/pulumi/pulumi/pull/4765) to add the import command included no tests.

I have also been unable to repro this particular failure manually since I do not have the correct access to use the `PushRestrictions` feature for `BranchProtection` in Github as I do not have an organization using the team or enterprise tiers.

I tested this change by manually adding a panic to the `generateImportedDefinitions` function and observing the resulting output. 

Related to: #7112 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
