### PR TITLE
Enable workaround for Yarn workspaces for inline functions

### DIFF
--- a/sdk/nodejs/runtime/closure/codePaths.ts
+++ b/sdk/nodejs/runtime/closure/codePaths.ts
@@ -132,8 +132,8 @@ async function computeCodePathsWorker(options: CodePathOptions): Promise<Map<str
         // The Asset model does not support a consistent way to embed a file-or-directory into an
         // `AssetArchive`, so we stat the path to figure out which it is and use the appropriate
         // Asset constructor.
-        const stats = fs.lstatSync(normalizedPath);
-        if (stats.isDirectory() || stats.isSymbolicLink()) {
+        const stats = fs.statSync(normalizedPath);
+        if (stats.isDirectory()) {
             codePaths.set(normalizedPath, new asset.FileArchive(normalizedPath));
         }
         else {


### PR DESCRIPTION
Signed-off-by: Liam White <liam@tetrate.io>

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Basically, yarn workspaces rely on symlinks for monorepo-local packages. See https://github.com/pulumi/pulumi/issues/2661#issuecomment-939531284 for full context.

I think this also resolves https://github.com/pulumi/pulumi/issues/2980

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works -> I manually verified this works as there is no testing framework in this section of the code.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
