### PR TITLE
Fix Node.js intermediate module import path generation

### DIFF
--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/nodejs/deeply/nested/index.ts
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/nodejs/deeply/nested/index.ts
@@ -2,8 +2,8 @@
 // *** Do not edit by hand unless you're certain you know what you are doing! ***
 
 // Export sub-modules:
-import * as nested/module from "./nested/module";
+import * as module from "./module";
 
 export {
-    nested/module,
+    module,
 };

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1546,7 +1546,12 @@ func (mod *modContext) genIndex(exports []string) string {
 		}
 		fmt.Fprintf(w, "// Export sub-modules:\n")
 
-		sorted := children.SortedValues()
+		directChildren := codegen.NewStringSet()
+		for _, child := range children.SortedValues() {
+			directChildren.Add(path.Base(child))
+		}
+		sorted := directChildren.SortedValues()
+
 		for _, mod := range sorted {
 			fmt.Fprintf(w, "import * as %[1]s from \"./%[1]s\";\n", mod)
 		}
@@ -1670,7 +1675,12 @@ func (mod *modContext) genEnums(buffer *bytes.Buffer, enums []*schema.EnumType) 
 		if len(children) > 0 {
 			fmt.Fprintf(buffer, "// Export sub-modules:\n")
 
-			sorted := children.SortedValues()
+			directChildren := codegen.NewStringSet()
+			for _, child := range children.SortedValues() {
+				directChildren.Add(path.Base(child))
+			}
+			sorted := directChildren.SortedValues()
+
 			for _, mod := range sorted {
 				fmt.Fprintf(buffer, "import * as %[1]s from \"./%[1]s\";\n", mod)
 			}


### PR DESCRIPTION
# Description

This commit fixes code generation for intermediate module paths to produce valid TypeScript identifiers.

Before this change, the following (non-compilable) import was produced in `./jetstack/certmanager/acme`:

```
import * as jetstack/certmanager/acme/v1alpha2 from "./jetstack/certmanager/acme/v1alpha2";
```

After this change, the following import is produced:

```
import * as v1alpha2 from "./v1alpha2";
```

This example is repeated at each level of the module tree. Test expectations are adjusted to reflect this change.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

This is not a user-facing change.

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
