### PR TITLE
[sdk/go] Add Contains method to PropertyPath

### DIFF
--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -257,3 +257,37 @@ func (p PropertyPath) Delete(dest PropertyValue) bool {
 	return true
 
 }
+
+// Contains returns true if the receiver property path contains the other pproperty path.
+// For example, the path `foo["bar"][1]` contains the path `foo.bar[1].baz`.  The key `"*"`
+// is a wildcard which matches any string or int index at that same nesting level.  So for example,
+// the path `foo.*.baz` contains `foo.bar.baz.bam`, and the path `*` contains any path.
+func (p PropertyPath) Contains(other PropertyPath) bool {
+	if len(other) < len(p) {
+		return false
+	}
+
+	for i := range p {
+		pp := p[i]
+		otherp := other[i]
+
+		switch pp.(type) {
+		case int:
+			if otherpi, ok := otherp.(int); !ok || otherpi != pp.(int) {
+				return false
+			}
+		case string:
+			if pp.(string) == "*" {
+				continue
+			}
+			if otherps, ok := otherp.(string); !ok || otherps != pp.(string) {
+				return false
+			}
+		default:
+			// Invalid path, return false
+			return false
+		}
+	}
+
+	return true
+}

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -258,7 +258,7 @@ func (p PropertyPath) Delete(dest PropertyValue) bool {
 
 }
 
-// Contains returns true if the receiver property path contains the other pproperty path.
+// Contains returns true if the receiver property path contains the other property path.
 // For example, the path `foo["bar"][1]` contains the path `foo.bar[1].baz`.  The key `"*"`
 // is a wildcard which matches any string or int index at that same nesting level.  So for example,
 // the path `foo.*.baz` contains `foo.bar.baz.bam`, and the path `*` contains any path.
@@ -271,16 +271,16 @@ func (p PropertyPath) Contains(other PropertyPath) bool {
 		pp := p[i]
 		otherp := other[i]
 
-		switch pp.(type) {
+		switch pp := pp.(type) {
 		case int:
-			if otherpi, ok := otherp.(int); !ok || otherpi != pp.(int) {
+			if otherpi, ok := otherp.(int); !ok || otherpi != pp {
 				return false
 			}
 		case string:
-			if pp.(string) == "*" {
+			if pp == "*" {
 				continue
 			}
-			if otherps, ok := otherp.(string); !ok || otherps != pp.(string) {
+			if otherps, ok := otherp.(string); !ok || otherps != pp {
 				return false
 			}
 		default:

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -171,6 +171,90 @@ func TestPropertyPath(t *testing.T) {
 	}
 }
 
+func TestPropertyPathContains(t *testing.T) {
+	cases := []struct {
+		p1       PropertyPath
+		p2       PropertyPath
+		expected bool
+	}{
+		{
+			PropertyPath{"root", "nested"},
+			PropertyPath{"root"},
+			false,
+		},
+		{
+			PropertyPath{"root"},
+			PropertyPath{"root", "nested"},
+			true,
+		},
+		{
+			PropertyPath{"root", 1},
+			PropertyPath{"root"},
+			false,
+		},
+		{
+			PropertyPath{"root"},
+			PropertyPath{"root", 1},
+			true,
+		},
+		{
+			PropertyPath{"root", "double", "nest1"},
+			PropertyPath{"root", "double", "nest2"},
+			false,
+		},
+		{
+			PropertyPath{"root", "nest1", "double"},
+			PropertyPath{"root", "nest2", "double"},
+			false,
+		},
+		{
+			PropertyPath{"root", "nest", "double"},
+			PropertyPath{"root", "nest", "double"},
+			true,
+		},
+		{
+			PropertyPath{"root", 1, "double"},
+			PropertyPath{"root", 1, "double"},
+			true,
+		},
+		{
+			PropertyPath{},
+			PropertyPath{},
+			true,
+		},
+		{
+			PropertyPath{"root"},
+			PropertyPath{},
+			false,
+		},
+		{
+			PropertyPath{},
+			PropertyPath{"root"},
+			true,
+		},
+		{
+			PropertyPath{"foo", "bar", 1},
+			PropertyPath{"foo", "bar", 1, "baz"},
+			true,
+		},
+		{
+			PropertyPath{"foo", "*", "baz"},
+			PropertyPath{"foo", "bar", "baz", "bam"},
+			true,
+		},
+		{
+			PropertyPath{"*"},
+			PropertyPath{"a", "b"},
+			true,
+		},
+	}
+
+	for _, tcase := range cases {
+		res := tcase.p1.Contains(tcase.p2)
+		assert.Equal(t, tcase.expected, res)
+	}
+}
+
 func TestAddResizePropertyPath(t *testing.T) {
 	// Regression test for https://github.com/pulumi/pulumi/issues/5871:
 	// Ensure that adding a new element beyond the size of an array will resize it.

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -243,8 +243,33 @@ func TestPropertyPathContains(t *testing.T) {
 			true,
 		},
 		{
+			PropertyPath{"*", "bar", "baz"},
+			PropertyPath{"foo", "bar", "baz", "bam"},
+			true,
+		},
+		{
+			PropertyPath{"foo", "*", "baz"},
+			PropertyPath{"foo", 1, "baz", "bam"},
+			true,
+		},
+		{
+			PropertyPath{"foo", 1, "*", "bam"},
+			PropertyPath{"foo", 1, "baz", "bam"},
+			true,
+		},
+		{
 			PropertyPath{"*"},
 			PropertyPath{"a", "b"},
+			true,
+		},
+		{
+			PropertyPath{"*"},
+			PropertyPath{"a", 1},
+			true,
+		},
+		{
+			PropertyPath{"*"},
+			PropertyPath{"a", 1, "b"},
 			true,
 		},
 	}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Related to https://github.com/pulumi/pulumi/issues/6753

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
