### PR TITLE
[auto/go] Fix stack config loading

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -14,3 +14,5 @@
   [#7865](https://github.com/pulumi/pulumi/pull/7865)
 
 ### Bug Fixes
+- [automation/go] Fix loading of stack settings/configs from yaml files.
+  [#pulumi-kubernetes-operator/183](https://github.com/pulumi/pulumi-kubernetes-operator/issues/183)

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -78,7 +78,7 @@ func (l *LocalWorkspace) StackSettings(ctx context.Context, stackName string) (*
 	name := getStackSettingsName(stackName)
 	for _, ext := range settingsExtensions {
 		stackPath := filepath.Join(l.WorkDir(), fmt.Sprintf("Pulumi.%s%s", name, ext))
-		if _, err := os.Stat(stackPath); err != nil {
+		if _, err := os.Stat(stackPath); err == nil {
 			proj, err := workspace.LoadProjectStack(stackPath)
 			if err != nil {
 				return nil, errors.Wrap(err, "found stack settings, but failed to load")

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -1223,11 +1223,26 @@ func TestNestedConfig(t *testing.T) {
 		t.FailNow()
 	}
 
+	// Also retrieve the stack settings directly from the yaml file and
+	// make sure the config agrees with the config loaded by Pulumi.
+	stackSettings, err := s.Workspace().StackSettings(ctx, stackName)
+	require.NoError(t, err)
+	confKeys := map[string]bool{}
+	for k := range stackSettings.Config {
+		confKeys[k.String()] = true
+	}
+
 	allConfig, err := s.GetAllConfig(ctx)
 	if err != nil {
 		t.Errorf("failed to get config, err: %v", err)
 		t.FailNow()
 	}
+	allConfKeys := map[string]bool{}
+	for k := range allConfig {
+		allConfKeys[k] = true
+	}
+	assert.Equal(t, confKeys, allConfKeys)
+	assert.NotEmpty(t, confKeys)
 
 	outerVal, ok := allConfig["nested_config:outer"]
 	assert.True(t, ok)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes https://github.com/pulumi/pulumi-kubernetes-operator/issues/183

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
