### PR TITLE
Actually close the issue after being marked as stale

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -20,3 +20,4 @@ jobs:
         stale-issue-message: 'Since we haven''t heard back from you, closing this issue for now. Please feel free to comment with more information and we can get this reopened.'
         stale-issue-label: awaiting-feedback-stale
         days-before-stale: 14
+        days-before-close: 1


### PR DESCRIPTION
We merged https://github.com/pulumi/pulumi/pull/7476 which is applying the [awaiting-feedback-stale](https://github.com/pulumi/pulumi/issues?q=is%3Aopen+is%3Aissue+label%3Aawaiting-feedback-stale) label appropriately, but the issues aren't actually set to close. 

Adding [days-before-close ](https://github.com/actions/stale#days-before-close)solves this