### PR TITLE
Allow Python dynamic provider resources to be constructed outside of `__main__`

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 
 ### Bug Fixes
 
+- [sdk/python] Allow Python dynamic provider resources to be constructed outside of `__main__`. 
+  [#7755](https://github.com/pulumi/pulumi/pull/7755)

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -225,7 +225,7 @@ def serialize_provider(provider: ResourceProvider) -> str:
     pty = type(provider)
     oldptymod = pty.__module__
     try:
-        # TODO[uqfoundation/dill#424]: Dill currently only serializes classes by value when they are in `__main__`. 
+        # TODO[uqfoundation/dill#424]: Dill currently only serializes classes by value when they are in `__main__`.
         # Since we need to ensure classes are serialized by value for dynamic provider serialization to work, we
         # for now will overwrite the `__module__` to be `__main__` on the provider class.  When uqfoundation/dill#424
         # is addressed, we may be able to accomplish the desired results in a less invasive way.

--- a/sdk/python/lib/pulumi/dynamic/dynamic.py
+++ b/sdk/python/lib/pulumi/dynamic/dynamic.py
@@ -222,10 +222,18 @@ def serialize_provider(provider: ResourceProvider) -> str:
     pickle.Pickler.save_dict = save_dict_sorted
 
     # Use dill to recursively pickle the provider and store base64 encoded form
+    pty = type(provider)
+    oldptymod = pty.__module__
     try:
+        # TODO[uqfoundation/dill#424]: Dill currently only serializes classes by value when they are in `__main__`. 
+        # Since we need to ensure classes are serialized by value for dynamic provider serialization to work, we
+        # for now will overwrite the `__module__` to be `__main__` on the provider class.  When uqfoundation/dill#424
+        # is addressed, we may be able to accomplish the desired results in a less invasive way.
+        pty.__module__ = '__main__'
         byts = dill.dumps(provider, protocol=pickle.DEFAULT_PROTOCOL, recurse=True)
         return base64.b64encode(byts).decode('utf-8')
     finally:
+        pty.__module__ = oldptymod
         # Restore the original pickler
         pickle.Pickler = old_pickler
 

--- a/tests/integration/dynamic/python-non-main/.gitignore
+++ b/tests/integration/dynamic/python-non-main/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+/.pulumi/
+/dist/
+/*.egg-info

--- a/tests/integration/dynamic/python-non-main/Pulumi.yaml
+++ b/tests/integration/dynamic/python-non-main/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: dynamic_py
+description: A simple Python program that uses dynamic providers.
+runtime: python

--- a/tests/integration/dynamic/python-non-main/__main__.py
+++ b/tests/integration/dynamic/python-non-main/__main__.py
@@ -1,0 +1,7 @@
+# Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+from pulumi import export
+from other import r
+
+export("random_id", r.id)
+export("random_val", r.val)

--- a/tests/integration/dynamic/python-non-main/other.py
+++ b/tests/integration/dynamic/python-non-main/other.py
@@ -1,0 +1,20 @@
+# Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import binascii
+import os
+from pulumi.dynamic import Resource, ResourceProvider, CreateResult
+
+# Define the dynamic provider and create the dynamic provider resource from a
+# file that is not `__main__` per pulumi/pulumi#7453.
+
+class RandomResourceProvider(ResourceProvider):
+    def create(self, props):
+        val = binascii.b2a_hex(os.urandom(15)).decode("ascii")
+        return CreateResult(val, { "val": val })
+
+class Random(Resource):
+    val: str
+    def __init__(self, name, opts = None):
+        super().__init__(RandomResourceProvider(), name, {"val": ""}, opts)
+
+r = Random("foo")

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -407,6 +407,15 @@ func TestDynamicPython(t *testing.T) {
 	})
 }
 
+func TestDynamicPythonNonMain(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir: filepath.Join("dynamic", "python-non-main"),
+		Dependencies: []string{
+			filepath.Join("..", "..", "sdk", "python", "env", "src"),
+		},
+	})
+}
+
 func TestPartialValuesPython(t *testing.T) {
 	if runtime.GOOS == WindowsOS {
 		t.Skip("Temporarily skipping test on Windows - pulumi/pulumi#3811")


### PR DESCRIPTION
The underlying library `dill` that we use for serializing dynamic providers into Pulumi state for Python dynamic providers serializes classes differently depending on whether they are in `__main__` or in another module.  We need the by-value serialization to be applied in all cases.

https://github.com/uqfoundation/dill/issues/424 is tracking adding the ability into `dill` to specify this by-value serialization explicitly, but until then, we will temporarily re-write the `__module__` of a provider class prior to serialization, so that `dill` behaves as we need for the dynamic provider use case.

Fixes #7453.