### PR TITLE
python: Use Sequence rather than List in Resource fields

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,8 +6,12 @@
 
 - [cli] - Properly parse Git remotes with periods or hyphens.
   [#7386](https://github.com/pulumi/pulumi/pull/7386)
-  
+
 - [codegen/python] - Recover good IDE completion experience over
   module imports that was compromised when introducing the lazy import
   optimization.
   [#7487](https://github.com/pulumi/pulumi/pull/7487)
+
+- [sdk/python] - Use `Sequence[T]` instead of `List[T]` for several `Resource`
+  parameters.
+  [#7698](https://github.com/pulumi/pulumi/pull/7698)

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -15,7 +15,7 @@ import asyncio
 import os
 import traceback
 
-from typing import Optional, Any, Callable, List, NamedTuple, Dict, Set, Tuple, Union, TYPE_CHECKING, cast, Mapping
+from typing import Optional, Any, Callable, List, NamedTuple, Dict, Set, Tuple, Union, TYPE_CHECKING, cast, Mapping, Sequence
 from google.protobuf import struct_pb2
 import grpc
 
@@ -644,14 +644,14 @@ class RegisterResponse:
 def convert_providers(
         provider: Optional['ProviderResource'],
         providers: Optional[Union[Mapping[str, 'ProviderResource'],
-                                  List['ProviderResource']]]) -> Mapping[str, 'ProviderResource']:
+                                  Sequence['ProviderResource']]]) -> Mapping[str, 'ProviderResource']:
     if provider is not None:
         return convert_providers(None, [provider])
 
     if providers is None:
         return {}
 
-    if not isinstance(providers, list):
+    if isinstance(providers, Mapping):
         return providers
 
     result = {}


### PR DESCRIPTION
# Description

Similar to #5282, but for core SDK types. The tl;dr is that because
Sequence[T] is covariant, constructing resources becomes much more
ergonomic.

Fix #7693.

## Checklist


- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
