### PR TITLE
[sdk/dotnet] Improve collection initializers

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -22,6 +22,9 @@
 - [sdk/go] - Emit `pulumiplugin.json`
   [#8530](https://github.com/pulumi/pulumi/pull/8530)
 
+- [sdk/dotnet] - Improve collection initializers.
+  [#8498](https://github.com/pulumi/pulumi/pull/8498)
+
 ### Bug Fixes
 
 - [codegen/schema] - Error on type token names missing the correct prefix.

--- a/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
+++ b/sdk/dotnet/Pulumi.Automation/Pulumi.Automation.xml
@@ -1370,34 +1370,12 @@
             <param name="force">A boolean indicating whether the deletion should be forced.</param>
             <param name="cancellationToken">A cancellation token.</param>
         </member>
-        <member name="M:Pulumi.Automation.WorkspaceStackState.UnprotectAsync(System.String)">
-            <summary>
-            Unprotect a resource in a stack's state.
-            This command clears the ‘protect’ bit on the provided resource <paramref name="urn"/>, allowing the resource to be deleted.
-            </summary>
-            <param name="urn">The Pulumi URN to be unprotected.</param>
-        </member>
         <member name="M:Pulumi.Automation.WorkspaceStackState.UnprotectAsync(System.String,System.Threading.CancellationToken)">
             <summary>
             Unprotect a resource in a stack's state.
             This command clears the ‘protect’ bit on the provided resource <paramref name="urn"/>, allowing the resource to be deleted.
             </summary>
             <param name="urn">The Pulumi URN to be unprotected.</param>
-            <param name="cancellationToken">A cancellation token.</param>
-        </member>
-        <member name="M:Pulumi.Automation.WorkspaceStackState.UnprotectAsync(System.Collections.Generic.IEnumerable{System.String})">
-            <summary>
-            Unprotect resources in a stack's state.
-            This command clears the ‘protect’ bit on the provided resource <paramref name="urns"/>, allowing those resources to be deleted.
-            </summary>
-            <param name="urns">The Pulumi URNs to be unprotected.</param>
-        </member>
-        <member name="M:Pulumi.Automation.WorkspaceStackState.UnprotectAsync(System.Collections.Generic.IEnumerable{System.String},System.Threading.CancellationToken)">
-            <summary>
-            Unprotect resources in a stack's state.
-            This command clears the ‘protect’ bit on the provided resource <paramref name="urns"/>, allowing those resources to be deleted.
-            </summary>
-            <param name="urns">The Pulumi URNs to be unprotected.</param>
             <param name="cancellationToken">A cancellation token.</param>
         </member>
         <member name="M:Pulumi.Automation.WorkspaceStackState.UnprotectAllAsync(System.Threading.CancellationToken)">

--- a/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright 2016-2019, Pulumi Corporation
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
 using Xunit;
@@ -45,6 +46,22 @@ namespace Pulumi.Tests.Core
             });
 
         [Fact]
+        public Task InputMapCollectionInitializers()
+            => RunInPreview(async () =>
+            {
+                var map = new InputMap<string>
+                {
+                    { "K1", "V1" },
+                    { "K2", Output.Create("V2") },
+                    new Dictionary<string, string> { { "K3", "V3" }, { "K4", "V4"} },
+                    Output.Create(new Dictionary<string, string> { ["K5"] = "V5", ["K6"] = "V6" }.ToImmutableDictionary())
+                };
+                var data = await map.ToOutput().DataTask.ConfigureAwait(false);
+                Assert.Equal(6, data.Value.Count);
+                Assert.Equal(new Dictionary<string, string> { ["K1"] = "V1", ["K2"] = "V2", ["K3"] = "V3", ["K4"] = "V4", ["K5"] = "V5", ["K6"] = "V6" }, data.Value);
+            });
+
+        [Fact]
         public Task InputMapUnionInitializer()
             => RunInPreview(async () =>
             {
@@ -61,7 +78,24 @@ namespace Pulumi.Tests.Core
                 Assert.True(data.Value.ContainsValue("testValue"));
                 Assert.True(data.Value.ContainsValue(123));
             });
-        
+
+        [Fact]
+        public Task InputListCollectionInitializers()
+            => RunInPreview(async () =>
+            {
+                var list = new InputList<string>
+                {
+                    "V1",
+                    Output.Create("V2"),
+                    new[] { "V3", "V4" },
+                    new List<string> { "V5", "V6" },
+                    Output.Create(ImmutableArray.Create("V7", "V8"))
+                };
+                var data = await list.ToOutput().DataTask.ConfigureAwait(false);
+                Assert.Equal(8, data.Value.Length);
+                Assert.Equal(new[] { "V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8" }, data.Value);
+            });
+
         [Fact]
         public Task InputListUnionInitializer()
             => RunInPreview(async () =>

--- a/sdk/dotnet/Pulumi/Core/InputList.cs
+++ b/sdk/dotnet/Pulumi/Core/InputList.cs
@@ -66,13 +66,6 @@ namespace Pulumi
         }
 
         /// <summary>
-        /// Concatenates the values in this list with the value in <paramref name="other"/>,
-        /// returning the concatenated sequence in a new <see cref="InputList{T}"/>.
-        /// </summary>
-        public InputList<T> Concat(Input<T> other)
-            => Output.Concat(_outputValue, other);
-
-        /// <summary>
         /// Concatenates the values in this list with the values in <paramref name="other"/>,
         /// returning the concatenated sequence in a new <see cref="InputList{T}"/>.
         /// </summary>

--- a/sdk/dotnet/Pulumi/Core/InputList.cs
+++ b/sdk/dotnet/Pulumi/Core/InputList.cs
@@ -55,29 +55,29 @@ namespace Pulumi
         {
         }
 
-        public void Add(Input<T> value)
+        public void Add(params Input<T>[] inputs)
         {
-            _outputValue = Concat(value);
+            _outputValue = Concat(inputs);
         }
 
-        public void Add(InputList<T> values)
+        public void Add(InputList<T> inputs)
         {
-            _outputValue = Concat(values);
+            _outputValue = Concat(inputs);
         }
 
         /// <summary>
-        /// Concatenates the values in this list with the given <paramref name="value"/>,
+        /// Concatenates the values in this list with the value in <paramref name="other"/>,
         /// returning the concatenated sequence in a new <see cref="InputList{T}"/>.
         /// </summary>
-        public InputList<T> Concat(Input<T> value)
-            => Output.Concat(_outputValue, value);
+        public InputList<T> Concat(Input<T> other)
+            => Output.Concat(_outputValue, other);
 
         /// <summary>
-        /// Concatenates the values in this list with the given <paramref name="values"/>,
+        /// Concatenates the values in this list with the values in <paramref name="other"/>,
         /// returning the concatenated sequence in a new <see cref="InputList{T}"/>.
         /// </summary>
-        public InputList<T> Concat(InputList<T> values)
-            => Output.Concat(_outputValue, values._outputValue);
+        public InputList<T> Concat(InputList<T> other)
+            => Output.Concat(_outputValue, other._outputValue);
 
         internal InputList<T> Clone()
             => new InputList<T>(_outputValue);

--- a/sdk/dotnet/Pulumi/Core/InputList.cs
+++ b/sdk/dotnet/Pulumi/Core/InputList.cs
@@ -55,19 +55,29 @@ namespace Pulumi
         {
         }
 
-        public void Add(params Input<T>[] inputs)
+        public void Add(Input<T> value)
         {
-            // Make an Output from the values passed in, mix in with our own Output, and combine
-            // both to produce the final array that we will now point at.
-            _outputValue = Output.Concat(_outputValue, Output.All(inputs));
+            _outputValue = Concat(value);
+        }
+
+        public void Add(InputList<T> values)
+        {
+            _outputValue = Concat(values);
         }
 
         /// <summary>
-        /// Concatenates the values in this list with the values in <paramref name="other"/>,
+        /// Concatenates the values in this list with the given <paramref name="value"/>,
         /// returning the concatenated sequence in a new <see cref="InputList{T}"/>.
         /// </summary>
-        public InputList<T> Concat(InputList<T> other)
-            => Output.Concat(_outputValue, other._outputValue);
+        public InputList<T> Concat(Input<T> value)
+            => Output.Concat(_outputValue, value);
+
+        /// <summary>
+        /// Concatenates the values in this list with the given <paramref name="values"/>,
+        /// returning the concatenated sequence in a new <see cref="InputList{T}"/>.
+        /// </summary>
+        public InputList<T> Concat(InputList<T> values)
+            => Output.Concat(_outputValue, values._outputValue);
 
         internal InputList<T> Clone()
             => new InputList<T>(_outputValue);

--- a/sdk/dotnet/Pulumi/Core/InputList.cs
+++ b/sdk/dotnet/Pulumi/Core/InputList.cs
@@ -60,7 +60,15 @@ namespace Pulumi
             _outputValue = Concat(inputs);
         }
 
+        /// <summary>
+        /// Note: this is non-standard convenience for use with collection initializers.
+        /// </summary>
         public void Add(InputList<T> inputs)
+        {
+            AddRange(inputs);
+        }
+
+        public void AddRange(InputList<T> inputs)
         {
             _outputValue = Concat(inputs);
         }

--- a/sdk/dotnet/Pulumi/Core/InputMap.cs
+++ b/sdk/dotnet/Pulumi/Core/InputMap.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016-2021, Pulumi Corporation
+// Copyright 2016-2021, Pulumi Corporation
 
 using System;
 using System.Collections;
@@ -55,7 +55,14 @@ namespace Pulumi
         {
             var inputDictionary = (Input<ImmutableDictionary<string, V>>)_outputValue;
             _outputValue = Output.Tuple(inputDictionary, value)
-                                 .Apply(x => x.Item1.Add(key, x.Item2));
+                .Apply(x => x.Item1.Add(key, x.Item2));
+        }
+
+        public void Add(InputMap<V> values)
+        {
+            var inputDictionary = (Input<ImmutableDictionary<string, V>>)_outputValue;
+            _outputValue = Output.Tuple(inputDictionary, values)
+                .Apply(x => x.Item1.AddRange(x.Item2));
         }
 
         public Input<V> this[string key]

--- a/sdk/dotnet/Pulumi/Core/InputMap.cs
+++ b/sdk/dotnet/Pulumi/Core/InputMap.cs
@@ -58,7 +58,15 @@ namespace Pulumi
                 .Apply(x => x.Item1.Add(key, x.Item2));
         }
 
+        /// <summary>
+        /// Note: this is non-standard convenience for use with collection initializers.
+        /// </summary>
         public void Add(InputMap<V> values)
+        {
+            AddRange(values);
+        }
+
+        public void AddRange(InputMap<V> values)
         {
             var inputDictionary = (Input<ImmutableDictionary<string, V>>)_outputValue;
             _outputValue = Output.Tuple(inputDictionary, values)

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -101,9 +101,6 @@ namespace Pulumi
                 string.Format(formattableString.Format, objs.ToArray()));
         }
 
-        internal static Output<ImmutableArray<T>> Concat<T>(Output<ImmutableArray<T>> values, Output<T> value)
-            => Tuple(values, value).Apply(tuple => tuple.Item1.Add(tuple.Item2));
-
         internal static Output<ImmutableArray<T>> Concat<T>(Output<ImmutableArray<T>> values1, Output<ImmutableArray<T>> values2)
             => Tuple(values1, values2).Apply(tuple => tuple.Item1.AddRange(tuple.Item2));
     }

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -101,8 +101,11 @@ namespace Pulumi
                 string.Format(formattableString.Format, objs.ToArray()));
         }
 
+        internal static Output<ImmutableArray<T>> Concat<T>(Output<ImmutableArray<T>> values, Output<T> value)
+            => Tuple(values, value).Apply(tuple => tuple.Item1.Add(tuple.Item2));
+
         internal static Output<ImmutableArray<T>> Concat<T>(Output<ImmutableArray<T>> values1, Output<ImmutableArray<T>> values2)
-            => Tuple(values1, values2).Apply(a => a.Item1.AddRange(a.Item2));
+            => Tuple(values1, values2).Apply(tuple => tuple.Item1.AddRange(tuple.Item2));
     }
 
     /// <summary>

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -107,11 +107,14 @@ Pulumi.InputMapExtensions
 Pulumi.InputJson
 Pulumi.InputJson.InputJson() -> void
 Pulumi.InputList<T>
-Pulumi.InputList<T>.Add(params Pulumi.Input<T>[] inputs) -> void
-Pulumi.InputList<T>.Concat(Pulumi.InputList<T> other) -> Pulumi.InputList<T>
+Pulumi.InputList<T>.Add(Pulumi.Input<T> value) -> void
+Pulumi.InputList<T>.Add(Pulumi.InputList<T> values) -> void
+Pulumi.InputList<T>.Concat(Pulumi.Input<T> value) -> Pulumi.InputList<T>
+Pulumi.InputList<T>.Concat(Pulumi.InputList<T> values) -> Pulumi.InputList<T>
 Pulumi.InputList<T>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerator<Pulumi.Input<T>>
 Pulumi.InputList<T>.InputList() -> void
 Pulumi.InputMap<V>
+Pulumi.InputMap<V>.Add(Pulumi.InputMap<V> values) -> void
 Pulumi.InputMap<V>.Add(string key, Pulumi.Input<V> value) -> void
 Pulumi.InputMap<V>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerator<Pulumi.Input<System.Collections.Generic.KeyValuePair<string, V>>>
 Pulumi.InputMap<V>.InputMap() -> void
@@ -178,6 +181,8 @@ Pulumi.ResourceOptions.Protect.get -> bool?
 Pulumi.ResourceOptions.Protect.set -> void
 Pulumi.ResourceOptions.Provider.get -> Pulumi.ProviderResource
 Pulumi.ResourceOptions.Provider.set -> void
+Pulumi.ResourceOptions.ReplaceOnChanges.get -> System.Collections.Generic.List<string>
+Pulumi.ResourceOptions.ReplaceOnChanges.set -> void
 Pulumi.ResourceOptions.ResourceOptions() -> void
 Pulumi.ResourceOptions.ResourceTransformations.get -> System.Collections.Generic.List<Pulumi.ResourceTransformation>
 Pulumi.ResourceOptions.ResourceTransformations.set -> void

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -107,10 +107,10 @@ Pulumi.InputMapExtensions
 Pulumi.InputJson
 Pulumi.InputJson.InputJson() -> void
 Pulumi.InputList<T>
-Pulumi.InputList<T>.Add(Pulumi.Input<T> value) -> void
-Pulumi.InputList<T>.Add(Pulumi.InputList<T> values) -> void
-Pulumi.InputList<T>.Concat(Pulumi.Input<T> value) -> Pulumi.InputList<T>
-Pulumi.InputList<T>.Concat(Pulumi.InputList<T> values) -> Pulumi.InputList<T>
+Pulumi.InputList<T>.Add(params Pulumi.Input<T>[] inputs) -> void
+Pulumi.InputList<T>.Add(Pulumi.InputList<T> inputs) -> void
+Pulumi.InputList<T>.Concat(Pulumi.Input<T> other) -> Pulumi.InputList<T>
+Pulumi.InputList<T>.Concat(Pulumi.InputList<T> other) -> Pulumi.InputList<T>
 Pulumi.InputList<T>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerator<Pulumi.Input<T>>
 Pulumi.InputList<T>.InputList() -> void
 Pulumi.InputMap<V>

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -109,12 +109,14 @@ Pulumi.InputJson.InputJson() -> void
 Pulumi.InputList<T>
 Pulumi.InputList<T>.Add(params Pulumi.Input<T>[] inputs) -> void
 Pulumi.InputList<T>.Add(Pulumi.InputList<T> inputs) -> void
+Pulumi.InputList<T>.AddRange(Pulumi.InputList<T> inputs) -> void
 Pulumi.InputList<T>.Concat(Pulumi.InputList<T> other) -> Pulumi.InputList<T>
 Pulumi.InputList<T>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerator<Pulumi.Input<T>>
 Pulumi.InputList<T>.InputList() -> void
 Pulumi.InputMap<V>
 Pulumi.InputMap<V>.Add(Pulumi.InputMap<V> values) -> void
 Pulumi.InputMap<V>.Add(string key, Pulumi.Input<V> value) -> void
+Pulumi.InputMap<V>.AddRange(Pulumi.InputMap<V> values) -> void
 Pulumi.InputMap<V>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerator<Pulumi.Input<System.Collections.Generic.KeyValuePair<string, V>>>
 Pulumi.InputMap<V>.InputMap() -> void
 Pulumi.InputMap<V>.this[string key].set -> void

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -109,7 +109,6 @@ Pulumi.InputJson.InputJson() -> void
 Pulumi.InputList<T>
 Pulumi.InputList<T>.Add(params Pulumi.Input<T>[] inputs) -> void
 Pulumi.InputList<T>.Add(Pulumi.InputList<T> inputs) -> void
-Pulumi.InputList<T>.Concat(Pulumi.Input<T> other) -> Pulumi.InputList<T>
 Pulumi.InputList<T>.Concat(Pulumi.InputList<T> other) -> Pulumi.InputList<T>
 Pulumi.InputList<T>.GetAsyncEnumerator(System.Threading.CancellationToken cancellationToken) -> System.Collections.Generic.IAsyncEnumerator<Pulumi.Input<T>>
 Pulumi.InputList<T>.InputList() -> void

--- a/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Unshipped.txt
@@ -1,2 +1,0 @@
-Pulumi.ResourceOptions.ReplaceOnChanges.get -> System.Collections.Generic.List<string>
-Pulumi.ResourceOptions.ReplaceOnChanges.set -> void


### PR DESCRIPTION
Fixes #8497. See the [InputMapCollectionInitializers](https://github.com/pulumi/pulumi/blob/af99d3cbe087d38f40a64e7d50701cb197c3e8c2/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs#L49) and [InputListCollectionInitializers](https://github.com/pulumi/pulumi/blob/af99d3cbe087d38f40a64e7d50701cb197c3e8c2/sdk/dotnet/Pulumi.Tests/Core/InputTests.cs#L83) tests for examples of flexibility and usability.