### PR TITLE
[sdk/dotnet] Clean obj & bin dirs when building

### DIFF
--- a/build.proj
+++ b/build.proj
@@ -63,6 +63,8 @@
       <VersionPart>$(Version.Split("-")[0])</VersionPart>
       <VersionPrefix>$(VersionPart.Replace("v",""))</VersionPrefix>
     </PropertyGroup>
+    <Exec Command="dotnet clean"
+          WorkingDirectory="$(DotNetSdkDirectory)" />
     <Exec Command="dotnet build dotnet.sln /p:Version=$(Version)"
           WorkingDirectory="$(DotNetSdkDirectory)" />
     <Exec Command="go install -ldflags &quot;-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=$(Version)&quot; github.com/pulumi/pulumi/sdk/v3/dotnet/cmd/pulumi-language-dotnet"

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -21,7 +21,7 @@ build::
 	# following:
 	#
 	#     -alpha: Alpha release, typically used for work-in-progress and experimentation
-	#dotnet clean
+	dotnet clean
 	dotnet build dotnet.sln /p:Version=${DOTNET_VERSION}
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${DOTNET_VERSION}" ${LANGHOST_PKG}
 


### PR DESCRIPTION
This should avoid occasional errors like:

```
attempting to find a local Pulumi NuGet package yielded [/opt/pulumi/nuget/Pulumi.3.8.0-alpha.1626397740.nupkg /opt/pulumi/nuget/Pulumi.3.8.0-alpha.1626408887.nupkg] results
```

When there are more then one versions leftover from prior builds.

@stack72, I noticed `dotnet clean` was already in the Makefile, but commented out. Any downside you're aware of to uncommenting?