### PR TITLE
Go codegen flag to disable fnOutput generation to save space

### DIFF
--- a/pkg/codegen/go/importer.go
+++ b/pkg/codegen/go/importer.go
@@ -49,6 +49,10 @@ type GoPackageInfo struct {
 	// The version of the Pulumi SDK used with this provider, e.g. 3.
 	// Used to generate doc links for pulumi builtin types. If omitted, the latest SDK version is used.
 	PulumiSDKVersion int `json:"pulumiSDKVersion,omitempty"`
+
+	// Feature flag to disable generating `$fnOutput` invoke
+	// function versions to save space.
+	DisableFunctionOutputVersions bool `json:"disableFunctionOutputVersions,omitempty"`
 }
 
 // Importer implements schema.Language for Go.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #7835 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
