### PR TITLE
[experimental] Add support for YAML schemas.

### DIFF
--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1655,14 +1655,17 @@ func (t *types) bindEnumValues(values []*EnumValueSpec, typ Type) ([]*Enum, erro
 				return nil, errorMessage(spec.Value, typ.String())
 			}
 		case IntType:
-			v, ok := spec.Value.(float64)
-			if !ok {
+			switch v := spec.Value.(type) {
+			case float64:
+				if math.Trunc(v) != v || v < math.MinInt32 || v > math.MaxInt32 {
+					return nil, errors.Errorf("cannot assign enum value of type 'number' to enum of type 'integer'")
+				}
+				spec.Value = int32(v)
+			case int:
+				spec.Value = int32(v)
+			default:
 				return nil, errorMessage(spec.Value, typ.String())
 			}
-			if math.Trunc(v) != v || v < math.MinInt32 || v > math.MaxInt32 {
-				return nil, errors.Errorf("cannot assign enum value of type 'number' to enum of type 'integer'")
-			}
-			spec.Value = int32(v)
 		case NumberType:
 			if _, ok := spec.Value.(float64); !ok {
 				return nil, errorMessage(spec.Value, typ.String())

--- a/pkg/codegen/schema/yaml/doc.go
+++ b/pkg/codegen/schema/yaml/doc.go
@@ -1,0 +1,188 @@
+package yaml
+
+// Package yaml provides an alternative method for authoring Pulumi schemas. Rather than hewing closely to the design of
+// OpenAPI, this package chooses a YAML-based approach that allows for a much more concise description of a Pulumi
+// schema. Although this package is intended to cover the majority of use cases, it is not intended to have feature
+// parity with the JSON-based schema language, and omits some advanced features for the sake of simplicity.
+//
+// The two most striking differences are the representations of package members and property types.
+//
+// Rather than using separate, flat namespaces for types, resources, and functions, a YAML schema uses a single,
+// hierarchical namespace. The type of a member is indicated using a YAML tag; members may be object types, enum types,
+// resources, components, functions, or modules.
+//
+// YAML schemas also make use of tags and the module tree to simplify type references. A type reference may be a
+// primitive type, constructed type, or a reference to an object type, enum type, or resource. Primitive types are
+// booleans, strings, integers, and numbers; constructued types are inputs, arrays, maps, and unions. At the
+// outermost level, a property's type may also be optional, in which case the property does not require a value.
+//
+// An example schema that showcases the differences and its JSON equivalent are given below.
+//
+// YAML:
+//
+//     version: "0.0.1"
+//     name: example
+//     imports:
+//       aws: /aws/v3.14.0/schema.json
+//     members:
+//       # A simple object type.
+//       MyObject: !Object
+//         foo: !Input [MyResource]
+//         bar: !Optional [!Input [string]]
+//         baz: !Optional [!Input [!Array [!Input [!Array [!Input [string]]]]]] # List of lists of strings
+//         qux: !Optional [!Input [!Map [!Input [!Array [!Input [number]]]]]] # Mapping from string to list of numbers
+//       MyResource: !Resource
+//         inouts:
+//           foo: !Optional [!Input [MyObject]]
+//           bar: !Optional [!Input [string]]
+//           bar: !Optional [!Input [string]]
+//           baz: !Input [string]
+//           qux: !Array [!Input [number]]
+//       MyComponent: !Component
+//         inouts:
+//           resource: !Optional [!Input [MyResource]]
+//           bucket: /aws/resources/s3/bucket/Bucket
+//       myFunction: !Function
+//         parameters:
+//           arg1: !Optional [MyResource]
+//         returns:
+//           result: !Optional [MyResource]
+//
+// JSON:
+//
+//     {
+//       "name": "example",
+//       "version": "0.0.1",
+//       "config": {},
+//       "types": {
+//         "example::MyObject": {
+//           "description": "A simple object type.\n",
+//           "properties": {
+//             "bar": {
+//               "type": "string"
+//             },
+//             "baz": {
+//               "type": "array",
+//               "items": {
+//                 "type": "array",
+//                 "items": {
+//                   "type": "string"
+//                 }
+//               },
+//               "description": "List of lists of strings\n"
+//             },
+//             "foo": {
+//               "$ref": "#/resources/example::MyResource"
+//             },
+//             "qux": {
+//               "type": "object",
+//               "additionalProperties": {
+//                 "type": "array",
+//                 "items": {
+//                   "type": "number"
+//                 }
+//               },
+//               "description": "Mapping from string to list of numbers\n"
+//             }
+//           },
+//           "type": "object",
+//           "required": [
+//             "foo"
+//           ]
+//         }
+//       },
+//       "provider": {},
+//       "resources": {
+//         "example::MyComponent": {
+//           "properties": {
+//             "bucket": {
+//               "$ref": "/aws/v3.14.0/schema.json#/resources/aws:s3/bucket:Bucket"
+//             },
+//             "resource": {
+//               "$ref": "#/resources/example::MyResource"
+//             }
+//           },
+//           "required": [
+//             "bucket"
+//           ],
+//           "inputProperties": {
+//             "bucket": {
+//               "$ref": "/aws/v3.14.0/schema.json#/resources/aws:s3/bucket:Bucket"
+//             },
+//             "resource": {
+//               "$ref": "#/resources/example::MyResource"
+//             }
+//           },
+//           "requiredInputs": [
+//             "bucket"
+//           ],
+//           "isComponent": true
+//         },
+//         "example::MyResource": {
+//           "properties": {
+//             "bar": {
+//               "type": "string"
+//             },
+//             "baz": {
+//               "type": "string"
+//             },
+//             "foo": {
+//               "$ref": "#/types/example::MyObject"
+//             },
+//             "qux": {
+//               "type": "array",
+//               "items": {
+//                 "type": "number"
+//               }
+//             }
+//           },
+//           "required": [
+//             "baz",
+//             "qux"
+//           ],
+//           "inputProperties": {
+//             "bar": {
+//               "type": "string"
+//             },
+//             "baz": {
+//               "type": "string"
+//             },
+//             "foo": {
+//               "$ref": "#/types/example::MyObject"
+//             },
+//             "qux": {
+//               "type": "array",
+//               "items": {
+//                 "type": "number"
+//               },
+//               "plain": true
+//             }
+//           },
+//           "requiredInputs": [
+//             "baz",
+//             "qux"
+//           ]
+//         }
+//       },
+//       "functions": {
+//         "example::myFunction": {
+//           "inputs": {
+//             "properties": {
+//               "arg1": {
+//                 "$ref": "#/resources/example::MyResource",
+//                 "plain": true
+//               }
+//             },
+//             "type": "object"
+//           },
+//           "outputs": {
+//             "properties": {
+//               "result": {
+//                 "$ref": "#/resources/example::MyResource"
+//               }
+//             },
+//             "type": "object"
+//           }
+//         }
+//       }
+//     }

--- a/pkg/codegen/schema/yaml/testdata/enum.json
+++ b/pkg/codegen/schema/yaml/testdata/enum.json
@@ -1,0 +1,102 @@
+{
+    "name": "plant",
+    "version": "0.0.1",
+    "config": {},
+    "types": {
+        "plant::Container": {
+            "properties": {
+                "brightness": {
+                    "$ref": "#/types/plant::ContainerBrightness",
+                    "default": 1
+                },
+                "color": {
+                    "oneOf": [
+                        {
+                            "$ref": "#/types/plant::ContainerColor"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "material": {
+                    "type": "string"
+                },
+                "size": {
+                    "$ref": "#/types/plant::ContainerSize"
+                }
+            },
+            "type": "object",
+            "required": [
+                "size"
+            ]
+        },
+        "plant::ContainerBrightness": {
+            "type": "number",
+            "enum": [
+                {
+                    "name": "One",
+                    "value": 1
+                },
+                {
+                    "name": "ZeroPointOne",
+                    "value": 0.1
+                }
+            ]
+        },
+        "plant::ContainerColor": {
+            "description": "plant container colors\n",
+            "type": "string",
+            "enum": [
+                {
+                    "value": "red"
+                },
+                {
+                    "value": "blue"
+                },
+                {
+                    "value": "yellow"
+                }
+            ]
+        },
+        "plant::ContainerSize": {
+            "description": "plant container sizes\n",
+            "type": "integer",
+            "enum": [
+                {
+                    "name": "EightInch",
+                    "value": 8
+                },
+                {
+                    "name": "FourInch",
+                    "value": 4
+                },
+                {
+                    "name": "SixInch",
+                    "value": 6
+                }
+            ]
+        }
+    },
+    "provider": {},
+    "language": {
+        "csharp": {
+            "namespace": {
+                "plant": "Plant",
+                "tree/v1": "Tree.V1"
+            }
+        },
+        "go": {
+            "importBasePath": "github.com/pulumi/pulumi/pkg/v3/codegen/internal/test/testdata/simple-enum-schema/go/plant",
+            "packageImportAliases": {
+                "github.com/pulumi/pulumi/pkg/v3/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1": "treev1"
+            }
+        },
+        "nodejs": {},
+        "python": {
+            "moduleNameOverrides": {
+                "tree/v1": "tree/v1"
+            }
+        }
+    }
+}

--- a/pkg/codegen/schema/yaml/testdata/enum.yaml
+++ b/pkg/codegen/schema/yaml/testdata/enum.yaml
@@ -1,0 +1,100 @@
+version: "0.0.1"
+name: plant
+language:
+  csharp:
+    namespace:
+      plant: Plant
+      tree/v1: Tree.V1
+  go:
+    importBasePath: github.com/pulumi/pulumi/pkg/v3/codegen/internal/test/testdata/simple-enum-schema/go/plant
+    packageImportAliases:
+      github.com/pulumi/pulumi/pkg/v3/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1: "treev1"
+  nodejs: {}
+  python:
+    moduleNameOverrides:
+      tree/v1: tree/v1
+members:
+  Container: !Object
+    size: !Input [ContainerSize]
+    material: !Optional [!Input [string]]
+    color: !Optional [!Input [!Union [!Input [ContainerColor], !Input [string]]]]
+    brightness:
+      type: !Optional [!Input [ContainerBrightness]]
+      default: 1.0
+
+  # plant container sizes
+  ContainerSize: !Enum
+    type: integer
+    values:
+      FourInch: 4
+      SixInch: 6
+      EightInch:
+        value: 8
+        deprecationMessage: Eight inch pots are no longer supported.
+
+  # plant container colors
+  ContainerColor: !Enum
+    type: string
+    values:
+      - red
+      - blue
+      - yellow
+
+  ContainerBrightness: !Enum
+    type: number
+    values:
+      ZeroPointOne: 0.1
+      One: 1.0
+
+  tree: !Module
+    v1: !Module
+      # types of rubber trees
+      RubberTreeVariety: !Enum
+        type: string
+        values:
+          - Burgundy # A burgundy rubber tree.
+          - Ruby     # A ruby rubber tree.
+          - Tineke   # A tineke rubber tree.
+
+      Farm: !Enum
+        type: string
+        values:
+          - Pulumi Planters Inc.
+          - Plans'R'Us
+
+      TreeSize: !Enum
+        type: string
+        values:
+          - small
+          - medium
+          - large
+
+      Diameter: !Enum
+        type: number
+        values:
+          sixinch: 6
+          twelveinch: 12
+
+      Nursery: !Resource
+        inputs:
+          varieties: !Input [!Array [!Input [RubberTreeVariety]]] # The varieties available
+          sizes: !Optional [!Input [!Map [!Input [TreeSize]]]]    # The sizes of trees available
+      RubberTree: !Resource
+        inouts:
+          container: !Optional [!Input [/Container]]
+          type:
+            type: !Input [RubberTree]
+            default: Burgundy
+          farm:
+            type: !Optional [!Input [!Union [!Input [Farm], !Input [string]]]]
+            default: (unknown)
+          size:
+            type: !Optional [!Input [TreeSize]]
+            defaut: medium
+          diameter:
+            type: !Input [Diameter]
+            default: 6
+        stateInputs:
+          farm:
+            type: !Optional [!Input [!Union [!Input [Farm], !Input [string]]]]
+            default: (unknown)

--- a/pkg/codegen/schema/yaml/testdata/example.json
+++ b/pkg/codegen/schema/yaml/testdata/example.json
@@ -1,0 +1,136 @@
+{
+    "name": "example",
+    "version": "0.0.1",
+    "config": {},
+    "types": {
+        "example::MyObject": {
+            "description": "A simple object type.\n",
+            "properties": {
+                "bar": {
+                    "type": "string"
+                },
+                "baz": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "description": "List of lists of strings\n"
+                },
+                "foo": {
+                    "$ref": "#/resources/example::MyResource"
+                },
+                "qux": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "type": "number"
+                        }
+                    },
+                    "description": "Mapping from string to list of numbers\n"
+                }
+            },
+            "type": "object",
+            "required": [
+                "foo"
+            ]
+        }
+    },
+    "provider": {},
+    "resources": {
+        "example::MyComponent": {
+            "properties": {
+                "bucket": {
+                    "$ref": "/aws/v3.14.0/schema.json#/resources/aws:s3/bucket:Bucket"
+                },
+                "resource": {
+                    "$ref": "#/resources/example::MyResource"
+                }
+            },
+            "required": [
+                "bucket"
+            ],
+            "inputProperties": {
+                "bucket": {
+                    "$ref": "/aws/v3.14.0/schema.json#/resources/aws:s3/bucket:Bucket"
+                },
+                "resource": {
+                    "$ref": "#/resources/example::MyResource"
+                }
+            },
+            "requiredInputs": [
+                "bucket"
+            ],
+            "isComponent": true
+        },
+        "example::MyResource": {
+            "properties": {
+                "bar": {
+                    "type": "string"
+                },
+                "baz": {
+                    "type": "string"
+                },
+                "foo": {
+                    "$ref": "#/types/example::MyObject"
+                },
+                "qux": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                }
+            },
+            "required": [
+                "baz",
+                "qux"
+            ],
+            "inputProperties": {
+                "bar": {
+                    "type": "string"
+                },
+                "baz": {
+                    "type": "string"
+                },
+                "foo": {
+                    "$ref": "#/types/example::MyObject"
+                },
+                "qux": {
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    },
+                    "plain": true
+                }
+            },
+            "requiredInputs": [
+                "baz",
+                "qux"
+            ]
+        }
+    },
+    "functions": {
+        "example::myFunction": {
+            "inputs": {
+                "properties": {
+                    "arg1": {
+                        "$ref": "#/resources/example::MyResource",
+                        "plain": true
+                    }
+                },
+                "type": "object"
+            },
+            "outputs": {
+                "properties": {
+                    "result": {
+                        "$ref": "#/resources/example::MyResource"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    }
+}

--- a/pkg/codegen/schema/yaml/testdata/example.yaml
+++ b/pkg/codegen/schema/yaml/testdata/example.yaml
@@ -1,0 +1,27 @@
+version: "0.0.1"
+name: example
+imports:
+  aws: /aws/v3.14.0/schema.json
+members:
+  # A simple object type.
+  MyObject: !Object
+    foo: !Input [MyResource]
+    bar: !Optional [!Input [string]]
+    baz: !Optional [!Input [!Array [!Input [!Array [!Input [string]]]]]] # List of lists of strings
+    qux: !Optional [!Input [!Map [!Input [!Array [!Input [number]]]]]] # Mapping from string to list of numbers
+  MyResource: !Resource
+    inouts:
+      foo: !Optional [!Input [MyObject]]
+      bar: !Optional [!Input [string]]
+      bar: !Optional [!Input [string]]
+      baz: !Input [string]
+      qux: !Array [!Input [number]]
+  MyComponent: !Component
+    inouts:
+      resource: !Optional [!Input [MyResource]]
+      bucket: /aws/resources/s3/bucket/Bucket
+  myFunction: !Function
+    parameters:
+      arg1: !Optional [MyResource]
+    returns:
+      result: !Optional [MyResource]

--- a/pkg/codegen/schema/yaml/testdata/external.json
+++ b/pkg/codegen/schema/yaml/testdata/external.json
@@ -1,0 +1,158 @@
+{
+    "name": "example",
+    "version": "0.0.1",
+    "config": {},
+    "types": {
+        "example::Pet": {
+            "properties": {
+                "age": {
+                    "type": "integer"
+                },
+                "name": {
+                    "$ref": "/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet"
+                },
+                "nameArray": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/random/v2.3.1/schema.json#/resources/random:index%2FrandomPet:RandomPet"
+                    }
+                },
+                "nameMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet"
+                    }
+                },
+                "requireNameMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet"
+                    }
+                },
+                "requiredName": {
+                    "$ref": "/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet"
+                },
+                "requiredNameArray": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet"
+                    }
+                }
+            },
+            "type": "object",
+            "required": [
+                "age",
+                "requireNameMap",
+                "requiredName",
+                "requiredNameArray"
+            ]
+        }
+    },
+    "provider": {},
+    "resources": {
+        "example::Cat": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "inputProperties": {
+                "age": {
+                    "type": "integer"
+                },
+                "pet": {
+                    "$ref": "#/types/example::Pet"
+                }
+            }
+        },
+        "example::Component": {
+            "properties": {
+                "provider": {
+                    "$ref": "/kubernetes/v2.6.3/schema.json#/provider"
+                },
+                "securityGroup": {
+                    "$ref": "/aws/v3.14.0/schema.json#/resources/aws:ec2/securityGroup:SecurityGroup"
+                },
+                "storageClasses": {
+                    "$ref": "/kubernetes/v2.7.3/schema.json#/resources/kubernetes:storage.k8s.io/v1:StorageClass"
+                }
+            },
+            "required": [
+                "securityGroup"
+            ],
+            "inputProperties": {
+                "metadata": {
+                    "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta/v1:ObjectMeta"
+                },
+                "metadataArray": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta/v1:ObjectMeta"
+                    }
+                },
+                "metadataMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta/v1:ObjectMeta"
+                    }
+                },
+                "requiredMetadata": {
+                    "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta/v1:ObjectMeta"
+                },
+                "requiredMetadataArray": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta/v1:ObjectMeta"
+                    }
+                },
+                "requiredMetadataMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:meta/v1:ObjectMeta"
+                    }
+                }
+            },
+            "requiredInputs": [
+                "requiredMetadata",
+                "requiredMetadataArray",
+                "requiredMetadataMap"
+            ],
+            "isComponent": true
+        },
+        "example::Workload": {
+            "properties": {
+                "pod": {
+                    "$ref": "/kubernetes/v2.6.3/schema.json#/types/kubernetes:core/v1:Pod"
+                }
+            }
+        }
+    },
+    "functions": {
+        "example::argFunction": {
+            "inputs": {
+                "properties": {
+                    "name": {
+                        "$ref": "/random/v2.3.1/schema.json#/resources/random:index/randomPet:RandomPet"
+                    }
+                },
+                "type": "object"
+            },
+            "outputs": {
+                "properties": {
+                    "arg": {
+                        "type": "integer"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    },
+    "language": {
+        "csharp": {},
+        "go": {
+            "generateResourceContainerTypes": true
+        },
+        "nodejs": {},
+        "python": {}
+    }
+}

--- a/pkg/codegen/schema/yaml/testdata/external.yaml
+++ b/pkg/codegen/schema/yaml/testdata/external.yaml
@@ -1,0 +1,52 @@
+version: "0.0.1"
+name: example
+language:
+  csharp: {}
+  go:
+    generateResourceContainerTypes: true
+  nodejs: {}
+  python: {}
+imports:
+  random: /random/v2.3.1/schema.json 
+  aws: /aws/v3.14.0/schema.json
+  k8s263:
+    path: /kubernetes/v2.6.3/schema.json
+    package: kubernetes
+  k8s273:
+    path: /kubernetes/v2.7.3/schema.json
+    package: kubernetes
+members:
+  Pet: !Object
+    name: !Optional [!Input [/random/resources/index/randomPet/RandomPet]]
+    requiredName: !Input [/random/resources/index/randomPet/RandomPet]
+    nameArray: !Optional [!Input [!Array [!Input [/random/resources/index%2FrandomPet/RandomPet]]]]
+    requiredNameArray: !Input [!Array [!Input [/random/resources/index/randomPet/RandomPet]]]
+    nameMap: !Optional [!Input [!Map [!Input [/random/resources/index/randomPet/RandomPet]]]]
+    requireNameMap: !Input [!Map [!Input [/random/resources/index/randomPet/RandomPet]]]
+    age: !Input [integer]
+  Cat: !Resource
+    outputs:
+      name: !Optional [string]
+    inputs:
+      age: !Optional [!Input [integer]]
+      pet: !Optional [!Input [Pet]]
+  Workload: !Resource
+    outputs:
+      pod: !Optional [/k8s263/types/core/v1/Pod]
+  Component: !Component
+    outputs:
+      provider: !Optional [/k8s263/provider]
+      securityGroup: /aws/resources/ec2/securityGroup/SecurityGroup
+      storageClasses: !Optional [/k8s273/resources/storage.k8s.io/v1/StorageClass]
+    inputs:
+      metadata: !Optional [!Input [/k8s263/types/meta/v1/ObjectMeta]]
+      requiredMetadata: !Input [/k8s263/types/meta/v1/ObjectMeta]
+      metadataArray: !Optional [!Input [!Array [!Input [/k8s263/types/meta/v1/ObjectMeta]]]]
+      requiredMetadataArray: !Input [!Array [!Input [/k8s263/types/meta/v1/ObjectMeta]]]
+      metadataMap: !Optional [!Input [!Map [!Input [/k8s263/types/meta/v1/ObjectMeta]]]]
+      requiredMetadataMap: !Input [!Map [!Input [/k8s263/types/meta/v1/ObjectMeta]]]
+  argFunction: !Function
+    parameters:
+      name: !Optional [/random/resources/index/randomPet/RandomPet]
+    returns:
+      arg: !Optional [integer]

--- a/pkg/codegen/schema/yaml/testdata/plain.json
+++ b/pkg/codegen/schema/yaml/testdata/plain.json
@@ -1,0 +1,163 @@
+{
+    "name": "example",
+    "version": "0.0.1",
+    "config": {},
+    "types": {
+        "example::Foo": {
+            "properties": {
+                "a": {
+                    "type": "boolean",
+                    "plain": true
+                },
+                "b": {
+                    "type": "boolean",
+                    "plain": true
+                },
+                "c": {
+                    "type": "integer",
+                    "plain": true
+                },
+                "d": {
+                    "type": "integer",
+                    "plain": true
+                },
+                "e": {
+                    "type": "string",
+                    "plain": true
+                },
+                "f": {
+                    "type": "string",
+                    "plain": true
+                }
+            },
+            "type": "object",
+            "required": [
+                "a",
+                "c",
+                "e"
+            ]
+        }
+    },
+    "provider": {},
+    "resources": {
+        "example::Component": {
+            "properties": {
+                "a": {
+                    "type": "boolean"
+                },
+                "b": {
+                    "type": "boolean"
+                },
+                "bar": {
+                    "$ref": "#/types/example::Foo"
+                },
+                "baz": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/example::Foo"
+                    }
+                },
+                "c": {
+                    "type": "integer"
+                },
+                "d": {
+                    "type": "integer"
+                },
+                "e": {
+                    "type": "string"
+                },
+                "f": {
+                    "type": "string"
+                },
+                "foo": {
+                    "$ref": "#/types/example::Foo"
+                }
+            },
+            "required": [
+                "a",
+                "baz",
+                "c",
+                "e"
+            ],
+            "inputProperties": {
+                "a": {
+                    "type": "boolean",
+                    "plain": true
+                },
+                "b": {
+                    "type": "boolean",
+                    "plain": true
+                },
+                "bar": {
+                    "$ref": "#/types/example::Foo",
+                    "plain": true
+                },
+                "baz": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/example::Foo"
+                    },
+                    "plain": true
+                },
+                "bazMap": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/types/example::Foo"
+                    },
+                    "plain": true
+                },
+                "c": {
+                    "type": "integer",
+                    "plain": true
+                },
+                "d": {
+                    "type": "integer",
+                    "plain": true
+                },
+                "e": {
+                    "type": "string",
+                    "plain": true
+                },
+                "f": {
+                    "type": "string",
+                    "plain": true
+                },
+                "foo": {
+                    "$ref": "#/types/example::Foo"
+                }
+            },
+            "requiredInputs": [
+                "a",
+                "baz",
+                "bazMap",
+                "c",
+                "e"
+            ],
+            "isComponent": true
+        }
+    },
+    "functions": {
+        "example::doFoo": {
+            "inputs": {
+                "properties": {
+                    "foo": {
+                        "$ref": "#/types/example::Foo",
+                        "plain": true
+                    }
+                },
+                "type": "object",
+                "required": [
+                    "foo"
+                ]
+            }
+        }
+    },
+    "language": {
+        "csharp": {},
+        "go": {
+            "importBasePath": "github.com/pulumi/pulumi/pkg/v3/codegen/internal/test/testdata/simple-plain-schema/go/example"
+        },
+        "nodejs": {},
+        "python": {}
+    }
+}

--- a/pkg/codegen/schema/yaml/testdata/plain.yaml
+++ b/pkg/codegen/schema/yaml/testdata/plain.yaml
@@ -1,0 +1,32 @@
+version: "0.0.1"
+name: example
+language:
+  csharp: {}
+  go:
+    importBasePath: github.com/pulumi/pulumi/pkg/v3/codegen/internal/test/testdata/simple-plain-schema/go/example
+  nodejs: {}
+  python: {}
+members:
+  Foo: !Object
+    a: boolean
+    b: !Optional [boolean]
+    c: integer
+    d: !Optional [integer]
+    e: string
+    f: !Optional [string]
+  Component: !Component
+    inouts:
+      a: boolean
+      b: !Optional [boolean]
+      c: integer
+      d: !Optional [integer]
+      e: string
+      f: !Optional [string]
+      foo: !Optional [!Input [Foo]]
+      bar: !Optional [Foo]
+      baz: !Array [!Input [Foo]]
+    inputs:
+      bazMap: !Map [!Input [Foo]]
+  doFoo: !Function
+    parameters:
+      foo: Foo

--- a/pkg/codegen/schema/yaml/testdata/simple.json
+++ b/pkg/codegen/schema/yaml/testdata/simple.json
@@ -1,0 +1,119 @@
+{
+    "name": "example",
+    "version": "0.0.1",
+    "config": {},
+    "types": {
+        "example::ConfigMap": {
+            "properties": {
+                "config": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "example::Object": {
+            "properties": {
+                "bar": {
+                    "type": "string"
+                },
+                "configs": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/types/example::ConfigMap"
+                    }
+                },
+                "foo": {
+                    "$ref": "#/resources/example::Resource"
+                },
+                "others": {
+                    "type": "array",
+                    "items": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/types/example::SomeOtherObject"
+                        }
+                    },
+                    "description": "List of lists of other objects\n"
+                },
+                "stillOthers": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/types/example::SomeOtherObject"
+                        }
+                    },
+                    "description": "Mapping from string to list of some other object\n"
+                }
+            },
+            "type": "object"
+        },
+        "example::OtherResourceOutput": {
+            "properties": {
+                "foo": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "example::SomeOtherObject": {
+            "properties": {
+                "baz": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        }
+    },
+    "provider": {},
+    "resources": {
+        "example::OtherResource": {
+            "properties": {
+                "foo": {
+                    "$ref": "#/resources/example::Resource"
+                }
+            },
+            "inputProperties": {
+                "foo": {
+                    "$ref": "#/resources/example::Resource"
+                }
+            },
+            "isComponent": true
+        },
+        "example::Resource": {
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "secret": true
+                }
+            },
+            "inputProperties": {
+                "bar": {
+                    "type": "string",
+                    "secret": true
+                }
+            }
+        }
+    },
+    "functions": {
+        "example::argFunction": {
+            "inputs": {
+                "properties": {
+                    "arg1": {
+                        "$ref": "#/resources/example::Resource",
+                        "plain": true
+                    }
+                },
+                "type": "object"
+            },
+            "outputs": {
+                "properties": {
+                    "result": {
+                        "$ref": "#/resources/example::Resource"
+                    }
+                },
+                "type": "object"
+            }
+        }
+    }
+}

--- a/pkg/codegen/schema/yaml/testdata/simple.yaml
+++ b/pkg/codegen/schema/yaml/testdata/simple.yaml
@@ -1,0 +1,28 @@
+version: "0.0.1"
+name: example
+members:
+  Object: !Object
+    foo: !Optional [!Input [Resource]]
+    bar: !Optional [!Input [string]]
+    others: !Optional [!Input [!Array [!Input [!Array [!Input [SomeOtherObject]]]]]] # List of lists of other objects
+    configs: !Optional [!Input [!Array [!Input [ConfigMap]]]]
+    stillOthers: !Optional [!Input [!Map [!Input [!Array [!Input [SomeOtherObject]]]]]] # Mapping from string to list of some other object
+  OtherResourceOutput: !Object 
+    foo: !Optional [!Input [string]]
+  SomeOtherObject: !Object 
+    baz: !Optional [!Input [string]]
+  ConfigMap: !Object 
+    config: !Optional [!Input [string]]
+  Resource: !Resource
+    inouts:
+      bar:
+        type: !Optional [!Input [string]]
+        secret: true
+  OtherResource: !Component 
+    inouts:
+      foo: !Optional [!Input [Resource]]
+  argFunction: !Function 
+    parameters:
+      arg1: !Optional [Resource]
+    returns:
+      result: !Optional [Resource]

--- a/pkg/codegen/schema/yaml/yaml.go
+++ b/pkg/codegen/schema/yaml/yaml.go
@@ -1,0 +1,767 @@
+//nolint: goconst
+package yaml
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"gopkg.in/yaml.v3"
+)
+
+// Package describes a Pulumi package.
+type Package struct {
+	// Name is the unqualified name of the package (e.g. "aws", "azure", "gcp", "kubernetes", "random")
+	Name string `yaml:"name"`
+	// Version is the version of the package. The version must be valid semver.
+	Version string `yaml:"version,omitempty"`
+	// Description is the description of the package.
+	Description string `yaml:"description,omitempty"`
+	// Keywords is the list of keywords that are associated with the package, if any.
+	Keywords []string `yaml:"keywords,omitempty"`
+	// Homepage is the package's homepage.
+	Homepage string `yaml:"homepage,omitempty"`
+	// License indicates which license is used for the package's contents.
+	License string `yaml:"license,omitempty"`
+	// Attribution allows freeform text attribution of derived work, if needed.
+	Attribution string `yaml:"attribution,omitempty"`
+	// Repository is the URL at which the source for the package can be found.
+	Repository string `yaml:"repository,omitempty"`
+	// LogoURL is the URL for the package's logo, if any.
+	LogoURL string `yaml:"logoUrl,omitempty"`
+	// PluginDownloadURL is the URL to use to acquire the provider plugin binary, if any.
+	PluginDownloadURL string `yaml:"pluginDownloadURL,omitempty"`
+
+	// Import describes the packages this package imports.
+	Imports Imports `yaml:"imports"`
+	// Provider describes the provider type for this package.
+	Provider *Resource `yaml:"provider"`
+
+	// Members describes the members of the package. A member may be an object type,
+	// enum type, resource, component, function, or module. Modules are themselves
+	// collections of members.
+	Members Members `yaml:"members"`
+
+	// Language specifies additional language-specific data about the package.
+	Language map[string]interface{} `yaml:"language"`
+}
+
+// Spec translates the Package and its members to a PackageSpec.
+func (p *Package) Spec() (spec *schema.PackageSpec, err error) {
+	var language map[string]json.RawMessage
+	if len(p.Language) != 0 {
+		language, err = languageSpec(p.Language)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	spec = &schema.PackageSpec{
+		Name:              p.Name,
+		Version:           p.Version,
+		Description:       p.Description,
+		Keywords:          p.Keywords,
+		Homepage:          p.Homepage,
+		License:           p.License,
+		Attribution:       p.Attribution,
+		Repository:        p.Repository,
+		LogoURL:           p.LogoURL,
+		PluginDownloadURL: p.PluginDownloadURL,
+		Types:             map[string]schema.ComplexTypeSpec{},
+		Resources:         map[string]schema.ResourceSpec{},
+		Functions:         map[string]schema.FunctionSpec{},
+		Language:          language,
+	}
+
+	// TODO: config
+
+	if p.Provider != nil {
+		ps, err := p.Provider.spec(p, "", "Provider")
+		if err != nil {
+			return nil, err
+		}
+		spec.Provider = *ps
+	}
+
+	if err := p.module(spec, "/", p.Members); err != nil {
+		return nil, err
+	}
+
+	return spec, nil
+}
+
+func (p *Package) module(spec *schema.PackageSpec, module string, members map[string]Member) error {
+	for name, m := range members {
+		token := spec.Name + ":" + module[1:] + ":" + name
+		switch d := m.(type) {
+		case *Object:
+			o, err := d.spec(p, module, false)
+			if err != nil {
+				return err
+			}
+			spec.Types[token] = schema.ComplexTypeSpec{ObjectTypeSpec: *o}
+		case *Enum:
+			spec.Types[token] = d.spec()
+		case *Resource:
+			r, err := d.spec(p, module, name)
+			if err != nil {
+				return err
+			}
+			spec.Resources[token] = *r
+		case *Component:
+			r, err := d.spec(p, module, name)
+			if err != nil {
+				return err
+			}
+			spec.Resources[token] = *r
+		case *Function:
+			f, err := d.spec(p, module)
+			if err != nil {
+				return err
+			}
+			spec.Functions[token] = *f
+		case Members:
+			if err := p.module(spec, path.Join(module, name), d); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type Imports map[string]Import
+
+func (i *Imports) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("imports must be a mapping")
+	}
+
+	result := Imports{}
+	for i := 0; i < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+
+		var name string
+		if err := key.Decode(&name); err != nil {
+			return err
+		}
+
+		var imp Import
+		if err := value.Decode(&imp); err != nil {
+			return err
+		}
+		if imp.Package == "" {
+			imp.Package = name
+		}
+
+		result[name] = imp
+	}
+
+	*i = result
+	return nil
+}
+
+type importData struct {
+	Path    string `yaml:"path"`
+	Package string `yaml:"package"`
+}
+
+type Import importData
+
+func (i *Import) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.MappingNode {
+		return node.Decode((*importData)(i))
+	}
+	return node.Decode(&i.Path)
+}
+
+type Members map[string]Member
+
+func (m *Members) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("members must be a mapping")
+	}
+
+	result := Members{}
+	for i := 0; i < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+
+		var name string
+		if err := key.Decode(&name); err != nil {
+			return err
+		}
+
+		var member Member
+		switch value.Tag {
+		case "!Object":
+			member = &Object{}
+		case "!Enum":
+			member = &Enum{}
+		case "!Resource":
+			member = &Resource{}
+		case "!Component":
+			member = &Component{}
+		case "!Function":
+			member = &Function{}
+		case "!Module":
+			m := Members{}
+			member = &m
+		default:
+			return fmt.Errorf("unrecognized member tag '%v'", value.Tag)
+		}
+		if err := value.Decode(member); err != nil {
+			return err
+		}
+		member.setDescription(commentText(key.HeadComment))
+
+		result[name] = member
+	}
+
+	*m = result
+	return nil
+}
+
+func (m Members) setDescription(string) {
+}
+
+type Member interface {
+	setDescription(description string)
+}
+
+type Object struct {
+	Description string
+	Properties  Properties
+}
+
+func (o *Object) spec(pkg *Package, module string, outputs bool) (*schema.ObjectTypeSpec, error) {
+	props, required, err := properties(pkg, module, o.Properties, outputs)
+	if err != nil {
+		return nil, err
+	}
+	return &schema.ObjectTypeSpec{
+		Description: o.Description,
+		Type:        "object",
+		Properties:  props,
+		Required:    required,
+	}, nil
+}
+
+func (o *Object) UnmarshalYAML(node *yaml.Node) error {
+	return node.Decode(&o.Properties)
+}
+
+func (o *Object) setDescription(d string) {
+	o.Description = d
+}
+
+type Enum struct {
+	Description string     `yaml:"-"`
+	Type        string     `yaml:"type"`
+	Values      EnumValues `yaml:"values"`
+}
+
+func (e *Enum) spec() schema.ComplexTypeSpec {
+	values := make([]*schema.EnumValueSpec, 0, len(e.Values))
+	for _, v := range e.Values {
+		values = append(values, v.spec())
+	}
+	return schema.ComplexTypeSpec{
+		ObjectTypeSpec: schema.ObjectTypeSpec{
+			Description: e.Description,
+			Type:        e.Type,
+		},
+		Enum: values,
+	}
+}
+
+func (e *Enum) setDescription(d string) {
+	e.Description = d
+}
+
+type EnumValues []EnumValue
+
+func (e *EnumValues) UnmarshalYAML(node *yaml.Node) error {
+	var result EnumValues
+	switch node.Kind {
+	case yaml.SequenceNode:
+		result = make(EnumValues, len(node.Content))
+		for i, value := range node.Content {
+			var enumValue EnumValue
+			if err := value.Decode(&enumValue); err != nil {
+				return err
+			}
+			enumValue.Description = propertyDescription(value, value)
+
+			result[i] = enumValue
+		}
+	case yaml.MappingNode:
+		result = make(EnumValues, len(node.Content)/2)
+		for i := 0; i < len(node.Content); i += 2 {
+			key, value := node.Content[i], node.Content[i+1]
+
+			var name string
+			if err := key.Decode(&name); err != nil {
+				return err
+			}
+
+			var enumValue EnumValue
+			if err := value.Decode(&enumValue); err != nil {
+				return err
+			}
+			enumValue.Name = name
+			enumValue.Description = propertyDescription(key, value)
+
+			result[i/2] = enumValue
+		}
+		sort.Slice(result, func(i, j int) bool {
+			return result[i].Name < result[j].Name
+		})
+	default:
+		return fmt.Errorf("enum must be a mapping or sequence")
+	}
+
+	*e = result
+	return nil
+}
+
+type enumValueData struct {
+	Description        string      `yaml:"-"`
+	DeprecationMessage string      `yaml:"deprecationMessage"`
+	Name               string      `yaml:"name"`
+	Value              interface{} `yaml:"value"`
+}
+
+type EnumValue enumValueData
+
+func (e *EnumValue) spec() *schema.EnumValueSpec {
+	return &schema.EnumValueSpec{
+		Name:        e.Name,
+		Description: e.Description,
+		Value:       e.Value,
+	}
+}
+
+func (e *EnumValue) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.MappingNode {
+		return node.Decode((*enumValueData)(e))
+	}
+	return node.Decode(&e.Value)
+}
+
+type resourceData struct {
+	Description string              `yaml:"-"`
+	Inputs      Properties          `yaml:"inputs"`
+	Outputs     Properties          `yaml:"outputs"`
+	Inouts      Properties          `yaml:"inouts"`
+	StateInputs Properties          `yaml:"stateInputs"`
+	Aliases     []Alias             `yaml:"aliases"`
+	Methods     map[string]Function `yaml:"methods"`
+}
+
+func (r *resourceData) spec(pkg *Package, module, name string,
+	isComponent bool) (spec *schema.ResourceSpec, err error) {
+
+	// TODO: methods, aliases
+
+	inputs := Properties{}
+	for name, prop := range r.Inputs {
+		inputs[name] = prop
+	}
+	outputs := Properties{}
+	for name, prop := range r.Outputs {
+		outputs[name] = prop
+	}
+	for name, prop := range r.Inouts {
+		inputs[name], outputs[name] = prop, prop
+	}
+
+	var state *schema.ObjectTypeSpec
+	if len(r.StateInputs) != 0 {
+		state, err = (&Object{Properties: r.StateInputs}).spec(pkg, module, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	inputsSpec, requiredInputs, err := properties(pkg, module, inputs, false)
+	if err != nil {
+		return nil, err
+	}
+	outputsSpec, requiredOutputs, err := properties(pkg, module, outputs, true)
+	if err != nil {
+		return nil, err
+	}
+	return &schema.ResourceSpec{
+		ObjectTypeSpec: schema.ObjectTypeSpec{
+			Description: r.Description,
+			Properties:  outputsSpec,
+			Required:    requiredOutputs,
+		},
+		InputProperties: inputsSpec,
+		RequiredInputs:  requiredInputs,
+		StateInputs:     state,
+		IsComponent:     isComponent,
+	}, nil
+}
+
+type Resource resourceData
+
+func (r *Resource) spec(pkg *Package, module, name string) (*schema.ResourceSpec, error) {
+	return (*resourceData)(r).spec(pkg, module, name, false)
+}
+
+func (r *Resource) setDescription(d string) {
+	r.Description = d
+}
+
+type Component resourceData
+
+func (c *Component) spec(pkg *Package, module, name string) (*schema.ResourceSpec, error) {
+	return (*resourceData)(c).spec(pkg, module, name, true)
+}
+
+func (c *Component) setDescription(d string) {
+	c.Description = d
+}
+
+type Alias struct {
+	Name string `yaml:"name"`
+	Type string `yaml:"type"`
+}
+
+type Function struct {
+	Description string     `yaml:"-"`
+	Parameters  Properties `yaml:"parameters"`
+	Returns     Properties `yaml:"returns"`
+}
+
+func (f *Function) spec(pkg *Package, module string) (spec *schema.FunctionSpec, err error) {
+	var inputs *schema.ObjectTypeSpec
+	if len(f.Parameters) != 0 {
+		inputs, err = (&Object{Properties: f.Parameters}).spec(pkg, module, false)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var outputs *schema.ObjectTypeSpec
+	if len(f.Returns) != 0 {
+		outputs, err = (&Object{Properties: f.Returns}).spec(pkg, module, true)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &schema.FunctionSpec{
+		Description: f.Description,
+		Inputs:      inputs,
+		Outputs:     outputs,
+	}, nil
+}
+
+func (f *Function) setDescription(d string) {
+	f.Description = d
+}
+
+type Properties map[string]Property
+
+func (p *Properties) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("properties must be a mapping")
+	}
+
+	result := Properties{}
+	for i := 0; i < len(node.Content); i += 2 {
+		key, value := node.Content[i], node.Content[i+1]
+
+		var name string
+		if err := key.Decode(&name); err != nil {
+			return err
+		}
+
+		var property Property
+
+		var err error
+		if value.Kind != yaml.MappingNode {
+			err = value.Decode(&property.Type)
+		} else {
+			err = value.Decode(&property)
+		}
+		if err != nil {
+			return err
+		}
+
+		property.Description = propertyDescription(key, value)
+		result[name] = property
+	}
+
+	*p = result
+	return nil
+}
+
+type Property struct {
+	Description string      `yaml:"-"`
+	Type        TypeRef     `yaml:"type"`
+	Const       interface{} `yaml:"const"`
+	Default     *Default    `yaml:"default"`
+	Secret      bool        `yaml:"secret"`
+}
+
+func (p *Property) spec(pkg *Package, module string,
+	output bool) (required bool, spec *schema.PropertySpec, err error) {
+
+	required = true
+
+	typ := p.Type
+	if typ.Constructor == "!Optional" {
+		if len(typ.Args) != 1 {
+			return false, nil, fmt.Errorf("!Optional accepts a single type argument")
+		}
+		required, typ = false, typ.Args[0]
+	}
+	typeSpec, err := typ.spec(pkg, module, output)
+	if err != nil {
+		return false, nil, err
+	}
+
+	defaultValue, defaultInfo := p.Default.spec()
+	return required, &schema.PropertySpec{
+		TypeSpec:    *typeSpec,
+		Description: p.Description,
+		Const:       p.Const,
+		Default:     defaultValue,
+		DefaultInfo: defaultInfo,
+		Secret:      p.Secret,
+	}, nil
+}
+
+type TypeRef struct {
+	Constructor string
+	Args        []TypeRef
+	Spec        *schema.TypeSpec
+	Object      *Object
+}
+
+func (t *TypeRef) UnmarshalYAML(node *yaml.Node) error {
+	t.Constructor = node.Tag
+
+	switch node.Tag {
+	case "!!str":
+		return node.Decode(&t.Constructor)
+	case "!Spec":
+		var spec schema.TypeSpec
+		if err := node.Decode(&spec); err != nil {
+			return err
+		}
+		t.Spec = &spec
+		return nil
+	case "!Object":
+		var object Object
+		if err := node.Decode(&object); err != nil {
+			return err
+		}
+		t.Object = &object
+		return nil
+	default:
+		if err := node.Decode(&t.Args); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+func (t *TypeRef) spec(p *Package, module string, output bool) (*schema.TypeSpec, error) {
+	switch t.Constructor {
+	case "!Input":
+		if len(t.Args) != 1 {
+			return nil, fmt.Errorf("!Input accepts a single type argument")
+		}
+		spec, err := t.Args[0].spec(p, module, output)
+		if err != nil {
+			return nil, err
+		}
+		spec.Plain = false
+		return spec, nil
+	case "!Array":
+		if len(t.Args) != 1 {
+			return nil, fmt.Errorf("!Array accepts a single type argument")
+		}
+		element, err := t.Args[0].spec(p, module, output)
+		if err != nil {
+			return nil, err
+		}
+		return &schema.TypeSpec{Type: "array", Items: element, Plain: !output}, nil
+	case "!Map":
+		if len(t.Args) != 1 {
+			return nil, fmt.Errorf("!Map accepts a single type argument")
+		}
+		element, err := t.Args[0].spec(p, module, output)
+		if err != nil {
+			return nil, err
+		}
+		return &schema.TypeSpec{Type: "object", AdditionalProperties: element, Plain: !output}, nil
+	case "!Object":
+		return nil, fmt.Errorf("NYI: anonymous object types")
+	case "!Union":
+		if len(t.Args) < 2 {
+			return nil, fmt.Errorf("!Union requires at least two type arguments")
+		}
+		oneOf := make([]schema.TypeSpec, len(t.Args))
+		for i, e := range t.Args {
+			element, err := e.spec(p, module, output)
+			if err != nil {
+				return nil, err
+			}
+			oneOf[i] = *element
+		}
+		return &schema.TypeSpec{OneOf: oneOf, Plain: !output}, nil
+	case "!Spec":
+		return t.Spec, nil
+	case "boolean", "string", "integer", "number":
+		return &schema.TypeSpec{Type: t.Constructor, Plain: !output}, nil
+	default:
+		refPath := t.Constructor
+		if !path.IsAbs(refPath) {
+			refPath = path.Clean(path.Join(module, t.Constructor))
+		}
+		components := strings.Split(refPath, "/")[1:]
+
+		members := p.Members
+		if len(components) > 1 {
+			if _, ok := p.Members[components[0]]; !ok {
+				components = strings.Split(t.Constructor, "/")[1:]
+				if imp, ok := p.Imports[components[0]]; ok {
+					section := components[1]
+					if len(components) == 2 {
+						return &schema.TypeSpec{Ref: fmt.Sprintf("%s#/%s", imp.Path, section)}, nil
+					}
+					module := components[2 : len(components)-1]
+					name := components[len(components)-1]
+					token := fmt.Sprintf("%s:%s:%s", imp.Package, strings.Join(module, "/"), name)
+					return &schema.TypeSpec{Ref: fmt.Sprintf("%s#/%s/%s", imp.Path, section, token)}, nil
+				}
+			}
+
+			for _, c := range components[:len(components)-1] {
+				next, ok := members[c]
+				if !ok {
+					return nil, fmt.Errorf("unknown member %v in %v", c, refPath)
+				}
+				mod, ok := next.(Members)
+				if !ok {
+					return nil, fmt.Errorf("member %v in %v is not a module", c, refPath)
+				}
+				members = mod
+			}
+		}
+
+		leaf := components[len(components)-1]
+		ref, ok := members[leaf]
+		if !ok {
+			return nil, fmt.Errorf("unknown member %v in %v", leaf, refPath)
+		}
+
+		kind := ""
+		switch ref.(type) {
+		case *Enum, *Object:
+			kind = "types"
+		case *Resource, *Component:
+			kind = "resources"
+		default:
+			return nil, fmt.Errorf("types may only reference other types or resources")
+		}
+
+		moduleRef := ""
+		if len(components) > 1 {
+			moduleRef = strings.Join(components[:len(components)-1], "/")
+		}
+
+		return &schema.TypeSpec{Ref: fmt.Sprintf("#/%s/%s:%s:%s", kind, p.Name, moduleRef, leaf), Plain: !output}, nil
+	}
+}
+
+type DefaultData struct {
+	Value interface{} `yaml:"value"`
+	Env   []string    `yaml:"env"`
+}
+
+type Default struct {
+	DefaultData
+}
+
+func (d *Default) UnmarshalYAML(node *yaml.Node) error {
+	if node.Kind == yaml.MappingNode {
+		return node.Decode(&d.DefaultData)
+	}
+	return node.Decode(&d.Value)
+}
+
+func (d *Default) spec() (value interface{}, spec *schema.DefaultSpec) {
+	if d != nil {
+		value = d.Value
+		if len(d.Env) != 0 {
+			spec = &schema.DefaultSpec{Environment: d.Env}
+		}
+	}
+	return
+}
+
+func properties(pkg *Package, module string, props Properties,
+	output bool) (specs map[string]schema.PropertySpec, required []string, err error) {
+
+	specs = map[string]schema.PropertySpec{}
+	for name, prop := range props {
+		isRequired, spec, err := prop.spec(pkg, module, output)
+		if err != nil {
+			return nil, nil, err
+		}
+		if isRequired {
+			required = append(required, name)
+		}
+		specs[name] = *spec
+	}
+	sort.Strings(required)
+	return
+}
+
+func commentText(comment string) string {
+	if comment == "" {
+		return ""
+	}
+
+	lines := strings.Split(comment, "\n")
+
+	var text strings.Builder
+	for _, l := range lines {
+		text.WriteString(strings.TrimSpace(strings.TrimPrefix(l, "#")))
+		text.WriteRune('\n')
+	}
+
+	return text.String()
+}
+
+func propertyDescription(key, value *yaml.Node) string {
+	description := ""
+	if key.HeadComment != "" {
+		description = key.HeadComment
+	}
+	if value.LineComment != "" {
+		if description != "" {
+			description += "\n"
+		}
+		description += value.LineComment
+	}
+	return commentText(description)
+}
+
+func languageSpec(language map[string]interface{}) (map[string]json.RawMessage, error) {
+	result := make(map[string]json.RawMessage)
+	for lang, value := range language {
+		bytes, err := json.Marshal(value)
+		if err != nil {
+			return nil, err
+		}
+		result[lang] = json.RawMessage(bytes)
+	}
+	return result, nil
+}

--- a/pkg/codegen/schema/yaml/yaml_test.go
+++ b/pkg/codegen/schema/yaml/yaml_test.go
@@ -1,0 +1,65 @@
+package yaml
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func decodeFile(path string) (*Package, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var pkg *Package
+	if err := yaml.NewDecoder(f).Decode(&pkg); err != nil {
+		return nil, err
+	}
+	return pkg, nil
+}
+
+func TestSchemas(t *testing.T) {
+	files, err := os.ReadDir("testdata")
+	require.NoError(t, err)
+
+	for _, f := range files {
+		name := f.Name()
+		if filepath.Ext(name) != ".yaml" {
+			continue
+		}
+
+		t.Run(name, func(t *testing.T) {
+			syntax, err := decodeFile(filepath.Join("testdata", name))
+			require.NoError(t, err)
+
+			spec, err := syntax.Spec()
+			require.NoError(t, err)
+
+			_, err = schema.ImportSpec(*spec, nil)
+			assert.NoError(t, err)
+
+			bytes, err := json.MarshalIndent(spec, "", "    ")
+			require.NoError(t, err)
+
+			jsonPath := filepath.Join("testdata", name[:len(name)-len(".yaml")]+".json")
+			if os.Getenv("PULUMI_ACCEPT") != "" {
+				err = os.WriteFile(jsonPath, bytes, 0600)
+				require.NoError(t, err)
+			} else {
+				expected, err := os.ReadFile(jsonPath)
+				require.NoError(t, err)
+
+				assert.Equal(t, expected, bytes)
+			}
+		})
+	}
+}

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -55,6 +55,7 @@ require (
 	google.golang.org/grpc v1.37.0
 	gopkg.in/AlecAivazis/survey.v1 v1.8.9-0.20200217094205-6773bdf39b7f
 	gopkg.in/src-d/go-git.v4 v4.13.1
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67 // indirect
 )


### PR DESCRIPTION
These changes provide an alternative method for authoring Pulumi
schemas. Rather than hewing closely to the design of OpenAPI, this
package chooses a YAML-based approach that allows for a much more
concise description of a Pulumi schema. Although this package is
intended to cover the majority of use cases, it is not intended to have
feature parity with the JSON-based schema language, and omits some
advanced features for the sake of simplicity.

The two most striking differences are the representations of package
members and property types.

Rather than using separate, flat namespaces for types, resources, and
functions, a YAML schema uses a single, hierarchical namespace. The type
of a member is indicated using a YAML tag; members may be object types,
enum types, resources, components, functions, or modules.

YAML schemas also make use of tags and the module tree to simplify type
references. A type reference may be a primitive type, constructed type,
or a reference to an object type, enum type, or resource. Primitive
types are booleans, strings, integers, and numbers; constructued types
are inputs, arrays, maps, and unions. At the outermost level, a
property's type may also be optional, in which case the property does
not require a value.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
