### PR TITLE
Include children when targeting components.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,5 @@
 ### Improvements
 
-
 - [sdk/go] - Add stack output helpers for numeric types.
   [#7410](https://github.com/pulumi/pulumi/pull/7410)
 
@@ -8,6 +7,9 @@
 
 - [sdk/{go,python,nodejs}] - Rehydrate provider resources in `Construct`.
   [#7624](https://github.com/pulumi/pulumi/pull/7624)
+  
+- [engine] - Include children when targeting components.
+  [#7605](https://github.com/pulumi/pulumi/pull/7605)
 
 - [cli] - Restore passing log options to providers when `--logflow` is specified
   https://github.com/pulumi/pulumi/pull/7640

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -67,7 +67,7 @@ func newUpCmd() *cobra.Command {
 	var showReads bool
 	var skipPreview bool
 	var suppressOutputs bool
-	var suppressPermaLink string
+	var suppressPermalink string
 	var yes bool
 	var secretsProvider string
 	var targets []string
@@ -373,7 +373,7 @@ func newUpCmd() *cobra.Command {
 
 			// we only suppress permalinks if the user passes true. the default is an empty string
 			// which we pass as 'false'
-			if suppressPermaLink == "true" {
+			if suppressPermalink == "true" {
 				opts.Display.SuppressPermaLink = true
 			} else {
 				opts.Display.SuppressPermaLink = false
@@ -386,7 +386,7 @@ func newUpCmd() *cobra.Command {
 
 			// by default, we are going to suppress the permalink when using self-managed backends
 			// this can be re-enabled by explicitly passing "false" to the `supppress-permalink` flag
-			if suppressPermaLink != "false" && filestateBackend {
+			if suppressPermalink != "false" && filestateBackend {
 				opts.Display.SuppressPermaLink = true
 			}
 
@@ -481,7 +481,7 @@ func newUpCmd() *cobra.Command {
 		&suppressOutputs, "suppress-outputs", false,
 		"Suppress display of stack outputs (in case they contain sensitive values)")
 	cmd.PersistentFlags().StringVar(
-		&suppressPermaLink, "suppress-permalink", "",
+		&suppressPermalink, "suppress-permalink", "",
 		"Suppress display of the state permalink")
 	cmd.Flag("suppress-permalink").NoOptDefVal = "false"
 	cmd.PersistentFlags().BoolVarP(

--- a/pkg/engine/lifeycletest/delete_before_replace_test.go
+++ b/pkg/engine/lifeycletest/delete_before_replace_test.go
@@ -18,13 +18,14 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
+type propertyDependencies map[resource.PropertyKey][]resource.URN
+
 var complexTestDependencyGraphNames = []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L"}
 
 func generateComplexTestDependencyGraph(
 	t *testing.T, p *TestPlan) ([]resource.URN, *deploy.Snapshot, plugin.LanguageRuntime) {
 
 	resType := tokens.Type("pkgA:m:typA")
-	type propertyDependencies map[resource.PropertyKey][]resource.URN
 
 	names := complexTestDependencyGraphNames
 
@@ -48,24 +49,7 @@ func generateComplexTestDependencyGraph(
 
 	newResource := func(urn resource.URN, id resource.ID, provider string, dependencies []resource.URN,
 		propertyDeps propertyDependencies, outputs resource.PropertyMap) *resource.State {
-
-		inputs := resource.PropertyMap{}
-		for k := range propertyDeps {
-			inputs[k] = resource.NewStringProperty("foo")
-		}
-
-		return &resource.State{
-			Type:                 urn.Type(),
-			URN:                  urn,
-			Custom:               true,
-			Delete:               false,
-			ID:                   id,
-			Inputs:               inputs,
-			Outputs:              outputs,
-			Dependencies:         dependencies,
-			Provider:             provider,
-			PropertyDependencies: propertyDeps,
-		}
+		return newResource(urn, "", id, provider, dependencies, propertyDeps, outputs, true)
 	}
 
 	old := &deploy.Snapshot{

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -148,8 +148,8 @@ func (ex *deploymentExecutor) Execute(callerCtx context.Context, opts Options, p
 		}
 	}
 
-	// The set of -t targets provided on hte command line.  'nil' means 'update everything'.
-	// Non-nill means 'update only in this set'.  We don't error if the user specifies an target
+	// The set of -t targets provided on the command line.  'nil' means 'update everything'.
+	// Non-nil means 'update only in this set'.  We don't error if the user specifies a target
 	// during `update` that we don't know about because it might be the urn for a resource they
 	// want to create.
 	updateTargetsOpt := createTargetMap(opts.UpdateTargets)

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -819,9 +819,13 @@ func (sg *stepGenerator) determineAllowedResourcesToDeleteFromTargets(
 			}
 
 			if _, has := resourcesToDelete[res.Parent]; has {
-				sg.deployment.Diag().Errorf(diag.GetCannotDeleteParentResourceWithoutAlsoDeletingChildError(res.Parent),
-					res.Parent, res.URN)
-				return nil, result.Bail()
+				if sg.opts.TargetDependents {
+					resourcesToDelete[res.URN] = true
+				} else {
+					sg.deployment.Diag().Errorf(diag.GetCannotDeleteParentResourceWithoutAlsoDeletingChildError(res.Parent),
+						res.Parent, res.URN)
+					return nil, result.Bail()
+				}
 			}
 		}
 	}

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -805,6 +805,7 @@ func (sg *stepGenerator) determineAllowedResourcesToDeleteFromTargets(
 	targetsIncludingChildren := make(map[resource.URN]bool)
 
 	for target := range targetsOpt {
+		// If target is a component, include all its children as targets too.
 		children := sg.getChildrenOfTarget(target)
 		for child := range children {
 			targetsIncludingChildren[child] = true


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Prior to this change, when a component was targeted without including all of its children in the list of targets, it would result in an error like below:

```
Diagnostics:
  infrastructure:k8s-istio-operator (web-dev):
    error: Cannot delete parent resource 'urn:pulumi:istio-operator::infrastructure::infrastructure:k8s-istio-operator::web-dev' without also deleting child 'urn:pulumi:istio-operator::infrastructure::infrastructure:k8s-istio-operator$kubernetes:yaml:ConfigGroup::web-dev'
```

However, when a component is targeted, it is logical that the user intended to also target the component's children, since the component itself is a wrapper for all of its children. This PR changes the behavior to include children when a component is targeted instead of erroring. 

**Note:** This changes the default behavior of `--target` to include a component's children. Should this be behind a flag (should we be including this in `--target-dependents`)? Do we want some way to preserve the old behavior? 

Fixes #4032 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
