### PR TITLE
[nodejs/sdk] GetRequiredPlugins: Return plugins even when there're errors

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -18,3 +18,6 @@
   where the engine ignored the final line of stdout/stderr if it didn't terminate
   with a newline. 
   [#8671](https://github.com/pulumi/pulumi/pull/8671)
+
+- [nodejs/sdk] - GetRequiredPlugins: Return plugins even when there're errors.
+  [#8699](https://github.com/pulumi/pulumi/pull/8699)

--- a/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
+++ b/sdk/nodejs/cmd/pulumi-language-nodejs/main.go
@@ -277,8 +277,8 @@ func getPluginsFromDir(
 				curr, pulumiPackagePathToVersionMap, inNodeModules || filepath.Base(dir) == "node_modules")
 			if err != nil {
 				allErrors = multierror.Append(allErrors, err)
-				continue
 			}
+			// Even if there was an error, still append any plugins found in the dir.
 			plugins = append(plugins, more...)
 		} else if inNodeModules && name == "package.json" {
 			// if a package.json file within a node_modules package, parse it, and see if it's a source of plugins.


### PR DESCRIPTION
The implementation of `GetRequiredPlugins` in the Node.js language host will return an empty set of plugins if it encounters errors reading `package.json` inside a subdirectory. The [intended behavior](https://github.com/pulumi/pulumi/blob/684d7aad3920042ce1982b5fedddea62a6e5bb61/sdk/nodejs/cmd/pulumi-language-nodejs/main.go#L244-L249) is to return any plugins that were found (even if there were some errors in the process) and to log any errors that occurred along the way. This change fixes the implementation to behave as intended.

Fixes #8697