### PR TITLE
[sdk/python] Ensure Output objects are not iterable

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,5 +18,8 @@
 
 - [sdk/python] - Fix regression in behaviour for `Output.from_input({})`
 
+- [sdk/python] - Prevent infinite loops when iterating `Output` objects
+  [#7288](https://github.com/pulumi/pulumi/pull/7288)
+
 - [codegen/python] - Rename conflicting ResourceArgs classes
   [#7171](https://github.com/pulumi/pulumi/pull/7171)

--- a/sdk/python/lib/pulumi/output.py
+++ b/sdk/python/lib/pulumi/output.py
@@ -235,6 +235,13 @@ class Output(Generic[T]):
         """
         return self.apply(lambda v: UNKNOWN if isinstance(v, Unknown) else cast(Any, v)[key], True)
 
+    def __iter__(self) -> Any:
+        """
+        Output instances are not iterable, but since they implement __getitem__ we need to explicitly prevent
+        iteration by implementing __iter__ to raise a TypeError.
+        """
+        raise TypeError("'Output' object is not iterable, consider iterating the underlying value inside an 'apply'")
+
     @staticmethod
     def from_input(val: Input[T]) -> 'Output[T]':
         """

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -193,3 +193,33 @@ class OutputFromInputTests(unittest.TestCase):
         self.assertIsInstance(x_val, OutputFromInputTests.FooArgs)
         self.assertIsInstance(x_val.nested, OutputFromInputTests.NestedArgs)
         self.assertEqual(x_val.nested.hello, "world")
+
+class Obj:
+    def __init__(self, x: str):
+        self.x = x
+
+class OutputHoistingTests(unittest.TestCase):
+    @pulumi_test
+    async def test_item(self):
+        o = Output.from_input([1,2,3])
+        x = o[0]
+        x_val = await x.future()
+        self.assertEqual(x_val, 1)
+
+    @pulumi_test
+    async def test_attr(self):
+        o = Output.from_input(Obj("hello"))
+        x = o.x
+        x_val = await x.future()
+        self.assertEqual(x_val, "hello")
+
+    @pulumi_test
+    async def test_no_iter(self):
+        x = Output.from_input([1,2,3])
+        errored = False
+        try:
+            for i in x:
+                print(i)
+        except TypeError:
+            errored = True
+        self.assertTrue(errored)    

--- a/sdk/python/lib/test/test_output.py
+++ b/sdk/python/lib/test/test_output.py
@@ -216,10 +216,6 @@ class OutputHoistingTests(unittest.TestCase):
     @pulumi_test
     async def test_no_iter(self):
         x = Output.from_input([1,2,3])
-        errored = False
-        try:
+        with self.assertRaises(TypeError):
             for i in x:
                 print(i)
-        except TypeError:
-            errored = True
-        self.assertTrue(errored)    


### PR DESCRIPTION
Although `Output` objects can never correctly support iteration, Python will see the implementation of `__getitem__` and try to iterate the object, leading to an infinite loop.  To prevent this, we need to explicitly implement `__iter__` and make it return a `TypeError` to prevent iteration (and offer a useful error message).

Fixes #5028.
