### PR TITLE
Stop producing pointers for map and slice elements

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -396,15 +396,9 @@ func (pkg *pkgContext) typeStringImpl(t schema.Type, argsType bool) string {
 		return pkg.tokenToEnum(t.Token)
 	case *schema.ArrayType:
 		typ := "[]"
-		if !argsType && pkg.isExternalObjectType(t.ElementType) {
-			typ += "*"
-		}
 		return typ + pkg.typeStringImpl(t.ElementType, argsType)
 	case *schema.MapType:
 		typ := "map[string]"
-		if !argsType && pkg.isExternalObjectType(t.ElementType) {
-			typ += "*"
-		}
 		return typ + pkg.typeStringImpl(t.ElementType, argsType)
 	case *schema.ObjectType:
 		return pkg.resolveObjectType(t)

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
@@ -71,12 +71,12 @@ func (ComponentState) ElementType() reflect.Type {
 }
 
 type componentArgs struct {
-	Metadata              *metav1.ObjectMeta            `pulumi:"metadata"`
-	MetadataArray         []*metav1.ObjectMeta          `pulumi:"metadataArray"`
-	MetadataMap           map[string]*metav1.ObjectMeta `pulumi:"metadataMap"`
-	RequiredMetadata      metav1.ObjectMeta             `pulumi:"requiredMetadata"`
-	RequiredMetadataArray []*metav1.ObjectMeta          `pulumi:"requiredMetadataArray"`
-	RequiredMetadataMap   map[string]*metav1.ObjectMeta `pulumi:"requiredMetadataMap"`
+	Metadata              *metav1.ObjectMeta           `pulumi:"metadata"`
+	MetadataArray         []metav1.ObjectMeta          `pulumi:"metadataArray"`
+	MetadataMap           map[string]metav1.ObjectMeta `pulumi:"metadataMap"`
+	RequiredMetadata      metav1.ObjectMeta            `pulumi:"requiredMetadata"`
+	RequiredMetadataArray []metav1.ObjectMeta          `pulumi:"requiredMetadataArray"`
+	RequiredMetadataMap   map[string]metav1.ObjectMeta `pulumi:"requiredMetadataMap"`
 }
 
 // The set of arguments for constructing a Component resource.


### PR DESCRIPTION
# Description

This commit modifies Go program generation to prevent producing array and slice object elements as pointers in args structures, which fails at runtime and does not make sense in any case. For example, in the case of a type defined like this in schema:

```json
"statements": {
  "type": "array",
  "items": {
    "$ref": "/aws/v4.8.0/schema.json#/types/aws:iam/getPolicyDocumentStatement:getPolicyDocumentStatement"
  }
},
```

The following (which fails at runtime) was produced before this change:

```go
Statements []*iam.GetPolicyDocumentStatement `pulumi:"statements"`
```

And the following is produced after after this change:

```go
Statements []iam.GetPolicyDocumentStatement `pulumi:"statements"`
```

Test expectations are updated accordingly.


## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

This is not a user-facing change.

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
