### PR TITLE
Fix a hang in nodejs remote components when an error is thrown within an apply

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,3 +22,6 @@
   
 - [multilang/python] - Fix nested module generation.
   [#7353](https://github.com/pulumi/pulumi/pull/7353)
+
+- [multilang/nodejs] - Fix a hang when an error is thrown within an apply in a remote component.
+  [#7365](https://github.com/pulumi/pulumi/pull/7365)

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ test_build:: $(SUB_PROJECTS:%=%_install)
 	cd tests/integration/construct_component_unknown/testcomponent-go && go build -o pulumi-resource-testcomponent
 	cd tests/integration/component_provider_schema/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/component_provider_schema/testcomponent-go && go build -o pulumi-resource-testcomponent
+	cd tests/integration/construct_component_error_apply/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 
 test_all:: build test_build $(SUB_PROJECTS:%=%_install)
 	cd pkg && $(GO_TEST) ${PROJECT_PKGS}

--- a/build.proj
+++ b/build.proj
@@ -284,6 +284,10 @@
       WorkingDirectory="$(TestsDirectory)\integration\construct_component_unknown\testcomponent" />
     <Exec Command="yarn link @pulumi/pulumi"
       WorkingDirectory="$(TestsDirectory)\integration\construct_component_unknown\testcomponent" />
+    <Exec Command="yarn install"
+      WorkingDirectory="$(TestsDirectory)\integration\construct_component_error_apply\testcomponent" />
+    <Exec Command="yarn link @pulumi/pulumi"
+      WorkingDirectory="$(TestsDirectory)\integration\construct_component_error_apply\testcomponent" />
   </Target>
 
   <Target Name="TestBuild">
@@ -297,6 +301,7 @@
     <Exec Command="go build -o pulumi-resource-testcomponent.exe" WorkingDirectory="$(TestsDirectory)\integration\component_provider_schema\testcomponent-go" />
     <Exec Command="yarn run tsc" WorkingDirectory="$(TestsDirectory)\integration\construct_component_unknown\testcomponent" />
     <Exec Command="go build -o pulumi-resource-testcomponent.exe" WorkingDirectory="$(TestsDirectory)\integration\construct_component_unknown\testcomponent-go" />
+    <Exec Command="yarn run tsc" WorkingDirectory="$(TestsDirectory)\integration\construct_component_error_apply\testcomponent" />
 
     <!-- Install pulumi SDK into the venv managed by pipenv. -->
     <Exec Command="pipenv run pip install -e ."

--- a/sdk/nodejs/provider/server.ts
+++ b/sdk/nodejs/provider/server.ts
@@ -275,9 +275,6 @@ class Server implements grpc.UntypedServiceImplementation {
         const uncaughtHandler = (err: Error) => {
             if (!this.uncaughtErrors.has(err)) {
                 this.uncaughtErrors.add(err);
-                // Use `pulumi.log.error` here to tell the engine there was a fatal error, which should
-                // stop processing subsequent resource operations.
-                log.error(err.stack || err.message || ("" + err));
             }
             // bubble the uncaught error in the user code back and terminate the outstanding gRPC request.
             callback(err, undefined);

--- a/tests/integration/construct_component_error_apply/nodejs/.gitignore
+++ b/tests/integration/construct_component_error_apply/nodejs/.gitignore
@@ -1,0 +1,3 @@
+/.pulumi/
+/bin/
+/node_modules/

--- a/tests/integration/construct_component_error_apply/nodejs/Pulumi.yaml
+++ b/tests/integration/construct_component_error_apply/nodejs/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: construct_component_nodejs_error_apply
+description: A program that constructs remote component resources.
+runtime: nodejs

--- a/tests/integration/construct_component_error_apply/nodejs/component.ts
+++ b/tests/integration/construct_component_error_apply/nodejs/component.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
 import * as pulumi from "@pulumi/pulumi";
 

--- a/tests/integration/construct_component_error_apply/nodejs/component.ts
+++ b/tests/integration/construct_component_error_apply/nodejs/component.ts
@@ -1,0 +1,19 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+interface ComponentArgs {
+    foo: pulumi.Input<string>;
+}
+
+export class Component extends pulumi.ComponentResource {
+    public readonly foo!: pulumi.Output<string>;
+
+    constructor(name: string, args: ComponentArgs, opts?: pulumi.ComponentResourceOptions) {
+        const inputs: any = {};
+        inputs["foo"] = args.foo;
+
+        super("testcomponent:index:Component", name, inputs, opts, true);
+    }
+}
+

--- a/tests/integration/construct_component_error_apply/nodejs/index.ts
+++ b/tests/integration/construct_component_error_apply/nodejs/index.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
 import { Component } from "./component";
 

--- a/tests/integration/construct_component_error_apply/nodejs/index.ts
+++ b/tests/integration/construct_component_error_apply/nodejs/index.ts
@@ -1,0 +1,6 @@
+// Copyright 2016-2020, Pulumi Corporation.  All rights reserved.
+
+import { Component } from "./component";
+
+const componentA = new Component("a", {foo: "bar"});
+

--- a/tests/integration/construct_component_error_apply/nodejs/package.json
+++ b/tests/integration/construct_component_error_apply/nodejs/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "steps",
+    "license": "Apache-2.0",
+    "devDependencies": {
+        "typescript": "^3.0.0"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/construct_component_error_apply/testcomponent/index.ts
+++ b/tests/integration/construct_component_error_apply/testcomponent/index.ts
@@ -1,0 +1,47 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as provider from "@pulumi/pulumi/provider";
+
+class Component extends pulumi.ComponentResource {
+    public readonly foo: pulumi.Output<string>;
+
+    constructor(name: string, foo: pulumi.Input<string>, opts?: pulumi.ComponentResourceOptions) {
+        super("testcomponent:index:Component", name, {}, opts);
+
+        this.foo = pulumi.output(foo);
+
+        this.registerOutputs({
+            foo: this.foo,
+        })
+    }
+}
+
+class Provider implements provider.Provider {
+    public readonly version = "0.0.1";
+
+    construct(name: string, type: string, inputs: pulumi.Inputs,
+              options: pulumi.ComponentResourceOptions): Promise<provider.ConstructResult> {
+        if (type != "testcomponent:index:Component") {
+            throw new Error(`unknown resource type ${type}`);
+        }
+
+       const foo = pulumi.output("").apply(a => {
+           throw new Error("intentional error from within an apply");
+           return a;
+       });
+
+
+        const component = new Component(name, foo);
+        return Promise.resolve({
+            urn: component.urn,
+            state: {
+                foo: component.foo
+            },
+        });
+    }
+}
+
+export function main(args: string[]) {
+    return provider.main(new Provider(), args);
+}
+
+main(process.argv.slice(2));

--- a/tests/integration/construct_component_error_apply/testcomponent/index.ts
+++ b/tests/integration/construct_component_error_apply/testcomponent/index.ts
@@ -1,3 +1,5 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
 import * as pulumi from "@pulumi/pulumi";
 import * as provider from "@pulumi/pulumi/provider";
 

--- a/tests/integration/construct_component_error_apply/testcomponent/package.json
+++ b/tests/integration/construct_component_error_apply/testcomponent/package.json
@@ -1,0 +1,11 @@
+{
+    "name": "pulumi-resource-testcomponent",
+    "main": "index.js",
+    "devDependencies": {
+        "typescript": "^3.0.0",
+        "@types/node": "latest"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    }
+}

--- a/tests/integration/construct_component_error_apply/testcomponent/pulumi-resource-testcomponent
+++ b/tests/integration/construct_component_error_apply/testcomponent/pulumi-resource-testcomponent
@@ -1,0 +1,3 @@
+#!/bin/bash
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+node $SCRIPT_DIR/bin $@

--- a/tests/integration/construct_component_error_apply/testcomponent/pulumi-resource-testcomponent.cmd
+++ b/tests/integration/construct_component_error_apply/testcomponent/pulumi-resource-testcomponent.cmd
@@ -1,0 +1,4 @@
+@echo off
+setlocal
+set SCRIPT_DIR=%~dp0
+@node "%SCRIPT_DIR%/bin" %*

--- a/tests/integration/construct_component_error_apply/testcomponent/tsconfig.json
+++ b/tests/integration/construct_component_error_apply/testcomponent/tsconfig.json
@@ -1,0 +1,20 @@
+{
+    "compilerOptions": {
+        "strict": true,
+        "outDir": "bin",
+        "target": "es2016",
+        "module": "commonjs",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": false,
+        "stripInternal": true,
+        "experimentalDecorators": true,
+        "pretty": true,
+        "noFallthroughCasesInSwitch": true,
+        "noImplicitReturns": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "files": [
+        "index.ts",
+    ]
+}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1017,3 +1017,35 @@ func TestComponentProviderSchemaNode(t *testing.T) {
 	}
 	testComponentProviderSchema(t, path)
 }
+
+// Test throwing an error within an apply in a remote component written in nodejs.
+// The provider should return the error and shutdown gracefully rather than hanging.
+func TestConstructNodeErrorApply(t *testing.T) {
+	if runtime.GOOS == WindowsOS {
+		t.Skip("Temporarily skipping test on Windows")
+	}
+
+	dir := "construct_component_error_apply"
+	componentDir := "testcomponent"
+
+	stderr := &bytes.Buffer{}
+	expectedError := "intentional error from within an apply"
+
+	opts := &integration.ProgramTestOptions{
+		Env:           []string{pathEnv(t, filepath.Join(dir, componentDir))},
+		Dir:           filepath.Join(dir, "nodejs"),
+		Dependencies:  []string{"@pulumi/pulumi"},
+		Quick:         true,
+		NoParallel:    true,
+		Stderr:        stderr,
+		ExpectFailure: true,
+		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
+			output := stderr.String()
+			assert.Contains(t, output, expectedError)
+		},
+	}
+
+	t.Run(componentDir, func(t *testing.T) {
+		integration.ProgramTest(t, opts)
+	})
+}

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1021,10 +1021,6 @@ func TestComponentProviderSchemaNode(t *testing.T) {
 // Test throwing an error within an apply in a remote component written in nodejs.
 // The provider should return the error and shutdown gracefully rather than hanging.
 func TestConstructNodeErrorApply(t *testing.T) {
-	if runtime.GOOS == WindowsOS {
-		t.Skip("Temporarily skipping test on Windows")
-	}
-
 	dir := "construct_component_error_apply"
 	componentDir := "testcomponent"
 


### PR DESCRIPTION


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The uncaught handler wasn't terminating the outstanding gRPC request causing a hang. This change adds/removes an uncaught handler around constructImpl calls that bubbles the uncaught error back via the gRPC callback. 

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # https://github.com/pulumi/pulumi/issues/6991

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->