### PR TITLE
Work around node SDK tsc failure

### DIFF
--- a/sdk/nodejs/package.json
+++ b/sdk/nodejs/package.json
@@ -29,7 +29,7 @@
         "@types/js-yaml": "^3.12.5",
         "@types/minimist": "^1.2.0",
         "@types/mocha": "^2.2.42",
-        "@types/node": "^12.0.0",
+        "@types/node": "14.18.3",
         "@types/normalize-package-data": "^2.4.0",
         "@types/read-package-tree": "^5.2.0",
         "@types/semver": "^5.5.0",
@@ -50,5 +50,8 @@
     },
     "mocha": {
         "require": ["ts-node/register", "source-map-support/register"]
-    }
+    },
+    "//": [
+       "NOTE: @types/node is pinned due to grpc/grpc-node#2002"
+    ]
 }

--- a/sdk/nodejs/runtime/closure/createClosure.ts
+++ b/sdk/nodejs/runtime/closure/createClosure.ts
@@ -1358,7 +1358,8 @@ async function findNormalizedModuleNameAsync(obj: any): Promise<string | undefin
     // don't pre-compute this because the require cache will get populated
     // dynamically during execution.
     for (const path of Object.keys(require.cache)) {
-        if (require.cache[path].exports === obj) {
+        const c = require.cache[path];
+        if (c !== undefined && c.exports === obj) {
             // Rewrite the path to be a local module reference relative to the current working
             // directory.
             const modPath = upath.relative(process.cwd(), path);


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Applying a workaround from https://github.com/grpc/grpc-node/issues/2002 discussion.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8678

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
