### PR TITLE
Fix help message to fix formatting on docs page

### DIFF
--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -65,7 +65,7 @@ func newStackInitCmd() *cobra.Command {
 			"\n" +
 			"A stack can be created based on the configuration of an existing stack by passing the\n" +
 			"`--copy-config-from` flag.\n" +
-			"* `pulumi stack init --copy-config-from dev",
+			"* `pulumi stack init --copy-config-from dev`",
 		Run: cmdutil.RunFunc(func(cmd *cobra.Command, args []string) error {
 			opts := display.Options{
 				Color: cmdutil.GetGlobalColorization(),


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes a formatting issue on https://www.pulumi.com/docs/reference/cli/pulumi_stack_init/.

![screenshot-2021-10-13-11-14-40@2x](https://user-images.githubusercontent.com/293763/137189946-cc08fd2b-1020-45d1-b9ca-53875cb2787c.png)
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- ~[ ] I have added tests that prove my fix is effective or that my feature works.~ Just a docs change.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- ~[ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change~  Just a docs change.
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- ~[ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version~  Just a docs change.
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
