### PR TITLE
[cli] check main after master

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,7 @@
 ### Improvements
 
-- [cli] - Allow specifying branch with `#branch` in `pulumi new`.
+- [cli] - When running `pulumi new https://github.com/name/repo`, check 
+  for branch `main` if branch `master` doesn't exist.
   [#8463](https://github.com/pulumi/pulumi/pull/8463)
 
 - [codegen/python] - Program generator now uses `fn_output` forms where

--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- [cli] - Allow specifying branch with `#branch` in `pulumi new`.
+  [#8463](https://github.com/pulumi/pulumi/pull/8463)
+
 ### Bug Fixes
 
 - [codegen/typescript] - Respect default values in Pulumi object types.

--- a/sdk/go/common/util/gitutil/git.go
+++ b/sdk/go/common/util/gitutil/git.go
@@ -328,39 +328,39 @@ func parseGistURL(u *url.URL) (string, error) {
 // ParseGitRepoURL returns the URL to the Git repository and path from a raw URL.
 // For example, an input of "https://github.com/pulumi/templates/templates/javascript" returns
 // "https://github.com/pulumi/templates.git" and "templates/javascript".
-func ParseGitRepoURL(rawurl string) (string, string, string, error) {
+func ParseGitRepoURL(rawurl string) (string, string, error) {
 	u, err := url.Parse(rawurl)
 	if err != nil {
-		return "", "", "", err
+		return "", "", err
 	}
 
 	if u.Scheme != "https" {
-		return "", "", "", errors.New("invalid URL scheme")
+		return "", "", errors.New("invalid URL scheme")
 	}
 
 	// Special case Gists.
 	if u.Hostname() == "gist.github.com" {
 		repo, err := parseGistURL(u)
 		if err != nil {
-			return "", "", "", err
+			return "", "", err
 		}
-		return repo, "", "", nil
+		return repo, "", nil
 	}
 
 	path := strings.TrimPrefix(u.Path, "/")
 	paths := strings.Split(path, "/")
 	if len(paths) < 2 {
-		return "", "", "", errors.New("invalid Git URL")
+		return "", "", errors.New("invalid Git URL")
 	}
 
 	owner := paths[0]
 	if owner == "" {
-		return "", "", "", errors.New("invalid Git URL; no owner")
+		return "", "", errors.New("invalid Git URL; no owner")
 	}
 
 	repo := paths[1]
 	if repo == "" {
-		return "", "", "", errors.New("invalid Git URL; no repository")
+		return "", "", errors.New("invalid Git URL; no repository")
 	}
 
 	if !strings.HasSuffix(repo, ".git") {
@@ -368,10 +368,9 @@ func ParseGitRepoURL(rawurl string) (string, string, string, error) {
 	}
 
 	resultURL := u.Scheme + "://" + u.Host + "/" + owner + "/" + repo
-	branch := u.Fragment
 	resultPath := strings.TrimSuffix(strings.Join(paths[2:], "/"), "/")
 
-	return resultURL, resultPath, branch, nil
+	return resultURL, resultPath, nil
 }
 
 var gitSHARegex = regexp.MustCompile(`^[0-9a-fA-F]{40}$`)

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -25,38 +25,41 @@ import (
 )
 
 func TestParseGitRepoURL(t *testing.T) {
-	test := func(expectedURL string, expectedURLPath string, rawurl string) {
-		actualURL, actualURLPath, err := ParseGitRepoURL(rawurl)
+	test := func(expectedURL, expectedURLPath, expectedBranch string, rawurl string) {
+		actualURL, actualURLPath, actualBranch, err := ParseGitRepoURL(rawurl)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)
 		assert.Equal(t, expectedURLPath, actualURLPath)
+		assert.Equal(t, expectedBranch, actualBranch)
 	}
 
 	// GitHub.
 	pre := "https://github.com/pulumi/templates"
 	exp := pre + ".git"
-	test(exp, "", pre+".git")
-	test(exp, "", pre)
-	test(exp, "", pre+"/")
-	test(exp, "templates", pre+"/templates")
-	test(exp, "templates", pre+"/templates/")
-	test(exp, "templates/javascript", pre+"/templates/javascript")
-	test(exp, "templates/javascript", pre+"/templates/javascript/")
-	test(exp, "tree/master/templates", pre+"/tree/master/templates")
-	test(exp, "tree/master/templates/python", pre+"/tree/master/templates/python")
-	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates",
+	test(exp, "", "", pre+".git")
+	test(exp, "", "", pre)
+	test(exp, "", "", pre+"/")
+	test(exp, "templates", "", pre+"/templates")
+	test(exp, "templates", "", pre+"/templates/")
+	test(exp, "templates/javascript", "", pre+"/templates/javascript")
+	test(exp, "templates/javascript", "", pre+"/templates/javascript/")
+	test(exp, "tree/master/templates", "", pre+"/tree/master/templates")
+	test(exp, "tree/master/templates/python", "", pre+"/tree/master/templates/python")
+	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates", "",
 		pre+"/tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates")
-	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates/python",
+	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates/python", "",
 		pre+"/tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates/python")
+	test(exp, "foo", "bar", pre+"/foo"+"#bar")
+	//TODO: test branches
 
 	// Gists.
 	pre = "https://gist.github.com/user/1c8c6e43daf20924287c0d476e17de9a"
 	exp = "https://gist.github.com/1c8c6e43daf20924287c0d476e17de9a.git"
-	test(exp, "", pre)
-	test(exp, "", pre+"/")
+	test(exp, "", "", pre)
+	test(exp, "", "", pre+"/")
 
 	testError := func(rawurl string) {
-		_, _, err := ParseGitRepoURL(rawurl)
+		_, _, _, err := ParseGitRepoURL(rawurl)
 		assert.Error(t, err)
 	}
 

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -52,8 +52,8 @@ func TestParseGitRepoURL(t *testing.T) {
 	// Gists.
 	pre = "https://gist.github.com/user/1c8c6e43daf20924287c0d476e17de9a"
 	exp = "https://gist.github.com/1c8c6e43daf20924287c0d476e17de9a.git"
-	test(exp, "", "", pre)
-	test(exp, "", "", pre+"/")
+	test(exp, "", pre)
+	test(exp, "", pre+"/")
 
 	testError := func(rawurl string) {
 		_, _, err := ParseGitRepoURL(rawurl)

--- a/sdk/go/common/util/gitutil/git_test.go
+++ b/sdk/go/common/util/gitutil/git_test.go
@@ -25,32 +25,29 @@ import (
 )
 
 func TestParseGitRepoURL(t *testing.T) {
-	test := func(expectedURL, expectedURLPath, expectedBranch string, rawurl string) {
-		actualURL, actualURLPath, actualBranch, err := ParseGitRepoURL(rawurl)
+	test := func(expectedURL, expectedURLPath string, rawurl string) {
+		actualURL, actualURLPath, err := ParseGitRepoURL(rawurl)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedURL, actualURL)
 		assert.Equal(t, expectedURLPath, actualURLPath)
-		assert.Equal(t, expectedBranch, actualBranch)
 	}
 
 	// GitHub.
 	pre := "https://github.com/pulumi/templates"
 	exp := pre + ".git"
-	test(exp, "", "", pre+".git")
-	test(exp, "", "", pre)
-	test(exp, "", "", pre+"/")
-	test(exp, "templates", "", pre+"/templates")
-	test(exp, "templates", "", pre+"/templates/")
-	test(exp, "templates/javascript", "", pre+"/templates/javascript")
-	test(exp, "templates/javascript", "", pre+"/templates/javascript/")
-	test(exp, "tree/master/templates", "", pre+"/tree/master/templates")
-	test(exp, "tree/master/templates/python", "", pre+"/tree/master/templates/python")
-	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates", "",
+	test(exp, "", pre+".git")
+	test(exp, "", pre)
+	test(exp, "", pre+"/")
+	test(exp, "templates", pre+"/templates")
+	test(exp, "templates", pre+"/templates/")
+	test(exp, "templates/javascript", pre+"/templates/javascript")
+	test(exp, "templates/javascript", pre+"/templates/javascript/")
+	test(exp, "tree/master/templates", pre+"/tree/master/templates")
+	test(exp, "tree/master/templates/python", pre+"/tree/master/templates/python")
+	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates",
 		pre+"/tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates")
-	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates/python", "",
+	test(exp, "tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates/python",
 		pre+"/tree/929b6e4c5c39196ae2482b318f145e0d765e9608/templates/python")
-	test(exp, "foo", "bar", pre+"/foo"+"#bar")
-	//TODO: test branches
 
 	// Gists.
 	pre = "https://gist.github.com/user/1c8c6e43daf20924287c0d476e17de9a"
@@ -59,7 +56,7 @@ func TestParseGitRepoURL(t *testing.T) {
 	test(exp, "", "", pre+"/")
 
 	testError := func(rawurl string) {
-		_, _, _, err := ParseGitRepoURL(rawurl)
+		_, _, err := ParseGitRepoURL(rawurl)
 		assert.Error(t, err)
 	}
 

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -376,7 +376,7 @@ func RetrieveGitFolder(rawurl string, path string) (string, error) {
 	}
 	if ref != "" {
 
-		// Diffrent reference attempts to cycle through
+		// Different reference attempts to cycle through
 		var refAttempts []plumbing.ReferenceName
 		if ref != plumbing.HEAD {
 			// If we have a non-default reference, we just use it
@@ -393,7 +393,8 @@ func RetrieveGitFolder(rawurl string, path string) (string, error) {
 			// already existing processes for repos that already have a master and main branch.
 			refAttempts = []plumbing.ReferenceName{plumbing.Master, plumbing.NewBranchReferenceName("main")}
 		}
-		var cloneErr error = nil
+
+		var cloneErr error
 		for _, ref := range refAttempts {
 			// Attempt the clone. If it succeeds, break
 			cloneErr := gitutil.GitCloneOrPull(url, ref, path, true /*shallow*/)
@@ -404,6 +405,7 @@ func RetrieveGitFolder(rawurl string, path string) (string, error) {
 		if cloneErr != nil {
 			return "", fmt.Errorf("failed to clone ref '%s': %w", refAttempts[len(refAttempts)-1], cloneErr)
 		}
+
 	} else {
 		if cloneErr := gitutil.GitCloneAndCheckoutCommit(url, commit, path); cloneErr != nil {
 			return "", fmt.Errorf("failed to clone and checkout %s(%s): %w", url, commit, cloneErr)

--- a/sdk/go/common/workspace/templates.go
+++ b/sdk/go/common/workspace/templates.go
@@ -365,7 +365,7 @@ func retrievePulumiTemplates(templateName string, offline bool, templateKind Tem
 
 // RetrieveGitFolder downloads the repo to path and returns the full path on disk.
 func RetrieveGitFolder(rawurl string, path string) (string, error) {
-	url, urlPath, branch, err := gitutil.ParseGitRepoURL(rawurl)
+	url, urlPath, err := gitutil.ParseGitRepoURL(rawurl)
 	if err != nil {
 		return "", err
 	}
@@ -377,21 +377,13 @@ func RetrieveGitFolder(rawurl string, path string) (string, error) {
 	if ref != "" {
 
 		// Different reference attempts to cycle through
-		var refAttempts []plumbing.ReferenceName
+		// We default to master then main in that order. We need to order them to avoid breaking
+		// already existing processes for repos that already have a master and main branch.
+		refAttempts := []plumbing.ReferenceName{plumbing.Master, plumbing.NewBranchReferenceName("main")}
+
 		if ref != plumbing.HEAD {
 			// If we have a non-default reference, we just use it
 			refAttempts = []plumbing.ReferenceName{ref}
-		} else if branch != "" {
-			// If the branch is specified, we use that instead
-			ref = plumbing.ReferenceName(branch)
-			if len(strings.Split(branch, "/")) == 1 {
-				ref = plumbing.NewBranchReferenceName(branch)
-			}
-			refAttempts = []plumbing.ReferenceName{ref}
-		} else {
-			// We default to master then main in that order. We need to order them to avoid breaking
-			// already existing processes for repos that already have a master and main branch.
-			refAttempts = []plumbing.ReferenceName{plumbing.Master, plumbing.NewBranchReferenceName("main")}
 		}
 
 		var cloneErr error


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

If no branch is specified, probe `master`, then probe `main` before failing. 

Fixes #8428

I would be curious if anyone has a different idea on how to download branches from both master and main without breaking changes. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
