### PR TITLE
Bump ts-node version 7.0.1=>10.2.0

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -7,6 +7,9 @@
   [#5758](https://github.com/pulumi/pulumi/issues/) for Go, making it
   easier to compose functions/datasources with Pulumi resources.
   [#7784](https://github.com/pulumi/pulumi/pull/7784)
+  
+- [sdk/nodejs] - Bump the ts-node version to 10.2.0
+  [#7828](https://github.com/pulumi/pulumi/pull/7828)
 
 ### Bug Fixes
 

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -22,7 +22,7 @@
         "semver": "^6.1.0",
         "source-map-support": "^0.4.16",
         "ts-node": "^10.2.0",
-        "typescript": "~3.7.3",
+        "typescript": "~3.8.3",
         "upath": "^1.1.0"
     },
     "devDependencies": {

--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -21,7 +21,7 @@
         "require-from-string": "^2.0.1",
         "semver": "^6.1.0",
         "source-map-support": "^0.4.16",
-        "ts-node": "^7.0.1",
+        "ts-node": "^10.2.0",
         "typescript": "~3.7.3",
         "upath": "^1.1.0"
     },


### PR DESCRIPTION
# Description

Bump `ts-node` version from 7 to 10.

Fixes #4876

We are using the CI to test this. We can also look at the time it took for test's to run to check for performance regressions. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
