### PR TITLE
Add force flag for RemoveStack

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,7 @@
 ### Improvements
 
+- [automation] - Add force flag for RemoveStack in workspace
+  [#7523](https://github.com/pulumi/pulumi/pull/7523)
 ### Bug Fixes
 
 - [cli] - Properly parse Git remotes with periods or hyphens.

--- a/sdk/go/auto/optremove/optremove.go
+++ b/sdk/go/auto/optremove/optremove.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2020, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package optremove contains functional options to be used with workspace stack remove operations
+// github.com/sdk/v2/go/x/auto workspace.RemoveStack(stackName, ...optremove.Option)
+package optremove
+
+// Force causes the remove operation to occur even if there are resources existing in the stack
+func Force() Option {
+	return optionFunc(func(opts *Options) {
+		opts.Force = true
+	})
+}
+
+// Option is a parameter to be applied to a Stack.Remove() operation
+type Option interface {
+	ApplyOption(*Options)
+}
+
+// ---------------------------------- implementation details ----------------------------------
+
+// Options is an implementation detail
+type Options struct {
+	// forces a stack to be deleted
+	Force bool
+}
+
+type optionFunc func(*Options)
+
+// ApplyOption is an implementation detail
+func (o optionFunc) ApplyOption(opts *Options) {
+	o(opts)
+}

--- a/sdk/go/auto/workspace.go
+++ b/sdk/go/auto/workspace.go
@@ -17,8 +17,10 @@ package auto
 import (
 	"context"
 
+	"github.com/pulumi/pulumi/sdk/v3/go/auto/optremove"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 
@@ -84,7 +86,7 @@ type Workspace interface {
 	// SelectStack selects and sets an existing stack matching the stack name, failing if none exists.
 	SelectStack(context.Context, string) error
 	// RemoveStack deletes the stack and all associated configuration and history.
-	RemoveStack(context.Context, string) error
+	RemoveStack(context.Context, string, ...optremove.Option) error
 	// ListStacks returns all Stacks created under the current Project.
 	// This queries underlying backend and may return stacks not present in the Workspace.
 	ListStacks(context.Context) ([]StackSummary, error)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
I'm in the need for forcibly delete certain stacks from the state, even though they have resources in it.
This is relevant for us for kubeneretes stacks that we wish to delete because we are going to destroy the infra stack anyway.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
