### PR TITLE
[sdk/go] Fix copyInputTo for enums.

### DIFF
--- a/sdk/go/pulumi/provider.go
+++ b/sdk/go/pulumi/provider.go
@@ -341,25 +341,33 @@ func copyInputTo(ctx *Context, v resource.PropertyValue, dest reflect.Value) err
 				if !v.IsBool() {
 					return fmt.Errorf("expected a %v, got a %s", inputType, v.TypeString())
 				}
-				dest.Set(reflect.ValueOf(Bool(v.BoolValue())))
+				result := reflect.New(inputType).Elem()
+				result.SetBool(v.BoolValue())
+				dest.Set(result)
 				return nil
 			case reflect.Int:
 				if !v.IsNumber() {
 					return fmt.Errorf("expected an %v, got a %s", inputType, v.TypeString())
 				}
-				dest.Set(reflect.ValueOf(Int(int64(v.NumberValue()))))
+				result := reflect.New(inputType).Elem()
+				result.SetInt(int64(v.NumberValue()))
+				dest.Set(result)
 				return nil
 			case reflect.Float64:
 				if !v.IsNumber() {
 					return fmt.Errorf("expected an %v, got a %s", inputType, v.TypeString())
 				}
-				dest.Set(reflect.ValueOf(Float64(v.NumberValue())))
+				result := reflect.New(inputType).Elem()
+				result.SetFloat(v.NumberValue())
+				dest.Set(result)
 				return nil
 			case reflect.String:
 				if !v.IsString() {
 					return fmt.Errorf("expected a %v, got a %s", inputType, v.TypeString())
 				}
-				dest.Set(reflect.ValueOf(String(v.StringValue())))
+				result := reflect.New(inputType).Elem()
+				result.SetString(v.StringValue())
+				dest.Set(result)
 				return nil
 			case reflect.Slice:
 				return copyToSlice(ctx, v, inputType, dest)

--- a/sdk/go/pulumi/provider_test.go
+++ b/sdk/go/pulumi/provider_test.go
@@ -26,6 +26,162 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 )
 
+type BoolEnumInput interface {
+	Input
+
+	ToBoolEnumOutput() BoolEnumOutput
+	ToBoolEnumOutputWithContext(context.Context) BoolEnumOutput
+}
+
+type BoolEnumOutput struct{ *OutputState }
+
+func (BoolEnumOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*BoolEnum)(nil)).Elem()
+}
+
+func (o BoolEnumOutput) ToBoolEnumOutput() BoolEnumOutput {
+	return o
+}
+
+func (o BoolEnumOutput) ToBoolEnumOutputWithContext(ctx context.Context) BoolEnumOutput {
+	return o
+}
+
+type BoolEnum bool
+
+func (BoolEnum) ElementType() reflect.Type {
+	return reflect.TypeOf((*BoolEnum)(nil)).Elem()
+}
+
+func (e BoolEnum) ToBoolEnumOutput() BoolEnumOutput {
+	return e.ToBoolEnumOutputWithContext(context.Background())
+}
+
+func (e BoolEnum) ToBoolEnumOutputWithContext(ctx context.Context) BoolEnumOutput {
+	return ToOutputWithContext(ctx, e).(BoolEnumOutput)
+}
+
+type BoolEnumInputArgs struct {
+	Value BoolEnumInput `pulumi:"value"`
+}
+
+type IntEnumInput interface {
+	Input
+
+	ToIntEnumOutput() IntEnumOutput
+	ToIntEnumOutputWithContext(context.Context) IntEnumOutput
+}
+
+type IntEnumOutput struct{ *OutputState }
+
+func (IntEnumOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*IntEnum)(nil)).Elem()
+}
+
+func (o IntEnumOutput) ToIntEnumOutput() IntEnumOutput {
+	return o
+}
+
+func (o IntEnumOutput) ToIntEnumOutputWithContext(ctx context.Context) IntEnumOutput {
+	return o
+}
+
+type IntEnum int
+
+func (IntEnum) ElementType() reflect.Type {
+	return reflect.TypeOf((*IntEnum)(nil)).Elem()
+}
+
+func (e IntEnum) ToIntEnumOutput() IntEnumOutput {
+	return e.ToIntEnumOutputWithContext(context.Background())
+}
+
+func (e IntEnum) ToIntEnumOutputWithContext(ctx context.Context) IntEnumOutput {
+	return ToOutputWithContext(ctx, e).(IntEnumOutput)
+}
+
+type IntEnumInputArgs struct {
+	Value IntEnumInput `pulumi:"value"`
+}
+
+type FloatEnumInput interface {
+	Input
+
+	ToFloatEnumOutput() FloatEnumOutput
+	ToFloatEnumOutputWithContext(context.Context) FloatEnumOutput
+}
+
+type FloatEnumOutput struct{ *OutputState }
+
+func (FloatEnumOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*FloatEnum)(nil)).Elem()
+}
+
+func (o FloatEnumOutput) ToFloatEnumOutput() FloatEnumOutput {
+	return o
+}
+
+func (o FloatEnumOutput) ToFloatEnumOutputWithContext(ctx context.Context) FloatEnumOutput {
+	return o
+}
+
+type FloatEnum float64
+
+func (FloatEnum) ElementType() reflect.Type {
+	return reflect.TypeOf((*FloatEnum)(nil)).Elem()
+}
+
+func (e FloatEnum) ToFloatEnumOutput() FloatEnumOutput {
+	return e.ToFloatEnumOutputWithContext(context.Background())
+}
+
+func (e FloatEnum) ToFloatEnumOutputWithContext(ctx context.Context) FloatEnumOutput {
+	return ToOutputWithContext(ctx, e).(FloatEnumOutput)
+}
+
+type FloatEnumInputArgs struct {
+	Value FloatEnumInput `pulumi:"value"`
+}
+
+type StringEnumInput interface {
+	Input
+
+	ToStringEnumOutput() StringEnumOutput
+	ToStringEnumOutputWithContext(context.Context) StringEnumOutput
+}
+
+type StringEnumOutput struct{ *OutputState }
+
+func (StringEnumOutput) ElementType() reflect.Type {
+	return reflect.TypeOf((*StringEnum)(nil)).Elem()
+}
+
+func (o StringEnumOutput) ToStringEnumOutput() StringEnumOutput {
+	return o
+}
+
+func (o StringEnumOutput) ToStringEnumOutputWithContext(ctx context.Context) StringEnumOutput {
+	return o
+}
+
+type StringEnum string
+
+func (StringEnum) ElementType() reflect.Type {
+	return reflect.TypeOf((*StringEnum)(nil)).Elem()
+}
+
+func (e StringEnum) ToStringEnumOutput() StringEnumOutput {
+	return e.ToStringEnumOutputWithContext(context.Background())
+}
+
+func (e StringEnum) ToStringEnumOutputWithContext(ctx context.Context) StringEnumOutput {
+	return ToOutputWithContext(ctx, e).(StringEnumOutput)
+}
+
+type StringEnumInputArgs struct {
+	Value StringEnumInput `pulumi:"value"`
+}
+
 type StringInputArgs struct {
 	Value StringInput `pulumi:"value"`
 }
@@ -391,6 +547,13 @@ type LaunchTemplateArgs struct {
 	Value LaunchTemplateOptionsPtrInput `pulumi:"value"`
 }
 
+func init() {
+	RegisterInputType(reflect.TypeOf((*BoolEnumInput)(nil)).Elem(), BoolEnum(false))
+	RegisterInputType(reflect.TypeOf((*IntEnumInput)(nil)).Elem(), IntEnum(0))
+	RegisterInputType(reflect.TypeOf((*FloatEnumInput)(nil)).Elem(), FloatEnum(0))
+	RegisterInputType(reflect.TypeOf((*StringEnumInput)(nil)).Elem(), StringEnum(""))
+}
+
 func assertOutputEqual(t *testing.T, value interface{}, known bool, secret bool, deps urnSet, output interface{}) {
 	actualValue, actualKnown, actualSecret, actualDeps, err := await(output.(Output))
 	assert.NoError(t, err)
@@ -660,6 +823,43 @@ func TestConstructInputsCopyTo(t *testing.T) {
 			input:         resource.NewStringProperty("foo"),
 			args:          &IntArgs{},
 			expectedError: "unmarshaling value: expected an int, got a string",
+		},
+
+		// BoolEnumInputArgs
+		{
+			name:  "BoolEnumInput no deps",
+			input: resource.NewBoolProperty(true),
+			args:  &BoolEnumInputArgs{},
+			assert: func(t *testing.T, actual interface{}) {
+				assert.Equal(t, BoolEnum(true), actual)
+			},
+		},
+		// IntEnumInputArgs
+		{
+			name:  "IntEnumInput no deps",
+			input: resource.NewNumberProperty(42),
+			args:  &IntEnumInputArgs{},
+			assert: func(t *testing.T, actual interface{}) {
+				assert.Equal(t, IntEnum(42), actual)
+			},
+		},
+		// FloatEnumInputArgs
+		{
+			name:  "FloatEnumInput no deps",
+			input: resource.NewNumberProperty(42),
+			args:  &FloatEnumInputArgs{},
+			assert: func(t *testing.T, actual interface{}) {
+				assert.Equal(t, FloatEnum(42), actual)
+			},
+		},
+		// StringEnumInputArgs
+		{
+			name:  "StringEnumInput no deps",
+			input: resource.NewStringProperty("hello"),
+			args:  &StringEnumInputArgs{},
+			assert: func(t *testing.T, actual interface{}) {
+				assert.Equal(t, StringEnum("hello"), actual)
+			},
 		},
 
 		// StringArrayArgs


### PR DESCRIPTION
Rather than setting the destination to a value of one of the `pulumi.`
primitive types, set the destination to a value of the appropriate args
type. For example, consider the following definitions:

```
type StringEnumInput interface {
	Input

	ToStringEnumOutput() StringEnumOutput
	ToStringEnumOutputWithContext(context.Context) StringEnumOutput
}

...

type StringEnum string

...

type StringEnumInputArgs struct {
	Value StringEnumInput `pulumi:"value"`
}

func init() {
	RegisterInputType(reflect.TypeOf((*StringEnumInput)(nil)).Elem(), StringEnum(""))
}

```

The original code would have attempted to set
`StringEnumInputArgs.Value` to a value of type `pulumi.String`, but
`pulumi.String` does not implement `StringEnumInput`. The fixed code
creates a value of type `StringEnum`, sets its value to whatever is
present in the object to deserialize, and then sets
`StringEnumInputArgs.Value` to the deserialized value.

Fixes #8588.