### PR TITLE
Prepare for v3.13.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 CHANGELOG
 =========
 
-## 3.13.1 (2021-09-27)
+## 3.13.2 (2021-09-27)
+
+**Please Note:** The v3.13.1 failed in our build pipeline and was re-released as v3.13.2.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ CHANGELOG
 
 ## 3.13.2 (2021-09-27)
 
-**Please Note:** The v3.13.1 failed in our build pipeline and was re-released as v3.13.2.
+**Please Note:** The v3.13.1 release failed in our build pipeline and was re-released as v3.13.2.
 
 ### Improvements
 

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,5 @@
+**Please Note:** The v3.13.1 failed in our build pipeline and was re-released as v3.13.2.
+
 ### Improvements
 
 - [CLI] - Enable output values in the engine by default.

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,4 @@
-**Please Note:** The v3.13.1 failed in our build pipeline and was re-released as v3.13.2.
+**Please Note:** The v3.13.1 release failed in our build pipeline and was re-released as v3.13.2.
 
 ### Improvements
 


### PR DESCRIPTION
This is patterned off the similar note for v3.5.0/v3.5.1, but there are slight differences between what's in the CHANGELOG vs. GH release notes. I went with consistent text for both for in this change.

https://github.com/pulumi/pulumi/blob/472f14c992406f673ec905bdc65c0c8fb2fdeeb6/CHANGELOG.md#L424

vs

https://github.com/pulumi/pulumi/releases/tag/v3.5.1

> **Please Note:** Release v3.5.0 failed in our build pipeline so will be rebuilt with a new tag of v3.5.1