### PR TITLE
Demo an issue with naive Input/Output wrappers for interfaces

### DIFF
--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -649,3 +649,84 @@ func TestMixedWaitGroupsApply(t *testing.T) {
 		})
 	})
 }
+
+// Here we want to have an interface type Example, and build
+// ExampleInput/ExampleOutput types for it in the usual way. Yet
+// something is not quite right, as the failure of this test
+// demonstrates.
+func TestInputOutputWrappersForInterfaces(t *testing.T) {
+	var id = "x"
+	var ex Example = &example{id}
+
+	assert.Equal(t, id, getExampleId(ex))
+
+	var exi ExampleInput = ex
+	assert.Equal(t, id, getExampleId(exi))
+
+	var exOutput ExampleOutput = ToOutput(ex).(ExampleOutput)
+	assert.Equal(t, id, getExampleId(exOutput))
+}
+
+type Example interface {
+	ExampleInput
+	Id() string
+}
+
+var exampleType = reflect.TypeOf((*Example)(nil)).Elem()
+
+type example struct{ id string }
+
+func (e *example) Id() string {
+	return e.id
+}
+
+var _ Example = &example{}
+
+func (*example) ElementType() reflect.Type {
+	return exampleType
+}
+
+func (in *example) ToExampleOutput() ExampleOutput {
+	return ToOutput(in).(ExampleOutput)
+}
+
+func (in *example) ToExampleOutputWithContext(ctx context.Context) ExampleOutput {
+	return ToOutputWithContext(ctx, in).(ExampleOutput)
+}
+
+// ExampleInput is an input type that accepts Example and ExampleOutput values.
+type ExampleInput interface {
+	Input
+
+	ToExampleOutput() ExampleOutput
+	ToExampleOutputWithContext(ctx context.Context) ExampleOutput
+}
+
+// ExampleOutput is an Output that returns Example values.
+type ExampleOutput struct{ *OutputState }
+
+// ElementType returns the element type of this Output (Example).
+func (ExampleOutput) ElementType() reflect.Type {
+	return exampleType
+}
+
+func (o ExampleOutput) ToExampleOutput() ExampleOutput {
+	return o
+}
+
+func (o ExampleOutput) ToExampleOutputWithContext(ctx context.Context) ExampleOutput {
+	return o
+}
+
+func getExampleId(input ExampleInput) string {
+	c := make(chan string)
+	input.ToExampleOutput().ApplyT(func(x Example) int {
+		c <- x.Id()
+		return 0
+	})
+	return <-c
+}
+
+func init() {
+	RegisterOutputType(ExampleOutput{})
+}

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -658,25 +658,25 @@ func TestInputOutputWrappersForInterfaces(t *testing.T) {
 	var id = "x"
 	var ex Example = &example{id}
 
-	assert.Equal(t, id, getExampleId(ex))
+	assert.Equal(t, id, getExampleID(ex))
 
 	var exi ExampleInput = ex
-	assert.Equal(t, id, getExampleId(exi))
+	assert.Equal(t, id, getExampleID(exi))
 
 	var exOutput ExampleOutput = ToOutput(ex).(ExampleOutput)
-	assert.Equal(t, id, getExampleId(exOutput))
+	assert.Equal(t, id, getExampleID(exOutput))
 }
 
 type Example interface {
 	ExampleInput
-	Id() string
+	ID() string
 }
 
 var exampleType = reflect.TypeOf((*Example)(nil)).Elem()
 
 type example struct{ id string }
 
-func (e *example) Id() string {
+func (e *example) ID() string {
 	return e.id
 }
 
@@ -686,12 +686,12 @@ func (*example) ElementType() reflect.Type {
 	return exampleType
 }
 
-func (in *example) ToExampleOutput() ExampleOutput {
-	return ToOutput(in).(ExampleOutput)
+func (e *example) ToExampleOutput() ExampleOutput {
+	return ToOutput(e).(ExampleOutput)
 }
 
-func (in *example) ToExampleOutputWithContext(ctx context.Context) ExampleOutput {
-	return ToOutputWithContext(ctx, in).(ExampleOutput)
+func (e *example) ToExampleOutputWithContext(ctx context.Context) ExampleOutput {
+	return ToOutputWithContext(ctx, e).(ExampleOutput)
 }
 
 // ExampleInput is an input type that accepts Example and ExampleOutput values.
@@ -718,10 +718,10 @@ func (o ExampleOutput) ToExampleOutputWithContext(ctx context.Context) ExampleOu
 	return o
 }
 
-func getExampleId(input ExampleInput) string {
+func getExampleID(input ExampleInput) string {
 	c := make(chan string)
 	input.ToExampleOutput().ApplyT(func(x Example) int {
-		c <- x.Id()
+		c <- x.ID()
 		return 0
 	})
 	return <-c


### PR DESCRIPTION
# Description

Demonstrates an issue with naive Input/Output wrappers around an Example type that happens to be an interface.

```
go test -run TestInputOutputWrappersForInterfaces
panic: interface conversion: pulumi.example is not pulumi.Input: missing method ElementType

goroutine 20 [running]:
github.com/pulumi/pulumi/sdk/v3/go/pulumi.awaitInputs(0x1b8a418, 0xc0001a8000, 0x1979f20, 0xc0004385f0, 0x16, 0x196dd00, 0xc000438600, 0x194, 0x9a00000, 0x0, ...)
	/Users/anton/pulumi/sdk/go/pulumi/types.go:691 +0x280d
github.com/pulumi/pulumi/sdk/v3/go/pulumi.toOutputTWithContext.func3(0xc0001cb840, 0x1979f20, 0xc0004385f0, 0x1b8b3a0, 0xc000436460, 0x1b8a418, 0xc0001a8000, 0x196dd00, 0xc000438600, 0x194, ...)
	/Users/anton/pulumi/sdk/go/pulumi/types.go:828 +0x137
created by github.com/pulumi/pulumi/sdk/v3/go/pulumi.toOutputTWithContext
	/Users/anton/pulumi/sdk/go/pulumi/types.go:820 +0x216
exit status 2
FAIL	github.com/pulumi/pulumi/sdk/v3/go/pulumi	0.170s
```

In the real tasks I've encountered this trying to build a ResourceInput wrapper for the Resource interface type. The workaround is to not embed XInput interface in X interface, but then some explicit conversion methods are needed. Do we have a convention for these? Or should we consider this a bug we can fix in awaitInputs and make the example work as written. 


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
