### PR TITLE
Reject unknowns in context.go when not in preview

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -253,10 +253,12 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 		resolvedArgsMap = resolvedArgs.ObjectValue()
 	}
 
-	keepUnknowns := ctx.DryRun()
 	rpcArgs, err := plugin.MarshalProperties(
 		resolvedArgsMap,
-		plugin.MarshalOptions{KeepUnknowns: keepUnknowns, KeepSecrets: true, KeepResources: ctx.keepResources},
+		ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+			KeepSecrets:   true,
+			KeepResources: ctx.keepResources,
+		}),
 	)
 	if err != nil {
 		return fmt.Errorf("marshaling arguments: %w", err)
@@ -290,7 +292,10 @@ func (ctx *Context) Invoke(tok string, args interface{}, result interface{}, opt
 	// Otherwise, simply unmarshal the output properties and return the result.
 	outProps, err := plugin.UnmarshalProperties(
 		resp.Return,
-		plugin.MarshalOptions{KeepSecrets: true, KeepResources: true, KeepUnknowns: keepUnknowns},
+		ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+			KeepSecrets:   true,
+			KeepResources: true,
+		}),
 	)
 	if err != nil {
 		return err
@@ -375,10 +380,12 @@ func (ctx *Context) Call(tok string, args Input, output Output, self Resource, o
 		}
 
 		// Marshal all properties for the RPC call.
-		keepUnknowns := ctx.DryRun()
 		rpcArgs, err := plugin.MarshalProperties(
 			resolvedArgs,
-			plugin.MarshalOptions{KeepSecrets: true, KeepUnknowns: keepUnknowns, KeepResources: ctx.keepResources})
+			ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+				KeepSecrets:   true,
+				KeepResources: ctx.keepResources,
+			}))
 		if err != nil {
 			return nil, fmt.Errorf("marshaling args: %w", err)
 		}
@@ -420,11 +427,10 @@ func (ctx *Context) Call(tok string, args Input, output Output, self Resource, o
 
 			var outprops resource.PropertyMap
 			if err == nil {
-				outprops, err = plugin.UnmarshalProperties(ret, plugin.MarshalOptions{
+				outprops, err = plugin.UnmarshalProperties(ret, ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
 					KeepSecrets:   true,
 					KeepResources: true,
-					KeepUnknowns:  ctx.DryRun(),
-				})
+				}))
 			}
 			if err != nil {
 				logging.V(9).Infof("Call(%s, ...): success: w/ unmarshal error: %v", tok, err)
@@ -571,7 +577,7 @@ func (ctx *Context) ReadResource(
 		var state *structpb.Struct
 		var err error
 		defer func() {
-			res.resolve(ctx, ctx.DryRun(), err, inputs, urn, resID, state, nil)
+			res.resolve(ctx, err, inputs, urn, resID, state, nil)
 			ctx.endRPC(err)
 		}()
 
@@ -649,10 +655,12 @@ func (ctx *Context) getResource(urn string) (*pulumirpc.RegisterResourceResponse
 		"urn": urn,
 	})
 
-	keepUnknowns := ctx.DryRun()
 	rpcArgs, err := plugin.MarshalProperties(
 		resolvedArgsMap,
-		plugin.MarshalOptions{KeepUnknowns: keepUnknowns, KeepSecrets: true, KeepResources: ctx.keepResources},
+		ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+			KeepSecrets:   true,
+			KeepResources: ctx.keepResources,
+		}),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("marshaling arguments: %w", err)
@@ -754,7 +762,7 @@ func (ctx *Context) registerResource(
 		deps := make(map[string][]Resource)
 		var err error
 		defer func() {
-			resState.resolve(ctx, ctx.DryRun(), err, inputs, urn, resID, state, deps)
+			resState.resolve(ctx, err, inputs, urn, resID, state, deps)
 			ctx.endRPC(err)
 		}()
 
@@ -1046,8 +1054,10 @@ func (ctx *Context) makeResourceState(t, name string, resourceV Resource, provid
 }
 
 // resolve resolves the resource outputs using the given error and/or values.
-func (state *resourceState) resolve(ctx *Context, dryrun bool, err error, inputs *resourceInputs, urn, id string,
+func (state *resourceState) resolve(ctx *Context, err error, inputs *resourceInputs, urn, id string,
 	result *structpb.Struct, deps map[string][]Resource) {
+
+	dryrun := ctx.DryRun()
 
 	var inprops resource.PropertyMap
 	if inputs != nil {
@@ -1058,7 +1068,10 @@ func (state *resourceState) resolve(ctx *Context, dryrun bool, err error, inputs
 	if err == nil {
 		outprops, err = plugin.UnmarshalProperties(
 			result,
-			plugin.MarshalOptions{KeepSecrets: true, KeepResources: true, KeepUnknowns: dryrun},
+			ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+				KeepSecrets:   true,
+				KeepResources: true,
+			}),
 		)
 	}
 	if err != nil {
@@ -1155,10 +1168,12 @@ func (ctx *Context) prepareResourceInputs(props Input, t string, opts *resourceO
 	}
 
 	// Marshal all properties for the RPC call.
-	keepUnknowns := ctx.DryRun()
 	rpcProps, err := plugin.MarshalProperties(
 		resolvedProps,
-		plugin.MarshalOptions{KeepSecrets: true, KeepUnknowns: keepUnknowns, KeepResources: ctx.keepResources})
+		ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+			KeepSecrets:   true,
+			KeepResources: ctx.keepResources,
+		}))
 	if err != nil {
 		return nil, fmt.Errorf("marshaling properties: %w", err)
 	}
@@ -1366,10 +1381,12 @@ func (ctx *Context) RegisterResourceOutputs(resource Resource, outs Map) error {
 			return
 		}
 
-		keepUnknowns := ctx.DryRun()
 		outsMarshalled, err := plugin.MarshalProperties(
 			outsResolved.ObjectValue(),
-			plugin.MarshalOptions{KeepSecrets: true, KeepUnknowns: keepUnknowns, KeepResources: ctx.keepResources})
+			ctx.withKeepOrRejectUnknowns(plugin.MarshalOptions{
+				KeepSecrets:   true,
+				KeepResources: ctx.keepResources,
+			}))
 		if err != nil {
 			return
 		}
@@ -1409,4 +1426,17 @@ func (ctx *Context) newOutput(typ reflect.Type, deps ...Resource) Output {
 // NewOutput creates a new output associated with this context.
 func (ctx *Context) NewOutput() (Output, func(interface{}), func(error)) {
 	return newAnyOutput(&ctx.join)
+}
+
+// Sets marshalling flags based on `ctx.DryRun()`: we will either
+// preserve unknowns as-is or fail strictly with an exception if any
+// unkowns are found. The third option, filtering out unkown values
+// from the data structure being marshalled, is never used.
+func (ctx *Context) withKeepOrRejectUnknowns(options plugin.MarshalOptions) plugin.MarshalOptions {
+	if ctx.DryRun() {
+		options.KeepUnknowns = true
+	} else {
+		options.RejectUnknowns = true
+	}
+	return options
 }

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1430,7 +1430,7 @@ func (ctx *Context) NewOutput() (Output, func(interface{}), func(error)) {
 
 // Sets marshalling flags based on `ctx.DryRun()`: we will either
 // preserve unknowns as-is or fail strictly with an exception if any
-// unkowns are found. The third option, filtering out unkown values
+// unkowns are found. The third option, filtering out unknown values
 // from the data structure being marshalled, is never used.
 func (ctx *Context) withKeepOrRejectUnknowns(options plugin.MarshalOptions) plugin.MarshalOptions {
 	if ctx.DryRun() {

--- a/sdk/go/pulumi/rpc_test.go
+++ b/sdk/go/pulumi/rpc_test.go
@@ -436,7 +436,7 @@ func TestResourceState(t *testing.T) {
 		resolved,
 		plugin.MarshalOptions{KeepUnknowns: true})
 	assert.NoError(t, err)
-	state.resolve(ctx, false, nil, nil, "foo", "bar", s, nil)
+	state.resolve(ctx, nil, nil, "foo", "bar", s, nil)
 
 	input := &testResourceInputs{
 		URN:     theResource.URN(),


### PR DESCRIPTION
# Description

Based on a conversation in https://github.com/pulumi/pulumi/pull/7437#discussion_r665748931 we might prefer to be strict and fail with an exception in the Go SDK when unknowns are being marshaled in a context that does not expect them. Currently the behavior instead is to filter them out of the data structure. There were issues around this such as https://github.com/pulumi/pulumi/pull/7214

There are many other places in the codebase that have the similar problem, but I only attempt to edit context.go here to keep the change small and see this passes CI checks.



## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
