### PR TITLE
Split coverage results into projects

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,28 @@
 coverage:
   status:
     project:
-      default:
+      default: false
+      core:
         informational: true
+        paths:
+          - "pkg/*"
+          - "sdk/go/common/*"
+          - "sdk/go/auto/*"
+          - "sdk/proto/*"
+      sdk/dotnet:
+        informational: true
+        paths: "sdk/dotnet/*"
+      sdk/go:
+        informational: true
+        paths:
+          - "sdk/go/pulumi/*"
+          - "sdk/go/pulumi-language-go/*"
+      sdk/nodejs:
+        informational: true
+        paths: "sdk/nodejs/*"
+      sdk/python:
+        informational: true
+        paths: "sdk/python/*"
     patch:
       default:
         informational: true


### PR DESCRIPTION
Take advantage of [Codecov's support for subprojects](https://github.com/pulumi/pulumi/pull/8685) to split the results for this repo into results for the CLI/core packages and each SDK.

If this works, I'm hoping that it will help us better track down sources of non-determinism and confusing coverage results.