### PR TITLE
Use $(PYTHON) for makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,9 +19,9 @@ ensure::
 	$(call STEP_MESSAGE)
 	@echo "Check for pulumictl"; [ -e "$(shell which pulumictl)" ]
 
-	@echo "cd sdk && go mod download"; cd sdk && go mod download
-	@echo "cd pkg && go mod download"; cd pkg && go mod download
-	@echo "cd tests && go mod download"; cd tests && go mod download
+	cd sdk && go mod download
+	cd pkg && go mod download
+	cd tests && go mod download
 
 build-proto::
 	cd sdk/proto && ./generate.sh
@@ -78,36 +78,36 @@ test_build:: $(TEST_ALL_DEPS)
 	cd tests/testprovider && go build -o pulumi-resource-testprovider
 	cd tests/integration/construct_component/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/construct_component_output_values/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_output_values/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component_output_values/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component_output_values/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/construct_component_slow/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_plain/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_plain/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component_plain/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component_plain/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/construct_component_unknown/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_unknown/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component_unknown/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component_unknown/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/component_provider_schema/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/component_provider_schema/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/component_provider_schema/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/component_provider_schema/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/construct_component_error_apply/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_methods/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_methods/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component_methods/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component_methods/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/construct_component_provider/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_provider/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component_provider/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component_provider/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/construct_component_methods_unknown/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_methods_unknown/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component_methods_unknown/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component_methods_unknown/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/construct_component_methods_resources/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_methods_resources/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component_methods_resources/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component_methods_resources/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 	cd tests/integration/construct_component_methods_errors/testcomponent && yarn install && yarn link @pulumi/pulumi && yarn run tsc
 	cd tests/integration/construct_component_methods_errors/testcomponent-go && go build -o pulumi-resource-testcomponent
-	cd tests/integration/construct_component_methods_errors/testcomponent-python && python -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
+	cd tests/integration/construct_component_methods_errors/testcomponent-python && $(PYTHON) -m venv venv && venv/bin/python -m pip install -e ../../../../sdk/python/env/src
 
 test_all:: test_build
 	cd pkg && $(GO_TEST) ${PROJECT_PKGS}

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,14 @@ brew:: BREW_VERSION := $(shell scripts/get-version HEAD)
 brew::
 	cd pkg && go install -ldflags "-X github.com/pulumi/pulumi/pkg/v3/version.Version=${BREW_VERSION}" ${PROJECT}
 
-lint::
-	@[ "$(shell cd pkg && golangci-lint run -c ../.golangci.yml --timeout 5m 1>&2; echo $$?)" -eq 0 ] && \
-	[ "$(shell cd sdk && golangci-lint run -c ../.golangci.yml --timeout 5m 1>&2; echo $$?)" -eq 0 ] && \
-	[ "$(shell cd tests && golangci-lint run -c ../.golangci.yml --timeout 5m 1>&2; echo $$?)" -eq 0 ]
+.PHONY: lint_pkg lint_sdk lint_tests
+lint:: lint_pkg lint_sdk lint_tests
+lint_pkg:
+	cd pkg && golangci-lint run -c ../.golangci.yml --timeout 5m
+lint_sdk:
+	cd sdk && golangci-lint run -c ../.golangci.yml --timeout 5m
+lint_tests:
+	cd tests && golangci-lint run -c ../.golangci.yml --timeout 5m
 
 test_fast:: build
 	cd pkg && $(GO_TEST_FAST) ${PROJECT_PKGS}

--- a/build/common.mk
+++ b/build/common.mk
@@ -1,4 +1,4 @@
-# Copyright 2016-2018, Pulumi Corporation.  All rights reserved.
+# Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
 
 # common.mk provides most of the scalfholding for our build system. It
 # provides default targets for each project we want to build.
@@ -110,9 +110,9 @@ PULUMI_BIN          := $(PULUMI_ROOT)/bin
 PULUMI_NODE_MODULES := $(PULUMI_ROOT)/node_modules
 PULUMI_NUGET        := $(PULUMI_ROOT)/nuget
 
-RUN_TESTSUITE = python3 ${PROJECT_ROOT}/scripts/run-testsuite.py
-GO_TEST_FAST = PATH="$(PULUMI_BIN):$(PATH)" python3 ${PROJECT_ROOT}/scripts/go-test.py -short -count=1 -cover -tags=all -timeout 1h -parallel ${TESTPARALLELISM}
-GO_TEST = PATH="$(PULUMI_BIN):$(PATH)" python3 $(PROJECT_ROOT)/scripts/go-test.py -count=1 -cover -timeout 1h -tags=all -parallel ${TESTPARALLELISM}
+RUN_TESTSUITE = $(PYTHON) ${PROJECT_ROOT}/scripts/run-testsuite.py
+GO_TEST_FAST = PATH="$(PULUMI_BIN):$(PATH)" $(PYTHON) ${PROJECT_ROOT}/scripts/go-test.py -short -count=1 -cover -tags=all -timeout 1h -parallel ${TESTPARALLELISM}
+GO_TEST = PATH="$(PULUMI_BIN):$(PATH)" $(PYTHON) $(PROJECT_ROOT)/scripts/go-test.py -count=1 -cover -timeout 1h -tags=all -parallel ${TESTPARALLELISM}
 GOPROXY = 'https://proxy.golang.org'
 
 .PHONY: default all ensure only_build only_test build lint install test_all core
@@ -157,6 +157,7 @@ all:: build install lint test_all
 ensure::
 	$(call STEP_MESSAGE)
 	@if [ -e 'package.json' ]; then echo "yarn install"; yarn install; fi
+
 build::
 	$(call STEP_MESSAGE)
 
@@ -168,7 +169,7 @@ test_fast::
 
 install::
 	$(call STEP_MESSAGE)
-	# Implicitly creates PULUMI_ROOT.
+	@# Implicitly creates PULUMI_ROOT.
 	@mkdir -p $(PULUMI_BIN)
 	@mkdir -p $(PULUMI_NODE_MODULES)
 	@mkdir -p $(PULUMI_NUGET)
@@ -201,7 +202,7 @@ only_test_fast:: lint test_fast
 
 # Generate targets for each sub project. This project's default and
 # all targets will depend on the sub project's targets, and the
-# individual targets for sub projects are added as a convience when
+# individual targets for sub projects are added as a convenience when
 # invoking make from the command line
 ifneq ($(SUB_PROJECTS),)
 $(SUB_PROJECTS:%=%_default):

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -17,7 +17,7 @@ include ../../build/common.mk
 TEST_ALL_DEPS = build
 
 ensure::
-	python -m venv venv
+	$(PYTHON) -m venv venv
 	venv/bin/python -m pip install -r requirements.txt
 	mkdir -p $(PYENVSRC)
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Python kept failing to build. It was because we were invoking `python` instead of `$(PYTHON)`. This fixes the problem, along with a few other small nits. 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
