### PR TITLE
[apitype] Add a JSON schema for deployments.

### DIFF
--- a/developer-docs/Makefile
+++ b/developer-docs/Makefile
@@ -28,12 +28,17 @@ SVG_FILES = \
 graphics: Makefile $(SVG_FILES)
 
 MD_FILES = \
+	architecture/deployment-schema.md \
 	providers/metaschema.md
 
 generated_markdown: Makefile $(MD_FILES)
 
 providers/metaschema.md: utils/jsonschema2md.go ../pkg/codegen/schema/pulumi.json
 	go run ./utils/jsonschema2md.go < ../pkg/codegen/schema/pulumi.json >providers/metaschema.md
+
+architecture/deployment-schema.md: utils/jsonschema2md.go ../sdk/go/common/apitype/*.json
+	go run ./utils/jsonschema2md.go -title "Deployment Schema" -ids "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/deployments.json=-,https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json=../sdk/go/common/apitype/resources.json,https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json=../sdk/go/common/apitype/property-values.json" <../sdk/go/common/apitype/deployments.json >architecture/deployment-schema.md
+
 
 clean:
 	rm -rf $(BUILDDIR)/*

--- a/developer-docs/architecture/deployment-schema.md
+++ b/developer-docs/architecture/deployment-schema.md
@@ -1,0 +1,723 @@
+# Deployment Schema
+
+## Pulumi Deployment States
+
+A schema for Pulumi deployment states.
+
+`object`
+
+One of:
+
+### Properties
+
+---
+
+#### `deployment` (_required_)
+
+The deployment object.
+
+`object`
+
+---
+
+#### `version` (_required_)
+
+The deployment version.
+
+`integer`
+
+---
+
+### Deployment Manifest
+
+Captures meta-information about a deployment, such as versions of binaries, etc.
+
+`object`
+
+#### Properties
+
+---
+
+##### `magic` (_required_)
+
+A magic number used to validate the manifest's integrity.
+
+`string`
+
+---
+
+##### `plugins`
+
+Information about the plugins used by the deployment.
+
+`array`
+
+Items: [Plugin Info](#plugin-info)
+
+---
+
+##### `time` (_required_)
+
+The deployment's start time.
+
+`string`
+
+Format: `date-time`
+
+---
+
+##### `version` (_required_)
+
+The version of the Pulumi engine that produced the deployment.
+
+`string`
+
+---
+
+### Plugin Info
+
+Information about a plugin.
+
+`object`
+
+#### Properties
+
+---
+
+##### `name` (_required_)
+
+The plugin's name.
+
+`string`
+
+---
+
+##### `path` (_required_)
+
+The path of the plugin's binary.
+
+`string`
+
+---
+
+##### `type` (_required_)
+
+The plugin's type.
+
+Enum: `"analyzer"` | `"language"` | `"resource"`
+
+---
+
+##### `version` (_required_)
+
+The plugin's version.
+
+`string`
+
+---
+
+### Resource Operation V2
+
+Version 2 of a resource operation state
+
+`object`
+
+#### Properties
+
+---
+
+##### `resource` (_required_)
+
+The state of the affected resource as of the start of this operation.
+
+[Resource V3](https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json#/$defs/resourceV3)
+
+---
+
+##### `type` (_required_)
+
+A string representation of the operation.
+
+Enum: `"creating"` | `"updating"` | `"deleting"` | `"reading"`
+
+---
+
+### Secrets Provider
+
+Configuration information for a secrets provider.
+
+`object`
+
+#### Properties
+
+---
+
+##### `state`
+
+The secrets provider's state, if any.
+
+---
+
+##### `type` (_required_)
+
+The secrets provider's type.
+
+`string`
+
+---
+
+### Unknown Version
+
+Catchall for unknown deployment versions.
+
+`object`
+
+#### Properties
+
+---
+
+##### `deployment`
+
+The deployment object.
+
+`object`
+
+---
+
+##### `version`
+
+The deployment version.
+
+---
+
+### Version 3
+
+The third version of the deployment state.
+
+`object`
+
+#### Properties
+
+---
+
+##### `deployment` (_required_)
+
+The deployment state.
+
+`object`
+
+###### Properties
+
+---
+
+####### `manifest` (_required_)
+
+Metadata about the deployment.
+
+[Deployment Manifest](#deployment-manifest)
+
+---
+
+####### `pending_operations`
+
+Any operations that were pending at the time the deployment finished.
+
+`array`
+
+Items: [Resource Operation V2](#resource-operation-v2)
+
+---
+
+####### `resources`
+
+All resources that are part of the stack.
+
+`array`
+
+Items: [Resource V3](https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json#/$defs/resourceV3)
+
+---
+
+####### `secrets_providers`
+
+Configuration for this stack's secrets provider.
+
+[Secrets Provider](#secrets-provider)
+
+---
+
+---
+
+##### `version` (_required_)
+
+The deployment version. Must be `3`.
+
+Constant: `3`
+
+---
+
+## Pulumi Property Value
+
+A schema for Pulumi Property values.
+
+One of:
+
+### Archive property values
+
+`object`
+
+One of:
+
+#### Properties
+
+---
+
+##### `4dabf18193072939515e22adb298388d` (_required_)
+
+Archive signature
+
+Constant: `"0def7320c3a5731c473e5ecbe6d01bc7"`
+
+---
+
+##### `hash`
+
+The SHA256 hash of the archive's contents.
+
+`string`
+
+---
+
+### Array property values
+
+`array`
+
+Items: [Pulumi Property Value](#pulumi-property-value)
+
+### Asset property values
+
+`object`
+
+One of:
+
+#### Properties
+
+---
+
+##### `4dabf18193072939515e22adb298388d` (_required_)
+
+Asset signature
+
+Constant: `"c44067f5952c0a294b673a41bacd8c17"`
+
+---
+
+##### `hash`
+
+The SHA256 hash of the asset's contents.
+
+`string`
+
+---
+
+### Decrypted Secret
+
+`object`
+
+#### Properties
+
+---
+
+##### `plaintext` (_required_)
+
+The decrypted, JSON-serialized property value
+
+`string`
+
+---
+
+### Encrypted Secret
+
+`object`
+
+#### Properties
+
+---
+
+##### `ciphertext` (_required_)
+
+The encrypted, JSON-serialized property value
+
+`string`
+
+---
+
+### Hash-only Archive
+
+### Hash-only Asset
+
+### Literal Archive
+
+#### Properties
+
+---
+
+##### `assets` (_required_)
+
+The literal contents of the archive.
+
+`object`
+
+Additional properties: [`https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json#/oneOf/5/oneOf/1/properties/assets/additionalProperties`](#httpsgithubcompulumipulumiblobmastersdkgocommonapitypeproperty-valuesjsononeof5oneof1propertiesassetsadditionalproperties)
+
+---
+
+### Literal Asset
+
+#### Properties
+
+---
+
+##### `text` (_required_)
+
+The literal contents of the asset.
+
+`string`
+
+---
+
+### Local File Archive
+
+#### Properties
+
+---
+
+##### `path` (_required_)
+
+The path to a local file that contains the archive's contents.
+
+`string`
+
+---
+
+### Local File Asset
+
+#### Properties
+
+---
+
+##### `path` (_required_)
+
+The path to a local file that contains the asset's contents.
+
+`string`
+
+---
+
+### Object property values
+
+`object`
+
+Additional properties: [Pulumi Property Value](#pulumi-property-value)
+
+### Primitive property values
+
+`null` | `boolean` | `number` | `string`
+
+### Pulumi Property Value
+
+A schema for Pulumi Property values.
+
+One of:
+
+### Resource reference property values
+
+`object`
+
+#### Properties
+
+---
+
+##### `4dabf18193072939515e22adb298388d` (_required_)
+
+Resource reference signature
+
+Constant: `"5cf8f73096256a8f31e491e813e4eb8e"`
+
+---
+
+##### `id`
+
+The ID of the referenced resource.
+
+`string`
+
+---
+
+##### `packageVersion`
+
+The package version of the referenced resource.
+
+`string`
+
+---
+
+##### `urn` (_required_)
+
+The URN of the referenced resource.
+
+`string`
+
+---
+
+### Secret Property Values
+
+`object`
+
+One of:
+
+#### Properties
+
+---
+
+##### `4dabf18193072939515e22adb298388d` (_required_)
+
+Secret signature
+
+Constant: `"1b47061264138c4ac30d75fd1eb44270"`
+
+---
+
+### URI File Archive
+
+#### Properties
+
+---
+
+##### `uri` (_required_)
+
+The URI of a file that contains the archive's contents.
+
+`string`
+
+Format: `uri`
+
+---
+
+### URI File Asset
+
+#### Properties
+
+---
+
+##### `uri` (_required_)
+
+The URI of a file that contains the asset's contents.
+
+`string`
+
+Format: `uri`
+
+---
+
+### Unknown property values
+
+Constant: `"04da6b54-80e4-46f7-96ec-b56ff0331ba9"`
+
+### `https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json#/oneOf/5/oneOf/1/properties/assets/additionalProperties`
+
+One of:
+
+## Pulumi Resource State
+
+Schemas for Pulumi resource states.
+
+One of:
+
+### Resource V3
+
+Version 3 of a Pulumi resource state.
+
+`object`
+
+#### Properties
+
+---
+
+##### `additionalSecretOutputs`
+
+A list of outputs that were explicitly marked as secret when the resource was created.
+
+`array`
+
+Items: `string`
+
+---
+
+##### `aliases`
+
+A list of previous URNs that this resource may have had in previous deployments
+
+`array`
+
+Items: [Unique Resource Name (URN)](#unique-resource-name-urn)
+
+---
+
+##### `custom`
+
+True when the resource is managed by a plugin.
+
+`boolean`
+
+---
+
+##### `customTimeouts`
+
+A configuration block that can be used to control timeouts of CRUD operations
+
+`object`
+
+---
+
+##### `delete`
+
+True when the resource should be deleted during the next update.
+
+`boolean`
+
+---
+
+##### `dependencies`
+
+The dependency edges to other resources that this depends on.
+
+`array`
+
+Items: [Unique Resource Name (URN)](#unique-resource-name-urn)
+
+---
+
+##### `external`
+
+True when the lifecycle of this resource is not managed by Pulumi.
+
+`boolean`
+
+---
+
+##### `id`
+
+The provider-assigned resource ID, if any, for custom resources.
+
+`string`
+
+---
+
+##### `importID`
+
+The import input used for imported resources.
+
+`string`
+
+---
+
+##### `initErrors`
+
+The set of errors encountered in the process of initializing resource (i.e. during create or update).
+
+`array`
+
+Items: `string`
+
+---
+
+##### `inputs`
+
+The input properties supplied to the provider.
+
+`object`
+
+Additional properties: [Pulumi Property Value](https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json#)
+
+---
+
+##### `outputs`
+
+The output properties returned by the provider after provisioning.
+
+`object`
+
+Additional properties: [Pulumi Property Value](https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json#)
+
+---
+
+##### `parent`
+
+An optional parent URN if this resource is a child of it.
+
+[Unique Resource Name (URN)](#unique-resource-name-urn)
+
+---
+
+##### `pendingReplacement`
+
+Tracks delete-before-replace resources that have been deleted but not yet recreated.
+
+`boolean`
+
+---
+
+##### `propertyDependencies`
+
+A map from each input property name to the set of resources that property depends on.
+
+`object`
+
+Additional properties: [`https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json#/$defs/resourceV3/properties/propertyDependencies/additionalProperties`](#httpsgithubcompulumipulumiblobmastersdkgocommonapityperesourcesjsondefsresourcev3propertiespropertydependenciesadditionalproperties)
+
+---
+
+##### `protect`
+
+True when this resource is "protected" and may not be deleted.
+
+`boolean`
+
+---
+
+##### `provider`
+
+A reference to the provider that is associated with this resource.
+
+`string`
+
+---
+
+##### `type`
+
+The resource's full type token.
+
+`string`
+
+---
+
+##### `urn` (_required_)
+
+The resource's unique name.
+
+[Unique Resource Name (URN)](#unique-resource-name-urn)
+
+---
+
+### Unique Resource Name (URN)
+
+The unique name for a resource in a Pulumi stack.
+
+`string`
+
+### `https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json#/$defs/resourceV3/properties/propertyDependencies/additionalProperties`
+
+`array`
+
+Items: [Unique Resource Name (URN)](#unique-resource-name-urn)

--- a/developer-docs/index.md
+++ b/developer-docs/index.md
@@ -15,6 +15,7 @@ Use the navigation bar to the left to browse the docs.
 
 architecture/overview
 architecture/resource-registration
+architecture/deployment-schema
 ```
 
 ```{toctree}

--- a/developer-docs/providers/metaschema.md
+++ b/developer-docs/providers/metaschema.md
@@ -1,3 +1,4 @@
+
 # Pulumi Package Metaschema
 
 A description of the schema for a Pulumi Package
@@ -138,7 +139,7 @@ The unqualified name of the package (e.g. "aws", "azure", "gcp", "kubernetes", "
 
 `string`
 
-Pattern: `^[^0-9][-a-zA-Z0-9]*$`
+Pattern: `^[a-zA-Z][-a-zA-Z0-9_]*$`
 
 ---
 
@@ -690,7 +691,7 @@ An optional objectTypeSpec that describes additional inputs that mau be necessar
 
 `string`
 
-Pattern: `^[^0-9][-a-zA-Z0-9]*:([^0-9][a-zA-Z0-9._/]*)?:[^0-9][a-zA-Z0-9._/]*$`
+Pattern: `^[a-zA-Z][-a-zA-Z0-9_]*:([^0-9][a-zA-Z0-9._/]*)?:[^0-9][a-zA-Z0-9._/]*$`
 
 ## Type Definition
 

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -17,7 +17,10 @@ package stack
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"reflect"
+	"strings"
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
@@ -29,6 +32,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
 const (
@@ -54,6 +58,46 @@ var (
 	// untyped deployment being deserialized is too new to understand.
 	ErrDeploymentSchemaVersionTooNew = fmt.Errorf("this stack's deployment version is too new")
 )
+
+var deploymentSchema *jsonschema.Schema
+var resourceSchema *jsonschema.Schema
+var propertyValueSchema *jsonschema.Schema
+
+func init() {
+	compiler := jsonschema.NewCompiler()
+	compiler.LoadURL = func(s string) (io.ReadCloser, error) {
+		var schema string
+		switch s {
+		case apitype.DeploymentSchemaID:
+			schema = apitype.DeploymentSchema()
+		case apitype.ResourceSchemaID:
+			schema = apitype.ResourceSchema()
+		case apitype.PropertyValueSchemaID:
+			schema = apitype.PropertyValueSchema()
+		default:
+			return jsonschema.LoadURL(s)
+		}
+		return ioutil.NopCloser(strings.NewReader(schema)), nil
+	}
+	deploymentSchema = compiler.MustCompile(apitype.DeploymentSchemaID)
+	resourceSchema = compiler.MustCompile(apitype.ResourceSchemaID)
+	propertyValueSchema = compiler.MustCompile(apitype.PropertyValueSchemaID)
+}
+
+// ValidateUntypedDeployment validates a deployment against the Deployment JSON schema.
+func ValidateUntypedDeployment(deployment *apitype.UntypedDeployment) error {
+	bytes, err := json.Marshal(deployment)
+	if err != nil {
+		return err
+	}
+
+	var raw interface{}
+	if err := json.Unmarshal(bytes, &raw); err != nil {
+		return err
+	}
+
+	return deploymentSchema.Validate(raw)
+}
 
 // SerializeDeployment serializes an entire snapshot as a deploy record.
 func SerializeDeployment(snap *deploy.Snapshot, sm secrets.Manager, showSecrets bool) (*apitype.DeploymentV3, error) {

--- a/sdk/go/common/apitype/core.go
+++ b/sdk/go/common/apitype/core.go
@@ -29,6 +29,7 @@
 package apitype
 
 import (
+	_ "embed" // for embedded schemas
 	"encoding/json"
 	"time"
 
@@ -37,6 +38,40 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
+
+//go:embed deployments.json
+var deploymentSchema string
+
+// DeploymentSchemaID is the $id for the deployment schema.
+const DeploymentSchemaID = "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/deployments.json"
+
+// DeploymentSchema returns a JSON schema that can be used to validate serialized deployments (i.e. `UntypedDeployment`
+// objects).
+func DeploymentSchema() string {
+	return deploymentSchema
+}
+
+//go:embed resources.json
+var resourceSchema string
+
+// ResourceSchemaID is the $id for the deployment schema.
+const ResourceSchemaID = "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json"
+
+// ResourceSchema returns a JSON schema that can be used to validate serialized resource values (e.g. `ResourceV3`).
+func ResourceSchema() string {
+	return resourceSchema
+}
+
+//go:embed property-values.json
+var propertyValueSchema string
+
+// PropertyValueSchemaID is the $id for the property value schema.
+const PropertyValueSchemaID = "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json"
+
+// PropertyValueSchema returns a JSON schema that can be used to validate serialized property values.
+func PropertyValueSchema() string {
+	return propertyValueSchema
+}
 
 const (
 	// DeploymentSchemaVersionCurrent is the current version of the `Deployment` schema.

--- a/sdk/go/common/apitype/deployments.json
+++ b/sdk/go/common/apitype/deployments.json
@@ -1,0 +1,173 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/deployments.json",
+    "title": "Pulumi Deployment States",
+    "description": "A schema for Pulumi deployment states.",
+    "type": "object",
+    "properties": {
+        "version": {
+            "description": "The deployment version.",
+            "type": "integer"
+        },
+        "deployment": {
+            "description": "The deployment object.",
+            "type": "object"
+        }
+    },
+    "required": ["version", "deployment"],
+    "additionalProperties": false,
+    "oneOf": [
+        { "$ref": "#/$defs/deploymentV3" },
+        {
+            "title": "Unknown Version",
+            "description": "Catchall for unknown deployment versions.",
+            "type": "object",
+            "properties": {
+                "version": {
+                    "description": "The deployment version.",
+                    "not": {
+                        "enum": [ 3 ]
+                    }
+                },
+                "deployment": {
+                    "description": "The deployment object.",
+                    "type": "object"
+                }
+            }
+        }
+    ],
+    "$defs": {
+        "deploymentV3": {
+            "$anchor": "v3",
+            "title": "Version 3",
+            "description": "The third version of the deployment state.",
+            "type": "object",
+            "properties": {
+                "version": {
+                    "description": "The deployment version. Must be `3`.",
+                    "const": 3
+                },
+                "deployment": {
+                    "description": "The deployment state.",
+                    "type": "object",
+                    "properties": {
+                        "manifest": {
+                            "description": "Metadata about the deployment.",
+                            "$ref": "#/$defs/manifestV1"
+                        },
+                        "secrets_providers": {
+                            "description": "Configuration for this stack's secrets provider.",
+                            "$ref": "#/$defs/secretsProviderV1"
+                        },
+                        "resources": {
+                            "description": "All resources that are part of the stack.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json#v3"
+                            }
+                        },
+                        "pending_operations": {
+                            "description": "Any operations that were pending at the time the deployment finished.",
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/$defs/operationV2"
+                            }
+                        }
+                    },
+                    "required": ["manifest"],
+                    "additionalProperties": false
+                }
+            },
+            "required": ["version", "deployment"],
+            "additionalProperties": false
+        },
+        "manifestV1": {
+            "title": "Deployment Manifest",
+            "description": "Captures meta-information about a deployment, such as versions of binaries, etc.",
+            "type": "object",
+            "properties": {
+                "time": {
+                    "description": "The deployment's start time.",
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "magic": {
+                    "description": "A magic number used to validate the manifest's integrity.",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "The version of the Pulumi engine that produced the deployment.",
+                    "type": "string"
+                },
+                "plugins": {
+                    "description": "Information about the plugins used by the deployment.",
+                    "type": "array",
+                    "items": {
+                        "title": "Plugin Info",
+                        "description": "Information about a plugin.",
+                        "type": "object",
+                        "properties": {
+                            "name": {
+                                "description": "The plugin's name.",
+                                "type": "string"
+                            },
+                            "path": {
+                                "description": "The path of the plugin's binary.",
+                                "type": "string"
+                            },
+                            "type": {
+                                "description": "The plugin's type.",
+                                "enum": [
+                                    "analyzer",
+                                    "language",
+                                    "resource"
+                                ]
+                            },
+                            "version": {
+                                "description": "The plugin's version.",
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name", "path", "type", "version"],
+                        "additionalProperties": false
+                    }
+                }
+            },
+            "required": ["time", "magic", "version"],
+            "additionalProperties": false
+        },
+        "secretsProviderV1": {
+            "title": "Secrets Provider",
+            "description": "Configuration information for a secrets provider.",
+            "type": "object",
+            "properties": {
+                "type": {
+                    "description": "The secrets provider's type.",
+                    "type": "string"
+                },
+                "state": {
+                    "description": "The secrets provider's state, if any."
+                }
+            },
+            "required": ["type"],
+            "additionalProperties": false
+        },
+        "operationV2": {
+            "title": "Resource Operation V2",
+            "description": "Version 2 of a resource operation state",
+            "type": "object",
+            "properties": {
+                "resource": {
+                    "description": "The state of the affected resource as of the start of this operation.",
+                    "$ref": "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json#v3"
+                },
+                "type": {
+                    "description": "A string representation of the operation.",
+                    "enum": ["creating", "updating", "deleting", "reading"]
+                }
+            },
+            "required": ["resource", "type"],
+            "additionalProperties": false
+        }
+    }
+}

--- a/sdk/go/common/apitype/property-values.json
+++ b/sdk/go/common/apitype/property-values.json
@@ -1,0 +1,231 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json",
+    "$anchor": "property_value",
+    "title": "Pulumi Property Value",
+    "description": "A schema for Pulumi Property values.",
+    "oneOf": [
+        {
+            "title": "Primitive property values",
+            "type": ["null", "boolean", "number", "string"],
+            "not": { "$ref": "#unknown_value" }
+        },
+        {
+            "$anchor": "unknown_value",
+            "title": "Unknown property values",
+            "const": "04da6b54-80e4-46f7-96ec-b56ff0331ba9"
+        },
+        {
+            "title": "Array property values",
+            "type": "array",
+            "items": {
+                "$ref": "#property_value"
+            }
+        },
+        {
+            "title": "Object property values",
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "#property_value"
+            },
+            "$comment": "The properties map below prevents the object schema from matching special objects",
+            "properties": {
+                "4dabf18193072939515e22adb298388d": false
+            }
+        },
+        {
+            "$anchor": "asset_value",
+            "title": "Asset property values",
+            "type": "object",
+            "properties": {
+                "4dabf18193072939515e22adb298388d": {
+                    "description": "Asset signature",
+                    "const": "c44067f5952c0a294b673a41bacd8c17"
+                },
+                "hash": {
+                    "description": "The SHA256 hash of the asset's contents.",
+                    "type": "string"
+                }
+            },
+            "required": ["4dabf18193072939515e22adb298388d"],
+            "oneOf": [
+                {
+                    "title": "Hash-only Asset",
+                    "properties": {
+                        "text": false,
+                        "path": false,
+                        "uri": false
+                    },
+                    "required": ["hash"]
+                },
+                {
+                    "title": "Literal Asset",
+                    "properties": {
+                        "text": {
+                            "description": "The literal contents of the asset.",
+                            "type": "string"
+                        },
+                        "path": false,
+                        "uri": false
+                    },
+                    "required": ["text"]
+                },
+                {
+                    "title": "Local File Asset",
+                    "properties": {
+                        "path": {
+                            "description": "The path to a local file that contains the asset's contents.",
+                            "type": "string"
+                        },
+                        "text": false,
+                        "uri": false
+                    },
+                    "required": ["path"]
+                },
+                {
+                    "title": "URI File Asset",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of a file that contains the asset's contents.",
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "text": false,
+                        "path": false
+                    },
+                    "required": ["uri"]
+                }
+            ]
+        },
+        {
+            "$anchor": "archive_value",
+            "title": "Archive property values",
+            "type": "object",
+            "properties": {
+                "4dabf18193072939515e22adb298388d": {
+                    "description": "Archive signature",
+                    "const": "0def7320c3a5731c473e5ecbe6d01bc7"
+                },
+                "hash": {
+                    "description": "The SHA256 hash of the archive's contents.",
+                    "type": "string"
+                }
+            },
+            "required": ["4dabf18193072939515e22adb298388d"],
+            "oneOf": [
+                {
+                    "title": "Hash-only Archive",
+                    "properties": {
+                        "assets": false,
+                        "path": false,
+                        "uri": false
+                    },
+                    "required": ["hash"]
+                },
+                {
+                    "title": "Literal Archive",
+                    "properties": {
+                        "assets": {
+                            "description": "The literal contents of the archive.",
+                            "type": "object",
+                            "additionalProperties": {
+                                "oneOf": [
+                                    { "$ref": "#asset_value" },
+                                    { "$ref": "#archive_value" }
+                                ]
+                            }
+                        },
+                        "path": false,
+                        "uri": false
+                    },
+                    "required": ["assets"]
+                },
+                {
+                    "title": "Local File Archive",
+                    "properties": {
+                        "path": {
+                            "description": "The path to a local file that contains the archive's contents.",
+                            "type": "string"
+                        },
+                        "assets": false,
+                        "uri": false
+                    },
+                    "required": ["path"]
+                },
+                {
+                    "title": "URI File Archive",
+                    "properties": {
+                        "uri": {
+                            "description": "The URI of a file that contains the archive's contents.",
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "assets": false,
+                        "path": false
+                    },
+                    "required": ["uri"]
+                }
+            ]
+        },
+        {
+            "title": "Secret Property Values",
+            "type": "object",
+            "properties": {
+                "4dabf18193072939515e22adb298388d": {
+                    "description": "Secret signature",
+                    "const": "1b47061264138c4ac30d75fd1eb44270"
+                }
+            },
+            "required": ["4dabf18193072939515e22adb298388d"],
+            "oneOf": [
+                {
+                    "title": "Encrypted Secret",
+                    "type": "object",
+                    "properties": {
+                        "ciphertext": {
+                            "description": "The encrypted, JSON-serialized property value",
+                            "type": "string"
+                        },
+                        "plaintext": false
+                    },
+                    "required": ["ciphertext"]
+                },
+                {
+                    "title": "Decrypted Secret",
+                    "type": "object",
+                    "properties": {
+                        "plaintext": {
+                            "description": "The decrypted, JSON-serialized property value",
+                            "type": "string"
+                        },
+                        "ciphertext": false
+                    },
+                    "required": ["plaintext"]
+                }
+            ]
+        },
+        {
+            "title": "Resource reference property values",
+            "type": "object",
+            "properties": {
+                "4dabf18193072939515e22adb298388d": {
+                    "description": "Resource reference signature",
+                    "const": "5cf8f73096256a8f31e491e813e4eb8e"
+                },
+                "packageVersion": {
+                    "description": "The package version of the referenced resource.",
+                    "type": "string"
+                },
+                "urn": {
+                    "description": "The URN of the referenced resource.",
+                    "type": "string"
+                },
+                "id": {
+                    "description": "The ID of the referenced resource.",
+                    "type": "string"
+                }
+            },
+            "required": ["4dabf18193072939515e22adb298388d", "urn"]
+        }
+    ]
+}

--- a/sdk/go/common/apitype/resources.json
+++ b/sdk/go/common/apitype/resources.json
@@ -1,0 +1,127 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/resources.json",
+    "title": "Pulumi Resource State",
+    "description": "Schemas for Pulumi resource states.",
+    "oneOf": [
+        { "$ref": "#v3" }
+    ],
+    "$defs": {
+        "urn": {
+            "$comment": "It would be wonderful to include a regex here for validation, but we generate _many_ invalid URNs in tests for readability + expediency",
+            "title": "Unique Resource Name (URN)",
+            "description": "The unique name for a resource in a Pulumi stack.",
+            "type": "string"
+        },
+        "resourceV3": {
+            "$anchor": "v3",
+            "title": "Resource V3",
+            "description": "Version 3 of a Pulumi resource state.",
+            "type": "object",
+            "properties": {
+                "urn": {
+                    "description": "The resource's unique name.",
+                    "$ref": "#/$defs/urn"
+                },
+                "custom": {
+                    "description": "True when the resource is managed by a plugin.",
+                    "type": "boolean"
+                },
+                "delete": {
+                    "description": "True when the resource should be deleted during the next update.",
+                    "type": "boolean"
+                },
+                "id": {
+                    "description": "The provider-assigned resource ID, if any, for custom resources.",
+                    "type": "string"
+                },
+                "type": {
+                    "description": "The resource's full type token.",
+                    "type": "string"
+                },
+                "inputs": {
+                    "description": "The input properties supplied to the provider.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json"
+                    }
+                },
+                "outputs": {
+                    "description": "The output properties returned by the provider after provisioning.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "https://github.com/pulumi/pulumi/blob/master/sdk/go/common/apitype/property-values.json"
+                    }
+                },
+                "parent": {
+                    "description": "An optional parent URN if this resource is a child of it.",
+                    "$ref": "#/$defs/urn"
+                },
+                "protect": {
+                    "description": "True when this resource is \"protected\" and may not be deleted.",
+                    "type": "boolean"
+                },
+                "external": {
+                    "description": "True when the lifecycle of this resource is not managed by Pulumi.",
+                    "type": "boolean"
+                },
+                "dependencies": {
+                    "description": "The dependency edges to other resources that this depends on.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/urn"
+                    }
+                },
+                "initErrors": {
+                    "description": "The set of errors encountered in the process of initializing resource (i.e. during create or update).",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "provider": {
+                    "description": "A reference to the provider that is associated with this resource.",
+                    "type": "string"
+                },
+                "propertyDependencies": {
+                    "description": "A map from each input property name to the set of resources that property depends on.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/$defs/urn"
+                        }
+                    }
+                },
+                "pendingReplacement": {
+                    "description": "Tracks delete-before-replace resources that have been deleted but not yet recreated.",
+                    "type": "boolean"
+                },
+                "additionalSecretOutputs": {
+                    "description": "A list of outputs that were explicitly marked as secret when the resource was created.",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "aliases": {
+                    "description": "A list of previous URNs that this resource may have had in previous deployments",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/urn"
+                    }
+                },
+                "customTimeouts": {
+                    "description": "A configuration block that can be used to control timeouts of CRUD operations",
+                    "type": "object"
+                },
+                "importID": {
+                    "description": "The import input used for imported resources.",
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": ["urn"]
+        }
+    }
+}


### PR DESCRIPTION
This schema can be used to validate the contents of a Pulumi deployment.
If a deployment validates against this schema, it should be considered
syntactically valid, though it may contain certain classes of semantic
errors (e.g. references to unknown resources in dependency lists,
dependency cycles, etc.).

This schema is not yet used for validation in practice and may not be
entirely accurate.

These changes also add this schema (and the schemas on which it depends)
to the developer documentation. jsonschema2md.go has been updated to
support multi-file schemas.