### PR TITLE
Faster CI PR verification on Mac OS: run fewer tests, use fewer workers

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -209,7 +209,7 @@ jobs:
         node-version: [ 14.x ]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
+        test-subset: [ integration, integration-and-codegen, auto, etc ]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,14 +300,7 @@ jobs:
         node-version: [ 14.x ]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ native, etc ]
-
-        exclude:
-          - platform: macos-latest
-
-        include:
-          - platform: macos-latest
-            test-subset: native
+        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
         node-version: [ 14.x ]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
+        test-subset: [ native, etc ]
 
         exclude:
           - platform: macos-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,7 @@ jobs:
         node-version: [ 14.x ]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
+        test-subset: [ integration, integration-and-codegen, auto, etc ]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,6 +302,13 @@ jobs:
         # See scripts/tests_subsets.py when editing
         test-subset: [ integration, auto-and-lifecycletest, native, etc ]
 
+        exclude:
+          - platform: macos-latest
+
+        include:
+          - platform: macos-latest
+            test-subset: native
+
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set PULUMI_TEST_SUBSET env var

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -118,9 +118,17 @@ jobs:
         exclude:
           - platform: macos-latest
 
+        # Only run catch-all `etc` test-subset on Mac for PR
+        # verification because of a throughput bottleneck on Mac
+        # runners. Note that `master.yml` specifies all test subsets
+        # to still run on `master` branch verifications.
         include:
           - platform: macos-latest
           - test-subset: etc
+          - go-version: 1.16.x
+          - python-version: 3.9.x
+          - dotnet-version: 3.1.x
+          - node-version: 14.x
 
       fail-fast: false
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -124,11 +124,11 @@ jobs:
         # to still run on `master` branch verifications.
         include:
           - platform: macos-latest
-          - test-subset: etc
-          - go-version: 1.16.x
-          - python-version: 3.9.x
-          - dotnet-version: 3.1.x
-          - node-version: 14.x
+            test-subset: etc
+            go-version: 1.16.x
+            python-version: 3.9.x
+            dotnet-version: 3.1.x
+            node-version: 14.x
 
       fail-fast: false
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -115,12 +115,12 @@ jobs:
         # See scripts/tests_subsets.py when editing
         test-subset: [ native, etc ]
 
-        exclude:
-          - platform: macos-latest
+        # exclude:
+        #   - platform: macos-latest
 
-        include:
-          - platform: macos-latest
-            test-subset: native
+        # include:
+        #   - platform: macos-latest
+        #     test-subset: native
 
       fail-fast: false
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -113,7 +113,15 @@ jobs:
         node-version: [ 14.x ]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
+        test-subset: [ integration, integration-and-codegen, auto, etc ]
+
+        exclude:
+          - platform: macos-latest
+
+        include:
+          - platform: macos-latest
+          - test-subset: etc
+
       fail-fast: false
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-latest ]
-        go-version: [1.16.x]
+        go-version: [ 1.16.x ]
         python-version: [ 3.9.x ]
         dotnet-version: [ 3.1.x ]
         node-version: [ 14.x ]

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -113,15 +113,7 @@ jobs:
         node-version: [ 14.x ]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ native, etc ]
-
-        # exclude:
-        #   - platform: macos-latest
-
-        # include:
-        #   - platform: macos-latest
-        #     test-subset: native
-
+        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
       fail-fast: false
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -113,7 +113,15 @@ jobs:
         node-version: [ 14.x ]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ integration, auto-and-lifecycletest, native, etc ]
+        test-subset: [ native, etc ]
+
+        exclude:
+          - platform: macos-latest
+
+        include:
+          - platform: macos-latest
+            test-subset: native
+
       fail-fast: false
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.platform }}

--- a/scripts/test_subsets.py
+++ b/scripts/test_subsets.py
@@ -14,25 +14,63 @@ A note on the format of TEST_SUBSETS. The keys are test configuration
 names, and the values are lists of either Go packages containing the
 tests, or test suites names as passed to `run-testsuite.py`.
 
+The special `etc` test subset catches all unlisted tests. This subset
+will always run on every PR. Other tests subsets may be skipped on PR
+verification for platforms such as Mac OS where there is currently a
+shortage of runners; these tests will still run on `master` and
+`release` verifications.
+
 """
 
 TEST_SUBSETS = {
     'integration': [
-        'github.com/pulumi/pulumi/tests/integration'
+        'github.com/pulumi/pulumi/tests/integration',
     ],
-    'auto-and-lifecycletest': [
-        'auto-dotnet',
-        'auto-nodejs',
-        'auto-python',
+
+    'integration-and-codegen': [
+        'github.com/pulumi/pulumi/tests/integration/aliases',
+        'github.com/pulumi/pulumi/tests/integration/custom_timeouts',
+        'github.com/pulumi/pulumi/tests/integration/delete_before_create',
+        'github.com/pulumi/pulumi/tests/integration/dependency_steps',
+        'github.com/pulumi/pulumi/tests/integration/double_pending_delete',
+        'github.com/pulumi/pulumi/tests/integration/duplicate_urns',
+        'github.com/pulumi/pulumi/tests/integration/partial_state',
+        'github.com/pulumi/pulumi/tests/integration/policy',
+        'github.com/pulumi/pulumi/tests/integration/protect_resources',
+        'github.com/pulumi/pulumi/tests/integration/query',
+        'github.com/pulumi/pulumi/tests/integration/read/import_acquire',
+        'github.com/pulumi/pulumi/tests/integration/read/read_dbr',
+        'github.com/pulumi/pulumi/tests/integration/read/read_relinquish',
+        'github.com/pulumi/pulumi/tests/integration/read/read_replace',
+        'github.com/pulumi/pulumi/tests/integration/recreate_resource_check',
+        'github.com/pulumi/pulumi/tests/integration/steps',
+        'github.com/pulumi/pulumi/tests/integration/targets',
+        'github.com/pulumi/pulumi/tests/integration/transformations',
+        'github.com/pulumi/pulumi/tests/integration/types',
+        'github.com/pulumi/pulumi/pkg/v3/codegen',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/docs',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/dotnet',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/go',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/hcl2',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/importer',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/nodejs',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/python',
+        'github.com/pulumi/pulumi/pkg/v3/codegen/schema',
+    ],
+
+    'auto': [
+        # Primary Go-driven Auto API tests
         'github.com/pulumi/pulumi/sdk/v3/go/auto',
-        'github.com/pulumi/pulumi/pkg/v3/engine/lifeycletest'
-    ],
-    'native': [
-        'dotnet-test',
-        'istanbul',
-        'istanbul-with-mocks',
-        'python/lib/test',
-        'python/lib/test/langhost/resource_thens',
-        'python/lib/test_with_mocks'
+
+        # Auto API tests driven by dotnet
+        'auto-dotnet',
+
+        # Auto API tests driven by npm
+        'auto-nodejs',
+
+        # Auto API tests driven by pytest
+        'auto-python',
     ]
 }


### PR DESCRIPTION
# Description

The goal of this change is to facilitate merging PRs faster.

In particular we have a shortage of Mac OS workers and therefore have PRs waiting to be verified until workers become available. With this change:

- the number of workers booked for a PR verification goes down from **4** to **1**

- by skipping integration and Automation API tests on the Mac OS worker, the Mac OS worker PR verification time is **36 min**

- after a PR is merged, the full set of tests will still run on 4 Mac OS workers on every commit in `master` branch

In addition to skipping tests on Mac OS, the PR changes the partitioning of the tests into test subsets. This is done so that the subset of checks that *do* run on every PR on Mac OS (this subset is called `etc`) conservatively includes all the important tests. This subset will also include all the newly introduced tests until they are explicitly reassigned to a different subset.

After the repartitioning the timings are (the intent is to have these somewhat balanced to make good use of the existing workers):

- Ubuntu integration: 43 min
- Ubuntu integration-and-codegen: 45 min
- Ubuntu auto: 29 min
- Ubuntu etc: 30 min
- Mac OS etc: 36 min
- Windows: TBD


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
