### PR TITLE
Fix duplicate go module name

### DIFF
--- a/tests/integration/printf/go/go.mod
+++ b/tests/integration/printf/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/pulumi/pulumi/tests/empty/go
+module github.com/pulumi/pulumi/tests/printf/go
 
 go 1.16
 


### PR DESCRIPTION
This was preventing the gopls server from working correctly in vscode.