### PR TITLE
[codegen/python] - Fix required vs default values in provider config

### DIFF
--- a/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/config/__init__.pyi
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/config/__init__.pyi
@@ -17,13 +17,13 @@ favoriteSandwich: Optional[str]
 omg my favorite sandwich
 """
 
-isMember: Optional[str]
+isMember: bool
 
 kids: Optional[str]
 
-name: str
+name: Optional[str]
 
-numberOfSheep: Optional[str]
+numberOfSheep: Optional[int]
 
 secretCode: Optional[str]
 """

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/config/vars.py
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/config/vars.py
@@ -28,7 +28,7 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get('favoriteSandwich')
 
     @property
-    def is_member(self) -> Optional[str]:
+    def is_member(self) -> str:
         return __config__.get('isMember') or True
 
     @property
@@ -36,7 +36,7 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get('kids')
 
     @property
-    def name(self) -> str:
+    def name(self) -> Optional[str]:
         return __config__.get('name')
 
     @property

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/config/vars.py
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/config/vars.py
@@ -28,8 +28,8 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get('favoriteSandwich')
 
     @property
-    def is_member(self) -> str:
-        return __config__.get('isMember') or True
+    def is_member(self) -> bool:
+        return __config__.get_bool('isMember') or True
 
     @property
     def kids(self) -> Optional[str]:
@@ -40,8 +40,8 @@ class _ExportableConfig(types.ModuleType):
         return __config__.get('name')
 
     @property
-    def number_of_sheep(self) -> Optional[str]:
-        return __config__.get('numberOfSheep')
+    def number_of_sheep(self) -> Optional[int]:
+        return __config__.get_int('numberOfSheep')
 
     @property
     def secret_code(self) -> Optional[str]:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes the type annotations for config variables with default values. In doing this, I realized that some of the existing type annotations were really broken, for instance:

```python
@property
def is_member(self) -> str:
    return __config__.get('isMember') or True
```

This will actually return a string or a bool... so the type hint is definitely wrong (and it's also just bizarre behavior). 

I decided to fix the type annotations and corresponding `config.get` functions for primitive types. This seems like a palatable breaking change, not quite going to the extents of the more complex objects which are still tracked in #7493 which would be a more obviously breaking change for users.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
Not updating CHANGELOG-PENDING as this is a follow-on from #7447 
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
