### PR TITLE
[sdk/go] Fix methods panic when marshaling `self`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -17,6 +17,9 @@
 
 - [sdk/go] - Fix target and replace options for the Automation API.
   [#7426](https://github.com/pulumi/pulumi/pull/7426)
-  
+
 - [cli] - Don't escape special characters when printing JSON.
   [#7593](https://github.com/pulumi/pulumi/pull/7593)
+
+- [sdk/go] - Fix panic when marshaling `self` in a method.
+  [#7604](https://github.com/pulumi/pulumi/pull/7604)

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -364,7 +364,7 @@ func (ctx *Context) Call(tok string, args Input, output Output, self Resource, o
 		// If we have a value for self, add it to the arguments.
 		if self != nil {
 			var deps []URN
-			resolvedSelf, selfDeps, err := marshalInput(self, anyType, true)
+			resolvedSelf, selfDeps, err := marshalInput(self, reflect.TypeOf(self), true)
 			if err != nil {
 				return nil, fmt.Errorf("marshaling __self__: %w", err)
 			}

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -364,7 +364,7 @@ func (ctx *Context) Call(tok string, args Input, output Output, self Resource, o
 		// If we have a value for self, add it to the arguments.
 		if self != nil {
 			var deps []URN
-			resolvedSelf, selfDeps, err := marshalInput(self, nil, true)
+			resolvedSelf, selfDeps, err := marshalInput(self, anyType, true)
 			if err != nil {
 				return nil, fmt.Errorf("marshaling __self__: %w", err)
 			}

--- a/tests/integration/construct_component_methods/go/main.go
+++ b/tests/integration/construct_component_methods/go/main.go
@@ -72,6 +72,10 @@ func (o ComponentGetMessageResultOutput) Message() pulumi.StringOutput {
 	return o.ApplyT(func(v ComponentGetMessageResult) string { return v.Message }).(pulumi.StringOutput)
 }
 
+func (*Component) ElementType() reflect.Type {
+	return reflect.TypeOf((*Component)(nil))
+}
+
 func init() {
 	pulumi.RegisterOutputType(ComponentGetMessageResultOutput{})
 }


### PR DESCRIPTION
Pass a valid `destType` to `marshalInput` to avoid panicing when the `self` resource implements `pulumi.Input`.

This issue would have been caught by testing the generated code, in addition to comparing it to what is expected.

Fixes #7603