### PR TITLE
Preliminary fix for #7359.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,6 +9,9 @@
 - [auto/nodejs] - Fail early when multiple versions of `@pulumi/pulumi` are detected in nodejs inline programs.'
   [#7349](https://github.com/pulumi/pulumi/pull/7349)
 
+- [sdk/go] - Add preliminary support for unmarshaling plain arrays and maps of output values.
+  [#7369](https://github.com/pulumi/pulumi/pull/7369)
+
 ### Bug Fixes
 
 - [sdk/dotnet] - Fix swallowed nested exceptions with inline program so they correctly bubble to consumer

--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -242,7 +242,11 @@ func constructInputsCopyTo(ctx *Context, inputs map[string]interface{}, args int
 				return reflect.ValueOf(output), nil
 			}
 
-			if field.Type.Implements(outputType) || field.Type.Implements(inputType) {
+			isInputType := func(typ reflect.Type) bool {
+				return typ.Implements(outputType) || typ.Implements(inputType)
+			}
+
+			if isInputType(field.Type) {
 				val, err := handleField(field.Type, ci.value, ci.deps)
 				if err != nil {
 					return err
@@ -251,7 +255,7 @@ func constructInputsCopyTo(ctx *Context, inputs map[string]interface{}, args int
 				continue
 			}
 
-			if field.Type.Kind() == reflect.Slice && (field.Type.Elem().Implements(outputType) || field.Type.Elem().Implements(inputType)) {
+			if field.Type.Kind() == reflect.Slice && isInputType(field.Type.Elem()) {
 				elemType := field.Type.Elem()
 				length := len(ci.value.ArrayValue())
 				dest := reflect.MakeSlice(field.Type, length, length)
@@ -266,7 +270,7 @@ func constructInputsCopyTo(ctx *Context, inputs map[string]interface{}, args int
 				continue
 			}
 
-			if field.Type.Kind() == reflect.Map && (field.Type.Elem().Implements(outputType) || field.Type.Elem().Implements(inputType)) {
+			if field.Type.Kind() == reflect.Map && isInputType(field.Type.Elem()) {
 				elemType := field.Type.Elem()
 				length := len(ci.value.ObjectValue())
 				dest := reflect.MakeMapWithSize(field.Type, length)


### PR DESCRIPTION
These changes contain a preliminary fix for #7359 in the Go SDK. The fix
handles input values that are nested one level deep within maps and
arrays, but does not handle other cases of nested input types.