### PR TITLE
[codegen/hcl2] Improve ConversionFrom perf.

### DIFF
--- a/pkg/codegen/hcl2/model/diagnostics.go
+++ b/pkg/codegen/hcl2/model/diagnostics.go
@@ -35,7 +35,8 @@ func diagf(severity hcl.DiagnosticSeverity, subject hcl.Range, f string, args ..
 }
 
 func ExprNotConvertible(destType Type, expr Expression) *hcl.Diagnostic {
-	_, why := destType.conversionFrom(expr.Type(), false, map[Type]struct{}{})
+	_, whyF := destType.conversionFrom(expr.Type(), false, map[Type]struct{}{})
+	why := whyF()
 	if len(why) != 0 {
 		return errorf(expr.SyntaxNode().Range(), why[0].Summary)
 	}

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -45,7 +45,6 @@ type Type interface {
 
 	equals(other Type, seen map[Type]struct{}) bool
 	conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics)
-	//conversionTo(dest Type, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics)
 	string(seen map[Type]struct{}) string
 	unify(other Type) (Type, ConversionKind)
 	isType()

--- a/pkg/codegen/hcl2/model/type_const.go
+++ b/pkg/codegen/hcl2/model/type_const.go
@@ -74,8 +74,8 @@ func (t *ConstType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *ConstType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, hcl.Diagnostics) {
+func (t *ConstType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
 		if t.Type.ConversionFrom(src) != NoConversion {
 			return UnsafeConversion, nil
 		}

--- a/pkg/codegen/hcl2/model/type_eventuals.go
+++ b/pkg/codegen/hcl2/model/type_eventuals.go
@@ -69,7 +69,7 @@ func resolveEventualsImpl(t Type, resolveOutputs bool, seen map[Type]Type) (Type
 			}
 			elementTypes[i] = element
 		}
-		return NewUnionType(elementTypes...), transform
+		return NewUnionTypeAnnotated(elementTypes, t.Annotations...), transform
 	case *ObjectType:
 		transform := makeIdentity
 		if already, ok := seen[t]; ok {
@@ -267,10 +267,6 @@ func inputTypeImpl(t Type, seen map[Type]Type) Type {
 		return t
 	}
 
-	if already, ok := seen[t]; ok {
-		return already
-	}
-
 	var src Type
 	switch t := t.(type) {
 	case *OutputType:
@@ -288,6 +284,10 @@ func inputTypeImpl(t Type, seen map[Type]Type) Type {
 		}
 		src = NewUnionTypeAnnotated(elementTypes, t.Annotations...)
 	case *ObjectType:
+		if already, ok := seen[t]; ok {
+			return already
+		}
+
 		properties := map[string]Type{}
 		src = NewObjectType(properties, t.Annotations...)
 		seen[t] = src

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -92,8 +92,8 @@ func (t *ListType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *ListType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, hcl.Diagnostics) {
+func (t *ListType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *ListType:
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)
@@ -101,7 +101,7 @@ func (t *ListType) conversionFrom(src Type, unifying bool, seen map[Type]struct{
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)
 		case *TupleType:
 			conversionKind := SafeConversion
-			var diags hcl.Diagnostics
+			var diags lazyDiagnostics
 			for _, src := range src.ElementTypes {
 				if ck, why := t.ElementType.conversionFrom(src, unifying, seen); ck < conversionKind {
 					conversionKind, diags = ck, why
@@ -112,7 +112,7 @@ func (t *ListType) conversionFrom(src Type, unifying bool, seen map[Type]struct{
 			}
 			return conversionKind, diags
 		}
-		return NoConversion, hcl.Diagnostics{typeNotConvertible(t, src)}
+		return NoConversion, func() hcl.Diagnostics { return hcl.Diagnostics{typeNotConvertible(t, src)} }
 	})
 }
 

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -93,14 +93,14 @@ func (t *MapType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *MapType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, hcl.Diagnostics) {
+func (t *MapType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *MapType:
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)
 		case *ObjectType:
 			conversionKind := SafeConversion
-			var diags hcl.Diagnostics
+			var diags lazyDiagnostics
 			for _, src := range src.Properties {
 				if ck, _ := t.ElementType.conversionFrom(src, unifying, seen); ck < conversionKind {
 					conversionKind = ck
@@ -111,7 +111,7 @@ func (t *MapType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}
 			}
 			return conversionKind, diags
 		}
-		return NoConversion, hcl.Diagnostics{typeNotConvertible(t, src)}
+		return NoConversion, func() hcl.Diagnostics { return hcl.Diagnostics{typeNotConvertible(t, src)} }
 	})
 }
 

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -49,8 +49,8 @@ func (noneType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (noneType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
-	return conversionFrom(NoneType, src, unifying, seen, func() (ConversionKind, hcl.Diagnostics) {
+func (noneType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(NoneType, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
 		return NoConversion, nil
 	})
 }

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -96,8 +96,8 @@ func (t *OpaqueType) AssignableFrom(src Type) bool {
 }
 
 func (t *OpaqueType) conversionFromImpl(
-	src Type, unifying, checkUnsafe bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, hcl.Diagnostics) {
+	src Type, unifying, checkUnsafe bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
 		if constType, ok := src.(*ConstType); ok {
 			return t.conversionFrom(constType.Type, unifying, seen)
 		}
@@ -150,7 +150,7 @@ func (t *OpaqueType) conversionFromImpl(
 	})
 }
 
-func (t *OpaqueType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
+func (t *OpaqueType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
 	return t.conversionFromImpl(src, unifying, true, seen)
 }
 

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -81,8 +81,8 @@ func (t *OutputType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *OutputType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, hcl.Diagnostics) {
+func (t *OutputType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *OutputType:
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -79,8 +79,8 @@ func (t *PromiseType) ConversionFrom(src Type) ConversionKind {
 }
 
 func (t *PromiseType) conversionFrom(
-	src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, hcl.Diagnostics) {
+	src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
 		if src, ok := src.(*PromiseType); ok {
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)
 		}

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -76,8 +76,8 @@ func (t *SetType) ConversionFrom(src Type) ConversionKind {
 	return kind
 }
 
-func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, hcl.Diagnostics) {
-	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, hcl.Diagnostics) {
+func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}) (ConversionKind, lazyDiagnostics) {
+	return conversionFrom(t, src, unifying, seen, func() (ConversionKind, lazyDiagnostics) {
 		switch src := src.(type) {
 		case *SetType:
 			return t.ElementType.conversionFrom(src.ElementType, unifying, seen)
@@ -94,7 +94,7 @@ func (t *SetType) conversionFrom(src Type, unifying bool, seen map[Type]struct{}
 			}
 			return UnsafeConversion, nil
 		}
-		return NoConversion, hcl.Diagnostics{typeNotConvertible(t, src)}
+		return NoConversion, func() hcl.Diagnostics { return hcl.Diagnostics{typeNotConvertible(t, src)} }
 	})
 }
 

--- a/pkg/codegen/hcl2/model/type_union.go
+++ b/pkg/codegen/hcl2/model/type_union.go
@@ -198,6 +198,7 @@ func (t *UnionType) conversionFrom(src Type, unifying bool, seen map[Type]struct
 			return NoConversion, func() hcl.Diagnostics {
 				var all hcl.Diagnostics
 				for _, why := range diags {
+					//nolint:errcheck
 					all.Extend(why())
 				}
 				return all


### PR DESCRIPTION
- Lazily produce conversion failure diagnostics. This lowers the
  allocation volume and cuts down on execution time by avoiding the
  conversion of source and dest types to strings.
- Add a fast path for union conversions that checks if the source type
  is identical to any of the union's element types. Type equality
  checks are generally much faster than type conversion checks.

These changes lead to a significant speedup in codegen time in
azure-native.