### PR TITLE
Demonstrate depends_on ignoring ComponentResource

### DIFF
--- a/sdk/nodejs/output.ts
+++ b/sdk/nodejs/output.ts
@@ -25,7 +25,7 @@ import * as utils from "./utils";
  * value as well as the Resource the value came from.  This allows for a precise 'Resource
  * dependency graph' to be created, which properly tracks the relationship between resources.
  */
-class OutputImpl<T> implements OutputInstance<T> {
+export class OutputImpl<T> implements OutputInstance<T> {
     /**
      * A private field to help with RTTI that works in SxS scenarios.
      *

--- a/sdk/nodejs/test.sh
+++ b/sdk/nodejs/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+export PATH=$(yarn bin 2>/dev/null):$PATH
+
+./node_modules/.bin/tsc
+./node_modules/.bin/istanbul test --print none _mocha -- 'bin/tests_with_mocks/*.spec.js'


### PR DESCRIPTION
# Description

Passing ComponentResource to depends_on ignores its URN when talking to the engine. 

Is this a bug or a feature?

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
