### PR TITLE
Always lock in filestate backends, previously feature-flagged

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,13 +18,18 @@
 - [sdk/dotnet] - Lookup packages by searching for `pulumiplugin.json`.
   Pulumi packages need not be prefixed by `Pulumi.` anymore.
   [#8517](https://github.com/pulumi/pulumi/pull/8517)
-  
+
 - [sdk/go] - Emit `pulumiplugin.json`
   [#8530](https://github.com/pulumi/pulumi/pull/8530)
 
+- [cli] - Always use locking in filestate backends. This feature was
+  previously disabled by default and activated by setting the
+  `PULUMI_SELF_MANAGED_STATE_LOCKING=1` environment variable.
+  [#8565](https://github.com/pulumi/pulumi/pull/8565)
+
 ### Bug Fixes
 
-- [codegen/schema] - Error on type token names that are not allowed (schema.Name 
+- [codegen/schema] - Error on type token names that are not allowed (schema.Name
   or specified in allowedPackageNames).
   [#8538](https://github.com/pulumi/pulumi/pull/8538)
   [#8558](https://github.com/pulumi/pulumi/pull/8558)

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -280,13 +280,11 @@ func (b *localBackend) DoesProjectExist(ctx context.Context, projectName string)
 func (b *localBackend) CreateStack(ctx context.Context, stackRef backend.StackReference,
 	opts interface{}) (backend.Stack, error) {
 
-	if cmdutil.IsTruthy(os.Getenv(PulumiFilestateLockingEnvVar)) {
-		err := b.Lock(ctx, stackRef)
-		if err != nil {
-			return nil, err
-		}
-		defer b.Unlock(ctx, stackRef)
+	err := b.Lock(ctx, stackRef)
+	if err != nil {
+		return nil, err
 	}
+	defer b.Unlock(ctx, stackRef)
 
 	contract.Requiref(opts == nil, "opts", "local stacks do not support any options")
 
@@ -360,13 +358,11 @@ func (b *localBackend) ListStacks(
 
 func (b *localBackend) RemoveStack(ctx context.Context, stack backend.Stack, force bool) (bool, error) {
 
-	if cmdutil.IsTruthy(os.Getenv(PulumiFilestateLockingEnvVar)) {
-		err := b.Lock(ctx, stack.Ref())
-		if err != nil {
-			return false, err
-		}
-		defer b.Unlock(ctx, stack.Ref())
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return false, err
 	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	stackName := stack.Ref().Name()
 	snapshot, _, err := b.getStack(stackName)
@@ -385,13 +381,11 @@ func (b *localBackend) RemoveStack(ctx context.Context, stack backend.Stack, for
 func (b *localBackend) RenameStack(ctx context.Context, stack backend.Stack,
 	newName tokens.QName) (backend.StackReference, error) {
 
-	if cmdutil.IsTruthy(os.Getenv(PulumiFilestateLockingEnvVar)) {
-		err := b.Lock(ctx, stack.Ref())
-		if err != nil {
-			return nil, err
-		}
-		defer b.Unlock(ctx, stack.Ref())
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, err
 	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	// Get the current state from the stack to be renamed.
 	stackName := stack.Ref().Name()
@@ -463,13 +457,11 @@ func (b *localBackend) PackPolicies(
 func (b *localBackend) Preview(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
 
-	if cmdutil.IsTruthy(os.Getenv(PulumiFilestateLockingEnvVar)) {
-		err := b.Lock(ctx, stack.Ref())
-		if err != nil {
-			return nil, result.FromError(err)
-		}
-		defer b.Unlock(ctx, stack.Ref())
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, result.FromError(err)
 	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	// We can skip PreviewThenPromptThenExecute and just go straight to Execute.
 	opts := backend.ApplierOptions{
@@ -482,13 +474,11 @@ func (b *localBackend) Preview(ctx context.Context, stack backend.Stack,
 func (b *localBackend) Update(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
 
-	if cmdutil.IsTruthy(os.Getenv(PulumiFilestateLockingEnvVar)) {
-		err := b.Lock(ctx, stack.Ref())
-		if err != nil {
-			return nil, result.FromError(err)
-		}
-		defer b.Unlock(ctx, stack.Ref())
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, result.FromError(err)
 	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.UpdateUpdate, stack, op, b.apply)
 }
@@ -496,13 +486,11 @@ func (b *localBackend) Update(ctx context.Context, stack backend.Stack,
 func (b *localBackend) Import(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation, imports []deploy.Import) (engine.ResourceChanges, result.Result) {
 
-	if cmdutil.IsTruthy(os.Getenv(PulumiFilestateLockingEnvVar)) {
-		err := b.Lock(ctx, stack.Ref())
-		if err != nil {
-			return nil, result.FromError(err)
-		}
-		defer b.Unlock(ctx, stack.Ref())
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, result.FromError(err)
 	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	op.Imports = imports
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.ResourceImportUpdate, stack, op, b.apply)
@@ -511,13 +499,11 @@ func (b *localBackend) Import(ctx context.Context, stack backend.Stack,
 func (b *localBackend) Refresh(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
 
-	if cmdutil.IsTruthy(os.Getenv(PulumiFilestateLockingEnvVar)) {
-		err := b.Lock(ctx, stack.Ref())
-		if err != nil {
-			return nil, result.FromError(err)
-		}
-		defer b.Unlock(ctx, stack.Ref())
+	err := b.Lock(ctx, stack.Ref())
+	if err != nil {
+		return nil, result.FromError(err)
 	}
+	defer b.Unlock(ctx, stack.Ref())
 
 	return backend.PreviewThenPromptThenExecute(ctx, apitype.RefreshUpdate, stack, op, b.apply)
 }
@@ -795,16 +781,14 @@ func (b *localBackend) ExportDeployment(ctx context.Context,
 func (b *localBackend) ImportDeployment(ctx context.Context, stk backend.Stack,
 	deployment *apitype.UntypedDeployment) error {
 
-	if cmdutil.IsTruthy(os.Getenv(PulumiFilestateLockingEnvVar)) {
-		err := b.Lock(ctx, stk.Ref())
-		if err != nil {
-			return err
-		}
-		defer b.Unlock(ctx, stk.Ref())
+	err := b.Lock(ctx, stk.Ref())
+	if err != nil {
+		return err
 	}
+	defer b.Unlock(ctx, stk.Ref())
 
 	stackName := stk.Ref().Name()
-	_, _, err := b.getStack(stackName)
+	_, _, err = b.getStack(stackName)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/filestate/lock.go
+++ b/pkg/backend/filestate/lock.go
@@ -32,9 +32,6 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
-// PulumiFilestateLockingEnvVar is an env var that must be truthy to enable locking when using a filestate backend.
-const PulumiFilestateLockingEnvVar = "PULUMI_SELF_MANAGED_STATE_LOCKING"
-
 type lockContent struct {
 	Pid       int       `json:"pid"`
 	Username  string    `json:"username"`

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -423,9 +423,6 @@ func TestLocalStateLocking(t *testing.T) {
 	e.RunCommand("yarn", "install")
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
 
-	// Enable self-managed backend locking
-	e.SetEnvVars([]string{fmt.Sprintf("%s=1", filestate.PulumiFilestateLockingEnvVar)})
-
 	// Run 10 concurrent updates
 	count := 10
 	stderrs := make(chan string, count)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #6536

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
