### PR TITLE
Add a unit test to check Array/Index

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -16,6 +16,12 @@
   appropriate, simplifying auto-generated examples.
   [#8432](https://github.com/pulumi/pulumi/pull/8432)
 
+- [codegen/go] - Remove `ResourcePtr` types from generated SDKs. Besides being
+  unnecessary--`Resource` types already accommodate `nil` to indicate the lack of
+  a value--the implementation of `Ptr` types for resources was incorrect, making
+  these types virtually unusable in practice.
+  [#8449](https://github.com/pulumi/pulumi/pull/8449)
+
 ### Bug Fixes
 
 - [codegen/typescript] - Respect default values in Pulumi object types.

--- a/pkg/codegen/internal/test/testdata/cyclic-types/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/cyclic-types/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/dash-named-schema/go/foo/provider.go
+++ b/pkg/codegen/internal/test/testdata/dash-named-schema/go/foo/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/dash-named-schema/go/foo/submodule1/moduleResource.go
+++ b/pkg/codegen/internal/test/testdata/dash-named-schema/go/foo/submodule1/moduleResource.go
@@ -76,7 +76,7 @@ type ModuleResourceInput interface {
 }
 
 func (*ModuleResource) ElementType() reflect.Type {
-	return reflect.TypeOf((*ModuleResource)(nil))
+	return reflect.TypeOf((**ModuleResource)(nil)).Elem()
 }
 
 func (i *ModuleResource) ToModuleResourceOutput() ModuleResourceOutput {
@@ -90,7 +90,7 @@ func (i *ModuleResource) ToModuleResourceOutputWithContext(ctx context.Context) 
 type ModuleResourceOutput struct{ *pulumi.OutputState }
 
 func (ModuleResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*ModuleResource)(nil))
+	return reflect.TypeOf((**ModuleResource)(nil)).Elem()
 }
 
 func (o ModuleResourceOutput) ToModuleResourceOutput() ModuleResourceOutput {

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/go/plant-provider/provider.go
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/go/plant-provider/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/nursery.go
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/nursery.go
@@ -83,7 +83,7 @@ type NurseryInput interface {
 }
 
 func (*Nursery) ElementType() reflect.Type {
-	return reflect.TypeOf((*Nursery)(nil))
+	return reflect.TypeOf((**Nursery)(nil)).Elem()
 }
 
 func (i *Nursery) ToNurseryOutput() NurseryOutput {
@@ -97,7 +97,7 @@ func (i *Nursery) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput 
 type NurseryOutput struct{ *pulumi.OutputState }
 
 func (NurseryOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Nursery)(nil))
+	return reflect.TypeOf((**Nursery)(nil)).Elem()
 }
 
 func (o NurseryOutput) ToNurseryOutput() NurseryOutput {

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/go/plant-provider/tree/v1/rubberTree.go
@@ -103,7 +103,7 @@ type RubberTreeInput interface {
 }
 
 func (*RubberTree) ElementType() reflect.Type {
-	return reflect.TypeOf((*RubberTree)(nil))
+	return reflect.TypeOf((**RubberTree)(nil)).Elem()
 }
 
 func (i *RubberTree) ToRubberTreeOutput() RubberTreeOutput {
@@ -117,7 +117,7 @@ func (i *RubberTree) ToRubberTreeOutputWithContext(ctx context.Context) RubberTr
 type RubberTreeOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*RubberTree)(nil))
+	return reflect.TypeOf((**RubberTree)(nil)).Elem()
 }
 
 func (o RubberTreeOutput) ToRubberTreeOutput() RubberTreeOutput {

--- a/pkg/codegen/internal/test/testdata/env-helper/go/example/foo.go
+++ b/pkg/codegen/internal/test/testdata/env-helper/go/example/foo.go
@@ -93,7 +93,7 @@ type FooInput interface {
 }
 
 func (*Foo) ElementType() reflect.Type {
-	return reflect.TypeOf((*Foo)(nil))
+	return reflect.TypeOf((**Foo)(nil)).Elem()
 }
 
 func (i *Foo) ToFooOutput() FooOutput {
@@ -107,7 +107,7 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Foo)(nil))
+	return reflect.TypeOf((**Foo)(nil)).Elem()
 }
 
 func (o FooOutput) ToFooOutput() FooOutput {

--- a/pkg/codegen/internal/test/testdata/env-helper/go/example/moduleTest.go
+++ b/pkg/codegen/internal/test/testdata/env-helper/go/example/moduleTest.go
@@ -76,7 +76,7 @@ type ModuleTestInput interface {
 }
 
 func (*ModuleTest) ElementType() reflect.Type {
-	return reflect.TypeOf((*ModuleTest)(nil))
+	return reflect.TypeOf((**ModuleTest)(nil)).Elem()
 }
 
 func (i *ModuleTest) ToModuleTestOutput() ModuleTestOutput {
@@ -90,7 +90,7 @@ func (i *ModuleTest) ToModuleTestOutputWithContext(ctx context.Context) ModuleTe
 type ModuleTestOutput struct{ *pulumi.OutputState }
 
 func (ModuleTestOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*ModuleTest)(nil))
+	return reflect.TypeOf((**ModuleTest)(nil)).Elem()
 }
 
 func (o ModuleTestOutput) ToModuleTestOutput() ModuleTestOutput {

--- a/pkg/codegen/internal/test/testdata/env-helper/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/env-helper/go/example/provider.go
@@ -53,7 +53,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -67,7 +67,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/cat.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/cat.go
@@ -77,7 +77,7 @@ type CatInput interface {
 }
 
 func (*Cat) ElementType() reflect.Type {
-	return reflect.TypeOf((*Cat)(nil))
+	return reflect.TypeOf((**Cat)(nil)).Elem()
 }
 
 func (i *Cat) ToCatOutput() CatOutput {
@@ -86,35 +86,6 @@ func (i *Cat) ToCatOutput() CatOutput {
 
 func (i *Cat) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatOutput)
-}
-
-func (i *Cat) ToCatPtrOutput() CatPtrOutput {
-	return i.ToCatPtrOutputWithContext(context.Background())
-}
-
-func (i *Cat) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(CatPtrOutput)
-}
-
-type CatPtrInput interface {
-	pulumi.Input
-
-	ToCatPtrOutput() CatPtrOutput
-	ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput
-}
-
-type catPtrType CatArgs
-
-func (*catPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Cat)(nil))
-}
-
-func (i *catPtrType) ToCatPtrOutput() CatPtrOutput {
-	return i.ToCatPtrOutputWithContext(context.Background())
-}
-
-func (i *catPtrType) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(CatPtrOutput)
 }
 
 // CatArrayInput is an input type that accepts CatArray and CatArrayOutput values.
@@ -170,7 +141,7 @@ func (i CatMap) ToCatMapOutputWithContext(ctx context.Context) CatMapOutput {
 type CatOutput struct{ *pulumi.OutputState }
 
 func (CatOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Cat)(nil))
+	return reflect.TypeOf((**Cat)(nil)).Elem()
 }
 
 func (o CatOutput) ToCatOutput() CatOutput {
@@ -181,44 +152,10 @@ func (o CatOutput) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return o
 }
 
-func (o CatOutput) ToCatPtrOutput() CatPtrOutput {
-	return o.ToCatPtrOutputWithContext(context.Background())
-}
-
-func (o CatOutput) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Cat) *Cat {
-		return &v
-	}).(CatPtrOutput)
-}
-
-type CatPtrOutput struct{ *pulumi.OutputState }
-
-func (CatPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Cat)(nil))
-}
-
-func (o CatPtrOutput) ToCatPtrOutput() CatPtrOutput {
-	return o
-}
-
-func (o CatPtrOutput) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return o
-}
-
-func (o CatPtrOutput) Elem() CatOutput {
-	return o.ApplyT(func(v *Cat) Cat {
-		if v != nil {
-			return *v
-		}
-		var ret Cat
-		return ret
-	}).(CatOutput)
-}
-
 type CatArrayOutput struct{ *pulumi.OutputState }
 
 func (CatArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Cat)(nil))
+	return reflect.TypeOf((*[]*Cat)(nil)).Elem()
 }
 
 func (o CatArrayOutput) ToCatArrayOutput() CatArrayOutput {
@@ -230,15 +167,15 @@ func (o CatArrayOutput) ToCatArrayOutputWithContext(ctx context.Context) CatArra
 }
 
 func (o CatArrayOutput) Index(i pulumi.IntInput) CatOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Cat {
-		return vs[0].([]Cat)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Cat {
+		return vs[0].([]*Cat)[vs[1].(int)]
 	}).(CatOutput)
 }
 
 type CatMapOutput struct{ *pulumi.OutputState }
 
 func (CatMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Cat)(nil))
+	return reflect.TypeOf((*map[string]*Cat)(nil)).Elem()
 }
 
 func (o CatMapOutput) ToCatMapOutput() CatMapOutput {
@@ -250,18 +187,16 @@ func (o CatMapOutput) ToCatMapOutputWithContext(ctx context.Context) CatMapOutpu
 }
 
 func (o CatMapOutput) MapIndex(k pulumi.StringInput) CatOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Cat {
-		return vs[0].(map[string]Cat)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Cat {
+		return vs[0].(map[string]*Cat)[vs[1].(string)]
 	}).(CatOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*CatInput)(nil)).Elem(), &Cat{})
-	pulumi.RegisterInputType(reflect.TypeOf((*CatPtrInput)(nil)).Elem(), &Cat{})
 	pulumi.RegisterInputType(reflect.TypeOf((*CatArrayInput)(nil)).Elem(), CatArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*CatMapInput)(nil)).Elem(), CatMap{})
 	pulumi.RegisterOutputType(CatOutput{})
-	pulumi.RegisterOutputType(CatPtrOutput{})
 	pulumi.RegisterOutputType(CatArrayOutput{})
 	pulumi.RegisterOutputType(CatMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/component.go
@@ -101,7 +101,7 @@ type ComponentInput interface {
 }
 
 func (*Component) ElementType() reflect.Type {
-	return reflect.TypeOf((*Component)(nil))
+	return reflect.TypeOf((**Component)(nil)).Elem()
 }
 
 func (i *Component) ToComponentOutput() ComponentOutput {
@@ -110,35 +110,6 @@ func (i *Component) ToComponentOutput() ComponentOutput {
 
 func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ComponentOutput)
-}
-
-func (i *Component) ToComponentPtrOutput() ComponentPtrOutput {
-	return i.ToComponentPtrOutputWithContext(context.Background())
-}
-
-func (i *Component) ToComponentPtrOutputWithContext(ctx context.Context) ComponentPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ComponentPtrOutput)
-}
-
-type ComponentPtrInput interface {
-	pulumi.Input
-
-	ToComponentPtrOutput() ComponentPtrOutput
-	ToComponentPtrOutputWithContext(ctx context.Context) ComponentPtrOutput
-}
-
-type componentPtrType ComponentArgs
-
-func (*componentPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Component)(nil))
-}
-
-func (i *componentPtrType) ToComponentPtrOutput() ComponentPtrOutput {
-	return i.ToComponentPtrOutputWithContext(context.Background())
-}
-
-func (i *componentPtrType) ToComponentPtrOutputWithContext(ctx context.Context) ComponentPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ComponentPtrOutput)
 }
 
 // ComponentArrayInput is an input type that accepts ComponentArray and ComponentArrayOutput values.
@@ -194,7 +165,7 @@ func (i ComponentMap) ToComponentMapOutputWithContext(ctx context.Context) Compo
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Component)(nil))
+	return reflect.TypeOf((**Component)(nil)).Elem()
 }
 
 func (o ComponentOutput) ToComponentOutput() ComponentOutput {
@@ -205,44 +176,10 @@ func (o ComponentOutput) ToComponentOutputWithContext(ctx context.Context) Compo
 	return o
 }
 
-func (o ComponentOutput) ToComponentPtrOutput() ComponentPtrOutput {
-	return o.ToComponentPtrOutputWithContext(context.Background())
-}
-
-func (o ComponentOutput) ToComponentPtrOutputWithContext(ctx context.Context) ComponentPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Component) *Component {
-		return &v
-	}).(ComponentPtrOutput)
-}
-
-type ComponentPtrOutput struct{ *pulumi.OutputState }
-
-func (ComponentPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Component)(nil))
-}
-
-func (o ComponentPtrOutput) ToComponentPtrOutput() ComponentPtrOutput {
-	return o
-}
-
-func (o ComponentPtrOutput) ToComponentPtrOutputWithContext(ctx context.Context) ComponentPtrOutput {
-	return o
-}
-
-func (o ComponentPtrOutput) Elem() ComponentOutput {
-	return o.ApplyT(func(v *Component) Component {
-		if v != nil {
-			return *v
-		}
-		var ret Component
-		return ret
-	}).(ComponentOutput)
-}
-
 type ComponentArrayOutput struct{ *pulumi.OutputState }
 
 func (ComponentArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Component)(nil))
+	return reflect.TypeOf((*[]*Component)(nil)).Elem()
 }
 
 func (o ComponentArrayOutput) ToComponentArrayOutput() ComponentArrayOutput {
@@ -254,15 +191,15 @@ func (o ComponentArrayOutput) ToComponentArrayOutputWithContext(ctx context.Cont
 }
 
 func (o ComponentArrayOutput) Index(i pulumi.IntInput) ComponentOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Component {
-		return vs[0].([]Component)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Component {
+		return vs[0].([]*Component)[vs[1].(int)]
 	}).(ComponentOutput)
 }
 
 type ComponentMapOutput struct{ *pulumi.OutputState }
 
 func (ComponentMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Component)(nil))
+	return reflect.TypeOf((*map[string]*Component)(nil)).Elem()
 }
 
 func (o ComponentMapOutput) ToComponentMapOutput() ComponentMapOutput {
@@ -274,18 +211,16 @@ func (o ComponentMapOutput) ToComponentMapOutputWithContext(ctx context.Context)
 }
 
 func (o ComponentMapOutput) MapIndex(k pulumi.StringInput) ComponentOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Component {
-		return vs[0].(map[string]Component)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Component {
+		return vs[0].(map[string]*Component)[vs[1].(string)]
 	}).(ComponentOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ComponentInput)(nil)).Elem(), &Component{})
-	pulumi.RegisterInputType(reflect.TypeOf((*ComponentPtrInput)(nil)).Elem(), &Component{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ComponentArrayInput)(nil)).Elem(), ComponentArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*ComponentMapInput)(nil)).Elem(), ComponentMap{})
 	pulumi.RegisterOutputType(ComponentOutput{})
-	pulumi.RegisterOutputType(ComponentPtrOutput{})
 	pulumi.RegisterOutputType(ComponentArrayOutput{})
 	pulumi.RegisterOutputType(ComponentMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -59,39 +59,10 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
-type ProviderPtrInput interface {
-	pulumi.Input
-
-	ToProviderPtrOutput() ProviderPtrOutput
-	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
-}
-
-type providerPtrType ProviderArgs
-
-func (*providerPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (i *providerPtrType) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {
@@ -102,43 +73,7 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
-func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
-		return &v
-	}).(ProviderPtrOutput)
-}
-
-type ProviderPtrOutput struct{ *pulumi.OutputState }
-
-func (ProviderPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) Elem() ProviderOutput {
-	return o.ApplyT(func(v *Provider) Provider {
-		if v != nil {
-			return *v
-		}
-		var ret Provider
-		return ret
-	}).(ProviderOutput)
-}
-
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ProviderInput)(nil)).Elem(), &Provider{})
-	pulumi.RegisterInputType(reflect.TypeOf((*ProviderPtrInput)(nil)).Elem(), &Provider{})
 	pulumi.RegisterOutputType(ProviderOutput{})
-	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/workload.go
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/go/example/workload.go
@@ -74,7 +74,7 @@ type WorkloadInput interface {
 }
 
 func (*Workload) ElementType() reflect.Type {
-	return reflect.TypeOf((*Workload)(nil))
+	return reflect.TypeOf((**Workload)(nil)).Elem()
 }
 
 func (i *Workload) ToWorkloadOutput() WorkloadOutput {
@@ -83,35 +83,6 @@ func (i *Workload) ToWorkloadOutput() WorkloadOutput {
 
 func (i *Workload) ToWorkloadOutputWithContext(ctx context.Context) WorkloadOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(WorkloadOutput)
-}
-
-func (i *Workload) ToWorkloadPtrOutput() WorkloadPtrOutput {
-	return i.ToWorkloadPtrOutputWithContext(context.Background())
-}
-
-func (i *Workload) ToWorkloadPtrOutputWithContext(ctx context.Context) WorkloadPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(WorkloadPtrOutput)
-}
-
-type WorkloadPtrInput interface {
-	pulumi.Input
-
-	ToWorkloadPtrOutput() WorkloadPtrOutput
-	ToWorkloadPtrOutputWithContext(ctx context.Context) WorkloadPtrOutput
-}
-
-type workloadPtrType WorkloadArgs
-
-func (*workloadPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Workload)(nil))
-}
-
-func (i *workloadPtrType) ToWorkloadPtrOutput() WorkloadPtrOutput {
-	return i.ToWorkloadPtrOutputWithContext(context.Background())
-}
-
-func (i *workloadPtrType) ToWorkloadPtrOutputWithContext(ctx context.Context) WorkloadPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(WorkloadPtrOutput)
 }
 
 // WorkloadArrayInput is an input type that accepts WorkloadArray and WorkloadArrayOutput values.
@@ -167,7 +138,7 @@ func (i WorkloadMap) ToWorkloadMapOutputWithContext(ctx context.Context) Workloa
 type WorkloadOutput struct{ *pulumi.OutputState }
 
 func (WorkloadOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Workload)(nil))
+	return reflect.TypeOf((**Workload)(nil)).Elem()
 }
 
 func (o WorkloadOutput) ToWorkloadOutput() WorkloadOutput {
@@ -178,44 +149,10 @@ func (o WorkloadOutput) ToWorkloadOutputWithContext(ctx context.Context) Workloa
 	return o
 }
 
-func (o WorkloadOutput) ToWorkloadPtrOutput() WorkloadPtrOutput {
-	return o.ToWorkloadPtrOutputWithContext(context.Background())
-}
-
-func (o WorkloadOutput) ToWorkloadPtrOutputWithContext(ctx context.Context) WorkloadPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Workload) *Workload {
-		return &v
-	}).(WorkloadPtrOutput)
-}
-
-type WorkloadPtrOutput struct{ *pulumi.OutputState }
-
-func (WorkloadPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Workload)(nil))
-}
-
-func (o WorkloadPtrOutput) ToWorkloadPtrOutput() WorkloadPtrOutput {
-	return o
-}
-
-func (o WorkloadPtrOutput) ToWorkloadPtrOutputWithContext(ctx context.Context) WorkloadPtrOutput {
-	return o
-}
-
-func (o WorkloadPtrOutput) Elem() WorkloadOutput {
-	return o.ApplyT(func(v *Workload) Workload {
-		if v != nil {
-			return *v
-		}
-		var ret Workload
-		return ret
-	}).(WorkloadOutput)
-}
-
 type WorkloadArrayOutput struct{ *pulumi.OutputState }
 
 func (WorkloadArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Workload)(nil))
+	return reflect.TypeOf((*[]*Workload)(nil)).Elem()
 }
 
 func (o WorkloadArrayOutput) ToWorkloadArrayOutput() WorkloadArrayOutput {
@@ -227,15 +164,15 @@ func (o WorkloadArrayOutput) ToWorkloadArrayOutputWithContext(ctx context.Contex
 }
 
 func (o WorkloadArrayOutput) Index(i pulumi.IntInput) WorkloadOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Workload {
-		return vs[0].([]Workload)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Workload {
+		return vs[0].([]*Workload)[vs[1].(int)]
 	}).(WorkloadOutput)
 }
 
 type WorkloadMapOutput struct{ *pulumi.OutputState }
 
 func (WorkloadMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Workload)(nil))
+	return reflect.TypeOf((*map[string]*Workload)(nil)).Elem()
 }
 
 func (o WorkloadMapOutput) ToWorkloadMapOutput() WorkloadMapOutput {
@@ -247,18 +184,16 @@ func (o WorkloadMapOutput) ToWorkloadMapOutputWithContext(ctx context.Context) W
 }
 
 func (o WorkloadMapOutput) MapIndex(k pulumi.StringInput) WorkloadOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Workload {
-		return vs[0].(map[string]Workload)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Workload {
+		return vs[0].(map[string]*Workload)[vs[1].(string)]
 	}).(WorkloadOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*WorkloadInput)(nil)).Elem(), &Workload{})
-	pulumi.RegisterInputType(reflect.TypeOf((*WorkloadPtrInput)(nil)).Elem(), &Workload{})
 	pulumi.RegisterInputType(reflect.TypeOf((*WorkloadArrayInput)(nil)).Elem(), WorkloadArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*WorkloadMapInput)(nil)).Elem(), WorkloadMap{})
 	pulumi.RegisterOutputType(WorkloadOutput{})
-	pulumi.RegisterOutputType(WorkloadPtrOutput{})
 	pulumi.RegisterOutputType(WorkloadArrayOutput{})
 	pulumi.RegisterOutputType(WorkloadMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/hyphen-url/go/registrygeoreplication/provider.go
+++ b/pkg/codegen/internal/test/testdata/hyphen-url/go/registrygeoreplication/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -59,39 +59,10 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
-type ProviderPtrInput interface {
-	pulumi.Input
-
-	ToProviderPtrOutput() ProviderPtrOutput
-	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
-}
-
-type providerPtrType ProviderArgs
-
-func (*providerPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (i *providerPtrType) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {
@@ -102,43 +73,7 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
-func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
-		return &v
-	}).(ProviderPtrOutput)
-}
-
-type ProviderPtrOutput struct{ *pulumi.OutputState }
-
-func (ProviderPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) Elem() ProviderOutput {
-	return o.ApplyT(func(v *Provider) Provider {
-		if v != nil {
-			return *v
-		}
-		var ret Provider
-		return ret
-	}).(ProviderOutput)
-}
-
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ProviderInput)(nil)).Elem(), &Provider{})
-	pulumi.RegisterInputType(reflect.TypeOf((*ProviderPtrInput)(nil)).Elem(), &Provider{})
 	pulumi.RegisterOutputType(ProviderOutput{})
-	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/hyphen-url/go/registrygeoreplication/registryGeoReplication.go
+++ b/pkg/codegen/internal/test/testdata/hyphen-url/go/registrygeoreplication/registryGeoReplication.go
@@ -65,7 +65,7 @@ type RegistryGeoReplicationInput interface {
 }
 
 func (*RegistryGeoReplication) ElementType() reflect.Type {
-	return reflect.TypeOf((*RegistryGeoReplication)(nil))
+	return reflect.TypeOf((**RegistryGeoReplication)(nil)).Elem()
 }
 
 func (i *RegistryGeoReplication) ToRegistryGeoReplicationOutput() RegistryGeoReplicationOutput {
@@ -74,35 +74,6 @@ func (i *RegistryGeoReplication) ToRegistryGeoReplicationOutput() RegistryGeoRep
 
 func (i *RegistryGeoReplication) ToRegistryGeoReplicationOutputWithContext(ctx context.Context) RegistryGeoReplicationOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(RegistryGeoReplicationOutput)
-}
-
-func (i *RegistryGeoReplication) ToRegistryGeoReplicationPtrOutput() RegistryGeoReplicationPtrOutput {
-	return i.ToRegistryGeoReplicationPtrOutputWithContext(context.Background())
-}
-
-func (i *RegistryGeoReplication) ToRegistryGeoReplicationPtrOutputWithContext(ctx context.Context) RegistryGeoReplicationPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(RegistryGeoReplicationPtrOutput)
-}
-
-type RegistryGeoReplicationPtrInput interface {
-	pulumi.Input
-
-	ToRegistryGeoReplicationPtrOutput() RegistryGeoReplicationPtrOutput
-	ToRegistryGeoReplicationPtrOutputWithContext(ctx context.Context) RegistryGeoReplicationPtrOutput
-}
-
-type registryGeoReplicationPtrType RegistryGeoReplicationArgs
-
-func (*registryGeoReplicationPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**RegistryGeoReplication)(nil))
-}
-
-func (i *registryGeoReplicationPtrType) ToRegistryGeoReplicationPtrOutput() RegistryGeoReplicationPtrOutput {
-	return i.ToRegistryGeoReplicationPtrOutputWithContext(context.Background())
-}
-
-func (i *registryGeoReplicationPtrType) ToRegistryGeoReplicationPtrOutputWithContext(ctx context.Context) RegistryGeoReplicationPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(RegistryGeoReplicationPtrOutput)
 }
 
 // RegistryGeoReplicationArrayInput is an input type that accepts RegistryGeoReplicationArray and RegistryGeoReplicationArrayOutput values.
@@ -158,7 +129,7 @@ func (i RegistryGeoReplicationMap) ToRegistryGeoReplicationMapOutputWithContext(
 type RegistryGeoReplicationOutput struct{ *pulumi.OutputState }
 
 func (RegistryGeoReplicationOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*RegistryGeoReplication)(nil))
+	return reflect.TypeOf((**RegistryGeoReplication)(nil)).Elem()
 }
 
 func (o RegistryGeoReplicationOutput) ToRegistryGeoReplicationOutput() RegistryGeoReplicationOutput {
@@ -169,44 +140,10 @@ func (o RegistryGeoReplicationOutput) ToRegistryGeoReplicationOutputWithContext(
 	return o
 }
 
-func (o RegistryGeoReplicationOutput) ToRegistryGeoReplicationPtrOutput() RegistryGeoReplicationPtrOutput {
-	return o.ToRegistryGeoReplicationPtrOutputWithContext(context.Background())
-}
-
-func (o RegistryGeoReplicationOutput) ToRegistryGeoReplicationPtrOutputWithContext(ctx context.Context) RegistryGeoReplicationPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v RegistryGeoReplication) *RegistryGeoReplication {
-		return &v
-	}).(RegistryGeoReplicationPtrOutput)
-}
-
-type RegistryGeoReplicationPtrOutput struct{ *pulumi.OutputState }
-
-func (RegistryGeoReplicationPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**RegistryGeoReplication)(nil))
-}
-
-func (o RegistryGeoReplicationPtrOutput) ToRegistryGeoReplicationPtrOutput() RegistryGeoReplicationPtrOutput {
-	return o
-}
-
-func (o RegistryGeoReplicationPtrOutput) ToRegistryGeoReplicationPtrOutputWithContext(ctx context.Context) RegistryGeoReplicationPtrOutput {
-	return o
-}
-
-func (o RegistryGeoReplicationPtrOutput) Elem() RegistryGeoReplicationOutput {
-	return o.ApplyT(func(v *RegistryGeoReplication) RegistryGeoReplication {
-		if v != nil {
-			return *v
-		}
-		var ret RegistryGeoReplication
-		return ret
-	}).(RegistryGeoReplicationOutput)
-}
-
 type RegistryGeoReplicationArrayOutput struct{ *pulumi.OutputState }
 
 func (RegistryGeoReplicationArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]RegistryGeoReplication)(nil))
+	return reflect.TypeOf((*[]*RegistryGeoReplication)(nil)).Elem()
 }
 
 func (o RegistryGeoReplicationArrayOutput) ToRegistryGeoReplicationArrayOutput() RegistryGeoReplicationArrayOutput {
@@ -218,15 +155,15 @@ func (o RegistryGeoReplicationArrayOutput) ToRegistryGeoReplicationArrayOutputWi
 }
 
 func (o RegistryGeoReplicationArrayOutput) Index(i pulumi.IntInput) RegistryGeoReplicationOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) RegistryGeoReplication {
-		return vs[0].([]RegistryGeoReplication)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *RegistryGeoReplication {
+		return vs[0].([]*RegistryGeoReplication)[vs[1].(int)]
 	}).(RegistryGeoReplicationOutput)
 }
 
 type RegistryGeoReplicationMapOutput struct{ *pulumi.OutputState }
 
 func (RegistryGeoReplicationMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]RegistryGeoReplication)(nil))
+	return reflect.TypeOf((*map[string]*RegistryGeoReplication)(nil)).Elem()
 }
 
 func (o RegistryGeoReplicationMapOutput) ToRegistryGeoReplicationMapOutput() RegistryGeoReplicationMapOutput {
@@ -238,18 +175,16 @@ func (o RegistryGeoReplicationMapOutput) ToRegistryGeoReplicationMapOutputWithCo
 }
 
 func (o RegistryGeoReplicationMapOutput) MapIndex(k pulumi.StringInput) RegistryGeoReplicationOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) RegistryGeoReplication {
-		return vs[0].(map[string]RegistryGeoReplication)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *RegistryGeoReplication {
+		return vs[0].(map[string]*RegistryGeoReplication)[vs[1].(string)]
 	}).(RegistryGeoReplicationOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*RegistryGeoReplicationInput)(nil)).Elem(), &RegistryGeoReplication{})
-	pulumi.RegisterInputType(reflect.TypeOf((*RegistryGeoReplicationPtrInput)(nil)).Elem(), &RegistryGeoReplication{})
 	pulumi.RegisterInputType(reflect.TypeOf((*RegistryGeoReplicationArrayInput)(nil)).Elem(), RegistryGeoReplicationArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*RegistryGeoReplicationMapInput)(nil)).Elem(), RegistryGeoReplicationMap{})
 	pulumi.RegisterOutputType(RegistryGeoReplicationOutput{})
-	pulumi.RegisterOutputType(RegistryGeoReplicationPtrOutput{})
 	pulumi.RegisterOutputType(RegistryGeoReplicationArrayOutput{})
 	pulumi.RegisterOutputType(RegistryGeoReplicationMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/naming-collisions/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/naming-collisions/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/naming-collisions/go/example/resource.go
+++ b/pkg/codegen/internal/test/testdata/naming-collisions/go/example/resource.go
@@ -73,7 +73,7 @@ type ResourceInput interface {
 }
 
 func (*Resource) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (i *Resource) ToResourceOutput() ResourceOutput {
@@ -87,7 +87,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (o ResourceOutput) ToResourceOutput() ResourceOutput {

--- a/pkg/codegen/internal/test/testdata/naming-collisions/go/example/resourceInput.go
+++ b/pkg/codegen/internal/test/testdata/naming-collisions/go/example/resourceInput.go
@@ -73,7 +73,7 @@ type ResourceInputResourceInput interface {
 }
 
 func (*ResourceInputResource) ElementType() reflect.Type {
-	return reflect.TypeOf((*ResourceInputResource)(nil))
+	return reflect.TypeOf((**ResourceInputResource)(nil)).Elem()
 }
 
 func (i *ResourceInputResource) ToResourceInputResourceOutput() ResourceInputResourceOutput {
@@ -87,7 +87,7 @@ func (i *ResourceInputResource) ToResourceInputResourceOutputWithContext(ctx con
 type ResourceInputResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceInputResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*ResourceInputResource)(nil))
+	return reflect.TypeOf((**ResourceInputResource)(nil)).Elem()
 }
 
 func (o ResourceInputResourceOutput) ToResourceInputResourceOutput() ResourceInputResourceOutput {

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/go/foo/deeply/nested/module/resource.go
@@ -82,7 +82,7 @@ type ResourceInput interface {
 }
 
 func (*Resource) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (i *Resource) ToResourceOutput() ResourceOutput {
@@ -96,7 +96,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (o ResourceOutput) ToResourceOutput() ResourceOutput {

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/go/foo/provider.go
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/go/foo/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/nested-module/go/foo/nested/module/resource.go
+++ b/pkg/codegen/internal/test/testdata/nested-module/go/foo/nested/module/resource.go
@@ -82,7 +82,7 @@ type ResourceInput interface {
 }
 
 func (*Resource) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (i *Resource) ToResourceOutput() ResourceOutput {
@@ -96,7 +96,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (o ResourceOutput) ToResourceOutput() ResourceOutput {

--- a/pkg/codegen/internal/test/testdata/nested-module/go/foo/provider.go
+++ b/pkg/codegen/internal/test/testdata/nested-module/go/foo/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/go/myedgeorder/provider.go
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/go/myedgeorder/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/go/mypkg/provider.go
+++ b/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/go/mypkg/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/output-funcs/go/mypkg/provider.go
+++ b/pkg/codegen/internal/test/testdata/output-funcs/go/mypkg/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/plain-and-default/go/foo/moduleResource.go
+++ b/pkg/codegen/internal/test/testdata/plain-and-default/go/foo/moduleResource.go
@@ -155,7 +155,7 @@ type ModuleResourceInput interface {
 }
 
 func (*ModuleResource) ElementType() reflect.Type {
-	return reflect.TypeOf((*ModuleResource)(nil))
+	return reflect.TypeOf((**ModuleResource)(nil)).Elem()
 }
 
 func (i *ModuleResource) ToModuleResourceOutput() ModuleResourceOutput {
@@ -169,7 +169,7 @@ func (i *ModuleResource) ToModuleResourceOutputWithContext(ctx context.Context) 
 type ModuleResourceOutput struct{ *pulumi.OutputState }
 
 func (ModuleResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*ModuleResource)(nil))
+	return reflect.TypeOf((**ModuleResource)(nil)).Elem()
 }
 
 func (o ModuleResourceOutput) ToModuleResourceOutput() ModuleResourceOutput {

--- a/pkg/codegen/internal/test/testdata/plain-and-default/go/foo/provider.go
+++ b/pkg/codegen/internal/test/testdata/plain-and-default/go/foo/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/provider.go
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -59,39 +59,10 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
-type ProviderPtrInput interface {
-	pulumi.Input
-
-	ToProviderPtrOutput() ProviderPtrOutput
-	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
-}
-
-type providerPtrType ProviderArgs
-
-func (*providerPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (i *providerPtrType) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {
@@ -102,43 +73,7 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
-func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
-		return &v
-	}).(ProviderPtrOutput)
-}
-
-type ProviderPtrOutput struct{ *pulumi.OutputState }
-
-func (ProviderPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) Elem() ProviderOutput {
-	return o.ApplyT(func(v *Provider) Provider {
-		if v != nil {
-			return *v
-		}
-		var ret Provider
-		return ret
-	}).(ProviderOutput)
-}
-
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ProviderInput)(nil)).Elem(), &Provider{})
-	pulumi.RegisterInputType(reflect.TypeOf((*ProviderPtrInput)(nil)).Elem(), &Provider{})
 	pulumi.RegisterOutputType(ProviderOutput{})
-	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/go/xyz/staticPage.go
@@ -64,7 +64,7 @@ type StaticPageInput interface {
 }
 
 func (*StaticPage) ElementType() reflect.Type {
-	return reflect.TypeOf((*StaticPage)(nil))
+	return reflect.TypeOf((**StaticPage)(nil)).Elem()
 }
 
 func (i *StaticPage) ToStaticPageOutput() StaticPageOutput {
@@ -73,35 +73,6 @@ func (i *StaticPage) ToStaticPageOutput() StaticPageOutput {
 
 func (i *StaticPage) ToStaticPageOutputWithContext(ctx context.Context) StaticPageOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(StaticPageOutput)
-}
-
-func (i *StaticPage) ToStaticPagePtrOutput() StaticPagePtrOutput {
-	return i.ToStaticPagePtrOutputWithContext(context.Background())
-}
-
-func (i *StaticPage) ToStaticPagePtrOutputWithContext(ctx context.Context) StaticPagePtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(StaticPagePtrOutput)
-}
-
-type StaticPagePtrInput interface {
-	pulumi.Input
-
-	ToStaticPagePtrOutput() StaticPagePtrOutput
-	ToStaticPagePtrOutputWithContext(ctx context.Context) StaticPagePtrOutput
-}
-
-type staticPagePtrType StaticPageArgs
-
-func (*staticPagePtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**StaticPage)(nil))
-}
-
-func (i *staticPagePtrType) ToStaticPagePtrOutput() StaticPagePtrOutput {
-	return i.ToStaticPagePtrOutputWithContext(context.Background())
-}
-
-func (i *staticPagePtrType) ToStaticPagePtrOutputWithContext(ctx context.Context) StaticPagePtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(StaticPagePtrOutput)
 }
 
 // StaticPageArrayInput is an input type that accepts StaticPageArray and StaticPageArrayOutput values.
@@ -157,7 +128,7 @@ func (i StaticPageMap) ToStaticPageMapOutputWithContext(ctx context.Context) Sta
 type StaticPageOutput struct{ *pulumi.OutputState }
 
 func (StaticPageOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*StaticPage)(nil))
+	return reflect.TypeOf((**StaticPage)(nil)).Elem()
 }
 
 func (o StaticPageOutput) ToStaticPageOutput() StaticPageOutput {
@@ -168,44 +139,10 @@ func (o StaticPageOutput) ToStaticPageOutputWithContext(ctx context.Context) Sta
 	return o
 }
 
-func (o StaticPageOutput) ToStaticPagePtrOutput() StaticPagePtrOutput {
-	return o.ToStaticPagePtrOutputWithContext(context.Background())
-}
-
-func (o StaticPageOutput) ToStaticPagePtrOutputWithContext(ctx context.Context) StaticPagePtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v StaticPage) *StaticPage {
-		return &v
-	}).(StaticPagePtrOutput)
-}
-
-type StaticPagePtrOutput struct{ *pulumi.OutputState }
-
-func (StaticPagePtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**StaticPage)(nil))
-}
-
-func (o StaticPagePtrOutput) ToStaticPagePtrOutput() StaticPagePtrOutput {
-	return o
-}
-
-func (o StaticPagePtrOutput) ToStaticPagePtrOutputWithContext(ctx context.Context) StaticPagePtrOutput {
-	return o
-}
-
-func (o StaticPagePtrOutput) Elem() StaticPageOutput {
-	return o.ApplyT(func(v *StaticPage) StaticPage {
-		if v != nil {
-			return *v
-		}
-		var ret StaticPage
-		return ret
-	}).(StaticPageOutput)
-}
-
 type StaticPageArrayOutput struct{ *pulumi.OutputState }
 
 func (StaticPageArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]StaticPage)(nil))
+	return reflect.TypeOf((*[]*StaticPage)(nil)).Elem()
 }
 
 func (o StaticPageArrayOutput) ToStaticPageArrayOutput() StaticPageArrayOutput {
@@ -217,15 +154,15 @@ func (o StaticPageArrayOutput) ToStaticPageArrayOutputWithContext(ctx context.Co
 }
 
 func (o StaticPageArrayOutput) Index(i pulumi.IntInput) StaticPageOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) StaticPage {
-		return vs[0].([]StaticPage)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *StaticPage {
+		return vs[0].([]*StaticPage)[vs[1].(int)]
 	}).(StaticPageOutput)
 }
 
 type StaticPageMapOutput struct{ *pulumi.OutputState }
 
 func (StaticPageMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]StaticPage)(nil))
+	return reflect.TypeOf((*map[string]*StaticPage)(nil)).Elem()
 }
 
 func (o StaticPageMapOutput) ToStaticPageMapOutput() StaticPageMapOutput {
@@ -237,18 +174,16 @@ func (o StaticPageMapOutput) ToStaticPageMapOutputWithContext(ctx context.Contex
 }
 
 func (o StaticPageMapOutput) MapIndex(k pulumi.StringInput) StaticPageOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) StaticPage {
-		return vs[0].(map[string]StaticPage)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *StaticPage {
+		return vs[0].(map[string]*StaticPage)[vs[1].(string)]
 	}).(StaticPageOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*StaticPageInput)(nil)).Elem(), &StaticPage{})
-	pulumi.RegisterInputType(reflect.TypeOf((*StaticPagePtrInput)(nil)).Elem(), &StaticPage{})
 	pulumi.RegisterInputType(reflect.TypeOf((*StaticPageArrayInput)(nil)).Elem(), StaticPageArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*StaticPageMapInput)(nil)).Elem(), StaticPageMap{})
 	pulumi.RegisterOutputType(StaticPageOutput{})
-	pulumi.RegisterOutputType(StaticPagePtrOutput{})
 	pulumi.RegisterOutputType(StaticPageArrayOutput{})
 	pulumi.RegisterOutputType(StaticPageMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/go/configstation/provider.go
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/go/configstation/provider.go
@@ -55,7 +55,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -69,7 +69,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/regress-node-8110/go/my8110/provider.go
+++ b/pkg/codegen/internal/test/testdata/regress-node-8110/go/my8110/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/replace-on-change/go/example/cat.go
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/go/example/cat.go
@@ -93,7 +93,7 @@ type CatInput interface {
 }
 
 func (*Cat) ElementType() reflect.Type {
-	return reflect.TypeOf((*Cat)(nil))
+	return reflect.TypeOf((**Cat)(nil)).Elem()
 }
 
 func (i *Cat) ToCatOutput() CatOutput {
@@ -102,35 +102,6 @@ func (i *Cat) ToCatOutput() CatOutput {
 
 func (i *Cat) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(CatOutput)
-}
-
-func (i *Cat) ToCatPtrOutput() CatPtrOutput {
-	return i.ToCatPtrOutputWithContext(context.Background())
-}
-
-func (i *Cat) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(CatPtrOutput)
-}
-
-type CatPtrInput interface {
-	pulumi.Input
-
-	ToCatPtrOutput() CatPtrOutput
-	ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput
-}
-
-type catPtrType CatArgs
-
-func (*catPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Cat)(nil))
-}
-
-func (i *catPtrType) ToCatPtrOutput() CatPtrOutput {
-	return i.ToCatPtrOutputWithContext(context.Background())
-}
-
-func (i *catPtrType) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(CatPtrOutput)
 }
 
 // CatArrayInput is an input type that accepts CatArray and CatArrayOutput values.
@@ -186,7 +157,7 @@ func (i CatMap) ToCatMapOutputWithContext(ctx context.Context) CatMapOutput {
 type CatOutput struct{ *pulumi.OutputState }
 
 func (CatOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Cat)(nil))
+	return reflect.TypeOf((**Cat)(nil)).Elem()
 }
 
 func (o CatOutput) ToCatOutput() CatOutput {
@@ -197,44 +168,10 @@ func (o CatOutput) ToCatOutputWithContext(ctx context.Context) CatOutput {
 	return o
 }
 
-func (o CatOutput) ToCatPtrOutput() CatPtrOutput {
-	return o.ToCatPtrOutputWithContext(context.Background())
-}
-
-func (o CatOutput) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Cat) *Cat {
-		return &v
-	}).(CatPtrOutput)
-}
-
-type CatPtrOutput struct{ *pulumi.OutputState }
-
-func (CatPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Cat)(nil))
-}
-
-func (o CatPtrOutput) ToCatPtrOutput() CatPtrOutput {
-	return o
-}
-
-func (o CatPtrOutput) ToCatPtrOutputWithContext(ctx context.Context) CatPtrOutput {
-	return o
-}
-
-func (o CatPtrOutput) Elem() CatOutput {
-	return o.ApplyT(func(v *Cat) Cat {
-		if v != nil {
-			return *v
-		}
-		var ret Cat
-		return ret
-	}).(CatOutput)
-}
-
 type CatArrayOutput struct{ *pulumi.OutputState }
 
 func (CatArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Cat)(nil))
+	return reflect.TypeOf((*[]*Cat)(nil)).Elem()
 }
 
 func (o CatArrayOutput) ToCatArrayOutput() CatArrayOutput {
@@ -246,15 +183,15 @@ func (o CatArrayOutput) ToCatArrayOutputWithContext(ctx context.Context) CatArra
 }
 
 func (o CatArrayOutput) Index(i pulumi.IntInput) CatOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Cat {
-		return vs[0].([]Cat)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Cat {
+		return vs[0].([]*Cat)[vs[1].(int)]
 	}).(CatOutput)
 }
 
 type CatMapOutput struct{ *pulumi.OutputState }
 
 func (CatMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Cat)(nil))
+	return reflect.TypeOf((*map[string]*Cat)(nil)).Elem()
 }
 
 func (o CatMapOutput) ToCatMapOutput() CatMapOutput {
@@ -266,14 +203,13 @@ func (o CatMapOutput) ToCatMapOutputWithContext(ctx context.Context) CatMapOutpu
 }
 
 func (o CatMapOutput) MapIndex(k pulumi.StringInput) CatOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Cat {
-		return vs[0].(map[string]Cat)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Cat {
+		return vs[0].(map[string]*Cat)[vs[1].(string)]
 	}).(CatOutput)
 }
 
 func init() {
 	pulumi.RegisterOutputType(CatOutput{})
-	pulumi.RegisterOutputType(CatPtrOutput{})
 	pulumi.RegisterOutputType(CatArrayOutput{})
 	pulumi.RegisterOutputType(CatMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/replace-on-change/go/example/dog.go
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/go/example/dog.go
@@ -77,7 +77,7 @@ type DogInput interface {
 }
 
 func (*Dog) ElementType() reflect.Type {
-	return reflect.TypeOf((*Dog)(nil))
+	return reflect.TypeOf((**Dog)(nil)).Elem()
 }
 
 func (i *Dog) ToDogOutput() DogOutput {
@@ -86,35 +86,6 @@ func (i *Dog) ToDogOutput() DogOutput {
 
 func (i *Dog) ToDogOutputWithContext(ctx context.Context) DogOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(DogOutput)
-}
-
-func (i *Dog) ToDogPtrOutput() DogPtrOutput {
-	return i.ToDogPtrOutputWithContext(context.Background())
-}
-
-func (i *Dog) ToDogPtrOutputWithContext(ctx context.Context) DogPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(DogPtrOutput)
-}
-
-type DogPtrInput interface {
-	pulumi.Input
-
-	ToDogPtrOutput() DogPtrOutput
-	ToDogPtrOutputWithContext(ctx context.Context) DogPtrOutput
-}
-
-type dogPtrType DogArgs
-
-func (*dogPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Dog)(nil))
-}
-
-func (i *dogPtrType) ToDogPtrOutput() DogPtrOutput {
-	return i.ToDogPtrOutputWithContext(context.Background())
-}
-
-func (i *dogPtrType) ToDogPtrOutputWithContext(ctx context.Context) DogPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(DogPtrOutput)
 }
 
 // DogArrayInput is an input type that accepts DogArray and DogArrayOutput values.
@@ -170,7 +141,7 @@ func (i DogMap) ToDogMapOutputWithContext(ctx context.Context) DogMapOutput {
 type DogOutput struct{ *pulumi.OutputState }
 
 func (DogOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Dog)(nil))
+	return reflect.TypeOf((**Dog)(nil)).Elem()
 }
 
 func (o DogOutput) ToDogOutput() DogOutput {
@@ -181,44 +152,10 @@ func (o DogOutput) ToDogOutputWithContext(ctx context.Context) DogOutput {
 	return o
 }
 
-func (o DogOutput) ToDogPtrOutput() DogPtrOutput {
-	return o.ToDogPtrOutputWithContext(context.Background())
-}
-
-func (o DogOutput) ToDogPtrOutputWithContext(ctx context.Context) DogPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Dog) *Dog {
-		return &v
-	}).(DogPtrOutput)
-}
-
-type DogPtrOutput struct{ *pulumi.OutputState }
-
-func (DogPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Dog)(nil))
-}
-
-func (o DogPtrOutput) ToDogPtrOutput() DogPtrOutput {
-	return o
-}
-
-func (o DogPtrOutput) ToDogPtrOutputWithContext(ctx context.Context) DogPtrOutput {
-	return o
-}
-
-func (o DogPtrOutput) Elem() DogOutput {
-	return o.ApplyT(func(v *Dog) Dog {
-		if v != nil {
-			return *v
-		}
-		var ret Dog
-		return ret
-	}).(DogOutput)
-}
-
 type DogArrayOutput struct{ *pulumi.OutputState }
 
 func (DogArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Dog)(nil))
+	return reflect.TypeOf((*[]*Dog)(nil)).Elem()
 }
 
 func (o DogArrayOutput) ToDogArrayOutput() DogArrayOutput {
@@ -230,15 +167,15 @@ func (o DogArrayOutput) ToDogArrayOutputWithContext(ctx context.Context) DogArra
 }
 
 func (o DogArrayOutput) Index(i pulumi.IntInput) DogOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Dog {
-		return vs[0].([]Dog)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Dog {
+		return vs[0].([]*Dog)[vs[1].(int)]
 	}).(DogOutput)
 }
 
 type DogMapOutput struct{ *pulumi.OutputState }
 
 func (DogMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Dog)(nil))
+	return reflect.TypeOf((*map[string]*Dog)(nil)).Elem()
 }
 
 func (o DogMapOutput) ToDogMapOutput() DogMapOutput {
@@ -250,14 +187,13 @@ func (o DogMapOutput) ToDogMapOutputWithContext(ctx context.Context) DogMapOutpu
 }
 
 func (o DogMapOutput) MapIndex(k pulumi.StringInput) DogOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Dog {
-		return vs[0].(map[string]Dog)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Dog {
+		return vs[0].(map[string]*Dog)[vs[1].(string)]
 	}).(DogOutput)
 }
 
 func init() {
 	pulumi.RegisterOutputType(DogOutput{})
-	pulumi.RegisterOutputType(DogPtrOutput{})
 	pulumi.RegisterOutputType(DogArrayOutput{})
 	pulumi.RegisterOutputType(DogMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/replace-on-change/go/example/god.go
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/go/example/god.go
@@ -73,7 +73,7 @@ type GodInput interface {
 }
 
 func (*God) ElementType() reflect.Type {
-	return reflect.TypeOf((*God)(nil))
+	return reflect.TypeOf((**God)(nil)).Elem()
 }
 
 func (i *God) ToGodOutput() GodOutput {
@@ -82,35 +82,6 @@ func (i *God) ToGodOutput() GodOutput {
 
 func (i *God) ToGodOutputWithContext(ctx context.Context) GodOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(GodOutput)
-}
-
-func (i *God) ToGodPtrOutput() GodPtrOutput {
-	return i.ToGodPtrOutputWithContext(context.Background())
-}
-
-func (i *God) ToGodPtrOutputWithContext(ctx context.Context) GodPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(GodPtrOutput)
-}
-
-type GodPtrInput interface {
-	pulumi.Input
-
-	ToGodPtrOutput() GodPtrOutput
-	ToGodPtrOutputWithContext(ctx context.Context) GodPtrOutput
-}
-
-type godPtrType GodArgs
-
-func (*godPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**God)(nil))
-}
-
-func (i *godPtrType) ToGodPtrOutput() GodPtrOutput {
-	return i.ToGodPtrOutputWithContext(context.Background())
-}
-
-func (i *godPtrType) ToGodPtrOutputWithContext(ctx context.Context) GodPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(GodPtrOutput)
 }
 
 // GodArrayInput is an input type that accepts GodArray and GodArrayOutput values.
@@ -166,7 +137,7 @@ func (i GodMap) ToGodMapOutputWithContext(ctx context.Context) GodMapOutput {
 type GodOutput struct{ *pulumi.OutputState }
 
 func (GodOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*God)(nil))
+	return reflect.TypeOf((**God)(nil)).Elem()
 }
 
 func (o GodOutput) ToGodOutput() GodOutput {
@@ -177,44 +148,10 @@ func (o GodOutput) ToGodOutputWithContext(ctx context.Context) GodOutput {
 	return o
 }
 
-func (o GodOutput) ToGodPtrOutput() GodPtrOutput {
-	return o.ToGodPtrOutputWithContext(context.Background())
-}
-
-func (o GodOutput) ToGodPtrOutputWithContext(ctx context.Context) GodPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v God) *God {
-		return &v
-	}).(GodPtrOutput)
-}
-
-type GodPtrOutput struct{ *pulumi.OutputState }
-
-func (GodPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**God)(nil))
-}
-
-func (o GodPtrOutput) ToGodPtrOutput() GodPtrOutput {
-	return o
-}
-
-func (o GodPtrOutput) ToGodPtrOutputWithContext(ctx context.Context) GodPtrOutput {
-	return o
-}
-
-func (o GodPtrOutput) Elem() GodOutput {
-	return o.ApplyT(func(v *God) God {
-		if v != nil {
-			return *v
-		}
-		var ret God
-		return ret
-	}).(GodOutput)
-}
-
 type GodArrayOutput struct{ *pulumi.OutputState }
 
 func (GodArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]God)(nil))
+	return reflect.TypeOf((*[]*God)(nil)).Elem()
 }
 
 func (o GodArrayOutput) ToGodArrayOutput() GodArrayOutput {
@@ -226,15 +163,15 @@ func (o GodArrayOutput) ToGodArrayOutputWithContext(ctx context.Context) GodArra
 }
 
 func (o GodArrayOutput) Index(i pulumi.IntInput) GodOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) God {
-		return vs[0].([]God)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *God {
+		return vs[0].([]*God)[vs[1].(int)]
 	}).(GodOutput)
 }
 
 type GodMapOutput struct{ *pulumi.OutputState }
 
 func (GodMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]God)(nil))
+	return reflect.TypeOf((*map[string]*God)(nil)).Elem()
 }
 
 func (o GodMapOutput) ToGodMapOutput() GodMapOutput {
@@ -246,14 +183,13 @@ func (o GodMapOutput) ToGodMapOutputWithContext(ctx context.Context) GodMapOutpu
 }
 
 func (o GodMapOutput) MapIndex(k pulumi.StringInput) GodOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) God {
-		return vs[0].(map[string]God)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *God {
+		return vs[0].(map[string]*God)[vs[1].(string)]
 	}).(GodOutput)
 }
 
 func init() {
 	pulumi.RegisterOutputType(GodOutput{})
-	pulumi.RegisterOutputType(GodPtrOutput{})
 	pulumi.RegisterOutputType(GodArrayOutput{})
 	pulumi.RegisterOutputType(GodMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/replace-on-change/go/example/noRecursive.go
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/go/example/noRecursive.go
@@ -78,7 +78,7 @@ type NoRecursiveInput interface {
 }
 
 func (*NoRecursive) ElementType() reflect.Type {
-	return reflect.TypeOf((*NoRecursive)(nil))
+	return reflect.TypeOf((**NoRecursive)(nil)).Elem()
 }
 
 func (i *NoRecursive) ToNoRecursiveOutput() NoRecursiveOutput {
@@ -87,35 +87,6 @@ func (i *NoRecursive) ToNoRecursiveOutput() NoRecursiveOutput {
 
 func (i *NoRecursive) ToNoRecursiveOutputWithContext(ctx context.Context) NoRecursiveOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(NoRecursiveOutput)
-}
-
-func (i *NoRecursive) ToNoRecursivePtrOutput() NoRecursivePtrOutput {
-	return i.ToNoRecursivePtrOutputWithContext(context.Background())
-}
-
-func (i *NoRecursive) ToNoRecursivePtrOutputWithContext(ctx context.Context) NoRecursivePtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(NoRecursivePtrOutput)
-}
-
-type NoRecursivePtrInput interface {
-	pulumi.Input
-
-	ToNoRecursivePtrOutput() NoRecursivePtrOutput
-	ToNoRecursivePtrOutputWithContext(ctx context.Context) NoRecursivePtrOutput
-}
-
-type noRecursivePtrType NoRecursiveArgs
-
-func (*noRecursivePtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**NoRecursive)(nil))
-}
-
-func (i *noRecursivePtrType) ToNoRecursivePtrOutput() NoRecursivePtrOutput {
-	return i.ToNoRecursivePtrOutputWithContext(context.Background())
-}
-
-func (i *noRecursivePtrType) ToNoRecursivePtrOutputWithContext(ctx context.Context) NoRecursivePtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(NoRecursivePtrOutput)
 }
 
 // NoRecursiveArrayInput is an input type that accepts NoRecursiveArray and NoRecursiveArrayOutput values.
@@ -171,7 +142,7 @@ func (i NoRecursiveMap) ToNoRecursiveMapOutputWithContext(ctx context.Context) N
 type NoRecursiveOutput struct{ *pulumi.OutputState }
 
 func (NoRecursiveOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*NoRecursive)(nil))
+	return reflect.TypeOf((**NoRecursive)(nil)).Elem()
 }
 
 func (o NoRecursiveOutput) ToNoRecursiveOutput() NoRecursiveOutput {
@@ -182,44 +153,10 @@ func (o NoRecursiveOutput) ToNoRecursiveOutputWithContext(ctx context.Context) N
 	return o
 }
 
-func (o NoRecursiveOutput) ToNoRecursivePtrOutput() NoRecursivePtrOutput {
-	return o.ToNoRecursivePtrOutputWithContext(context.Background())
-}
-
-func (o NoRecursiveOutput) ToNoRecursivePtrOutputWithContext(ctx context.Context) NoRecursivePtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v NoRecursive) *NoRecursive {
-		return &v
-	}).(NoRecursivePtrOutput)
-}
-
-type NoRecursivePtrOutput struct{ *pulumi.OutputState }
-
-func (NoRecursivePtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**NoRecursive)(nil))
-}
-
-func (o NoRecursivePtrOutput) ToNoRecursivePtrOutput() NoRecursivePtrOutput {
-	return o
-}
-
-func (o NoRecursivePtrOutput) ToNoRecursivePtrOutputWithContext(ctx context.Context) NoRecursivePtrOutput {
-	return o
-}
-
-func (o NoRecursivePtrOutput) Elem() NoRecursiveOutput {
-	return o.ApplyT(func(v *NoRecursive) NoRecursive {
-		if v != nil {
-			return *v
-		}
-		var ret NoRecursive
-		return ret
-	}).(NoRecursiveOutput)
-}
-
 type NoRecursiveArrayOutput struct{ *pulumi.OutputState }
 
 func (NoRecursiveArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]NoRecursive)(nil))
+	return reflect.TypeOf((*[]*NoRecursive)(nil)).Elem()
 }
 
 func (o NoRecursiveArrayOutput) ToNoRecursiveArrayOutput() NoRecursiveArrayOutput {
@@ -231,15 +168,15 @@ func (o NoRecursiveArrayOutput) ToNoRecursiveArrayOutputWithContext(ctx context.
 }
 
 func (o NoRecursiveArrayOutput) Index(i pulumi.IntInput) NoRecursiveOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) NoRecursive {
-		return vs[0].([]NoRecursive)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *NoRecursive {
+		return vs[0].([]*NoRecursive)[vs[1].(int)]
 	}).(NoRecursiveOutput)
 }
 
 type NoRecursiveMapOutput struct{ *pulumi.OutputState }
 
 func (NoRecursiveMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]NoRecursive)(nil))
+	return reflect.TypeOf((*map[string]*NoRecursive)(nil)).Elem()
 }
 
 func (o NoRecursiveMapOutput) ToNoRecursiveMapOutput() NoRecursiveMapOutput {
@@ -251,14 +188,13 @@ func (o NoRecursiveMapOutput) ToNoRecursiveMapOutputWithContext(ctx context.Cont
 }
 
 func (o NoRecursiveMapOutput) MapIndex(k pulumi.StringInput) NoRecursiveOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) NoRecursive {
-		return vs[0].(map[string]NoRecursive)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *NoRecursive {
+		return vs[0].(map[string]*NoRecursive)[vs[1].(string)]
 	}).(NoRecursiveOutput)
 }
 
 func init() {
 	pulumi.RegisterOutputType(NoRecursiveOutput{})
-	pulumi.RegisterOutputType(NoRecursivePtrOutput{})
 	pulumi.RegisterOutputType(NoRecursiveArrayOutput{})
 	pulumi.RegisterOutputType(NoRecursiveMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/replace-on-change/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -59,39 +59,10 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
-type ProviderPtrInput interface {
-	pulumi.Input
-
-	ToProviderPtrOutput() ProviderPtrOutput
-	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
-}
-
-type providerPtrType ProviderArgs
-
-func (*providerPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (i *providerPtrType) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {
@@ -102,41 +73,6 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
-func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
-		return &v
-	}).(ProviderPtrOutput)
-}
-
-type ProviderPtrOutput struct{ *pulumi.OutputState }
-
-func (ProviderPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) Elem() ProviderOutput {
-	return o.ApplyT(func(v *Provider) Provider {
-		if v != nil {
-			return *v
-		}
-		var ret Provider
-		return ret
-	}).(ProviderOutput)
-}
-
 func init() {
 	pulumi.RegisterOutputType(ProviderOutput{})
-	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/replace-on-change/go/example/toyStore.go
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/go/example/toyStore.go
@@ -84,7 +84,7 @@ type ToyStoreInput interface {
 }
 
 func (*ToyStore) ElementType() reflect.Type {
-	return reflect.TypeOf((*ToyStore)(nil))
+	return reflect.TypeOf((**ToyStore)(nil)).Elem()
 }
 
 func (i *ToyStore) ToToyStoreOutput() ToyStoreOutput {
@@ -93,35 +93,6 @@ func (i *ToyStore) ToToyStoreOutput() ToyStoreOutput {
 
 func (i *ToyStore) ToToyStoreOutputWithContext(ctx context.Context) ToyStoreOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(ToyStoreOutput)
-}
-
-func (i *ToyStore) ToToyStorePtrOutput() ToyStorePtrOutput {
-	return i.ToToyStorePtrOutputWithContext(context.Background())
-}
-
-func (i *ToyStore) ToToyStorePtrOutputWithContext(ctx context.Context) ToyStorePtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ToyStorePtrOutput)
-}
-
-type ToyStorePtrInput interface {
-	pulumi.Input
-
-	ToToyStorePtrOutput() ToyStorePtrOutput
-	ToToyStorePtrOutputWithContext(ctx context.Context) ToyStorePtrOutput
-}
-
-type toyStorePtrType ToyStoreArgs
-
-func (*toyStorePtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**ToyStore)(nil))
-}
-
-func (i *toyStorePtrType) ToToyStorePtrOutput() ToyStorePtrOutput {
-	return i.ToToyStorePtrOutputWithContext(context.Background())
-}
-
-func (i *toyStorePtrType) ToToyStorePtrOutputWithContext(ctx context.Context) ToyStorePtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ToyStorePtrOutput)
 }
 
 // ToyStoreArrayInput is an input type that accepts ToyStoreArray and ToyStoreArrayOutput values.
@@ -177,7 +148,7 @@ func (i ToyStoreMap) ToToyStoreMapOutputWithContext(ctx context.Context) ToyStor
 type ToyStoreOutput struct{ *pulumi.OutputState }
 
 func (ToyStoreOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*ToyStore)(nil))
+	return reflect.TypeOf((**ToyStore)(nil)).Elem()
 }
 
 func (o ToyStoreOutput) ToToyStoreOutput() ToyStoreOutput {
@@ -188,44 +159,10 @@ func (o ToyStoreOutput) ToToyStoreOutputWithContext(ctx context.Context) ToyStor
 	return o
 }
 
-func (o ToyStoreOutput) ToToyStorePtrOutput() ToyStorePtrOutput {
-	return o.ToToyStorePtrOutputWithContext(context.Background())
-}
-
-func (o ToyStoreOutput) ToToyStorePtrOutputWithContext(ctx context.Context) ToyStorePtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v ToyStore) *ToyStore {
-		return &v
-	}).(ToyStorePtrOutput)
-}
-
-type ToyStorePtrOutput struct{ *pulumi.OutputState }
-
-func (ToyStorePtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**ToyStore)(nil))
-}
-
-func (o ToyStorePtrOutput) ToToyStorePtrOutput() ToyStorePtrOutput {
-	return o
-}
-
-func (o ToyStorePtrOutput) ToToyStorePtrOutputWithContext(ctx context.Context) ToyStorePtrOutput {
-	return o
-}
-
-func (o ToyStorePtrOutput) Elem() ToyStoreOutput {
-	return o.ApplyT(func(v *ToyStore) ToyStore {
-		if v != nil {
-			return *v
-		}
-		var ret ToyStore
-		return ret
-	}).(ToyStoreOutput)
-}
-
 type ToyStoreArrayOutput struct{ *pulumi.OutputState }
 
 func (ToyStoreArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]ToyStore)(nil))
+	return reflect.TypeOf((*[]*ToyStore)(nil)).Elem()
 }
 
 func (o ToyStoreArrayOutput) ToToyStoreArrayOutput() ToyStoreArrayOutput {
@@ -237,15 +174,15 @@ func (o ToyStoreArrayOutput) ToToyStoreArrayOutputWithContext(ctx context.Contex
 }
 
 func (o ToyStoreArrayOutput) Index(i pulumi.IntInput) ToyStoreOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) ToyStore {
-		return vs[0].([]ToyStore)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *ToyStore {
+		return vs[0].([]*ToyStore)[vs[1].(int)]
 	}).(ToyStoreOutput)
 }
 
 type ToyStoreMapOutput struct{ *pulumi.OutputState }
 
 func (ToyStoreMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]ToyStore)(nil))
+	return reflect.TypeOf((*map[string]*ToyStore)(nil)).Elem()
 }
 
 func (o ToyStoreMapOutput) ToToyStoreMapOutput() ToyStoreMapOutput {
@@ -257,14 +194,13 @@ func (o ToyStoreMapOutput) ToToyStoreMapOutputWithContext(ctx context.Context) T
 }
 
 func (o ToyStoreMapOutput) MapIndex(k pulumi.StringInput) ToyStoreOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) ToyStore {
-		return vs[0].(map[string]ToyStore)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *ToyStore {
+		return vs[0].(map[string]*ToyStore)[vs[1].(string)]
 	}).(ToyStoreOutput)
 }
 
 func init() {
 	pulumi.RegisterOutputType(ToyStoreOutput{})
-	pulumi.RegisterOutputType(ToyStorePtrOutput{})
 	pulumi.RegisterOutputType(ToyStoreArrayOutput{})
 	pulumi.RegisterOutputType(ToyStoreMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/go/example/person.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/go/example/person.go
@@ -78,7 +78,7 @@ type PersonInput interface {
 }
 
 func (*Person) ElementType() reflect.Type {
-	return reflect.TypeOf((*Person)(nil))
+	return reflect.TypeOf((**Person)(nil)).Elem()
 }
 
 func (i *Person) ToPersonOutput() PersonOutput {
@@ -87,35 +87,6 @@ func (i *Person) ToPersonOutput() PersonOutput {
 
 func (i *Person) ToPersonOutputWithContext(ctx context.Context) PersonOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PersonOutput)
-}
-
-func (i *Person) ToPersonPtrOutput() PersonPtrOutput {
-	return i.ToPersonPtrOutputWithContext(context.Background())
-}
-
-func (i *Person) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PersonPtrOutput)
-}
-
-type PersonPtrInput interface {
-	pulumi.Input
-
-	ToPersonPtrOutput() PersonPtrOutput
-	ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput
-}
-
-type personPtrType PersonArgs
-
-func (*personPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Person)(nil))
-}
-
-func (i *personPtrType) ToPersonPtrOutput() PersonPtrOutput {
-	return i.ToPersonPtrOutputWithContext(context.Background())
-}
-
-func (i *personPtrType) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PersonPtrOutput)
 }
 
 // PersonArrayInput is an input type that accepts PersonArray and PersonArrayOutput values.
@@ -171,7 +142,7 @@ func (i PersonMap) ToPersonMapOutputWithContext(ctx context.Context) PersonMapOu
 type PersonOutput struct{ *pulumi.OutputState }
 
 func (PersonOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Person)(nil))
+	return reflect.TypeOf((**Person)(nil)).Elem()
 }
 
 func (o PersonOutput) ToPersonOutput() PersonOutput {
@@ -182,44 +153,10 @@ func (o PersonOutput) ToPersonOutputWithContext(ctx context.Context) PersonOutpu
 	return o
 }
 
-func (o PersonOutput) ToPersonPtrOutput() PersonPtrOutput {
-	return o.ToPersonPtrOutputWithContext(context.Background())
-}
-
-func (o PersonOutput) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Person) *Person {
-		return &v
-	}).(PersonPtrOutput)
-}
-
-type PersonPtrOutput struct{ *pulumi.OutputState }
-
-func (PersonPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Person)(nil))
-}
-
-func (o PersonPtrOutput) ToPersonPtrOutput() PersonPtrOutput {
-	return o
-}
-
-func (o PersonPtrOutput) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return o
-}
-
-func (o PersonPtrOutput) Elem() PersonOutput {
-	return o.ApplyT(func(v *Person) Person {
-		if v != nil {
-			return *v
-		}
-		var ret Person
-		return ret
-	}).(PersonOutput)
-}
-
 type PersonArrayOutput struct{ *pulumi.OutputState }
 
 func (PersonArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Person)(nil))
+	return reflect.TypeOf((*[]*Person)(nil)).Elem()
 }
 
 func (o PersonArrayOutput) ToPersonArrayOutput() PersonArrayOutput {
@@ -231,15 +168,15 @@ func (o PersonArrayOutput) ToPersonArrayOutputWithContext(ctx context.Context) P
 }
 
 func (o PersonArrayOutput) Index(i pulumi.IntInput) PersonOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Person {
-		return vs[0].([]Person)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Person {
+		return vs[0].([]*Person)[vs[1].(int)]
 	}).(PersonOutput)
 }
 
 type PersonMapOutput struct{ *pulumi.OutputState }
 
 func (PersonMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Person)(nil))
+	return reflect.TypeOf((*map[string]*Person)(nil)).Elem()
 }
 
 func (o PersonMapOutput) ToPersonMapOutput() PersonMapOutput {
@@ -251,18 +188,16 @@ func (o PersonMapOutput) ToPersonMapOutputWithContext(ctx context.Context) Perso
 }
 
 func (o PersonMapOutput) MapIndex(k pulumi.StringInput) PersonOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Person {
-		return vs[0].(map[string]Person)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Person {
+		return vs[0].(map[string]*Person)[vs[1].(string)]
 	}).(PersonOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*PersonInput)(nil)).Elem(), &Person{})
-	pulumi.RegisterInputType(reflect.TypeOf((*PersonPtrInput)(nil)).Elem(), &Person{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PersonArrayInput)(nil)).Elem(), PersonArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PersonMapInput)(nil)).Elem(), PersonMap{})
 	pulumi.RegisterOutputType(PersonOutput{})
-	pulumi.RegisterOutputType(PersonPtrOutput{})
 	pulumi.RegisterOutputType(PersonArrayOutput{})
 	pulumi.RegisterOutputType(PersonMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/go/example/pet.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/go/example/pet.go
@@ -75,7 +75,7 @@ type PetInput interface {
 }
 
 func (*Pet) ElementType() reflect.Type {
-	return reflect.TypeOf((*Pet)(nil))
+	return reflect.TypeOf((**Pet)(nil)).Elem()
 }
 
 func (i *Pet) ToPetOutput() PetOutput {
@@ -84,35 +84,6 @@ func (i *Pet) ToPetOutput() PetOutput {
 
 func (i *Pet) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetOutput)
-}
-
-func (i *Pet) ToPetPtrOutput() PetPtrOutput {
-	return i.ToPetPtrOutputWithContext(context.Background())
-}
-
-func (i *Pet) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PetPtrOutput)
-}
-
-type PetPtrInput interface {
-	pulumi.Input
-
-	ToPetPtrOutput() PetPtrOutput
-	ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput
-}
-
-type petPtrType PetArgs
-
-func (*petPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Pet)(nil))
-}
-
-func (i *petPtrType) ToPetPtrOutput() PetPtrOutput {
-	return i.ToPetPtrOutputWithContext(context.Background())
-}
-
-func (i *petPtrType) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PetPtrOutput)
 }
 
 // PetArrayInput is an input type that accepts PetArray and PetArrayOutput values.
@@ -168,7 +139,7 @@ func (i PetMap) ToPetMapOutputWithContext(ctx context.Context) PetMapOutput {
 type PetOutput struct{ *pulumi.OutputState }
 
 func (PetOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Pet)(nil))
+	return reflect.TypeOf((**Pet)(nil)).Elem()
 }
 
 func (o PetOutput) ToPetOutput() PetOutput {
@@ -179,44 +150,10 @@ func (o PetOutput) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return o
 }
 
-func (o PetOutput) ToPetPtrOutput() PetPtrOutput {
-	return o.ToPetPtrOutputWithContext(context.Background())
-}
-
-func (o PetOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Pet) *Pet {
-		return &v
-	}).(PetPtrOutput)
-}
-
-type PetPtrOutput struct{ *pulumi.OutputState }
-
-func (PetPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Pet)(nil))
-}
-
-func (o PetPtrOutput) ToPetPtrOutput() PetPtrOutput {
-	return o
-}
-
-func (o PetPtrOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return o
-}
-
-func (o PetPtrOutput) Elem() PetOutput {
-	return o.ApplyT(func(v *Pet) Pet {
-		if v != nil {
-			return *v
-		}
-		var ret Pet
-		return ret
-	}).(PetOutput)
-}
-
 type PetArrayOutput struct{ *pulumi.OutputState }
 
 func (PetArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Pet)(nil))
+	return reflect.TypeOf((*[]*Pet)(nil)).Elem()
 }
 
 func (o PetArrayOutput) ToPetArrayOutput() PetArrayOutput {
@@ -228,15 +165,15 @@ func (o PetArrayOutput) ToPetArrayOutputWithContext(ctx context.Context) PetArra
 }
 
 func (o PetArrayOutput) Index(i pulumi.IntInput) PetOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Pet {
-		return vs[0].([]Pet)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Pet {
+		return vs[0].([]*Pet)[vs[1].(int)]
 	}).(PetOutput)
 }
 
 type PetMapOutput struct{ *pulumi.OutputState }
 
 func (PetMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Pet)(nil))
+	return reflect.TypeOf((*map[string]*Pet)(nil)).Elem()
 }
 
 func (o PetMapOutput) ToPetMapOutput() PetMapOutput {
@@ -248,18 +185,16 @@ func (o PetMapOutput) ToPetMapOutputWithContext(ctx context.Context) PetMapOutpu
 }
 
 func (o PetMapOutput) MapIndex(k pulumi.StringInput) PetOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Pet {
-		return vs[0].(map[string]Pet)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Pet {
+		return vs[0].(map[string]*Pet)[vs[1].(string)]
 	}).(PetOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*PetInput)(nil)).Elem(), &Pet{})
-	pulumi.RegisterInputType(reflect.TypeOf((*PetPtrInput)(nil)).Elem(), &Pet{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PetArrayInput)(nil)).Elem(), PetArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PetMapInput)(nil)).Elem(), PetMap{})
 	pulumi.RegisterOutputType(PetOutput{})
-	pulumi.RegisterOutputType(PetPtrOutput{})
 	pulumi.RegisterOutputType(PetArrayOutput{})
 	pulumi.RegisterOutputType(PetMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -59,39 +59,10 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
-type ProviderPtrInput interface {
-	pulumi.Input
-
-	ToProviderPtrOutput() ProviderPtrOutput
-	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
-}
-
-type providerPtrType ProviderArgs
-
-func (*providerPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (i *providerPtrType) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {
@@ -102,43 +73,7 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
-func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
-		return &v
-	}).(ProviderPtrOutput)
-}
-
-type ProviderPtrOutput struct{ *pulumi.OutputState }
-
-func (ProviderPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) Elem() ProviderOutput {
-	return o.ApplyT(func(v *Provider) Provider {
-		if v != nil {
-			return *v
-		}
-		var ret Provider
-		return ret
-	}).(ProviderOutput)
-}
-
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ProviderInput)(nil)).Elem(), &Provider{})
-	pulumi.RegisterInputType(reflect.TypeOf((*ProviderPtrInput)(nil)).Elem(), &Provider{})
 	pulumi.RegisterOutputType(ProviderOutput{})
-	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go/example/person.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go/example/person.go
@@ -78,7 +78,7 @@ type PersonInput interface {
 }
 
 func (*Person) ElementType() reflect.Type {
-	return reflect.TypeOf((*Person)(nil))
+	return reflect.TypeOf((**Person)(nil)).Elem()
 }
 
 func (i *Person) ToPersonOutput() PersonOutput {
@@ -87,35 +87,6 @@ func (i *Person) ToPersonOutput() PersonOutput {
 
 func (i *Person) ToPersonOutputWithContext(ctx context.Context) PersonOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PersonOutput)
-}
-
-func (i *Person) ToPersonPtrOutput() PersonPtrOutput {
-	return i.ToPersonPtrOutputWithContext(context.Background())
-}
-
-func (i *Person) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PersonPtrOutput)
-}
-
-type PersonPtrInput interface {
-	pulumi.Input
-
-	ToPersonPtrOutput() PersonPtrOutput
-	ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput
-}
-
-type personPtrType PersonArgs
-
-func (*personPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Person)(nil))
-}
-
-func (i *personPtrType) ToPersonPtrOutput() PersonPtrOutput {
-	return i.ToPersonPtrOutputWithContext(context.Background())
-}
-
-func (i *personPtrType) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PersonPtrOutput)
 }
 
 // PersonArrayInput is an input type that accepts PersonArray and PersonArrayOutput values.
@@ -171,7 +142,7 @@ func (i PersonMap) ToPersonMapOutputWithContext(ctx context.Context) PersonMapOu
 type PersonOutput struct{ *pulumi.OutputState }
 
 func (PersonOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Person)(nil))
+	return reflect.TypeOf((**Person)(nil)).Elem()
 }
 
 func (o PersonOutput) ToPersonOutput() PersonOutput {
@@ -182,44 +153,10 @@ func (o PersonOutput) ToPersonOutputWithContext(ctx context.Context) PersonOutpu
 	return o
 }
 
-func (o PersonOutput) ToPersonPtrOutput() PersonPtrOutput {
-	return o.ToPersonPtrOutputWithContext(context.Background())
-}
-
-func (o PersonOutput) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Person) *Person {
-		return &v
-	}).(PersonPtrOutput)
-}
-
-type PersonPtrOutput struct{ *pulumi.OutputState }
-
-func (PersonPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Person)(nil))
-}
-
-func (o PersonPtrOutput) ToPersonPtrOutput() PersonPtrOutput {
-	return o
-}
-
-func (o PersonPtrOutput) ToPersonPtrOutputWithContext(ctx context.Context) PersonPtrOutput {
-	return o
-}
-
-func (o PersonPtrOutput) Elem() PersonOutput {
-	return o.ApplyT(func(v *Person) Person {
-		if v != nil {
-			return *v
-		}
-		var ret Person
-		return ret
-	}).(PersonOutput)
-}
-
 type PersonArrayOutput struct{ *pulumi.OutputState }
 
 func (PersonArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Person)(nil))
+	return reflect.TypeOf((*[]*Person)(nil)).Elem()
 }
 
 func (o PersonArrayOutput) ToPersonArrayOutput() PersonArrayOutput {
@@ -231,15 +168,15 @@ func (o PersonArrayOutput) ToPersonArrayOutputWithContext(ctx context.Context) P
 }
 
 func (o PersonArrayOutput) Index(i pulumi.IntInput) PersonOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Person {
-		return vs[0].([]Person)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Person {
+		return vs[0].([]*Person)[vs[1].(int)]
 	}).(PersonOutput)
 }
 
 type PersonMapOutput struct{ *pulumi.OutputState }
 
 func (PersonMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Person)(nil))
+	return reflect.TypeOf((*map[string]*Person)(nil)).Elem()
 }
 
 func (o PersonMapOutput) ToPersonMapOutput() PersonMapOutput {
@@ -251,18 +188,16 @@ func (o PersonMapOutput) ToPersonMapOutputWithContext(ctx context.Context) Perso
 }
 
 func (o PersonMapOutput) MapIndex(k pulumi.StringInput) PersonOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Person {
-		return vs[0].(map[string]Person)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Person {
+		return vs[0].(map[string]*Person)[vs[1].(string)]
 	}).(PersonOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*PersonInput)(nil)).Elem(), &Person{})
-	pulumi.RegisterInputType(reflect.TypeOf((*PersonPtrInput)(nil)).Elem(), &Person{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PersonArrayInput)(nil)).Elem(), PersonArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PersonMapInput)(nil)).Elem(), PersonMap{})
 	pulumi.RegisterOutputType(PersonOutput{})
-	pulumi.RegisterOutputType(PersonPtrOutput{})
 	pulumi.RegisterOutputType(PersonArrayOutput{})
 	pulumi.RegisterOutputType(PersonMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go/example/pet.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go/example/pet.go
@@ -75,7 +75,7 @@ type PetInput interface {
 }
 
 func (*Pet) ElementType() reflect.Type {
-	return reflect.TypeOf((*Pet)(nil))
+	return reflect.TypeOf((**Pet)(nil)).Elem()
 }
 
 func (i *Pet) ToPetOutput() PetOutput {
@@ -84,35 +84,6 @@ func (i *Pet) ToPetOutput() PetOutput {
 
 func (i *Pet) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(PetOutput)
-}
-
-func (i *Pet) ToPetPtrOutput() PetPtrOutput {
-	return i.ToPetPtrOutputWithContext(context.Background())
-}
-
-func (i *Pet) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PetPtrOutput)
-}
-
-type PetPtrInput interface {
-	pulumi.Input
-
-	ToPetPtrOutput() PetPtrOutput
-	ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput
-}
-
-type petPtrType PetArgs
-
-func (*petPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Pet)(nil))
-}
-
-func (i *petPtrType) ToPetPtrOutput() PetPtrOutput {
-	return i.ToPetPtrOutputWithContext(context.Background())
-}
-
-func (i *petPtrType) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(PetPtrOutput)
 }
 
 // PetArrayInput is an input type that accepts PetArray and PetArrayOutput values.
@@ -168,7 +139,7 @@ func (i PetMap) ToPetMapOutputWithContext(ctx context.Context) PetMapOutput {
 type PetOutput struct{ *pulumi.OutputState }
 
 func (PetOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Pet)(nil))
+	return reflect.TypeOf((**Pet)(nil)).Elem()
 }
 
 func (o PetOutput) ToPetOutput() PetOutput {
@@ -179,44 +150,10 @@ func (o PetOutput) ToPetOutputWithContext(ctx context.Context) PetOutput {
 	return o
 }
 
-func (o PetOutput) ToPetPtrOutput() PetPtrOutput {
-	return o.ToPetPtrOutputWithContext(context.Background())
-}
-
-func (o PetOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Pet) *Pet {
-		return &v
-	}).(PetPtrOutput)
-}
-
-type PetPtrOutput struct{ *pulumi.OutputState }
-
-func (PetPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Pet)(nil))
-}
-
-func (o PetPtrOutput) ToPetPtrOutput() PetPtrOutput {
-	return o
-}
-
-func (o PetPtrOutput) ToPetPtrOutputWithContext(ctx context.Context) PetPtrOutput {
-	return o
-}
-
-func (o PetPtrOutput) Elem() PetOutput {
-	return o.ApplyT(func(v *Pet) Pet {
-		if v != nil {
-			return *v
-		}
-		var ret Pet
-		return ret
-	}).(PetOutput)
-}
-
 type PetArrayOutput struct{ *pulumi.OutputState }
 
 func (PetArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Pet)(nil))
+	return reflect.TypeOf((*[]*Pet)(nil)).Elem()
 }
 
 func (o PetArrayOutput) ToPetArrayOutput() PetArrayOutput {
@@ -228,15 +165,15 @@ func (o PetArrayOutput) ToPetArrayOutputWithContext(ctx context.Context) PetArra
 }
 
 func (o PetArrayOutput) Index(i pulumi.IntInput) PetOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Pet {
-		return vs[0].([]Pet)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Pet {
+		return vs[0].([]*Pet)[vs[1].(int)]
 	}).(PetOutput)
 }
 
 type PetMapOutput struct{ *pulumi.OutputState }
 
 func (PetMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Pet)(nil))
+	return reflect.TypeOf((*map[string]*Pet)(nil)).Elem()
 }
 
 func (o PetMapOutput) ToPetMapOutput() PetMapOutput {
@@ -248,18 +185,16 @@ func (o PetMapOutput) ToPetMapOutputWithContext(ctx context.Context) PetMapOutpu
 }
 
 func (o PetMapOutput) MapIndex(k pulumi.StringInput) PetOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Pet {
-		return vs[0].(map[string]Pet)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Pet {
+		return vs[0].(map[string]*Pet)[vs[1].(string)]
 	}).(PetOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*PetInput)(nil)).Elem(), &Pet{})
-	pulumi.RegisterInputType(reflect.TypeOf((*PetPtrInput)(nil)).Elem(), &Pet{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PetArrayInput)(nil)).Elem(), PetArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*PetMapInput)(nil)).Elem(), PetMap{})
 	pulumi.RegisterOutputType(PetOutput{})
-	pulumi.RegisterOutputType(PetPtrOutput{})
 	pulumi.RegisterOutputType(PetArrayOutput{})
 	pulumi.RegisterOutputType(PetMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -59,39 +59,10 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
-type ProviderPtrInput interface {
-	pulumi.Input
-
-	ToProviderPtrOutput() ProviderPtrOutput
-	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
-}
-
-type providerPtrType ProviderArgs
-
-func (*providerPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (i *providerPtrType) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {
@@ -102,43 +73,7 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
-func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
-		return &v
-	}).(ProviderPtrOutput)
-}
-
-type ProviderPtrOutput struct{ *pulumi.OutputState }
-
-func (ProviderPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) Elem() ProviderOutput {
-	return o.ApplyT(func(v *Provider) Provider {
-		if v != nil {
-			return *v
-		}
-		var ret Provider
-		return ret
-	}).(ProviderOutput)
-}
-
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ProviderInput)(nil)).Elem(), &Provider{})
-	pulumi.RegisterInputType(reflect.TypeOf((*ProviderPtrInput)(nil)).Elem(), &Provider{})
 	pulumi.RegisterOutputType(ProviderOutput{})
-	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/docs/rec/_index.md
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/docs/rec/_index.md
@@ -191,7 +191,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#rec_csharp" style="color: inherit; text-decoration: inherit;">Rec</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Rec</span>
+        <span class="property-type">Pulumi.<wbr>Example.<wbr>Rec</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}
@@ -251,7 +251,7 @@ All [input](#inputs) properties are implicitly available as output properties. A
 <a href="#rec_python" style="color: inherit; text-decoration: inherit;">rec</a>
 </span>
         <span class="property-indicator"></span>
-        <span class="property-type">Any</span>
+        <span class="property-type">Rec</span>
     </dt>
     <dd>{{% md %}}{{% /md %}}</dd></dl>
 {{% /choosable %}}

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/dotnet/Rec.cs
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/dotnet/Rec.cs
@@ -13,7 +13,7 @@ namespace Pulumi.Example
     public partial class Rec : Pulumi.CustomResource
     {
         [Output("rec")]
-        public Output<Pulumi.Example.Outputs.Rec?> Rec { get; private set; } = null!;
+        public Output<Pulumi.Example.Rec?> Rec { get; private set; } = null!;
 
 
         /// <summary>

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/go-extras/tests/go_test.go
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/go-extras/tests/go_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"resource-property-overlap/example"
+)
+
+// Tests that XArray{x}.ToXArrayOutput().Index(pulumi.Int(0)) == x.
+func TestArrayOutputIndex(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+
+		r1, err := example.NewRec(ctx, "rec1", &example.RecArgs{})
+		if err != nil {
+			return err
+		}
+
+		r1o := r1.ToRecOutput()
+
+		r2o := example.RecArray{r1o}.ToRecArrayOutput().
+			Index(pulumi.Int(0))
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+
+		pulumi.All(r1o, r2o).ApplyT(func(xs []interface{}) int {
+			assert.Equal(t, xs[0], xs[1])
+			wg.Done()
+			return 0
+		})
+
+		wg.Wait()
+		return nil
+	}, pulumi.WithMocks("project", "stack", mocks(0)))
+	assert.NoError(t, err)
+}
+
+type mocks int
+
+func (mocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	return args.Name + "_id", args.Inputs, nil
+}
+
+func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -59,39 +59,10 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 	return pulumi.ToOutputWithContext(ctx, i).(ProviderOutput)
 }
 
-func (i *Provider) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *Provider) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
-type ProviderPtrInput interface {
-	pulumi.Input
-
-	ToProviderPtrOutput() ProviderPtrOutput
-	ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput
-}
-
-type providerPtrType ProviderArgs
-
-func (*providerPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (i *providerPtrType) ToProviderPtrOutput() ProviderPtrOutput {
-	return i.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (i *providerPtrType) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(ProviderPtrOutput)
-}
-
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {
@@ -102,43 +73,7 @@ func (o ProviderOutput) ToProviderOutputWithContext(ctx context.Context) Provide
 	return o
 }
 
-func (o ProviderOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o.ToProviderPtrOutputWithContext(context.Background())
-}
-
-func (o ProviderOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Provider) *Provider {
-		return &v
-	}).(ProviderPtrOutput)
-}
-
-type ProviderPtrOutput struct{ *pulumi.OutputState }
-
-func (ProviderPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Provider)(nil))
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutput() ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) ToProviderPtrOutputWithContext(ctx context.Context) ProviderPtrOutput {
-	return o
-}
-
-func (o ProviderPtrOutput) Elem() ProviderOutput {
-	return o.ApplyT(func(v *Provider) Provider {
-		if v != nil {
-			return *v
-		}
-		var ret Provider
-		return ret
-	}).(ProviderOutput)
-}
-
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*ProviderInput)(nil)).Elem(), &Provider{})
-	pulumi.RegisterInputType(reflect.TypeOf((*ProviderPtrInput)(nil)).Elem(), &Provider{})
 	pulumi.RegisterOutputType(ProviderOutput{})
-	pulumi.RegisterOutputType(ProviderPtrOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/go/example/rec.go
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/go/example/rec.go
@@ -13,7 +13,7 @@ import (
 type Rec struct {
 	pulumi.CustomResourceState
 
-	Rec RecPtrOutput `pulumi:"rec"`
+	Rec RecOutput `pulumi:"rec"`
 }
 
 // NewRec registers a new resource with the given unique name, arguments, and options.
@@ -73,7 +73,7 @@ type RecInput interface {
 }
 
 func (*Rec) ElementType() reflect.Type {
-	return reflect.TypeOf((*Rec)(nil))
+	return reflect.TypeOf((**Rec)(nil)).Elem()
 }
 
 func (i *Rec) ToRecOutput() RecOutput {
@@ -82,35 +82,6 @@ func (i *Rec) ToRecOutput() RecOutput {
 
 func (i *Rec) ToRecOutputWithContext(ctx context.Context) RecOutput {
 	return pulumi.ToOutputWithContext(ctx, i).(RecOutput)
-}
-
-func (i *Rec) ToRecPtrOutput() RecPtrOutput {
-	return i.ToRecPtrOutputWithContext(context.Background())
-}
-
-func (i *Rec) ToRecPtrOutputWithContext(ctx context.Context) RecPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(RecPtrOutput)
-}
-
-type RecPtrInput interface {
-	pulumi.Input
-
-	ToRecPtrOutput() RecPtrOutput
-	ToRecPtrOutputWithContext(ctx context.Context) RecPtrOutput
-}
-
-type recPtrType RecArgs
-
-func (*recPtrType) ElementType() reflect.Type {
-	return reflect.TypeOf((**Rec)(nil))
-}
-
-func (i *recPtrType) ToRecPtrOutput() RecPtrOutput {
-	return i.ToRecPtrOutputWithContext(context.Background())
-}
-
-func (i *recPtrType) ToRecPtrOutputWithContext(ctx context.Context) RecPtrOutput {
-	return pulumi.ToOutputWithContext(ctx, i).(RecPtrOutput)
 }
 
 // RecArrayInput is an input type that accepts RecArray and RecArrayOutput values.
@@ -166,7 +137,7 @@ func (i RecMap) ToRecMapOutputWithContext(ctx context.Context) RecMapOutput {
 type RecOutput struct{ *pulumi.OutputState }
 
 func (RecOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Rec)(nil))
+	return reflect.TypeOf((**Rec)(nil)).Elem()
 }
 
 func (o RecOutput) ToRecOutput() RecOutput {
@@ -177,44 +148,10 @@ func (o RecOutput) ToRecOutputWithContext(ctx context.Context) RecOutput {
 	return o
 }
 
-func (o RecOutput) ToRecPtrOutput() RecPtrOutput {
-	return o.ToRecPtrOutputWithContext(context.Background())
-}
-
-func (o RecOutput) ToRecPtrOutputWithContext(ctx context.Context) RecPtrOutput {
-	return o.ApplyTWithContext(ctx, func(_ context.Context, v Rec) *Rec {
-		return &v
-	}).(RecPtrOutput)
-}
-
-type RecPtrOutput struct{ *pulumi.OutputState }
-
-func (RecPtrOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((**Rec)(nil))
-}
-
-func (o RecPtrOutput) ToRecPtrOutput() RecPtrOutput {
-	return o
-}
-
-func (o RecPtrOutput) ToRecPtrOutputWithContext(ctx context.Context) RecPtrOutput {
-	return o
-}
-
-func (o RecPtrOutput) Elem() RecOutput {
-	return o.ApplyT(func(v *Rec) Rec {
-		if v != nil {
-			return *v
-		}
-		var ret Rec
-		return ret
-	}).(RecOutput)
-}
-
 type RecArrayOutput struct{ *pulumi.OutputState }
 
 func (RecArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]Rec)(nil))
+	return reflect.TypeOf((*[]*Rec)(nil)).Elem()
 }
 
 func (o RecArrayOutput) ToRecArrayOutput() RecArrayOutput {
@@ -226,15 +163,15 @@ func (o RecArrayOutput) ToRecArrayOutputWithContext(ctx context.Context) RecArra
 }
 
 func (o RecArrayOutput) Index(i pulumi.IntInput) RecOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) Rec {
-		return vs[0].([]Rec)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) *Rec {
+		return vs[0].([]*Rec)[vs[1].(int)]
 	}).(RecOutput)
 }
 
 type RecMapOutput struct{ *pulumi.OutputState }
 
 func (RecMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]Rec)(nil))
+	return reflect.TypeOf((*map[string]*Rec)(nil)).Elem()
 }
 
 func (o RecMapOutput) ToRecMapOutput() RecMapOutput {
@@ -246,18 +183,16 @@ func (o RecMapOutput) ToRecMapOutputWithContext(ctx context.Context) RecMapOutpu
 }
 
 func (o RecMapOutput) MapIndex(k pulumi.StringInput) RecOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) Rec {
-		return vs[0].(map[string]Rec)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) *Rec {
+		return vs[0].(map[string]*Rec)[vs[1].(string)]
 	}).(RecOutput)
 }
 
 func init() {
 	pulumi.RegisterInputType(reflect.TypeOf((*RecInput)(nil)).Elem(), &Rec{})
-	pulumi.RegisterInputType(reflect.TypeOf((*RecPtrInput)(nil)).Elem(), &Rec{})
 	pulumi.RegisterInputType(reflect.TypeOf((*RecArrayInput)(nil)).Elem(), RecArray{})
 	pulumi.RegisterInputType(reflect.TypeOf((*RecMapInput)(nil)).Elem(), RecMap{})
 	pulumi.RegisterOutputType(RecOutput{})
-	pulumi.RegisterOutputType(RecPtrOutput{})
 	pulumi.RegisterOutputType(RecArrayOutput{})
 	pulumi.RegisterOutputType(RecMapOutput{})
 }

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/python/pulumi_example/rec.py
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/python/pulumi_example/rec.py
@@ -93,6 +93,6 @@ class Rec(pulumi.CustomResource):
 
     @property
     @pulumi.getter
-    def rec(self) -> pulumi.Output[Optional[Any]]:
+    def rec(self) -> pulumi.Output[Optional['Rec']]:
         return pulumi.get(self, "rec")
 

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/schema.json
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/schema.json
@@ -5,7 +5,7 @@
     "example::Rec": {
       "properties": {
         "rec": {
-          "$ref": "#/types/example::Rec"
+          "$ref": "#/resources/example::Rec"
         }
       }
     }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/nursery.go
@@ -83,7 +83,7 @@ type NurseryInput interface {
 }
 
 func (*Nursery) ElementType() reflect.Type {
-	return reflect.TypeOf((*Nursery)(nil))
+	return reflect.TypeOf((**Nursery)(nil)).Elem()
 }
 
 func (i *Nursery) ToNurseryOutput() NurseryOutput {
@@ -97,7 +97,7 @@ func (i *Nursery) ToNurseryOutputWithContext(ctx context.Context) NurseryOutput 
 type NurseryOutput struct{ *pulumi.OutputState }
 
 func (NurseryOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Nursery)(nil))
+	return reflect.TypeOf((**Nursery)(nil)).Elem()
 }
 
 func (o NurseryOutput) ToNurseryOutput() NurseryOutput {

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/go/plant/tree/v1/rubberTree.go
@@ -103,7 +103,7 @@ type RubberTreeInput interface {
 }
 
 func (*RubberTree) ElementType() reflect.Type {
-	return reflect.TypeOf((*RubberTree)(nil))
+	return reflect.TypeOf((**RubberTree)(nil)).Elem()
 }
 
 func (i *RubberTree) ToRubberTreeOutput() RubberTreeOutput {
@@ -117,7 +117,7 @@ func (i *RubberTree) ToRubberTreeOutputWithContext(ctx context.Context) RubberTr
 type RubberTreeOutput struct{ *pulumi.OutputState }
 
 func (RubberTreeOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*RubberTree)(nil))
+	return reflect.TypeOf((**RubberTree)(nil)).Elem()
 }
 
 func (o RubberTreeOutput) ToRubberTreeOutput() RubberTreeOutput {

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/go/example/foo.go
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/go/example/foo.go
@@ -85,7 +85,7 @@ type FooInput interface {
 }
 
 func (*Foo) ElementType() reflect.Type {
-	return reflect.TypeOf((*Foo)(nil))
+	return reflect.TypeOf((**Foo)(nil)).Elem()
 }
 
 func (i *Foo) ToFooOutput() FooOutput {
@@ -99,7 +99,7 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Foo)(nil))
+	return reflect.TypeOf((**Foo)(nil)).Elem()
 }
 
 func (o FooOutput) ToFooOutput() FooOutput {

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/foo.go
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/foo.go
@@ -149,7 +149,7 @@ type FooInput interface {
 }
 
 func (*Foo) ElementType() reflect.Type {
-	return reflect.TypeOf((*Foo)(nil))
+	return reflect.TypeOf((**Foo)(nil)).Elem()
 }
 
 func (i *Foo) ToFooOutput() FooOutput {
@@ -163,7 +163,7 @@ func (i *Foo) ToFooOutputWithContext(ctx context.Context) FooOutput {
 type FooOutput struct{ *pulumi.OutputState }
 
 func (FooOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Foo)(nil))
+	return reflect.TypeOf((**Foo)(nil)).Elem()
 }
 
 func (o FooOutput) ToFooOutput() FooOutput {

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/component.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/component.go
@@ -77,7 +77,7 @@ type ComponentInput interface {
 }
 
 func (*Component) ElementType() reflect.Type {
-	return reflect.TypeOf((*Component)(nil))
+	return reflect.TypeOf((**Component)(nil)).Elem()
 }
 
 func (i *Component) ToComponentOutput() ComponentOutput {
@@ -91,7 +91,7 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Component)(nil))
+	return reflect.TypeOf((**Component)(nil)).Elem()
 }
 
 func (o ComponentOutput) ToComponentOutput() ComponentOutput {

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/go/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/component.go
@@ -79,7 +79,7 @@ type ComponentInput interface {
 }
 
 func (*Component) ElementType() reflect.Type {
-	return reflect.TypeOf((*Component)(nil))
+	return reflect.TypeOf((**Component)(nil)).Elem()
 }
 
 func (i *Component) ToComponentOutput() ComponentOutput {
@@ -93,7 +93,7 @@ func (i *Component) ToComponentOutputWithContext(ctx context.Context) ComponentO
 type ComponentOutput struct{ *pulumi.OutputState }
 
 func (ComponentOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Component)(nil))
+	return reflect.TypeOf((**Component)(nil)).Elem()
 }
 
 func (o ComponentOutput) ToComponentOutput() ComponentOutput {

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/otherResource.go
@@ -52,7 +52,7 @@ type OtherResourceInput interface {
 }
 
 func (*OtherResource) ElementType() reflect.Type {
-	return reflect.TypeOf((*OtherResource)(nil))
+	return reflect.TypeOf((**OtherResource)(nil)).Elem()
 }
 
 func (i *OtherResource) ToOtherResourceOutput() OtherResourceOutput {
@@ -66,7 +66,7 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*OtherResource)(nil))
+	return reflect.TypeOf((**OtherResource)(nil)).Elem()
 }
 
 func (o OtherResourceOutput) ToOtherResourceOutput() OtherResourceOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/resource.go
@@ -75,7 +75,7 @@ type ResourceInput interface {
 }
 
 func (*Resource) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (i *Resource) ToResourceOutput() ResourceOutput {
@@ -89,7 +89,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (o ResourceOutput) ToResourceOutput() ResourceOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/otherResource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/otherResource.go
@@ -52,7 +52,7 @@ type OtherResourceInput interface {
 }
 
 func (*OtherResource) ElementType() reflect.Type {
-	return reflect.TypeOf((*OtherResource)(nil))
+	return reflect.TypeOf((**OtherResource)(nil)).Elem()
 }
 
 func (i *OtherResource) ToOtherResourceOutput() OtherResourceOutput {
@@ -66,7 +66,7 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*OtherResource)(nil))
+	return reflect.TypeOf((**OtherResource)(nil)).Elem()
 }
 
 func (o OtherResourceOutput) ToOtherResourceOutput() OtherResourceOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/resource.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/resource.go
@@ -82,7 +82,7 @@ type ResourceInput interface {
 }
 
 func (*Resource) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (i *Resource) ToResourceOutput() ResourceOutput {
@@ -96,7 +96,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (o ResourceOutput) ToResourceOutput() ResourceOutput {

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/typeUses.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/typeUses.go
@@ -81,7 +81,7 @@ type TypeUsesInput interface {
 }
 
 func (*TypeUses) ElementType() reflect.Type {
-	return reflect.TypeOf((*TypeUses)(nil))
+	return reflect.TypeOf((**TypeUses)(nil)).Elem()
 }
 
 func (i *TypeUses) ToTypeUsesOutput() TypeUsesOutput {
@@ -95,7 +95,7 @@ func (i *TypeUses) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutp
 type TypeUsesOutput struct{ *pulumi.OutputState }
 
 func (TypeUsesOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*TypeUses)(nil))
+	return reflect.TypeOf((**TypeUses)(nil)).Elem()
 }
 
 func (o TypeUsesOutput) ToTypeUsesOutput() TypeUsesOutput {

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/otherResource.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/otherResource.go
@@ -54,7 +54,7 @@ type OtherResourceInput interface {
 }
 
 func (*OtherResource) ElementType() reflect.Type {
-	return reflect.TypeOf((*OtherResource)(nil))
+	return reflect.TypeOf((**OtherResource)(nil)).Elem()
 }
 
 func (i *OtherResource) ToOtherResourceOutput() OtherResourceOutput {
@@ -68,7 +68,7 @@ func (i *OtherResource) ToOtherResourceOutputWithContext(ctx context.Context) Ot
 type OtherResourceOutput struct{ *pulumi.OutputState }
 
 func (OtherResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*OtherResource)(nil))
+	return reflect.TypeOf((**OtherResource)(nil)).Elem()
 }
 
 func (o OtherResourceOutput) ToOtherResourceOutput() OtherResourceOutput {

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/provider.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/provider.go
@@ -48,7 +48,7 @@ type ProviderInput interface {
 }
 
 func (*Provider) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (i *Provider) ToProviderOutput() ProviderOutput {
@@ -62,7 +62,7 @@ func (i *Provider) ToProviderOutputWithContext(ctx context.Context) ProviderOutp
 type ProviderOutput struct{ *pulumi.OutputState }
 
 func (ProviderOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Provider)(nil))
+	return reflect.TypeOf((**Provider)(nil)).Elem()
 }
 
 func (o ProviderOutput) ToProviderOutput() ProviderOutput {

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/resource.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/resource.go
@@ -82,7 +82,7 @@ type ResourceInput interface {
 }
 
 func (*Resource) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (i *Resource) ToResourceOutput() ResourceOutput {
@@ -96,7 +96,7 @@ func (i *Resource) ToResourceOutputWithContext(ctx context.Context) ResourceOutp
 type ResourceOutput struct{ *pulumi.OutputState }
 
 func (ResourceOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*Resource)(nil))
+	return reflect.TypeOf((**Resource)(nil)).Elem()
 }
 
 func (o ResourceOutput) ToResourceOutput() ResourceOutput {

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/typeUses.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/typeUses.go
@@ -84,7 +84,7 @@ type TypeUsesInput interface {
 }
 
 func (*TypeUses) ElementType() reflect.Type {
-	return reflect.TypeOf((*TypeUses)(nil))
+	return reflect.TypeOf((**TypeUses)(nil)).Elem()
 }
 
 func (i *TypeUses) ToTypeUsesOutput() TypeUsesOutput {
@@ -98,7 +98,7 @@ func (i *TypeUses) ToTypeUsesOutputWithContext(ctx context.Context) TypeUsesOutp
 type TypeUsesOutput struct{ *pulumi.OutputState }
 
 func (TypeUsesOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*TypeUses)(nil))
+	return reflect.TypeOf((**TypeUses)(nil)).Elem()
 }
 
 func (o TypeUsesOutput) ToTypeUsesOutput() TypeUsesOutput {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Adds a unit test  to check that `XArray{x}.ToXArrayOutput().Index(pulumi.Int(0)) == x` over the generated code.


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
