### PR TITLE
Update workflows to pin goreleaser to v0.181.1

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v0.181.1
           args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate
   #  examples_smoke_test:
   #    name: Trigger Examples Smoke Test

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v0.181.1
           args: -p 3 -f .goreleaser.prerelease.yml --rm-dist
   lint:
     container: golangci/golangci-lint:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v0.181.1
           args: -p 3 -f .goreleaser.yml --rm-dist --release-notes=CHANGELOG_PENDING.md
   lint:
     container: golangci/golangci-lint:latest


### PR DESCRIPTION
~Updating from `macos-latest` which currently is picking up macos-11 workers.  This is a temporary workaround due to Goreleaser not being able to be installed on Mac Os 11 see: https://github.com/goreleaser/goreleaser/issues/2575~

edit: ...because there's a better way to solve it, pin the dependency - v0.181.1 has the right assets we need