### PR TITLE
Update of CONTRIBUTING.md to reflect 3.0 changelog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ For larger features, we'd appreciate it if you open a [new issue](https://github
 To hack on Pulumi, you'll need to get a development environment set up. You'll want to install the following on your machine:
 
 - Go 1.16
-- NodeJS 11.X.X or later
+- NodeJS 12.X.X or later
 - Python 3.6 or later
 - [.NET Core](https://dotnet.microsoft.com/download)
 - [pipenv](https://github.com/pypa/pipenv)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ For larger features, we'd appreciate it if you open a [new issue](https://github
 To hack on Pulumi, you'll need to get a development environment set up. You'll want to install the following on your machine:
 
 - Go 1.16
-- NodeJS 10.X.X or later
+- NodeJS 11.X.X or later
 - Python 3.6 or later
 - [.NET Core](https://dotnet.microsoft.com/download)
 - [pipenv](https://github.com/pypa/pipenv)


### PR DESCRIPTION
CONTRIBUTING.md updated to require NodeJS v11.x rather than v10.x, as Pulumi 3.0 no longer supports the latter.
