### PR TITLE
Allow hyphen in schema path

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,5 +5,6 @@
 
 - [cli] - Avoid `missing go.sum entry for module` for new Go projects.
   [#7808](https://github.com/pulumi/pulumi/pull/7808)
+
 - [codegen/schema] - Allow hyphen in schema path reference.
   [#7824](https://github.com/pulumi/pulumi/pull/7824)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,3 +5,5 @@
 
 - [cli] - Avoid `missing go.sum entry for module` for new Go projects.
   [#7808](https://github.com/pulumi/pulumi/pull/7808)
+- [codegen/schema] - Allow hyphen in schema path reference.
+  [#7824](https://github.com/pulumi/pulumi/pull/7824)

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -1541,7 +1541,7 @@ const (
 )
 
 // Regex used to parse external schema paths. This is declared at the package scope to avoid repeated recompilation.
-var refPathRegex = regexp.MustCompile(`^/?(?P<package>\w+)/(?P<version>v[^/]*)/schema\.json$`)
+var refPathRegex = regexp.MustCompile(`^/?(?P<package>[-\w]+)/(?P<version>v[^/]*)/schema\.json$`)
 
 func (t *types) parseTypeSpecRef(ref string) (typeSpecRef, error) {
 	parsedURL, err := url.Parse(ref)

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -41,6 +41,14 @@ func readSchemaFile(file string) (pkgSpec PackageSpec) {
 	return pkgSpec
 }
 
+func TestRefPathRegex(t *testing.T) {
+	path := []byte("/azure-native/v1.22.0/schema.json")
+	assert.True(t, refPathRegex.Match(path), "Hyphens are allowed in paths.")
+	path = []byte("/aws/v4.0.0/schema.json")
+	assert.True(t, refPathRegex.Match(path), "Hyphens are not required though.")
+
+}
+
 func TestImportSpec(t *testing.T) {
 	// Read in, decode, and import the schema.
 	pkgSpec := readSchemaFile("kubernetes.json")

--- a/pkg/codegen/schema/schema_test.go
+++ b/pkg/codegen/schema/schema_test.go
@@ -41,14 +41,6 @@ func readSchemaFile(file string) (pkgSpec PackageSpec) {
 	return pkgSpec
 }
 
-func TestRefPathRegex(t *testing.T) {
-	path := []byte("/azure-native/v1.22.0/schema.json")
-	assert.True(t, refPathRegex.Match(path), "Hyphens are allowed in paths.")
-	path = []byte("/aws/v4.0.0/schema.json")
-	assert.True(t, refPathRegex.Match(path), "Hyphens are not required though.")
-
-}
-
 func TestImportSpec(t *testing.T) {
 	// Read in, decode, and import the schema.
 	pkgSpec := readSchemaFile("kubernetes.json")
@@ -316,6 +308,17 @@ func Test_parseTypeSpecRef(t *testing.T) {
 				Version: toVersionPtr("2.6.3"),
 				Kind:    "provider",
 				Token:   "pulumi:providers:kubernetes",
+			},
+		},
+		{
+			name: "hyphenatedUrlPath",
+			ref:  "/azure-native/v1.22.0/schema.json#/resources/azure-native:web:WebApp",
+			want: typeSpecRef{
+				URL:     toURL("/azure-native/v1.22.0/schema.json#/resources/azure-native:web:WebApp"),
+				Package: "azure-native",
+				Version: toVersionPtr("1.22.0"),
+				Kind:    "resources",
+				Token:   "azure-native:web:WebApp",
 			},
 		},
 	}


### PR DESCRIPTION
Allow hyphens to be used in package names. 

# Description

Fixes #7775

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
