### PR TITLE
Revert "Cancel checks on outdated PR commits (#8016)"

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -12,18 +12,6 @@ env:
   PULUMI_TEST_OWNER: "moolumi"
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
 
-# Cancel checks on prior commits when new commits are added to a PR.
-# This is motivated by temporary throughput issues on our GitHub
-# Actions workers availability.
-#
-# Note from GitHub docs: Concurrency is currently in beta and subject
-# to change.
-#
-# See also: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
-concurrency:
-  group: ${{ github.head_ref }}
-  cancel-in-progress: true
-
 jobs:
   comment-notification:
     # We only care about adding the result to the PR if it's a repository_dispatch event


### PR DESCRIPTION
This reverts commit a9c9853e85fb628979569701e8714f1694a6a719.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Per [docs](https://docs.github.com/en/actions/learn-github-actions/contexts) `github.head_ref` is only available via `pull_request` or `pull_request_target`.   

This breaks as `/run-acceptance-tests` is triggered via `repository_dispatch`, eg:
https://github.com/pulumi/pulumi/actions/runs/1295914761/workflow

To get unblocked, let's revert and figure out an alternative way to do concurrency later.

cc: @t0yv0 
