### PR TITLE
Add a command for the current package name

### DIFF
--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -181,6 +181,7 @@ func newStackCmd() *cobra.Command {
 	cmd.AddCommand(newStackRenameCmd())
 	cmd.AddCommand(newStackChangeSecretsProviderCmd())
 	cmd.AddCommand(newStackHistoryCmd())
+	cmd.AddCommand(newStackCurrentNameCmd())
 
 	return cmd
 }

--- a/pkg/cmd/pulumi/stack_current.go
+++ b/pkg/cmd/pulumi/stack_current.go
@@ -1,0 +1,44 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// Returns a command that displays the name of the current stack quickly.
+func newStackCurrentNameCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:    "current-name",
+		Short:  "Display the name of the current stack",
+		Args:   cmdutil.NoArgs,
+		Hidden: true,
+		Run: cmdutil.RunFunc(func(_ *cobra.Command, _ []string) error {
+			w, err := workspace.New()
+			if err != nil {
+				return err
+			}
+			s := w.Settings().Stack
+			fmt.Print(s)
+			return err
+		}),
+	}
+	return cmd
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

It would be great to be able to get some contextual information (like the current stack) and use it programmatically. We have this in `pulumi stack ls`. Unfortunately, this is not viable for certain use cases that require UI speed and latency. 

```
❯ hyperfine 'pulumi stack ls'
Benchmark #1: pulumi stack ls
  Time (mean ± σ):     345.2 ms ±  13.3 ms    [User: 138.9 ms, System: 31.1 ms]
  Range (min … max):   325.5 ms … 369.1 ms    10 runs
```

We would need to introduce a new command that does not perform a network authentication (which is where `pulumi stack ls` spends most of its time) to do this. 

```
❯ hyperfine pulumi 'pulumi stack current-name'
Benchmark #1: pulumi stack current-name
  Time (mean ± σ):      68.0 ms ±   1.9 ms    [User: 74.4 ms, System: 14.6 ms]
  Range (min … max):    65.9 ms …  74.6 ms    18 runs
 ```

This new (hidden) command is intended to solve this problem. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
