### PR TITLE
 Support "lifting" single-valued method returns to their return type

### DIFF
--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -108,6 +108,9 @@ type pkgContext struct {
 	// Name overrides set in GoPackageInfo
 	modToPkg         map[string]string // Module name -> package name
 	pkgImportAliases map[string]string // Package name -> import alias
+
+	// Determines whether to make single-return-value methods return an output struct or the value
+	liftSingleValueMethodReturns bool
 }
 
 func (pkg *pkgContext) detailsForType(t schema.Type) *typeDetails {
@@ -1529,6 +1532,8 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 		methodName := Title(method.Name)
 		f := method.Function
 
+		shouldLiftReturn := pkg.liftSingleValueMethodReturns && f.Outputs != nil && len(f.Outputs.Properties) == 1
+
 		var args []*schema.Property
 		if f.Inputs != nil {
 			for _, arg := range f.Inputs.InputShape.Properties {
@@ -1547,6 +1552,8 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 		var retty string
 		if f.Outputs == nil {
 			retty = "error"
+		} else if shouldLiftReturn {
+			retty = fmt.Sprintf("(%s, error)", pkg.outputType(f.Outputs.Properties[0].Type))
 		} else {
 			retty = fmt.Sprintf("(%s%sResultOutput, error)", name, methodName)
 		}
@@ -1568,11 +1575,23 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 		// Now simply invoke the runtime function with the arguments.
 		outputsType := "pulumi.AnyOutput"
 		if f.Outputs != nil {
-			outputsType = fmt.Sprintf("%s%sResultOutput", name, methodName)
+			if shouldLiftReturn {
+				outputsType = fmt.Sprintf("%s%sResultOutput", camel(name), methodName)
+			} else {
+				outputsType = fmt.Sprintf("%s%sResultOutput", name, methodName)
+			}
 		}
 		fmt.Fprintf(w, "\t%s, err := ctx.Call(%q, %s, %s{}, r)\n", resultVar, f.Token, inputsVar, outputsType)
 		if f.Outputs == nil {
 			fmt.Fprintf(w, "\treturn err\n")
+		} else if shouldLiftReturn {
+			// Check the error before proceeding.
+			fmt.Fprintf(w, "\tif err != nil {\n")
+			fmt.Fprintf(w, "\t\treturn %s{}, err\n", pkg.outputType(f.Outputs.Properties[0].Type))
+			fmt.Fprintf(w, "\t}\n")
+
+			// Get the name of the method to return the output
+			fmt.Fprintf(w, "\treturn %s.(%s).%s(), nil\n", resultVar, camel(outputsType), Title(f.Outputs.Properties[0].Name))
 		} else {
 			// Check the error before proceeding.
 			fmt.Fprintf(w, "\tif err != nil {\n")
@@ -1608,23 +1627,30 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 			fmt.Fprintf(w, "}\n\n")
 		}
 		if f.Outputs != nil {
+			outputStructName := name
+
+			// Don't export the result struct if we're lifting the value
+			if shouldLiftReturn {
+				outputStructName = camel(name)
+			}
+
 			fmt.Fprintf(w, "\n")
-			pkg.genPlainType(w, fmt.Sprintf("%s%sResult", name, methodName), f.Outputs.Comment, "",
+			pkg.genPlainType(w, fmt.Sprintf("%s%sResult", outputStructName, methodName), f.Outputs.Comment, "",
 				f.Outputs.Properties)
 
 			fmt.Fprintf(w, "\n")
-			fmt.Fprintf(w, "type %s%sResultOutput struct{ *pulumi.OutputState }\n\n", name, methodName)
+			fmt.Fprintf(w, "type %s%sResultOutput struct{ *pulumi.OutputState }\n\n", outputStructName, methodName)
 
-			fmt.Fprintf(w, "func (%s%sResultOutput) ElementType() reflect.Type {\n", name, methodName)
-			fmt.Fprintf(w, "\treturn reflect.TypeOf((*%s%sResult)(nil)).Elem()\n", name, methodName)
+			fmt.Fprintf(w, "func (%s%sResultOutput) ElementType() reflect.Type {\n", outputStructName, methodName)
+			fmt.Fprintf(w, "\treturn reflect.TypeOf((*%s%sResult)(nil)).Elem()\n", outputStructName, methodName)
 			fmt.Fprintf(w, "}\n")
 
 			for _, p := range f.Outputs.Properties {
 				fmt.Fprintf(w, "\n")
 				printCommentWithDeprecationMessage(w, p.Comment, p.DeprecationMessage, false)
-				fmt.Fprintf(w, "func (o %s%sResultOutput) %s() %s {\n", name, methodName, Title(p.Name),
+				fmt.Fprintf(w, "func (o %s%sResultOutput) %s() %s {\n", outputStructName, methodName, Title(p.Name),
 					pkg.outputType(p.Type))
-				fmt.Fprintf(w, "\treturn o.ApplyT(func(v %s%sResult) %s { return v.%s }).(%s)\n", name, methodName,
+				fmt.Fprintf(w, "\treturn o.ApplyT(func(v %s%sResult) %s { return v.%s }).(%s)\n", outputStructName, methodName,
 					pkg.typeString(codegen.ResolvedType(p.Type)), Title(p.Name), pkg.outputType(p.Type))
 				fmt.Fprintf(w, "}\n")
 			}
@@ -1682,7 +1708,11 @@ func (pkg *pkgContext) genResource(w io.Writer, r *schema.Resource, generateReso
 	fmt.Fprintf(w, "\tpulumi.RegisterOutputType(%sOutput{})\n", name)
 	for _, method := range r.Methods {
 		if method.Function.Outputs != nil {
-			fmt.Fprintf(w, "\tpulumi.RegisterOutputType(%s%sResultOutput{})\n", name, Title(method.Name))
+			if len(method.Function.Outputs.Properties) == 1 {
+				fmt.Fprintf(w, "\tpulumi.RegisterOutputType(%s%sResultOutput{})\n", camel(name), Title(method.Name))
+			} else {
+				fmt.Fprintf(w, "\tpulumi.RegisterOutputType(%s%sResultOutput{})\n", name, Title(method.Name))
+			}
 		}
 	}
 
@@ -2389,20 +2419,21 @@ func generatePackageContextMap(tool string, pkg *schema.Package, goInfo GoPackag
 		pack, ok := packages[mod]
 		if !ok {
 			pack = &pkgContext{
-				pkg:              pkg,
-				mod:              mod,
-				importBasePath:   goInfo.ImportBasePath,
-				rootPackageName:  goInfo.RootPackageName,
-				typeDetails:      map[schema.Type]*typeDetails{},
-				names:            codegen.NewStringSet(),
-				schemaNames:      codegen.NewStringSet(),
-				renamed:          map[string]string{},
-				duplicateTokens:  map[string]bool{},
-				functionNames:    map[*schema.Function]string{},
-				tool:             tool,
-				modToPkg:         goInfo.ModuleToPackage,
-				pkgImportAliases: goInfo.PackageImportAliases,
-				packages:         packages,
+				pkg:                          pkg,
+				mod:                          mod,
+				importBasePath:               goInfo.ImportBasePath,
+				rootPackageName:              goInfo.RootPackageName,
+				typeDetails:                  map[schema.Type]*typeDetails{},
+				names:                        codegen.NewStringSet(),
+				schemaNames:                  codegen.NewStringSet(),
+				renamed:                      map[string]string{},
+				duplicateTokens:              map[string]bool{},
+				functionNames:                map[*schema.Function]string{},
+				tool:                         tool,
+				modToPkg:                     goInfo.ModuleToPackage,
+				pkgImportAliases:             goInfo.PackageImportAliases,
+				packages:                     packages,
+				liftSingleValueMethodReturns: goInfo.LiftSingleValueMethodReturns,
 			}
 			packages[mod] = pack
 		}

--- a/pkg/codegen/go/importer.go
+++ b/pkg/codegen/go/importer.go
@@ -49,6 +49,9 @@ type GoPackageInfo struct {
 	// The version of the Pulumi SDK used with this provider, e.g. 3.
 	// Used to generate doc links for pulumi builtin types. If omitted, the latest SDK version is used.
 	PulumiSDKVersion int `json:"pulumiSDKVersion,omitempty"`
+
+	// Determines whether to make single-return-value methods return an output struct or the value.
+	LiftSingleValueMethodReturns bool `json:"liftSingleValueMethodReturns,omitempty"`
 }
 
 // Importer implements schema.Language for Go.

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -58,6 +58,8 @@ type NodePackageInfo struct {
 	PluginName string `json:"pluginName,omitempty"`
 	// The version of the plugin, which might be different from the version of the package..
 	PluginVersion string `json:"pluginVersion,omitempty"`
+	// Determines whether to make single-return-value methods return an output object or the single value.
+	LiftSingleValueMethodReturns bool `json:"liftSingleValueMethodReturns,omitempty"`
 }
 
 // NodeObjectInfo contains NodeJS-specific information for an object.

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -108,6 +108,9 @@ type modContext struct {
 	// Name overrides set in PackageInfo
 	modNameOverrides map[string]string // Optional overrides for Pulumi module names
 	compatibility    string            // Toggle compatibility mode for a specified target.
+
+	// Determine whether to lift single-value method return values
+	liftSingleValueMethodReturns bool
 }
 
 func (mod *modContext) isTopLevel() bool {
@@ -1445,12 +1448,20 @@ func (mod *modContext) genMethods(w io.Writer, res *schema.Resource) {
 		methodName := PyName(method.Name)
 		fun := method.Function
 
+		shouldLiftReturn := mod.liftSingleValueMethodReturns && method.Function.Outputs != nil && len(method.Function.Outputs.Properties) == 1
+
 		// If there is a return type, emit it.
-		var retTypeName, retTypeNameQualified, retTypeNameQualifiedOutput string
+		var retTypeName, retTypeNameQualified, retTypeNameQualifiedOutput, methodRetType string
 		if fun.Outputs != nil {
 			retTypeName = genReturnType(method)
 			retTypeNameQualified = fmt.Sprintf("%s.%s", resourceName(res), retTypeName)
 			retTypeNameQualifiedOutput = fmt.Sprintf("pulumi.Output['%s']", retTypeNameQualified)
+
+			if shouldLiftReturn {
+				methodRetType = fmt.Sprintf("pulumi.Output['%s']", mod.pyType(fun.Outputs.Properties[0].Type))
+			} else {
+				methodRetType = retTypeNameQualifiedOutput
+			}
 		}
 
 		var args []*schema.Property
@@ -1496,7 +1507,7 @@ func (mod *modContext) genMethods(w io.Writer, res *schema.Resource) {
 			fmt.Fprintf(w, ",\n%s%s: %s%s", indent, pname, ty, defaultValue)
 		}
 		if retTypeNameQualifiedOutput != "" {
-			fmt.Fprintf(w, ") -> %s:\n", retTypeNameQualifiedOutput)
+			fmt.Fprintf(w, ") -> %s:\n", methodRetType)
 		} else {
 			fmt.Fprintf(w, ") -> None:\n")
 		}
@@ -1528,14 +1539,24 @@ func (mod *modContext) genMethods(w io.Writer, res *schema.Resource) {
 		}
 
 		// Now simply call the function with the arguments.
-		var typ, ret string
+		var typ string
 		if retTypeNameQualified != "" {
 			// Pass along the private output_type we generated, so any nested output classes are instantiated by
 			// the call.
 			typ = fmt.Sprintf(", typ=%s", retTypeNameQualified)
-			ret = "return "
 		}
-		fmt.Fprintf(w, "        %spulumi.runtime.call('%s', __args__, res=__self__%s)\n", ret, fun.Token, typ)
+
+		if method.Function.Outputs == nil {
+			fmt.Fprintf(w, "        pulumi.runtime.call('%s', __args__, res=__self__%s)\n", fun.Token, typ)
+		} else if shouldLiftReturn {
+			// Store the return in a variable and return the property output
+			fmt.Fprintf(w, "        res = pulumi.runtime.call('%s', __args__, res=__self__%s)\n", fun.Token, typ)
+			fmt.Fprintf(w, "        return res.%s\n", PyName(fun.Outputs.Properties[0].Name))
+		} else {
+			// Otherwise return the call directly
+			fmt.Fprintf(w, "        return pulumi.runtime.call('%s', __args__, res=__self__%s)\n", fun.Token, typ)
+		}
+
 		fmt.Fprintf(w, "\n")
 	}
 
@@ -2535,12 +2556,13 @@ func generateModuleContextMap(tool string, pkg *schema.Package, info PackageInfo
 		mod, ok := modules[modName]
 		if !ok {
 			mod = &modContext{
-				pkg:              p,
-				pyPkgName:        pyPkgName,
-				mod:              modName,
-				tool:             tool,
-				modNameOverrides: info.ModuleNameOverrides,
-				compatibility:    info.Compatibility,
+				pkg:                          p,
+				pyPkgName:                    pyPkgName,
+				mod:                          modName,
+				tool:                         tool,
+				modNameOverrides:             info.ModuleNameOverrides,
+				compatibility:                info.Compatibility,
+				liftSingleValueMethodReturns: info.LiftSingleValueMethodReturns,
 			}
 
 			if modName != "" && p == pkg {

--- a/pkg/codegen/python/importer.go
+++ b/pkg/codegen/python/importer.go
@@ -49,6 +49,8 @@ type PackageInfo struct {
 	UsesIOClasses bool `json:"usesIOClasses,omitempty"`
 	// Indicates whether the pulumiplugin.json file should be generated.
 	EmitPulumiPluginFile bool `json:"emitPulumiPluginFile,omitempty"`
+	// Determines whether to make single-return-value methods return an output object or the single value.
+	LiftSingleValueMethodReturns bool `json:"liftSingleValueMethodReturns,omitempty"`
 }
 
 // Importer implements schema.Language for Python.


### PR DESCRIPTION
# Description

This commit allows lifting single valued method returns rather than using an output structure in each of the three languages we are currently targeting.

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works

No current test coverage - I think this can be added to method tests however.

- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change

Not a user-facing change

- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version

N/A