### PR TITLE
Run validate function even if dryRun=true

### DIFF
--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -159,7 +159,7 @@ func TestSingleResourceDiffUnavailable(t *testing.T) {
 			for _, e := range events {
 				if e.Type == DiagEvent {
 					p := e.Payload().(DiagEventPayload)
-					if p.URN == resURN && p.Severity == diag.Warning && p.Message == "diff unavailable" {
+					if p.URN == resURN && p.Severity == diag.Warning && p.Message == "<{%reset%}>diff unavailable<{%reset%}>\n" {
 						found = true
 						break
 					}

--- a/pkg/engine/lifeycletest/test_plan.go
+++ b/pkg/engine/lifeycletest/test_plan.go
@@ -96,11 +96,11 @@ func (op TestOp) RunWithContext(
 	_, res := op(info, ctx, opts, dryRun)
 	contract.IgnoreClose(journal)
 
-	if dryRun {
-		return nil, res
-	}
 	if validate != nil {
 		res = validate(project, target, journal.Entries(), firedEvents, res)
+	}
+	if dryRun {
+		return nil, res
 	}
 
 	snap := journal.Snap(target.Snapshot)
@@ -210,7 +210,8 @@ func (p *TestPlan) Run(t *testing.T, snapshot *deploy.Snapshot) *deploy.Snapshot
 		if !step.SkipPreview {
 			previewSnap := CloneSnapshot(t, snap)
 			previewTarget := p.GetTarget(previewSnap)
-			_, res := step.Op.Run(project, previewTarget, p.Options, true, p.BackendClient, step.Validate)
+			// Don't run validate on the preview step
+			_, res := step.Op.Run(project, previewTarget, p.Options, true, p.BackendClient, nil)
 			if step.ExpectFailure {
 				assertIsErrorOrBailResult(t, res)
 				continue


### PR DESCRIPTION
Hit this while trying to add some validation checks to runs of Preview while using plans. Seems one test actually was assuming this was the case already and just hasn't been running it's expected validate function.