### PR TITLE
Fix Go automation API --target / --replace args

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -11,3 +11,6 @@
 
 - [codegen/go] - Fix generation of cyclic struct types.
   [#8049](https://github.com/pulumi/pulumi/pull/8049)
+
+- [sdk/go] - Fix --target / --replace args
+  [#8109](https://github.com/pulumi/pulumi/pull/8109)

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -227,10 +227,10 @@ func (s *Stack) Preview(ctx context.Context, opts ...optpreview.Option) (Preview
 		sharedArgs = append(sharedArgs, "--diff")
 	}
 	for _, rURN := range preOpts.Replace {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--replace %s", rURN))
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--replace=%s", rURN))
 	}
 	for _, tURN := range preOpts.Target {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--target %s", tURN))
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--target=%s", tURN))
 	}
 	if preOpts.TargetDependents {
 		sharedArgs = append(sharedArgs, "--target-dependents")
@@ -322,10 +322,10 @@ func (s *Stack) Up(ctx context.Context, opts ...optup.Option) (UpResult, error) 
 		sharedArgs = append(sharedArgs, "--diff")
 	}
 	for _, rURN := range upOpts.Replace {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--replace %s", rURN))
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--replace=%s", rURN))
 	}
 	for _, tURN := range upOpts.Target {
-		sharedArgs = append(sharedArgs, fmt.Sprintf("--target %s", tURN))
+		sharedArgs = append(sharedArgs, fmt.Sprintf("--target=%s", tURN))
 	}
 	if upOpts.TargetDependents {
 		sharedArgs = append(sharedArgs, "--target-dependents")
@@ -409,7 +409,7 @@ func (s *Stack) Refresh(ctx context.Context, opts ...optrefresh.Option) (Refresh
 		args = append(args, "--expect-no-changes")
 	}
 	for _, tURN := range refreshOpts.Target {
-		args = append(args, fmt.Sprintf("--target %s", tURN))
+		args = append(args, fmt.Sprintf("--target=%s", tURN))
 	}
 	if refreshOpts.Parallel > 0 {
 		args = append(args, fmt.Sprintf("--parallel=%d", refreshOpts.Parallel))
@@ -474,7 +474,7 @@ func (s *Stack) Destroy(ctx context.Context, opts ...optdestroy.Option) (Destroy
 		args = append(args, fmt.Sprintf("--message=%q", destroyOpts.Message))
 	}
 	for _, tURN := range destroyOpts.Target {
-		args = append(args, fmt.Sprintf("--target %s", tURN))
+		args = append(args, fmt.Sprintf("--target=%s", tURN))
 	}
 	if destroyOpts.TargetDependents {
 		args = append(args, "--target-dependents")


### PR DESCRIPTION
# Description

This MR fixes an issue in the Pulumi Go automation API where --target / --replace args are not correctly formated, causing the CLI to not recognize the flag :

Error: unknown flag: --target urn:pulumi:stack::project::pulumi:providers:kubernetes::k8s


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
