### PR TITLE
[ci] Disable coverage annotations.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,6 @@ coverage:
     patch:
       default:
         informational: true
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
These annotations are currently a bit noisy. Disable them for now (and
maybe forever).

See https://docs.codecov.com/docs/github-checks for details on Codecov
and GitHub checks/annotations.