### PR TITLE
[sdk/go] Fix a typo in marshaling.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,9 @@
 
 ### Bug Fixes
 
+- [sdk/go] - Fix marshaling behavior for undefined properties.
+  [#7768](https://github.com/pulumi/pulumi/pull/7768)
+
 - [sdk/python] - Fix program hangs when monitor becomes unavailable.
   [#7734](https://github.com/pulumi/pulumi/pull/7734)
 

--- a/pkg/engine/lifeycletest/golang_sdk_test.go
+++ b/pkg/engine/lifeycletest/golang_sdk_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	. "github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -799,4 +800,96 @@ func TestReplaceOnChangesGolangLifecycle(t *testing.T) {
 	// replace on changes empty
 	replaceOnChanges = []string{}
 	setupAndRunProgram(replaceOnChanges)
+}
+
+type remoteComponentArgs struct {
+	Foo pulumi.URN `pulumi:"foo"`
+	Bar *string    `pulumi:"bar"`
+}
+
+type remoteComponentInputs struct {
+	Foo pulumi.URNInput       `pulumi:"foo"`
+	Bar pulumi.StringPtrInput `pulumi:"bar"`
+}
+
+func (*remoteComponentInputs) ElementType() reflect.Type {
+	return reflect.TypeOf((*remoteComponentArgs)(nil)).Elem()
+}
+
+type remoteComponent struct {
+	pulumi.ResourceState
+
+	Foo pulumi.StringOutput `pulumi:"foo"`
+	Baz pulumi.StringOutput `pulumi:"baz"`
+}
+
+func TestRemoteComponentGolang(t *testing.T) {
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				CreateF: func(urn resource.URN, news resource.PropertyMap, timeout float64,
+					preview bool) (resource.ID, resource.PropertyMap, resource.Status, error) {
+
+					return "created-id", news, resource.StatusOK, nil
+				},
+			}, nil
+		}),
+		deploytest.NewProviderLoader("pkgB", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{
+				ConstructF: func(monitor *deploytest.ResourceMonitor, typ, name string, parent resource.URN,
+					inputs resource.PropertyMap, options plugin.ConstructOptions) (plugin.ConstructResult, error) {
+
+					_, ok := inputs["bar"]
+					assert.False(t, ok)
+
+					urn, _, _, err := monitor.RegisterResource("pkgB:index:component", "componentA", false)
+					require.NoError(t, err)
+
+					outs := resource.PropertyMap{}
+
+					err = monitor.RegisterResourceOutputs(urn, outs)
+
+					return plugin.ConstructResult{
+						URN:     urn,
+						Outputs: outs,
+					}, nil
+				},
+			}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(info plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		ctx, err := pulumi.NewContext(context.Background(), pulumi.RunInfo{
+			Project:     info.Project,
+			Stack:       info.Stack,
+			Parallel:    info.Parallel,
+			DryRun:      info.DryRun,
+			MonitorAddr: info.MonitorAddress,
+		})
+		require.NoError(t, err)
+
+		return pulumi.RunWithContext(ctx, func(ctx *pulumi.Context) error {
+			var resB pulumi.CustomResourceState
+			err := ctx.RegisterResource("pkgA:index:typA", "resA", pulumi.Map{}, &resB)
+			require.NoError(t, err)
+
+			inputs := remoteComponentInputs{
+				Foo: resB.URN(),
+			}
+
+			var res remoteComponent
+			err = ctx.RegisterRemoteComponentResource("pkgB:index:component", "componentA", &inputs, &res)
+			require.NoError(t, err)
+
+			return nil
+		})
+	})
+
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+		Steps:   []TestStep{{Op: Update}},
+	}
+	p.Run(t, nil)
 }

--- a/pkg/engine/lifeycletest/golang_sdk_test.go
+++ b/pkg/engine/lifeycletest/golang_sdk_test.go
@@ -848,6 +848,7 @@ func TestRemoteComponentGolang(t *testing.T) {
 					outs := resource.PropertyMap{}
 
 					err = monitor.RegisterResourceOutputs(urn, outs)
+					require.NoError(t, err)
 
 					return plugin.ConstructResult{
 						URN:     urn,

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -148,7 +148,7 @@ func marshalInputs(props Input) (resource.PropertyMap, map[string][]URN, []URN, 
 			pdeps[pname] = allDeps.values()
 		}
 
-		if !v.IsNull() || len(deps) > 0 {
+		if !v.IsNull() || len(allDeps) > 0 {
 			pmap[resource.PropertyKey(pname)] = v
 		}
 		return nil


### PR DESCRIPTION
A few identically-typed variables got confused with the changes in #7737.
The confusion caused empty property values to be included in resources
that had any dependencies on other resources, which confused the
unmarshaling code for Go multi-language components. These changes fix
the typo and restore the original behavior, which is to omit empty
property values.