### PR TITLE
stabilize go codegen for nested collection types

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -1738,8 +1738,21 @@ func (pkg *pkgContext) collectNestedCollectionTypes(types map[string]map[string]
 // in a second step, we avoid collision and redeclaration.
 func (pkg *pkgContext) genNestedCollectionTypes(w io.Writer, types map[string]map[string]bool) []string {
 	var names []string
-	for elementTypeName, v := range types {
-		for name := range v {
+
+	// map iteration is unstable so sort items for deterministic codegen
+	sortedElems := []string{}
+	for k := range types {
+		sortedElems = append(sortedElems, k)
+	}
+	sort.Strings(sortedElems)
+
+	for _, elementTypeName := range sortedElems {
+		collectionTypes := []string{}
+		for k := range types[elementTypeName] {
+			collectionTypes = append(collectionTypes, k)
+		}
+		sort.Strings(collectionTypes)
+		for _, name := range collectionTypes {
 			names = append(names, name)
 			if strings.HasSuffix(name, "Array") {
 				fmt.Fprintf(w, "type %s []%sInput\n\n", name, elementTypeName)


### PR DESCRIPTION
Fixes non-determinism introduced in https://github.com/pulumi/pulumi/pull/7779 by sorting. 

Tested this locally against azure native and it results in no diff (other than sorting a few declarations). 

Iterating over maps when generating code is a bag sad. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
