### PR TITLE
Set less agressive timeouts for HTTP retries

### DIFF
--- a/pkg/backend/httpstate/client/api.go
+++ b/pkg/backend/httpstate/client/api.go
@@ -26,6 +26,7 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
+	"time"
 
 	"github.com/pulumi/pulumi/sdk/v2/go/common/diag"
 
@@ -112,6 +113,18 @@ func (updateAccessToken) Kind() accessTokenKind {
 
 func (t updateAccessToken) String() string {
 	return string(t)
+}
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}
+
+func durationPtr(d time.Duration) *time.Duration {
+	return &d
+}
+
+func intPtr(i int) *int {
+	return &i
 }
 
 // pulumiAPICall makes an HTTP request to the Pulumi API.
@@ -204,7 +217,17 @@ func pulumiAPICall(ctx context.Context, d diag.Sink, cloudAPI, method, path stri
 
 	var resp *http.Response
 	if req.Method == "GET" || opts.RetryAllMethods {
-		resp, err = httputil.DoWithRetry(req, http.DefaultClient)
+		// Wait 1s before retrying on failure. Then increase by 2x until the
+		// maximum delay is reached. Stop after maxRetryCount requests have
+		// been made.
+		opts := httputil.RetryOpts{
+			Delay:    durationPtr(time.Second),
+			Backoff:  float64Ptr(2.0),
+			MaxDelay: durationPtr(30 * time.Second),
+
+			MaxRetryCount: intPtr(4),
+		}
+		resp, err = httputil.DoWithRetryOpts(req, http.DefaultClient, opts)
 	} else {
 		resp, err = http.DefaultClient.Do(req)
 	}


### PR DESCRIPTION
The Pulumi CLI's `httpstate` backend retries HTTP requests if it sees a 5xx error. This presumably makes stack updates a little more reliable in the face of transient network errors and things.

However, in practice the default values for the delay/retry logic are much too aggressive to actually be useful.
https://github.com/pulumi/pulumi/blob/a952140b34c667d005116ee53be08077b5863948/sdk/go/common/util/retry/until.go#L34-L38

Here are some timestamps I'm seeing for repeated HTTP requests that arise from failures. The first value is the initial 5xx, and the next four are the additional attempts to the same URL. Notice how all 5 requests are attempted in less than 2 seconds. (In-line with the default retry values... though not accounting for the time it takes to actually send the request, and for the server to send the response, etc.)

```
2021-12-06T23:08:53.497787Z
2021-12-06T23:08:53.678658Z
2021-12-06T23:08:53.941169Z
2021-12-06T23:08:54.328391Z
2021-12-06T23:08:54.866719Z
```

```
2021-12-06T23:08:51.009979Z
2021-12-06T23:08:51.249725Z
2021-12-06T23:08:51.567933Z
2021-12-06T23:08:51.995871Z
2021-12-06T23:08:52.592026Z
```

This PR makes the timeouts much more generous, so that hopefully if there is some meaningful error on the server-side it can be corrected before the last retry is sent. (Delaying 1s, 2s, 4s, and finally 8s between subsequent attempts.)

Waiting a total of 15s before failing an HTTP request is a long time... if the end result is that a stack update fails and/or potentially leaves the checkpoint file in a bad state, I'd think we should err on the side of letting the CLI wait and retry. 

Though, perhaps that's the wrong way to think about it. What do you think?
