### PR TITLE
[codegen/python] Delete dead code around casing tables

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -48,13 +48,6 @@ var (
 	packagedTemplates  map[string][]byte
 	docHelpers         map[string]codegen.DocLanguageHelper
 
-	// The following property case maps are for rendering property
-	// names of nested properties in Python language with the correct
-	// casing.
-	snakeCaseToCamelCase map[string]string
-	camelCaseToSnakeCase map[string]string
-	seenCasingTypes      codegen.Set
-
 	// The language-specific info objects for a certain package (provider).
 	goPkgInfo     go_gen.GoPackageInfo
 	csharpPkgInfo dotnet.CSharpPackageInfo
@@ -146,9 +139,6 @@ func init() {
 		}
 	}
 
-	snakeCaseToCamelCase = map[string]string{}
-	camelCaseToSnakeCase = map[string]string{}
-	seenCasingTypes = codegen.Set{}
 	langModuleNameLookup = map[string]string{}
 }
 
@@ -1734,17 +1724,6 @@ func getMod(pkg *schema.Package, token string, tokenPkg *schema.Package, modules
 	return mod
 }
 
-func generatePythonPropertyCaseMaps(mod *modContext, r *schema.Resource, seenTypes codegen.Set) {
-	pyLangHelper := getLanguageDocHelper("python").(*python.DocLanguageHelper)
-	for _, p := range r.Properties {
-		pyLangHelper.GenPropertyCaseMap(mod.pkg, mod.mod, mod.tool, p, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
-	}
-
-	for _, p := range r.InputProperties {
-		pyLangHelper.GenPropertyCaseMap(mod.pkg, mod.mod, mod.tool, p, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
-	}
-}
-
 func generateModulesFromSchemaPackage(tool string, pkg *schema.Package) map[string]*modContext {
 	// Group resources, types, and functions into modules.
 	modules := map[string]*modContext{}
@@ -1792,8 +1771,6 @@ func generateModulesFromSchemaPackage(tool string, pkg *schema.Package) map[stri
 		mod := getMod(pkg, r.Token, r.Package, modules, tool, true)
 		mod.resources = append(mod.resources, r)
 		visitObjects(r)
-
-		generatePythonPropertyCaseMaps(mod, r, seenCasingTypes)
 	}
 
 	scanK8SResource := func(r *schema.Resource) {

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -19,11 +19,9 @@
 package docs
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/internal/test"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
 )
@@ -261,86 +259,6 @@ $ pulumi import prov:module/resource:Resource test test
 				},
 			},
 		},
-	}
-}
-
-// TestResourceNestedPropertyPythonCasing tests that the properties
-// of a nested object have the expected casing.
-func TestResourceNestedPropertyPythonCasing(t *testing.T) {
-	initTestPackageSpec(t)
-
-	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
-	assert.NoError(t, err, "importing spec")
-
-	modules := generateModulesFromSchemaPackage(unitTestTool, schemaPkg)
-	mod := modules["module"]
-	for _, r := range mod.resources {
-		nestedTypes := mod.genNestedTypes(r, true)
-		if len(nestedTypes) == 0 {
-			t.Error("did not find any nested types")
-			return
-		}
-
-		t.Run("InputPropertiesAreSnakeCased", func(t *testing.T) {
-			props := mod.getProperties(r.InputProperties, "python", true, false, false)
-			for _, p := range props {
-				assert.True(t, strings.Contains(p.Name, "_"), "input property name in python must use snake_case")
-			}
-		})
-
-		// Non-unique nested properties are ones that have names that occur as direct input properties
-		// of the resource or elsewhere in the package and are mapped as snake_case even if the property
-		// itself has a "Language" spec with the `MapCase` value of `false`.
-		t.Run("NonUniqueNestedProperties", func(t *testing.T) {
-			n := nestedTypes[0]
-			assert.Equal(t, "Resource<wbr>Options", n.Name, "got %v instead of Resource<wbr>Options", n.Name)
-
-			pyProps := n.Properties["python"]
-			nestedObject, ok := testPackageSpec.Types["prov:module/ResourceOptions:ResourceOptions"]
-			if !ok {
-				t.Error("sample schema package spec does not contain known object type")
-				return
-			}
-
-			for name := range nestedObject.Properties {
-				found := false
-				pyName := python.PyName(name)
-				for _, prop := range pyProps {
-					if prop.Name == pyName {
-						found = true
-						break
-					}
-				}
-
-				assert.True(t, found, "expected to find %q", pyName)
-			}
-		})
-
-		// Unique nested properties are those that only appear inside a nested object and should also be snake_cased.
-		t.Run("UniqueNestedProperties", func(t *testing.T) {
-			n := nestedTypes[1]
-			assert.Equal(t, "Resource<wbr>Options2", n.Name, "got %v instead of Resource<wbr>Options2", n.Name)
-
-			pyProps := n.Properties["python"]
-			nestedObject, ok := testPackageSpec.Types["prov:module/ResourceOptions2:ResourceOptions2"]
-			if !ok {
-				t.Error("sample schema package spec does not contain known object type")
-				return
-			}
-
-			for name := range nestedObject.Properties {
-				found := false
-				pyName := python.PyName(name)
-				for _, prop := range pyProps {
-					if prop.Name == pyName {
-						found = true
-						break
-					}
-				}
-
-				assert.True(t, found, "expected to find %q", name)
-			}
-		})
 	}
 }
 

--- a/pkg/codegen/python/doc.go
+++ b/pkg/codegen/python/doc.go
@@ -103,18 +103,6 @@ func (d DocLanguageHelper) GetResourceFunctionResultName(modName string, f *sche
 	return title(tokenToName(f.Token)) + "Result"
 }
 
-// GenPropertyCaseMap generates the case maps for a property.
-func (d DocLanguageHelper) GenPropertyCaseMap(pkg *schema.Package, modName, tool string, prop *schema.Property, snakeCaseToCamelCase, camelCaseToSnakeCase map[string]string, seenTypes codegen.Set) {
-	if _, imported := pkg.Language["python"]; !imported {
-		if err := pkg.ImportLanguages(map[string]schema.Language{"python": Importer}); err != nil {
-			fmt.Printf("error building case map for %q in module %q", prop.Name, modName)
-			return
-		}
-	}
-
-	recordProperty(prop, snakeCaseToCamelCase, camelCaseToSnakeCase, seenTypes)
-}
-
 // GetPropertyName returns the property name specific to Python.
 func (d DocLanguageHelper) GetPropertyName(p *schema.Property) (string, error) {
 	return PyName(p.Name), nil

--- a/pkg/codegen/python/gen_program_expressions.go
+++ b/pkg/codegen/python/gen_program_expressions.go
@@ -234,11 +234,8 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 
 		g.Fgenf(w, "%s(", name)
 
-		casingTable := g.casingTables[pkg]
 		if obj, ok := expr.Args[1].(*model.FunctionCallExpression); ok {
 			if obj, ok := obj.Args[0].(*model.ObjectConsExpression); ok {
-				g.lowerObjectKeys(expr.Args[1], casingTable)
-
 				indenter := func(f func()) { f() }
 				if len(obj.Items) > 1 {
 					indenter = g.Indented

--- a/pkg/codegen/python/gen_program_lower.go
+++ b/pkg/codegen/python/gen_program_lower.go
@@ -6,7 +6,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/zclconf/go-cty/cty"
 )
 
 func isParameterReference(parameters codegen.Set, x model.Expression) bool {
@@ -101,24 +100,4 @@ func (g *generator) lowerProxyApplies(expr model.Expression) (model.Expression, 
 		return expr, nil
 	}
 	return model.VisitExpression(expr, model.IdentityVisitor, rewriter)
-}
-
-func (g *generator) lowerObjectKeys(expr model.Expression, camelCaseToSnakeCase map[string]string) {
-	switch expr := expr.(type) {
-	case *model.ObjectConsExpression:
-		for _, item := range expr.Items {
-			// Ignore non-literal keys
-			if key, ok := item.Key.(*model.LiteralValueExpression); ok && key.Value.Type().Equals(cty.String) {
-				if keyVal, ok := camelCaseToSnakeCase[key.Value.AsString()]; ok {
-					key.Value = cty.StringVal(keyVal)
-				}
-			}
-
-			g.lowerObjectKeys(item.Value, camelCaseToSnakeCase)
-		}
-	case *model.TupleConsExpression:
-		for _, element := range expr.Expressions {
-			g.lowerObjectKeys(element, camelCaseToSnakeCase)
-		}
-	}
 }

--- a/pkg/codegen/python/gen_program_quotes.go
+++ b/pkg/codegen/python/gen_program_quotes.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
-	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -53,19 +52,8 @@ func (g *generator) rewriteTraversal(traversal hcl.Traversal, source model.Expre
 		keyVal, objectKey := key.AsString(), false
 
 		receiver := parts[i]
-		if schemaType, ok := hcl2.GetSchemaForType(model.GetTraversableType(receiver)); ok {
-			obj := schemaType.(*schema.ObjectType)
-
-			info, ok := obj.Language["python"].(objectTypeInfo)
-			if ok {
-				objectKey = !info.isDictionary
-				if mapped, ok := info.camelCaseToSnakeCase[keyVal]; ok {
-					keyVal = mapped
-				}
-			} else {
-				objectKey, keyVal = true, PyName(keyVal)
-			}
-
+		if _, ok := hcl2.GetSchemaForType(model.GetTraversableType(receiver)); ok {
+			objectKey, keyVal = true, PyName(keyVal)
 			switch t := traverser.(type) {
 			case hcl.TraverseAttr:
 				t.Name = keyVal


### PR DESCRIPTION
Coincident with the release of Pulumi 3.0, we updated the provider SDK codegen for Python to no longer use casing tables for translating Python snake_case names to Pulumi camelCase names (and vice versa). Instead, the mapping is encoded in decorators applied on class properties.

Some of the code that was used to generate and use the casing tables has persisted. This commits removes this code, as it's no longer necessary, and will improve the quality of our generated examples.

Follow-up from https://github.com/pulumi/pulumi/pull/7547#issuecomment-881659505