### PR TITLE
Type inference for out var differs by compiler

### DIFF
--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -384,7 +384,7 @@ namespace Pulumi.Automation
 
         internal static SemVersion? ParseAndValidatePulumiVersion(SemVersion minVersion, string currentVersion, bool optOut)
         {
-            if (!SemVersion.TryParse(currentVersion, out var version))
+            if (!SemVersion.TryParse(currentVersion, out SemVersion? version))
             {
                 version = null;
             }


### PR DESCRIPTION
While our CI seems happy with this line of code on master, my machine
with the 3.1 sdk is resolving it to non-nullable type and complaining
about the "= null" line later.

```
LocalWorkspace.cs(389,27): error CS8600: Converting null literal or
possible null value to non-nullable type.
[/workspaces/pulumi/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj]
```

Quick fix to just not use "var" here.