### PR TITLE
Fix CHANGELOG_PENDING.md spelling

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -5,12 +5,12 @@
 
 - [codegen/python] - Add helper function forms `$fn_output` that
   accept `Input`s, return an `Output`, and wrap the underlying `$fn`
-  call. This change addreses
+  call. This change addresses
   [#5758](https://github.com/pulumi/pulumi/issues/) for Python,
   making it easier to compose functions/datasources with Pulumi
   resources. [#7784](https://github.com/pulumi/pulumi/pull/7784)
 
-- [cli/about] - Add comand for debug information
+- [cli/about] - Add command for debug information
   [#7817](https://github.com/pulumi/pulumi/pull/7817)
 
 - [codegen/schema] Add a `pulumi schema check` command to validate package schemas.


### PR DESCRIPTION
One of these is mine. Sorry

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

`addreses` is spelled `addresses` and `comand` is spelled `command`. 

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
