### PR TITLE
Re-enable tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include build/common.mk
 
 PROJECT         := github.com/pulumi/pulumi/pkg/v3/cmd/pulumi
 PROJECT_PKGS    := $(shell cd ./pkg && go list ./... | grep -v /vendor/)
-TESTS_PKGS      := $(shell cd ./tests && go list ./... | grep -v tests/templates | grep -v /vendor/)
+TESTS_PKGS      := $(shell cd ./tests && go list ./... -tags all | grep -v tests/templates | grep -v /vendor/)
 VERSION         := $(shell pulumictl get version)
 
 TESTPARALLELISM := 10


### PR DESCRIPTION
A number of tests have likely not been running since tags were added to
each test file. This is because `go list` uses build flags when scanning
files, so any pacakges that did not include at least one file that did
not have any tags (read: about half of the integration tests) were not
picked up by the command used in the Makefile to detect tests.