### PR TITLE
Add workflow commands test on windows, unix, lint

### DIFF
--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -17,6 +17,48 @@ jobs:
           permission: write
           issue-type: pull-request
           repository: pulumi/pulumi
+  command-dispatch-for-testing-windows:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Build
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: run-windows-tests
+          permission: write
+          issue-type: pull-request
+          repository: pulumi/pulumi
+          static-args: only-windows
+  command-dispatch-for-testing-unix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Build
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: run-unix-tests
+          permission: write
+          issue-type: pull-request
+          repository: pulumi/pulumi
+          static-args: only-unix
+  command-dispatch-for-testing-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run Build
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PULUMI_BOT_TOKEN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          commands: run-lint
+          permission: write
+          issue-type: pull-request
+          repository: pulumi/pulumi
+          static-args: only-lint
   command-dispatch-for-docs-generation:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/command-dispatch.yml
+++ b/.github/workflows/command-dispatch.yml
@@ -17,48 +17,6 @@ jobs:
           permission: write
           issue-type: pull-request
           repository: pulumi/pulumi
-  command-dispatch-for-testing-windows:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run Build
-        uses: peter-evans/slash-command-dispatch@v2
-        with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
-          commands: run-windows-tests
-          permission: write
-          issue-type: pull-request
-          repository: pulumi/pulumi
-          static-args: only-windows
-  command-dispatch-for-testing-unix:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run Build
-        uses: peter-evans/slash-command-dispatch@v2
-        with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
-          commands: run-unix-tests
-          permission: write
-          issue-type: pull-request
-          repository: pulumi/pulumi
-          static-args: only-unix
-  command-dispatch-for-testing-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run Build
-        uses: peter-evans/slash-command-dispatch@v2
-        with:
-          token: ${{ secrets.PULUMI_BOT_TOKEN }}
-          reaction-token: ${{ secrets.GITHUB_TOKEN }}
-          commands: run-lint
-          permission: write
-          issue-type: pull-request
-          repository: pulumi/pulumi
-          static-args: only-lint
   command-dispatch-for-docs-generation:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -225,7 +225,7 @@ jobs:
       (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
       ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-unix') &&
-      ! contains(github.event.client_payload.slash_command.args.unamed.all, only-lint')
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-lint')
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -1,10 +1,10 @@
 on:
   repository_dispatch:
-    types: [ run-acceptance-tests-command ]
+    types: [run-acceptance-tests-command]
   pull_request:
     paths-ignore:
-      - 'CHANGELOG.md'
-      - 'CHANGELOG_PENDING.md'
+      - "CHANGELOG.md"
+      - "CHANGELOG_PENDING.md"
 
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
@@ -33,13 +33,13 @@ jobs:
             [1]: ${{ steps.vars.outputs.run-url }}
   go-lint:
     if: |
-      ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") 
+      ! contains(github.event.client_payload.slash_command.args.unamed, only-windows) &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, only-unix)
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}
     strategy:
       matrix:
-        directory: [ sdk, pkg, tests ]
+        directory: [sdk, pkg, tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -52,8 +52,8 @@ jobs:
 
   sdk-lint:
     if: |
-      ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") 
+      ! contains(github.event.client_payload.slash_command.args.unamed, only-windows) &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, only-unix)
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
@@ -113,20 +113,20 @@ jobs:
     name: Build & Test
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest ]
+        platform: [ubuntu-latest, macos-latest]
         go-version: [1.16.x]
-        python-version: [ 3.9.x ]
-        dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        python-version: [3.9.x]
+        dotnet-version: [3.1.x]
+        node-version: [14.x]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
+        test-subset: [integration, auto-and-lifecycletest, native, etc]
 
     if: |
       (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, "only-lint")
+      ! contains(github.event.client_payload.slash_command.args.unamed, only-windows) &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, only-lint)
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set PULUMI_TEST_SUBSET env var
@@ -213,7 +213,6 @@ jobs:
         run: |
           goteststats -statistic test-time test-results/*.json | head -n 100
 
-
   windows-build:
     name: Windows Build + Test
     strategy:
@@ -225,8 +224,8 @@ jobs:
     if: |
       (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, "only-lint") 
+      ! contains(github.event.client_payload.slash_command.args.unamed, only-unix) &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, only-lint)
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -32,6 +32,7 @@ jobs:
 
             [1]: ${{ steps.vars.outputs.run-url }}
   go-lint:
+    if: ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&  ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") 
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}
     strategy:
@@ -46,7 +47,9 @@ jobs:
       - name: Lint ${{ matrix.directory }}
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
+
   sdk-lint:
+    if: ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&  ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") 
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
@@ -115,7 +118,7 @@ jobs:
         # See scripts/tests_subsets.py when editing
         test-subset: [ integration, auto-and-lifecycletest, native, etc ]
 
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    if: (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") && ! contains(github.event.client_payload.slash_command.args.unamed, "only-lint")
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set PULUMI_TEST_SUBSET env var
@@ -211,7 +214,7 @@ jobs:
         node-version: [14.x]
         python-version: [3.9.x]
         dotnet: [3.1.x]
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    if: (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") &&  ! contains(github.event.client_payload.slash_command.args.unamed, "only-lint") 
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -33,8 +33,8 @@ jobs:
             [1]: ${{ steps.vars.outputs.run-url }}
   go-lint:
     if: |
-      ! contains(github.event.client_payload.slash_command.args.unamed, only-windows) &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, only-unix)
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-windows') &&
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-unix')
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}
     strategy:
@@ -52,8 +52,8 @@ jobs:
 
   sdk-lint:
     if: |
-      ! contains(github.event.client_payload.slash_command.args.unamed, only-windows) &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, only-unix)
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-windows') &&
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-unix')
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
@@ -125,8 +125,8 @@ jobs:
     if: |
       (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, only-windows) &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, only-lint)
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-windows') &&
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-lint')
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set PULUMI_TEST_SUBSET env var
@@ -224,8 +224,8 @@ jobs:
     if: |
       (github.event_name == 'repository_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository) &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, only-unix) &&
-      ! contains(github.event.client_payload.slash_command.args.unamed, only-lint)
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, 'only-unix') &&
+      ! contains(github.event.client_payload.slash_command.args.unamed.all, only-lint')
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -32,7 +32,9 @@ jobs:
 
             [1]: ${{ steps.vars.outputs.run-url }}
   go-lint:
-    if: ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&  ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") 
+    if: |
+      ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") 
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}
     strategy:
@@ -49,7 +51,9 @@ jobs:
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
 
   sdk-lint:
-    if: ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&  ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") 
+    if: |
+      ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") 
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
@@ -118,7 +122,11 @@ jobs:
         # See scripts/tests_subsets.py when editing
         test-subset: [ integration, auto-and-lifecycletest, native, etc ]
 
-    if: (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") && ! contains(github.event.client_payload.slash_command.args.unamed, "only-lint")
+    if: |
+      (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, "only-windows") &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, "only-lint")
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set PULUMI_TEST_SUBSET env var
@@ -214,7 +222,11 @@ jobs:
         node-version: [14.x]
         python-version: [3.9.x]
         dotnet: [3.1.x]
-    if: (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) && ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") &&  ! contains(github.event.client_payload.slash_command.args.unamed, "only-lint") 
+    if: |
+      (github.event_name == 'repository_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository) &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, "only-unix") &&
+      ! contains(github.event.client_payload.slash_command.args.unamed, "only-lint") 
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Allows Pulumi members to run `/run-acceptance-tests windows-only`, `/run-acceptance-tests unix-only`, `/run-acceptance-tests lint-only` as a comment and run the expected workflow. This is to make it easier to develop when tests are failing on a specific platform. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
