### PR TITLE
Turn off fail-fast for codegen tests

### DIFF
--- a/.github/workflows/run-codegen-test.yml
+++ b/.github/workflows/run-codegen-test.yml
@@ -37,6 +37,7 @@ jobs:
     strategy:
       matrix:
         provider: ["aws", "gcp", "azure", "azuread", "random", "kubernetes", "azure-native"]
+      fail-fast: false
     steps:
       - name: Install Go
         uses: actions/setup-go@v1


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

### Problem

Currently, all downstream codegen test jobs get canceled if just one fails. 

### Solution

This PR changes the behavior so that some tests may run to completion even if others fail. 

### Reasoning

While we strive to always have all of the downstream codegen jobs run to completion, there are occasions where certain providers cannot be updated due to extenuating circumstances. In those situations, it is better to see the result of **some** downstream provider codegen tests rather than none at all.
