### PR TITLE
[sdk/common] allow names with hyphens

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -12,6 +12,8 @@
 - [sdk/nodejs] Support a `nodeargs` option for passing `node` arguments to the Node language host
   [#8655](https://github.com/pulumi/pulumi/pull/8655)
 
+- [common] Allow names with hyphens.
+
 ### Bug Fixes
 
 - [cli/engine] - Fix [#3982](https://github.com/pulumi/pulumi/issues/3982), a bug

--- a/pkg/resource/deploy/providers/provider_test.go
+++ b/pkg/resource/deploy/providers/provider_test.go
@@ -39,7 +39,7 @@ func TestProviderRequestNameNoPreURL(t *testing.T) {
 func TestProviderRequestNameDevURL(t *testing.T) {
 	ver := semver.MustParse("0.17.7-dev.1555435978+gb7030aa4.dirty")
 	req := NewProviderRequest(&ver, "pkg", "company.com/artifact-storage/pkg")
-	assert.Equal(t, "default_0_17_7_dev_1555435978_gb7030aa4_dirty_company.com/artifact_storage/pkg", req.Name().String())
+	assert.Equal(t, "default_0_17_7_dev_1555435978_gb7030aa4_dirty_company.com/artifact-storage/pkg", req.Name().String())
 	assert.Equal(t, "pkg-0.17.7-dev.1555435978+gb7030aa4.dirty-company.com/artifact-storage/pkg", req.String())
 }
 

--- a/sdk/go/common/tokens/names.go
+++ b/sdk/go/common/tokens/names.go
@@ -36,7 +36,7 @@ var nameRestCharRegexp = regexp.MustCompile("^" + nameRestCharRegexpPattern + "$
 var NameRegexpPattern = nameFirstCharRegexpPattern + nameRestCharRegexpPattern
 
 const nameFirstCharRegexpPattern = "[A-Za-z_.]"
-const nameRestCharRegexpPattern = `[A-Za-z0-9_.]*`
+const nameRestCharRegexpPattern = `[A-Za-z0-9_.-]*`
 
 // IsName checks whether a string is a legal Name.
 func IsName(s string) bool {

--- a/sdk/go/common/tokens/names.go
+++ b/sdk/go/common/tokens/names.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
 )
 
-// Name is an identifier.  It conforms to the regex [A-Za-z_.][A-Za-z0-9_]*.
+// Name is an identifier.  It conforms to NameRegexpPattern.
 type Name string
 
 func (nm Name) String() string { return string(nm) }
@@ -50,7 +50,7 @@ func AsName(s string) Name {
 }
 
 // QName is a qualified identifier.  The "/" character optionally delimits different pieces of the name.  Each element
-// conforms to the Name regex [A-Za-z_.][A-Za-z0-9_.]*.  For example, "pulumi/pulumi/stack".
+// conforms to NameRegexpPattern.  For example, "pulumi/pulumi/stack".
 type QName string
 
 func (nm QName) String() string { return string(nm) }

--- a/sdk/go/common/tokens/names_test.go
+++ b/sdk/go/common/tokens/names_test.go
@@ -31,6 +31,7 @@ func TestIsAsName(t *testing.T) {
 		"_",       // permit underscore.
 		"s1MPl3_", // mixed-case alphanumeric/underscore.
 		"_s1MPl3", // ditto.
+		"hy-phy",  // permit hyphens.
 	}
 	for _, nm := range goodNames {
 		assert.True(t, IsName(nm), "IsName expected to be true: %v", nm)


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Allow names with hyphens.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
