### PR TITLE
Improve corrupt workspace settings experience

### DIFF
--- a/sdk/go/common/workspace/workspace.go
+++ b/sdk/go/common/workspace/workspace.go
@@ -19,6 +19,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -105,7 +106,7 @@ func NewFrom(dir string) (W, error) {
 
 	err = w.readSettings()
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to read workspace settings")
+		return nil, fmt.Errorf("unable to read workspace settings: %w", err)
 	}
 
 	upsertIntoCache(dir, w)

--- a/sdk/go/common/workspace/workspace.go
+++ b/sdk/go/common/workspace/workspace.go
@@ -144,7 +144,7 @@ func (pw *projectWorkspace) Save() error {
 
 // atomicWriteFile provides a rename based atomic write through a temporary file.
 func atomicWriteFile(path string, b []byte) error {
-	tmp, err := ioutil.TempFile("", filepath.Base(path))
+	tmp, err := ioutil.TempFile(filepath.Dir(path), filepath.Base(path))
 	if err != nil {
 		return errors.Wrapf(err, "failed to create temporary file %s", path)
 	}

--- a/sdk/go/common/workspace/workspace.go
+++ b/sdk/go/common/workspace/workspace.go
@@ -19,14 +19,13 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 
+	"github.com/docker/docker/pkg/ioutils"
 	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -141,25 +140,7 @@ func (pw *projectWorkspace) Save() error {
 	if err != nil {
 		return err
 	}
-	return atomicWrite(settingsFile, b)
-}
-
-// atomicWrite writes to a file path atomically.
-//
-// It uses the write mv/rename trick to atomically write a file.
-func atomicWrite(path string, b []byte) error {
-	// This RNG provides no security. It is intended only to generate
-	// probabilistically unique names.
-	tmpFile := fmt.Sprintf("%s%d.tmp", path, rand.Int31()) // nolint: gosec
-	err := ioutil.WriteFile(tmpFile, b, 0600)
-	if err != nil {
-		return err
-	}
-	err = os.Rename(tmpFile, path)
-	if err != nil {
-		return err
-	}
-	return os.Remove(tmpFile)
+	return ioutils.AtomicWriteFile(settingsFile, b, 0600)
 }
 
 func (pw *projectWorkspace) readSettings() error {


### PR DESCRIPTION
This improvement comes in two parts.

1. The error message for a corrupt workspace settings file now clearly
indicates both the file and the parsing error.

2. Writing the workspace settings is now atomic. This prevents
corruption from multiple concurrent calls.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #6287

This change also lessons the impact of #8186, though it is still something we need to address. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
