### PR TITLE
Remove use of /opt/pulumi for nuget packages

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -160,8 +160,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -230,8 +228,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -266,7 +262,6 @@ jobs:
           make dist
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Install
         run: |
@@ -276,14 +271,12 @@ jobs:
           python -m pip install -e sdk/python/env/src
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Test
         run: |
           make TEST_ALL_DEPS= test_all
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
   windows-build:
     name: Windows Build + Test + Publish
@@ -296,7 +289,6 @@ jobs:
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}
-      PULUMI_LOCAL_NUGET: "D:\\Pulumi\\nuget"
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_LEGACY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_LEGACY }}
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -305,10 +297,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
-      - name: Create Local Nuget
-        run: mkdir -p "${{ env.PULUMI_LOCAL_NUGET }}"
-        shell: bash
-      - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -143,8 +143,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -207,8 +205,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -243,7 +239,6 @@ jobs:
           make dist
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Install
         run: |
@@ -253,14 +248,12 @@ jobs:
           python -m pip install -e sdk/python/env/src
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Test
         run: |
           make test_all
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
   windows-build:
     name: Windows Build
@@ -273,7 +266,6 @@ jobs:
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}
-      PULUMI_LOCAL_NUGET: "D:\\Pulumi\\nuget"
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_LEGACY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_LEGACY }}
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -282,10 +274,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
-      - name: Create Local Nuget
-        run: mkdir -p "${{ env.PULUMI_LOCAL_NUGET }}"
-        shell: bash
-      - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,8 +236,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -306,8 +304,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -347,7 +343,6 @@ jobs:
           make dist
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Check worktree is clean
         run: ./ci-scripts/ci/check-worktree-is-clean
@@ -359,14 +354,12 @@ jobs:
           python -m pip install -e sdk/python/env/src
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Test
         run: |
           make TEST_ALL_DEPS= test_all
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
   windows-build:
     name: Windows Build
@@ -379,7 +372,6 @@ jobs:
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}
-      PULUMI_LOCAL_NUGET: "D:\\Pulumi\\nuget"
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID_LEGACY }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_LEGACY }}
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
@@ -388,10 +380,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet }}
-      - name: Create Local Nuget
-        run: mkdir -p "${{ env.PULUMI_LOCAL_NUGET }}"
-        shell: bash
-      - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -82,8 +82,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -171,8 +169,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
-      - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
-      - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -218,7 +214,6 @@ jobs:
           make dist
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Install
         run: |
@@ -228,13 +223,11 @@ jobs:
           python -m pip install -e sdk/python/env/src
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Test
         run: make TEST_ALL_DEPS= test_all
         env:
           PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
           PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
       - name: Summarize Test Time by Package
         run: |
@@ -258,7 +251,6 @@ jobs:
     runs-on: windows-latest
     env:
       GOPATH: ${{ github.workspace }}
-      PULUMI_LOCAL_NUGET: "D:\\Pulumi\\nuget"
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - name: Install DotNet ${{ matrix.dotnet }}
@@ -281,10 +273,6 @@ jobs:
         run: |
           pip3 install pyenv-win
           pip3 install pipenv
-      - name: Create Local Nuget
-        run: mkdir -p "${{ env.PULUMI_LOCAL_NUGET }}"
-        shell: bash
-      - run: dotnet nuget add source ${{ env.PULUMI_LOCAL_NUGET }}
       - name: Set Build Env Vars
         shell: bash
         run: |

--- a/build/common.mk
+++ b/build/common.mk
@@ -108,7 +108,6 @@ PIP ?= pip3
 
 PULUMI_BIN          := $(PULUMI_ROOT)/bin
 PULUMI_NODE_MODULES := $(PULUMI_ROOT)/node_modules
-PULUMI_NUGET        := $(PULUMI_ROOT)/nuget
 
 RUN_TESTSUITE = python3 ${PROJECT_ROOT}/scripts/run-testsuite.py
 GO_TEST_FAST = PATH="$(PULUMI_BIN):$(PATH)" python3 ${PROJECT_ROOT}/scripts/go-test.py -short -count=1 -cover -tags=all -timeout 1h -parallel ${TESTPARALLELISM}
@@ -170,7 +169,6 @@ install::
 	$(call STEP_MESSAGE)
 	@mkdir -p $(PULUMI_BIN)
 	@mkdir -p $(PULUMI_NODE_MODULES)
-	@mkdir -p $(PULUMI_NUGET)
 
 dist::
 	$(call STEP_MESSAGE)

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -38,10 +38,7 @@ install_plugin::
 	GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${DOTNET_VERSION}" ${LANGHOST_PKG}
 
 install:: build install_plugin
-	echo "Copying NuGet packages to ${PULUMI_NUGET}"
-	[ ! -e "$(PULUMI_NUGET)" ] || rm -rf "$(PULUMI_NUGET)/*"
-	rm -f $(PULUMI_NUGET)/*.nupkg
-	find . -name '*${VERSION_PREFIX}*.nupkg' -exec cp -p {} ${PULUMI_NUGET} \;
+	dotnet pack dotnet.sln --configuration Release /p:Version=${DOTNET_VERSION}
 
 dotnet_test:: $(TEST_ALL_DEPS)
 	# include the version prefix/suffix to avoid generating a separate nupkg file
@@ -66,5 +63,5 @@ brew::
 
 publish:: build install
 	echo "Publishing .nupkgs to nuget.org:"
-	find /opt/pulumi/nuget -name 'Pulumi*.nupkg' \
+	find . -name 'Pulumi*${VERSION_PREFIX}*.nupkg' -path '*/Release/*' \
 		-exec dotnet nuget push -k ${NUGET_PUBLISH_KEY} -s https://api.nuget.org/v3/index.json {} ';'

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>
     <Description>Pulumi Automation API, the programmatic interface for driving Pulumi programs without the CLI.</Description>

--- a/sdk/dotnet/Pulumi.FSharp/Pulumi.FSharp.fsproj
+++ b/sdk/dotnet/Pulumi.FSharp/Pulumi.FSharp.fsproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>
     <Description>F#-specific helpers for the Pulumi .NET SDK.</Description>

--- a/sdk/dotnet/Pulumi/Pulumi.csproj
+++ b/sdk/dotnet/Pulumi/Pulumi.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Nullable>enable</Nullable>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Pulumi</Authors>
     <Company>Pulumi Corp.</Company>
     <Description>The Pulumi .NET SDK lets you write cloud programs in C#, F#, and VB.NET.</Description>


### PR DESCRIPTION
Stop using /opt/pulumi/nuget, this makes some progress towards fixing

There are three main changes here:
1) We no longer pack on build, instead requiring an explicit pack command
(which runs in relase configuration). This should be a small speed improvement
for standard builds.
2) The integration tests no longer rely on a nuget package, instead we just
reference the project directly. This removes the need for a local nuget feed
that had to be setup and installed into.
3) As we've got rid of the local nuget feed `make install` simply runs "dotnet
pack" and `make publish` picks up the .nupkg from the sdk bin folder.

The one workflow this changes is if people have pulumi programs outside
pulumi/pulumi that they we're using `make install` to get a build of the
dotnet sdk into. Anyone using that workflow instead needs to either:
1) Manually copy the .nupkg from the build folder to wherever they have
setup their local nuget feed.
2) Change that project to refer to Pulumi via a project reference.