### PR TITLE
[cli] Log Secret Decryption events when using 3rd party secrets + service

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -37,6 +37,9 @@
   NullReferenceException to be raised when constructing resources
   [#8495](https://github.com/pulumi/pulumi/pull/8495)
 
+- [cli] Log secret decryption events when a project uses the Pulumi Service and a 3rd party secrets provider
+  [#8563](https://github.com/pulumi/pulumi/pull/8563)
+
 ### Bug Fixes
 
 - [codegen/schema] - Error on type token names that are not allowed (schema.Name

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -374,6 +374,26 @@ func (pc *Client) DecryptValue(ctx context.Context, stack StackIdentifier, ciphe
 	return resp.Plaintext, nil
 }
 
+func (pc *Client) Log3rdPartySecretsProviderDecryptionEvent(ctx context.Context, stack StackIdentifier,
+	secretName string) error {
+	req := apitype.Log3rdPartyDecryptionEvent{SecretName: secretName}
+	if err := pc.restCall(ctx, "POST", path.Join(getStackPath(stack, "decrypt"), "log-decryption"),
+		nil, &req, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (pc *Client) LogBulk3rdPartySecretsProviderDecryptionEvent(ctx context.Context, stack StackIdentifier,
+	command string) error {
+	req := apitype.Log3rdPartyDecryptionEvent{CommandName: command}
+	if err := pc.restCall(ctx, "POST", path.Join(getStackPath(stack, "decrypt"), "log-batch-decryption"), nil,
+		&req, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
 // GetStackUpdates returns all updates to the indicated stack.
 func (pc *Client) GetStackUpdates(
 	ctx context.Context,

--- a/pkg/cmd/pulumi/config.go
+++ b/pkg/cmd/pulumi/config.go
@@ -811,6 +811,10 @@ func listConfig(stack backend.Stack, showSecrets bool, jsonOut bool) error {
 		})
 	}
 
+	if showSecrets {
+		log3rdPartySecretsProviderDecryptionEvent(commandContext(), stack, "", "pulumi config")
+	}
+
 	return nil
 }
 
@@ -863,6 +867,8 @@ func getConfig(stack backend.Stack, key config.Key, path, jsonOut bool) error {
 		} else {
 			fmt.Printf("%v\n", raw)
 		}
+
+		log3rdPartySecretsProviderDecryptionEvent(commandContext(), stack, key.Name(), "")
 
 		return nil
 	}

--- a/pkg/cmd/pulumi/stack.go
+++ b/pkg/cmd/pulumi/stack.go
@@ -140,6 +140,10 @@ func newStackCmd() *cobra.Command {
 					fmt.Printf("\n")
 					printStackOutputs(outputs)
 				}
+
+				if showSecrets {
+					log3rdPartySecretsProviderDecryptionEvent(commandContext(), s, "", "pulumi stack")
+				}
 			}
 
 			// Add a link to the pulumi.com console page for this stack, if it has one.

--- a/pkg/cmd/pulumi/stack_export.go
+++ b/pkg/cmd/pulumi/stack_export.go
@@ -89,6 +89,7 @@ func newStackExportCmd() *cobra.Command {
 			}
 
 			if showSecrets {
+				// log show secrets event
 				snap, err := stack.DeserializeUntypedDeployment(deployment, stack.DefaultSecretsProvider)
 				if err != nil {
 					return checkDeploymentVersionError(err, stackName)
@@ -108,6 +109,8 @@ func newStackExportCmd() *cobra.Command {
 					Version:    3,
 					Deployment: data,
 				}
+
+				log3rdPartySecretsProviderDecryptionEvent(ctx, s, "", "pulumi stack export")
 			}
 
 			// Write the deployment.

--- a/pkg/cmd/pulumi/stack_history.go
+++ b/pkg/cmd/pulumi/stack_history.go
@@ -58,6 +58,10 @@ This command displays data about previous updates for a stack.`,
 				decrypter = crypter
 			}
 
+			if showSecrets {
+				log3rdPartySecretsProviderDecryptionEvent(commandContext(), s, "", "pulumi stack history")
+			}
+
 			if jsonOut {
 				return displayUpdatesJSON(updates, decrypter)
 			}

--- a/pkg/cmd/pulumi/stack_output.go
+++ b/pkg/cmd/pulumi/stack_output.go
@@ -84,6 +84,11 @@ func newStackOutputCmd() *cobra.Command {
 			} else {
 				printStackOutputs(outputs)
 			}
+
+			if showSecrets {
+				log3rdPartySecretsProviderDecryptionEvent(commandContext(), s, "", "pulumi stack output")
+			}
+
 			return nil
 		}),
 	}

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -882,3 +882,34 @@ func buildStackName(stackName string) (string, error) {
 
 	return stackName, nil
 }
+
+// we only want to log a secrets decryption for a service backend project
+// we will allow any secrets provider to be used (service or self managed)
+// we will log the message and not worry about the response. The types
+// of messages we will log here will range from single secret decryption events
+// to requesting a list of secrets in an individual event e.g. stack export
+// the logging event will only happen during the `--show-secrets` path within the cli
+func log3rdPartySecretsProviderDecryptionEvent(ctx context.Context, backend backend.Stack,
+	secretName, commandName string) {
+	if stack, ok := backend.(httpstate.Stack); ok {
+		// we only want to do something if this is a service backend
+		if be, ok := stack.Backend().(httpstate.Backend); ok {
+			client := be.Client()
+			if client != nil {
+				id := backend.(httpstate.Stack).StackIdentifier()
+				// we don't really care if these logging calls fail as they should not stop the execution
+				if secretName != "" {
+					contract.Assert(commandName == "")
+					err := client.Log3rdPartySecretsProviderDecryptionEvent(ctx, id, secretName)
+					contract.IgnoreError(err)
+				}
+
+				if commandName != "" {
+					contract.Assert(secretName == "")
+					err := client.LogBulk3rdPartySecretsProviderDecryptionEvent(ctx, id, commandName)
+					contract.IgnoreError(err)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
For users who use the Pulumi Service for their state BUT a 3rd party
secrets provider, we now log when that secret decryption has happened.

We have 2 forms of logs:

* single secret when a user uses `pulumi config get x --show-secrets`
* batch decryption for when a user runs a stack export or config list

The API logs to request are fire and forget. The API response is a 204
so we don't need to do anything with the response.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
