### PR TITLE
Fix watch command in macos arm64 builds

### DIFF
--- a/pkg/backend/watch_darwin_arm64.go
+++ b/pkg/backend/watch_darwin_arm64.go
@@ -21,6 +21,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
-func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, apply Applier) result.Result {
+func Watch(ctx context.Context, b Backend, stack Stack, op UpdateOperation, apply Applier, paths []string) result.Result {
 	return result.FromError(errors.New("pulumi watch is not currently supported on darwin/arm64"))
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

https://github.com/pulumi/pulumi/pull/7247 added the ability to specify paths in `pulumi watch`, but this PR didn't update the alternative handling we have for `darwin/arm64` where `watch` isn't supported. This led to a [failure](https://github.com/pulumi/pulumi/runs/2878255663?check_suite_focus=true#step:8:77) in p/p master.

This PR corrects the issue by updating the darwin/arm64 function signature.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
