### PR TITLE
Improve concurrent ID computation for /run-acceptance-tests

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -21,7 +21,7 @@ env:
 #
 # See also: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: run-build-acceptance-tests-${{(fromJSON(format('[{0},{1}]',to_json(github.run_id),to_json(github.head_ref))))[github.head_ref=='']}}
+  group: run-build-acceptance-tests-${{(fromJSON(format('[{0},{1}]',toJSON(github.run_id),toJSON(github.head_ref))))[github.head_ref=='']}}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -21,7 +21,7 @@ env:
 #
 # See also: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: run-build-acceptance-tests-${{ github.ref }}-${{ github.head_ref }}
+  group: run-build-acceptance-tests-${{(fromJSON(format('[{0},{1}]',to_json(github.run_id),to_json(github.head_ref))))[github.head_ref=='']}}
   cancel-in-progress: true
 
 jobs:
@@ -62,10 +62,11 @@ jobs:
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
-      - name: debug ref vs head_ref 2
+      - name: debug concurrent_id
         run: |
-          echo "github.ref      = ${{ github.ref }}"
+          echo "github.run_id   = ${{ github.run_id }}"
           echo "github.head_ref = ${{ github.head_ref }}"
+          echo "concurrent_id   = ${{(fromJSON(format('[{0},{1}]',to_json(github.run_id),to_json(github.head_ref))))[github.head_ref=='']}}"
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -20,6 +20,14 @@ env:
 # to change.
 #
 # See also: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+#
+# Note on the the `group` computed expression: it is compiling
+# `github.head_ref == '' ? github.run_id : github.head_ref` expression
+# to the primitives available in GitHub Actions. The idea to use
+# `head_ref` on `pull_request` triggers, but use unique
+# `github.run_id` on `run-acceptance-tests-command` triggers. This
+# effectively disables `concurrency` checks for
+# `run-acceptance-tests-command` triggers.
 concurrency:
   group: run-build-acceptance-tests-${{(fromJSON(format('[{0},{1}]',toJSON(github.head_ref),toJSON(github.run_id))))[github.head_ref=='']}}
   cancel-in-progress: true
@@ -62,11 +70,6 @@ jobs:
     name: Lint SDKs
     runs-on: ubuntu-latest
     steps:
-      - name: debug concurrent_id
-        run: |
-          echo "github.run_id   = ${{ github.run_id }}"
-          echo "github.head_ref = ${{ github.head_ref }}"
-          echo "concurrent_id   = ${{(fromJSON(format('[{0},{1}]',toJSON(github.head_ref),toJSON(github.run_id))))[github.head_ref=='']}}"
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           echo "github.run_id   = ${{ github.run_id }}"
           echo "github.head_ref = ${{ github.head_ref }}"
-          echo "concurrent_id   = ${{(fromJSON(format('[{0},{1}]',to_json(github.run_id),to_json(github.head_ref))))[github.head_ref=='']}}"
+          echo "concurrent_id   = ${{(fromJSON(format('[{0},{1}]',toJSON(github.run_id),toJSON(github.head_ref))))[github.head_ref=='']}}"
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -21,7 +21,7 @@ env:
 #
 # See also: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
 concurrency:
-  group: run-build-acceptance-tests-${{(fromJSON(format('[{0},{1}]',toJSON(github.run_id),toJSON(github.head_ref))))[github.head_ref=='']}}
+  group: run-build-acceptance-tests-${{(fromJSON(format('[{0},{1}]',toJSON(github.head_ref),toJSON(github.run_id))))[github.head_ref=='']}}
   cancel-in-progress: true
 
 jobs:
@@ -66,7 +66,7 @@ jobs:
         run: |
           echo "github.run_id   = ${{ github.run_id }}"
           echo "github.head_ref = ${{ github.head_ref }}"
-          echo "concurrent_id   = ${{(fromJSON(format('[{0},{1}]',toJSON(github.run_id),toJSON(github.head_ref))))[github.head_ref=='']}}"
+          echo "concurrent_id   = ${{(fromJSON(format('[{0},{1}]',toJSON(github.head_ref),toJSON(github.run_id))))[github.head_ref=='']}}"
       - name: Set up Go ${{ matrix.go-version }}
         uses: actions/setup-go@v1
         with:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Continuing to work out PR concurrency controls. Currently on master all `/run-acceptance-tests` get the same concurrency ID which makes the latest one cancel all in-progress runs. This is not desirable. Experimenting with computing a unique concurrency ID for `/run-acceptance-tests` dispatches.


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
