### PR TITLE
Turn off grpc info log in Provider

### DIFF
--- a/pkg/resource/provider/host.go
+++ b/pkg/resource/provider/host.go
@@ -15,6 +15,8 @@
 package provider
 
 import (
+	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -24,6 +26,7 @@ import (
 	lumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/grpclog"
 )
 
 // HostClient is a client interface into the host's engine RPC interface.
@@ -34,6 +37,9 @@ type HostClient struct {
 
 // NewHostClient dials the target address, connects over gRPC, and returns a client interface.
 func NewHostClient(addr string) (*HostClient, error) {
+	// GRPC info logging to stdout introduces a race condition with the printing of the port, so drop them.
+	// See https://github.com/pulumi/pulumi/issues/7156
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
 	conn, err := grpc.Dial(
 		addr,
 		grpc.WithInsecure(),

--- a/pkg/resource/provider/host.go
+++ b/pkg/resource/provider/host.go
@@ -37,9 +37,9 @@ type HostClient struct {
 
 // NewHostClient dials the target address, connects over gRPC, and returns a client interface.
 func NewHostClient(addr string) (*HostClient, error) {
-	// GRPC info logging to stdout introduces a race condition with the printing of the port, so drop them.
+	// Provider client is sensitive to GRPC info logging to stdout, so ensure they are dropped.
 	// See https://github.com/pulumi/pulumi/issues/7156
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, ioutil.Discard, os.Stderr))
 	conn, err := grpc.Dial(
 		addr,
 		grpc.WithInsecure(),


### PR DESCRIPTION
Signed-off-by: Liam White <liam@tetrate.io>

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

As described in #7156. When I run Pulumi up I get:

```
pulumi:providers:tsb (tsb):
    error: tsb (resource) plugin [/Users/liamwhite/go/bin/pulumi-resource-tsb] wrote a non-numeric port to stdout ('2021-05-27T13:44:04.073942Z	info	[core]parsed scheme: ""'): strconv.Atoi: parsing "2021-05-27T13:44:04.073942Z\tinfo\t[core]parsed scheme: \"\"": invalid syntax
```

This is due to grpc logging to stdout before the provider writes the port to stdout. This PR explicitly sets the GRPC defaults to prevent users from overriding them and breaking their providers.

Fixes #7156

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works -> There are no tests in this section of the code, but I have verified manually that it solves my problem.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change. -> unsure if this requires a changelog update
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
