### PR TITLE
Fix master build: ignore errors in Python coverage cmd

### DIFF
--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -63,7 +63,7 @@ test_auto:: test_fast $(TEST_ALL_DEPS)
 	# Note that this target depends on test-fast for the call to `pip install`
 	PATH=venv/bin:$$PATH $(RUN_TESTSUITE) auto-python coverage run -m pytest lib/test/automation
 ifneq ($(PULUMI_TEST_COVERAGE_PATH),)
-	if [ -e .coverage ]; then PATH=venv/bin:$$PATH coverage xml -o $(PULUMI_TEST_COVERAGE_PATH)/python-auto.xml; fi
+	if [ -e .coverage ]; then PATH=venv/bin:$$PATH coverage xml -i -o $(PULUMI_TEST_COVERAGE_PATH)/python-auto.xml; fi
 endif
 
 test_all:: test_fast test_auto


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Fixes a broken master build. These previously fatal errors now become warnings:

```
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-10>': No source for code: '/Users/anton/pulumi/sdk/python/rep-10>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-11>': No source for code: '/Users/anton/pulumi/sdk/python/rep-11>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-12>': No source for code: '/Users/anton/pulumi/sdk/python/rep-12>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-13>': No source for code: '/Users/anton/pulumi/sdk/python/rep-13>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-14>': No source for code: '/Users/anton/pulumi/sdk/python/rep-14>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-15>': No source for code: '/Users/anton/pulumi/sdk/python/rep-15>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-16>': No source for code: '/Users/anton/pulumi/sdk/python/rep-16>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-17>': No source for code: '/Users/anton/pulumi/sdk/python/rep-17>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-18>': No source for code: '/Users/anton/pulumi/sdk/python/rep-18>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-19>': No source for code: '/Users/anton/pulumi/sdk/python/rep-19>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-1>': No source for code: '/Users/anton/pulumi/sdk/python/rep-1>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-20>': No source for code: '/Users/anton/pulumi/sdk/python/rep-20>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-21>': No source for code: '/Users/anton/pulumi/sdk/python/rep-21>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-22>': No source for code: '/Users/anton/pulumi/sdk/python/rep-22>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-23>': No source for code: '/Users/anton/pulumi/sdk/python/rep-23>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-24>': No source for code: '/Users/anton/pulumi/sdk/python/rep-24>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-25>': No source for code: '/Users/anton/pulumi/sdk/python/rep-25>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-26>': No source for code: '/Users/anton/pulumi/sdk/python/rep-26>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-27>': No source for code: '/Users/anton/pulumi/sdk/python/rep-27>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-28>': No source for code: '/Users/anton/pulumi/sdk/python/rep-28>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-29>': No source for code: '/Users/anton/pulumi/sdk/python/rep-29>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-2>': No source for code: '/Users/anton/pulumi/sdk/python/rep-2>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-30>': No source for code: '/Users/anton/pulumi/sdk/python/rep-30>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-3>': No source for code: '/Users/anton/pulumi/sdk/python/rep-3>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-4>': No source for code: '/Users/anton/pulumi/sdk/python/rep-4>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-5>': No source for code: '/Users/anton/pulumi/sdk/python/rep-5>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-6>': No source for code: '/Users/anton/pulumi/sdk/python/rep-6>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-7>': No source for code: '/Users/anton/pulumi/sdk/python/rep-7>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-8>': No source for code: '/Users/anton/pulumi/sdk/python/rep-8>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/rep-9>': No source for code: '/Users/anton/pulumi/sdk/python/rep-9>'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
/Users/anton/pulumi/sdk/python/venv/lib/python3.9/site-packages/coverage/report.py:87: CoverageWarning: Couldn't parse '/Users/anton/pulumi/sdk/python/repr': No source for code: '/Users/anton/pulumi/sdk/python/repr'. (couldnt-parse)
  coverage._warn(msg, slug="couldnt-parse")
```

I am not sure I understand where the 'repr' module references are coming from, but it seems worth it to ignore this to fix the main build.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
