### PR TITLE
Fix 7422 - NullPointerException race on Urn property in C# SDK

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,6 +27,10 @@
   `PULUMI_SELF_MANAGED_STATE_LOCKING=1` environment variable.
   [#8565](https://github.com/pulumi/pulumi/pull/8565)
 
+- [sdk/dotnet] - Fixes a rare race condition that sporadically caused
+  NullReferenceException to be raised when constructing resources
+  [#8495](https://github.com/pulumi/pulumi/pull/8495)
+
 ### Bug Fixes
 
 - [codegen/schema] - Error on type token names that are not allowed (schema.Name

--- a/sdk/dotnet/Pulumi.Tests/Mocks/Issue7422.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/Issue7422.cs
@@ -75,8 +75,9 @@ namespace Pulumi.Tests.Mocks.Issue7422
 
     public sealed class Issue7422Component : ComponentResource
     {
-        public Issue7422Component(string name,
-                           ComponentResourceOptions? options = null)
+        public Issue7422Component(
+            string name,
+            ComponentResourceOptions? options = null)
             : base("issue7422::Component", name, options)
         {
             var parent = this;

--- a/sdk/dotnet/Pulumi.Tests/Mocks/Issue7422.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/Issue7422.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Pulumi;
+using Pulumi.Testing;
+
+namespace Pulumi.Tests.Mocks.Issue7422
+{
+    /// <summary>
+    /// It used to be possible to have a thread race causing the
+    /// framework to observe null in the Urn property. The test
+    /// attempts to increase the likelihood of the race by a few well
+    /// placed `Task.Delay` and `Thread.Sleep`, but is in principle
+    /// non-deterministic.
+    ///
+    /// See https://github.com/pulumi/pulumi/issues/7422
+    /// </summary>
+    class Issue7422Stack : Stack
+    {
+        public Issue7422Stack()
+        {
+            // Component Resource with delayed child (such as
+            // Kubernetes ConfigGroup with children defined in yaml).
+            // The child is provisioned in an apply, introducing
+            // concurrency here.
+            var comp1 = new Issue7422Component("comp1");
+
+            // Any resource depending on the Component Resource. This
+            // will race to find the child introduced in `apply`
+            // before the child's constructor completes.
+            new Issue7422Resource("res1", null, new CustomResourceOptions
+            {
+                DependsOn = comp1
+            });
+        }
+    }
+
+    public sealed class Issue7422ResourceArgs : ResourceArgs
+    {
+    }
+
+    [ResourceType("issue7422::Resource", null)]
+    public class Issue7422Resource : CustomResource
+    {
+
+        private Output<string> _someOutput = null!;
+
+        [Output("someOutput")]
+        public Output<string> SomeOutput
+        {
+            get
+            {
+                return _someOutput;
+            }
+            private set
+            {
+                if (GetResourceName() == "comp1-child")
+                {
+                    Thread.Sleep(5);
+                }
+                _someOutput = value;
+            }
+        }
+
+        public Issue7422Resource(
+            string name,
+            Issue7422ResourceArgs? args = null,
+            CustomResourceOptions? options = null)
+            : base("issue7422::Resource", name, args, options)
+        {
+        }
+    }
+
+    public sealed class Issue7422Component : ComponentResource
+    {
+        public Issue7422Component(string name,
+                           ComponentResourceOptions? options = null)
+            : base("issue7422::Component", name, options)
+        {
+            var parent = this;
+            Output.Create(Later()).Apply(x =>
+            {
+                new Issue7422Resource($"{name}-child", null,
+                                      new CustomResourceOptions()
+                                      {
+                                          Parent = parent,
+                                      });
+                return x;
+            });
+        }
+
+        private async Task<int> Later()
+        {
+            await Task.Delay(2);
+            return 1;
+        }
+    }
+
+    class Issue7422Mocks : IMocks
+    {
+        public Task<object> CallAsync(MockCallArgs args)
+        {
+            return Task.FromResult<object>(args);
+        }
+
+        public async Task<(string? id, object state)> NewResourceAsync(
+            MockResourceArgs args)
+        {
+            var emptyDict = new Dictionary<string, object>();
+            (string?, object) empty = ($"i-{Guid.NewGuid()}", emptyDict);
+            await Task.Delay(0);
+            return args.Type switch
+            {
+                "issue7422::Component" => empty,
+                "issue7422::Resource" => empty,
+                _ => throw new Exception($"Unknown resource {args.Type}")
+            };
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
@@ -176,6 +176,13 @@ namespace Pulumi.Tests.Mocks
 
             throw new Exception("Expected to fail");
         }
+
+        [Fact]
+        public async Task TestUrnOutputPropertyIsNeverNull()
+        {
+            await Deployment.TestAsync<Issue7422.Issue7422Stack>(
+                new Issue7422.Issue7422Mocks());
+        }
     }
 
     public static class Testing

--- a/sdk/dotnet/Pulumi.Tests/TestDeploymentLogger.cs
+++ b/sdk/dotnet/Pulumi.Tests/TestDeploymentLogger.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Pulumi.Tests
+{
+    internal class TestDeploymentLogger : IEngineLogger
+    {
+        private Action<LogEntry> Logger { get; set; }
+
+        public TestDeploymentLogger()
+        {
+            Logger = (entry) =>
+            {
+                Console.WriteLine($"IEngineLogger: {entry}");
+            };
+        }
+
+        public TestDeploymentLogger(Action<LogEntry> logger)
+        {
+            Logger = logger;
+        }
+
+        public bool LoggedErrors { get; private set; }
+
+        public Task SendAsync(string severity,
+                              string message,
+                              Resource? resource = null,
+                              int? streamId = null,
+                              bool? ephemeral = null)
+        {
+            if (severity == "Error")
+            {
+                LoggedErrors = true;
+            }
+            Logger.Invoke(new LogEntry
+            {
+                Severity = severity,
+                Message = message,
+                Resource = resource,
+                StreamId = streamId,
+                Ephemeral = ephemeral
+            });
+            return Task.FromResult(0);
+        }
+
+        public Task DebugAsync(string message, Resource? resource = null, int? streamId = null, bool? ephemeral = null)
+            => SendAsync("Debug", message, resource, streamId, ephemeral);
+
+        public Task InfoAsync(string message, Resource? resource = null, int? streamId = null, bool? ephemeral = null)
+            => SendAsync("Info", message, resource, streamId, ephemeral);
+
+        public Task WarnAsync(string message, Resource? resource = null, int? streamId = null, bool? ephemeral = null)
+            => SendAsync("Warn", message, resource, streamId, ephemeral);
+
+        public Task ErrorAsync(string message, Resource? resource = null, int? streamId = null, bool? ephemeral = null)
+            => SendAsync("Error", message, resource, streamId, ephemeral);
+
+        internal class LogEntry
+        {
+            public string Severity { get; set; } = "Error";
+            public string Message { get; set; } = "";
+            public Resource? Resource { get; set; }
+            public int? StreamId { get; set; }
+            public bool? Ephemeral { get; set; }
+
+            public override string ToString()
+            {
+                return $"[{Severity}] {Message} [Resource={Resource} StreamId={StreamId} Ephemeral={Ephemeral}";
+            }
+        }
+    }
+}

--- a/sdk/dotnet/Pulumi/Deployment/Deployment_ReadOrRegisterResource.cs
+++ b/sdk/dotnet/Pulumi/Deployment/Deployment_ReadOrRegisterResource.cs
@@ -22,17 +22,9 @@ namespace Pulumi
             // finished.  Otherwise, we might actually read and get the result back *prior* to the
             // object finishing initializing.  Note: this is not a speculative concern. This is
             // something that does happen and has to be accounted for.
-            //
-            // IMPORTANT! We have to make sure we run 'OutputCompletionSource.InitializeOutputs'
-            // synchronously directly when `resource`'s constructor runs since this will set all of
-            // the `[Output(...)] Output<T>` properties.  We need those properties assigned by the
-            // time the base 'Resource' constructor finishes so that both derived classes and
-            // external consumers can use the Output properties of `resource`.
-            var completionSources = OutputCompletionSource.InitializeOutputs(resource);
-
             _runner.RegisterTask(
                 $"{nameof(IDeploymentInternal.ReadOrRegisterResource)}: {resource.GetResourceType()}-{resource.GetResourceName()}",
-                CompleteResourceAsync(resource, remote, newDependency, args, options, completionSources));
+                CompleteResourceAsync(resource, remote, newDependency, args, options, resource.CompletionSources));
         }
 
         private async Task<(string urn, string id, Struct data, ImmutableDictionary<string, ImmutableHashSet<Resource>> dependencies)> ReadOrRegisterResourceAsync(

--- a/sdk/dotnet/Pulumi/Exceptions/RunException.cs
+++ b/sdk/dotnet/Pulumi/Exceptions/RunException.cs
@@ -1,6 +1,7 @@
-﻿// Copyright 2016-2019, Pulumi Corporation
+﻿// Copyright 2016-2021, Pulumi Corporation
 
 using System;
+using System.Collections.Generic;
 
 namespace Pulumi
 {
@@ -21,6 +22,13 @@ namespace Pulumi
         public RunException(string message, Exception? innerException)
             : base(message, innerException)
         {
+        }
+
+        public static RunException OutputsHaveIncorrectType(
+            IEnumerable<string> outputAttributeNames)
+        {
+            var message = $"Output(s) '{string.Join(", ", outputAttributeNames)}' have incorrect type. [Output] attributed properties must be instances of Output<T>.";
+            return new RunException(message);
         }
     }
 }

--- a/sdk/dotnet/Pulumi/Resources/Resource.cs
+++ b/sdk/dotnet/Pulumi/Resources/Resource.cs
@@ -20,33 +20,33 @@ namespace Pulumi
         /// The child resources of this resource.  We use these (only from a ComponentResource) to
         /// allow code to dependOn a ComponentResource and have that effectively mean that it is
         /// depending on all the CustomResource children of that component.
-        /// 
+        ///
         /// Important!  We only walk through ComponentResources.They're the only resources that
         /// serve as an aggregation of other primitive(i.e.custom) resources.While a custom resource
         /// can be a parent of other resources, we don't want to ever depend on those child
         /// resource.  If we do, it's simple to end up in a situation where we end up depending on a
         /// child resource that has a data cycle dependency due to the data passed into it. An
         /// example of how this would be bad is:
-        /// 
+        ///
         /// <c>
         ///     var c1 = new CustomResource("c1");
         ///     var c2 = new CustomResource("c2", { parentId = c1.id }, { parent = c1 });
         ///     var c3 = new CustomResource("c3", { parentId = c1.id }, { parent = c1 });
         /// </c>
-        /// 
+        ///
         /// The problem here is that 'c2' has a data dependency on 'c1'.  If it tries to wait on
         /// 'c1' it will walk to the children and wait on them.This will mean it will wait on 'c3'.
         /// But 'c3' will be waiting in the same manner on 'c2', and a cycle forms. This normally
         /// does not happen with ComponentResources as they do not have any data flowing into
         /// them.The only way you would be able to have a problem is if you had this sort of coding
         /// pattern:
-        /// 
+        ///
         /// <c>
         ///     var c1 = new ComponentResource("c1");
         ///     var c2 = new CustomResource("c2", { parentId = c1.urn }, { parent: c1 });
         ///     var c3 = new CustomResource("c3", { parentId = c1.urn }, { parent: c1 });
         /// </c>
-        /// 
+        ///
         /// However, this would be pretty nonsensical as there is zero need for a custom resource to
         /// ever need to reference the urn of a component resource.  So it's acceptable if that sort
         /// of pattern failed in practice.
@@ -103,6 +103,8 @@ namespace Pulumi
         /// </summary>
         internal readonly string? _version;
 
+        internal readonly ImmutableDictionary<string,IOutputCompletionSource> CompletionSources;
+
         /// <summary>
         /// Creates and registers a new resource object.  <paramref name="type"/> is the fully
         /// qualified type token and <paramref name="name"/> is the "name" part to use in creating a
@@ -128,6 +130,7 @@ namespace Pulumi
                 _name = "";
                 _protect = false;
                 _providers = ImmutableDictionary<string, ProviderResource>.Empty;
+                CompletionSources = ImmutableDictionary<string, IOutputCompletionSource>.Empty;
                 return;
             }
 
@@ -136,6 +139,13 @@ namespace Pulumi
 
             if (string.IsNullOrEmpty(name))
                 throw new ArgumentException("'name' cannot be null or empty.", nameof(name));
+
+            // Initialize all Output properties crucially including
+            // `Urn` to non-nil Output values, record
+            // `CompletionSources`. This needs to happen before
+            // partially initialized `this` is exposed to other
+            // threads via `parentResource.ChildResources`.
+            CompletionSources = OutputCompletionSource.InitializeOutputs(this);
 
             // Before anything else - if there are transformations registered, invoke them in order
             // to transform the properties and options assigned to this resource.

--- a/sdk/dotnet/Pulumi/Serialization/OutputCompletionSource.cs
+++ b/sdk/dotnet/Pulumi/Serialization/OutputCompletionSource.cs
@@ -17,7 +17,7 @@ namespace Pulumi.Serialization
 
         void TrySetException(Exception exception);
         void TrySetDefaultResult(bool isKnown);
-        
+
         void SetStringValue(string value, bool isKnown);
         void SetValue(OutputData<object?> data);
     }
@@ -72,7 +72,7 @@ namespace Pulumi.Serialization
                 if (!propType.IsConstructedGenericType ||
                     propType.GetGenericTypeDefinition() != typeof(Output<>))
                 {
-                    throw new InvalidOperationException($"{propFullName} was not an Output<T>");
+                    throw RunException.OutputsHaveIncorrectType(new[] { attrName });
                 }
 
                 var setMethod = prop.DeclaringType!.GetMethod("set_" + prop.Name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);

--- a/sdk/dotnet/Pulumi/Stack.cs
+++ b/sdk/dotnet/Pulumi/Stack.cs
@@ -50,7 +50,7 @@ namespace Pulumi
         /// Create a Stack with stack resources defined in derived class constructor.
         /// </summary>
         public Stack(StackOptions? options = null)
-            : base(_rootPulumiStackTypeName, 
+            : base(_rootPulumiStackTypeName,
                 $"{Deployment.Instance.ProjectName}-{Deployment.Instance.StackName}",
                 ConvertOptions(options))
         {
@@ -103,8 +103,7 @@ namespace Pulumi
                               select kv.Key).ToList();
             if (wrongTypes.Any())
             {
-                var message = $"Output(s) '{string.Join(", ", wrongTypes)}' have incorrect type. [Output] attributed properties must be instances of Output<T>.";
-                throw new RunException(message);
+                throw RunException.OutputsHaveIncorrectType(wrongTypes);
             }
 
             IDictionary<string, object?> dict = new Dictionary<string, object?>(outputs);
@@ -117,12 +116,12 @@ namespace Pulumi
             var dictionary = await init().ConfigureAwait(false);
             return dictionary.ToImmutableDictionary();
         }
-        
+
         private static ComponentResourceOptions? ConvertOptions(StackOptions? options)
         {
             if (options == null)
                 return null;
-            
+
             return new ComponentResourceOptions
             {
                 ResourceTransformations = options.ResourceTransformations


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Under certain conditions, C# SDK can race to observe nulls in Urn property of a resource. This is reproduced via a non-deterministic mock test, and fixed in this PR.

Fixes #7422 

On top of https://github.com/pulumi/pulumi/pull/8577 (requires merging that first).

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
