### PR TITLE
Add an option to skip resource typechecking.

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -31,6 +31,7 @@ import (
 type bindOptions struct {
 	allowMissingVariables  bool
 	allowMissingProperties bool
+	skipResourceTypecheck  bool
 	loader                 schema.Loader
 	packageCache           *PackageCache
 }
@@ -61,6 +62,10 @@ func AllowMissingVariables(options *bindOptions) {
 
 func AllowMissingProperties(options *bindOptions) {
 	options.allowMissingProperties = true
+}
+
+func SkipResourceTypechecking(options *bindOptions) {
+	options.skipResourceTypecheck = true
 }
 
 func PluginHost(host plugin.Host) BindOption {

--- a/pkg/codegen/hcl2/binder_resource.go
+++ b/pkg/codegen/hcl2/binder_resource.go
@@ -264,7 +264,7 @@ func (b *binder) bindResourceBody(node *Resource) hcl.Diagnostics {
 	}
 
 	// Typecheck the attributes.
-	if objectType, ok := node.InputType.(*model.ObjectType); ok {
+	if objectType, ok := node.InputType.(*model.ObjectType); ok && !b.options.skipResourceTypecheck {
 		attrNames := codegen.StringSet{}
 		for _, attr := range node.Inputs {
 			attrNames.Add(attr.Name)


### PR DESCRIPTION
More testing has found further issues with incorrect attribute shapes
generated by tf2pulumi. This knob will allow us to continue to generate
examples until those bugs are fixed.