### PR TITLE
[FIX] unprotect cmd example

### DIFF
--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -341,7 +341,7 @@ func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 			"as it is currently marked for protection. To unprotect the resource, "+
 			"either remove the `protect` flag from the resource in your Pulumi"+
 			"program and run `pulumi up` or use the command:\n"+
-			"`pulumi state unprotect `%s``", s.old.URN, s.old.URN)
+			"`pulumi state unprotect '%s'`", s.old.URN, s.old.URN)
 	}
 
 	// Deleting an External resource is a no-op, since Pulumi does not own the lifecycle.

--- a/pkg/resource/deploy/step.go
+++ b/pkg/resource/deploy/step.go
@@ -341,7 +341,7 @@ func (s *DeleteStep) Apply(preview bool) (resource.Status, StepCompleteFunc, err
 			"as it is currently marked for protection. To unprotect the resource, "+
 			"either remove the `protect` flag from the resource in your Pulumi"+
 			"program and run `pulumi up` or use the command:\n"+
-			"`pulumi state unprotect %s`", s.old.URN, s.old.URN)
+			"`pulumi state unprotect `%s``", s.old.URN, s.old.URN)
 	}
 
 	// Deleting an External resource is a no-op, since Pulumi does not own the lifecycle.


### PR DESCRIPTION
when I run `pulumi up` with a protected resource pulumi give an example , but that example is not working

```
    error: Preview failed: unable to delete resource "urn:pulumi:XXXXXX::XXXX::gcp:component:all_resource$gcp:storage/bucket:Bucket::bucket_XXXXX"
    as it is currently marked for protection. To unprotect the resource, either remove the `protect` flag from the resource in your Pulumiprogram and run `pulumi up` or use the command:
    `pulumi state unprotect urn:pulumi:XXXX::XXXX::gcp:component:all_resource$gcp:storage/bucket:Bucket::bucket_XXXXXX`
```

If I run the example cmd , it throw : 

```log
error: No such resource "urn:pulumi:XXXX::XXX::gcp:component:all_resource:storage/bucket:Bucket::bucket_XXXXX" exists in the current state
```

If i put around the urn some **`**  it work  : 

```
pulumi state unprotect `urn:pulumi:XXXX::XXXX::gcp:component:all_resource$gcp:storage/bucket:Bucket::bucket_XXXXXX`
```

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
