### PR TITLE
Change CI and prerelease builds to send dispatches.

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,12 +1,11 @@
 on:
   workflow_dispatch: {}
   push:
-    branches:
-      [ "master", "feature/**", "feature-**" ]
+    branches: ["master", "feature/**", "feature-**"]
     paths-ignore:
-      - 'CHANGELOG.md'
-      - 'CHANGELOG_PENDING.md'
-      - 'README.md'
+      - "CHANGELOG.md"
+      - "CHANGELOG_PENDING.md"
+      - "README.md"
 
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
@@ -25,11 +24,11 @@ jobs:
     needs: publish-binaries
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
-        python-version: [ 3.9.x ]
-        dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
-        language: [ "nodejs", "python", "dotnet" ]
+        go-version: [1.16.x]
+        python-version: [3.9.x]
+        dotnet-version: [3.1.x]
+        node-version: [14.x]
+        language: ["nodejs", "python", "dotnet"]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
@@ -83,7 +82,7 @@ jobs:
     needs: [build-and-test, windows-build]
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [1.16.x]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
@@ -115,28 +114,28 @@ jobs:
         with:
           version: latest
           args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate
-#  examples_smoke_test:
-#    name: Trigger Examples Smoke Test
-#    runs-on: ubuntu-latest
-#    needs: publish-sdks
-#    steps:
-#      - name: Checkout Repo
-#        uses: actions/checkout@v2
-#      - name: Install pulumictl
-#        uses: jaxxstorm/action-install-gh-release@v1.2.0
-#        with:
-#          repo: pulumi/pulumictl
-#      - name: Repository Dispatch
-#        run: |
-#          pulumictl dispatch -r pulumi/examples -c smoke-test-cli $(pulumictl get version --language generic -o)
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN}}
+  #  examples_smoke_test:
+  #    name: Trigger Examples Smoke Test
+  #    runs-on: ubuntu-latest
+  #    needs: publish-sdks
+  #    steps:
+  #      - name: Checkout Repo
+  #        uses: actions/checkout@v2
+  #      - name: Install pulumictl
+  #        uses: jaxxstorm/action-install-gh-release@v1.2.0
+  #        with:
+  #          repo: pulumi/pulumictl
+  #      - name: Repository Dispatch
+  #        run: |
+  #          pulumictl dispatch -r pulumi/examples -c smoke-test-cli $(pulumictl get version --language generic -o)
+  #        env:
+  #          GITHUB_TOKEN: ${{ secrets.PULUMI_BOT_TOKEN}}
   lint:
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}
     strategy:
       matrix:
-        directory: [ sdk, pkg, tests ]
+        directory: [sdk, pkg, tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -202,14 +201,14 @@ jobs:
     name: Build & Test
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest ]
+        platform: [ubuntu-latest, macos-latest]
         go-version: [1.16.x]
-        python-version: [ 3.9.x ]
-        dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        python-version: [3.9.x]
+        dotnet-version: [3.1.x]
+        node-version: [14.x]
 
         # See scripts/tests_subsets.py when editing
-        test-subset: [ integration, integration-and-codegen, auto, etc ]
+        test-subset: [integration, integration-and-codegen, auto, etc]
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -365,21 +364,11 @@ jobs:
         run: |
           cd src\github.com\${{ github.repository }}
           dotnet msbuild /t:Tests /v:Detailed build.proj /p:PulumiRoot="D:\\Pulumi"
-  verify-containers:
-    name: Run Container Tests
+  dispatch-docker-containers-ci-build:
+    name: Trigger Docker containers CI build
     needs: [publish-binaries, publish-sdks]
-    strategy:
-      matrix:
-        go-version: [1.16.x]
-        python-version: [ 3.9.x ]
-        dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
@@ -390,4 +379,4 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Run Container Tests
-        run: make test_containers VERSION=v$(pulumictl get version --language generic -o)
+        run: pulumictl dispatch -r pulumi/pulumi-docker-containers -c ci-build $(pulumictl get version --language generic -o)

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -3,9 +3,9 @@ on:
     tags:
       - v*.*.*-**
     paths-ignore:
-      - 'CHANGELOG.md'
-      - 'CHANGELOG_PENDING.md'
-      - 'README.md'
+      - "CHANGELOG.md"
+      - "CHANGELOG_PENDING.md"
+      - "README.md"
 env:
   PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -24,11 +24,11 @@ jobs:
     needs: publish-binaries
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
-        python-version: [ 3.9.x ]
-        dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
-        language: [ "nodejs", "python", "dotnet" ]
+        go-version: [1.16.x]
+        python-version: [3.9.x]
+        dotnet-version: [3.1.x]
+        node-version: [14.x]
+        language: ["nodejs", "python", "dotnet"]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
@@ -81,7 +81,7 @@ jobs:
     needs: [build-and-test, windows-build]
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
+        go-version: [1.16.x]
     steps:
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
@@ -118,7 +118,7 @@ jobs:
     name: Lint ${{ matrix.directory }}
     strategy:
       matrix:
-        directory: [ sdk, pkg, tests ]
+        directory: [sdk, pkg, tests]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
@@ -184,12 +184,12 @@ jobs:
     name: Build & Test
     strategy:
       matrix:
-        platform: [ ubuntu-latest, macos-latest ]
+        platform: [ubuntu-latest, macos-latest]
 
         go-version: [1.16.x]
-        python-version: [ 3.9.x ]
-        dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
+        python-version: [3.9.x]
+        dotnet-version: [3.1.x]
+        node-version: [14.x]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Set up Go ${{ matrix.go-version }}
@@ -258,10 +258,10 @@ jobs:
     name: Windows Build
     strategy:
       matrix:
-        go-version: [ 1.16.x ]
-        node-version: [ 14.x ]
-        python-version: [ 3.9.x ]
-        dotnet: [ 3.1.x ]
+        go-version: [1.16.x]
+        node-version: [14.x]
+        python-version: [3.9.x]
+        dotnet: [3.1.x]
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}
@@ -337,21 +337,11 @@ jobs:
         run: |
           cd src\github.com\${{ github.repository }}
           dotnet msbuild /t:Build /v:Detailed build.proj /p:PulumiRoot="D:\\Pulumi"
-  verify-containers:
-    name: Run Container Tests
+  dispatch-docker-containers-ci-build:
+    name: Trigger Docker containers CI build
     needs: [publish-binaries, publish-sdks]
-    strategy:
-      matrix:
-        go-version: [1.16.x]
-        python-version: [ 3.9.x ]
-        dotnet-version: [ 3.1.x ]
-        node-version: [ 14.x ]
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go ${{ matrix.go-version }}
-        uses: actions/setup-go@v1
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Install pulumictl
         uses: jaxxstorm/action-install-gh-release@v1.2.0
         with:
@@ -362,4 +352,4 @@ jobs:
         run: |
           git fetch --quiet --prune --unshallow --tags
       - name: Run Container Tests
-        run: make test_containers VERSION=v$(pulumictl get version --language generic -o)
+        run: pulumictl dispatch -r pulumi/pulumi-docker-containers -c ci-build $(pulumictl get version --language generic -o)


### PR DESCRIPTION
We've moved the code for our Docker containers to
pulumi/pulumi-docker-containers.  As part of this move, we want Pulumi
builds to delegate the building and testing of Docker containers to the
new repo.

This commit also contains some autoformatting.