### PR TITLE
Deterministic builds for goreleaser

### DIFF
--- a/.goreleaser.prerelease.yml
+++ b/.goreleaser.prerelease.yml
@@ -29,6 +29,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-windows
   binary: pulumi-language-nodejs
@@ -43,6 +44,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-windows
   binary: pulumi-language-python
@@ -54,6 +56,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-windows
   binary: pulumi-language-dotnet
@@ -65,6 +68,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-windows
   binary: pulumi-language-go
@@ -76,6 +80,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./go/pulumi-language-go
 # UNIX builds
 - id: pulumi-unix
@@ -90,6 +95,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-unix
   binary: pulumi-language-nodejs
@@ -103,6 +109,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-unix
   binary: pulumi-language-python
@@ -116,6 +123,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-unix
   binary: pulumi-language-dotnet
@@ -129,6 +137,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-unix
   binary: pulumi-language-go
@@ -142,6 +151,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./go/pulumi-language-go
 
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,6 +24,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-windows
   binary: pulumi-language-nodejs
@@ -34,6 +35,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-windows
   binary: pulumi-language-python
@@ -44,6 +46,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-windows
   binary: pulumi-language-dotnet
@@ -54,6 +57,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-windows
   binary: pulumi-language-go
@@ -64,6 +68,7 @@ builds:
     - windows
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./go/pulumi-language-go
 # UNIX builds
 - id: pulumi-unix
@@ -77,6 +82,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./cmd/pulumi
 - id: pulumi-language-nodejs-unix
   binary: pulumi-language-nodejs
@@ -89,6 +95,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./nodejs/cmd/pulumi-language-nodejs
 - id: pulumi-language-python-unix
   binary: pulumi-language-python
@@ -101,6 +108,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./python/cmd/pulumi-language-python
 - id: pulumi-language-dotnet-unix
   binary: pulumi-language-dotnet
@@ -113,6 +121,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./dotnet/cmd/pulumi-language-dotnet
 - id: pulumi-language-go-unix
   binary: pulumi-language-go
@@ -125,6 +134,7 @@ builds:
     - darwin
   ldflags:
     - -X github.com/pulumi/pulumi/pkg/v3/version.Version={{.Tag}}
+  mod_timestamp: '{{ .CommitTimestamp }}'
   main: ./go/pulumi-language-go
 
 archives:
@@ -167,7 +177,7 @@ archives:
   name_template: "{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}"
 snapshot:
   name_template: "{{ .Version }}-SNAPSHOT"
-checksum: 
+checksum:
   name_template: "{{ .ProjectName }}-{{ .Version }}-checksums.txt"
 brews:
   -

--- a/scripts/prep-for-goreleaser.sh
+++ b/scripts/prep-for-goreleaser.sh
@@ -10,14 +10,13 @@ go mod tidy
 go mod download
 popd
 
-
-COMMIT_TIME=$(git show -s --format=%ci HEAD)
+COMMIT_TIME=$(git log -n1 --pretty='format:%cd' --date=format:'%Y%m%d%H%M')
 
 install_file () {
     src="$1"
     dest=$(basename "$src")
     cp "$src" "$dest"
-    touch -d "$COMMIT_TIME" "$dest"
+    touch -t "$COMMIT_TIME" "$dest"
 }
 
 install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs

--- a/scripts/prep-for-goreleaser.sh
+++ b/scripts/prep-for-goreleaser.sh
@@ -5,19 +5,29 @@ go mod tidy
 go mod download
 popd
 
-pushd pkg 
+pushd pkg
 go mod tidy
 go mod download
 popd
 
-cp sdk/nodejs/dist/pulumi-resource-pulumi-nodejs .
-cp sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd .
-cp sdk/python/dist/pulumi-resource-pulumi-python .
-cp sdk/python/dist/pulumi-resource-pulumi-python.cmd .
-cp sdk/python/dist/pulumi-python3-shim.cmd .
-cp sdk/python/dist/pulumi-python-shim.cmd .
-cp sdk/nodejs/dist/pulumi-analyzer-policy .
-cp sdk/nodejs/dist/pulumi-analyzer-policy.cmd .
-cp sdk/python/dist/pulumi-analyzer-policy-python .
-cp sdk/python/dist/pulumi-analyzer-policy-python.cmd .
-cp sdk/python/cmd/pulumi-language-python-exec .
+
+COMMIT_TIME=$(git show -s --format=%ci HEAD)
+
+install_file () {
+    src="$1"
+    dest=$(basename "$src")
+    cp "$src" "$dest"
+    touch -d "$COMMIT_TIME" "$dest"
+}
+
+install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs
+install_file sdk/nodejs/dist/pulumi-resource-pulumi-nodejs.cmd
+install_file sdk/python/dist/pulumi-resource-pulumi-python .
+install_file sdk/python/dist/pulumi-resource-pulumi-python.cmd .
+install_file sdk/python/dist/pulumi-python3-shim.cmd .
+install_file sdk/python/dist/pulumi-python-shim.cmd .
+install_file sdk/nodejs/dist/pulumi-analyzer-policy .
+install_file sdk/nodejs/dist/pulumi-analyzer-policy.cmd .
+install_file sdk/python/dist/pulumi-analyzer-policy-python .
+install_file sdk/python/dist/pulumi-analyzer-policy-python.cmd .
+install_file sdk/python/cmd/pulumi-language-python-exec .


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Unfortunately file mtimes affect archive checksums. Before this change, running `goreleaser` twice on the same machine and same file-set would produce a new checksum for the generated archives every single run, that is, checksum was not reproducible from the file-set. The changes fix that.

It is my hope that with the changes we can continue using goreleaser for post-release utility steps rather than recoding them, by running it twice but checking checksums from the second run against the ones in the first run.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
