### PR TITLE
Update typescript version

### DIFF
--- a/sdk/nodejs/log/index.ts
+++ b/sdk/nodejs/log/index.ts
@@ -106,7 +106,7 @@ function log(
         : Promise.resolve("");
 
     lastLog = Promise.all([lastLog, urnPromise]).then(([_, urn]) => {
-        return new Promise((resolve, reject) => {
+        return new Promise<void>((resolve, reject) => {
             try {
                 const req = new engproto.LogRequest();
                 req.setSeverity(sev);

--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -216,7 +216,7 @@ This function may throw in a future version of @pulumi/pulumi.`;
         };
 
         return new Proxy(this, {
-            get: (obj, prop: keyof T) => {
+            get: (obj, prop) => {
                 // Recreate the prototype walk to ensure we find any actual members defined directly
                 // on `Output<T>`.
                 for (let o = obj; o; o = Object.getPrototypeOf(o)) {

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -22,7 +22,7 @@
         "semver": "^6.1.0",
         "source-map-support": "^0.4.16",
         "ts-node": "^7.0.1",
-        "typescript": "~3.7.3",
+        "typescript": "^4.3.5",
         "upath": "^1.1.0"
     },
     "devDependencies": {

--- a/sdk/nodejs/queryable/index.ts
+++ b/sdk/nodejs/queryable/index.ts
@@ -42,10 +42,4 @@ type ResolvedSimple<T> = T extends primitive
 
 interface ResolvedArray<T> extends Array<Resolved<T>> {}
 
-type ResolvedObject<T> = ModifyOptionalProperties<{ [P in keyof T]: Resolved<T[P]> }>;
-
-type RequiredKeys<T> = { [P in keyof T]: undefined extends T[P] ? never : P }[keyof T];
-type OptionalKeys<T> = { [P in keyof T]: undefined extends T[P] ? P : never }[keyof T];
-
-type ModifyOptionalProperties<T> = { [P in RequiredKeys<T>]: T[P] } &
-    { [P in OptionalKeys<T>]?: T[P] };
+type ResolvedObject<T> = { [P in keyof T]: Resolved<T[P]> };

--- a/sdk/nodejs/runtime/asyncIterableUtil.ts
+++ b/sdk/nodejs/runtime/asyncIterableUtil.ts
@@ -64,7 +64,7 @@ export class PushableAsyncIterable<T> implements AsyncIterable<T | undefined> {
                 }
                 this.nextQueue.push(resolve);
             } else {
-                resolve(this.bufferedData.shift());
+                resolve(this.bufferedData.shift()!);
             }
         });
     }

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -735,7 +735,7 @@ export function registerResourceOutputs(res: Resource, outputs: Inputs | Promise
             req.setOutputs(outputsObj);
 
             const label = `monitor.registerResourceOutputs(${urn}, ...)`;
-            await debuggablePromise(new Promise((resolve, reject) =>
+            await debuggablePromise(new Promise<void>((resolve, reject) =>
                 (monitor as any).registerResourceOutputs(req, (err: grpc.ServiceError, innerResponse: any) => {
                     log.debug(`RegisterResourceOutputs RPC finished: urn=${urn}; ` +
                         `err: ${err}, resp: ${innerResponse}`);

--- a/sdk/nodejs/tests/runtime/asyncIterableUtil.spec.ts
+++ b/sdk/nodejs/tests/runtime/asyncIterableUtil.spec.ts
@@ -63,7 +63,7 @@ describe("PushableAsyncIterable", () => {
         asyncTest(async () => {
             const queue = new PushableAsyncIterable<number>();
             const queueIter = queue[Symbol.asyncIterator]();
-            const terminates = new Promise(async resolve => {
+            const terminates = new Promise<void>(async resolve => {
                 assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
                 assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });
                 assert.deepStrictEqual(await queueIter.next(), { value: undefined, done: true });

--- a/sdk/nodejs/tests/runtime/tsClosureCases.ts
+++ b/sdk/nodejs/tests/runtime/tsClosureCases.ts
@@ -6128,6 +6128,7 @@ return function () { const v = testConfig.get("TestingKey1"); console.log(v); };
            func: function () { const v = new deploymentOnlyModule.Config("test").get("TestingKey2"); console.log(v); },
            expectText: `exports.handler = __f0;
 
+var __deploymentOnlyModule = {};
 var __f1_prototype = {};
 Object.defineProperty(__f1_prototype, "constructor", { configurable: true, writable: true, value: __f1 });
 var __config = {["test:TestingKey1"]: "TestingValue1", ["test:TestingKey2"]: "TestingValue2"};
@@ -6135,7 +6136,10 @@ var __runtimeConfig_1 = {getConfig: __getConfig};
 Object.defineProperty(__f1_prototype, "get", { configurable: true, writable: true, value: __f2 });
 Object.defineProperty(__f1_prototype, "fullKey", { configurable: true, writable: true, value: __f3 });
 __f1.prototype = __f1_prototype;
-var __deploymentOnlyModule = {Config: __f1};
+var __m = {};
+Object.defineProperty(__m, "__esModule", { value: true });
+__m.Config = __f1;
+Object.defineProperty(__deploymentOnlyModule, "Config", { enumerable: true, get: __f4 });
 
 function __f1(__0) {
   return (function() {
@@ -6187,6 +6191,16 @@ function __f3(__0) {
 return function /*fullKey*/(key) {
         return this.name + ":" + key;
     };
+
+    }
+  }).apply(undefined, undefined).apply(this, arguments);
+}
+
+function __f4() {
+  return (function() {
+    with({ m: __m, k: "Config" }) {
+
+return function () { return m[k]; };
 
     }
   }).apply(undefined, undefined).apply(this, arguments);
@@ -6625,7 +6639,7 @@ return function () { console.log(regex); foo(); };
             });
         }
         else if (test.factoryFunc) {
-            return await runtime.serializeFunction(test.factoryFunc!, { 
+            return await runtime.serializeFunction(test.factoryFunc!, {
               allowSecrets: test.allowSecrets,
               isFactoryFunction: true,
             });


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Precursor to the nodejs part of #5582

This PR kinda goes against the premise of #7184 since updating typescript actually makes this dependency size larger. Wanted to get multiple folks' input on this and what we can do here. 

From @justinvp in slack as to why we need to update typescript:

We’re currently using TypeScript 3.7.7 as declared in @pulumi/pulumi:
https://github.com/pulumi/pulumi/blob/a41ed7594272adcbc5494ddc1f4ed08e64a093c4/sdk/nodejs/package.json#L25

The index.ts inside the config dir basically looks like this:
```
export * from "./vars";
From this, the 3.7.7 TS compiler generates this JS:
"use strict";
function __export(m) {
    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
}
Object.defineProperty(exports, "__esModule", { value: true });
__export(require("./vars"));
//# sourceMappingURL=index.js.map
```

Which doesn’t do what we want... It’ll greedily read each variable from vars once and keep the values, so our getter only gets called once. It’s not lazy and it’s not “live”.
However, the latest 4.3.4 TS compiler generates this JS:
```
"use strict";
var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
    if (k2 === undefined) k2 = k;
    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
}) : (function(o, m, k, k2) {
    if (k2 === undefined) k2 = k;
    o[k2] = m[k];
}));
var __exportStar = (this && this.__exportStar) || function(m, exports) {
    for (var p in m) if (p !== "default" && !Object.prototype.hasOwnProperty.call(exports, p)) __createBinding(exports, m, p);
};
Object.defineProperty(exports, "__esModule", { value: true });
__exportStar(require("./vars"), exports);
//# sourceMappingURL=index.js.map
```

Which does do what we want: it makes it lazy, and each time `aws.config.secretKey` is accessed our getter is called.

Looks like this was changed for TS 3.9 in https://github.com/microsoft/TypeScript/pull/35967

I’m guessing we’re going to need to upgrade the version of TypeScript as part of this work. I’m not sure the implications of that and if it will impact any other areas. Regardless, we’re going to want to upgrade TS at some point eventually  to stay up-to-date.

One thing to note. The new JS that the latest 4.3.4 compiler generates only provides a getter with its use of Object.defineProperty.
So the workaround Luke used at https://github.com/lukehoban/pulumi-package-aws-apigateway/blob/a6ceea9081a4161939670707be20403d1e48123f/provider/cmd/pulumi-resource-apigateway/restAPI.ts#L89-L90 isn’t going to work after we upgrade to the latest TypeScript because `aws.config.secretKey` will no longer be settable at runtime. Trying aws.config.secretKey = "whatever" will no longer work; it fails at runtime with an exception:
```
TypeError: Cannot set property secretKey of #<Object> which has only a getter
```
If setting the value isn’t going to work after upgrading TS, and if we need to upgrade TS for this, there’s really no need to provide a setter or make it configurable: true. And we should consider changing the emitted variables to const rather than let to make it a compiler error to try to set these rather than an error at runtime.
So the simplified version would be something like:
```
const __config = new pulumi.Config("aws");
/**
 * The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
 */
export declare const secretKey: string | undefined;
Object.defineProperty(exports, "secretKey", {
    get() {
        return __config.get("secretKey");
    },
    enumerable: true,
});
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
