### PR TITLE
Use variable over placeholder for Python version

### DIFF
--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the example resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource example ${PLUGIN_VERSION}`
+                `pulumi plugin install resource example {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'foo-bar', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'foo-bar', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the foo-bar resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource foo-bar ${PLUGIN_VERSION}`
+                `pulumi plugin install resource foo-bar {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='foo_bar',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/nested-module/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/nested-module/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'foo', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'foo', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the foo resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource foo ${PLUGIN_VERSION}`
+                `pulumi plugin install resource foo {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_foo',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'xyz', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'xyz', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the xyz resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource xyz ${PLUGIN_VERSION}`
+                `pulumi plugin install resource xyz {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_xyz',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/resource-args-python/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the example resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource example ${PLUGIN_VERSION}`
+                `pulumi plugin install resource example {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'plant', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'plant', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the plant resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource plant ${PLUGIN_VERSION}`
+                `pulumi plugin install resource plant {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_plant',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the example resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource example ${PLUGIN_VERSION}`
+                `pulumi plugin install resource example {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the example resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource example ${PLUGIN_VERSION}`
+                `pulumi plugin install resource example {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the example resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource example ${PLUGIN_VERSION}`
+                `pulumi plugin install resource example {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the example resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource example ${PLUGIN_VERSION}`
+                `pulumi plugin install resource example {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='custom_py_package',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/setup.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/setup.py
@@ -8,19 +8,22 @@ from setuptools.command.install import install
 from subprocess import check_call
 
 
+VERSION = "0.0.0"
+PLUGIN_VERSION = "0.0.0"
+
 class InstallPluginCommand(install):
     def run(self):
         install.run(self)
         try:
-            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', '${PLUGIN_VERSION}'])
+            check_call(['pulumi', 'plugin', 'install', 'resource', 'example', PLUGIN_VERSION])
         except OSError as error:
             if error.errno == errno.ENOENT:
-                print("""
+                print(f"""
                 There was an error installing the example resource provider plugin.
                 It looks like `pulumi` is not installed on your system.
                 Please visit https://pulumi.com/ to install the Pulumi CLI.
                 You may try manually installing the plugin by running
-                `pulumi plugin install resource example ${PLUGIN_VERSION}`
+                `pulumi plugin install resource example {PLUGIN_VERSION}`
                 """)
             else:
                 raise
@@ -35,7 +38,7 @@ def readme():
 
 
 setup(name='pulumi_example',
-      version='${VERSION}',
+      version=VERSION,
       long_description=readme(),
       long_description_content_type='text/markdown',
       cmdclass={

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -1726,24 +1726,28 @@ func genPackageMetadata(
 	fmt.Fprintf(w, "from subprocess import check_call\n")
 	fmt.Fprintf(w, "\n\n")
 
+	// Create a constant for the version number to replace during build
+	fmt.Fprintf(w, "VERSION = \"0.0.0\"\n")
+	fmt.Fprintf(w, "PLUGIN_VERSION = \"0.0.0\"\n\n")
+
 	// Create a command that will install the Pulumi plugin for this resource provider.
 	fmt.Fprintf(w, "class InstallPluginCommand(install):\n")
 	fmt.Fprintf(w, "    def run(self):\n")
 	fmt.Fprintf(w, "        install.run(self)\n")
 	fmt.Fprintf(w, "        try:\n")
 	if pkg.PluginDownloadURL == "" {
-		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}'])\n", pkg.Name)
+		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', PLUGIN_VERSION])\n", pkg.Name)
 	} else {
-		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', '${PLUGIN_VERSION}', '--server', '%s'])\n", pkg.Name, pkg.PluginDownloadURL)
+		fmt.Fprintf(w, "            check_call(['pulumi', 'plugin', 'install', 'resource', '%s', PLUGIN_VERSION, '--server', '%s'])\n", pkg.Name, pkg.PluginDownloadURL)
 	}
 	fmt.Fprintf(w, "        except OSError as error:\n")
 	fmt.Fprintf(w, "            if error.errno == errno.ENOENT:\n")
-	fmt.Fprintf(w, "                print(\"\"\"\n")
+	fmt.Fprintf(w, "                print(f\"\"\"\n")
 	fmt.Fprintf(w, "                There was an error installing the %s resource provider plugin.\n", pkg.Name)
 	fmt.Fprintf(w, "                It looks like `pulumi` is not installed on your system.\n")
 	fmt.Fprintf(w, "                Please visit https://pulumi.com/ to install the Pulumi CLI.\n")
 	fmt.Fprintf(w, "                You may try manually installing the plugin by running\n")
-	fmt.Fprintf(w, "                `pulumi plugin install resource %s ${PLUGIN_VERSION}`\n", pkg.Name)
+	fmt.Fprintf(w, "                `pulumi plugin install resource %s {PLUGIN_VERSION}`\n", pkg.Name)
 	fmt.Fprintf(w, "                \"\"\")\n")
 	fmt.Fprintf(w, "            else:\n")
 	fmt.Fprintf(w, "                raise\n")
@@ -1761,7 +1765,7 @@ func genPackageMetadata(
 
 	// Finally, the actual setup part.
 	fmt.Fprintf(w, "setup(name='%s',\n", pyPkgName)
-	fmt.Fprintf(w, "      version='${VERSION}',\n")
+	fmt.Fprintf(w, "      version=VERSION,\n")
 	if pkg.Description != "" {
 		fmt.Fprintf(w, "      description=%q,\n", sanitizePackageDescription(pkg.Description))
 	}


### PR DESCRIPTION
This commit modifies the generation of `setup.py` to use Python variables as the source for the package version and plugin version instead of placeholder strings. This has the effect of making the packages installable via the `-e` flag directly from their source directory rather than requiring a build step, which is useful while developing a plugin and examples in tandem.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Not a user-facing change.

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version