### PR TITLE
Add flag for printing full stack names

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,7 +12,7 @@
 - [sdk/go] - Add preliminary support for unmarshaling plain arrays and maps of output values.
   [#7369](https://github.com/pulumi/pulumi/pull/7369)
 
-- [cli] - Add global flag to print fully qualified stack names.
+- [cli] - Add global flag to print fully qualified stack names. [#7388](https://github.com/pulumi/pulumi/pull/7388)
 
 ### Bug Fixes
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@
 - [sdk/go] - Add preliminary support for unmarshaling plain arrays and maps of output values.
   [#7369](https://github.com/pulumi/pulumi/pull/7369)
 
+- [cli] - Add global flag to print fully qualified stack names.
+
 ### Bug Fixes
 
 - [sdk/dotnet] - Fix swallowed nested exceptions with inline program, so they correctly bubble to the consumer.

--- a/pkg/backend/httpstate/stack.go
+++ b/pkg/backend/httpstate/stack.go
@@ -30,6 +30,9 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/result"
 )
 
+// PrintFullStackNames can be set to have stacks print fully qualified names, instead of eliding org or project name.
+var PrintFullStackNames bool
+
 // Stack is a cloud stack.  This simply adds some cloud-specific properties atop the standard backend stack interface.
 type Stack interface {
 	backend.Stack
@@ -49,17 +52,19 @@ type cloudBackendReference struct {
 }
 
 func (c cloudBackendReference) String() string {
-	curUser, err := c.b.CurrentUser()
-	if err != nil {
-		curUser = ""
-	}
-
-	// If the project names match, we can elide them.
-	if c.b.currentProject != nil && c.project == string(c.b.currentProject.Name) {
-		if c.owner == curUser {
-			return string(c.name) // Elide owner too, if it is the current user.
+	if !PrintFullStackNames {
+		curUser, err := c.b.CurrentUser()
+		if err != nil {
+			curUser = ""
 		}
-		return fmt.Sprintf("%s/%s", c.owner, c.name)
+
+		// If the project names match, we can elide them.
+		if c.b.currentProject != nil && c.project == string(c.b.currentProject.Name) {
+			if c.owner == curUser {
+				return string(c.name) // Elide owner too, if it is the current user.
+			}
+			return fmt.Sprintf("%s/%s", c.owner, c.name)
+		}
 	}
 
 	return fmt.Sprintf("%s/%s/%s", c.owner, c.project, c.name)

--- a/pkg/backend/httpstate/stack_test.go
+++ b/pkg/backend/httpstate/stack_test.go
@@ -1,0 +1,24 @@
+package httpstate
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestStackString(t *testing.T) {
+	t.Run("PrintsFullNames", func(t *testing.T) {
+		defer func(prev bool) {
+			PrintFullStackNames = prev
+		}(PrintFullStackNames)
+		PrintFullStackNames = true
+		ref := cloudBackendReference{
+			name:    "stackName",
+			project: "projectName",
+			owner:   "ownerName",
+			b:       nil,
+		}
+
+		assert.Equal(t, fmt.Sprintf("%s/%s/%s", ref.owner, ref.project, ref.name), ref.String())
+	})
+}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -180,6 +180,8 @@ func NewPulumiCmd() *cobra.Command {
 		"Enable verbose logging (e.g., v=3); anything >3 is very verbose")
 	cmd.PersistentFlags().StringVar(
 		&color, "color", "auto", "Colorize output. Choices are: always, never, raw, auto")
+	cmd.PersistentFlags().BoolVar(&httpstate.PrintFullStackNames, "full-name", false,
+		"Print fully qualified stack names")
 
 	// Common commands:
 	//     - Getting Started Commands:

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -62,7 +62,7 @@ func newStackCmd() *cobra.Command {
 			}
 
 			if showStackName {
-				fmt.Printf("%s\n", s.Ref().Name())
+				fmt.Printf("%s\n", s.Ref())
 				return nil
 			}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
Add a global flag, `--full-name`, that will print the fully qualified stack name, instead of possibly eliding the org or project name.

### Output before:
```
❯ pulumi stack --show-name
full-name-test
```
### Output after:
```
❯ pulumi stack --show-name --full-name
fooOrg/barProject/full-name-test
```

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
I wasn't able to find tests that exercise the `pulumi stack --show-name` command with a service backend, but I've included a unit test for `cloudBackendReference.String()` 
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
