### PR TITLE
Add a unit test over generated Go code to verify ArrayOutput/Index

### DIFF
--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/go-extras/tests/go_test.go
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/go-extras/tests/go_test.go
@@ -1,0 +1,52 @@
+package tests
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+
+	"resource-property-overlap/example"
+)
+
+// Tests that XArray{x}.ToXArrayOutput().Index(pulumi.Int(0)) == x.
+func TestArrayOutputIndex(t *testing.T) {
+	err := pulumi.RunErr(func(ctx *pulumi.Context) error {
+
+		r1, err := example.NewRec(ctx, "rec1", &example.RecArgs{})
+		if err != nil {
+			return err
+		}
+
+		r1o := r1.ToRecOutput()
+
+		r2o := example.RecArray{r1o}.ToRecArrayOutput().
+			Index(pulumi.Int(0))
+
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+
+		pulumi.All(r1o, r2o).ApplyT(func(xs []interface{}) int {
+			assert.Equal(t, xs[0], xs[1])
+			wg.Done()
+			return 0
+		})
+
+		wg.Wait()
+		return nil
+	}, pulumi.WithMocks("project", "stack", mocks(0)))
+	assert.NoError(t, err)
+}
+
+type mocks int
+
+func (mocks) NewResource(args pulumi.MockResourceArgs) (string, resource.PropertyMap, error) {
+	return args.Name + "_id", args.Inputs, nil
+}
+
+func (mocks) Call(args pulumi.MockCallArgs) (resource.PropertyMap, error) {
+	return args.Args, nil
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This simply covers the ArrayOutput/Index code generation with a unit test.  This was broken until pgavlin/resourcePtr pointer but now is fixed. The test will help keep it fixed.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
