### PR TITLE
Check worktree is clean before releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
   publish-binaries:
     name: Publish Binaries
     runs-on: macos-latest
-    needs: [check-clean-worktree, lint, build-and-test, windows-build]
+    needs: [lint, build-and-test, windows-build]
     strategy:
       matrix:
         go-version: [ 1.16.x ]
@@ -289,17 +289,6 @@ jobs:
       - name: Lint .NET
         run: |
           cd sdk/dotnet && make lint
-  check-clean-worktree:
-    name: Check git worktree is clean
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Scripts Repo
-        uses: actions/checkout@v2
-        with:
-          path: ci-scripts
-          repository: pulumi/scripts
-      - name: Check worktree clean
-        run: ./ci-scripts/ci/check-worktree-is-clean
   build-and-test:
     name: Build & Test
     strategy:
@@ -346,6 +335,11 @@ jobs:
           echo "${{ runner.temp }}/opt/pulumi/bin" >> $GITHUB_PATH
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v2
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
       - name: Fetch Tags
         run: |
           git fetch --quiet --prune --unshallow --tags
@@ -366,6 +360,8 @@ jobs:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
           PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
+      - name: Check worktree is clean
+        run: ./ci-scripts/ci/check-worktree-is-clean
       - name: Install
         run: |
           make install_all

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
   publish-binaries:
     name: Publish Binaries
     runs-on: macos-latest
-    needs: [build-and-test, windows-build]
+    needs: [check-clean-worktree, lint, build-and-test, windows-build]
     strategy:
       matrix:
         go-version: [ 1.16.x ]
@@ -289,6 +289,17 @@ jobs:
       - name: Lint .NET
         run: |
           cd sdk/dotnet && make lint
+  check-clean-worktree:
+    name: Check git worktree is clean
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Scripts Repo
+        uses: actions/checkout@v2
+        with:
+          path: ci-scripts
+          repository: pulumi/scripts
+      - name: Check worktree clean
+        run: ./ci-scripts/ci/check-worktree-is-clean
   build-and-test:
     name: Build & Test
     strategy:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

* Adds `lint` step as required before release.
* Adds a new job `check-clean-worktree` to ensure the git work tree is clean before releasing.

I elected to add a separate job for this step to avoid doing it 8 times as part of build-and-test.

I unfortunately don't know how to test this without a release. However, this is already a part of the `master` workflow: https://github.com/pulumi/pulumi-aws/blob/master/.github/workflows/master.yml#L68-L69

Fixes https://github.com/pulumi/pulumi/issues/8092

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
