### PR TITLE
Some improvements to the vscode devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -32,8 +32,12 @@ RUN mkdir -p /go/bin \
 
 USER $USER_NAME
 
+# The base container sets XDG_CACHE_HOME XDG_CONFIG_HOME specifically for the root user, we can't unset them in a way that vscode will pick up, so we set them to values for the new user.
+# Installing go extensions via vscode use these paths so if we just leave it set to /root/.cache we'll get permission errors.
+ENV XDG_CONFIG_HOME=/home/$USER_NAME/.config
+ENV XDG_CACHE_HOME=/home/$USER_NAME/.cache
+
 RUN echo "export PATH=/opt/pulumi:/opt/pulumi/bin:$GOPATH/bin:/usr/local/go/bin:$PATH" >> ~/.bashrc \
-    && echo "unset XDG_CACHE_HOME XDG_CONFIG_HOME" >> ~/.bashrc \
     && echo "alias l='ls -aF'" >> ~/.bash_aliases \
     && echo "alias ll='ls -ahlF'" >> ~/.bash_aliases \
     && echo "alias ls='ls --color=auto --group-directories-first'" >> ~/.bash_aliases

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,15 +9,29 @@
         }
     },
 
-    "runArgs": [
-        "-e",
-        "PULUMI_ACCESS_TOKEN",
-        "-e",
-        "PULUMI_TEST_ORG"
-    ],
+    "containerEnv": {
+        "PULUMI_ACCESS_TOKEN": "${localEnv:PULUMI_ACCESS_TOKEN}",
+        "PULUMI_TEST_ORG": "${localEnv:PULUMI_TEST_ORG}"
+    },
+
     "remoteUser": "user",
 
+    "extensions": ["golang.go", "ms-dotnettools.csharp", "ms-python.python"],
+
+    // We want to dotnet restore all projects on startup so that omnisharp doesn't complain about lots of missing types on startup.
+    "postCreateCommand": "find -name \"*.??proj\" | xargs -L1 dotnet restore",
+
     "settings": {
+        "gopls": {
+            // A couple of modules get copied as part of builds and this confuse gopls as it sees the module name twice, just ignore the copy in the build folders.
+            "build.directoryFilters": [
+                "-sdk/dotnet/Pulumi.Automation.Tests/bin",
+                "-sdk/nodejs/bin",
+                "-sdk/python/env"
+            ],
+            // Experimental but seems to work and means we don't need a vscode instance per go.mod file.
+            "experimentalWorkspaceModule": true,
+        },
         "extensions.ignoreRecommendations": true
     }
 }


### PR DESCRIPTION
* Installed the go, dotnet, and python extensions by default.
* Set the gopls settings to ignore copies of modules in build directories.
* Set XDG_CACHE_DIR/CONFIG_DIR so that vscode can install go tools.
* Use "containerEnv" instead of "runArgs" to set the container environment.
* Turn on gopls "experimentalWorkspaceModule" so we can open at the root pulumi directory.
* Use "postCreateCommand" to restore all dotnet projects so ominisharp doesn't complain about missing types on startup.