### PR TITLE
reformat error message string

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,5 @@
 ### Improvements
 
+* reformat error message string in `sdk/go/common/diag/errors.go`
 
 ### Bug Fixes

--- a/sdk/go/common/diag/errors.go
+++ b/sdk/go/common/diag/errors.go
@@ -38,7 +38,7 @@ func GetResourceInvalidError(urn resource.URN) *Diag {
 }
 
 func GetResourcePropertyInvalidValueError(urn resource.URN) *Diag {
-	return newError(urn, 2003, "%v resource '%v's property '%v' value %v has a problem: %v")
+	return newError(urn, 2003, "%v resource '%v': property %v value %v has a problem: %v")
 }
 
 func GetPreviewFailedError(urn resource.URN) *Diag {


### PR DESCRIPTION
# Description

reformat error message string to make a bit clear to the end user

Fixes https://github.com/pulumi/pulumi/issues/8057

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
