### PR TITLE
[auto/python] - Fix deserialization of event 

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,5 +3,8 @@
 
 ### Bug Fixes
 
+- [automation/python] - Fix deserialization of events.
+  [#8375](https://github.com/pulumi/pulumi/pull/8375)
+
 - [programgen/go] - Don't change imported resource names.
   [#8353](https://github.com/pulumi/pulumi/pull/8353)

--- a/sdk/python/lib/pulumi/automation/events.py
+++ b/sdk/python/lib/pulumi/automation/events.py
@@ -431,7 +431,8 @@ class ResourcePreEvent(BaseEvent):
 
     @classmethod
     def from_json(cls, data: dict) -> 'ResourcePreEvent':
-        return cls(**data)
+        return cls(metadata=StepEventMetadata.from_json(data.get("metadata")), 
+                   planning=data.get("planning"))
 
 
 class ResOutputsEvent(BaseEvent):
@@ -446,7 +447,8 @@ class ResOutputsEvent(BaseEvent):
 
     @classmethod
     def from_json(cls, data: dict) -> 'ResOutputsEvent':
-        return cls(**data)
+        return cls(metadata=StepEventMetadata.from_json(data.get("metadata")), 
+                   planning=data.get("planning"))
 
 
 class ResOpFailedEvent(BaseEvent):
@@ -464,7 +466,9 @@ class ResOpFailedEvent(BaseEvent):
 
     @classmethod
     def from_json(cls, data: dict) -> 'ResOpFailedEvent':
-        return cls(**data)
+        return cls(metadata=StepEventMetadata.from_json(data.get("metadata")), 
+                   status=data.get("status", 0),
+                   steps=data.get("steps", 0))
 
 
 class EngineEvent(BaseEvent):

--- a/sdk/python/lib/pulumi/automation/events.py
+++ b/sdk/python/lib/pulumi/automation/events.py
@@ -431,7 +431,8 @@ class ResourcePreEvent(BaseEvent):
 
     @classmethod
     def from_json(cls, data: dict) -> 'ResourcePreEvent':
-        return cls(metadata=StepEventMetadata.from_json(data.get("metadata")), 
+        metadata: dict = data.get("metadata", {})
+        return cls(metadata=StepEventMetadata.from_json(metadata),
                    planning=data.get("planning"))
 
 
@@ -447,7 +448,8 @@ class ResOutputsEvent(BaseEvent):
 
     @classmethod
     def from_json(cls, data: dict) -> 'ResOutputsEvent':
-        return cls(metadata=StepEventMetadata.from_json(data.get("metadata")), 
+        metadata: dict = data.get("metadata", {})
+        return cls(metadata=StepEventMetadata.from_json(metadata),
                    planning=data.get("planning"))
 
 
@@ -466,7 +468,8 @@ class ResOpFailedEvent(BaseEvent):
 
     @classmethod
     def from_json(cls, data: dict) -> 'ResOpFailedEvent':
-        return cls(metadata=StepEventMetadata.from_json(data.get("metadata")), 
+        metadata: dict = data.get("metadata", {})
+        return cls(metadata=StepEventMetadata.from_json(metadata),
                    status=data.get("status", 0),
                    steps=data.get("steps", 0))
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes the deserialization for the `metadata` property on `ResourcePreEvent`, `ResOutputsEvent` and `ResOpFailedEvent`. There are no existing tests for the deserialization of engine events, so I haven't added any but this fixes my issue locally.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
