### PR TITLE
Remove threading from mock tests to fix AIO waits on diff event loop

### DIFF
--- a/sdk/python/lib/test_with_mocks/test_testing_with_mocks.py
+++ b/sdk/python/lib/test_with_mocks/test_testing_with_mocks.py
@@ -1,4 +1,4 @@
-# Copyright 2016-2018, Pulumi Corporation.
+# Copyright 2016-2021, Pulumi Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,9 +11,99 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import unittest
-import pulumi
+
+from concurrent.futures import ThreadPoolExecutor
+import asyncio
 import grpc
+import pulumi
+import pytest
+import resources
+import unittest
+
+
+@pytest.fixture
+def my_resources():
+    loop = asyncio.get_event_loop()
+    loop.set_default_executor(ImmediateExecutor())
+
+    old_settings = pulumi.runtime.settings.SETTINGS
+    try:
+        pulumi.runtime.mocks.set_mocks(MyMocks())
+        yield resources.define_resources()
+    finally:
+        pulumi.runtime.settings.configure(old_settings)
+        loop.set_default_executor(ThreadPoolExecutor())
+
+
+@pulumi.runtime.test
+def test_component(my_resources):
+
+    def check_outprop(outprop):
+        assert outprop == 'output: hello'
+
+    return my_resources['mycomponent'].outprop.apply(check_outprop)
+
+
+@pulumi.runtime.test
+def test_custom(my_resources):
+
+    def check_ip(ip):
+        assert ip == '203.0.113.12'
+
+    return my_resources['myinstance'].public_ip.apply(check_ip)
+
+
+@pulumi.runtime.test
+def test_custom_resource_reference(my_resources):
+
+    def check_instance(instance):
+        assert isinstance(instance, resources.Instance)
+
+        def check_ip(ip):
+            assert ip == '203.0.113.12'
+
+        instance.public_ip.apply(check_ip)
+
+    return my_resources['mycustom'].instance.apply(check_instance)
+
+
+@pulumi.runtime.test
+def test_invoke(my_resources):
+    assert my_resources['invoke_result'] == 59
+
+
+@pulumi.runtime.test
+def test_invoke_failures(my_resources):
+    caught = False
+
+    try:
+        pulumi.runtime.invoke("test:index:FailFunction", props={})
+    except Exception as e:
+        caught = str(e)
+
+    assert 'this function fails!' in caught
+
+
+@pulumi.runtime.test
+def test_invoke_throws(my_resources):
+    caught = None
+
+    try:
+        pulumi.runtime.invoke("test:index:ThrowFunction", props={})
+    except Exception as e:
+        caught = str(e)
+
+    assert 'this function throws!' in caught
+
+
+@pulumi.runtime.test
+def test_stack_reference(my_resources):
+
+    def check_outputs(outputs):
+        assert outputs["haha"] == "business"
+
+    my_resources['dns_ref'].outputs.apply(check_outputs)
+
 
 
 class GrpcError(grpc.RpcError):
@@ -66,59 +156,27 @@ class MyMocks(pulumi.runtime.Mocks):
             return ['', {}]
 
 
-pulumi.runtime.set_mocks(MyMocks())
+class ImmediateExecutor(ThreadPoolExecutor):
+    """This removes multithreading from current tests. Unfortunately in
+    presence of multithreading the tests are flaky. The proper fix is
+    postponed in #ref.
 
-# Now actually import the code that creates resources, and then test it.
-import resources
+    """
 
+    def __init__(self):
+        super()
+        self._default_executor = ThreadPoolExecutor()
 
-class TestingWithMocks(unittest.TestCase):
-    @unittest.skip(reason="Skipping flaky test tracked in https://github.com/pulumi/pulumi/issues/6561")
-    @pulumi.runtime.test
-    def test_component(self):
-        def check_outprop(outprop):
-            self.assertEqual(outprop, 'output: hello')
-        return resources.mycomponent.outprop.apply(check_outprop)
+    def submit(self, fn, *args, **kwargs):
+        v = fn(*args, **kwargs)
+        return self._default_executor.submit(ImmediateExecutor._identity, v)
 
-    @pulumi.runtime.test
-    def test_custom(self):
-        def check_ip(ip):
-            self.assertEqual(ip, '203.0.113.12')
-        return resources.myinstance.public_ip.apply(check_ip)
+    def map(self, func, *iterables, timeout=None, chunksize=1):
+        raise Exception('map not implemented')
 
-    @pulumi.runtime.test
-    def test_custom_resource_reference(self):
-        def check_instance(instance):
-            self.assertIsInstance(instance, resources.Instance)
-            def check_ip(ip):
-                self.assertEqual(ip, '203.0.113.12')
-            instance.public_ip.apply(check_ip)
-        return resources.mycustom.instance.apply(check_instance)
+    def shutdown(self, wait=True, cancel_futures=False):
+        raise Exception('shutdown not implemented')
 
-    @pulumi.runtime.test
-    def test_invoke(self):
-        return self.assertEqual(resources.invoke_result, 59)
-
-    @pulumi.runtime.test
-    def test_invoke_failures(self):
-        caught = False
-        try:
-            pulumi.runtime.invoke("test:index:FailFunction", props={})
-        except Exception:
-            caught = True
-        self.assertTrue(caught)
-
-    @pulumi.runtime.test
-    def test_invoke_throws(self):
-        caught = False
-        try:
-            pulumi.runtime.invoke("test:index:ThrowFunction", props={})
-        except Exception:
-            caught = True
-        self.assertTrue(caught)
-
-    @pulumi.runtime.test
-    def test_stack_reference(self):
-        def check_outputs(outputs):
-            self.assertEqual(outputs["haha"], "business")
-        resources.dns_ref.outputs.apply(check_outputs)
+    @staticmethod
+    def _identity(x):
+        return x

--- a/sdk/python/lib/test_with_mocks/test_testing_with_mocks.py
+++ b/sdk/python/lib/test_with_mocks/test_testing_with_mocks.py
@@ -159,7 +159,7 @@ class MyMocks(pulumi.runtime.Mocks):
 class ImmediateExecutor(ThreadPoolExecutor):
     """This removes multithreading from current tests. Unfortunately in
     presence of multithreading the tests are flaky. The proper fix is
-    postponed in #ref.
+    postponed - see https://github.com/pulumi/pulumi/issues/7663
 
     """
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #6561

I could not reproduce 6561 locally except by replacing `sync_await._ensure_event_loop()` with `get_event_loop`. These refactored tests pass under plain `get_event_loop`. This is because all action now happens on the main thread, unlike on ThreadPoolExecutor as in the product. 

So it is unfortunate that the refactored tests are working in a context that's different from product context.

On the upside, I believe they will stop flaking up the PR verification. This is a big relief.

TO reduce blast radius, I refactored the test suite to use Pytest fixtures so that the modifications to the default executor are "local" to the test suite and do not bleed into other tests.


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
