### PR TITLE
Clarify error message for deleting protected resources

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -341,7 +341,8 @@ func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		return resource.StatusOK, nil,
 			errors.Errorf("unable to delete resource %q\n"+
 				"as it is currently marked for protection. To unprotect the resource, "+
-				"either remove the `protect` flag from the resource in your Pulumi program or use the command:\n"+
+				"either remove the `protect` flag from the resource in your Pulumi"+
+				"program and run `pulumi up` or use the command:\n"+
 				"`pulumi state unprotect %s`", s.old.URN, s.old.URN)
 	}
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Specify that one needs to run `pulumi up` after removing the `protected` flag from the stack. 

Fixes #8158

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
