### PR TITLE
Increase default go test timeout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "go.buildTags": "all"
+    "go.buildTags": "all",
+    "go.testTimeout": "1h"
 }


### PR DESCRIPTION
Our makefiles always run `go test` with a 1h timeout. This updates the default vscode settings to the same.