### PR TITLE
[codegen/go] Improve codegen performance.

### DIFF
--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -6,6 +6,7 @@ import (
 	gofmt "go/format"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/pkg/errors"
@@ -100,7 +101,13 @@ func GenerateProgram(program *hcl2.Program) (map[string][]byte, hcl.Diagnostics,
 	return files, g.diagnostics, nil
 }
 
+var packageContexts sync.Map
+
 func getPackages(tool string, pkg *schema.Package) map[string]*pkgContext {
+	if v, ok := packageContexts.Load(pkg); ok {
+		return v.(map[string]*pkgContext)
+	}
+
 	if err := pkg.ImportLanguages(map[string]schema.Language{"go": Importer}); err != nil {
 		return nil
 	}
@@ -109,7 +116,9 @@ func getPackages(tool string, pkg *schema.Package) map[string]*pkgContext {
 	if goInfo, ok := pkg.Language["go"].(GoPackageInfo); ok {
 		goPkgInfo = goInfo
 	}
-	return generatePackageContextMap(tool, pkg, goPkgInfo)
+	v := generatePackageContextMap(tool, pkg, goPkgInfo)
+	packageContexts.Store(pkg, v)
+	return v
 }
 
 func (g *generator) collectScopeRoots(n hcl2.Node) {


### PR DESCRIPTION
- Track which languages have been imported for a package. If a language
  has already been imported, do not re-run its importers.
- Track which package contexts have been loaded in the Go code
  generator, and do not reload a context that already exists.

These changes shave a significant amount of time off of codegen in
azure-native.