### PR TITLE
[codegen/go] Unify some output type generation

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1576,12 +1576,12 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 			// Generate the resource array input.
 			pkg.genInputInterface(w, name+"Array")
 			fmt.Fprintf(w, "type %[1]sArray []%[1]sInput\n\n", name)
-			genInputMethods(w, name+"Array", name+"Array", "[]*"+name, false, false)
+			genInputImplementation(w, name+"Array", name+"Array", "[]*"+name, false, false)
 
 			// Generate the resource map input.
 			pkg.genInputInterface(w, name+"Map")
 			fmt.Fprintf(w, "type %[1]sMap map[string]%[1]sInput\n\n", name)
-			genInputMethods(w, name+"Map", name+"Map", "map[string]*"+name, false, false)
+			genInputImplementation(w, name+"Map", name+"Map", "map[string]*"+name, false, false)
 		}
 	}
 

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -706,7 +706,7 @@ func (pkg *pkgContext) getInputUsage(name string) string {
 	}, "\n")
 }
 
-func genInputMethods(w io.Writer, name, receiverType, elementType string, ptrMethods, resourceType bool) {
+func genInputImplementation(w io.Writer, name, receiverType, elementType string, ptrMethods, resourceType bool) {
 	fmt.Fprintf(w, "func (%s) ElementType() reflect.Type {\n", receiverType)
 	if resourceType {
 		fmt.Fprintf(w, "\treturn reflect.TypeOf((*%s)(nil))\n", elementType)
@@ -797,7 +797,7 @@ func (pkg *pkgContext) genEnumType(w io.Writer, name string, enumType *schema.En
 
 		fmt.Fprintf(w, "type %[1]sArray []%[1]s\n\n", name)
 
-		genInputMethods(w, name+"Array", name+"Array", "[]"+name, false, false)
+		genInputImplementation(w, name+"Array", name+"Array", "[]"+name, false, false)
 	}
 
 	// Generate the map input.
@@ -806,7 +806,7 @@ func (pkg *pkgContext) genEnumType(w io.Writer, name string, enumType *schema.En
 
 		fmt.Fprintf(w, "type %[1]sMap map[string]%[1]s\n\n", name)
 
-		genInputMethods(w, name+"Map", name+"Map", "map[string]"+name, false, false)
+		genInputImplementation(w, name+"Map", name+"Map", "map[string]"+name, false, false)
 	}
 
 	// Generate the array output
@@ -1046,7 +1046,7 @@ func (pkg *pkgContext) genInputTypes(w io.Writer, t *schema.ObjectType, details 
 	}
 	fmt.Fprintf(w, "}\n\n")
 
-	genInputMethods(w, name, name+"Args", name, details.ptrElement, false)
+	genInputImplementation(w, name, name+"Args", name, details.ptrElement, false)
 
 	// Generate the pointer input.
 	if details.ptrElement {
@@ -1060,7 +1060,7 @@ func (pkg *pkgContext) genInputTypes(w io.Writer, t *schema.ObjectType, details 
 		fmt.Fprintf(w, "\treturn (*%s)(v)\n", ptrTypeName)
 		fmt.Fprintf(w, "}\n\n")
 
-		genInputMethods(w, name+"Ptr", "*"+ptrTypeName, "*"+name, false, false)
+		genInputImplementation(w, name+"Ptr", "*"+ptrTypeName, "*"+name, false, false)
 	}
 
 	// Generate the array input.
@@ -1069,7 +1069,7 @@ func (pkg *pkgContext) genInputTypes(w io.Writer, t *schema.ObjectType, details 
 
 		fmt.Fprintf(w, "type %[1]sArray []%[1]sInput\n\n", name)
 
-		genInputMethods(w, name+"Array", name+"Array", "[]"+name, false, false)
+		genInputImplementation(w, name+"Array", name+"Array", "[]"+name, false, false)
 	}
 
 	// Generate the map input.
@@ -1078,7 +1078,7 @@ func (pkg *pkgContext) genInputTypes(w io.Writer, t *schema.ObjectType, details 
 
 		fmt.Fprintf(w, "type %[1]sMap map[string]%[1]sInput\n\n", name)
 
-		genInputMethods(w, name+"Map", name+"Map", "map[string]"+name, false, false)
+		genInputImplementation(w, name+"Map", name+"Map", "map[string]"+name, false, false)
 	}
 }
 
@@ -1596,7 +1596,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 	fmt.Fprintf(w, "\tTo%[1]sOutputWithContext(ctx context.Context) %[1]sOutput\n", name)
 	fmt.Fprintf(w, "}\n\n")
 
-	genInputMethods(w, name, "*"+name, name, generateResourceContainerTypes, true)
+	genInputImplementation(w, name, "*"+name, name, generateResourceContainerTypes, true)
 
 	if generateResourceContainerTypes {
 		// Emit the resource pointer input type.
@@ -1607,7 +1607,7 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 		fmt.Fprintf(w, "}\n\n")
 		ptrTypeName := camel(name) + "PtrType"
 		fmt.Fprintf(w, "type %s %sArgs\n\n", ptrTypeName, name)
-		genInputMethods(w, name+"Ptr", "*"+ptrTypeName, "*"+name, false, true)
+		genInputImplementation(w, name+"Ptr", "*"+ptrTypeName, "*"+name, false, true)
 
 		if !r.IsProvider {
 			// Generate the resource array input.
@@ -1794,7 +1794,7 @@ func (pkg *pkgContext) genNestedCollectionType(w io.Writer, typ schema.Type) []s
 	for _, name := range names {
 		if strings.HasSuffix(name, "Array") {
 			fmt.Fprintf(w, "type %s []%sInput\n\n", name, elementTypeName)
-			genInputMethods(w, name, name, elementTypeName, false, false)
+			genInputImplementation(w, name, name, elementTypeName, false, false)
 
 			fmt.Fprintf(w, "type %sOutput struct { *pulumi.OutputState }\n\n", name)
 			genOutputMethods(w, name, elementTypeName, false)
@@ -1808,7 +1808,7 @@ func (pkg *pkgContext) genNestedCollectionType(w io.Writer, typ schema.Type) []s
 
 		if strings.HasSuffix(name, "Map") {
 			fmt.Fprintf(w, "type %s map[string]%sInput\n\n", name, elementTypeName)
-			genInputMethods(w, name, name, elementTypeName, false, false)
+			genInputImplementation(w, name, name, elementTypeName, false, false)
 
 			fmt.Fprintf(w, "type %sOutput struct { *pulumi.OutputState }\n\n", name)
 			genOutputMethods(w, name, elementTypeName, false)

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/cat.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/cat.go
@@ -167,9 +167,7 @@ func (i CatMap) ToCatMapOutputWithContext(ctx context.Context) CatMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatMapOutput)
 }
 
-type CatOutput struct {
-	*pulumi.OutputState
-}
+type CatOutput struct{ *pulumi.OutputState }
 
 func (CatOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Cat)(nil))
@@ -188,14 +186,12 @@ func (o CatOutput) ToCatPtrOutput() CatPtrOutput {
 }
 
 func (o CatOutput) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return o.ApplyT(func(v Cat) *Cat {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Cat) *Cat {
 		return &v
 	}).(CatPtrOutput)
 }
 
-type CatPtrOutput struct {
-	*pulumi.OutputState
-}
+type CatPtrOutput struct{ *pulumi.OutputState }
 
 func (CatPtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**Cat)(nil))
@@ -207,6 +203,16 @@ func (o CatPtrOutput) ToCatPtrOutput() CatPtrOutput {
 
 func (o CatPtrOutput) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
 	return o
+}
+
+func (o CatPtrOutput) Elem() CatOutput {
+	return o.ApplyT(func(v *Cat) Cat {
+		if v != nil {
+			return *v
+		}
+		var ret Cat
+		return ret
+	}).(CatOutput)
 }
 
 type CatArrayOutput struct{ *pulumi.OutputState }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
@@ -191,9 +191,7 @@ func (i ComponentMap) ToComponentMapOutputWithContext(ctx context.Context) Compo
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentMapOutput)
 }
 
-type ComponentOutput struct {
-	*pulumi.OutputState
-}
+type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Component)(nil))
@@ -212,14 +210,12 @@ func (o ComponentOutput) ToComponentPtrOutput() ComponentPtrOutput {
 }
 
 func (o ComponentOutput) ToComponentPtrOutputWithContext(ctx context.Context) ComponentPtrOutput {
-	return o.ApplyT(func(v Component) *Component {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Component) *Component {
 		return &v
 	}).(ComponentPtrOutput)
 }
 
-type ComponentPtrOutput struct {
-	*pulumi.OutputState
-}
+type ComponentPtrOutput struct{ *pulumi.OutputState }
 
 func (ComponentPtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**Component)(nil))
@@ -231,6 +227,16 @@ func (o ComponentPtrOutput) ToComponentPtrOutput() ComponentPtrOutput {
 
 func (o ComponentPtrOutput) ToComponentPtrOutputWithContext(ctx context.Context) ComponentPtrOutput {
 	return o
+}
+
+func (o ComponentPtrOutput) Elem() ComponentOutput {
+	return o.ApplyT(func(v *Component) Component {
+		if v != nil {
+			return *v
+		}
+		var ret Component
+		return ret
+	}).(ComponentOutput)
 }
 
 type ComponentArrayOutput struct{ *pulumi.OutputState }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/provider.go
@@ -88,9 +88,7 @@ func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) Pr
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))
@@ -109,14 +107,12 @@ func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
 }
 
 func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyT(func(v Provider) *Provider {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
 		return &v
 	}).(ProviderPtrOutput)
 }
 
-type ProviderPtrOutput struct {
-	*pulumi.OutputState
-}
+type ProviderPtrOutput struct{ *pulumi.OutputState }
 
 func (ProviderPtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**Provider)(nil))
@@ -128,6 +124,16 @@ func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
 
 func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
 	return o
+}
+
+func (o ProviderPtrOutput) Elem() ProviderOutput {
+	return o.ApplyT(func(v *Provider) Provider {
+		if v != nil {
+			return *v
+		}
+		var ret Provider
+		return ret
+	}).(ProviderOutput)
 }
 
 func init() {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/pulumiTypes.go
@@ -114,10 +114,11 @@ func (o PetOutput) ToPetPtrOutput() PetPtrOutput {
 }
 
 func (o PetOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return o.ApplyT(func(v Pet) *Pet {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Pet) *Pet {
 		return &v
 	}).(PetPtrOutput)
 }
+
 func (o PetOutput) Age() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v Pet) *int { return v.Age }).(pulumi.IntPtrOutput)
 }
@@ -161,7 +162,13 @@ func (o PetPtrOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutpu
 }
 
 func (o PetPtrOutput) Elem() PetOutput {
-	return o.ApplyT(func(v *Pet) Pet { return *v }).(PetOutput)
+	return o.ApplyT(func(v *Pet) Pet {
+		if v != nil {
+			return *v
+		}
+		var ret Pet
+		return ret
+	}).(PetOutput)
 }
 
 func (o PetPtrOutput) Age() pulumi.IntPtrOutput {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/workload.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/workload.go
@@ -164,9 +164,7 @@ func (i WorkloadMap) ToWorkloadMapOutputWithContext(ctx context.Context) Workloa
 	return pulumi.ToOutputWithContext(ctx, i).(WorkloadMapOutput)
 }
 
-type WorkloadOutput struct {
-	*pulumi.OutputState
-}
+type WorkloadOutput struct{ *pulumi.OutputState }
 
 func (WorkloadOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Workload)(nil))
@@ -185,14 +183,12 @@ func (o WorkloadOutput) ToWorkloadPtrOutput() WorkloadPtrOutput {
 }
 
 func (o WorkloadOutput) ToWorkloadPtrOutputWithContext(ctx context.Context) WorkloadPtrOutput {
-	return o.ApplyT(func(v Workload) *Workload {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Workload) *Workload {
 		return &v
 	}).(WorkloadPtrOutput)
 }
 
-type WorkloadPtrOutput struct {
-	*pulumi.OutputState
-}
+type WorkloadPtrOutput struct{ *pulumi.OutputState }
 
 func (WorkloadPtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**Workload)(nil))
@@ -204,6 +200,16 @@ func (o WorkloadPtrOutput) ToWorkloadPtrOutput() WorkloadPtrOutput {
 
 func (o WorkloadPtrOutput) ToWorkloadPtrOutputWithContext(ctx context.Context) WorkloadPtrOutput {
 	return o
+}
+
+func (o WorkloadPtrOutput) Elem() WorkloadOutput {
+	return o.ApplyT(func(v *Workload) Workload {
+		if v != nil {
+			return *v
+		}
+		var ret Workload
+		return ret
+	}).(WorkloadOutput)
 }
 
 type WorkloadArrayOutput struct{ *pulumi.OutputState }

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
@@ -93,9 +93,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
-type ResourceOutput struct {
-	*pulumi.OutputState
-}
+type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Resource)(nil))

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/go/foo/provider.go
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/go/foo/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/nested-module/go/foo/nested/module/resource.go
+++ b/pkg/codegen/internal/test/testdata/nested-module/go/foo/nested/module/resource.go
@@ -93,9 +93,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
-type ResourceOutput struct {
-	*pulumi.OutputState
-}
+type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Resource)(nil))

--- a/pkg/codegen/internal/test/testdata/nested-module/go/foo/provider.go
+++ b/pkg/codegen/internal/test/testdata/nested-module/go/foo/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/provider.go
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/provider.go
@@ -88,9 +88,7 @@ func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) Pr
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))
@@ -109,14 +107,12 @@ func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
 }
 
 func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyT(func(v Provider) *Provider {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
 		return &v
 	}).(ProviderPtrOutput)
 }
 
-type ProviderPtrOutput struct {
-	*pulumi.OutputState
-}
+type ProviderPtrOutput struct{ *pulumi.OutputState }
 
 func (ProviderPtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**Provider)(nil))
@@ -128,6 +124,16 @@ func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
 
 func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
 	return o
+}
+
+func (o ProviderPtrOutput) Elem() ProviderOutput {
+	return o.ApplyT(func(v *Provider) Provider {
+		if v != nil {
+			return *v
+		}
+		var ret Provider
+		return ret
+	}).(ProviderOutput)
 }
 
 func init() {

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/pulumiTypes.go
@@ -101,10 +101,11 @@ func (o FooOutput) ToFooPtrOutput() FooPtrOutput {
 }
 
 func (o FooOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
-	return o.ApplyT(func(v Foo) *Foo {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Foo) *Foo {
 		return &v
 	}).(FooPtrOutput)
 }
+
 func (o FooOutput) A() pulumi.BoolPtrOutput {
 	return o.ApplyT(func(v Foo) *bool { return v.A }).(pulumi.BoolPtrOutput)
 }
@@ -124,7 +125,13 @@ func (o FooPtrOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutpu
 }
 
 func (o FooPtrOutput) Elem() FooOutput {
-	return o.ApplyT(func(v *Foo) Foo { return *v }).(FooOutput)
+	return o.ApplyT(func(v *Foo) Foo {
+		if v != nil {
+			return *v
+		}
+		var ret Foo
+		return ret
+	}).(FooOutput)
 }
 
 func (o FooPtrOutput) A() pulumi.BoolPtrOutput {

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
@@ -154,9 +154,7 @@ func (i StaticPageMap) ToStaticPageMapOutputWithContext(ctx context.Context) Sta
 	return pulumi.ToOutputWithContext(ctx, i).(StaticPageMapOutput)
 }
 
-type StaticPageOutput struct {
-	*pulumi.OutputState
-}
+type StaticPageOutput struct{ *pulumi.OutputState }
 
 func (StaticPageOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*StaticPage)(nil))
@@ -175,14 +173,12 @@ func (o StaticPageOutput) ToStaticPagePtrOutput() StaticPagePtrOutput {
 }
 
 func (o StaticPageOutput) ToStaticPagePtrOutputWithContext(ctx context.Context) StaticPagePtrOutput {
-	return o.ApplyT(func(v StaticPage) *StaticPage {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v StaticPage) *StaticPage {
 		return &v
 	}).(StaticPagePtrOutput)
 }
 
-type StaticPagePtrOutput struct {
-	*pulumi.OutputState
-}
+type StaticPagePtrOutput struct{ *pulumi.OutputState }
 
 func (StaticPagePtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**StaticPage)(nil))
@@ -194,6 +190,16 @@ func (o StaticPagePtrOutput) ToStaticPagePtrOutput() StaticPagePtrOutput {
 
 func (o StaticPagePtrOutput) ToStaticPagePtrOutputWithContext(ctx context.Context) StaticPagePtrOutput {
 	return o
+}
+
+func (o StaticPagePtrOutput) Elem() StaticPageOutput {
+	return o.ApplyT(func(v *StaticPage) StaticPage {
+		if v != nil {
+			return *v
+		}
+		var ret StaticPage
+		return ret
+	}).(StaticPageOutput)
 }
 
 type StaticPageArrayOutput struct{ *pulumi.OutputState }

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/go/configstation/provider.go
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/go/configstation/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go/example/person.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go/example/person.go
@@ -168,9 +168,7 @@ func (i PersonMap) ToPersonMapOutputWithContext(ctx context.Context) PersonMapOu
 	return pulumi.ToOutputWithContext(ctx, i).(PersonMapOutput)
 }
 
-type PersonOutput struct {
-	*pulumi.OutputState
-}
+type PersonOutput struct{ *pulumi.OutputState }
 
 func (PersonOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Person)(nil))
@@ -189,14 +187,12 @@ func (o PersonOutput) ToPersonPtrOutput() PersonPtrOutput {
 }
 
 func (o PersonOutput) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return o.ApplyT(func(v Person) *Person {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Person) *Person {
 		return &v
 	}).(PersonPtrOutput)
 }
 
-type PersonPtrOutput struct {
-	*pulumi.OutputState
-}
+type PersonPtrOutput struct{ *pulumi.OutputState }
 
 func (PersonPtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**Person)(nil))
@@ -208,6 +204,16 @@ func (o PersonPtrOutput) ToPersonPtrOutput() PersonPtrOutput {
 
 func (o PersonPtrOutput) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
 	return o
+}
+
+func (o PersonPtrOutput) Elem() PersonOutput {
+	return o.ApplyT(func(v *Person) Person {
+		if v != nil {
+			return *v
+		}
+		var ret Person
+		return ret
+	}).(PersonOutput)
 }
 
 type PersonArrayOutput struct{ *pulumi.OutputState }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go/example/pet.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go/example/pet.go
@@ -165,9 +165,7 @@ func (i PetMap) ToPetMapOutputWithContext(ctx context.Context) PetMapOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetMapOutput)
 }
 
-type PetOutput struct {
-	*pulumi.OutputState
-}
+type PetOutput struct{ *pulumi.OutputState }
 
 func (PetOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Pet)(nil))
@@ -186,14 +184,12 @@ func (o PetOutput) ToPetPtrOutput() PetPtrOutput {
 }
 
 func (o PetOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return o.ApplyT(func(v Pet) *Pet {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Pet) *Pet {
 		return &v
 	}).(PetPtrOutput)
 }
 
-type PetPtrOutput struct {
-	*pulumi.OutputState
-}
+type PetPtrOutput struct{ *pulumi.OutputState }
 
 func (PetPtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**Pet)(nil))
@@ -205,6 +201,16 @@ func (o PetPtrOutput) ToPetPtrOutput() PetPtrOutput {
 
 func (o PetPtrOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
 	return o
+}
+
+func (o PetPtrOutput) Elem() PetOutput {
+	return o.ApplyT(func(v *Pet) Pet {
+		if v != nil {
+			return *v
+		}
+		var ret Pet
+		return ret
+	}).(PetOutput)
 }
 
 type PetArrayOutput struct{ *pulumi.OutputState }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go/example/provider.go
@@ -88,9 +88,7 @@ func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) Pr
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))
@@ -109,14 +107,12 @@ func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
 }
 
 func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyT(func(v Provider) *Provider {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
 		return &v
 	}).(ProviderPtrOutput)
 }
 
-type ProviderPtrOutput struct {
-	*pulumi.OutputState
-}
+type ProviderPtrOutput struct{ *pulumi.OutputState }
 
 func (ProviderPtrOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((**Provider)(nil))
@@ -128,6 +124,16 @@ func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
 
 func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
 	return o
+}
+
+func (o ProviderPtrOutput) Elem() ProviderOutput {
+	return o.ApplyT(func(v *Provider) Provider {
+		if v != nil {
+			return *v
+		}
+		var ret Provider
+		return ret
+	}).(ProviderOutput)
 }
 
 func init() {

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/pulumiEnums.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/pulumiEnums.go
@@ -101,7 +101,7 @@ func (o ContainerBrightnessOutput) ToFloat64PtrOutputWithContext(ctx context.Con
 type ContainerBrightnessPtrOutput struct{ *pulumi.OutputState }
 
 func (ContainerBrightnessPtrOutput) ElementType() reflect.Type {
-	return containerBrightnessPtrType
+	return reflect.TypeOf((**ContainerBrightness)(nil)).Elem()
 }
 
 func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutput() ContainerBrightnessPtrOutput {
@@ -110,6 +110,16 @@ func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutput() Container
 
 func (o ContainerBrightnessPtrOutput) ToContainerBrightnessPtrOutputWithContext(ctx context.Context) ContainerBrightnessPtrOutput {
 	return o
+}
+
+func (o ContainerBrightnessPtrOutput) Elem() ContainerBrightnessOutput {
+	return o.ApplyT(func(v *ContainerBrightness) ContainerBrightness {
+		if v != nil {
+			return *v
+		}
+		var ret ContainerBrightness
+		return ret
+	}).(ContainerBrightnessOutput)
 }
 
 func (o ContainerBrightnessPtrOutput) ToFloat64PtrOutput() pulumi.Float64PtrOutput {
@@ -124,16 +134,6 @@ func (o ContainerBrightnessPtrOutput) ToFloat64PtrOutputWithContext(ctx context.
 		v := float64(*e)
 		return &v
 	}).(pulumi.Float64PtrOutput)
-}
-
-func (o ContainerBrightnessPtrOutput) Elem() ContainerBrightnessOutput {
-	return o.ApplyT(func(v *ContainerBrightness) ContainerBrightness {
-		var ret ContainerBrightness
-		if v != nil {
-			ret = *v
-		}
-		return ret
-	}).(ContainerBrightnessOutput)
 }
 
 // ContainerBrightnessInput is an input type that accepts ContainerBrightnessArgs and ContainerBrightnessOutput values.
@@ -267,7 +267,7 @@ func (o ContainerColorOutput) ToStringPtrOutputWithContext(ctx context.Context) 
 type ContainerColorPtrOutput struct{ *pulumi.OutputState }
 
 func (ContainerColorPtrOutput) ElementType() reflect.Type {
-	return containerColorPtrType
+	return reflect.TypeOf((**ContainerColor)(nil)).Elem()
 }
 
 func (o ContainerColorPtrOutput) ToContainerColorPtrOutput() ContainerColorPtrOutput {
@@ -276,6 +276,16 @@ func (o ContainerColorPtrOutput) ToContainerColorPtrOutput() ContainerColorPtrOu
 
 func (o ContainerColorPtrOutput) ToContainerColorPtrOutputWithContext(ctx context.Context) ContainerColorPtrOutput {
 	return o
+}
+
+func (o ContainerColorPtrOutput) Elem() ContainerColorOutput {
+	return o.ApplyT(func(v *ContainerColor) ContainerColor {
+		if v != nil {
+			return *v
+		}
+		var ret ContainerColor
+		return ret
+	}).(ContainerColorOutput)
 }
 
 func (o ContainerColorPtrOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
@@ -290,16 +300,6 @@ func (o ContainerColorPtrOutput) ToStringPtrOutputWithContext(ctx context.Contex
 		v := string(*e)
 		return &v
 	}).(pulumi.StringPtrOutput)
-}
-
-func (o ContainerColorPtrOutput) Elem() ContainerColorOutput {
-	return o.ApplyT(func(v *ContainerColor) ContainerColor {
-		var ret ContainerColor
-		if v != nil {
-			ret = *v
-		}
-		return ret
-	}).(ContainerColorOutput)
 }
 
 // ContainerColorInput is an input type that accepts ContainerColorArgs and ContainerColorOutput values.
@@ -434,7 +434,7 @@ func (o ContainerSizeOutput) ToIntPtrOutputWithContext(ctx context.Context) pulu
 type ContainerSizePtrOutput struct{ *pulumi.OutputState }
 
 func (ContainerSizePtrOutput) ElementType() reflect.Type {
-	return containerSizePtrType
+	return reflect.TypeOf((**ContainerSize)(nil)).Elem()
 }
 
 func (o ContainerSizePtrOutput) ToContainerSizePtrOutput() ContainerSizePtrOutput {
@@ -443,6 +443,16 @@ func (o ContainerSizePtrOutput) ToContainerSizePtrOutput() ContainerSizePtrOutpu
 
 func (o ContainerSizePtrOutput) ToContainerSizePtrOutputWithContext(ctx context.Context) ContainerSizePtrOutput {
 	return o
+}
+
+func (o ContainerSizePtrOutput) Elem() ContainerSizeOutput {
+	return o.ApplyT(func(v *ContainerSize) ContainerSize {
+		if v != nil {
+			return *v
+		}
+		var ret ContainerSize
+		return ret
+	}).(ContainerSizeOutput)
 }
 
 func (o ContainerSizePtrOutput) ToIntPtrOutput() pulumi.IntPtrOutput {
@@ -457,16 +467,6 @@ func (o ContainerSizePtrOutput) ToIntPtrOutputWithContext(ctx context.Context) p
 		v := int(*e)
 		return &v
 	}).(pulumi.IntPtrOutput)
-}
-
-func (o ContainerSizePtrOutput) Elem() ContainerSizeOutput {
-	return o.ApplyT(func(v *ContainerSize) ContainerSize {
-		var ret ContainerSize
-		if v != nil {
-			ret = *v
-		}
-		return ret
-	}).(ContainerSizeOutput)
 }
 
 // ContainerSizeInput is an input type that accepts ContainerSizeArgs and ContainerSizeOutput values.

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/pulumiTypes.go
@@ -107,10 +107,11 @@ func (o ContainerOutput) ToContainerPtrOutput() ContainerPtrOutput {
 }
 
 func (o ContainerOutput) ToContainerPtrOutputWithContext(ctx context.Context) ContainerPtrOutput {
-	return o.ApplyT(func(v Container) *Container {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Container) *Container {
 		return &v
 	}).(ContainerPtrOutput)
 }
+
 func (o ContainerOutput) Brightness() ContainerBrightnessPtrOutput {
 	return o.ApplyT(func(v Container) *ContainerBrightness { return v.Brightness }).(ContainerBrightnessPtrOutput)
 }
@@ -142,7 +143,13 @@ func (o ContainerPtrOutput) ToContainerPtrOutputWithContext(ctx context.Context)
 }
 
 func (o ContainerPtrOutput) Elem() ContainerOutput {
-	return o.ApplyT(func(v *Container) Container { return *v }).(ContainerOutput)
+	return o.ApplyT(func(v *Container) Container {
+		if v != nil {
+			return *v
+		}
+		var ret Container
+		return ret
+	}).(ContainerOutput)
 }
 
 func (o ContainerPtrOutput) Brightness() ContainerBrightnessPtrOutput {

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
@@ -94,9 +94,7 @@ func (i *Nursery) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput 
 	return pulumi.ToOutputWithContext(ctx, i).(NurseryOutput)
 }
 
-type NurseryOutput struct {
-	*pulumi.OutputState
-}
+type NurseryOutput struct{ *pulumi.OutputState }
 
 func (NurseryOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Nursery)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/pulumiEnums.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/pulumiEnums.go
@@ -101,7 +101,7 @@ func (o DiameterOutput) ToFloat64PtrOutputWithContext(ctx context.Context) pulum
 type DiameterPtrOutput struct{ *pulumi.OutputState }
 
 func (DiameterPtrOutput) ElementType() reflect.Type {
-	return diameterPtrType
+	return reflect.TypeOf((**Diameter)(nil)).Elem()
 }
 
 func (o DiameterPtrOutput) ToDiameterPtrOutput() DiameterPtrOutput {
@@ -110,6 +110,16 @@ func (o DiameterPtrOutput) ToDiameterPtrOutput() DiameterPtrOutput {
 
 func (o DiameterPtrOutput) ToDiameterPtrOutputWithContext(ctx context.Context) DiameterPtrOutput {
 	return o
+}
+
+func (o DiameterPtrOutput) Elem() DiameterOutput {
+	return o.ApplyT(func(v *Diameter) Diameter {
+		if v != nil {
+			return *v
+		}
+		var ret Diameter
+		return ret
+	}).(DiameterOutput)
 }
 
 func (o DiameterPtrOutput) ToFloat64PtrOutput() pulumi.Float64PtrOutput {
@@ -124,16 +134,6 @@ func (o DiameterPtrOutput) ToFloat64PtrOutputWithContext(ctx context.Context) pu
 		v := float64(*e)
 		return &v
 	}).(pulumi.Float64PtrOutput)
-}
-
-func (o DiameterPtrOutput) Elem() DiameterOutput {
-	return o.ApplyT(func(v *Diameter) Diameter {
-		var ret Diameter
-		if v != nil {
-			ret = *v
-		}
-		return ret
-	}).(DiameterOutput)
 }
 
 // DiameterInput is an input type that accepts DiameterArgs and DiameterOutput values.
@@ -265,7 +265,7 @@ func (o FarmOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.Str
 type FarmPtrOutput struct{ *pulumi.OutputState }
 
 func (FarmPtrOutput) ElementType() reflect.Type {
-	return farmPtrType
+	return reflect.TypeOf((**Farm)(nil)).Elem()
 }
 
 func (o FarmPtrOutput) ToFarmPtrOutput() FarmPtrOutput {
@@ -274,6 +274,16 @@ func (o FarmPtrOutput) ToFarmPtrOutput() FarmPtrOutput {
 
 func (o FarmPtrOutput) ToFarmPtrOutputWithContext(ctx context.Context) FarmPtrOutput {
 	return o
+}
+
+func (o FarmPtrOutput) Elem() FarmOutput {
+	return o.ApplyT(func(v *Farm) Farm {
+		if v != nil {
+			return *v
+		}
+		var ret Farm
+		return ret
+	}).(FarmOutput)
 }
 
 func (o FarmPtrOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
@@ -288,16 +298,6 @@ func (o FarmPtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi.
 		v := string(*e)
 		return &v
 	}).(pulumi.StringPtrOutput)
-}
-
-func (o FarmPtrOutput) Elem() FarmOutput {
-	return o.ApplyT(func(v *Farm) Farm {
-		var ret Farm
-		if v != nil {
-			ret = *v
-		}
-		return ret
-	}).(FarmOutput)
 }
 
 // FarmInput is an input type that accepts FarmArgs and FarmOutput values.
@@ -434,7 +434,7 @@ func (o RubberTreeVarietyOutput) ToStringPtrOutputWithContext(ctx context.Contex
 type RubberTreeVarietyPtrOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeVarietyPtrOutput) ElementType() reflect.Type {
-	return rubberTreeVarietyPtrType
+	return reflect.TypeOf((**RubberTreeVariety)(nil)).Elem()
 }
 
 func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutput() RubberTreeVarietyPtrOutput {
@@ -443,6 +443,16 @@ func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutput() RubberTreeVar
 
 func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return o
+}
+
+func (o RubberTreeVarietyPtrOutput) Elem() RubberTreeVarietyOutput {
+	return o.ApplyT(func(v *RubberTreeVariety) RubberTreeVariety {
+		if v != nil {
+			return *v
+		}
+		var ret RubberTreeVariety
+		return ret
+	}).(RubberTreeVarietyOutput)
 }
 
 func (o RubberTreeVarietyPtrOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
@@ -457,16 +467,6 @@ func (o RubberTreeVarietyPtrOutput) ToStringPtrOutputWithContext(ctx context.Con
 		v := string(*e)
 		return &v
 	}).(pulumi.StringPtrOutput)
-}
-
-func (o RubberTreeVarietyPtrOutput) Elem() RubberTreeVarietyOutput {
-	return o.ApplyT(func(v *RubberTreeVariety) RubberTreeVariety {
-		var ret RubberTreeVariety
-		if v != nil {
-			ret = *v
-		}
-		return ret
-	}).(RubberTreeVarietyOutput)
 }
 
 // RubberTreeVarietyInput is an input type that accepts RubberTreeVarietyArgs and RubberTreeVarietyOutput values.
@@ -547,8 +547,8 @@ func (o RubberTreeVarietyArrayOutput) ToRubberTreeVarietyArrayOutputWithContext(
 }
 
 func (o RubberTreeVarietyArrayOutput) Index(i pulumi.IntInput) RubberTreeVarietyOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) RubberTreeVarietyOutput {
-		return vs[0].([]RubberTreeVariety)[vs[1].(int)].ToRubberTreeVarietyOutput()
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) RubberTreeVariety {
+		return vs[0].([]RubberTreeVariety)[vs[1].(int)]
 	}).(RubberTreeVarietyOutput)
 }
 
@@ -644,7 +644,7 @@ func (o TreeSizeOutput) ToStringPtrOutputWithContext(ctx context.Context) pulumi
 type TreeSizePtrOutput struct{ *pulumi.OutputState }
 
 func (TreeSizePtrOutput) ElementType() reflect.Type {
-	return treeSizePtrType
+	return reflect.TypeOf((**TreeSize)(nil)).Elem()
 }
 
 func (o TreeSizePtrOutput) ToTreeSizePtrOutput() TreeSizePtrOutput {
@@ -653,6 +653,16 @@ func (o TreeSizePtrOutput) ToTreeSizePtrOutput() TreeSizePtrOutput {
 
 func (o TreeSizePtrOutput) ToTreeSizePtrOutputWithContext(ctx context.Context) TreeSizePtrOutput {
 	return o
+}
+
+func (o TreeSizePtrOutput) Elem() TreeSizeOutput {
+	return o.ApplyT(func(v *TreeSize) TreeSize {
+		if v != nil {
+			return *v
+		}
+		var ret TreeSize
+		return ret
+	}).(TreeSizeOutput)
 }
 
 func (o TreeSizePtrOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
@@ -667,16 +677,6 @@ func (o TreeSizePtrOutput) ToStringPtrOutputWithContext(ctx context.Context) pul
 		v := string(*e)
 		return &v
 	}).(pulumi.StringPtrOutput)
-}
-
-func (o TreeSizePtrOutput) Elem() TreeSizeOutput {
-	return o.ApplyT(func(v *TreeSize) TreeSize {
-		var ret TreeSize
-		if v != nil {
-			ret = *v
-		}
-		return ret
-	}).(TreeSizeOutput)
 }
 
 // TreeSizeInput is an input type that accepts TreeSizeArgs and TreeSizeOutput values.
@@ -757,8 +757,8 @@ func (o TreeSizeMapOutput) ToTreeSizeMapOutputWithContext(ctx context.Context) T
 }
 
 func (o TreeSizeMapOutput) MapIndex(k pulumi.StringInput) TreeSizeOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) TreeSizeOutput {
-		return vs[0].(map[string]TreeSize)[vs[1].(string)].ToTreeSizeOutput()
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) TreeSize {
+		return vs[0].(map[string]TreeSize)[vs[1].(string)]
 	}).(TreeSizeOutput)
 }
 

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -114,9 +114,7 @@ func (i *RubberTree) ToRubberTreeOutputWithContext(ctx context.Context) RubberTr
 	return pulumi.ToOutputWithContext(ctx, i).(RubberTreeOutput)
 }
 
-type RubberTreeOutput struct {
-	*pulumi.OutputState
-}
+type RubberTreeOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*RubberTree)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/foo.go
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/foo.go
@@ -160,9 +160,7 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(FooOutput)
 }
 
-type FooOutput struct {
-	*pulumi.OutputState
-}
+type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Foo)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/component.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/component.go
@@ -88,9 +88,7 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
-type ComponentOutput struct {
-	*pulumi.OutputState
-}
+type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Component)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/pulumiTypes.go
@@ -136,10 +136,11 @@ func (o FooOutput) ToFooPtrOutput() FooPtrOutput {
 }
 
 func (o FooOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
-	return o.ApplyT(func(v Foo) *Foo {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Foo) *Foo {
 		return &v
 	}).(FooPtrOutput)
 }
+
 func (o FooOutput) A() pulumi.BoolOutput {
 	return o.ApplyT(func(v Foo) bool { return v.A }).(pulumi.BoolOutput)
 }
@@ -179,7 +180,13 @@ func (o FooPtrOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutpu
 }
 
 func (o FooPtrOutput) Elem() FooOutput {
-	return o.ApplyT(func(v *Foo) Foo { return *v }).(FooOutput)
+	return o.ApplyT(func(v *Foo) Foo {
+		if v != nil {
+			return *v
+		}
+		var ret Foo
+		return ret
+	}).(FooOutput)
 }
 
 func (o FooPtrOutput) A() pulumi.BoolPtrOutput {

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
@@ -90,9 +90,7 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
 }
 
-type ComponentOutput struct {
-	*pulumi.OutputState
-}
+type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Component)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/pulumiTypes.go
@@ -161,10 +161,11 @@ func (o FooOutput) ToFooPtrOutput() FooPtrOutput {
 }
 
 func (o FooOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutput {
-	return o.ApplyT(func(v Foo) *Foo {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Foo) *Foo {
 		return &v
 	}).(FooPtrOutput)
 }
+
 func (o FooOutput) A() pulumi.BoolOutput {
 	return o.ApplyT(func(v Foo) bool { return v.A }).(pulumi.BoolOutput)
 }
@@ -204,7 +205,13 @@ func (o FooPtrOutput) ToFooPtrOutputWithContext(ctx context.Context) FooPtrOutpu
 }
 
 func (o FooPtrOutput) Elem() FooOutput {
-	return o.ApplyT(func(v *Foo) Foo { return *v }).(FooOutput)
+	return o.ApplyT(func(v *Foo) Foo {
+		if v != nil {
+			return *v
+		}
+		var ret Foo
+		return ret
+	}).(FooOutput)
 }
 
 func (o FooPtrOutput) A() pulumi.BoolPtrOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
@@ -63,9 +63,7 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutput)
 }
 
-type OtherResourceOutput struct {
-	*pulumi.OutputState
-}
+type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*OtherResource)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/pulumiTypes.go
@@ -343,7 +343,7 @@ func (i SomeOtherObjectArgsArrayArray) ToSomeOtherObjectArgsArrayArrayOutputWith
 type SomeOtherObjectArgsArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArgsArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArgsArray)(nil)).Elem()
+	return reflect.TypeOf((*[]SomeOtherObjectArgsArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArgsArrayArrayOutput) ToSomeOtherObjectArgsArrayArrayOutput() SomeOtherObjectArgsArrayArrayOutput {
@@ -388,7 +388,7 @@ func (i SomeOtherObjectArgsArrayMap) ToSomeOtherObjectArgsArrayMapOutputWithCont
 type SomeOtherObjectArgsArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArgsArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArgsArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string]SomeOtherObjectArgsArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArgsArrayMapOutput) ToSomeOtherObjectArgsArrayMapOutput() SomeOtherObjectArgsArrayMapOutput {
@@ -433,7 +433,7 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(
 type SomeOtherObjectArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[]SomeOtherObjectArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -478,7 +478,7 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx 
 type SomeOtherObjectArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string]SomeOtherObjectArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
@@ -86,9 +86,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
-type ResourceOutput struct {
-	*pulumi.OutputState
-}
+type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Resource)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/otherResource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/otherResource.go
@@ -63,9 +63,7 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutput)
 }
 
-type OtherResourceOutput struct {
-	*pulumi.OutputState
-}
+type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*OtherResource)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
@@ -207,10 +207,11 @@ func (o ObjectOutput) ToObjectPtrOutput() ObjectPtrOutput {
 }
 
 func (o ObjectOutput) ToObjectPtrOutputWithContext(ctx context.Context) ObjectPtrOutput {
-	return o.ApplyT(func(v Object) *Object {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Object) *Object {
 		return &v
 	}).(ObjectPtrOutput)
 }
+
 func (o ObjectOutput) Bar() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Object) *string { return v.Bar }).(pulumi.StringPtrOutput)
 }
@@ -248,7 +249,13 @@ func (o ObjectPtrOutput) ToObjectPtrOutputWithContext(ctx context.Context) Objec
 }
 
 func (o ObjectPtrOutput) Elem() ObjectOutput {
-	return o.ApplyT(func(v *Object) Object { return *v }).(ObjectOutput)
+	return o.ApplyT(func(v *Object) Object {
+		if v != nil {
+			return *v
+		}
+		var ret Object
+		return ret
+	}).(ObjectOutput)
 }
 
 func (o ObjectPtrOutput) Bar() pulumi.StringPtrOutput {
@@ -391,10 +398,11 @@ func (o ObjectWithNodeOptionalInputsOutput) ToObjectWithNodeOptionalInputsPtrOut
 }
 
 func (o ObjectWithNodeOptionalInputsOutput) ToObjectWithNodeOptionalInputsPtrOutputWithContext(ctx context.Context) ObjectWithNodeOptionalInputsPtrOutput {
-	return o.ApplyT(func(v ObjectWithNodeOptionalInputs) *ObjectWithNodeOptionalInputs {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v ObjectWithNodeOptionalInputs) *ObjectWithNodeOptionalInputs {
 		return &v
 	}).(ObjectWithNodeOptionalInputsPtrOutput)
 }
+
 func (o ObjectWithNodeOptionalInputsOutput) Bar() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ObjectWithNodeOptionalInputs) *int { return v.Bar }).(pulumi.IntPtrOutput)
 }
@@ -418,7 +426,13 @@ func (o ObjectWithNodeOptionalInputsPtrOutput) ToObjectWithNodeOptionalInputsPtr
 }
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) Elem() ObjectWithNodeOptionalInputsOutput {
-	return o.ApplyT(func(v *ObjectWithNodeOptionalInputs) ObjectWithNodeOptionalInputs { return *v }).(ObjectWithNodeOptionalInputsOutput)
+	return o.ApplyT(func(v *ObjectWithNodeOptionalInputs) ObjectWithNodeOptionalInputs {
+		if v != nil {
+			return *v
+		}
+		var ret ObjectWithNodeOptionalInputs
+		return ret
+	}).(ObjectWithNodeOptionalInputsOutput)
 }
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) Bar() pulumi.IntPtrOutput {
@@ -604,10 +618,11 @@ func (o SomeOtherObjectOutput) ToSomeOtherObjectPtrOutput() SomeOtherObjectPtrOu
 }
 
 func (o SomeOtherObjectOutput) ToSomeOtherObjectPtrOutputWithContext(ctx context.Context) SomeOtherObjectPtrOutput {
-	return o.ApplyT(func(v SomeOtherObject) *SomeOtherObject {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v SomeOtherObject) *SomeOtherObject {
 		return &v
 	}).(SomeOtherObjectPtrOutput)
 }
+
 func (o SomeOtherObjectOutput) Baz() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SomeOtherObject) *string { return v.Baz }).(pulumi.StringPtrOutput)
 }
@@ -627,7 +642,13 @@ func (o SomeOtherObjectPtrOutput) ToSomeOtherObjectPtrOutputWithContext(ctx cont
 }
 
 func (o SomeOtherObjectPtrOutput) Elem() SomeOtherObjectOutput {
-	return o.ApplyT(func(v *SomeOtherObject) SomeOtherObject { return *v }).(SomeOtherObjectOutput)
+	return o.ApplyT(func(v *SomeOtherObject) SomeOtherObject {
+		if v != nil {
+			return *v
+		}
+		var ret SomeOtherObject
+		return ret
+	}).(SomeOtherObjectOutput)
 }
 
 func (o SomeOtherObjectPtrOutput) Baz() pulumi.StringPtrOutput {
@@ -676,7 +697,7 @@ func (i SomeOtherObjectArgsArrayArray) ToSomeOtherObjectArgsArrayArrayOutputWith
 type SomeOtherObjectArgsArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArgsArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArgsArray)(nil)).Elem()
+	return reflect.TypeOf((*[]SomeOtherObjectArgsArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArgsArrayArrayOutput) ToSomeOtherObjectArgsArrayArrayOutput() SomeOtherObjectArgsArrayArrayOutput {
@@ -721,7 +742,7 @@ func (i SomeOtherObjectArgsArrayMap) ToSomeOtherObjectArgsArrayMapOutputWithCont
 type SomeOtherObjectArgsArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArgsArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArgsArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string]SomeOtherObjectArgsArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArgsArrayMapOutput) ToSomeOtherObjectArgsArrayMapOutput() SomeOtherObjectArgsArrayMapOutput {
@@ -766,7 +787,7 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(
 type SomeOtherObjectArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[]SomeOtherObjectArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -811,7 +832,7 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx 
 type SomeOtherObjectArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string]SomeOtherObjectArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/resource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/resource.go
@@ -93,9 +93,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
-type ResourceOutput struct {
-	*pulumi.OutputState
-}
+type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Resource)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/typeUses.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/typeUses.go
@@ -92,9 +92,7 @@ func (i *TypeUses) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutp
 	return pulumi.ToOutputWithContext(ctx, i).(TypeUsesOutput)
 }
 
-type TypeUsesOutput struct {
-	*pulumi.OutputState
-}
+type TypeUsesOutput struct{ *pulumi.OutputState }
 
 func (TypeUsesOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*TypeUses)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/otherResource.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/otherResource.go
@@ -65,9 +65,7 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 	return pulumi.ToOutputWithContext(ctx, i).(OtherResourceOutput)
 }
 
-type OtherResourceOutput struct {
-	*pulumi.OutputState
-}
+type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*OtherResource)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/provider.go
@@ -59,9 +59,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-type ProviderOutput struct {
-	*pulumi.OutputState
-}
+type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Provider)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/pulumiEnums.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/pulumiEnums.go
@@ -106,7 +106,7 @@ func (o RubberTreeVarietyOutput) ToStringPtrOutputWithContext(ctx context.Contex
 type RubberTreeVarietyPtrOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeVarietyPtrOutput) ElementType() reflect.Type {
-	return rubberTreeVarietyPtrType
+	return reflect.TypeOf((**RubberTreeVariety)(nil)).Elem()
 }
 
 func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutput() RubberTreeVarietyPtrOutput {
@@ -115,6 +115,16 @@ func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutput() RubberTreeVar
 
 func (o RubberTreeVarietyPtrOutput) ToRubberTreeVarietyPtrOutputWithContext(ctx context.Context) RubberTreeVarietyPtrOutput {
 	return o
+}
+
+func (o RubberTreeVarietyPtrOutput) Elem() RubberTreeVarietyOutput {
+	return o.ApplyT(func(v *RubberTreeVariety) RubberTreeVariety {
+		if v != nil {
+			return *v
+		}
+		var ret RubberTreeVariety
+		return ret
+	}).(RubberTreeVarietyOutput)
 }
 
 func (o RubberTreeVarietyPtrOutput) ToStringPtrOutput() pulumi.StringPtrOutput {
@@ -129,16 +139,6 @@ func (o RubberTreeVarietyPtrOutput) ToStringPtrOutputWithContext(ctx context.Con
 		v := string(*e)
 		return &v
 	}).(pulumi.StringPtrOutput)
-}
-
-func (o RubberTreeVarietyPtrOutput) Elem() RubberTreeVarietyOutput {
-	return o.ApplyT(func(v *RubberTreeVariety) RubberTreeVariety {
-		var ret RubberTreeVariety
-		if v != nil {
-			ret = *v
-		}
-		return ret
-	}).(RubberTreeVarietyOutput)
 }
 
 // RubberTreeVarietyInput is an input type that accepts RubberTreeVarietyArgs and RubberTreeVarietyOutput values.

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/pulumiTypes.go
@@ -207,10 +207,11 @@ func (o ObjectOutput) ToObjectPtrOutput() ObjectPtrOutput {
 }
 
 func (o ObjectOutput) ToObjectPtrOutputWithContext(ctx context.Context) ObjectPtrOutput {
-	return o.ApplyT(func(v Object) *Object {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v Object) *Object {
 		return &v
 	}).(ObjectPtrOutput)
 }
+
 func (o ObjectOutput) Bar() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v Object) *string { return v.Bar }).(pulumi.StringPtrOutput)
 }
@@ -248,7 +249,13 @@ func (o ObjectPtrOutput) ToObjectPtrOutputWithContext(ctx context.Context) Objec
 }
 
 func (o ObjectPtrOutput) Elem() ObjectOutput {
-	return o.ApplyT(func(v *Object) Object { return *v }).(ObjectOutput)
+	return o.ApplyT(func(v *Object) Object {
+		if v != nil {
+			return *v
+		}
+		var ret Object
+		return ret
+	}).(ObjectOutput)
 }
 
 func (o ObjectPtrOutput) Bar() pulumi.StringPtrOutput {
@@ -391,10 +398,11 @@ func (o ObjectWithNodeOptionalInputsOutput) ToObjectWithNodeOptionalInputsPtrOut
 }
 
 func (o ObjectWithNodeOptionalInputsOutput) ToObjectWithNodeOptionalInputsPtrOutputWithContext(ctx context.Context) ObjectWithNodeOptionalInputsPtrOutput {
-	return o.ApplyT(func(v ObjectWithNodeOptionalInputs) *ObjectWithNodeOptionalInputs {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v ObjectWithNodeOptionalInputs) *ObjectWithNodeOptionalInputs {
 		return &v
 	}).(ObjectWithNodeOptionalInputsPtrOutput)
 }
+
 func (o ObjectWithNodeOptionalInputsOutput) Bar() pulumi.IntPtrOutput {
 	return o.ApplyT(func(v ObjectWithNodeOptionalInputs) *int { return v.Bar }).(pulumi.IntPtrOutput)
 }
@@ -418,7 +426,13 @@ func (o ObjectWithNodeOptionalInputsPtrOutput) ToObjectWithNodeOptionalInputsPtr
 }
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) Elem() ObjectWithNodeOptionalInputsOutput {
-	return o.ApplyT(func(v *ObjectWithNodeOptionalInputs) ObjectWithNodeOptionalInputs { return *v }).(ObjectWithNodeOptionalInputsOutput)
+	return o.ApplyT(func(v *ObjectWithNodeOptionalInputs) ObjectWithNodeOptionalInputs {
+		if v != nil {
+			return *v
+		}
+		var ret ObjectWithNodeOptionalInputs
+		return ret
+	}).(ObjectWithNodeOptionalInputsOutput)
 }
 
 func (o ObjectWithNodeOptionalInputsPtrOutput) Bar() pulumi.IntPtrOutput {
@@ -604,10 +618,11 @@ func (o SomeOtherObjectOutput) ToSomeOtherObjectPtrOutput() SomeOtherObjectPtrOu
 }
 
 func (o SomeOtherObjectOutput) ToSomeOtherObjectPtrOutputWithContext(ctx context.Context) SomeOtherObjectPtrOutput {
-	return o.ApplyT(func(v SomeOtherObject) *SomeOtherObject {
+	return o.ApplyTWithContext(ctx, func(_ context.Context, v SomeOtherObject) *SomeOtherObject {
 		return &v
 	}).(SomeOtherObjectPtrOutput)
 }
+
 func (o SomeOtherObjectOutput) Baz() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v SomeOtherObject) *string { return v.Baz }).(pulumi.StringPtrOutput)
 }
@@ -627,7 +642,13 @@ func (o SomeOtherObjectPtrOutput) ToSomeOtherObjectPtrOutputWithContext(ctx cont
 }
 
 func (o SomeOtherObjectPtrOutput) Elem() SomeOtherObjectOutput {
-	return o.ApplyT(func(v *SomeOtherObject) SomeOtherObject { return *v }).(SomeOtherObjectOutput)
+	return o.ApplyT(func(v *SomeOtherObject) SomeOtherObject {
+		if v != nil {
+			return *v
+		}
+		var ret SomeOtherObject
+		return ret
+	}).(SomeOtherObjectOutput)
 }
 
 func (o SomeOtherObjectPtrOutput) Baz() pulumi.StringPtrOutput {
@@ -676,7 +697,7 @@ func (i SomeOtherObjectArgsArrayArray) ToSomeOtherObjectArgsArrayArrayOutputWith
 type SomeOtherObjectArgsArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArgsArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArgsArray)(nil)).Elem()
+	return reflect.TypeOf((*[]SomeOtherObjectArgsArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArgsArrayArrayOutput) ToSomeOtherObjectArgsArrayArrayOutput() SomeOtherObjectArgsArrayArrayOutput {
@@ -721,7 +742,7 @@ func (i SomeOtherObjectArgsArrayMap) ToSomeOtherObjectArgsArrayMapOutputWithCont
 type SomeOtherObjectArgsArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArgsArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArgsArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string]SomeOtherObjectArgsArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArgsArrayMapOutput) ToSomeOtherObjectArgsArrayMapOutput() SomeOtherObjectArgsArrayMapOutput {
@@ -766,7 +787,7 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(
 type SomeOtherObjectArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[]SomeOtherObjectArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -811,7 +832,7 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx 
 type SomeOtherObjectArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string]SomeOtherObjectArray)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/resource.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/resource.go
@@ -93,9 +93,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ResourceOutput)
 }
 
-type ResourceOutput struct {
-	*pulumi.OutputState
-}
+type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*Resource)(nil))

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/typeUses.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/typeUses.go
@@ -95,9 +95,7 @@ func (i *TypeUses) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutp
 	return pulumi.ToOutputWithContext(ctx, i).(TypeUsesOutput)
 }
 
-type TypeUsesOutput struct {
-	*pulumi.OutputState
-}
+type TypeUsesOutput struct{ *pulumi.OutputState }
 
 func (TypeUsesOutput) ElementType() reflect.Type {
 	return reflect.TypeOf((*TypeUses)(nil))


### PR DESCRIPTION
These changes take a step towards simplifying and unifying the
generation of output types in the Go SDKs, especially for pointer,
array, and map outputs. This code was previously duplicated amongst the
various specialized output type generators, which led to inconsistencies
between the various implementaitons.

This is prep work for fixing #7595.