### PR TITLE
[cli] Add the ability to control auto-refresh of stacks by Pulumi.yaml

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,10 @@
 - [cli] - Differentiate in-progress actions by bolding output.
   [#7918](https://github.com/pulumi/pulumi/pull/7918)
 
+- [CLI] Adding the ability to set `refresh: always` in an options object at a Pulumi.yaml level
+  to allow a user to be able to always refresh their derivative stacks by default
+  [#8071](https://github.com/pulumi/pulumi/pull/8071)
+
 ### Bug Fixes
 
 - [codegen/go] - Fix generation of cyclic struct types.

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -209,7 +209,7 @@ func newDestroyCmd() *cobra.Command {
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
 	cmd.PersistentFlags().StringVarP(
-		&refresh, "refresh", "r", "no",
+		&refresh, "refresh", "r", "",
 		"Refresh the state of the stack's resources before this update")
 	cmd.PersistentFlags().Lookup("refresh").NoOptDefVal = "true"
 	cmd.PersistentFlags().BoolVar(

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -41,7 +41,7 @@ func newDestroyCmd() *cobra.Command {
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int
-	var refresh bool
+	var refresh string
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
@@ -143,10 +143,14 @@ func newDestroyCmd() *cobra.Command {
 				targetUrns = append(targetUrns, resource.URN(t))
 			}
 
+			refreshOption, err := getRefreshOption(proj, refresh)
+			if err != nil {
+				return result.FromError(err)
+			}
 			opts.Engine = engine.UpdateOptions{
 				Parallel:                  parallel,
 				Debug:                     debug,
-				Refresh:                   refresh,
+				Refresh:                   refreshOption,
 				DestroyTargets:            targetUrns,
 				TargetDependents:          targetDependents,
 				UseLegacyDiff:             useLegacyDiff(),
@@ -204,9 +208,10 @@ func newDestroyCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
-	cmd.PersistentFlags().BoolVarP(
-		&refresh, "refresh", "r", false,
+	cmd.PersistentFlags().StringVarP(
+		&refresh, "refresh", "r", "no",
 		"Refresh the state of the stack's resources before this update")
+	cmd.PersistentFlags().Lookup("refresh").NoOptDefVal = "true"
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,
 		"Show configuration keys and variables")

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -262,7 +262,7 @@ func newPreviewCmd() *cobra.Command {
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
 	cmd.PersistentFlags().StringVarP(
-		&refresh, "refresh", "r", "no",
+		&refresh, "refresh", "r", "",
 		"Refresh the state of the stack's resources before this update")
 	cmd.PersistentFlags().Lookup("refresh").NoOptDefVal = "true"
 	cmd.PersistentFlags().BoolVar(

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -44,7 +44,7 @@ func newPreviewCmd() *cobra.Command {
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int
-	var refresh bool
+	var refresh string
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
@@ -160,12 +160,17 @@ func newPreviewCmd() *cobra.Command {
 				replaceURNs = append(replaceURNs, resource.URN(tr))
 			}
 
+			refreshOption, err := getRefreshOption(proj, refresh)
+			if err != nil {
+				return result.FromError(err)
+			}
+
 			opts := backend.UpdateOptions{
 				Engine: engine.UpdateOptions{
 					LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
 					Parallel:                  parallel,
 					Debug:                     debug,
-					Refresh:                   refresh,
+					Refresh:                   refreshOption,
 					ReplaceTargets:            replaceURNs,
 					UseLegacyDiff:             useLegacyDiff(),
 					DisableProviderPreview:    disableProviderPreview(),
@@ -256,9 +261,10 @@ func newPreviewCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
-	cmd.PersistentFlags().BoolVarP(
-		&refresh, "refresh", "r", false,
+	cmd.PersistentFlags().StringVarP(
+		&refresh, "refresh", "r", "no",
 		"Refresh the state of the stack's resources before this update")
+	cmd.PersistentFlags().Lookup("refresh").NoOptDefVal = "true"
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,
 		"Show configuration keys and variables")

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -468,7 +468,7 @@ func newUpCmd() *cobra.Command {
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
 	cmd.PersistentFlags().StringVarP(
-		&refresh, "refresh", "r", "no",
+		&refresh, "refresh", "r", "",
 		"Refresh the state of the stack's resources before this update")
 	cmd.PersistentFlags().Lookup("refresh").NoOptDefVal = "true"
 	cmd.PersistentFlags().BoolVar(

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -60,7 +60,7 @@ func newUpCmd() *cobra.Command {
 	var diffDisplay bool
 	var eventLogPath string
 	var parallel int
-	var refresh bool
+	var refresh string
 	var showConfig bool
 	var showReplacementSteps bool
 	var showSames bool
@@ -122,11 +122,15 @@ func newUpCmd() *cobra.Command {
 			replaceURNs = append(replaceURNs, resource.URN(tr))
 		}
 
+		refreshOption, err := getRefreshOption(proj, refresh)
+		if err != nil {
+			return result.FromError(err)
+		}
 		opts.Engine = engine.UpdateOptions{
 			LocalPolicyPacks:          engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
 			Parallel:                  parallel,
 			Debug:                     debug,
-			Refresh:                   refresh,
+			Refresh:                   refreshOption,
 			RefreshTargets:            targetURNs,
 			ReplaceTargets:            replaceURNs,
 			UseLegacyDiff:             useLegacyDiff(),
@@ -287,11 +291,16 @@ func newUpCmd() *cobra.Command {
 			return result.FromError(errors.Wrap(err, "getting stack configuration"))
 		}
 
+		refreshOption, err := getRefreshOption(proj, refresh)
+		if err != nil {
+			return result.FromError(err)
+		}
+
 		opts.Engine = engine.UpdateOptions{
 			LocalPolicyPacks: engine.MakeLocalPolicyPacks(policyPackPaths, policyPackConfigPaths),
 			Parallel:         parallel,
 			Debug:            debug,
-			Refresh:          refresh,
+			Refresh:          refreshOption,
 		}
 
 		// TODO for the URL case:
@@ -458,9 +467,10 @@ func newUpCmd() *cobra.Command {
 	cmd.PersistentFlags().IntVarP(
 		&parallel, "parallel", "p", defaultParallel,
 		"Allow P resource operations to run in parallel at once (1 for no parallelism). Defaults to unbounded.")
-	cmd.PersistentFlags().BoolVarP(
-		&refresh, "refresh", "r", false,
+	cmd.PersistentFlags().StringVarP(
+		&refresh, "refresh", "r", "no",
 		"Refresh the state of the stack's resources before this update")
+	cmd.PersistentFlags().Lookup("refresh").NoOptDefVal = "true"
 	cmd.PersistentFlags().BoolVar(
 		&showConfig, "show-config", false,
 		"Show configuration keys and variables")

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -839,3 +839,26 @@ func checkDeploymentVersionError(err error, stackName string) error {
 	}
 	return errors.Wrap(err, "could not deserialize deployment")
 }
+
+func getRefreshOption(proj *workspace.Project, refresh string) (bool, error) {
+	// we want to check for an explicit --refresh or a --refresh=true or --refresh=false
+	// no is the default we assign to the refresh default to be able to understand
+	// the difference between when the user actually interacted with the cli argument
+	// and the default functionality today
+	if refresh != "" && refresh != "no" {
+		refreshDetails, boolErr := strconv.ParseBool(refresh)
+		if boolErr != nil {
+			// the user has passed a --refresh but with a random value that we don't support
+			return false, errors.New("unable to determine value for --refresh")
+		}
+		return refreshDetails, nil
+	}
+
+	// the user has not specifically passed an argument on the cli to refresh but has set a Project option to refresh
+	if proj.Options != nil && proj.Options.Refresh == "always" {
+		return true, nil
+	}
+
+	// the default functionality right now is to always skip a refresh
+	return false, nil
+}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -842,10 +842,10 @@ func checkDeploymentVersionError(err error, stackName string) error {
 
 func getRefreshOption(proj *workspace.Project, refresh string) (bool, error) {
 	// we want to check for an explicit --refresh or a --refresh=true or --refresh=false
-	// no is the default we assign to the refresh default to be able to understand
-	// the difference between when the user actually interacted with the cli argument
+	// refresh is assigned the empty string by default to distinguish the difference between
+	// when the user actually interacted with the cli argument (`NoOptDefVal`)
 	// and the default functionality today
-	if refresh != "" && refresh != "no" {
+	if refresh != "" {
 		refreshDetails, boolErr := strconv.ParseBool(refresh)
 		if boolErr != nil {
 			// the user has passed a --refresh but with a random value that we don't support

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -17,10 +17,12 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	pul_testing "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/gitutil"
-	"github.com/stretchr/testify/assert"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // assertEnvValue assert the update metadata's Environment map contains the given value.
@@ -260,6 +262,69 @@ func Test_makeJSONString(t *testing.T) {
 			}
 			if got != tt.expected {
 				t.Errorf("makeJSONString() got = %v, expected %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetRefreshOption(t *testing.T) {
+	tests := []struct {
+		name                 string
+		refresh              string
+		project              workspace.Project
+		expectedRefreshState bool
+	}{
+		{
+			"No options specified means no refresh",
+			"no",
+			workspace.Project{},
+			false,
+		},
+		{
+			"Passing --refresh=true causes a refresh",
+			"true",
+			workspace.Project{},
+			true,
+		},
+		{
+			"Passing --refresh=false causes no refresh",
+			"false",
+			workspace.Project{},
+			false,
+		},
+		{
+			"Setting Refresh at a project level via Pulumi.yaml and no CLI args",
+			"no",
+			workspace.Project{
+				Name:    "auto-refresh",
+				Runtime: workspace.ProjectRuntimeInfo{},
+				Options: &workspace.ProjectOptions{
+					Refresh: "always",
+				},
+			},
+			true,
+		},
+		{
+			"Setting Refresh at a project level via Pulumi.yaml and --refresh=false",
+			"false",
+			workspace.Project{
+				Name:    "auto-refresh",
+				Runtime: workspace.ProjectRuntimeInfo{},
+				Options: &workspace.ProjectOptions{
+					Refresh: "always",
+				},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			shouldRefresh, err := getRefreshOption(&tt.project, tt.refresh)
+			if err != nil {
+				t.Errorf("getRefreshOption() error = %v", err)
+			}
+			if shouldRefresh != tt.expectedRefreshState {
+				t.Errorf("getRefreshOption got = %t, expected %t", shouldRefresh, tt.expectedRefreshState)
 			}
 		})
 	}

--- a/pkg/cmd/pulumi/util_test.go
+++ b/pkg/cmd/pulumi/util_test.go
@@ -276,7 +276,7 @@ func TestGetRefreshOption(t *testing.T) {
 	}{
 		{
 			"No options specified means no refresh",
-			"no",
+			"",
 			workspace.Project{},
 			false,
 		},
@@ -294,7 +294,7 @@ func TestGetRefreshOption(t *testing.T) {
 		},
 		{
 			"Setting Refresh at a project level via Pulumi.yaml and no CLI args",
-			"no",
+			"",
 			workspace.Project{
 				Name:    "auto-refresh",
 				Runtime: workspace.ProjectRuntimeInfo{},

--- a/sdk/go/common/workspace/project.go
+++ b/sdk/go/common/workspace/project.go
@@ -58,6 +58,11 @@ type ProjectBackend struct {
 	URL string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
+type ProjectOptions struct {
+	// Refresh is the ability to always run a refresh as part of a pulumi update / preview / destroy
+	Refresh string `json:"refresh,omitempty" yaml:"refresh,omitempty"`
+}
+
 // Project is a Pulumi project manifest.
 //
 // We explicitly add yaml tags (instead of using the default behavior from https://github.com/ghodss/yaml which works
@@ -90,6 +95,9 @@ type Project struct {
 
 	// Backend is an optional backend configuration
 	Backend *ProjectBackend `json:"backend,omitempty" yaml:"backend,omitempty"`
+
+	// Options is an optional set of project options
+	Options *ProjectOptions `json:"options,omitempty" yaml:"options,omitempty"`
 }
 
 func (proj *Project) Validate() error {


### PR DESCRIPTION
Fixes: #8058

A user can now specify the following in their Pulumi.yaml

```
options:
  refresh: always
```

This will cause the derivative stacks to refresh by default when running an update, preview
or destroy command. We can override this with `--refresh=false`

the specific CLI commands still override this argument. Therefore:

* If a user sets refresh: always, they can override this behaviour with `--refresh==false`
* if a user sets `--refresh` or `--refresh=true` then it will use that by default
* if no cli args are passed but `refresh: always` then we will perform a refresh
* the default behaviour still exists of no refresh

https://asciinema.org/a/2BQoAe9gx9E07gBiM9h9A1cra

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
