### PR TITLE
Satisfy Python lint: factor out URN parsing in Python and other fixes

### DIFF
--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -117,7 +117,7 @@ class LocalWorkspace(Workspace):
                 break
         path = os.path.join(self.work_dir, f"Pulumi{found_ext}")
         writable_settings = {key: settings.__dict__[key] for key in settings.__dict__ if settings.__dict__[key] is not None}
-        with open(path, "w") as file:
+        with open(path, "w", encoding="utf-8") as file:
             if found_ext == ".json":
                 json.dump(writable_settings, file, indent=4)
             else:
@@ -129,7 +129,7 @@ class LocalWorkspace(Workspace):
             path = os.path.join(self.work_dir, f"Pulumi.{stack_settings_name}{ext}")
             if not os.path.exists(path):
                 continue
-            with open(path, "r") as file:
+            with open(path, "r", encoding="utf-8") as file:
                 settings = json.load(file) if ext == ".json" else yaml.safe_load(file)
                 return StackSettings._deserialize(settings)
         raise FileNotFoundError(f"failed to find stack settings file in workdir: {self.work_dir}")
@@ -143,7 +143,7 @@ class LocalWorkspace(Workspace):
                 found_ext = ext
                 break
         path = os.path.join(self.work_dir, f"Pulumi.{stack_settings_name}{found_ext}")
-        with open(path, "w") as file:
+        with open(path, "w", encoding="utf-8") as file:
             if found_ext == ".json":
                 json.dump(settings._serialize(), file, indent=4)
             else:
@@ -490,7 +490,7 @@ def _load_project_settings(work_dir: str) -> ProjectSettings:
         project_path = os.path.join(work_dir, f"Pulumi{ext}")
         if not os.path.exists(project_path):
             continue
-        with open(project_path, "r") as file:
+        with open(project_path, "r", encoding="utf-8") as file:
             settings = json.load(file) if ext == ".json" else yaml.safe_load(file)
             return ProjectSettings(**settings)
     raise FileNotFoundError(f"failed to find project settings file in workdir: {work_dir}")

--- a/sdk/python/lib/pulumi/automation/_representable.py
+++ b/sdk/python/lib/pulumi/automation/_representable.py
@@ -1,0 +1,23 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class _Representable:
+    """This mix-in improves the default `__repr__` to be more readable."""
+
+    def __repr__(self):
+        inputs = self.__dict__
+        fields = [f"{key}={inputs[key]!r}" for key in inputs]  # pylint: disable=consider-using-dict-items
+        fields = ", ".join(fields)
+        return f"{self.__class__.__name__}({fields})"

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -32,6 +32,7 @@ from ._server import LanguageServer
 from ._workspace import Workspace, PulumiFn, Deployment
 from ..runtime.settings import _GRPC_CHANNEL_OPTIONS
 from ..runtime.proto import language_pb2_grpc
+from ._representable import _Representable
 
 _DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 
@@ -84,16 +85,10 @@ class UpdateSummary:
                f"resource_changes={self.resource_changes!r}, config={self.config!r}, Deployment={self.Deployment!r})"
 
 
-class BaseResult:
+class BaseResult(_Representable):
     def __init__(self, stdout: str, stderr: str):
         self.stdout = stdout
         self.stderr = stderr
-
-    def __repr__(self):
-        inputs = self.__dict__
-        fields = [f"{key}={inputs[key]!r}" for key in inputs]  # pylint: disable=consider-using-dict-items
-        fields = ", ".join(fields)
-        return f"{self.__class__.__name__}({fields})"
 
 
 class PreviewResult(BaseResult):

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -642,13 +642,13 @@ def _create_log_file(command: str) -> Tuple[str, tempfile.TemporaryDirectory]:
     filepath = os.path.join(log_dir.name, "eventlog.txt")
 
     # Open and close the file to ensure it exists before we start polling for logs
-    with open(filepath, "w+"):
+    with open(filepath, "w+", encoding="utf-8"):
         pass
     return filepath, log_dir
 
 
 def _watch_logs(filename: str, callback: OnEvent):
-    with open(filename) as f:
+    with open(filename, encoding="utf-8") as f:
         while True:
             line = f.readline()
 

--- a/sdk/python/lib/pulumi/automation/events.py
+++ b/sdk/python/lib/pulumi/automation/events.py
@@ -17,6 +17,7 @@
 
 from enum import Enum
 from typing import Optional, List, Mapping, Any, MutableMapping
+from ._representable import _Representable
 
 
 class OpType(str, Enum):
@@ -43,13 +44,8 @@ class OpType(str, Enum):
 OpMap = MutableMapping[OpType, int]
 
 
-class BaseEvent:
-    def __repr__(self):
-        # pylint: disable=duplicate-code
-        inputs = self.__dict__
-        fields = [f"{key}={inputs[key]!r}" for key in inputs]  # pylint: disable=consider-using-dict-items
-        fields = ", ".join(fields)
-        return f"{self.__class__.__name__}({fields})"
+class BaseEvent(_Representable):
+    pass
 
 
 class CancelEvent(BaseEvent):

--- a/sdk/python/lib/pulumi/provider/server.py
+++ b/sdk/python/lib/pulumi/provider/server.py
@@ -337,15 +337,10 @@ def _create_provider_resource(ref: str) -> ProviderResource:
     otherwise return an instance of DependencyProviderResource.
     """
     urn, _ = _parse_resource_reference(ref)
-    urn_parts = urn.split("::")
-    urn_name = urn_parts[3]
-    qualified_type = urn_parts[2]
-    typ = qualified_type.split("$")[-1]
-    typ_parts = typ.split(":")
-    typ_name = typ_parts[2] if len(typ_parts) > 2 else ""
-
-    resource_package = rpc.get_resource_package(typ_name, version="")
+    urn_parts = pulumi.urn._parse_urn(urn)
+    resource_package = rpc.get_resource_package(urn_parts.typ_name, version="")
     if resource_package is not None:
-        return cast(ProviderResource, resource_package.construct_provider(urn_name, typ, urn))
+        return cast(ProviderResource, resource_package.construct_provider(
+            urn_parts.urn_name, urn_parts.typ, urn))
 
     return DependencyProviderResource(ref)

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -24,6 +24,7 @@ from .runtime.resource import get_resource, register_resource, register_resource
     convert_providers
 from .runtime.settings import get_root_resource
 from .output import _is_prompt, _map_input, _map2_input, T, Output
+from . import urn as urn_util
 
 if TYPE_CHECKING:
     from .output import Input, Inputs
@@ -985,12 +986,11 @@ class DependencyProviderResource(ProviderResource):
 
     def __init__(self, ref: str) -> None:
         ref_urn, ref_id = _parse_resource_reference(ref)
-        urn_parts = ref_urn.split("::")
-        qualified_type = urn_parts[2]
-        typ = qualified_type.split("$")[-1]
-        typ_parts = typ.split(":")
-        # typ will be "pulumi:providers:<package>" and we want the last part.
-        pkg = typ_parts[2] if len(typ_parts) > 2 else ""
+        urn_parts = urn_util._parse_urn(ref_urn)
+
+        # `typ` will be `pulumi:providers:<package>` and we want the
+        # last part, which normally parses as `typ_name`.
+        pkg = urn_parts.typ_name
 
         super().__init__(pkg=pkg, name="", props={}, opts=None, dependency=True)
 

--- a/sdk/python/lib/pulumi/runtime/config.py
+++ b/sdk/python/lib/pulumi/runtime/config.py
@@ -21,7 +21,7 @@ import json
 import os
 
 # default to an empty map for config.
-CONFIG: Dict[str, Any] = dict()
+CONFIG: Dict[str, Any] = {}
 
 # default to an empty set for config secret keys.
 _SECRET_KEYS: Set[str] = set()
@@ -56,7 +56,7 @@ def get_config_env() -> Dict[str, Any]:
     if 'PULUMI_CONFIG' in os.environ:
         env_config = os.environ['PULUMI_CONFIG']
         return json.loads(env_config)
-    return dict()
+    return {}
 
 
 def get_config_env_key(k: str) -> str:

--- a/sdk/python/lib/pulumi/runtime/mocks.py
+++ b/sdk/python/lib/pulumi/runtime/mocks.py
@@ -139,7 +139,7 @@ class MockMonitor:
 
     def __init__(self, mocks: Mocks):
         self.mocks = mocks
-        self.resources = dict()
+        self.resources = {}
 
     def make_urn(self, parent: str, type_: str, name: str) -> str:
         if parent != "":

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -26,6 +26,7 @@ from .rpc_manager import RPC_MANAGER
 from .settings import handle_grpc_error
 from ..output import Output
 from .. import _types
+from .. import urn as urn_util
 
 
 if TYPE_CHECKING:
@@ -194,9 +195,8 @@ def get_resource(res: 'Resource',
     transform_using_type_metadata = typ is not None
 
     # Extract the resource type from the URN.
-    urn_parts = urn.split("::")
-    qualified_type = urn_parts[2]
-    ty = qualified_type.split("$")[-1]
+    urn_parts = urn_util._parse_urn(urn)
+    ty = urn_parts.typ
 
     # Initialize the URN property on the resource.
     (resolve_urn, res.__dict__["urn"]) = resource_output(res)

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -29,6 +29,7 @@ import six
 from . import known_types, settings
 from .. import log
 from .. import _types
+from .. import urn as urn_util
 
 if TYPE_CHECKING:
     from ..output import Inputs, Input, Output
@@ -399,15 +400,12 @@ def deserialize_resource(ref_struct: struct_pb2.Struct, keep_unknowns: Optional[
     urn = ref_struct["urn"]
     version = ref_struct["packageVersion"] if "packageVersion" in ref_struct else ""
 
-    urn_parts = urn.split("::")
-    urn_name = urn_parts[3]
-    qualified_type = urn_parts[2]
-    typ = qualified_type.split("$")[-1]
-
-    typ_parts = typ.split(":")
-    pkg_name = typ_parts[0]
-    mod_name = typ_parts[1] if len(typ_parts) > 1 else ""
-    typ_name = typ_parts[2] if len(typ_parts) > 2 else ""
+    urn_parts = urn_util._parse_urn(urn)
+    urn_name = urn_parts.urn_name
+    typ = urn_parts.typ
+    pkg_name = urn_parts.pkg_name
+    mod_name = urn_parts.mod_name
+    typ_name = urn_parts.typ_name
 
     is_provider = pkg_name == "pulumi" and mod_name == "providers"
     if is_provider:

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -879,7 +879,7 @@ class ResourcePackage(ABC):
         pass
 
 
-_RESOURCE_PACKAGES: Dict[str, List[ResourcePackage]] = dict()
+_RESOURCE_PACKAGES: Dict[str, List[ResourcePackage]] = {}
 
 
 def register_resource_package(pkg: str, package: ResourcePackage):
@@ -920,7 +920,7 @@ class ResourceModule(ABC):
         pass
 
 
-_RESOURCE_MODULES: Dict[str, List[ResourceModule]] = dict()
+_RESOURCE_MODULES: Dict[str, List[ResourceModule]] = {}
 
 
 def _module_key(pkg: str, mod: str) -> str:

--- a/sdk/python/lib/pulumi/runtime/stack.py
+++ b/sdk/python/lib/pulumi/runtime/stack.py
@@ -127,7 +127,7 @@ class Stack(ComponentResource):
         super().__init__('pulumi:pulumi:Stack', name, None, None)
 
         # Invoke the function while this stack is active and then register its outputs.
-        self.outputs = dict()
+        self.outputs = {}
         set_root_resource(self)
         try:
             func()

--- a/sdk/python/lib/pulumi/urn.py
+++ b/sdk/python/lib/pulumi/urn.py
@@ -23,16 +23,19 @@ _UrnParts = namedtuple('_UrnParts', ['urn_name',
 
 
 def _parse_urn(urn: str) -> _UrnParts:
-    urn_parts = urn.split('::')
-    urn_name = urn_parts[3]
-    qualified_type = urn_parts[2]
-    typ = qualified_type.split("$")[-1]
-    typ_parts = typ.split(":")
-    pkg_name = typ_parts[0]
-    mod_name = typ_parts[1] if len(typ_parts) > 1 else ""
-    typ_name = typ_parts[2] if len(typ_parts) > 2 else ""
-    return _UrnParts(urn_name=urn_name,
-                     typ=typ,
-                     pkg_name=pkg_name,
-                     mod_name=mod_name,
-                     typ_name=typ_name)
+    try:
+        urn_parts = urn.split('::')
+        urn_name = urn_parts[3] if len(urn_parts) >= 4 else ""
+        qualified_type = urn_parts[2]
+        typ = qualified_type.split("$")[-1]
+        typ_parts = typ.split(":")
+        pkg_name = typ_parts[0]
+        mod_name = typ_parts[1] if len(typ_parts) > 1 else ""
+        typ_name = typ_parts[2] if len(typ_parts) > 2 else ""
+        return _UrnParts(urn_name=urn_name,
+                         typ=typ,
+                         pkg_name=pkg_name,
+                         mod_name=mod_name,
+                         typ_name=typ_name)
+    except Exception as e:
+        raise ValueError(f'Cannot parse URN: {urn}') from e

--- a/sdk/python/lib/pulumi/urn.py
+++ b/sdk/python/lib/pulumi/urn.py
@@ -1,0 +1,38 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import namedtuple
+
+
+_UrnParts = namedtuple('_UrnParts', ['urn_name',
+                                     'typ',
+                                     'pkg_name',
+                                     'mod_name',
+                                     'typ_name'])
+
+
+def _parse_urn(urn: str) -> _UrnParts:
+    urn_parts = urn.split('::')
+    urn_name = urn_parts[3]
+    qualified_type = urn_parts[2]
+    typ = qualified_type.split("$")[-1]
+    typ_parts = typ.split(":")
+    pkg_name = typ_parts[0]
+    mod_name = typ_parts[1] if len(typ_parts) > 1 else ""
+    typ_name = typ_parts[2] if len(typ_parts) > 2 else ""
+    return _UrnParts(urn_name=urn_name,
+                     typ=typ,
+                     pkg_name=pkg_name,
+                     mod_name=mod_name,
+                     typ_name=typ_name)

--- a/sdk/python/lib/test/test_urn.py
+++ b/sdk/python/lib/test/test_urn.py
@@ -1,0 +1,34 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pulumi import urn as urn_util
+
+
+def test_parse_urn_with_name():
+    res = urn_util._parse_urn('urn:pulumi:stack::project::pulumi:providers:aws::default_4_13_0')
+    assert res.urn_name == 'default_4_13_0'
+    assert res.typ == 'pulumi:providers:aws'
+    assert res.pkg_name == 'pulumi'
+    assert res.mod_name == 'providers'
+    assert res.typ_name == 'aws'
+
+
+def test_parse_urn_without_name():
+    res = urn_util._parse_urn('urn:pulumi:stack::project::pulumi:providers:aws')
+    assert res.urn_name == ''
+    assert res.typ == 'pulumi:providers:aws'
+    assert res.pkg_name == 'pulumi'
+    assert res.mod_name == 'providers'
+    assert res.typ_name == 'aws'


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Python LINT started flagging duplicate code in our codebase, including on master, so I'm starting to clean up. This PR just lifts URN parsing into a shared function.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
