### PR TITLE
Fix for 8518 automation API issue with set_config "-value"

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,3 +27,7 @@
 - [sdk/python] - Fixes an issue with stack outputs persisting after
   they are removed from the Pulumi program
   [#8583](https://github.com/pulumi/pulumi/pull/8583)
+
+- [auto/*] - Fixes `stack.setConfig()` breaking when trying to set
+  values that look like flags (such as `-value`)
+  [#8518](https://github.com/pulumi/pulumi/pull/8614)

--- a/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
+++ b/sdk/dotnet/Pulumi.Automation/LocalWorkspace.cs
@@ -527,7 +527,7 @@ namespace Pulumi.Automation
         public override async Task SetConfigAsync(string stackName, string key, ConfigValue value, CancellationToken cancellationToken = default)
         {
             var secretArg = value.IsSecret ? "--secret" : "--plaintext";
-            await this.RunCommandAsync(new[] { "config", "set", key, value.Value, secretArg, "--stack", stackName }, cancellationToken).ConfigureAwait(false);
+            await this.RunCommandAsync(new[] { "config", "set", key, secretArg, "--stack", stackName, "--non-interactive", "--", value.Value }, cancellationToken).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/sdk/go/auto/cmd.go
+++ b/sdk/go/auto/cmd.go
@@ -33,7 +33,7 @@ func runPulumiCommandSync(
 ) (string, string, int, error) {
 	// all commands should be run in non-interactive mode.
 	// this causes commands to fail rather than prompting for input (and thus hanging indefinitely)
-	args = append(args, "--non-interactive")
+	args = withNonInteractiveArg(args)
 	cmd := exec.CommandContext(ctx, "pulumi", args...)
 	cmd.Dir = workdir
 	cmd.Env = append(os.Environ(), additionalEnv...)
@@ -50,4 +50,19 @@ func runPulumiCommandSync(
 		code = exitError.ExitCode()
 	}
 	return stdout.String(), stderr.String(), code, err
+}
+
+func withNonInteractiveArg(args []string) []string {
+	var out []string
+	seen := false
+	for _, a := range args {
+		out = append(out, a)
+		if a == "--non-interactive" {
+			seen = true
+		}
+	}
+	if !seen {
+		out = append(out, "--non-interactive")
+	}
+	return out
 }

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -162,7 +162,8 @@ func (l *LocalWorkspace) SetConfig(ctx context.Context, stackName string, key st
 	}
 
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx,
-		"config", "set", key, val.Value, secretArg, "--stack", stackName)
+		"config", "set", key, secretArg, "--stack", stackName,
+		"--non-interactive", "--", val.Value)
 	if err != nil {
 		return newAutoError(errors.Wrap(err, "unable to set config"), stdout, stderr, errCode)
 	}

--- a/sdk/go/auto/local_workspace_test.go
+++ b/sdk/go/auto/local_workspace_test.go
@@ -49,6 +49,7 @@ var pulumiOrg = getTestOrg()
 
 const pName = "testproj"
 const agent = "pulumi/pulumi/test"
+const pulumiTestOrg = "pulumi-test"
 
 func TestWorkspaceSecretsProvider(t *testing.T) {
 	ctx := context.Background()
@@ -1209,7 +1210,7 @@ func TestImportExportStack(t *testing.T) {
 }
 
 func TestConfigFlagLike(t *testing.T) {
-	if getTestOrg() != "pulumi-test" {
+	if getTestOrg() != pulumiTestOrg {
 		return
 	}
 	ctx := context.Background()
@@ -1242,7 +1243,7 @@ func TestConfigFlagLike(t *testing.T) {
 }
 
 func TestNestedConfig(t *testing.T) {
-	if getTestOrg() != "pulumi-test" {
+	if getTestOrg() != pulumiTestOrg {
 		return
 	}
 	ctx := context.Background()
@@ -2354,7 +2355,7 @@ func BenchmarkBulkSetConfigSecret(b *testing.B) {
 }
 
 func getTestOrg() string {
-	testOrg := "pulumi-test"
+	testOrg := pulumiTestOrg
 	if _, set := os.LookupEnv("PULUMI_TEST_ORG"); set {
 		testOrg = os.Getenv("PULUMI_TEST_ORG")
 	}

--- a/sdk/nodejs/automation/cmd.ts
+++ b/sdk/nodejs/automation/cmd.ts
@@ -48,7 +48,11 @@ export function runPulumiCmd(
 ): Promise<CommandResult> {
     // all commands should be run in non-interactive mode.
     // this causes commands to fail rather than prompting for input (and thus hanging indefinitely)
-    args.push("--non-interactive");
+
+    if (!args.includes("--non-interactive")) {
+        args.push("--non-interactive");
+    }
+
     const env = { ...process.env, ...additionalEnv };
 
     return new Promise<CommandResult>((resolve, reject) => {

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -409,7 +409,13 @@ export class LocalWorkspace implements Workspace {
      */
     async setConfig(stackName: string, key: string, value: ConfigValue): Promise<void> {
         const secretArg = value.secret ? "--secret" : "--plaintext";
-        await this.runPulumiCmd(["config", "set", key, value.value, secretArg, "--stack", stackName]);
+        await this.runPulumiCmd(["config", "set", key,
+                                 "--stack", stackName,
+                                 secretArg,
+                                 "--non-interactive",
+                                 "--",
+                                 value.value,
+                                ]);
     }
     /**
      * Sets all values in the provided config map for the specified stack name.

--- a/sdk/nodejs/automation/localWorkspace.ts
+++ b/sdk/nodejs/automation/localWorkspace.ts
@@ -409,13 +409,7 @@ export class LocalWorkspace implements Workspace {
      */
     async setConfig(stackName: string, key: string, value: ConfigValue): Promise<void> {
         const secretArg = value.secret ? "--secret" : "--plaintext";
-        await this.runPulumiCmd(["config", "set", key,
-                                 "--stack", stackName,
-                                 secretArg,
-                                 "--non-interactive",
-                                 "--",
-                                 value.value,
-                                ]);
+        await this.runPulumiCmd(["config", "set", key, "--stack", stackName, secretArg, "--non-interactive", "--", value.value]);
     }
     /**
      * Sets all values in the provided config map for the specified stack name.

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -131,6 +131,34 @@ describe("LocalWorkspace", () => {
 
         await ws.removeStack(stackName);
     }));
+    it(`config_flag_like`, asyncTest(async () => {
+        const projectName = "config_flag_like";
+        const projectSettings: ProjectSettings = {
+            name: projectName,
+            runtime: "nodejs",
+        };
+        const ws = await LocalWorkspace.create({ projectSettings });
+        const stackName = fullyQualifiedStackName(getTestOrg(),
+                                                  projectName,
+                                                  `int_test${getTestSuffix()}`);
+        const stack = await Stack.create(stackName, ws);
+        await stack.setConfig("key", {value: "-value"});
+        await stack.setConfig("secret-key", {value: "-value", secret: true});
+        let values = await stack.getAllConfig();
+        assert.strictEqual(values["config_flag_like:key"].value, "-value");
+        assert.strictEqual(values["config_flag_like:key"].secret, false);
+        assert.strictEqual(values["config_flag_like:secret-key"].value, "-value");
+        assert.strictEqual(values["config_flag_like:secret-key"].secret, true);
+        await stack.setAllConfig({
+            "key": {value: "-value2"},
+            "secret-key": {value: "-value2", secret: true},
+        });
+        let values2 = await stack.getAllConfig();
+        assert.strictEqual(values2["config_flag_like:key"].value, "-value2");
+        assert.strictEqual(values2["config_flag_like:key"].secret, false);
+        assert.strictEqual(values2["config_flag_like:secret-key"].value, "-value2");
+        assert.strictEqual(values2["config_flag_like:secret-key"].secret, true);
+    }));
     it(`nested_config`, asyncTest(async () => {
         if (getTestOrg() !== "pulumi-test") {
             return;

--- a/sdk/nodejs/tests/automation/localWorkspace.spec.ts
+++ b/sdk/nodejs/tests/automation/localWorkspace.spec.ts
@@ -138,13 +138,11 @@ describe("LocalWorkspace", () => {
             runtime: "nodejs",
         };
         const ws = await LocalWorkspace.create({ projectSettings });
-        const stackName = fullyQualifiedStackName(getTestOrg(),
-                                                  projectName,
-                                                  `int_test${getTestSuffix()}`);
+        const stackName = fullyQualifiedStackName(getTestOrg(), projectName, `int_test${getTestSuffix()}`);
         const stack = await Stack.create(stackName, ws);
         await stack.setConfig("key", {value: "-value"});
         await stack.setConfig("secret-key", {value: "-value", secret: true});
-        let values = await stack.getAllConfig();
+        const values = await stack.getAllConfig();
         assert.strictEqual(values["config_flag_like:key"].value, "-value");
         assert.strictEqual(values["config_flag_like:key"].secret, false);
         assert.strictEqual(values["config_flag_like:secret-key"].value, "-value");
@@ -153,7 +151,7 @@ describe("LocalWorkspace", () => {
             "key": {value: "-value2"},
             "secret-key": {value: "-value2", secret: true},
         });
-        let values2 = await stack.getAllConfig();
+        const values2 = await stack.getAllConfig();
         assert.strictEqual(values2["config_flag_like:key"].value, "-value2");
         assert.strictEqual(values2["config_flag_like:key"].secret, false);
         assert.strictEqual(values2["config_flag_like:secret-key"].value, "-value2");

--- a/sdk/python/lib/pulumi/automation/_cmd.py
+++ b/sdk/python/lib/pulumi/automation/_cmd.py
@@ -41,7 +41,8 @@ def _run_pulumi_cmd(args: List[str],
                     on_output: Optional[OnOutput] = None) -> CommandResult:
     # All commands should be run in non-interactive mode.
     # This causes commands to fail rather than prompting for input (and thus hanging indefinitely).
-    args.append("--non-interactive")
+    if "--non-interactive" not in args:
+        args.append("--non-interactive")
     env = {**os.environ, **additional_env}
     cmd = ["pulumi"]
     cmd.extend(args)

--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -185,7 +185,12 @@ class LocalWorkspace(Workspace):
 
     def set_config(self, stack_name: str, key: str, value: ConfigValue) -> None:
         secret_arg = "--secret" if value.secret else "--plaintext"
-        self._run_pulumi_cmd_sync(["config", "set", key, value.value, secret_arg, "--stack", stack_name])
+        self._run_pulumi_cmd_sync(["config", "set", key,
+                                   secret_arg,
+                                   "--stack", stack_name,
+                                   "--non-interactive",
+                                   "--",
+                                   value.value])
 
     def set_all_config(self, stack_name: str, config: ConfigMap) -> None:
         args = ["config", "set-all", "--stack", stack_name]

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -291,6 +291,21 @@ class TestLocalWorkspace(unittest.TestCase):
 
         ws.remove_stack(stack_name)
 
+    def test_config_flag_like(self):
+        project_name = "python_test"
+        project_settings = ProjectSettings(project_name, runtime="python")
+        ws = LocalWorkspace(project_settings=project_settings)
+        stack_name = stack_namer(project_name)
+        stack = Stack.create(stack_name, ws)
+        stack.set_config("key", ConfigValue(value="-value"))
+        stack.set_config("secret-key", ConfigValue(value="-value", secret=True))
+        cfg = stack.get_all_config()
+        self.assertFalse(all_config["python_test:key"].secret)
+        self.assertEqual(all_config["python_test:key"].value, "-value")
+        self.assertTrue(all_config["python_test:secret-key"].secret)
+        self.assertEqual(all_config["python_test:secret-key"].value, "-value")
+        ws.remove_stack(stack_name)
+
     def test_nested_config(self):
         if get_test_org() != "pulumi-test":
             return

--- a/sdk/python/lib/test/automation/test_local_workspace.py
+++ b/sdk/python/lib/test/automation/test_local_workspace.py
@@ -299,7 +299,7 @@ class TestLocalWorkspace(unittest.TestCase):
         stack = Stack.create(stack_name, ws)
         stack.set_config("key", ConfigValue(value="-value"))
         stack.set_config("secret-key", ConfigValue(value="-value", secret=True))
-        cfg = stack.get_all_config()
+        all_config = stack.get_all_config()
         self.assertFalse(all_config["python_test:key"].secret)
         self.assertEqual(all_config["python_test:key"].value, "-value")
         self.assertTrue(all_config["python_test:secret-key"].secret)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8518  for all languages.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
