### PR TITLE
Include the Go provider in the Node.js methods test

### DIFF
--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1008,6 +1008,9 @@ func TestConstructMethodsNode(t *testing.T) {
 		{
 			componentDir: "testcomponent",
 		},
+		{
+			componentDir: "testcomponent-go",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.componentDir, func(t *testing.T) {


### PR DESCRIPTION
Updates the Node.js test to include the Go provider, like the Go and Python tests:

https://github.com/pulumi/pulumi/blob/6887f76ff7ce52fc04763a4f7ba553b2a186ca57/tests/integration/integration_go_test.go#L583-L592

https://github.com/pulumi/pulumi/blob/6887f76ff7ce52fc04763a4f7ba553b2a186ca57/tests/integration/integration_python_test.go#L698-L707