### PR TITLE
Check in default vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/vendor/
 **/node_modules/
 **/bin
-**/.vscode/
+**/.vscode/**/*
 **/.vs/
 **/.ionide/
 **/.idea/
@@ -16,6 +16,9 @@ coverage.cov
 
 # VSCode creates this binary when running tests in the debugger
 **/debug.test
+
+# Check in vscode settings for this workspace. This is so we can save common settings like setting go build tags to use by default.
+!**/.vscode/settings.json
 
 # Go tests run "in tree" and this folder will linger if they fail (the integration test framework cleans
 # it up when they pass.)

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.buildTags": "all"
+}


### PR DESCRIPTION
Currently this is just setting go.buildTags to "all" so the language
specific tests are included in build and test commands by default.

Missing this leads to the confusing (at least to new people) behavior
of clicking run test on a test method and vscode then saying there is no
test to run.