### PR TITLE
[automation-api] Exclude tests from test_fast.

### DIFF
--- a/scripts/test_subsets.py
+++ b/scripts/test_subsets.py
@@ -21,6 +21,9 @@ TEST_SUBSETS = {
         'github.com/pulumi/pulumi/tests/integration'
     ],
     'auto-and-lifecycletest': [
+        'auto-dotnet',
+        'auto-nodejs',
+        'auto-python',
         'github.com/pulumi/pulumi/sdk/v3/go/auto',
         'github.com/pulumi/pulumi/pkg/v3/engine/lifeycletest'
     ],

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -45,7 +45,7 @@ dotnet_test:: $(TEST_ALL_DEPS)
 
 auto_test:: $(TEST_ALL_DEPS)
 	# include the version prefix/suffix to avoid generating a separate nupkg file
-	$(RUN_TESTSUITE) dotnet-test dotnet test --no-build --filter --filter FullyQualifiedName~Pulumi.Automation.Tests /p:Version=${DOTNET_VERSION}
+	$(RUN_TESTSUITE) auto-dotnet dotnet test --no-build --filter --filter FullyQualifiedName~Pulumi.Automation.Tests /p:Version=${DOTNET_VERSION}
 
 test_fast:: dotnet_test
 	$(GO_TEST_FAST) ${PROJECT_PKGS}

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -41,7 +41,11 @@ install:: build install_plugin
 
 dotnet_test:: $(TEST_ALL_DEPS)
 	# include the version prefix/suffix to avoid generating a separate nupkg file
-	$(RUN_TESTSUITE) dotnet-test dotnet test /p:Version=${DOTNET_VERSION}
+	$(RUN_TESTSUITE) dotnet-test dotnet test --no-build --filter --filter FullyQualifiedName\\!~Pulumi.Automation.Tests /p:Version=${DOTNET_VERSION}
+
+auto_test:: $(TEST_ALL_DEPS)
+	# include the version prefix/suffix to avoid generating a separate nupkg file
+	$(RUN_TESTSUITE) dotnet-test dotnet test --no-build --filter --filter FullyQualifiedName~Pulumi.Automation.Tests /p:Version=${DOTNET_VERSION}
 
 test_fast:: dotnet_test
 	$(GO_TEST_FAST) ${PROJECT_PKGS}

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -50,7 +50,7 @@ auto_test:: $(TEST_ALL_DEPS)
 test_fast:: dotnet_test
 	$(GO_TEST_FAST) ${PROJECT_PKGS}
 
-test_all:: dotnet_test
+test_all:: dotnet_test auto_test
 	$(GO_TEST) ${PROJECT_PKGS}
 
 dist::

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -22,10 +22,13 @@ install_plugin::
 
 install:: install_plugin
 
-test_all:: test_fast
+test_all:: test_fast test_auto
 
 test_fast:: $(TEST_ALL_DEPS)
-	$(GO_TEST_FAST) ${PROJECT_PKGS}
+	$(GO_TEST_FAST) ./pulumi/... ./common/... ./pulumi-language-go/...
+
+test_auto:: $(TEST_ALL_DEPS)
+	$(GO_TEST) ./auto/...
 
 dist::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -1,7 +1,8 @@
 PROJECT_NAME     := Pulumi Go SDK
 LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/go/pulumi-language-go
 VERSION          := $(shell cd ../../ && pulumictl get version)
-PROJECT_PKGS     := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... ./auto/...| grep -v /vendor/ | grep -v templates)
+TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
+TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
 TESTPARALLELISM  := 10
 PROJECT_ROOT     := $(realpath ../..)
 
@@ -25,10 +26,10 @@ install:: install_plugin
 test_all:: test_fast test_auto
 
 test_fast:: $(TEST_ALL_DEPS)
-	$(GO_TEST_FAST) ./pulumi/... ./common/... ./pulumi-language-go/...
+	$(GO_TEST_FAST) $(TEST_FAST_PKGS)
 
 test_auto:: $(TEST_ALL_DEPS)
-	$(GO_TEST) ./auto/...
+	$(GO_TEST) $(TEST_AUTO_PKGS)
 
 dist::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -53,7 +53,7 @@ istanbul_tests:: $(TEST_ALL_DEPS)
 	$(RUN_TESTSUITE) istanbul-with-mocks ./node_modules/.bin/istanbul test --print none _mocha -- 'bin/tests_with_mocks/**/*.spec.js'
 
 auto_tests:: $(TEST_ALL_DEPS)
-	$(RUN_TESTSUITE) istanbul ./node_modules/.bin/istanbul test --print none _mocha -- --timeout 120000 'bin/tests/automation/**/*.spec.js'
+	$(RUN_TESTSUITE) auto-nodejs ./node_modules/.bin/istanbul test --print none _mocha -- --timeout 120000 'bin/tests/automation/**/*.spec.js'
 	./node_modules/.bin/istanbul report text-summary
 	./node_modules/.bin/istanbul report text
 

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -47,10 +47,15 @@ install_plugin:: build
 install:: install_package install_plugin
 
 istanbul_tests:: $(TEST_ALL_DEPS)
-	$(RUN_TESTSUITE) istanbul ./node_modules/.bin/istanbul test --print none _mocha -- --timeout 120000 'bin/tests/**/*.spec.js'
+	$(RUN_TESTSUITE) istanbul ./node_modules/.bin/istanbul test --print none _mocha -- --timeout 120000 --exclude 'bin/tests/automation/**/*.spec.js' 'bin/tests/**/*.spec.js'
 	./node_modules/.bin/istanbul report text-summary
 	./node_modules/.bin/istanbul report text
 	$(RUN_TESTSUITE) istanbul-with-mocks ./node_modules/.bin/istanbul test --print none _mocha -- 'bin/tests_with_mocks/**/*.spec.js'
+
+auto_tests:: $(TEST_ALL_DEPS)
+	$(RUN_TESTSUITE) istanbul ./node_modules/.bin/istanbul test --print none _mocha -- --timeout 120000 'bin/tests/automation/**/*.spec.js'
+	./node_modules/.bin/istanbul report text-summary
+	./node_modules/.bin/istanbul report text
 
 sxs_tests:: $(TEST_ALL_DEPS)
 	pushd tests/sxs_ts_3.6 && yarn ; tsc ; popd
@@ -59,7 +64,7 @@ sxs_tests:: $(TEST_ALL_DEPS)
 test_fast:: sxs_tests istanbul_tests
 	$(GO_TEST_FAST) ${PROJECT_PKGS}
 
-test_all:: sxs_tests istanbul_tests
+test_all:: sxs_tests istanbul_tests auto_tests
 	$(GO_TEST) ${PROJECT_PKGS}
 
 dist:: build

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -50,12 +50,16 @@ test_fast:: $(TEST_ALL_DEPS)
 	$(GO_TEST) ${PROJECT_PKGS}
 	pipenv run pip install ./env/src
 	# TODO the ignored test seems to fail in pytest but not unittest. Need to trackdown why
-	$(RUN_TESTSUITE) python/lib/test pipenv run pytest lib/test --ignore lib/test/langhost/resource_thens/test_resource_thens.py
+	$(RUN_TESTSUITE) python/lib/test pipenv run pytest lib/test --ignore lib/test/automation --ignore lib/test/langhost/resource_thens/test_resource_thens.py
 	$(RUN_TESTSUITE) python/lib/test/langhost/resource_thens pipenv run python -m unittest lib/test/langhost/resource_thens/test_resource_thens.py
 	# Using python -m also adds lib/test_with_mocks to sys.path which avoids package resolution issues.
 	pushd lib/test_with_mocks; $(RUN_TESTSUITE) python/lib/test_with_mocks pipenv run python -m pytest; popd
 
-test_all:: test_fast
+test_auto:: test_fast $(TEST_ALL_DEPS)
+	# Note that this target depends on test-fast for the call to `pipenv run pip install`
+	pipenv run pytest lib/test/automation
+
+test_all:: test_fast test_auto
 
 dist::
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${VERSION}" ${LANGHOST_PKG}

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -57,7 +57,7 @@ test_fast:: $(TEST_ALL_DEPS)
 
 test_auto:: test_fast $(TEST_ALL_DEPS)
 	# Note that this target depends on test-fast for the call to `pipenv run pip install`
-	pipenv run pytest lib/test/automation
+	$(RUN_TESTSUITE) auto-python pipenv run pytest lib/test/automation
 
 test_all:: test_fast test_auto
 

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -13,7 +13,7 @@ semver = ">=2.8.1"
 pyyaml = ">=5.3.1"
 
 [dev-packages]
-pylint = ">=2.1"
+pylint = "2.10.2"
 mypy = ">=0.78"
 pytest = "*"
 pytest-timeout = "*"

--- a/sdk/python/Pipfile
+++ b/sdk/python/Pipfile
@@ -13,7 +13,7 @@ semver = ">=2.8.1"
 pyyaml = ">=5.3.1"
 
 [dev-packages]
-pylint = "2.10.2"
+pylint = "==2.10.2"
 mypy = ">=0.78"
 pytest = "*"
 pytest-timeout = "*"


### PR DESCRIPTION
The Automation API tests take long enough that thay don't really fit
into `test_fast`. These changes move those tests to `test_all`.