### PR TITLE
[codegen/pcl] Allocate fewer type instances.

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -47,7 +47,7 @@ type binder struct {
 	options bindOptions
 
 	referencedPackages map[string]*schema.Package
-	typeSchemas        map[model.Type]schema.Type
+	schemaTypes        map[schema.Type]model.Type
 
 	tokens syntax.TokenMap
 	nodes  []Node
@@ -117,7 +117,7 @@ func BindProgram(files []*syntax.File, opts ...BindOption) (*Program, hcl.Diagno
 		options:            options,
 		tokens:             syntax.NewTokenMapForFiles(files),
 		referencedPackages: map[string]*schema.Package{},
-		typeSchemas:        map[model.Type]schema.Type{},
+		schemaTypes:        map[schema.Type]model.Type{},
 		root:               model.NewRootScope(syntax.None),
 	}
 


### PR DESCRIPTION
When converting a `schema.InputType` to a `model.Type`, calculate the
resolved form of the type in the schema type system rather than the
model type system. The results are semantically identical, but the
number of type objects that are allocated is much smaller b/c
`model.NewOutputType` no longer allocates.

This deserves a little more explanation.

In order to prevent nested outputs and/or promises, `model.NewOutputType`
calculates the resolved form of its argument prior to allocating a new
`OutputType` value. Calculating the resolved form of the argument is a
no-op if the argument is already fully resolved. Therefore, passing in a
fully-resolved schema type prevents `model.NewOutputType` from
calulating the resolved form, and `model.NewOutputType` will only
allocate the `OutputType` itself instead of the `OutputType` and the
resolved form of any eventuals present in its argument.

This has a _very important_ knock-on benefit: the schema -> model type
translator ensures that given a `schema.Type` instance `T` it will
always return the same `model.Type` instance `U`. This termendously
speeds up type equality checks for complex types, as they will now be
referentially identical.

This change alone gives a profound speedup in azure-native code
generation.