### PR TITLE
Add issue management Actions

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -2,7 +2,7 @@ name: Issue management
 
 on:
   schedule:
-  - cron: '41 8 * * *'
+  - cron: '12 13 * * *'
 
 jobs:
   stale:
@@ -18,4 +18,5 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         only-labels: awaiting-feedback
         stale-issue-message: 'Since we haven''t heard back from you, closing this issue for now. Please feel free to comment with more information and we can get this reopened.'
+        stale-issue-label: awaiting-feedback-stale
         days-before-stale: 14

--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -1,0 +1,21 @@
+name: Issue management
+
+on:
+  schedule:
+  - cron: '41 8 * * *'
+
+jobs:
+  stale:
+    name: Close stale awaiting-feedback issues
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        only-labels: awaiting-feedback
+        stale-issue-message: 'Since we haven''t heard back from you, closing this issue for now. Please feel free to comment with more information and we can get this reopened.'
+        days-before-stale: 14


### PR DESCRIPTION
# Description

Adding some issue management automation, including:

- Automatically closing issues that have had the `awaiting-feedback` label for more than 14 days