### PR TITLE
[auto/python] - Fix a bug in printing stack.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [automation/python] Fix a bug in printing `Stack` if no program is provided.
+  [#8032](https://github.com/pulumi/pulumi/pull/8032)

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -101,7 +101,8 @@ class LocalWorkspace(Workspace):
                 self.save_stack_settings(key, stack_settings[key])
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(work_dir={self.work_dir!r}, program={self.program.__name__}, " \
+        return f"{self.__class__.__name__}(work_dir={self.work_dir!r}, " \
+               f"program={self.program.__name__ if self.program else None}, " \
                f"pulumi_home={self.pulumi_home!r}, env_vars={self.env_vars!r}, " \
                f"secrets_provider={self.secrets_provider})"
 

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -327,7 +327,7 @@ class TestLocalWorkspace(unittest.TestCase):
         stack_name = stack_namer(project_name)
         work_dir = test_path("data", project_name)
         stack = create_stack(stack_name, work_dir=work_dir)
-        print(stack)
+        self.assertIsNone(print(stack))
 
         config: ConfigMap = {
             "bar": ConfigValue(value="abc"),

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -327,6 +327,7 @@ class TestLocalWorkspace(unittest.TestCase):
         stack_name = stack_namer(project_name)
         work_dir = test_path("data", project_name)
         stack = create_stack(stack_name, work_dir=work_dir)
+        print(stack)
 
         config: ConfigMap = {
             "bar": ConfigValue(value="abc"),


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

This repro'd with `print(stack)` in a local program so I added that to the test.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
