### PR TITLE
Cleanup CHANGELOG_PENDING after 3.17.1

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,18 +1,3 @@
 ### Improvements
 
-- [codegen/docs] Edit docs codegen to document `$fnOutput` function
-  invoke forms in API documentation.
-  [#8287](https://github.com/pulumi/pulumi/pull/8287)
-
-
 ### Bug Fixes
-
-- [automation/python] - Fix deserialization of events.
-  [#8375](https://github.com/pulumi/pulumi/pull/8375)
-
-- [sdk/dotnet] - Fixes failing preview for programs that call data
-  sources (`F.Invoke`) with unknown outputs
-  [#8339](https://github.com/pulumi/pulumi/pull/8339)
-
-- [programgen/go] - Don't change imported resource names.
-  [#8353](https://github.com/pulumi/pulumi/pull/8353)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
