### PR TITLE
[sdk/python] Fix serializing output values within dicts

### DIFF
--- a/sdk/python/lib/pulumi/runtime/rpc.py
+++ b/sdk/python/lib/pulumi/runtime/rpc.py
@@ -327,7 +327,7 @@ async def serialize_property(value: 'Input[Any]',
         types = _types.input_type_types(value_cls)
 
         return {
-            k: await serialize_property(v, deps, input_transformer, types.get(k))
+            k: await serialize_property(v, deps, input_transformer, types.get(k), keep_output_values)
             for k, v in value.items()
         }
 
@@ -373,7 +373,8 @@ async def serialize_property(value: 'Input[Any]',
                 transformed_key = translate(k)
                 if settings.excessive_debug_output:
                     log.debug(f"transforming input property: {k} -> {transformed_key}")
-            obj[transformed_key] = await serialize_property(value[k], deps, input_transformer, get_type(transformed_key))
+            obj[transformed_key] = await serialize_property(value[k], deps, input_transformer,
+                get_type(transformed_key), keep_output_values)
 
         return obj
 

--- a/sdk/python/lib/test/test_next_serialize.py
+++ b/sdk/python/lib/test/test_next_serialize.py
@@ -1470,6 +1470,27 @@ class OutputValueSerializationTests(unittest.TestCase):
                 actual = await rpc.serialize_properties(inputs, {}, keep_output_values=True)
                 self.assertDictEqual(json_format.MessageToDict(expected), json_format.MessageToDict(actual))
 
+    @pulumi_test
+    async def test_serialize_nested_dict(self):
+        settings.SETTINGS.feature_support["outputValues"] = True
+
+        inputs = {
+            "value": {
+                "foo": Output(set(), future("bar"), future(True), future(True)),
+            }
+        }
+        expected = struct_pb2.Struct()
+        expected["value"] = {
+            "foo": {
+                rpc._special_sig_key: rpc._special_output_value_sig,
+                "value": "bar",
+                "secret": True,
+            },
+        }
+        actual = await rpc.serialize_properties(inputs, {}, keep_output_values=True)
+        self.assertDictEqual(json_format.MessageToDict(expected), json_format.MessageToDict(actual))
+
+
 def future(val):
     fut = asyncio.Future()
     fut.set_result(val)


### PR DESCRIPTION
Pass along the `keep_output_values` param when serializing values within dicts.