### PR TITLE
[sdk/python] Stack preview: enable json output

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -13,4 +13,7 @@
 - [codegen/schema] Add a `pulumi schema check` command to validate package schemas.
   [#7865](https://github.com/pulumi/pulumi/pull/7865)
 
+- [sdk/python] - Automation API: Enable JSON output for stack preview.
+  [#7868](https://github.com/pulumi/pulumi/pull/7868)
+
 ### Bug Fixes

--- a/sdk/python/lib/pulumi/automation/_stack.py
+++ b/sdk/python/lib/pulumi/automation/_stack.py
@@ -269,6 +269,7 @@ class Stack:
                 target: Optional[List[str]] = None,
                 expect_no_changes: Optional[bool] = None,
                 diff: Optional[bool] = None,
+                json_output: Optional[bool] = None,
                 target_dependents: Optional[bool] = None,
                 replace: Optional[List[str]] = None,
                 on_output: Optional[OnOutput] = None,
@@ -284,6 +285,7 @@ class Stack:
         :param target: Specify an exclusive list of resource URNs to update.
         :param expect_no_changes: Return an error if any changes occur during this update.
         :param diff: Display operation as a rich diff showing the overall change.
+        :param json_output: Serialize the preview diffs, operations, and overall output as JSON.
         :param target_dependents: Allows updating of dependent targets discovered but not specified in the Target list.
         :param replace: Specify resources to replace.
         :param on_output: A function to process the stdout stream.
@@ -594,6 +596,7 @@ def _parse_extra_args(**kwargs) -> List[str]:
     message = kwargs.get("message")
     expect_no_changes = kwargs.get("expect_no_changes")
     diff = kwargs.get("diff")
+    json_output = kwargs.get("json_output")
     replace = kwargs.get("replace")
     target = kwargs.get("target")
     target_dependents = kwargs.get("target_dependents")
@@ -605,6 +608,8 @@ def _parse_extra_args(**kwargs) -> List[str]:
         extra_args.append("--expect-no-changes")
     if diff:
         extra_args.append("--diff")
+    if json_output:
+        extra_args.append("--json")
     if replace:
         for r in replace:
             extra_args.extend(["--replace", r])


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

The pulumi preview CLI command has an option that allows the preview diffs, operations, and overall output to be returned as JSON.
This change allows setting this option also when using the Python Automation API.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
