### PR TITLE
Fixes to KillChildren function

### DIFF
--- a/sdk/go/common/util/cmdutil/child.go
+++ b/sdk/go/common/util/cmdutil/child.go
@@ -21,11 +21,14 @@ import (
 	"syscall"
 )
 
-// `KillChildren` kills every child or indirect descendant process of
-// the root process represented by `pid`.
+// `KillChildren` kills the root process respresented by `pid` process
+// identifier, as well as any child or descendant processes it
+// detects. It ignores errors if it appears that the processes are no
+// longer live.
 //
-// Intended to be used with `RegisterProcessGroup` to make sure
-// misbehaving commands do not leave any orphan sub-processes running:
+// `KillChildren` is Intended to be used with `RegisterProcessGroup`
+// to make sure misbehaving commands do not leave any orphan
+// sub-processes running:
 //
 //	cmd := exec.Command(name, args...)
 //	cmdutil.RegisterProcessGroup(cmd)

--- a/sdk/go/common/util/cmdutil/child_test.go
+++ b/sdk/go/common/util/cmdutil/child_test.go
@@ -47,10 +47,14 @@ func TestKillChildren(t *testing.T) {
 	err = cmd.Start()
 	require.NoError(t, err)
 
+	// Give subprocess time to spawn children.
 	time.Sleep(1 * time.Second)
 
 	err = KillChildren(cmd.Process.Pid)
 	require.NoError(t, err)
+
+	// Give SIGKILL time to propagate.
+	time.Sleep(1 * time.Second)
 
 	procs, err := ps.Processes()
 	require.NoError(t, err)

--- a/sdk/go/common/util/cmdutil/child_test.go
+++ b/sdk/go/common/util/cmdutil/child_test.go
@@ -27,11 +27,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const windows = "windows"
+
 func TestKillChildren(t *testing.T) {
 	d := t.TempDir()
 
 	exe := "processtree"
-	if runtime.GOOS == "windows" {
+	if runtime.GOOS == windows {
 		exe = "processtree.exe"
 	}
 	exe = filepath.Join(d, exe)

--- a/sdk/go/common/util/cmdutil/child_test.go
+++ b/sdk/go/common/util/cmdutil/child_test.go
@@ -62,7 +62,7 @@ func TestKillChildren(t *testing.T) {
 	go func() {
 		pstate, err := cmd.Process.Wait()
 		require.NoError(t, err)
-		require.True(t, pstate.Success())
+		require.False(t, pstate.Success())
 	}()
 
 	// Give SIGKILL time to propagate.

--- a/sdk/go/common/util/cmdutil/child_test.go
+++ b/sdk/go/common/util/cmdutil/child_test.go
@@ -1,0 +1,89 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdutil
+
+import (
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKillChildren(t *testing.T) {
+	d := t.TempDir()
+
+	run := func(kill bool, logFile string) {
+		cmd := exec.Command("go", "run", "processtree.go",
+			"-depth", "3",
+			"-out", logFile)
+
+		cmd.Dir = "testdata"
+
+		if kill {
+			RegisterProcessGroup(cmd)
+		}
+
+		err := cmd.Start()
+		require.NoError(t, err)
+
+		if kill {
+			err := KillChildren(cmd.Process.Pid)
+			require.NoError(t, err)
+		} else {
+			err = cmd.Wait()
+			require.NoError(t, err)
+			require.Equal(t, 0, cmd.ProcessState.ExitCode())
+		}
+	}
+
+	readFile := func(path string) (string, error) {
+		attempt := 1
+		delay := 50 * time.Millisecond
+		maxAttempts := 5
+		for {
+			bytes, err := ioutil.ReadFile(path)
+			if err != nil || len(bytes) == 0 {
+				if attempt == maxAttempts {
+					return "", err
+				}
+				attempt = attempt + 1
+				time.Sleep(delay)
+				delay = 2 * delay
+				continue
+			}
+
+			return string(bytes), nil
+		}
+	}
+
+	// First check the test process writes OK to ok.log via a
+	// descendant process when allowed to run normally.
+	okLog := filepath.Join(d, "ok.log")
+	run(false, okLog)
+	contents, err := readFile(okLog)
+	require.NoError(t, err)
+	require.Equal(t, "OK", contents)
+
+	// Now check that nothing gets written if we do kill the
+	// group. Indirectly this verifies the descendant has been
+	// killed.
+	noLog := filepath.Join(d, "no.log")
+	run(true, noLog)
+	_, err = readFile(noLog)
+	require.Error(t, err)
+}

--- a/sdk/go/common/util/cmdutil/child_test.go
+++ b/sdk/go/common/util/cmdutil/child_test.go
@@ -15,11 +15,14 @@
 package cmdutil
 
 import (
-	"io/ioutil"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
+
+	ps "github.com/mitchellh/go-ps"
 
 	"github.com/stretchr/testify/require"
 )
@@ -27,63 +30,34 @@ import (
 func TestKillChildren(t *testing.T) {
 	d := t.TempDir()
 
-	run := func(kill bool, logFile string) {
-		cmd := exec.Command("go", "run", "processtree.go",
-			"-depth", "3",
-			"-out", logFile)
-
-		cmd.Dir = "testdata"
-
-		if kill {
-			RegisterProcessGroup(cmd)
-		}
-
-		err := cmd.Start()
-		require.NoError(t, err)
-
-		if kill {
-			err := KillChildren(cmd.Process.Pid)
-			require.NoError(t, err)
-		} else {
-			err = cmd.Wait()
-			require.NoError(t, err)
-			require.Equal(t, 0, cmd.ProcessState.ExitCode())
-		}
+	exe := "processtree"
+	if runtime.GOOS == "windows" {
+		exe = "processtree.exe"
 	}
+	exe = filepath.Join(d, exe)
 
-	readFile := func(path string) (string, error) {
-		attempt := 1
-		delay := 50 * time.Millisecond
-		maxAttempts := 5
-		for {
-			bytes, err := ioutil.ReadFile(path)
-			if err != nil || len(bytes) == 0 {
-				if attempt == maxAttempts {
-					return "", err
-				}
-				attempt = attempt + 1
-				time.Sleep(delay)
-				delay = 2 * delay
-				continue
-			}
-
-			return string(bytes), nil
-		}
-	}
-
-	// First check the test process writes OK to ok.log via a
-	// descendant process when allowed to run normally.
-	okLog := filepath.Join(d, "ok.log")
-	run(false, okLog)
-	contents, err := readFile(okLog)
+	gocmd := exec.Command("go", "build", "-o", exe)
+	gocmd.Dir = "testdata"
+	err := gocmd.Run()
 	require.NoError(t, err)
-	require.Equal(t, "OK", contents)
 
-	// Now check that nothing gets written if we do kill the
-	// group. Indirectly this verifies the descendant has been
-	// killed.
-	noLog := filepath.Join(d, "no.log")
-	run(true, noLog)
-	_, err = readFile(noLog)
-	require.Error(t, err)
+	cmd := exec.Command(exe, "-depth", "3")
+	RegisterProcessGroup(cmd)
+
+	err = cmd.Start()
+	require.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	err = KillChildren(cmd.Process.Pid)
+	require.NoError(t, err)
+
+	procs, err := ps.Processes()
+	require.NoError(t, err)
+
+	for _, p := range procs {
+		if strings.Contains(p.Executable(), "processtree") {
+			t.Errorf("Runaway process: %s pid=%d", p.Executable(), p.Pid())
+		}
+	}
 }

--- a/sdk/go/common/util/cmdutil/child_test.go
+++ b/sdk/go/common/util/cmdutil/child_test.go
@@ -55,6 +55,16 @@ func TestKillChildren(t *testing.T) {
 	err = KillChildren(cmd.Process.Pid)
 	require.NoError(t, err)
 
+	// Need to `cmd.Process.Wait()` on Linux, otherwise the
+	// process entry remains in the process table (`ps` shows as
+	// `<defunct>`) and it appears to be active per
+	// `activeProcesses`.
+	go func() {
+		pstate, err := cmd.Process.Wait()
+		require.NoError(t, err)
+		require.True(t, pstate.Success())
+	}()
+
 	// Give SIGKILL time to propagate.
 	attempt := 0
 	maxAttempt := 50

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -37,7 +37,7 @@ import (
 // This is the Windows-specific implementation that sends scans all
 // system processes using native syscalls (via go-ps) and attempts to
 // Kill them, aggregating any errors it encounters.
-func KillChildrenW(pid int) error {
+func KillChildren(pid int) error {
 	procs, err := ps.Processes()
 	if err != nil {
 		return err
@@ -126,6 +126,6 @@ func isDescendant(p int, parents map[int]int) bool {
 }
 
 // RegisterProcessGroup does nothing on Windows.
-func RegisterProcessGroupW(cmd *exec.Cmd) {
+func RegisterProcessGroup(cmd *exec.Cmd) {
 	// nothing to do on Windows.
 }

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,11 +11,11 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-// +build windows
 
 package cmdutil
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 
@@ -23,56 +23,109 @@ import (
 	ps "github.com/mitchellh/go-ps"
 )
 
-// KillChildren calls os.Process.Kill() on every child process of `pid`'s, stoping after the first error (if any). It
-// also only kills direct child process, not any children they may have. This function is only implemented on Windows.
-func KillChildren(pid int) error {
+// `KillChildren` kills every child or indirect descendant process of
+// the root process represented by `pid`.
+//
+// Intended to be used with `RegisterProcessGroup` to make sure
+// misbehaving commands do not leave any orphan sub-processes running:
+//
+//	cmd := exec.Command(name, args...)
+//	cmdutil.RegisterProcessGroup(cmd)
+//      cmd.Start() // or any other method that actually starts the process
+//      err := cmdutil.KillChildren(cmd.Process.Pid)
+//
+// This is the Windows-specific implementation that sends scans all
+// system processes using native syscalls (via go-ps) and attempts to
+// Kill them, aggregating any errors it encounters.
+func KillChildrenW(pid int) error {
 	procs, err := ps.Processes()
 	if err != nil {
 		return err
 	}
 
+	descendants := filterDescendants(pid, procs)
+
+	// Try to kill the descendants and collect errors by PID.
+	// These errors may not be relevant if the descendant
+	// terminates in some other way.
+	errors := map[int]error{}
+	for _, proc := range descendants {
+		procPid := proc.Pid()
+		toKill, err := os.FindProcess(procPid)
+		if err != nil {
+			errors[procPid] = fmt.Errorf("FindProcess(%d) failed: %w", procPid, err)
+		}
+
+		err = toKill.Kill()
+		if err != nil {
+			errors[procPid] = fmt.Errorf("proc.Kill() failed for pid=%d: %w", procPid, err)
+		}
+	}
+
+	survivingProcesses, err := ps.Processes()
+	if err != nil {
+		return err
+	}
+
+	survivingPids := map[int]bool{}
+	for _, p := range survivingProcesses {
+		survivingPids[p.Pid()] = true
+	}
+
+	// Only report errors for descendants that survived our
+	// attempt to kill them.
+	//
+	// There are races inherent in sending a `Kill()` and
+	// observing the process in the `survivingPids`. This method
+	// would rather return a `nil` error when unsure than error
+	// out incorrectly.
 	var result error
 
-	for _, proc := range procs {
-		if proc.PPid() == pid {
-			toKill, err := os.FindProcess(proc.Pid())
-			if err != nil {
-				// It's possible that the process has already exited, let's see if it still exists. Either way, we won't
-				// try to kill it but we will add the original error from os.FindProcess() if we can't prove it doesn't
-				// exits.
-				exists, existsErr := processExistsWithParent(proc.Pid(), proc.PPid())
-				if existsErr != nil || exists {
-					result = multierror.Append(result, err)
-				}
-				continue
-			}
-
-			err = toKill.Kill()
-			if err != nil {
+	for _, proc := range descendants {
+		_, surviving := survivingPids[proc.Pid()]
+		if surviving {
+			err, gotErr := errors[proc.Pid()]
+			if gotErr {
 				result = multierror.Append(result, err)
 			}
 		}
 	}
-
 	return result
 }
 
-func processExistsWithParent(pid int, ppid int) (bool, error) {
-	procs, err := ps.Processes()
-	if err != nil {
-		return false, err
-	}
-
-	for _, proc := range procs {
-		if proc.Pid() == pid {
-			return proc.PPid() == ppid, nil
+func filterDescendants(rootPid int, processes []ps.Process) []ps.Process {
+	parents := map[int]int{}
+	for _, p := range processes {
+		pid := p.Pid()
+		ppid := p.PPid()
+		// Can have PID=0 with PPID=0, ignore it.
+		if ppid != pid {
+			parents[pid] = ppid
 		}
 	}
+	filtered := []ps.Process{}
+	for _, p := range processes {
+		if isDescendant(p.Pid(), parents) {
+			filtered = append(filtered, p)
+		}
+	}
+	return filtered
+}
 
-	return false, nil
+func isDescendant(p int, parents map[int]int) bool {
+	for {
+		pp, gotParent := parents[p]
+		if !gotParent {
+			return false
+		}
+		if pp == p {
+			return true
+		}
+		p = pp
+	}
 }
 
 // RegisterProcessGroup does nothing on Windows.
-func RegisterProcessGroup(cmd *exec.Cmd) {
+func RegisterProcessGroupW(cmd *exec.Cmd) {
 	// nothing to do on Windows.
 }

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -23,20 +23,23 @@ import (
 	ps "github.com/mitchellh/go-ps"
 )
 
-// `KillChildren` kills every child or indirect descendant process of
-// the root process represented by `pid`.
+// `KillChildren` kills the root process respresented by `pid` process
+// identifier, as well as any child or descendant processes it
+// detects. It ignores errors if it appears that the processes are no
+// longer live.
 //
-// Intended to be used with `RegisterProcessGroup` to make sure
-// misbehaving commands do not leave any orphan sub-processes running:
+// `KillChildren` is Intended to be used with `RegisterProcessGroup`
+// to make sure misbehaving commands do not leave any orphan
+// sub-processes running:
 //
 //	cmd := exec.Command(name, args...)
 //	cmdutil.RegisterProcessGroup(cmd)
 //      cmd.Start() // or any other method that actually starts the process
 //      err := cmdutil.KillChildren(cmd.Process.Pid)
 //
-// This is the Windows-specific implementation that sends scans all
-// system processes using native syscalls (via go-ps) and attempts to
-// Kill them, aggregating any errors it encounters.
+// This is the Windows-specific implementation that scans all system
+// processes using native syscalls (via go-ps) and attempts to kill
+// them, aggregating any errors it encounters.
 func KillChildren(pid int) error {
 	procs, err := ps.Processes()
 	if err != nil {

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -99,7 +99,10 @@ func filterDescendants(rootPid int, processes []ps.Process) []ps.Process {
 	for _, p := range processes {
 		pid := p.Pid()
 		ppid := p.PPid()
-		// Can have PID=0 with PPID=0, ignore it.
+		// Ignore cases where PID=PPID, for example it seems
+		// to happen on Windows with the root process
+		// PID=PPID=0. The code below assumes that there are
+		// no cycles in the parent relation.
 		if ppid != pid {
 			parents[pid] = ppid
 		}

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -105,20 +105,21 @@ func filterDescendants(rootPid int, processes []ps.Process) []ps.Process {
 	}
 	filtered := []ps.Process{}
 	for _, p := range processes {
-		if isDescendant(p.Pid(), parents) {
+		if isDescendant(p.Pid(), rootPid, parents) || p.Pid() == rootPid {
 			filtered = append(filtered, p)
 		}
 	}
 	return filtered
 }
 
-func isDescendant(p int, parents map[int]int) bool {
+func isDescendant(descendant, ancestor int, parents map[int]int) bool {
+	p := descendant
 	for {
 		pp, gotParent := parents[p]
 		if !gotParent {
 			return false
 		}
-		if pp == p {
+		if pp == ancestor {
 			return true
 		}
 		p = pp

--- a/sdk/go/common/util/cmdutil/child_windows.go
+++ b/sdk/go/common/util/cmdutil/child_windows.go
@@ -59,8 +59,7 @@ func KillChildren(pid int) error {
 			errors[procPid] = fmt.Errorf("FindProcess(%d) failed: %w", procPid, err)
 		}
 
-		err = toKill.Kill()
-		if err != nil {
+		if err = toKill.Kill(); err != nil {
 			errors[procPid] = fmt.Errorf("proc.Kill() failed for pid=%d: %w", procPid, err)
 		}
 	}
@@ -85,8 +84,7 @@ func KillChildren(pid int) error {
 	var result error
 
 	for _, proc := range descendants {
-		_, surviving := survivingPids[proc.Pid()]
-		if surviving {
+		if _, surviving := survivingPids[proc.Pid()]; surviving {
 			err, gotErr := errors[proc.Pid()]
 			if gotErr {
 				result = multierror.Append(result, err)

--- a/sdk/go/common/util/cmdutil/testdata/processtree.go
+++ b/sdk/go/common/util/cmdutil/testdata/processtree.go
@@ -17,30 +17,24 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
+	"time"
 )
 
 func main() {
 	depth := flag.Int("depth", 0, "depth of the process tree")
-	out := flag.String("out", "", "path to touch at the bottom of the process tree")
-
 	handle(flag.CommandLine.Parse(os.Args[1:]))
 
 	if *depth > 0 {
-		cmd := exec.Command("go",
-			"run",
-			"processtree.go",
-			"--depth", fmt.Sprintf("%d", *depth-1),
-			"--out", *out)
+		cmd := exec.Command(os.Args[0], "--depth", fmt.Sprintf("%d", *depth-1))
 		handle(cmd.Start())
 		handle(cmd.Process.Release())
 	}
 
-	if *depth == 0 {
-		handle(ioutil.WriteFile(*out, []byte("OK"), 0600))
+	for {
+		time.Sleep(1 * time.Second)
 	}
 }
 

--- a/sdk/go/common/util/cmdutil/testdata/processtree.go
+++ b/sdk/go/common/util/cmdutil/testdata/processtree.go
@@ -1,0 +1,51 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	depth := flag.Int("depth", 0, "depth of the process tree")
+	out := flag.String("out", "", "path to touch at the bottom of the process tree")
+
+	handle(flag.CommandLine.Parse(os.Args[1:]))
+
+	if *depth > 0 {
+		cmd := exec.Command("go",
+			"run",
+			"processtree.go",
+			"--depth", fmt.Sprintf("%d", *depth-1),
+			"--out", *out)
+		handle(cmd.Start())
+		handle(cmd.Process.Release())
+	}
+
+	if *depth == 0 {
+		handle(ioutil.WriteFile(*out, []byte("OK"), 0600))
+	}
+}
+
+func handle(err error) {
+	if err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The Windows platform-specific implementation of KillChildren as well as the comment on KillChildren were a bit misleading. What happens on Mac and Linux is that typically KillChildren(pid) would kill pid as well as any direct or indirect child. This happens because PGID gets assigned to pid as well as to recursive descendants of pid (it inherits) by default, unless those sub-processes explicitly change PGID. I've added a test to demonstrate this.

With the change - to the Windows implementation - Windows version will try to kill self and descendants now also. 

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
