### PR TITLE
Iwahbe/7881/thread replace on chages through sdks

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,5 +11,5 @@
 - [cli] Use json.Unmarshal instead of custom parser
   [#7954](https://github.com/pulumi/pulumi/pull/7954)
 
-- [sdk] - Thread replaceOnChanges through Go and .NET
+- [sdk/{go,dotnet}] - Thread replaceOnChanges through Go and .NET
   [#7967](https://github.com/pulumi/pulumi/pull/7967)

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -10,3 +10,6 @@
 
 - [cli] Use json.Unmarshal instead of custom parser
   [#7954](https://github.com/pulumi/pulumi/pull/7954)
+
+- [sdk] - Thread replaceOnChanges through Go and .NET
+  [#7967](https://github.com/pulumi/pulumi/pull/7967)

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResource.cs
@@ -92,10 +92,12 @@ namespace Pulumi
             };
 
             if (customOpts != null)
+            {
                 request.AdditionalSecretOutputs.AddRange(customOpts.AdditionalSecretOutputs);
+                request.ReplaceOnChanges.AddRange(customOpts.ReplaceOnChanges);
+            }
 
             request.IgnoreChanges.AddRange(options.IgnoreChanges);
-            request.ReplaceOnChanges.AddRange(options.ReplaceOnChanges);
 
             return request;
         }

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_RegisterResource.cs
@@ -95,6 +95,7 @@ namespace Pulumi
                 request.AdditionalSecretOutputs.AddRange(customOpts.AdditionalSecretOutputs);
 
             request.IgnoreChanges.AddRange(options.IgnoreChanges);
+            request.ReplaceOnChanges.AddRange(options.ReplaceOnChanges);
 
             return request;
         }

--- a/sdk/go/pulumi/context.go
+++ b/sdk/go/pulumi/context.go
@@ -1231,6 +1231,7 @@ func (ctx *Context) prepareResourceInputs(res Resource, props Input, t string, o
 		aliases:                 aliases,
 		additionalSecretOutputs: resOpts.additionalSecretOutputs,
 		version:                 state.version,
+		replaceOnChanges:        resOpts.replaceOnChanges,
 	}, nil
 }
 
@@ -1255,6 +1256,7 @@ type resourceOpts struct {
 	importID                ID
 	ignoreChanges           []string
 	additionalSecretOutputs []string
+	replaceOnChanges        []string
 }
 
 // getOpts returns a set of resource options from an array of them. This includes the parent URN, any dependency URNs,
@@ -1328,6 +1330,7 @@ func (ctx *Context) getOpts(res Resource, t string, provider ProviderResource, o
 		importID:                importID,
 		ignoreChanges:           opts.IgnoreChanges,
 		additionalSecretOutputs: opts.AdditionalSecretOutputs,
+		replaceOnChanges:        opts.ReplaceOnChanges,
 	}, nil
 }
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

We finish threading `replaceOnChanges` through the Go and .NET SDKs. 

Fixes #7922
Fixes #7881

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
