### PR TITLE
Clean up changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,6 @@ CHANGELOG
 - [cli] - Reformat error message string in `sdk/go/common/diag/errors.go`.
   [#8284](https://github.com/pulumi/pulumi/pull/8284)
 
-### Bug Fixes
-
-- [sdk/go] - Respect implicit parents in alias resolution.
-  [#8288](https://github.com/pulumi/pulumi/pull/8288)
-
-- Clarify error message string in `sdk/go/common/diag/errors.go`.
-  [#8284](https://github.com/pulumi/pulumi/pull/8284)
-
 - [cli] - Add `--json` flag to `up`, `destroy` and `refresh`.
 
   Passing the `--json` flag to `up`, `destroy` and `refresh` will stream JSON events from the engine to stdout.
@@ -23,6 +15,11 @@ CHANGELOG
   However, the streaming output can be extended to `preview` by using the `PULUMI_ENABLE_STREAMING_JSON_PREVIEW` environment variable.
 
   [#8275](https://github.com/pulumi/pulumi/pull/8275)
+
+### Bug Fixes
+
+- [sdk/go] - Respect implicit parents in alias resolution.
+  [#8288](https://github.com/pulumi/pulumi/pull/8288)
 
 - [sdk/python] - Expand dependencies when marshaling output values.
   [#8301](https://github.com/pulumi/pulumi/pull/8301)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

@komalali points out we list a fix twice and mis-classify an improvement as a bugfix.


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
