### PR TITLE
update gRPC client to grpc-dotnet

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,6 +4,7 @@
 
 - [schema] - Support for unmarshaling/marshaling schemas from/to YAML
   [#7509](https://github.com/pulumi/pulumi/pull/7509)
+- [sdk/dotnet] - Update gRPC client to [grpc-dotnet](https://grpc.io/blog/grpc-csharp-future/). Fixes missing libgrpc for Apple silicon.
 
 ### Bug Fixes
 

--- a/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
+++ b/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
@@ -1,8 +1,9 @@
 // Copyright 2016-2020, Pulumi Corporation
 
-using System.Collections.Generic;
+using System;
 using System.Threading.Tasks;
 using Grpc.Core;
+using Grpc.Net.Client;
 using Pulumirpc;
 
 namespace Pulumi
@@ -15,8 +16,8 @@ namespace Pulumi
         {
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             var maxRpcMessageSize = 400 * 1024 * 1024;
-            var grpcChannelOptions = new List<ChannelOption> { new ChannelOption(ChannelOptions.MaxReceiveMessageLength, maxRpcMessageSize)};
-            this._engine = new Engine.EngineClient(new Channel(engine, ChannelCredentials.Insecure, grpcChannelOptions));
+            var grpcChannelOptions = new GrpcChannelOptions { MaxReceiveMessageSize = maxRpcMessageSize, Credentials = ChannelCredentials.Insecure };
+            this._engine = new Engine.EngineClient(GrpcChannel.ForAddress(new Uri($"http://{engine}"), grpcChannelOptions));
         }
         
         public async Task LogAsync(LogRequest request)

--- a/sdk/dotnet/Pulumi/Deployment/GrpcMonitor.cs
+++ b/sdk/dotnet/Pulumi/Deployment/GrpcMonitor.cs
@@ -1,8 +1,9 @@
 // Copyright 2016-2020, Pulumi Corporation
 
-using System.Collections.Generic;
+using System;
 using System.Threading.Tasks;
 using Grpc.Core;
+using Grpc.Net.Client;
 using Pulumirpc;
 
 namespace Pulumi
@@ -15,8 +16,9 @@ namespace Pulumi
         {
             // maxRpcMessageSize raises the gRPC Max Message size from `4194304` (4mb) to `419430400` (400mb)
             var maxRpcMessageSize = 400 * 1024 * 1024;
-            var grpcChannelOptions = new List<ChannelOption> { new ChannelOption(ChannelOptions.MaxReceiveMessageLength, maxRpcMessageSize)};
-            this._client = new ResourceMonitor.ResourceMonitorClient(new Channel(monitor, ChannelCredentials.Insecure, grpcChannelOptions));
+            var grpcChannelOptions = new GrpcChannelOptions { MaxReceiveMessageSize = maxRpcMessageSize, Credentials = ChannelCredentials.Insecure };
+            this._client =
+                new ResourceMonitor.ResourceMonitorClient(GrpcChannel.ForAddress(new Uri($"http://{monitor}"), grpcChannelOptions));
         }
         
         public async Task<SupportsFeatureResponse> SupportsFeatureAsync(SupportsFeatureRequest request)

--- a/sdk/dotnet/Pulumi/Pulumi.csproj
+++ b/sdk/dotnet/Pulumi/Pulumi.csproj
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ben.Demystifier" Version="0.4.1" />
-    <PackageReference Include="Grpc" Version="2.37.0" />
-    <PackageReference Include="Grpc.Tools" Version="2.37.0">
+    <PackageReference Include="Grpc.Net.Client" Version="2.38.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.38.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes 
- Missing libgrpc dependency for Apple silicon (used by Grpc.Core)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
There are already test cases that cover this change
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
