### PR TITLE
Add a helper record to name fields in a very long tuple

### DIFF
--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1142,8 +1142,6 @@ func (ctx *Context) prepareResourceInputs(props Input, t string, opts *resourceO
 
 	// Get the parent and dependency URNs from the options, in addition to the protection bit.  If there wasn't an
 	// explicit parent, and a root stack resource exists, we will automatically parent to that.
-	//parent, optDeps, protect, provider, providers, deleteBeforeReplace, importID, ignoreChanges,
-	// additionalSecretOutputs,
 	resOpts, err := ctx.getOpts(t, resource.provider, opts, remote)
 	if err != nil {
 		return nil, fmt.Errorf("resolving options: %w", err)


### PR DESCRIPTION
# Description

Mechanical refactor to avoid a 16-element tuple. While fairly local, was a nuisance.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
