### PR TITLE
update codecov setting to not fail ci on error

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -292,7 +292,7 @@ jobs:
         with:
           directory: coverage
           files: '*'
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
   windows-build:
     name: Windows Build + Test + Publish

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -245,7 +245,7 @@ jobs:
         with:
           directory: coverage
           files: '*'
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           verbose: true
       - name: Summarize Test Time by Package
         run: |


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

We've been having issues with codecov where uploading results would fail to some token error (`Passed token was 0 characters long`) - @iwahbe has opened this as an issue upstream here https://github.com/codecov/codecov-action/issues/598

Open for discussion if we should make this blocking on the Main branch, but for now let's disable `fail_ci_if_error`


## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
