### PR TITLE
Initial support for (un)marshaling output values

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,10 @@
 ### Improvements
 
-- [sdk] Improve error messages for (un)marshalling properties
+- [sdk/go] - Improve error messages for (un)marshalling properties.
   [#7936](https://github.com/pulumi/pulumi/pull/7936)
+
+- [sdk/go] - Initial support for (un)marshalling output values.
+  [#7861](https://github.com/pulumi/pulumi/pull/7861)
 
 ### Bug Fixes
 

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -1141,6 +1141,7 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
+pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -47,6 +47,6 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.2.8
-	pgregory.net/rapid v0.4.7 // indirect
+	pgregory.net/rapid v0.4.7
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 )

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -47,5 +47,6 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.2.8
+	pgregory.net/rapid v0.4.7 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 )

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -344,5 +344,7 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
+pgregory.net/rapid v0.4.7 h1:MTNRktPuv5FNqOO151TM9mDTa+XHcX6ypYeISDVD14g=
+pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0 h1:ucqkfpjg9WzSUubAO62csmucvxl4/JeW3F4I4909XkM=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -72,7 +72,7 @@ func MarshalProperties(props resource.PropertyMap, opts MarshalOptions) (*struct
 	for _, key := range props.StableKeys() {
 		v := props[key]
 		logging.V(9).Infof("Marshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
-		if v.IsOutput() && !opts.KeepOutputValues {
+		if v.IsOutput() && !v.OutputValue().Known && !opts.KeepOutputValues {
 			logging.V(9).Infof("Skipping output property for RPC[%s]: %v", opts.Label, key)
 		} else if opts.SkipNulls && v.IsNull() {
 			logging.V(9).Infof("Skipping null property for RPC[%s]: %s (as requested)", opts.Label, key)

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ type MarshalOptions struct {
 	RejectAssets       bool   // true if we should return errors on Asset and Archive values.
 	KeepResources      bool   // true if we are keeping resoures (otherwise we return raw urn).
 	SkipInternalKeys   bool   // true to skip internal property keys (keys that start with "__") in the resulting map.
+	KeepOutputValues   bool   // true if we are keeping output values.
 }
 
 const (
@@ -71,7 +72,7 @@ func MarshalProperties(props resource.PropertyMap, opts MarshalOptions) (*struct
 	for _, key := range props.StableKeys() {
 		v := props[key]
 		logging.V(9).Infof("Marshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
-		if v.IsOutput() {
+		if v.IsOutput() && !opts.KeepOutputValues {
 			logging.V(9).Infof("Skipping output property for RPC[%s]: %v", opts.Label, key)
 		} else if opts.SkipNulls && v.IsNull() {
 			logging.V(9).Infof("Skipping null property for RPC[%s]: %s (as requested)", opts.Label, key)
@@ -150,12 +151,35 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 		}
 		return nil, nil // return nil and the caller will ignore it.
 	} else if v.IsOutput() {
-		// Note that at the moment we don't differentiate between computed and output properties on the wire.  As
-		// a result, they will show up as computed on the other end.  This distinction isn't currently interesting.
-		if opts.KeepUnknowns {
-			return marshalUnknownProperty(v.OutputValue().Element, opts), nil
+		if !opts.KeepOutputValues {
+			if !v.OutputValue().Known {
+				// Unknown outputs are marshaled the same as Computed.
+				computed := resource.MakeComputed(v.OutputValue().Element)
+				return MarshalPropertyValue(computed, opts)
+			} else if v.OutputValue().Secret {
+				secret := resource.MakeSecret(v.OutputValue().Element)
+				return MarshalPropertyValue(secret, opts)
+			}
+			return MarshalPropertyValue(v.OutputValue().Element, opts)
 		}
-		return nil, nil // return nil and the caller will ignore it.
+		obj := resource.PropertyMap{
+			resource.SigKey: resource.NewStringProperty(resource.OutputValueSig),
+		}
+		if v.OutputValue().Known {
+			obj["value"] = v.OutputValue().Element
+		}
+		if v.OutputValue().Secret {
+			obj["secret"] = resource.NewBoolProperty(v.OutputValue().Secret)
+		}
+		if len(v.OutputValue().Dependencies) > 0 {
+			deps := make([]resource.PropertyValue, len(v.OutputValue().Dependencies))
+			for i, dep := range v.OutputValue().Dependencies {
+				deps[i] = resource.NewStringProperty(string(dep))
+			}
+			obj["dependencies"] = resource.NewArrayProperty(deps)
+		}
+		output := resource.NewObjectProperty(obj)
+		return MarshalPropertyValue(output, opts)
 	} else if v.IsSecret() {
 		if !opts.KeepSecrets {
 			logging.V(5).Infof("marshalling secret value as raw value as opts.KeepSecrets is false")
@@ -366,12 +390,7 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 			if !ok {
 				return nil, fmt.Errorf("malformed RPC secret: missing value for %q", key)
 			}
-			if !opts.KeepSecrets {
-				logging.V(5).Infof("unmarshalling secret as raw value, as opts.KeepSecrets is false")
-				return &value, nil
-			}
-			s := resource.MakeSecret(value)
-			return &s, nil
+			return unmarshalSecretPropertyValue(value, opts), nil
 		case resource.ResourceReferenceSig:
 			urn, ok := obj["urn"]
 			if !ok {
@@ -425,6 +444,50 @@ func UnmarshalPropertyValue(key resource.PropertyKey, v *structpb.Value,
 				ref = resource.MakeComponentResourceReference(resource.URN(urn.StringValue()), packageVersion)
 			}
 			return &ref, nil
+		case resource.OutputValueSig:
+			value, known := obj["value"]
+
+			var secret bool
+			if secretProp, ok := obj["secret"]; ok {
+				if !secretProp.IsBool() {
+					return nil, errors.New("malformed output value: secret not a bool")
+				}
+				secret = secretProp.BoolValue()
+			}
+
+			if !opts.KeepOutputValues {
+				if !known {
+					v := structpb.Value{
+						Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+					}
+					return UnmarshalPropertyValue(&v, opts)
+				} else if secret {
+					return unmarshalSecretPropertyValue(value, opts), nil
+				}
+				return &value, nil
+			}
+
+			var dependencies []resource.URN
+			if dependenciesProp, ok := obj["dependencies"]; ok {
+				if !dependenciesProp.IsArray() {
+					return nil, errors.New("malformed output value: dependencies not an array")
+				}
+				dependencies = make([]resource.URN, len(dependenciesProp.ArrayValue()))
+				for i, dep := range dependenciesProp.ArrayValue() {
+					if !dep.IsString() {
+						return nil, errors.New("malformed output value: element in dependencies not a string")
+					}
+					dependencies[i] = resource.URN(dep.StringValue())
+				}
+			}
+
+			output := resource.NewOutputProperty(resource.Output{
+				Element:      value,
+				Known:        known,
+				Secret:       secret,
+				Dependencies: dependencies,
+			})
+			return &output, nil
 		default:
 			return nil, fmt.Errorf("unrecognized signature '%v' in property map for %q", sig, key)
 		}
@@ -459,6 +522,15 @@ func unmarshalUnknownPropertyValue(s string, opts MarshalOptions) (resource.Prop
 		return resource.NewComputedProperty(comp), true
 	}
 	return resource.PropertyValue{}, false
+}
+
+func unmarshalSecretPropertyValue(v resource.PropertyValue, opts MarshalOptions) *resource.PropertyValue {
+	if !opts.KeepSecrets {
+		logging.V(5).Infof("unmarshalling secret as raw value, as opts.KeepSecrets is false")
+		return &v
+	}
+	s := resource.MakeSecret(v)
+	return &s
 }
 
 // MarshalNull marshals a nil to its protobuf form.

--- a/sdk/go/common/resource/plugin/rpc_rapid_test.go
+++ b/sdk/go/common/resource/plugin/rpc_rapid_test.go
@@ -67,12 +67,12 @@ func TestOutputValueTurnaround(t *testing.T) {
 		v := resource.NewOutputProperty(out)
 
 		opts := MarshalOptions{KeepOutputValues: true}
-		pb, err := MarshalPropertyValue(v, opts)
+		pb, err := MarshalPropertyValue("", v, opts)
 		assert.NoError(t, err)
 		if err != nil {
 			t.FailNow()
 		}
-		v2, err := UnmarshalPropertyValue(pb, opts)
+		v2, err := UnmarshalPropertyValue("", pb, opts)
 		assert.NoError(t, err)
 		if err != nil {
 			t.FailNow()

--- a/sdk/go/common/resource/plugin/rpc_rapid_test.go
+++ b/sdk/go/common/resource/plugin/rpc_rapid_test.go
@@ -1,0 +1,86 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"pgregory.net/rapid"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
+
+func urnGen() *rapid.Generator {
+	return rapid.StringMatching(`urn:pulumi:a::b::c:d:e::[abcd][123]`).
+		Map(func(x string) resource.URN { return resource.URN(x) })
+}
+
+// Generates PropertyValue values.
+func propertyValueGen() *rapid.Generator {
+	return rapid.Just(resource.NewNullProperty())
+}
+
+// Generates Output values.
+func outputGen() *rapid.Generator {
+	propertyValueG := propertyValueGen()
+	urnsG := rapid.SliceOf(urnGen())
+	return rapid.Custom(func(t *rapid.T) resource.Output {
+		element := propertyValueG.Draw(t, "element").(resource.PropertyValue)
+		known := rapid.Bool().Draw(t, "known").(bool)
+		secret := rapid.Bool().Draw(t, "secret").(bool)
+		deps := urnsG.Draw(t, "dependencies").([]resource.URN)
+		return resource.Output{
+			Element:      element,
+			Known:        known,
+			Secret:       secret,
+			Dependencies: deps,
+		}
+	})
+}
+
+func normOutput(pv *resource.PropertyValue) {
+	if pv.IsOutput() {
+		out := pv.OutputValue()
+		if len(out.Dependencies) == 0 && out.Dependencies != nil {
+			out.Dependencies = nil
+		}
+		pv.V = out
+	}
+}
+
+func TestOutputValueTurnaround(t *testing.T) {
+	rapid.Check(t, func(t *rapid.T) {
+		out := outputGen().Draw(t, "output").(resource.Output)
+		v := resource.NewOutputProperty(out)
+
+		opts := MarshalOptions{KeepOutputValues: true}
+		pb, err := MarshalPropertyValue(v, opts)
+		assert.NoError(t, err)
+		if err != nil {
+			t.FailNow()
+		}
+		v2, err := UnmarshalPropertyValue(pb, opts)
+		assert.NoError(t, err)
+		if err != nil {
+			t.FailNow()
+		}
+		assert.NotNil(t, v2)
+
+		normOutput(&v)
+		normOutput(v2)
+		assert.Equal(t, v, *v2)
+	})
+}

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -342,7 +342,13 @@ func TestMarshalProperties(t *testing.T) {
 				}),
 			},
 			expected: &structpb.Struct{
-				Fields: map[string]*structpb.Value{},
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StringValue{
+							StringValue: "hello",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -355,7 +361,13 @@ func TestMarshalProperties(t *testing.T) {
 				}),
 			},
 			expected: &structpb.Struct{
-				Fields: map[string]*structpb.Value{},
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StringValue{
+							StringValue: "hello",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -368,7 +380,13 @@ func TestMarshalProperties(t *testing.T) {
 				}),
 			},
 			expected: &structpb.Struct{
-				Fields: map[string]*structpb.Value{},
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StringValue{
+							StringValue: "hello",
+						},
+					},
+				},
 			},
 		},
 		{
@@ -382,7 +400,13 @@ func TestMarshalProperties(t *testing.T) {
 				}),
 			},
 			expected: &structpb.Struct{
-				Fields: map[string]*structpb.Value{},
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StringValue{
+							StringValue: "hello",
+						},
+					},
+				},
 			},
 		},
 		{

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -815,9 +815,9 @@ func TestOutputValueRoundTrip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := MarshalOptions{KeepOutputValues: true}
-			prop, err := MarshalPropertyValue(tt.raw, opts)
+			prop, err := MarshalPropertyValue("", tt.raw, opts)
 			assert.NoError(t, err)
-			actual, err := UnmarshalPropertyValue(prop, opts)
+			actual, err := UnmarshalPropertyValue("", prop, opts)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.raw, *actual)
 		})
@@ -1096,7 +1096,7 @@ func TestOutputValueMarshaling(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actual, err := MarshalPropertyValue(tt.raw, tt.opts)
+			actual, err := MarshalPropertyValue("", tt.raw, tt.opts)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, actual)
 		})
@@ -1521,7 +1521,7 @@ func TestOutputValueUnmarshaling(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prop, err := UnmarshalPropertyValue(tt.raw, tt.opts)
+			prop, err := UnmarshalPropertyValue("", tt.raw, tt.opts)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, prop)
 		})

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -296,6 +296,418 @@ func TestSkipInternalKeys(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestMarshalProperties(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     MarshalOptions
+		props    resource.PropertyMap
+		expected *structpb.Struct
+	}{
+		{
+			name: "empty (default)",
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "unknown (default)",
+			props: resource.PropertyMap{
+				"foo": resource.MakeOutput(resource.NewStringProperty("")),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "unknown with deps (default)",
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element:      resource.NewStringProperty(""),
+					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "known (default)",
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element: resource.NewStringProperty("hello"),
+					Known:   true,
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "known with deps (default)",
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element:      resource.NewStringProperty("hello"),
+					Known:        true,
+					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "secret (default)",
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element: resource.NewStringProperty("hello"),
+					Known:   true,
+					Secret:  true,
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "secret with deps (default)",
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element:      resource.NewStringProperty("hello"),
+					Known:        true,
+					Secret:       true,
+					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "unknown secret (default)",
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element: resource.NewStringProperty("shhh"),
+					Secret:  true,
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "unknown secret with deps (default)",
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element:      resource.NewStringProperty("shhh"),
+					Secret:       true,
+					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{},
+			},
+		},
+		{
+			name: "empty (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unknown (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.MakeOutput(resource.NewStringProperty("")),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unknown with deps (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element:      resource.NewStringProperty(""),
+					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+									"dependencies": {
+										Kind: &structpb.Value_ListValue{
+											ListValue: &structpb.ListValue{
+												Values: []*structpb.Value{
+													{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+													{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "known (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element: resource.NewStringProperty("hello"),
+					Known:   true,
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+									"value": {
+										Kind: &structpb.Value_StringValue{StringValue: "hello"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "known with deps (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element:      resource.NewStringProperty("hello"),
+					Known:        true,
+					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+									"value": {
+										Kind: &structpb.Value_StringValue{StringValue: "hello"},
+									},
+									"dependencies": {
+										Kind: &structpb.Value_ListValue{
+											ListValue: &structpb.ListValue{
+												Values: []*structpb.Value{
+													{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+													{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "secret (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element: resource.NewStringProperty("shhh"),
+					Known:   true,
+					Secret:  true,
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+									"value": {
+										Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+									},
+									"secret": {
+										Kind: &structpb.Value_BoolValue{BoolValue: true},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "secret with deps (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element:      resource.NewStringProperty("shhh"),
+					Known:        true,
+					Secret:       true,
+					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+									"value": {
+										Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+									},
+									"secret": {
+										Kind: &structpb.Value_BoolValue{BoolValue: true},
+									},
+									"dependencies": {
+										Kind: &structpb.Value_ListValue{
+											ListValue: &structpb.ListValue{
+												Values: []*structpb.Value{
+													{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+													{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unknown secret (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element: resource.NewStringProperty("shhh"),
+					Secret:  true,
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+									"secret": {
+										Kind: &structpb.Value_BoolValue{BoolValue: true},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unknown secret with deps (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"foo": resource.NewOutputProperty(resource.Output{
+					Element:      resource.NewStringProperty("shhh"),
+					Secret:       true,
+					Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"foo": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+									"secret": {
+										Kind: &structpb.Value_BoolValue{BoolValue: true},
+									},
+									"dependencies": {
+										Kind: &structpb.Value_ListValue{
+											ListValue: &structpb.ListValue{
+												Values: []*structpb.Value{
+													{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+													{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := MarshalProperties(tt.props, tt.opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
 func TestResourceReference(t *testing.T) {
 	// Test round-trip
 	opts := MarshalOptions{KeepResources: true}
@@ -339,12 +751,696 @@ func TestResourceReference(t *testing.T) {
 	assert.Equal(t, resource.NewStringProperty(string(rawProp.ResourceReferenceValue().URN)), *actual)
 }
 
+func TestOutputValueRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  resource.PropertyValue
+	}{
+		{
+			name: "unknown",
+			raw:  resource.NewOutputProperty(resource.Output{}),
+		},
+		{
+			name: "unknown with deps",
+			raw: resource.NewOutputProperty(resource.Output{
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+		},
+		{
+			name: "known",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element: resource.NewStringProperty("hello"),
+				Known:   true,
+			}),
+		},
+		{
+			name: "known with deps",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("hello"),
+				Known:        true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+		},
+		{
+			name: "secret",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element: resource.NewStringProperty("secret"),
+				Known:   true,
+				Secret:  true,
+			}),
+		},
+		{
+			name: "secret with deps",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("secret"),
+				Known:        true,
+				Secret:       true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+		},
+		{
+			name: "unknown secret",
+			raw: resource.NewOutputProperty(resource.Output{
+				Secret: true,
+			}),
+		},
+		{
+			name: "unknown secret with deps",
+			raw: resource.NewOutputProperty(resource.Output{
+				Secret:       true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := MarshalOptions{KeepOutputValues: true}
+			prop, err := MarshalPropertyValue(tt.raw, opts)
+			assert.NoError(t, err)
+			actual, err := UnmarshalPropertyValue(prop, opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.raw, *actual)
+		})
+	}
+}
+
+func TestOutputValueMarshaling(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     MarshalOptions
+		raw      resource.PropertyValue
+		expected *structpb.Value
+	}{
+		{
+			name:     "empty (default)",
+			raw:      resource.NewOutputProperty(resource.Output{}),
+			expected: nil,
+		},
+		{
+			name:     "unknown (default)",
+			raw:      resource.MakeOutput(resource.NewStringProperty("")),
+			expected: nil,
+		},
+		{
+			name: "unknown with deps (default)",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("hello"),
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+			expected: nil,
+		},
+		{
+			name: "known (default)",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element: resource.NewStringProperty("hello"),
+				Known:   true,
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: "hello"},
+			},
+		},
+		{
+			name: "known with deps (default)",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("hello"),
+				Known:        true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: "hello"},
+			},
+		},
+		{
+			name: "secret (default)",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element: resource.NewStringProperty("shhh"),
+				Known:   true,
+				Secret:  true,
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+			},
+		},
+		{
+			name: "secret with deps (default)",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("shhh"),
+				Known:        true,
+				Secret:       true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+			},
+		},
+		{
+			name: "unknown secret (default)",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element: resource.NewStringProperty("shhh"),
+				Secret:  true,
+			}),
+			expected: nil,
+		},
+		{
+			name: "unknown secret with deps (default)",
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("shhh"),
+				Secret:       true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+			expected: nil,
+		},
+		{
+			name: "empty (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw:  resource.NewOutputProperty(resource.Output{}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_NullValue{NullValue: 0},
+			},
+		},
+		{
+			name: "unknown (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw:  resource.MakeOutput(resource.NewStringProperty("")),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+			},
+		},
+		{
+			name: "unknown with deps (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("hello"),
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+			},
+		},
+		{
+			name: "unknown secret (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: resource.NewOutputProperty(resource.Output{
+				Element: resource.NewStringProperty("shhh"),
+				Secret:  true,
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+			},
+		},
+		{
+			name: "unknown secret with deps (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("shhh"),
+				Secret:       true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+			},
+		},
+		{
+			name: "secret (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: resource.NewOutputProperty(resource.Output{
+				Element: resource.NewStringProperty("shhh"),
+				Known:   true,
+				Secret:  true,
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+			},
+		},
+		{
+			name: "secret with deps (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("shhh"),
+				Known:        true,
+				Secret:       true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+			},
+		},
+		{
+			name: "secret (KeepSecrets)",
+			opts: MarshalOptions{KeepSecrets: true},
+			raw: resource.NewOutputProperty(resource.Output{
+				Element: resource.NewStringProperty("shhh"),
+				Known:   true,
+				Secret:  true,
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.SecretSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "secret with deps (KeepSecrets)",
+			opts: MarshalOptions{KeepSecrets: true},
+			raw: resource.NewOutputProperty(resource.Output{
+				Element:      resource.NewStringProperty("shhh"),
+				Known:        true,
+				Secret:       true,
+				Dependencies: []resource.URN{"fakeURN1", "fakeURN2"},
+			}),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.SecretSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "unknown value (KeepOutputValues)",
+			opts: MarshalOptions{KeepOutputValues: true},
+			raw:  resource.MakeOutput(resource.NewStringProperty("")),
+			expected: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := MarshalPropertyValue(tt.raw, tt.opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestOutputValueUnmarshaling(t *testing.T) {
+	ptr := func(v resource.PropertyValue) *resource.PropertyValue {
+		return &v
+	}
+	tests := []struct {
+		name     string
+		opts     MarshalOptions
+		raw      *structpb.Value
+		expected *resource.PropertyValue
+	}{
+		{
+			name: "unknown (default)",
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "known (default)",
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "hello"},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.NewStringProperty("hello")),
+		},
+		{
+			name: "known with deps (default)",
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "hello"},
+							},
+							"dependencies": {
+								Kind: &structpb.Value_ListValue{
+									ListValue: &structpb.ListValue{
+										Values: []*structpb.Value{
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.NewStringProperty("hello")),
+		},
+		{
+			name: "secret (default)",
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.NewStringProperty("shhh")),
+		},
+		{
+			name: "secret with deps (default)",
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+							"dependencies": {
+								Kind: &structpb.Value_ListValue{
+									ListValue: &structpb.ListValue{
+										Values: []*structpb.Value{
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.NewStringProperty("shhh")),
+		},
+		{
+			name: "unknown secret (default)",
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "unknown secret with deps (default)",
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+							"dependencies": {
+								Kind: &structpb.Value_ListValue{
+									ListValue: &structpb.ListValue{
+										Values: []*structpb.Value{
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "unknown (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.MakeComputed(resource.NewStringProperty(""))),
+		},
+		{
+			name: "unknown with deps (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"dependencies": {
+								Kind: &structpb.Value_ListValue{
+									ListValue: &structpb.ListValue{
+										Values: []*structpb.Value{
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.MakeComputed(resource.NewStringProperty(""))),
+		},
+		{
+			name: "unknown secret (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.MakeComputed(resource.NewStringProperty(""))),
+		},
+		{
+			name: "unknown secret with deps (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+							"dependencies": {
+								Kind: &structpb.Value_ListValue{
+									ListValue: &structpb.ListValue{
+										Values: []*structpb.Value{
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.MakeComputed(resource.NewStringProperty(""))),
+		},
+		{
+			name: "secret (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.NewStringProperty("shhh")),
+		},
+		{
+			name: "secret with deps (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+							"dependencies": {
+								Kind: &structpb.Value_ListValue{
+									ListValue: &structpb.ListValue{
+										Values: []*structpb.Value{
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.NewStringProperty("shhh")),
+		},
+		{
+			name: "secret (KeepSecrets)",
+			opts: MarshalOptions{KeepSecrets: true},
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.MakeSecret(resource.NewStringProperty("shhh"))),
+		},
+		{
+			name: "secret with deps (KeepSecrets)",
+			opts: MarshalOptions{KeepSecrets: true},
+			raw: &structpb.Value{
+				Kind: &structpb.Value_StructValue{
+					StructValue: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							resource.SigKey: {
+								Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+							},
+							"value": {
+								Kind: &structpb.Value_StringValue{StringValue: "shhh"},
+							},
+							"secret": {
+								Kind: &structpb.Value_BoolValue{BoolValue: true},
+							},
+							"dependencies": {
+								Kind: &structpb.Value_ListValue{
+									ListValue: &structpb.ListValue{
+										Values: []*structpb.Value{
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN1"}},
+											{Kind: &structpb.Value_StringValue{StringValue: "fakeURN2"}},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: ptr(resource.MakeSecret(resource.NewStringProperty("shhh"))),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prop, err := UnmarshalPropertyValue(tt.raw, tt.opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, prop)
+		})
+	}
+}
+
 func TestMarshalPropertiesDiscardsListNestedUnknowns(t *testing.T) {
 	proto := pbStruct("resources", pbList(pbString(UnknownStringValue)))
 
 	propsWithUnknowns, err := UnmarshalProperties(proto, MarshalOptions{KeepUnknowns: true})
 	if err != nil {
-		t.Errorf("UnmarhsalProperties failed: %w", err)
+		t.Errorf("UnmarshalProperties failed: %w", err)
 	}
 
 	protobufStruct, err := MarshalProperties(propsWithUnknowns, MarshalOptions{KeepUnknowns: false})

--- a/sdk/go/common/resource/properties.go
+++ b/sdk/go/common/resource/properties.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -84,7 +84,10 @@ type Computed struct {
 // encountered, it means the resource has not yet been created, and so the output value is unavailable.  Note that an
 // output property is a special case of computed, but carries additional semantic meaning.
 type Output struct {
-	Element PropertyValue // the eventual value (type) of the output property.
+	Element      PropertyValue // the value of this output if it is resolved.
+	Known        bool          `json:"-"` // true if this output's value is known.
+	Secret       bool          `json:"-"` // true if this output's value is secret.
+	Dependencies []URN         `json:"-"` // the dependencies associated with this output.
 }
 
 // Secret indicates that the underlying value should be persisted securely.
@@ -364,12 +367,15 @@ func NewPropertyValueRepl(v interface{},
 
 // HasValue returns true if a value is semantically meaningful.
 func (v PropertyValue) HasValue() bool {
-	return !v.IsNull() && !v.IsOutput()
+	if v.IsOutput() {
+		return v.OutputValue().Known
+	}
+	return !v.IsNull()
 }
 
 // ContainsUnknowns returns true if the property value contains at least one unknown (deeply).
 func (v PropertyValue) ContainsUnknowns() bool {
-	if v.IsComputed() || v.IsOutput() {
+	if v.IsComputed() || (v.IsOutput() && !v.OutputValue().Known) {
 		return true
 	} else if v.IsArray() {
 		for _, e := range v.ArrayValue() {
@@ -392,7 +398,7 @@ func (v PropertyValue) ContainsSecrets() bool {
 	} else if v.IsComputed() {
 		return v.Input().Element.ContainsSecrets()
 	} else if v.IsOutput() {
-		return v.OutputValue().Element.ContainsSecrets()
+		return v.OutputValue().Secret || v.OutputValue().Element.ContainsSecrets()
 	} else if v.IsArray() {
 		for _, e := range v.ArrayValue() {
 			if e.ContainsSecrets() {
@@ -530,7 +536,12 @@ func (v PropertyValue) TypeString() string {
 	} else if v.IsComputed() {
 		return "output<" + v.Input().Element.TypeString() + ">"
 	} else if v.IsOutput() {
-		return "output<" + v.OutputValue().Element.TypeString() + ">"
+		if !v.OutputValue().Known {
+			return MakeComputed(v.OutputValue().Element).TypeString()
+		} else if v.OutputValue().Secret {
+			return MakeSecret(v.OutputValue().Element).TypeString()
+		}
+		return v.OutputValue().Element.TypeString()
 	} else if v.IsSecret() {
 		return "secret<" + v.SecretValue().Element.TypeString() + ">"
 	} else if v.IsResourceReference() {
@@ -588,9 +599,16 @@ func (v PropertyValue) MapRepl(replk func(string) (string, bool),
 
 // String implements the fmt.Stringer interface to add slightly more information to the output.
 func (v PropertyValue) String() string {
-	if v.IsComputed() || v.IsOutput() {
-		// For computed and output properties, show their type followed by an empty object string.
+	if v.IsComputed() {
+		// For computed properties, show the type followed by an empty object string.
 		return fmt.Sprintf("%v{}", v.TypeString())
+	} else if v.IsOutput() {
+		if !v.OutputValue().Known {
+			return MakeComputed(v.OutputValue().Element).String()
+		} else if v.OutputValue().Secret {
+			return MakeSecret(v.OutputValue().Element).String()
+		}
+		return v.OutputValue().Element.String()
 	}
 	// For all others, just display the underlying property value.
 	return fmt.Sprintf("{%v}", v.V)
@@ -619,6 +637,9 @@ const SecretSig = "1b47061264138c4ac30d75fd1eb44270"
 
 // ResourceReferenceSig is the unique resource reference signature.
 const ResourceReferenceSig = "5cf8f73096256a8f31e491e813e4eb8e"
+
+// OutputValueSig is the unique output value signature.
+const OutputValueSig = "d0e6a833031e9bbcd3f4e8bde6ca49a4"
 
 // IsInternalPropertyKey returns true if the given property key is an internal key that should not be displayed to
 // users.

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -1128,6 +1128,7 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 nhooyr.io/websocket v1.8.6/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
 nhooyr.io/websocket v1.8.7/go.mod h1:B70DZP8IakI65RVQ51MsWP/8jndNma26DVA/nFSCgW0=
+pgregory.net/rapid v0.4.7/go.mod h1:UYpPVyjFHzYBGHIxLFoupi8vwk6rXNzRY9OMvVxFIOU=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=


### PR DESCRIPTION
This change expands the definition of `resource.Output` in the Go SDK with additional information about the output, i.e. dependencies and secretness, and adds support in the core Go RPC code for (un)marshaling output values.

Output values are marshaled as special objects ala archives, assets, and resource refs and are unmarshaled as `resource.Output` values.

Note: The current plan is to scope this to only be used when marshaling inputs to a multi-lang component and for method calls using `Call`.

Subsequent PRs will add:
 - A monitor feature for output values, which will initially be disabled by default but available to turn on via an envvar
 - A way for component providers to indicate support for accepting output values (for `Construct` and `Call`)
 - Support for (un)marshaling output values in each language SDKs
 - E2E tests
 - Turn the monitor feature on by default (w/ env var to disable)

Fixes #7846
Fixes #7847

Part of #7434