### PR TITLE
Validate python version

### DIFF
--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -65,7 +65,7 @@ const (
 )
 
 var (
-	mimimumPythonVersion      = semver.MustParse("3.6.0")
+	mimimumPythonVersion      = semver.MustParse("3.7.0")
 	minimumPythonVersionIssue = "pulumi/pulumi issue #8131"
 )
 

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -65,8 +65,12 @@ const (
 )
 
 var (
-	mimimumPythonVersion      = semver.MustParse("3.7.0")
-	minimumPythonVersionIssue = "pulumi/pulumi issue #8131"
+	// The minimum python version that Pulumi supports
+	minimumSupportedPythonVersion = semver.MustParse("3.6.0")
+	// Any version less then `eolPythonVersion` is EOL.
+	eolPythonVersion = semver.MustParse("3.7.0")
+	// An url to the issue discussing EOL.
+	eolPythonVersionIssue = "https://github.com/pulumi/pulumi/issues/8131"
 )
 
 // Launches the language host RPC endpoint, which in turn fires up an RPC server implementing the
@@ -691,9 +695,12 @@ func validateVersion(virtualEnvPath string) {
 		fmt.Fprintf(os.Stderr, "Failed to parse python version: '%s'\n", version)
 		return
 	}
-	if parsed.LT(mimimumPythonVersion) {
+	if parsed.LT(minimumSupportedPythonVersion) {
+		fmt.Fprintf(os.Stderr, "Pulumi does not support Python %s."+
+			" Please upgrade to at least %s\n", parsed, minimumSupportedPythonVersion)
+	} else if parsed.LT(eolPythonVersion) {
 		fmt.Fprintf(os.Stderr, "Python %d.%d is approaching EOL and will not be supported in Pulumi soon."+
-			" Check %s for more details\n", mimimumPythonVersion.Major,
-			mimimumPythonVersion.Minor, minimumPythonVersionIssue)
+			" Check %s for more details\n", parsed.Major,
+			eolPythonVersion.Minor, eolPythonVersionIssue)
 	}
 }


### PR DESCRIPTION
Note: we do this at the language plugin level because extremely old
version of python (python2) have different syntax, and we don't want
parse errors to occlude our version message.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8325

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
