### PR TITLE
Bring back PR automatic outdated commit check pre-emption

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -62,7 +62,7 @@ jobs:
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
-      - name: debug ref vs head_ref
+      - name: debug ref vs head_ref 2
         run: |
           echo "github.ref      = ${{ github.ref }}"
           echo "github.head_ref = ${{ github.head_ref }}"

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -12,6 +12,18 @@ env:
   PULUMI_TEST_OWNER: "moolumi"
   PR_COMMIT_SHA: ${{ github.event.client_payload.pull_request.head.sha }}
 
+# Cancel checks on prior commits when new commits are added to a PR.
+# This is motivated by temporary throughput issues on our GitHub
+# Actions workers availability.
+#
+# Note from GitHub docs: Concurrency is currently in beta and subject
+# to change.
+#
+# See also: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+concurrency:
+  group: run-build-acceptance-tests-${{ github.ref }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   comment-notification:
     # We only care about adding the result to the PR if it's a repository_dispatch event
@@ -50,6 +62,10 @@ jobs:
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
+      - name: debug ref vs head_ref
+        run: |
+          echo "github.ref      = ${{ github.ref }}"
+          echo "github.head_ref = ${{ github.head_ref }}"
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
         with:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Reworking the reverted PR    https://github.com/pulumi/pulumi/pull/8118


```
   github.ref      = refs/pull/8145/merge
   github.head_ref = t0yv0/cancel-checks-on-outdated-pr-commits-2

```

Using both data points now to compute the pre-emption ID. This does still work to cancel outdated checks on this PRs. I suspect this might fix the `/run-acceptance-tests` since `github.ref` should still be available, but I'm not sure that I can test it without merging to master first, as right now `/run-acceptance-tests` uses the workflow definition from master it seems, which makes sense for security...

Can I merge this and test it and quickly follow up with either revert or fixup/removal of debug statements? 

 
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
