### PR TITLE
Clean CHANGELOG_PENDING.md after v3.15.0

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,40 +1,4 @@
 ### Improvements
 
-- [automation/python] - Use `rstrip` rather than `strip` for the sake of indentation
-  [#8160](https://github.com/pulumi/pulumi/pull/8160)
-- [codegen/nodejs] - Add helper function forms `$fnOutput` that accept
-  `Input`s, return an `Output`, and wrap the underlying `$fn` call.
-  This change addreses
-  [#5758](https://github.com/pulumi/pulumi/issues/5758) for NodeJS,
-  making it easier to compose functions/datasources with Pulumi
-  resources.
-  [#8047](https://github.com/pulumi/pulumi/pull/8047)
-
-- [sdk/dotnet] - Update SDK to support the upcoming codegen feature that
-  will enable functions to accept Outputs
-  ([5758](https://github.com/pulumi/pulumi/issues/5758)). Specifically
-  add `Pulumi.DeploymentInstance.Invoke` and remove the now redundant
-  `Pulumi.Utilities.CodegenUtilities`.
-  [#8142](https://github.com/pulumi/pulumi/pull/8142)
-
-- [cli] - Upgrade CLI to go1.17
-  [#8171](https://github.com/pulumi/pulumi/pull/8171)
-
-- [codegen/go] Register input types for schema object types.
-  [#7959](https://github.com/pulumi/pulumi/pull/7959)
-  
-- [codegen/go] Register input types for schema resource and enum types.
-  [#8204]((https://github.com/pulumi/pulumi/pull/8204))
-
-- [codegen/go] Add schema flag to disable registering input types.
-  [#8198](https://github.com/pulumi/pulumi/pull/8198)
 
 ### Bug Fixes
-
-- [codegen/go] - Use `importBasePath` before `name` if specified for name 
-  and path.
-  [#8159](https://github.com/pulumi/pulumi/pull/8159)
-  [#8187](https://github.com/pulumi/pulumi/pull/8187)
-
-- [auto/go] - Mark entire exported map as secret if key in map is secret.
-  [#8179](https://github.com/pulumi/pulumi/pull/8179)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
