### PR TITLE
[sdk/python] Transitive component dependencies.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -4,5 +4,9 @@
   child resources.
   [#7732](https://github.com/pulumi/pulumi/pull/7732)
 
+- [sdk/python] - Depending on a component now depends on the transitive closure of its
+  child resources.
+  [#7732](https://github.com/pulumi/pulumi/pull/7732)
+
 ### Bug Fixes
 

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -641,6 +641,8 @@ class Resource:
     The name assigned to the resource at construction.
     """
 
+    _childResources: Set['Resource']
+
 # !!! IMPORTANT !!! If you add a new attribute to this type, make sure to verify that merge_options
 # works properly for it.
 
@@ -723,10 +725,15 @@ class Resource:
         opts = copy.copy(opts)
 
         self._providers = {}
+        self._childResources = set()
+
         # Check the parent type if one exists and fill in any default options.
         if opts.parent is not None:
             if not isinstance(opts.parent, Resource):
                 raise TypeError("Resource parent is not a valid Resource")
+
+            # Add this resource to its parent's set of child resources.
+            opts.parent._childResources.add(self)
 
             # Infer protection from parent, if one was provided.
             if opts.protect is None:
@@ -886,6 +893,8 @@ class ComponentResource(Resource):
     operations for provisioning.
     """
 
+    _remote: bool
+
     def __init__(self,
                  t: str,
                  name: str,
@@ -902,6 +911,7 @@ class ComponentResource(Resource):
         """
         Resource.__init__(self, t, name, False, props, opts, remote, False)
         self.__dict__["id"] = None
+        self._remote = remote
 
     def register_outputs(self, outputs):
         """

--- a/sdk/python/lib/test/langhost/component_dependencies/__init__.py
+++ b/sdk/python/lib/test/langhost/component_dependencies/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/component_dependencies/__main__.py
+++ b/sdk/python/lib/test/langhost/component_dependencies/__main__.py
@@ -1,0 +1,41 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+from pulumi import ComponentResource, CustomResource, Output, ResourceOptions
+
+class MyResource(CustomResource):
+    def __init__(self, name, args, opts=None):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={
+            **args,
+            "outprop": None,
+        }, opts=opts)
+
+class MyComponent(ComponentResource):
+    def __init__(self, name, opts=None):
+        ComponentResource.__init__(self, "test:index:MyComponent", name, props={}, opts=opts)
+
+resA = MyResource("resA", {})
+comp1 = MyComponent("comp1")
+resB = MyResource("resB", {}, ResourceOptions(parent=comp1))
+resC = MyResource("resC", {}, ResourceOptions(parent=resB))
+comp2 = MyComponent("comp2", ResourceOptions(parent=comp1))
+
+resD = MyResource("resD", {"propA": resA}, ResourceOptions(parent=comp2))
+resE = MyResource("resE", {"propA": resD}, ResourceOptions(parent=comp2))
+
+resF = MyResource("resF", {"propA": resA})
+resG = MyResource("resG", {"propA": comp1})
+resH = MyResource("resH", {"propA": comp2})
+resI = MyResource("resI", {"propA": resG})
+resJ = MyResource("resJ", {}, ResourceOptions(depends_on=[comp2]))

--- a/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
+++ b/sdk/python/lib/test/langhost/component_dependencies/test_component_dependencies.py
@@ -1,0 +1,69 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+import unittest
+from ..util import LanghostTest
+
+
+class ComponentDependenciesTest(LanghostTest):
+    def test_component_dependencies(self):
+        self.run_test(
+            program=path.join(self.base_path(), "component_dependencies"),
+            expected_resource_count=12)
+
+    def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
+                          _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
+                          _replace_on_changes):
+
+        if name == "resD":
+            self.assertListEqual(_dependencies, ["resA"], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {
+                "propA": ["resA"],
+            }, msg=f"{name}._property_deps")
+        elif name == "resE":
+            self.assertListEqual(_dependencies, ["resD"], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {
+                "propA": ["resD"],
+            }, msg=f"{name}._property_deps")
+        elif name == "resF":
+            self.assertListEqual(_dependencies, ["resA"], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {
+                "propA": ["resA"],
+            }, msg=f"{name}._property_deps")
+        elif name == "resG":
+            self.assertListEqual(_dependencies, ["resB", "resD", "resE"], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {
+                "propA": ["resB", "resD", "resE"],
+            }, msg=f"{name}._property_deps")
+        elif name == "resH":
+            self.assertListEqual(_dependencies, ["resD", "resE"], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {
+                "propA": ["resD", "resE"],
+            }, msg=f"{name}._property_deps")
+        elif name == "resI":
+            self.assertListEqual(_dependencies, ["resG"], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {
+                "propA": ["resG"],
+            }, msg=f"{name}._property_deps")
+        elif name == "resJ":
+            self.assertListEqual(_dependencies, ["resD", "resE"], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {}, msg=f"{name}._property_deps")
+
+        return {
+            "urn": name,
+            "id": name,
+            "object": {
+                "outprop": "qux",
+            }
+        }

--- a/sdk/python/lib/test/langhost/property_dependencies/test_property_dependencies.py
+++ b/sdk/python/lib/test/langhost/property_dependencies/test_property_dependencies.py
@@ -27,32 +27,32 @@ class PropertyDependenciesTest(LanghostTest):
                           _replace_on_changes):
         self.assertEqual(ty, "test:index:MyResource")
         if name == "resA":
-            self.assertListEqual(_dependencies, [])
-            self.assertDictEqual(_property_deps, {})
+            self.assertListEqual(_dependencies, [], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {}, msg=f"{name}._property_deps")
         elif name == "resB":
-            self.assertListEqual(_dependencies, [ "resA" ])
-            self.assertDictEqual(_property_deps, {})
+            self.assertListEqual(_dependencies, [ "resA" ], msg=f"{name}._dependencies")
+            self.assertDictEqual(_property_deps, {}, msg=f"{name}._property_deps")
         elif name == "resC":
-            self.assertListEqual(_dependencies, [ "resA", "resB" ])
+            self.assertListEqual(_dependencies, [ "resA", "resB" ], msg=f"{name}._dependencies")
             self.assertDictEqual(_property_deps, {
                 "propA": [ "resA" ],
                 "propB": [ "resB" ],
                 "propC": [],
-            })
+            }, msg=f"{name}._property_deps")
         elif name == "resD":
-            self.assertListEqual(_dependencies, [ "resA", "resB", "resC" ])
+            self.assertListEqual(_dependencies, [ "resA", "resB", "resC" ], msg=f"{name}._dependencies")
             self.assertDictEqual(_property_deps, {
                 "propA": [ "resA", "resB" ],
                 "propB": [ "resC" ],
                 "propC": [],
-            })
+            }, msg=f"{name}._property_deps")
         elif name == "resE":
-            self.assertListEqual(_dependencies, [ "resA", "resB", "resC", "resD" ])
+            self.assertListEqual(_dependencies, [ "resA", "resB", "resC", "resD" ], msg=f"{name}._dependencies")
             self.assertDictEqual(_property_deps, {
                 "propA": [ "resC" ],
                 "propB": [ "resA", "resB" ],
                 "propC": [],
-            })
+            }, msg=f"{name}._property_deps")
 
         return {
             "urn": name,


### PR DESCRIPTION
Implement Node/.NET-style dependency semantics for component resources.
Depending on a component implicitly depends on all of the component's
children. The exact set of children depends on exactly when the
component resource is observed.

Part of #7542.