### PR TITLE
Fix pip not found error

### DIFF
--- a/sdk/python/lib/test/automation/test_errors.py
+++ b/sdk/python/lib/test/automation/test_errors.py
@@ -56,7 +56,8 @@ class TestErrors(unittest.TestCase):
                 subprocess.run(["npm", "install"], check=True, cwd=project_dir, capture_output=True)
             if lang == "python":
                 subprocess.run(["python3", "-m", "venv", "venv"], check=True, cwd=project_dir, capture_output=True)
-                subprocess.run([os.path.join("venv", "bin", "pip"), "install", "-r", "requirements.txt"],
+                subprocess.run([os.path.join("venv", "bin", "python"),
+                                "-m", "pip", "install", "-r", "requirements.txt"],
                                check=True, cwd=project_dir, capture_output=True)
 
             stack = create_stack(stack_name, work_dir=project_dir)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Locally I get a failure of `cd sdk/python && make test_auto` that is fixed with this little change.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
