### PR TITLE
Fix the module name of Helm for Python doc generation

### DIFF
--- a/pkg/codegen/docs/gen_kubernetes.go
+++ b/pkg/codegen/docs/gen_kubernetes.go
@@ -21,6 +21,7 @@
 package docs
 
 import (
+	"fmt"
 	"path"
 	"strings"
 
@@ -52,7 +53,7 @@ func (mod *modContext) isComponentResource() bool {
 func getKubernetesOverlayPythonFormalParams(modName string) []formalParam {
 	var params []formalParam
 	switch modName {
-	case "helm/v2", "helm/v3":
+	case "helm.sh/v2", "helm.sh/v3":
 		params = []formalParam{
 			{
 				Name: "config",
@@ -115,6 +116,8 @@ func getKubernetesOverlayPythonFormalParams(modName string) []formalParam {
 				DefaultValue: "=None",
 			},
 		}
+	default:
+		panic(fmt.Sprintf("Unknown kubernetes overlay module %q", modName))
 	}
 	return params
 }


### PR DESCRIPTION
The change needed for https://github.com/pulumi/pulumi-kubernetes/issues/1799 (we'll need to propagate it to the resourcegen tool in docs).

I'm not sure at which point this got broken - have we changed the module names for Helm? Anyway - I fixed it and added a panic instead of silently returning a blank collection.