### PR TITLE
[CLI] add support for `pulumi diagnostic environment`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,6 +5,8 @@
 - [cli] - Added support for passing custom paths that need
   to be watched by the `pulumi watch` command.
   [#7115](https://github.com/pulumi/pulumi/pull/7247)
+- [cli] - Add `pulumi diagnostic environment` command to output information for support
+  [#2715](https://github.com/pulumi/pulumi/issues/2715)  
 
 
 ### Bug Fixes

--- a/pkg/cmd/pulumi/diagnostic.go
+++ b/pkg/cmd/pulumi/diagnostic.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/cmd/pulumi/diagnostic.go
+++ b/pkg/cmd/pulumi/diagnostic.go
@@ -1,0 +1,32 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newDiagnosticCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "diagnostic",
+		Short: "Diagnostic commands",
+		Args:  cmdutil.NoArgs,
+	}
+
+	cmd.AddCommand(newDiagnosticEnvironmentCmd())
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/diagnostic_environment.go
+++ b/pkg/cmd/pulumi/diagnostic_environment.go
@@ -1,0 +1,66 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	//"os"
+	"runtime"
+	"github.com/pulumi/pulumi/pkg/v3/version"
+	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func newDiagnosticEnvironmentCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "environment",
+		Short: "Display diagnostic environment information",
+		Long: "Display the Pulumi version, OS, \n" +
+			"console and backend URLs",
+		Args: cmdutil.NoArgs,
+		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
+			opts := display.Options{
+				Color: cmdutil.GetGlobalColorization(),
+			}
+
+			var os string = runtime.GOOS
+			// TODO: See how to get actual OS version numbers
+			switch os {
+		    case "windows":
+		        os = "Windows"
+		    case "darwin":
+		        os = "MacOs"
+		    case "linux":
+		        os = "Linux"
+		    }
+
+			b, err := currentBackend(opts)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Pulumi Version: %s\n", version.Version)
+			fmt.Printf("OS: %s %s\n", os, runtime.GOARCH)
+			fmt.Printf("Backend URL: %s\n", b.URL())
+
+
+			return nil
+		}),
+	}
+
+
+	return cmd
+}

--- a/pkg/cmd/pulumi/diagnostic_environment.go
+++ b/pkg/cmd/pulumi/diagnostic_environment.go
@@ -16,15 +16,16 @@ package main
 
 import (
 	"fmt"
-	//"os"
 	"runtime"
 	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 	"github.com/spf13/cobra"
 )
 
 func newDiagnosticEnvironmentCmd() *cobra.Command {
+
 	cmd := &cobra.Command{
 		Use:   "environment",
 		Short: "Display diagnostic environment information",
@@ -52,15 +53,19 @@ func newDiagnosticEnvironmentCmd() *cobra.Command {
 				return err
 			}
 
+			cloudURL, err := workspace.GetCurrentCloudURL()
+			if err != nil {
+				return err
+			}
+
 			fmt.Printf("Pulumi Version: %s\n", version.Version)
 			fmt.Printf("OS: %s %s\n", os, runtime.GOARCH)
-			fmt.Printf("Backend URL: %s\n", b.URL())
-
+			fmt.Printf("Console URL: %s\n", b.URL())
+			fmt.Printf("Backend URL: %s\n", cloudURL)
 
 			return nil
 		}),
 	}
-
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/diagnostic_environment.go
+++ b/pkg/cmd/pulumi/diagnostic_environment.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -29,8 +29,7 @@ func newDiagnosticEnvironmentCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "environment",
 		Short: "Display diagnostic environment information",
-		Long: "Display the Pulumi version, OS, \n" +
-			"console and backend URLs",
+		Long:  "Display the Pulumi version, OS, runtime info, backend URL and stack data",
 		Args: cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			opts := display.Options{

--- a/pkg/cmd/pulumi/diagnostic_environment.go
+++ b/pkg/cmd/pulumi/diagnostic_environment.go
@@ -16,12 +16,12 @@ package main
 
 import (
 	"fmt"
-	"runtime"
-	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
+	"github.com/pulumi/pulumi/pkg/v3/version"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
 	"os/exec"
+	"runtime"
 )
 
 func newDiagnosticEnvironmentCmd() *cobra.Command {
@@ -30,7 +30,7 @@ func newDiagnosticEnvironmentCmd() *cobra.Command {
 		Use:   "environment",
 		Short: "Display diagnostic environment information",
 		Long:  "Display the Pulumi version, OS, runtime info, backend URL and stack data",
-		Args: cmdutil.NoArgs,
+		Args:  cmdutil.NoArgs,
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),
@@ -40,15 +40,15 @@ func newDiagnosticEnvironmentCmd() *cobra.Command {
 			// TODO: See how to get actual OS version numbers
 			var os string = runtime.GOOS
 			switch os {
-		    case "windows":
-		        os = "Windows"
-		    case "darwin":
-		        os = "MacOs"
-		    case "linux":
-		        os = "Linux"
-		    }
+			case "windows":
+				os = "Windows"
+			case "darwin":
+				os = "MacOs"
+			case "linux":
+				os = "Linux"
+			}
 
-		    // Console URL Info
+			// Console URL Info
 			b, err := currentBackend(opts)
 			if err != nil {
 				return err

--- a/pkg/cmd/pulumi/diagnostic_environment.go
+++ b/pkg/cmd/pulumi/diagnostic_environment.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/spf13/cobra"
+	"os/exec"
 )
 
 func newDiagnosticEnvironmentCmd() *cobra.Command {
@@ -69,10 +70,35 @@ func newDiagnosticEnvironmentCmd() *cobra.Command {
 				rescnt = len(snap.Resources)
 			}
 
+			// Runtime versions info
+			proj, _, err := readProject()
+			if err != nil {
+				return err
+			}
+
+			var runtimeName string = proj.Runtime.Name()
+			var runtimeVersion string = ""
+			switch runtimeName {
+			case "dotnet":
+				cmdOutput, _ := exec.Command("dotnet", "--version").Output()
+				runtimeVersion = string(cmdOutput[:])
+			case "go":
+				cmdOutput, _ := exec.Command("go", "version").Output()
+				runtimeVersion = string(cmdOutput[:])
+			case "nodejs":
+				cmdOutput, _ := exec.Command("npm", "--version").Output()
+				runtimeVersion = string(cmdOutput[:])
+			case "python":
+				cmdOutput, _ := exec.Command("python3", "--version").Output()
+				runtimeVersion = string(cmdOutput[:])
+
+			}
+
 			// Outputs
 			fmt.Printf("Pulumi Version: %s\n", version.Version)
 			fmt.Printf("OS: %s %s\n", os, runtime.GOARCH)
-			fmt.Printf("Console URL: %s\n", b.URL())
+			fmt.Printf("Runtime: %s %s", runtimeName, runtimeVersion)
+			fmt.Printf("Backend URL: %s\n", b.URL())
 			fmt.Printf("Current stack resources (%d):\n", rescnt)
 			if rescnt == 0 {
 				fmt.Printf("    No resources currently in this stack\n")

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -208,6 +208,7 @@ func NewPulumiCmd() *cobra.Command {
 	cmd.AddCommand(newPluginCmd())
 	cmd.AddCommand(newVersionCmd())
 	cmd.AddCommand(newConsoleCmd())
+	cmd.AddCommand(newDiagnosticCmd())
 
 	// Less common, and thus hidden, commands:
 	cmd.AddCommand(newGenCompletionCmd(cmd))


### PR DESCRIPTION
# Description
Adds a `pulumi diagnostic environment` command to the CLI to output basic debug info that could be shared when contacting support, eg:

```go
$  ~/go/bin/pulumi diagnostic environment
Pulumi Version: 3.6.0-alpha.1624390656+daa9532e.dirty
OS: MacOs amd64
Runtime: dotnet 3.1.403
Backend URL: https://app.pulumi.com/emiliza
Current stack resources (3):
    TYPE                              NAME
    pulumi:pulumi:Stack               pulumi-gcp-demo1-dev
    ├─ gcp:storage/bucket:Bucket      my-bucket
    └─ pulumi:providers:gcp           default_5_8_1

Current stack outputs (1):
    OUTPUT      VALUE
    BucketName  gs://my-bucket-109311f
```

Fixes: https://github.com/pulumi/pulumi/issues/2715

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
