### PR TITLE
Add support for pulumiplugin.json in .NET and Go

### DIFF
--- a/pkg/codegen/utilities.go
+++ b/pkg/codegen/utilities.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
@@ -156,4 +158,32 @@ func ExpandShortEnumName(name string) string {
 		return replacement
 	}
 	return name
+}
+
+// GenPulumiPluginFile generates pulumiplugin.json for Python, Go and .NET
+// packages.
+func GenPulumiPluginFile(pkg *schema.Package) ([]byte, error) {
+	plugin := &plugin.PulumiPluginJSON{
+		Resource: true,
+		Name:     pkg.Name,
+		// TODO[pulumi/pulumi#8105] - Put in the correct versions
+		Version: "${PLUGIN_VERSION}",
+		Server:  pkg.PluginDownloadURL,
+	}
+	return plugin.JSON()
+}
+
+// Fs represents a folder hierarchy used for code generation. A path is
+// represented as relative to the package root.
+type Fs map[string][]byte
+
+// Add a new file to Fs. The file path must be unique.
+func (fs Fs) Add(path string, contents []byte) {
+	_, has := fs[path]
+	contract.Assertf(!has, "duplicate file: %q", path)
+	fs[path] = contents
+}
+
+func NewFs() Fs {
+	return map[string][]byte{}
 }


### PR DESCRIPTION
I add support for generating pulumiplugin.json in both .NET and Go.
Python already has this, and nodejs has it embedded in package.json.

I also standardized our `fs` wrapper on `map[string][]byte`. Otherwise
there would be 5 identical copies in our codebase.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #7245
Fixes #7244

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [X] Update codegen to generate `pulumipackage.json`.
- [ ] Update langhost to use new information
  - [ ] Go: Allow non pulumi prefixed modules when searching for plugins in `GetRequiredPlugins`.
  - [ ] .NET: Allow non Pulumi. prefixed packages when searching for packages that need plugins in `GetRequiredPlugins`.
