### PR TITLE
[sdk/dotnet] Fix collections in input unions.

### DIFF
--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -259,9 +259,10 @@ func simplifyInputUnion(union *schema.UnionType) *schema.UnionType {
 		if input, ok := et.(*schema.InputType); ok {
 			switch input.ElementType.(type) {
 			case *schema.ArrayType, *schema.MapType:
-				// do not replace Input<{Array,Map}> with {Array,Map}: typeString needs to see the enclosing input type in order to
-				// generate correct type names.
-				elements[i] = input
+				// Instead of just replacing Input<{Array,Map}<T>> with {Array,Map}<T>, replace it with
+				// {Array,Map}<Plain(T)>. This matches the behavior of typeString when presented with an
+				// Input<{Array,Map}<T>>.
+				elements[i] = codegen.PlainType(input.ElementType)
 			default:
 				elements[i] = input.ElementType
 			}

--- a/pkg/codegen/internal/test/testdata/types.json
+++ b/pkg/codegen/internal/test/testdata/types.json
@@ -6,6 +6,9 @@
   },
   "config": {},
   "types": {
+    "types::object": {
+      "type": "object"
+    },
     "typetests::plainCollections": {
       "description": "Tests for singly-nested plain collections",
       "properties": {
@@ -522,32 +525,36 @@
     "typetests:regressions:pulumi/pulumi/7454": {
       "description": "Regression test for pulumi/pulumi#7454",
       "properties": {
-        "nestedArray": {
-          "type": "array",
-          "items": {
-            "type": "array",
-            "items": {
-              "type": "string"
+        "inputUnion": {
+          "oneOf": [
+            {
+              "$ref": "#/types/types::object"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "pulumi.json#/Json"
+              }
             }
-          },
+          ],
           "language": {
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "InputList<ImmutableArray<string>>",
-                  "plain": "ImmutableArray<ImmutableArray<string>>"
+                  "input": "InputUnion<Pulumi.Types.ObjectArgs, InputList<System.Text.Json.JsonElement>>?",
+                  "plain": "Union<Pulumi.Types.Object, ImmutableArray<System.Text.Json.JsonElement>>?"
                 },
                 "go": {
-                  "input": "pulumi.StringArrayArrayInput",
-                  "plain": "[][]string"
+                  "input": "pulumi.Input",
+                  "plain": "interface{}"
                 },
                 "nodejs": {
-                  "input": "pulumi.Input<pulumi.Input<pulumi.Input<string>[]>[]> | undefined",
-                  "plain": "string[][] | undefined"
+                  "input": "pulumi.Input<outputs.ObjectArgs | any[]> | undefined",
+                  "plain": "outputs.Object | any[] | undefined"
                 },
                 "python": {
-                  "input": "Optional[pulumi.Input[Sequence[pulumi.Input[Sequence[pulumi.Input[str]]]]]]",
-                  "plain": "Optional[Sequence[Sequence[str]]]"
+                  "input": "Optional[Any]",
+                  "plain": "Optional[Any]"
                 }
               }
             }

--- a/pkg/codegen/internal/test/testdata/types.json
+++ b/pkg/codegen/internal/test/testdata/types.json
@@ -541,7 +541,7 @@
             "test": {
               "expected": {
                 "dotnet": {
-                  "input": "InputUnion<Pulumi.Types.ObjectArgs, InputList<System.Text.Json.JsonElement>>?",
+                  "input": "InputUnion<Pulumi.Types.ObjectArgs, ImmutableArray<System.Text.Json.JsonElement>>?",
                   "plain": "Union<Pulumi.Types.Object, ImmutableArray<System.Text.Json.JsonElement>>?"
                 },
                 "go": {


### PR DESCRIPTION
Collection types nested inside of Input<Union<...>> types need to abide
by the usual rules for collection types nested inside of input types.
These changes replace the use of the generic SimplifyInputUnion with a
.NET-specific simplifyInputUnion that does not remove Input types
inside of a union if those Input types wrap collection types. Retaining
these Input types allows the usual logic for handling
Input<Collection<...> types in typeString to kick in.

Fixes #7569.