### PR TITLE
Fix IDE completion issues for lazy imports

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,7 @@
 
 ### Bug Fixes
 
+- [codegen/python] - Recover good IDE completion experience over
+  module imports that was compromised when introducing the lazy import
+  optimization.
+  [#7487](https://github.com/pulumi/pulumi/pull/7487)

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/foo_bar/__init__.py
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/foo_bar/__init__.py
@@ -9,7 +9,8 @@ from .provider import *
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import foo_bar.deeply as deeply
+    import foo_bar.deeply as __deeply
+    deeply = __deeply
 else:
     deeply = _utilities.lazy_import('foo_bar.deeply')
 

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/__init__.py
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/__init__.py
@@ -7,7 +7,8 @@ import typing
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import foo_bar.deeply.nested as nested
+    import foo_bar.deeply.nested as __nested
+    nested = __nested
 else:
     nested = _utilities.lazy_import('foo_bar.deeply.nested')
 

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/nested/__init__.py
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/foo_bar/deeply/nested/__init__.py
@@ -7,7 +7,8 @@ import typing
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import foo_bar.deeply.nested.module as module
+    import foo_bar.deeply.nested.module as __module
+    module = __module
 else:
     module = _utilities.lazy_import('foo_bar.deeply.nested.module')
 

--- a/pkg/codegen/internal/test/testdata/nested-module/python/pulumi_foo/__init__.py
+++ b/pkg/codegen/internal/test/testdata/nested-module/python/pulumi_foo/__init__.py
@@ -9,7 +9,8 @@ from .provider import *
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import pulumi_foo.nested as nested
+    import pulumi_foo.nested as __nested
+    nested = __nested
 else:
     nested = _utilities.lazy_import('pulumi_foo.nested')
 

--- a/pkg/codegen/internal/test/testdata/nested-module/python/pulumi_foo/nested/__init__.py
+++ b/pkg/codegen/internal/test/testdata/nested-module/python/pulumi_foo/nested/__init__.py
@@ -7,7 +7,8 @@ import typing
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import pulumi_foo.nested.module as module
+    import pulumi_foo.nested.module as __module
+    module = __module
 else:
     module = _utilities.lazy_import('pulumi_foo.nested.module')
 

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/__init__.py
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/__init__.py
@@ -10,7 +10,8 @@ from . import outputs
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import pulumi_configstation.config as config
+    import pulumi_configstation.config as __config
+    config = __config
 else:
     config = _utilities.lazy_import('pulumi_configstation.config')
 

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/__init__.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/__init__.py
@@ -12,7 +12,8 @@ from . import outputs
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import pulumi_plant.tree as tree
+    import pulumi_plant.tree as __tree
+    tree = __tree
 else:
     tree = _utilities.lazy_import('pulumi_plant.tree')
 

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/__init__.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/tree/__init__.py
@@ -7,7 +7,8 @@ import typing
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import pulumi_plant.tree.v1 as v1
+    import pulumi_plant.tree.v1 as __v1
+    v1 = __v1
 else:
     v1 = _utilities.lazy_import('pulumi_plant.tree.v1')
 

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/python/pulumi_example/__init__.py
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/python/pulumi_example/__init__.py
@@ -10,7 +10,8 @@ from .provider import *
 
 # Make subpackages available:
 if typing.TYPE_CHECKING:
-    import pulumi_example.nested as nested
+    import pulumi_example.nested as __nested
+    nested = __nested
 else:
     nested = _utilities.lazy_import('pulumi_example.nested')
 

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -608,9 +608,18 @@ func (mod *modContext) genInit(exports []string) string {
 
 		for _, submod := range children {
 			if !submod.isEmpty() {
-				fmt.Fprintf(w, "    import %s as %s\n",
+				unq := submod.unqualifiedImportName()
+
+				// The `__iam = iam` hack enables
+				// PyCharm and VSCode completion to do
+				// better.
+				//
+				// See https://github.com/pulumi/pulumi/issues/7367
+				fmt.Fprintf(w, "    import %s as __%s\n    %s = __%s\n",
 					submod.fullyQualifiedImportName(),
-					submod.unqualifiedImportName())
+					unq,
+					unq,
+					unq)
 			}
 		}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes  module completion part of #7367

The issues with sub-package discovery are fixed for VSCode and PyCharm.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
