### PR TITLE
[codegen/go] Unify input method generation.

### DIFF
--- a/pkg/codegen/internal/test/helpers.go
+++ b/pkg/codegen/internal/test/helpers.go
@@ -112,16 +112,20 @@ func LoadBaseline(dir, lang string) (map[string][]byte, error) {
 }
 
 // ValidateFileEquality compares maps of files for equality.
-func ValidateFileEquality(t *testing.T, actual, expected map[string][]byte) {
+func ValidateFileEquality(t *testing.T, actual, expected map[string][]byte) bool {
+	ok := true
 	for name, file := range expected {
-		assert.Contains(t, actual, name)
-		assert.Equal(t, string(file), string(actual[name]), name)
-	}
-	for name := range actual {
-		if _, ok := expected[name]; !ok {
-			t.Logf("missing data for %s", name)
+		if !assert.Contains(t, actual, name) || !assert.Equal(t, string(file), string(actual[name]), name) {
+			ok = false
 		}
 	}
+	for name := range actual {
+		if _, has := expected[name]; !has {
+			t.Logf("missing data for %s", name)
+			ok = false
+		}
+	}
+	return ok
 }
 
 // If PULUMI_ACCEPT is set, writes out actual output to the expected

--- a/pkg/codegen/internal/test/sdk_driver.go
+++ b/pkg/codegen/internal/test/sdk_driver.go
@@ -2,17 +2,22 @@ package test
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+type ThenFunc func(t *testing.T, testDir string)
 
 type sdkTest struct {
 	Directory   string
 	Description string
 	Skip        codegen.StringSet
+	Then        map[string]ThenFunc
 }
 
 var sdkTests = []sdkTest{
@@ -35,6 +40,17 @@ var sdkTests = []sdkTest{
 	{
 		Directory:   "resource-args-python",
 		Description: "Resource args with same named resource and type",
+		Then: map[string]ThenFunc{
+			"go": func(t *testing.T, testDir string) {
+				cmd := exec.Command("go", "test", "./...")
+				cmd.Dir = filepath.Join(testDir, "go-program")
+
+				out, err := cmd.CombinedOutput()
+				if !assert.NoError(t, err) {
+					t.Logf("output: %v", string(out))
+				}
+			},
+		},
 	},
 	{
 		Directory:   "simple-enum-schema",
@@ -102,18 +118,20 @@ func TestSDKCodegen(t *testing.T, language string, genPackage GenPkgSignature) {
 			}
 
 			files, err := GeneratePackageFilesFromSchema(schemaPath, genPackage)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
-			dir := filepath.Join(testDir, tt.Directory)
+			if !RewriteFilesWhenPulumiAccept(t, dirPath, language, files) {
+				expectedFiles, err := LoadBaseline(dirPath, language)
+				require.NoError(t, err)
 
-			if RewriteFilesWhenPulumiAccept(t, dir, language, files) {
-				return
+				if !ValidateFileEquality(t, files, expectedFiles) {
+					return
+				}
 			}
 
-			expectedFiles, err := LoadBaseline(dir, language)
-			assert.NoError(t, err)
-
-			ValidateFileEquality(t, files, expectedFiles)
+			if then, ok := tt.Then[language]; ok {
+				then(t, dirPath)
+			}
 		})
 	}
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/cat.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/cat.go
@@ -131,7 +131,7 @@ type CatArrayInput interface {
 type CatArray []CatInput
 
 func (CatArray) ElementType() reflect.Type {
-	return reflect.TypeOf(([]*Cat)(nil))
+	return reflect.TypeOf((*[]*Cat)(nil)).Elem()
 }
 
 func (i CatArray) ToCatArrayOutput() CatArrayOutput {
@@ -156,7 +156,7 @@ type CatMapInput interface {
 type CatMap map[string]CatInput
 
 func (CatMap) ElementType() reflect.Type {
-	return reflect.TypeOf((map[string]*Cat)(nil))
+	return reflect.TypeOf((*map[string]*Cat)(nil)).Elem()
 }
 
 func (i CatMap) ToCatMapOutput() CatMapOutput {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
@@ -155,7 +155,7 @@ type ComponentArrayInput interface {
 type ComponentArray []ComponentInput
 
 func (ComponentArray) ElementType() reflect.Type {
-	return reflect.TypeOf(([]*Component)(nil))
+	return reflect.TypeOf((*[]*Component)(nil)).Elem()
 }
 
 func (i ComponentArray) ToComponentArrayOutput() ComponentArrayOutput {
@@ -180,7 +180,7 @@ type ComponentMapInput interface {
 type ComponentMap map[string]ComponentInput
 
 func (ComponentMap) ElementType() reflect.Type {
-	return reflect.TypeOf((map[string]*Component)(nil))
+	return reflect.TypeOf((*map[string]*Component)(nil)).Elem()
 }
 
 func (i ComponentMap) ToComponentMapOutput() ComponentMapOutput {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/workload.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/workload.go
@@ -128,7 +128,7 @@ type WorkloadArrayInput interface {
 type WorkloadArray []WorkloadInput
 
 func (WorkloadArray) ElementType() reflect.Type {
-	return reflect.TypeOf(([]*Workload)(nil))
+	return reflect.TypeOf((*[]*Workload)(nil)).Elem()
 }
 
 func (i WorkloadArray) ToWorkloadArrayOutput() WorkloadArrayOutput {
@@ -153,7 +153,7 @@ type WorkloadMapInput interface {
 type WorkloadMap map[string]WorkloadInput
 
 func (WorkloadMap) ElementType() reflect.Type {
-	return reflect.TypeOf((map[string]*Workload)(nil))
+	return reflect.TypeOf((*map[string]*Workload)(nil)).Elem()
 }
 
 func (i WorkloadMap) ToWorkloadMapOutput() WorkloadMapOutput {

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
@@ -118,7 +118,7 @@ type StaticPageArrayInput interface {
 type StaticPageArray []StaticPageInput
 
 func (StaticPageArray) ElementType() reflect.Type {
-	return reflect.TypeOf(([]*StaticPage)(nil))
+	return reflect.TypeOf((*[]*StaticPage)(nil)).Elem()
 }
 
 func (i StaticPageArray) ToStaticPageArrayOutput() StaticPageArrayOutput {
@@ -143,7 +143,7 @@ type StaticPageMapInput interface {
 type StaticPageMap map[string]StaticPageInput
 
 func (StaticPageMap) ElementType() reflect.Type {
-	return reflect.TypeOf((map[string]*StaticPage)(nil))
+	return reflect.TypeOf((*map[string]*StaticPage)(nil)).Elem()
 }
 
 func (i StaticPageMap) ToStaticPageMapOutput() StaticPageMapOutput {

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go-program/go_test.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go-program/go_test.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen/internal/test/testdata/resource-args-python/go/example"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestArrayElemType(t *testing.T) {
+	var arr example.PersonArray
+	assert.Equal(t, reflect.TypeOf([]*example.Person(nil)), arr.ElementType())
+}
+
+func TestMapElemType(t *testing.T) {
+	var m example.PersonMap
+	assert.Equal(t, reflect.TypeOf(map[string]*example.Person(nil)), m.ElementType())
+}

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go/example/person.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go/example/person.go
@@ -132,7 +132,7 @@ type PersonArrayInput interface {
 type PersonArray []PersonInput
 
 func (PersonArray) ElementType() reflect.Type {
-	return reflect.TypeOf(([]*Person)(nil))
+	return reflect.TypeOf((*[]*Person)(nil)).Elem()
 }
 
 func (i PersonArray) ToPersonArrayOutput() PersonArrayOutput {
@@ -157,7 +157,7 @@ type PersonMapInput interface {
 type PersonMap map[string]PersonInput
 
 func (PersonMap) ElementType() reflect.Type {
-	return reflect.TypeOf((map[string]*Person)(nil))
+	return reflect.TypeOf((*map[string]*Person)(nil)).Elem()
 }
 
 func (i PersonMap) ToPersonMapOutput() PersonMapOutput {

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go/example/pet.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go/example/pet.go
@@ -129,7 +129,7 @@ type PetArrayInput interface {
 type PetArray []PetInput
 
 func (PetArray) ElementType() reflect.Type {
-	return reflect.TypeOf(([]*Pet)(nil))
+	return reflect.TypeOf((*[]*Pet)(nil)).Elem()
 }
 
 func (i PetArray) ToPetArrayOutput() PetArrayOutput {
@@ -154,7 +154,7 @@ type PetMapInput interface {
 type PetMap map[string]PetInput
 
 func (PetMap) ElementType() reflect.Type {
-	return reflect.TypeOf((map[string]*Pet)(nil))
+	return reflect.TypeOf((*map[string]*Pet)(nil)).Elem()
 }
 
 func (i PetMap) ToPetMapOutput() PetMapOutput {


### PR DESCRIPTION
The code for input method generation was duplicated. These changes
remove the duplicated code.

This is prep for fixing #7595.