### PR TITLE
Add ProviderMain function

### DIFF
--- a/tests/integration/component_provider_schema/testcomponent-go/main.go
+++ b/tests/integration/component_provider_schema/testcomponent-go/main.go
@@ -21,9 +21,14 @@ func main() {
 	if _, ok := os.LookupEnv("INCLUDE_SCHEMA"); ok {
 		schema = `{"hello": "world"}`
 	}
-	err := provider.ComponentMain(providerName, version, []byte(schema), func(ctx *pulumi.Context, typ, name string,
-		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
-		return nil, errors.Errorf("unknown resource type %s", typ)
+	err := provider.MainWithOptions(provider.Options{
+		Name:    providerName,
+		Version: version,
+		Schema:  []byte(schema),
+		Construct: func(ctx *pulumi.Context, typ, name string,
+			inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
+			return nil, errors.Errorf("unknown resource type %s", typ)
+		},
 	})
 	if err != nil {
 		cmdutil.ExitError(err.Error())


### PR DESCRIPTION
This commit adds a new counterpart to `ComponentMain` which accepts functional options for specifying callback functions. Currently it supports `construct` (for components) and `call` (for methods), but is extensible in a non-breaking fashion in future to support all other provider methods as they become desirable to implement.

The original `ComponentMain` still exists, though it may be desirable to deprecate it in future in favor of `ProviderMain`.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

Existing test uses new function.

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Not a user facing change.

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version

N/A.
