### PR TITLE
Deduplicate a couple of go module names

### DIFF
--- a/tests/integration/construct_component_provider/go/go.mod
+++ b/tests/integration/construct_component_provider/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi/tests/construct_component
+module github.com/pulumi/pulumi/tests/construct_component_provider
 
 go 1.16
 

--- a/tests/integration/rotate_passphrase/go.mod
+++ b/tests/integration/rotate_passphrase/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi/tests/empty/go
+module github.com/pulumi/pulumi/tests/rotate_passphrase
 
 go 1.16
 


### PR DESCRIPTION
Picked these duplicates up when running gopls across the whole repo.
Module names should reflect the folder path they are in, but these two
looked like copy-paste bugs.
