### PR TITLE
Cleanup CHANGELOG_PENDING after a release

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,28 +1,3 @@
 ### Improvements
 
-- [sdk/go] - Add stack output helpers for numeric types.
-  [#7410](https://github.com/pulumi/pulumi/pull/7410)
-
-- [sdk/python] - Permit `Input[Resource]` values in `depends_on`.
-  [#7559](https://github.com/pulumi/pulumi/pull/7559)
-
-- [backend/filestate] - Allow pulumi stack ls to see all stacks regardless of passphrase.
-  [#7660](https://github.com/pulumi/pulumi/pull/7660)
-
-
 ### Bug Fixes
-
-- [sdk/{go,python,nodejs}] - Rehydrate provider resources in `Construct`.
-  [#7624](https://github.com/pulumi/pulumi/pull/7624)
-  
-- [engine] - Include children when targeting components.
-  [#7605](https://github.com/pulumi/pulumi/pull/7605)
-
-- [cli] - Restore passing log options to providers when `--logflow` is specified
-  https://github.com/pulumi/pulumi/pull/7640
-
-- [sdk/nodejs] - Fix `pulumi up --logflow` causing Node multi-lang components to hang
-  [#7644](https://github.com/pulumi/pulumi/pull/)
-
-- [sdk/{dotnet,python,nodejs}] - Set the package on DependencyProviderResource.
-  [#7630](https://github.com/pulumi/pulumi/pull/7630)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
