### PR TITLE
Avoid repeatedly invoking `pip show` in Python lang host

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -188,8 +188,7 @@ func (host *pythonLanguageHost) GetRequiredPlugins(ctx context.Context,
 
 	plugins := []*pulumirpc.PluginDependency{}
 	for _, pkg := range pulumiPackages {
-
-		plugin, err := determinePluginDependency(host.virtualenvPath, host.cwd, pkg.Name, pkg.Version)
+		plugin, err := determinePluginDependency(host.virtualenvPath, host.cwd, pkg)
 		if err != nil {
 			return nil, err
 		}
@@ -318,15 +317,16 @@ var packagesWithoutPlugins = map[string]struct{}{
 }
 
 type pythonPackage struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
+	Name     string `json:"name"`
+	Version  string `json:"version"`
+	Location string `json:"location"`
 }
 
 func determinePulumiPackages(virtualenv, cwd string) ([]pythonPackage, error) {
 	logging.V(5).Infof("GetRequiredPlugins: Determining pulumi packages")
 
-	// Run the `python -m pip list --format json` command.
-	args := []string{"-m", "pip", "list", "--format", "json"}
+	// Run the `python -m pip list -v --format json` command.
+	args := []string{"-m", "pip", "list", "-v", "--format", "json"}
 	output, err := runPythonCommand(virtualenv, cwd, args...)
 	if err != nil {
 		return nil, err
@@ -365,23 +365,17 @@ func determinePulumiPackages(virtualenv, cwd string) ([]pythonPackage, error) {
 // are derived from the package name and version. If the plugin version cannot be determined from the package version,
 // nil is returned.
 func determinePluginDependency(
-	virtualenv, cwd, packageName, packageVersion string) (*pulumirpc.PluginDependency, error) {
+	virtualenv, cwd string, pkg pythonPackage) (*pulumirpc.PluginDependency, error) {
 
-	logging.V(5).Infof("GetRequiredPlugins: Determining plugin dependency: %v, %v", packageName, packageVersion)
-
-	// Determine the location of the installed package.
-	packageLocation, err := determinePackageLocation(virtualenv, cwd, packageName)
-	if err != nil {
-		return nil, err
-	}
+	logging.V(5).Infof("GetRequiredPlugins: Determining plugin dependency: %v, %v", pkg.Name, pkg.Version)
 
 	// The name of the module inside the package can be different from the package name.
 	// However, our convention is to always use the same name, e.g. a package name of
 	// "pulumi-aws" will have a module named "pulumi_aws", so we can determine the module
 	// by replacing hyphens with underscores.
-	packageModuleName := strings.ReplaceAll(packageName, "-", "_")
+	packageModuleName := strings.ReplaceAll(pkg.Name, "-", "_")
 
-	pulumiPluginFilePath := filepath.Join(packageLocation, packageModuleName, "pulumiplugin.json")
+	pulumiPluginFilePath := filepath.Join(pkg.Location, packageModuleName, "pulumiplugin.json")
 	logging.V(5).Infof("GetRequiredPlugins: pulumiplugin.json file path: %s", pulumiPluginFilePath)
 
 	var name, version, server string
@@ -390,7 +384,7 @@ func determinePluginDependency(
 		// If `resource` is set to false, the Pulumi package has indicated that there is no associated plugin.
 		// Ignore it.
 		if !plugin.Resource {
-			logging.V(5).Infof("GetRequiredPlugins: Ignoring package %s with resource set to false", packageName)
+			logging.V(5).Infof("GetRequiredPlugins: Ignoring package %s with resource set to false", pkg.Name)
 			return nil, nil
 		}
 
@@ -403,7 +397,7 @@ func determinePluginDependency(
 	}
 
 	if name == "" {
-		name = strings.TrimPrefix(packageName, "pulumi-")
+		name = strings.TrimPrefix(pkg.Name, "pulumi-")
 	}
 
 	if version == "" {
@@ -413,11 +407,11 @@ func determinePluginDependency(
 		// "3.31.0a1605189729" will have an associated plugin with a version of "3.31.0-alpha.1605189729+42435656".
 		// The "+42435656" suffix cannot be determined so the plugin version cannot be determined. In such cases,
 		// log the issue and skip the package.
-		version, err = determinePluginVersion(packageVersion)
+		version, err = determinePluginVersion(pkg.Version)
 		if err != nil {
 			logging.V(5).Infof(
 				"GetRequiredPlugins: Could not determine plugin version for package %s with version %s",
-				packageName, packageVersion)
+				pkg.Name, pkg.Version)
 			return nil, nil
 		}
 	}
@@ -435,16 +429,6 @@ func determinePluginDependency(
 
 	logging.V(5).Infof("GetRequiredPlugins: Determining plugin dependency: %#v", result)
 	return &result, nil
-}
-
-// determinePackageLocation determines the location on disk of the package by running `python -m pip show <package>`
-// and parsing the output.
-func determinePackageLocation(virtualenv, cwd, packageName string) (string, error) {
-	b, err := runPythonCommand(virtualenv, cwd, "-m", "pip", "show", packageName)
-	if err != nil {
-		return "", err
-	}
-	return parseLocation(packageName, string(b))
 }
 
 func parseLocation(packageName, pipShowOutput string) (string, error) {


### PR DESCRIPTION
# Description

The Python language host invokes `pip show` for each Pulumi package in a
project at startup. But `pip show` is quite slow in large projects: it
takes 2+ seconds per invocation in a project at @MaterializeInc.

`pip show` is invoked to compute the installed location of each plugin
package. But it turns out `pip list` takes a `-v` flag that can supply
this information in one shot, avoiding the need to ever invoke `pip
show`.

This patch shaves about 20s off our boot time for `pulumi up`.

(There's probably a separate bug in Pip that causes `pip show` to be so
slow, because `pip list` is an order of magnitude faster and does a lot
more work, but I didn't bother tracking that down.)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

Seems hard to write a test for. If the existing tests pass then this at least didn't break anything.

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Are perf improvements like this usually noted in the changelog?

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version

Nope.