### PR TITLE
[sdk/go] Unmarshal output values in component provider

### DIFF
--- a/pkg/resource/provider/component_provider.go
+++ b/pkg/resource/provider/component_provider.go
@@ -103,6 +103,7 @@ func (p *componentProvider) Configure(ctx context.Context,
 		AcceptSecrets:   true,
 		SupportsPreview: true,
 		AcceptResources: true,
+		AcceptOutputs:   true,
 	}, nil
 }
 

--- a/sdk/go/pulumi/rpc.go
+++ b/sdk/go/pulumi/rpc.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 	"sync"
 
 	"github.com/blang/semver"
@@ -697,8 +696,7 @@ func unmarshalOutput(ctx *Context, v resource.PropertyValue, dest reflect.Value)
 		result := reflect.MakeMap(dest.Type())
 		secret := false
 		for k, e := range v.ObjectValue() {
-			// ignore properties internal to the pulumi engine
-			if strings.HasPrefix(string(k), "__") {
+			if resource.IsInternalPropertyKey(k) {
 				continue
 			}
 			elem := reflect.New(elemType).Elem()

--- a/sdk/go/pulumi/urnset.go
+++ b/sdk/go/pulumi/urnset.go
@@ -29,6 +29,15 @@ func (s urnSet) has(v URN) bool {
 	return ok
 }
 
+func (s urnSet) contains(other urnSet) bool {
+	for v := range other {
+		if !s.has(v) {
+			return false
+		}
+	}
+	return true
+}
+
 func (s urnSet) union(other urnSet) {
 	for v := range other {
 		s.add(v)


### PR DESCRIPTION
This adds support for unmarshaling output values in the `CopyTo` helper used when copying inputs to an args struct. More details here: https://github.com/pulumi/pulumi/pull/7928#issuecomment-916227805

Note: I'd like to add more test cases and clean up the implementation a bit, but I'll do that in a subsequent change.

Fixes #7848
Part of #7434