### PR TITLE
Add String and GoString to Result

### DIFF
--- a/sdk/go/common/util/result/result.go
+++ b/sdk/go/common/util/result/result.go
@@ -57,7 +57,7 @@ func (r *simpleResult) String() string {
 	if r.err == nil {
 		return "Bail"
 	}
-	return fmt.Sprintf("Error: %w", r.err)
+	return fmt.Sprintf("Error: %s", r.err)
 }
 func (r *simpleResult) GoString() string {
 	if r.err == nil {

--- a/sdk/go/common/util/result/result.go
+++ b/sdk/go/common/util/result/result.go
@@ -15,6 +15,8 @@
 package result
 
 import (
+	"fmt"
+
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
@@ -51,6 +53,18 @@ type simpleResult struct {
 
 func (r *simpleResult) Error() error { return r.err }
 func (r *simpleResult) IsBail() bool { return r.err == nil }
+func (r *simpleResult) String() string {
+	if r.err == nil {
+		return "Bail"
+	}
+	return fmt.Sprintf("Error: %w", r.err)
+}
+func (r *simpleResult) GoString() string {
+	if r.err == nil {
+		return "&simpleResult{}"
+	}
+	return fmt.Sprintf("&simpleResult{err: %#v}", r.err)
+}
 
 // Bail produces a Result that represents a computation that failed to complete
 // successfully but is not a bug in Pulumi.


### PR DESCRIPTION
I got fed up of assert errors in tests that looked like:
```
Expected nil, but got: &result.simpleResult{err:(*errors.fundamental)(0xc0002fa5d0)}
```

It was very hard to work out at a glance what had gone wrong and I kept
having to hook a debugger just to look at what the error was.

With GoString these now print something like:
```
Expected nil, but got: &simpleResult{err: Unexpected diag message: <{%reset%}>resource violates plan: properties changed: -zed, -baz, -foo<{%reset%}>
}
```

Which is much more useful.
