### PR TITLE
specify plugin arguments before other flags

### DIFF
--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -280,6 +280,7 @@ func newPlugin(ctx *Context, pwd, bin, prefix string, args, env []string, option
 // execPlugin starts the plugin executable.
 func execPlugin(bin string, pluginArgs []string, pwd string, env []string) (*plugin, error) {
 	var args []string
+	args = append(args, pluginArgs...)
 	// Flow the logging information if set.
 	if logging.LogFlow {
 		if logging.LogToStderr {
@@ -293,7 +294,6 @@ func execPlugin(bin string, pluginArgs []string, pwd string, env []string) (*plu
 	if cmdutil.TracingEndpoint != "" && !cmdutil.TracingToFile {
 		args = append(args, "--tracing", cmdutil.TracingEndpoint)
 	}
-	args = append(args, pluginArgs...)
 
 	cmd := exec.Command(bin, args...)
 	cmdutil.RegisterProcessGroup(cmd)

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -892,6 +892,8 @@ func optsForConstructNode(t *testing.T, expectedResourceCount int, env ...string
 		},
 		Quick:      true,
 		NoParallel: true,
+		// verify that additional flags don't cause the component provider hang
+		UpdateCommandlineFlags: []string{"--logflow", "--logtostderr"},
 		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
 			assert.NotNil(t, stackInfo.Deployment)
 			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This change alters the order in which we provide arguments to plugins. Previously we were adding flags like `--logflow` ahead of standard plugin args like the engine address. This causes hangs in nodejs multi-lang provider servers which don't have super robust argument parsing (also applies to dynamic providers) and expect the first argument to be the engine grpc address.

This fix is just a bandaid, with a test to ensure we don't regress. I've filed a follow up issue here to add the full flagset to all multi-lang provider servers: https://github.com/pulumi/pulumi/issues/7402

Fixes https://github.com/pulumi/pulumi/issues/6912

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
