### PR TITLE
[codegen/dotnet] Emit `pulumiplugin json` during codegen

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,7 +1,8 @@
 ### Improvements
 
-- [codegen/python] - Emit `pulumiplugin.json` unconditionally. 
+- [codegen/{python,dotnet}] - Emit `pulumiplugin.json` unconditionally.
   [#8527](https://github.com/pulumi/pulumi/pull/8527)
+  [#8532](https://github.com/pulumi/pulumi/pull/8532)
 
 - [sdk/python] - Lookup Pulumi packages by searching for `pulumiplugin.json`.
   Pulumi packages need not be prefixed by `pulumi-` anymore.

--- a/pkg/codegen/dotnet/gen.go
+++ b/pkg/codegen/dotnet/gen.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
 	"github.com/pulumi/pulumi/pkg/v3/codegen/schema"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/diag"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
@@ -2138,9 +2139,18 @@ func genPackageMetadata(pkg *schema.Package,
 	if err != nil {
 		return err
 	}
+	plugin, err := (&plugin.PulumiPluginJSON{
+		Resource: true,
+		Name:     pkg.Name,
+		Server:   pkg.PluginDownloadURL,
+	}).JSON()
+	if err != nil {
+		return err
+	}
 
 	files.add(assemblyName+".csproj", projectFile)
 	files.add("logo.png", logo)
+	files.add("pulumiplugin.json", plugin)
 	return nil
 }
 

--- a/pkg/codegen/dotnet/templates.go
+++ b/pkg/codegen/dotnet/templates.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2020, Pulumi Corporation.
+// Copyright 2016-2021, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -161,6 +161,11 @@ const csharpProjectFileTemplateText = `<Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <EmbeddedResource Include="version.txt" />
     <None Include="version.txt" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
   </ItemGroup>
 
   <ItemGroup>

--- a/pkg/codegen/internal/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/cyclic-types/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/cyclic-types/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/cyclic-types/dotnet/codegen-manifest.json
@@ -4,6 +4,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/cyclic-types/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/cyclic-types/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/internal/test/testdata/dash-named-schema/dotnet/Pulumi.FooBar.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
     <PackageReference Include="Pulumi.Aws" Version="4.20" ExcludeAssets="contentFiles" />

--- a/pkg/codegen/internal/test/testdata/dash-named-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/dash-named-schema/dotnet/codegen-manifest.json
@@ -8,6 +8,7 @@
     "Submodule1/ModuleResource.cs",
     "Submodule1/README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/dash-named-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/dash-named-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "foo-bar"
+}

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/dotnet/Pulumi.Plant.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/dotnet/codegen-manifest.json
@@ -12,6 +12,7 @@
     "Tree/V1/README.md",
     "Tree/V1/RubberTree.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/dashed-import-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/dashed-import-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "plant"
+}

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.13" />
     <PackageReference Include="Pulumi.Aws" Version="4.20" ExcludeAssets="contentFiles" />

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/codegen-manifest.json
@@ -9,6 +9,7 @@
     "README.md",
     "Utilities.cs",
     "Workload.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/external-resource-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
+++ b/pkg/codegen/internal/test/testdata/hyphen-url/dotnet/Pulumi.Registrygeoreplication.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.AzureNative" Version="1.28.*" ExcludeAssets="contentFiles" />

--- a/pkg/codegen/internal/test/testdata/hyphen-url/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/hyphen-url/dotnet/codegen-manifest.json
@@ -5,6 +5,7 @@
     "README.md",
     "RegistryGeoReplication.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/hyphen-url/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/hyphen-url/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "registrygeoreplication"
+}

--- a/pkg/codegen/internal/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/naming-collisions/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/naming-collisions/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/naming-collisions/dotnet/codegen-manifest.json
@@ -7,6 +7,7 @@
     "Resource.cs",
     "ResourceInput.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/naming-collisions/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/naming-collisions/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/dotnet/Pulumi.Foo-bar.csproj
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/dotnet/Pulumi.Foo-bar.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
   </ItemGroup>
 

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/dotnet/codegen-manifest.json
@@ -8,6 +8,7 @@
     "Pulumi.Foo-bar.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/nested-module-thirdparty/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/nested-module-thirdparty/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "foo-bar"
+}

--- a/pkg/codegen/internal/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
+++ b/pkg/codegen/internal/test/testdata/nested-module/dotnet/Pulumi.Foo.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/nested-module/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/nested-module/dotnet/codegen-manifest.json
@@ -7,6 +7,7 @@
     "Pulumi.Foo.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/nested-module/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/nested-module/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "foo"
+}

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/dotnet/Pulumi.Myedgeorder.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
   </ItemGroup>
 

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/dotnet/codegen-manifest.json
@@ -33,6 +33,7 @@
     "Pulumi.Myedgeorder.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "myedgeorder"
+}

--- a/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/dotnet/Pulumi.Mypkg.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/dotnet/codegen-manifest.json
@@ -10,6 +10,7 @@
     "Pulumi.Mypkg.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/output-funcs-tfbridge20/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "mypkg"
+}

--- a/pkg/codegen/internal/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
+++ b/pkg/codegen/internal/test/testdata/output-funcs/dotnet/Pulumi.Mypkg.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.10.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/pkg/codegen/internal/test/testdata/output-funcs/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/output-funcs/dotnet/codegen-manifest.json
@@ -23,6 +23,7 @@
     "Pulumi.Mypkg.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/output-funcs/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/output-funcs/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "mypkg"
+}

--- a/pkg/codegen/internal/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
+++ b/pkg/codegen/internal/test/testdata/plain-and-default/dotnet/Pulumi.FooBar.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/plain-and-default/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/plain-and-default/dotnet/codegen-manifest.json
@@ -6,6 +6,7 @@
     "Pulumi.FooBar.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/plain-and-default/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/plain-and-default/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "foobar"
+}

--- a/pkg/codegen/internal/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/plain-object-defaults/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/plain-object-defaults/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/plain-object-defaults/dotnet/codegen-manifest.json
@@ -17,6 +17,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/plain-object-defaults/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/plain-object-defaults/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/plain-object-disable-defaults/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/plain-object-disable-defaults/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/plain-object-disable-defaults/dotnet/codegen-manifest.json
@@ -17,6 +17,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/plain-object-disable-defaults/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/plain-object-disable-defaults/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/dotnet/Pulumi.Xyz.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.*" />
     <PackageReference Include="Pulumi.Aws" Version="4.*" ExcludeAssets="contentFiles" />

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/dotnet/codegen-manifest.json
@@ -6,6 +6,7 @@
     "README.md",
     "StaticPage.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/plain-schema-gh6957/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/plain-schema-gh6957/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "xyz"
+}

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/dotnet/Pulumi.Configstation.csproj
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/dotnet/Pulumi.Configstation.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/dotnet/codegen-manifest.json
@@ -8,6 +8,7 @@
     "Pulumi.Configstation.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/provider-config-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/provider-config-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "configstation"
+}

--- a/pkg/codegen/internal/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
+++ b/pkg/codegen/internal/test/testdata/regress-8403/dotnet/Pulumi.Mongodbatlas.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
   </ItemGroup>
 

--- a/pkg/codegen/internal/test/testdata/regress-8403/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/regress-8403/dotnet/codegen-manifest.json
@@ -6,6 +6,7 @@
     "Pulumi.Mongodbatlas.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/regress-8403/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/regress-8403/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "mongodbatlas"
+}

--- a/pkg/codegen/internal/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
+++ b/pkg/codegen/internal/test/testdata/regress-node-8110/dotnet/Pulumi.My8110.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/regress-node-8110/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/regress-node-8110/dotnet/codegen-manifest.json
@@ -6,6 +6,7 @@
     "Pulumi.My8110.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/regress-node-8110/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/regress-node-8110/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "my8110"
+}

--- a/pkg/codegen/internal/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/replace-on-change/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/dotnet/codegen-manifest.json
@@ -13,6 +13,7 @@
     "README.md",
     "ToyStore.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/replace-on-change/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/replace-on-change/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12.0" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/dotnet/codegen-manifest.json
@@ -8,6 +8,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/resource-args-python-case-insensitive/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12.0" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/resource-args-python/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/dotnet/codegen-manifest.json
@@ -8,6 +8,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/resource-args-python/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/resource-args-python/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
   </ItemGroup>
 

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/dotnet/codegen-manifest.json
@@ -5,6 +5,7 @@
     "README.md",
     "Rec.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/resource-property-overlap/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/resource-property-overlap/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/Pulumi.Plant.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/codegen-manifest.json
@@ -12,6 +12,7 @@
     "Tree/V1/README.md",
     "Tree/V1/RubberTree.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/simple-enum-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "plant"
+}

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/dotnet/codegen-manifest.json
@@ -5,6 +5,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema-single-value-returns/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
     <PackageReference Include="Pulumi.Random" Version="4.2.0" ExcludeAssets="contentFiles" />

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/dotnet/codegen-manifest.json
@@ -8,6 +8,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/simple-methods-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/simple-methods-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/dotnet/codegen-manifest.json
@@ -7,6 +7,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema-with-root-package/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.12" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/codegen-manifest.json
@@ -9,6 +9,7 @@
     "Pulumi.Example.csproj",
     "README.md",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/simple-plain-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.13" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/codegen-manifest.json
@@ -7,6 +7,7 @@
     "README.md",
     "Resource.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.13" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/dotnet/codegen-manifest.json
@@ -16,6 +16,7 @@
     "Resource.cs",
     "TypeUses.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/dotnet/Pulumi.Example.csproj
@@ -39,6 +39,11 @@
     <None Include="version.txt" Pack="True" PackagePath="content" />
   </ItemGroup>
 
+   <ItemGroup>
+    <EmbeddedResource Include="pulumiplugin.json" />
+    <None Include="pulumiplugin.json" Pack="True" PackagePath="content" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Pulumi" Version="3.13" />
   </ItemGroup>

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/dotnet/codegen-manifest.json
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/dotnet/codegen-manifest.json
@@ -17,6 +17,7 @@
     "Resource.cs",
     "TypeUses.cs",
     "Utilities.cs",
-    "logo.png"
+    "logo.png",
+    "pulumiplugin.json"
   ]
 }

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/dotnet/pulumiplugin.json
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/dotnet/pulumiplugin.json
@@ -1,0 +1,4 @@
+{
+  "resource": true,
+  "name": "example"
+}

--- a/sdk/go/common/resource/plugin/plugin.go
+++ b/sdk/go/common/resource/plugin/plugin.go
@@ -63,7 +63,7 @@ func (plugin *PulumiPluginJSON) JSON() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return json, nil
+	return append(json, '\n'), nil
 }
 
 func LoadPulumiPluginJSON(path string) (*PulumiPluginJSON, error) {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

First commit is changes, second commit is the test updates. 

Fixes #8531

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
