### PR TITLE
Fix #8172

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -19,7 +19,7 @@
 
   [#8275](https://github.com/pulumi/pulumi/pull/8275)
 
-- [codegen/go] - Interaction between the `plain` and `default` tags of a type. 
+- [codegen/go] - Interaction between the `plain` and `default` tags of a type.
   [#8254](https://github.com/pulumi/pulumi/pull/8254)
 
 - [sdk/dotnet] - Fix a race condition when detecting exceptions in stack creation
@@ -30,6 +30,10 @@
 
 - [sdk/dotnet] - Don't panic on schema mismatches
   [#8286](https://github.com/pulumi/pulumi/pull/8286)
+
+- [codegen/python] - Fixes issue with `$fn_output` functions failing in
+  preview when called with unknown arguments
+  [#8320](https://github.com/pulumi/pulumi/pull/8320)
 
 ### Miscellaneous
 

--- a/pkg/codegen/internal/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/cyclic-types/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/dash-named-schema/python/pulumi_foo_bar/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/python/pulumi_plant/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/hyphen-url/python/pulumi_registrygeoreplication/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/naming-collisions/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/python/foo_bar/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/nested-module/python/pulumi_foo/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/nested-module/python/pulumi_foo/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/python/pulumi_myedgeorder/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/python/pulumi_mypkg/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/output-funcs/python-extras/tests/test_codegen.py
+++ b/pkg/codegen/internal/test/testdata/output-funcs/python-extras/tests/test_codegen.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import asyncio
 import json
 import pytest
 
@@ -32,8 +33,20 @@ def my_mocks():
         pulumi.runtime.settings.configure(old_settings)
 
 
+@pytest.fixture
+def my_preview_mocks():
+    old_settings = pulumi.runtime.settings.SETTINGS
+    try:
+        mocks = MyMocks()
+        pulumi.runtime.mocks.set_mocks(mocks, preview=True)
+        yield mocks
+    finally:
+        pulumi.runtime.settings.configure(old_settings)
+
+
 class MyMocks(pulumi.runtime.Mocks):
     def call(self, args):
+
         if args.token in ['mypkg::funcWithAllOptionalInputs',
                           'mypkg::funcWithDefaultValue']:
             a = args.args.get('a', None)
@@ -49,6 +62,15 @@ class MyMocks(pulumi.runtime.Mocks):
                     'value': [args.args]}
 
         if args.token == 'mypkg::listStorageAccountKeys':
+
+            if 'accountName' not in args.args or \
+               not args.args['accountName'] or \
+               pulumi.contains_unknowns(args.args['accountName']):
+                raise Exception(
+                    'Missing required argument: '
+                    'The argument "account_name" is required, '
+                    'but no definition was found')
+
             return {'keys': [
                 dict(creationTime='my-creation-time',
                      keyName='my-key-name',
@@ -193,6 +215,15 @@ def test_list_storage_accounts(my_mocks):
         )])
 
 
+@pulumi.runtime.test
+def test_preview_with_unknowns(my_preview_mocks):
+
+    def check(r):
+        assert False, 'check() should not be called when args contain unknowns'
+
+    return list_storage_account_keys_output(account_name=unknown()).apply(check)
+
+
 def jstr(x):
     return json.dumps(x, sort_keys=True)
 
@@ -203,3 +234,14 @@ def r(x):
 
 def out(x):
     return pulumi.Output.from_input(x).apply(lambda x: x)
+
+
+def unknown():
+    is_known_fut: asyncio.Future[bool] = asyncio.Future()
+    is_secret_fut: asyncio.Future[bool] = asyncio.Future()
+    is_known_fut.set_result(False)
+    is_secret_fut.set_result(False)
+
+    value_fut: asyncio.Future[Any] = asyncio.Future()
+    value_fut.set_result(pulumi.UNKNOWN)
+    return pulumi.Output(set(), value_fut, is_known_fut, is_secret_fut)

--- a/pkg/codegen/internal/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/output-funcs/python/pulumi_mypkg/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/plain-and-default/python/pulumi_foobar/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/python/pulumi_xyz/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/python/pulumi_configstation/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/regress-node-8110/python/pulumi_my8110/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/python/pulumi_plant/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/python/custom_py_package/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/python/pulumi_example/_utilities.py
@@ -224,9 +224,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -3017,9 +3017,10 @@ def lift_output_func(func: typing.Any) -> typing.Callable[[_F], _F]:
 
     def lifted_func(*args, opts=None, **kwargs):
         bound_args = func_sig.bind(*args, **kwargs)
-
+        # Convert tuple to list, see pulumi/pulumi#8172
+        args_list = list(bound_args.args)
         return pulumi.Output.from_input({
-            'args': bound_args.args,
+            'args': args_list,
             'kwargs': bound_args.kwargs
         }).apply(lambda resolved_args: func(*resolved_args['args'],
                                             opts=opts,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description


Fixes #8172

To take effect, the change needs to flow through providers unfortunately (lift_output_func is not in the SDK but each provider's utilities.py).

The core problem is that lists and tuples are treated fundamentally differently by the Python SDK. https://github.com/pulumi/pulumi/issues/8321

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
