### PR TITLE
[engine/test] Add a repro for #7786.

### DIFF
--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -251,9 +251,10 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 			Validate: func(project workspace.Project, target deploy.Target, entries JournalEntries,
 				_ []Event, res result.Result) result.Result {
 
-				// Should see only creates.
+				// Should see only creates or reads.
 				for _, entry := range entries {
-					assert.Equal(t, deploy.OpCreate, entry.Step.Op())
+					op := entry.Step.Op()
+					assert.True(t, op == deploy.OpCreate || op == deploy.OpRead)
 				}
 				assert.Len(t, entries.Snap(target.Snapshot).Resources, resCount)
 				return res
@@ -282,7 +283,8 @@ func MakeBasicLifecycleSteps(t *testing.T, resCount int) []TestStep {
 
 				// Should see only sames.
 				for _, entry := range entries {
-					assert.Equal(t, deploy.OpSame, entry.Step.Op())
+					op := entry.Step.Op()
+					assert.True(t, op == deploy.OpSame || op == deploy.OpRead)
 				}
 				assert.Len(t, entries.Snap(target.Snapshot).Resources, resCount)
 				return res

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -101,6 +101,7 @@ type ResourceOptions struct {
 	CustomTimeouts        *resource.CustomTimeouts
 	SupportsPartialValues *bool
 	Remote                bool
+	Providers             map[string]string
 
 	DisableSecrets            bool
 	DisableResourceReferences bool
@@ -187,6 +188,7 @@ func (rm *ResourceMonitor) RegisterResource(t tokens.Type, name string, custom b
 		SupportsPartialValues:      supportsPartialValues,
 		Remote:                     opts.Remote,
 		ReplaceOnChanges:           opts.ReplaceOnChanges,
+		Providers:                  opts.Providers,
 	}
 
 	// submit request

--- a/pkg/resource/deploy/source_eval.go
+++ b/pkg/resource/deploy/source_eval.go
@@ -994,6 +994,7 @@ func (rm *resmon) RegisterResource(ctx context.Context,
 		// Invoke the provider's Construct RPC method.
 		options := plugin.ConstructOptions{
 			Aliases:              aliases,
+			Dependencies:         dependencies,
 			Protect:              protect,
 			PropertyDependencies: propertyDependencies,
 			Providers:            providerRefs,


### PR DESCRIPTION
This test is derived from a user-reported issue rooted in dependencies
on remote components.

Closes #7786.