### PR TITLE
Use `provider.MainWithOptions` to reduce boilerplate in integration tests

### DIFF
--- a/tests/examples/examples_test.go
+++ b/tests/examples/examples_test.go
@@ -4,6 +4,7 @@ package examples
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -358,7 +358,7 @@ func getNodeVersion() (semver.Version, error) {
 	nodeVersionCmd := exec.Command("node", "--version")
 	nodeVersionCmd.Stdout = &buf
 	if err := nodeVersionCmd.Run(); err != nil {
-		return semver.Version{}, errors.Wrap(err, "running node --version")
+		return semver.Version{}, fmt.Errorf("running node --version: %w", err)
 	}
 
 	return semver.ParseTolerant(buf.String())

--- a/tests/integration/component_provider_schema/testcomponent-go/main.go
+++ b/tests/integration/component_provider_schema/testcomponent-go/main.go
@@ -3,9 +3,8 @@
 package main
 
 import (
+	"fmt"
 	"os"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -27,7 +26,7 @@ func main() {
 		Schema:  []byte(schema),
 		Construct: func(ctx *pulumi.Context, typ, name string,
 			inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
-			return nil, errors.Errorf("unknown resource type %s", typ)
+			return nil, fmt.Errorf("unknown resource type %s", typ)
 		},
 	})
 	if err != nil {

--- a/tests/integration/construct_component/testcomponent-go/main.go
+++ b/tests/integration/construct_component/testcomponent-go/main.go
@@ -4,10 +4,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -68,7 +67,7 @@ func NewComponent(ctx *pulumi.Context, name string, args *ComponentArgs,
 	secretKey := "secret"
 	fullSecretKey := fmt.Sprintf("%s:%s", ctx.Project(), secretKey)
 	if !ctx.IsConfigSecret(fullSecretKey) {
-		return nil, errors.Errorf("expected configuration key to be secret: %s", fullSecretKey)
+		return nil, fmt.Errorf("expected configuration key to be secret: %s", fullSecretKey)
 	}
 
 	conf := config.New(ctx, "")
@@ -133,7 +132,7 @@ func (p *testcomponentProvider) Create(ctx context.Context,
 	urn := resource.URN(req.GetUrn())
 	typ := urn.Type()
 	if typ != "testcomponent:index:Resource" {
-		return nil, errors.Errorf("Unknown resource type '%s'", typ)
+		return nil, fmt.Errorf("Unknown resource type '%s'", typ)
 	}
 
 	id := currentID
@@ -150,17 +149,17 @@ func (p *testcomponentProvider) Construct(ctx context.Context,
 		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
 
 		if typ != "testcomponent:index:Component" {
-			return nil, errors.Errorf("unknown resource type %s", typ)
+			return nil, fmt.Errorf("unknown resource type %s", typ)
 		}
 
 		args := &ComponentArgs{}
 		if err := inputs.CopyTo(args); err != nil {
-			return nil, errors.Wrap(err, "setting args")
+			return nil, fmt.Errorf("setting args: %w", err)
 		}
 
 		component, err := NewComponent(ctx, name, args, options)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating component")
+			return nil, fmt.Errorf("creating component: %w", err)
 		}
 
 		return pulumiprovider.NewConstructResult(component)
@@ -188,17 +187,17 @@ func (p *testcomponentProvider) Configure(ctx context.Context,
 
 func (p *testcomponentProvider) Invoke(ctx context.Context,
 	req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
-	return nil, errors.Errorf("Unknown Invoke token '%s'", req.GetTok())
+	return nil, fmt.Errorf("Unknown Invoke token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) StreamInvoke(req *pulumirpc.InvokeRequest,
 	server pulumirpc.ResourceProvider_StreamInvokeServer) error {
-	return errors.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
+	return fmt.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) Call(ctx context.Context,
 	req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
-	return nil, errors.Errorf("Unknown Call token '%s'", req.GetTok())
+	return nil, fmt.Errorf("Unknown Call token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) Check(ctx context.Context,

--- a/tests/integration/construct_component_methods/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods/testcomponent-go/main.go
@@ -3,10 +3,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -98,36 +98,36 @@ func main() {
 			options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
 
 			if typ != "testcomponent:index:Component" {
-				return nil, errors.Errorf("unknown resource type %s", typ)
+				return nil, fmt.Errorf("unknown resource type %s", typ)
 			}
 
 			args := &ComponentArgs{}
 			if err := inputs.CopyTo(args); err != nil {
-				return nil, errors.Wrap(err, "setting args")
+				return nil, fmt.Errorf("setting args: %w", err)
 			}
 
 			component, err := NewComponent(ctx, name, args, options)
 			if err != nil {
-				return nil, errors.Wrap(err, "creating component")
+				return nil, fmt.Errorf("creating component: %w", err)
 			}
 
 			return pulumiprovider.NewConstructResult(component)
 		},
 		Call: func(ctx *pulumi.Context, tok string, args pulumiprovider.CallArgs) (*pulumiprovider.CallResult, error) {
 			if tok != "testcomponent:index:Component/getMessage" {
-				return nil, errors.Errorf("unknown method %s", tok)
+				return nil, fmt.Errorf("unknown method %s", tok)
 			}
 
 			methodArgs := &ComponentGetMessageArgs{}
 			res, err := args.CopyTo(methodArgs)
 			if err != nil {
-				return nil, errors.Wrap(err, "setting args")
+				return nil, fmt.Errorf("setting args: %w", err)
 			}
 			component := res.(*Component)
 
 			result, err := component.GetMessage(methodArgs)
 			if err != nil {
-				return nil, errors.Wrap(err, "calling method")
+				return nil, fmt.Errorf("calling method: %w", err)
 			}
 
 			return pulumiprovider.NewCallResult(result)

--- a/tests/integration/construct_component_methods/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods/testcomponent-go/main.go
@@ -3,20 +3,15 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	pbempty "github.com/golang/protobuf/ptypes/empty"
 )
 
 type Component struct {
@@ -96,150 +91,48 @@ func main() {
 	// Register any resources that can come back as resource references that need to be rehydrated.
 	pulumi.RegisterResourceModule("testcomponent", "index", &module{semver.MustParse(version)})
 
-	err := provider.Main(providerName, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-		return makeProvider(host, providerName, version)
-	})
-	if err != nil {
+	if err := provider.MainWithOptions(provider.Options{
+		Name:    providerName,
+		Version: version,
+		Construct: func(ctx *pulumi.Context, typ, name string, inputs pulumiprovider.ConstructInputs,
+			options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
+
+			if typ != "testcomponent:index:Component" {
+				return nil, errors.Errorf("unknown resource type %s", typ)
+			}
+
+			args := &ComponentArgs{}
+			if err := inputs.CopyTo(args); err != nil {
+				return nil, errors.Wrap(err, "setting args")
+			}
+
+			component, err := NewComponent(ctx, name, args, options)
+			if err != nil {
+				return nil, errors.Wrap(err, "creating component")
+			}
+
+			return pulumiprovider.NewConstructResult(component)
+		},
+		Call: func(ctx *pulumi.Context, tok string, args pulumiprovider.CallArgs) (*pulumiprovider.CallResult, error) {
+			if tok != "testcomponent:index:Component/getMessage" {
+				return nil, errors.Errorf("unknown method %s", tok)
+			}
+
+			methodArgs := &ComponentGetMessageArgs{}
+			res, err := args.CopyTo(methodArgs)
+			if err != nil {
+				return nil, errors.Wrap(err, "setting args")
+			}
+			component := res.(*Component)
+
+			result, err := component.GetMessage(methodArgs)
+			if err != nil {
+				return nil, errors.Wrap(err, "calling method")
+			}
+
+			return pulumiprovider.NewCallResult(result)
+		},
+	}); err != nil {
 		cmdutil.ExitError(err.Error())
 	}
-}
-
-type testcomponentProvider struct {
-	host    *provider.HostClient
-	name    string
-	version string
-}
-
-func makeProvider(host *provider.HostClient, name, version string) (pulumirpc.ResourceProviderServer, error) {
-	return &testcomponentProvider{
-		host:    host,
-		name:    name,
-		version: version,
-	}, nil
-}
-
-func (p *testcomponentProvider) Create(ctx context.Context,
-	req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	urn := resource.URN(req.GetUrn())
-	typ := urn.Type()
-	return nil, errors.Errorf("Unknown resource type '%s'", typ)
-}
-
-func (p *testcomponentProvider) Construct(ctx context.Context,
-	req *pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error) {
-	return pulumiprovider.Construct(ctx, req, p.host.EngineConn(), func(ctx *pulumi.Context, typ, name string,
-		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
-
-		if typ != "testcomponent:index:Component" {
-			return nil, errors.Errorf("unknown resource type %s", typ)
-		}
-
-		args := &ComponentArgs{}
-		if err := inputs.CopyTo(args); err != nil {
-			return nil, errors.Wrap(err, "setting args")
-		}
-
-		component, err := NewComponent(ctx, name, args, options)
-		if err != nil {
-			return nil, errors.Wrap(err, "creating component")
-		}
-
-		return pulumiprovider.NewConstructResult(component)
-	})
-}
-
-func (p *testcomponentProvider) CheckConfig(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.GetNews()}, nil
-}
-
-func (p *testcomponentProvider) DiffConfig(ctx context.Context,
-	req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Configure(ctx context.Context,
-	req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	return &pulumirpc.ConfigureResponse{
-		AcceptSecrets:   true,
-		SupportsPreview: true,
-		AcceptResources: true,
-	}, nil
-}
-
-func (p *testcomponentProvider) Invoke(ctx context.Context,
-	req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
-	return nil, errors.Errorf("Unknown Invoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) StreamInvoke(req *pulumirpc.InvokeRequest,
-	server pulumirpc.ResourceProvider_StreamInvokeServer) error {
-	return errors.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) Call(ctx context.Context,
-	req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
-	return pulumiprovider.Call(ctx, req, p.host.EngineConn(), func(ctx *pulumi.Context, tok string,
-		args pulumiprovider.CallArgs) (*pulumiprovider.CallResult, error) {
-
-		if tok != "testcomponent:index:Component/getMessage" {
-			return nil, errors.Errorf("unknown method %s", tok)
-		}
-
-		methodArgs := &ComponentGetMessageArgs{}
-		res, err := args.CopyTo(methodArgs)
-		if err != nil {
-			return nil, errors.Wrap(err, "setting args")
-		}
-		component := res.(*Component)
-
-		result, err := component.GetMessage(methodArgs)
-		if err != nil {
-			return nil, errors.Wrap(err, "calling method")
-		}
-
-		return pulumiprovider.NewCallResult(result)
-	})
-}
-
-func (p *testcomponentProvider) Check(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (p *testcomponentProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	return &pulumirpc.ReadResponse{
-		Id:         req.GetId(),
-		Properties: req.GetProperties(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Update(ctx context.Context,
-	req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	return &pulumirpc.UpdateResponse{
-		Properties: req.GetNews(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
-}
-
-func (p *testcomponentProvider) GetPluginInfo(context.Context, *pbempty.Empty) (*pulumirpc.PluginInfo, error) {
-	return &pulumirpc.PluginInfo{
-		Version: p.version,
-	}, nil
-}
-
-func (p *testcomponentProvider) GetSchema(ctx context.Context,
-	req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
-	return &pulumirpc.GetSchemaResponse{}, nil
-}
-
-func (p *testcomponentProvider) Cancel(context.Context, *pbempty.Empty) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
 }

--- a/tests/integration/construct_component_methods_unknown/testcomponent-go/main.go
+++ b/tests/integration/construct_component_methods_unknown/testcomponent-go/main.go
@@ -3,19 +3,14 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/blang/semver"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	pbempty "github.com/golang/protobuf/ptypes/empty"
 )
 
 type Component struct {
@@ -81,144 +76,43 @@ func main() {
 	// Register any resources that can come back as resource references that need to be rehydrated.
 	pulumi.RegisterResourceModule("testcomponent", "index", &module{semver.MustParse(version)})
 
-	if err := provider.Main(providerName, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-		return makeProvider(host, providerName, version)
+	if err := provider.MainWithOptions(provider.Options{
+		Name:    providerName,
+		Version: version,
+		Construct: func(ctx *pulumi.Context, typ, name string, inputs pulumiprovider.ConstructInputs,
+			options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
+
+			if typ != "testcomponent:index:Component" {
+				return nil, fmt.Errorf("unknown resource type %s", typ)
+			}
+
+			component, err := NewComponent(ctx, name, options)
+			if err != nil {
+				return nil, fmt.Errorf("creating component: %w", err)
+			}
+
+			return pulumiprovider.NewConstructResult(component)
+		},
+		Call: func(ctx *pulumi.Context, tok string, args pulumiprovider.CallArgs) (*pulumiprovider.CallResult, error) {
+			if tok != "testcomponent:index:Component/getMessage" {
+				return nil, fmt.Errorf("unknown method %s", tok)
+			}
+
+			methodArgs := &ComponentGetMessageArgs{}
+			res, err := args.CopyTo(methodArgs)
+			if err != nil {
+				return nil, fmt.Errorf("setting args: %w", err)
+			}
+			component := res.(*Component)
+
+			result, err := component.GetMessage(methodArgs)
+			if err != nil {
+				return nil, fmt.Errorf("calling method: %w", err)
+			}
+
+			return pulumiprovider.NewCallResult(result)
+		},
 	}); err != nil {
 		cmdutil.ExitError(err.Error())
 	}
-}
-
-type testcomponentProvider struct {
-	host    *provider.HostClient
-	name    string
-	version string
-}
-
-func makeProvider(host *provider.HostClient, name, version string) (pulumirpc.ResourceProviderServer, error) {
-	return &testcomponentProvider{
-		host:    host,
-		name:    name,
-		version: version,
-	}, nil
-}
-
-func (p *testcomponentProvider) Create(ctx context.Context,
-	req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	urn := resource.URN(req.GetUrn())
-	typ := urn.Type()
-	return nil, fmt.Errorf("Unknown resource type '%s'", typ)
-}
-
-func (p *testcomponentProvider) Construct(ctx context.Context,
-	req *pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error) {
-	return pulumiprovider.Construct(ctx, req, p.host.EngineConn(), func(ctx *pulumi.Context, typ, name string,
-		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
-
-		if typ != "testcomponent:index:Component" {
-			return nil, fmt.Errorf("unknown resource type %s", typ)
-		}
-
-		component, err := NewComponent(ctx, name, options)
-		if err != nil {
-			return nil, fmt.Errorf("creating component: %w", err)
-		}
-
-		return pulumiprovider.NewConstructResult(component)
-	})
-}
-
-func (p *testcomponentProvider) CheckConfig(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.GetNews()}, nil
-}
-
-func (p *testcomponentProvider) DiffConfig(ctx context.Context,
-	req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Configure(ctx context.Context,
-	req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	return &pulumirpc.ConfigureResponse{
-		AcceptSecrets:   true,
-		SupportsPreview: true,
-		AcceptResources: true,
-	}, nil
-}
-
-func (p *testcomponentProvider) Invoke(ctx context.Context,
-	req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
-	return nil, fmt.Errorf("Unknown Invoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) StreamInvoke(req *pulumirpc.InvokeRequest,
-	server pulumirpc.ResourceProvider_StreamInvokeServer) error {
-	return fmt.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) Call(ctx context.Context,
-	req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
-	return pulumiprovider.Call(ctx, req, p.host.EngineConn(), func(ctx *pulumi.Context, tok string,
-		args pulumiprovider.CallArgs) (*pulumiprovider.CallResult, error) {
-
-		if tok != "testcomponent:index:Component/getMessage" {
-			return nil, fmt.Errorf("unknown method %s", tok)
-		}
-
-		methodArgs := &ComponentGetMessageArgs{}
-		res, err := args.CopyTo(methodArgs)
-		if err != nil {
-			return nil, fmt.Errorf("setting args: %w", err)
-		}
-		component := res.(*Component)
-
-		result, err := component.GetMessage(methodArgs)
-		if err != nil {
-			return nil, fmt.Errorf("calling method: %w", err)
-		}
-
-		return pulumiprovider.NewCallResult(result)
-	})
-}
-
-func (p *testcomponentProvider) Check(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (p *testcomponentProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	return &pulumirpc.ReadResponse{
-		Id:         req.GetId(),
-		Properties: req.GetProperties(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Update(ctx context.Context,
-	req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	return &pulumirpc.UpdateResponse{
-		Properties: req.GetNews(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
-}
-
-func (p *testcomponentProvider) GetPluginInfo(context.Context, *pbempty.Empty) (*pulumirpc.PluginInfo, error) {
-	return &pulumirpc.PluginInfo{
-		Version: p.version,
-	}, nil
-}
-
-func (p *testcomponentProvider) GetSchema(ctx context.Context,
-	req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
-	return &pulumirpc.GetSchemaResponse{}, nil
-}
-
-func (p *testcomponentProvider) Cancel(context.Context, *pbempty.Empty) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
 }

--- a/tests/integration/construct_component_plain/testcomponent-go/main.go
+++ b/tests/integration/construct_component_plain/testcomponent-go/main.go
@@ -4,9 +4,8 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -99,7 +98,7 @@ func (p *testcomponentProvider) Create(ctx context.Context,
 	urn := resource.URN(req.GetUrn())
 	typ := urn.Type()
 	if typ != "testcomponent:index:Resource" {
-		return nil, errors.Errorf("Unknown resource type '%s'", typ)
+		return nil, fmt.Errorf("Unknown resource type '%s'", typ)
 	}
 
 	id := currentID
@@ -116,17 +115,17 @@ func (p *testcomponentProvider) Construct(ctx context.Context,
 		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
 
 		if typ != "testcomponent:index:Component" {
-			return nil, errors.Errorf("unknown resource type %s", typ)
+			return nil, fmt.Errorf("unknown resource type %s", typ)
 		}
 
 		args := &ComponentArgs{}
 		if err := inputs.CopyTo(args); err != nil {
-			return nil, errors.Wrap(err, "setting args")
+			return nil, fmt.Errorf("setting args: %w", err)
 		}
 
 		component, err := NewComponent(ctx, name, args, options)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating component")
+			return nil, fmt.Errorf("creating component: %w", err)
 		}
 
 		return pulumiprovider.NewConstructResult(component)
@@ -154,17 +153,17 @@ func (p *testcomponentProvider) Configure(ctx context.Context,
 
 func (p *testcomponentProvider) Invoke(ctx context.Context,
 	req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
-	return nil, errors.Errorf("Unknown Invoke token '%s'", req.GetTok())
+	return nil, fmt.Errorf("Unknown Invoke token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) StreamInvoke(req *pulumirpc.InvokeRequest,
 	server pulumirpc.ResourceProvider_StreamInvokeServer) error {
-	return errors.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
+	return fmt.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) Call(ctx context.Context,
 	req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
-	return nil, errors.Errorf("Unknown Call token '%s'", req.GetTok())
+	return nil, fmt.Errorf("Unknown Call token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) Check(ctx context.Context,

--- a/tests/integration/construct_component_unknown/go/random.go
+++ b/tests/integration/construct_component_unknown/go/random.go
@@ -6,9 +6,9 @@
 package main
 
 import (
+	"errors"
 	"reflect"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
 

--- a/tests/integration/construct_component_unknown/testcomponent-go/main.go
+++ b/tests/integration/construct_component_unknown/testcomponent-go/main.go
@@ -4,10 +4,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -128,7 +127,7 @@ func (p *testcomponentProvider) Create(ctx context.Context,
 	urn := resource.URN(req.GetUrn())
 	typ := urn.Type()
 	if typ != "testcomponent:index:Resource" {
-		return nil, errors.Errorf("Unknown resource type '%s'", typ)
+		return nil, fmt.Errorf("Unknown resource type '%s'", typ)
 	}
 
 	id := currentID
@@ -145,17 +144,17 @@ func (p *testcomponentProvider) Construct(ctx context.Context,
 		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
 
 		if typ != "testcomponent:index:Component" {
-			return nil, errors.Errorf("unknown resource type %s", typ)
+			return nil, fmt.Errorf("unknown resource type %s", typ)
 		}
 
 		args := &ComponentArgs{}
 		if err := inputs.CopyTo(args); err != nil {
-			return nil, errors.Wrap(err, "setting args")
+			return nil, fmt.Errorf("setting args: %w", err)
 		}
 
 		component, err := NewComponent(ctx, name, args, options)
 		if err != nil {
-			return nil, errors.Wrap(err, "creating component")
+			return nil, fmt.Errorf("creating component: %w", err)
 		}
 
 		return pulumiprovider.NewConstructResult(component)
@@ -183,17 +182,17 @@ func (p *testcomponentProvider) Configure(ctx context.Context,
 
 func (p *testcomponentProvider) Invoke(ctx context.Context,
 	req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
-	return nil, errors.Errorf("Unknown Invoke token '%s'", req.GetTok())
+	return nil, fmt.Errorf("Unknown Invoke token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) StreamInvoke(req *pulumirpc.InvokeRequest,
 	server pulumirpc.ResourceProvider_StreamInvokeServer) error {
-	return errors.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
+	return fmt.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) Call(ctx context.Context,
 	req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
-	return nil, errors.Errorf("Unknown Call token '%s'", req.GetTok())
+	return nil, fmt.Errorf("Unknown Call token '%s'", req.GetTok())
 }
 
 func (p *testcomponentProvider) Check(ctx context.Context,


### PR DESCRIPTION
We can use the new `provider.MainWithOptions` from #7598 to reduce boilerplate in some of our testcomponent providers.

Also, while cleaning up here, I took this as an opportunity to replace use of `github.com/pkg/errors` in the `tests` dir to use the built-in functionality of the Go standard library.