### PR TITLE
Python Auto API fix to clear RPC_MANAGER

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,6 +1,8 @@
 ### Improvements
 
-- [sdk/nodejs] Support using native ES modules as Pulumi scripts
-  [#7764](https://github.com/pulumi/pulumi/pull/7764)
-
 ### Bug Fixes
+
+- [auto/python] - Fixes an issue with exception isolation in a
+  sequence of inline programs that caused all inline programs to fail
+  after the first one failed
+  [#8643](https://github.com/pulumi/pulumi/pull/8643)

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -22,6 +22,7 @@ from ._workspace import PulumiFn
 from .. import log
 from ..runtime.proto import language_pb2, plugin_pb2, LanguageRuntimeServicer
 from ..runtime import run_in_stack, reset_options, set_all_config
+from ..runtime.rpc_manager import RPC_MANAGER
 from ..errors import RunError
 
 _py_version_less_than_3_7 = sys.version_info[0] == 3 and sys.version_info[1] < 7
@@ -98,6 +99,7 @@ class LanguageServer(LanguageRuntimeServicer):
             loop.close()
             sys.stdout.flush()
             sys.stderr.flush()
+            RPC_MANAGER.clear()
 
         return result
 

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import asyncio
+import logging
 import sys
 import traceback
 from contextlib import suppress
@@ -43,6 +44,8 @@ class LanguageServer(LanguageRuntimeServicer):
         return language_pb2.GetRequiredPluginsResponse()
 
     def Run(self, request, context):
+        _suppress_unobserved_task_logging()
+
         # Configure the runtime so that the user program hooks up to Pulumi as appropriate.
         engine_address = request.args[0] if request.args else ""
         reset_options(
@@ -105,3 +108,12 @@ class LanguageServer(LanguageRuntimeServicer):
 
     def GetPluginInfo(self, request, context):
         return plugin_pb2.PluginInfo()
+
+
+"""Suppresses logs about faulted unobserved tasks. This is similar to
+Python Pulumi user programs. See rationale in
+`sdk/python/cmd/pulumi-language-python-exec`.
+
+"""
+def _suppress_unobserved_task_logging():
+    logging.getLogger('asyncio').setLevel(logging.CRITICAL)

--- a/sdk/python/lib/pulumi/automation/_server.py
+++ b/sdk/python/lib/pulumi/automation/_server.py
@@ -110,10 +110,10 @@ class LanguageServer(LanguageRuntimeServicer):
         return plugin_pb2.PluginInfo()
 
 
-"""Suppresses logs about faulted unobserved tasks. This is similar to
-Python Pulumi user programs. See rationale in
-`sdk/python/cmd/pulumi-language-python-exec`.
-
-"""
 def _suppress_unobserved_task_logging():
+    """Suppresses logs about faulted unobserved tasks. This is similar to
+    Python Pulumi user programs. See rationale in
+    `sdk/python/cmd/pulumi-language-python-exec`.
+
+    """
     logging.getLogger('asyncio').setLevel(logging.CRITICAL)

--- a/sdk/python/lib/pulumi/runtime/rpc_manager.py
+++ b/sdk/python/lib/pulumi/runtime/rpc_manager.py
@@ -78,7 +78,7 @@ class RPCManager:
         return rpc_wrapper
 
     def clear(self) -> None:
-        """Clears any tracked state. For use in testing to ensure test isolation."""
+        """Clears any tracked state."""
         self.rpcs = []
         self.exception_traceback = None
         self.unhandled_exception = None

--- a/sdk/python/lib/test/automation/test_isolation.py
+++ b/sdk/python/lib/test/automation/test_isolation.py
@@ -1,0 +1,59 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Regresses [pulumi/pulumi#8633]: sequential operations like
+# `stack.up` with inline programs should be isolated from each other,
+# so that errors from the first operation do not infect the subsequent
+# operations.
+
+import pytest
+import typing
+import uuid
+
+import pulumi
+from pulumi import automation
+
+
+class BadResource(pulumi.CustomResource):
+    def __init__(self,
+                 resource_name: str,
+                 opts: typing.Optional[pulumi.ResourceOptions] = None):
+        if opts is None:
+            opts = pulumi.ResourceOptions()
+        super().__init__("badprovider::BadResource", resource_name, {}, opts)
+
+
+def program():
+    config = pulumi.Config()
+    bad = config.get_int('bad') or 0
+    if bad == 1:
+        BadResource('bad_resource')
+
+
+def ignore(*args, **kw):
+    pass
+
+
+def test_isolation():
+    stack = automation.create_stack(
+        stack_name=f'isolation-test-{uuid.uuid4()}',
+        project_name='isolation-test',
+        program=program)
+
+    with pytest.raises(automation.errors.CommandError):
+        stack.set_config('bad', automation.ConfigValue('1'))
+        stack.up(on_output=ignore)
+
+    stack.set_config('bad', automation.ConfigValue('0'))
+    stack.up(on_output=ignore)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Clearing RPC_MANAGER prevents state contamination between several Automation API operations that intend to be distinct, such as exception poisoning from failed up 1 to otherwise successful up 2.

Fixes #8633 for Python

- [x] add test

Separate PRs needed for:

- [ ] check node
- [ ] check dotnet
- [ ] check go

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
