### PR TITLE
[codegen/nodejs] Fix missing args param

### DIFF
--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/foo.go
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/foo.go
@@ -105,6 +105,42 @@ func (r *Foo) Baz(ctx *pulumi.Context) error {
 	return err
 }
 
+// Do something with something else
+func (r *Foo) GenerateKubeconfig(ctx *pulumi.Context, args *FooGenerateKubeconfigArgs) (FooGenerateKubeconfigResultOutput, error) {
+	out, err := ctx.Call("example::Foo/generateKubeconfig", args, FooGenerateKubeconfigResultOutput{}, r)
+	if err != nil {
+		return FooGenerateKubeconfigResultOutput{}, err
+	}
+	return out.(FooGenerateKubeconfigResultOutput), nil
+}
+
+type fooGenerateKubeconfigArgs struct {
+	BoolValue bool `pulumi:"boolValue"`
+}
+
+// The set of arguments for the GenerateKubeconfig method of the Foo resource.
+type FooGenerateKubeconfigArgs struct {
+	BoolValue bool
+}
+
+func (FooGenerateKubeconfigArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*fooGenerateKubeconfigArgs)(nil)).Elem()
+}
+
+type FooGenerateKubeconfigResult struct {
+	Kubeconfig string `pulumi:"kubeconfig"`
+}
+
+type FooGenerateKubeconfigResultOutput struct{ *pulumi.OutputState }
+
+func (FooGenerateKubeconfigResultOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*FooGenerateKubeconfigResult)(nil)).Elem()
+}
+
+func (o FooGenerateKubeconfigResultOutput) Kubeconfig() pulumi.StringOutput {
+	return o.ApplyT(func(v FooGenerateKubeconfigResult) string { return v.Kubeconfig }).(pulumi.StringOutput)
+}
+
 type FooInput interface {
 	pulumi.Input
 
@@ -143,4 +179,5 @@ func (o FooOutput) ToFooOutputWithContext(ctx context.Context) FooOutput {
 func init() {
 	pulumi.RegisterOutputType(FooOutput{})
 	pulumi.RegisterOutputType(FooBarResultOutput{})
+	pulumi.RegisterOutputType(FooGenerateKubeconfigResultOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/nodejs/foo.ts
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/nodejs/foo.ts
@@ -68,6 +68,16 @@ export class Foo extends pulumi.ComponentResource {
             "__self__": this,
         }, this);
     }
+
+    /**
+     * Do something with something else
+     */
+    generateKubeconfig(args: Foo.GenerateKubeconfigArgs): pulumi.Output<Foo.GenerateKubeconfigResult> {
+        return pulumi.runtime.call("example::Foo/generateKubeconfig", {
+            "__self__": this,
+            "boolValue": args.boolValue,
+        }, this);
+    }
 }
 
 /**
@@ -100,6 +110,20 @@ export namespace Foo {
      */
     export interface BarResult {
         readonly someValue: string;
+    }
+
+    /**
+     * The set of arguments for the Foo.generateKubeconfig method.
+     */
+    export interface GenerateKubeconfigArgs {
+        boolValue: boolean;
+    }
+
+    /**
+     * The results of the Foo.generateKubeconfig method.
+     */
+    export interface GenerateKubeconfigResult {
+        readonly kubeconfig: string;
     }
 
 }

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/python/pulumi_example/foo.py
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/python/pulumi_example/foo.py
@@ -125,3 +125,25 @@ class Foo(pulumi.ComponentResource):
         __args__['__self__'] = __self__
         pulumi.runtime.call('example::Foo/baz', __args__, res=__self__)
 
+    @pulumi.output_type
+    class GenerateKubeconfigResult:
+        def __init__(__self__, kubeconfig=None):
+            if kubeconfig and not isinstance(kubeconfig, str):
+                raise TypeError("Expected argument 'kubeconfig' to be a str")
+            pulumi.set(__self__, "kubeconfig", kubeconfig)
+
+        @property
+        @pulumi.getter
+        def kubeconfig(self) -> str:
+            return pulumi.get(self, "kubeconfig")
+
+    def generate_kubeconfig(__self__, *,
+                            bool_value: bool) -> pulumi.Output['Foo.GenerateKubeconfigResult']:
+        """
+        Do something with something else
+        """
+        __args__ = dict()
+        __args__['__self__'] = __self__
+        __args__['boolValue'] = bool_value
+        return pulumi.runtime.call('example::Foo/generateKubeconfig', __args__, res=__self__, typ=Foo.GenerateKubeconfigResult)
+

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/schema.json
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/schema.json
@@ -19,7 +19,8 @@
             "isComponent": true,
             "methods": {
                 "bar": "example::Foo/bar",
-                "baz": "example::Foo/baz"
+                "baz": "example::Foo/baz",
+                "generateKubeconfig": "example::Foo/generateKubeconfig"
             }
         }
     },
@@ -100,6 +101,34 @@
                 },
                 "required": [
                     "__self__"
+                ]
+            }
+        },
+        "example::Foo/generateKubeconfig": {
+            "description": "Do something with something else",
+            "inputs": {
+                "properties": {
+                    "__self__": {
+                        "$ref": "#/resources/example::Foo"
+                    },
+                    "boolValue": {
+                        "type": "boolean",
+                        "plain": true
+                    }
+                },
+                "required": [
+                    "__self__",
+                    "boolValue"
+                ]
+            },
+            "outputs": {
+                "properties": {
+                    "kubeconfig": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "kubeconfig"
                 ]
             }
         }

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -726,7 +726,6 @@ func (mod *modContext) genResource(w io.Writer, r *schema.Resource) error {
 				}
 				if arg.IsRequired() {
 					argsOptional = false
-					break
 				}
 				args = append(args, arg)
 			}


### PR DESCRIPTION
This is the before/after:

```diff
-generateKubeconfig(): pulumi.Output<Foo.GenerateKubeconfigResult> {
+generateKubeconfig(args: Foo.GenerateKubeconfigArgs): pulumi.Output<Foo.GenerateKubeconfigResult> {
```

Fixes #7538