### PR TITLE
Helm doc override: exclude Release and add description for Chart

### DIFF
--- a/pkg/codegen/docs/gen.go
+++ b/pkg/codegen/docs/gen.go
@@ -814,7 +814,7 @@ func (mod *modContext) genConstructorPython(r *schema.Resource, argsOptional, ar
 	isDockerImageResource := mod.pkg.Name == "docker" && resourceName(r) == "Image"
 
 	// Kubernetes overlay resources use a different ordering of formal params in Python.
-	if isK8sOverlayMod {
+	if isK8sOverlayMod && r.IsOverlay {
 		return getKubernetesOverlayPythonFormalParams(mod.mod)
 	} else if isDockerImageResource {
 		return getDockerImagePythonFormalParams()

--- a/pkg/codegen/docs/gen_kubernetes.go
+++ b/pkg/codegen/docs/gen_kubernetes.go
@@ -54,13 +54,21 @@ func getKubernetesOverlayPythonFormalParams(modName string) []formalParam {
 	var params []formalParam
 	switch modName {
 	case "helm.sh/v2", "helm.sh/v3":
+		// Chart options.
 		params = []formalParam{
 			{
-				Name: "config",
+				Name:    "release_name",
+				Type:    propertyType{Name: "str"},
+				Comment: "Name of the Chart (e.g., nginx-ingress).",
+			},
+			{
+				Name:    "config",
+				Comment: "Configuration options for the Chart.",
 			},
 			{
 				Name:         "opts",
 				DefaultValue: "=None",
+				Comment:      "A bag of options that control this resource's behavior.",
 			},
 		}
 	case "kustomize":


### PR DESCRIPTION
Follow-up and further improvement to #8579:

- Excluded Release from override: [preview](http://pulumi-docs-origin-pr-6918-2bd7c18b.s3-website.us-west-2.amazonaws.com/registry/packages/kubernetes/api-docs/helm/v3/release/)
- Add descriptions to Chart args: [preview](http://pulumi-docs-origin-pr-6918-2bd7c18b.s3-website.us-west-2.amazonaws.com/registry/packages/kubernetes/api-docs/helm/v3/chart/)