### PR TITLE
Tidy up generator trees

### DIFF
--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
@@ -441,10 +442,12 @@ func TestDeserializeInvalidResourceErrors(t *testing.T) {
 }
 
 func TestSerializePropertyValue(t *testing.T) {
+	gen := resource_testing.PropertyValueGenerator(6)
 	rapid.Check(t, func(t *rapid.T) {
-		v := resource_testing.PropertyValueGenerator(6).Draw(t, "property value").(resource.PropertyValue)
+		v := gen.Draw(t, "property value").(resource.PropertyValue)
+		t.Logf("Drawn v resource.PropertyValue: %v\n", spew.Sdump(v))
 		_, err := SerializePropertyValue(v, config.NopEncrypter, false)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -447,7 +447,7 @@ func TestSerializePropertyValue(t *testing.T) {
 		v := gen.Draw(t, "property value").(resource.PropertyValue)
 		t.Logf("Drawn v resource.PropertyValue: %v\n", spew.Sdump(v))
 		_, err := SerializePropertyValue(v, config.NopEncrypter, false)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	})
 }
 

--- a/sdk/go/common/resource/testing/rapid.go
+++ b/sdk/go/common/resource/testing/rapid.go
@@ -2,7 +2,7 @@
 package testing
 
 import (
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"pgregory.net/rapid"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -197,7 +197,7 @@ func StringPropertyGenerator() *rapid.Generator {
 func TextAssetGenerator() *rapid.Generator {
 	return rapid.Custom(func(t *rapid.T) *resource.Asset {
 		asset, err := resource.NewTextAsset(rapid.String().Draw(t, "text asset contents").(string))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		return asset
 	})
 }
@@ -223,7 +223,7 @@ func LiteralArchiveGenerator(maxDepth int) *rapid.Generator {
 		gen0: rapid.Custom(func(t *rapid.T) *resource.Archive {
 			contents := emptyContentsGen.Draw(t, "literal archive contents").(map[string]interface{})
 			archive, err := resource.NewAssetArchive(contents)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return archive
 		}),
 		gen1: func(self *rapid.Generator) *rapid.Generator {
@@ -233,7 +233,7 @@ func LiteralArchiveGenerator(maxDepth int) *rapid.Generator {
 			return rapid.Custom(func(t *rapid.T) *resource.Archive {
 				content := contentsGen.Draw(t, "literal archive contents").(map[string]interface{})
 				archive, err := resource.NewAssetArchive(content)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				return archive
 			})
 		},


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes #8464 

I played with #8464 repro which reproduces on master but I could not get the Go system to print the generated value or the error.

I was also noticing how slow it was generating the first example.

I also noticed that it doesn't reproduce if depth is lowered to 5.

The repro is basically this:

```
git co f98d39b84bc0e3a78a13dc09f80730e39a297b10 -b repro
cd pkg/resource/stack
go test -test.v -run="TestSerializePropertyValue" -rapid.seed=1314149388578197325

=== RUN   TestSerializePropertyValue
    deployment_test.go:444: [rapid] failed after 0 tests: (*T).FailNow() called
        To reproduce, specify -run="TestSerializePropertyValue" -rapid.failfile="TestSerializePropertyValue-20211119164007-93661.fail" (or -rapid.seed=1314149388578197325)
        Failed test output:
--- FAIL: TestSerializePropertyValue (105.05s)
FAIL

```

It is frying CPU for 105s.

It is quite concerning that I cannot print the value out. I am still playing with that a bit.

On a slight tangent, I found a way to generate recursive trees in Rapid that shrinks to smaller trees correctly and does not waste as many generator objects. Introducing this mechanically makes the test complete in <2s and I can no longer reproduce the problem. It might be possible that the reason for this is also accidentally lowering maxDepth by 1, but I think we want to take the change anyway.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
