### PR TITLE
Updates to build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,6 +118,12 @@ jobs:
             name: pulumi-${{ matrix.os }}-x64
             path: goreleaser/pulumi*-${{ matrix.os }}-x64*
             retention-days: 2
+      - name: Upload pulumi-${{ matrix.os }}-checksums
+        uses: actions/upload-artifact@v2
+        with:
+            name: pulumi-${{ matrix.os }}-checksums
+            path: goreleaser/pulumi*-checksums.txt
+            retention-days: 2
 
   build_python_sdk:
     name: Build Pulumi Python SDK wheel

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,12 +100,12 @@ jobs:
           echo "GORELEASER_CURRENT_TAG=v$(pulumictl get version --language generic -o)" >> $GITHUB_ENV
       - name: Filter goreleaser config by OS
         run: |
-          cat ${{ inputs.goreleaser-config }} | goreleaser-filter -no-blobs -goos ${{ matrix.os }} > .goreleaser.current.yml
+          cat ${{ inputs.goreleaser-config }} | goreleaser-filter -no-blobs -goos ${{ matrix.os }} > /tmp/.goreleaser.current.yml
       - name: Run GoReleaser to build Go Pulumi binaries
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: -f .goreleaser.current.yml ${{ inputs.goreleaser-flags }}
+          args: -f /tmp/.goreleaser.current.yml ${{ inputs.goreleaser-flags }}
       - name: Upload pulumi-${{ matrix.os }}-arm64
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,11 @@ on:
         default: false
         required: false
         type: boolean
+      default-build-platform:
+        description: 'Default platform to cross-compile on'
+        default: 'ubuntu-latest'
+        required: false
+        type: string
     secrets: {}
 
 env:
@@ -50,9 +55,9 @@ jobs:
         include:
           - platform: macos-latest
             os: darwin
-          - platform: ubuntu-latest
+          - platform: ${{ inputs.default-build-platform }}
             os: linux
-          - platform: ubuntu-latest
+          - platform: ${{ inputs.default-build-platform }}
             os: windows
       fail-fast: false
 

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -130,7 +130,7 @@ jobs:
 
   build:
     name: Build
-    uses: pulumi/pulumi/.github/workflows/build.yml@master
+    uses: pulumi/pulumi/.github/workflows/build.yml@a0d543d91bfb271f1e93b2a5252dd09d5e5e3644
     with:
       enable-coverage: true
 

--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -130,7 +130,7 @@ jobs:
 
   build:
     name: Build
-    uses: pulumi/pulumi/.github/workflows/build.yml@a0d543d91bfb271f1e93b2a5252dd09d5e5e3644
+    uses: pulumi/pulumi/.github/workflows/build.yml@master
     with:
       enable-coverage: true
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

This PR aggregates small tweaks to build.yml that will be needed by the new version of release.yml.

- parameter for default build platform so the caller can opt to building everything on macos-latest so checksums match
- upload checksums as an artifact
- move edited goreleaser config out of worktree to pass goreleaser dirty worktree tests ( /tmp/.goreleaser.current.yml )

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
