### PR TITLE
Fix rmdir DeprecationWarning

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,3 +11,5 @@
   resources. [#7784](https://github.com/pulumi/pulumi/pull/7784)
 
 ### Bug Fixes
+
+- Fix Node `fs.rmdir` DeprecationWarning

--- a/sdk/nodejs/automation/stack.ts
+++ b/sdk/nodejs/automation/stack.ts
@@ -809,6 +809,6 @@ const cleanUp = async (logFile?: string, rl?: ReadlineResult) => {
     }
     if (logFile) {
         // remove the logfile
-        fs.rmdir(path.dirname(logFile), { recursive: true }, () => { return; });
+        fs.rm(path.dirname(logFile), { recursive: true }, () => { return; });
     }
 };


### PR DESCRIPTION
```
(node:346333) [DEP0147] DeprecationWarning: In future versions of Node.js, fs.rm
sive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
(Use `node --trace-deprecation ...` to show where the warning was created)
```