### PR TITLE
Revert "Pin goreleaser to v0.181.1 (#8216)"

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.181.1
+          version: latest
           args: -p 3 -f .goreleaser.prerelease.yml --rm-dist --skip-validate
   #  examples_smoke_test:
   #    name: Trigger Examples Smoke Test

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.181.1
+          version: latest
           args: -p 3 -f .goreleaser.prerelease.yml --rm-dist
   lint:
     container: golangci/golangci-lint:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.181.1
+          version: latest
           args: -p 3 -f .goreleaser.yml --rm-dist --release-notes=CHANGELOG_PENDING.md
   lint:
     container: golangci/golangci-lint:latest


### PR DESCRIPTION
This reverts commit 793c7db17225cc6b398209fc1f668e5189d8d808.

[Publish Binaries](https://github.com/pulumi/pulumi/runs/3927153670) failed with: 
`Downloading https://github.com/goreleaser/goreleaser/releases/download/v0.181.1/goreleaser_Darwin_all.tar.gz`

The base image `goreleaser/goreleaser-action@v2` changed [3 days ago](https://github.com/goreleaser/goreleaser-action/releases), with a fix for our workaround. 

Reverting the pin should fix this.