### PR TITLE
[sdk/python] Marshal output values

### DIFF
--- a/sdk/python/lib/pulumi/runtime/invoke.py
+++ b/sdk/python/lib/pulumi/runtime/invoke.py
@@ -183,7 +183,8 @@ def call(tok: str, props: 'Inputs', res: Optional['Resource'] = None, typ: Optio
             # Serialize out all props to their final values. In doing so, we'll also collect all the Resources pointed to
             # by any Dependency objects we encounter, adding them to 'implicit_dependencies'.
             property_dependencies_resources: Dict[str, List['Resource']] = {}
-            inputs = await rpc.serialize_properties(props, property_dependencies_resources)
+            # We keep output values when serializing inputs for call.
+            inputs = await rpc.serialize_properties(props, property_dependencies_resources, keep_output_values=True)
 
             property_dependencies = {}
             for key, property_deps in property_dependencies_resources.items():

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -100,7 +100,10 @@ async def prepare_resource(res: 'Resource',
     if typ is not None:
         translate = None
 
-    serialized_props = await rpc.serialize_properties(props, property_dependencies_resources, translate, typ)
+    # To initially scope the use of this new feature, we only keep output values when
+    # remote is true (for multi-lang components).
+    serialized_props = await rpc.serialize_properties(props, property_dependencies_resources, translate, typ,
+        keep_output_values=remote)
 
     # Wait for our parent to resolve
     parent_urn: Optional[str] = ""

--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -290,7 +290,7 @@ async def serialize_property(value: 'Input[Any]',
         value = await serialize_property(output.future(), deps, input_transformer, typ, keep_output_values=False)
 
         if keep_output_values and await settings.monitor_supports_output_values():
-            # TODO expand the dependencies
+            # TODO[pulumi/pulumi#7977]: Expand dependencies
             dependencies: Set[str] = set()
             for resource in value_resources:
                 urn = await serialize_property(resource.urn, deps, input_transformer, keep_output_values=False)

--- a/sdk/python/lib/pulumi/runtime/settings.py
+++ b/sdk/python/lib/pulumi/runtime/settings.py
@@ -262,6 +262,10 @@ async def monitor_supports_resource_references() -> bool:
     return await monitor_supports_feature("resourceReferences")
 
 
+async def monitor_supports_output_values() -> bool:
+    return await monitor_supports_feature("outputValues")
+
+
 def reset_options(project: Optional[str] = None,
                   stack: Optional[str] = None,
                   parallel: Optional[int] = None,

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -14,11 +14,12 @@
 import asyncio
 import unittest
 from enum import Enum
-from typing import Any, Dict, List, Mapping, Optional, Sequence, cast
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, cast
 
 from google.protobuf import struct_pb2
-from pulumi.resource import ComponentResource, CustomResource, ResourceOptions
-from pulumi.runtime import Mocks, MockCallArgs, MockResourceArgs, ResourceModule, rpc, rpc_manager, known_types, set_mocks, settings
+from google.protobuf import json_format
+from pulumi.resource import ComponentResource, CustomResource, DependencyResource, Resource, ResourceOptions
+from pulumi.runtime import Mocks, MockCallArgs, MockResourceArgs, ResourceModule, rpc, rpc_manager, set_mocks, settings
 from pulumi import Input, Output, UNKNOWN, input_type
 from pulumi.asset import (
     FileAsset,
@@ -1434,3 +1435,42 @@ class TypeMetaDataSerializationTests(unittest.TestCase):
         self.assertEqual("second", result.some_bar["a"]["the_first"])
         self.assertEqual({"the_second": "later"}, result.some_bar["a"].the_second)
         self.assertEqual({"the_second": "later"}, result.some_bar["a"]["the_second"])
+
+
+class OutputValueSerializationTests(unittest.TestCase):
+    @pulumi_test
+    async def test_serialize(self):
+        settings.SETTINGS.feature_support["outputValues"] = True
+
+        def gen_test_parameters():
+            for value in [None, 0, 1, "", "hi", {}, []]:
+                for deps in [[], ["fakeURN1", "fakeURN2"]]:
+                    for is_known in [True, False]:
+                        for is_secret in [True, False]:
+                            yield (value, deps, is_known, is_secret)
+
+        for (value, deps, is_known, is_secret) in gen_test_parameters():
+            with self.subTest(value=value, deps=deps, is_known=is_known, is_secret=is_secret):
+                resources: Set[Resource] = set(map(DependencyResource, deps))
+
+                obj: Dict[str, Any] = {
+                    rpc._special_sig_key: rpc._special_output_value_sig
+                }
+                if is_known:
+                    obj["value"] = value
+                if is_secret:
+                    obj["secret"] = is_secret
+                if deps:
+                    obj["dependencies"] = deps
+
+                inputs = {"value": Output(resources, future(value), future(is_known), future(is_secret))}
+                expected = struct_pb2.Struct()
+                expected["value"] = obj
+
+                actual = await rpc.serialize_properties(inputs, {}, keep_output_values=True)
+                self.assertDictEqual(json_format.MessageToDict(expected), json_format.MessageToDict(actual))
+
+def future(val):
+    fut = asyncio.Future()
+    fut.set_result(val)
+    return fut


### PR DESCRIPTION
This change adds support for marshaling outputs as output values in the Python SDK.

Fixes #7851

Related to #7925
Part of #7434