### PR TITLE
Update package import handling for Node.js

### DIFF
--- a/pkg/codegen/internal/test/testdata/external-resource-schema/docs/argfunction/_index.md
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/docs/argfunction/_index.md
@@ -79,7 +79,7 @@ The following arguments are supported:
 <a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">random<wbr>Random<wbr>Pet</span>
+        <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/docs/cat/_index.md
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/docs/cat/_index.md
@@ -459,7 +459,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#requiredname_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">random<wbr>Random<wbr>Pet</span>
+        <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
@@ -467,7 +467,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#requirednamearray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">random<wbr>Random<wbr>Pet[]</span>
+        <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet[]</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
@@ -475,7 +475,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#requirednamemap_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Name<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: random<wbr>Random<wbr>Pet}</span>
+        <span class="property-type">{[key: string]: pulumi<wbr>Random<wbr>Random<wbr>Pet}</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
@@ -491,7 +491,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#name_nodejs" style="color: inherit; text-decoration: inherit;">name</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">random<wbr>Random<wbr>Pet</span>
+        <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
@@ -499,7 +499,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#namearray_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">random<wbr>Random<wbr>Pet[]</span>
+        <span class="property-type">pulumi<wbr>Random<wbr>Random<wbr>Pet[]</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
@@ -507,7 +507,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#namemap_nodejs" style="color: inherit; text-decoration: inherit;">name<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: random<wbr>Random<wbr>Pet}</span>
+        <span class="property-type">{[key: string]: pulumi<wbr>Random<wbr>Random<wbr>Pet}</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/docs/component/_index.md
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/docs/component/_index.md
@@ -268,7 +268,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <a href="#requiredmetadata_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args</a></span>
+        <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args</a></span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
@@ -276,7 +276,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <a href="#requiredmetadataarray_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args[]</a></span>
+        <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args[]</a></span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-required"
             title="Required">
@@ -284,7 +284,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <a href="#requiredmetadatamap_nodejs" style="color: inherit; text-decoration: inherit;">required<wbr>Metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args}</span>
+        <span class="property-type">{[key: string]: pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args}</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
@@ -292,7 +292,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <a href="#metadata_nodejs" style="color: inherit; text-decoration: inherit;">metadata</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args</a></span>
+        <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args</a></span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
@@ -300,7 +300,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <a href="#metadataarray_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Array</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#objectmeta">kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args[]</a></span>
+        <span class="property-type"><a href="#objectmeta">pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args[]</a></span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-optional"
             title="Optional">
@@ -308,7 +308,7 @@ The Component resource accepts the following [input]({{< relref "/docs/intro/con
 <a href="#metadatamap_nodejs" style="color: inherit; text-decoration: inherit;">metadata<wbr>Map</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args}</span>
+        <span class="property-type">{[key: string]: pulumi<wbr>Kubernetestypesinputmetav1Object<wbr>Meta<wbr>Args}</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
@@ -459,7 +459,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#securitygroup_nodejs" style="color: inherit; text-decoration: inherit;">security<wbr>Group</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">awsec2Security<wbr>Group</span>
+        <span class="property-type">pulumi<wbr>Awsec2Security<wbr>Group</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
@@ -467,7 +467,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#provider_nodejs" style="color: inherit; text-decoration: inherit;">provider</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">kubernetes<wbr>Provider</span>
+        <span class="property-type">pulumi<wbr>Kubernetes<wbr>Provider</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd><dt class="property-"
             title="">
@@ -475,7 +475,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#storageclasses_nodejs" style="color: inherit; text-decoration: inherit;">storage<wbr>Classes</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">{[key: string]: kubernetesstoragev1Storage<wbr>Class}</span>
+        <span class="property-type">{[key: string]: pulumi<wbr>Kubernetesstoragev1Storage<wbr>Class}</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/docs/workload/_index.md
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/docs/workload/_index.md
@@ -229,7 +229,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#pod_nodejs" style="color: inherit; text-decoration: inherit;">pod</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type"><a href="#pod">kubernetestypesoutputcorev1Pod</a></span>
+        <span class="property-type"><a href="#pod">pulumi<wbr>Kubernetestypesoutputcorev1Pod</a></span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/argFunction.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/argFunction.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "./types";
 import * as utilities from "./utilities";
 
-import * as random from "@pulumi/random";
+import * as pulumiRandom from "@pulumi/random";
 
 export function argFunction(args?: ArgFunctionArgs, opts?: pulumi.InvokeOptions): Promise<ArgFunctionResult> {
     args = args || {};
@@ -22,7 +22,7 @@ export function argFunction(args?: ArgFunctionArgs, opts?: pulumi.InvokeOptions)
 }
 
 export interface ArgFunctionArgs {
-    name?: random.RandomPet;
+    name?: pulumiRandom.RandomPet;
 }
 
 export interface ArgFunctionResult {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/cat.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/cat.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "./types";
 import * as utilities from "./utilities";
 
-import * as random from "@pulumi/random";
+import * as pulumiRandom from "@pulumi/random";
 
 export class Cat extends pulumi.CustomResource {
     /**

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/component.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/component.ts
@@ -4,8 +4,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
-import * as aws from "@pulumi/aws";
-import * as kubernetes from "@pulumi/kubernetes";
+import * as pulumiAws from "@pulumi/aws";
+import * as pulumiKubernetes from "@pulumi/kubernetes";
 
 export class Component extends pulumi.CustomResource {
     /**
@@ -34,9 +34,9 @@ export class Component extends pulumi.CustomResource {
         return obj['__pulumiType'] === Component.__pulumiType;
     }
 
-    public /*out*/ readonly provider!: pulumi.Output<kubernetes.Provider | undefined>;
-    public /*out*/ readonly securityGroup!: pulumi.Output<aws.ec2.SecurityGroup>;
-    public /*out*/ readonly storageClasses!: pulumi.Output<{[key: string]: kubernetes.storage.v1.StorageClass} | undefined>;
+    public /*out*/ readonly provider!: pulumi.Output<pulumiKubernetes.Provider | undefined>;
+    public /*out*/ readonly securityGroup!: pulumi.Output<pulumiAws.ec2.SecurityGroup>;
+    public /*out*/ readonly storageClasses!: pulumi.Output<{[key: string]: pulumiKubernetes.storage.v1.StorageClass} | undefined>;
 
     /**
      * Create a Component resource with the given unique name, arguments, and options.
@@ -83,10 +83,10 @@ export class Component extends pulumi.CustomResource {
  * The set of arguments for constructing a Component resource.
  */
 export interface ComponentArgs {
-    metadata?: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>;
-    metadataArray?: pulumi.Input<pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>[]>;
-    metadataMap?: pulumi.Input<{[key: string]: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>}>;
-    requiredMetadata: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>;
-    requiredMetadataArray: pulumi.Input<pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>[]>;
-    requiredMetadataMap: pulumi.Input<{[key: string]: pulumi.Input<kubernetes.types.input.meta.v1.ObjectMetaArgs>}>;
+    metadata?: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>;
+    metadataArray?: pulumi.Input<pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>[]>;
+    metadataMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>}>;
+    requiredMetadata: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>;
+    requiredMetadataArray: pulumi.Input<pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>[]>;
+    requiredMetadataMap: pulumi.Input<{[key: string]: pulumi.Input<pulumiKubernetes.types.input.meta.v1.ObjectMetaArgs>}>;
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/types/input.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/types/input.ts
@@ -4,14 +4,14 @@
 import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "../types";
 
-import * as random from "@pulumi/random";
+import * as pulumiRandom from "@pulumi/random";
 
 export interface PetArgs {
     age?: pulumi.Input<number>;
-    name?: pulumi.Input<random.RandomPet>;
-    nameArray?: pulumi.Input<pulumi.Input<random.RandomPet>[]>;
-    nameMap?: pulumi.Input<{[key: string]: pulumi.Input<random.RandomPet>}>;
-    requiredName: pulumi.Input<random.RandomPet>;
-    requiredNameArray: pulumi.Input<pulumi.Input<random.RandomPet>[]>;
-    requiredNameMap: pulumi.Input<{[key: string]: pulumi.Input<random.RandomPet>}>;
+    name?: pulumi.Input<pulumiRandom.RandomPet>;
+    nameArray?: pulumi.Input<pulumi.Input<pulumiRandom.RandomPet>[]>;
+    nameMap?: pulumi.Input<{[key: string]: pulumi.Input<pulumiRandom.RandomPet>}>;
+    requiredName: pulumi.Input<pulumiRandom.RandomPet>;
+    requiredNameArray: pulumi.Input<pulumi.Input<pulumiRandom.RandomPet>[]>;
+    requiredNameMap: pulumi.Input<{[key: string]: pulumi.Input<pulumiRandom.RandomPet>}>;
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/types/output.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/types/output.ts
@@ -4,5 +4,5 @@
 import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "../types";
 
-import * as random from "@pulumi/random";
+import * as pulumiRandom from "@pulumi/random";
 

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/workload.ts
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/nodejs/workload.ts
@@ -4,7 +4,7 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as utilities from "./utilities";
 
-import * as kubernetes from "@pulumi/kubernetes";
+import * as pulumiKubernetes from "@pulumi/kubernetes";
 
 export class Workload extends pulumi.CustomResource {
     /**
@@ -33,7 +33,7 @@ export class Workload extends pulumi.CustomResource {
         return obj['__pulumiType'] === Workload.__pulumiType;
     }
 
-    public /*out*/ readonly pod!: pulumi.Output<kubernetes.types.output.core.v1.Pod | undefined>;
+    public /*out*/ readonly pod!: pulumi.Output<pulumiKubernetes.types.output.core.v1.Pod | undefined>;
 
     /**
      * Create a Workload resource with the given unique name, arguments, and options.

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/docs/staticpage/_index.md
@@ -303,7 +303,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#bucket_nodejs" style="color: inherit; text-decoration: inherit;">bucket</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">awss3Bucket</span>
+        <span class="property-type">pulumi<wbr>Awss3Bucket</span>
     </dt>
     <dd>{{% md %}}The bucket resource.{{% /md %}}</dd><dt class="property-"
             title="">

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/nodejs/staticPage.ts
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/nodejs/staticPage.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "./types";
 import * as utilities from "./utilities";
 
-import * as aws from "@pulumi/aws";
+import * as pulumiAws from "@pulumi/aws";
 
 export class StaticPage extends pulumi.ComponentResource {
     /** @internal */
@@ -25,7 +25,7 @@ export class StaticPage extends pulumi.ComponentResource {
     /**
      * The bucket resource.
      */
-    public /*out*/ readonly bucket!: pulumi.Output<aws.s3.Bucket>;
+    public /*out*/ readonly bucket!: pulumi.Output<pulumiAws.s3.Bucket>;
     /**
      * The website URL.
      */

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/nodejs/foo.ts
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/nodejs/foo.ts
@@ -5,7 +5,7 @@ import * as pulumi from "@pulumi/pulumi";
 import { input as inputs, output as outputs } from "./types";
 import * as utilities from "./utilities";
 
-import * as random from "@pulumi/random";
+import * as pulumiRandom from "@pulumi/random";
 
 export class Foo extends pulumi.ComponentResource {
     /** @internal */
@@ -97,9 +97,9 @@ export namespace Foo {
         boolValue?: pulumi.Input<boolean>;
         boolValuePlain?: boolean;
         boolValueRequired: pulumi.Input<boolean>;
-        name?: pulumi.Input<random.RandomPet>;
-        namePlain?: random.RandomPet;
-        nameRequired: pulumi.Input<random.RandomPet>;
+        name?: pulumi.Input<pulumiRandom.RandomPet>;
+        namePlain?: pulumiRandom.RandomPet;
+        nameRequired: pulumi.Input<pulumiRandom.RandomPet>;
         stringValue?: pulumi.Input<string>;
         stringValuePlain?: string;
         stringValueRequired: pulumi.Input<string>;

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -32,6 +32,7 @@ import (
 	"unicode"
 
 	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -144,6 +145,7 @@ func (mod *modContext) objectType(pkg *schema.Package, tok string, input, args, 
 
 	namingCtx, pkgName, external := mod.namingContext(pkg)
 	if external {
+		pkgName = fmt.Sprintf("pulumi%s", title(pkgName))
 		root = "types.output."
 		if input {
 			root = "types.input."
@@ -165,6 +167,10 @@ func (mod *modContext) objectType(pkg *schema.Package, tok string, input, args, 
 func (mod *modContext) resourceType(r *schema.ResourceType) string {
 	if strings.HasPrefix(r.Token, "pulumi:providers:") {
 		pkgName := strings.TrimPrefix(r.Token, "pulumi:providers:")
+		if pkgName != mod.pkg.Name {
+			pkgName = fmt.Sprintf("pulumi%s", title(pkgName))
+		}
+
 		return fmt.Sprintf("%s.Provider", pkgName)
 	}
 
@@ -172,7 +178,10 @@ func (mod *modContext) resourceType(r *schema.ResourceType) string {
 	if r.Resource != nil {
 		pkg = r.Resource.Package
 	}
-	namingCtx, pkgName, _ := mod.namingContext(pkg)
+	namingCtx, pkgName, external := mod.namingContext(pkg)
+	if external {
+		pkgName = fmt.Sprintf("pulumi%s", title(pkgName))
+	}
 
 	modName, name := namingCtx.tokenToModName(r.Token), tokenToName(r.Token)
 
@@ -986,6 +995,11 @@ func (mod *modContext) getTypeImportsForResource(t schema.Type, recurse bool, ex
 		return false
 	}
 
+	var nodePackageInfo NodePackageInfo
+	if languageInfo, hasLanguageInfo := mod.pkg.Language["nodejs"]; hasLanguageInfo {
+		nodePackageInfo = languageInfo.(NodePackageInfo)
+	}
+
 	switch t := t.(type) {
 	case *schema.OptionalType:
 		return mod.getTypeImports(t.ElementType, recurse, externalImports, imports, seen)
@@ -1001,14 +1015,10 @@ func (mod *modContext) getTypeImportsForResource(t schema.Type, recurse bool, ex
 		// If it's from another package, add an import for the external package.
 		if t.Package != nil && t.Package != mod.pkg {
 			pkg := t.Package.Name
-			var nodePackageInfo NodePackageInfo
-			if languageInfo, hasLanguageInfo := mod.pkg.Language["nodejs"]; hasLanguageInfo {
-				nodePackageInfo = languageInfo.(NodePackageInfo)
-			}
 			if imp, ok := nodePackageInfo.ProviderNameToModuleName[pkg]; ok {
-				externalImports.Add(fmt.Sprintf("import * as %[1]s from \"%[2]s\";", pkg, imp))
+				externalImports.Add(fmt.Sprintf("import * as %s from \"%s\";", fmt.Sprintf("pulumi%s", title(pkg)), imp))
 			} else {
-				externalImports.Add(fmt.Sprintf("import * as %[1]s from \"@pulumi/%[1]s\";", pkg))
+				externalImports.Add(fmt.Sprintf("import * as %s from \"@pulumi/%s\";", fmt.Sprintf("pulumi%s", title(pkg)), pkg))
 			}
 			return false
 		}
@@ -1021,7 +1031,11 @@ func (mod *modContext) getTypeImportsForResource(t schema.Type, recurse bool, ex
 		// If it's from another package, add an import for the external package.
 		if t.Resource != nil && t.Resource.Package != mod.pkg {
 			pkg := t.Resource.Package.Name
-			externalImports.Add(fmt.Sprintf("import * as %[1]s from \"@pulumi/%[1]s\";", pkg))
+			if imp, ok := nodePackageInfo.ProviderNameToModuleName[pkg]; ok {
+				externalImports.Add(fmt.Sprintf("import * as %s from \"%s\";", fmt.Sprintf("pulumi%s", title(pkg)), imp))
+			} else {
+				externalImports.Add(fmt.Sprintf("import * as %s from \"@pulumi/%s\";", fmt.Sprintf("pulumi%s", title(pkg)), pkg))
+			}
 			return false
 		}
 

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1001,7 +1001,15 @@ func (mod *modContext) getTypeImportsForResource(t schema.Type, recurse bool, ex
 		// If it's from another package, add an import for the external package.
 		if t.Package != nil && t.Package != mod.pkg {
 			pkg := t.Package.Name
-			externalImports.Add(fmt.Sprintf("import * as %[1]s from \"@pulumi/%[1]s\";", pkg))
+			var nodePackageInfo NodePackageInfo
+			if languageInfo, hasLanguageInfo := mod.pkg.Language["nodejs"]; hasLanguageInfo {
+				nodePackageInfo = languageInfo.(NodePackageInfo)
+			}
+			if imp, ok := nodePackageInfo.ProviderNameToModuleName[pkg]; ok {
+				externalImports.Add(fmt.Sprintf("import * as %[1]s from \"%[2]s\";", pkg, imp))
+			} else {
+				externalImports.Add(fmt.Sprintf("import * as %[1]s from \"@pulumi/%[1]s\";", pkg))
+			}
 			return false
 		}
 

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -52,6 +52,8 @@ type NodePackageInfo struct {
 	DisableUnionOutputTypes bool `json:"disableUnionOutputTypes,omitempty"`
 	// An indicator for whether the package contains enums.
 	ContainsEnums bool `json:"containsEnums,omitempty"`
+	// A map allowing you to map the name of a provider to the name of the module encapsulating the provider
+	ProviderNameToModuleName map[string]string `json:"providerNameToModuleName,omitempty"`
 }
 
 // NodeObjectInfo contains NodeJS-specific information for an object.


### PR DESCRIPTION
# Description

This pull request includes two related changes - the second builds upon the first.

1. Allow non-pulumi imports for Node.js

  Currently the code generator is assuming that Node.js dependencies are following a naming scheme that is prefixed with `@pulumi/`. If this is not the case the generated import statement is incorrect.

  This commit adds a map `ProviderNameToModuleName` to the language definition that allows you to map the name of the extracted provider of a dependency to a module name that the generator now uses to create the import statement.

2.  Prepend "pulumi" to import names in Node.js SDK

  It is common when writing multi-language components to have a module name which conflicts with a provider name. This can produce unusable code, since you cannot simultaneously import a package as `aws` and have a namespace `aws`, for example.

  This commit makes this situation much less likely, by renaming the imported identifier for providers to `pulumiX` where it would previously have been `x`.

  This has an unfortunate side effect of making the tags in the documentation slightly uglier, since import statements for external packages are now of the form `import * as pulumiAws from "@pulumi/aws"`. I don't see a way to discern whether code generation is for SDKs vs examples however, and short of plumbing that through, I don't see a way around this, so test expectations are updated accordingly.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Not a user-facing change.

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version