### PR TITLE
Change Docker build to use Pulumi's fork of action-docker-build.

### DIFF
--- a/.github/workflows/trigger-container-build-event.yml
+++ b/.github/workflows/trigger-container-build-event.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Pulumi Image
-        uses: jaxxstorm/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
+        uses: pulumi/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
         with:
           repository: pulumi/pulumi
           username: "pulumibot"
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build base image
-        uses: jaxxstorm/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
+        uses: pulumi/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
         with:
           repository: pulumi/pulumi-base
           buildkit: true
@@ -79,11 +79,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubi", "debian" ]
+        os: ["ubi", "debian"]
     steps:
       - uses: actions/checkout@master
       - name: Build base image
-        uses: jaxxstorm/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
+        uses: pulumi/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
         with:
           repository: pulumi/pulumi-base
           buildkit: true
@@ -100,11 +100,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ "nodejs", "python", "dotnet", "go" ]
+        sdk: ["nodejs", "python", "dotnet", "go"]
     steps:
       - uses: actions/checkout@master
       - name: Build image
-        uses: jaxxstorm/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
+        uses: pulumi/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
         with:
           repository: pulumi/pulumi-${{matrix.sdk}}
           buildkit: true
@@ -152,12 +152,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ "nodejs", "python", "dotnet", "go" ]
-        os: [ "ubi", "debian" ]
+        sdk: ["nodejs", "python", "dotnet", "go"]
+        os: ["ubi", "debian"]
     steps:
       - uses: actions/checkout@master
       - name: Build image
-        uses: jaxxstorm/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
+        uses: pulumi/action-docker-build@e98e474ca0312b1a0300cdbf9357dd2df3c62c22
         with:
           repository: pulumi/pulumi-${{matrix.sdk}}
           buildkit: true
@@ -194,8 +194,8 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        image: [ "base", "nodejs", "python", "go" ]
-        os: [ "ubi" ]
+        image: ["base", "nodejs", "python", "go"]
+        os: ["ubi"]
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check Docker images for vulnerabilities


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
