### PR TITLE
Toward 5642 for C#: allow DependsOn accept outputs

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/Resources/ResourceOptionsTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Resources/ResourceOptionsTests.cs
@@ -1,0 +1,202 @@
+// Copyright 2016-2021, Pulumi Corporation
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+using Pulumirpc;
+using Pulumi.Testing;
+
+namespace Pulumi.Tests.Resources
+{
+    public class ResourceOptionsTests
+    {
+        [Fact]
+        public async Task DependsOnAcceptsInputs()
+        {
+            var resources = await Testing.RunAsync<DependsOnAcceptsInputsStack>();
+
+            var stack = resources.OfType<DependsOnAcceptsInputsStack>().FirstOrDefault();
+            Assert.NotNull(stack);
+        }
+
+        class DependsOnAcceptsInputsStack : Stack
+        {
+            public DependsOnAcceptsInputsStack()
+            {
+                var arg = new TestResourceArgs() { N = 1 };
+                new TestResource("r1", arg);
+            }
+        }
+    }
+
+    public sealed class TestResourceArgs : ResourceArgs
+    {
+	[Input("n", required: true)]
+	public Input<int> N { get; set; } = null!;
+
+	public TestResourceArgs()
+	{
+	}
+    }
+
+    sealed class TestResource : CustomResource
+    {
+	[Output("nextInteger")]
+	public Output<int> NextInteger { get; private set; } = null!;
+
+	public TestResource(string name, TestResourceArgs args, CustomResourceOptions? options = null)
+		: base("test:index:TestResource", name, args, options)
+	{
+            NextInteger = args.N.Apply(n => n + 1);
+	}
+    }
+
+    sealed class MyMocks : IMocks
+    {
+        public Task<object> CallAsync(MockCallArgs args)
+        {
+            return Task.FromResult<object>(args);
+        }
+
+        public Task<(string? id, object state)> NewResourceAsync(MockResourceArgs args)
+        {
+            return Task.FromResult<(string?, object)>((args.Name + "_id", args.Inputs));
+        }
+    }
+
+    static class Testing
+    {
+        public static Task<ImmutableArray<Resource>> RunAsync<T>() where T : Stack, new()
+        {
+            var opts = new TestOptions { IsPreview = false };
+            var internalTestOpts = Deployment.InternalTestOptions.Create(opts);
+            internalTestOpts.ConfigureMonitor = m => new DependencyTrackingMonitor(m);
+            return Deployment.TestAsync<T>(new MyMocks(), internalTestOpts);
+        }
+    }
+
+    class DependencyTrackingMonitor : IMockMonitor, IMonitor
+    {
+        private IMockMonitor Inner { get; }
+
+        public DependencyTrackingMonitor(IMockMonitor inner)
+        {
+            Inner = inner;
+        }
+
+        ImmutableList<Resource> IMockMonitor.Resources
+        {
+            get
+            {
+                return Inner.Resources;
+            }
+        }
+
+        async Task<SupportsFeatureResponse> IMonitor.SupportsFeatureAsync(SupportsFeatureRequest request)
+        {
+            return await Inner.SupportsFeatureAsync(request);
+        }
+
+        async Task<InvokeResponse> IMonitor.InvokeAsync(InvokeRequest request)
+        {
+            return await Inner.InvokeAsync(request);
+        }
+
+        async Task<ReadResourceResponse> IMonitor.ReadResourceAsync(Resource resource, ReadResourceRequest request)
+        {
+            return await Inner.ReadResourceAsync(resource, request);
+        }
+
+        async Task<RegisterResourceResponse> IMonitor.RegisterResourceAsync(Resource resource, RegisterResourceRequest request)
+        {
+            var resp = await Inner.RegisterResourceAsync(resource, request);
+            Console.WriteLine($"resp.URN = {resp.Urn}; req.DEps = ${request.Dependencies}");
+            return resp;
+        }
+
+        async Task IMonitor.RegisterResourceOutputsAsync(RegisterResourceOutputsRequest request)
+        {
+            await Inner.RegisterResourceOutputsAsync(request);
+        }
+    }
+}
+
+
+// func TestDependsOnInputs(t *testing.T) {
+// 	t.Run("known", func(t *testing.T) {
+// 		err := RunErr(func(ctx *Context) error {
+// 			depTracker := trackDependencies(ctx)
+
+// 			dep1 := newTestRes(t, ctx, "dep1")
+// 			dep2 := newTestRes(t, ctx, "dep2")
+
+// 			output := outputDependingOnResource(dep1, true).
+// 				ApplyT(func(int) Resource { return dep2 }).(ResourceOutput)
+
+// 			res := newTestRes(t, ctx, "res", DependsOnInputs([]ResourceInput{output}))
+// 			assertHasDeps(t, ctx, depTracker, res, dep1, dep2)
+// 			return nil
+// 		}, WithMocks("project", "stack", &testMonitor{}))
+// 		assert.NoError(t, err)
+// 	})
+// 	t.Run("unknown", func(t *testing.T) {
+// 		err := RunErr(func(ctx *Context) error {
+// 			depTracker := trackDependencies(ctx)
+
+// 			dep1 := newTestRes(t, ctx, "dep1")
+// 			dep2 := newTestRes(t, ctx, "dep2")
+// 			dep3 := newTestRes(t, ctx, "dep3")
+
+// 			out := outputDependingOnResource(dep1, true).
+// 				ApplyT(func(int) Resource { return dep2 }).(ResourceOutput)
+
+// 			out2 := outputDependingOnResource(dep3, false).
+// 				ApplyT(func(int) Resource { return dep2 }).(ResourceOutput)
+
+// 			res := newTestRes(t, ctx, "res", DependsOnInputs([]ResourceInput{out, out2}))
+// 			assertHasDeps(t, ctx, depTracker, res, dep1, dep2, dep3)
+// 			return nil
+// 		}, WithMocks("project", "stack", &testMonitor{}))
+// 		assert.NoError(t, err)
+// 	})
+// }
+
+// func TestDependsOnOutput(t *testing.T) {
+// 	err := RunErr(func(ctx *Context) error {
+// 		depTracker := trackDependencies(ctx)
+
+// 		anyOut := func(value interface{}) AnyOutput {
+// 			out, resolve, _ := ctx.NewOutput()
+// 			resolve(value)
+// 			return out.(AnyOutput)
+// 		}
+
+// 		checkDeps := func(name string, dependsOn AnyOutput, expectedDeps ...Resource) {
+// 			res := newTestRes(t, ctx, name, DependsOnOutput(dependsOn))
+// 			assertHasDeps(t, ctx, depTracker, res, expectedDeps...)
+// 		}
+
+// 		dep1 := newTestRes(t, ctx, "dep1")
+// 		dep2 := newTestRes(t, ctx, "dep2")
+// 		dep3 := newTestRes(t, ctx, "dep3")
+
+// 		out := outputDependingOnResource(dep1, true).
+// 			ApplyT(func(int) Resource { return dep2 }).(ResourceOutput)
+
+// 		checkDeps("r1", anyOut([]Resource{dep1, dep2}), dep1, dep2)
+// 		checkDeps("r2", anyOut([]ResourceInput{out}), dep1, dep2)
+// 		checkDeps("r3", anyOut([]interface{}{out, dep3}), dep1, dep2, dep3)
+
+// 		dep4 := newTestRes(t, ctx, "dep4")
+// 		out4 := outputDependingOnResource(dep4, true).
+// 			ApplyT(func(int) AnyOutput { return anyOut([]Resource{dep1, dep2}) }).(AnyOutput)
+// 		checkDeps("r4", out4, dep1, dep2, dep4)
+
+// 		return nil
+// 	}, WithMocks("project", "stack", &testMonitor{}))
+// 	assert.NoError(t, err)
+// }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment.cs
@@ -23,7 +23,7 @@ namespace Pulumi
     /// static Task&lt;int&gt; Main(string[] args)
     /// {
     ///     // program initialization code ...
-    ///     
+    ///
     ///     return Deployment.Run(async () =>
     ///     {
     ///         // Code that creates resources.

--- a/sdk/dotnet/Pulumi/Deployment/IMonitor.cs
+++ b/sdk/dotnet/Pulumi/Deployment/IMonitor.cs
@@ -10,11 +10,11 @@ namespace Pulumi
         Task<SupportsFeatureResponse> SupportsFeatureAsync(SupportsFeatureRequest request);
 
         Task<InvokeResponse> InvokeAsync(InvokeRequest request);
-        
+
         Task<ReadResourceResponse> ReadResourceAsync(Resource resource, ReadResourceRequest request);
-        
+
         Task<RegisterResourceResponse> RegisterResourceAsync(Resource resource, RegisterResourceRequest request);
-        
+
         Task RegisterResourceOutputsAsync(RegisterResourceOutputsRequest request);
     }
 }

--- a/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
+++ b/sdk/dotnet/Pulumi/Testing/MockMonitor.cs
@@ -11,7 +11,12 @@ using Pulumirpc;
 
 namespace Pulumi.Testing
 {
-    internal class MockMonitor : IMonitor
+    internal interface IMockMonitor : IMonitor
+    {
+        public ImmutableList<Resource> Resources { get; }
+    }
+
+    internal class MockMonitor : IMonitor, IMockMonitor
     {
         private readonly IMocks _mocks;
         private readonly Serializer _serializer = new Serializer(excessiveDebugOutput: false);
@@ -47,7 +52,7 @@ namespace Pulumi.Testing
                 }
                 return new InvokeResponse { Return = await SerializeAsync(registeredResource).ConfigureAwait(false) };
             }
-            
+
             var result = await _mocks.CallAsync(new MockCallArgs
                 {
                     Token = request.Tok,
@@ -182,6 +187,14 @@ namespace Pulumi.Testing
         {
             var dict = await SerializeToDictionary(o).ConfigureAwait(false);
             return Serializer.CreateStruct(dict);
+        }
+
+        ImmutableList<Resource> IMockMonitor.Resources
+        {
+            get
+            {
+                return Resources.ToImmutableList();
+            }
         }
     }
 }

--- a/sdk/dotnet/Pulumi/Testing/TestOptions.cs
+++ b/sdk/dotnet/Pulumi/Testing/TestOptions.cs
@@ -1,7 +1,7 @@
 namespace Pulumi.Testing
 {
     /// <summary>
-    /// Optional settings for <see cref="Deployment.TestAsync{T}"/>.
+    /// Optional settings for <see cref="Deployment.TestAsync{T}(IMocks, TestOptions?)"/>.
     /// </summary>
     public class TestOptions
     {
@@ -9,12 +9,12 @@ namespace Pulumi.Testing
         /// Project name. Defaults to <b>"project"</b> if not specified.
         /// </summary>
         public string? ProjectName { get; set; }
-        
+
         /// <summary>
         /// Stack name. Defaults to <b>"stack"</b> if not specified.
         /// </summary>
         public string? StackName { get; set; }
-        
+
         /// <summary>
         /// Whether the test runs in Preview mode. Defaults to <b>true</b> if not specified.
         /// </summary>


### PR DESCRIPTION
# Description

It turns out that .NET SDK already supports passing Input/Output of Resource as an option to DependsOn when constructing resources. However, there are subtle semantic differences in how dependencies are propagated. Most importantly, the current C# implementation discards indirect dependencies implicit in the `Output<>` wrapper, and in this differs from existing Node and forthcoming Python and Go implementations. 

Fixes #5642 (C#)

Status: this PR currently does not have a fix for the issue, but it does introduce failing unit tests demonstrating the problem.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
