### PR TITLE
Experiment with moving old grpc compilation out of the test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ test_build:: $(TEST_ALL_DEPS)
 	PYTHON=$(PYTHON) ./scripts/prepare-test.sh construct_component_methods_unknown
 	PYTHON=$(PYTHON) ./scripts/prepare-test.sh construct_component_methods_resources
 	PYTHON=$(PYTHON) ./scripts/prepare-test.sh construct_component_methods_errors
+	cd tests/examples/compat/v0.10.0/minimal/ && yarn install
 
 test_all:: test_build test_pkg test_integration
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Investigating what looks like Windows OOM on:

```
   PULUMI_TEST_SUBSET=etc make TEST_ALL_DEPS= test_integration
```

This is rather strange since there are few tests in play. It seems each Node process accumulates up to 100MB but they are short-lived. Pulumi processes are <30MB each RAM. but I am noting that one of the tests is compiling Pulumi 0.10 so it compiles an old grpc library which needs node-gyp and the C++ toolchain. I was unable to see it run successfully yet on my test Windows machine. This PR moves the timing of when it happens - moves this compilation into the `make test_build` which might help at least see the cost of it. It will also reduce the number of processes in flight when this is running. 

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
