### PR TITLE
Update error handling

### DIFF
--- a/pkg/backend/apply.go
+++ b/pkg/backend/apply.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/pkg/errors"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 
@@ -171,7 +170,7 @@ func confirmBeforeUpdating(kind apitype.UpdateKind, stack Stack,
 			Options: choices,
 			Default: string(no),
 		}, &response, nil); err != nil {
-			return result.FromError(errors.Wrapf(err, "confirmation cancelled, not proceeding with the %s", kind))
+			return result.FromError(fmt.Errorf("confirmation cancelled, not proceeding with the %s: %w", kind, err))
 		}
 
 		if response == string(no) {

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -16,11 +16,10 @@ package backend
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -298,7 +297,7 @@ func (c *backendClient) GetStackOutputs(ctx context.Context, name string) (resou
 		return nil, err
 	}
 	if s == nil {
-		return nil, errors.Errorf("unknown stack %q", name)
+		return nil, fmt.Errorf("unknown stack %q", name)
 	}
 	snap, err := s.Snapshot(ctx)
 	if err != nil {
@@ -306,7 +305,7 @@ func (c *backendClient) GetStackOutputs(ctx context.Context, name string) (resou
 	}
 	res, err := stack.GetRootStackResource(snap)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting root stack resources")
+		return nil, fmt.Errorf("getting root stack resources: %w", err)
 	}
 	if res == nil {
 		return resource.PropertyMap{}, nil
@@ -325,7 +324,7 @@ func (c *backendClient) GetStackResourceOutputs(
 		return nil, err
 	}
 	if s == nil {
-		return nil, errors.Errorf("unknown stack %q", name)
+		return nil, fmt.Errorf("unknown stack %q", name)
 	}
 	snap, err := s.Snapshot(ctx)
 	if err != nil {

--- a/pkg/backend/display/events.go
+++ b/pkg/backend/display/events.go
@@ -1,7 +1,7 @@
 package display
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
@@ -21,7 +21,7 @@ func ConvertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
 	var apiEvent apitype.EngineEvent
 
 	// Error to return if the payload doesn't match expected.
-	eventTypePayloadMismatch := errors.Errorf("unexpected payload for event type %v", e.Type)
+	eventTypePayloadMismatch := fmt.Errorf("unexpected payload for event type %v", e.Type)
 
 	switch e.Type {
 	case engine.CancelEvent:
@@ -130,7 +130,7 @@ func ConvertEngineEvent(e engine.Event) (apitype.EngineEvent, error) {
 		}
 
 	default:
-		return apiEvent, errors.Errorf("unknown event type %q", e.Type)
+		return apiEvent, fmt.Errorf("unknown event type %q", e.Type)
 	}
 
 	return apiEvent, nil

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -322,7 +322,7 @@ func (b *localBackend) GetStack(ctx context.Context, stackRef backend.StackRefer
 	stackName := stackRef.Name()
 	snapshot, path, err := b.getStack(stackName)
 	switch {
-	case gcerrors.Code(legacyErrorCause(err)) == gcerrors.NotFound:
+	case gcerrors.Code(errors.Unwrap(err)) == gcerrors.NotFound:
 		return nil, nil
 	case err != nil:
 		return nil, err

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -321,8 +321,15 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 func (b *localBackend) GetStack(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
 	stackName := stackRef.Name()
 	snapshot, path, err := b.getStack(stackName)
+	drillError := func(err error) error {
+		e := err
+		for errors.Unwrap(e) != nil {
+			e = errors.Unwrap(e)
+		}
+		return e
+	}
 	switch {
-	case gcerrors.Code(errors.Unwrap(err)) == gcerrors.NotFound:
+	case gcerrors.Code(drillError(err)) == gcerrors.NotFound:
 		return nil, nil
 	case err != nil:
 		return nil, err

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -321,13 +321,7 @@ func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackRe
 func (b *localBackend) GetStack(ctx context.Context, stackRef backend.StackReference) (backend.Stack, error) {
 	stackName := stackRef.Name()
 	snapshot, path, err := b.getStack(stackName)
-	drillError := func(err error) error {
-		e := err
-		for errors.Unwrap(e) != nil {
-			e = errors.Unwrap(e)
-		}
-		return e
-	}
+
 	switch {
 	case gcerrors.Code(drillError(err)) == gcerrors.NotFound:
 		return nil, nil
@@ -887,4 +881,13 @@ func (b *localBackend) UpdateStackTags(ctx context.Context,
 
 	// The local backend does not currently persist tags.
 	return errors.New("stack tags not supported in --local mode")
+}
+
+// Returns the original error in the chain. If `err` is nil, nil is returned.
+func drillError(err error) error {
+	e := err
+	for errors.Unwrap(e) != nil {
+		e = errors.Unwrap(e)
+	}
+	return e
 }

--- a/pkg/backend/filestate/bucket.go
+++ b/pkg/backend/filestate/bucket.go
@@ -2,11 +2,11 @@ package filestate
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path"
 	"path/filepath"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 	"gocloud.dev/blob"
 )
@@ -77,7 +77,7 @@ func listBucket(bucket Bucket, dir string) ([]*blob.ListObject, error) {
 			break
 		}
 		if err != nil {
-			return nil, errors.Wrap(err, "could not list bucket")
+			return nil, fmt.Errorf("could not list bucket: %w", err)
 		}
 		files = append(files, file)
 	}
@@ -95,7 +95,7 @@ func objectName(obj *blob.ListObject) string {
 func removeAllByPrefix(bucket Bucket, dir string) error {
 	files, err := listBucket(bucket, dir)
 	if err != nil {
-		return errors.Wrap(err, "unable to list bucket objects for removal")
+		return fmt.Errorf("unable to list bucket objects for removal: %w", err)
 	}
 
 	for _, file := range files {
@@ -113,7 +113,7 @@ func removeAllByPrefix(bucket Bucket, dir string) error {
 func renameObject(bucket Bucket, source string, dest string) error {
 	err := bucket.Copy(context.TODO(), dest, source, nil)
 	if err != nil {
-		return errors.Wrapf(err, "copying %s to %s", source, dest)
+		return fmt.Errorf("copying %s to %s: %w", source, dest, err)
 	}
 
 	err = bucket.Delete(context.TODO(), source)

--- a/pkg/backend/filestate/gcpauth.go
+++ b/pkg/backend/filestate/gcpauth.go
@@ -3,6 +3,8 @@ package filestate
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 
 	"golang.org/x/oauth2/google"
@@ -11,7 +13,6 @@ import (
 
 	"cloud.google.com/go/storage"
 
-	"github.com/pkg/errors"
 	"gocloud.dev/blob"
 	"gocloud.dev/gcp"
 )
@@ -33,7 +34,7 @@ func googleCredentials(ctx context.Context) (*google.Credentials, error) {
 		// so that users can override the default creds
 		credentials, err := google.CredentialsFromJSON(ctx, []byte(creds), storage.ScopeReadWrite)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to parse credentials from $GOOGLE_CREDENTIALS")
+			return nil, fmt.Errorf("unable to parse credentials from $GOOGLE_CREDENTIALS: %w", err)
 		}
 		return credentials, nil
 	}
@@ -43,7 +44,7 @@ func googleCredentials(ctx context.Context) (*google.Credentials, error) {
 	// 2. application_default_credentials.json file in ~/.config/gcloud or $APPDATA\gcloud
 	credentials, err := gcp.DefaultCredentials(ctx)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to find gcp credentials")
+		return nil, fmt.Errorf("unable to find gcp credentials: %w", err)
 	}
 	return credentials, nil
 }

--- a/pkg/backend/filestate/lock.go
+++ b/pkg/backend/filestate/lock.go
@@ -17,13 +17,12 @@ package filestate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/user"
 	"path"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -17,6 +17,7 @@ package filestate
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 
-	"github.com/pkg/errors"
 	"gocloud.dev/blob"
 	"gocloud.dev/gcerrors"
 
@@ -133,7 +133,7 @@ func (b *localBackend) getStack(name tokens.QName) (*deploy.Snapshot, string, er
 
 	chk, err := b.getCheckpoint(name)
 	if err != nil {
-		return nil, file, errors.Wrap(err, "failed to load checkpoint")
+		return nil, file, fmt.Errorf("failed to load checkpoint: %w", err)
 	}
 
 	// Materialize an actual snapshot object.
@@ -145,8 +145,7 @@ func (b *localBackend) getStack(name tokens.QName) (*deploy.Snapshot, string, er
 	// Ensure the snapshot passes verification before returning it, to catch bugs early.
 	if !DisableIntegrityChecking {
 		if verifyerr := snapshot.VerifyIntegrity(); verifyerr != nil {
-			return nil, file,
-				errors.Wrapf(verifyerr, "%s: snapshot integrity failure; refusing to use it", file)
+			return nil, file, fmt.Errorf("%s: snapshot integrity failure; refusing to use it: %w", file, verifyerr)
 		}
 	}
 
@@ -169,18 +168,18 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 	file := b.stackPath(name)
 	m, ext := encoding.Detect(file)
 	if m == nil {
-		return "", errors.Errorf("resource serialization failed; illegal markup extension: '%v'", ext)
+		return "", fmt.Errorf("resource serialization failed; illegal markup extension: '%v'", ext)
 	}
 	if filepath.Ext(file) == "" {
 		file = file + ext
 	}
 	chk, err := stack.SerializeCheckpoint(name, snap, sm, false /* showSecrets */)
 	if err != nil {
-		return "", errors.Wrap(err, "serializaing checkpoint")
+		return "", fmt.Errorf("serializaing checkpoint: %w", err)
 	}
 	byts, err := m.Marshal(chk)
 	if err != nil {
-		return "", errors.Wrap(err, "An IO error occurred while marshalling the checkpoint")
+		return "", fmt.Errorf("An IO error occurred while marshalling the checkpoint: %w", err)
 	}
 
 	// Back up the existing file if it already exists.
@@ -208,7 +207,7 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 				if err != nil {
 					logging.V(7).Infof("Error while writing snapshot to: %s (attempt=%d, error=%s)", file, try, err)
 					if try > 10 {
-						return false, nil, errors.Wrap(err, "An IO error occurred while writing the new snapshot file")
+						return false, nil, fmt.Errorf("An IO error occurred while writing the new snapshot file: %w", err)
 					}
 					return false, nil, nil
 				}
@@ -225,7 +224,7 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 	// And if we are retaining historical checkpoint information, write it out again
 	if cmdutil.IsTruthy(os.Getenv("PULUMI_RETAIN_CHECKPOINTS")) {
 		if err = b.bucket.WriteAll(context.TODO(), fmt.Sprintf("%v.%v", file, time.Now().UnixNano()), byts, nil); err != nil {
-			return "", errors.Wrap(err, "An IO error occurred while writing the new snapshot file")
+			return "", fmt.Errorf("An IO error occurred while writing the new snapshot file: %w", err)
 		}
 	}
 
@@ -234,9 +233,10 @@ func (b *localBackend) saveStack(name tokens.QName, snap *deploy.Snapshot, sm se
 		// out the checkpoint file since it may contain resource state updates.  But we will warn the user that the
 		// file is already written and might be bad.
 		if verifyerr := snap.VerifyIntegrity(); verifyerr != nil {
-			return "", errors.Wrapf(verifyerr,
-				"%s: snapshot integrity failure; it was already written, but is invalid (backup available at %s)",
-				file, bck)
+			return "", fmt.Errorf(
+				"%s: snapshot integrity failure; it was already written, but is invalid (backup available at %s): %w",
+				file, bck, verifyerr)
+
 		}
 	}
 
@@ -323,7 +323,7 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 	allFiles, err := listBucket(b.bucket, dir)
 	if err != nil {
 		// History doesn't exist until a stack has been updated.
-		if gcerrors.Code(errors.Cause(err)) == gcerrors.NotFound {
+		if gcerrors.Code(legacyErrorCause(err)) == gcerrors.NotFound {
 			return nil, nil
 		}
 		return nil, err
@@ -368,11 +368,11 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 		var update backend.UpdateInfo
 		b, err := b.bucket.ReadAll(context.TODO(), filepath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "reading history file %s", filepath)
+			return nil, fmt.Errorf("reading history file %s: %w", filepath, err)
 		}
 		err = json.Unmarshal(b, &update)
 		if err != nil {
-			return nil, errors.Wrapf(err, "reading history file %s", filepath)
+			return nil, fmt.Errorf("reading history file %s: %w", filepath, err)
 		}
 
 		updates = append(updates, update)
@@ -391,7 +391,7 @@ func (b *localBackend) renameHistory(oldName tokens.QName, newName tokens.QName)
 	allFiles, err := listBucket(b.bucket, oldHistory)
 	if err != nil {
 		// if there's nothing there, we don't really need to do a rename.
-		if gcerrors.Code(errors.Cause(err)) == gcerrors.NotFound {
+		if gcerrors.Code(legacyErrorCause(err)) == gcerrors.NotFound {
 			return nil
 		}
 		return err
@@ -407,10 +407,10 @@ func (b *localBackend) renameHistory(oldName tokens.QName, newName tokens.QName)
 		newBlob := path.Join(newHistory, newFileName)
 
 		if err := b.bucket.Copy(context.TODO(), newBlob, oldBlob, nil); err != nil {
-			return errors.Wrap(err, "copying history file")
+			return fmt.Errorf("copying history file: %w", err)
 		}
 		if err := b.bucket.Delete(context.TODO(), oldBlob); err != nil {
-			return errors.Wrap(err, "deleting existing history file")
+			return fmt.Errorf("deleting existing history file: %w", err)
 		}
 	}
 
@@ -440,4 +440,35 @@ func (b *localBackend) addToHistory(name tokens.QName, update backend.UpdateInfo
 	// Make a copy of the checkpoint file. (Assuming it already exists.)
 	checkpointFile := fmt.Sprintf("%s.checkpoint.json", pathPrefix)
 	return b.bucket.Copy(context.TODO(), checkpointFile, b.stackPath(name), nil)
+}
+
+// This was copied from
+// https://github.com/pkg/errors/blob/5dd12d0cfe7f152f80558d591504ce685299311e/errors.go#L264-L288.
+func legacyErrorCause(err error) error {
+	// Cause returns the underlying cause of the error, if possible.
+	// An error value has a cause if it implements the following
+	// interface:
+	//
+	//     type causer interface {
+	//            Cause() error
+	//     }
+	//
+	// If the error does not implement Cause, the original error will
+	// be returned. If the error is nil, nil will be returned without further
+	// investigation.
+	cause := func(err error) error {
+		type causer interface {
+			Cause() error
+		}
+
+		for err != nil {
+			cause, ok := err.(causer)
+			if !ok {
+				break
+			}
+			err = cause.Cause()
+		}
+		return err
+	}
+	return cause(err)
 }

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -323,7 +323,7 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 	allFiles, err := listBucket(b.bucket, dir)
 	if err != nil {
 		// History doesn't exist until a stack has been updated.
-		if gcerrors.Code(errors.Unwrap(err)) == gcerrors.NotFound {
+		if gcerrors.Code(drillError(err)) == gcerrors.NotFound {
 			return nil, nil
 		}
 		return nil, err
@@ -391,7 +391,7 @@ func (b *localBackend) renameHistory(oldName tokens.QName, newName tokens.QName)
 	allFiles, err := listBucket(b.bucket, oldHistory)
 	if err != nil {
 		// if there's nothing there, we don't really need to do a rename.
-		if gcerrors.Code(errors.Unwrap(err)) == gcerrors.NotFound {
+		if gcerrors.Code(drillError(err)) == gcerrors.NotFound {
 			return nil
 		}
 		return err

--- a/pkg/backend/httpstate/backend.go
+++ b/pkg/backend/httpstate/backend.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	cryptorand "crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -31,7 +32,7 @@ import (
 	"time"
 
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
+
 	"github.com/skratchdot/open-golang/open"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -126,7 +127,7 @@ func New(d diag.Sink, cloudURL string) (Backend, error) {
 	cloudURL = ValueOrDefaultURL(cloudURL)
 	account, err := workspace.GetAccount(cloudURL)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting stored credentials")
+		return nil, fmt.Errorf("getting stored credentials: %w", err)
 	}
 	apiToken := account.AccessToken
 
@@ -163,13 +164,13 @@ func loginWithBrowser(ctx context.Context, d diag.Sink, cloudURL string, opts di
 	c := make(chan string)
 	l, err := net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
-		return nil, errors.Wrap(err, "could not start listener")
+		return nil, fmt.Errorf("could not start listener: %w", err)
 	}
 
 	// Extract the port
 	_, port, err := net.SplitHostPort(l.Addr().String())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not determine port")
+		return nil, fmt.Errorf("could not determine port: %w", err)
 	}
 
 	// Generate a nonce we'll send with the request.
@@ -269,8 +270,7 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	} else if !cmdutil.Interactive() {
 		// If interactive mode isn't enabled, the only way to specify a token is through the environment variable.
 		// Fail the attempt to login.
-		return nil, errors.Errorf(
-			"%s must be set for login during non-interactive CLI sessions", AccessTokenEnvVar)
+		return nil, fmt.Errorf("%s must be set for login during non-interactive CLI sessions", AccessTokenEnvVar)
 	} else {
 		// If no access token is available from the environment, and we are interactive, prompt and offer to
 		// open a browser to make it easy to generate and use a fresh token.
@@ -333,7 +333,7 @@ func Login(ctx context.Context, d diag.Sink, cloudURL string, opts display.Optio
 	if err != nil {
 		return nil, err
 	} else if !valid {
-		return nil, errors.Errorf("invalid access token")
+		return nil, fmt.Errorf("invalid access token")
 	}
 
 	// Save them.
@@ -426,7 +426,7 @@ func (b *cloudBackend) parsePolicyPackReference(s string) (backend.PolicyPackRef
 		orgName = split[0]
 		policyPackName = split[1]
 	default:
-		return nil, errors.Errorf("could not parse policy pack name '%s'; must be of the form "+
+		return nil, fmt.Errorf("could not parse policy pack name '%s'; must be of the form "+
 			"<org-name>/<policy-pack-name>", s)
 	}
 
@@ -507,7 +507,7 @@ func (b *cloudBackend) parseStackName(s string) (qualifiedStackReference, error)
 		q.Project = split[1]
 		q.Name = split[2]
 	default:
-		return qualifiedStackReference{}, errors.Errorf("could not parse stack name '%s'", s)
+		return qualifiedStackReference{}, fmt.Errorf("could not parse stack name '%s'", s)
 	}
 
 	return q, nil
@@ -692,14 +692,14 @@ func (b *cloudBackend) CreateStack(
 
 	tags, err := backend.GetEnvironmentTagsForCurrentStack()
 	if err != nil {
-		return nil, errors.Wrap(err, "error determining initial tags")
+		return nil, fmt.Errorf("error determining initial tags: %w", err)
 	}
 
 	// Confirm the stack identity matches the environment. e.g. stack init foo/bar/baz shouldn't work
 	// if the project name in Pulumi.yaml is anything other than "bar".
 	projNameTag, ok := tags[apitype.ProjectNameTag]
 	if ok && stackID.Project != projNameTag {
-		return nil, errors.Errorf("provided project name %q doesn't match Pulumi.yaml", stackID.Project)
+		return nil, fmt.Errorf("provided project name %q doesn't match Pulumi.yaml", stackID.Project)
 	}
 
 	apistack, err := b.client.CreateStack(ctx, stackID, tags)
@@ -905,7 +905,7 @@ func (b *cloudBackend) createAndStartUpdate(
 	// metadata changes.
 	tags, err := backend.GetMergedStackTags(ctx, stack)
 	if err != nil {
-		return client.UpdateIdentifier{}, 0, "", errors.Wrap(err, "getting stack tags")
+		return client.UpdateIdentifier{}, 0, "", fmt.Errorf("getting stack tags: %w", err)
 	}
 	version, token, err := b.client.StartUpdate(ctx, update, tags)
 	if err != nil {
@@ -1070,7 +1070,7 @@ func (b *cloudBackend) runEngineAction(
 	}
 	completeErr := u.Complete(status)
 	if completeErr != nil {
-		res = result.Merge(res, result.FromError(errors.Wrap(completeErr, "failed to complete update")))
+		res = result.Merge(res, result.FromError(fmt.Errorf("failed to complete update: %w", completeErr)))
 	}
 
 	return changes, res
@@ -1087,7 +1087,7 @@ func (b *cloudBackend) CancelCurrentUpdate(ctx context.Context, stackRef backend
 	}
 
 	if stack.ActiveUpdate == "" {
-		return errors.Errorf("stack %v has never been updated", stackRef)
+		return fmt.Errorf("stack %v has never been updated", stackRef)
 	}
 
 	// Compute the update identifier and attempt to cancel the update.
@@ -1122,7 +1122,7 @@ func (b *cloudBackend) GetHistory(
 		// Convert types from the apitype package into their internal counterparts.
 		cfg, err := convertConfig(update.Config)
 		if err != nil {
-			return nil, errors.Wrap(err, "converting configuration")
+			return nil, fmt.Errorf("converting configuration: %w", err)
 		}
 
 		beUpdates = append(beUpdates, backend.UpdateInfo{
@@ -1217,7 +1217,9 @@ func (b *cloudBackend) ExportDeploymentForVersion(
 	// The first stack update version is 1, and monotonically increasing from there.
 	versionNumber, err := strconv.Atoi(version)
 	if err != nil || versionNumber <= 0 {
-		return nil, errors.Errorf("%q is not a valid stack version. It should be a positive integer.", version)
+		return nil, fmt.Errorf(
+			"%q is not a valid stack version. It should be a positive integer",
+			version)
 	}
 
 	return b.exportDeployment(ctx, stack.Ref(), &versionNumber)
@@ -1257,9 +1259,9 @@ func (b *cloudBackend) ImportDeployment(ctx context.Context, stack backend.Stack
 		ctx, backend.ActionLabel(apitype.StackImportUpdate, false /*dryRun*/), update,
 		display.Options{Color: colors.Always})
 	if err != nil {
-		return errors.Wrap(err, "waiting for import")
+		return fmt.Errorf("waiting for import: %w", err)
 	} else if status != apitype.StatusSucceeded {
-		return errors.Errorf("import unsuccessful: status %v", status)
+		return fmt.Errorf("import unsuccessful: status %v", status)
 	}
 	return nil
 }
@@ -1448,7 +1450,7 @@ func IsValidAccessToken(ctx context.Context, cloudURL, accessToken string) (bool
 		if errResp, ok := err.(*apitype.ErrorResponse); ok && errResp.Code == 401 {
 			return false, "", nil
 		}
-		return false, "", errors.Wrapf(err, "getting user info from %v", cloudURL)
+		return false, "", fmt.Errorf("getting user info from %v: %w", cloudURL, err)
 	}
 
 	return true, username, nil
@@ -1480,7 +1482,7 @@ func (c httpstateBackendClient) GetStackOutputs(ctx context.Context, name string
 	// When using the cloud backend, require that stack references are fully qualified so they
 	// look like "<org>/<project>/<stack>"
 	if strings.Count(name, "/") != 2 {
-		return nil, errors.Errorf("a stack reference's name should be of the form " +
+		return nil, fmt.Errorf("a stack reference's name should be of the form " +
 			"'<organization>/<project>/<stack>'. See https://pulumi.io/help/stack-reference for more information.")
 	}
 

--- a/pkg/backend/httpstate/backend_test.go
+++ b/pkg/backend/httpstate/backend_test.go
@@ -14,9 +14,10 @@
 package httpstate
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestValueOrDefaultURL(t *testing.T) {

--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -19,6 +19,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/google/go-querystring/query"
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/util/tracing"
 	"github.com/pulumi/pulumi/pkg/v3/version"
@@ -134,14 +134,14 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 		writer := gzip.NewWriter(&buf)
 		defer contract.IgnoreClose(writer)
 		if _, err := writer.Write(body); err != nil {
-			return "", nil, errors.Wrapf(err, "compressing payload")
+			return "", nil, fmt.Errorf("compressing payload: %w", err)
 		}
 
 		// gzip.Writer will not actually write anything unless it is flushed,
 		//  and it will not actually write the GZip footer unless it is closed. (Close also flushes)
 		// Without this, the compressed bytes do not decompress properly e.g. in python.
 		if err := writer.Close(); err != nil {
-			return "", nil, errors.Wrapf(err, "closing compressed payload")
+			return "", nil, fmt.Errorf("closing compressed payload: %w", err)
 		}
 
 		logging.V(apiRequestDetailLogLevel).Infof("gzip compression ratio: %f, original size: %d bytes",
@@ -153,7 +153,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 
 	req, err := http.NewRequest(method, url, bodyReader)
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "creating new HTTP request")
+		return "", nil, fmt.Errorf("creating new HTTP request: %w", err)
 	}
 
 	requestSpan, requestContext := opentracing.StartSpanFromContext(ctx, getEndpointName(method, path),
@@ -210,7 +210,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 	}
 
 	if err != nil {
-		return "", nil, errors.Wrapf(err, "performing HTTP request")
+		return "", nil, fmt.Errorf("performing HTTP request: %w", err)
 	}
 	logging.V(apiRequestLogLevel).Infof("Pulumi API call response code (%s): %v", url, resp.Status)
 
@@ -228,8 +228,7 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 		// type, and if not just return the raw response text.
 		respBody, err := readBody(resp)
 		if err != nil {
-			return "", nil, errors.Wrapf(
-				err, "API call failed (%s), could not read response", resp.Status)
+			return "", nil, fmt.Errorf("API call failed (%s), could not read response: %w", resp.Status, err)
 		}
 
 		// Provide a better error if using an authenticated call without having logged in first.
@@ -260,7 +259,7 @@ func pulumiRESTCall(ctx context.Context, diag diag.Sink, cloudAPI, method, path 
 	if queryObj != nil {
 		queryValues, err := query.Values(queryObj)
 		if err != nil {
-			return errors.Wrapf(err, "marshalling query object as JSON")
+			return fmt.Errorf("marshalling query object as JSON: %w", err)
 		}
 		query := queryValues.Encode()
 		if len(query) > 0 {
@@ -274,7 +273,7 @@ func pulumiRESTCall(ctx context.Context, diag diag.Sink, cloudAPI, method, path 
 	if reqObj != nil {
 		reqBody, err = json.Marshal(reqObj)
 		if err != nil {
-			return errors.Wrapf(err, "marshalling request object as JSON")
+			return fmt.Errorf("marshalling request object as JSON: %w", err)
 		}
 	}
 
@@ -287,7 +286,7 @@ func pulumiRESTCall(ctx context.Context, diag diag.Sink, cloudAPI, method, path 
 	// Read API response
 	respBody, err := readBody(resp)
 	if err != nil {
-		return errors.Wrapf(err, "reading response from API")
+		return fmt.Errorf("reading response from API: %w", err)
 	}
 	if logging.V(apiRequestDetailLogLevel) {
 		logging.V(apiRequestDetailLogLevel).Infof("Pulumi API call response body (%s): %v", url, string(respBody))
@@ -303,7 +302,7 @@ func pulumiRESTCall(ctx context.Context, diag diag.Sink, cloudAPI, method, path 
 		} else {
 			// Else, unmarshal as JSON.
 			if err = json.Unmarshal(respBody, respObj); err != nil {
-				return errors.Wrapf(err, "unmarshalling response object")
+				return fmt.Errorf("unmarshalling response object: %w", err)
 			}
 		}
 	}
@@ -323,7 +322,7 @@ func readBody(resp *http.Response) ([]byte, error) {
 
 	if len(contentEncoding) > 1 {
 		// We only know how to deal with gzip. We can't handle additional encodings layered on top of it.
-		return nil, errors.Errorf("can't handle content encodings %v", contentEncoding)
+		return nil, fmt.Errorf("can't handle content encodings %v", contentEncoding)
 	}
 
 	switch contentEncoding[0] {
@@ -337,11 +336,11 @@ func readBody(resp *http.Response) ([]byte, error) {
 			defer contract.IgnoreClose(reader)
 		}
 		if err != nil {
-			return nil, errors.Wrap(err, "reading gzip-compressed body")
+			return nil, fmt.Errorf("reading gzip-compressed body: %w", err)
 		}
 
 		return ioutil.ReadAll(reader)
 	default:
-		return nil, errors.Errorf("unrecognized encoding %s", contentEncoding[0])
+		return nil, fmt.Errorf("unrecognized encoding %s", contentEncoding[0])
 	}
 }

--- a/pkg/backend/httpstate/policypack.go
+++ b/pkg/backend/httpstate/policypack.go
@@ -12,7 +12,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
@@ -183,8 +182,7 @@ func (pack *cloudPolicyPack) Publish(
 	if strings.EqualFold(runtime, "nodejs") {
 		packTarball, err = npm.Pack(op.PlugCtx.Pwd, os.Stderr)
 		if err != nil {
-			return result.FromError(
-				errors.Wrap(err, "could not publish policies because of error running npm pack"))
+			return result.FromError(fmt.Errorf("could not publish policies because of error running npm pack: %w", err))
 		}
 	} else {
 		// npm pack puts all the files in a "package" subdirectory inside the .tgz it produces, so we'll do
@@ -192,8 +190,7 @@ func (pack *cloudPolicyPack) Publish(
 		// package directory to determine the runtime of the policy pack.
 		packTarball, err = archive.TGZ(op.PlugCtx.Pwd, "package", true /*useDefaultExcludes*/)
 		if err != nil {
-			return result.FromError(
-				errors.Wrap(err, "could not publish policies because of error creating the .tgz"))
+			return result.FromError(fmt.Errorf("could not publish policies because of error creating the .tgz: %w", err))
 		}
 	}
 
@@ -253,18 +250,18 @@ func installRequiredPolicy(finalDir string, tgz io.ReadCloser) error {
 	// If part of the directory tree is missing, ioutil.TempDir will return an error, so make sure
 	// the path we're going to create the temporary folder in actually exists.
 	if err := os.MkdirAll(filepath.Dir(finalDir), 0700); err != nil {
-		return errors.Wrap(err, "creating plugin root")
+		return fmt.Errorf("creating plugin root: %w", err)
 	}
 
 	tempDir, err := ioutil.TempDir(filepath.Dir(finalDir), fmt.Sprintf("%s.tmp", filepath.Base(finalDir)))
 	if err != nil {
-		return errors.Wrapf(err, "creating plugin directory %s", tempDir)
+		return fmt.Errorf("creating plugin directory %s: %w", tempDir, err)
 	}
 
 	// The policy pack files are actually in a directory called `package`.
 	tempPackageDir := filepath.Join(tempDir, packageDir)
 	if err := os.MkdirAll(tempPackageDir, 0700); err != nil {
-		return errors.Wrap(err, "creating plugin root")
+		return fmt.Errorf("creating plugin root: %w", err)
 	}
 
 	// If we early out of this function, try to remove the temp folder we created.
@@ -284,13 +281,13 @@ func installRequiredPolicy(finalDir string, tgz io.ReadCloser) error {
 	// unable to rename the directory. That's OK, just ignore the error. The temp directory created
 	// as part of the install will be cleaned up when we exit by the defer above.
 	if err := os.Rename(tempPackageDir, finalDir); err != nil && !os.IsExist(err) {
-		return errors.Wrap(err, "moving plugin")
+		return fmt.Errorf("moving plugin: %w", err)
 	}
 
 	projPath := filepath.Join(finalDir, "PulumiPolicy.yaml")
 	proj, err := workspace.LoadPolicyPack(projPath)
 	if err != nil {
-		return errors.Wrapf(err, "failed to load policy project at %s", finalDir)
+		return fmt.Errorf("failed to load policy project at %s: %w", finalDir, err)
 	}
 
 	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
@@ -312,10 +309,9 @@ func installRequiredPolicy(finalDir string, tgz io.ReadCloser) error {
 
 func completeNodeJSInstall(finalDir string) error {
 	if bin, err := npm.Install(finalDir, false /*production*/, nil, os.Stderr); err != nil {
-		return errors.Wrapf(
-			err,
-			"failed to install dependencies of policy pack; you may need to re-run `%s install` "+
-				"in %q before this policy pack works", bin, finalDir)
+		return fmt.Errorf("failed to install dependencies of policy pack; you may need to re-run `%s install` "+
+			"in %q before this policy pack works"+": %w", bin, finalDir, err)
+
 	}
 
 	return nil
@@ -330,7 +326,7 @@ func completePythonInstall(finalDir, projPath string, proj *workspace.PolicyPack
 	// Save project with venv info.
 	proj.Runtime.SetOption("virtualenv", venvDir)
 	if err := proj.Save(projPath); err != nil {
-		return errors.Wrapf(err, "saving project at %s", projPath)
+		return fmt.Errorf("saving project at %s: %w", projPath, err)
 	}
 
 	return nil

--- a/pkg/backend/httpstate/snapshot.go
+++ b/pkg/backend/httpstate/snapshot.go
@@ -16,8 +16,8 @@ package httpstate
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -45,7 +45,7 @@ func (persister *cloudSnapshotPersister) Save(snapshot *deploy.Snapshot) error {
 	}
 	deployment, err := stack.SerializeDeployment(snapshot, persister.sm, false /* showSecrets */)
 	if err != nil {
-		return errors.Wrap(err, "serializing deployment")
+		return fmt.Errorf("serializing deployment: %w", err)
 	}
 	return persister.backend.client.PatchUpdateCheckpoint(persister.context, persister.update, deployment, token)
 }

--- a/pkg/backend/httpstate/state.go
+++ b/pkg/backend/httpstate/state.go
@@ -24,7 +24,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/logging"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
@@ -171,7 +170,7 @@ func (u *cloudUpdate) recordEngineEvents(startingSeqNumber int, events []engine.
 	for idx, event := range events {
 		apiEvent, convErr := display.ConvertEngineEvent(event)
 		if convErr != nil {
-			return errors.Wrap(convErr, "converting engine event")
+			return fmt.Errorf("converting engine event: %w", convErr)
 		}
 
 		// Each event within an update must have a unique sequence number. Any request to
@@ -294,7 +293,7 @@ func (b *cloudBackend) getTarget(ctx context.Context, stackRef backend.StackRefe
 			return nil, fmt.Errorf("the stack '%s' is newer than what this version of the Pulumi CLI understands. "+
 				"Please update your version of the Pulumi CLI", stackRef.Name())
 		default:
-			return nil, errors.Wrap(err, "could not deserialize deployment")
+			return nil, fmt.Errorf("could not deserialize deployment: %w", err)
 		}
 	}
 

--- a/pkg/backend/snapshot.go
+++ b/pkg/backend/snapshot.go
@@ -15,11 +15,11 @@
 package backend
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 	"sort"
 	"time"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -603,14 +603,14 @@ func (sm *SnapshotManager) snap() *deploy.Snapshot {
 func (sm *SnapshotManager) saveSnapshot() error {
 	snap := sm.snap()
 	if err := snap.NormalizeURNReferences(); err != nil {
-		return errors.Wrap(err, "failed to normalize URN references")
+		return fmt.Errorf("failed to normalize URN references: %w", err)
 	}
 	if err := sm.persister.Save(snap); err != nil {
-		return errors.Wrap(err, "failed to save snapshot")
+		return fmt.Errorf("failed to save snapshot: %w", err)
 	}
 	if sm.doVerify {
 		if err := snap.VerifyIntegrity(); err != nil {
-			return errors.Wrapf(err, "failed to verify snapshot")
+			return fmt.Errorf("failed to verify snapshot: %w", err)
 		}
 	}
 	return nil

--- a/pkg/backend/stack.go
+++ b/pkg/backend/stack.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -178,7 +176,7 @@ func GetEnvironmentTagsForCurrentStack() (map[apitype.StackTagName]string, error
 	if projPath != "" {
 		proj, err := workspace.LoadProject(projPath)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error loading project %q", projPath)
+			return nil, fmt.Errorf("error loading project %q: %w", projPath, err)
 		}
 		tags[apitype.ProjectNameTag] = proj.Name.String()
 		tags[apitype.ProjectRuntimeTag] = proj.Runtime.Name()
@@ -219,7 +217,7 @@ func addGitMetadataToStackTags(tags map[apitype.StackTagName]string, projPath st
 		tags[apitype.VCSRepositoryNameTag] = vcsInfo.Repo
 		tags[apitype.VCSRepositoryKindTag] = vcsInfo.Kind
 	} else {
-		return errors.Wrapf(err, "detecting VCS info for stack tags for remote %v", remoteURL)
+		return fmt.Errorf("detecting VCS info for stack tags for remote %v: %w", remoteURL, err)
 	}
 	// Set the old stack tags keys as GitHub so that the UI will continue to work,
 	// regardless of whether the remote URL is a GitHub URL or not.

--- a/pkg/cmd/pulumi/crypto.go
+++ b/pkg/cmd/pulumi/crypto.go
@@ -15,10 +15,10 @@
 package main
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
@@ -70,7 +70,7 @@ func getStackSecretsManager(s backend.Stack) (secrets.Manager, error) {
 			return newServiceSecretsManager(s.(httpstate.Stack), s.Ref().Name(), stackConfigFile)
 		}
 
-		return nil, errors.Errorf("unknown stack type %s", reflect.TypeOf(s))
+		return nil, fmt.Errorf("unknown stack type %s", reflect.TypeOf(s))
 	}()
 	if err != nil {
 		return nil, err
@@ -86,9 +86,8 @@ func validateSecretsProvider(typ string) error {
 			return nil
 		}
 	}
-	return errors.Errorf(
-		"unknown secrets provider type '%s' (supported values: %s)",
+	return fmt.Errorf("unknown secrets provider type '%s' (supported values: %s)",
 		kind,
-		strings.Join(supportedKinds, ","),
-	)
+		strings.Join(supportedKinds, ","))
+
 }

--- a/pkg/cmd/pulumi/crypto_local.go
+++ b/pkg/cmd/pulumi/crypto_local.go
@@ -17,13 +17,13 @@ package main
 import (
 	cryptorand "crypto/rand"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/passphrase"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -42,11 +42,11 @@ func readPassphraseImpl(prompt string, useEnv bool) (phrase string, interactive 
 		if phraseFile, ok := os.LookupEnv("PULUMI_CONFIG_PASSPHRASE_FILE"); ok {
 			phraseFilePath, err := filepath.Abs(phraseFile)
 			if err != nil {
-				return "", false, errors.Wrap(err, "unable to construct a path the PULUMI_CONFIG_PASSPHRASE_FILE")
+				return "", false, fmt.Errorf("unable to construct a path the PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
 			}
 			phraseDetails, err := ioutil.ReadFile(phraseFilePath)
 			if err != nil {
-				return "", false, errors.Wrap(err, "unable to read PULUMI_CONFIG_PASSPHRASE_FILE")
+				return "", false, fmt.Errorf("unable to read PULUMI_CONFIG_PASSPHRASE_FILE: %w", err)
 			}
 			return strings.TrimSpace(string(phraseDetails)), false, nil
 		}

--- a/pkg/cmd/pulumi/destroy.go
+++ b/pkg/cmd/pulumi/destroy.go
@@ -16,9 +16,9 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -127,17 +127,17 @@ func newDestroyCmd() *cobra.Command {
 
 			m, err := getUpdateMetadata(message, root, execKind, execAgent)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
+				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
 			cfg, err := getStackConfiguration(s, sm)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
+				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
 
 			targetUrns := []resource.URN{}

--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -25,7 +26,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -187,7 +188,7 @@ func getCurrentDeploymentForStack(s backend.Stack) (*deploy.Snapshot, error) {
 			return nil, fmt.Errorf("the stack '%s' is newer than what this version of the Pulumi CLI understands. "+
 				"Please update your version of the Pulumi CLI", s.Ref().Name())
 		}
-		return nil, errors.Wrap(err, "could not deserialize deployment")
+		return nil, fmt.Errorf("could not deserialize deployment: %w", err)
 	}
 	return snap, err
 }
@@ -351,7 +352,7 @@ func newImportCmd() *cobra.Command {
 				}
 				f, err := readImportFile(importFilePath)
 				if err != nil {
-					return result.FromError(errors.Wrap(err, "could not read import file"))
+					return result.FromError(fmt.Errorf("could not read import file: %w", err))
 				}
 				importFile = f
 			} else {
@@ -454,17 +455,17 @@ func newImportCmd() *cobra.Command {
 
 			m, err := getUpdateMetadata(message, root, execKind, execAgent)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
+				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
 			cfg, err := getStackConfiguration(s, sm)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
+				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
 
 			opts.Engine = engine.UpdateOptions{
@@ -493,7 +494,7 @@ func newImportCmd() *cobra.Command {
 				protectResources)
 			if err != nil {
 				if _, ok := err.(*importer.DiagnosticsError); ok {
-					err = errors.Wrap(err, "internal error")
+					err = fmt.Errorf("internal error: %w", err)
 				}
 				return result.FromError(err)
 			}

--- a/pkg/cmd/pulumi/login.go
+++ b/pkg/cmd/pulumi/login.go
@@ -15,12 +15,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -114,7 +114,7 @@ func newLoginCmd() *cobra.Command {
 				var err error
 				cloudURL, err = workspace.GetCurrentCloudURL()
 				if err != nil {
-					return errors.Wrap(err, "could not determine current cloud")
+					return fmt.Errorf("could not determine current cloud: %w", err)
 				}
 			} else {
 				// Ensure we have the correct cloudurl type before logging in
@@ -131,7 +131,7 @@ func newLoginCmd() *cobra.Command {
 				be, err = httpstate.Login(commandContext(), cmdutil.Diag(), cloudURL, displayOptions)
 			}
 			if err != nil {
-				return errors.Wrapf(err, "problem logging in")
+				return fmt.Errorf("problem logging in: %w", err)
 			}
 
 			if currentUser, err := be.CurrentUser(); err == nil {
@@ -158,9 +158,8 @@ func validateCloudBackendType(typ string) error {
 			return nil
 		}
 	}
-	return errors.Errorf(
-		"unknown backend cloudUrl format '%s' (supported Url formats are: "+
-			"azblob://, gs://, s3://, file://, https:// and http://)",
-		kind,
-	)
+	return fmt.Errorf("unknown backend cloudUrl format '%s' (supported Url formats are: "+
+		"azblob://, gs://, s3://, file://, https:// and http://)",
+		kind)
+
 }

--- a/pkg/cmd/pulumi/logout.go
+++ b/pkg/cmd/pulumi/logout.go
@@ -15,7 +15,9 @@
 package main
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -65,7 +67,7 @@ func newLogoutCmd() *cobra.Command {
 				var err error
 				cloudURL, err = workspace.GetCurrentCloudURL()
 				if err != nil {
-					return errors.Wrap(err, "could not determine current cloud")
+					return fmt.Errorf("could not determine current cloud: %w", err)
 				}
 			}
 

--- a/pkg/cmd/pulumi/logs.go
+++ b/pkg/cmd/pulumi/logs.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	mobytime "github.com/docker/docker/api/types/time"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -63,17 +63,17 @@ func newLogsCmd() *cobra.Command {
 
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
-				return errors.Wrap(err, "getting secrets manager")
+				return fmt.Errorf("getting secrets manager: %w", err)
 			}
 
 			cfg, err := getStackConfiguration(s, sm)
 			if err != nil {
-				return errors.Wrap(err, "getting stack configuration")
+				return fmt.Errorf("getting stack configuration: %w", err)
 			}
 
 			startTime, err := parseSince(since, time.Now())
 			if err != nil {
-				return errors.Wrapf(err, "failed to parse argument to '--since' as duration or timestamp")
+				return fmt.Errorf("failed to parse argument to '--since' as duration or timestamp: %w", err)
 			}
 			var resourceFilter *operations.ResourceFilter
 			if resource != "" {
@@ -102,7 +102,7 @@ func newLogsCmd() *cobra.Command {
 					ResourceFilter: resourceFilter,
 				})
 				if err != nil {
-					return errors.Wrapf(err, "failed to get logs")
+					return fmt.Errorf("failed to get logs: %w", err)
 				}
 
 				// When we are emitting a fixed number of log entries, and outputing JSON, wrap them in an array.

--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -16,6 +16,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,7 +27,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
@@ -83,7 +83,7 @@ func runNew(args newArgs) error {
 
 	// Validate name (if specified) before further prompts/operations.
 	if args.name != "" && workspace.ValidateProjectName(args.name) != nil {
-		return errors.Errorf("'%s' is not a valid project name. %s.", args.name, workspace.ValidateProjectName(args.name))
+		return fmt.Errorf("'%s' is not a valid project name. %s", args.name, workspace.ValidateProjectName(args.name))
 	}
 
 	// Validate secrets provider type
@@ -94,7 +94,7 @@ func runNew(args newArgs) error {
 	// Get the current working directory.
 	cwd, err := os.Getwd()
 	if err != nil {
-		return errors.Wrap(err, "getting the working directory")
+		return fmt.Errorf("getting the working directory: %w", err)
 	}
 	originalCwd := cwd
 
@@ -159,7 +159,7 @@ func runNew(args newArgs) error {
 	if !args.force {
 		if err = workspace.CopyTemplateFilesDryRun(template.Dir, cwd, args.name); err != nil {
 			if os.IsNotExist(err) {
-				return errors.Wrapf(err, "template '%s' not found", args.templateNameOrURL)
+				return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 			}
 			return err
 		}
@@ -228,7 +228,7 @@ func runNew(args newArgs) error {
 	// Actually copy the files.
 	if err = workspace.CopyTemplateFiles(template.Dir, cwd, args.force, args.name, args.description); err != nil {
 		if os.IsNotExist(err) {
-			return errors.Wrapf(err, "template '%s' not found", args.templateNameOrURL)
+			return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 		}
 		return err
 	}
@@ -245,7 +245,7 @@ func runNew(args newArgs) error {
 	proj.Description = &args.description
 	proj.Template = nil
 	if err = workspace.SaveProject(proj); err != nil {
-		return errors.Wrap(err, "saving project")
+		return fmt.Errorf("saving project: %w", err)
 	}
 
 	// Create the stack, if needed.
@@ -299,19 +299,19 @@ func runNew(args newArgs) error {
 func useSpecifiedDir(dir string) (string, error) {
 	// Ensure the directory exists.
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
-		return "", errors.Wrap(err, "creating the directory")
+		return "", fmt.Errorf("creating the directory: %w", err)
 	}
 
 	// Change the working directory to the specified directory.
 	if err := os.Chdir(dir); err != nil {
-		return "", errors.Wrap(err, "changing the working directory")
+		return "", fmt.Errorf("changing the working directory: %w", err)
 	}
 
 	// Get the new working directory.
 	var cwd string
 	var err error
 	if cwd, err = os.Getwd(); err != nil {
-		return "", errors.Wrap(err, "getting the working directory")
+		return "", fmt.Errorf("getting the working directory: %w", err)
 	}
 	return cwd, nil
 }
@@ -445,7 +445,7 @@ func errorIfNotEmptyDirectory(path string) error {
 	}
 
 	if len(infos) > 0 {
-		return errors.Errorf("%s is not empty; "+
+		return fmt.Errorf("%s is not empty; "+
 			"rerun in an empty directory, pass the path to an empty directory to --dir, or use --force", path)
 	}
 
@@ -577,8 +577,9 @@ func installDependencies(proj *workspace.Project, root string) error {
 	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
 	if strings.EqualFold(proj.Runtime.Name(), "nodejs") {
 		if bin, err := nodeInstallDependencies(); err != nil {
-			return errors.Wrapf(err, "%s install failed; rerun manually to try again, "+
-				"then run 'pulumi up' to perform an initial deployment", bin)
+			return fmt.Errorf("%s install failed; rerun manually to try again, "+
+				"then run 'pulumi up' to perform an initial deployment"+": %w", bin, err)
+
 		}
 	} else if strings.EqualFold(proj.Runtime.Name(), "python") {
 		return pythonInstallDependencies(proj, root)
@@ -620,7 +621,7 @@ func pythonInstallDependencies(proj *workspace.Project, root string) error {
 	// Save project with venv info.
 	proj.Runtime.SetOption("virtualenv", venvDir)
 	if err := workspace.SaveProject(proj); err != nil {
-		return errors.Wrap(err, "saving project")
+		return fmt.Errorf("saving project: %w", err)
 	}
 	return nil
 }
@@ -671,8 +672,9 @@ func goInstallDependencies() error {
 	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 
 	if err := cmd.Run(); err != nil {
-		return errors.Wrapf(err, "`go mod tidy` failed to install dependencies; rerun manually to try again, "+
-			"then run 'pulumi up' to perform an initial deployment")
+		return fmt.Errorf("`go mod tidy` failed to install dependencies; rerun manually to try again, "+
+			"then run 'pulumi up' to perform an initial deployment"+": %w", err)
+
 	}
 
 	fmt.Println("Finished installing dependencies")

--- a/pkg/cmd/pulumi/new_test.go
+++ b/pkg/cmd/pulumi/new_test.go
@@ -16,12 +16,13 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"

--- a/pkg/cmd/pulumi/plugin_ls.go
+++ b/pkg/cmd/pulumi/plugin_ls.go
@@ -19,7 +19,7 @@ import (
 	"sort"
 
 	"github.com/dustin/go-humanize"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -39,11 +39,11 @@ func newPluginLsCmd() *cobra.Command {
 			var err error
 			if projectOnly {
 				if plugins, err = getProjectPlugins(); err != nil {
-					return errors.Wrapf(err, "loading project plugins")
+					return fmt.Errorf("loading project plugins: %w", err)
 				}
 			} else {
 				if plugins, err = workspace.GetPluginsWithMetadata(); err != nil {
-					return errors.Wrapf(err, "loading plugins")
+					return fmt.Errorf("loading plugins: %w", err)
 				}
 			}
 

--- a/pkg/cmd/pulumi/plugin_rm.go
+++ b/pkg/cmd/pulumi/plugin_rm.go
@@ -16,11 +16,12 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
 
 	"github.com/blang/semver"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -58,11 +59,11 @@ func newPluginRmCmd() *cobra.Command {
 			var version *semver.Range
 			if len(args) > 0 {
 				if !workspace.IsPluginKind(args[0]) {
-					return errors.Errorf("unrecognized plugin kind: %s", kind)
+					return fmt.Errorf("unrecognized plugin kind: %s", kind)
 				}
 				kind = workspace.PluginKind(args[0])
 			} else if !all {
-				return errors.Errorf("please pass --all if you'd like to remove all plugins")
+				return fmt.Errorf("please pass --all if you'd like to remove all plugins")
 			}
 			if len(args) > 1 {
 				name = args[1]
@@ -70,7 +71,7 @@ func newPluginRmCmd() *cobra.Command {
 			if len(args) > 2 {
 				r, err := semver.ParseRange(args[2])
 				if err != nil {
-					return errors.Wrap(err, "invalid plugin semver")
+					return fmt.Errorf("invalid plugin semver: %w", err)
 				}
 				version = &r
 			}
@@ -79,7 +80,7 @@ func newPluginRmCmd() *cobra.Command {
 			var deletes []workspace.PluginInfo
 			plugins, err := workspace.GetPlugins()
 			if err != nil {
-				return errors.Wrap(err, "loading plugins")
+				return fmt.Errorf("loading plugins: %w", err)
 			}
 			for _, plugin := range plugins {
 				if (kind == "" || plugin.Kind == kind) &&
@@ -112,7 +113,7 @@ func newPluginRmCmd() *cobra.Command {
 				for _, plugin := range deletes {
 					if err := plugin.Delete(); err != nil {
 						result = multierror.Append(
-							result, errors.Wrapf(err, "failed to delete %s plugin %s", plugin.Kind, plugin))
+							result, fmt.Errorf("failed to delete %s plugin %s: %w", plugin.Kind, plugin, err))
 					}
 				}
 				if result != nil {

--- a/pkg/cmd/pulumi/policy_new.go
+++ b/pkg/cmd/pulumi/policy_new.go
@@ -15,12 +15,12 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag/colors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -98,7 +98,7 @@ func runNewPolicyPack(args newPolicyArgs) error {
 	// Get the current working directory.
 	cwd, err := os.Getwd()
 	if err != nil {
-		return errors.Wrap(err, "getting the working directory")
+		return fmt.Errorf("getting the working directory: %w", err)
 	}
 
 	// If dir was specified, ensure it exists and use it as the
@@ -147,7 +147,7 @@ func runNewPolicyPack(args newPolicyArgs) error {
 	if !args.force {
 		if err = workspace.CopyTemplateFilesDryRun(template.Dir, cwd, ""); err != nil {
 			if os.IsNotExist(err) {
-				return errors.Wrapf(err, "template '%s' not found", args.templateNameOrURL)
+				return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 			}
 			return err
 		}
@@ -156,7 +156,7 @@ func runNewPolicyPack(args newPolicyArgs) error {
 	// Actually copy the files.
 	if err = workspace.CopyTemplateFiles(template.Dir, cwd, args.force, "", ""); err != nil {
 		if os.IsNotExist(err) {
-			return errors.Wrapf(err, "template '%s' not found", args.templateNameOrURL)
+			return fmt.Errorf("template '%s' not found: %w", args.templateNameOrURL, err)
 		}
 		return err
 	}
@@ -190,7 +190,7 @@ func installPolicyPackDependencies(proj *workspace.PolicyPackProject, projPath, 
 	// TODO[pulumi/pulumi#1334]: move to the language plugins so we don't have to hard code here.
 	if strings.EqualFold(proj.Runtime.Name(), "nodejs") {
 		if bin, err := nodeInstallDependencies(); err != nil {
-			return errors.Wrapf(err, "`%s install` failed; rerun manually to try again.", bin)
+			return fmt.Errorf("`%s install` failed; rerun manually to try again.: %w", bin, err)
 		}
 	} else if strings.EqualFold(proj.Runtime.Name(), "python") {
 		const venvDir = "venv"
@@ -201,7 +201,7 @@ func installPolicyPackDependencies(proj *workspace.PolicyPackProject, projPath, 
 		// Save project with venv info.
 		proj.Runtime.SetOption("virtualenv", venvDir)
 		if err := proj.Save(projPath); err != nil {
-			return errors.Wrapf(err, "saving project at %s", projPath)
+			return fmt.Errorf("saving project at %s: %w", projPath, err)
 		}
 	}
 	return nil

--- a/pkg/cmd/pulumi/policy_publish.go
+++ b/pkg/cmd/pulumi/policy_publish.go
@@ -15,10 +15,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate"
@@ -110,8 +110,8 @@ func requirePolicyPack(policyPack string) (backend.PolicyPack, error) {
 
 	cloudURL, err := workspace.GetCurrentCloudURL()
 	if err != nil {
-		return nil, errors.Wrap(err,
-			"`pulumi policy` command requires the user to be logged into the Pulumi service")
+		return nil, fmt.Errorf("`pulumi policy` command requires the user to be logged into the Pulumi service: %w", err)
+
 	}
 
 	displayOptions := display.Options{

--- a/pkg/cmd/pulumi/policy_rm.go
+++ b/pkg/cmd/pulumi/policy_rm.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"

--- a/pkg/cmd/pulumi/preview.go
+++ b/pkg/cmd/pulumi/preview.go
@@ -15,7 +15,9 @@
 package main
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -132,17 +134,17 @@ func newPreviewCmd() *cobra.Command {
 
 			m, err := getUpdateMetadata(message, root, execKind, execAgent)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
+				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
 			cfg, err := getStackConfiguration(s, sm)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
+				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
 
 			targetURNs := []resource.URN{}

--- a/pkg/cmd/pulumi/pulumi.go
+++ b/pkg/cmd/pulumi/pulumi.go
@@ -18,8 +18,8 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
-	user "github.com/tweekmonster/luser"
 	"net/http"
 	"net/url"
 	"os"
@@ -30,10 +30,12 @@ import (
 	"strings"
 	"time"
 
+	user "github.com/tweekmonster/luser"
+
 	"github.com/blang/semver"
 	"github.com/djherbis/times"
 	"github.com/docker/docker/pkg/term"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -435,7 +437,7 @@ func isBrewInstall(exe string) (bool, error) {
 		if ee, ok := err.(*exec.ExitError); ok {
 			ee.Stderr = stderr.Bytes()
 		}
-		return false, errors.Wrapf(err, "'brew --prefix pulumi' failed")
+		return false, fmt.Errorf("'brew --prefix pulumi' failed: %w", err)
 	}
 
 	brewPrefixCmdOutput := strings.TrimSpace(stdout.String())

--- a/pkg/cmd/pulumi/refresh.go
+++ b/pkg/cmd/pulumi/refresh.go
@@ -16,8 +16,9 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -124,17 +125,17 @@ func newRefreshCmd() *cobra.Command {
 
 			m, err := getUpdateMetadata(message, root, execKind, execAgent)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
+				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
 			cfg, err := getStackConfiguration(s, sm)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
+				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
 
 			targetUrns := []resource.URN{}

--- a/pkg/cmd/pulumi/schema_check.go
+++ b/pkg/cmd/pulumi/schema_check.go
@@ -16,13 +16,14 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 

--- a/pkg/cmd/pulumi/stack_change_secrets_provider.go
+++ b/pkg/cmd/pulumi/stack_change_secrets_provider.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -16,9 +16,9 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/resource/stack"
 	"github.com/spf13/cobra"
 
@@ -69,8 +69,7 @@ func newStackExportCmd() *cobra.Command {
 				be := s.Backend()
 				specificExpBE, ok := be.(backend.SpecificDeploymentExporter)
 				if !ok {
-					return errors.Errorf(
-						"the current backend (%s) does not provide the ability to export previous deployments",
+					return fmt.Errorf("the current backend (%s) does not provide the ability to export previous deployments",
 						be.Name())
 				}
 
@@ -85,7 +84,7 @@ func newStackExportCmd() *cobra.Command {
 			if file != "" {
 				writer, err = os.Create(file)
 				if err != nil {
-					return errors.Wrap(err, "could not open file")
+					return fmt.Errorf("could not open file: %w", err)
 				}
 			}
 
@@ -116,7 +115,7 @@ func newStackExportCmd() *cobra.Command {
 			enc.SetIndent("", "    ")
 
 			if err = enc.Encode(deployment); err != nil {
-				return errors.Wrap(err, "could not export deployment")
+				return fmt.Errorf("could not export deployment: %w", err)
 			}
 
 			return nil

--- a/pkg/cmd/pulumi/stack_graph.go
+++ b/pkg/cmd/pulumi/stack_graph.go
@@ -15,7 +15,7 @@
 package main
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 	"os"
 	"strings"
 
@@ -68,7 +68,7 @@ func newStackGraphCmd() *cobra.Command {
 
 			// This will prevent a panic when trying to assemble a dependencyGraph when no snapshot is found
 			if snap == nil {
-				return errors.Errorf("unable to find snapshot for stack %q", stackName)
+				return fmt.Errorf("unable to find snapshot for stack %q", stackName)
 			}
 
 			dg := makeDependencyGraph(snap)

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/dustin/go-humanize"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -47,13 +47,13 @@ This command displays data about previous updates for a stack.`,
 			b := s.Backend()
 			updates, err := b.GetHistory(commandContext(), s.Ref(), pageSize, page)
 			if err != nil {
-				return errors.Wrap(err, "getting history")
+				return fmt.Errorf("getting history: %w", err)
 			}
 			var decrypter config.Decrypter
 			if showSecrets {
 				crypter, err := getStackDecrypter(s)
 				if err != nil {
-					return errors.Wrap(err, "decrypting secrets")
+					return fmt.Errorf("decrypting secrets: %w", err)
 				}
 				decrypter = crypter
 			}

--- a/pkg/cmd/pulumi/stack_import.go
+++ b/pkg/cmd/pulumi/stack_import.go
@@ -16,11 +16,12 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -61,7 +62,7 @@ func newStackImportCmd() *cobra.Command {
 			if file != "" {
 				reader, err = os.Open(file)
 				if err != nil {
-					return errors.Wrap(err, "could not open file")
+					return fmt.Errorf("could not open file: %w", err)
 				}
 			}
 
@@ -122,7 +123,7 @@ func newStackImportCmd() *cobra.Command {
 			}
 			sdp, err := stack.SerializeDeployment(snapshot, snapshot.SecretsManager, false /* showSecrets */)
 			if err != nil {
-				return errors.Wrap(err, "constructing deployment for upload")
+				return fmt.Errorf("constructing deployment for upload: %w", err)
 			}
 
 			bytes, err := json.Marshal(sdp)
@@ -137,7 +138,7 @@ func newStackImportCmd() *cobra.Command {
 
 			// Now perform the deployment.
 			if err = s.ImportDeployment(commandContext(), &dep); err != nil {
-				return errors.Wrap(err, "could not import deployment")
+				return fmt.Errorf("could not import deployment: %w", err)
 			}
 			fmt.Printf("Import successful.\n")
 			return nil

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -15,9 +15,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"

--- a/pkg/cmd/pulumi/stack_ls.go
+++ b/pkg/cmd/pulumi/stack_ls.go
@@ -15,12 +15,14 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/dustin/go-humanize"
-	"github.com/pkg/errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -110,14 +112,14 @@ func runStackLS(args stackLSArgs) error {
 		// Ensure we are in a project; if not, we will fail.
 		projPath, err := workspace.DetectProjectPath()
 		if err != nil {
-			return errors.Wrapf(err, "could not detect current project")
+			return fmt.Errorf("could not detect current project: %w", err)
 		} else if projPath == "" {
 			return errors.New("no Pulumi.yaml found; please run this command in a project directory")
 		}
 
 		proj, err := workspace.LoadProject(projPath)
 		if err != nil {
-			return errors.Wrap(err, "could not load current project")
+			return fmt.Errorf("could not load current project: %w", err)
 		}
 		projName := string(proj.Name)
 		filter.Project = &projName

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -17,7 +17,6 @@ package main
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -57,7 +56,7 @@ func newStackOutputCmd() *cobra.Command {
 
 			outputs, err := getStackOutputs(snap, showSecrets)
 			if err != nil {
-				return errors.Wrap(err, "getting outputs")
+				return fmt.Errorf("getting outputs: %w", err)
 			}
 			if outputs == nil {
 				outputs = make(map[string]interface{})
@@ -76,7 +75,7 @@ func newStackOutputCmd() *cobra.Command {
 						fmt.Printf("%v\n", stringifyOutput(v))
 					}
 				} else {
-					return errors.Errorf("current stack does not have output property '%v'", name)
+					return fmt.Errorf("current stack does not have output property '%v'", name)
 				}
 			} else if jsonOut {
 				if err := printJSON(outputs); err != nil {

--- a/pkg/cmd/pulumi/stack_rename.go
+++ b/pkg/cmd/pulumi/stack_rename.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -79,15 +78,15 @@ func newStackRenameCmd() *cobra.Command {
 				// Stack doesn't have any configuration, ignore.
 			case configStatErr == nil:
 				if err := os.Rename(oldConfigPath, newConfigPath); err != nil {
-					return errors.Wrapf(err, "renaming configuration file to %s", filepath.Base(newConfigPath))
+					return fmt.Errorf("renaming configuration file to %s: %w", filepath.Base(newConfigPath), err)
 				}
 			default:
-				return errors.Wrapf(err, "checking current configuration file %v", oldConfigPath)
+				return fmt.Errorf("checking current configuration file %v: %w", oldConfigPath, err)
 			}
 
 			// Update the current workspace state to have selected the new stack.
 			if err := state.SetCurrentStack(newStackName); err != nil {
-				return errors.Wrap(err, "setting current stack")
+				return fmt.Errorf("setting current stack: %w", err)
 			}
 
 			fmt.Printf("Renamed %s to %s\n", s.Ref().String(), newStackRef.String())

--- a/pkg/cmd/pulumi/stack_select.go
+++ b/pkg/cmd/pulumi/stack_select.go
@@ -15,7 +15,9 @@
 package main
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+	"fmt"
+
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
@@ -80,7 +82,7 @@ func newStackSelectCmd() *cobra.Command {
 					return state.SetCurrentStack(s.Ref().String())
 				}
 
-				return errors.Errorf("no stack named '%s' found", stackRef)
+				return fmt.Errorf("no stack named '%s' found", stackRef)
 			}
 
 			// If no stack was given, prompt the user to select a name from the available ones.

--- a/pkg/cmd/pulumi/stack_tag.go
+++ b/pkg/cmd/pulumi/stack_tag.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -79,8 +78,7 @@ func newStackTagGetCmd(stack *string) *cobra.Command {
 				return nil
 			}
 
-			return errors.Errorf(
-				"stack tag '%s' not found for stack '%s'", name, s.Ref())
+			return fmt.Errorf("stack tag '%s' not found for stack '%s'", name, s.Ref())
 		}),
 	}
 }

--- a/pkg/cmd/pulumi/state.go
+++ b/pkg/cmd/pulumi/state.go
@@ -16,9 +16,9 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/backend/display"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/edit"
@@ -57,7 +57,7 @@ func locateStackResource(opts display.Options, snap *deploy.Snapshot, urn resour
 	candidateResources := edit.LocateResource(snap, urn)
 	switch {
 	case len(candidateResources) == 0: // resource was not found
-		return nil, errors.Errorf("No such resource %q exists in the current state", urn)
+		return nil, fmt.Errorf("No such resource %q exists in the current state", urn)
 	case len(candidateResources) == 1: // resource was unambiguously found
 		return candidateResources[0], nil
 	}
@@ -170,7 +170,7 @@ func runTotalStateEdit(
 
 	sdep, err := stack.SerializeDeployment(snap, snap.SecretsManager, false /* showSecrets */)
 	if err != nil {
-		return result.FromError(errors.Wrap(err, "serializing deployment"))
+		return result.FromError(fmt.Errorf("serializing deployment: %w", err))
 	}
 
 	// Once we've mutated the snapshot, import it back into the backend so that it can be persisted.

--- a/pkg/cmd/pulumi/up.go
+++ b/pkg/cmd/pulumi/up.go
@@ -16,12 +16,12 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -96,17 +96,17 @@ func newUpCmd() *cobra.Command {
 
 		m, err := getUpdateMetadata(message, root, execKind, execAgent)
 		if err != nil {
-			return result.FromError(errors.Wrap(err, "gathering environment metadata"))
+			return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 		}
 
 		sm, err := getStackSecretsManager(s)
 		if err != nil {
-			return result.FromError(errors.Wrap(err, "getting secrets manager"))
+			return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 		}
 
 		cfg, err := getStackConfiguration(s, sm)
 		if err != nil {
-			return result.FromError(errors.Wrap(err, "getting stack configuration"))
+			return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 		}
 
 		targetURNs := []resource.URN{}
@@ -208,7 +208,7 @@ func newUpCmd() *cobra.Command {
 
 		// Change the working directory to the "virtual workspace" directory.
 		if err = os.Chdir(temp); err != nil {
-			return result.FromError(errors.Wrap(err, "changing the working directory"))
+			return result.FromError(fmt.Errorf("changing the working directory: %w", err))
 		}
 
 		// If a stack was specified via --stack, see if it already exists.
@@ -256,7 +256,7 @@ func newUpCmd() *cobra.Command {
 		proj.Description = &description
 		proj.Template = nil
 		if err = workspace.SaveProject(proj); err != nil {
-			return result.FromError(errors.Wrap(err, "saving project"))
+			return result.FromError(fmt.Errorf("saving project: %w", err))
 		}
 
 		// Create the stack, if needed.
@@ -280,17 +280,17 @@ func newUpCmd() *cobra.Command {
 
 		m, err := getUpdateMetadata(message, root, execKind, execAgent)
 		if err != nil {
-			return result.FromError(errors.Wrap(err, "gathering environment metadata"))
+			return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 		}
 
 		sm, err := getStackSecretsManager(s)
 		if err != nil {
-			return result.FromError(errors.Wrap(err, "getting secrets manager"))
+			return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 		}
 
 		cfg, err := getStackConfiguration(s, sm)
 		if err != nil {
-			return result.FromError(errors.Wrap(err, "getting stack configuration"))
+			return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 		}
 
 		refreshOption, err := getRefreshOption(proj, refresh)
@@ -588,7 +588,7 @@ func handleConfig(
 	// Save the config.
 	if len(c) > 0 {
 		if err = saveConfig(s, c); err != nil {
-			return errors.Wrap(err, "saving config")
+			return fmt.Errorf("saving config: %w", err)
 		}
 
 		fmt.Println("Saved config")

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -30,7 +31,7 @@ import (
 
 	multierror "github.com/hashicorp/go-multierror"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
+
 	survey "gopkg.in/AlecAivazis/survey.v1"
 	surveycore "gopkg.in/AlecAivazis/survey.v1/core"
 	git "gopkg.in/src-d/go-git.v4"
@@ -99,7 +100,7 @@ func isFilestateBackend(opts display.Options) (bool, error) {
 
 	url, err := workspace.GetCurrentCloudURL()
 	if err != nil {
-		return false, errors.Wrapf(err, "could not get cloud url")
+		return false, fmt.Errorf("could not get cloud url: %w", err)
 	}
 
 	return filestate.IsFileStateBackendURL(url), nil
@@ -112,7 +113,7 @@ func currentBackend(opts display.Options) (backend.Backend, error) {
 
 	url, err := workspace.GetCurrentCloudURL()
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not get cloud url")
+		return nil, fmt.Errorf("could not get cloud url: %w", err)
 	}
 
 	if filestate.IsFileStateBackendURL(url) {
@@ -184,7 +185,7 @@ func createSecretsManager(b backend.Backend, stackRef backend.StackReference, se
 		if strings.HasPrefix(secretsProvider, "azurekeyvault://") {
 			parsed, err := url.Parse(secretsProvider)
 			if err != nil {
-				return errors.Wrap(err, "failed to parse secrets provider URL")
+				return fmt.Errorf("failed to parse secrets provider URL: %w", err)
 			}
 
 			if parsed.Query().Get("algorithm") == "" {
@@ -215,7 +216,7 @@ func createStack(
 		if _, ok := err.(*backend.OverStackLimitError); ok {
 			return nil, err
 		}
-		return nil, errors.Wrapf(err, "could not create stack")
+		return nil, fmt.Errorf("could not create stack: %w", err)
 	}
 
 	if err := createSecretsManager(b, stackRef, secretsProvider,
@@ -272,7 +273,7 @@ func requireStack(
 		return createStack(b, stackRef, nil, setCurrent, "")
 	}
 
-	return nil, errors.Errorf("no stack named '%s' found", stackName)
+	return nil, fmt.Errorf("no stack named '%s' found", stackName)
 }
 
 func requireCurrentStack(offerNew bool, opts display.Options, setCurrent bool) (backend.Stack, error) {
@@ -324,7 +325,7 @@ func chooseStack(
 	for {
 		summaries, outContToken, err := b.ListStacks(ctx, backend.ListStacksFilter{Project: &project}, inContToken)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not query backend for stacks")
+			return nil, fmt.Errorf("could not query backend for stacks: %w", err)
 		}
 
 		allSummaries = append(allSummaries, summaries...)
@@ -404,15 +405,15 @@ func chooseStack(
 	// With the stack name selected, look it up from the backend.
 	stackRef, err := b.ParseStackReference(option)
 	if err != nil {
-		return nil, errors.Wrap(err, "parsing selected stack")
+		return nil, fmt.Errorf("parsing selected stack: %w", err)
 	}
 	// GetStack may return (nil, nil) if the stack isn't found.
 	stack, err := b.GetStack(ctx, stackRef)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting selected stack")
+		return nil, fmt.Errorf("getting selected stack: %w", err)
 	}
 	if stack == nil {
-		return nil, errors.Errorf("no stack named '%s' found", stackRef)
+		return nil, fmt.Errorf("no stack named '%s' found", stackRef)
 	}
 
 	// If setCurrent is true, we'll persist this choice so it'll be used for future CLI operations.
@@ -437,7 +438,7 @@ func parseAndSaveConfigArray(s backend.Stack, configArray []string, path bool) e
 	}
 
 	if err = saveConfig(s, commandLineConfig); err != nil {
-		return errors.Wrap(err, "saving config")
+		return fmt.Errorf("saving config: %w", err)
 	}
 	return nil
 }
@@ -472,8 +473,9 @@ func readProject() (*workspace.Project, string, error) {
 	// Now that we got here, we have a path, so we will try to load it.
 	path, err := workspace.DetectProjectPathFrom(pwd)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "failed to find current Pulumi project because of "+
-			"an error when searching for the Pulumi.yaml file (searching upwards from %s)", pwd)
+		return nil, "", fmt.Errorf("failed to find current Pulumi project because of "+
+			"an error when searching for the Pulumi.yaml file (searching upwards from %s)"+": %w", pwd, err)
+
 	} else if path == "" {
 		return nil, "", fmt.Errorf(
 			"no Pulumi.yaml project file found (searching upwards from %s). If you have not "+
@@ -481,7 +483,7 @@ func readProject() (*workspace.Project, string, error) {
 	}
 	proj, err := workspace.LoadProject(path)
 	if err != nil {
-		return nil, "", errors.Wrapf(err, "failed to load Pulumi project located at %q", path)
+		return nil, "", fmt.Errorf("failed to load Pulumi project located at %q: %w", path, err)
 	}
 
 	return proj, filepath.Dir(path), nil
@@ -499,14 +501,15 @@ func readPolicyProject() (*workspace.PolicyPackProject, string, string, error) {
 	// Now that we got here, we have a path, so we will try to load it.
 	path, err := workspace.DetectPolicyPackPathFrom(pwd)
 	if err != nil {
-		return nil, "", "", errors.Wrapf(err, "failed to find current Pulumi project because of "+
-			"an error when searching for the PulumiPolicy.yaml file (searching upwards from %s)", pwd)
+		return nil, "", "", fmt.Errorf("failed to find current Pulumi project because of "+
+			"an error when searching for the PulumiPolicy.yaml file (searching upwards from %s)"+": %w", pwd, err)
+
 	} else if path == "" {
 		return nil, "", "", fmt.Errorf("no PulumiPolicy.yaml project file found (searching upwards from %s)", pwd)
 	}
 	proj, err := workspace.LoadPolicyPack(path)
 	if err != nil {
-		return nil, "", "", errors.Wrapf(err, "failed to load Pulumi policy project located at %q", path)
+		return nil, "", "", fmt.Errorf("failed to load Pulumi policy project located at %q: %w", path, err)
 	}
 
 	return proj, path, filepath.Dir(path), nil
@@ -540,7 +543,7 @@ func isGitWorkTreeDirty(repoRoot string) (bool, error) {
 		if ee, ok := err.(*exec.ExitError); ok {
 			ee.Stderr = stderr.Bytes()
 		}
-		return false, errors.Wrapf(err, "'git status' failed")
+		return false, fmt.Errorf("'git status' failed: %w", err)
 	}
 
 	return bool(anyOutput), nil
@@ -572,7 +575,7 @@ func addGitMetadata(repoRoot string, m *backend.UpdateMetadata) error {
 	// Gather git-related data as appropriate. (Returns nil, nil if no repo found.)
 	repo, err := gitutil.GetGitRepository(repoRoot)
 	if err != nil {
-		return errors.Wrapf(err, "detecting Git repository")
+		return fmt.Errorf("detecting Git repository: %w", err)
 	}
 	if repo == nil {
 		return nil
@@ -596,7 +599,7 @@ func AddGitRemoteMetadataToMap(repo *git.Repository, env map[string]string) erro
 	// Get the remote URL for this repo.
 	remoteURL, err := gitutil.GetGitRemoteURL(repo, "origin")
 	if err != nil {
-		return errors.Wrap(err, "detecting Git remote URL")
+		return fmt.Errorf("detecting Git remote URL: %w", err)
 	}
 	if remoteURL == "" {
 		return nil
@@ -615,7 +618,7 @@ func addVCSMetadataToEnvironment(remoteURL string, env map[string]string) error 
 	// We don't require a cloud-hosted VCS, so swallow errors.
 	vcsInfo, err := gitutil.TryGetVCSInfo(remoteURL)
 	if err != nil {
-		return errors.Wrap(err, "detecting VCS project information")
+		return fmt.Errorf("detecting VCS project information: %w", err)
 	}
 	env[backend.VCSRepoOwner] = vcsInfo.Owner
 	env[backend.VCSRepoName] = vcsInfo.Repo
@@ -633,14 +636,14 @@ func addGitCommitMetadata(repo *git.Repository, repoRoot string, m *backend.Upda
 	// Commit at HEAD
 	head, err := repo.Head()
 	if err != nil {
-		return errors.Wrap(err, "getting repository HEAD")
+		return fmt.Errorf("getting repository HEAD: %w", err)
 	}
 
 	hash := head.Hash()
 	m.Environment[backend.GitHead] = hash.String()
 	commit, commitErr := repo.CommitObject(hash)
 	if commitErr != nil {
-		return errors.Wrap(commitErr, "getting HEAD commit info")
+		return fmt.Errorf("getting HEAD commit info: %w", commitErr)
 	}
 
 	// If in detached head, will be "HEAD", and fallback to use value from CI/CD system if possible.
@@ -671,7 +674,7 @@ func addGitCommitMetadata(repo *git.Repository, repoRoot string, m *backend.Upda
 	// If the worktree is dirty, set a bit, as this could be a mistake.
 	isDirty, err := isGitWorkTreeDirty(repoRoot)
 	if err != nil {
-		return errors.Wrapf(err, "checking git worktree dirty state")
+		return fmt.Errorf("checking git worktree dirty state: %w", err)
 	}
 	m.Environment[backend.GitDirty] = strconv.FormatBool(isDirty)
 
@@ -837,7 +840,7 @@ func checkDeploymentVersionError(err error, stackName string) error {
 		return fmt.Errorf("the stack '%s' is newer than what this version of the Pulumi CLI understands. "+
 			"Please update your version of the Pulumi CLI", stackName)
 	}
-	return errors.Wrap(err, "could not deserialize deployment")
+	return fmt.Errorf("could not deserialize deployment: %w", err)
 }
 
 func getRefreshOption(proj *workspace.Project, refresh string) (bool, error) {

--- a/pkg/cmd/pulumi/watch.go
+++ b/pkg/cmd/pulumi/watch.go
@@ -16,8 +16,9 @@ package main
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend"
@@ -101,17 +102,17 @@ func newWatchCmd() *cobra.Command {
 
 			m, err := getUpdateMetadata(message, root, execKind, "" /* execAgent */)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "gathering environment metadata"))
+				return result.FromError(fmt.Errorf("gathering environment metadata: %w", err))
 			}
 
 			sm, err := getStackSecretsManager(s)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting secrets manager"))
+				return result.FromError(fmt.Errorf("getting secrets manager: %w", err))
 			}
 
 			cfg, err := getStackConfiguration(s, sm)
 			if err != nil {
-				return result.FromError(errors.Wrap(err, "getting stack configuration"))
+				return result.FromError(fmt.Errorf("getting stack configuration: %w", err))
 			}
 
 			opts.Engine = engine.UpdateOptions{

--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -23,6 +23,7 @@ package docs
 import (
 	"bytes"
 	"embed"
+	"errors"
 	"fmt"
 	"html"
 	"html/template"
@@ -31,7 +32,6 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/dotnet"
@@ -431,7 +431,7 @@ func (dctx *docGenContext) getLanguageDocHelper(lang string) codegen.DocLanguage
 	if h, ok := dctx.docHelpers[lang]; ok {
 		return h
 	}
-	panic(errors.Errorf("could not find a doc lang helper for %s", lang))
+	panic(fmt.Errorf("could not find a doc lang helper for %s", lang))
 }
 
 type propertyCharacteristics struct {
@@ -1174,7 +1174,7 @@ func (mod *modContext) getConstructorResourceInfo(resourceTypeName string) map[s
 
 			resourceTypeName = fmt.Sprintf("Pulumi.%s.%s.%s", namespace, modName, resourceTypeName)
 		default:
-			panic(errors.Errorf("cannot generate constructor info for unhandled language %q", lang))
+			panic(fmt.Errorf("cannot generate constructor info for unhandled language %q", lang))
 		}
 
 		parts := strings.Split(resourceTypeName, ".")

--- a/pkg/codegen/docs/gen_function.go
+++ b/pkg/codegen/docs/gen_function.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	go_gen "github.com/pulumi/pulumi/pkg/v3/codegen/go"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/python"
@@ -113,7 +112,7 @@ func (mod *modContext) getFunctionResourceInfo(f *schema.Function, outputVersion
 		case "python":
 			resultTypeName = docLangHelper.GetResourceFunctionResultName(mod.mod, f)
 		default:
-			panic(errors.Errorf("cannot generate function resource info for unhandled language %q", lang))
+			panic(fmt.Errorf("cannot generate function resource info for unhandled language %q", lang))
 		}
 
 		parts := strings.Split(resultTypeName, ".")

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -20,10 +20,11 @@ package docs
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/internal/test"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 const (

--- a/pkg/codegen/docs/package_tree.go
+++ b/pkg/codegen/docs/package_tree.go
@@ -1,7 +1,7 @@
 package docs
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 	"sort"
 )
 
@@ -36,7 +36,7 @@ func generatePackageTree(rootMod modContext) ([]PackageTreeItem, error) {
 
 		children, err := generatePackageTree(*m)
 		if err != nil {
-			return nil, errors.Wrapf(err, "generating children for module %s (mod token: %s)", displayName, m.mod)
+			return nil, fmt.Errorf("generating children for module %s (mod token: %s): %w", displayName, m.mod, err)
 		}
 
 		ti := PackageTreeItem{

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -767,7 +766,7 @@ func primitiveValue(value interface{}) (string, error) {
 	case reflect.String:
 		return fmt.Sprintf("%q", v.String()), nil
 	default:
-		return "", errors.Errorf("unsupported default value of type %T", value)
+		return "", fmt.Errorf("unsupported default value of type %T", value)
 	}
 }
 
@@ -796,7 +795,7 @@ func (mod *modContext) getDefaultValue(dv *schema.DefaultValue, t schema.Type) (
 				break
 			}
 			if val == "" {
-				return "", errors.Errorf("default value '%v' not found in enum '%s'", dv.Value, enumName)
+				return "", fmt.Errorf("default value '%v' not found in enum '%s'", dv.Value, enumName)
 			}
 		default:
 			v, err := primitiveValue(dv.Value)

--- a/pkg/codegen/dotnet/utilities.go
+++ b/pkg/codegen/dotnet/utilities.go
@@ -15,13 +15,12 @@
 package dotnet
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 	"unicode"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
-
-	"github.com/pkg/errors"
 )
 
 // isReservedWord returns true if s is a C# reserved word as per
@@ -97,7 +96,7 @@ func makeSafeEnumName(name, typeName string) (string, error) {
 
 	// If the name is one illegal character, return an error.
 	if len(safeName) == 1 && !isLegalIdentifierStart(rune(safeName[0])) {
-		return "", errors.Errorf("enum name %s is not a valid identifier", safeName)
+		return "", fmt.Errorf("enum name %s is not a valid identifier", safeName)
 	}
 
 	// Capitalize and make a valid identifier.

--- a/pkg/codegen/dotnet/utilities_test.go
+++ b/pkg/codegen/dotnet/utilities_test.go
@@ -1,6 +1,8 @@
 package dotnet
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestMakeSafeEnumName(t *testing.T) {
 	tests := []struct {

--- a/pkg/codegen/go/gen.go
+++ b/pkg/codegen/go/gen.go
@@ -31,8 +31,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pkg/errors"
-
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -1283,7 +1281,7 @@ func goPrimitiveValue(value interface{}) (string, error) {
 	case reflect.String:
 		return fmt.Sprintf("%q", v.String()), nil
 	default:
-		return "", errors.Errorf("unsupported default value of type %T", value)
+		return "", fmt.Errorf("unsupported default value of type %T", value)
 	}
 }
 
@@ -3130,14 +3128,14 @@ func GeneratePackage(tool string, pkg *schema.Package) (map[string][]byte, error
 	setFile := func(relPath, contents string) {
 		relPath = path.Join(pathPrefix, relPath)
 		if _, ok := files[relPath]; ok {
-			panic(errors.Errorf("duplicate file: %s", relPath))
+			panic(fmt.Errorf("duplicate file: %s", relPath))
 		}
 
 		// Run Go formatter on the code before saving to disk
 		formattedSource, err := format.Source([]byte(contents))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Invalid content:\n%s\n%s\n", relPath, contents)
-			panic(errors.Wrapf(err, "invalid Go source code:\n\n%s\n", relPath))
+			panic(fmt.Errorf("invalid Go source code:\n\n%s\n: %w", relPath, err))
 		}
 
 		files[relPath] = formattedSource

--- a/pkg/codegen/go/gen_crd2pulumi.go
+++ b/pkg/codegen/go/gen_crd2pulumi.go
@@ -2,8 +2,8 @@ package gen
 
 import (
 	"bytes"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 )
 
@@ -37,7 +37,7 @@ func CRDTypes(tool string, pkg *schema.Package) (map[string]*bytes.Buffer, error
 			pkg.genHeader(buffer, []string{"context", "reflect"}, importsAndAliases)
 
 			if err := pkg.genResource(buffer, r, goPkgInfo.GenerateResourceContainerTypes); err != nil {
-				return nil, errors.Wrapf(err, "generating resource %s", mod)
+				return nil, fmt.Errorf("generating resource %s: %w", mod, err)
 			}
 		}
 

--- a/pkg/codegen/go/gen_program.go
+++ b/pkg/codegen/go/gen_program.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/hcl/v2"
-	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model/format"
@@ -93,7 +93,7 @@ func GenerateProgram(program *pcl.Program) (map[string][]byte, hcl.Diagnostics, 
 	// Run Go formatter on the code before saving to disk
 	formattedSource, err := gofmt.Source(index.Bytes())
 	if err != nil {
-		panic(errors.Errorf("invalid Go source code:\n\n%s", index.String()))
+		panic(fmt.Errorf("invalid Go source code:\n\n%s", index.String()))
 	}
 
 	files := map[string][]byte{
@@ -287,7 +287,7 @@ func (g *generator) getVersionPath(program *pcl.Program, pkg string) (string, er
 		}
 	}
 
-	return "", errors.Errorf("could not find package version information for pkg: %s", pkg)
+	return "", fmt.Errorf("could not find package version information for pkg: %s", pkg)
 
 }
 

--- a/pkg/codegen/go/utilities.go
+++ b/pkg/codegen/go/utilities.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 )
 
@@ -84,7 +83,7 @@ func makeSafeEnumName(name, typeName string) (string, error) {
 
 	// If the name is one illegal character, return an error.
 	if len(safeName) == 1 && !isLegalIdentifierStart(rune(safeName[0])) {
-		return "", errors.Errorf("enum name %s is not a valid identifier", safeName)
+		return "", fmt.Errorf("enum name %s is not a valid identifier", safeName)
 	}
 
 	// Capitalize and make a valid identifier.

--- a/pkg/codegen/hcl2/model/format/func.go
+++ b/pkg/codegen/hcl2/model/format/func.go
@@ -14,7 +14,9 @@
 
 package format
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Func is a function type that implements the fmt.Formatter interface. This can be used to conveniently
 // implement this interface for types defined in other packages.

--- a/pkg/codegen/hcl2/model/type_collection.go
+++ b/pkg/codegen/hcl2/model/type_collection.go
@@ -14,7 +14,9 @@
 
 package model
 
-import "github.com/hashicorp/hcl/v2"
+import (
+	"github.com/hashicorp/hcl/v2"
+)
 
 // unwrapIterableSourceType removes any eventual types that wrap a type intended for iteration.
 func unwrapIterableSourceType(t Type) Type {

--- a/pkg/codegen/hcl2/model/type_opaque.go
+++ b/pkg/codegen/hcl2/model/type_opaque.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
-	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/syntax"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -55,7 +55,7 @@ func MustNewOpaqueType(name string, annotations ...interface{}) *OpaqueType {
 // NewOpaqueType creates a new opaque type with the given name.
 func NewOpaqueType(name string, annotations ...interface{}) (*OpaqueType, error) {
 	if _, ok := opaqueTypes[name]; ok {
-		return nil, errors.Errorf("opaque type %s is already defined", name)
+		return nil, fmt.Errorf("opaque type %s is already defined", name)
 	}
 
 	t := &OpaqueType{Name: name, Annotations: annotations}

--- a/pkg/codegen/hcl2/syntax/utilities.go
+++ b/pkg/codegen/hcl2/syntax/utilities.go
@@ -1,6 +1,8 @@
 package syntax
 
-import "github.com/hashicorp/hcl/v2/hclsyntax"
+import (
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
 
 // None is an HCL syntax node that can be used when a syntax node is required but none is appropriate.
 var None hclsyntax.Node = &hclsyntax.Body{}

--- a/pkg/codegen/internal/test/helpers.go
+++ b/pkg/codegen/internal/test/helpers.go
@@ -17,6 +17,7 @@ package test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -26,7 +27,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -442,7 +442,7 @@ func currentVersion(path string) (string, error) {
 	}
 	json, ok := data.(map[string]interface{})
 	if !ok {
-		return "", errors.Errorf("%s could not be read", path)
+		return "", fmt.Errorf("%s could not be read", path)
 	}
 	version, ok := json["version"]
 	if !ok {
@@ -468,7 +468,7 @@ func replaceSchema(c chan error, path, version, url string) {
 
 	err = os.Remove(path)
 	if !os.IsNotExist(err) && err != nil {
-		c <- errors.Wrap(err, "failed to replace schema")
+		c <- fmt.Errorf("failed to replace schema: %w", err)
 		return
 	}
 	schemaFile, err := os.Create(path)

--- a/pkg/codegen/nodejs/gen.go
+++ b/pkg/codegen/nodejs/gen.go
@@ -21,6 +21,7 @@ package nodejs
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -30,8 +31,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/internal/tstypes"
@@ -443,7 +442,7 @@ func tsPrimitiveValue(value interface{}) (string, error) {
 	case reflect.String:
 		return fmt.Sprintf("%q", v.String()), nil
 	default:
-		return "", errors.Errorf("unsupported default value of type %T", value)
+		return "", fmt.Errorf("unsupported default value of type %T", value)
 	}
 }
 

--- a/pkg/codegen/nodejs/gen_intrinsics.go
+++ b/pkg/codegen/nodejs/gen_intrinsics.go
@@ -14,7 +14,9 @@
 
 package nodejs
 
-import "github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+import (
+	"github.com/pulumi/pulumi/pkg/v3/codegen/hcl2/model"
+)
 
 const (
 	// intrinsicAwait is the name of the await intrinsic.

--- a/pkg/codegen/nodejs/utilities.go
+++ b/pkg/codegen/nodejs/utilities.go
@@ -15,12 +15,12 @@
 package nodejs
 
 import (
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
 	"unicode"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 )
 
@@ -109,7 +109,7 @@ func makeSafeEnumName(name, typeName string) (string, error) {
 
 	// If the name is one illegal character, return an error.
 	if len(safeName) == 1 && !isLegalIdentifierStart(rune(safeName[0])) {
-		return "", errors.Errorf("enum name %s is not a valid identifier", safeName)
+		return "", fmt.Errorf("enum name %s is not a valid identifier", safeName)
 	}
 
 	// Capitalize and make a valid identifier.

--- a/pkg/codegen/nodejs/utilities_test.go
+++ b/pkg/codegen/nodejs/utilities_test.go
@@ -1,7 +1,9 @@
 // nolint: lll
 package nodejs
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestMakeSafeEnumName(t *testing.T) {
 	tests := []struct {

--- a/pkg/codegen/python/gen.go
+++ b/pkg/codegen/python/gen.go
@@ -32,7 +32,6 @@ import (
 	"unicode"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
@@ -1104,8 +1103,7 @@ func (mod *modContext) genResource(res *schema.Resource) (string, error) {
 		for _, t := range mod.types {
 			if mod.details(t).inputType {
 				if mod.unqualifiedObjectTypeName(t, true) == resourceArgsName {
-					return "", errors.Errorf(
-						"resource args class named %s in %s conflicts with input type", resourceArgsName, mod.mod)
+					return "", fmt.Errorf("resource args class named %s in %s conflicts with input type", resourceArgsName, mod.mod)
 				}
 			}
 		}
@@ -1883,7 +1881,7 @@ func (mod *modContext) genEnum(w io.Writer, enum *schema.EnumType) error {
 			}
 		}
 	default:
-		return errors.Errorf("enums of type %s are not yet implemented for this language", enum.ElementType.String())
+		return fmt.Errorf("enums of type %s are not yet implemented for this language", enum.ElementType.String())
 	}
 
 	return nil
@@ -2054,15 +2052,15 @@ func genPackageMetadata(
 		// We expect a specific pattern of ">=version,<version" here.
 		matches := requirementRegex.FindStringSubmatch(pulumiReq)
 		if len(matches) != 2 {
-			return "", errors.Errorf("invalid requirement specifier \"%s\"; expected \">=version1,<version2\"", pulumiReq)
+			return "", fmt.Errorf("invalid requirement specifier \"%s\"; expected \">=version1,<version2\"", pulumiReq)
 		}
 
 		lowerBound, err := pep440VersionToSemver(matches[1])
 		if err != nil {
-			return "", errors.Errorf("invalid version for lower bound: %v", err)
+			return "", fmt.Errorf("invalid version for lower bound: %v", err)
 		}
 		if lowerBound.LT(oldestAllowedPulumi) {
-			return "", errors.Errorf("lower version bound must be at least %v", oldestAllowedPulumi)
+			return "", fmt.Errorf("lower version bound must be at least %v", oldestAllowedPulumi)
 		}
 	} else {
 		if requires == nil {
@@ -2544,7 +2542,7 @@ func getPrimitiveValue(value interface{}) (string, error) {
 	case reflect.String:
 		return fmt.Sprintf("'%s'", v.String()), nil
 	default:
-		return "", errors.Errorf("unsupported default value of type %T", value)
+		return "", fmt.Errorf("unsupported default value of type %T", value)
 	}
 }
 

--- a/pkg/codegen/python/utilities.go
+++ b/pkg/codegen/python/utilities.go
@@ -1,12 +1,13 @@
 package python
 
 import (
-	"github.com/pkg/errors"
-	"github.com/pulumi/pulumi/pkg/v3/codegen"
+	"fmt"
 	"io"
 	"regexp"
 	"strings"
 	"unicode"
+
+	"github.com/pulumi/pulumi/pkg/v3/codegen"
 )
 
 // isLegalIdentifierStart returns true if it is legal for c to be the first character of a Python identifier as per
@@ -66,7 +67,7 @@ func makeSafeEnumName(name, typeName string) (string, error) {
 
 	// If the name is one illegal character, return an error.
 	if len(safeName) == 1 && !isLegalIdentifierStart(rune(safeName[0])) {
-		return "", errors.Errorf("enum name %s is not a valid identifier", safeName)
+		return "", fmt.Errorf("enum name %s is not a valid identifier", safeName)
 	}
 
 	// If it's camelCase, change it to snake_case.

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/blang/semver"
 	jsoniter "github.com/json-iterator/go"
-	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
@@ -110,15 +110,15 @@ func (l *pluginLoader) ensurePlugin(pkg string, version *semver.Version) error {
 	if !workspace.HasPlugin(pkgPlugin) {
 		tarball, err := downloadToFileWithRetry()
 		if err != nil {
-			return errors.Wrapf(err, "failed to download plugin: %s", pkgPlugin)
+			return fmt.Errorf("failed to download plugin: %s: %w", pkgPlugin, err)
 		}
 		defer os.Remove(tarball)
 		reader, err := os.Open(tarball)
 		if err != nil {
-			return errors.Wrapf(err, "failed to open downloaded plugin: %s", pkgPlugin)
+			return fmt.Errorf("failed to open downloaded plugin: %s: %w", pkgPlugin, err)
 		}
 		if err := pkgPlugin.Install(reader); err != nil {
-			return errors.Wrapf(err, "failed to install plugin %s", pkgPlugin)
+			return fmt.Errorf("failed to install plugin %s: %w", pkgPlugin, err)
 		}
 	}
 

--- a/pkg/codegen/utilities_types.go
+++ b/pkg/codegen/utilities_types.go
@@ -1,6 +1,8 @@
 package codegen
 
-import "github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+import (
+	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
+)
 
 func visitTypeClosure(t schema.Type, visitor func(t schema.Type), seen Set) {
 	if seen.Has(t) {

--- a/pkg/engine/deployment.go
+++ b/pkg/engine/deployment.go
@@ -16,10 +16,12 @@ package engine
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -176,7 +178,7 @@ func newDeployment(ctx *Context, info *deploymentContext, opts deploymentOptions
 			imp := &opts.imports[i]
 			_, err := tokens.ParseTypeToken(imp.Type.String())
 			if err != nil {
-				return nil, errors.Errorf("import type %q is not a valid resource type token. "+
+				return nil, fmt.Errorf("import type %q is not a valid resource type token. "+
 					"Type tokens must be of the format <package>:<module>:<type> - "+
 					"refer to the import section of the provider resource documentation.", imp.Type.String())
 			}

--- a/pkg/engine/journal.go
+++ b/pkg/engine/journal.go
@@ -1,7 +1,7 @@
 package engine
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -17,6 +17,7 @@ package lifecycletest
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -26,7 +27,7 @@ import (
 
 	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -656,7 +657,7 @@ func TestStackReference(t *testing.T) {
 						"foo": "bar",
 					}), nil
 				default:
-					return nil, errors.Errorf("unknown stack \"%s\"", name)
+					return nil, fmt.Errorf("unknown stack \"%s\"", name)
 				}
 			},
 		},
@@ -2104,7 +2105,7 @@ func (ctx *updateContext) Run(_ context.Context, req *pulumirpc.RunRequest) (*pu
 		rpcutil.GrpcChannelOptions(),
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not connect to resource monitor")
+		return nil, fmt.Errorf("could not connect to resource monitor: %w", err)
 	}
 	defer contract.IgnoreClose(conn)
 

--- a/pkg/engine/plugin_host.go
+++ b/pkg/engine/plugin_host.go
@@ -15,7 +15,8 @@
 package engine
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -34,7 +35,7 @@ func connectToLanguageRuntime(ctx *plugin.Context, address string) (plugin.Host,
 	conn, err := grpc.Dial(address, grpc.WithInsecure(),
 		grpc.WithUnaryInterceptor(rpcutil.OpenTracingClientInterceptor()), rpcutil.GrpcChannelOptions())
 	if err != nil {
-		return nil, errors.Wrap(err, "could not connect to language host")
+		return nil, fmt.Errorf("could not connect to language host: %w", err)
 	}
 
 	client := pulumirpc.NewLanguageRuntimeClient(conn)

--- a/pkg/engine/plugins.go
+++ b/pkg/engine/plugins.go
@@ -20,7 +20,7 @@ import (
 	"sort"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
@@ -183,8 +183,9 @@ func installPlugin(plugin workspace.PluginInfo) error {
 	logging.V(preparePluginVerboseLog).Infof(
 		"installPlugin(%s, %s): extracting tarball to installation directory", plugin.Name, plugin.Version)
 	if err := plugin.Install(stream); err != nil {
-		return errors.Wrapf(err, "installing plugin; run `pulumi plugin install %s %s v%s` to retry manually",
-			plugin.Kind, plugin.Name, plugin.Version)
+		return fmt.Errorf("installing plugin; run `pulumi plugin install %s %s v%s` to retry manually: %w",
+			plugin.Kind, plugin.Name, plugin.Version, err)
+
 	}
 
 	logging.V(7).Infof("installPlugin(%s, %s): successfully installed", plugin.Name, plugin.Version)

--- a/pkg/engine/project.go
+++ b/pkg/engine/project.go
@@ -15,10 +15,9 @@
 package engine
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
@@ -59,7 +58,7 @@ func getPwdMain(root, main string) (string, string, error) {
 		// of the main program's parent directory.  How we do this depends on if the target is a dir or not.
 		maininfo, err := os.Stat(main)
 		if err != nil {
-			return "", "", errors.Wrapf(err, "project 'main' could not be read")
+			return "", "", fmt.Errorf("project 'main' could not be read: %w", err)
 		}
 		if maininfo.IsDir() {
 			pwd = main

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pgavlin/goldmark v1.1.33-0.20200616210433-b5eb04559386
-	github.com/pkg/errors v0.9.1
 	github.com/pulumi/pulumi/sdk/v3 v3.17.1
 	github.com/rjeczalik/notify v0.9.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
@@ -128,6 +127,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opentracing/basictracer-go v1.0.0 // indirect
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/russross/blackfriday/v2 v2.0.1 // indirect

--- a/pkg/graph/topsort.go
+++ b/pkg/graph/topsort.go
@@ -15,7 +15,7 @@
 package graph
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // Topsort topologically sorts the graph, yielding an array of nodes that are in dependency order, using a simple

--- a/pkg/operations/operations_aws.go
+++ b/pkg/operations/operations_aws.go
@@ -15,6 +15,8 @@
 package operations
 
 import (
+	"errors"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -23,7 +25,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -140,7 +141,7 @@ func getAWSSession(awsRegion, awsAccessKey, awsSecretKey, token string) (*sessio
 	if awsDefaultSession == nil {
 		sess, err := session.NewSession()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to create AWS session")
+			return nil, fmt.Errorf("failed to create AWS session: %w", err)
 		}
 
 		awsDefaultSession = sess

--- a/pkg/operations/operations_gcp.go
+++ b/pkg/operations/operations_gcp.go
@@ -27,7 +27,6 @@ import (
 	"google.golang.org/api/option"
 	loggingpb "google.golang.org/genproto/googleapis/logging/v2"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -147,10 +146,10 @@ func getLogEntryMessage(e *loggingpb.LogEntry) (string, error) {
 	case *loggingpb.LogEntry_JsonPayload:
 		byts, err := json.Marshal(payload.JsonPayload)
 		if err != nil {
-			return "", errors.Wrap(err, "encoding to JSON")
+			return "", fmt.Errorf("encoding to JSON: %w", err)
 		}
 		return string(byts), nil
 	default:
-		return "", errors.Errorf("can't decode entry of type %s", reflect.TypeOf(e))
+		return "", fmt.Errorf("can't decode entry of type %s", reflect.TypeOf(e))
 	}
 }

--- a/pkg/resource/deploy/builtins.go
+++ b/pkg/resource/deploy/builtins.go
@@ -2,11 +2,11 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
 	uuid "github.com/gofrs/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -70,7 +70,7 @@ func (p *builtinProvider) Check(urn resource.URN, state, inputs resource.Propert
 
 	typ := urn.Type()
 	if typ != stackReferenceType {
-		return nil, nil, errors.Errorf("unrecognized resource type '%v'", urn.Type())
+		return nil, nil, fmt.Errorf("unrecognized resource type '%v'", urn.Type())
 	}
 
 	var name resource.PropertyValue
@@ -193,7 +193,7 @@ func (p *builtinProvider) Invoke(tok tokens.ModuleMember,
 		}
 		return outs, nil, nil
 	default:
-		return nil, nil, errors.Errorf("unrecognized function name: '%v'", tok)
+		return nil, nil, fmt.Errorf("unrecognized function name: '%v'", tok)
 	}
 }
 
@@ -280,7 +280,7 @@ func (p *builtinProvider) getResource(inputs resource.PropertyMap) (resource.Pro
 
 	state, ok := p.resources.get(resource.URN(urn.StringValue()))
 	if !ok {
-		return nil, errors.Errorf("unknown resource %v", urn.StringValue())
+		return nil, fmt.Errorf("unknown resource %v", urn.StringValue())
 	}
 
 	return resource.PropertyMap{

--- a/pkg/resource/deploy/deployment.go
+++ b/pkg/resource/deploy/deployment.go
@@ -16,12 +16,12 @@ package deploy
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 
 	"github.com/blang/semver"
 	uuid "github.com/gofrs/uuid"
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -198,7 +198,7 @@ func addDefaultProviders(target *Target, source Source, prev *Snapshot) error {
 		if !ok {
 			inputs, err := target.GetPackageConfig(pkg)
 			if err != nil {
-				return errors.Errorf("could not fetch configuration for default provider '%v'", pkg)
+				return fmt.Errorf("could not fetch configuration for default provider '%v'", pkg)
 			}
 			if version, ok := defaultProviderVersions[pkg]; ok {
 				inputs["version"] = resource.NewStringProperty(version.String())
@@ -282,7 +282,7 @@ func buildResourceMap(prev *Snapshot, preview bool) ([]*resource.State, map[reso
 
 		urn := oldres.URN
 		if olds[urn] != nil {
-			return nil, nil, errors.Errorf("unexpected duplicate resource '%s'", urn)
+			return nil, nil, fmt.Errorf("unexpected duplicate resource '%s'", urn)
 		}
 		olds[urn] = oldres
 	}

--- a/pkg/resource/deploy/deployment_executor.go
+++ b/pkg/resource/deploy/deployment_executor.go
@@ -16,10 +16,10 @@ package deploy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -16,13 +16,14 @@ package deploytest
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
 
 	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
-	"github.com/pkg/errors"
+
 	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -148,7 +149,7 @@ func (e *hostEngine) Log(_ context.Context, req *pulumirpc.LogRequest) (*pbempty
 	case pulumirpc.LogSeverity_ERROR:
 		sev = diag.Error
 	default:
-		return nil, errors.Errorf("Unrecognized logging severity: %v", req.Severity)
+		return nil, fmt.Errorf("Unrecognized logging severity: %v", req.Severity)
 	}
 
 	if req.Ephemeral {

--- a/pkg/resource/deploy/deploytest/resourcemonitor.go
+++ b/pkg/resource/deploy/deploytest/resourcemonitor.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
@@ -44,7 +43,7 @@ func dialMonitor(ctx context.Context, endpoint string) (*ResourceMonitor, error)
 		rpcutil.GrpcChannelOptions(),
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not connect to resource monitor")
+		return nil, fmt.Errorf("could not connect to resource monitor: %w", err)
 	}
 	resmon := pulumirpc.NewResourceMonitorClient(conn)
 

--- a/pkg/resource/deploy/providers/reference.go
+++ b/pkg/resource/deploy/providers/reference.go
@@ -15,9 +15,9 @@
 package providers
 
 import (
+	"errors"
+	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
@@ -59,11 +59,11 @@ func GetProviderPackage(typ tokens.Type) tokens.Package {
 
 func validateURN(urn resource.URN) error {
 	if !urn.IsValid() {
-		return errors.Errorf("%s is not a valid URN", urn)
+		return fmt.Errorf("%s is not a valid URN", urn)
 	}
 	typ := urn.Type()
 	if typ.Module() != "pulumi:providers" {
-		return errors.Errorf("invalid module in type: expected 'pulumi:providers', got '%v'", typ.Module())
+		return fmt.Errorf("invalid module in type: expected 'pulumi:providers', got '%v'", typ.Module())
 	}
 	if typ.Name() == "" {
 		return errors.New("provider URNs must specify a type name")
@@ -117,7 +117,7 @@ func ParseReference(s string) (Reference, error) {
 	// of the reference.
 	lastSep := strings.LastIndex(s, resource.URNNameDelimiter)
 	if lastSep == -1 {
-		return Reference{}, errors.Errorf("expected '%v' in provider reference '%v'", resource.URNNameDelimiter, s)
+		return Reference{}, fmt.Errorf("expected '%v' in provider reference '%v'", resource.URNNameDelimiter, s)
 	}
 	urn, id := resource.URN(s[:lastSep]), resource.ID(s[lastSep+len(resource.URNNameDelimiter):])
 	if err := validateURN(urn); err != nil {

--- a/pkg/resource/deploy/providers/registry_test.go
+++ b/pkg/resource/deploy/providers/registry_test.go
@@ -15,11 +15,12 @@
 package providers
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/blang/semver"
-	"github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"

--- a/pkg/resource/deploy/source_query.go
+++ b/pkg/resource/deploy/source_query.go
@@ -22,7 +22,7 @@ import (
 	"github.com/blang/semver"
 	pbempty "github.com/golang/protobuf/ptypes/empty"
 	opentracing "github.com/opentracing/opentracing-go"
-	"github.com/pkg/errors"
+
 	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -53,7 +53,7 @@ func NewQuerySource(cancel context.Context, plugctx *plugin.Context, client Back
 
 	reg, err := providers.NewRegistry(plugctx.Host, nil, false, builtins)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to start resource monitor")
+		return nil, fmt.Errorf("failed to start resource monitor: %w", err)
 	}
 
 	// Allows queryResmon to communicate errors loading providers.
@@ -67,7 +67,7 @@ func NewQuerySource(cancel context.Context, plugctx *plugin.Context, client Back
 	mon, err := newQueryResourceMonitor(builtins, defaultProviderVersions, provs, reg, plugctx,
 		providerRegErrChan, opentracing.SpanFromContext(cancel), runinfo)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to start resource monitor")
+		return nil, fmt.Errorf("failed to start resource monitor: %w", err)
 	}
 
 	// Create a new iterator with appropriate channels, and gear up to go!
@@ -144,7 +144,7 @@ func runLangPlugin(src *querySource) result.Result {
 	rt := src.runinfo.Proj.Runtime.Name()
 	langhost, err := src.plugctx.Host.LanguageRuntime(rt)
 	if err != nil {
-		return result.FromError(errors.Wrapf(err, "failed to launch language host %s", rt))
+		return result.FromError(fmt.Errorf("failed to launch language host %s: %w", rt, err))
 	}
 	contract.Assertf(langhost != nil, "expected non-nil language host %s", rt)
 
@@ -187,7 +187,7 @@ func runLangPlugin(src *querySource) result.Result {
 
 	if err == nil && progerr != "" {
 		// If the program had an unhandled error; propagate it to the caller.
-		err = errors.Errorf("an unhandled error occurred: %v", progerr)
+		err = fmt.Errorf("an unhandled error occurred: %v", progerr)
 	}
 	return result.WrapIfNonNil(err)
 }
@@ -342,14 +342,14 @@ func (rm *queryResmon) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest)
 			KeepResources: true,
 		})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal %v args", tok)
+		return nil, fmt.Errorf("failed to unmarshal %v args: %w", tok, err)
 	}
 
 	// Do the invoke and then return the arguments.
 	logging.V(5).Infof("QueryResourceMonitor.Invoke received: tok=%v #args=%v", tok, len(args))
 	ret, failures, err := prov.Invoke(tok, args)
 	if err != nil {
-		return nil, errors.Wrapf(err, "invocation of %v returned an error", tok)
+		return nil, fmt.Errorf("invocation of %v returned an error: %w", tok, err)
 	}
 	mret, err := plugin.MarshalProperties(ret, plugin.MarshalOptions{
 		Label:         label,
@@ -357,7 +357,7 @@ func (rm *queryResmon) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest)
 		KeepResources: req.GetAcceptResources(),
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to marshal return")
+		return nil, fmt.Errorf("failed to marshal return: %w", err)
 	}
 
 	var chkfails []*pulumirpc.CheckFailure
@@ -389,7 +389,7 @@ func (rm *queryResmon) StreamInvoke(
 	args, err := plugin.UnmarshalProperties(
 		req.GetArgs(), plugin.MarshalOptions{Label: label, KeepUnknowns: true})
 	if err != nil {
-		return errors.Wrapf(err, "failed to unmarshal %v args", tok)
+		return fmt.Errorf("failed to unmarshal %v args: %w", tok, err)
 	}
 
 	// Synchronously do the StreamInvoke and then return the arguments. This will block until the
@@ -398,13 +398,13 @@ func (rm *queryResmon) StreamInvoke(
 	failures, err := prov.StreamInvoke(tok, args, func(event resource.PropertyMap) error {
 		mret, err := plugin.MarshalProperties(event, plugin.MarshalOptions{Label: label, KeepUnknowns: true})
 		if err != nil {
-			return errors.Wrapf(err, "failed to marshal return")
+			return fmt.Errorf("failed to marshal return: %w", err)
 		}
 
 		return stream.Send(&pulumirpc.InvokeResponse{Return: mret})
 	})
 	if err != nil {
-		return errors.Wrapf(err, "streaming invocation of %v returned an error", tok)
+		return fmt.Errorf("streaming invocation of %v returned an error: %w", tok, err)
 	}
 
 	var chkfails []*pulumirpc.CheckFailure
@@ -443,7 +443,7 @@ func (rm *queryResmon) Call(ctx context.Context, req *pulumirpc.CallRequest) (*p
 			KeepResources: true,
 		})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to unmarshal %v args", tok)
+		return nil, fmt.Errorf("failed to unmarshal %v args: %w", tok, err)
 	}
 
 	argDependencies := map[resource.PropertyKey][]resource.URN{}
@@ -463,7 +463,7 @@ func (rm *queryResmon) Call(ctx context.Context, req *pulumirpc.CallRequest) (*p
 		"QueryResourceMonitor.Call received: tok=%v #args=%v #info=%v #options=%v", tok, len(args), rm.callInfo, options)
 	ret, err := prov.Call(tok, args, rm.callInfo, options)
 	if err != nil {
-		return nil, errors.Wrapf(err, "call of %v returned an error", tok)
+		return nil, fmt.Errorf("call of %v returned an error: %w", tok, err)
 	}
 	mret, err := plugin.MarshalProperties(ret.Return, plugin.MarshalOptions{
 		Label:         label,
@@ -472,7 +472,7 @@ func (rm *queryResmon) Call(ctx context.Context, req *pulumirpc.CallRequest) (*p
 		KeepResources: true,
 	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to marshal return")
+		return nil, fmt.Errorf("failed to marshal return: %w", err)
 	}
 
 	returnDependencies := map[string]*pulumirpc.CallResponse_ReturnDependencies{}

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -15,10 +15,9 @@
 package deploy
 
 import (
+	"errors"
 	"fmt"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
@@ -129,8 +128,8 @@ func (s *SameStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error
 	if providers.IsProviderType(s.new.Type) {
 		ref, err := providers.NewReference(s.new.URN, s.new.ID)
 		if err != nil {
-			return resource.StatusOK, nil, errors.Errorf(
-				"bad provider reference '%v' for resource %v: %v", s.Provider(), s.URN(), err)
+			return resource.StatusOK, nil,
+				fmt.Errorf("bad provider reference '%v' for resource %v: %v", s.Provider(), s.URN(), err)
 		}
 		if s.Deployment() != nil {
 			s.Deployment().SameProvider(ref)
@@ -338,12 +337,11 @@ func (s *DeleteStep) Logical() bool           { return !s.replacing }
 func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error) {
 	// Refuse to delete protected resources.
 	if s.old.Protect {
-		return resource.StatusOK, nil,
-			errors.Errorf("unable to delete resource %q\n"+
-				"as it is currently marked for protection. To unprotect the resource, "+
-				"either remove the `protect` flag from the resource in your Pulumi"+
-				"program and run `pulumi up` or use the command:\n"+
-				"`pulumi state unprotect %s`", s.old.URN, s.old.URN)
+		return resource.StatusOK, nil, fmt.Errorf("unable to delete resource %q\n"+
+			"as it is currently marked for protection. To unprotect the resource, "+
+			"either remove the `protect` flag from the resource in your Pulumi"+
+			"program and run `pulumi up` or use the command:\n"+
+			"`pulumi state unprotect %s`", s.old.URN, s.old.URN)
 	}
 
 	// Deleting an External resource is a no-op, since Pulumi does not own the lifecycle.
@@ -650,7 +648,7 @@ func (s *ReadStep) Apply(preview bool) (resource.Status, StepCompleteFunc, error
 
 		// If there is no such resource, return an error indicating as such.
 		if result.Outputs == nil {
-			return resource.StatusOK, nil, errors.Errorf("resource '%s' does not exist", id)
+			return resource.StatusOK, nil, fmt.Errorf("resource '%s' does not exist", id)
 		}
 		s.new.Outputs = result.Outputs
 
@@ -875,11 +873,11 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 	// If this is a planned import, ensure that the resource does not exist in the old state file.
 	if s.planned {
 		if _, ok := s.deployment.olds[s.new.URN]; ok {
-			return resource.StatusOK, nil, errors.Errorf("resource '%v' already exists", s.new.URN)
+			return resource.StatusOK, nil, fmt.Errorf("resource '%v' already exists", s.new.URN)
 		}
 		if s.new.Parent.Type() != resource.RootStackType {
 			if _, ok := s.deployment.olds[s.new.Parent]; !ok {
-				return resource.StatusOK, nil, errors.Errorf("unknown parent '%v' for resource '%v'",
+				return resource.StatusOK, nil, fmt.Errorf("unknown parent '%v' for resource '%v'",
 					s.new.Parent, s.new.URN)
 			}
 		}
@@ -900,12 +898,12 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 		}
 	}
 	if read.Outputs == nil {
-		return rst, nil, errors.Errorf("resource '%v' does not exist", s.new.ID)
+		return rst, nil, fmt.Errorf("resource '%v' does not exist", s.new.ID)
 	}
 	if read.Inputs == nil {
-		return resource.StatusOK, nil, errors.Errorf(
-			"provider does not support importing resources; please try updating the '%v' plugin",
-			s.new.URN.Type().Package())
+		return resource.StatusOK, nil,
+			fmt.Errorf("provider does not support importing resources; please try updating the '%v' plugin",
+				s.new.URN.Type().Package())
 	}
 	if read.ID != "" {
 		s.new.ID = read.ID
@@ -925,12 +923,12 @@ func (s *ImportStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 
 		pkg, err := s.deployment.schemaLoader.LoadPackage(string(s.new.Type.Package()), nil)
 		if err != nil {
-			return resource.StatusOK, nil, errors.Wrapf(err, "failed to fetch provider schema")
+			return resource.StatusOK, nil, fmt.Errorf("failed to fetch provider schema: %w", err)
 		}
 
 		r, ok := pkg.GetResource(string(s.new.Type))
 		if !ok {
-			return resource.StatusOK, nil, errors.Errorf("unknown resource type '%v'", s.new.Type)
+			return resource.StatusOK, nil, fmt.Errorf("unknown resource type '%v'", s.new.Type)
 		}
 		for _, p := range r.InputProperties {
 			if p.IsRequired() {
@@ -1175,11 +1173,11 @@ func getProvider(s Step) (plugin.Provider, error) {
 	}
 	ref, err := providers.ParseReference(s.Provider())
 	if err != nil {
-		return nil, errors.Errorf("bad provider reference '%v' for resource %v: %v", s.Provider(), s.URN(), err)
+		return nil, fmt.Errorf("bad provider reference '%v' for resource %v: %v", s.Provider(), s.URN(), err)
 	}
 	provider, ok := s.Deployment().GetProvider(ref)
 	if !ok {
-		return nil, errors.Errorf("unknown provider '%v' for resource %v", s.Provider(), s.URN())
+		return nil, fmt.Errorf("unknown provider '%v' for resource %v", s.Provider(), s.URN())
 	}
 	return provider, nil
 }

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -15,9 +15,9 @@
 package deploy
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/resource/graph"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
@@ -1013,7 +1013,7 @@ func (sg *stepGenerator) providerChanged(urn resource.URN, old, new *resource.St
 	// performance problem, this result can be cached.
 	newProv, ok := sg.deployment.providers.GetProvider(newRef)
 	if !ok {
-		return false, errors.Errorf("failed to resolve provider reference: %q", oldRef.String())
+		return false, fmt.Errorf("failed to resolve provider reference: %q", oldRef.String())
 	}
 
 	oldRes, ok := sg.deployment.olds[oldRef.URN()]

--- a/pkg/resource/edit/operations.go
+++ b/pkg/resource/edit/operations.go
@@ -15,7 +15,7 @@
 package edit
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
@@ -147,7 +147,7 @@ func RenameStack(snap *deploy.Snapshot, newName tokens.QName, newProject tokens.
 	}
 
 	if err := snap.VerifyIntegrity(); err != nil {
-		return errors.Wrap(err, "checkpoint is invalid")
+		return fmt.Errorf("checkpoint is invalid: %w", err)
 	}
 
 	for _, res := range snap.Resources {

--- a/pkg/resource/graph/resource_set.go
+++ b/pkg/resource/graph/resource_set.go
@@ -14,7 +14,9 @@
 
 package graph
 
-import "github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+)
 
 // ResourceSet represents a set of Resources.
 type ResourceSet map[*resource.State]bool

--- a/pkg/resource/provider/component_provider.go
+++ b/pkg/resource/provider/component_provider.go
@@ -15,7 +15,7 @@
 package provider
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
@@ -87,7 +87,7 @@ func (p *componentProvider) GetPluginInfo(context.Context, *pbempty.Empty) (*pul
 func (p *componentProvider) GetSchema(ctx context.Context,
 	req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
 	if v := req.GetVersion(); v != 0 {
-		return nil, errors.Errorf("unsupported schema version %d", v)
+		return nil, fmt.Errorf("unsupported schema version %d", v)
 	}
 	schema := string(p.schema)
 	if schema == "" {

--- a/pkg/resource/provider/main.go
+++ b/pkg/resource/provider/main.go
@@ -15,10 +15,10 @@
 package provider
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 
-	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
@@ -48,7 +48,7 @@ func Main(name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderSe
 	}
 	host, err := NewHostClient(args[0])
 	if err != nil {
-		return errors.Errorf("fatal: could not connect to host RPC: %v", err)
+		return fmt.Errorf("fatal: could not connect to host RPC: %v", err)
 	}
 
 	// Fire up a gRPC server, letting the kernel choose a free port for us.
@@ -63,7 +63,7 @@ func Main(name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderSe
 		},
 	}, nil)
 	if err != nil {
-		return errors.Errorf("fatal: %v", err)
+		return fmt.Errorf("fatal: %v", err)
 	}
 
 	// The resource provider protocol requires that we now write out the port we have chosen to listen on.
@@ -71,7 +71,7 @@ func Main(name string, provMaker func(*HostClient) (pulumirpc.ResourceProviderSe
 
 	// Finally, wait for the server to stop serving.
 	if err := <-done; err != nil {
-		return errors.Errorf("fatal: %v", err)
+		return fmt.Errorf("fatal: %v", err)
 	}
 
 	return nil

--- a/pkg/resource/stack/checkpoint.go
+++ b/pkg/resource/stack/checkpoint.go
@@ -16,8 +16,7 @@ package stack
 
 import (
 	"encoding/json"
-
-	"github.com/pkg/errors"
+	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -73,7 +72,7 @@ func UnmarshalVersionedCheckpointToLatestCheckpoint(bytes []byte) (*apitype.Chec
 
 		return &v3checkpoint, nil
 	default:
-		return nil, errors.Errorf("unsupported checkpoint version %d", versionedCheckpoint.Version)
+		return nil, fmt.Errorf("unsupported checkpoint version %d", versionedCheckpoint.Version)
 	}
 }
 
@@ -85,7 +84,7 @@ func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
 	if snap != nil {
 		dep, err := SerializeDeployment(snap, sm, showSecrets)
 		if err != nil {
-			return nil, errors.Wrap(err, "serializing deployment")
+			return nil, fmt.Errorf("serializing deployment: %w", err)
 		}
 		latest = dep
 	}
@@ -95,7 +94,7 @@ func SerializeCheckpoint(stack tokens.QName, snap *deploy.Snapshot,
 		Latest: latest,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "marshalling checkpoint")
+		return nil, fmt.Errorf("marshalling checkpoint: %w", err)
 	}
 
 	return &apitype.VersionedCheckpoint{

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -16,8 +16,8 @@ package stack
 
 import (
 	"encoding/json"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/pkg/v3/secrets/cloud"
@@ -56,10 +56,10 @@ func (defaultSecretsProvider) OfType(ty string, state json.RawMessage) (secrets.
 	case cloud.Type:
 		sm, err = cloud.NewCloudSecretsManagerFromState(state)
 	default:
-		return nil, errors.Errorf("no known secrets provider for type %q", ty)
+		return nil, fmt.Errorf("no known secrets provider for type %q", ty)
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "constructing secrets manager of type %q", ty)
+		return nil, fmt.Errorf("constructing secrets manager of type %q: %w", ty, err)
 	}
 
 	return NewCachingSecretsManager(sm), nil

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -2,11 +2,11 @@ package stack
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
 	"github.com/stretchr/testify/assert"

--- a/pkg/secrets/cloud/manager.go
+++ b/pkg/secrets/cloud/manager.go
@@ -19,8 +19,8 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"fmt"
 
-	"github.com/pkg/errors"
 	gosecrets "gocloud.dev/secrets"
 	_ "gocloud.dev/secrets/awskms"        // support for awskms://
 	_ "gocloud.dev/secrets/azurekeyvault" // support for azurekeyvault://
@@ -45,7 +45,7 @@ type cloudSecretsManagerState struct {
 func NewCloudSecretsManagerFromState(state json.RawMessage) (secrets.Manager, error) {
 	var s cloudSecretsManagerState
 	if err := json.Unmarshal(state, &s); err != nil {
-		return nil, errors.Wrap(err, "unmarshalling state")
+		return nil, fmt.Errorf("unmarshalling state: %w", err)
 	}
 
 	return NewCloudSecretsManager(s.URL, s.EncryptedKey)

--- a/pkg/secrets/passphrase/manager_test.go
+++ b/pkg/secrets/passphrase/manager_test.go
@@ -1,10 +1,11 @@
 package passphrase
 
 import (
-	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
-
-	"github.com/pkg/errors"
 
 	"github.com/pulumi/pulumi/pkg/v3/backend/httpstate/client"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
@@ -112,17 +111,17 @@ func NewServiceSecretsManager(c *client.Client, id client.StackIdentifier) (secr
 func NewServiceSecretsManagerFromState(state json.RawMessage) (secrets.Manager, error) {
 	var s serviceSecretsManagerState
 	if err := json.Unmarshal(state, &s); err != nil {
-		return nil, errors.Wrap(err, "unmarshalling state")
+		return nil, fmt.Errorf("unmarshalling state: %w", err)
 	}
 
 	account, err := workspace.GetAccount(s.URL)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting access token")
+		return nil, fmt.Errorf("getting access token: %w", err)
 	}
 	token := account.AccessToken
 
 	if token == "" {
-		return nil, errors.Errorf("could not find access token for %s, have you logged in?", s.URL)
+		return nil, fmt.Errorf("could not find access token for %s, have you logged in?", s.URL)
 	}
 
 	id := client.StackIdentifier{

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -19,6 +19,7 @@ import (
 	cryptorand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -34,7 +35,7 @@ import (
 	"time"
 
 	multierror "github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
+
 	"github.com/pulumi/pulumi/pkg/v3/backend/filestate"
 	"github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/operations"
@@ -716,7 +717,7 @@ func (pt *ProgramTester) getPythonBin() (string, error) {
 				}
 			}
 			if err != nil {
-				return "", errors.Wrapf(err, "Expected to find one of %q on $PATH", pythonCmds)
+				return "", fmt.Errorf("Expected to find one of %q on $PATH: %w", pythonCmds, err)
 			}
 		}
 	}
@@ -829,7 +830,7 @@ func (pt *ProgramTester) runPulumiCommand(name string, args []string, wd string,
 			} else if _, ok := runerr.(*exec.ExitError); ok && isUpdate && !expectFailure {
 				// the update command failed, let's try again, assuming we haven't failed a few times.
 				if try+1 >= pt.maxStepTries {
-					return false, nil, errors.Errorf("%v did not succeed after %v tries", cmd, try+1)
+					return false, nil, fmt.Errorf("%v did not succeed after %v tries", cmd, try+1)
 				}
 
 				pt.t.Logf("%v failed: %v; retrying...", cmd, runerr)
@@ -862,7 +863,7 @@ func (pt *ProgramTester) runYarnCommand(name string, args []string, wd string) e
 			} else if _, ok := runerr.(*exec.ExitError); ok {
 				// yarn failed, let's try again, assuming we haven't failed a few times.
 				if try+1 >= 3 {
-					return false, nil, errors.Errorf("%v did not complete after %v tries", cmd, try+1)
+					return false, nil, fmt.Errorf("%v did not complete after %v tries", cmd, try+1)
 				}
 
 				return false, nil, nil
@@ -1006,7 +1007,7 @@ func (pt *ProgramTester) TestCleanUp() {
 func (pt *ProgramTester) TestLifeCycleInitAndDestroy() error {
 	err := pt.TestLifeCyclePrepare()
 	if err != nil {
-		return errors.Wrapf(err, "copying test to temp dir %s", pt.tmpdir)
+		return fmt.Errorf("copying test to temp dir %s: %w", pt.tmpdir, err)
 	}
 
 	pt.TestFinished = false
@@ -1014,7 +1015,7 @@ func (pt *ProgramTester) TestLifeCycleInitAndDestroy() error {
 
 	err = pt.TestLifeCycleInitialize()
 	if err != nil {
-		return errors.Wrap(err, "initializing test project")
+		return fmt.Errorf("initializing test project: %w", err)
 	}
 
 	// Ensure that before we exit, we attempt to destroy and remove the stack.
@@ -1024,17 +1025,17 @@ func (pt *ProgramTester) TestLifeCycleInitAndDestroy() error {
 	}()
 
 	if err = pt.TestPreviewUpdateAndEdits(); err != nil {
-		return errors.Wrap(err, "running test preview, update, and edits")
+		return fmt.Errorf("running test preview, update, and edits: %w", err)
 	}
 
 	if pt.opts.RunUpdateTest {
 		err = upgradeProjectDeps(pt.projdir, pt)
 		if err != nil {
-			return errors.Wrap(err, "upgrading project dependencies")
+			return fmt.Errorf("upgrading project dependencies: %w", err)
 		}
 
 		if err = pt.TestPreviewUpdateAndEdits(); err != nil {
-			return errors.Wrap(err, "running test preview, update, and edits")
+			return fmt.Errorf("running test preview, update, and edits: %w", err)
 		}
 	}
 
@@ -1045,7 +1046,7 @@ func (pt *ProgramTester) TestLifeCycleInitAndDestroy() error {
 func upgradeProjectDeps(projectDir string, pt *ProgramTester) error {
 	projInfo, err := pt.getProjinfo(projectDir)
 	if err != nil {
-		return errors.Wrap(err, "getting project info")
+		return fmt.Errorf("getting project info: %w", err)
 	}
 
 	switch rt := projInfo.Proj.Runtime.Name(); rt {
@@ -1058,7 +1059,7 @@ func upgradeProjectDeps(projectDir string, pt *ProgramTester) error {
 			return err
 		}
 	default:
-		return errors.Errorf("unrecognized project runtime: %s", rt)
+		return fmt.Errorf("unrecognized project runtime: %s", rt)
 	}
 
 	return nil
@@ -1355,13 +1356,13 @@ func (pt *ProgramTester) testEdit(dir string, i int, edit EditDir) error {
 	if edit.Additive {
 		// Just copy new files into dir
 		if err := fsutil.CopyFile(dir, edit.Dir, nil); err != nil {
-			return errors.Wrapf(err, "Couldn't copy %v into %v", edit.Dir, dir)
+			return fmt.Errorf("Couldn't copy %v into %v: %w", edit.Dir, dir, err)
 		}
 	} else {
 		// Create a new temporary directory
 		newDir, err := ioutil.TempDir("", pt.opts.StackName+"-")
 		if err != nil {
-			return errors.Wrapf(err, "Couldn't create new temporary directory")
+			return fmt.Errorf("Couldn't create new temporary directory: %w", err)
 		}
 
 		// Delete whichever copy of the test is unused when we return
@@ -1379,7 +1380,7 @@ func (pt *ProgramTester) testEdit(dir string, i int, edit EditDir) error {
 		exclusions[configYaml] = true
 
 		if err := fsutil.CopyFile(newDir, edit.Dir, exclusions); err != nil {
-			return errors.Wrapf(err, "Couldn't copy %v into %v", edit.Dir, newDir)
+			return fmt.Errorf("Couldn't copy %v into %v: %w", edit.Dir, newDir, err)
 		}
 
 		// Copy Pulumi.yaml, Pulumi.<stack-name>.yaml, and .pulumi from old directory to new directory
@@ -1393,25 +1394,25 @@ func (pt *ProgramTester) testEdit(dir string, i int, edit EditDir) error {
 		newProjectDir := filepath.Join(newDir, workspace.BookkeepingDir)
 
 		if err := fsutil.CopyFile(newProjectYaml, oldProjectYaml, nil); err != nil {
-			return errors.Wrap(err, "Couldn't copy Pulumi.yaml")
+			return fmt.Errorf("Couldn't copy Pulumi.yaml: %w", err)
 		}
 		if err := fsutil.CopyFile(newConfigYaml, oldConfigYaml, nil); err != nil {
-			return errors.Wrapf(err, "Couldn't copy Pulumi.%s.yaml", pt.opts.StackName)
+			return fmt.Errorf("Couldn't copy Pulumi.%s.yaml: %w", pt.opts.StackName, err)
 		}
 		if err := fsutil.CopyFile(newProjectDir, oldProjectDir, nil); err != nil {
-			return errors.Wrap(err, "Couldn't copy .pulumi")
+			return fmt.Errorf("Couldn't copy .pulumi: %w", err)
 		}
 
 		// Finally, replace our current temp directory with the new one.
 		dirOld := dir + ".old"
 		if err := os.Rename(dir, dirOld); err != nil {
-			return errors.Wrapf(err, "Couldn't rename %v to %v", dir, dirOld)
+			return fmt.Errorf("Couldn't rename %v to %v: %w", dir, dirOld, err)
 		}
 
 		// There's a brief window here where the old temp dir name could be taken from us.
 
 		if err := os.Rename(newDir, dir); err != nil {
-			return errors.Wrapf(err, "Couldn't rename %v to %v", newDir, dir)
+			return fmt.Errorf("Couldn't rename %v to %v: %w", newDir, dir, err)
 		}
 
 		// Keep dir, delete oldDir
@@ -1420,7 +1421,7 @@ func (pt *ProgramTester) testEdit(dir string, i int, edit EditDir) error {
 
 	err := pt.prepareProjectDir(dir)
 	if err != nil {
-		return errors.Wrapf(err, "Couldn't prepare project in %v", dir)
+		return fmt.Errorf("Couldn't prepare project in %v: %w", dir, err)
 	}
 
 	oldStdOut := pt.opts.Stdout
@@ -1482,13 +1483,13 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 	}
 	if err = pt.runPulumiCommand("pulumi-export",
 		pulumiCommand, dir, false); err != nil {
-		return errors.Wrapf(err, "expected to export stack to file: %s", fileName)
+		return fmt.Errorf("expected to export stack to file: %s: %w", fileName, err)
 	}
 
 	// Open the exported JSON file
 	f, err := os.Open(fileName)
 	if err != nil {
-		return errors.Wrapf(err, "expected to be able to open file with stack exports: %s", fileName)
+		return fmt.Errorf("expected to be able to open file with stack exports: %s: %w", fileName, err)
 	}
 	defer func() {
 		contract.IgnoreClose(f)
@@ -1518,7 +1519,7 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 	// Read the event log.
 	eventsFile, err := os.Open(pt.eventLog)
 	if err != nil && !os.IsNotExist(err) {
-		return errors.Wrapf(err, "expected to be able to open event log file %s", pt.eventLog)
+		return fmt.Errorf("expected to be able to open event log file %s: %w", pt.eventLog, err)
 	}
 	defer contract.IgnoreClose(eventsFile)
 	decoder, events := json.NewDecoder(eventsFile), []apitype.EngineEvent{}
@@ -1528,7 +1529,7 @@ func (pt *ProgramTester) performExtraRuntimeValidation(
 			if err == io.EOF {
 				break
 			}
-			return errors.Wrapf(err, "decoding engine event")
+			return fmt.Errorf("decoding engine event: %w", err)
 		}
 		events = append(events, event)
 	}
@@ -1579,14 +1580,14 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 	if projinfo.Proj.Runtime.Name() == "go" {
 		targetDir, err := tools.CreateTemporaryGoFolder("stackName")
 		if err != nil {
-			return "", "", errors.Wrap(err, "Couldn't create temporary directory")
+			return "", "", fmt.Errorf("Couldn't create temporary directory: %w", err)
 		}
 		tmpdir = targetDir
 		projdir = targetDir
 	} else {
 		targetDir, tempErr := ioutil.TempDir("", stackName+"-")
 		if tempErr != nil {
-			return "", "", errors.Wrap(tempErr, "Couldn't create temporary directory")
+			return "", "", fmt.Errorf("Couldn't create temporary directory: %w", tempErr)
 		}
 		tmpdir = targetDir
 		projdir = targetDir
@@ -1599,7 +1600,7 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 
 	err = pt.prepareProject(projinfo)
 	if err != nil {
-		return "", "", errors.Wrapf(err, "Failed to prepare %v", projdir)
+		return "", "", fmt.Errorf("Failed to prepare %v: %w", projdir, err)
 	}
 
 	// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
@@ -1659,7 +1660,7 @@ func (pt *ProgramTester) prepareProject(projinfo *engine.Projinfo) error {
 	case DotNetRuntime:
 		return pt.prepareDotNetProject(projinfo)
 	default:
-		return errors.Errorf("unrecognized project runtime: %s", rt)
+		return fmt.Errorf("unrecognized project runtime: %s", rt)
 	}
 }
 
@@ -1745,13 +1746,13 @@ func (pt *ProgramTester) prepareNodeJSProject(projinfo *engine.Projinfo) error {
 func readPackageJSON(pathToPackage string) (map[string]interface{}, error) {
 	f, err := os.Open(filepath.Join(pathToPackage, "package.json"))
 	if err != nil {
-		return nil, errors.Wrap(err, "opening package.json")
+		return nil, fmt.Errorf("opening package.json: %w", err)
 	}
 	defer contract.IgnoreClose(f)
 
 	var ret map[string]interface{}
 	if err := json.NewDecoder(f).Decode(&ret); err != nil {
-		return nil, errors.Wrap(err, "decoding package.json")
+		return nil, fmt.Errorf("decoding package.json: %w", err)
 	}
 
 	return ret, nil
@@ -1761,14 +1762,14 @@ func writePackageJSON(pathToPackage string, metadata map[string]interface{}) err
 	// os.Create truncates the already existing file.
 	f, err := os.Create(filepath.Join(pathToPackage, "package.json"))
 	if err != nil {
-		return errors.Wrap(err, "opening package.json")
+		return fmt.Errorf("opening package.json: %w", err)
 	}
 	defer contract.IgnoreClose(f)
 
 	encoder := json.NewEncoder(f)
 	encoder.SetIndent("", "  ")
 
-	return errors.Wrap(encoder.Encode(metadata), "writing package.json")
+	return fmt.Errorf("writing package.json: %w", encoder.Encode(metadata))
 }
 
 // preparePythonProject runs setup necessary to get a Python project ready for `pulumi` commands.
@@ -1790,7 +1791,7 @@ func (pt *ProgramTester) preparePythonProject(projinfo *engine.Projinfo) error {
 		projinfo.Proj.Runtime.SetOption("virtualenv", "venv")
 		projfile := filepath.Join(projinfo.Root, workspace.ProjectFile+".yaml")
 		if err = projinfo.Proj.Save(projfile); err != nil {
-			return errors.Wrap(err, "saving project")
+			return fmt.Errorf("saving project: %w", err)
 		}
 
 		if err := pt.runVirtualEnvCommand("virtualenv-pip-install",
@@ -1881,7 +1882,7 @@ func getVirtualenvBinPath(cwd, bin string) (string, error) {
 		virtualenvBinPath = filepath.Join(cwd, "venv", "Scripts", fmt.Sprintf("%s.exe", bin))
 	}
 	if info, err := os.Stat(virtualenvBinPath); err != nil || info.IsDir() {
-		return "", errors.Errorf("Expected %s to exist in virtual environment at %q", bin, virtualenvBinPath)
+		return "", fmt.Errorf("Expected %s to exist in virtual environment at %q", bin, virtualenvBinPath)
 	}
 	return virtualenvBinPath, nil
 }
@@ -1927,7 +1928,7 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 	// Go programs are compiled, so we will compile the project first.
 	goBin, err := pt.getGoBin()
 	if err != nil {
-		return errors.Wrap(err, "locating `go` binary")
+		return fmt.Errorf("locating `go` binary: %w", err)
 	}
 
 	// Ensure GOPATH is known.
@@ -1997,7 +1998,7 @@ func (pt *ProgramTester) prepareGoProject(projinfo *engine.Projinfo) error {
 func (pt *ProgramTester) prepareDotNetProject(projinfo *engine.Projinfo) error {
 	dotNetBin, err := pt.getDotNetBin()
 	if err != nil {
-		return errors.Wrap(err, "locating `dotnet` binary")
+		return fmt.Errorf("locating `dotnet` binary: %w", err)
 	}
 
 	cwd, _, err := projinfo.GetPwdMain()
@@ -2015,10 +2016,10 @@ func (pt *ProgramTester) prepareDotNetProject(projinfo *engine.Projinfo) error {
 		// dotnet add package requires a specific version in case of a pre-release, so we have to look it up.
 		matches, err := filepath.Glob(filepath.Join(localNuget, dep+".?.*.nupkg"))
 		if err != nil {
-			return errors.Wrap(err, "failed to find a local Pulumi NuGet package")
+			return fmt.Errorf("failed to find a local Pulumi NuGet package: %w", err)
 		}
 		if len(matches) != 1 {
-			return errors.Errorf("attempting to find a local Pulumi NuGet package yielded %v results", matches)
+			return fmt.Errorf("attempting to find a local Pulumi NuGet package yielded %v results", matches)
 		}
 		file := filepath.Base(matches[0])
 		r := strings.NewReplacer(dep+".", "", ".nupkg", "")
@@ -2027,7 +2028,7 @@ func (pt *ProgramTester) prepareDotNetProject(projinfo *engine.Projinfo) error {
 		err = pt.runCommand("dotnet-add-package",
 			[]string{dotNetBin, "add", "package", dep, "-v", version}, cwd)
 		if err != nil {
-			return errors.Wrapf(err, "failed to add dependency on %s", dep)
+			return fmt.Errorf("failed to add dependency on %s: %w", dep, err)
 		}
 	}
 

--- a/pkg/testing/integration/util.go
+++ b/pkg/testing/integration/util.go
@@ -16,7 +16,6 @@ package integration
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -28,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
@@ -42,8 +41,9 @@ func DecodeMapString(val string) (map[string]string, error) {
 		for _, overrideClause := range strings.Split(val, ":") {
 			data := strings.Split(overrideClause, "=")
 			if len(data) != 2 {
-				return nil, errors.Errorf(
-					"could not decode %s as an override, should be of the form <package>=<version>", overrideClause)
+				return nil, fmt.Errorf(
+					"could not decode %s as an override, should be of the form <package>=<version>",
+					overrideClause)
 			}
 			packageName := data[0]
 			packageVersion := data[1]
@@ -73,7 +73,7 @@ func getCmdBin(loc *string, bin, def string) (string, error) {
 			var err error
 			*loc, err = exec.LookPath(bin)
 			if err != nil {
-				return "", errors.Wrapf(err, "Expected to find `%s` binary on $PATH", bin)
+				return "", fmt.Errorf("Expected to find `%s` binary on $PATH: %w", bin, err)
 			}
 		}
 	}
@@ -95,13 +95,13 @@ const (
 func writeCommandOutput(commandName, runDir string, output []byte) (string, error) {
 	logFileDir := filepath.Join(runDir, commandOutputFolderName)
 	if err := os.MkdirAll(logFileDir, 0700); err != nil {
-		return "", errors.Wrapf(err, "Failed to create '%s'", logFileDir)
+		return "", fmt.Errorf("Failed to create '%s': %w", logFileDir, err)
 	}
 
 	logFile := filepath.Join(logFileDir, commandName+uniqueSuffix()+".log")
 
 	if err := ioutil.WriteFile(logFile, output, 0600); err != nil {
-		return "", errors.Wrapf(err, "Failed to write '%s'", logFile)
+		return "", fmt.Errorf("Failed to write '%s': %w", logFile, err)
 	}
 
 	return logFile, nil

--- a/pkg/util/tracing/tracing.go
+++ b/pkg/util/tracing/tracing.go
@@ -14,7 +14,9 @@
 
 package tracing
 
-import "context"
+import (
+	"context"
+)
 
 // tracingOptionsKey is the value used as the context key for TracingOptions.
 var tracingOptionsKey struct{}

--- a/pkg/util/validation/stack.go
+++ b/pkg/util/validation/stack.go
@@ -15,9 +15,10 @@
 package validation
 
 import (
+	"errors"
+	"fmt"
 	"regexp"
 
-	"github.com/pkg/errors"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 )
 
@@ -37,10 +38,10 @@ func validateStackTagName(s string) error {
 	const maxTagName = 40
 
 	if len(s) == 0 {
-		return errors.Errorf("invalid stack tag %q", s)
+		return fmt.Errorf("invalid stack tag %q", s)
 	}
 	if len(s) > maxTagName {
-		return errors.Errorf("stack tag %q is too long (max length %d characters)", s, maxTagName)
+		return fmt.Errorf("stack tag %q is too long (max length %d characters)", s, maxTagName)
 	}
 
 	var tagNameRE = regexp.MustCompile("^[a-zA-Z0-9-_.:]{1,40}$")
@@ -59,7 +60,7 @@ func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 			return err
 		}
 		if len(v) > maxTagValue {
-			return errors.Errorf("stack tag %q value is too long (max length %d characters)", t, maxTagValue)
+			return fmt.Errorf("stack tag %q value is too long (max length %d characters)", t, maxTagValue)
 		}
 	}
 
@@ -71,7 +72,7 @@ func ValidateStackTags(tags map[apitype.StackTagName]string) error {
 func ValidateStackProperties(stack string, tags map[apitype.StackTagName]string) error {
 	const maxStackName = 100 // Derived from the regex in validateStackName.
 	if len(stack) > maxStackName {
-		return errors.Errorf("stack name too long (max length %d characters)", maxStackName)
+		return fmt.Errorf("stack name too long (max length %d characters)", maxStackName)
 	}
 	if err := validateStackName(stack); err != nil {
 		return err


### PR DESCRIPTION
This is the result of a change applied via `go-rewrap-errors`.

The one place where the new interface was not complient was the
`errors.Cause` method. This was copied directly from the go/pkg/errors
implementation.


<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #Modernize error handling in `pkg`. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
