### PR TITLE
[cli/import] Support import of values with map type keys with non-identifier names

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -34,3 +34,6 @@
 
 - [sdk/dotnet] - Don't throw converting value types that don't match schema
   [#8628](https://github.com/pulumi/pulumi/pull/8628)
+
+- [cli/import] - Fix import of resource with non-identifier map keys
+  [#8645](https://github.com/pulumi/pulumi/pull/8645)

--- a/pkg/codegen/importer/hcl2.go
+++ b/pkg/codegen/importer/hcl2.go
@@ -439,12 +439,8 @@ func generateValue(typ schema.Type, value resource.PropertyValue) (model.Express
 					return nil, err
 				}
 
-				// we need to take into account when we have a complex key - without this
-				// we will return key as an array as the / will show as 2 parts
-				propKey := string(k)
-				if strings.Contains(string(k), "/") {
-					propKey = fmt.Sprintf("%q", string(k))
-				}
+				// Always quote the key in case it includes invalid identifier characters (like '/' or ':')
+				propKey := fmt.Sprintf("%q", string(k))
 
 				items = append(items, model.ObjectConsItem{
 					Key: &model.LiteralValueExpression{

--- a/pkg/codegen/importer/testdata/cases.json
+++ b/pkg/codegen/importer/testdata/cases.json
@@ -484,7 +484,7 @@
 				"instanceTenancy": "foobar",
 				"tags": {
 					"Name": "foobar",
-					"pulummi:Project": "tag-check"
+					"pulumi:Project": "tag-check"
 				}
 			}
 		},

--- a/pkg/codegen/importer/testdata/cases.json
+++ b/pkg/codegen/importer/testdata/cases.json
@@ -483,7 +483,8 @@
 				"enableDnsSupport": true,
 				"instanceTenancy": "foobar",
 				"tags": {
-					"Name": "foobar"
+					"Name": "foobar",
+					"pulummi:Project": "tag-check"
 				}
 			}
 		},


### PR DESCRIPTION
Map-typed values now always quote their keys, to ensure that non-identifier key names do not fail.

Fixes #7046.
Fixes #8454.
Fixes pulumi/pulumi-aws#1368.