### PR TITLE
Use NPM instead of yarn

### DIFF
--- a/pkg/codegen/internal/test/testdata/output-funcs/nodejs/package.json
+++ b/pkg/codegen/internal/test/testdata/output-funcs/nodejs/package.json
@@ -2,17 +2,16 @@
     "name": "@pulumi/mypkg",
     "version": "0.0.1",
     "scripts": {
-        "build": "tsc"
+        "build": "tsc",
+        "test": "mocha -r ts-node/register tests/**/*.spec.ts"
     },
     "devDependencies": {
+        "@pulumi/pulumi": "file:../../../../../../../sdk/nodejs/bin",
         "@types/mocha": "latest",
         "@types/node": "latest",
         "mocha": "latest",
         "ts-node": "latest",
         "typescript": "^4.3.5"
-    },
-    "peerDependencies": {
-        "@pulumi/pulumi": "latest"
     },
     "pulumi": {
         "resource": true

--- a/pkg/codegen/internal/test/testdata/output-funcs/schema.json
+++ b/pkg/codegen/internal/test/testdata/output-funcs/schema.json
@@ -577,11 +577,15 @@
         "@types/mocha": "latest",
         "@types/node": "latest",
         "mocha": "latest",
-        "ts-node": "latest"
+        "ts-node": "latest",
+        "@pulumi/pulumi": "file:../../../../../../../sdk/nodejs/bin"
       },
       "extraTypeScriptFiles": [
-          "tests/codegen.spec.ts"
-      ]
+        "tests/codegen.spec.ts"
+      ],
+      "scripts": {
+        "test": "mocha -r ts-node/register tests/**/*.spec.ts"
+      }
     }
   }
 }

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -1845,22 +1845,30 @@ func genNPMPackageMetadata(pkg *schema.Package, info NodePackageInfo) string {
 		packageVersion = pkg.Version.String()
 	}
 
+	// Ideally, this `scripts` section would include an install
+	// script that installs the provider, however, doing so causes
+	// problems when we try to restore package dependencies, since
+	// we must do an install for that. So we have another process
+	// that adds the install script when generating the
+	// package.json that we actually publish.
+	scripts := map[string]string{
+		"build": "tsc",
+	}
+
+	for k, v := range info.Scripts {
+		scripts[k] = v
+	}
+
 	// Create info that will get serialized into an NPM package.json.
 	npminfo := npmPackage{
-		Name:        packageName,
-		Version:     packageVersion,
-		Description: info.PackageDescription,
-		Keywords:    pkg.Keywords,
-		Homepage:    pkg.Homepage,
-		Repository:  pkg.Repository,
-		License:     pkg.License,
-		// Ideally, this `scripts` section would include an install script that installs the provider, however, doing
-		// so causes problems when we try to restore package dependencies, since we must do an install for that. So
-		// we have another process that adds the install script when generating the package.json that we actually
-		// publish.
-		Scripts: map[string]string{
-			"build": "tsc",
-		},
+		Name:            packageName,
+		Version:         packageVersion,
+		Description:     info.PackageDescription,
+		Keywords:        pkg.Keywords,
+		Homepage:        pkg.Homepage,
+		Repository:      pkg.Repository,
+		License:         pkg.License,
+		Scripts:         scripts,
 		DevDependencies: devDependencies,
 		Pulumi: npmPulumiManifest{
 			Resource:          true,

--- a/pkg/codegen/nodejs/gen_test.go
+++ b/pkg/codegen/nodejs/gen_test.go
@@ -22,33 +22,12 @@ func TestGeneratePackage(t *testing.T) {
 }
 
 func typeCheckGeneratedPackage(t *testing.T, pwd string) {
-	// TODO: previous attempt used npm. It may be more popular and
-	// better target than yarn, however our build uses yarn in
-	// other places at the moment, and yarn does not run into the
-	// ${VERSION} problem; use yarn for now.
-	//
-	// var npm string
-	// npm, err = executable.FindExecutable("npm")
-	// require.NoError(t, err)
-	// // TODO remove when https://github.com/pulumi/pulumi/pull/7938 lands
-	// file := filepath.Join(pwd, "package.json")
-	// oldFile, err := ioutil.ReadFile(file)
-	// require.NoError(t, err)
-	// newFile := strings.ReplaceAll(string(oldFile), "${VERSION}", "0.0.1")
-	// err = ioutil.WriteFile(file, []byte(newFile), 0600)
-	// require.NoError(t, err)
-	// err = integration.RunCommand(t, "npm install", []string{npm, "i"}, pwd, &cmdOptions)
-	// require.NoError(t, err)
-
-	test.RunCommand(t, "yarn_link", pwd, "yarn", "link", "@pulumi/pulumi")
-	test.RunCommand(t, "yarn_install", pwd, "yarn", "install")
-	test.RunCommand(t, "tsc", pwd, "yarn", "run", "tsc", "--noEmit")
+	test.RunCommand(t, "npm_install", pwd, "npm", "install")
+	test.RunCommand(t, "npm_build", pwd, "npm", "run", "build")
 }
 
-// Runs unit tests against the generated code.
 func testGeneratedPackage(t *testing.T, pwd string) {
-	test.RunCommand(t, "mocha", pwd,
-		"yarn", "run", "mocha", "-r", "ts-node/register", "tests/**/*.spec.ts")
+	test.RunCommand(t, "npm_test", pwd, "npm", "run", "test")
 }
 
 func TestGenerateTypeNames(t *testing.T) {

--- a/pkg/codegen/nodejs/importer.go
+++ b/pkg/codegen/nodejs/importer.go
@@ -64,6 +64,10 @@ type NodePackageInfo struct {
 	// compiling hand-authored unit test files that check the
 	// generated code.
 	ExtraTypeScriptFiles []string `json:"extraTypeScriptFiles,omitempty"`
+	// NPM script definitions. These define the `scripts` property
+	// of the generated `package.json`. See also:
+	// https://docs.npmjs.com/cli/v7/using-npm/scripts
+	Scripts map[string]string `json:"scripts,omitempty"`
 }
 
 // NodeObjectInfo contains NodeJS-specific information for an object.


### PR DESCRIPTION
On top of t0yv0/5758-node-wip for now - till we get it merged.

# Description

Switches yarn in favor of NPM as discussed with @iwahbe it's more valuable.

A bit of extra mechanism is needed:

- To run `npm run test` we need to put a scripts decl into package.json
- To link locally we use file:/ relative dependency references

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
