### PR TITLE
Initialize stack in mocks mode

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,3 +1,6 @@
 ### Improvements
 
 ### Bug Fixes
+
+- [sdk/nodejs] - Fix [#4669](https://github.com/pulumi/pulumi/issues/4669), enabling
+  stack transformations in unit test mocking mode [#8672](https://github.com/pulumi/pulumi/pull/8672).

--- a/sdk/nodejs/runtime/mocks.ts
+++ b/sdk/nodejs/runtime/mocks.ts
@@ -14,6 +14,7 @@
 
 import { deserializeProperties, serializeProperties } from "./rpc";
 import { getProject, getStack, setMockOptions } from "./settings";
+import { ensureMockStackResource } from "./stack";
 
 const provproto = require("../proto/provider_pb.js");
 const resproto = require("../proto/resource_pb.js");
@@ -228,4 +229,5 @@ export class MockMonitor {
  */
 export function setMocks(mocks: Mocks, project?: string, stack?: string, preview?: boolean) {
     setMockOptions(new MockMonitor(mocks), project, stack, preview);
+    ensureMockStackResource();
 }

--- a/sdk/nodejs/runtime/stack.ts
+++ b/sdk/nodejs/runtime/stack.ts
@@ -33,6 +33,16 @@ export function getStackResource(): Stack | undefined {
 }
 
 /**
+ * ensureMockStackResource creates and populates a Stack component. This is only used during mock
+ * testing mode, since in normal runs, the Pulumi runtime is responsible for setting it up.
+ */
+export function ensureMockStackResource() {
+    if (!stackResource) {
+        stackResource = new Stack(async () => ({}));
+    }
+}
+
+/**
  * runInPulumiStack creates a new Pulumi stack resource and executes the callback inside of it.  Any outputs
  * returned by the callback will be stored as output properties on this resulting Stack object.
  */

--- a/sdk/nodejs/tests_with_mocks/mocks.spec.ts
+++ b/sdk/nodejs/tests_with_mocks/mocks.spec.ts
@@ -151,4 +151,20 @@ describe("mocks", function() {
             });
         });
     });
+
+    describe("stackTransformations", function() {
+        it("gets invoked", done => {
+            pulumi.runtime.registerStackTransformation((args) => {
+                if (args.type === "pkg:index:MyCustom") {
+                    if (args.props["x"] === 42) {
+                        done();
+                    } else {
+                        done(new Error("received stack transform event for pkg:index:Custom, but x !== 42"));
+                    }
+                }
+                return undefined;
+            });
+            new MyCustom("mycustom", { x: 42 });
+        });
+    });
 });


### PR DESCRIPTION
This change initializes a root stack resource when run in
mocks mode, fixing #4669. This lets you use, for instance,
stack transformations during unit testing. This is effectively the
equivalent to what we did for Python in
https://github.com/pulumi/pulumi/pull/4670/files, just for Node.js.