### PR TITLE
Split Manifest type to it's own file

### DIFF
--- a/pkg/resource/deploy/manifest.go
+++ b/pkg/resource/deploy/manifest.go
@@ -1,4 +1,4 @@
-// Copyright 2016-2018, Pulumi Corporation.
+// Copyright 2016-2022, Pulumi Corporation.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/resource/deploy/manifest.go
+++ b/pkg/resource/deploy/manifest.go
@@ -1,0 +1,89 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploy
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	"github.com/blang/semver"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+// Manifest captures versions for all binaries used to construct this snapshot.
+type Manifest struct {
+	Time    time.Time              // the time this snapshot was taken.
+	Magic   string                 // a magic cookie.
+	Version string                 // the pulumi command version.
+	Plugins []workspace.PluginInfo // the plugin versions also loaded.
+}
+
+// Serialize turns a manifest into a data structure suitable for serialization.
+func (m Manifest) Serialize() apitype.ManifestV1 {
+	manifest := apitype.ManifestV1{
+		Time:    m.Time,
+		Magic:   m.Magic,
+		Version: m.Version,
+	}
+	for _, plug := range m.Plugins {
+		var version string
+		if plug.Version != nil {
+			version = plug.Version.String()
+		}
+		manifest.Plugins = append(manifest.Plugins, apitype.PluginInfoV1{
+			Name:    plug.Name,
+			Path:    plug.Path,
+			Type:    plug.Kind,
+			Version: version,
+		})
+	}
+	return manifest
+}
+
+// DeserializeManifest deserializes a typed ManifestV1 into a `deploy.Manifest`.
+func DeserializeManifest(m apitype.ManifestV1) (*Manifest, error) {
+	manifest := Manifest{
+		Time:    m.Time,
+		Magic:   m.Magic,
+		Version: m.Version,
+	}
+	for _, plug := range m.Plugins {
+		var version *semver.Version
+		if v := plug.Version; v != "" {
+			sv, err := semver.ParseTolerant(v)
+			if err != nil {
+				return nil, err
+			}
+			version = &sv
+		}
+		manifest.Plugins = append(manifest.Plugins, workspace.PluginInfo{
+			Name:    plug.Name,
+			Kind:    plug.Type,
+			Version: version,
+		})
+	}
+	return &manifest, nil
+}
+
+// NewMagic creates a magic cookie out of a manifest; this can be used to check for tampering.  This ignores
+// any existing magic value already stored on the manifest.
+func (m Manifest) NewMagic() string {
+	if m.Version == "" {
+		return ""
+	}
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(m.Version)))
+}

--- a/pkg/resource/deploy/snapshot.go
+++ b/pkg/resource/deploy/snapshot.go
@@ -15,15 +15,12 @@
 package deploy
 
 import (
-	"crypto/sha256"
 	"fmt"
-	"time"
 
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/providers"
 	"github.com/pulumi/pulumi/pkg/v3/secrets"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/util/contract"
-	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
 )
 
 // Snapshot is a view of a collection of resources in an stack at a point in time.  It describes resources; their
@@ -34,23 +31,6 @@ type Snapshot struct {
 	SecretsManager    secrets.Manager      // the manager to use use when seralizing this snapshot.
 	Resources         []*resource.State    // fetches all resources and their associated states.
 	PendingOperations []resource.Operation // all currently pending resource operations.
-}
-
-// Manifest captures versions for all binaries used to construct this snapshot.
-type Manifest struct {
-	Time    time.Time              // the time this snapshot was taken.
-	Magic   string                 // a magic cookie.
-	Version string                 // the pulumi command version.
-	Plugins []workspace.PluginInfo // the plugin versions also loaded.
-}
-
-// NewMagic creates a magic cookie out of a manifest; this can be used to check for tampering.  This ignores
-// any existing magic value already stored on the manifest.
-func (m Manifest) NewMagic() string {
-	if m.Version == "" {
-		return ""
-	}
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(m.Version)))
 }
 
 // NewSnapshot creates a snapshot from the given arguments.  The resources must be in topologically sorted order.


### PR DESCRIPTION
Given that update plans also use the Manifest type it makes sense to implement it's serialisation and deserialisation methods on it directly.
This commit also moves it into it's own file so that code is separate from snapshot.