### PR TITLE
Add optionality to disable meta-schema validation

### DIFF
--- a/pkg/cmd/pulumi/import.go
+++ b/pkg/cmd/pulumi/import.go
@@ -248,7 +248,7 @@ func generateImportedDefinitions(out io.Writer, stackName tokens.QName, projectN
 	if err != nil {
 		return false, err
 	}
-	loader := schema.NewPluginLoader(ctx.Host)
+	loader := schema.NewPluginLoader(ctx.Host, schema.DisableValidation())
 	return true, importer.GenerateLanguageDefinitions(out, loader, func(w io.Writer, p *pcl.Program) error {
 		files, _, err := programGenerator(p)
 		if err != nil {

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -23,13 +23,16 @@ type Loader interface {
 type pluginLoader struct {
 	m sync.RWMutex
 
+	specOpts []SpecOpts
 	host    plugin.Host
 	entries map[string]*Package
 }
 
-func NewPluginLoader(host plugin.Host) Loader {
+func NewPluginLoader(host plugin.Host, s ...SpecOpts) Loader {
+
 	return &pluginLoader{
 		host:    host,
+		specOpts: s,
 		entries: map[string]*Package{},
 	}
 }
@@ -155,7 +158,7 @@ func (l *pluginLoader) LoadPackage(pkg string, version *semver.Version) (*Packag
 		return nil, err
 	}
 
-	p, diags, err := bindSpec(spec, nil, l)
+	p, diags, err := bindSpec(spec, nil, l, l.specOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resource/deploy/import.go
+++ b/pkg/resource/deploy/import.go
@@ -93,7 +93,7 @@ func NewImportDeployment(ctx *plugin.Context, target *Target, projectName tokens
 		goals:        newGoals,
 		imports:      imports,
 		isImport:     true,
-		schemaLoader: schema.NewPluginLoader(ctx.Host),
+		schemaLoader: schema.NewPluginLoader(ctx.Host, schema.DisableValidation()),
 		source:       NewErrorSource(projectName),
 		preview:      preview,
 		providers:    reg,


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Optionally disable metaschema validation
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)
One possible fix for https://github.com/pulumi/pulumi/issues/8541

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
