### PR TITLE
[codegen/schema] Do not validate in ImportSchema.

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -40,6 +40,10 @@
 - [cli] Log secret decryption events when a project uses the Pulumi Service and a 3rd party secrets provider
   [#8563](https://github.com/pulumi/pulumi/pull/8563)
 
+- [schema] Do not validate against the metaschema in ImportSpec. Clients that need to
+  validate input schemas should use the BindSpec API instead.
+  [#8543](https://github.com/pulumi/pulumi/pull/8543)
+
 ### Bug Fixes
 
 - [codegen/schema] - Error on type token names that are not allowed (schema.Name

--- a/pkg/codegen/schema/loader.go
+++ b/pkg/codegen/schema/loader.go
@@ -155,7 +155,7 @@ func (l *pluginLoader) LoadPackage(pkg string, version *semver.Version) (*Packag
 		return nil, err
 	}
 
-	p, diags, err := bindSpec(spec, nil, l)
+	p, diags, err := bindSpec(spec, nil, l, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Allow consumers to load package specs without validating them against
the Pulumi package metaschema. This dramatically reduces the package
load time for scenarios in which packages can be assumed to be
well-formed (e.g. program codegen + packages that are referenced by a
root schema).

Fixes #8541.