### PR TITLE
Fix reflecting list type annotations

### DIFF
--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -68,6 +68,11 @@ def _get_list_element_type(typ: Optional[type]) -> Optional[type]:
     if typ is None:
         return None
 
+    # Annotations not specifying the element type are assumed by mypy
+    # to signify Any element type. Follow suite here.
+    if typ in {list, List, Sequence, abc.Sequence}:
+        return cast(Any, type)
+
     # If typ is a list, get the type for its values, to pass
     # along for each item.
     origin = _types.get_origin(typ)

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -69,7 +69,7 @@ def _get_list_element_type(typ: Optional[type]) -> Optional[type]:
         return None
 
     # Annotations not specifying the element type are assumed by mypy
-    # to signify Any element type. Follow suite here.
+    # to signify Any element type. Follow suit here.
     if typ in {list, List, Sequence, abc.Sequence}:
         return cast(type, Any)
 

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -71,7 +71,7 @@ def _get_list_element_type(typ: Optional[type]) -> Optional[type]:
     # Annotations not specifying the element type are assumed by mypy
     # to signify Any element type. Follow suite here.
     if typ in {list, List, Sequence, abc.Sequence}:
-        return cast(Any, type)
+        return cast(type, Any)
 
     # If typ is a list, get the type for its values, to pass
     # along for each item.

--- a/sdk/python/lib/test/runtime/test_rpc.py
+++ b/sdk/python/lib/test/runtime/test_rpc.py
@@ -1,0 +1,36 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import abc
+from pulumi.runtime import rpc
+from typing import Any
+import typing
+
+
+def test_get_list_element_type():
+    assert rpc._get_list_element_type(None) is None
+
+    assert rpc._get_list_element_type(list) == Any
+    assert rpc._get_list_element_type(abc.Sequence) == Any
+    assert rpc._get_list_element_type(typing.List) == Any
+    assert rpc._get_list_element_type(typing.Sequence) == Any
+
+    assert rpc._get_list_element_type(typing.List[Any]) == Any
+    assert rpc._get_list_element_type(typing.Sequence[Any]) == Any
+
+    assert rpc._get_list_element_type(typing.List[int]) == int
+    assert rpc._get_list_element_type(typing.Sequence[int]) == int
+
+    assert rpc._get_list_element_type(typing.List[typing.List[int]]) == typing.List[int]
+    assert rpc._get_list_element_type(typing.Sequence[typing.Sequence[int]]) == typing.Sequence[int]

--- a/sdk/python/lib/test/runtime/test_rpc.py
+++ b/sdk/python/lib/test/runtime/test_rpc.py
@@ -34,3 +34,5 @@ def test_get_list_element_type():
 
     assert rpc._get_list_element_type(typing.List[typing.List[int]]) == typing.List[int]
     assert rpc._get_list_element_type(typing.Sequence[typing.Sequence[int]]) == typing.Sequence[int]
+
+    assert rpc._get_list_element_type(typing.List[typing.List]) == typing.List


### PR DESCRIPTION
# Description

This makes the example from https://github.com/pulumi/pulumi/issues/7313 pass (examples/aws-py-ec2-provisioners).

Fixes #7313 

It did not hang this time but it did fail with a relatively obscure stack trace. It works with the fix.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
