### PR TITLE
Allow setting plugin name and version for Node.js

### DIFF
--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1759,6 +1759,8 @@ type npmPackage struct {
 }
 
 type npmPulumiManifest struct {
+	Name              string `json:"name,omitempty"`
+	Version           string `json:"version,omitempty"`
 	Resource          bool   `json:"resource,omitempty"`
 	PluginDownloadURL string `json:"pluginDownloadURL,omitempty"`
 }
@@ -1796,6 +1798,8 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 		Pulumi: npmPulumiManifest{
 			Resource:          true,
 			PluginDownloadURL: pkg.PluginDownloadURL,
+			Name:              info.PluginName,
+			Version:           info.PluginVersion,
 		},
 	}
 

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -52,8 +52,12 @@ type NodePackageInfo struct {
 	DisableUnionOutputTypes bool `json:"disableUnionOutputTypes,omitempty"`
 	// An indicator for whether the package contains enums.
 	ContainsEnums bool `json:"containsEnums,omitempty"`
-	// A map allowing you to map the name of a provider to the name of the module encapsulating the provider
+	// A map allowing you to map the name of a provider to the name of the module encapsulating the provider.
 	ProviderNameToModuleName map[string]string `json:"providerNameToModuleName,omitempty"`
+	// The name of the plugin, which might be different from the package name.
+	PluginName string `json:"pluginName,omitempty"`
+	// The version of the plugin, which might be different from the version of the package..
+	PluginVersion string `json:"pluginVersion,omitempty"`
 }
 
 // NodeObjectInfo contains NodeJS-specific information for an object.


### PR DESCRIPTION
# Description

This commit adds two new fields to the Node package info struct to permit setting the plugin name if it differs from the package name, and the version if it differs from the package version. This was already supported by the loader.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

No test coverage of this area.

- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Not a user-facing change.

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version

N/A.
