### PR TITLE
Add project support for local backend

### DIFF
--- a/pkg/backend/filestate/snapshot.go
+++ b/pkg/backend/filestate/snapshot.go
@@ -17,15 +17,14 @@ package filestate
 import (
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 )
 
 // localSnapshotManager is a simple SnapshotManager implementation that persists snapshots
 // to disk on the local machine.
 type localSnapshotPersister struct {
-	name    tokens.QName
-	backend *localBackend
-	sm      secrets.Manager
+	stackRef localBackendReference
+	backend  *localBackend
+	sm       secrets.Manager
 }
 
 func (sp *localSnapshotPersister) SecretsManager() secrets.Manager {
@@ -33,11 +32,11 @@ func (sp *localSnapshotPersister) SecretsManager() secrets.Manager {
 }
 
 func (sp *localSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
-	_, err := sp.backend.saveStack(sp.name, snapshot, sp.sm)
+	_, err := sp.backend.saveStack(sp.stackRef, snapshot, sp.sm)
 	return err
 
 }
 
-func (b *localBackend) newSnapshotPersister(stackName tokens.QName, sm secrets.Manager) *localSnapshotPersister {
-	return &localSnapshotPersister{name: stackName, backend: b, sm: sm}
+func (b *localBackend) newSnapshotPersister(stackRef localBackendReference, sm secrets.Manager) *localSnapshotPersister {
+	return &localSnapshotPersister{stackRef: stackRef, backend: b, sm: sm}
 }

--- a/sdk/go/common/workspace/paths.go
+++ b/sdk/go/common/workspace/paths.go
@@ -37,6 +37,8 @@ const (
 	ConfigDir = "config"
 	// GitDir is the name of the folder git uses to store information.
 	GitDir = ".git"
+	// ProjectDir is the name of the directory that holds projects.
+	ProjectDir = "projects"
 	// HistoryDir is the name of the directory that holds historical information for projects.
 	HistoryDir = "history"
 	// PluginDir is the name of the directory containing plugins.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Add project support for local backend. I'm not sure local project would need organization too.
I've put new project enabled local stacks under `.pulumi/projects/{stacks,locks,...}`.

Fixes: #2814

## Checklist

This is not a finished PR. I just wanted to get feedbacks before I work in depth.

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
