### PR TITLE
[codegen/dotnet] Deeply unwrap collection element types.

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -300,9 +300,9 @@ func (mod *modContext) typeString(t schema.Type, qualifier string, input, state,
 		elem := t.ElementType
 		switch e := t.ElementType.(type) {
 		case *schema.ArrayType:
-			inputType, elem = "InputList", codegen.UnwrapType(e.ElementType)
+			inputType, elem = "InputList", codegen.PlainType(e.ElementType)
 		case *schema.MapType:
-			inputType, elem = "InputMap", codegen.UnwrapType(e.ElementType)
+			inputType, elem = "InputMap", codegen.PlainType(e.ElementType)
 		default:
 			if e == schema.JSONType {
 				return "InputJson"

--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -4,8 +4,55 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/internal/test"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGeneratePackage(t *testing.T) {
 	test.TestSDKCodegen(t, "dotnet", GeneratePackage)
+}
+
+func TestGenerateType(t *testing.T) {
+	cases := []struct {
+		typ      schema.Type
+		expected string
+	}{
+		{
+			&schema.InputType{
+				ElementType: &schema.ArrayType{
+					ElementType: &schema.InputType{
+						ElementType: &schema.ArrayType{
+							ElementType: &schema.InputType{
+								ElementType: schema.NumberType,
+							},
+						},
+					},
+				},
+			},
+			"InputList<ImmutableArray<double>>",
+		},
+		{
+			&schema.InputType{
+				ElementType: &schema.MapType{
+					ElementType: &schema.InputType{
+						ElementType: &schema.ArrayType{
+							ElementType: &schema.InputType{
+								ElementType: schema.NumberType,
+							},
+						},
+					},
+				},
+			},
+			"InputMap<ImmutableArray<double>>",
+		},
+	}
+
+	mod := &modContext{mod: "main"}
+	for _, c := range cases {
+		t.Run(c.type_.String(), func(t *testing.T) {
+			typeString := mod.typeString(c.typ, "", true, false, false)
+			assert.Equal(t, c.expected, typeString)
+		})
+	}
 }

--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -50,7 +50,7 @@ func TestGenerateType(t *testing.T) {
 
 	mod := &modContext{mod: "main"}
 	for _, c := range cases {
-		t.Run(c.type_.String(), func(t *testing.T) {
+		t.Run(c.typ.String(), func(t *testing.T) {
 			typeString := mod.typeString(c.typ, "", true, false, false)
 			assert.Equal(t, c.expected, typeString)
 		})


### PR DESCRIPTION
`Input{List,Map}` handle some of this themselves.