### PR TITLE
[codegen/model] Speed up union types.

### DIFF
--- a/pkg/codegen/hcl2/binder_schema.go
+++ b/pkg/codegen/hcl2/binder_schema.go
@@ -161,6 +161,7 @@ func (b *binder) schemaTypeToType(src schema.Type) (result model.Type) {
 
 		properties := map[string]model.Type{}
 		objType := model.NewObjectType(properties, src)
+
 		b.schemaTypes[src] = objType
 		for _, prop := range src.Properties {
 			typ := prop.Type

--- a/pkg/codegen/hcl2/model/type.go
+++ b/pkg/codegen/hcl2/model/type.go
@@ -76,7 +76,6 @@ const (
 	hashKindConst
 	hashKindList
 	hashKindMap
-	hashKindNamed
 	hashKindObject
 	hashKindOpaque
 	hashKindOutput

--- a/pkg/codegen/hcl2/model/type_const.go
+++ b/pkg/codegen/hcl2/model/type_const.go
@@ -45,6 +45,14 @@ func (t *ConstType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnost
 	return t.Type.Traverse(traverser)
 }
 
+func (t *ConstType) hash(stack objTypeSet) uint32 {
+	fnv := newFNV()
+	fnv.addUint32(hashKindConst)
+	fnv.addUint32(uint32(t.Value.Hash()))
+	fnv.addUint32(t.Type.hash(stack))
+	return fnv.sum()
+}
+
 // Equals returns true if this type has the same identity as the given type.
 func (t *ConstType) Equals(other Type) bool {
 	return t.equals(other, nil)

--- a/pkg/codegen/hcl2/model/type_list.go
+++ b/pkg/codegen/hcl2/model/type_list.go
@@ -50,6 +50,10 @@ func (t *ListType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnosti
 	return t.ElementType, diagnostics
 }
 
+func (t *ListType) hash(stack objTypeSet) uint32 {
+	return hashCombine(hashKindList, t.ElementType.hash(stack))
+}
+
 // Equals returns true if this type has the same identity as the given type.
 func (t *ListType) Equals(other Type) bool {
 	return t.equals(other, nil)

--- a/pkg/codegen/hcl2/model/type_map.go
+++ b/pkg/codegen/hcl2/model/type_map.go
@@ -50,6 +50,10 @@ func (*MapType) SyntaxNode() hclsyntax.Node {
 	return syntax.None
 }
 
+func (t *MapType) hash(stack objTypeSet) uint32 {
+	return hashCombine(hashKindMap, t.ElementType.hash(stack))
+}
+
 // Equals returns true if this type has the same identity as the given type.
 func (t *MapType) Equals(other Type) bool {
 	return t.equals(other, nil)

--- a/pkg/codegen/hcl2/model/type_none.go
+++ b/pkg/codegen/hcl2/model/type_none.go
@@ -30,6 +30,12 @@ func (noneType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostics)
 	return NoneType, hcl.Diagnostics{unsupportedReceiverType(NoneType, traverser.SourceRange())}
 }
 
+func (noneType) hash(_ objTypeSet) uint32 {
+	fnv := newFNV()
+	fnv.addUint32(hashKindNone)
+	return fnv.sum()
+}
+
 func (n noneType) Equals(other Type) bool {
 	return n.equals(other, nil)
 }

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -78,6 +78,13 @@ func (t *OpaqueType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 	return DynamicType, hcl.Diagnostics{unsupportedReceiverType(t, traverser.SourceRange())}
 }
 
+func (t *OpaqueType) hash(_ objTypeSet) uint32 {
+	fnv := newFNV()
+	fnv.addUint32(hashKindOpaque)
+	fnv.addString(t.Name)
+	return fnv.sum()
+}
+
 // Equals returns true if this type has the same identity as the given type.
 func (t *OpaqueType) Equals(other Type) bool {
 	return t.equals(other, nil)

--- a/pkg/codegen/hcl2/model/type_output.go
+++ b/pkg/codegen/hcl2/model/type_output.go
@@ -46,6 +46,10 @@ func (t *OutputType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 	return NewOutputType(element.(Type)), diagnostics
 }
 
+func (t *OutputType) hash(stack objTypeSet) uint32 {
+	return hashCombine(hashKindOutput, t.ElementType.hash(stack))
+}
+
 // Equals returns true if this type has the same identity as the given type.
 func (t *OutputType) Equals(other Type) bool {
 	return t.equals(other, nil)

--- a/pkg/codegen/hcl2/model/type_promise.go
+++ b/pkg/codegen/hcl2/model/type_promise.go
@@ -46,6 +46,10 @@ func (t *PromiseType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagno
 	return NewPromiseType(element.(Type)), diagnostics
 }
 
+func (t *PromiseType) hash(stack objTypeSet) uint32 {
+	return hashCombine(hashKindPromise, t.ElementType.hash(stack))
+}
+
 // Equals returns true if this type has the same identity as the given type.
 func (t *PromiseType) Equals(other Type) bool {
 	return t.equals(other, nil)

--- a/pkg/codegen/hcl2/model/type_set.go
+++ b/pkg/codegen/hcl2/model/type_set.go
@@ -43,6 +43,10 @@ func (t *SetType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnostic
 	return DynamicType, hcl.Diagnostics{unsupportedReceiverType(t, traverser.SourceRange())}
 }
 
+func (t *SetType) hash(stack objTypeSet) uint32 {
+	return hashCombine(hashKindSet, t.ElementType.hash(stack))
+}
+
 // Equals returns true if this type has the same identity as the given type.
 func (t *SetType) Equals(other Type) bool {
 	return t.equals(other, nil)

--- a/pkg/codegen/hcl2/model/type_table.go
+++ b/pkg/codegen/hcl2/model/type_table.go
@@ -34,7 +34,7 @@ func (tt *typeTable) init(size int) {
 	tt.tail = &tt.head
 }
 
-func (tt *typeTable) insert(k Type, v interface{}) error {
+func (tt *typeTable) insert(k Type, v interface{}) {
 	if tt.table == nil {
 		tt.init(1)
 	}
@@ -61,7 +61,7 @@ retry:
 			if k.Equals(e.key) {
 				// Key already present; update value.
 				e.value = v
-				return nil
+				return
 			}
 		}
 		if p.next == nil {
@@ -97,7 +97,7 @@ retry:
 
 	tt.len++
 
-	return nil
+	return
 }
 
 func overloaded(elems, buckets int) bool {

--- a/pkg/codegen/hcl2/model/type_table.go
+++ b/pkg/codegen/hcl2/model/type_table.go
@@ -1,0 +1,140 @@
+package model
+
+type typeTable struct {
+	table []bucket // len is zero or a power of two
+	len   int
+	head  *entry  // insertion order doubly-linked list; may be nil
+	tail  **entry // address of nil link at end of list (perhaps &head)
+}
+
+const bucketSize = 8
+
+type bucket struct {
+	entries [bucketSize]entry
+	next    *bucket
+}
+
+type entry struct {
+	hash  uint32 // nonzero => in use
+	key   Type
+	value interface{}
+	next  *entry  // insertion order doubly-linked list; may be nil
+	prev  **entry // address of link to this entry (perhaps &head)
+}
+
+func (tt *typeTable) init(size int) {
+	if size < 0 {
+		panic("size < 0")
+	}
+	nb := 1
+	for overloaded(size, nb) {
+		nb = nb << 1
+	}
+	tt.table = make([]bucket, nb)
+	tt.tail = &tt.head
+}
+
+func (tt *typeTable) insert(k Type, v interface{}) error {
+	if tt.table == nil {
+		tt.init(1)
+	}
+	h := k.hash(nil)
+	if h == 0 {
+		h = 1 // zero is reserved
+	}
+
+retry:
+	var insert *entry
+
+	// Inspect each bucket in the bucket list.
+	p := &tt.table[h&(uint32(len(tt.table)-1))]
+	for {
+		for i := range p.entries {
+			e := &p.entries[i]
+			if e.hash != h {
+				if e.hash == 0 {
+					// Found empty entry; make a note.
+					insert = e
+				}
+				continue
+			}
+			if k.Equals(e.key) {
+				// Key already present; update value.
+				e.value = v
+				return nil
+			}
+		}
+		if p.next == nil {
+			break
+		}
+		p = p.next
+	}
+
+	// Key not found. p points to the last bucket.
+
+	// Check the load factor.
+	if overloaded(tt.len, len(tt.table)) {
+		tt.grow()
+		goto retry
+	}
+
+	if insert == nil {
+		// No space in existing buckets. Add a new one to the bucket list.
+		b := &bucket{}
+		p.next = b
+		insert = &b.entries[0]
+	}
+
+	// Insert key/value pair.
+	insert.hash = h
+	insert.key = k
+	insert.value = v
+
+	// Append entry to doubly-linked list.
+	insert.prev = tt.tail
+	*tt.tail = insert
+	tt.tail = &insert.next
+
+	tt.len++
+
+	return nil
+}
+
+func overloaded(elems, buckets int) bool {
+	const loadFactor = 6.5 // just a guess
+	return elems >= bucketSize && float64(elems) >= loadFactor*float64(buckets)
+}
+
+func (tt *typeTable) grow() {
+	tt.table = make([]bucket, len(tt.table)<<1)
+	oldhead := tt.head
+	tt.head = nil
+	tt.tail = &tt.head
+	tt.len = 0
+	for e := oldhead; e != nil; e = e.next {
+		tt.insert(e.key, e.value)
+	}
+}
+
+func (tt *typeTable) lookup(k Type, seen map[Type]struct{}) (v interface{}, found bool) {
+	h := k.hash(nil)
+	if h == 0 {
+		h = 1 // zero is reserved
+	}
+	if tt.table == nil {
+		return nil, false // empty
+	}
+
+	// Inspect each bucket in the bucket list.
+	for p := &tt.table[h&(uint32(len(tt.table)-1))]; p != nil; p = p.next {
+		for i := range p.entries {
+			e := &p.entries[i]
+			if e.hash == h {
+				if k.equals(e.key, seen) {
+					return e.value, true // found
+				}
+			}
+		}
+	}
+	return nil, false // not found
+}

--- a/pkg/codegen/hcl2/model/type_tuple.go
+++ b/pkg/codegen/hcl2/model/type_tuple.go
@@ -32,6 +32,7 @@ type TupleType struct {
 
 	elementUnion Type
 	s            string
+	h            uint32
 }
 
 // NewTupleType creates a new tuple type with the given element types.
@@ -67,6 +68,18 @@ func (t *TupleType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnost
 		return DynamicType, hcl.Diagnostics{tupleIndexOutOfRange(len(t.ElementTypes), traverser.SourceRange())}
 	}
 	return t.ElementTypes[int(elementIndex)], nil
+}
+
+func (t *TupleType) hash(stack objTypeSet) uint32 {
+	if t.h == 0 {
+		fnv := newFNV()
+		fnv.addUint32(hashKindTuple)
+		for _, t := range t.ElementTypes {
+			fnv.addUint32(t.hash(stack))
+		}
+		t.h = fnv.sum()
+	}
+	return t.h
 }
 
 // Equals returns true if this type has the same identity as the given type.


### PR DESCRIPTION
The goal of these changes is to reduce the allocation volume incurred by
union types.

Union types currently allocate a large volume of data when they are
created in order to deduplicate element types and sort element types
into a canonical order. The deduplication is important as it allows for
a fast path during comparison based on the number of elements, but the
sorting--also used to simplify equality checks--generally costs more
than it is worth, as it requires stringifying each element type.

These changes replace the string-based deduplication process with either
a simple O(N^2) approach for small numbers of element types or a more
complex hashtable-based approach for larger numbers of element types.
The same approach is used for equality checks.

These changes speed up the code generation process by decreasing the
amount of time spent in the allocator and garbage collector.