### PR TITLE
Fix lint

### DIFF
--- a/pkg/backend/watch.go
+++ b/pkg/backend/watch.go
@@ -1,3 +1,4 @@
+//go:build !darwin || !arm64
 // +build !darwin !arm64
 
 // Copyright 2016-2019, Pulumi Corporation.

--- a/sdk/go/common/util/cmdutil/child.go
+++ b/sdk/go/common/util/cmdutil/child.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//go:build !windows
 // +build !windows
 
 package cmdutil

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/proxy_unix.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/proxy_unix.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package main
 

--- a/sdk/python/shim_unix.go
+++ b/sdk/python/shim_unix.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 // Copyright 2020, Pulumi Corporation.
 //


### PR DESCRIPTION
# Description

Fixed build failures around Go lint. Apparently there is a change between 1.16 and 1.17 on the conditional compilation syntax.

```
cd pulumi/sdk
docker run --rm -v $(pwd)/..:/pulumi -w /pulumi/sdk golangci/golangci-lint:latest golangci-lint run -c ../.golangci.yml
```

Fixes derived by running `gofmt -w -s` on offending files in the same container.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
