### PR TITLE
[sdk/dotnet] Avoid eager conversion to Output<T> in Input<T>

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/Serialization/MarshalOutputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Serialization/MarshalOutputTests.cs
@@ -91,6 +91,21 @@ namespace Pulumi.Tests.Serialization
             },
             new object[]
             {
+                new InputList<string> { "hello" },
+                ImmutableArray<object>.Empty.Add("hello")
+            },
+            new object[]
+            {
+                new InputList<string> { Output.Create("hello") },
+                ImmutableArray<object>.Empty.Add("hello")
+            },
+            new object[]
+            {
+                new InputList<string> { Output.CreateSecret("hello") },
+                ImmutableArray<object>.Empty.Add(CreateOutputValue("hello", isSecret: true))
+            },
+            new object[]
+            {
                 new Dictionary<string, Input<string>> { { "foo", "hello" } },
                 ImmutableDictionary<string, object>.Empty.Add("foo", "hello")
             },
@@ -102,6 +117,21 @@ namespace Pulumi.Tests.Serialization
             new object[]
             {
                 new Dictionary<string, Input<string>> { { "foo", Output.CreateSecret("hello") } },
+                ImmutableDictionary<string, object>.Empty.Add("foo", CreateOutputValue("hello", isSecret: true))
+            },
+            new object[]
+            {
+                new InputMap<string> { { "foo", "hello" } },
+                ImmutableDictionary<string, object>.Empty.Add("foo", "hello")
+            },
+            new object[]
+            {
+                new InputMap<string> { { "foo", Output.Create("hello") } },
+                ImmutableDictionary<string, object>.Empty.Add("foo", "hello")
+            },
+            new object[]
+            {
+                new InputMap<string> { { "foo", Output.CreateSecret("hello") } },
                 ImmutableDictionary<string, object>.Empty.Add("foo", CreateOutputValue("hello", isSecret: true))
             },
             new object[]

--- a/sdk/dotnet/Pulumi/Core/InputUnion.cs
+++ b/sdk/dotnet/Pulumi/Core/InputUnion.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2019, Pulumi Corporation
+﻿// Copyright 2016-2021, Pulumi Corporation
 
 namespace Pulumi
 {
@@ -9,7 +9,12 @@ namespace Pulumi
     /// </summary>
     public sealed class InputUnion<T0, T1> : Input<Union<T0, T1>>
     {
-        public InputUnion() : this(Output.Create(default(Union<T0, T1>)))
+        public InputUnion() : this(default(Union<T0, T1>))
+        {
+        }
+
+        private InputUnion(Union<T0, T1> oneOf)
+            : base(oneOf)
         {
         }
 
@@ -21,10 +26,10 @@ namespace Pulumi
         #region common conversions
 
         public static implicit operator InputUnion<T0, T1>(T0 value)
-            => Output.Create(value);
+            => new InputUnion<T0, T1>(Union<T0, T1>.FromT0(value));
 
         public static implicit operator InputUnion<T0, T1>(T1 value)
-            => Output.Create(value);
+            => new InputUnion<T0, T1>(Union<T0, T1>.FromT1(value));
 
         public static implicit operator InputUnion<T0, T1>(Output<T0> value)
             => new InputUnion<T0, T1>(value.Apply(Union<T0, T1>.FromT0));

--- a/sdk/dotnet/Pulumi/Serialization/Serializer.cs
+++ b/sdk/dotnet/Pulumi/Serialization/Serializer.cs
@@ -110,7 +110,7 @@ $"Tasks are not allowed inside ResourceArgs. Please wrap your Task in an Output:
                     Log.Debug($"Serialize property[{ctx}]: Recursing into IInput");
                 }
 
-                return await SerializeAsync(ctx, input.ToOutput(), keepResources, keepOutputValues).ConfigureAwait(false);
+                return await SerializeAsync(ctx, input.Value, keepResources, keepOutputValues).ConfigureAwait(false);
             }
 
             if (prop is IUnion union)


### PR DESCRIPTION
This changes `Input<T>`, `InputList<T>`, `InputMap<V>`, and `InputUnion<T0, T1>` to no longer eagerly convert plain values to `Output<T>`.

Fixes pulumi/pulumi-dotnet#22