### PR TITLE
[programgen/go] Don't change imported resource names

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,3 +3,5 @@
 
 ### Bug Fixes
 
+- [programgen/go] - Don't change imported resource names.
+  [#8353](https://github.com/pulumi/pulumi/pull/8353)

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -431,7 +431,7 @@ func (g *generator) genResourceOptions(w io.Writer, block *model.Block) {
 
 func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 
-	resName := makeValidIdentifier(r.Name())
+	resName, resNameVar := r.Name(), makeValidIdentifier(r.Name())
 	pkg, mod, typ, _ := r.DecomposeToken()
 	if mod == "" || strings.HasPrefix(mod, "/") || strings.HasPrefix(mod, "index/") {
 		mod = pkg
@@ -487,7 +487,7 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 		rangeExpr, temps := g.lowerExpression(r.Options.Range, rangeType)
 		g.genTemps(w, temps)
 
-		g.Fgenf(w, "var %s []*%s.%s\n", resName, modOrAlias, typ)
+		g.Fgenf(w, "var %s []*%s.%s\n", resNameVar, modOrAlias, typ)
 
 		// ahead of range statement declaration generate the resource instantiation
 		// to detect and removed unused k,v variables
@@ -502,11 +502,11 @@ func (g *generator) genResource(w io.Writer, r *pcl.Resource) {
 
 		g.Fgenf(w, "for key0, %s := range %.v {\n", valVar, rangeExpr)
 		g.Fgen(w, instantiation)
-		g.Fgenf(w, "%s = append(%s, __res)\n", resName, resName)
+		g.Fgenf(w, "%[1]s = append(%[1]s, __res)\n", resNameVar)
 		g.Fgenf(w, "}\n")
 
 	} else {
-		instantiate(resName, fmt.Sprintf("%q", resName), w)
+		instantiate(resNameVar, fmt.Sprintf("%q", resName), w)
 	}
 
 }

--- a/pkg/codegen/internal/test/testdata/random-pet-pp/dotnet/random-pet.cs
+++ b/pkg/codegen/internal/test/testdata/random-pet-pp/dotnet/random-pet.cs
@@ -5,7 +5,7 @@ class MyStack : Stack
 {
     public MyStack()
     {
-        var random_pet = new Random.RandomPet("random_pet", new Random.RandomPetArgs
+        var random_pet = new Random.RandomPet("random-pet", new Random.RandomPetArgs
         {
             Prefix = "doggo",
         });

--- a/pkg/codegen/internal/test/testdata/random-pet-pp/go/random-pet.go
+++ b/pkg/codegen/internal/test/testdata/random-pet-pp/go/random-pet.go
@@ -7,7 +7,7 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		_, err := random.NewRandomPet(ctx, "random_pet", &random.RandomPetArgs{
+		_, err := random.NewRandomPet(ctx, "random-pet", &random.RandomPetArgs{
 			Prefix: pulumi.String("doggo"),
 		})
 		if err != nil {

--- a/pkg/codegen/internal/test/testdata/random-pet-pp/nodejs/random-pet.ts
+++ b/pkg/codegen/internal/test/testdata/random-pet-pp/nodejs/random-pet.ts
@@ -1,4 +1,4 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as random from "@pulumi/random";
 
-const random_pet = new random.RandomPet("random_pet", {prefix: "doggo"});
+const random_pet = new random.RandomPet("random-pet", {prefix: "doggo"});

--- a/pkg/codegen/internal/test/testdata/random-pet-pp/python/random-pet.py
+++ b/pkg/codegen/internal/test/testdata/random-pet-pp/python/random-pet.py
@@ -1,4 +1,4 @@
 import pulumi
 import pulumi_random as random
 
-random_pet = random.RandomPet("random_pet", prefix="doggo")
+random_pet = random.RandomPet("random-pet", prefix="doggo")

--- a/pkg/codegen/internal/test/testdata/random-pet-pp/random-pet.pp
+++ b/pkg/codegen/internal/test/testdata/random-pet-pp/random-pet.pp
@@ -1,3 +1,3 @@
-resource random_pet "random:index/randomPet:RandomPet" {
+resource random-pet "random:index/randomPet:RandomPet" {
   prefix = "doggo"
 }


### PR DESCRIPTION
When importing a resource in Go, we change resource names with hyphens to snake_case. This happens because we [introduced a change](https://github.com/pulumi/pulumi/pull/4915/files#diff-d6817c1c54a334e663ae7a8ef2bcc697641fcddf412b0d2b97c884a9e297a5f3R247) that converts the resource name to a valid Go identifier so it can be used as a local variable. But we were also using this converted name as the string resource name, which causes problems with import: the imported resource in the state file has the original resource name, but the generated program uses the converted name, causing Pulumi to delete and recreate the resource when adopting the generated import code.

This change fixes the issue by maintaining the original resource name, and only using the converted name for variables.

Fixes #8295