### PR TITLE
Fixing WaitGroup related panics in the Go SDK

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,3 +4,7 @@
 
 - [cli] - Respect provider aliases
   [#7166](https://github.com/pulumi/pulumi/pull/7166)
+
+- [sdk/go] - Fix panics caused by logging from `ApplyT`, affecting
+  `pulumi-docker` and potentially other providers
+  [#7661](https://github.com/pulumi/pulumi/pull/7661)

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -58,7 +58,7 @@ type Context struct {
 	rpcsLock sync.Mutex // a lock protecting the RPC count and event.
 	rpcError error      // the first error (if any) encountered during an RPC.
 
-	join sync.WaitGroup // the waitgroup for non-RPC async work associated with this context
+	join workGroup // the waitgroup for non-RPC async work associated with this context
 
 	Log Log // the logging interface for the Pulumi log stream.
 }

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -1,0 +1,106 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// The test is extracted from a panic using pulumi-docker and minified
+// while still reproducing the panic. The issue is that the resource
+// constructor `NewImage` processes `StringInput` and logs into a
+// captured `*pulumi.Context` from `ApplyT`. The user program passes a
+// vanilla `String`. The `ApplyT` is not tracked against the context
+// join group, but the logging is, which causes the logging statement
+// to appear as "dynamic" work that appeared unexpectedly after "all
+// work was done", and race with the program completion `Wait`.
+func TestLoggingFromApplyCausesNoPanics(t *testing.T) {
+	// Usually panics on iteration 100-200
+	for i := 0; i < 1000; i++ {
+		fmt.Printf("Iteration %d\n", i)
+		mocks := &testMonitor{}
+		err := RunErr(func(ctx *Context) error {
+			String("X").ToStringOutput().ApplyT(func(string) int {
+				ctx.Log.Debug("Zzz", &LogArgs{})
+				return 0
+			})
+			return nil
+		}, WithMocks("project", "stack", mocks))
+		assert.NoError(t, err)
+	}
+}
+
+type LoggingTestResource struct {
+	ResourceState
+	TestOutput StringOutput
+}
+
+func NewLoggingTestResource(ctx *Context, name string, input StringInput, opts ...ResourceOption) (*LoggingTestResource, error) {
+	resource := &LoggingTestResource{}
+	err := ctx.RegisterComponentResource("test:go:NewLoggingTestResource", name, resource, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	resource.TestOutput = input.ToStringOutput().ApplyT(func(inputValue string) (string, error) {
+		time.Sleep(10)
+		ctx.Log.Debug("Zzz", &LogArgs{})
+		return inputValue, nil
+	}).(StringOutput)
+
+	outputs := Map(map[string]Input{
+		"testOutput": resource.TestOutput,
+	})
+
+	err = ctx.RegisterResourceOutputs(resource, outputs)
+	if err != nil {
+		return nil, err
+	}
+
+	return resource, nil
+}
+
+// The following test reproduced a panic but is somewhat contrived. It
+// can happen if we queue new work (ApplyT) dynamically (from Apply)
+// against a single join group in the Context. If the concurrency
+// cards are dealt just right, the program is already executing
+// context.wg.Wait() and is about to complete, since wg count is 0,
+// when we increment the count via ApplyT. Go surfaces this as a
+// panic. Even if the program did not panic, there would be a race
+// condition there, since it is unclear whether the new dynamic work
+// should have been awaited or not.
+//
+// Do we care about this case? User programs need to engage goroutines
+// and out of band Pulumi work creation, more than just straight
+// ApplyT, to get this.
+//
+// func TestWaitingCausesNoPanics(t *testing.T) {
+// 	for i := 0; i < 10; i++ {
+// 		mocks := &testMonitor{}
+// 		err := RunErr(func(ctx *Context) error {
+// 			o, set, _ := ctx.NewOutput()
+// 			go func() {
+// 				set(1)
+// 				o.ApplyT(func(x interface{}) interface{} { return x })
+// 			}()
+// 			return nil
+// 		}, WithMocks("project", "stack", mocks))
+// 		assert.NoError(t, err)
+// 	}
+// }

--- a/sdk/go/pulumi/context_test.go
+++ b/sdk/go/pulumi/context_test.go
@@ -46,6 +46,22 @@ func TestLoggingFromApplyCausesNoPanics(t *testing.T) {
 	}
 }
 
+// An extended version of the same test, showing how things happen via
+// a custom resource. This would admit fixes going in
+// `RegisterResourceOutputs` for example.
+func TestLoggingFromApplyCausesNoPanics2(t *testing.T) {
+	// Usually panics on iteration 100-200
+	for i := 0; i < 1000; i++ {
+		fmt.Printf("Iteration %d\n", i)
+		mocks := &testMonitor{}
+		err := RunErr(func(ctx *Context) error {
+			NewLoggingTestResource(ctx, "res", String("A"))
+			return nil
+		}, WithMocks("project", "stack", mocks))
+		assert.NoError(t, err)
+	}
+}
+
 type LoggingTestResource struct {
 	ResourceState
 	TestOutput StringOutput

--- a/sdk/go/pulumi/log.go
+++ b/sdk/go/pulumi/log.go
@@ -18,7 +18,6 @@ package pulumi
 
 import (
 	"strings"
-	"sync"
 
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"golang.org/x/net/context"
@@ -37,7 +36,7 @@ type Log interface {
 type logState struct {
 	engine pulumirpc.EngineClient
 	ctx    context.Context
-	join   *sync.WaitGroup
+	join   *workGroup
 }
 
 // LogArgs may be used to specify arguments to be used for logging.

--- a/sdk/go/pulumi/types_test.go
+++ b/sdk/go/pulumi/types_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -599,7 +598,7 @@ func TestDeps(t *testing.T) {
 }
 
 func testMixedWaitGroups(t *testing.T, combine func(o1, o2 Output) Output) {
-	var wg1, wg2 sync.WaitGroup
+	var wg1, wg2 workGroup
 
 	o1 := newOutput(&wg1, anyOutputType)
 	o2 := newOutput(&wg2, anyOutputType)

--- a/sdk/go/pulumi/workgroup.go
+++ b/sdk/go/pulumi/workgroup.go
@@ -1,0 +1,71 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Mimicks the interface of `sync.WaitGroup` but does not panic in
+// case of races between `Wait` and `Add` with a positive delta in the
+// state with a zero counter. The reason `sync.WaitGroup` panics is to
+// warn about a race condition. Using `workGroup` implicitly accept
+// these race conditions instead. Use sparingly and document why it is
+// used.
+type workGroup struct {
+	mutex   sync.Mutex
+	cond    *sync.Cond
+	counter int
+}
+
+func (wg *workGroup) Wait() {
+	wg.mutex.Lock()
+	defer wg.mutex.Unlock()
+
+	if wg.cond == nil {
+		wg.cond = sync.NewCond(&wg.mutex)
+	}
+
+	for wg.counter > 0 {
+		wg.cond.Wait()
+	}
+}
+
+func (wg *workGroup) Add(delta int) {
+	wg.mutex.Lock()
+	defer wg.mutex.Unlock()
+
+	if wg.cond == nil {
+		wg.cond = sync.NewCond(&wg.mutex)
+	}
+
+	c := wg.counter + delta
+
+	if c < 0 {
+		panic(fmt.Sprintf("Adding %d would make workGroup counter negative: %d + %d = %d",
+			delta, wg.counter, delta, c))
+	}
+
+	wg.counter = c
+
+	if c == 0 {
+		wg.cond.Broadcast()
+	}
+}
+
+func (wg *workGroup) Done() {
+	wg.Add(-1)
+}

--- a/sdk/go/pulumi/workgroup_test.go
+++ b/sdk/go/pulumi/workgroup_test.go
@@ -1,0 +1,53 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWorkGroupActsAsWaitGroup(t *testing.T) {
+	check := func(j int) func(*testing.T) {
+		return func(*testing.T) {
+			var n int32 = 0
+			wg := &workGroup{}
+			wg.Add(j)
+
+			for k := 0; k < j; k++ {
+				go func() {
+					time.Sleep(10 * time.Millisecond)
+					atomic.AddInt32(&n, 1)
+					wg.Done()
+				}()
+			}
+
+			wg.Wait()
+			assert.Equal(t, int32(j), atomic.AddInt32(&n, 0))
+		}
+	}
+
+	t.Run("j=1", check(1))
+	t.Run("j=2", check(2))
+	t.Run("j=3", check(3))
+	t.Run("j=4", check(4))
+
+	// test Wait does not block on empty
+	wg := &workGroup{}
+	wg.Wait()
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #7275 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
