### PR TITLE
feat: Improve error messages for (un)marshalling

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,7 @@
 ### Improvements
 
+- [sdk] Improve error messages for (un)marshalling properties
+  [#7936](https://github.com/pulumi/pulumi/pull/7936)
+
 ### Bug Fixes
 


### PR DESCRIPTION
# Description

Currently whenever an issue occurs in `UnmarshalProperties` and
`MarshalProperties` the offending property is hidden and very difficult
to track down.

This commit changes the behavior. For `Assets` and `Archives` the error
message now includes the URI and for other properties it includes the
key of the `PropertyMap`.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

Existing tests use new functionality.

- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
