### PR TITLE
Factor out Go builds in CI into a dedicated x-platform step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,240 @@
+name: Builds CLI and SDK binaries.
+
+on:
+  workflow_call:
+    inputs:
+      go-version:
+        description: 'Version of the Go toolchain for the build'
+        default: '1.17.x'
+        required: false
+        type: string
+      python-version:
+        description: 'Version of the Python toolchain for the build'
+        default: '3.9.x'
+        required: false
+        type: string
+      node-version:
+        description: 'Version of the Node toolchain for the build'
+        default: '14.x'
+        required: false
+        type: string
+      dotnet-version:
+        description: 'Version of the .NET toolchain for the build'
+        default: '3.1.x'
+        required: false
+        type: string
+      goreleaser-config:
+        description: 'Config file for goreleaser'
+        default: '.goreleaser.prerelease.yml'
+        required: false
+        type: string
+      goreleaser-flags:
+        description: 'Command-line flags to pass to goreleaser'
+        default: '-p 3 --snapshot --skip-validate'
+        required: false
+        type: string
+      enable-coverage:
+        description: 'Builds executables with coverage analysis enabled'
+        default: false
+        required: false
+        type: boolean
+    secrets: {}
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build_pulumi_go_binaries:
+    strategy:
+      matrix:
+        include:
+          - platform: macos-latest
+            os: darwin
+          - platform: ubuntu-latest
+            os: linux
+          - platform: ubuntu-latest
+            os: windows
+      fail-fast: false
+
+    name: Build Pulumi Go binaries
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Enable code coverage
+        run: |
+          echo "PULUMI_TEST_COVERAGE_PATH=$(pwd)/coverage" >> $GITHUB_ENV
+        if: ${{ inputs.enable-coverage }}
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
+      - name: Fetch Tags
+        run: |
+          git fetch --quiet --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Install goreleaser-filter
+        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        with:
+          repo: t0yv0/goreleaser-filter
+      - name: Set up Go ${{ inputs.go-version }}
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ inputs.go-version }}
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - name: Go Cache
+        uses: actions/cache@v2
+        id: go-cache
+        with:
+          path: |
+              ${{ steps.go-cache-paths.outputs.go-build }}
+              ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ matrix.os }}-go-cache-${{ hashFiles('**/go.sum') }}
+      - name: Compute current version to inform GoReleaser
+        run: |
+          echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
+      - name: Filter goreleaser config by OS
+        run: |
+          cat ${{ inputs.goreleaser-config }} | goreleaser-filter -no-blobs -goos ${{ matrix.os }} > .goreleaser.current.yml
+      - name: Run GoReleaser to build Go Pulumi binaries
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: -f .goreleaser.current.yml ${{ inputs.goreleaser-flags }}
+      - name: Upload pulumi-${{ matrix.os }}-arm64
+        uses: actions/upload-artifact@v2
+        with:
+            name: pulumi-${{ matrix.os }}-arm64
+            path: goreleaser/pulumi*-${{ matrix.os }}-arm64*
+            retention-days: 2
+      - name: Upload pulumi-${{ matrix.os }}-x64
+        uses: actions/upload-artifact@v2
+        with:
+            name: pulumi-${{ matrix.os }}-x64
+            path: goreleaser/pulumi*-${{ matrix.os }}-x64*
+            retention-days: 2
+
+  build_python_sdk:
+    name: Build Pulumi Python SDK wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
+      - name: Fetch Tags
+        run: |
+          git fetch --quiet --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Set up Python ${{ inputs.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ inputs.python-version }}
+      - name: Compute current version to inform wheel build
+        run: |
+          echo "PYPY_VERSION=$(pulumictl get version --language python)" >> $GITHUB_ENV
+      - name: Build Pulumi Python SDK wheel
+        run: |
+            # TODO unify with sdk/python/Makefile once that does not use pipenv
+            cp README.md sdk/python/lib
+            cd sdk/python/lib
+            sed -i.bak "s/\${VERSION}/$PYPY_VERSION/g" setup.py
+            rm setup.py.bak
+            python3 -m venv venv
+            source venv/bin/activate
+            python -m pip install wheel
+            python setup.py build bdist_wheel --python-tag py3
+      - name: Upload pulumi.whl
+        uses: actions/upload-artifact@v2
+        with:
+            name: pulumi.whl
+            path: sdk/python/lib/dist/*.whl
+
+  build_node_sdk:
+    name: Build Pulumi Node SDK tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
+      - name: Fetch Tags
+        run: |
+          git fetch --quiet --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Set up Node ${{ inputs.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ inputs.node-version }}
+      - name: Install yarn
+        run: |
+          npm install -g yarn
+      - name: Make no-op Go command to avoid Go builds
+        run: |
+          cd sdk/nodejs
+          mkdir -p bin
+          ln -s $(which echo) bin/go
+      - name: Ensure installed dependencies
+        run: |
+          cd sdk/nodejs
+          PATH=./bin:$PATH make ensure
+      - name: Build the Node SDK package
+        run: |
+          cd sdk/nodejs
+          PATH=./bin:$PATH make build_package
+      - name: Pack the Node SDK
+        run: |
+          cd sdk/nodejs/bin
+          npm pack
+      - name: Upload pulumi-node-sdk.tgz
+        uses: actions/upload-artifact@v2
+        with:
+            name: pulumi-node-sdk.tgz
+            path: sdk/nodejs/bin/*.tgz
+
+  build_dotnet_sdk:
+    name: Build Pulumi .NET SDK NuGet packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ env.PR_COMMIT_SHA }}
+      - name: Fetch Tags
+        run: |
+          git fetch --quiet --prune --unshallow --tags
+      - name: Install pulumictl
+        uses: jaxxstorm/action-install-gh-release@v1.2.0
+        with:
+          repo: pulumi/pulumictl
+      - name: Set up DotNet ${{ inputs.dotnet-version }}
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: ${{ inputs.dotnet-version }}
+      - name: Compute current version to inform the NuGet package build
+        run: |
+          echo "DOTNET_VERSION=$(pulumictl get version --language dotnet)" >> $GITHUB_ENV
+      - name: Build the .NET SDK package
+        run: |
+          cd sdk/dotnet
+          dotnet build --configuration Release dotnet.sln /p:Version=$DOTNET_VERSION
+      - name: Pack the .NET SDK package
+        run: |
+          cd sdk/dotnet
+          dotnet pack --configuration Release --output nupkgs dotnet.sln /p:Version=$DOTNET_VERSION
+      - name: Upload the NuGet packages
+        uses: actions/upload-artifact@v2
+        with:
+            name: pulumi-nuget-packages
+            path: sdk/dotnet/nupkgs/*.nupkg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,11 +180,14 @@ jobs:
       - name: Install yarn
         run: |
           npm install -g yarn
-      # - name: Make no-op Go command to avoid Go builds
-      #   run: |
-      #     cd sdk/nodejs
-      #     mkdir -p bin
-      #     ln -s $(which echo) bin/go
+      # TODO something in `cd sdk/nodejs && make ensure` executes Go
+      # downloads, which is unfortunate and wasteful in this context.
+      # When this is fixed the no-op Go command can be removed.
+      - name: Make no-op Go command to avoid Go builds
+        run: |
+           cd sdk/nodejs
+           mkdir -p bin
+           ln -s $(which echo) bin/go
       - name: Ensure installed dependencies
         run: |
           cd sdk/nodejs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,11 +180,11 @@ jobs:
       - name: Install yarn
         run: |
           npm install -g yarn
-      - name: Make no-op Go command to avoid Go builds
-        run: |
-          cd sdk/nodejs
-          mkdir -p bin
-          ln -s $(which echo) bin/go
+      # - name: Make no-op Go command to avoid Go builds
+      #   run: |
+      #     cd sdk/nodejs
+      #     mkdir -p bin
+      #     ln -s $(which echo) bin/go
       - name: Ensure installed dependencies
         run: |
           cd sdk/nodejs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,13 +140,13 @@ jobs:
           python-version: ${{ inputs.python-version }}
       - name: Compute current version to inform wheel build
         run: |
-          echo "PYPY_VERSION=$(pulumictl get version --language python)" >> $GITHUB_ENV
+          echo "PYPI_VERSION=$(pulumictl get version --language python)" >> $GITHUB_ENV
       - name: Build Pulumi Python SDK wheel
         run: |
             # TODO unify with sdk/python/Makefile once that does not use pipenv
             cp README.md sdk/python/lib
             cd sdk/python/lib
-            sed -i.bak "s/\${VERSION}/$PYPY_VERSION/g" setup.py
+            sed -i.bak "s/\${VERSION}/$PYPI_VERSION/g" setup.py
             rm setup.py.bak
             python3 -m venv venv
             source venv/bin/activate

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -33,6 +33,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   comment-notification:
     # We only care about adding the result to the PR if it's a repository_dispatch event
     if: github.event_name == 'repository_dispatch'
@@ -51,6 +52,7 @@ jobs:
             Please view the results of the PR Build + Acceptance Tests Run [Here][1]
 
             [1]: ${{ steps.vars.outputs.run-url }}
+
   go-lint:
     container: golangci/golangci-lint:latest
     name: Lint ${{ matrix.directory }}
@@ -66,6 +68,7 @@ jobs:
       - name: Lint ${{ matrix.directory }}
         run: |
           cd ${{ matrix.directory }} && golangci-lint run -c ../.golangci.yml
+
   sdk-lint:
     name: Lint SDKs
     runs-on: ubuntu-latest
@@ -124,8 +127,16 @@ jobs:
       - name: Lint .NET
         run: |
           cd sdk/dotnet && make lint
-  build_and_test:
-    name: Build & Test
+
+  build:
+    name: Build
+    uses: pulumi/pulumi/.github/workflows/build.yml@master
+    with:
+      enable-coverage: true
+
+  test:
+    name: Test
+    needs: build
     strategy:
       matrix:
         platform: [ ubuntu-latest, macos-latest ]
@@ -177,9 +188,12 @@ jobs:
       - run: mkdir -p ${{ runner.temp }}/opt/pulumi/nuget
       - run: dotnet nuget add source ${{ runner.temp }}/opt/pulumi/nuget
       - name: Set up Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Install yarn
+        run: |
+          npm install -g yarn
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip requests wheel urllib3 chardet
@@ -213,23 +227,62 @@ jobs:
         with:
           repo: t0yv0/goteststats
           tag: v0.0.7
-      - name: Ensure
+      - name: Download Pulumi Go Binaries (linux-x64)
+        if: ${{ matrix.platform == 'ubuntu-latest' }}
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-linux-x64
+          path: artifacts/go
+      - name: Download Pulumi Go Binaries (darwin-x64)
+        if: ${{ matrix.platform == 'macos-latest' }}
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-darwin-x64
+          path: artifacts/go
+      - name: Install Pulumi Go Binaries
         run: |
+          mkdir -p bin
+          tar -xf artifacts/go/*.tar.gz -C bin
+          echo "$PWD/bin/pulumi" >> $GITHUB_PATH
+      - name: Download Pulumi .NET NuGet packages
+        uses: actions/download-artifact@v2
+        with:
+          name: pulumi-nuget-packages
+          # path set to match PULUMI_LOCAL_NUGET
+          path: ${{ runner.temp }}/opt/pulumi/nuget
+      - name: Verify Pulumi Version
+        run: |
+          which pulumi
+          pulumi version
+          find ./bin
+      - name: Inspect downloaded artifacts
+        run: |
+          find artifacts
+          echo "PULUMI_LOCAL_NUGET=$PULUMI_LOCAL_NUGET"
+          ls $PULUMI_LOCAL_NUGET
+        env:
+          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
+      - name: Ensure dependencies for the Node SDK
+        run: |
+          cd sdk/nodejs
           make ensure
-      - name: Dist
+      - name: Build the Node SDK
         run: |
-          make dist
-        env:
-          PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
-          PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
-      - name: Install
+          cd sdk/nodejs
+          make build_package
+          cd bin
+          yarn link
+      - name: Ensure dependencies for the Python SDK
         run: |
-          make install_all
-        env:
-          PULUMI_NODE_MODULES: ${{ runner.temp }}/opt/pulumi/node_modules
-          PULUMI_LOCAL_NUGET: ${{ runner.temp }}/opt/pulumi/nuget
-          PULUMI_ROOT: ${{ runner.temp }}/opt/pulumi
+           cd sdk/python
+           make ensure
+      - name: Install Python SDK
+        run: |
+           cd sdk/python
+           make build_package
+      - name: Ensure coverage gathering dependencies
+        run: |
+           make ensure_cover
       - name: Test
         run: make TEST_ALL_DEPS= test_all
         env:
@@ -255,7 +308,6 @@ jobs:
       - name: Summarize Test Times by Indivudal Test
         run: |
           goteststats -statistic test-time test-results/*.json | head -n 100
-
 
   windows-build:
     name: Windows Build + Test

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -130,7 +130,7 @@ jobs:
 
   build:
     name: Build
-    uses: pulumi/pulumi/.github/workflows/build.yml@master
+    uses: pulumi/pulumi/.github/workflows/build.yml@ac24c5a52dd6849eb7f3eacebc2f9fcc85523cf7
     with:
       enable-coverage: true
 

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -130,7 +130,7 @@ jobs:
 
   build:
     name: Build
-    uses: pulumi/pulumi/.github/workflows/build.yml@ac24c5a52dd6849eb7f3eacebc2f9fcc85523cf7
+    uses: pulumi/pulumi/.github/workflows/build.yml@2d05be1c30797c026480b296c919d084860dbdb7
     with:
       enable-coverage: true
 

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -130,7 +130,7 @@ jobs:
 
   build:
     name: Build
-    uses: pulumi/pulumi/.github/workflows/build.yml@2d05be1c30797c026480b296c919d084860dbdb7
+    uses: pulumi/pulumi/.github/workflows/build.yml@1e2aeb1fa5ba85eec0c35629c180cf658d8cf3a5
     with:
       enable-coverage: true
 

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -130,7 +130,7 @@ jobs:
 
   build:
     name: Build
-    uses: pulumi/pulumi/.github/workflows/build.yml@1e2aeb1fa5ba85eec0c35629c180cf658d8cf3a5
+    uses: pulumi/pulumi/.github/workflows/build.yml@047dfbe3546c2b70a1b74a4cd3357c5472eb78c7
     with:
       enable-coverage: true
 

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -21,6 +21,7 @@ builds:
 # Windows builds
 - id: pulumi-windows
   binary: pulumi
+  gobinary: ../scripts/go-wrapper.sh
   dir: pkg
   goarch:
     - amd64
@@ -31,6 +32,7 @@ builds:
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-windows
   binary: pulumi-language-nodejs
+  # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -41,6 +43,7 @@ builds:
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-windows
   binary: pulumi-language-python
+  # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -51,6 +54,7 @@ builds:
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-windows
   binary: pulumi-language-dotnet
+  # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -61,6 +65,7 @@ builds:
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-windows
   binary: pulumi-language-go
+  # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -72,6 +77,7 @@ builds:
 # UNIX builds
 - id: pulumi-unix
   binary: pulumi
+  gobinary: ../scripts/go-wrapper.sh
   dir: pkg
   goarch:
     - amd64
@@ -84,6 +90,7 @@ builds:
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-unix
   binary: pulumi-language-nodejs
+  # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -96,6 +103,7 @@ builds:
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-unix
   binary: pulumi-language-python
+  # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -108,6 +116,7 @@ builds:
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-unix
   binary: pulumi-language-dotnet
+  # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -120,6 +129,7 @@ builds:
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-unix
   binary: pulumi-language-go
+  # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:
     - amd64
@@ -172,5 +182,5 @@ archives:
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 snapshot:
   name_template: "{{ .Version }}-SNAPSHOT"
-checksum: 
+checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"

--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -32,6 +32,9 @@ builds:
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-windows
   binary: pulumi-language-nodejs
+  # TODO[pulumi/pulumi#8615] - uncomment gobinary line below to enable
+  # coverage-aware builds of the language providers.
+  #
   # gobinary: ../scripts/go-wrapper.sh
   dir: sdk
   goarch:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,9 @@ build::
 install::
 	cd pkg && GOBIN=$(PULUMI_BIN) go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${VERSION}" ${PROJECT}
 else
-build:: build_cover
+build:: build_cover ensure_cover
+
+ensure_cover::
 	mkdir -p $(PULUMI_TEST_COVERAGE_PATH)
 
 install:: install_cover

--- a/scripts/go-wrapper.sh
+++ b/scripts/go-wrapper.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# To be used as a replacement for the `go` toolchain. The wrapper
+# unifies building binaries normally and building them with coverage
+# support using `go test -c`.
+
+PULUMI_TEST_COVERAGE_PATH=$PULUMI_TEST_COVERAGE_PATH
+
+set -euo pipefail
+
+PKG=github.com/pulumi/pulumi/pkg/v3/...
+SDK=github.com/pulumi/pulumi/sdk/v3/...
+COVERPKG=$PKG,$SDK
+
+if [ -z "$PULUMI_TEST_COVERAGE_PATH" ]; then
+    go "$@"
+else
+    case $1 in
+        build)
+            shift
+            go test -c -cover -coverpkg $COVERPKG "$@"
+            ;;
+        install)
+            echo "install command is not supported, please use build"
+            exit 1
+            ;;
+        *)
+            go "$@"
+            ;;
+    esac
+fi


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Enable a dedicated GitHub Actions step to build the Go binaries:

- uses [Goreleaser](https://goreleaser.com/) similarly to our released binaries
- coverage support: with enable-coverage flag, builds produce a `pulumi` CLI compiled for coverage tracking
- tests download and test the exact same binaries
- builds run in a parallel matrix per platform to speed them up
- macos builds necessarily run on a macos-latest worker because of CGO
- windows builds run on an ubuntu-latest worker with cross-compilation
  
Remaining work will build upon this:

- Refactor Windows builds (not touched with this change) to use the same structure
- Apply the changes to non-PR workflows - release, prerelease, master
- Figure out release integration so during release it's obvious that exact same binaries are tested as being released

Some ideas were attempted but look to require non-trivial changes to the test scripts and will not be done:

- Factor out Python wheel build similarly so it is not rebuilt during testing
- Ditto for Node tarball
- Ditto for Go SDK and test suites (separate from CLI pulumi binary and providers)

Internal notes available at https://github.com/pulumi/home/issues/1287

Fixes pulumi/home#1691

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
