### PR TITLE
Remove .gitignore for file we no longer generate

### DIFF
--- a/pkg/codegen/docs/.gitignore
+++ b/pkg/codegen/docs/.gitignore
@@ -1,1 +1,0 @@
-packaged.go

--- a/pkg/codegen/docs/gen_test.go
+++ b/pkg/codegen/docs/gen_test.go
@@ -506,10 +506,6 @@ func generatePackage(tool string, pkg *schema.Package, extraFiles map[string][]b
 }
 
 func TestGeneratePackage(t *testing.T) {
-	// When running this test locally, be sure to run
-	// `make generate` first. That will regenerate the
-	// compiled templates file packaged.go. See README.md
-	// in this package for more info.
 	test.TestSDKCodegen(t, &test.SDKCodegenOptions{
 		Language:   "docs",
 		GenPackage: generatePackage,


### PR DESCRIPTION
Praneet removed the generation of the packaged.go file in https://github.com/pulumi/pulumi/pull/8389 but I still had it sitting around in my local repo because it was still .gitignored. Was very confusing why "make lint" kept throwing up lint error even on a fresh master checkout.
This removes the .gitignore in that folder and also an out of date comment for one test that used that old file.