### PR TITLE
Fixed invalid go source code issue

### DIFF
--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -77,7 +77,7 @@ func (g *generator) genAnonymousFunctionExpression(
 	leadingSep := ""
 	for _, param := range expr.Signature.Parameters {
 		isInput := isInputty(param.Type)
-		g.Fgenf(w, "%s%s %s", leadingSep, param.Name, g.argumentTypeName(nil, param.Type, isInput))
+		g.Fgenf(w, "%s%s %s", leadingSep, makeValidIdentifier(param.Name), g.argumentTypeName(nil, param.Type, isInput))
 		leadingSep = ", "
 	}
 


### PR DESCRIPTION
# Description

Fixed `invalid Go source code` error that would occur when converting example `#/resources/aws:directoryservice/logService:LogService`.

Before, the error was identified by the coverage tracker in this way:
```
{
	"ProviderName": "aws",
	"ProviderVersion": "4.15.0+dirty",
	"ExampleName": "#/resources/aws:directoryservice/logService:LogService",
	"IsDuplicated": false,
	"FailedLanguages": [
		{
			"TargetLanguage": "go",
			"FailureSeverity": 3,
			"FailureInfo": "invalid Go source code:\n\n20:59: expected ')', found '-' (and 10 more errors)",
			"MultipleTranslations": false
		}
	]
}
```
The error occurred because the input's `ad-log-policyPolicyDocument` wasn't formatted to use underscores, while the return's `ad_log_policyPolicyDocument` was. 
```
import (
    "fmt"

    "github.com/pulumi/pulumi/sdk/v3/go/pulumi"
    "github.com/pulumi/pulumi-aws/sdk/v4/go/aws/cloudwatch"
    "github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
)
func main() {
    pulumi.Run(func(ctx *pulumi.Context) error {
        example, err := cloudwatch.NewLogGroup(ctx, "example", nil)
        if err != nil {
            return err
        }
        _, err = cloudwatch.NewLogResourcePolicy(ctx, "ad_log_policyLogResourcePolicy", &cloudwatch.LogResourcePolicyArgs{
            PolicyDocument: ad_log_document.ApplyT(func(ad-log-policyPolicyDocument iam.GetPolicyDocumentResult) (string, error) {
                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^ // Should be ad_log_policyPolicyDocument
                return ad_log_policyPolicyDocument.Json, nil
            }).(pulumi.StringOutput),
        })
        if err != nil {
            return err
        }
        return nil
    })
}
```



After the correction:
```
{
	"ProviderName": "aws",
	"ProviderVersion": "4.15.0+dirty",
	"ExampleName": "#/resources/aws:directoryservice/logService:LogService",
	"IsDuplicated": false,
	"FailedLanguages": []
}
```