### PR TITLE
Experiment with reducing test parallelism to free up runners

### DIFF
--- a/scripts/test_subsets.py
+++ b/scripts/test_subsets.py
@@ -13,18 +13,47 @@ tests, or test suites names as passed to `run-testsuite.py`.
 
 TEST_SUBSETS = {
     'integration': [
-        'github.com/pulumi/pulumi/tests/integration'
-    ],
-    'auto-and-lifecycletest': [
-        'github.com/pulumi/pulumi/sdk/v3/go/auto',
-        'github.com/pulumi/pulumi/pkg/v3/engine/lifeycletest'
-    ],
-    'native': [
-        'dotnet-test',
-        'istanbul',
-        'istanbul-with-mocks',
-        'python/lib/test',
-        'python/lib/test/langhost/resource_thens',
-        'python/lib/test_with_mocks'
+        "github.com/pulumi/pulumi/tests/integration/aliases",
+        "github.com/pulumi/pulumi/tests/integration/custom_timeouts",
+        "github.com/pulumi/pulumi/tests/integration/delete_before_create",
+        "github.com/pulumi/pulumi/tests/integration/dependency_steps",
+        "github.com/pulumi/pulumi/tests/integration/double_pending_delete",
+        "github.com/pulumi/pulumi/tests/integration/duplicate_urns",
+        "github.com/pulumi/pulumi/tests/integration/partial_state",
+        "github.com/pulumi/pulumi/tests/integration/policy",
+        "github.com/pulumi/pulumi/tests/integration/protect_resources",
+        "github.com/pulumi/pulumi/tests/integration/query",
+        "github.com/pulumi/pulumi/tests/integration/read/import_acquire",
+        "github.com/pulumi/pulumi/tests/integration/read/read_dbr",
+        "github.com/pulumi/pulumi/tests/integration/read/read_relinquish",
+        "github.com/pulumi/pulumi/tests/integration/read/read_replace",
+        "github.com/pulumi/pulumi/tests/integration/recreate_resource_check",
+        "github.com/pulumi/pulumi/tests/integration/steps",
+        "github.com/pulumi/pulumi/tests/integration/targets",
+        "github.com/pulumi/pulumi/tests/integration/transformations",
+        "github.com/pulumi/pulumi/tests/integration/types",
+        'github.com/pulumi/pulumi/tests/integration',
     ]
 }
+
+# The previous config used 4 runners and while it finished CI faster,
+# the project started hitting throughput problems on not having enough
+# Mac OS runners available:
+#
+# TEST_SUBSETS = {
+#     'integration': [
+#         'github.com/pulumi/pulumi/tests/integration'
+#     ],
+#     'auto-and-lifecycletest': [
+#         'github.com/pulumi/pulumi/sdk/v3/go/auto',
+#         'github.com/pulumi/pulumi/pkg/v3/engine/lifeycletest'
+#     ],
+#     'native': [
+#         'dotnet-test',
+#         'istanbul',
+#         'istanbul-with-mocks',
+#         'python/lib/test',
+#         'python/lib/test/langhost/resource_thens',
+#         'python/lib/test_with_mocks'
+#     ]
+# }


### PR DESCRIPTION
# Description

Gets us to 2 test subsets and parallel runners instead of 4. Hypothesis here is that because of repeat work in the parallel runners, this will help the total CI throughput and reduce "waiting for Mac OS runner" delays.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
