### PR TITLE
Allow interpolating plugin custom server URLs

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -6,6 +6,8 @@
   these types virtually unusable in practice.
   [#8449](https://github.com/pulumi/pulumi/pull/8449)
 
+- Allow interpolating plugin custom server URLs.
+  [#8507](https://github.com/pulumi/pulumi/pull/8507)
 ### Bug Fixes
 
 - [codegen/go] - Respect default values in Pulumi object types.

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -234,3 +234,19 @@ func TestPluginSelection_EmptyVersionWithAlternatives(t *testing.T) {
 	assert.Equal(t, "myplugin", result.Name)
 	assert.Equal(t, "0.2.0", result.Version.String())
 }
+
+func TestInterpolateURL(t *testing.T) {
+	version := semver.MustParse("1.0.0")
+	const os = "linux"
+	const arch = "amd64"
+	assert.Equal(t, "", interpolateURL("", version, os, arch))
+	assert.Equal(t,
+		"https://get.pulumi.com/releases/plugins",
+		interpolateURL("https://get.pulumi.com/releases/plugins", version, os, arch))
+	assert.Equal(t,
+		"https://github.com/org/repo/releases/download/1.0.0",
+		interpolateURL("https://github.com/org/repo/releases/download/${VERSION}", version, os, arch))
+	assert.Equal(t,
+		"https://github.com/org/repo/releases/download/1.0.0/linux/amd64",
+		interpolateURL("https://github.com/org/repo/releases/download/${VERSION}/${OS}/${ARCH}", version, os, arch))
+}


### PR DESCRIPTION
A custom server URL can contain `${VERSION}`, `${OS}`, or `${ARCH}` (case sensitive) in the URL and these values will be interpolated when downloading the plugin.

Fixes #8263