### PR TITLE
Fixed nil pointer error with BindExpressionText and typeExpr

### DIFF
--- a/pkg/codegen/hcl2/binder.go
+++ b/pkg/codegen/hcl2/binder.go
@@ -15,6 +15,7 @@
 package hcl2
 
 import (
+	"fmt"
 	"os"
 	"sort"
 
@@ -187,6 +188,9 @@ func (b *binder) declareNodes(file *syntax.File) (hcl.Diagnostics, error) {
 
 					typeExpr, diags := model.BindExpressionText(item.Labels[1], model.TypeScope, item.LabelRanges[1].Start)
 					diagnostics = append(diagnostics, diags...)
+					if typeExpr == nil {
+						return diagnostics, fmt.Errorf("cannot bind expression: %v", diagnostics.Error())
+					}
 					typ = typeExpr.Type()
 				default:
 					diagnostics = append(diagnostics, labelsErrorf(item, "config variables must have exactly one or two labels"))


### PR DESCRIPTION
# Description

`BindExpressionText()` has the potential to return a nil `typeExpr`, which leads to the subsequent `typeExpr.Type()` call panicking. A guard condition is added to return with an error if `typeExpr` is found to be nil after calling `BindExpressionText()`.

Before, the error was identified by the coverage tracker in this way:
```
{
      "Reason": "runtime error: invalid memory address or nil pointer dereference",
      "Count": 1
},
```
Now, it is more specific:
```
{
      "Reason": "cannot bind expression: \u003canonymous\u003e:0,61-62: Missing attribute separator; Expected a newline or comma to mark the beginning of the next attribute.",
      "Count": 1
},
```
