### PR TITLE
Add ContinuationToken to ListStacksResponse

### DIFF
--- a/sdk/go/common/apitype/stacks.go
+++ b/sdk/go/common/apitype/stacks.go
@@ -33,6 +33,12 @@ type StackSummary struct {
 // ListStacksResponse returns a set of stack summaries. This call is designed to be inexpensive.
 type ListStacksResponse struct {
 	Stacks []StackSummary `json:"stacks"`
+
+	// ContinuationToken is an opaque value used to mark the end of the all stacks. If non-nil,
+	// pass it into a subsequent call in order to get the next batch of results.
+	//
+	// A value of nil means that all stacks have been returned.
+	ContinuationToken *string `json:"continuationToken,omitempty"`
 }
 
 // CreateStackRequest defines the request body for creating a new Stack


### PR DESCRIPTION
# Description

This PR adds an optional `ContinuationToken *string` field to `apitype.ListStacksResponse`. This is the REST API type returned from the Pulumi Service (or any HTTP State backend), and will be used to enable paginating results when running `pulumi stack ls`.

Once checked in, the Pulumi Service will then support a newer variant of the ListStacks API endpoint that will support pagination using this new field. And a follow-up commit into the Pulumi CLI will emit a new `Accept` header value, flagging the Pulumi Service to return stacks in a paginated fashion. (So newer CLIs will take advantage of the newer API semantics, while older clients -- with the older `Accept` header value -- will receive the previous behavior.)

Being an optional field also means that any existing HTTPState backend implementations can opt-into the paginated behavior too by simply setting the `ContinuationToken` value in their responses. If ignored and kept `nil`, then the behavior will be the same. (The assumption being that a `nil` `ContinuationToken` means that all results have been seen, and there isn't another page to go and fetch.)

(Part of https://github.com/pulumi/pulumi-service/issues/6136.)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

NA

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

I'll update the `CHANGELOG_PENDING.md` when I make the change to actually _inspect/use_ the new field. But for now, we just need to add it so the Pulumi Service can start setting the field when it sees `req.Header.Set("Accept", "application/vnd.pulumi+8")`.

- [x] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version

Yup, and I'll take care of that.
