### PR TITLE
Run workflow from tags

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Lint ${{ matrix.directory }}
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
-      - name: Remove Label ci/lint
   sdk-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -2,6 +2,8 @@ on:
   repository_dispatch:
     types: [ run-acceptance-tests-command ]
   pull_request:
+    # types defaults to [ opened, synchronize, reopened ]
+    types: [ labeled, opened, synchronize, reopened ]
     paths-ignore:
       - 'CHANGELOG.md'
       - 'CHANGELOG_PENDING.md'
@@ -32,6 +34,8 @@ jobs:
 
             [1]: ${{ steps.vars.outputs.run-url }}
   go-lint:
+    if: |
+      github.event.label.name == 'ci/lint' || github.event.type != labeled
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}
     strategy:
@@ -47,6 +51,8 @@ jobs:
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
   sdk-lint:
+    if: |
+      github.event.label.name == 'ci/lint' || github.event.type != labeled
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
@@ -103,6 +109,7 @@ jobs:
         run: |
           cd sdk/dotnet && make lint
   build_and_test:
+      
     name: Build & Test
     strategy:
       matrix:
@@ -115,7 +122,9 @@ jobs:
         # See scripts/tests_subsets.py when editing
         test-subset: [ integration, auto-and-lifecycletest, native, etc ]
 
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event.label.name == 'ci/build-unix' || github.event.type != labeled)
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set PULUMI_TEST_SUBSET env var
@@ -211,7 +220,9 @@ jobs:
         node-version: [14.x]
         python-version: [3.9.x]
         dotnet: [3.1.x]
-    if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    if: |
+      (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) &&
+      (github.event.label.name == 'ci/build-windows' || github.event.type != labeled)
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -50,6 +50,11 @@ jobs:
       - name: Lint ${{ matrix.directory }}
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
+      - name: Remove Label ci/lint
+        uses: actions/github-script@v4
+        with:
+          script: |
+            octokit.rest.issues.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: "ci/lint"});
   sdk-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -33,26 +33,6 @@ jobs:
             Please view the results of the PR Build + Acceptance Tests Run [Here][1]
 
             [1]: ${{ steps.vars.outputs.run-url }}
-  cleanup-lint:
-    runs-on: ubuntu-latest
-    name: Cleanup ci/lint Tag
-    needs: [ sdk-lint, go-lint]
-    if: always()
-    steps:
-      - name: Cleanup ci/lint Tag
-        uses: actions/github-script@v4
-        with:
-          script: |
-            try {
-              github.issues.removeLabel({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: 'ci/lint'
-                })
-            } catch (error) {
-                console.log(error)
-            }
   go-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'
@@ -320,3 +300,67 @@ jobs:
         run: |
           cd src\github.com\${{ github.repository }}
           dotnet msbuild /t:Tests /v:Detailed build.proj /p:PulumiRoot="D:\\Pulumi"
+
+  cleanup-lint:
+    runs-on: ubuntu-latest
+    name: Cleanup ci/lint Tag
+    needs: [ sdk-lint, go-lint ]
+    if: github.event.label.name == 'ci/lint'
+    steps:
+      - name: Cleanup ci/lint Tag
+        uses: actions/github-script@v4
+        with:
+          script: |
+            try {
+              github.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ci/lint'
+                })
+            } catch (error) {
+                console.log(error)
+            }
+
+  cleanup-unix:
+    runs-on: ubuntu-latest
+    name: Cleanup ci/build-unix Tag
+    needs: [ build_and_test ]
+    if: github.event.label.name == 'ci/build-unix'
+    steps:
+      - name: Cleanup ci/build-unix Tag
+        uses: actions/github-script@v4
+        with:
+          script: |
+            try {
+              github.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ci/build-unix'
+                })
+            } catch (error) {
+                console.log(error)
+            }
+
+  cleanup-windows:
+    runs-on: ubuntu-latest
+    name: Cleanup ci/build-windows Tag
+    needs: [ windows-build ]
+    if: github.event.label.name == 'ci/build-windows'
+    steps:
+      - name: Cleanup ci/build-windows Tag
+        uses: actions/github-script@v4
+        with:
+          script: |
+            try {
+              github.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ci/build-windows'
+                })
+            } catch (error) {
+                console.log(error)
+            }
+ 

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            octokit.rest.issues.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: "ci/lint"});
+            github.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: "ci/lint"});
   sdk-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            github.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: "ci/lint"});
+            github.issue.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: "ci/lint"});
   sdk-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -33,6 +33,26 @@ jobs:
             Please view the results of the PR Build + Acceptance Tests Run [Here][1]
 
             [1]: ${{ steps.vars.outputs.run-url }}
+  cleanup-lint:
+    runs-on: ubuntu-latest
+    name: Cleanup ci/lint Tag
+    needs: [ sdk-lint, go-lint]
+    if: always()
+    steps:
+      - name: Cleanup ci/lint Tag
+        uses: actions/github-script@v4
+        with:
+          script: |
+            try {
+              github.issues.removeLabel({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'ci/lint'
+                })
+            } catch (error) {
+                console.log(error)
+            }
   go-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'
@@ -51,15 +71,6 @@ jobs:
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
       - name: Remove Label ci/lint
-        uses: actions/github-script@v4
-        with:
-          script: |
-            github.issues.removeLabel({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              name: 'ci/lint'
-            })
   sdk-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/github-script@v4
         with:
           script: |
-            github.issue.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: "ci/lint"});
+            github.rest.issue.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: "ci/lint"});
   sdk-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
       - name: Remove Label ci/lint
-      - uses: actions/github-script@v4
+        uses: actions/github-script@v4
         with:
           script: |
             github.issues.removeLabel({

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -35,7 +35,7 @@ jobs:
             [1]: ${{ steps.vars.outputs.run-url }}
   go-lint:
     if: |
-      github.event.label.name == 'ci/lint' || github.event.type != labeled
+      github.event.label.name == 'ci/lint' || github.event.action != 'labeled'
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}
     strategy:
@@ -52,7 +52,7 @@ jobs:
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
   sdk-lint:
     if: |
-      github.event.label.name == 'ci/lint' || github.event.type != labeled
+      github.event.label.name == 'ci/lint' || github.event.action != 'labeled'
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
@@ -124,7 +124,7 @@ jobs:
 
     if: |
       (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event.label.name == 'ci/build-unix' || github.event.type != labeled)
+      (github.event.label.name == 'ci/build-unix' || github.event.action != 'labeled')
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set PULUMI_TEST_SUBSET env var
@@ -222,7 +222,7 @@ jobs:
         dotnet: [3.1.x]
     if: |
       (github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) &&
-      (github.event.label.name == 'ci/build-windows' || github.event.type != labeled)
+      (github.event.label.name == 'ci/build-windows' || github.event.action != 'labeled')
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -51,10 +51,15 @@ jobs:
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
       - name: Remove Label ci/lint
-        uses: actions/github-script@v4
+      - uses: actions/github-script@v4
         with:
           script: |
-            github.rest.issue.removeLabel({owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, name: "ci/lint"});
+            github.issues.removeLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'ci/lint'
+            })
   sdk-lint:
     if: |
       github.event.label.name == 'ci/lint' || github.event.action != 'labeled'

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -305,7 +305,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Cleanup ci/lint Tag
     needs: [ sdk-lint, go-lint ]
-    if: github.event.label.name == 'ci/lint'
+    if: |
+      always() && github.event.label.name == 'ci/lint'
     steps:
       - name: Cleanup ci/lint Tag
         uses: actions/github-script@v4
@@ -326,7 +327,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Cleanup ci/build-unix Tag
     needs: [ build_and_test ]
-    if: github.event.label.name == 'ci/build-unix'
+    if: |
+      always() && github.event.label.name == 'ci/build-unix'
     steps:
       - name: Cleanup ci/build-unix Tag
         uses: actions/github-script@v4
@@ -347,7 +349,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Cleanup ci/build-windows Tag
     needs: [ windows-build ]
-    if: github.event.label.name == 'ci/build-windows'
+    if: |
+      always() && github.event.label.name == 'ci/build-windows'
     steps:
       - name: Cleanup ci/build-windows Tag
         uses: actions/github-script@v4

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -15,6 +15,9 @@
 
 - [codegen/schema] Add a `pulumi schema check` command to validate package schemas.
   [#7865](https://github.com/pulumi/pulumi/pull/7865)
+  
+- [ci] Add a tag that will run parts of the test system. 
+  [#7885](https://github.com/pulumi/pulumi/pull/7885)
 
 ### Bug Fixes
 - [automation/go] Fix loading of stack settings/configs from yaml files.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Attempt to run test workflows by adding tags. 
This includes 3 tags: `ci/lint`, `ci/build-windows`, and `ci/build-unix`. When these tags are added to a PR, they cause the CI to activate the relevant test. Other tests are skipped. This has no effect on test triggers already in place. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
       This needs to be tested manually. 
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [X] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
