### PR TITLE
Do not FailNow() in generators

### DIFF
--- a/sdk/go/common/resource/testing/rapid.go
+++ b/sdk/go/common/resource/testing/rapid.go
@@ -2,7 +2,7 @@
 package testing
 
 import (
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"pgregory.net/rapid"
 
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
@@ -191,7 +191,7 @@ func StringPropertyGenerator() *rapid.Generator {
 func TextAssetGenerator() *rapid.Generator {
 	return rapid.Custom(func(t *rapid.T) *resource.Asset {
 		asset, err := resource.NewTextAsset(rapid.String().Draw(t, "text asset contents").(string))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		return asset
 	})
 }
@@ -218,7 +218,7 @@ func LiteralArchiveGenerator(maxDepth int) *rapid.Generator {
 			contentsGenerator = rapid.Just(map[string]interface{}{})
 		}
 		archive, err := resource.NewAssetArchive(contentsGenerator.Draw(t, "literal archive contents").(map[string]interface{}))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		return archive
 	})
 }


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

It turns out that `require` calls t.FailNow() which causes undesirable quiet failure sometimes. IN contrast, it would seem that `assert.NoError(t, err)` in a generator skips the example and reruns the generator until a better example is found. This fixes #8464.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8464 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
