### PR TITLE
[codegen] Add type name generation tests.

### DIFF
--- a/pkg/codegen/dotnet/gen_test.go
+++ b/pkg/codegen/dotnet/gen_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGeneratePackage(t *testing.T) {
@@ -55,4 +56,18 @@ func TestGenerateType(t *testing.T) {
 			assert.Equal(t, c.expected, typeString)
 		})
 	}
+}
+
+func TestGenerateTypeNames(t *testing.T) {
+	test.TestTypeNameCodegen(t, "dotnet", func(pkg *schema.Package) test.TypeNameGeneratorFunc {
+		modules, _, err := generateModuleContextMap("test", pkg)
+		require.NoError(t, err)
+
+		root, ok := modules[""]
+		require.True(t, ok)
+
+		return func(t schema.Type) string {
+			return root.typeString(t, "", false, false, false)
+		}
+	})
 }

--- a/pkg/codegen/go/gen_test.go
+++ b/pkg/codegen/go/gen_test.go
@@ -60,6 +60,26 @@ func TestGeneratePackage(t *testing.T) {
 	test.TestSDKCodegen(t, "go", generatePackage)
 }
 
+func TestGenerateTypeNames(t *testing.T) {
+	test.TestTypeNameCodegen(t, "go", func(pkg *schema.Package) test.TypeNameGeneratorFunc {
+		err := pkg.ImportLanguages(map[string]schema.Language{"go": Importer})
+		require.NoError(t, err)
+
+		var goPkgInfo GoPackageInfo
+		if goInfo, ok := pkg.Language["go"].(GoPackageInfo); ok {
+			goPkgInfo = goInfo
+		}
+		packages := generatePackageContextMap("test", pkg, goPkgInfo)
+
+		root, ok := packages[""]
+		require.True(t, ok)
+
+		return func(t schema.Type) string {
+			return root.typeString(t)
+		}
+	})
+}
+
 type mocks int
 
 func (mocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {

--- a/pkg/codegen/internal/test/testdata/types.json
+++ b/pkg/codegen/internal/test/testdata/types.json
@@ -1,0 +1,224 @@
+{
+  "name": "typetests",
+  "version": "0.0.1",
+  "meta": {
+    "moduleFormat": "(.*)"
+  },
+  "config": {},
+  "types": {
+    "typetests::primitives": {
+      "properties": {
+        "boolean": {
+          "type": "boolean",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input\u003cbool\u003e?",
+                  "plain": "bool?"
+                },
+                "go": {
+                  "input": "pulumi.BoolPtrInput",
+                  "plain": "*bool"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input\u003cboolean\u003e | undefined",
+                  "plain": "boolean | undefined"
+                },
+                "python": {
+                  "input": "Optional[pulumi.Input[bool]]",
+                  "plain": "Optional[bool]"
+                }
+              }
+            }
+          }
+        },
+        "integer": {
+          "type": "integer",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input\u003cint\u003e?",
+                  "plain": "int?"
+                },
+                "go": {
+                  "input": "pulumi.IntPtrInput",
+                  "plain": "*int"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input\u003cnumber\u003e | undefined",
+                  "plain": "number | undefined"
+                },
+                "python": {
+                  "input": "Optional[pulumi.Input[int]]",
+                  "plain": "Optional[int]"
+                }
+              }
+            }
+          }
+        },
+        "number": {
+          "type": "number",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input\u003cdouble\u003e?",
+                  "plain": "double?"
+                },
+                "go": {
+                  "input": "pulumi.Float64PtrInput",
+                  "plain": "*float64"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input\u003cnumber\u003e | undefined",
+                  "plain": "number | undefined"
+                },
+                "python": {
+                  "input": "Optional[pulumi.Input[float]]",
+                  "plain": "Optional[float]"
+                }
+              }
+            }
+          }
+        },
+        "requiredBoolean": {
+          "type": "boolean",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input\u003cbool\u003e",
+                  "plain": "bool"
+                },
+                "go": {
+                  "input": "pulumi.BoolInput",
+                  "plain": "bool"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input\u003cboolean\u003e",
+                  "plain": "boolean"
+                },
+                "python": {
+                  "input": "pulumi.Input[bool]",
+                  "plain": "bool"
+                }
+              }
+            }
+          }
+        },
+        "requiredInteger": {
+          "type": "integer",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input\u003cint\u003e",
+                  "plain": "int"
+                },
+                "go": {
+                  "input": "pulumi.IntInput",
+                  "plain": "int"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input\u003cnumber\u003e",
+                  "plain": "number"
+                },
+                "python": {
+                  "input": "pulumi.Input[int]",
+                  "plain": "int"
+                }
+              }
+            }
+          }
+        },
+        "requiredNumber": {
+          "type": "number",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input\u003cdouble\u003e",
+                  "plain": "double"
+                },
+                "go": {
+                  "input": "pulumi.Float64Input",
+                  "plain": "float64"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input\u003cnumber\u003e",
+                  "plain": "number"
+                },
+                "python": {
+                  "input": "pulumi.Input[float]",
+                  "plain": "float"
+                }
+              }
+            }
+          }
+        },
+        "requiredString": {
+          "type": "string",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input\u003cstring\u003e",
+                  "plain": "string"
+                },
+                "go": {
+                  "input": "pulumi.StringInput",
+                  "plain": "string"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input\u003cstring\u003e",
+                  "plain": "string"
+                },
+                "python": {
+                  "input": "pulumi.Input[str]",
+                  "plain": "str"
+                }
+              }
+            }
+          }
+        },
+        "string": {
+          "type": "string",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input\u003cstring\u003e?",
+                  "plain": "string?"
+                },
+                "go": {
+                  "input": "pulumi.StringPtrInput",
+                  "plain": "*string"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input\u003cstring\u003e | undefined",
+                  "plain": "string | undefined"
+                },
+                "python": {
+                  "input": "Optional[pulumi.Input[str]]",
+                  "plain": "Optional[str]"
+                }
+              }
+            }
+          }
+        }
+      },
+      "type": "object",
+      "required": [
+        "requiredBoolean",
+        "requiredInteger",
+        "requiredNumber",
+        "requiredString"
+      ]
+    }
+  },
+  "provider": {
+    "type": "object"
+  }
+}

--- a/pkg/codegen/internal/test/testdata/types.json
+++ b/pkg/codegen/internal/test/testdata/types.json
@@ -7,14 +7,90 @@
   "config": {},
   "types": {
     "typetests::primitives": {
+      "description": "Tests name generation for the primitive schame types. See https://pkg.go.dev/github.com/pulumi/pulumi/pkg/v3/codegen/schema#Type for a complete list",
       "properties": {
+        "any": {
+          "$ref": "pulumi.json#/Any",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input<object>?",
+                  "plain": "object?"
+                },
+                "go": {
+                  "input": "pulumi.Input",
+                  "plain": "interface{}"
+                },
+                "nodejs": {
+                  "input": "any | undefined",
+                  "plain": "any | undefined"
+                },
+                "python": {
+                  "input": "Optional[Any]",
+                  "plain": "Optional[Any]"
+                }
+              }
+            }
+          }
+        },
+        "archive": {
+          "$ref": "pulumi.json#/Archive",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input<Archive>?",
+                  "plain": "Archive?"
+                },
+                "go": {
+                  "input": "pulumi.ArchiveInput",
+                  "plain": "pulumi.Archive"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input<pulumi.asset.Archive> | undefined",
+                  "plain": "pulumi.asset.Archive | undefined"
+                },
+                "python": {
+                  "input": "Optional[pulumi.Input[pulumi.Archive]]",
+                  "plain": "Optional[pulumi.Archive]"
+                }
+              }
+            }
+          }
+        },
+        "asset": {
+          "$ref": "pulumi.json#/Asset",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input<AssetOrArchive>?",
+                  "plain": "AssetOrArchive?"
+                },
+                "go": {
+                  "input": "pulumi.AssetOrArchiveInput",
+                  "plain": "pulumi.AssetOrArchive"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive> | undefined",
+                  "plain": "pulumi.asset.Asset | pulumi.asset.Archive | undefined"
+                },
+                "python": {
+                  "input": "Optional[pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]]",
+                  "plain": "Optional[Union[pulumi.Asset, pulumi.Archive]]"
+                }
+              }
+            }
+          }
+        },
         "boolean": {
           "type": "boolean",
           "language": {
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input\u003cbool\u003e?",
+                  "input": "Input<bool>?",
                   "plain": "bool?"
                 },
                 "go": {
@@ -22,7 +98,7 @@
                   "plain": "*bool"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input\u003cboolean\u003e | undefined",
+                  "input": "pulumi.Input<boolean> | undefined",
                   "plain": "boolean | undefined"
                 },
                 "python": {
@@ -39,7 +115,7 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input\u003cint\u003e?",
+                  "input": "Input<int>?",
                   "plain": "int?"
                 },
                 "go": {
@@ -47,12 +123,37 @@
                   "plain": "*int"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input\u003cnumber\u003e | undefined",
+                  "input": "pulumi.Input<number> | undefined",
                   "plain": "number | undefined"
                 },
                 "python": {
                   "input": "Optional[pulumi.Input[int]]",
                   "plain": "Optional[int]"
+                }
+              }
+            }
+          }
+        },
+        "json": {
+          "$ref": "pulumi.json#/Json",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "InputJson?",
+                  "plain": "System.Text.Json.JsonElement?"
+                },
+                "go": {
+                  "input": "pulumi.Input",
+                  "plain": "interface{}"
+                },
+                "nodejs": {
+                  "input": "any | undefined",
+                  "plain": "any | undefined"
+                },
+                "python": {
+                  "input": "Optional[Any]",
+                  "plain": "Optional[Any]"
                 }
               }
             }
@@ -64,7 +165,7 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input\u003cdouble\u003e?",
+                  "input": "Input<double>?",
                   "plain": "double?"
                 },
                 "go": {
@@ -72,12 +173,87 @@
                   "plain": "*float64"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input\u003cnumber\u003e | undefined",
+                  "input": "pulumi.Input<number> | undefined",
                   "plain": "number | undefined"
                 },
                 "python": {
                   "input": "Optional[pulumi.Input[float]]",
                   "plain": "Optional[float]"
+                }
+              }
+            }
+          }
+        },
+        "requiredAny": {
+          "$ref": "pulumi.json#/Any",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input<object>",
+                  "plain": "object"
+                },
+                "go": {
+                  "input": "pulumi.Input",
+                  "plain": "interface{}"
+                },
+                "nodejs": {
+                  "input": "any",
+                  "plain": "any"
+                },
+                "python": {
+                  "input": "Any",
+                  "plain": "Any"
+                }
+              }
+            }
+          }
+        },
+        "requiredArchive": {
+          "$ref": "pulumi.json#/Archive",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input<Archive>",
+                  "plain": "Archive"
+                },
+                "go": {
+                  "input": "pulumi.ArchiveInput",
+                  "plain": "pulumi.Archive"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input<pulumi.asset.Archive>",
+                  "plain": "pulumi.asset.Archive"
+                },
+                "python": {
+                  "input": "pulumi.Input[pulumi.Archive]",
+                  "plain": "pulumi.Archive"
+                }
+              }
+            }
+          }
+        },
+        "requiredAsset": {
+          "$ref": "pulumi.json#/Asset",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "Input<AssetOrArchive>",
+                  "plain": "AssetOrArchive"
+                },
+                "go": {
+                  "input": "pulumi.AssetOrArchiveInput",
+                  "plain": "pulumi.AssetOrArchive"
+                },
+                "nodejs": {
+                  "input": "pulumi.Input<pulumi.asset.Asset | pulumi.asset.Archive>",
+                  "plain": "pulumi.asset.Asset | pulumi.asset.Archive"
+                },
+                "python": {
+                  "input": "pulumi.Input[Union[pulumi.Asset, pulumi.Archive]]",
+                  "plain": "Union[pulumi.Asset, pulumi.Archive]"
                 }
               }
             }
@@ -89,7 +265,7 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input\u003cbool\u003e",
+                  "input": "Input<bool>",
                   "plain": "bool"
                 },
                 "go": {
@@ -97,7 +273,7 @@
                   "plain": "bool"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input\u003cboolean\u003e",
+                  "input": "pulumi.Input<boolean>",
                   "plain": "boolean"
                 },
                 "python": {
@@ -114,7 +290,7 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input\u003cint\u003e",
+                  "input": "Input<int>",
                   "plain": "int"
                 },
                 "go": {
@@ -122,12 +298,37 @@
                   "plain": "int"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input\u003cnumber\u003e",
+                  "input": "pulumi.Input<number>",
                   "plain": "number"
                 },
                 "python": {
                   "input": "pulumi.Input[int]",
                   "plain": "int"
+                }
+              }
+            }
+          }
+        },
+        "requiredJson": {
+          "$ref": "pulumi.json#/Json",
+          "language": {
+            "test": {
+              "expected": {
+                "dotnet": {
+                  "input": "InputJson",
+                  "plain": "System.Text.Json.JsonElement"
+                },
+                "go": {
+                  "input": "pulumi.Input",
+                  "plain": "interface{}"
+                },
+                "nodejs": {
+                  "input": "any",
+                  "plain": "any"
+                },
+                "python": {
+                  "input": "Any",
+                  "plain": "Any"
                 }
               }
             }
@@ -139,7 +340,7 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input\u003cdouble\u003e",
+                  "input": "Input<double>",
                   "plain": "double"
                 },
                 "go": {
@@ -147,7 +348,7 @@
                   "plain": "float64"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input\u003cnumber\u003e",
+                  "input": "pulumi.Input<number>",
                   "plain": "number"
                 },
                 "python": {
@@ -164,7 +365,7 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input\u003cstring\u003e",
+                  "input": "Input<string>",
                   "plain": "string"
                 },
                 "go": {
@@ -172,7 +373,7 @@
                   "plain": "string"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input\u003cstring\u003e",
+                  "input": "pulumi.Input<string>",
                   "plain": "string"
                 },
                 "python": {
@@ -189,7 +390,7 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "Input\u003cstring\u003e?",
+                  "input": "Input<string>?",
                   "plain": "string?"
                 },
                 "go": {
@@ -197,7 +398,7 @@
                   "plain": "*string"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input\u003cstring\u003e | undefined",
+                  "input": "pulumi.Input<string> | undefined",
                   "plain": "string | undefined"
                 },
                 "python": {
@@ -211,8 +412,12 @@
       },
       "type": "object",
       "required": [
+        "requiredAny",
+        "requiredArchive",
+        "requiredAsset",
         "requiredBoolean",
         "requiredInteger",
+        "requiredJson",
         "requiredNumber",
         "requiredString"
       ]

--- a/pkg/codegen/internal/test/type_driver.go
+++ b/pkg/codegen/internal/test/type_driver.go
@@ -1,0 +1,191 @@
+package test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type typeTestCase struct {
+	Expected map[string]interface{} `json:"expected"`
+}
+
+type typeTestImporter int
+
+func (typeTestImporter) ImportDefaultSpec(def *schema.DefaultValue, bytes json.RawMessage) (interface{}, error) {
+	return bytes, nil
+}
+
+func (typeTestImporter) ImportPropertySpec(property *schema.Property, bytes json.RawMessage) (interface{}, error) {
+	var test typeTestCase
+	if err := json.Unmarshal([]byte(bytes), &test); err != nil {
+		return nil, err
+	}
+	return &test, nil
+}
+
+func (typeTestImporter) ImportObjectTypeSpec(object *schema.ObjectType, bytes json.RawMessage) (interface{}, error) {
+	return bytes, nil
+}
+
+func (typeTestImporter) ImportResourceSpec(resource *schema.Resource, bytes json.RawMessage) (interface{}, error) {
+	return bytes, nil
+}
+
+func (typeTestImporter) ImportFunctionSpec(function *schema.Function, bytes json.RawMessage) (interface{}, error) {
+	return bytes, nil
+}
+
+func (typeTestImporter) ImportPackageSpec(pkg *schema.Package, bytes json.RawMessage) (interface{}, error) {
+	return bytes, nil
+}
+
+type NewTypeNameGeneratorFunc func(pkg *schema.Package) TypeNameGeneratorFunc
+
+type TypeNameGeneratorFunc func(t schema.Type) string
+
+func TestTypeNameCodegen(t *testing.T, language string, newTypeNameGenerator NewTypeNameGeneratorFunc) {
+	// Read in, decode, and import the schema.
+	schemaBytes, err := os.ReadFile(filepath.FromSlash("../internal/test/testdata/types.json"))
+	require.NoError(t, err)
+
+	var pkgSpec schema.PackageSpec
+	err = json.Unmarshal(schemaBytes, &pkgSpec)
+	require.NoError(t, err)
+
+	pkg, err := schema.ImportSpec(pkgSpec, map[string]schema.Language{"test": typeTestImporter(0)})
+	require.NoError(t, err)
+
+	typeName := newTypeNameGenerator(pkg)
+
+	if os.Getenv("PULUMI_ACCEPT") == "" {
+		runTests := func(where string, props []*schema.Property, inputShape bool) {
+			for _, p := range props {
+				if testCase, ok := p.Language["test"].(*typeTestCase); ok {
+					if expected, ok := testCase.Expected[language]; ok {
+						typ := p.Type
+						t.Run(where+"/"+p.Name, func(t *testing.T) {
+							var expectedName string
+							switch expected := expected.(type) {
+							case string:
+								expectedName = expected
+							case map[string]interface{}:
+								if inputShape {
+									expectedName = expected["input"].(string)
+								} else {
+									expectedName = expected["plain"].(string)
+								}
+							}
+
+							assert.Equal(t, expectedName, typeName(typ))
+						})
+					}
+				}
+			}
+		}
+
+		runTests("#/config", pkg.Config, false)
+
+		runTests("#/provider/properties", pkg.Provider.Properties, false)
+		runTests("#/provider/inputProperties", pkg.Provider.InputProperties, false)
+		if pkg.Provider.StateInputs != nil {
+			runTests("#/provider/stateInputs/properties", pkg.Provider.StateInputs.Properties, false)
+		}
+
+		for _, typ := range pkg.Types {
+			if o, ok := typ.(*schema.ObjectType); ok {
+				if o.IsInputShape() {
+					continue
+				}
+
+				runTests("#/types/"+o.Token+"/properties", o.Properties, false)
+				runTests("#/types/"+o.InputShape.Token+"/properties", o.InputShape.Properties, true)
+			}
+		}
+		for _, r := range pkg.Resources {
+			runTests("#/resources/"+r.Token+"/properties", r.Properties, false)
+			runTests("#/resources/"+r.Token+"/inputProperties", r.InputProperties, false)
+			if r.StateInputs != nil {
+				runTests("#/resources/"+r.Token+"/properties", r.StateInputs.Properties, false)
+			}
+		}
+		for _, f := range pkg.Functions {
+			if f.Inputs != nil {
+				runTests("/functions/"+f.Token+"/inputs/properties", f.Inputs.Properties, false)
+			}
+			if f.Outputs != nil {
+				runTests("/functions/"+f.Token+"/outputs/properties", f.Outputs.Properties, false)
+			}
+		}
+		return
+	}
+
+	updateTests := func(props []*schema.Property) {
+		for _, p := range props {
+			testCase, _ := p.Language["test"].(*typeTestCase)
+			if testCase == nil {
+				testCase = &typeTestCase{}
+				p.Language["test"] = testCase
+			}
+			if testCase.Expected == nil {
+				testCase.Expected = map[string]interface{}{}
+			}
+			testCase.Expected[language] = typeName(p.Type)
+		}
+	}
+
+	updateTests(pkg.Config)
+
+	updateTests(pkg.Provider.Properties)
+	updateTests(pkg.Provider.InputProperties)
+	if pkg.Provider.StateInputs != nil {
+		updateTests(pkg.Provider.StateInputs.Properties)
+	}
+
+	for _, typ := range pkg.Types {
+		if o, ok := typ.(*schema.ObjectType); ok {
+			if o.IsInputShape() {
+				continue
+			}
+
+			updateTests(o.Properties)
+			updateTests(o.InputShape.Properties)
+
+			for i, p := range o.Properties {
+				testCase := p.Language["test"].(*typeTestCase)
+				plain := testCase.Expected[language].(string)
+				input := o.InputShape.Properties[i].Language["test"].(*typeTestCase).Expected[language].(string)
+				testCase.Expected[language] = map[string]interface{}{
+					"plain": plain,
+					"input": input,
+				}
+			}
+		}
+	}
+	for _, r := range pkg.Resources {
+		updateTests(r.Properties)
+		updateTests(r.InputProperties)
+		if r.StateInputs != nil {
+			updateTests(r.StateInputs.Properties)
+		}
+	}
+	for _, f := range pkg.Functions {
+		if f.Inputs != nil {
+			updateTests(f.Inputs.Properties)
+		}
+		if f.Outputs != nil {
+			updateTests(f.Outputs.Properties)
+		}
+	}
+
+	bytes, err := json.MarshalIndent(pkg, "", "  ")
+	require.NoError(t, err)
+
+	err = os.WriteFile(filepath.FromSlash("../internal/test/testdata/types.json"), bytes, 0600)
+	require.NoError(t, err)
+}

--- a/pkg/codegen/internal/test/type_driver.go
+++ b/pkg/codegen/internal/test/type_driver.go
@@ -183,9 +183,14 @@ func TestTypeNameCodegen(t *testing.T, language string, newTypeNameGenerator New
 		}
 	}
 
-	bytes, err := json.MarshalIndent(pkg, "", "  ")
+	f, err := os.Create(filepath.FromSlash("../internal/test/testdata/types.json"))
 	require.NoError(t, err)
+	defer f.Close()
 
-	err = os.WriteFile(filepath.FromSlash("../internal/test/testdata/types.json"), bytes, 0600)
+	encoder := json.NewEncoder(f)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+
+	err = encoder.Encode(pkg)
 	require.NoError(t, err)
 }

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -5,8 +5,32 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/internal/test"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGeneratePackage(t *testing.T) {
 	test.TestSDKCodegen(t, "nodejs", GeneratePackage)
+}
+
+func TestGenerateTypeNames(t *testing.T) {
+	test.TestTypeNameCodegen(t, "nodejs", func(pkg *schema.Package) test.TypeNameGeneratorFunc {
+		// Decode node-specific info
+		err := pkg.ImportLanguages(map[string]schema.Language{"nodejs": Importer})
+		require.NoError(t, err)
+
+		info, _ := pkg.Language["nodejs"].(NodePackageInfo)
+
+		modules, info, err := generateModuleContextMap("test", pkg, info, nil)
+		require.NoError(t, err)
+
+		pkg.Language["nodejs"] = info
+
+		root, ok := modules[""]
+		require.True(t, ok)
+
+		return func(t schema.Type) string {
+			return root.typeString(t, false, nil)
+		}
+	})
 }

--- a/pkg/codegen/python/gen_test.go
+++ b/pkg/codegen/python/gen_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/internal/test"
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/stretchr/testify/require"
 )
 
 var pathTests = []struct {
@@ -33,4 +35,24 @@ func TestRelPathToRelImport(t *testing.T) {
 
 func TestGeneratePackage(t *testing.T) {
 	test.TestSDKCodegen(t, "python", GeneratePackage)
+}
+
+func TestGenerateTypeNames(t *testing.T) {
+	test.TestTypeNameCodegen(t, "python", func(pkg *schema.Package) test.TypeNameGeneratorFunc {
+		// Decode python-specific info
+		err := pkg.ImportLanguages(map[string]schema.Language{"python": Importer})
+		require.NoError(t, err)
+
+		info, _ := pkg.Language["python"].(PackageInfo)
+
+		modules, err := generateModuleContextMap("test", pkg, info, nil)
+		require.NoError(t, err)
+
+		root, ok := modules[""]
+		require.True(t, ok)
+
+		return func(t schema.Type) string {
+			return root.typeString(t, false, false)
+		}
+	})
 }

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -947,7 +947,7 @@ func (pkg *Package) marshalProperties(props []*Property) (required []string, spe
 			Secret:             p.Secret,
 		}
 	}
-	return
+	return required, specs, nil
 }
 
 func (pkg *Package) marshalType(t Type) TypeSpec {

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -15,6 +15,7 @@
 package schema
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -768,7 +769,7 @@ func (pkg *Package) MarshalJSON() (bytes []byte, err error) {
 		spec.Functions[fn.Token] = f
 	}
 
-	return json.Marshal(spec)
+	return jsonMarshal(spec)
 }
 
 func (pkg *Package) marshalObjectData(
@@ -1053,7 +1054,7 @@ func marshalLanguage(lang map[string]interface{}) (map[string]json.RawMessage, e
 
 	result := map[string]json.RawMessage{}
 	for name, data := range lang {
-		bytes, err := json.Marshal(data)
+		bytes, err := jsonMarshal(data)
 		if err != nil {
 			return nil, fmt.Errorf("marshaling %v language data: %w", name, err)
 		}
@@ -2341,4 +2342,15 @@ func bindFunctions(specs map[string]FunctionSpec, types *types) ([]*Function, ma
 	})
 
 	return functions, functionTable, nil
+}
+
+func jsonMarshal(v interface{}) ([]byte, error) {
+	var b bytes.Buffer
+	enc := json.NewEncoder(&b)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }


### PR DESCRIPTION
The inputs and expected outputs for the tests are encoded using a
schema. Each property present in the schema forms a testcase; the
expected outputs for each language are stored in each property's
`Language` field with the language name "test". Expected outputs can be
regenerated using `PULUMI_ACCEPT`.