### PR TITLE
[schema] Add `inouts` to the schema JSON.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,9 @@
 - [sdk/go] - Support for calling resource methods
   [#7437](https://github.com/pulumi/pulumi/pull/7437)
 
+- [schema] - Support for inputs in schema JSON
+  [#7461](https://github.com/pulumi/pulumi/pull/7461)
+
 ### Bug Fixes
 
 - [codegen/go] - Reimplement strict go enums to be Inputs.

--- a/pkg/codegen/internal/test/testdata/schema/bad-inouts-1.json
+++ b/pkg/codegen/internal/test/testdata/schema/bad-inouts-1.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.0.1",
+  "name": "example",
+  "resources": {
+    "example::Resource": {
+      "inoutProperties": {
+        "foo": {
+          "type": "frob"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "language": {
+    "csharp": {},
+    "go": {},
+    "nodejs": {},
+    "python": {}
+  }
+}

--- a/pkg/codegen/internal/test/testdata/schema/bad-inouts-2.json
+++ b/pkg/codegen/internal/test/testdata/schema/bad-inouts-2.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.0.1",
+  "name": "example",
+  "resources": {
+    "example::Resource": {
+      "isComponent": true,
+      "inoutProperties": {
+        "bar": {
+          "$ref": "#/resources/example::Resource"
+        }
+      },
+      "inputProperties": {
+        "bar": {
+          "type": "integer"
+        }
+      },
+      "properties": {
+        "baz": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "language": {
+    "csharp": {},
+    "go": {},
+    "nodejs": {},
+    "python": {}
+  }
+}

--- a/pkg/codegen/internal/test/testdata/schema/bad-inouts-3.json
+++ b/pkg/codegen/internal/test/testdata/schema/bad-inouts-3.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.0.1",
+  "name": "example",
+  "resources": {
+    "example::Resource": {
+      "isComponent": true,
+      "inoutProperties": {
+        "baz": {
+          "$ref": "#/resources/example::Resource"
+        }
+      },
+      "inputProperties": {
+        "bar": {
+          "type": "integer"
+        }
+      },
+      "properties": {
+        "baz": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "language": {
+    "csharp": {},
+    "go": {},
+    "nodejs": {},
+    "python": {}
+  }
+}

--- a/pkg/codegen/internal/test/testdata/schema/bad-inouts-4.json
+++ b/pkg/codegen/internal/test/testdata/schema/bad-inouts-4.json
@@ -1,0 +1,21 @@
+{
+  "version": "0.0.1",
+  "name": "example",
+  "resources": {
+    "example::Resource": {
+      "inoutProperties": {
+        "foo": {
+          "type": "string"
+        }
+      },
+      "requiredInouts": ["bar"],
+      "type": "object"
+    }
+  },
+  "language": {
+    "csharp": {},
+    "go": {},
+    "nodejs": {},
+    "python": {}
+  }
+}

--- a/pkg/codegen/internal/test/testdata/schema/good-inouts-1.json
+++ b/pkg/codegen/internal/test/testdata/schema/good-inouts-1.json
@@ -1,0 +1,44 @@
+{
+  "version": "0.0.1",
+  "name": "example",
+  "resources": {
+    "example::Resource": {
+      "inoutProperties": {
+        "foo": {
+          "type": "number"
+        },
+        "bar": {
+          "type": "string"
+        }
+      },
+      "requiredInouts": ["bar"],
+      "type": "object"
+    },
+    "example::OtherResource": {
+      "isComponent": true,
+      "inoutProperties": {
+        "foo": {
+          "type": "number"
+        }
+      },
+      "inputProperties": {
+        "bar": {
+          "type": "integer"
+        }
+      },
+      "properties": {
+        "baz": {
+          "type": "string"
+        }
+      },
+      "requiredInouts": ["foo"],
+      "type": "object"
+    }
+  },
+  "language": {
+    "csharp": {},
+    "go": {},
+    "nodejs": {},
+    "python": {}
+  }
+}


### PR DESCRIPTION
These changes add support for new fields, `inouts` and `requiredInouts`,
to support simpler definitions of resources that share property
definitions between their inputs and outputs. This is intended to make
hand-authored schemas less tedious to write.