### PR TITLE
Add that pulumictl is needed to make pulumi

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ To hack on Pulumi, you'll need to get a development environment set up. You'll w
 - [pipenv](https://github.com/pypa/pipenv)
 - [Golangci-lint](https://github.com/golangci/golangci-lint)
 - [Yarn](https://yarnpkg.com/)
+- [Pulumictl](https://github.com/pulumi/pulumictl)
 
 ## Getting dependencies on macOS
 

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,8 @@ TEST_ALL_DEPS = build $(SUB_PROJECTS:%=%_install)
 
 ensure::
 	$(call STEP_MESSAGE)
+	@echo "Check for pulumictl"; [ -e "$(shell which pulumictl)" ]
+
 	@echo "cd sdk && go mod download"; cd sdk && go mod download
 	@echo "cd pkg && go mod download"; cd pkg && go mod download
 	@echo "cd tests && go mod download"; cd tests && go mod download


### PR DESCRIPTION
# Description

Add pulumictl to the list of required dependencies in CONTRIBUTING.
Also add a test to "make ensure" to error if pulumictl can't be found.
Various parts of "make" won't work correctly with pulumictl missing, and
in my case the dotnet sdk wouldn't build at all.