### PR TITLE
Better logging from ConcurrentUpdateError test

### DIFF
--- a/sdk/go/auto/errors_test.go
+++ b/sdk/go/auto/errors_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestConcurrentUpdateError(t *testing.T) {
+	n := 50
 	ctx := context.Background()
 	pName := "conflict_error"
 	sName := fmt.Sprintf("int_test%d", rangeIn(10000000, 99999999))
@@ -50,7 +51,7 @@ func TestConcurrentUpdateError(t *testing.T) {
 	c := make(chan error)
 
 	// parallel updates to cause conflict
-	for i := 0; i < 50; i++ {
+	for i := 0; i < n; i++ {
 		go func() {
 			_, err := s.Up(ctx)
 			c <- err
@@ -58,11 +59,16 @@ func TestConcurrentUpdateError(t *testing.T) {
 	}
 
 	conflicts := 0
+	var otherErrors []error
 
-	for i := 0; i < 50; i++ {
+	for i := 0; i < n; i++ {
 		err := <-c
-		if IsConcurrentUpdateError(err) {
-			conflicts++
+		if err != nil {
+			if IsConcurrentUpdateError(err) {
+				conflicts++
+			} else {
+				otherErrors = append(otherErrors, err)
+			}
 		}
 	}
 
@@ -74,8 +80,16 @@ func TestConcurrentUpdateError(t *testing.T) {
 		t.FailNow()
 	}
 
-	// should have at least one conflict
-	assert.Greater(t, conflicts, 0)
+	if len(otherErrors) > 0 {
+		t.Logf("Concurrent updates incurred %d non-conflict errors, including:", len(otherErrors))
+		for _, err := range otherErrors {
+			t.Error(err)
+		}
+	}
+
+	if conflicts == 0 {
+		t.Errorf("Expected at least one conflict error from the %d concurrent updates, but got none", n)
+	}
 }
 
 func TestInlineConcurrentUpdateError(t *testing.T) {


### PR DESCRIPTION
# Description

So we have seen TestConcurrentUpdateError flake up on CI but it is not clear why. I have added a bit more diagnostic output information in cases of failures. Note that this makes it stricter in not accepting non-conflict errors from the updates.

Running it on my machine a bunch of times has indeed ran into two problems:

- reproduce the 0 conflicts situation, all updates succeed; this is a legit though unlikely outcome? reducing probability can be achieved by increasing N currently N=50. It feels a bit worrisome though due to already high resource use.

- more frequently I get 404 not found errors like below. I wonder what is not found, the stack? These are more concerning to me. How can it be possible? Does `NewStackLocalSource` return success and unblock the auto api caller before the service backend has setup the stack? We might need to account for eventual consistency in the service backend. Anyway it sounds like a legit issue that warrants a retry/backoff loop somewhere (key is where?) around 404, if these are from the stack issue.

```
=== RUN   TestConcurrentUpdateError
    errors_test.go:84: Concurrent updates incurred 1 non-conflict errors, including:
    errors_test.go:86: failed to run update: exit status 255
        code: 255
        stdout: Updating (int_test22968189)
        
        
        stderr: warning: A new version of Pulumi is available. To upgrade from version '3.11.0' to '3.12.0', visit https://pulumi.com/docs/reference/install/ for manual instructions and release notes.
        error: [404] Not found
```

I'll let it run a few times in CI.

I think we should skip it though. The cost is high. I get this from my `ps` (see below). So N=50 processes in flight. And it's at best probabilistic. Perhaps there's a lower-cost way to verify locking in Auto API?

```
44439 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44440 s003  S+     0:00.19 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44441 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44442 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44443 s003  S+     0:00.24 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44444 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44446 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44448 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44449 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44450 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44452 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44453 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44454 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44456 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44457 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44458 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44459 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44460 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44461 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44462 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44464 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44466 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44467 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44469 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44470 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44473 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44474 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44475 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44476 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44477 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44479 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44480 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44481 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44482 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44483 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44484 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44485 s003  S+     0:00.18 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44486 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
44487 s003  S+     0:00.17 pulumi up --yes --skip-preview --exec-kind=auto.local --stack t0yv0/conflict_error/int_test9914759
```

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
e You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
