### PR TITLE
[sdk/python] Reduce `log.debug` calls for improved performance

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,6 +14,9 @@
 - [cli] - Provide a more helpful error instead of panicking when codegen fails during import.
   [#7265](https://github.com/pulumi/pulumi/pull/7265)
 
+- [sdk/python] - Reduce `log.debug` calls for improved performance
+  [#7295](https://github.com/pulumi/pulumi/pull/7295)
+
 ### Bug Fixes
 
 - [sdk/python] - Fix regression in behaviour for `Output.from_input({})`

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -81,7 +81,6 @@ async def prepare_resource(res: 'Resource',
                            opts: Optional['ResourceOptions'],
                            typ: Optional[type] = None) -> ResourceResolverOperations:
     from .. import Output  # pylint: disable=import-outside-toplevel
-    log.debug(f"resource {props} preparing to wait for dependencies")
     # Before we can proceed, all our dependencies must be finished.
     explicit_urn_dependencies = []
     if opts is not None and opts.depends_on is not None:
@@ -154,7 +153,6 @@ async def prepare_resource(res: 'Resource',
         if not alias_val in aliases:
             aliases.append(alias_val)
 
-    log.debug(f"resource {props} prepared")
     return ResourceResolverOperations(
         parent_urn,
         serialized_props,
@@ -311,7 +309,6 @@ def read_resource(res: 'CustomResource',
     # that we are populating the Resource object with properties associated with an already-live resource.
     #
     # Same as below, we initialize the URN property on the resource, which will always be resolved.
-    log.debug("preparing read resource for RPC")
     (resolve_urn, res.__dict__["urn"]) = resource_output(res)
 
     # Furthermore, since resources being Read must always be custom resources (enforced in the
@@ -328,7 +325,6 @@ def read_resource(res: 'CustomResource',
 
     async def do_read():
         try:
-            log.debug(f"preparing read: ty={ty}, name={name}, id={opts.id}")
             resolver = await prepare_resource(res, ty, True, False, props, opts, typ)
 
             # Resolve the ID that we were given. Note that we are explicitly discarding the list of
@@ -419,7 +415,6 @@ def register_resource(res: 'Resource',
     # Simply initialize the URN property and get prepared to resolve it later on.
     # Note: a resource urn will always get a value, and thus the output property
     # for it can always run .apply calls.
-    log.debug("preparing resource for RPC")
     (resolve_urn, res.__dict__["urn"]) = resource_output(res)
 
     # If a custom resource, make room for the ID property.
@@ -434,7 +429,6 @@ def register_resource(res: 'Resource',
 
     async def do_register():
         try:
-            log.debug(f"preparing resource registration: ty={ty}, name={name}")
             resolver = await prepare_resource(res, ty, custom, remote, props, opts, typ)
             log.debug(f"resource registration prepared: ty={ty}, name={name}")
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -126,7 +126,8 @@ async def serialize_properties(inputs: 'Inputs',
             translated_name = k
             if translate is not None:
                 translated_name = translate(k)
-                log.debug(f"top-level input property translated: {k} -> {translated_name}")
+                if settings.excessive_debug_output:
+                    log.debug(f"top-level input property translated: {k} -> {translated_name}")
             # pylint: disable=unsupported-assignment-operation
             struct[translated_name] = result
             property_deps[translated_name] = deps
@@ -316,7 +317,8 @@ async def serialize_property(value: 'Input[Any]',
             transformed_key = k
             if translate is not None:
                 transformed_key = translate(k)
-                log.debug(f"transforming input property: {k} -> {transformed_key}")
+                if settings.excessive_debug_output:
+                    log.debug(f"transforming input property: {k} -> {transformed_key}")
             obj[transformed_key] = await serialize_property(value[k], deps, input_transformer, get_type(transformed_key))
 
         return obj
@@ -543,7 +545,6 @@ def transfer_properties(res: 'Resource', props: 'Inputs') -> Dict[str, Resolver]
         # Important to note here is that the resolver's future is assigned to the resource object using the
         # name before translation. When properties are returned from the engine, we must first translate the name
         # from the Pulumi name to the Python name and then use *that* name to index into the resolvers table.
-        log.debug(f"adding resolver {name}")
         resolvers[name] = functools.partial(do_resolve, res, resolve_value, resolve_is_known, resolve_is_secret, resolve_deps)
         res.__dict__[name] = Output(resolve_deps, resolve_value, resolve_is_known, resolve_is_secret)
 
@@ -696,8 +697,9 @@ def resolve_outputs(res: 'Resource',
         translated_key = translate(key)
         translated_value = translate_output_properties(value, translate_to_pass, types.get(key),
                                                        transform_using_type_metadata)
-        log.debug(f"incoming output property translated: {key} -> {translated_key}")
-        log.debug(f"incoming output value translated: {value} -> {translated_value}")
+        if settings.excessive_debug_output:
+            log.debug(f"incoming output property translated: {key} -> {translated_key}")
+            log.debug(f"incoming output value translated: {value} -> {translated_value}")
         all_properties[translated_key] = translated_value
 
     if not settings.is_dry_run() or settings.is_legacy_apply_enabled():
@@ -721,7 +723,8 @@ def resolve_properties(resolvers: Dict[str, Resolver], all_properties: Dict[str,
             continue
 
         # Otherwise, unmarshal the value, and store it on the resource object.
-        log.debug(f"looking for resolver using translated name {key}")
+        if settings.excessive_debug_output:
+            log.debug(f"looking for resolver using translated name {key}")
         resolve = resolvers.get(key)
         if resolve is None:
             # engine returned a property that was not in our initial property-map.  This can happen
@@ -773,7 +776,8 @@ def resolve_outputs_due_to_exception(resolvers: Dict[str, Resolver], exn: Except
     :param exn: The exception that occurred when trying (and failing) to create this resource.
     """
     for key, resolve in resolvers.items():
-        log.debug(f"sending exception to resolver for {key}")
+        if settings.excessive_debug_output:
+            log.debug(f"sending exception to resolver for {key}")
         resolve(None, False, False, None, exn)
 
 
@@ -811,7 +815,8 @@ def register_resource_package(pkg: str, package: ResourcePackage):
         resource_packages = []
         _RESOURCE_PACKAGES[pkg] = resource_packages
 
-    log.debug(f"registering package {pkg}@{package.version()}")
+    if settings.excessive_debug_output:
+        log.debug(f"registering package {pkg}@{package.version()}")
     resource_packages.append(package)
 
 
@@ -857,7 +862,8 @@ def register_resource_module(pkg: str, mod: str, module: ResourceModule):
         resource_modules = []
         _RESOURCE_MODULES[key] = resource_modules
 
-    log.debug(f"registering module {key}@{module.version()}")
+    if settings.excessive_debug_output:
+        log.debug(f"registering module {key}@{module.version()}")
     resource_modules.append(module)
 
 

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -31,6 +31,10 @@ _MAX_RPC_MESSAGE_SIZE = 1024 * 1024 * 400
 _GRPC_CHANNEL_OPTIONS = [('grpc.max_receive_message_length', _MAX_RPC_MESSAGE_SIZE)]
 
 
+# excessive_debug_output enables, well, pretty excessive debug output pertaining to resources and properties.
+excessive_debug_output = False
+
+
 class Settings:
     monitor: Optional[Union[resource_pb2_grpc.ResourceMonitorStub, Any]]
     engine: Optional[Union[engine_pb2_grpc.EngineStub, Any]]


### PR DESCRIPTION
`log.debug` messages are part of an update and get sent to the service. Reducing the number of `log.debug` calls can significantly improve the performance of a program. This commit changes the debug logging in the Python SDK to be similar to the debug logging in the Node.js SDK.

 - An `excessive_debug_output` variable has been added (that can be set to `True` during debugging), but otherwise will avoid a large number of `log.debug` calls.
- Some unhelpful/redundant `log.debug` calls have been deleted.

Fixes #7292

---

The following program run with `pulumi preview` (plus the fix from #7293):

```python
from pulumi_aws import s3
bucket = s3.Bucket("mybucket")
for x in range(5000):
    s3.BucketObject(f"{x}", bucket=bucket.id, content="hello")
```

Duration Before: 35.8 seconds
Duration After: 6.35 seconds

29.45 second improvement!

### Before

<img width="1092" alt="Screen Shot 2021-06-14 at 7 31 41 AM" src="https://user-images.githubusercontent.com/710598/121909226-92a69d00-cce2-11eb-8d80-226b022a5a84.png">

### After

<img width="1088" alt="Screen Shot 2021-06-14 at 7 31 57 AM" src="https://user-images.githubusercontent.com/710598/121909268-9b976e80-cce2-11eb-9ae4-7dd676786e1c.png">
