### PR TITLE
Add DisplayName and Publisher to the schema

### DIFF
--- a/pkg/codegen/schema/pulumi.json
+++ b/pkg/codegen/schema/pulumi.json
@@ -10,6 +10,10 @@
             "type": "string",
             "pattern": "^[a-zA-Z][-a-zA-Z0-9_]*$"
         },
+        "displayName": {
+            "description": "The human-friendly name of the package.",
+            "type": "string"
+        },
         "version": {
             "description": "The version of the package. The version must be valid semver.",
             "type": "string",
@@ -48,6 +52,10 @@
         },
         "pluginDownloadUrl": {
             "description": "The URL to use when downloading the provider plugin binary.",
+            "type": "string"
+        },
+        "publisher": {
+            "description": "The name of the person or organization that authored and published the package.",
             "type": "string"
         },
         "meta": {

--- a/pkg/codegen/schema/schema.go
+++ b/pkg/codegen/schema/schema.go
@@ -541,6 +541,8 @@ type Package struct {
 
 	// Name is the unqualified name of the package (e.g. "aws", "azure", "gcp", "kubernetes". "random")
 	Name string
+	// DisplayName is the human-friendly name of the package.
+	DisplayName string
 	// Version is the version of the package.
 	Version *semver.Version
 	// Description is the description of the package.
@@ -559,6 +561,8 @@ type Package struct {
 	LogoURL string
 	// PluginDownloadURL is the URL to use to acquire the provider plugin binary, if any.
 	PluginDownloadURL string
+	// Publisher is the name of the person or organization that authored and published the package.
+	Publisher string
 
 	// Types is the list of non-resource types defined by the package.
 	Types []Type
@@ -1462,6 +1466,8 @@ type MetadataSpec struct {
 type PackageSpec struct {
 	// Name is the unqualified name of the package (e.g. "aws", "azure", "gcp", "kubernetes", "random")
 	Name string `json:"name" yaml:"name"`
+	// DisplayName is the human-friendly name of the package.
+	DisplayName string `json:"displayName,omitempty" yaml:"displayName,omitempty"`
 	// Version is the version of the package. The version must be valid semver.
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 	// Description is the description of the package.
@@ -1480,6 +1486,8 @@ type PackageSpec struct {
 	LogoURL string `json:"logoUrl,omitempty" yaml:"logoUrl,omitempty"`
 	// PluginDownloadURL is the URL to use to acquire the provider plugin binary, if any.
 	PluginDownloadURL string `json:"pluginDownloadURL,omitempty" yaml:"pluginDownloadURL,omitempty"`
+	// Publisher is the name of the person or organization that authored and published the package.
+	Publisher string `json:"publisher,omitempty" yaml:"publisher,omitempty"`
 
 	// Meta contains information for the importer about this package.
 	Meta *MetadataSpec `json:"meta,omitempty" yaml:"meta,omitempty"`
@@ -1691,6 +1699,7 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader) (*
 	*pkg = Package{
 		moduleFormat:      moduleFormatRegexp,
 		Name:              spec.Name,
+		DisplayName:       spec.DisplayName,
 		Version:           version,
 		Description:       spec.Description,
 		Keywords:          spec.Keywords,
@@ -1699,6 +1708,7 @@ func bindSpec(spec PackageSpec, languages map[string]Language, loader Loader) (*
 		Attribution:       spec.Attribution,
 		Repository:        spec.Repository,
 		PluginDownloadURL: spec.PluginDownloadURL,
+		Publisher:         spec.Publisher,
 		Config:            config,
 		Types:             typeList,
 		Provider:          provider,


### PR DESCRIPTION
# Description

Just as the title states. Note that I didn't add anything for identifying if a package is a component. I see that we have an `IsComponent` on a `ResourceSpec` but not on the `PackageSpec` itself. However, just as with the suggestions for `category` being in the `keywords` with a GH-label like format I think we could do `kind/component` in the `keywords` and therefore, not have to add anything explicitly. Let me know if you think otherwise.

These additions will help ensuring that we generate package documentation from the schema and don't have to rely on users to specify them manually while running the various docs generator tools.

Related to #7813

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
  - I didn't add tests. Let me know if you think these changes warrant a test.
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
- [ ] ~Yes, there are changes in this PR that warrants bumping the Pulumi Service API version~
  - No changes related to the service.
