### PR TITLE
[sdk/pthon] Version Check: Handle virtual env correctly

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,3 +16,6 @@
 
 - [codegen/typescript] - Respect default values in Pulumi object types.
   [#8400](https://github.com/pulumi/pulumi/pull/8400)
+
+- [sdk/python] - Correctly handle version checking python virtual environments.
+  [#8465](https://github.com/pulumi/pulumi/pull/8465)

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -701,6 +701,6 @@ func validateVersion(virtualEnvPath string) {
 	} else if parsed.LT(eolPythonVersion) {
 		fmt.Fprintf(os.Stderr, "Python %d.%d is approaching EOL and will not be supported in Pulumi soon."+
 			" Check %s for more details\n", parsed.Major,
-			eolPythonVersion.Minor, eolPythonVersionIssue)
+			parsed.Minor, eolPythonVersionIssue)
 	}
 }

--- a/sdk/python/cmd/pulumi-language-python/main.go
+++ b/sdk/python/cmd/pulumi-language-python/main.go
@@ -678,7 +678,7 @@ func validateVersion(virtualEnvPath string) {
 	var versionCmd *exec.Cmd
 	var err error
 	versionArgs := []string{"--version"}
-	if virtualEnvPath == "" {
+	if virtualEnvPath != "" {
 		versionCmd = python.VirtualEnvCommand(virtualEnvPath, "python", versionArgs...)
 	} else if versionCmd, err = python.Command(versionArgs...); err != nil {
 		fmt.Fprintf(os.Stderr, "Failed to find python executable\n")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8460
Fixes #8468

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
