### PR TITLE
More updates to build.yml that are needed by release.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,12 @@ jobs:
             name: pulumi-${{ matrix.os }}-x64
             path: goreleaser/pulumi*-${{ matrix.os }}-x64*
             retention-days: 2
+      - name: Upload pulumi-${{ matrix.os }}-checksums
+        uses: actions/upload-artifact@v2
+        with:
+            name: pulumi-${{ matrix.os }}-checksums
+            path: goreleaser/pulumi*-checksums.txt
+            retention-days: 2
 
   build_python_sdk:
     name: Build Pulumi Python SDK wheel


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

On top of https://github.com/pulumi/pulumi/pull/8662 

Adds GHA artifacts for goreleaser checksum files. The release.yml pipeline will need these checksums to validate that the released binaries are identical to tested binaries. 

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
