### PR TITLE
Add CodegenUtilities to C# SDK in prep for 5758

### DIFF
--- a/sdk/dotnet/Pulumi/Core/CodegenUtilities.cs
+++ b/sdk/dotnet/Pulumi/Core/CodegenUtilities.cs
@@ -1,0 +1,50 @@
+// Copyright 2016-2021, Pulumi Corporation
+
+using System.Collections.Generic;
+
+namespace Pulumi.Utilities
+{
+    /// <summary>
+    /// Supports automatically generated Pulumi code, such as
+    /// `pulumi-azure-native` provider.
+    /// </summary>
+    public static class CodegenUtilities
+    {
+        public static Input<Dictionary<string,T>> ToDictionary<T>(this InputMap<T> inputMap)
+            => inputMap.Apply(v => new Dictionary<string,T>(v));
+
+        public static Input<List<T>> ToList<T>(this InputList<T> inputList)
+            => inputList.Apply(v => new List<T>(v));
+
+        public sealed class Boxed
+        {
+            public object? Value { get; private set; }
+
+            private Boxed(object? value)
+            {
+                Value = value;
+            }
+
+            public static Boxed Create(object? value)
+                => new Boxed(value);
+
+            public void Set(object target, string propertyName)
+            {
+                var v = this.Value;
+                if (v != null)
+                {
+                    var p = target.GetType().GetProperty(propertyName);
+                    if (p != null)
+                    {
+                        p.SetValue(target, v);
+                    }
+                }
+            }
+        }
+
+        public static Output<Boxed> Box<T>(this Input<T>? input)
+            => input == null
+                ? Output.Create(Boxed.Create(null))
+                : input.Apply(v => Boxed.Create(v));
+    }
+}

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -372,3 +372,11 @@ static Pulumi.Urn.Create(Pulumi.Input<string> name, Pulumi.Input<string> type, P
 static readonly Pulumi.CallArgs.Empty -> Pulumi.CallArgs
 static readonly Pulumi.InvokeArgs.Empty -> Pulumi.InvokeArgs
 static readonly Pulumi.ResourceArgs.Empty -> Pulumi.ResourceArgs
+Pulumi.Utilities.CodegenUtilities
+Pulumi.Utilities.CodegenUtilities.Boxed
+Pulumi.Utilities.CodegenUtilities.Boxed.Set(object target, string propertyName) -> void
+static Pulumi.Utilities.CodegenUtilities.Boxed.Create(object value) -> Pulumi.Utilities.CodegenUtilities.Boxed
+Pulumi.Utilities.CodegenUtilities.Boxed.Value.get -> object
+static Pulumi.Utilities.CodegenUtilities.Box<T>(this Pulumi.Input<T> input) -> Pulumi.Output<Pulumi.Utilities.CodegenUtilities.Boxed>
+static Pulumi.Utilities.CodegenUtilities.ToDictionary<T>(this Pulumi.InputMap<T> inputMap) -> Pulumi.Input<System.Collections.Generic.Dictionary<string, T>>
+static Pulumi.Utilities.CodegenUtilities.ToList<T>(this Pulumi.InputList<T> inputList) -> Pulumi.Input<System.Collections.Generic.List<T>>


### PR DESCRIPTION
# Description

This is the part of https://github.com/pulumi/pulumi/pull/7899 that needs to ship first so that providers upgrade to this SDK. It has been tested as part of 7899.



## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
