### PR TITLE
[ci] Switch code coverage status to informational.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      informational: true
+    patch:
+      informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,8 @@
 coverage:
   status:
     project:
-      informational: true
+      default:
+        informational: true
     patch:
-      informational: true
+      default:
+        informational: true


### PR DESCRIPTION
Until we've figured out why we seem to be seeing inaccurate code
coverage information (e.g. the status checks on #8627), make the code
coverage statuses informational.

Related to #8629.