### PR TITLE
[engine] Include acyclic children in delete deps.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,6 @@
 
 ### Bug Fixes
 
+- [engine] Include acyclic children in dependency list for deletes.
+  [#7852](https://github.com/pulumi/pulumi/pull/7852)
+

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -251,9 +251,10 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 				_ []Event, res result.Result) result.Result {
 
-				// Should see only creates.
+				// Should see only creates or reads.
 				for _, entry := range entries {
-					assert.Equal(t, deploy.OpCreate, entry.Step.Op())
+					op := entry.Step.Op()
+					assert.True(t, op == deploy.OpCreate || op == deploy.OpRead)
 				}
 				assert.Len(t, entries.Snap(target.Snapshot).Resources, resCount)
 				return res
@@ -282,7 +283,8 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 
 				// Should see only sames.
 				for _, entry := range entries {
-					assert.Equal(t, deploy.OpSame, entry.Step.Op())
+					op := entry.Step.Op()
+					assert.True(t, op == deploy.OpSame || op == deploy.OpRead)
 				}
 				assert.Len(t, entries.Snap(target.Snapshot).Resources, resCount)
 				return res

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -101,6 +101,7 @@ type ResourceOptions struct {
 	CustomTimeouts        *resource.CustomTimeouts
 	SupportsPartialValues *bool
 	Remote                bool
+	Providers             map[string]string
 
 	DisableSecrets            bool
 	DisableResourceReferences bool
@@ -187,6 +188,7 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 		SupportsPartialValues:      supportsPartialValues,
 		Remote:                     opts.Remote,
 		ReplaceOnChanges:           opts.ReplaceOnChanges,
+		Providers:                  opts.Providers,
 	}
 
 	// submit request

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -984,6 +984,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		// Invoke the provider's Construct RPC method.
 		options := plugin.ConstructOptions{
 			Aliases:              aliases,
+			Dependencies:         dependencies,
 			Protect:              protect,
 			PropertyDependencies: propertyDependencies,
 			Providers:            providerRefs,

--- a/pkg/resource/graph/dependency_graph.go
+++ b/pkg/resource/graph/dependency_graph.go
@@ -167,7 +167,7 @@ func NewDependencyGraph(resources []*resource.State) *DependencyGraph {
 	// create cycles in the dependency graph.
 	//
 	// This expansion works by looping over all of the resources in the graph and adding edges between each resource
-	// and the resources that depend on its ancestors.
+	// and the resources that have a declared dependency on its ancestors.
 	for _, res := range resources {
 		descendentNode := nodes[res.URN]
 		contract.Assert(descendentNode != nil)

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -11,16 +11,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func NewProviderResource(pkg, name, id string, deps ...resource.URN) *resource.State {
+func NewStack() *resource.State {
+	return &resource.State{
+		Type: resource.RootStackType,
+		URN:  resource.NewURN("test", "test", "", resource.RootStackType, "Stack"),
+	}
+}
+
+func NewProvider(pkg, name, id string, deps ...resource.URN) *resource.State {
 	t := providers.MakeProviderType(tokens.Package(pkg))
 	return &resource.State{
 		Type:         t,
+		Custom:       true,
 		URN:          resource.NewURN("test", "test", "", t, tokens.QName(name)),
 		ID:           resource.ID(id),
 		Inputs:       resource.PropertyMap{},
 		Outputs:      resource.PropertyMap{},
 		Dependencies: deps,
 	}
+}
+
+func NewChildProvider(pkg, name, id string, parent resource.URN, deps ...resource.URN) *resource.State {
+	prov := NewProvider(pkg, name, id, deps...)
+	prov.Parent = parent
+	return prov
 }
 
 func NewResource(name string, provider *resource.State, deps ...resource.URN) *resource.State {
@@ -36,6 +50,7 @@ func NewResource(name string, provider *resource.State, deps ...resource.URN) *r
 	t := tokens.Type("test:test:test")
 	return &resource.State{
 		Type:         t,
+		Custom:       true,
 		URN:          resource.NewURN("test", "test", "", t, tokens.QName(name)),
 		Inputs:       resource.PropertyMap{},
 		Outputs:      resource.PropertyMap{},
@@ -44,11 +59,31 @@ func NewResource(name string, provider *resource.State, deps ...resource.URN) *r
 	}
 }
 
+func NewChildResource(name string, provider *resource.State, parent resource.URN,
+	deps ...resource.URN) *resource.State {
+
+	res := NewResource(name, provider, deps...)
+	res.Parent = parent
+	return res
+}
+
+func NewComponent(name string, deps ...resource.URN) *resource.State {
+	res := NewResource(name, nil, deps...)
+	res.Custom = false
+	return res
+}
+
+func NewChildComponent(name string, parent resource.URN, deps ...resource.URN) *resource.State {
+	res := NewChildResource(name, nil, parent, deps...)
+	res.Custom = false
+	return res
+}
+
 func TestBasicGraph(t *testing.T) {
-	pA := NewProviderResource("test", "pA", "0")
+	pA := NewProvider("test", "pA", "0")
 	a := NewResource("a", pA)
 	b := NewResource("b", pA, a.URN)
-	pB := NewProviderResource("test", "pB", "1", a.URN, b.URN)
+	pB := NewProvider("test", "pB", "1", a.URN, b.URN)
 	c := NewResource("c", pB, a.URN)
 	d := NewResource("d", nil, b.URN)
 
@@ -137,12 +172,11 @@ func TestGraphNoDuplicates(t *testing.T) {
 }
 
 func TestDependenciesOf(t *testing.T) {
-	pA := NewProviderResource("test", "pA", "0")
+	pA := NewProvider("test", "pA", "0")
 	a := NewResource("a", pA)
 	b := NewResource("b", pA, a.URN)
 	c := NewResource("c", pA)
-	d := NewResource("d", pA)
-	d.Parent = a.URN
+	d := NewChildResource("d", pA, a.URN)
 
 	dg := NewDependencyGraph([]*resource.State{
 		pA,
@@ -174,17 +208,14 @@ func TestDependenciesOf(t *testing.T) {
 	assert.False(t, dDepends[c])
 }
 
-func TestDependenciesOfRemoteComponents(t *testing.T) {
-	aws := NewProviderResource("aws", "default", "0")
-	xyz := NewProviderResource("xyz", "default", "0")
-	first := NewResource("first", xyz)
-	firstNested := NewResource("firstNested", xyz)
-	firstNested.Parent = first.URN
-	sg := NewResource("sg", aws)
-	sg.Parent = firstNested.URN
-	second := NewResource("second", xyz)
-	rule := NewResource("rule", aws, first.URN)
-	rule.Parent = second.URN
+func TestDependenciesOfComponents(t *testing.T) {
+	aws := NewProvider("aws", "default", "0")
+	xyz := NewProvider("xyz", "default", "0")
+	first := NewComponent("first")
+	firstNested := NewChildComponent("firstNested", first.URN)
+	sg := NewChildResource("sg", aws, firstNested.URN)
+	second := NewComponent("second")
+	rule := NewChildResource("rule", aws, second.URN, first.URN)
 
 	dg := NewDependencyGraph([]*resource.State{
 		aws,
@@ -205,12 +236,11 @@ func TestDependenciesOfRemoteComponents(t *testing.T) {
 	assert.False(t, ruleDepends[xyz], "unrelated")
 }
 
-func TestDependenciesOfRemoteComponentsNoCycle(t *testing.T) {
-	aws := NewProviderResource("aws", "default", "0")
-	parent := NewResource("parent", aws)
+func TestComponentsNoCycle(t *testing.T) {
+	aws := NewProvider("aws", "default", "0")
+	parent := NewComponent("parent")
 	r := NewResource("r", aws, parent.URN)
-	child := NewResource("child", aws, r.URN)
-	child.Parent = parent.URN
+	child := NewChildResource("child", aws, parent.URN, r.URN)
 
 	dg := NewDependencyGraph([]*resource.State{
 		aws,
@@ -228,4 +258,415 @@ func TestDependenciesOfRemoteComponentsNoCycle(t *testing.T) {
 	assert.True(t, rDependencies[aws])
 	assert.True(t, rDependencies[parent])
 	assert.False(t, rDependencies[child])
+
+	parentDependents := dg.DependingOn(parent, nil)
+	assert.Equal(t, []*resource.State{r, child}, parentDependents)
+
+	providerDependents := dg.DependingOn(aws, nil)
+	assert.Equal(t, []*resource.State{r, child}, providerDependents)
+}
+
+func TestComponentsNoCycle2(t *testing.T) {
+	aws := NewProvider("aws", "default", "0")
+	parent := NewComponent("parent")
+	r := NewResource("r", aws, parent.URN)
+	child := NewChildResource("child", aws, parent.URN, r.URN)
+	child2 := NewChildResource("child2", aws, parent.URN)
+
+	dg := NewDependencyGraph([]*resource.State{
+		aws,
+		parent,
+		r,
+		child2,
+		child,
+	})
+
+	childDependencies := dg.DependenciesOf(child)
+	assert.True(t, childDependencies[aws])
+	assert.True(t, childDependencies[parent])
+	assert.True(t, childDependencies[r])
+
+	rDependencies := dg.DependenciesOf(r)
+	assert.True(t, rDependencies[aws])
+	assert.True(t, rDependencies[parent])
+	assert.False(t, rDependencies[child])
+	assert.True(t, rDependencies[child2])
+
+	child2Dependents := dg.DependingOn(child2, nil)
+	assert.Equal(t, []*resource.State{r, child}, child2Dependents)
+
+	parentDependents := dg.DependingOn(parent, nil)
+	assert.Equal(t, []*resource.State{r, child2, child}, parentDependents)
+
+	providerDependents := dg.DependingOn(aws, nil)
+	assert.Equal(t, []*resource.State{r, child2, child}, providerDependents)
+}
+
+// This tests the canonical delete dependency example for the following family tree.
+//
+//                              <root>
+//                                |
+//             ___________________|_________
+//             |                  |        |
+//           Comp1            Provider    Sink
+//      _______|__________
+//      |      |          |
+//   Cust1   Comp2      Comp3
+//          ___|___       |
+//          |     |       |
+//        Cust2  Cust3  Comp4
+//          |             |
+//        Cust4         Cust5
+//
+// The only _declared_ dependency is from Sink to Comp1. Each custom resource depends on Provider.
+//
+func TestCanonicalExample(t *testing.T) {
+	prov := NewProvider("pkg", "default", "0")
+	comp1 := NewComponent("comp1")
+	cust1 := NewChildResource("cust1", prov, comp1.URN)
+	comp2 := NewChildComponent("comp2", comp1.URN)
+	comp3 := NewChildComponent("comp3", comp1.URN)
+	cust2 := NewChildResource("cust2", prov, comp2.URN)
+	cust3 := NewChildResource("cust3", prov, comp2.URN)
+	comp4 := NewChildComponent("comp4", comp3.URN)
+	cust4 := NewChildResource("cust4", prov, cust2.URN)
+	cust5 := NewChildResource("cust5", prov, comp4.URN)
+	sink := NewResource("sink", prov, comp1.URN)
+
+	dg := NewDependencyGraph([]*resource.State{
+		prov,
+		comp1,
+		cust1,
+		comp2,
+		comp3,
+		cust2,
+		cust3,
+		comp4,
+		cust4,
+		cust5,
+		sink,
+	})
+
+	provDependencies := dg.DependenciesOf(prov)
+	assert.Empty(t, provDependencies)
+	provDependents := dg.DependingOn(prov, nil)
+	assert.Equal(t, []*resource.State{cust1, cust2, cust3, cust4, cust5, sink}, provDependents)
+
+	comp1Dependencies := dg.DependenciesOf(comp1)
+	assert.Empty(t, comp1Dependencies)
+	comp1Dependents := dg.DependingOn(comp1, nil)
+	assert.Equal(t, []*resource.State{cust1, comp2, comp3, cust2, cust3, comp4, cust4, cust5, sink}, comp1Dependents)
+
+	comp2Dependencies := dg.DependenciesOf(comp2)
+	assert.Equal(t, ResourceSet{comp1: true}, comp2Dependencies)
+	comp2Dependents := dg.DependingOn(comp2, nil)
+	assert.Equal(t, []*resource.State{cust2, cust3, cust4, sink}, comp2Dependents)
+
+	comp3Dependencies := dg.DependenciesOf(comp3)
+	assert.Equal(t, ResourceSet{comp1: true}, comp3Dependencies)
+	comp3Dependents := dg.DependingOn(comp3, nil)
+	assert.Equal(t, []*resource.State{comp4, cust5, sink}, comp3Dependents)
+
+	comp4Dependencies := dg.DependenciesOf(comp4)
+	assert.Equal(t, ResourceSet{comp3: true}, comp4Dependencies)
+	comp4Dependents := dg.DependingOn(comp4, nil)
+	assert.Equal(t, []*resource.State{cust5, sink}, comp4Dependents)
+
+	cust1Dependencies := dg.DependenciesOf(cust1)
+	assert.Equal(t, ResourceSet{prov: true, comp1: true}, cust1Dependencies)
+	cust1Dependents := dg.DependingOn(cust1, nil)
+	assert.Equal(t, []*resource.State{sink}, cust1Dependents)
+
+	cust2Dependencies := dg.DependenciesOf(cust2)
+	assert.Equal(t, ResourceSet{prov: true, comp2: true}, cust2Dependencies)
+	cust2Dependents := dg.DependingOn(cust2, nil)
+	assert.Equal(t, []*resource.State{cust4, sink}, cust2Dependents)
+
+	cust3Dependencies := dg.DependenciesOf(cust3)
+	assert.Equal(t, ResourceSet{prov: true, comp2: true}, cust3Dependencies)
+	cust3Dependents := dg.DependingOn(cust3, nil)
+	assert.Equal(t, []*resource.State{sink}, cust3Dependents)
+
+	cust4Dependencies := dg.DependenciesOf(cust4)
+	assert.Equal(t, ResourceSet{prov: true, cust2: true}, cust4Dependencies)
+	cust4Dependents := dg.DependingOn(cust4, nil)
+	assert.Equal(t, []*resource.State{sink}, cust4Dependents)
+
+	cust5Dependencies := dg.DependenciesOf(cust5)
+	assert.Equal(t, ResourceSet{prov: true, comp4: true}, cust5Dependencies)
+	cust5Dependents := dg.DependingOn(cust5, nil)
+	assert.Equal(t, []*resource.State{sink}, cust5Dependents)
+
+	sinkDependencies := dg.DependenciesOf(sink)
+	assert.Equal(t, ResourceSet{
+		prov:  true,
+		comp1: true,
+		cust1: true,
+		comp2: true,
+		comp3: true,
+		cust2: true,
+		cust3: true,
+		comp4: true,
+		cust4: true,
+		cust5: true,
+	}, sinkDependencies)
+	sinkDependents := dg.DependingOn(sink, nil)
+	assert.Empty(t, sinkDependents)
+}
+
+func TestEKSExample(t *testing.T) {
+	// Stack resource
+	stack := NewStack()
+
+	// Root providers
+	aws := NewChildProvider("aws", "default", "0", stack.URN)
+	eks := NewChildProvider("eks", "default", "0", stack.URN)
+
+	// EKS component resource
+	clusterComponent := NewChildComponent("eksCluster", stack.URN)
+	vpc := NewChildResource("vpc", aws, clusterComponent.URN)
+	subnet1 := NewChildResource("subnet1", aws, clusterComponent.URN, vpc.URN)
+	subnet2 := NewChildResource("subnet2", aws, clusterComponent.URN, vpc.URN)
+	eksRole := NewChildResource("eksRole", aws, clusterComponent.URN)
+	secGroup := NewChildResource("secGroup", aws, clusterComponent.URN, vpc.URN)
+	egressRule := NewChildResource("egressRule", aws, clusterComponent.URN, secGroup.URN)
+	cluster := NewChildResource("cluster", aws, clusterComponent.URN, eksRole.URN, secGroup.URN, subnet1.URN, subnet2.URN)
+	k8s := NewChildProvider("k8s", "eks", "0", clusterComponent.URN, cluster.URN)
+
+	// Helm chart
+	helmComponent := NewChildComponent("helm", stack.URN)
+	namespace := NewChildResource("namespace", k8s, helmComponent.URN)
+	service := NewChildResource("service", k8s, helmComponent.URN, namespace.URN)
+	deployment := NewChildResource("deployment", k8s, helmComponent.URN, namespace.URN)
+
+	// End user
+	sink := NewChildResource("sink", nil, stack.URN, helmComponent.URN)
+
+	// Dependency graph
+	dg := NewDependencyGraph([]*resource.State{
+		stack,
+		aws,
+		eks,
+		clusterComponent,
+		vpc,
+		subnet1,
+		subnet2,
+		eksRole,
+		secGroup,
+		egressRule,
+		cluster,
+		k8s,
+		helmComponent,
+		sink,
+		namespace, // These appear after sink to model the creation of the chart's resources inside of an apply
+		deployment,
+		service,
+	})
+
+	cases := []struct {
+		resource     *resource.State
+		dependencies ResourceSet
+		dependents   []*resource.State
+	}{
+		{
+			resource:     stack,
+			dependencies: ResourceSet{},
+			dependents: []*resource.State{
+				aws,
+				eks,
+				clusterComponent,
+				vpc,
+				subnet1,
+				subnet2,
+				eksRole,
+				secGroup,
+				egressRule,
+				cluster,
+				k8s,
+				helmComponent,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     aws,
+			dependencies: ResourceSet{stack: true},
+			dependents: []*resource.State{
+				vpc,
+				subnet1,
+				subnet2,
+				eksRole,
+				secGroup,
+				egressRule,
+				cluster,
+				k8s,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     eks,
+			dependencies: ResourceSet{stack: true},
+		},
+		{
+			resource:     clusterComponent,
+			dependencies: ResourceSet{stack: true},
+			dependents: []*resource.State{
+				vpc,
+				subnet1,
+				subnet2,
+				eksRole,
+				secGroup,
+				egressRule,
+				cluster,
+				k8s,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     vpc,
+			dependencies: ResourceSet{aws: true, clusterComponent: true},
+			dependents: []*resource.State{
+				subnet1,
+				subnet2,
+				secGroup,
+				egressRule,
+				cluster,
+				k8s,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     subnet1,
+			dependencies: ResourceSet{aws: true, clusterComponent: true, vpc: true},
+			dependents: []*resource.State{
+				cluster,
+				k8s,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     subnet2,
+			dependencies: ResourceSet{aws: true, clusterComponent: true, vpc: true},
+			dependents: []*resource.State{
+				cluster,
+				k8s,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     eksRole,
+			dependencies: ResourceSet{aws: true, clusterComponent: true},
+			dependents: []*resource.State{
+				cluster,
+				k8s,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     secGroup,
+			dependencies: ResourceSet{aws: true, clusterComponent: true, vpc: true},
+			dependents: []*resource.State{
+				egressRule,
+				cluster,
+				k8s,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     egressRule,
+			dependencies: ResourceSet{aws: true, clusterComponent: true, secGroup: true},
+		},
+		{
+			resource: cluster,
+			dependencies: ResourceSet{
+				aws:              true,
+				clusterComponent: true,
+				eksRole:          true,
+				secGroup:         true,
+				subnet1:          true,
+				subnet2:          true,
+			},
+			dependents: []*resource.State{
+				k8s,
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     k8s,
+			dependencies: ResourceSet{clusterComponent: true, cluster: true},
+			dependents: []*resource.State{
+				sink,
+				namespace,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource: sink,
+			dependencies: ResourceSet{
+				stack:         true,
+				helmComponent: true,
+				namespace:     true,
+				deployment:    true,
+				service:       true,
+			},
+		},
+		{
+			resource:     namespace,
+			dependencies: ResourceSet{k8s: true, helmComponent: true},
+			dependents: []*resource.State{
+				sink,
+				deployment,
+				service,
+			},
+		},
+		{
+			resource:     deployment,
+			dependencies: ResourceSet{k8s: true, helmComponent: true, namespace: true},
+			dependents: []*resource.State{
+				sink,
+			},
+		},
+		{
+			resource:     service,
+			dependencies: ResourceSet{k8s: true, helmComponent: true, namespace: true},
+			dependents: []*resource.State{
+				sink,
+			},
+		},
+	}
+
+	for _, c := range cases {
+		dependencies := dg.DependenciesOf(c.resource)
+		assert.Equal(t, c.dependencies, dependencies)
+
+		dependents := dg.DependingOn(c.resource, nil)
+		assert.Equal(t, c.dependents, dependents)
+	}
 }

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -357,7 +357,8 @@ func TestCanonicalExample(t *testing.T) {
 	comp1Dependencies := dg.DependenciesOf(comp1)
 	assert.Empty(t, comp1Dependencies)
 	comp1Dependents := dg.DependingOn(comp1, nil)
-	assert.Equal(t, []*resource.State{cust1, comp2, comp3, cust2, cust3, comp4, cust4, cust5, sink, sink2}, comp1Dependents)
+	assert.Equal(t, []*resource.State{cust1, comp2, comp3, cust2, cust3, comp4, cust4, cust5, sink, sink2},
+		comp1Dependents)
 
 	comp2Dependencies := dg.DependenciesOf(comp2)
 	assert.Equal(t, ResourceSet{comp1: true}, comp2Dependencies)

--- a/pkg/resource/graph/dependency_graph_test.go
+++ b/pkg/resource/graph/dependency_graph_test.go
@@ -332,6 +332,7 @@ func TestCanonicalExample(t *testing.T) {
 	cust4 := NewChildResource("cust4", prov, cust2.URN)
 	cust5 := NewChildResource("cust5", prov, comp4.URN)
 	sink := NewResource("sink", prov, comp1.URN)
+	sink2 := NewResource("sink2", prov, cust2.URN)
 
 	dg := NewDependencyGraph([]*resource.State{
 		prov,
@@ -345,22 +346,23 @@ func TestCanonicalExample(t *testing.T) {
 		cust4,
 		cust5,
 		sink,
+		sink2,
 	})
 
 	provDependencies := dg.DependenciesOf(prov)
 	assert.Empty(t, provDependencies)
 	provDependents := dg.DependingOn(prov, nil)
-	assert.Equal(t, []*resource.State{cust1, cust2, cust3, cust4, cust5, sink}, provDependents)
+	assert.Equal(t, []*resource.State{cust1, cust2, cust3, cust4, cust5, sink, sink2}, provDependents)
 
 	comp1Dependencies := dg.DependenciesOf(comp1)
 	assert.Empty(t, comp1Dependencies)
 	comp1Dependents := dg.DependingOn(comp1, nil)
-	assert.Equal(t, []*resource.State{cust1, comp2, comp3, cust2, cust3, comp4, cust4, cust5, sink}, comp1Dependents)
+	assert.Equal(t, []*resource.State{cust1, comp2, comp3, cust2, cust3, comp4, cust4, cust5, sink, sink2}, comp1Dependents)
 
 	comp2Dependencies := dg.DependenciesOf(comp2)
 	assert.Equal(t, ResourceSet{comp1: true}, comp2Dependencies)
 	comp2Dependents := dg.DependingOn(comp2, nil)
-	assert.Equal(t, []*resource.State{cust2, cust3, cust4, sink}, comp2Dependents)
+	assert.Equal(t, []*resource.State{cust2, cust3, cust4, sink, sink2}, comp2Dependents)
 
 	comp3Dependencies := dg.DependenciesOf(comp3)
 	assert.Equal(t, ResourceSet{comp1: true}, comp3Dependencies)
@@ -380,7 +382,7 @@ func TestCanonicalExample(t *testing.T) {
 	cust2Dependencies := dg.DependenciesOf(cust2)
 	assert.Equal(t, ResourceSet{prov: true, comp2: true}, cust2Dependencies)
 	cust2Dependents := dg.DependingOn(cust2, nil)
-	assert.Equal(t, []*resource.State{cust4, sink}, cust2Dependents)
+	assert.Equal(t, []*resource.State{cust4, sink, sink2}, cust2Dependents)
 
 	cust3Dependencies := dg.DependenciesOf(cust3)
 	assert.Equal(t, ResourceSet{prov: true, comp2: true}, cust3Dependencies)
@@ -390,7 +392,7 @@ func TestCanonicalExample(t *testing.T) {
 	cust4Dependencies := dg.DependenciesOf(cust4)
 	assert.Equal(t, ResourceSet{prov: true, cust2: true}, cust4Dependencies)
 	cust4Dependents := dg.DependingOn(cust4, nil)
-	assert.Equal(t, []*resource.State{sink}, cust4Dependents)
+	assert.Empty(t, cust4Dependents)
 
 	cust5Dependencies := dg.DependenciesOf(cust5)
 	assert.Equal(t, ResourceSet{prov: true, comp4: true}, cust5Dependencies)
@@ -407,11 +409,15 @@ func TestCanonicalExample(t *testing.T) {
 		cust2: true,
 		cust3: true,
 		comp4: true,
-		cust4: true,
 		cust5: true,
 	}, sinkDependencies)
 	sinkDependents := dg.DependingOn(sink, nil)
 	assert.Empty(t, sinkDependents)
+
+	sink2Dependencies := dg.DependenciesOf(sink2)
+	assert.Equal(t, ResourceSet{prov: true, cust2: true}, sink2Dependencies)
+	sink2Dependents := dg.DependingOn(sink2, nil)
+	assert.Empty(t, sink2Dependents)
 }
 
 func TestEKSExample(t *testing.T) {


### PR DESCRIPTION
Consider the following Pulumi program:

```typescript
class MyResource extends pulumi.CustomResource {
    // ...
}

class MyComponent extends pulumi.ComponentResource {
    constructor(name: string) {
        super("myComponent", name);

        this.child = new MyResource("child", {}, {parent: this});
    }
}

// Create a component resource. The constructor returns promptly, but
// the registration of the component itself happens asynchronously.
// Similarly, its child resource's constructor returns promptly, but
// its registration happens asynchronously. The SDK guarantees that the
// latter happens after the former by waiting on the parent's URN prior
// to registration (note that this is necessary in order for the runtime
// to fill out the `parent` field of the registration request).
const component = new MyComponent("component");

// Create a resource that depends on the component resource. The
// registration of this resource happens asynchronously, and races with
// the asynchronous registration of the component's child.
const res = new MyResource("resource", {}, {dependsOn: component});
```

Due to the races described in the comments, even when all of a
component's children are constructed prior to exiting the component's
constructor (e.g. not in applies, thens, etc.) we cannot guarantee that
the children have been registered prior to any resources that depend on
the component. Because of this, the approach that #7788 takes for
expanding dependencies on components to dependencies on their children
is not necessarily reliable, as it only adds children that appear prior
to dependents in the snapshot.

These changes adjust the dependency graph to add all children of a
component that would not create cycles in the dependency graph.

Fixes #7833.