### PR TITLE
Fix marshaling prompt slices/maps with input elems

### DIFF
--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -22,10 +22,11 @@ import (
 	"sync"
 
 	"github.com/blang/semver"
+	"golang.org/x/net/context"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"golang.org/x/net/context"
 )
 
 func mapStructTypes(from, to reflect.Type) func(reflect.Value, int) (reflect.StructField, reflect.Value) {
@@ -285,9 +286,6 @@ func marshalInputAndDetermineSecret(v interface{},
 			return resource.MakeComponentResourceReference(resource.URN(urn), ""), deps, secret, nil
 		}
 
-		contract.Assertf(valueType.AssignableTo(destType) || valueType.ConvertibleTo(destType),
-			"%v: cannot assign %v to %v", v, valueType, destType)
-
 		if destType.Kind() == reflect.Interface {
 			// This happens in the case of Any.
 			if valueType.Kind() == reflect.Interface {
@@ -297,6 +295,15 @@ func marshalInputAndDetermineSecret(v interface{},
 		}
 
 		rv := reflect.ValueOf(v)
+
+		switch rv.Type().Kind() {
+		case reflect.Array, reflect.Slice, reflect.Map:
+			// Not assignable in prompt form because of the difference in input and output shapes.
+		default:
+			contract.Assertf(valueType.AssignableTo(destType) || valueType.ConvertibleTo(destType),
+				"%v: cannot assign %v to %v", v, valueType, destType)
+		}
+
 		switch rv.Type().Kind() {
 		case reflect.Bool:
 			return resource.NewBoolProperty(rv.Bool()), deps, secret, nil


### PR DESCRIPTION
# Description

This fixes #7504, and is the other half of the interim fix corresponding to #7359. The case listed in #7509 no longer reproduces after this fix is applied.

The change to imports is the result of running `goimports` and is not a functional change.

Fixes #7504.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

No automated tests added, but repro case in #7504 no longer reproduces with this fix.

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Not a user-facing change.

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version

N/A.