### PR TITLE
Do not share maps so tests can run in parallel

### DIFF
--- a/pkg/codegen/docs/examples.go
+++ b/pkg/codegen/docs/examples.go
@@ -43,12 +43,12 @@ type docInfo struct {
 	importDetails string
 }
 
-func decomposeDocstring(docstring string) docInfo {
+func decomposeDocstring(dctx *docGenContext, docstring string) docInfo {
 	if docstring == "" {
 		return docInfo{}
 	}
 
-	languages := codegen.NewStringSet(snippetLanguages...)
+	languages := codegen.NewStringSet(dctx.snippetLanguages...)
 
 	source := []byte(docstring)
 	parsed := schema.ParseDocs(source)
@@ -70,7 +70,7 @@ func decomposeDocstring(docstring string) docInfo {
 				if exampleShortcode == nil {
 					exampleShortcode, title, snippets = shortcode, "", map[string]string{}
 				} else if !enter && shortcode == exampleShortcode {
-					for _, l := range snippetLanguages {
+					for _, l := range dctx.snippetLanguages {
 						if _, ok := snippets[l]; !ok {
 							snippets[l] = defaultMissingExampleSnippetPlaceholder
 						}

--- a/pkg/codegen/docs/gen_method.go
+++ b/pkg/codegen/docs/gen_method.go
@@ -63,9 +63,10 @@ func (mod *modContext) genMethods(r *schema.Resource) []methodDocArgs {
 }
 
 func (mod *modContext) genMethod(r *schema.Resource, m *schema.Method) methodDocArgs {
+	dctx := mod.docGenContext
 	f := m.Function
 	inputProps, outputProps := make(map[string][]property), make(map[string][]property)
-	for _, lang := range supportedLanguages {
+	for _, lang := range dctx.supportedLanguages {
 		if f.Inputs != nil {
 			exclude := func(name string) bool {
 				return name == "__self__"
@@ -84,12 +85,12 @@ func (mod *modContext) genMethod(r *schema.Resource, m *schema.Method) methodDoc
 
 	// Generate the per-language map for the method name.
 	methodNameMap := map[string]string{}
-	for _, lang := range supportedLanguages {
-		docHelper := getLanguageDocHelper(lang)
+	for _, lang := range dctx.supportedLanguages {
+		docHelper := getLanguageDocHelper(dctx, lang)
 		methodNameMap[lang] = docHelper.GetMethodName(m)
 	}
 
-	docInfo := decomposeDocstring(f.Comment)
+	docInfo := decomposeDocstring(dctx, f.Comment)
 	args := methodDocArgs{
 		Title: title(m.Name, ""),
 
@@ -187,7 +188,8 @@ func (mod *modContext) genMethodCS(f *schema.Function, resourceName, methodName 
 }
 
 func (mod *modContext) genMethodPython(f *schema.Function) []formalParam {
-	docLanguageHelper := getLanguageDocHelper("python")
+	dctx := mod.docGenContext
+	docLanguageHelper := getLanguageDocHelper(dctx, "python")
 	var params []formalParam
 
 	params = append(params, formalParam{
@@ -236,10 +238,11 @@ func (mod *modContext) genMethodPython(f *schema.Function) []formalParam {
 func (mod *modContext) genMethodArgs(r *schema.Resource, m *schema.Method,
 	methodNameMap map[string]string) map[string]string {
 
+	dctx := mod.docGenContext
 	f := m.Function
 
 	functionParams := make(map[string]string)
-	for _, lang := range supportedLanguages {
+	for _, lang := range dctx.supportedLanguages {
 		var (
 			paramTemplate string
 			params        []formalParam
@@ -283,7 +286,7 @@ func (mod *modContext) genMethodArgs(r *schema.Resource, m *schema.Method,
 			paramTemplate = "py_formal_param"
 			paramSeparatorTemplate = "py_param_separator"
 
-			docHelper := getLanguageDocHelper(lang)
+			docHelper := getLanguageDocHelper(dctx, lang)
 			methodName := docHelper.GetMethodName(m)
 			ps = paramSeparator{Indent: strings.Repeat(" ", len("def (")+len(methodName))}
 		}
@@ -295,11 +298,11 @@ func (mod *modContext) genMethodArgs(r *schema.Resource, m *schema.Method,
 		}
 
 		for i, p := range params {
-			if err := templates.ExecuteTemplate(b, paramTemplate, p); err != nil {
+			if err := dctx.templates.ExecuteTemplate(b, paramTemplate, p); err != nil {
 				panic(err)
 			}
 			if i != n-1 {
-				if err := templates.ExecuteTemplate(b, paramSeparatorTemplate, ps); err != nil {
+				if err := dctx.templates.ExecuteTemplate(b, paramSeparatorTemplate, ps); err != nil {
 					panic(err)
 				}
 			}
@@ -314,10 +317,12 @@ func (mod *modContext) genMethodArgs(r *schema.Resource, m *schema.Method,
 func (mod *modContext) getMethodResult(r *schema.Resource, m *schema.Method) map[string]propertyType {
 	resourceMap := make(map[string]propertyType)
 
+	dctx := mod.docGenContext
+
 	var resultTypeName string
-	for _, lang := range supportedLanguages {
+	for _, lang := range dctx.supportedLanguages {
 		if m.Function.Outputs != nil && len(m.Function.Outputs.Properties) > 0 {
-			resultTypeName = getLanguageDocHelper(lang).GetMethodResultName(mod.pkg, mod.mod, r, m)
+			resultTypeName = getLanguageDocHelper(dctx, lang).GetMethodResultName(mod.pkg, mod.mod, r, m)
 		}
 		resourceMap[lang] = propertyType{
 			Name: resultTypeName,

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -283,6 +283,7 @@ func getFunctionFromModule(function string, mod *modContext) *schema.Function {
 }
 
 func TestFunctionHeaders(t *testing.T) {
+	dctx := newDocGenContext()
 	initTestPackageSpec(t)
 
 	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
@@ -309,7 +310,7 @@ func TestFunctionHeaders(t *testing.T) {
 		},
 	}
 
-	modules := generateModulesFromSchemaPackage(unitTestTool, schemaPkg)
+	modules := generateModulesFromSchemaPackage(dctx, unitTestTool, schemaPkg)
 	for _, test := range tests {
 		t.Run(test.FunctionName, func(t *testing.T) {
 			mod, ok := modules[test.ModuleName]
@@ -329,6 +330,7 @@ func TestFunctionHeaders(t *testing.T) {
 }
 
 func TestResourceDocHeader(t *testing.T) {
+	dctx := newDocGenContext()
 	initTestPackageSpec(t)
 
 	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
@@ -358,7 +360,7 @@ func TestResourceDocHeader(t *testing.T) {
 		},
 	}
 
-	modules := generateModulesFromSchemaPackage(unitTestTool, schemaPkg)
+	modules := generateModulesFromSchemaPackage(dctx, unitTestTool, schemaPkg)
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			mod, ok := modules[test.ModuleName]
@@ -379,9 +381,10 @@ func TestResourceDocHeader(t *testing.T) {
 
 func TestExamplesProcessing(t *testing.T) {
 	initTestPackageSpec(t)
+	dctx := newDocGenContext()
 
 	description := testPackageSpec.Resources["prov:module/resource:Resource"].Description
-	docInfo := decomposeDocstring(description)
+	docInfo := decomposeDocstring(dctx, description)
 	examplesSection := docInfo.examples
 	importSection := docInfo.importDetails
 
@@ -407,8 +410,9 @@ func TestExamplesProcessing(t *testing.T) {
 }
 
 func generatePackage(tool string, pkg *schema.Package, extraFiles map[string][]byte) (map[string][]byte, error) {
-	Initialize(tool, pkg)
-	return GeneratePackage(tool, pkg)
+	dctx := newDocGenContext()
+	Initialize(dctx, tool, pkg)
+	return GeneratePackage(dctx, tool, pkg)
 }
 
 func TestGeneratePackage(t *testing.T) {

--- a/pkg/codegen/docs/package_tree_test.go
+++ b/pkg/codegen/docs/package_tree_test.go
@@ -23,13 +23,14 @@ import (
 )
 
 func TestGeneratePackageTree(t *testing.T) {
+	dctx := newDocGenContext()
 	initTestPackageSpec(t)
 
 	schemaPkg, err := schema.ImportSpec(testPackageSpec, nil)
 	assert.NoError(t, err, "importing spec")
 
-	Initialize(unitTestTool, schemaPkg)
-	pkgTree, err := GeneratePackageTree()
+	Initialize(dctx, unitTestTool, schemaPkg)
+	pkgTree, err := GeneratePackageTree(dctx)
 	if err != nil {
 		t.Errorf("Error generating the package tree for package %s: %v", schemaPkg.Name, err)
 	}


### PR DESCRIPTION
Running under `PULUMI_PARALLEL_SDK_CODEGEN_TESTS=1` is nice in development but it used to crash docs/ tests. The crash was resulting from concurrent access to module-static state. This is now a struct private to the test.


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
