### PR TITLE
Tracing enhancements for CLI perf metrics capture

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -222,7 +222,7 @@ type ProgramTestOptions struct {
 	//
 	// Template `{command}` syntax will be expanded to the current
 	// command name such as `pulumi-stack-rm`. This is useful for
-	// file-based tracing since `ProgramTest` performs mutliple
+	// file-based tracing since `ProgramTest` performs multiple
 	// CLI invocations that can inadvertently overwrite the trace
 	// file.
 	Tracing string

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -216,8 +216,17 @@ type ProgramTestOptions struct {
 	// environment during tests.
 	StackName string
 
-	// Tracing specifies the Zipkin endpoint if any to use for tracing Pulumi invocations.
+	// If non-empty, specifies the value of the `--tracing` flag to pass
+	// to Pulumi CLI, which may be a Zipkin endpoint or a
+	// `file:./local.trace` style url for AppDash tracing.
+	//
+	// Template `{command}` syntax will be expanded to the current
+	// command name such as `pulumi-stack-rm`. This is useful for
+	// file-based tracing since `ProgramTest` performs mutliple
+	// CLI invocations that can inadvertently overwrite the trace
+	// file.
 	Tracing string
+
 	// NoParallel will opt the test out of being ran in parallel.
 	NoParallel bool
 
@@ -719,7 +728,7 @@ func (pt *ProgramTester) getDotNetBin() (string, error) {
 	return getCmdBin(&pt.dotNetBin, "dotnet", pt.opts.DotNetBin)
 }
 
-func (pt *ProgramTester) pulumiCmd(args []string) ([]string, error) {
+func (pt *ProgramTester) pulumiCmd(name string, args []string) ([]string, error) {
 	bin, err := pt.getBin()
 	if err != nil {
 		return nil, err
@@ -730,7 +739,7 @@ func (pt *ProgramTester) pulumiCmd(args []string) ([]string, error) {
 	}
 	cmd = append(cmd, args...)
 	if tracing := pt.opts.Tracing; tracing != "" {
-		cmd = append(cmd, "--tracing", tracing)
+		cmd = append(cmd, "--tracing", strings.ReplaceAll(tracing, "{command}", name))
 	}
 	return cmd, nil
 }
@@ -770,7 +779,7 @@ func (pt *ProgramTester) runCommand(name string, args []string, wd string) error
 }
 
 func (pt *ProgramTester) runPulumiCommand(name string, args []string, wd string, expectFailure bool) error {
-	cmd, err := pt.pulumiCmd(args)
+	cmd, err := pt.pulumiCmd(name, args)
 	if err != nil {
 		return err
 	}

--- a/sdk/nodejs/runtime/rpc.ts
+++ b/sdk/nodejs/runtime/rpc.ts
@@ -628,7 +628,7 @@ export function register<T extends { readonly version?: string }>(source: Map<st
         for (const existing of items) {
             if (sameVersion(existing.version, item.version)) {
                 // It is possible for the same version of the same provider SDK to be loaded multiple times in Node.js.
-                // In this case, we might legitimately get mutliple registrations of the same resource.  It should not
+                // In this case, we might legitimately get multiple registrations of the same resource.  It should not
                 // matter which we use, so we can just skip re-registering.  De-serialized resources will always be
                 // instances of classes from the first registered package.
                 if (excessiveDebugOutput) {


### PR DESCRIPTION
I'm finding I need a few more hooks to enable trace collections easily in the integration tests. Everything in this PR is opt-in. If you don't set the magic env vars nothing should be affected for our regular users.

# Description

- Allows to run ProgramTest with `Tracing: "file:./pulumi-{command}.trace` resulting in multiple files depending on which command is being traced.

- Allows to set PULUMI_TRCING_TAG_FOO env vars to add tags to the top-level trace span

- Allows to set PULUMI_TRACING_MEMSTATS_POLL_INTERVAL=100ms to poll runtime.ReadMemStats and record in the trace

- Records os, arch, num_cpu in the trace


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
