### PR TITLE
[sdk/go] Transitive component dependencies.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,8 @@
 ### Improvements
 
+- [sdk/go] - Depending on a component now depends on the transitive closure of its
+  child resources.
+  [#7732](https://github.com/pulumi/pulumi/pull/7732)
+
 ### Bug Fixes
 

--- a/sdk/go/pulumi/resource.go
+++ b/sdk/go/pulumi/resource.go
@@ -16,6 +16,7 @@ package pulumi
 
 import (
 	"reflect"
+	"sync"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
@@ -33,50 +34,74 @@ var providerResourceStateType = reflect.TypeOf(ProviderResourceState{})
 
 // ResourceState is the base
 type ResourceState struct {
+	m sync.RWMutex
+
 	urn URNOutput `pulumi:"urn"`
 
-	providers map[string]ProviderResource
-
-	provider ProviderResource
-
-	version string
-
-	aliases []URNOutput
-
-	name string
-
+	children        resourceSet
+	providers       map[string]ProviderResource
+	provider        ProviderResource
+	version         string
+	aliases         []URNOutput
+	name            string
 	transformations []ResourceTransformation
+
+	remoteComponent bool
 }
 
-func (s ResourceState) URN() URNOutput {
+func (s *ResourceState) URN() URNOutput {
 	return s.urn
 }
 
-func (s ResourceState) GetProvider(token string) ProviderResource {
+func (s *ResourceState) GetProvider(token string) ProviderResource {
 	return s.providers[getPackage(token)]
 }
 
-func (s ResourceState) getProviders() map[string]ProviderResource {
+func (s *ResourceState) getChildren() []Resource {
+	s.m.RLock()
+	defer s.m.RUnlock()
+
+	var children []Resource
+	if len(s.children) != 0 {
+		children = make([]Resource, 0, len(s.children))
+		for r := range s.children {
+			children = append(children, r)
+		}
+	}
+	return children
+}
+
+func (s *ResourceState) addChild(r Resource) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if s.children == nil {
+		s.children = resourceSet{}
+	}
+	s.children.add(r)
+}
+
+func (s *ResourceState) getProviders() map[string]ProviderResource {
 	return s.providers
 }
 
-func (s ResourceState) getProvider() ProviderResource {
+func (s *ResourceState) getProvider() ProviderResource {
 	return s.provider
 }
 
-func (s ResourceState) getVersion() string {
+func (s *ResourceState) getVersion() string {
 	return s.version
 }
 
-func (s ResourceState) getAliases() []URNOutput {
+func (s *ResourceState) getAliases() []URNOutput {
 	return s.aliases
 }
 
-func (s ResourceState) getName() string {
+func (s *ResourceState) getName() string {
 	return s.name
 }
 
-func (s ResourceState) getTransformations() []ResourceTransformation {
+func (s *ResourceState) getTransformations() []ResourceTransformation {
 	return s.transformations
 }
 
@@ -84,12 +109,23 @@ func (s *ResourceState) addTransformation(t ResourceTransformation) {
 	s.transformations = append(s.transformations, t)
 }
 
-func (ResourceState) isResource() {}
+func (s *ResourceState) markRemoteComponent() {
+	s.remoteComponent = true
+}
+
+func (s *ResourceState) isRemoteComponent() bool {
+	return s.remoteComponent
+}
+
+func (*ResourceState) isResource() {}
 
 func (ctx *Context) newDependencyResource(urn URN) Resource {
 	var res ResourceState
 	res.urn.OutputState = ctx.newOutputState(res.urn.ElementType(), &res)
 	res.urn.resolve(urn, true, false, nil)
+
+	// For the purposes of dependency management, dependency resources are treated like remote components.
+	res.remoteComponent = true
 	return &res
 }
 
@@ -99,11 +135,11 @@ type CustomResourceState struct {
 	id IDOutput `pulumi:"id"`
 }
 
-func (s CustomResourceState) ID() IDOutput {
+func (s *CustomResourceState) ID() IDOutput {
 	return s.id
 }
 
-func (CustomResourceState) isCustomResource() {}
+func (*CustomResourceState) isCustomResource() {}
 
 func (ctx *Context) newDependencyCustomResource(urn URN, id ID) CustomResource {
 	var res CustomResourceState
@@ -120,7 +156,7 @@ type ProviderResourceState struct {
 	pkg string
 }
 
-func (s ProviderResourceState) getPackage() string {
+func (s *ProviderResourceState) getPackage() string {
 	return s.pkg
 }
 
@@ -138,6 +174,12 @@ func (ctx *Context) newDependencyProviderResource(urn URN, id ID) ProviderResour
 type Resource interface {
 	// URN is this resource's stable logical URN used to distinctly address it before, during, and after deployments.
 	URN() URNOutput
+
+	// getChildren returns the resource's children.
+	getChildren() []Resource
+
+	// addChild adds a child to the resource.
+	addChild(r Resource)
 
 	// getProviders returns the provider map for this resource.
 	getProviders() map[string]ProviderResource
@@ -162,6 +204,12 @@ type Resource interface {
 
 	// addTransformation adds a single transformation to the resource.
 	addTransformation(t ResourceTransformation)
+
+	// markRemoteComponent marks this resource as a remote component resource.
+	markRemoteComponent()
+
+	// isRemoteComponent returns true if this is not a local (i.e. in-process) component resource.
+	isRemoteComponent() bool
 }
 
 // CustomResource is a cloud resource whose create, read, update, and delete (CRUD) operations are managed by performing

--- a/sdk/go/pulumi/resource_set.go
+++ b/sdk/go/pulumi/resource_set.go
@@ -1,0 +1,20 @@
+package pulumi
+
+type resourceSet map[Resource]struct{}
+
+func (s resourceSet) add(r Resource) {
+	s[r] = struct{}{}
+}
+
+func (s resourceSet) any() bool {
+	return len(s) > 0
+}
+
+func (s resourceSet) delete(r Resource) {
+	delete(s, r)
+}
+
+func (s resourceSet) has(r Resource) bool {
+	_, ok := s[r]
+	return ok
+}


### PR DESCRIPTION
Implement Node/.NET-style dependency semantics for component resources.
Depending on a component implicitly depends on all of the component's
children. The exact set of children depends on exactly when the
component resource is observed.

Part of #7542.