### PR TITLE
[sdk/dotnet] - bug fix resources destroyed after exception thrown during inline program

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,9 @@
 
 ### Bug Fixes
 
+- [sdk/dotnet] - Fix resources destroyed after exception thrown during inline program
+  [#7299](https://github.com/pulumi/pulumi/pull/7299)
+  
 - [sdk/python] - Fix regression in behaviour for `Output.from_input({})`
 
 - [sdk/python] - Prevent infinite loops when iterating `Output` objects

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -84,6 +84,7 @@ namespace Pulumi.Automation.Commands
             {
                 throw CommandException.CreateFromResult(result);
             }
+
             return result;
         }
 

--- a/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
+++ b/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
+using System;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -60,7 +61,14 @@ namespace Pulumi.Automation
                 runner => this._callerContext.Program.InvokeAsync(runner, cts.Token))
                 .ConfigureAwait(false);
 
-            return new RunResponse();
+            if (this._callerContext.ExceptionDispatchInfo is null)
+                return new RunResponse();
+
+            return new RunResponse()
+            {
+                Bail = true,
+                Error = this._callerContext.ExceptionDispatchInfo.SourceException.Message,
+            };
         }
 
         public class CallerContext

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -275,9 +275,25 @@ namespace Pulumi.Automation
                 args.Add("--exec-kind");
                 args.Add(execKind);
 
-                var upResult = await this.RunCommandAsync(args, options?.OnStandardOutput, options?.OnStandardError, options?.OnEvent, cancellationToken).ConfigureAwait(false);
-                if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
-                    exceptionInfo.Throw();
+                CommandResult upResult;
+                try
+                {
+                    upResult = await this.RunCommandAsync(
+                        args,
+                        options?.OnStandardOutput,
+                        options?.OnStandardError,
+                        options?.OnEvent,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
+                        exceptionInfo.Throw();
+
+                    // this won't be hit if we have an inline
+                    // program exception
+                    throw;
+                }
 
                 var output = await this.GetOutputsAsync(cancellationToken).ConfigureAwait(false);
                 var summary = await this.GetInfoAsync(cancellationToken).ConfigureAwait(false);
@@ -390,9 +406,25 @@ namespace Pulumi.Automation
                 args.Add("--exec-kind");
                 args.Add(execKind);
 
-                var result = await this.RunCommandAsync(args, options?.OnStandardOutput, options?.OnStandardError, OnPreviewEvent, cancellationToken).ConfigureAwait(false);
-                if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
-                    exceptionInfo.Throw();
+                CommandResult result;
+                try
+                {
+                    result = await this.RunCommandAsync(
+                        args,
+                        options?.OnStandardOutput,
+                        options?.OnStandardError,
+                        OnPreviewEvent,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    if (inlineHost != null && inlineHost.TryGetExceptionInfo(out var exceptionInfo))
+                        exceptionInfo.Throw();
+
+                    // this won't be hit if we have an inline
+                    // program exception
+                    throw;
+                }
 
                 if (summaryEvent is null)
                 {


### PR DESCRIPTION
# Description

This resolves the issue of resources being destroyed after an exception is thrown during an inline program. The gRPC portion of the Automation API implementation is now correctly returning in the error case and the `WorkspaceStack` instance is now conditionally throwing the relevant exception if an inline exception is present, that way the correct exception bubbles up to the Automation API consumer.

Fixes #7050

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
