### PR TITLE
Fix order of go mod tidy

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1933,12 +1933,6 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 		}
 	}
 
-	// initial tidy to resolve dependencies
-	err = pt.runCommand("go-mod-tidy", []string{goBin, "mod", "tidy"}, cwd)
-	if err != nil {
-		return err
-	}
-
 	// link local dependencies
 	for _, pkg := range pt.opts.Dependencies {
 
@@ -1950,8 +1944,9 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 			return err
 		}
 	}
-	// resolve dependencies
-	err = pt.runCommand("go-mod-download", []string{goBin, "mod", "download"}, cwd)
+
+	// tidy to resolve all transitive dependencies including from local dependencies above
+	err = pt.runCommand("go-mod-tidy", []string{goBin, "mod", "tidy"}, cwd)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

Fixes issues similar to the one surfacing in:
https://github.com/pulumi/pulumi/pull/7781

Basically `go mod tidy` fetches transitive dependencies, if it's placed after edits that point to the local SDK, then any new dependencies from the local SDK propagate automatically into integration tests without having to explicitly declare them. 

Questions:

- do we want that? or we actually want to explicitly declare those in tests projects

- is it safe to remove `go mod download` - I think `go mod tidy` includes that work

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
