### PR TITLE
Fixed "unknown property '0'" error

### DIFF
--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -70,9 +70,10 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 	}
 
 	if keyType == NumberType {
-
 		// The key is of NumberType, which means that it refers to the legacy HCL indexation syntax (".0", ".1", etc)
 		return t, nil
+	}
+
 	// The key is of PropertyType, which means that it is most likely a property (".skuName", "tenantId", etc)
 	keyString, err := convert.Convert(key, cty.String)
 	contract.Assert(err == nil)
@@ -84,7 +85,6 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 		return DynamicType, hcl.Diagnostics{unknownObjectProperty(propertyName, traverser.SourceRange())}
 	}
 	return propertyType, nil
-	}
 }
 
 // Equals returns true if this type has the same identity as the given type.

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -73,20 +73,17 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 
 		// The key is of NumberType, which means that it refers to the legacy HCL indexation syntax (".0", ".1", etc)
 		return t, nil
-	} else {
+	// The key is of PropertyType, which means that it is most likely a property (".skuName", "tenantId", etc)
+	keyString, err := convert.Convert(key, cty.String)
+	contract.Assert(err == nil)
 
-		// The key is of PropertyType, which means that it is most likely a property (".skuName", "tenantId", etc)
-		keyString, err := convert.Convert(key, cty.String)
-		contract.Assert(err == nil)
-
-		propertyName := keyString.AsString()
-		propertyType, hasProperty := t.Properties[propertyName]
-		if !hasProperty {
-
-			// The specific key can't be found in our property list.
-			return DynamicType, hcl.Diagnostics{unknownObjectProperty(propertyName, traverser.SourceRange())}
-		}
-		return propertyType, nil
+	propertyName := keyString.AsString()
+	propertyType, hasProperty := t.Properties[propertyName]
+	if !hasProperty {
+		// The specific key can't be found in our property list.
+		return DynamicType, hcl.Diagnostics{unknownObjectProperty(propertyName, traverser.SourceRange())}
+	}
+	return propertyType, nil
 	}
 }
 

--- a/pkg/codegen/hcl2/model/type_object.go
+++ b/pkg/codegen/hcl2/model/type_object.go
@@ -69,15 +69,25 @@ func (t *ObjectType) Traverse(traverser hcl.Traverser) (Traversable, hcl.Diagnos
 		return t.propertyUnion, nil
 	}
 
-	keyString, err := convert.Convert(key, cty.String)
-	contract.Assert(err == nil)
+	if keyType == NumberType {
 
-	propertyName := keyString.AsString()
-	propertyType, hasProperty := t.Properties[propertyName]
-	if !hasProperty {
-		return DynamicType, hcl.Diagnostics{unknownObjectProperty(propertyName, traverser.SourceRange())}
+		// The key is of NumberType, which means that it refers to the legacy HCL indexation syntax (".0", ".1", etc)
+		return t, nil
+	} else {
+
+		// The key is of PropertyType, which means that it is most likely a property (".skuName", "tenantId", etc)
+		keyString, err := convert.Convert(key, cty.String)
+		contract.Assert(err == nil)
+
+		propertyName := keyString.AsString()
+		propertyType, hasProperty := t.Properties[propertyName]
+		if !hasProperty {
+
+			// The specific key can't be found in our property list.
+			return DynamicType, hcl.Diagnostics{unknownObjectProperty(propertyName, traverser.SourceRange())}
+		}
+		return propertyType, nil
 	}
-	return propertyType, nil
 }
 
 // Equals returns true if this type has the same identity as the given type.


### PR DESCRIPTION
# Description
No longer throws an error when encountering the [legacy HCL indexation operator](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md) ".0"

The following HCL example now successfully converts.

Original:
```hcl
...
    access_policy {
        tenant_id = azurerm_log_analytics_cluster.example.identity.0.tenant_id
        object_id = azurerm_log_analytics_cluster.example.identity.0.principal_id

        key_permissions = [
            "get",
            "unwrapkey",
            "wrapkey",
        ]
    }
}
...
```
Result:
```ts
...
        {
            tenantId: exampleCluster.identity.apply(identity => identity[0].tenantId),
            objectId: exampleCluster.identity.apply(identity => identity[0].principalId),
            keyPermissions: [
                "get",
                "unwrapkey",
                "wrapkey",
            ],
        },
    ],
...
```