### PR TITLE
Do report stdout and stderr in case of failure

### DIFF
--- a/pkg/codegen/internal/test/helpers.go
+++ b/pkg/codegen/internal/test/helpers.go
@@ -335,7 +335,6 @@ func RunCommand(t *testing.T, name string, cwd string, exec string, args ...stri
 		append([]string{exec}, args...),
 		wd,
 		&cmdOptions)
-	require.NoError(t, err)
 	if err != nil {
 		stdout := stdout.String()
 		stderr := stderr.String()
@@ -345,6 +344,7 @@ func RunCommand(t *testing.T, name string, cwd string, exec string, args ...stri
 		if len(stderr) > 0 {
 			t.Logf("stderr: %s", stderr)
 		}
+		require.NoError(t, err)
 		t.FailNow()
 	}
 }

--- a/pkg/codegen/internal/test/helpers.go
+++ b/pkg/codegen/internal/test/helpers.go
@@ -335,7 +335,7 @@ func RunCommand(t *testing.T, name string, cwd string, exec string, args ...stri
 		append([]string{exec}, args...),
 		wd,
 		&cmdOptions)
-	if err != nil {
+	if !assert.NoError(t, err) {
 		stdout := stdout.String()
 		stderr := stderr.String()
 		if len(stdout) > 0 {
@@ -344,7 +344,6 @@ func RunCommand(t *testing.T, name string, cwd string, exec string, args ...stri
 		if len(stderr) > 0 {
 			t.Logf("stderr: %s", stderr)
 		}
-		require.NoError(t, err)
 		t.FailNow()
 	}
 }


### PR DESCRIPTION
# Description

This change makes sure that we do get to see stdout/stderr of a failing command. I think the original code is a typo.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
