### PR TITLE
[cli] - Don't escape special characters when printing JSON

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -9,5 +9,8 @@
 
 ### Bug Fixes
 
-- [sdk/go] - Fix target and replace options for the Automation API
+- [sdk/go] - Fix target and replace options for the Automation API.
   [#7426](https://github.com/pulumi/pulumi/pull/7426)
+  
+- [cli] - Don't escape special characters when printing JSON.
+  [#7593](https://github.com/pulumi/pulumi/pull/7593)

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -791,11 +791,10 @@ func listConfig(stack backend.Stack, showSecrets bool, jsonOut bool) error {
 
 			configValues[key.String()] = entry
 		}
-		out, err := json.MarshalIndent(configValues, "", "  ")
+		err := printJSON(configValues)
 		if err != nil {
 			return err
 		}
-		fmt.Println(string(out))
 	} else {
 		rows := []cmdutil.TableRow{}
 		for _, key := range keys {

--- a/pkg/cmd/pulumi/stack_output_test.go
+++ b/pkg/cmd/pulumi/stack_output_test.go
@@ -30,9 +30,11 @@ func TestStringifyOutput(t *testing.T) {
 			"baz": true,
 		},
 	}
+	specialChar := "pass&word"
 
 	assert.Equal(t, "42", stringifyOutput(num))
 	assert.Equal(t, "ABC", stringifyOutput(str))
 	assert.Equal(t, "[\"hello\",\"goodbye\"]", stringifyOutput(arr))
 	assert.Equal(t, "{\"bar\":{\"baz\":true},\"foo\":42}", stringifyOutput(obj))
+	assert.Equal(t, "pass&word", stringifyOutput(specialChar))
 }

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -776,12 +776,11 @@ func (cancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bo
 }
 
 func makeJSONString(v interface{}) (string, error) {
-	out := bytes.NewBuffer([]byte{})
-	encoder := json.NewEncoder(out)
+	var out bytes.Buffer
+	encoder := json.NewEncoder(&out)
 	encoder.SetEscapeHTML(false)
 	encoder.SetIndent("", "  ")
-	err := encoder.Encode(v)
-	if err != nil {
+	if err := encoder.Encode(v); err != nil {
 		return "", err
 	}
 	return out.String(), nil

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -775,13 +775,25 @@ func (cancellationScopeSource) NewScope(events chan<- engine.Event, isPreview bo
 	return c
 }
 
+func makeJSONString(v interface{}) (string, error) {
+	out := bytes.NewBuffer([]byte{})
+	encoder := json.NewEncoder(out)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	err := encoder.Encode(v)
+	if err != nil {
+		return "", err
+	}
+	return out.String(), nil
+}
+
 // printJSON simply prints out some object, formatted as JSON, using standard indentation.
 func printJSON(v interface{}) error {
-	out, err := json.MarshalIndent(v, "", "  ")
+	jsonStr, err := makeJSONString(v)
 	if err != nil {
 		return err
 	}
-	fmt.Println(string(out))
+	fmt.Print(jsonStr)
 	return nil
 }
 

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -229,3 +229,38 @@ func TestReadingGitLabMetadata(t *testing.T) {
 		assertEnvValue(t, test, backend.VCSRepoKind, gitutil.GitLabHostName)
 	}
 }
+
+func Test_makeJSONString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected string
+	}{
+		{
+			"simple-string",
+			map[string]interface{}{"my_password": "password"},
+			`{
+  "my_password": "password"
+}
+`},
+		{
+			"special-char-string",
+			map[string]interface{}{"special_password": "pass&word"},
+			`{
+  "special_password": "pass&word"
+}
+`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := makeJSONString(tt.input)
+			if err != nil {
+				t.Errorf("makeJSONString() error = %v", err)
+				return
+			}
+			if got != tt.expected {
+				t.Errorf("makeJSONString() got = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/5474

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
