### PR TITLE
Enable output values by default

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- [CLI] Enable output values in the engine by default.
+  [#8014](https://github.com/pulumi/pulumi/pull/8014)
+
 ### Bug Fixes
 
 - [automation/python] Fix a bug in printing `Stack` if no program is provided.

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -76,7 +76,7 @@ func disableResourceReferences() bool {
 }
 
 func disableOutputValues() bool {
-	return !cmdutil.IsTruthy(os.Getenv("PULUMI_ENABLE_OUTPUT_VALUES"))
+	return cmdutil.IsTruthy(os.Getenv("PULUMI_DISABLE_OUTPUT_VALUES"))
 }
 
 // skipConfirmations returns whether or not confirmation prompts should

--- a/sdk/go/common/resource/plugin/provider_plugin.go
+++ b/sdk/go/common/resource/plugin/provider_plugin.go
@@ -1108,6 +1108,7 @@ func (p *provider) Construct(info ConstructInfo, typ tokens.Type, name tokens.QN
 		// To initially scope the use of this new feature, we only keep output values for
 		// Construct and Call (when the client accepts them).
 		KeepOutputValues: p.acceptOutputs,
+		DontSkipOutputs:  true,
 	})
 	if err != nil {
 		return ConstructResult{}, err
@@ -1362,6 +1363,7 @@ func (p *provider) Call(tok tokens.ModuleMember, args resource.PropertyMap, info
 		// To initially scope the use of this new feature, we only keep output values for
 		// Construct and Call (when the client accepts them).
 		KeepOutputValues: p.acceptOutputs,
+		DontSkipOutputs:  true,
 	})
 	if err != nil {
 		return CallResult{}, err

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -40,6 +40,7 @@ type MarshalOptions struct {
 	KeepResources      bool   // true if we are keeping resoures (otherwise we return raw urn).
 	SkipInternalKeys   bool   // true to skip internal property keys (keys that start with "__") in the resulting map.
 	KeepOutputValues   bool   // true if we are keeping output values.
+	DontSkipOutputs    bool   // true to not skip outputs.
 }
 
 const (
@@ -72,7 +73,7 @@ func MarshalProperties(props resource.PropertyMap, opts MarshalOptions) (*struct
 	for _, key := range props.StableKeys() {
 		v := props[key]
 		logging.V(9).Infof("Marshaling property for RPC[%s]: %s=%v", opts.Label, key, v)
-		if v.IsOutput() && !v.OutputValue().Known && !opts.KeepOutputValues {
+		if !opts.DontSkipOutputs && v.IsOutput() && !v.OutputValue().Known {
 			logging.V(9).Infof("Skipping output property for RPC[%s]: %v", opts.Label, key)
 		} else if opts.SkipNulls && v.IsNull() {
 			logging.V(9).Infof("Skipping null property for RPC[%s]: %s (as requested)", opts.Label, key)

--- a/sdk/go/common/resource/plugin/rpc.go
+++ b/sdk/go/common/resource/plugin/rpc.go
@@ -155,7 +155,7 @@ func MarshalPropertyValue(key resource.PropertyKey, v resource.PropertyValue,
 			result := v.OutputValue().Element
 			if !v.OutputValue().Known {
 				// Unknown outputs are marshaled the same as Computed.
-				result = resource.MakeComputed(result)
+				result = resource.MakeComputed(resource.NewStringProperty(""))
 			}
 			if v.OutputValue().Secret {
 				result = resource.MakeSecret(result)

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -436,7 +436,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "empty (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.NewOutputProperty(resource.Output{}),
 			},
@@ -458,7 +458,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "unknown (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.MakeOutput(resource.NewStringProperty("")),
 			},
@@ -480,7 +480,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "unknown with deps (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.NewOutputProperty(resource.Output{
 					Element:      resource.NewStringProperty(""),
@@ -515,7 +515,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "known (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.NewOutputProperty(resource.Output{
 					Element: resource.NewStringProperty("hello"),
@@ -543,7 +543,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "known with deps (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.NewOutputProperty(resource.Output{
 					Element:      resource.NewStringProperty("hello"),
@@ -582,7 +582,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "secret (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.NewOutputProperty(resource.Output{
 					Element: resource.NewStringProperty("shhh"),
@@ -614,7 +614,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "secret with deps (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.NewOutputProperty(resource.Output{
 					Element:      resource.NewStringProperty("shhh"),
@@ -657,7 +657,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "unknown secret (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.NewOutputProperty(resource.Output{
 					Element: resource.NewStringProperty("shhh"),
@@ -685,7 +685,7 @@ func TestMarshalProperties(t *testing.T) {
 		},
 		{
 			name: "unknown secret with deps (KeepOutputValues)",
-			opts: MarshalOptions{KeepOutputValues: true},
+			opts: MarshalOptions{DontSkipOutputs: true, KeepOutputValues: true},
 			props: resource.PropertyMap{
 				"foo": resource.NewOutputProperty(resource.Output{
 					Element:      resource.NewStringProperty("shhh"),
@@ -1649,4 +1649,165 @@ func walkValueSelfWithDescendants(
 		return fmt.Errorf("Bad *structpb.Value of unknown type at %s: %v", path, v)
 	}
 	return nil
+}
+
+func TestMarshalPropertiesDontSkipOutputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     MarshalOptions
+		props    resource.PropertyMap
+		expected *structpb.Struct
+	}{
+		{
+			name: "Computed (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			props: resource.PropertyMap{
+				"message": resource.MakeComputed(resource.NewStringProperty("")),
+				"nested": resource.NewObjectProperty(resource.PropertyMap{
+					"value": resource.MakeComputed(resource.NewStringProperty("")),
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"message": {
+						Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+					},
+					"nested": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"value": {
+										Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Output (KeepUnknowns)",
+			opts: MarshalOptions{KeepUnknowns: true},
+			props: resource.PropertyMap{
+				"message": resource.NewOutputProperty(resource.Output{}),
+				"nested": resource.NewObjectProperty(resource.PropertyMap{
+					"value": resource.NewOutputProperty(resource.Output{}),
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"nested": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Output (KeepUnknowns, KeepOutputValues)",
+			opts: MarshalOptions{KeepUnknowns: true, KeepOutputValues: true},
+			props: resource.PropertyMap{
+				"message": resource.NewOutputProperty(resource.Output{}),
+				"nested": resource.NewObjectProperty(resource.PropertyMap{
+					"value": resource.NewOutputProperty(resource.Output{}),
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"nested": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Output (KeepUnknowns, DontSkipOutputs)",
+			opts: MarshalOptions{KeepUnknowns: true, DontSkipOutputs: true},
+			props: resource.PropertyMap{
+				"message": resource.NewOutputProperty(resource.Output{}),
+				"nested": resource.NewObjectProperty(resource.PropertyMap{
+					"value": resource.NewOutputProperty(resource.Output{}),
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"message": {
+						Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+					},
+					"nested": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"value": {
+										Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Output (KeepUnknowns, KeepOutputValues, DontSkipOutputs)",
+			opts: MarshalOptions{KeepUnknowns: true, KeepOutputValues: true, DontSkipOutputs: true},
+			props: resource.PropertyMap{
+				"message": resource.NewOutputProperty(resource.Output{}),
+				"nested": resource.NewObjectProperty(resource.PropertyMap{
+					"value": resource.NewOutputProperty(resource.Output{}),
+				}),
+			},
+			expected: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"message": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									resource.SigKey: {
+										Kind: &structpb.Value_StringValue{StringValue: resource.OutputValueSig},
+									},
+								},
+							},
+						},
+					},
+					"nested": {
+						Kind: &structpb.Value_StructValue{
+							StructValue: &structpb.Struct{
+								Fields: map[string]*structpb.Value{
+									"value": {
+										Kind: &structpb.Value_StructValue{
+											StructValue: &structpb.Struct{
+												Fields: map[string]*structpb.Value{
+													resource.SigKey: {
+														Kind: &structpb.Value_StringValue{
+															StringValue: resource.OutputValueSig,
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := MarshalProperties(tt.props, tt.opts)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }

--- a/sdk/go/common/resource/plugin/rpc_test.go
+++ b/sdk/go/common/resource/plugin/rpc_test.go
@@ -939,7 +939,7 @@ func TestOutputValueMarshaling(t *testing.T) {
 			opts: MarshalOptions{KeepUnknowns: true},
 			raw:  resource.NewOutputProperty(resource.Output{}),
 			expected: &structpb.Value{
-				Kind: &structpb.Value_NullValue{NullValue: 0},
+				Kind: &structpb.Value_StringValue{StringValue: UnknownStringValue},
 			},
 		},
 		{


### PR DESCRIPTION
Enable output values by default in the resource monitor and change the polarity of the envvar from `PULUMI_ENABLE_OUTPUT_VALUES` to `PULUMI_DISABLE_OUTPUT_VALUES`.

We've had a cron job running in the `pulumi/examples` repro with the feature both enabled and disabled, and everything is looking good on those runs (as expected), so we're comfortable enabling it by default.

Fixes #8007