### PR TITLE
Fix python lint (mypy checks)

### DIFF
--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -415,10 +415,6 @@ def _py_properties(cls: type) -> Iterator[Tuple[str, str, builtins.property]]:
                 if pulumi_name is not MISSING:
                     yield (python_name, cast(str, pulumi_name), prop)
 
-# MYPYPATH=./stubs venv/bin/python -m mypy ./lib/pulumi --config-file=mypy.ini
-# lib/pulumi/_types.py:416: error: Incompatible types in "yield"
-# (actual type "Tuple[str, Union[Any, _MISSING_TYPE], property]", expected type "Tuple[str, str, property]")
-# Found 1 error in 1 file (checked 65 source files)
 
 def input_type(cls: Type[T]) -> Type[T]:
     """

--- a/sdk/python/lib/pulumi/_types.py
+++ b/sdk/python/lib/pulumi/_types.py
@@ -413,7 +413,12 @@ def _py_properties(cls: type) -> Iterator[Tuple[str, str, builtins.property]]:
                 prop = cast(builtins.property, v)
                 pulumi_name = getattr(prop.fget, _PULUMI_NAME, MISSING)
                 if pulumi_name is not MISSING:
-                    yield (python_name, pulumi_name, prop)
+                    yield (python_name, cast(str, pulumi_name), prop)
+
+# MYPYPATH=./stubs venv/bin/python -m mypy ./lib/pulumi --config-file=mypy.ini
+# lib/pulumi/_types.py:416: error: Incompatible types in "yield"
+# (actual type "Tuple[str, Union[Any, _MISSING_TYPE], property]", expected type "Tuple[str, str, property]")
+# Found 1 error in 1 file (checked 65 source files)
 
 def input_type(cls: Type[T]) -> Type[T]:
     """


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

`make lint` stopped passing on master. I believe we may have an unpinned mypy dep that auto-upgraded and started complaining about type-checking this little call site.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
