### PR TITLE
[sdk/dotnet] Fix async await warnings

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,9 @@
 
 ### Improvements
   
+- [sdk/dotnet] - Fix async await warnings
+  [#7537](https://github.com/pulumi/pulumi/pull/7537)
+
 - [codegen/dotnet] - Emit dynamic config-getters.
   [#7549](https://github.com/pulumi/pulumi/pull/7549)
 

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalWorkspaceTests.cs
@@ -1655,13 +1655,13 @@ namespace Pulumi.Automation.Tests
             var program = PulumiFn.Create(() =>
             {
                 var config = new Config();
-                var a = new ComponentResource("test:res:a", "a", null);
+                new ComponentResource("test:res:a", "a");
 
                 if (config.GetBoolean("ShouldFail") == true)
                     throw new FileNotFoundException("ShouldFail");
 
-                var b = new ComponentResource("test:res:b", "b", null);
-                var c = new ComponentResource("test:res:c", "c", null);
+                new ComponentResource("test:res:b", "b");
+                new ComponentResource("test:res:c", "c");
             });
             Assert.IsType<PulumiFnInline>(program);
 
@@ -1675,12 +1675,12 @@ namespace Pulumi.Automation.Tests
                 }
             });
 
-            var config = new Dictionary<string, ConfigValue>()
-            {
-                ["ShouldFail"] = new ConfigValue("false"),
-            };
             try
             {
+                var config = new Dictionary<string, ConfigValue>
+                {
+                    ["ShouldFail"] = new ConfigValue("false"),
+                };
                 await stack.SetAllConfigAsync(config);
 
                 // pulumi up

--- a/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
+++ b/sdk/dotnet/Pulumi.Automation/Commands/LocalPulumiCmd.cs
@@ -34,12 +34,12 @@ namespace Pulumi.Automation.Commands
                 using var eventLogWatcher = new EventLogWatcher(eventLogFile.FilePath, onEngineEvent, cancellationToken);
                 try
                 {
-                    return await RunAsyncInner(args, workingDir, additionalEnv, onStandardOutput, onStandardError, eventLogFile, cancellationToken);
+                    return await RunAsyncInner(args, workingDir, additionalEnv, onStandardOutput, onStandardError, eventLogFile, cancellationToken).ConfigureAwait(false);
                 } finally {
-                    await eventLogWatcher.Stop();
+                    await eventLogWatcher.Stop().ConfigureAwait(false);
                 }
             }
-            return await RunAsyncInner(args, workingDir, additionalEnv, onStandardOutput, onStandardError, eventLogFile: null, cancellationToken);
+            return await RunAsyncInner(args, workingDir, additionalEnv, onStandardOutput, onStandardError, eventLogFile: null, cancellationToken).ConfigureAwait(false);
         }
 
         private async Task<CommandResult> RunAsyncInner(

--- a/sdk/dotnet/Pulumi.Automation/Events/EventLogWatcher.cs
+++ b/sdk/dotnet/Pulumi.Automation/Events/EventLogWatcher.cs
@@ -37,7 +37,7 @@ namespace Pulumi.Automation.Events
         internal async Task Stop()
         {
             this._internalCancellationTokenSource.Cancel();
-            await this.AwaitPollingTask();
+            await this.AwaitPollingTask().ConfigureAwait(false);
 
             // Race condition workaround.
             //
@@ -53,8 +53,8 @@ namespace Pulumi.Automation.Events
             // a CommandDone or some such EngineEvent, and we would
             // keep reading until we see one.
 
-            await Task.Delay(_pollingIntervalMilliseconds);
-            await ReadEventsOnce();
+            await Task.Delay(_pollingIntervalMilliseconds).ConfigureAwait(false);
+            await ReadEventsOnce().ConfigureAwait(false);
         }
 
         /// Exposed for testing; use Stop instead.
@@ -62,7 +62,7 @@ namespace Pulumi.Automation.Events
         {
             try
             {
-                await this._pollingTask;
+                await this._pollingTask.ConfigureAwait(false);
             }
             catch (OperationCanceledException error) when (error.CancellationToken == this._cancellationToken)
             {
@@ -79,8 +79,8 @@ namespace Pulumi.Automation.Events
 
             while (true)
             {
-                await ReadEventsOnce();
-                await Task.Delay(_pollingIntervalMilliseconds, linkedSource.Token);
+                await ReadEventsOnce().ConfigureAwait(false);
+                await Task.Delay(_pollingIntervalMilliseconds, linkedSource.Token).ConfigureAwait(false);
             }
             // ReSharper disable once FunctionNeverReturns
         }
@@ -96,7 +96,7 @@ namespace Pulumi.Automation.Events
             using var reader = new StreamReader(fs);
             while (reader.Peek() >= 0)
             {
-                var line = await reader.ReadLineAsync();
+                var line = await reader.ReadLineAsync().ConfigureAwait(false);
                 this._position = fs.Position;
                 if (!string.IsNullOrWhiteSpace(line))
                 {

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -354,10 +354,10 @@ namespace Pulumi.Automation
             // the working dir. We do not want to override existing
             // settings with default settings though.
 
-            var existingSettings = await this.GetProjectSettingsAsync(cancellationToken);
+            var existingSettings = await this.GetProjectSettingsAsync(cancellationToken).ConfigureAwait(false);
             if (existingSettings == null)
             {
-                await this.SaveProjectSettingsAsync(projectSettings, cancellationToken);
+                await this.SaveProjectSettingsAsync(projectSettings, cancellationToken).ConfigureAwait(false);
             }
             else if (!projectSettings.IsDefault &&
                      !ProjectSettings.Comparer.Equals(projectSettings, existingSettings))
@@ -539,9 +539,7 @@ namespace Pulumi.Automation
 
         /// <inheritdoc/>
         public override async Task RemoveConfigAsync(string stackName, string key, CancellationToken cancellationToken = default)
-        {
-            await this.RunCommandAsync(new[] { "config", "rm", key, "--stack", stackName }, cancellationToken).ConfigureAwait(false);
-        }
+            => await this.RunCommandAsync(new[] { "config", "rm", key, "--stack", stackName }, cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc/>
         public override async Task RemoveAllConfigAsync(string stackName, IEnumerable<string> keys, CancellationToken cancellationToken = default)
@@ -615,7 +613,7 @@ namespace Pulumi.Automation
             var tempFileName = Path.GetTempFileName();
             try
             {
-                await File.WriteAllTextAsync(tempFileName, state.Json.GetRawText(), cancellationToken);
+                await File.WriteAllTextAsync(tempFileName, state.Json.GetRawText(), cancellationToken).ConfigureAwait(false);
                 await this.RunCommandAsync(new[] { "stack", "import", "--file", tempFileName, "--stack", stackName },
                                            cancellationToken).ConfigureAwait(false);
             }

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -739,6 +739,12 @@
             A Pulumi program as an inline function (in process).
             </summary>
         </member>
+        <member name="M:Pulumi.Automation.PulumiFn.InvokeAsync(Pulumi.IRunner,System.Threading.CancellationToken)">
+            <summary>
+            Invoke the appropriate run function on the <see cref="T:Pulumi.IRunner"/> instance. The exit code returned
+            from the appropriate run function should be forwarded here as well.
+            </summary>
+        </member>
         <member name="M:Pulumi.Automation.PulumiFn.Create(System.Func{System.Threading.CancellationToken,System.Threading.Tasks.Task{System.Collections.Generic.IDictionary{System.String,System.Object}}})">
             <summary>
             Creates an asynchronous inline (in process) pulumi program.
@@ -802,6 +808,15 @@
             </summary>
             <param name="serviceProvider">The service provider that will be used to resolve an instance of type <paramref name="stackType"/>.</param>
             <param name="stackType">The stack type, which must derive from <see cref="T:Pulumi.Stack"/>.</param>
+        </member>
+        <member name="M:Pulumi.Automation.PulumiFnInline.InvokeAsync(Pulumi.IRunner,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Pulumi.Automation.PulumiFnServiceProvider.InvokeAsync(Pulumi.IRunner,System.Threading.CancellationToken)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Pulumi.Automation.PulumiFn`1.InvokeAsync(Pulumi.IRunner,System.Threading.CancellationToken)">
+            <inheritdoc/>
         </member>
         <member name="T:Pulumi.Automation.RefreshOptions">
             <summary>

--- a/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
+++ b/sdk/dotnet/Pulumi.Automation/Runtime/LanguageRuntimeService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright 2016-2021, Pulumi Corporation
 
-using System;
 using System.Linq;
 using System.Runtime.ExceptionServices;
 using System.Threading;
@@ -57,6 +56,7 @@ namespace Pulumi.Automation
 
             var result = await Deployment.RunInlineAsync(
                 settings,
+                // ReSharper disable once AccessToDisposedClosure
                 runner => this._callerContext.Program.InvokeAsync(runner, cts.Token))
                 .ConfigureAwait(false);
 

--- a/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
+++ b/sdk/dotnet/Pulumi.Automation/WorkspaceStack.cs
@@ -642,10 +642,7 @@ namespace Pulumi.Automation
         /// supported for local backends.
         /// </summary>
         public async Task CancelAsync(CancellationToken cancellationToken = default)
-        {
-            await this.Workspace.RunCommandAsync(new[] { "cancel", "--stack", this.Name, "--yes" }, cancellationToken)
-                .ConfigureAwait(false);
-        }
+            => await this.Workspace.RunCommandAsync(new[] { "cancel", "--stack", this.Name, "--yes" }, cancellationToken).ConfigureAwait(false);
 
         private async Task<CommandResult> RunCommandAsync(
             IList<string> args,
@@ -655,7 +652,7 @@ namespace Pulumi.Automation
             CancellationToken cancellationToken)
         {
             args = args.Concat(new[] { "--stack", this.Name }).ToList();
-            return await this.Workspace.RunStackCommandAsync(this.Name, args, onStandardOutput, onStandardError, onEngineEvent, cancellationToken);
+            return await this.Workspace.RunStackCommandAsync(this.Name, args, onStandardOutput, onStandardError, onEngineEvent, cancellationToken).ConfigureAwait(false);
         }
 
         public void Dispose()

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.EnginerLogger.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.EnginerLogger.cs
@@ -115,7 +115,7 @@ namespace Pulumi
                         Urn = urn,
                         StreamId = streamId ?? 0,
                         Ephemeral = ephemeral ?? false,
-                    });
+                    }).ConfigureAwait(false);
                 }
                 catch (Exception e)
                 {

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Invoke.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Invoke.cs
@@ -19,7 +19,7 @@ namespace Pulumi
         private async Task<T> InvokeAsync<T>(
             string token, InvokeArgs args, InvokeOptions? options, bool convertResult)
         {
-            var result = await InvokeRawAsync(token, args, options);
+            var result = await InvokeRawAsync(token, args, options).ConfigureAwait(false);
             
             if (!convertResult)
             {
@@ -56,7 +56,7 @@ namespace Pulumi
                 Version = options?.Version ?? "",
                 Args = serialized,
                 AcceptResources = !_disableResourceReferences,
-            });
+            }).ConfigureAwait(false);
 
             if (result.Failures.Count > 0)
             {

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Prepare.cs
@@ -154,7 +154,7 @@ namespace Pulumi
 
             var transitivelyReachableCustomResources = transitivelyReachableResources.Where(res => {
                 switch (res) {
-                    case CustomResource custom: return true;
+                    case CustomResource _: return true;
                     case ComponentResource component: return component.remote;
                     default: return false; // Unreachable
                 }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_ReadOrRegisterResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_ReadOrRegisterResource.cs
@@ -45,7 +45,7 @@ namespace Pulumi
                 var result = await InvokeRawAsync(
                     "pulumi:pulumi:getResource",
                     new GetResourceInvokeArgs {Urn = options.Urn},
-                    new InvokeOptions());
+                    new InvokeOptions()).ConfigureAwait(false);
                 
                 var urn = result.Fields["urn"].StringValue;
                 var id = result.Fields["id"].StringValue;

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_ReadResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_ReadResource.cs
@@ -40,7 +40,7 @@ namespace Pulumi
             request.Dependencies.AddRange(prepareResult.AllDirectDependencyUrns);
 
             // Now run the operation, serializing the invocation if necessary.
-            var response = await this.Monitor.ReadResourceAsync(resource, request);
+            var response = await this.Monitor.ReadResourceAsync(resource, request).ConfigureAwait(false);
 
             return (response.Urn, id, response.Properties, ImmutableDictionary<string, ImmutableHashSet<Resource>>.Empty);
         }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResource.cs
@@ -30,7 +30,7 @@ namespace Pulumi
             PopulateRequest(request, prepareResult);
 
             Log.Debug($"Registering resource monitor start: t={type}, name={name}, custom={custom}, remote={remote}");
-            var result = await this.Monitor.RegisterResourceAsync(resource, request);
+            var result = await this.Monitor.RegisterResourceAsync(resource, request).ConfigureAwait(false);
             Log.Debug($"Registering resource monitor end: t={type}, name={name}, custom={custom}, remote={remote}");
 
             var dependencies = ImmutableDictionary.CreateBuilder<string, ImmutableHashSet<Resource>>();

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResourceOutputs.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResourceOutputs.cs
@@ -37,7 +37,7 @@ namespace Pulumi
             {
                 Urn = urn,
                 Outputs = serialized,
-            });
+            }).ConfigureAwait(false);
         }
     }
 }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_RootResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_RootResource.cs
@@ -42,9 +42,9 @@ namespace Pulumi
             await this.Engine.SetRootResourceAsync(new SetRootResourceRequest
             {
                 Urn = resUrn,
-            });
+            }).ConfigureAwait(false);
 
-            var getResponse = await this.Engine.GetRootResourceAsync(new GetRootResourceRequest());
+            var getResponse = await this.Engine.GetRootResourceAsync(new GetRootResourceRequest()).ConfigureAwait(false);
             return getResponse.Urn;
         }
     }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_Run.cs
@@ -37,7 +37,7 @@ namespace Pulumi
         public static Task<int> RunAsync(Func<Task> func)
             => RunAsync(async () =>
             {
-                await func();
+                await func().ConfigureAwait(false);
                 return ImmutableDictionary<string, object?>.Empty;
             });
 

--- a/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
+++ b/sdk/dotnet/Pulumi/Deployment/GrpcEngine.cs
@@ -21,7 +21,7 @@ namespace Pulumi
         
         public async Task LogAsync(LogRequest request)
             => await this._engine.LogAsync(request);
-        
+
         public async Task<SetRootResourceResponse> SetRootResourceAsync(SetRootResourceRequest request)
             => await this._engine.SetRootResourceAsync(request);
 

--- a/sdk/dotnet/Pulumi/Deployment/InlineDeploymentResult.cs
+++ b/sdk/dotnet/Pulumi/Deployment/InlineDeploymentResult.cs
@@ -6,7 +6,7 @@ namespace Pulumi
 {
     internal class InlineDeploymentResult
     {
-        public int ExitCode { get; set; } = 0;
+        public int ExitCode { get; set; }
 
         public ExceptionDispatchInfo? ExceptionDispatchInfo { get; set; }
     }


### PR DESCRIPTION
# Description

Fixes async await warnings found while looking into #7422. (Does not fix #7422 itself.)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
