### PR TITLE
Set the package on DependencyProviderResource

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,3 +11,6 @@
 
 - [sdk/nodejs] - Fix `pulumi up --logflow` causing Node multi-lang components to hang
   [#7644](https://github.com/pulumi/pulumi/pull/)
+
+- [sdk/{dotnet,python,nodejs}] - Set the package on DependencyProviderResource.
+  [#7630](https://github.com/pulumi/pulumi/pull/7630)

--- a/sdk/dotnet/Pulumi.Tests/Resources/DependencyProviderResourceTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Resources/DependencyProviderResourceTests.cs
@@ -1,0 +1,16 @@
+// Copyright 2016-2021, Pulumi Corporation
+
+using Xunit;
+
+namespace Pulumi.Tests.Resources
+{
+    public class DependencyProviderResourceTests
+    {
+        [Fact]
+        public void GetPackage()
+        {
+            var res = new DependencyProviderResource("urn:pulumi:stack::project::pulumi:providers:aws::default_4_13_0");
+            Assert.Equal("aws", res.Package);
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Resources/DependencyProviderResource.cs
+++ b/sdk/dotnet/Pulumi/Resources/DependencyProviderResource.cs
@@ -14,15 +14,9 @@ namespace Pulumi
     internal sealed class DependencyProviderResource : ProviderResource
     {
         public DependencyProviderResource(string reference)
-            : base(package: "", name: "", args: ResourceArgs.Empty, dependency: true)
+            : base(package: GetPackage(reference), name: "", args: ResourceArgs.Empty, dependency: true)
         {
-            var lastSep = reference.LastIndexOf("::", StringComparison.Ordinal);
-            if (lastSep == -1)
-            {
-                throw new ArgumentException($"Expected \"::\" in provider reference ${reference}.");
-            }
-            var urn = reference.Substring(0, lastSep);
-            var id = reference.Substring(lastSep + 2);
+            var (urn, id) = ParseReference(reference);
 
             var resources = ImmutableHashSet.Create<Resource>(this);
 
@@ -31,6 +25,30 @@ namespace Pulumi
 
             var idData = OutputData.Create(resources, id, isKnown: true, isSecret: false);
             this.Id = new Output<string>(Task.FromResult(idData));
+        }
+
+        private static string GetPackage(string reference)
+        {
+            var (urn, _) = ParseReference(reference);
+            var urnParts = urn.Split("::");
+            var qualifiedType = urnParts[2];
+            var qualifiedTypeParts = qualifiedType.Split('$');
+            var type = qualifiedTypeParts[^1];
+            var typeParts = type.Split(':');
+            // type will be "pulumi:providers:<package>" and we want the last part.
+            return typeParts.Length > 2 ? typeParts[2] : "";
+        }
+
+        private static (string Urn, string Id) ParseReference(string reference)
+        {
+            var lastSep = reference.LastIndexOf("::", StringComparison.Ordinal);
+            if (lastSep == -1)
+            {
+                throw new ArgumentException($"Expected \"::\" in provider reference ${reference}.");
+            }
+            var urn = reference[..lastSep];
+            var id = reference[(lastSep + 2)..];
+            return (urn, id);
         }
     }
 }

--- a/sdk/nodejs/resource.ts
+++ b/sdk/nodejs/resource.ts
@@ -1035,9 +1035,16 @@ export class DependencyResource extends CustomResource {
  */
 export class DependencyProviderResource extends ProviderResource {
     constructor(ref: string) {
-        super("", "", {}, {}, true);
-
         const [urn, id] = parseResourceReference(ref);
+        const urnParts = urn.split("::");
+        const qualifiedType = urnParts[2];
+        const type = qualifiedType.split("$").pop()!;
+        // type will be "pulumi:providers:<package>" and we want the last part.
+        const typeParts = type.split(":");
+        const pkg = typeParts.length > 2 ? typeParts[2] : "";
+
+        super(pkg, "", {}, {}, true);
+
         (<any>this).urn = new Output(<any>this, Promise.resolve(urn), Promise.resolve(true), Promise.resolve(false), Promise.resolve([]));
         (<any>this).id = new Output(<any>this, Promise.resolve(id), Promise.resolve(true), Promise.resolve(false), Promise.resolve([]));
     }

--- a/sdk/nodejs/tests/resource.spec.ts
+++ b/sdk/nodejs/tests/resource.spec.ts
@@ -18,7 +18,7 @@ import * as assert from "assert";
 import { Output, concat, interpolate, output } from "../output";
 import * as runtime from "../runtime";
 import { asyncTest } from "./util";
-import { createUrn, ComponentResource, CustomResourceOptions } from "../resource";
+import { createUrn, ComponentResource, CustomResourceOptions, DependencyProviderResource } from "../resource";
 
 class MyResource extends ComponentResource {
     constructor(name: string, opts?: CustomResourceOptions) {
@@ -63,4 +63,13 @@ describe("createUrn", () => {
         const urn = await createUrn("n", "t", res.child).promise();
         assert.strictEqual(urn, "urn:pulumi:mystack::myproject::my:mod:MyParentResource$my:mod:MyResource$t::n");
     }));
+});
+
+describe("DependencyProviderResource", () => {
+    describe("getPackage", () => {
+        it("returns the expected package", () => {
+            const res = new DependencyProviderResource("urn:pulumi:stack::project::pulumi:providers:aws::default_4_13_0");
+            assert.strictEqual(res.getPackage(), "aws");
+        });
+    });
 });

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -963,9 +963,15 @@ class DependencyProviderResource(ProviderResource):
     """
 
     def __init__(self, ref: str) -> None:
-        super().__init__(pkg="", name="", props={}, opts=None, dependency=True)
-
         ref_urn, ref_id = _parse_resource_reference(ref)
+        urn_parts = ref_urn.split("::")
+        qualified_type = urn_parts[2]
+        typ = qualified_type.split("$")[-1]
+        typ_parts = typ.split(":")
+        # typ will be "pulumi:providers:<package>" and we want the last part.
+        pkg = typ_parts[2] if len(typ_parts) > 2 else ""
+
+        super().__init__(pkg=pkg, name="", props={}, opts=None, dependency=True)
 
         from . import Output  # pylint: disable=import-outside-toplevel
 

--- a/sdk/python/lib/test/test_resource.py
+++ b/sdk/python/lib/test/test_resource.py
@@ -1,0 +1,23 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from pulumi.resource import DependencyProviderResource
+
+
+class DependencyProviderResourceTests(unittest.TestCase):
+    def test_get_package(self):
+        res = DependencyProviderResource("urn:pulumi:stack::project::pulumi:providers:aws::default_4_13_0")
+        self.assertEqual("aws", res.package)


### PR DESCRIPTION
When initializing `DependencyProviderResource` (Node.js, Python, and .NET), pass the package to the base constructor instead of an empty string s.t. the provider is usable when its package is read.

Note that the Go SDK was already doing this (line 133):

https://github.com/pulumi/pulumi/blob/eaf78edfef11c7ab97dc90b2bafd3c9fcc7eedf7/sdk/go/pulumi/resource.go#L127-L135

... so this is making the other language SDKs consistent.

Also worth noting that the likelihood of this being a problem is much less now after #7624, but it's still worth fixing because it's still possible to fallback to `DependencyProviderResource` when we can't rehydrate a provider.

Fixes #6895