### PR TITLE
Fixing broken lists in dotnet docs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,6 @@
 ### Improvements
-* Adds CI detector for Buildkite [#7933](https://github.com/pulumi/pulumi/pull/7933)
+- Adds CI detector for Buildkite
+  [#7933](https://github.com/pulumi/pulumi/pull/7933)
 
 - [cli] - Add `--exclude-protected` flag to `pulumi destroy`.
   [#8359](https://github.com/pulumi/pulumi/pull/8359)
@@ -24,3 +25,6 @@
 
 - [engine] - Compute dependents correctly during targeted deletes.
   [#8360](https://github.com/pulumi/pulumi/pull/8360)
+
+- [docs] - Fix broken lists in dotnet docs
+  [docs#6558](https://github.com/pulumi/docs/issues/6558)

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -127,8 +127,8 @@ namespace Pulumi
     /// created, these are represented using the special <see cref="Output{T}"/>s type, which
     /// internally represents two things:
     /// <list type="number">
-    /// <item>An eventually available value of the output</item>
-    /// <item>The dependency on the source(s) of the output value</item>
+    /// <item><description>An eventually available value of the output</description></item>
+    /// <item><description>The dependency on the source(s) of the output value</description></item>
     /// </list>
     /// In fact, <see cref="Output{T}"/>s is quite similar to <see cref="Task{TResult}"/>.
     /// Additionally, they carry along dependency information.

--- a/sdk/dotnet/Pulumi/Resources/ComponentResourceOptions.cs
+++ b/sdk/dotnet/Pulumi/Resources/ComponentResourceOptions.cs
@@ -36,18 +36,18 @@ namespace Pulumi
         /// <para/>
         /// Conceptually property merging follows these basic rules:
         /// <list type="number">
-        /// <item>
+        /// <item><description>
         /// If the property is a collection, the final value will be a collection containing the
         /// values from each options object.
-        /// </item>
-        /// <item>
+        /// </description></item>
+        /// <item><description>
         /// Simple scalar values from <paramref name="options2"/> (i.e. <see cref="string"/>s,
         /// <see cref="int"/>s, <see cref="bool"/>s) will replace the values of <paramref
         /// name="options1"/>.
-        /// </item>
-        /// <item>
+        /// </description></item>
+        /// <item><description>
         /// <see langword="null"/> values in <paramref name="options2"/> will be ignored.
-        /// </item>
+        /// </description></item>
         /// </list>
         /// </summary>
         public static ComponentResourceOptions Merge(ComponentResourceOptions? options1, ComponentResourceOptions? options2)

--- a/sdk/dotnet/Pulumi/Resources/CustomResourceOptions.cs
+++ b/sdk/dotnet/Pulumi/Resources/CustomResourceOptions.cs
@@ -51,18 +51,18 @@ namespace Pulumi
         /// <para/>
         /// Conceptually property merging follows these basic rules:
         /// <list type="number">
-        /// <item>
+        /// <item><description>
         /// If the property is a collection, the final value will be a collection containing the
         /// values from each options object.
-        /// </item>
-        /// <item>
+        /// </description></item>
+        /// <item><description>
         /// Simple scalar values from <paramref name="options2"/> (i.e. <see cref="string"/>s,
         /// <see cref="int"/>s, <see cref="bool"/>s) will replace the values of <paramref
         /// name="options1"/>.
-        /// </item>
-        /// <item>
+        /// </description></item>
+        /// <item><description>
         /// <see langword="null"/> values in <paramref name="options2"/> will be ignored.
-        /// </item>
+        /// </description></item>
         /// </list>
         /// </summary>
         public static CustomResourceOptions Merge(CustomResourceOptions? options1, CustomResourceOptions? options2)


### PR DESCRIPTION
# Description
Docs in a few places weren't actually showing list items, see:
- https://www.pulumi.com/docs/reference/pkg/dotnet/Pulumi/Pulumi.ComponentResourceOptions.html#Pulumi_ComponentResourceOptions_Merge_Pulumi_ComponentResourceOptions_Pulumi_ComponentResourceOptions
- https://www.pulumi.com/docs/reference/pkg/dotnet/Pulumi/Pulumi.CustomResourceOptions.html
- https://www.pulumi.com/docs/reference/pkg/dotnet/Pulumi/Pulumi.Output-1.html


The dotnet [xmldocs](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/recommended-tags#list) suggest:
>for a table, bulleted list, or numbered list, you only need to supply an entry for description

btw we have an example of this in code already here: https://github.com/pulumi/pulumi/blob/master/sdk/dotnet/Pulumi/Resources/DictionaryResourceArgs.cs#L18
https://www.pulumi.com/docs/reference/pkg/dotnet/Pulumi/Pulumi.DictionaryResourceArgs.html

Fixes: https://github.com/pulumi/docs/issues/6558

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
