### PR TITLE
Cleanup MLC integration tests

### DIFF
--- a/pkg/testing/integration/program.go
+++ b/pkg/testing/integration/program.go
@@ -1625,36 +1625,6 @@ func (pt *ProgramTester) copyTestToTemporaryDirectory() (string, string, error) 
 		return "", "", fmt.Errorf("Failed to prepare %v: %w", projdir, err)
 	}
 
-	// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-	// Until that's been fixed, this environment variable can be set by a test, which results in
-	// a package.json being emitted in the project directory and `yarn install && yarn link @pulumi/pulumi`
-	// being run.
-	// When the underlying issue has been fixed, the use of this environment variable should be removed.
-	var yarnLinkPulumi bool
-	for _, env := range pt.opts.Env {
-		if env == "PULUMI_TEST_YARN_LINK_PULUMI=true" {
-			yarnLinkPulumi = true
-			break
-		}
-	}
-	if yarnLinkPulumi {
-		const packageJSON = `{
-			"name": "test",
-			"peerDependencies": {
-				"@pulumi/pulumi": "latest"
-			}
-		}`
-		if err := ioutil.WriteFile(filepath.Join(projdir, "package.json"), []byte(packageJSON), 0600); err != nil {
-			return "", "", err
-		}
-		if err = pt.runYarnCommand("yarn-install", []string{"install"}, projdir); err != nil {
-			return "", "", err
-		}
-		if err := pt.runYarnCommand("yarn-link", []string{"link", "@pulumi/pulumi"}, projdir); err != nil {
-			return "", "", err
-		}
-	}
-
 	pt.t.Logf("projdir: %v", projdir)
 	return tmpdir, projdir, nil
 }

--- a/tests/integration/construct_component/testcomponent-go/echo.go
+++ b/tests/integration/construct_component/testcomponent-go/echo.go
@@ -1,0 +1,36 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+// Exposes the Echo resource from the testprovider.
+// Requires running `make test_build` and having the built provider on PATH.
+
+package main
+
+import (
+	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type Echo struct {
+	pulumi.CustomResourceState
+}
+
+func NewEcho(ctx *pulumi.Context, name string, args *EchoArgs, opts ...pulumi.ResourceOption) (*Echo, error) {
+	var resource Echo
+	if err := ctx.RegisterResource("testprovider:index:Echo", name, args, &resource, opts...); err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+type echoArgs struct {
+	Echo interface{} `pulumi:"echo"`
+}
+
+type EchoArgs struct {
+	Echo pulumi.Input
+}
+
+func (EchoArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*echoArgs)(nil)).Elem()
+}

--- a/tests/integration/construct_component/testcomponent-go/main.go
+++ b/tests/integration/construct_component/testcomponent-go/main.go
@@ -3,48 +3,15 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi/config"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	pbempty "github.com/golang/protobuf/ptypes/empty"
 )
-
-type Resource struct {
-	pulumi.CustomResourceState
-}
-
-type resourceArgs struct {
-	Echo interface{} `pulumi:"echo"`
-}
-
-type ResourceArgs struct {
-	Echo pulumi.Input
-}
-
-func (ResourceArgs) ElementType() reflect.Type {
-	return reflect.TypeOf((*resourceArgs)(nil)).Elem()
-}
-
-func NewResource(ctx *pulumi.Context, name string, echo pulumi.Input,
-	opts ...pulumi.ResourceOption) (*Resource, error) {
-	args := &ResourceArgs{Echo: echo}
-	var resource Resource
-	err := ctx.RegisterResource("testcomponent:index:Resource", name, args, &resource, opts...)
-	if err != nil {
-		return nil, err
-	}
-	return &resource, nil
-}
 
 type Component struct {
 	pulumi.ResourceState
@@ -79,7 +46,7 @@ func NewComponent(ctx *pulumi.Context, name string, args *ComponentArgs,
 		return nil, err
 	}
 
-	res, err := NewResource(ctx, fmt.Sprintf("child-%s", name), args.Echo, pulumi.Parent(component))
+	res, err := NewEcho(ctx, fmt.Sprintf("child-%s", name), &EchoArgs{Echo: args.Echo}, pulumi.Parent(component))
 	if err != nil {
 		return nil, err
 	}
@@ -102,142 +69,30 @@ func NewComponent(ctx *pulumi.Context, name string, args *ComponentArgs,
 const providerName = "testcomponent"
 const version = "0.0.1"
 
-var currentID int
-
 func main() {
-	err := provider.Main(providerName, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-		return makeProvider(host, providerName, version)
-	})
-	if err != nil {
+	if err := provider.MainWithOptions(provider.Options{
+		Name:    providerName,
+		Version: version,
+		Construct: func(ctx *pulumi.Context, typ, name string, inputs pulumiprovider.ConstructInputs,
+			options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
+
+			if typ != "testcomponent:index:Component" {
+				return nil, fmt.Errorf("unknown resource type %s", typ)
+			}
+
+			args := &ComponentArgs{}
+			if err := inputs.CopyTo(args); err != nil {
+				return nil, fmt.Errorf("setting args: %w", err)
+			}
+
+			component, err := NewComponent(ctx, name, args, options)
+			if err != nil {
+				return nil, fmt.Errorf("creating component: %w", err)
+			}
+
+			return pulumiprovider.NewConstructResult(component)
+		},
+	}); err != nil {
 		cmdutil.ExitError(err.Error())
 	}
-}
-
-type testcomponentProvider struct {
-	host    *provider.HostClient
-	name    string
-	version string
-}
-
-func makeProvider(host *provider.HostClient, name, version string) (pulumirpc.ResourceProviderServer, error) {
-	return &testcomponentProvider{
-		host:    host,
-		name:    name,
-		version: version,
-	}, nil
-}
-
-func (p *testcomponentProvider) Create(ctx context.Context,
-	req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	urn := resource.URN(req.GetUrn())
-	typ := urn.Type()
-	if typ != "testcomponent:index:Resource" {
-		return nil, fmt.Errorf("Unknown resource type '%s'", typ)
-	}
-
-	id := currentID
-	currentID++
-
-	return &pulumirpc.CreateResponse{
-		Id: fmt.Sprintf("%v", id),
-	}, nil
-}
-
-func (p *testcomponentProvider) Construct(ctx context.Context,
-	req *pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error) {
-	return pulumiprovider.Construct(ctx, req, p.host.EngineConn(), func(ctx *pulumi.Context, typ, name string,
-		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
-
-		if typ != "testcomponent:index:Component" {
-			return nil, fmt.Errorf("unknown resource type %s", typ)
-		}
-
-		args := &ComponentArgs{}
-		if err := inputs.CopyTo(args); err != nil {
-			return nil, fmt.Errorf("setting args: %w", err)
-		}
-
-		component, err := NewComponent(ctx, name, args, options)
-		if err != nil {
-			return nil, fmt.Errorf("creating component: %w", err)
-		}
-
-		return pulumiprovider.NewConstructResult(component)
-	})
-}
-
-func (p *testcomponentProvider) CheckConfig(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.GetNews()}, nil
-}
-
-func (p *testcomponentProvider) DiffConfig(ctx context.Context,
-	req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Configure(ctx context.Context,
-	req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	return &pulumirpc.ConfigureResponse{
-		AcceptSecrets:   true,
-		SupportsPreview: true,
-		AcceptResources: true,
-	}, nil
-}
-
-func (p *testcomponentProvider) Invoke(ctx context.Context,
-	req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
-	return nil, fmt.Errorf("Unknown Invoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) StreamInvoke(req *pulumirpc.InvokeRequest,
-	server pulumirpc.ResourceProvider_StreamInvokeServer) error {
-	return fmt.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) Call(ctx context.Context,
-	req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
-	return nil, fmt.Errorf("Unknown Call token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) Check(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (p *testcomponentProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	return &pulumirpc.ReadResponse{
-		Id:         req.GetId(),
-		Properties: req.GetProperties(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Update(ctx context.Context,
-	req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	return &pulumirpc.UpdateResponse{
-		Properties: req.GetNews(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
-}
-
-func (p *testcomponentProvider) GetPluginInfo(context.Context, *pbempty.Empty) (*pulumirpc.PluginInfo, error) {
-	return &pulumirpc.PluginInfo{
-		Version: p.version,
-	}, nil
-}
-
-func (p *testcomponentProvider) GetSchema(ctx context.Context,
-	req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
-	return &pulumirpc.GetSchemaResponse{}, nil
-}
-
-func (p *testcomponentProvider) Cancel(context.Context, *pbempty.Empty) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
 }

--- a/tests/integration/construct_component/testcomponent/echo.ts
+++ b/tests/integration/construct_component/testcomponent/echo.ts
@@ -1,0 +1,14 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+interface EchoArgs {
+    echo: pulumi.Input<any>;
+}
+
+export class Echo extends pulumi.CustomResource {
+    public readonly echo!: pulumi.Output<any>;
+    constructor(name: string, args: EchoArgs, opts?: pulumi.CustomResourceOptions) {
+        super("testprovider:index:Echo", name, args, opts);
+    }
+}

--- a/tests/integration/construct_component/testcomponent/index.ts
+++ b/tests/integration/construct_component/testcomponent/index.ts
@@ -1,21 +1,9 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
 import * as pulumi from "@pulumi/pulumi";
-import * as dynamic from "@pulumi/pulumi/dynamic";
 import * as provider from "@pulumi/pulumi/provider";
 
-let currentID = 0;
-
-class Resource extends dynamic.Resource {
-    constructor(name: string, echo: pulumi.Input<any>, opts?: pulumi.CustomResourceOptions) {
-        const provider = {
-            create: async (inputs: any) => ({
-                id: (currentID++).toString(),
-                outs: undefined,
-            }),
-        };
-
-        super(provider, name, {echo}, opts);
-    }
-}
+import { Echo } from "./echo";
 
 class Component extends pulumi.ComponentResource {
     public readonly echo: pulumi.Output<any>;
@@ -26,7 +14,7 @@ class Component extends pulumi.ComponentResource {
         super("testcomponent:index:Component", name, {}, opts);
 
         this.echo = pulumi.output(echo);
-        this.childId = (new Resource(`child-${name}`, echo, {parent: this})).id;
+        this.childId = (new Echo(`child-${name}`, {echo}, {parent: this})).id;
         this.secret = secret;
 
         this.registerOutputs({
@@ -50,9 +38,9 @@ class Provider implements provider.Provider {
         const secretKey = "secret";
         const fullSecretKey = `${config.name}:${secretKey}`;
         // use internal pulumi prop to check secretness
-        const isSecret = (pulumi.runtime as any).isConfigSecret(fullSecretKey); 
+        const isSecret = (pulumi.runtime as any).isConfigSecret(fullSecretKey);
         if (!isSecret) {
-            throw new Error(`expected config with key "${secretKey}" to be secret.`)
+            throw new Error(`expected config with key "${secretKey}" to be secret.`);
         }
         const secret = config.requireSecret(secretKey);
 

--- a/tests/integration/construct_component/testcomponent/tsconfig.json
+++ b/tests/integration/construct_component/testcomponent/tsconfig.json
@@ -16,5 +16,6 @@
     },
     "files": [
         "index.ts",
+        "echo.ts"
     ]
 }

--- a/tests/integration/construct_component_plain/testcomponent-go/main.go
+++ b/tests/integration/construct_component_plain/testcomponent-go/main.go
@@ -3,31 +3,14 @@
 package main
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	pbempty "github.com/golang/protobuf/ptypes/empty"
 )
-
-type Resource struct {
-	pulumi.CustomResourceState
-}
-
-func NewResource(ctx *pulumi.Context, name string, opts ...pulumi.ResourceOption) (*Resource, error) {
-	var resource Resource
-	if err := ctx.RegisterResource("testcomponent:index:Resource", name, nil, &resource, opts...); err != nil {
-		return nil, err
-	}
-	return &resource, nil
-}
 
 type Component struct {
 	pulumi.ResourceState
@@ -51,7 +34,8 @@ func NewComponent(ctx *pulumi.Context, name string, args *ComponentArgs,
 
 	if args.Children > 0 {
 		for i := 0; i < args.Children; i++ {
-			_, err := NewResource(ctx, fmt.Sprintf("child-%s-%v", name, i+1), pulumi.Parent(component))
+			rargs := &RandomArgs{Length: pulumi.Int(10)}
+			_, err := NewRandom(ctx, fmt.Sprintf("child-%s-%v", name, i+1), rargs, pulumi.Parent(component))
 			if err != nil {
 				return nil, err
 			}
@@ -68,142 +52,30 @@ func NewComponent(ctx *pulumi.Context, name string, args *ComponentArgs,
 const providerName = "testcomponent"
 const version = "0.0.1"
 
-var currentID int
-
 func main() {
-	err := provider.Main(providerName, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-		return makeProvider(host, providerName, version)
-	})
-	if err != nil {
+	if err := provider.MainWithOptions(provider.Options{
+		Name:    providerName,
+		Version: version,
+		Construct: func(ctx *pulumi.Context, typ, name string, inputs pulumiprovider.ConstructInputs,
+			options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
+
+			if typ != "testcomponent:index:Component" {
+				return nil, fmt.Errorf("unknown resource type %s", typ)
+			}
+
+			args := &ComponentArgs{}
+			if err := inputs.CopyTo(args); err != nil {
+				return nil, fmt.Errorf("setting args: %w", err)
+			}
+
+			component, err := NewComponent(ctx, name, args, options)
+			if err != nil {
+				return nil, fmt.Errorf("creating component: %w", err)
+			}
+
+			return pulumiprovider.NewConstructResult(component)
+		},
+	}); err != nil {
 		cmdutil.ExitError(err.Error())
 	}
-}
-
-type testcomponentProvider struct {
-	host    *provider.HostClient
-	name    string
-	version string
-}
-
-func makeProvider(host *provider.HostClient, name, version string) (pulumirpc.ResourceProviderServer, error) {
-	return &testcomponentProvider{
-		host:    host,
-		name:    name,
-		version: version,
-	}, nil
-}
-
-func (p *testcomponentProvider) Create(ctx context.Context,
-	req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	urn := resource.URN(req.GetUrn())
-	typ := urn.Type()
-	if typ != "testcomponent:index:Resource" {
-		return nil, fmt.Errorf("Unknown resource type '%s'", typ)
-	}
-
-	id := currentID
-	currentID++
-
-	return &pulumirpc.CreateResponse{
-		Id: fmt.Sprintf("%v", id),
-	}, nil
-}
-
-func (p *testcomponentProvider) Construct(ctx context.Context,
-	req *pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error) {
-	return pulumiprovider.Construct(ctx, req, p.host.EngineConn(), func(ctx *pulumi.Context, typ, name string,
-		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
-
-		if typ != "testcomponent:index:Component" {
-			return nil, fmt.Errorf("unknown resource type %s", typ)
-		}
-
-		args := &ComponentArgs{}
-		if err := inputs.CopyTo(args); err != nil {
-			return nil, fmt.Errorf("setting args: %w", err)
-		}
-
-		component, err := NewComponent(ctx, name, args, options)
-		if err != nil {
-			return nil, fmt.Errorf("creating component: %w", err)
-		}
-
-		return pulumiprovider.NewConstructResult(component)
-	})
-}
-
-func (p *testcomponentProvider) CheckConfig(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.GetNews()}, nil
-}
-
-func (p *testcomponentProvider) DiffConfig(ctx context.Context,
-	req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Configure(ctx context.Context,
-	req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	return &pulumirpc.ConfigureResponse{
-		AcceptSecrets:   true,
-		SupportsPreview: true,
-		AcceptResources: true,
-	}, nil
-}
-
-func (p *testcomponentProvider) Invoke(ctx context.Context,
-	req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
-	return nil, fmt.Errorf("Unknown Invoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) StreamInvoke(req *pulumirpc.InvokeRequest,
-	server pulumirpc.ResourceProvider_StreamInvokeServer) error {
-	return fmt.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) Call(ctx context.Context,
-	req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
-	return nil, fmt.Errorf("Unknown Call token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) Check(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (p *testcomponentProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	return &pulumirpc.ReadResponse{
-		Id:         req.GetId(),
-		Properties: req.GetProperties(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Update(ctx context.Context,
-	req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	return &pulumirpc.UpdateResponse{
-		Properties: req.GetNews(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
-}
-
-func (p *testcomponentProvider) GetPluginInfo(context.Context, *pbempty.Empty) (*pulumirpc.PluginInfo, error) {
-	return &pulumirpc.PluginInfo{
-		Version: p.version,
-	}, nil
-}
-
-func (p *testcomponentProvider) GetSchema(ctx context.Context,
-	req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
-	return &pulumirpc.GetSchemaResponse{}, nil
-}
-
-func (p *testcomponentProvider) Cancel(context.Context, *pbempty.Empty) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
 }

--- a/tests/integration/construct_component_plain/testcomponent-go/random.go
+++ b/tests/integration/construct_component_plain/testcomponent-go/random.go
@@ -1,0 +1,48 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+// Exposes the Random resource from the testprovider.
+// Requires running `make test_build` and having the built provider on PATH.
+
+package main
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+type Random struct {
+	pulumi.CustomResourceState
+
+	Length pulumi.IntOutput    `pulumi:"length"`
+	Result pulumi.StringOutput `pulumi:"result"`
+}
+
+func NewRandom(ctx *pulumi.Context,
+	name string, args *RandomArgs, opts ...pulumi.ResourceOption) (*Random, error) {
+	if args == nil || args.Length == nil {
+		return nil, errors.New("missing required argument 'Length'")
+	}
+	if args == nil {
+		args = &RandomArgs{}
+	}
+	var resource Random
+	err := ctx.RegisterResource("testprovider:index:Random", name, args, &resource, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &resource, nil
+}
+
+type randomArgs struct {
+	Length int `pulumi:"length"`
+}
+
+type RandomArgs struct {
+	Length pulumi.IntInput
+}
+
+func (RandomArgs) ElementType() reflect.Type {
+	return reflect.TypeOf((*randomArgs)(nil)).Elem()
+}

--- a/tests/integration/construct_component_plain/testcomponent/index.ts
+++ b/tests/integration/construct_component_plain/testcomponent/index.ts
@@ -1,24 +1,9 @@
 // Copyright 2016-2021, Pulumi Corporation.  All rights reserved
 
 import * as pulumi from "@pulumi/pulumi";
-import * as dynamic from "@pulumi/pulumi/dynamic";
 import * as provider from "@pulumi/pulumi/provider";
 
-let currentID = 0;
-
-class Resource extends dynamic.Resource {
-    constructor(name: string, opts?: pulumi.CustomResourceOptions) {
-        const provider = {
-            create: async (inputs: any) => {
-                return {
-                    id: (currentID++).toString(),
-                    outs: undefined,
-                };
-            },
-        };
-        super(provider, name, {}, opts);
-    }
-}
+import { Random } from "./random";
 
 interface ComponentArgs {
     children?: number;
@@ -32,7 +17,7 @@ class Component extends pulumi.ComponentResource {
             return;
         }
         for (let i = 0; i < children; i++) {
-            new Resource(`child-${name}-${i+1}`, {parent: this});
+            new Random(`child-${name}-${i+1}`, { length: 10 }, {parent: this});
         }
     }
 }

--- a/tests/integration/construct_component_plain/testcomponent/random.ts
+++ b/tests/integration/construct_component_plain/testcomponent/random.ts
@@ -1,0 +1,15 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+interface RandomArgs {
+    length: pulumi.Input<number>;
+}
+
+export class Random extends pulumi.CustomResource {
+    public readonly length!: pulumi.Output<number>;
+    public readonly result!: pulumi.Output<string>;
+    constructor(name: string, args: RandomArgs, opts?: pulumi.CustomResourceOptions) {
+        super("testprovider:index:Random", name, args, opts);
+    }
+}

--- a/tests/integration/construct_component_plain/testcomponent/tsconfig.json
+++ b/tests/integration/construct_component_plain/testcomponent/tsconfig.json
@@ -16,5 +16,6 @@
     },
     "files": [
         "index.ts",
+        "random.ts"
     ]
 }

--- a/tests/integration/construct_component_slow/testcomponent/index.ts
+++ b/tests/integration/construct_component_slow/testcomponent/index.ts
@@ -1,47 +1,19 @@
 // Copyright 2016-2021, Pulumi Corporation.  All rights reserved
 
 import * as pulumi from "@pulumi/pulumi";
-import * as dynamic from "@pulumi/pulumi/dynamic";
 import * as provider from "@pulumi/pulumi/provider";
+
+import { Slow } from "./slow";
 
 // The component has a child resource that takes a long time to be created.
 // We want to ensure the component's slow child resource will actually be created when the
 // component is created inside `construct`.
 
-const CREATION_DELAY = 15 * 1000; // 15 second delay in milliseconds
-
-let currentID = 0;
-
-class SlowResource extends dynamic.Resource {
-    constructor(name: string, opts?: pulumi.CustomResourceOptions) {
-        const provider = {
-            // Return the result after a delay to simulate a resource that takes a long time
-            // to be created.
-            create: async (inputs: any) => {
-                await delay(CREATION_DELAY);
-                return {
-                    id: (currentID++).toString(),
-                    outs: undefined,
-                };
-            },
-        };
-        super(provider, name, {}, opts);
-    }
-}
-
-function delay(timeout: number): Promise<void> {
-    return new Promise((resolve, reject) => {
-        setTimeout(() => {
-            resolve();
-        }, timeout);
-    });
-}
-
 class Component extends pulumi.ComponentResource {
     constructor(name: string, opts?: pulumi.ComponentResourceOptions) {
         super("testcomponent:index:Component", name, {}, opts);
         // Create a child resource that takes a long time in the provider to be created.
-        new SlowResource(`child-${name}`, {parent: this});
+        new Slow(`child-${name}`, {parent: this});
     }
 }
 

--- a/tests/integration/construct_component_slow/testcomponent/slow.ts
+++ b/tests/integration/construct_component_slow/testcomponent/slow.ts
@@ -1,0 +1,9 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+import * as pulumi from "@pulumi/pulumi";
+
+export class Slow extends pulumi.CustomResource {
+    constructor(name: string, opts?: pulumi.CustomResourceOptions) {
+        super("testprovider:index:Slow", name, {}, opts);
+    }
+}

--- a/tests/integration/construct_component_slow/testcomponent/tsconfig.json
+++ b/tests/integration/construct_component_slow/testcomponent/tsconfig.json
@@ -16,5 +16,6 @@
     },
     "files": [
         "index.ts",
+        "slow.ts"
     ]
 }

--- a/tests/integration/construct_component_unknown/testcomponent-go/main.go
+++ b/tests/integration/construct_component_unknown/testcomponent-go/main.go
@@ -9,13 +9,9 @@ import (
 	"reflect"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/provider"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/cmdutil"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	pulumiprovider "github.com/pulumi/pulumi/sdk/v3/go/pulumi/provider"
-	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
-
-	pbempty "github.com/golang/protobuf/ptypes/empty"
 )
 
 type Component struct {
@@ -97,144 +93,32 @@ func NewComponent(ctx *pulumi.Context, name string, args *ComponentArgs,
 const providerName = "testcomponent"
 const version = "0.0.1"
 
-var currentID int
-
 func main() {
-	err := provider.Main(providerName, func(host *provider.HostClient) (pulumirpc.ResourceProviderServer, error) {
-		return makeProvider(host, providerName, version)
-	})
-	if err != nil {
+	if err := provider.MainWithOptions(provider.Options{
+		Name:    providerName,
+		Version: version,
+		Construct: func(ctx *pulumi.Context, typ, name string, inputs pulumiprovider.ConstructInputs,
+			options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
+
+			if typ != "testcomponent:index:Component" {
+				return nil, fmt.Errorf("unknown resource type %s", typ)
+			}
+
+			args := &ComponentArgs{}
+			if err := inputs.CopyTo(args); err != nil {
+				return nil, fmt.Errorf("setting args: %w", err)
+			}
+
+			component, err := NewComponent(ctx, name, args, options)
+			if err != nil {
+				return nil, fmt.Errorf("creating component: %w", err)
+			}
+
+			return pulumiprovider.NewConstructResult(component)
+		},
+	}); err != nil {
 		cmdutil.ExitError(err.Error())
 	}
-}
-
-type testcomponentProvider struct {
-	host    *provider.HostClient
-	name    string
-	version string
-}
-
-func makeProvider(host *provider.HostClient, name, version string) (pulumirpc.ResourceProviderServer, error) {
-	return &testcomponentProvider{
-		host:    host,
-		name:    name,
-		version: version,
-	}, nil
-}
-
-func (p *testcomponentProvider) Create(ctx context.Context,
-	req *pulumirpc.CreateRequest) (*pulumirpc.CreateResponse, error) {
-	urn := resource.URN(req.GetUrn())
-	typ := urn.Type()
-	if typ != "testcomponent:index:Resource" {
-		return nil, fmt.Errorf("Unknown resource type '%s'", typ)
-	}
-
-	id := currentID
-	currentID++
-
-	return &pulumirpc.CreateResponse{
-		Id: fmt.Sprintf("%v", id),
-	}, nil
-}
-
-func (p *testcomponentProvider) Construct(ctx context.Context,
-	req *pulumirpc.ConstructRequest) (*pulumirpc.ConstructResponse, error) {
-	return pulumiprovider.Construct(ctx, req, p.host.EngineConn(), func(ctx *pulumi.Context, typ, name string,
-		inputs pulumiprovider.ConstructInputs, options pulumi.ResourceOption) (*pulumiprovider.ConstructResult, error) {
-
-		if typ != "testcomponent:index:Component" {
-			return nil, fmt.Errorf("unknown resource type %s", typ)
-		}
-
-		args := &ComponentArgs{}
-		if err := inputs.CopyTo(args); err != nil {
-			return nil, fmt.Errorf("setting args: %w", err)
-		}
-
-		component, err := NewComponent(ctx, name, args, options)
-		if err != nil {
-			return nil, fmt.Errorf("creating component: %w", err)
-		}
-
-		return pulumiprovider.NewConstructResult(component)
-	})
-}
-
-func (p *testcomponentProvider) CheckConfig(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.GetNews()}, nil
-}
-
-func (p *testcomponentProvider) DiffConfig(ctx context.Context,
-	req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Configure(ctx context.Context,
-	req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	return &pulumirpc.ConfigureResponse{
-		AcceptSecrets:   true,
-		SupportsPreview: true,
-		AcceptResources: true,
-	}, nil
-}
-
-func (p *testcomponentProvider) Invoke(ctx context.Context,
-	req *pulumirpc.InvokeRequest) (*pulumirpc.InvokeResponse, error) {
-	return nil, fmt.Errorf("Unknown Invoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) StreamInvoke(req *pulumirpc.InvokeRequest,
-	server pulumirpc.ResourceProvider_StreamInvokeServer) error {
-	return fmt.Errorf("Unknown StreamInvoke token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) Call(ctx context.Context,
-	req *pulumirpc.CallRequest) (*pulumirpc.CallResponse, error) {
-	return nil, fmt.Errorf("Unknown Call token '%s'", req.GetTok())
-}
-
-func (p *testcomponentProvider) Check(ctx context.Context,
-	req *pulumirpc.CheckRequest) (*pulumirpc.CheckResponse, error) {
-	return &pulumirpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
-}
-
-func (p *testcomponentProvider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	return &pulumirpc.DiffResponse{}, nil
-}
-
-func (p *testcomponentProvider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulumirpc.ReadResponse, error) {
-	return &pulumirpc.ReadResponse{
-		Id:         req.GetId(),
-		Properties: req.GetProperties(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Update(ctx context.Context,
-	req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	return &pulumirpc.UpdateResponse{
-		Properties: req.GetNews(),
-	}, nil
-}
-
-func (p *testcomponentProvider) Delete(ctx context.Context, req *pulumirpc.DeleteRequest) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
-}
-
-func (p *testcomponentProvider) GetPluginInfo(context.Context, *pbempty.Empty) (*pulumirpc.PluginInfo, error) {
-	return &pulumirpc.PluginInfo{
-		Version: p.version,
-	}, nil
-}
-
-func (p *testcomponentProvider) GetSchema(ctx context.Context,
-	req *pulumirpc.GetSchemaRequest) (*pulumirpc.GetSchemaResponse, error) {
-	return &pulumirpc.GetSchemaResponse{}, nil
-}
-
-func (p *testcomponentProvider) Cancel(context.Context, *pbempty.Empty) (*pbempty.Empty, error) {
-	return &pbempty.Empty{}, nil
 }
 
 func init() {

--- a/tests/integration/integration_go_test.go
+++ b/tests/integration/integration_go_test.go
@@ -16,7 +16,6 @@ import (
 	"sourcegraph.com/sourcegraph/appdash"
 
 	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	ptesting "github.com/pulumi/pulumi/sdk/v3/go/common/testing"
 )
 
@@ -408,178 +407,17 @@ func TestLargeResourceGo(t *testing.T) {
 
 // Test remote component construction in Go.
 func TestConstructGo(t *testing.T) {
-	tests := []struct {
-		componentDir          string
-		expectedResourceCount int
-		env                   []string
-	}{
-		{
-			componentDir:          "testcomponent",
-			expectedResourceCount: 9,
-			// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-			// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-			// module to run `yarn install && yarn link @pulumi/pulumi` in the Go program's directory, allowing
-			// the Node.js dynamic provider plugin to load.
-			// When the underlying issue has been fixed, the use of this environment variable inside the integration
-			// test module should be removed.
-			env: []string{"PULUMI_TEST_YARN_LINK_PULUMI=true"},
-		},
-		{
-			componentDir:          "testcomponent-python",
-			expectedResourceCount: 9,
-		},
-		{
-			componentDir:          "testcomponent-go",
-			expectedResourceCount: 8, // One less because no dynamic provider.
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.componentDir, func(t *testing.T) {
-			pathEnv := pathEnv(t,
-				filepath.Join("..", "testprovider"),
-				filepath.Join("construct_component", test.componentDir))
-			integration.ProgramTest(t, optsForConstructGo(t, test.expectedResourceCount, append(test.env, pathEnv)...))
-		})
-	}
-}
-
-func optsForConstructGo(t *testing.T, expectedResourceCount int, env ...string) *integration.ProgramTestOptions {
-	return &integration.ProgramTestOptions{
-		Env: env,
-		Dir: filepath.Join("construct_component", "go"),
-		Dependencies: []string{
-			"github.com/pulumi/pulumi/sdk/v3",
-		},
-		Secrets: map[string]string{
-			"secret": "this super secret is encrypted",
-		},
-		Quick:      true,
-		NoParallel: true, // avoid contention for Dir
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.NotNil(t, stackInfo.Deployment)
-			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {
-				stackRes := stackInfo.Deployment.Resources[0]
-				assert.NotNil(t, stackRes)
-				assert.Equal(t, resource.RootStackType, stackRes.Type)
-				assert.Equal(t, "", string(stackRes.Parent))
-
-				// Check that dependencies flow correctly between the originating program and the remote component
-				// plugin.
-				urns := make(map[string]resource.URN)
-				for _, res := range stackInfo.Deployment.Resources[1:] {
-					assert.NotNil(t, res)
-
-					urns[string(res.URN.Name())] = res.URN
-					switch res.URN.Name() {
-					case "child-a":
-						for _, deps := range res.PropertyDependencies {
-							assert.Empty(t, deps)
-						}
-					case "child-b":
-						expected := []resource.URN{urns["a"]}
-						assert.ElementsMatch(t, expected, res.Dependencies)
-						assert.ElementsMatch(t, expected, res.PropertyDependencies["echo"])
-					case "child-c":
-						expected := []resource.URN{urns["a"], urns["child-a"]}
-						assert.ElementsMatch(t, expected, res.Dependencies)
-						assert.ElementsMatch(t, expected, res.PropertyDependencies["echo"])
-					case "a", "b", "c":
-						secretPropValue, ok := res.Outputs["secret"].(map[string]interface{})
-						assert.Truef(t, ok, "secret output was not serialized as a secret")
-						assert.Equal(t, resource.SecretSig, secretPropValue[resource.SigKey].(string))
-					}
-				}
-			}
-		},
-	}
+	testConstruct(t, "go", "github.com/pulumi/pulumi/sdk/v3")
 }
 
 // Test remote component construction with a child resource that takes a long time to be created, ensuring it's created.
 func TestConstructSlowGo(t *testing.T) {
-	pathEnv := testComponentSlowPathEnv(t)
-
-	// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-	// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-	// module to run `yarn install && yarn link @pulumi/pulumi` in the Go program's directory, allowing
-	// the Node.js dynamic provider plugin to load.
-	// When the underlying issue has been fixed, the use of this environment variable inside the integration
-	// test module should be removed.
-	const testYarnLinkPulumiEnv = "PULUMI_TEST_YARN_LINK_PULUMI=true"
-
-	opts := &integration.ProgramTestOptions{
-		Env: []string{pathEnv, testYarnLinkPulumiEnv},
-		Dir: filepath.Join("construct_component_slow", "go"),
-		Dependencies: []string{
-			"github.com/pulumi/pulumi/sdk/v3",
-		},
-		Quick: true,
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.NotNil(t, stackInfo.Deployment)
-			if assert.Equal(t, 5, len(stackInfo.Deployment.Resources)) {
-				stackRes := stackInfo.Deployment.Resources[0]
-				assert.NotNil(t, stackRes)
-				assert.Equal(t, resource.RootStackType, stackRes.Type)
-				assert.Equal(t, "", string(stackRes.Parent))
-			}
-		},
-	}
-	integration.ProgramTest(t, opts)
+	testConstructSlow(t, "go", "github.com/pulumi/pulumi/sdk/v3")
 }
 
 // Test remote component construction with prompt inputs.
 func TestConstructPlainGo(t *testing.T) {
-	tests := []struct {
-		componentDir          string
-		expectedResourceCount int
-		env                   []string
-	}{
-		{
-			componentDir:          "testcomponent",
-			expectedResourceCount: 9,
-			// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-			// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-			// module to run `yarn install && yarn link @pulumi/pulumi` in the Go program's directory, allowing
-			// the Node.js dynamic provider plugin to load.
-			// When the underlying issue has been fixed, the use of this environment variable inside the integration
-			// test module should be removed.
-			env: []string{"PULUMI_TEST_YARN_LINK_PULUMI=true"},
-		},
-		{
-			componentDir:          "testcomponent-python",
-			expectedResourceCount: 9,
-		},
-		{
-			componentDir:          "testcomponent-go",
-			expectedResourceCount: 8, // One less because no dynamic provider.
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.componentDir, func(t *testing.T) {
-			pathEnv := pathEnv(t,
-				filepath.Join("..", "testprovider"),
-				filepath.Join("construct_component_plain", test.componentDir))
-			integration.ProgramTest(t,
-				optsForConstructPlainGo(t, test.expectedResourceCount, append(test.env, pathEnv)...))
-		})
-	}
-}
-
-func optsForConstructPlainGo(t *testing.T, expectedResourceCount int, env ...string) *integration.ProgramTestOptions {
-	return &integration.ProgramTestOptions{
-		Env: env,
-		Dir: filepath.Join("construct_component_plain", "go"),
-		Dependencies: []string{
-			"github.com/pulumi/pulumi/sdk/v2",
-		},
-		Quick:      true,
-		NoParallel: true, // avoid contention for Dir
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.NotNil(t, stackInfo.Deployment)
-			assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources))
-		},
-	}
+	testConstructPlain(t, "go", "github.com/pulumi/pulumi/sdk/v3")
 }
 
 // Test remote component inputs properly handle unknowns.
@@ -587,38 +425,9 @@ func TestConstructUnknownGo(t *testing.T) {
 	testConstructUnknown(t, "go", "github.com/pulumi/pulumi/sdk/v3")
 }
 
+// Test methods on remote components.
 func TestConstructMethodsGo(t *testing.T) {
-	tests := []struct {
-		componentDir string
-		env          []string
-	}{
-		{
-			componentDir: "testcomponent",
-		},
-		{
-			componentDir: "testcomponent-python",
-		},
-		{
-			componentDir: "testcomponent-go",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.componentDir, func(t *testing.T) {
-			pathEnv := pathEnv(t, filepath.Join("construct_component_methods", test.componentDir))
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Env: append(test.env, pathEnv),
-				Dir: filepath.Join("construct_component_methods", "go"),
-				Dependencies: []string{
-					"github.com/pulumi/pulumi/sdk/v3",
-				},
-				Quick:      true,
-				NoParallel: true, // avoid contention for Dir
-				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message"])
-				},
-			})
-		})
-	}
+	testConstructMethods(t, "go", "github.com/pulumi/pulumi/sdk/v3")
 }
 
 func TestConstructMethodsUnknownGo(t *testing.T) {
@@ -634,37 +443,7 @@ func TestConstructMethodsErrorsGo(t *testing.T) {
 }
 
 func TestConstructProviderGo(t *testing.T) {
-	const testDir = "construct_component_provider"
-	tests := []struct {
-		componentDir string
-	}{
-		{
-			componentDir: "testcomponent",
-		},
-		{
-			componentDir: "testcomponent-python",
-		},
-		{
-			componentDir: "testcomponent-go",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.componentDir, func(t *testing.T) {
-			pathEnv := pathEnv(t, filepath.Join(testDir, test.componentDir))
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Env: []string{pathEnv},
-				Dir: filepath.Join(testDir, "go"),
-				Dependencies: []string{
-					"github.com/pulumi/pulumi/sdk/v3",
-				},
-				Quick:      true,
-				NoParallel: true, // avoid contention for Dir
-				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-					assert.Equal(t, "hello world", stackInfo.Outputs["message"])
-				},
-			})
-		})
-	}
+	testConstructProvider(t, "go", "github.com/pulumi/pulumi/sdk/v3")
 }
 
 func TestGetResourceGo(t *testing.T) {

--- a/tests/integration/integration_python_test.go
+++ b/tests/integration/integration_python_test.go
@@ -535,180 +535,17 @@ func TestPythonResourceArgs(t *testing.T) {
 
 // Test remote component construction in Python.
 func TestConstructPython(t *testing.T) {
-	tests := []struct {
-		componentDir          string
-		expectedResourceCount int
-		env                   []string
-	}{
-		{
-			componentDir:          "testcomponent",
-			expectedResourceCount: 9,
-			// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-			// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-			// module to run `yarn install && yarn link @pulumi/pulumi` in the Go program's directory, allowing
-			// the Node.js dynamic provider plugin to load.
-			// When the underlying issue has been fixed, the use of this environment variable inside the integration
-			// test module should be removed.
-			env: []string{"PULUMI_TEST_YARN_LINK_PULUMI=true"},
-		},
-		{
-			componentDir:          "testcomponent-python",
-			expectedResourceCount: 9,
-		},
-		{
-			componentDir:          "testcomponent-go",
-			expectedResourceCount: 8, // One less because no dynamic provider.
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.componentDir, func(t *testing.T) {
-			pathEnv := pathEnv(t,
-				filepath.Join("..", "testprovider"),
-				filepath.Join("construct_component", test.componentDir))
-			integration.ProgramTest(t,
-				optsForConstructPython(t, test.expectedResourceCount, append(test.env, pathEnv)...))
-		})
-	}
-}
-
-func optsForConstructPython(t *testing.T, expectedResourceCount int, env ...string) *integration.ProgramTestOptions {
-	return &integration.ProgramTestOptions{
-		Env: env,
-		Dir: filepath.Join("construct_component", "python"),
-		Dependencies: []string{
-			filepath.Join("..", "..", "sdk", "python", "env", "src"),
-		},
-		Secrets: map[string]string{
-			"secret": "this super secret is encrypted",
-		},
-		Quick:      true,
-		NoParallel: true, // avoid contention for Dir
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.NotNil(t, stackInfo.Deployment)
-			if assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources)) {
-				stackRes := stackInfo.Deployment.Resources[0]
-				assert.NotNil(t, stackRes)
-				assert.Equal(t, resource.RootStackType, stackRes.Type)
-				assert.Equal(t, "", string(stackRes.Parent))
-
-				// Check that dependencies flow correctly between the originating program and the remote component
-				// plugin.
-				urns := make(map[string]resource.URN)
-				for _, res := range stackInfo.Deployment.Resources[1:] {
-					assert.NotNil(t, res)
-
-					urns[string(res.URN.Name())] = res.URN
-					switch res.URN.Name() {
-					case "child-a":
-						for _, deps := range res.PropertyDependencies {
-							assert.Empty(t, deps)
-						}
-					case "child-b":
-						expected := []resource.URN{urns["a"]}
-						assert.ElementsMatch(t, expected, res.Dependencies)
-						assert.ElementsMatch(t, expected, res.PropertyDependencies["echo"])
-					case "child-c":
-						expected := []resource.URN{urns["a"], urns["child-a"]}
-						assert.ElementsMatch(t, expected, res.Dependencies)
-						assert.ElementsMatch(t, expected, res.PropertyDependencies["echo"])
-					case "a", "b", "c":
-						secretPropValue, ok := res.Outputs["secret"].(map[string]interface{})
-						assert.Truef(t, ok, "secret output was not serialized as a secret")
-						assert.Equal(t, resource.SecretSig, secretPropValue[resource.SigKey].(string))
-					}
-				}
-			}
-		},
-	}
+	testConstruct(t, "python", filepath.Join("..", "..", "sdk", "python", "env", "src"))
 }
 
 // Test remote component construction with a child resource that takes a long time to be created, ensuring it's created.
 func TestConstructSlowPython(t *testing.T) {
-	pathEnv := testComponentSlowPathEnv(t)
-
-	// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-	// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-	// module to run `yarn install && yarn link @pulumi/pulumi` in the Python program's directory, allowing
-	// the Node.js dynamic provider plugin to load.
-	// When the underlying issue has been fixed, the use of this environment variable inside the integration
-	// test module should be removed.
-	const testYarnLinkPulumiEnv = "PULUMI_TEST_YARN_LINK_PULUMI=true"
-
-	opts := &integration.ProgramTestOptions{
-		Env: []string{pathEnv, testYarnLinkPulumiEnv},
-		Dir: filepath.Join("construct_component_slow", "python"),
-		Dependencies: []string{
-			filepath.Join("..", "..", "sdk", "python", "env", "src"),
-		},
-		Quick: true,
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.NotNil(t, stackInfo.Deployment)
-			if assert.Equal(t, 5, len(stackInfo.Deployment.Resources)) {
-				stackRes := stackInfo.Deployment.Resources[0]
-				assert.NotNil(t, stackRes)
-				assert.Equal(t, resource.RootStackType, stackRes.Type)
-				assert.Equal(t, "", string(stackRes.Parent))
-			}
-		},
-	}
-	integration.ProgramTest(t, opts)
+	testConstructSlow(t, "python", filepath.Join("..", "..", "sdk", "python", "env", "src"))
 }
 
 // Test remote component construction with prompt inputs.
 func TestConstructPlainPython(t *testing.T) {
-	tests := []struct {
-		componentDir          string
-		expectedResourceCount int
-		env                   []string
-	}{
-		{
-			componentDir:          "testcomponent",
-			expectedResourceCount: 9,
-			// TODO[pulumi/pulumi#5455]: Dynamic providers fail to load when used from multi-lang components.
-			// Until we've addressed this, set PULUMI_TEST_YARN_LINK_PULUMI, which tells the integration test
-			// module to run `yarn install && yarn link @pulumi/pulumi` in the Go program's directory, allowing
-			// the Node.js dynamic provider plugin to load.
-			// When the underlying issue has been fixed, the use of this environment variable inside the integration
-			// test module should be removed.
-			env: []string{"PULUMI_TEST_YARN_LINK_PULUMI=true"},
-		},
-		{
-			componentDir:          "testcomponent-python",
-			expectedResourceCount: 9,
-		},
-		{
-			componentDir:          "testcomponent-go",
-			expectedResourceCount: 8, // One less because no dynamic provider.
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.componentDir, func(t *testing.T) {
-			pathEnv := pathEnv(t,
-				filepath.Join("..", "testprovider"),
-				filepath.Join("construct_component_plain", test.componentDir))
-			integration.ProgramTest(t,
-				optsForConstructPlainPython(t, test.expectedResourceCount, append(test.env, pathEnv)...))
-		})
-	}
-}
-
-func optsForConstructPlainPython(t *testing.T, expectedResourceCount int,
-	env ...string) *integration.ProgramTestOptions {
-	return &integration.ProgramTestOptions{
-		Env: env,
-		Dir: filepath.Join("construct_component_plain", "python"),
-		Dependencies: []string{
-			filepath.Join("..", "..", "sdk", "python", "env", "src"),
-		},
-		Quick:      true,
-		NoParallel: true, // avoid contention for Dir
-		ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-			assert.NotNil(t, stackInfo.Deployment)
-			assert.Equal(t, expectedResourceCount, len(stackInfo.Deployment.Resources))
-		},
-	}
+	testConstructPlain(t, "python", filepath.Join("..", "..", "sdk", "python", "env", "src"))
 }
 
 // Test remote component inputs properly handle unknowns.
@@ -718,36 +555,7 @@ func TestConstructUnknownPython(t *testing.T) {
 
 // Test methods on remote components.
 func TestConstructMethodsPython(t *testing.T) {
-	tests := []struct {
-		componentDir string
-	}{
-		{
-			componentDir: "testcomponent",
-		},
-		{
-			componentDir: "testcomponent-python",
-		},
-		{
-			componentDir: "testcomponent-go",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.componentDir, func(t *testing.T) {
-			pathEnv := pathEnv(t, filepath.Join("construct_component_methods", test.componentDir))
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Env: []string{pathEnv},
-				Dir: filepath.Join("construct_component_methods", "python"),
-				Dependencies: []string{
-					filepath.Join("..", "..", "sdk", "python", "env", "src"),
-				},
-				Quick:      true,
-				NoParallel: true, // avoid contention for Dir
-				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-					assert.Equal(t, "Hello World, Alice!", stackInfo.Outputs["message"])
-				},
-			})
-		})
-	}
+	testConstructMethods(t, "python", filepath.Join("..", "..", "sdk", "python", "env", "src"))
 }
 
 func TestConstructMethodsUnknownPython(t *testing.T) {
@@ -763,37 +571,7 @@ func TestConstructMethodsErrorsPython(t *testing.T) {
 }
 
 func TestConstructProviderPython(t *testing.T) {
-	const testDir = "construct_component_provider"
-	tests := []struct {
-		componentDir string
-	}{
-		{
-			componentDir: "testcomponent",
-		},
-		{
-			componentDir: "testcomponent-python",
-		},
-		{
-			componentDir: "testcomponent-go",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.componentDir, func(t *testing.T) {
-			pathEnv := pathEnv(t, filepath.Join(testDir, test.componentDir))
-			integration.ProgramTest(t, &integration.ProgramTestOptions{
-				Env: []string{pathEnv},
-				Dir: filepath.Join(testDir, "python"),
-				Dependencies: []string{
-					filepath.Join("..", "..", "sdk", "python", "env", "src"),
-				},
-				Quick:      true,
-				NoParallel: true, // avoid contention for Dir
-				ExtraRuntimeValidation: func(t *testing.T, stackInfo integration.RuntimeValidationStackInfo) {
-					assert.Equal(t, "hello world", stackInfo.Outputs["message"])
-				},
-			})
-		})
-	}
+	testConstructProvider(t, "python", filepath.Join("..", "..", "sdk", "python", "env", "src"))
 }
 
 func TestGetResourcePython(t *testing.T) {

--- a/tests/testprovider/main.go
+++ b/tests/testprovider/main.go
@@ -45,6 +45,7 @@ type resourceProvider interface {
 var resourceProviders = map[string]resourceProvider{
 	"testprovider:index:Random": &randomResourceProvider{},
 	"testprovider:index:Echo":   &echoResourceProvider{},
+	"testprovider:index:Slow":   &slowResourceProvider{},
 }
 
 func providerForURN(urn string) (resourceProvider, string, bool) {

--- a/tests/testprovider/slow.go
+++ b/tests/testprovider/slow.go
@@ -1,0 +1,62 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	rpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
+
+	pbempty "github.com/golang/protobuf/ptypes/empty"
+)
+
+const creationDelay = 15 * time.Second
+
+type slowResourceProvider struct {
+	id int
+}
+
+func (p *slowResourceProvider) Check(ctx context.Context, req *rpc.CheckRequest) (*rpc.CheckResponse, error) {
+	return &rpc.CheckResponse{Inputs: req.News, Failures: nil}, nil
+}
+
+func (p *slowResourceProvider) Diff(ctx context.Context, req *rpc.DiffRequest) (*rpc.DiffResponse, error) {
+	return &rpc.DiffResponse{Changes: rpc.DiffResponse_DIFF_NONE}, nil
+}
+
+func (p *slowResourceProvider) Create(ctx context.Context, req *rpc.CreateRequest) (*rpc.CreateResponse, error) {
+	// Intentional delay creating the resource.
+	time.Sleep(creationDelay)
+
+	p.id++
+	return &rpc.CreateResponse{Id: fmt.Sprintf("%v", p.id)}, nil
+}
+
+func (p *slowResourceProvider) Read(ctx context.Context, req *rpc.ReadRequest) (*rpc.ReadResponse, error) {
+	return &rpc.ReadResponse{
+		Id:         req.Id,
+		Properties: req.Properties,
+	}, nil
+}
+
+func (p *slowResourceProvider) Update(ctx context.Context, req *rpc.UpdateRequest) (*rpc.UpdateResponse, error) {
+	panic("Update not implemented")
+}
+
+func (p *slowResourceProvider) Delete(ctx context.Context, req *rpc.DeleteRequest) (*pbempty.Empty, error) {
+	return &pbempty.Empty{}, nil
+}


### PR DESCRIPTION
Follow-up from https://github.com/pulumi/pulumi/pull/8548#discussion_r764135312

This change cleans up the MLC integration tests:

- Replace use of dynamic providers in Node.js MLC test components in favor of resources in the testprovider. This allows us to remove some hacks we have in the integration test package to make the dynamic providers work with programs written in other languages (since dynamic providers don't currently work well within MLCs). The use of the resources from the testprovider also aligns with the other languages which now all use it as well.

- Replace use of resources exposed from Go MLC test providers in favor of resources in the testprovider. This allows the MLC test providers to be much simpler. The use of the resources from the testprovider also aligns with the other languages which now all use it as well.

- Consolidates and cleans up all the MLC tests to remove a bunch of duplication.