### PR TITLE
Move gopls settings to .vscode from .devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,16 +22,6 @@
     "postCreateCommand": "find -name \"*.??proj\" | xargs -L1 dotnet restore",
 
     "settings": {
-        "gopls": {
-            // A couple of modules get copied as part of builds and this confuse gopls as it sees the module name twice, just ignore the copy in the build folders.
-            "build.directoryFilters": [
-                "-sdk/dotnet/Pulumi.Automation.Tests/bin",
-                "-sdk/nodejs/bin",
-                "-sdk/python/env"
-            ],
-            // Experimental but seems to work and means we don't need a vscode instance per go.mod file.
-            "experimentalWorkspaceModule": true,
-        },
         "extensions.ignoreRecommendations": true
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,14 @@
 {
     "go.buildTags": "all",
-    "go.testTimeout": "1h"
+    "go.testTimeout": "1h",
+    "gopls": {
+        // A couple of modules get copied as part of builds and this confuse gopls as it sees the module name twice, just ignore the copy in the build folders.
+        "build.directoryFilters": [
+            "-sdk/dotnet/Pulumi.Automation.Tests/bin",
+            "-sdk/nodejs/bin",
+            "-sdk/python/env"
+        ],
+        // Experimental but seems to work and means we don't need a vscode instance per go.mod file.
+        "experimentalWorkspaceModule": true,
+    },
 }


### PR DESCRIPTION
These gopls settings should apply to any vscode instance, not just ones in devcontainers.
