### PR TITLE
Set PULUMI_CONFIG_PASSPHRASE for Automation Tests

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/CommandExceptionTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/CommandExceptionTests.cs
@@ -41,6 +41,10 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
+                EnvironmentVariables = new Dictionary<string, string?>()
+                {
+                    ["PULUMI_CONFIG_PASSPHRASE"] = "test"
+                }
             });
 
             var stackName = $"already_existing_stack{GetTestSuffix()}";
@@ -66,6 +70,10 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 ProjectSettings = projectSettings,
+                EnvironmentVariables = new Dictionary<string, string?>()
+                {
+                    ["PULUMI_CONFIG_PASSPHRASE"] = "test"
+                }
             });
 
             var stackName = $"concurrent_update_stack{GetTestSuffix()}";

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -183,7 +183,11 @@ namespace Pulumi.Automation.Tests
             using var workspace = await LocalWorkspace.CreateAsync(new LocalWorkspaceOptions
             {
                 WorkDir = workingDir,
-                ProjectSettings = projectSettings
+                ProjectSettings = projectSettings,
+                EnvironmentVariables = new Dictionary<string, string?>()
+                {
+                    ["PULUMI_CONFIG_PASSPHRASE"] = "test"
+                }
             });
 
             var stackName = $"{RandomStackName()}";
@@ -1531,7 +1535,11 @@ namespace Pulumi.Automation.Tests
             var stack = await LocalWorkspace.CreateStackAsync(
                 new InlineProgramArgs(projectName, stackName, program)
                 {
-                    WorkDir = workdir
+                    WorkDir = workdir,
+                    EnvironmentVariables = new Dictionary<string, string?>()
+                    {
+                        ["PULUMI_CONFIG_PASSPHRASE"] = "test"
+                    }
                 });
 
             var settings = await stack.Workspace.GetProjectSettingsAsync();
@@ -1580,6 +1588,10 @@ namespace Pulumi.Automation.Tests
                 new InlineProgramArgs(projectName, stackName, program)
                 {
                     Logger = logger,
+                    EnvironmentVariables = new Dictionary<string, string?>()
+                    {
+                        ["PULUMI_CONFIG_PASSPHRASE"] = "test"
+                    }
                 });
 
             // make sure workspace logger is used
@@ -1620,7 +1632,11 @@ namespace Pulumi.Automation.Tests
             using var stack = await LocalWorkspace.CreateOrSelectStackAsync(
                 new InlineProgramArgs(projectName, stackName, program)
                 {
-                    Logger = TestLogger
+                    Logger = TestLogger,
+                    EnvironmentVariables = new Dictionary<string, string?>()
+                    {
+                        ["PULUMI_CONFIG_PASSPHRASE"] = "test"
+                    }
                 });
 
             TestLogger.LogInformation("Previewing stack...");


### PR DESCRIPTION
# Description

I have fixed the dotnet Automation.Tests that were failing because of missing PULUMI_CONFIG_PASSPHRASE environment variable.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
The change is fixing tests and no impact on existing behaviour
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
There is no changes related to calling Pulumi Service API