### PR TITLE
[schema] Support target-specific schema validation

### DIFF
--- a/pkg/cmd/pulumi/schema_check.go
+++ b/pkg/cmd/pulumi/schema_check.go
@@ -25,6 +25,10 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	dotnetgen "github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
+	gogen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
+	nodejsgen "github.com/pulumi/pulumi/pkg/v3/codegen/nodejs"
+	pythongen "github.com/pulumi/pulumi/pkg/v3/codegen/python"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -67,7 +71,12 @@ func newSchemaCheckCommand() *cobra.Command {
 				return fmt.Errorf("failed to unmarshal schema: %w", err)
 			}
 
-			_, diags, err := schema.BindSpec(pkgSpec, nil)
+			_, diags, err := schema.BindSpec(pkgSpec, map[string]schema.Language{
+				"dotnet": dotnetgen.Importer,
+				"go":     gogen.Importer,
+				"nodejs": nodejsgen.Importer,
+				"python": pythongen.Importer,
+			})
 			diagWriter := hcl.NewDiagnosticTextWriter(os.Stderr, nil, 0, true)
 			wrErr := diagWriter.WriteDiagnostics(diags)
 			contract.IgnoreError(wrErr)


### PR DESCRIPTION
Add a new interface, LanguageBinder, to the schema package to support
schema validation specific to a target language. This allows targets to
add their own validation rules on top of the schema spec.
Language-specific rules should not change the semantics of the schema.