### PR TITLE
[sdk/nodejs] Marshal output values

### DIFF
--- a/sdk/nodejs/runtime/invoke.ts
+++ b/sdk/nodejs/runtime/invoke.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -255,7 +255,10 @@ export function call<T>(tok: string, props: Inputs, res?: Resource): Output<T> {
                 version = res.__version;
             }
 
-            const [serialized, propertyDepsResources] = await serializePropertiesReturnDeps(`call:${tok}`, props);
+            // We keep output values when serializing inputs for call.
+            const [serialized, propertyDepsResources] = await serializePropertiesReturnDeps(`call:${tok}`, props, {
+                keepOutputValues: true,
+            });
             log.debug(`Call RPC prepared: tok=${tok}` + excessiveDebugOutput ? `, obj=${JSON.stringify(serialized)}` : ``);
 
             const req = await createCallRequest(tok, serialized, propertyDepsResources, provider, version);

--- a/sdk/nodejs/runtime/resource.ts
+++ b/sdk/nodejs/runtime/resource.ts
@@ -600,7 +600,8 @@ function addAll<T>(to: Set<T>, from: Set<T>) {
     }
 }
 
-async function getAllTransitivelyReferencedResourceURNs(resources: Set<Resource>): Promise<Set<string>> {
+/** @internal */
+export async function getAllTransitivelyReferencedResourceURNs(resources: Set<Resource>): Promise<Set<string>> {
     // Go through 'resources', but transitively walk through **Component** resources, collecting any
     // of their child resources.  This way, a Component acts as an aggregation really of all the
     // reachable resources it parents.  This walking will stop when it hits custom resources.

--- a/sdk/nodejs/runtime/settings.ts
+++ b/sdk/nodejs/runtime/settings.ts
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -555,6 +555,15 @@ export function monitorSupportsSecrets(): Promise<boolean> {
  */
 export async function monitorSupportsResourceReferences(): Promise<boolean> {
     return monitorSupportsFeature("resourceReferences");
+}
+
+/**
+ * monitorSupportsOutputValues returns a promise that when resolved tells you if the resource monitor we are
+ * connected to is able to support output values across its RPC interface. When it does, we marshal outputs
+ * in a special way.
+ */
+export async function monitorSupportsOutputValues(): Promise<boolean> {
+    return monitorSupportsFeature("outputValues");
 }
 
 // sxsRandomIdentifier is a module level global that is transfered to process.env.


### PR DESCRIPTION
This change adds support for marshaling outputs as output values in the Node.js SDK.

Fixes #7850

Part of #7434