### PR TITLE
Print actionable information on assertion failure

### DIFF
--- a/sdk/go/pulumi/types.go
+++ b/sdk/go/pulumi/types.go
@@ -705,7 +705,7 @@ func awaitInputs(ctx context.Context, v, resolved reflect.Value) (bool, bool, []
 		}
 	}
 
-	contract.Assert(valueType.AssignableTo(resolved.Type()))
+	contract.Assertf(valueType.AssignableTo(resolved.Type()), "%s not assignable to %s", valueType.String(), resolved.Type().String())
 
 	// If the resolved type is an interface, make an appropriate destination from the value's type.
 	if resolved.Kind() == reflect.Interface {


### PR DESCRIPTION
This commit moves from simply asserting on the assignability of types to using Assertf to print the types in question. This provides more information to a user whose code is panicking because of non-assignability.

Ultimately it would likely be better to surface this via error messages instead of via panic, but this at least improves the debuggability in the meantime.