### PR TITLE
[sdk/nodejs] Account for outstanding async work done in `prepareResource`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,3 +15,6 @@
 - [sdk/python] - Use `Sequence[T]` instead of `List[T]` for several `Resource`
   parameters.
   [#7698](https://github.com/pulumi/pulumi/pull/7698)
+
+- [auto/nodejs] - Fix a case where inline programs could exit with outstanding async work.
+  [#7704](https://github.com/pulumi/pulumi/pull/7704)

--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -90,12 +90,6 @@ export class LanguageServer<T> implements grpc.UntypedServiceImplementation {
 
             try {
                 await runtime.runInPulumiStack(this.program);
-                // pump the event loop.
-                // sometimes programs that don't capture stack outputs can terminate
-                // before work actually ends up in the rpcKeepAlive queue.
-                // we're forcing an extra turn of the loop before awaiting outstanding async work
-                // to give programs of this category a chance to get work scheduled. 
-                await new Promise(f => setTimeout(f, 200));
                 await runtime.disconnect();
                 process.off("uncaughtException", uncaughtHandler);
                 process.off("unhandledRejection", uncaughtHandler);

--- a/sdk/nodejs/automation/server.ts
+++ b/sdk/nodejs/automation/server.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import * as grpc from "@grpc/grpc-js";
-import { threadId } from "worker_threads";
 import { isGrpcError, ResourceError, RunError } from "../errors";
 import * as log from "../log";
 import * as runtime from "../runtime";

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -420,10 +420,10 @@ export function registerResource(res: Resource, t: string, name: string, custom:
 async function prepareResource(label: string, res: Resource, custom: boolean, remote: boolean,
                                props: Inputs, opts: ResourceOptions): Promise<ResourceResolverOperation> {
 
-    // add an entry to the rpc queue while we prepare the request. 
+    // add an entry to the rpc queue while we prepare the request.
     // automation api inline programs that don't have stack exports can exit quickly. If we don't do this,
     // sometimes they will exit right after `prepareResource` is called as a part of register resource, but before the
-    // .then() that adds to the queue via `runAsyncResourceOp`
+    // .then() that adds to the queue via `runAsyncResourceOp`.
     const done: () => void = rpcKeepAlive();
 
     // Simply initialize the URN property and get prepared to resolve it later on.

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -420,6 +420,12 @@ export function registerResource(res: Resource, t: string, name: string, custom:
 async function prepareResource(label: string, res: Resource, custom: boolean, remote: boolean,
                                props: Inputs, opts: ResourceOptions): Promise<ResourceResolverOperation> {
 
+    // add an entry to the rpc queue while we prepare the request. 
+    // automation api inline programs that don't have stack exports can exit quickly. If we don't do this,
+    // sometimes they will exit right after `prepareResource` is called as a part of register resource, but before the
+    // .then() that adds to the queue via `runAsyncResourceOp`
+    const done: () => void = rpcKeepAlive();
+
     // Simply initialize the URN property and get prepared to resolve it later on.
     // Note: a resource urn will always get a value, and thus the output property
     // for it can always run .apply calls.
@@ -562,6 +568,9 @@ async function prepareResource(label: string, res: Resource, custom: boolean, re
             aliases.push(aliasVal);
         }
     }
+
+    // free the RPC queue
+    done();
 
     return {
         resolveURN: resolveURN,


### PR DESCRIPTION
Fixes https://github.com/pulumi/pulumi/issues/6998

Turns out we weren't adding `prepareResource` work the the keep-alive queue. We were waiting until `runAsyncResourceOp` which happens in a `.then` chained off of `prepareResource`. The automation api shutdown routine, `runtime.disconnect`, was unaware of this outstanding work as a result. 