### PR TITLE
Update golint in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,12 +32,8 @@ RUN mkdir -p /go/bin \
 
 USER $USER_NAME
 
-# The base container sets XDG_CACHE_HOME XDG_CONFIG_HOME specifically for the root user, we can't unset them in a way that vscode will pick up, so we set them to values for the new user.
-# Installing go extensions via vscode use these paths so if we just leave it set to /root/.cache we'll get permission errors.
-ENV XDG_CONFIG_HOME=/home/$USER_NAME/.config
-ENV XDG_CACHE_HOME=/home/$USER_NAME/.cache
-
 RUN echo "export PATH=/opt/pulumi:/opt/pulumi/bin:$GOPATH/bin:/usr/local/go/bin:$PATH" >> ~/.bashrc \
+    && echo "unset XDG_CACHE_HOME XDG_CONFIG_HOME" >> ~/.bashrc \
     && echo "alias l='ls -aF'" >> ~/.bash_aliases \
     && echo "alias ll='ls -ahlF'" >> ~/.bash_aliases \
     && echo "alias ls='ls --color=auto --group-directories-first'" >> ~/.bash_aliases

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,14 +9,13 @@
         }
     },
 
-    "containerEnv": {
-        "PULUMI_ACCESS_TOKEN": "${localEnv:PULUMI_ACCESS_TOKEN}",
-        "PULUMI_TEST_ORG": "${localEnv:PULUMI_TEST_ORG}"
-    },
-
+    "runArgs": [
+        "-e",
+        "PULUMI_ACCESS_TOKEN",
+        "-e",
+        "PULUMI_TEST_ORG"
+    ],
     "remoteUser": "user",
-
-    "extensions": ["golang.go", "ms-dotnettools.csharp"],
 
     "settings": {
         "extensions.ignoreRecommendations": true


### PR DESCRIPTION
# Description

Update the golangci-lint tool used in the devcontainer. The version that was in place was complaining about various doc comments not having the right format. Given the CI pipelines look to just use the latest version a bump here should match this up (for a time).