### PR TITLE
Go install command is given proper DOTNET_VERSION

### DIFF
--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -31,7 +31,7 @@ build::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${DOTNET_VERSION}" ${LANGHOST_PKG}
 
 install_plugin::
-	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}
+	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${DOTNET_VERSION}" ${LANGHOST_PKG}
 
 install:: build install_plugin
 	echo "Copying NuGet packages to ${PULUMI_NUGET}"


### PR DESCRIPTION
# Description

Fixed small typo in build script. Previously, the -ldflags would be given an incorrect empty version.