### PR TITLE
[backend/filestate] Don't unwrap go-cloud errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,3 +16,6 @@
 
 - [codegen/typescript] - Respect default values in Pulumi object types.
   [#8400](https://github.com/pulumi/pulumi/pull/8400)
+
+- [cli] - Catch expected errors in filestate backend stacks.
+  [#8455](https://github.com/pulumi/pulumi/pull/8455)

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -882,14 +882,3 @@ func (b *localBackend) UpdateStackTags(ctx context.Context,
 	// The local backend does not currently persist tags.
 	return errors.New("stack tags not supported in --local mode")
 }
-
-// Returns the original error in the chain. If `err` is nil, nil is returned.
-func drillError(err error) error {
-	e := err
-	for errors.Unwrap(e) != nil {
-		if u := errors.Unwrap(e); u != nil {
-			e = u
-		}
-	}
-	return e
-}

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -323,7 +323,7 @@ func (b *localBackend) GetStack(ctx context.Context, stackRef backend.StackRefer
 	snapshot, path, err := b.getStack(stackName)
 
 	switch {
-	case gcerrors.Code(drillError(err)) == gcerrors.NotFound:
+	case gcerrors.Code(err) == gcerrors.NotFound:
 		return nil, nil
 	case err != nil:
 		return nil, err
@@ -887,7 +887,9 @@ func (b *localBackend) UpdateStackTags(ctx context.Context,
 func drillError(err error) error {
 	e := err
 	for errors.Unwrap(e) != nil {
-		e = errors.Unwrap(e)
+		if u := errors.Unwrap(e); u != nil {
+			e = u
+		}
 	}
 	return e
 }

--- a/pkg/backend/filestate/backend_test.go
+++ b/pkg/backend/filestate/backend_test.go
@@ -187,3 +187,20 @@ func TestListStacksWithMultiplePassphrases(t *testing.T) {
 	}
 
 }
+
+func TestDrillError(t *testing.T) {
+	// Login to a temp dir filestate backend
+	tmpDir, err := ioutil.TempDir("", "filestatebackend")
+	assert.NoError(t, err)
+	b, err := New(cmdutil.Diag(), "file://"+filepath.ToSlash(tmpDir))
+	assert.NoError(t, err)
+	ctx := context.Background()
+
+	// Get a non-existent stack and expect a nil error because it won't be found.
+	stackRef, err := b.ParseStackReference("dev")
+	if err != nil {
+		t.Fatalf("unexpected error %v when parsing stack reference", err)
+	}
+	_, err = b.GetStack(ctx, stackRef)
+	assert.Nil(t, err)
+}

--- a/pkg/backend/filestate/state.go
+++ b/pkg/backend/filestate/state.go
@@ -323,7 +323,7 @@ func (b *localBackend) getHistory(name tokens.QName, pageSize int, page int) ([]
 	allFiles, err := listBucket(b.bucket, dir)
 	if err != nil {
 		// History doesn't exist until a stack has been updated.
-		if gcerrors.Code(drillError(err)) == gcerrors.NotFound {
+		if gcerrors.Code(err) == gcerrors.NotFound {
 			return nil, nil
 		}
 		return nil, err
@@ -391,7 +391,7 @@ func (b *localBackend) renameHistory(oldName tokens.QName, newName tokens.QName)
 	allFiles, err := listBucket(b.bucket, oldHistory)
 	if err != nil {
 		// if there's nothing there, we don't really need to do a rename.
-		if gcerrors.Code(drillError(err)) == gcerrors.NotFound {
+		if gcerrors.Code(err) == gcerrors.NotFound {
 			return nil
 		}
 		return err


### PR DESCRIPTION
# Description

Pulumi CLI fails with the following error when running `pulumi stack select dev2 -c` to select a stack but first creating it, if it does not exist already.

```
pulumi stack select dev2 -c --cwd C:\GitHub\temp-pulumi-stacks\pr-test\
error: failed to load checkpoint: blob (key ".pulumi/stacks/dev2.json") (code=NotFound): CreateFile C:\temp\.pulumi\stacks\dev2.json: The system cannot find the file specified.
```

Fixes #8461 (Related to #8406)

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
