### PR TITLE
Set UseSharedCompilation to false

### DIFF
--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -136,6 +136,7 @@ const csharpProjectFileTemplateText = `<Project Sdk="Microsoft.NET.Sdk">
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/dotnet/Pulumi.Foo-bar.csproj
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/dotnet/Pulumi.Foo-bar.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
+++ b/pkg/codegen/internal/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/dotnet/Pulumi.Configstation.csproj
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/dotnet/Pulumi.Configstation.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
@@ -12,6 +12,7 @@
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
+    <UseSharedCompilation>false</UseSharedCompilation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Fix https://github.com/pulumi/pulumi-azure-native/issues/985 (once it propagates to azure-native)

This is only needed in Azure Native but as we only compile a single project for each provider, there should be no downside to enabling it for all providers.