### PR TITLE
reenable concurrent update test

### DIFF
--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestConcurrentUpdateError(t *testing.T) {
-	t.Skip("disabled, see https://github.com/pulumi/pulumi/issues/5312")
 	ctx := context.Background()
 	pName := "conflict_error"
 	sName := fmt.Sprintf("int_test%d", rangeIn(10000000, 99999999))

--- a/sdk/go/auto/test/errors/conflict_error/main.go
+++ b/sdk/go/auto/test/errors/conflict_error/main.go
@@ -8,7 +8,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		time.Sleep(1 * time.Second)
+		time.Sleep(5 * time.Second)
 		ctx.Export("exp_static", pulumi.String("foo"))
 		return nil
 	})


### PR DESCRIPTION
Just combing through the backlog and found this item. Tests pass consistently on my machine, but bumped up the from 1s to 5s (does not increase total runtime of test at all). 

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi/issues/5378 fixes https://github.com/pulumi/pulumi/issues/5312

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->

