### PR TITLE
Fix StackWithNullOutputsThrows test to actual prod behavior

### DIFF
--- a/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/Mocks/MocksTests.cs
@@ -150,6 +150,32 @@ namespace Pulumi.Tests.Mocks
 
             // TODO: It would be good to assert that a warning was logged to the engine but getting hold of warnings requires re-plumbing what TestAsync returns.
         }
+
+        private class NullOutputStack : Stack
+        {
+            [Output("foo")]
+            public Output<string>? Foo { get; } = null;
+        }
+
+        [Fact]
+        public async Task StackWithNullOutputsThrows()
+        {
+            try
+            {
+                await Testing.RunAsync<NullOutputStack>();
+            }
+            catch (Exception ex)
+            {
+                Assert.Contains(
+                    "System.InvalidOperationException: " +
+                    "[Output] Pulumi.Tests.Mocks.MocksTests+NullOutputStack.Foo " +
+                    "did not have a 'set' method",
+                    ex.ToString());
+                return;
+            }
+
+            throw new Exception("Expected to fail");
+        }
     }
 
     public static class Testing

--- a/sdk/dotnet/Pulumi.Tests/StackTests.cs
+++ b/sdk/dotnet/Pulumi.Tests/StackTests.cs
@@ -35,28 +35,6 @@ namespace Pulumi.Tests
             Assert.Same(stack.ImplicitName, outputs["ImplicitName"]);
         }
 
-        private class NullOutputStack : Stack
-        {
-            [Output("foo")]
-            public Output<string>? Foo { get; } = null;
-        }
-
-        [Fact]
-        public async Task StackWithNullOutputsThrows()
-        {
-            try
-            {
-                await Run<NullOutputStack>();
-            }
-            catch (RunException ex)
-            {
-                Assert.Contains("Output(s) 'foo' have no value assigned", ex.ToString());
-                return;
-            }
-
-            throw new XunitException("Should not come here");
-        }
-
         private class InvalidOutputTypeStack : Stack
         {
             [Output("foo")]


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The test StackWithNullOutputsThrows was preventing one of my other PRs https://github.com/pulumi/pulumi/pull/8495 from completing. It turns out that this test is invalid. If you try to run the null stack on a real Pulumi stack, it throws a different nasty exception wrapped in TargetInvocationException.  It complains that the output is not settable. The logic that checks for `Output(s) 'foo' have no value assigned` actually never has a chance to run. 

If I add a `set;` method to the Output, the stack initializes and does not throw at all. Again, the logic that checks for `Output(s) 'foo' have no value assigned` is misplaced and does not run, because it is preempted by this:

```
Resource ctor
  --> IDeploymentInternal.ReadOrRegisterResource
      --> OutputCompletionSource.InitializeOutputs(resource)
```

The actual Stack constructor runs only after Resource constructor, and by that time the Outputs have been set to non-null by the reflective InitializeOutputs, so information on whether the user set the outputs or not is lost by that point.

This PR does not yet fix the problem of checking that the user actually initializes every output. However it moves the test to use the Mocks framework at which point it uses the real `IDeploymentInternal.ReadOrRegisterResource` and becomes more realistic, failing in the same way as the actual production code. Expectation of the test is adjusted also.




<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
