### PR TITLE
[codegen/pcl] Allow missing object properties.

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -29,9 +29,10 @@ import (
 )
 
 type bindOptions struct {
-	allowMissingVariables bool
-	loader                schema.Loader
-	packageCache          *PackageCache
+	allowMissingVariables  bool
+	allowMissingProperties bool
+	loader                 schema.Loader
+	packageCache           *PackageCache
 }
 
 func (opts bindOptions) modelOptions() []model.BindOption {
@@ -56,6 +57,10 @@ type BindOption func(*bindOptions)
 
 func AllowMissingVariables(options *bindOptions) {
 	options.allowMissingVariables = true
+}
+
+func AllowMissingProperties(options *bindOptions) {
+	options.allowMissingProperties = true
 }
 
 func PluginHost(host plugin.Host) BindOption {

--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -168,7 +168,7 @@ func (b *binder) schemaTypeToTypeImpl(src schema.Type, seen map[schema.Type]mode
 		seen[src] = objType
 		for _, prop := range src.Properties {
 			t := b.schemaTypeToTypeImpl(prop.Type, seen)
-			if !prop.IsRequired {
+			if !prop.IsRequired || b.options.allowMissingProperties {
 				t = model.NewOptionalType(t)
 			}
 			if prop.ConstValue != nil {


### PR DESCRIPTION
Add an option to allow missing object properties. This will prevent us
from losing examples once resource typechecking is fixed (it is
currently unintentionally disabled because the resource inputs object
type has an unexpected shape).