### PR TITLE
Add force flag for RemoveStack

### DIFF
--- a/sdk/go/x/auto/errors_test.go
+++ b/sdk/go/x/auto/errors_test.go
@@ -43,7 +43,7 @@ func TestConcurrentUpdateError(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -98,7 +98,7 @@ func TestInlineConcurrentUpdateError(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -150,7 +150,7 @@ func TestCompilationErrorGo(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -202,7 +202,7 @@ func TestCreateStack409Error(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -235,7 +235,7 @@ func TestCompilationErrorDotnet(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -276,7 +276,7 @@ func TestCompilationErrorTypescript(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -310,7 +310,7 @@ func TestRuntimeErrorGo(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -345,7 +345,7 @@ func TestRuntimeErrorInlineGo(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -388,7 +388,7 @@ func TestRuntimeErrorPython(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -429,7 +429,7 @@ func TestRuntimeErrorJavascript(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -470,7 +470,7 @@ func TestRuntimeErrorTypescript(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 
@@ -502,7 +502,7 @@ func TestRuntimeErrorDotnet(t *testing.T) {
 
 	defer func() {
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 		assert.Nil(t, err, "failed to remove stack. Resources have leaked.")
 	}()
 

--- a/sdk/go/x/auto/example_test.go
+++ b/sdk/go/x/auto/example_test.go
@@ -500,7 +500,7 @@ func ExampleLocalWorkspace_RemoveStack() {
 	// create a workspace from a local project
 	w, _ := NewLocalWorkspace(ctx, WorkDir(filepath.Join(".", "program")))
 	stackName := FullyQualifiedStackName("org", "proj", "stack")
-	_ = w.RemoveStack(ctx, stackName)
+	_ = w.RemoveStack(ctx, stackName, false)
 }
 
 func ExampleLocalWorkspace_SelectStack() {
@@ -631,7 +631,7 @@ func ExampleStack() error {
 	defer func() {
 		// Workspace operations can be accessed via Stack.Workspace()
 		// -- pulumi stack rm --
-		err = s.Workspace().RemoveStack(ctx, s.Name())
+		err = s.Workspace().RemoveStack(ctx, s.Name(), false)
 	}()
 
 	err = s.SetAllConfig(ctx, cfg)

--- a/sdk/go/x/auto/local_workspace.go
+++ b/sdk/go/x/auto/local_workspace.go
@@ -345,8 +345,12 @@ func (l *LocalWorkspace) SelectStack(ctx context.Context, stackName string) erro
 }
 
 // RemoveStack deletes the stack and all associated configuration and history.
-func (l *LocalWorkspace) RemoveStack(ctx context.Context, stackName string) error {
-	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "rm", "--yes", stackName)
+func (l *LocalWorkspace) RemoveStack(ctx context.Context, stackName string, force bool) error {
+	args := []string{"stack", "rm", "--yes", stackName}
+	if force {
+		args = append(args, "--force")
+	}
+	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, args...)
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "failed to remove stack"), stdout, stderr, errCode)
 	}

--- a/sdk/go/x/auto/workspace.go
+++ b/sdk/go/x/auto/workspace.go
@@ -81,8 +81,9 @@ type Workspace interface {
 	CreateStack(context.Context, string) error
 	// SelectStack selects and sets an existing stack matching the stack name, failing if none exists.
 	SelectStack(context.Context, string) error
-	// RemoveStack deletes the stack and all associated configuration and history.
-	RemoveStack(context.Context, string) error
+	// RemoveStack deletes the stack and all associated configuration and history,
+	// pass true if you want to forcibly remove the stack
+	RemoveStack(context.Context, string, bool) error
 	// ListStacks returns all Stacks created under the current Project.
 	// This queries underlying backend and may return stacks not present in the Workspace.
 	ListStacks(context.Context) ([]StackSummary, error)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
I'm in the need for forcibly delete certain stacks from the state, even though they have resources in it.
This is relevant for us for kubeneretes stacks that we wish to delete because we are going to destroy the infra stack anyway.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
