### PR TITLE
Move `/opt/pulumi` to `$HOME/.pulumi`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,8 +28,8 @@ RUN groupadd --gid $USER_GID $USER_NAME \
 
 RUN mkdir -p /go/bin \
     && chown -R $USER_NAME: /go \
-    && mkdir -p /opt/pulumi/bin \
-    && chown -R $USER_NAME: /opt/pulumi
+    && mkdir -p $HOME/.pulumi/bin \
+    && chown -R $USER_NAME: $HOME/.pulumi
 
 USER $USER_NAME
 
@@ -38,7 +38,7 @@ USER $USER_NAME
 ENV XDG_CONFIG_HOME=/home/$USER_NAME/.config
 ENV XDG_CACHE_HOME=/home/$USER_NAME/.cache
 
-RUN echo "export PATH=/opt/pulumi:/opt/pulumi/bin:$GOPATH/bin:/usr/local/go/bin:$PATH" >> ~/.bashrc \
+RUN echo "export PATH=$HOME/.pulumi:$HOME/.pulumi/bin:$GOPATH/bin:/usr/local/go/bin:$PATH" >> ~/.bashrc \
     && echo "alias l='ls -aF'" >> ~/.bash_aliases \
     && echo "alias ll='ls -ahlF'" >> ~/.bash_aliases \
     && echo "alias ls='ls --color=auto --group-directories-first'" >> ~/.bash_aliases

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,7 +5,7 @@ image:
 tasks:
   - before: >
       mkdir -p /workspace/opt-pulumi &&
-      sudo ln -s /workspace/opt-pulumi /opt/pulumi
+      sudo ln -s /workspace/opt-pulumi $HOME/.pulumi
     init: >
       make ensure &&
       make install

--- a/.gitpod/Dockerfile
+++ b/.gitpod/Dockerfile
@@ -1,7 +1,7 @@
 FROM gitpod/workspace-full
 USER gitpod
 
-ENV PATH="/opt/pulumi:/opt/pulumi/bin:$PATH"
+ENV PATH="$HOME/.pulumi:$HOME/.pulumi/bin:$PATH"
 
 # Install .NET Core 3.1 SDK binaries on Ubuntu 20.04
 # Source: https://dev.to/carlos487/installing-dotnet-core-in-ubuntu-20-04-6jh

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ We use `make` as our build system, so you'll want to install that as well, if yo
 We build Pulumi in `$PULUMI_ROOT`, which defaults to `$HOME/.pulumi`. If you would like to build Pulumi in another location, you do so by setting `$PULUMI_ROOT`. 
 
 ```bash
-export PATH=$HOME/.pulumi:$HOME/.pulumi/bin:$PATH
+export PATH=$HOME/.pulumi/bin:$PATH
 ```
 
 You'll also need to make sure your maximum open file descriptor limit is set to 5000 at a minimum.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,12 +38,10 @@ If you have a web browser, you can get a fully pre-configured Pulumi development
 
 We use `make` as our build system, so you'll want to install that as well, if you don't have it already. We have extremely limited support for doing development on Windows (the bare minimum for us to get Windows validation of `pulumi`) so if you're on windows, we recommend that you use the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). We'd like to [make this better](https://github.com/pulumi/pulumi/issues/208) so feel free to pitch in if you can.
 
-For historical reasons (which we'd [like to address](https://github.com/pulumi/pulumi/issues/1515)) our build system requires that the folder `/opt/pulumi` exists and is writable by the current user. If you'd like, you can override this location by setting `PULUMI_ROOT` in your environment. The build is known to fail if this doesn't exist, so you'll need to create it first.
+We build Pulumi in `$PULUMI_ROOT`, which defaults to `$HOME/.pulumi`. If you would like to build Pulumi in another location, you do so by setting `$PULUMI_ROOT`. 
 
 ```bash
-mkdir /opt/pulumi
-sudo chown <your_user_name>: /opt/pulumi
-export PATH=/opt/pulumi:/opt/pulumi/bin:$PATH
+export PATH=$HOME/.pulumi:$HOME/.pulumi/bin:$PATH
 ```
 
 You'll also need to make sure your maximum open file descriptor limit is set to 5000 at a minimum.

--- a/build/common.mk
+++ b/build/common.mk
@@ -96,9 +96,9 @@ SHELL       := /bin/bash
 STEP_MESSAGE = @echo -e "\033[0;32m$(shell echo '$@' | tr a-z A-Z | tr '_' ' '):\033[0m"
 
 # Our install targets place items item into $PULUMI_ROOT, if it's
-# unset, default to /opt/pulumi.
+# unset, default to `$HOME/.pulumi`.
 ifeq ($(PULUMI_ROOT),)
-	PULUMI_ROOT:=/opt/pulumi
+	PULUMI_ROOT:=$(shell realpath "$$HOME/.pulumi")
 endif
 
 # Use Python 3 explicitly vs expecting that `python` will resolve to a python 3
@@ -168,6 +168,7 @@ test_fast::
 
 install::
 	$(call STEP_MESSAGE)
+	# Implicitly creates PULUMI_ROOT.
 	@mkdir -p $(PULUMI_BIN)
 	@mkdir -p $(PULUMI_NODE_MODULES)
 	@mkdir -p $(PULUMI_NUGET)

--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -2008,7 +2008,8 @@ func (pt *ProgramTester) prepareDotNetProject(projinfo *engine.Projinfo) error {
 
 	localNuget := os.Getenv("PULUMI_LOCAL_NUGET")
 	if localNuget == "" {
-		localNuget = "/opt/pulumi/nuget"
+		home := os.Getenv("HOME")
+		localNuget = filepath.Join(home, ".pulumi", "nuget")
 	}
 
 	for _, dep := range pt.opts.Dependencies {

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -66,5 +66,5 @@ brew::
 
 publish:: build install
 	echo "Publishing .nupkgs to nuget.org:"
-	find /opt/pulumi/nuget -name 'Pulumi*.nupkg' \
+	find $(PULUMI_NUGET) -name 'Pulumi*.nupkg' \
 		-exec dotnet nuget push -k ${NUGET_PUBLISH_KEY} -s https://api.nuget.org/v3/index.json {} ';'

--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -36,7 +36,7 @@ At the moment, we only support building on macOS and Linux, where standard GNU t
 To build the SDK, simply run `make` from the root directory (where this `README` lives, at `sdk/nodejs/` from the repo's
 root).  This will build the code, run tests, and install the package and its supporting artifacts.
 
-At the moment, for local development, we install everything into `/opt/pulumi`.  You will want this on your `$PATH`.
+At the moment, for local development, we install everything into `$HOME/.pulumi`.  You will want this on your `$PATH`.
 
 The tests will verify that everything works, but feel free to try running `pulumi preview` and/or `pulumi up` from
 the `examples/minimal/` directory.  Remember to run `tsc` first, since `pulumi` expects JavaScript, not TypeScript.


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

`/opt/pulumi` is legacy of our build system we are trying to fix. We still need a place to put executables and artifacts. Luckily, `~/.pulumi` already exists. This moves our build artifacts from `/opt/pulumi.{bin,nuget,node_modules}` to `~/.pulumi/{bin,nuget,node_modules}`. This fixes the insane permissions problems of `/opt/pulumi`, as `~/.pulumi` is normal user accessible space. 

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
