### PR TITLE
[codegen/schema] Fix intermittent failing test

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1620,8 +1620,16 @@ func bindTypes(pkg *Package, complexTypes map[string]ComplexTypeSpec, loader Loa
 
 func bindMethods(resourceToken string, methods map[string]string,
 	functionTable map[string]*Function) ([]*Method, error) {
-	var result []*Method
-	for name, token := range methods {
+
+	names := make([]string, 0, len(methods))
+	for name := range methods {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	result := make([]*Method, 0, len(methods))
+	for _, name := range names {
+		token := methods[name]
 		function, ok := functionTable[token]
 		if !ok {
 			return nil, errors.Errorf("unknown function %s for method %s", token, name)


### PR DESCRIPTION
The `bad-methods-2.json` test ensures there is an error when trying to use a function as a method twice.

The schema looks like:

```json
"methods": {
    "bar": "xyz:index:Foo/bar",
    "baz": "xyz:index:Foo/bar"
}
```

And the expected error is:

> function xyz:index:Foo/bar for method baz is already a method

However, when the schema is unmarshalled into a map, the keys in the map are unordered (just as JSON keys in objects are unordered), so occaisonally we'd see an error mentioning method `bar` rather than `baz`:

> function xyz:index:Foo/bar for method bar is already a method

To address this, we'll fix the portion of the code that is generating the error to walk the map in a deterministic order, and we'll also return the list of methods in the same deterministic order as well.

Fixes #7298