### PR TITLE
[codegen/go] Fix ElementType for nested collection types.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -21,3 +21,6 @@
 
 ### Bug Fixes
 
+- [codegen/go] - Fix `ElementType` for nested collection input and output types.
+  [#8535](https://github.com/pulumi/pulumi/pull/8535)
+

--- a/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/output-funcs-edgeorder/go/myedgeorder/pulumiTypes.go
@@ -2442,7 +2442,7 @@ func (o SpecificationResponseArrayOutput) Index(i pulumi.IntInput) Specification
 type FilterablePropertyArrayMap map[string]FilterablePropertyArrayInput
 
 func (FilterablePropertyArrayMap) ElementType() reflect.Type {
-	return reflect.TypeOf((*FilterablePropertyArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string][]FilterableProperty)(nil)).Elem()
 }
 
 func (i FilterablePropertyArrayMap) ToFilterablePropertyArrayMapOutput() FilterablePropertyArrayMapOutput {
@@ -2456,7 +2456,7 @@ func (i FilterablePropertyArrayMap) ToFilterablePropertyArrayMapOutputWithContex
 type FilterablePropertyArrayMapOutput struct{ *pulumi.OutputState }
 
 func (FilterablePropertyArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]FilterablePropertyArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string][]FilterableProperty)(nil)).Elem()
 }
 
 func (o FilterablePropertyArrayMapOutput) ToFilterablePropertyArrayMapOutput() FilterablePropertyArrayMapOutput {
@@ -2468,8 +2468,8 @@ func (o FilterablePropertyArrayMapOutput) ToFilterablePropertyArrayMapOutputWith
 }
 
 func (o FilterablePropertyArrayMapOutput) MapIndex(k pulumi.StringInput) FilterablePropertyArrayOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) FilterablePropertyArray {
-		return vs[0].(map[string]FilterablePropertyArray)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) []FilterableProperty {
+		return vs[0].(map[string][]FilterableProperty)[vs[1].(string)]
 	}).(FilterablePropertyArrayOutput)
 }
 

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema-custom-pypackage-name/go/example/pulumiTypes.go
@@ -329,7 +329,7 @@ func (o SomeOtherObjectArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectOutp
 type SomeOtherObjectArrayArray []SomeOtherObjectArrayInput
 
 func (SomeOtherObjectArrayArray) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[][]SomeOtherObject)(nil)).Elem()
 }
 
 func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -343,7 +343,7 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(
 type SomeOtherObjectArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[][]SomeOtherObject)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -355,8 +355,8 @@ func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutputWithCo
 }
 
 func (o SomeOtherObjectArrayArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectArrayOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SomeOtherObjectArray {
-		return vs[0].([]SomeOtherObjectArray)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []SomeOtherObject {
+		return vs[0].([][]SomeOtherObject)[vs[1].(int)]
 	}).(SomeOtherObjectArrayOutput)
 }
 
@@ -374,7 +374,7 @@ type SomeOtherObjectArrayArrayInput interface {
 type SomeOtherObjectArrayMap map[string]SomeOtherObjectArrayInput
 
 func (SomeOtherObjectArrayMap) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string][]SomeOtherObject)(nil)).Elem()
 }
 
 func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {
@@ -388,7 +388,7 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx 
 type SomeOtherObjectArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string][]SomeOtherObject)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {
@@ -400,8 +400,8 @@ func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutputWithContex
 }
 
 func (o SomeOtherObjectArrayMapOutput) MapIndex(k pulumi.StringInput) SomeOtherObjectArrayOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) SomeOtherObjectArray {
-		return vs[0].(map[string]SomeOtherObjectArray)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) []SomeOtherObject {
+		return vs[0].(map[string][]SomeOtherObject)[vs[1].(string)]
 	}).(SomeOtherObjectArrayOutput)
 }
 

--- a/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-resource-schema/go/example/pulumiTypes.go
@@ -683,7 +683,7 @@ func (o SomeOtherObjectArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectOutp
 type SomeOtherObjectArrayArray []SomeOtherObjectArrayInput
 
 func (SomeOtherObjectArrayArray) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[][]SomeOtherObject)(nil)).Elem()
 }
 
 func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -697,7 +697,7 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(
 type SomeOtherObjectArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[][]SomeOtherObject)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -709,8 +709,8 @@ func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutputWithCo
 }
 
 func (o SomeOtherObjectArrayArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectArrayOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SomeOtherObjectArray {
-		return vs[0].([]SomeOtherObjectArray)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []SomeOtherObject {
+		return vs[0].([][]SomeOtherObject)[vs[1].(int)]
 	}).(SomeOtherObjectArrayOutput)
 }
 
@@ -728,7 +728,7 @@ type SomeOtherObjectArrayArrayInput interface {
 type SomeOtherObjectArrayMap map[string]SomeOtherObjectArrayInput
 
 func (SomeOtherObjectArrayMap) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string][]SomeOtherObject)(nil)).Elem()
 }
 
 func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {
@@ -742,7 +742,7 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx 
 type SomeOtherObjectArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string][]SomeOtherObject)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {
@@ -754,8 +754,8 @@ func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutputWithContex
 }
 
 func (o SomeOtherObjectArrayMapOutput) MapIndex(k pulumi.StringInput) SomeOtherObjectArrayOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) SomeOtherObjectArray {
-		return vs[0].(map[string]SomeOtherObjectArray)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) []SomeOtherObject {
+		return vs[0].(map[string][]SomeOtherObject)[vs[1].(string)]
 	}).(SomeOtherObjectArrayOutput)
 }
 

--- a/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/pulumiTypes.go
+++ b/pkg/codegen/internal/test/testdata/simple-yaml-schema/go/example/pulumiTypes.go
@@ -683,7 +683,7 @@ func (o SomeOtherObjectArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectOutp
 type SomeOtherObjectArrayArray []SomeOtherObjectArrayInput
 
 func (SomeOtherObjectArrayArray) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[][]SomeOtherObject)(nil)).Elem()
 }
 
 func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -697,7 +697,7 @@ func (i SomeOtherObjectArrayArray) ToSomeOtherObjectArrayArrayOutputWithContext(
 type SomeOtherObjectArrayArrayOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayArrayOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*[]SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*[][]SomeOtherObject)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutput() SomeOtherObjectArrayArrayOutput {
@@ -709,8 +709,8 @@ func (o SomeOtherObjectArrayArrayOutput) ToSomeOtherObjectArrayArrayOutputWithCo
 }
 
 func (o SomeOtherObjectArrayArrayOutput) Index(i pulumi.IntInput) SomeOtherObjectArrayOutput {
-	return pulumi.All(o, i).ApplyT(func(vs []interface{}) SomeOtherObjectArray {
-		return vs[0].([]SomeOtherObjectArray)[vs[1].(int)]
+	return pulumi.All(o, i).ApplyT(func(vs []interface{}) []SomeOtherObject {
+		return vs[0].([][]SomeOtherObject)[vs[1].(int)]
 	}).(SomeOtherObjectArrayOutput)
 }
 
@@ -728,7 +728,7 @@ type SomeOtherObjectArrayArrayInput interface {
 type SomeOtherObjectArrayMap map[string]SomeOtherObjectArrayInput
 
 func (SomeOtherObjectArrayMap) ElementType() reflect.Type {
-	return reflect.TypeOf((*SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string][]SomeOtherObject)(nil)).Elem()
 }
 
 func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {
@@ -742,7 +742,7 @@ func (i SomeOtherObjectArrayMap) ToSomeOtherObjectArrayMapOutputWithContext(ctx 
 type SomeOtherObjectArrayMapOutput struct{ *pulumi.OutputState }
 
 func (SomeOtherObjectArrayMapOutput) ElementType() reflect.Type {
-	return reflect.TypeOf((*map[string]SomeOtherObjectArray)(nil)).Elem()
+	return reflect.TypeOf((*map[string][]SomeOtherObject)(nil)).Elem()
 }
 
 func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutput() SomeOtherObjectArrayMapOutput {
@@ -754,8 +754,8 @@ func (o SomeOtherObjectArrayMapOutput) ToSomeOtherObjectArrayMapOutputWithContex
 }
 
 func (o SomeOtherObjectArrayMapOutput) MapIndex(k pulumi.StringInput) SomeOtherObjectArrayOutput {
-	return pulumi.All(o, k).ApplyT(func(vs []interface{}) SomeOtherObjectArray {
-		return vs[0].(map[string]SomeOtherObjectArray)[vs[1].(string)]
+	return pulumi.All(o, k).ApplyT(func(vs []interface{}) []SomeOtherObject {
+		return vs[0].(map[string][]SomeOtherObject)[vs[1].(string)]
 	}).(SomeOtherObjectArrayOutput)
 }
 


### PR DESCRIPTION
The element types for nested collection types are currently incorrect.

For arrays, we generate an element type of `[]FooArgs`, where
`FooArgs` is an args type for `FooInput`. Instead, the element type
should be `[]Foo`, where `Foo` is the element type of `FooInput`.

For maps, we generate an element type of `FooArgs`. Instead, the element
type should be `map[string]Foo`, where `Foo` is the element type of
`FooInput`.

These changes correct the element types. This is prep for #7943.