### PR TITLE
Enable object types

### DIFF
--- a/pkg/cmd/pulumi/doc_object_type.tmpl
+++ b/pkg/cmd/pulumi/doc_object_type.tmpl
@@ -6,6 +6,5 @@
 
 | Name | Type |
 |------|------|
-{{range .Properties}}
-| {{.Name}} | {{.Type}} |
+{{range .Properties}}| {{.Name}} | {{.Type}} |
 {{end}}

--- a/pkg/cmd/pulumi/doc_reader.go
+++ b/pkg/cmd/pulumi/doc_reader.go
@@ -160,7 +160,8 @@ func openInBrowser(url string) error {
 type LinkResolver = func(link string, reader *markdownReader) (bool, error)
 
 type markdownReader struct {
-	view *mdk.MarkdownView
+	view  *mdk.MarkdownView
+	theme *chroma.Style
 
 	app *tview.Application
 
@@ -193,6 +194,7 @@ func newMarkdownReader(name, source string, theme *chroma.Style, app *tview.Appl
 		view:       mdk.NewMarkdownView(theme),
 		app:        app,
 		helpDialog: newTextDialog(helpText, "Help"),
+		theme:      theme,
 	}
 
 	r.view.SetText(name, source)
@@ -209,9 +211,9 @@ func newMarkdownReader(name, source string, theme *chroma.Style, app *tview.Appl
 }
 
 func (r *markdownReader) SetSource(name, source string) {
-	view := mdk.NewMarkdownView(nil)
+	view := mdk.NewMarkdownView(r.theme)
 	view.SetText(name, source)
-	r.view.SetGutter(true)
+	view.SetGutter(true)
 
 	r.rootPages.AddAndSwitchToPage(name, view, true)
 }

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -179,7 +179,7 @@ require (
 require (
 	github.com/gdamore/tcell v1.4.0
 	github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591
-	github.com/pgavlin/markdown-kit v0.0.0-20211214185658-303d75212708
+	github.com/pgavlin/markdown-kit v0.0.0-20211216181825-66ecaafef0ad
 	github.com/rivo/tview v0.0.0-20210125085121-dbc1f32bb1d0
 )
 

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -35,7 +35,6 @@ require (
 	github.com/nbutton23/zxcvbn-go v0.0.0-20180912185939-ae427f1e4c1d
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pgavlin/goldmark v1.1.33-0.20210916052350-16f491902b32
-	github.com/pgavlin/markdown-kit v0.0.0-20210919233640-5ae943a10f6e
 	github.com/pulumi/pulumi/sdk/v3 v3.19.0
 	github.com/rjeczalik/notify v0.9.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
@@ -178,9 +177,9 @@ require (
 )
 
 require (
-	github.com/atotto/clipboard v0.1.2
 	github.com/gdamore/tcell v1.4.0
 	github.com/gdamore/tcell/v2 v2.0.1-0.20201017141208-acf90d56d591
+	github.com/pgavlin/markdown-kit v0.0.0-20211214185658-303d75212708
 	github.com/rivo/tview v0.0.0-20210125085121-dbc1f32bb1d0
 )
 

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -583,8 +583,8 @@ github.com/pgavlin/ansicsi v0.0.0-20210128180815-facca45e1fdd h1:zo3gi6FOEW0KnRM
 github.com/pgavlin/ansicsi v0.0.0-20210128180815-facca45e1fdd/go.mod h1:EgxeiakKhj1sKJPP8Vcj/6DjHWDTA+5WqdU61WgDyRM=
 github.com/pgavlin/goldmark v1.1.33-0.20210916052350-16f491902b32 h1:6dWdvpLPcMW+FQ4k3K/mrPr+y3M8AgwvNL+jkC0i3iM=
 github.com/pgavlin/goldmark v1.1.33-0.20210916052350-16f491902b32/go.mod h1:MRxHTJrf9FhdfNQ8Hdeh9gmHevC9RJE/fu8M3JIGjoE=
-github.com/pgavlin/markdown-kit v0.0.0-20211214185658-303d75212708 h1:9go1/VxkPXLyP6csg2u6m5DRXCe52x71a1OPXvPYxHI=
-github.com/pgavlin/markdown-kit v0.0.0-20211214185658-303d75212708/go.mod h1:Mf7q6tJtnCfU1kTwRScn57bvm38p5gdil/MVmwPcxDA=
+github.com/pgavlin/markdown-kit v0.0.0-20211216181825-66ecaafef0ad h1:ObHIkPBSXOQxldfCxlnfMWJHEZBHfInRr4q7bn5Bpgo=
+github.com/pgavlin/markdown-kit v0.0.0-20211216181825-66ecaafef0ad/go.mod h1:Mf7q6tJtnCfU1kTwRScn57bvm38p5gdil/MVmwPcxDA=
 github.com/pgavlin/svg2 v0.0.0-20210919231505-4ace7308edc1 h1:pZyspNrqK1cqSk3oIUYgwE2/Si20ZYSGypML1Br3zEU=
 github.com/pgavlin/svg2 v0.0.0-20210919231505-4ace7308edc1/go.mod h1:/bl9WWdq/0JAXp6wvglMkCf9fcBPhT2SoxG7jP+hYqc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -135,7 +135,6 @@ github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/atotto/clipboard v0.1.2 h1:YZCtFu5Ie8qX2VmVTBnrqLSiU9XOWwqNRmdT3gIQzbY=
 github.com/atotto/clipboard v0.1.2/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -584,8 +583,8 @@ github.com/pgavlin/ansicsi v0.0.0-20210128180815-facca45e1fdd h1:zo3gi6FOEW0KnRM
 github.com/pgavlin/ansicsi v0.0.0-20210128180815-facca45e1fdd/go.mod h1:EgxeiakKhj1sKJPP8Vcj/6DjHWDTA+5WqdU61WgDyRM=
 github.com/pgavlin/goldmark v1.1.33-0.20210916052350-16f491902b32 h1:6dWdvpLPcMW+FQ4k3K/mrPr+y3M8AgwvNL+jkC0i3iM=
 github.com/pgavlin/goldmark v1.1.33-0.20210916052350-16f491902b32/go.mod h1:MRxHTJrf9FhdfNQ8Hdeh9gmHevC9RJE/fu8M3JIGjoE=
-github.com/pgavlin/markdown-kit v0.0.0-20210919233640-5ae943a10f6e h1:PKh2+pDjMcdzY+WSaMlNwz/MEKwct5e3BNOQE7rC4os=
-github.com/pgavlin/markdown-kit v0.0.0-20210919233640-5ae943a10f6e/go.mod h1:Mf7q6tJtnCfU1kTwRScn57bvm38p5gdil/MVmwPcxDA=
+github.com/pgavlin/markdown-kit v0.0.0-20211214185658-303d75212708 h1:9go1/VxkPXLyP6csg2u6m5DRXCe52x71a1OPXvPYxHI=
+github.com/pgavlin/markdown-kit v0.0.0-20211214185658-303d75212708/go.mod h1:Mf7q6tJtnCfU1kTwRScn57bvm38p5gdil/MVmwPcxDA=
 github.com/pgavlin/svg2 v0.0.0-20210919231505-4ace7308edc1 h1:pZyspNrqK1cqSk3oIUYgwE2/Si20ZYSGypML1Br3zEU=
 github.com/pgavlin/svg2 v0.0.0-20210919231505-4ace7308edc1/go.mod h1:/bl9WWdq/0JAXp6wvglMkCf9fcBPhT2SoxG7jP+hYqc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=


### PR DESCRIPTION
I also added some special handling for TypeScript Union types, as they
display with an `|` operator. This previously broke our tables.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
