### PR TITLE
[WIP] - Align cloud-backed and secret service providers

### DIFF
--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -740,17 +740,17 @@ func listConfig(stack backend.Stack, showSecrets bool, jsonOut bool) error {
 		return err
 	}
 
-	cfg := ps.Config
-
 	// By default, we will use a blinding decrypter to show "[secret]". If requested, display secrets in plaintext.
 	decrypter := config.NewBlindingDecrypter()
-	if cfg.HasSecureValue() && showSecrets {
+	if ps.Config.HasSecureValue() && showSecrets {
 		dec, decerr := getStackDecrypter(stack)
 		if decerr != nil {
 			return decerr
 		}
 		decrypter = dec
 	}
+
+	cfg := ps.Config
 
 	var keys config.KeyArray
 	for key := range cfg {

--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -67,7 +67,7 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 			return newPassphraseSecretsManager(s.Ref().Name(), stackConfigFile,
 				false /* rotatePassphraseSecretsProvider */)
 		case httpstate.Stack:
-			return newServiceSecretsManager(s.(httpstate.Stack), s.Ref().Name(), stackConfigFile)
+			return newServiceSecretsManager(s.(httpstate.Stack), s.Ref().Name(), stackConfigFile, ps.SecretsProvider)
 		}
 
 		return nil, errors.Errorf("unknown stack type %s", reflect.TypeOf(s))

--- a/pkg/cmd/pulumi/crypto_cloud.go
+++ b/pkg/cmd/pulumi/crypto_cloud.go
@@ -41,13 +41,11 @@ func newCloudSecretsManager(stackName tokens.QName, configFile, secretsProvider 
 	}
 
 	// Only a passphrase provider has an encryption salt. So changing a secrets provider
-	// from passphrase to a cloud secrets provider should ensure that we remove the enryptionsalt
+	// from passphrase to a cloud secrets provider should ensure that we remove the encryptionsalt
 	// as it's a legacy artifact and needs to be removed
 	if info.EncryptionSalt != "" {
 		info.EncryptionSalt = ""
 	}
-
-	var secretsManager *cloud.Manager
 
 	// if there is no key OR the secrets provider is changing
 	// then we need to generate the new key based on the new secrets provider
@@ -67,10 +65,6 @@ func newCloudSecretsManager(stackName tokens.QName, configFile, secretsProvider 
 	if err != nil {
 		return nil, err
 	}
-	secretsManager, err = cloud.NewCloudSecretsManager(secretsProvider, dataKey)
-	if err != nil {
-		return nil, err
-	}
 
-	return secretsManager, nil
+	return cloud.NewCloudSecretsManager(secretsProvider, dataKey)
 }

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -42,7 +42,7 @@ type SecretsProvider interface {
 type defaultSecretsProvider struct{}
 
 // OfType returns a secrets manager for the given secrets type. Returns an error
-// if the type is uknown or the state is invalid.
+// if the type is unknown or the state is invalid.
 func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.Manager, error) {
 	var sm secrets.Manager
 	var err error

--- a/pkg/secrets/cloud/manager.go
+++ b/pkg/secrets/cloud/manager.go
@@ -41,7 +41,7 @@ type cloudSecretsManagerState struct {
 
 // NewCloudSecretsManagerFromState deserialize configuration from state and returns a secrets
 // manager that uses the target cloud key management service to encrypt/decrypt a data key used for
-// envelope encyrtion of secrets values.
+// envelope encryption of secrets values.
 func NewCloudSecretsManagerFromState(state json.RawMessage) (secrets.Manager, error) {
 	var s cloudSecretsManagerState
 	if err := json.Unmarshal(state, &s); err != nil {
@@ -52,7 +52,7 @@ func NewCloudSecretsManagerFromState(state json.RawMessage) (secrets.Manager, er
 }
 
 // GenerateNewDataKey generates a new DataKey seeded by a fresh random 32-byte key and encrypted
-// using the target coud key management service.
+// using the target cloud key management service.
 func GenerateNewDataKey(url string) ([]byte, error) {
 	plaintextDataKey := make([]byte, 32)
 	_, err := rand.Read(plaintextDataKey)

--- a/sdk/nodejs/tests/automation/data/nested_config/Pulumi.dev.yaml
+++ b/sdk/nodejs/tests/automation/data/nested_config/Pulumi.dev.yaml
@@ -1,12 +1,13 @@
+encryptedkey: AAABALRPLGE1VvUNvXhcbpgkbbOIVtizBVZhf6a+mPmSAK1Fv3y1flXeI79GrfzLn+21NwmmLoE67PbOgUKCJg==
 config:
   aws:region: us-west-2
-  nested_config:bar: 1234
+  nested_config:bar: "1234"
   nested_config:foo: aha
   nested_config:myList:
-    - one
-    - two
-    - three
+  - one
+  - two
+  - three
   nested_config:outer:
     inner:
-      secure: AAABADOd8UPayqGlunla+Lo6kSSYA4LffCNBe84ElLwv0kyz7oIcYAw=
+      secure: v1:pHhiGv8ALQbJKP26:FRja7BaRaE4i9252QMxWUZkIcd3E/f1N+Q==
     other: something_else


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

**Before**

```
⇒  npm run repro

> repro
> ./node_modules/ts-node/dist/bin.js repro.ts

Calling [pulumi up] with [1] secrets... took [3.43] seconds.
Calling [pulumi stack] with [1] secrets took [0.37] seconds.

Calling [pulumi up] with [10] secrets... took [5.35] seconds.
Calling [pulumi stack] with [10] secrets took [0.75] seconds.

Calling [pulumi up] with [100] secrets... took [31.79] seconds.
Calling [pulumi stack] with [100] secrets took [3.88] seconds.

Calling [pulumi up] with [500] secrets... took [183.45] seconds.
Calling [pulumi stack] with [500] secrets took [14.73] seconds.

Calling [pulumi up] with [1000] secrets... took [462.24] seconds.
Calling [pulumi stack] with [1000] secrets took [30.27] seconds.
```

**After**
```
⇒  npm run repro

> repro
> ./node_modules/ts-node/dist/bin.js repro.ts

Calling [pulumi up] with [1] secrets... took [3.30] seconds.
Calling [pulumi stack] with [1] secrets took [0.36] seconds.

Calling [pulumi up] with [10] secrets... took [4.63] seconds.
Calling [pulumi stack] with [10] secrets took [0.39] seconds.

Calling [pulumi up] with [100] secrets... took [21.63] seconds.
Calling [pulumi stack] with [100] secrets took [0.52] seconds.

Calling [pulumi up] with [500] secrets... took [137.60] seconds.
Calling [pulumi stack] with [500] secrets took [0.71] seconds.

Calling [pulumi up] with [1000] secrets... took [362.92] seconds.
Calling [pulumi stack] with [1000] secrets took [0.71] seconds.
```

Fixes https://github.com/pulumi/pulumi/issues/6445

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
