### PR TITLE
Always RegisterOutputs even if empty

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,6 @@
 
 ### Bug Fixes
 
+- [sdk/python] - Fixes an issue with stack outputs persisting after
+  they are removed from the Pulumi program
+  [#8583](https://github.com/pulumi/pulumi/pull/8583)

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -921,8 +921,7 @@ class ComponentResource(Resource):
 
         :param dict output: A dictionary of outputs to associate with this resource.
         """
-        if outputs:
-            register_resource_outputs(self, outputs)
+        register_resource_outputs(self, outputs)
 
 
 class ProviderResource(CustomResource):

--- a/sdk/python/lib/test/test_stack_registers_outputs.py
+++ b/sdk/python/lib/test/test_stack_registers_outputs.py
@@ -1,0 +1,67 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verifies that a Stack always calls RegisterResourceOutputs even if
+there are no outputs. This makes sure removing stack outputs from a
+program actually deletes them from the stack.
+
+Regresses https://github.com/pulumi/pulumi/issues/8273
+
+"""
+
+import pytest
+from pulumi.runtime import settings, mocks
+import pulumi
+
+class MyMocks(pulumi.runtime.Mocks):
+
+    def new_resource(self, args: pulumi.runtime.MockResourceArgs):
+        raise Exception('new_resource')
+
+    def call(self, args: pulumi.runtime.MockCallArgs):
+        raise Exception('call')
+
+
+class MyMonitor:
+    def __init__(self):
+        self.outputs = None
+
+    def RegisterResourceOutputs(self, outputs):
+        self.outputs = outputs
+
+
+@pytest.fixture
+def my_mocks():
+    old_settings = settings.SETTINGS
+    settings.reset_options()
+    mm = MyMocks()
+    mocks.set_mocks(mm, preview=False)
+    monitor = MyMonitor()
+    settings.SETTINGS.monitor = monitor
+
+    try:
+        yield mm
+    finally:
+        settings.configure(old_settings)
+
+        # Asserts are here in an unusual place since it is tricky to
+        # place them inside a test and make the code run after the
+        # test stack completes constructing.
+        assert monitor.outputs is not None
+        assert type(monitor.outputs.urn) == str
+
+
+@pulumi.runtime.test
+def test_stack_registers_outputs(my_mocks):
+    pass


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8273 

The behavior is modified not just for Stack but for any ComponentResource. I cannot find a reason for the original `if` statement but it does seem reasonable to expect RegisterResourceOutputs to always be called. Let us see if the test suite passes with these changes.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
