### PR TITLE
Don't crash on null inputs for value types in IOutputCompletionSource.SetValue(OutputData<object?> data)

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -27,3 +27,6 @@
 - [sdk/python] - Fixes an issue with stack outputs persisting after
   they are removed from the Pulumi program
   [#8583](https://github.com/pulumi/pulumi/pull/8583)
+
+- [sdk/dotnet] - Don't throw converting value types that don't match schema
+  [#8628](https://github.com/pulumi/pulumi/pull/8628)

--- a/sdk/dotnet/Pulumi/Serialization/OutputCompletionSource.cs
+++ b/sdk/dotnet/Pulumi/Serialization/OutputCompletionSource.cs
@@ -45,7 +45,7 @@ namespace Pulumi.Serialization
 
         public void SetValue(OutputData<object?> data)
             => _taskCompletionSource.SetResult(new OutputData<T>(
-                _resources.Union(data.Resources), (T)data.Value!, data.IsKnown, data.IsSecret));
+                _resources.Union(data.Resources), (data.Value == null ? default(T) : (T)data.Value)! , data.IsKnown, data.IsSecret));
 
         public void TrySetDefaultResult(bool isKnown)
             => _taskCompletionSource.TrySetResult(new OutputData<T>(


### PR DESCRIPTION
SetValue correctly annotates that the object held in data might be null.
But then ignores that annotation and tries to cast to `T`, if the object
is null this is fine for reference types which just stay null, but for
value types this throws a NullReferenceException. Simple fix to just use
`default(T)` for when `data.Value` is null, and only cast when non-null.

This has the same behaviour as before for reference types (where
`default(T)` is null) but means that value types take their default
value rather than throwing.

Fixes #8625