### PR TITLE
[backend/filestate] Allow preview on locked stack

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -34,3 +34,6 @@
 
 - [sdk/dotnet] - Don't throw converting value types that don't match schema
   [#8628](https://github.com/pulumi/pulumi/pull/8628)
+
+- [backend/filestate] - Allow preview on locked stack
+  [#8642](https://github.com/pulumi/pulumi/pull/8642)

--- a/pkg/backend/filestate/backend.go
+++ b/pkg/backend/filestate/backend.go
@@ -457,12 +457,6 @@ func (b *localBackend) PackPolicies(
 func (b *localBackend) Preview(ctx context.Context, stack backend.Stack,
 	op backend.UpdateOperation) (engine.ResourceChanges, result.Result) {
 
-	err := b.Lock(ctx, stack.Ref())
-	if err != nil {
-		return nil, result.FromError(err)
-	}
-	defer b.Unlock(ctx, stack.Ref())
-
 	// We can skip PreviewThenPromptThenExecute and just go straight to Execute.
 	opts := backend.ApplierOptions{
 		DryRun:   true,

--- a/tests/stack_test.go
+++ b/tests/stack_test.go
@@ -423,9 +423,10 @@ func TestLocalStateLocking(t *testing.T) {
 	e.RunCommand("yarn", "install")
 	e.RunCommand("yarn", "link", "@pulumi/pulumi")
 
-	// Run 10 concurrent updates
 	count := 10
 	stderrs := make(chan string, count)
+
+	// Run 10 concurrent updates
 	for i := 0; i < count; i++ {
 		go func() {
 			_, stderr, err := e.GetCommandResults("pulumi", "up", "--non-interactive", "--skip-preview", "--yes")
@@ -456,6 +457,25 @@ func TestLocalStateLocking(t *testing.T) {
 			}
 		}
 	}
+
+	// Run 10 concurrent previews
+	for i := 0; i < count; i++ {
+		go func() {
+			_, stderr, err := e.GetCommandResults("pulumi", "preview", "--non-interactive")
+			if err == nil {
+				stderrs <- "" // success marker
+			} else {
+				stderrs <- stderr
+			}
+		}()
+	}
+
+	// Ensure that all of the concurrent previews succeed.
+	for i := 0; i < count; i++ {
+		stderr := <-stderrs
+		assert.Equal(t, "", stderr)
+	}
+
 }
 
 func getFileNames(infos []os.FileInfo) []string {


### PR DESCRIPTION
The `httpstate` backend allows previews to proceed even while an update is in progress.  This is potentially problematic as the preview may be relative to a partial state of the stack, but ensures that previews will not be blocked on stacks that have long running updates (for example, to allow for concurrent PR jobs to preview changes).  This behaviour has been consistent ~forever for the `httpstate` backend.

In the `filestate `backend, we recently introduced locking, using a quite different (more coarse-grained) approach. As part of this implementation, preview was added to the list of operations that require an exclusive lock on the stack.

For consistency, we should loosen this so that preview behaves the same relative to state locking in the `filestate` and `httpstate` backends.

In the future, we may well want to tighten this up for both backends, with some additional user controls.  Also, when the update plans feature lands shortly, that will provide some additional helpful guarantees that a previous preview was not accidentally relative to a partial state.

Fixes #8609.