### PR TITLE
Improve vscode dotnet support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,8 +18,7 @@
 
     "extensions": ["golang.go", "ms-dotnettools.csharp", "ms-python.python"],
 
-    // We want to dotnet restore all projects on startup so that omnisharp doesn't complain about lots of missing types on startup.
-    "postCreateCommand": "find -name \"*.??proj\" | xargs -L1 dotnet restore",
+    "postCreateCommand": "make ensure",
 
     "settings": {
         "extensions.ignoreRecommendations": true

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 
     "remoteUser": "user",
 
-    "extensions": ["golang.go", "ms-dotnettools.csharp", "ms-python.python"],
+    "extensions": ["golang.go", "ms-dotnettools.csharp", "ms-python.python", "formulahendry.dotnet-test-explorer"],
 
     "postCreateCommand": "make ensure",
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -303,6 +303,9 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - name: Create Local Nuget
+        run: mkdir -p "${{ env.PULUMI_LOCAL_NUGET }}"
+        shell: bash
       - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -160,6 +160,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -229,6 +230,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -143,6 +143,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -206,6 +207,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -280,6 +280,9 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - name: Create Local Nuget
+        run: mkdir -p "${{ env.PULUMI_LOCAL_NUGET }}"
+        shell: bash
       - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -295,9 +298,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Clean
         run: dotnet nuget locals all --clear
-      - name: Create Local Nuget
-        run: mkdir -p "D:\\Pulumi\\nuget"
-        shell: bash
       - name: Install Python Deps
         run: |
           pip3 install pyenv-win

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,6 +386,9 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
+      - name: Create Local Nuget
+        run: mkdir -p "${{ env.PULUMI_LOCAL_NUGET }}"
+        shell: bash
       - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,6 +236,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -305,6 +306,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -82,6 +82,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -170,6 +171,7 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
+      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -279,6 +279,9 @@ jobs:
         run: |
           pip3 install pyenv-win
           pip3 install pipenv
+      - name: Create Local Nuget
+        run: mkdir -p "${{ env.PULUMI_LOCAL_NUGET }}"
+        shell: bash
       - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Set Build Env Vars
         shell: bash

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,4 +11,7 @@
         // Experimental but seems to work and means we don't need a vscode instance per go.mod file.
         "experimentalWorkspaceModule": true,
     },
+
+    "omnisharp.defaultLaunchSolution": "sdk/dotnet/dotnet.sln",
+    "dotnet-test-explorer.testProjectPath": "sdk/dotnet",
 }

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -14,6 +14,10 @@ include ../../build/common.mk
 # `test_all` without the dependencies.
 TEST_ALL_DEPS = install
 
+ensure::
+	# We want to dotnet restore all projects on startup so that omnisharp doesn't complain about lots of missing types on startup.
+	dotnet restore dotnet.sln
+
 build::
 	# From the nuget docs:
 	#


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Improve support for dotnet (mostly) in vscode and the devcontainer.

This installs a test adapter for dotnet in the devcontainer so that our C# tests show in the vscode test explorer.
This also sets some default settings for onmisharp and the test-adapter to focus on the main sdk .sln.
Finally this changes the devcontainer startup to call "make ensure" rather than "dotnet restore" on every csproj. The main dotnet projects are now restored as part of "make ensure". The sum result of this is that once the devcontainer is started up there are working environments for all the languages (dotnet has projects restored, go has deps downloaded, python has a venv setup etc).