### PR TITLE
[codegen/python] Cache the package version

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,6 +14,9 @@
 - [cli] - Provide a more helpful error instead of panicking when codegen fails during import.
   [#7265](https://github.com/pulumi/pulumi/pull/7265)
 
+- [codegen/python] - Cache package version for improved performance.
+  [#7293](https://github.com/pulumi/pulumi/pull/7293)
+
 ### Bug Fixes
 
 - [sdk/python] - Fix regression in behaviour for `Output.from_input({})`


### PR DESCRIPTION
Every time a resource is created (without an explicit provider version specified), `_utilities.get_version()` is called to determine the package version. This call is expensive and can measurably impact performance, especially for programs with many resources. This change caches the value so it is only determined once.

This shaved off ~12 seconds from the following program:

```python
from pulumi_aws import s3
bucket = s3.Bucket("mybucket")
for x in range(5000):
    s3.BucketObject(f"{x}", bucket=bucket.id, content="hello")
```

Fixes #7291