### PR TITLE
Continue build fanout: split integration tests by tag 

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -111,7 +111,7 @@ jobs:
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
         node-version: [ 14.x ]
-        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
+        test-subset: [ integration-python, integration-nodejs, integration-go, integration-dotnet, auto-and-lifecycletest, native, etc ]
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.platform }}
     steps:

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -22,7 +22,7 @@ def options(options_and_packages, test_subset=None):
         if len(tags) == 0:
             return o
 
-        return '-tags="' + ' '.join(tags) + '"'
+        return '-tags=' + ' '.join(tags)
 
     return [rewrite(o) for o in options_and_packages if '/' not in o]
 

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -11,8 +11,20 @@ import sys
 import uuid
 
 
-def options(options_and_packages):
-    return [o for o in options_and_packages if '/' not in o]
+def options(options_and_packages, test_subset=None):
+
+    def rewrite(o):
+        if test_subset is None or o != '-tags=all':
+            return o
+
+        tags = TEST_SUBSETS[test_subset].tags
+
+        if len(tags) == 0:
+            return o
+
+        return '-tags="' + ' '.join(tags) + '"'
+
+    return [rewrite(o) for o in options_and_packages if '/' not in o]
 
 
 def packages(options_and_packages):
@@ -26,10 +38,10 @@ def filter_packages(packages, test_subset=None):
     if test_subset == 'etc':
         s = set([])
         for k in TEST_SUBSETS:
-            s = s | set(TEST_SUBSETS[k])
+            s = s | set(TEST_SUBSETS[k].go_packages)
         return [p for p in packages if p not in s]
 
-    s = set(TEST_SUBSETS[test_subset])
+    s = set(TEST_SUBSETS[test_subset].go_packages)
     return [p for p in packages if p in s]
 
 
@@ -44,7 +56,7 @@ if not packages:
     sys.exit(0)
 
 
-options_and_packages = options(options_and_packages) + packages
+options_and_packages = options(options_and_packages, test_subset=test_subset) + packages
 
 
 if shutil.which('gotestsum') is not None:

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -14,7 +14,7 @@ import uuid
 def options(options_and_packages, test_subset=None):
 
     def rewrite(o):
-        if test_subset is None or o != '-tags=all':
+        if test_subset is None or o != '-tags=all' or test_subset == 'etc':
             return o
 
         tags = TEST_SUBSETS[test_subset].tags

--- a/scripts/go-test.py
+++ b/scripts/go-test.py
@@ -17,7 +17,7 @@ def options(options_and_packages, test_subset=None):
         if test_subset is None or o != '-tags=all' or test_subset == 'etc':
             return o
 
-        tags = TEST_SUBSETS[test_subset].tags
+        tags = TEST_SUBSETS[test_subset].go_tags
 
         if len(tags) == 0:
             return o

--- a/scripts/run-testsuite.py
+++ b/scripts/run-testsuite.py
@@ -23,11 +23,11 @@ def should_run():
         s = set([])
 
         for k in TEST_SUBSETS:
-            s = s | set(TEST_SUBSETS[k])
+            s = s | set(TEST_SUBSETS[k].test_suites)
 
         return testsuite_name not in s
 
-    s = set(TEST_SUBSETS[test_subset])
+    s = set(TEST_SUBSETS[test_subset].test_suites)
     return testsuite_name in s
 
 

--- a/scripts/test_subsets.py
+++ b/scripts/test_subsets.py
@@ -11,20 +11,48 @@ tests, or test suites names as passed to `run-testsuite.py`.
 
 """
 
+from collections import namedtuple
+
+
+TestSubset = namedtuple(
+    'TestSubset',
+    ['go_packages',
+     'go_tags',
+     'test_suites'],
+    defaults={'go_packages': [],
+              'go_tags': [],
+              'test_suites': []})
+
+
 TEST_SUBSETS = {
-    'integration': [
-        'github.com/pulumi/pulumi/tests/integration'
-    ],
-    'auto-and-lifecycletest': [
-        'github.com/pulumi/pulumi/sdk/v3/go/auto',
-        'github.com/pulumi/pulumi/pkg/v3/engine/lifeycletest'
-    ],
-    'native': [
+    'integration-python': TestSubset(
+        go_packages=['github.com/pulumi/pulumi/tests/integration'],
+        go_tags=['python'],
+    ),
+    'integration-nodejs': TestSubset(
+        go_packages=['github.com/pulumi/pulumi/tests/integration'],
+        go_tags=['nodejs'],
+    ),
+    'integration-go': TestSubset(
+        go_packages=['github.com/pulumi/pulumi/tests/integration'],
+        go_tags=['go'],
+    ),
+    'integration-dotnet': TestSubset(
+        go_packages=['github.com/pulumi/pulumi/tests/integration'],
+        go_tags=['dotnet'],
+    ),
+    'auto-and-lifecycletest': TestSubset(
+        go_packages=[
+            'github.com/pulumi/pulumi/sdk/v3/go/auto',
+            'github.com/pulumi/pulumi/pkg/v3/engine/lifeycletest'
+        ]
+    ),
+    'native': TestSubset(test_suites=[
         'dotnet-test',
         'istanbul',
         'istanbul-with-mocks',
         'python/lib/test',
         'python/lib/test/langhost/resource_thens',
         'python/lib/test_with_mocks'
-    ]
+    ])
 }


### PR DESCRIPTION
# Description

Since integration tests were on the critical path, this further splits them by language tag to fan them out across workers. Some care is needed to utilize the workers well and not request too many. For starters - one worker per language.


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
