### PR TITLE
detect nodejs side by side pulumi for inline automation programs and fail fast

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,6 +6,8 @@
   to be watched by the `pulumi watch` command.
   [#7115](https://github.com/pulumi/pulumi/pull/7247)
 
+- [auto/nodejs] - Fail early when multiple versions of `@pulumi/pulumi` are detected in nodejs inline programs.'
+  [#7349](https://github.com/pulumi/pulumi/pull/7349)
 
 ### Bug Fixes
 

--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -37,6 +37,10 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
         this.program = program;
 
         this.running = false;
+
+        // set a bit in runtime settings to indicate that we're running in inline mode.
+        // this allows us to detect and fail fast for side by side pulumi scenarios.
+        runtime.setInline();
     }
 
     onPulumiExit(hasError: boolean) {

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -239,6 +239,8 @@ export function hasMonitor(): boolean {
  * getMonitor returns the current resource monitoring service client for RPC communications.
  */
 export function getMonitor(): Object | undefined {
+    // pre-emptive fail fast check for node inline programs
+    runSxSCheck();
     if (monitor === undefined) {
         const addr = options().monitorAddr;
         if (addr) {
@@ -329,6 +331,8 @@ export function serialize(): boolean {
 
  */
 function options(): Options {
+    // pre-emptive fail fast check for node inline programs
+    runSxSCheck();
     // The only option that needs parsing is the parallelism flag.  Ignore any failures.
     let parallel: number | undefined;
     const parallelOpt = process.env[nodeEnvKeys.parallel];
@@ -544,4 +548,38 @@ export function monitorSupportsSecrets(): Promise<boolean> {
  */
 export async function monitorSupportsResourceReferences(): Promise<boolean> {
     return monitorSupportsFeature("resourceReferences");
+}
+
+// sxsRandomIdentifier is a module level global that is transfered to process.env.
+// the goal is to detect side by side (sxs) pulumi/pulumi situations for inline programs
+// and fail fast. See https://github.com/pulumi/pulumi/issues/7333 for details.
+const sxsRandomIdentifier = Math.random().toString();
+
+// indicates that the current runtime context is via an inline program via automation api.
+let isInline = false;
+
+/** @internal only used by the internal inline language host implementation */
+export function setInline() {
+    isInline = true;
+}
+
+const pulumiSxSEnv = "PULUMI_NODEJS_SXS_FLAG";
+
+/**
+ * runSxSCheck checks an identifier stored in the environment to detect multiple versions of pulumi.
+ * if we're running in inline mode, it will throw an error to fail fast due to global state collisions that can occur.
+ */
+function runSxSCheck() {
+    const envSxS = process.env[pulumiSxSEnv];
+    process.env[pulumiSxSEnv] = sxsRandomIdentifier;
+
+    if (!isInline) {
+        return;
+    }
+
+    // if we see a different identifier, another version of pulumi has been loaded and we should fail.
+    if (!!envSxS && envSxS !== sxsRandomIdentifier) {
+        throw new Error("Detected multiple versions of '@pulumi/pulumi' in use in an inline automation api program.\n" +
+            "Use the yarn 'resolutions' field to pin to a single version: https://github.com/pulumi/pulumi/issues/5449.");
+    }
 }


### PR DESCRIPTION
# Description

This change detects when nodejs automation api inline programs load multiple instances of `@pulumi/pulumi` and triggers an early failure with a helpful error message:

```console
      pulumi:pulumi:Stack (inlineNode-dev):
          error: Unhandled exception: Error: Detected multiple versions of '@pulumi/pulumi' in use in an inline automation api program
          Use the yarn 'resolutions' field to resolve this: https://github.com/pulumi/pulumi/issues/5449.
```

Using multiple versions of pulumi/pulumi in inline programs can cause collisions in global state. Until we address https://github.com/pulumi/pulumi/issues/5449, inline node automation users need to pin to a single version of pulumi/pulumi to avoid issues like those seen in https://github.com/pulumi/pulumi/issues/6998

This change set adds a module level global (a random number) that each instance of pulumi/pulumi will write into the environment. We detect side by side scenarios by comparing the module level global to the value in the environment every time we observe settings, or do a resource operation (invoke, register resource, get, etc). 

Fixes https://github.com/pulumi/pulumi/issues/7333
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

