### PR TITLE
Added support for custom naming of dynamic provider resource

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,7 @@
 ### Improvements
 
+- [sdk/python] - Add support for custom naming of dynamic provider resource.
+  [#7633](https://github.com/pulumi/pulumi/pull/7633)
+
 ### Bug Fixes
 

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -242,6 +242,9 @@ class Resource(CustomResource):
     Resource represents a Pulumi Resource that incorporates an inline implementation of the Resource's CRUD operations.
     """
 
+    def __init_subclass__(cls, name: str ='dynamic:Resource'):
+        cls._resource_type_name = name
+
     def __init__(self,
                  provider: ResourceProvider,
                  name: str,
@@ -261,4 +264,4 @@ class Resource(CustomResource):
         props = cast(dict, props)
         props[PROVIDER_KEY] = serialize_provider(provider)
 
-        super().__init__("pulumi-python:dynamic:Resource", name, props, opts)
+        super().__init__(f"pulumi-python:{self._resource_type_name}", name, props, opts)

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -242,8 +242,10 @@ class Resource(CustomResource):
     Resource represents a Pulumi Resource that incorporates an inline implementation of the Resource's CRUD operations.
     """
 
-    def __init_subclass__(cls, name: str ='dynamic:Resource'):
-        cls._resource_type_name = name
+    def __init_subclass__(cls, module: str = '', name: str ='Resource'):
+        if module != '':
+            module = '/' + module
+        cls._resource_type_name = f"dynamic{module}:{name}"
 
     def __init__(self,
                  provider: ResourceProvider,

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -15,7 +15,7 @@
 import asyncio
 import base64
 import pickle
-from typing import Any, Optional, List, TYPE_CHECKING, no_type_check, cast
+from typing import Any, ClassVar, Optional, List, TYPE_CHECKING, no_type_check, cast
 
 import dill
 from .. import CustomResource, ResourceOptions
@@ -241,6 +241,8 @@ class Resource(CustomResource):
     """
     Resource represents a Pulumi Resource that incorporates an inline implementation of the Resource's CRUD operations.
     """
+
+    _resource_type_name: ClassVar[str]
 
     def __init_subclass__(cls, module: str = '', name: str = 'Resource'):
         if module:

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -242,7 +242,7 @@ class Resource(CustomResource):
     Resource represents a Pulumi Resource that incorporates an inline implementation of the Resource's CRUD operations.
     """
 
-    def __init_subclass__(cls, module: str = '', name: str ='Resource'):
+    def __init_subclass__(cls, module: str = '', name: str = 'Resource'):
         if module:
             module = f'/{module}'
         cls._resource_type_name = f'dynamic{module}:{name}'

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -243,9 +243,9 @@ class Resource(CustomResource):
     """
 
     def __init_subclass__(cls, module: str = '', name: str ='Resource'):
-        if module != '':
-            module = '/' + module
-        cls._resource_type_name = f"dynamic{module}:{name}"
+        if module:
+            module = f'/{module}'
+        cls._resource_type_name = f'dynamic{module}:{name}'
 
     def __init__(self,
                  provider: ResourceProvider,

--- a/tests/integration/dynamic/python-resource-type-name/Pulumi.yaml
+++ b/tests/integration/dynamic/python-resource-type-name/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: dynamic_resource_type_name_py
+description: A simple Python program that uses dynamic providers with custom resource type name.
+runtime: python

--- a/tests/integration/dynamic/python-resource-type-name/__main__.py
+++ b/tests/integration/dynamic/python-resource-type-name/__main__.py
@@ -1,0 +1,21 @@
+# Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+from pulumi import export
+from pulumi.dynamic import CreateResult, Resource, ResourceProvider
+
+
+class CustomResource(
+    Resource, module="custom-provider", name="CustomResource"
+):
+    def __init__(self, name, opts=None):
+        super().__init__(DummyResourceProvider(), name, {}, opts)
+
+
+class DummyResourceProvider(ResourceProvider):
+    def create(self, props):
+        return CreateResult("resource-id", {})
+
+
+resource = CustomResource("resource-name")
+
+export("urn", resource.urn)

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -419,17 +419,16 @@ func TestDynamicPythonNonMain(t *testing.T) {
 
 // Tests custom resource type name of dynamic provider in Python.
 func TestCustomResourceTypeNameDynamicPython(t *testing.T) {
-	var randomVal string
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir: filepath.Join("dynamic", "python-resource-type-name"),
 		Dependencies: []string{
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			urnOut = stack.Outputs["urn"].(string)
+			urnOut := stack.Outputs["urn"].(string)
 			urn := resource.URN(urnOut)
-			typ := urn.Type()
-			assert.Equal(t, typ, "pulumi-python:dynamic/custom-provider:CustomResource")
+			typ := urn.Type().String()
+			assert.Equal(t, "pulumi-python:dynamic/custom-provider:CustomResource", typ)
 		},
 	})
 }

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -426,9 +426,9 @@ func TestCustomResourceTypeNameDynamicPython(t *testing.T) {
 			filepath.Join("..", "..", "sdk", "python", "env", "src"),
 		},
 		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
-			urn_s = stack.Outputs["urn"].(string)
-			urn := resource.URN(urn_s)
-	        typ := urn.Type()
+			urnOut = stack.Outputs["urn"].(string)
+			urn := resource.URN(urnOut)
+			typ := urn.Type()
 			assert.Equal(t, typ, "pulumi-python:dynamic/custom-provider:CustomResource")
 		},
 	})

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -416,6 +416,25 @@ func TestDynamicPythonNonMain(t *testing.T) {
 	})
 }
 
+
+// Tests custom resource type name of dynamic provider in Python.
+func TestCustomResourceTypeNameDynamicPython(t *testing.T) {
+	var randomVal string
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join("dynamic", "python-resource-type-name"),
+		Dependencies: []string{
+			filepath.Join("..", "..", "sdk", "python", "env", "src"),
+		},
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			urn_s = stack.Outputs["urn"].(string)
+			urn := resource.URN(urn_s)
+	        typ := urn.Type()
+			assert.Equal(t, typ, "pulumi-python:dynamic/custom-provider:CustomResource")
+		},
+	})
+}
+
+
 func TestPartialValuesPython(t *testing.T) {
 	if runtime.GOOS == WindowsOS {
 		t.Skip("Temporarily skipping test on Windows - pulumi/pulumi#3811")


### PR DESCRIPTION
# Description

Now there is not possible to change a name of dynamic provider resource without copying a code of the `pulumi.sdk.python.lib.pulumi.dynamic.dynamic.Resource` and changing the hard-coded name `"pulumi-python:dynamic:Resource"`. I successfully uses this proposal to make it possible.

Usage:
```python
class CustomResource(
    Resource, name="my-custom-provider:CustomResource"
):
   ...
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
