### PR TITLE
[query] Do not access config with a nil Target.

### DIFF
--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -274,7 +274,7 @@ func newQueryResourceMonitor(
 
 	queryResmon.callInfo = plugin.CallInfo{
 		Project:        string(runinfo.Proj.Name),
-		Stack:          string(name),
+		Stack:          name,
 		Config:         config,
 		DryRun:         true,
 		Parallel:       math.MaxInt32,

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -206,11 +206,10 @@ func newQueryResourceMonitor(
 	providerRegChan := make(chan *registerResourceEvent)
 
 	// Create a new default provider manager.
-	var config *Target
 	d := &defaultProviders{
 		defaultVersions: defaultProviderVersions,
 		providers:       make(map[string]providers.Reference),
-		config:          config,
+		config:          runinfo.Target,
 		requests:        make(chan defaultProviderRequest),
 		providerRegChan: providerRegChan,
 		cancel:          cancel,
@@ -260,15 +259,23 @@ func newQueryResourceMonitor(
 
 	monitorAddress := fmt.Sprintf("127.0.0.1:%d", port)
 
-	cfg, err := runinfo.Target.Config.Decrypt(runinfo.Target.Decrypter)
-	if err != nil {
-		return nil, err
+	var config map[config.Key]string
+	if runinfo.Target != nil {
+		config, err = runinfo.Target.Config.Decrypt(runinfo.Target.Decrypter)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var name string
+	if runinfo.Target != nil {
+		name = string(runinfo.Target.Name)
 	}
 
 	queryResmon.callInfo = plugin.CallInfo{
 		Project:        string(runinfo.Proj.Name),
-		Stack:          string(runinfo.Target.Name),
-		Config:         cfg,
+		Stack:          string(name),
+		Config:         config,
 		DryRun:         true,
 		Parallel:       math.MaxInt32,
 		MonitorAddress: monitorAddress,


### PR DESCRIPTION
Query mode does not fill out the Target field of EvalRunInfo before
booting its resource monitor. These changes fix a recent update to query
mode that attempts to dereference the nil Target.

Note that the missing target is by design, and other portions of the
query infrastructure have identical code to compensate.