### PR TITLE
[codegen] Fix SimplifyInputUnion.

### DIFF
--- a/pkg/codegen/utilities_test.go
+++ b/pkg/codegen/utilities_test.go
@@ -15,8 +15,10 @@
 package codegen
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringSetContains(t *testing.T) {
@@ -41,4 +43,21 @@ func TestStringSetSubtract(t *testing.T) {
 	assert.Equal(t, set34, set1234.Subtract(set125))
 	assert.Equal(t, setEmpty, set1234.Subtract(set1234))
 	assert.Equal(t, set1234, set1234.Subtract(setEmpty))
+}
+
+func TestSimplifyInputUnion(t *testing.T) {
+	u1 := &schema.UnionType{
+		ElementTypes: []schema.Type{
+			&schema.InputType{ElementType: schema.StringType},
+			schema.NumberType,
+		},
+	}
+
+	u2 := SimplifyInputUnion(u1)
+	assert.Equal(t, &schema.UnionType{
+		ElementTypes: []schema.Type{
+			schema.StringType,
+			schema.NumberType,
+		},
+	}, u2)
 }

--- a/pkg/codegen/utilities_types.go
+++ b/pkg/codegen/utilities_types.go
@@ -47,6 +47,8 @@ func SimplifyInputUnion(t schema.Type) schema.Type {
 	for i, et := range union.ElementTypes {
 		if input, ok := et.(*schema.InputType); ok {
 			elements[i] = input.ElementType
+		} else {
+			elements[i] = et
 		}
 	}
 	return &schema.UnionType{


### PR DESCRIPTION
SimplifyInputUnion was dropping element types that were not inputs.
These changes fix that bug.

Fixes #7454.