### PR TITLE
fix multiple edge cases in go program gen

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -155,12 +155,13 @@ func (pkg *pkgContext) tokenToType(tok string) string {
 		}
 	}
 
-	if mod == pkg.mod {
-		return name
-	}
 	if mod == "" {
 		mod = components[0]
 	}
+	if mod == pkg.mod {
+		return name
+	}
+
 	mod = strings.Replace(mod, "/", "", -1) + "." + name
 	return strings.Replace(mod, "-provider", "", -1)
 }

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -599,12 +599,13 @@ func (g *generator) argumentTypeName(expr model.Expression, destType model.Type,
 			"Args", "Array", "Map", "Ptr", "Bool", "Int", "String", "Any",
 		}
 		hasSuffix := false
+		isInvokeArg := strings.Contains(typ, ".Lookup") || strings.Contains(typ, ".Get")
 		for _, s := range suffixes {
 			if strings.HasSuffix(typ, s) {
 				hasSuffix = true
 			}
 		}
-		if !hasSuffix {
+		if !hasSuffix && !isInvokeArg {
 			typ += "Args"
 		}
 		return typ

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -548,9 +548,6 @@ func (g *generator) genTupleConsExpression(w io.Writer, expr *model.TupleConsExp
 	}
 	g.genTemps(w, temps)
 	argType := g.argumentTypeName(expr, destType, isInput)
-	if strings.HasSuffix(argType, "Array") {
-		isInput = true
-	}
 	g.Fgenf(w, "%s{\n", argType)
 	switch len(expr.Expressions) {
 	case 0:

--- a/pkg/codegen/internal/test/program_driver.go
+++ b/pkg/codegen/internal/test/program_driver.go
@@ -52,7 +52,6 @@ var programTests = []programTest{
 	{
 		ProgramFile: "azure-native",
 		Description: "Azure Native",
-		Skip:        codegen.NewStringSet("go"),
 	},
 	{
 		ProgramFile: "azure-sa",

--- a/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-s3-folder.pp.go
@@ -46,8 +46,8 @@ func main() {
 		}
 		_, err = s3.NewBucketPolicy(ctx, "bucketPolicy", &s3.BucketPolicyArgs{
 			Bucket: siteBucket.ID(),
-			Policy: siteBucket.ID().ApplyT(func(id string) (pulumi.String, error) {
-				var _zero pulumi.String
+			Policy: siteBucket.ID().ApplyT(func(id string) (string, error) {
+				var _zero string
 				tmpJSON0, err := json.Marshal(map[string]interface{}{
 					"Version": "2012-10-17",
 					"Statement": []map[string]interface{}{

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
@@ -26,9 +26,9 @@ func main() {
 			return err
 		}
 		opt0 := true
-		ami, err := aws.GetAmi(ctx, &GetAmiArgs{
-			Filters: []GetAmiFilterArgs{
-				&GetAmiFilterArgs{
+		ami, err := aws.GetAmi(ctx, &aws.GetAmiArgs{
+			Filters: []aws.GetAmiFilter{
+				aws.GetAmiFilter{
 					Name: "name",
 					Values: []string{
 						"amzn-ami-hvm-*-x86_64-ebs",

--- a/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
+++ b/pkg/codegen/internal/test/testdata/aws-webserver.pp.go
@@ -27,8 +27,8 @@ func main() {
 		}
 		opt0 := true
 		ami, err := aws.GetAmi(ctx, &GetAmiArgs{
-			Filters: []GetAmiFilter{
-				GetAmiFilter{
+			Filters: []GetAmiFilterArgs{
+				&GetAmiFilterArgs{
 					Name: "name",
 					Values: []string{
 						"amzn-ami-hvm-*-x86_64-ebs",

--- a/pkg/codegen/internal/test/testdata/azure-native.pp.go
+++ b/pkg/codegen/internal/test/testdata/azure-native.pp.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-
-	"github.com/pulumi/pulumi/sdk/v2/go/pulumi"
 	cdn "github.com/pulumi/pulumi-azure-native/sdk/go/azure/cdn"
 	network "github.com/pulumi/pulumi-azure-native/sdk/go/azure/network"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 )
+
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
 		_, err := network.NewFrontDoor(ctx, "frontDoor", &network.FrontDoorArgs{
 			RoutingRules: network.RoutingRuleArray{
 				&network.RoutingRuleArgs{
-					RouteConfiguration: network.ForwardingConfiguration{
+					RouteConfiguration: &network.ForwardingConfigurationArgs{
 						OdataType: "#Microsoft.Azure.FrontDoor.Models.FrontdoorForwardingConfiguration",
-						BackendPool: network.SubResource{
+						BackendPool: &network.SubResourceArgs{
 							Id: "/subscriptions/subid/resourceGroups/rg1/providers/Microsoft.Network/frontDoors/frontDoor1/backendPools/backendPool1",
 						},
 					},
@@ -27,59 +27,59 @@ func main() {
 			DeliveryPolicy: &cdn.EndpointPropertiesUpdateParametersDeliveryPolicyArgs{
 				Rules: cdn.DeliveryRuleArray{
 					&cdn.DeliveryRuleArgs{
-						Actions: interface{}{
-						cdn.DeliveryRuleCacheExpirationAction{
-						Name: "CacheExpiration",
-						Parameters: cdn.CacheExpirationActionParameters{
-						CacheBehavior: "Override",
-						CacheDuration: "10:10:09",
-						CacheType: "All",
-						OdataType: "#Microsoft.Azure.Cdn.Models.DeliveryRuleCacheExpirationActionParameters",
-					},
-					},
-						cdn.DeliveryRuleResponseHeaderAction{
-						Name: "ModifyResponseHeader",
-						Parameters: cdn.HeaderActionParameters{
-						HeaderAction: "Overwrite",
-						HeaderName: "Access-Control-Allow-Origin",
-						OdataType: "#Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters",
-						Value: "*",
-					},
-					},
-						cdn.DeliveryRuleRequestHeaderAction{
-						Name: "ModifyRequestHeader",
-						Parameters: cdn.HeaderActionParameters{
-						HeaderAction: "Overwrite",
-						HeaderName: "Accept-Encoding",
-						OdataType: "#Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters",
-						Value: "gzip",
-					},
-					},
-					},
-						Conditions: interface{}{
-						cdn.DeliveryRuleRemoteAddressCondition{
-						Name: "RemoteAddress",
-						Parameters: cdn.RemoteAddressMatchConditionParameters{
-						MatchValues: []string{
-						"192.168.1.0/24",
-						"10.0.0.0/24",
-					},
-						NegateCondition: true,
-						OdataType: "#Microsoft.Azure.Cdn.Models.DeliveryRuleRemoteAddressConditionParameters",
-						Operator: "IPMatch",
-					},
-					},
-					},
-						Name: pulumi.String("rule1"),
+						Actions: pulumi.Array{
+							&cdn.DeliveryRuleCacheExpirationActionArgs{
+								Name: "CacheExpiration",
+								Parameters: &cdn.CacheExpirationActionParametersArgs{
+									CacheBehavior: "Override",
+									CacheDuration: "10:10:09",
+									CacheType:     "All",
+									OdataType:     "#Microsoft.Azure.Cdn.Models.DeliveryRuleCacheExpirationActionParameters",
+								},
+							},
+							&cdn.DeliveryRuleResponseHeaderActionArgs{
+								Name: "ModifyResponseHeader",
+								Parameters: &cdn.HeaderActionParametersArgs{
+									HeaderAction: "Overwrite",
+									HeaderName:   "Access-Control-Allow-Origin",
+									OdataType:    "#Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters",
+									Value:        "*",
+								},
+							},
+							&cdn.DeliveryRuleRequestHeaderActionArgs{
+								Name: "ModifyRequestHeader",
+								Parameters: &cdn.HeaderActionParametersArgs{
+									HeaderAction: "Overwrite",
+									HeaderName:   "Accept-Encoding",
+									OdataType:    "#Microsoft.Azure.Cdn.Models.DeliveryRuleHeaderActionParameters",
+									Value:        "gzip",
+								},
+							},
+						},
+						Conditions: pulumi.Array{
+							&cdn.DeliveryRuleRemoteAddressConditionArgs{
+								Name: "RemoteAddress",
+								Parameters: &cdn.RemoteAddressMatchConditionParametersArgs{
+									MatchValues: []string{
+										"192.168.1.0/24",
+										"10.0.0.0/24",
+									},
+									NegateCondition: true,
+									OdataType:       "#Microsoft.Azure.Cdn.Models.DeliveryRuleRemoteAddressConditionParameters",
+									Operator:        "IPMatch",
+								},
+							},
+						},
+						Name:  pulumi.String("rule1"),
 						Order: pulumi.Int(1),
 					},
 				},
 			},
-			EndpointName: pulumi.String("endpoint1"),
+			EndpointName:         pulumi.String("endpoint1"),
 			IsCompressionEnabled: pulumi.Bool(true),
-			IsHttpAllowed: pulumi.Bool(true),
-			IsHttpsAllowed: pulumi.Bool(true),
-			Location: pulumi.String("WestUs"),
+			IsHttpAllowed:        pulumi.Bool(true),
+			IsHttpsAllowed:       pulumi.Bool(true),
+			Location:             pulumi.String("WestUs"),
 		})
 		if err != nil {
 			return err

--- a/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.go
+++ b/pkg/codegen/internal/test/testdata/kubernetes-pod.pp.go
@@ -16,7 +16,7 @@ func main() {
 				Name:      pulumi.String("bar"),
 			},
 			Spec: &corev1.PodSpecArgs{
-				Containers: []corev1.ContainerArgs{
+				Containers: corev1.ContainerArray{
 					&corev1.ContainerArgs{
 						Name:  pulumi.String("nginx"),
 						Image: pulumi.String("nginx:1.14-alpine"),


### PR DESCRIPTION
Fixes multiple issues in go program gen that regressed in https://github.com/pulumi/pulumi/pull/7059

Fixes https://github.com/pulumi/pulumi/issues/6968 

The azure native example now generates correctly with the exception of some plain types not getting wrapped in pulumi types which was also a regression from 7059. 

Fixes are:

1. Use appropriate array types for input args
2. Fix some situations where Args suffixes were not being added appropriately
3. Fix some some typing issues within generated apply functions
4. add modules to root level types (ie `aws.GetAmiArgs`)

@pgavlin is opening follow up issues for the remaining regressions from 7059

update: currently blocked by https://github.com/pulumi/pulumi/issues/7713
