### PR TITLE
Using a decryptAll functionality when deserializing a deployment

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -3,6 +3,11 @@
 - [cli] Download provider plugins from GitHub Releases
   [#8785](https://github.com/pulumi/pulumi/pull/8785)
 
+- [cli] Using a decryptAll functionality when deserializing a deployment. This will allow
+  decryption of secrets stored in the Pulumi Service backend to happen in bulk for
+  performance increase
+  [#8676](https://github.com/pulumi/pulumi/pull/8676)
+
 - [sdk/dotnet] - Changed `Output<T>.ToString()` to return an informative message rather than just "Output`1[X]"
   [#8767](https://github.com/pulumi/pulumi/pull/8767)
 

--- a/pkg/backend/httpstate/client/client.go
+++ b/pkg/backend/httpstate/client/client.go
@@ -394,6 +394,18 @@ func (pc *Client) LogBulk3rdPartySecretsProviderDecryptionEvent(ctx context.Cont
 	return nil
 }
 
+// BulkDecryptValue decrypts a ciphertext value in the context of the indicated stack.
+func (pc *Client) BulkDecryptValue(ctx context.Context, stack StackIdentifier,
+	ciphertexts [][]byte) (map[string][]byte, error) {
+	req := apitype.BulkDecryptValueRequest{Ciphertexts: ciphertexts}
+	var resp apitype.BulkDecryptValueResponse
+	if err := pc.restCall(ctx, "POST", getStackPath(stack, "batch-decrypt"), nil, &req, &resp); err != nil {
+		return nil, err
+	}
+
+	return resp.Plaintexts, nil
+}
+
 // GetStackUpdates returns all updates to the indicated stack.
 func (pc *Client) GetStackUpdates(
 	ctx context.Context,

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -323,8 +323,12 @@ type brokenDecrypter struct {
 	ErrorMessage string
 }
 
-func (b brokenDecrypter) DecryptValue(ciphertext string) (string, error) {
+func (b brokenDecrypter) DecryptValue(_ string) (string, error) {
 	return "", fmt.Errorf(b.ErrorMessage)
+}
+
+func (b brokenDecrypter) BulkDecrypt(_ []string) (map[string]string, error) {
+	return nil, fmt.Errorf(b.ErrorMessage)
 }
 
 // Tests that the engine presents a reasonable error message when a decrypter fails to decrypt a config value.

--- a/pkg/go.mod
+++ b/pkg/go.mod
@@ -113,7 +113,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1 // indirect
-	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect

--- a/pkg/go.sum
+++ b/pkg/go.sum
@@ -452,7 +452,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxv
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=

--- a/pkg/resource/stack/deployment.go
+++ b/pkg/resource/stack/deployment.go
@@ -232,7 +232,23 @@ func DeserializeDeploymentV3(deployment apitype.DeploymentV3, secretsProv Secret
 		if err != nil {
 			return nil, err
 		}
-		dec = d
+		dec = config.NewCachedDecrypter(d)
+
+		// Do a first pass through state and collect all of the secrets that need decrypting.
+		// We will collect all secrets and decrypt them all at once, rather than just-in-time.
+		// We do this to avoid serial calls to the decryption endpoint which can result in long
+		// wait times in stacks with a large number of secrets.
+		var ciphertexts []string
+		for _, res := range deployment.Resources {
+			ciphertexts = append(ciphertexts, scanResource(res)...)
+		}
+
+		// we call BulkDecrypt to Prime the cache with the decrypted cipertexts
+		// we don't actually use the response here at this point
+		_, err = dec.BulkDecrypt(ciphertexts)
+		if err != nil {
+			return nil, err
+		}
 
 		e, err := secretsManager.Encrypter()
 		if err != nil {
@@ -397,7 +413,7 @@ func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
 
 	if prop.IsSecret() {
 		// Since we are going to encrypt property value, we can elide encrypting sub-elements. We'll mark them as
-		// "secret" so we retain that information when deserializaing the overall structure, but there is no
+		// "secret" so we retain that information when deserializing the overall structure, but there is no
 		// need to double encrypt everything.
 		value, err := SerializePropertyValue(prop.SecretValue().Element, config.NopEncrypter, showSecrets)
 		if err != nil {
@@ -437,6 +453,36 @@ func SerializePropertyValue(prop resource.PropertyValue, enc config.Encrypter,
 
 	// All others are returned as-is.
 	return prop.V, nil
+}
+
+// scanProperties collects encrypted secrets from resource properties.
+func scanProperties(props map[string]interface{}) []string {
+	var cipertexts []string
+	for _, prop := range props {
+		if prop != nil {
+			if obj, ok := prop.(map[string]interface{}); ok {
+				if sig, hasSig := obj[resource.SigKey]; hasSig {
+					if sig == resource.SecretSig {
+						if ciphertext, cipherOk := obj["ciphertext"].(string); cipherOk {
+							cipertexts = append(cipertexts, ciphertext)
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return cipertexts
+}
+
+// scanResource collects encrypted secrets from a serialized resource.
+func scanResource(res apitype.ResourceV3) []string {
+	var cipertexts []string
+	// Scan resource properties for secrets.
+	cipertexts = append(cipertexts, scanProperties(res.Inputs)...)
+	cipertexts = append(cipertexts, scanProperties(res.Outputs)...)
+
+	return cipertexts
 }
 
 // DeserializeResource turns a serialized resource back into its usual form.
@@ -559,7 +605,7 @@ func DeserializePropertyValue(v interface{}, dec config.Decrypter,
 					} else {
 						unencryptedText, err := dec.DecryptValue(ciphertext)
 						if err != nil {
-							return resource.PropertyValue{}, fmt.Errorf("decrypting secret value: %w", err)
+							return resource.PropertyValue{}, fmt.Errorf("error decrypting secret value: %s", err.Error())
 						}
 						plaintext = unencryptedText
 					}

--- a/pkg/resource/stack/deployment_test.go
+++ b/pkg/resource/stack/deployment_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"pgregory.net/rapid"
 
+	"github.com/pulumi/pulumi/pkg/v3/secrets/b64"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/config"
@@ -402,6 +403,22 @@ func TestCustomSerialization(t *testing.T) {
 			t.Logf("Full JSON encoding:\n%v", json)
 		}
 	})
+}
+
+func TestDeserializeDeploymentSecretCache(t *testing.T) {
+	urn := "urn:pulumi:prod::acme::acme:erp:Backend$aws:ebs/volume:Volume::PlatformBackendDb"
+	_, err := DeserializeDeploymentV3(apitype.DeploymentV3{
+		SecretsProviders: &apitype.SecretsProvidersV1{Type: b64.Type},
+		Resources: []apitype.ResourceV3{
+			{
+				URN:    resource.URN(urn),
+				Type:   "aws:ebs/volume:Volume",
+				Custom: true,
+				ID:     "vol-044ba5ad2bd959bc1",
+			},
+		},
+	}, DefaultSecretsProvider)
+	assert.NoError(t, err)
 }
 
 func TestDeserializeInvalidResourceErrors(t *testing.T) {

--- a/pkg/resource/stack/secrets.go
+++ b/pkg/resource/stack/secrets.go
@@ -129,6 +129,10 @@ func (c *cachingCrypter) DecryptValue(ciphertext string) (string, error) {
 	return c.decrypter.DecryptValue(ciphertext)
 }
 
+func (c *cachingCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	return c.decrypter.BulkDecrypt(ciphertexts)
+}
+
 // encryptSecret encrypts the plaintext associated with the given secret value.
 func (c *cachingCrypter) encryptSecret(secret *resource.Secret, plaintext string) (string, error) {
 	// If the cache has an entry for this secret and the plaintext has not changed, re-use the ciphertext.

--- a/pkg/resource/stack/secrets_test.go
+++ b/pkg/resource/stack/secrets_test.go
@@ -43,6 +43,21 @@ func (t *testSecretsManager) DecryptValue(ciphertext string) (string, error) {
 	return ciphertext[i+1:], nil
 }
 
+func (t *testSecretsManager) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	secretMap := map[string]string{}
+	for _, cip := range ciphertexts {
+		if _, ok := secretMap[cip]; ok {
+			continue
+		}
+		v, err := t.DecryptValue(cip)
+		if err != nil {
+			return nil, err
+		}
+		secretMap[cip] = v
+	}
+	return secretMap, nil
+}
+
 func deserializeProperty(v interface{}, dec config.Decrypter) (resource.PropertyValue, error) {
 	b, err := json.Marshal(v)
 	if err != nil {

--- a/pkg/secrets/b64/manager.go
+++ b/pkg/secrets/b64/manager.go
@@ -48,3 +48,18 @@ func (c *base64Crypter) DecryptValue(s string) (string, error) {
 	}
 	return string(b), nil
 }
+
+func (c *base64Crypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	secretMap := map[string]string{}
+	for _, cip := range ciphertexts {
+		if _, ok := secretMap[cip]; ok {
+			continue
+		}
+		v, err := c.DecryptValue(cip)
+		if err != nil {
+			return nil, err
+		}
+		secretMap[cip] = v
+	}
+	return secretMap, nil
+}

--- a/pkg/secrets/cloud/manager.go
+++ b/pkg/secrets/cloud/manager.go
@@ -41,7 +41,7 @@ type cloudSecretsManagerState struct {
 
 // NewCloudSecretsManagerFromState deserialize configuration from state and returns a secrets
 // manager that uses the target cloud key management service to encrypt/decrypt a data key used for
-// envelope encyrtion of secrets values.
+// envelope encryption of secrets values.
 func NewCloudSecretsManagerFromState(state json.RawMessage) (secrets.Manager, error) {
 	var s cloudSecretsManagerState
 	if err := json.Unmarshal(state, &s); err != nil {
@@ -52,7 +52,7 @@ func NewCloudSecretsManagerFromState(state json.RawMessage) (secrets.Manager, er
 }
 
 // GenerateNewDataKey generates a new DataKey seeded by a fresh random 32-byte key and encrypted
-// using the target coud key management service.
+// using the target cloud key management service.
 func GenerateNewDataKey(url string) ([]byte, error) {
 	plaintextDataKey := make([]byte, 32)
 	_, err := rand.Read(plaintextDataKey)

--- a/pkg/secrets/passphrase/manager.go
+++ b/pkg/secrets/passphrase/manager.go
@@ -217,12 +217,17 @@ func newLockedPasspharseSecretsManager(state localSecretsManagerState) secrets.M
 
 type errorCrypter struct{}
 
-func (ec *errorCrypter) EncryptValue(v string) (string, error) {
+func (ec *errorCrypter) EncryptValue(_ string) (string, error) {
 	return "", errors.New("failed to encrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }
 
-func (ec *errorCrypter) DecryptValue(v string) (string, error) {
+func (ec *errorCrypter) DecryptValue(_ string) (string, error) {
 	return "", errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
+		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
+}
+
+func (ec *errorCrypter) BulkDecrypt(_ []string) (map[string]string, error) {
+	return nil, errors.New("failed to decrypt: incorrect passphrase, please set PULUMI_CONFIG_PASSPHRASE to the " +
 		"correct passphrase or set PULUMI_CONFIG_PASSPHRASE_FILE to a file containing the passphrase")
 }

--- a/pkg/secrets/service/manager.go
+++ b/pkg/secrets/service/manager.go
@@ -55,11 +55,35 @@ func (c *serviceCrypter) DecryptValue(cipherstring string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	plaintext, err := c.client.DecryptValue(context.Background(), c.stack, ciphertext)
 	if err != nil {
 		return "", err
 	}
 	return string(plaintext), nil
+}
+
+func (c *serviceCrypter) BulkDecrypt(secrets []string) (map[string]string, error) {
+	var secretsToDecrypt [][]byte
+	for _, val := range secrets {
+		ciphertext, err := base64.StdEncoding.DecodeString(val)
+		if err != nil {
+			return nil, err
+		}
+		secretsToDecrypt = append(secretsToDecrypt, ciphertext)
+	}
+
+	decryptedList, err := c.client.BulkDecryptValue(context.Background(), c.stack, secretsToDecrypt)
+	if err != nil {
+		return nil, err
+	}
+
+	decryptedSecrets := make(map[string]string)
+	for name, val := range decryptedList {
+		decryptedSecrets[name] = string(val)
+	}
+
+	return decryptedSecrets, nil
 }
 
 type serviceSecretsManagerState struct {

--- a/sdk/go.mod
+++ b/sdk/go.mod
@@ -51,8 +51,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
-	github.com/kr/pretty v0.2.1 // indirect
-	github.com/kr/text v0.2.0 // indirect
+	github.com/kr/pretty v0.3.0 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/sdk/go.sum
+++ b/sdk/go.sum
@@ -115,8 +115,8 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
-github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
+github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -168,6 +168,7 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
+github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/sdk/go/common/resource/config/crypt.go
+++ b/sdk/go/common/resource/config/crypt.go
@@ -36,6 +36,7 @@ type Encrypter interface {
 // Decrypter decrypts encrypted ciphertext to its plaintext representation.
 type Decrypter interface {
 	DecryptValue(ciphertext string) (string, error)
+	BulkDecrypt(ciphertexts []string) (map[string]string, error)
 }
 
 // Crypter can both encrypt and decrypt values.
@@ -52,6 +53,14 @@ var NopEncrypter Encrypter = nopCrypter{}
 
 func (nopCrypter) DecryptValue(ciphertext string) (string, error) {
 	return ciphertext, nil
+}
+
+func (nopCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	secretMap := map[string]string{}
+	for _, c := range ciphertexts {
+		secretMap[c] = c
+	}
+	return secretMap, nil
 }
 
 func (nopCrypter) EncryptValue(plaintext string) (string, error) {
@@ -84,6 +93,22 @@ func (t *trackingDecrypter) DecryptValue(ciphertext string) (string, error) {
 	return v, nil
 }
 
+func (t *trackingDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	secretMap := map[string]string{}
+	for _, c := range ciphertexts {
+		if _, ok := secretMap[c]; ok {
+			continue
+		}
+		v, err := t.decrypter.DecryptValue(c)
+		if err != nil {
+			return secretMap, err
+		}
+		secretMap[c] = v
+		t.secureValues = append(t.secureValues, v)
+	}
+	return secretMap, nil
+}
+
 func (t *trackingDecrypter) SecureValues() []string {
 	return t.secureValues
 }
@@ -100,12 +125,82 @@ func NewBlindingDecrypter() Decrypter {
 
 type blindingCrypter struct{}
 
-func (b blindingCrypter) DecryptValue(ciphertext string) (string, error) {
-	return "[secret]", nil
+func (b blindingCrypter) DecryptValue(_ string) (string, error) {
+	return "[secret]", nil //nolint:goconst
+}
+
+func (b blindingCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	secretMap := map[string]string{}
+	for _, c := range ciphertexts {
+		if _, ok := secretMap[c]; ok {
+			continue
+		}
+		secretMap[c] = "[secret]"
+	}
+	return secretMap, nil
 }
 
 func (b blindingCrypter) EncryptValue(plaintext string) (string, error) {
 	return "[secret]", nil
+}
+
+type CachedDecrypter interface {
+	Decrypter
+}
+
+// cachedDecrypter is a Decrypter that keeps track if decrypted values, which
+// can be retrieved via SecureValues().
+type cachedDecrypter struct {
+	decrypter Decrypter
+	cache     map[string]string
+}
+
+func NewCachedDecrypter(decrypter Decrypter) CachedDecrypter {
+	return &cachedDecrypter{decrypter: decrypter}
+}
+
+func (c *cachedDecrypter) BulkDecrypt(ciperTexts []string) (map[string]string, error) {
+	secretMap, err := c.decrypter.BulkDecrypt(ciperTexts)
+	if err != nil {
+		return nil, err
+	}
+
+	if c.cache == nil {
+		c.cache = make(map[string]string, len(secretMap))
+	}
+
+	// lets ensure that we loop over the cipertexts to ensure that when we write to the cache
+	// an existing entry in the cache doesn't get updated with a new version of the decrypted value
+	// if this happens, we error as this may be a bug
+	for k, v := range secretMap {
+		if plaintext, ok := c.cache[k]; ok && plaintext != v {
+			return nil, fmt.Errorf("inconsistent decryption value found for cipertext: %q", k)
+		}
+
+		c.cache[k] = v
+	}
+
+	return secretMap, nil
+}
+
+func (c *cachedDecrypter) DecryptValue(ciperText string) (string, error) {
+	if plainText, ok := c.cache[ciperText]; ok {
+		return plainText, nil
+	}
+
+	// The value is not currently in the cache so we need to decrypt it
+	// and add it to the cache
+	plainText, err := c.decrypter.DecryptValue(ciperText)
+	if err != nil {
+		return "", err
+	}
+
+	if c.cache == nil {
+		c.cache = make(map[string]string)
+	}
+	c.cache[ciperText] = plainText
+
+	return plainText, nil
 }
 
 // NewPanicCrypter returns a new config crypter that will panic if used.
@@ -115,11 +210,15 @@ func NewPanicCrypter() Crypter {
 
 type panicCrypter struct{}
 
-func (p panicCrypter) EncryptValue(plaintext string) (string, error) {
+func (p panicCrypter) EncryptValue(_ string) (string, error) {
 	panic("attempt to encrypt value")
 }
 
-func (p panicCrypter) DecryptValue(ciphertext string) (string, error) {
+func (p panicCrypter) BulkDecrypt(_ []string) (map[string]string, error) {
+	return nil, nil
+}
+
+func (p panicCrypter) DecryptValue(_ string) (string, error) {
 	panic("attempt to decrypt value")
 }
 
@@ -133,7 +232,7 @@ func NewSymmetricCrypter(key []byte) Crypter {
 // NewSymmetricCrypterFromPassphrase uses a passphrase and salt to generate a key, and then returns a crypter using it.
 func NewSymmetricCrypterFromPassphrase(phrase string, salt []byte) Crypter {
 	// Generate a key using PBKDF2 to slow down attempts to crack it.  1,000,000 iterations was chosen because it
-	// took a little over a second on an i7-7700HQ Quad Core procesor
+	// took a little over a second on an i7-7700HQ Quad Core processor
 	key := pbkdf2.Key([]byte(phrase), salt, 1000000, SymmetricCrypterKeyBytes, sha256.New)
 	return NewSymmetricCrypter(key)
 }
@@ -173,6 +272,21 @@ func (s symmetricCrypter) DecryptValue(value string) (string, error) {
 	}
 
 	return decryptAES256GCM(enc, s.key, nonce)
+}
+
+func (s symmetricCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	secretMap := map[string]string{}
+	for _, c := range ciphertexts {
+		if _, ok := secretMap[c]; ok {
+			continue
+		}
+		v, err := s.DecryptValue(c)
+		if err != nil {
+			return nil, err
+		}
+		secretMap[c] = v
+	}
+	return secretMap, nil
 }
 
 // encryptAES256GCGM returns the ciphertext and the generated nonce
@@ -225,4 +339,19 @@ func (c prefixCrypter) DecryptValue(ciphertext string) (string, error) {
 
 func (c prefixCrypter) EncryptValue(plaintext string) (string, error) {
 	return c.prefix + plaintext, nil
+}
+
+func (c prefixCrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	secretMap := map[string]string{}
+	for _, cip := range ciphertexts {
+		if _, ok := secretMap[cip]; ok {
+			continue
+		}
+		v, err := c.DecryptValue(cip)
+		if err != nil {
+			return nil, err
+		}
+		secretMap[cip] = v
+	}
+	return secretMap, nil
 }

--- a/sdk/go/common/resource/config/value_test.go
+++ b/sdk/go/common/resource/config/value_test.go
@@ -199,6 +199,14 @@ func (d passThroughDecrypter) DecryptValue(ciphertext string) (string, error) {
 	return ciphertext, nil
 }
 
+func (d passThroughDecrypter) BulkDecrypt(ciphertexts []string) (map[string]string, error) {
+	secretMap := map[string]string{}
+	for _, c := range ciphertexts {
+		secretMap[c] = c
+	}
+	return secretMap, nil
+}
+
 func TestSecureValues(t *testing.T) {
 	tests := []struct {
 		Value    Value


### PR DESCRIPTION
Fixes: #6445

Previously, when a deserialisation operation, e.g, `pulumi stack` command
was carried out, each service based secret in the stack was decrypted one at a time
causing n times the number of API requests to the Pulumi service

This meant the following to the user:

```
Calling [pulumi stack] with [1000] secrets took [210.04] seconds.
```

With this new code, we now scan all the inputs and outputs for secrets,
and make a bulk secret decryption dequest to the service and then use
the secrets as a lookup for the deserialization operation. This means
we have a single API request to the service and now means the following
to the user:

```
Calling [pulumi stack] with [1000] secrets took [16.30] seconds.
```

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
