### PR TITLE
fixed obvious reference to stack name

### DIFF
--- a/pkg/cmd/pulumi/new.go
+++ b/pkg/cmd/pulumi/new.go
@@ -536,7 +536,7 @@ func promptAndCreateStack(prompt promptForValueFunc,
 	if b.SupportsOrganizations() {
 		fmt.Print("Please enter your desired stack name.\n" +
 			"To create a stack in an organization, " +
-			"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).\n")
+			"use the format [<org-name>/<project-name>/]<stack-name> (e.g. `acmecorp/shipping/dev`).\n")
 	}
 
 	for {

--- a/pkg/cmd/pulumi/stack_init.go
+++ b/pkg/cmd/pulumi/stack_init.go
@@ -35,7 +35,7 @@ func newStackInitCmd() *cobra.Command {
 	var stackToCopy string
 
 	cmd := &cobra.Command{
-		Use:   "init [<org-name>/]<stack-name>",
+		Use:   "init [<org-name>/<project-name>/]<stack-name>",
 		Args:  cmdutil.MaximumNArgs(1),
 		Short: "Create an empty stack with the given name, ready for updates",
 		Long: "Create an empty stack with the given name, ready for updates\n" +
@@ -93,7 +93,7 @@ func newStackInitCmd() *cobra.Command {
 				if b.SupportsOrganizations() {
 					fmt.Print("Please enter your desired stack name.\n" +
 						"To create a stack in an organization, " +
-						"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`).\n")
+						"use the format [<org-name>/<project-name>/]<stack-name> (e.g. `acmecorp/shipping/dev`).\n")
 				}
 
 				name, nameErr := promptForValue(false, "stack name", "dev", false, b.ValidateStackName, opts)

--- a/pkg/cmd/pulumi/util.go
+++ b/pkg/cmd/pulumi/util.go
@@ -387,7 +387,7 @@ func chooseStack(
 		hint := "Please enter your desired stack name"
 		if b.SupportsOrganizations() {
 			hint += ".\nTo create a stack in an organization, " +
-				"use the format <org-name>/<stack-name> (e.g. `acmecorp/dev`)"
+				"use the format [<org-name>/<project-name>/]<stack-name> (e.g. `acmecorp/shipping/dev`)"
 		}
 		stackName, readErr := cmdutil.ReadConsole(hint)
 		if readErr != nil {


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8292

Simple fix for the inconsistent documentation. Decided to go with the format of `[<org-name>/<project-name>/]<stack-name>` where the optional project-name is followed by a forward slash. In my head, it makes sense to separate project-name from stack name, and the forward slash is already used as a separator.

I'm looking at fixing the pulumi-hugo repo as well, but wanted to wait for someone to comment/approve on the format before beginning that one.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
