### PR TITLE
[core] Improve engine test coverage.

### DIFF
--- a/pkg/engine/lifeycletest/analyzer_test.go
+++ b/pkg/engine/lifeycletest/analyzer_test.go
@@ -1,14 +1,47 @@
 package lifecycletest
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/blang/semver"
 	. "github.com/pulumi/pulumi/pkg/v3/engine"
 	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
 	"github.com/stretchr/testify/assert"
 )
+
+type testRequiredPolicy struct {
+	name    string
+	version string
+	config  map[string]*json.RawMessage
+}
+
+func (p *testRequiredPolicy) Name() string {
+	return p.name
+}
+
+func (p *testRequiredPolicy) Version() string {
+	return p.version
+}
+
+func (p *testRequiredPolicy) Install(_ context.Context) (string, error) {
+	return "", nil
+}
+
+func (p *testRequiredPolicy) Config() map[string]*json.RawMessage {
+	return p.config
+}
+
+func NewRequiredPolicy(name, version string, config map[string]*json.RawMessage) RequiredPolicy {
+	return &testRequiredPolicy{
+		name:    name,
+		version: version,
+		config:  config,
+	}
+}
 
 func TestSimpleAnalyzer(t *testing.T) {
 	loaders := []*deploytest.PluginLoader{
@@ -22,6 +55,46 @@ func TestSimpleAnalyzer(t *testing.T) {
 
 	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
 		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+		assert.NoError(t, err)
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{
+			RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
+			Host:             host,
+		},
+	}
+
+	project := p.GetProject()
+	_, res := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	assert.Nil(t, res)
+}
+
+func TestSimpleAnalyzeResourceFailure(t *testing.T) {
+	loaders := []*deploytest.PluginLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewAnalyzerLoader("analyzerA", func(_ *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			return &deploytest.Analyzer{
+				AnalyzeF: func(r plugin.AnalyzerResource) ([]plugin.AnalyzeDiagnostic, error) {
+					return []plugin.AnalyzeDiagnostic{{
+						PolicyName:       "always-fails",
+						PolicyPackName:   "analyzerA",
+						Description:      "a policy that always fails",
+						Message:          "a policy failed",
+						EnforcementLevel: apitype.Mandatory,
+						URN:              r.URN,
+					}}, nil
+				},
+			}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
 		assert.Error(t, err)
 		return nil
 	})
@@ -29,7 +102,47 @@ func TestSimpleAnalyzer(t *testing.T) {
 
 	p := &TestPlan{
 		Options: UpdateOptions{
-			LocalPolicyPacks: []LocalPolicyPack{{Name: "analyzerA"}},
+			RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
+			Host:             host,
+		},
+	}
+
+	project := p.GetProject()
+	_, res := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	assert.NotNil(t, res)
+}
+
+func TestSimpleAnalyzeStackFailure(t *testing.T) {
+	loaders := []*deploytest.PluginLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewAnalyzerLoader("analyzerA", func(_ *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			return &deploytest.Analyzer{
+				AnalyzeStackF: func(rs []plugin.AnalyzerStackResource) ([]plugin.AnalyzeDiagnostic, error) {
+					return []plugin.AnalyzeDiagnostic{{
+						PolicyName:       "always-fails",
+						PolicyPackName:   "analyzerA",
+						Description:      "a policy that always fails",
+						Message:          "a policy failed",
+						EnforcementLevel: apitype.Mandatory,
+						URN:              rs[0].URN,
+					}}, nil
+				},
+			}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+		assert.NoError(t, err)
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{
+			RequiredPolicies: []RequiredPolicy{NewRequiredPolicy("analyzerA", "", nil)},
 			Host:             host,
 		},
 	}

--- a/pkg/engine/lifeycletest/analyzer_test.go
+++ b/pkg/engine/lifeycletest/analyzer_test.go
@@ -1,0 +1,40 @@
+package lifecycletest
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	. "github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimpleAnalyzer(t *testing.T) {
+	loaders := []*deploytest.PluginLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+		deploytest.NewAnalyzerLoader("analyzerA", func(_ *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
+			return &deploytest.Analyzer{}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+		assert.Error(t, err)
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{
+			LocalPolicyPacks: []LocalPolicyPack{{Name: "analyzerA"}},
+			Host:             host,
+		},
+	}
+
+	project := p.GetProject()
+	_, res := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	assert.NotNil(t, res)
+}

--- a/pkg/engine/lifeycletest/step_generator_test.go
+++ b/pkg/engine/lifeycletest/step_generator_test.go
@@ -1,0 +1,85 @@
+package lifecycletest
+
+import (
+	"testing"
+
+	"github.com/blang/semver"
+	. "github.com/pulumi/pulumi/pkg/v3/engine"
+	"github.com/pulumi/pulumi/pkg/v3/resource/deploy/deploytest"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDuplicateURN tests that duplicate URNs are disallowed.
+func TestDuplicateURN(t *testing.T) {
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	program := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+		require.NoError(t, err)
+
+		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resA", true)
+		assert.Error(t, err)
+		return nil
+	})
+	host := deploytest.NewPluginHost(nil, nil, program, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+	}
+
+	project := p.GetProject()
+	_, res := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	assert.NotNil(t, res)
+}
+
+// TestDuplicateAlias tests that multiple new resources may not claim to be aliases for the same old resource.
+func TestDuplicateAlias(t *testing.T) {
+	loaders := []*deploytest.ProviderLoader{
+		deploytest.NewProviderLoader("pkgA", semver.MustParse("1.0.0"), func() (plugin.Provider, error) {
+			return &deploytest.Provider{}, nil
+		}),
+	}
+
+	program := func(monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resA", true)
+		assert.NoError(t, err)
+		return nil
+	}
+
+	runtime := deploytest.NewLanguageRuntime(func(_ plugin.RunInfo, monitor *deploytest.ResourceMonitor) error {
+		return program(monitor)
+	})
+	host := deploytest.NewPluginHost(nil, nil, runtime, loaders...)
+
+	p := &TestPlan{
+		Options: UpdateOptions{Host: host},
+	}
+	resURN := p.NewURN("pkgA:m:typA", "resA", "")
+
+	project := p.GetProject()
+	snap, res := TestOp(Update).Run(project, p.GetTarget(t, nil), p.Options, false, p.BackendClient, nil)
+	assert.Nil(t, res)
+
+	program = func(monitor *deploytest.ResourceMonitor) error {
+		_, _, _, err := monitor.RegisterResource("pkgA:m:typA", "resB", true, deploytest.ResourceOptions{
+			Aliases: []resource.URN{resURN},
+		})
+		require.NoError(t, err)
+
+		_, _, _, err = monitor.RegisterResource("pkgA:m:typA", "resC", true, deploytest.ResourceOptions{
+			Aliases: []resource.URN{resURN},
+		})
+		assert.Error(t, err)
+		return nil
+	}
+
+	_, res = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, nil)
+	assert.NotNil(t, res)
+}

--- a/pkg/resource/deploy/deploytest/analyzer.go
+++ b/pkg/resource/deploy/deploytest/analyzer.go
@@ -1,0 +1,72 @@
+// Copyright 2016-2018, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package deploytest
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/common/resource/plugin"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/tokens"
+	"github.com/pulumi/pulumi/sdk/v3/go/common/workspace"
+)
+
+type Analyzer struct {
+	Info plugin.AnalyzerInfo
+
+	AnalyzeF      func(r plugin.AnalyzerResource) ([]plugin.AnalyzeDiagnostic, error)
+	AnalyzeStackF func(resources []plugin.AnalyzerStackResource) ([]plugin.AnalyzeDiagnostic, error)
+
+	ConfigureF func(policyConfig map[string]plugin.AnalyzerPolicyConfig) error
+}
+
+var _ = plugin.Analyzer((*Analyzer)(nil))
+
+func (a *Analyzer) Close() error {
+	return nil
+}
+
+func (a *Analyzer) Name() tokens.QName {
+	return tokens.QName(a.Info.Name)
+}
+
+func (a *Analyzer) Analyze(r plugin.AnalyzerResource) ([]plugin.AnalyzeDiagnostic, error) {
+	if a.AnalyzeF != nil {
+		return a.AnalyzeF(r)
+	}
+	return nil, nil
+}
+
+func (a *Analyzer) AnalyzeStack(resources []plugin.AnalyzerStackResource) ([]plugin.AnalyzeDiagnostic, error) {
+	if a.AnalyzeStackF != nil {
+		return a.AnalyzeStackF(resources)
+	}
+	return nil, nil
+}
+
+func (a *Analyzer) GetAnalyzerInfo() (plugin.AnalyzerInfo, error) {
+	return a.Info, nil
+}
+
+func (a *Analyzer) GetPluginInfo() (workspace.PluginInfo, error) {
+	return workspace.PluginInfo{
+		Kind: workspace.AnalyzerPlugin,
+		Name: string(a.Info.Name),
+	}, nil
+}
+
+func (a *Analyzer) Configure(policyConfig map[string]plugin.AnalyzerPolicyConfig) error {
+	if a.ConfigureF != nil {
+		return a.ConfigureF(policyConfig)
+	}
+	return nil
+}

--- a/pkg/resource/deploy/deploytest/analyzer.go
+++ b/pkg/resource/deploy/deploytest/analyzer.go
@@ -60,7 +60,7 @@ func (a *Analyzer) GetAnalyzerInfo() (plugin.AnalyzerInfo, error) {
 func (a *Analyzer) GetPluginInfo() (workspace.PluginInfo, error) {
 	return workspace.PluginInfo{
 		Kind: workspace.AnalyzerPlugin,
-		Name: string(a.Info.Name),
+		Name: a.Info.Name,
 	}, nil
 }
 

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -101,10 +101,10 @@ func NewProviderLoaderWithHost(pkg tokens.Package, version semver.Version,
 	return p
 }
 
-func NewAnalyzerLoader(name tokens.QName, load LoadAnalyzerFunc, opts ...PluginOption) *PluginLoader {
+func NewAnalyzerLoader(name string, load LoadAnalyzerFunc, opts ...PluginOption) *PluginLoader {
 	p := &PluginLoader{
 		kind: workspace.AnalyzerPlugin,
-		name: string(name),
+		name: name,
 		load: func(optsI interface{}) (interface{}, error) {
 			opts, _ := optsI.(*plugin.PolicyAnalyzerOptions)
 			return load(opts)
@@ -119,7 +119,7 @@ func NewAnalyzerLoader(name tokens.QName, load LoadAnalyzerFunc, opts ...PluginO
 func NewAnalyzerLoaderWithHost(name string, load LoadAnalyzerWithHostFunc, opts ...PluginOption) *PluginLoader {
 	p := &PluginLoader{
 		kind: workspace.AnalyzerPlugin,
-		name: string(name),
+		name: name,
 		loadWithHost: func(optsI interface{}, host plugin.Host) (interface{}, error) {
 			opts, _ := optsI.(*plugin.PolicyAnalyzerOptions)
 			return load(opts, host)

--- a/pkg/resource/deploy/deploytest/pluginhost.go
+++ b/pkg/resource/deploy/deploytest/pluginhost.go
@@ -36,37 +36,48 @@ import (
 	pulumirpc "github.com/pulumi/pulumi/sdk/v3/proto/go"
 )
 
-var UseGrpcProvidersByDefault = false
+var UseGrpcPluginsByDefault = false
+
+type LoadPluginFunc func(opts interface{}) (interface{}, error)
+type LoadPluginWithHostFunc func(opts interface{}, host plugin.Host) (interface{}, error)
 
 type LoadProviderFunc func() (plugin.Provider, error)
 type LoadProviderWithHostFunc func(host plugin.Host) (plugin.Provider, error)
 
-type ProviderOption func(p *ProviderLoader)
+type LoadAnalyzerFunc func(opts *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error)
+type LoadAnalyzerWithHostFunc func(opts *plugin.PolicyAnalyzerOptions, host plugin.Host) (plugin.Analyzer, error)
 
-func WithoutGrpc(p *ProviderLoader) {
+type PluginOption func(p *PluginLoader)
+
+func WithoutGrpc(p *PluginLoader) {
 	p.useGRPC = false
 }
 
-func WithGrpc(p *ProviderLoader) {
+func WithGrpc(p *PluginLoader) {
 	p.useGRPC = true
 }
 
-type ProviderLoader struct {
-	pkg          tokens.Package
+type PluginLoader struct {
+	kind         workspace.PluginKind
+	name         string
 	version      semver.Version
-	load         LoadProviderFunc
-	loadWithHost LoadProviderWithHostFunc
+	load         LoadPluginFunc
+	loadWithHost LoadPluginWithHostFunc
 	useGRPC      bool
 }
+
+type ProviderOption = PluginOption
+type ProviderLoader = PluginLoader
 
 func NewProviderLoader(pkg tokens.Package, version semver.Version, load LoadProviderFunc,
 	opts ...ProviderOption) *ProviderLoader {
 
 	p := &ProviderLoader{
-		pkg:     pkg,
+		kind:    workspace.ResourcePlugin,
+		name:    string(pkg),
 		version: version,
-		load:    load,
-		useGRPC: UseGrpcProvidersByDefault,
+		load:    func(_ interface{}) (interface{}, error) { return load() },
+		useGRPC: UseGrpcPluginsByDefault,
 	}
 	for _, o := range opts {
 		o(p)
@@ -78,10 +89,41 @@ func NewProviderLoaderWithHost(pkg tokens.Package, version semver.Version,
 	load LoadProviderWithHostFunc, opts ...ProviderOption) *ProviderLoader {
 
 	p := &ProviderLoader{
-		pkg:          pkg,
+		kind:         workspace.ResourcePlugin,
+		name:         string(pkg),
 		version:      version,
-		loadWithHost: load,
-		useGRPC:      UseGrpcProvidersByDefault,
+		loadWithHost: func(_ interface{}, host plugin.Host) (interface{}, error) { return load(host) },
+		useGRPC:      UseGrpcPluginsByDefault,
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+func NewAnalyzerLoader(name tokens.QName, load LoadAnalyzerFunc, opts ...PluginOption) *PluginLoader {
+	p := &PluginLoader{
+		kind: workspace.AnalyzerPlugin,
+		name: string(name),
+		load: func(optsI interface{}) (interface{}, error) {
+			opts, _ := optsI.(*plugin.PolicyAnalyzerOptions)
+			return load(opts)
+		},
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
+}
+
+func NewAnalyzerLoaderWithHost(name string, load LoadAnalyzerWithHostFunc, opts ...PluginOption) *PluginLoader {
+	p := &PluginLoader{
+		kind: workspace.AnalyzerPlugin,
+		name: string(name),
+		loadWithHost: func(optsI interface{}, host plugin.Host) (interface{}, error) {
+			opts, _ := optsI.(*plugin.PolicyAnalyzerOptions)
+			return load(opts, host)
+		},
 	}
 	for _, o := range opts {
 		o(p)
@@ -169,20 +211,22 @@ func (e *hostEngine) SetRootResource(_ context.Context,
 }
 
 type pluginHost struct {
-	providerLoaders []*ProviderLoader
+	pluginLoaders   []*ProviderLoader
 	languageRuntime plugin.LanguageRuntime
 	sink            diag.Sink
 	statusSink      diag.Sink
 
 	engine *hostEngine
 
-	providers map[plugin.Provider]io.Closer
+	providers []plugin.Provider
+	analyzers []plugin.Analyzer
+	plugins   map[interface{}]io.Closer
 	closed    bool
 	m         sync.Mutex
 }
 
 func NewPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRuntime,
-	providerLoaders ...*ProviderLoader) plugin.Host {
+	pluginLoaders ...*ProviderLoader) plugin.Host {
 
 	engine := &hostEngine{
 		sink:       sink,
@@ -201,12 +245,12 @@ func NewPluginHost(sink, statusSink diag.Sink, languageRuntime plugin.LanguageRu
 	engine.address = fmt.Sprintf("127.0.0.1:%v", port)
 
 	return &pluginHost{
-		providerLoaders: providerLoaders,
+		pluginLoaders:   pluginLoaders,
 		languageRuntime: languageRuntime,
 		sink:            sink,
 		statusSink:      statusSink,
 		engine:          engine,
-		providers:       map[plugin.Provider]io.Closer{},
+		plugins:         map[interface{}]io.Closer{},
 	}
 }
 
@@ -216,10 +260,12 @@ func (host *pluginHost) isClosed() bool {
 	return host.closed
 }
 
-func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
-	var best *ProviderLoader
-	for _, l := range host.providerLoaders {
-		if l.pkg != pkg {
+func (host *pluginHost) plugin(kind workspace.PluginKind, name string, version *semver.Version,
+	opts interface{}) (interface{}, error) {
+
+	var best *PluginLoader
+	for _, l := range host.pluginLoaders {
+		if l.kind != kind || l.name != name {
 			continue
 		}
 
@@ -238,19 +284,19 @@ func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (p
 
 	load := best.load
 	if load == nil {
-		load = func() (plugin.Provider, error) {
-			return best.loadWithHost(host)
+		load = func(opts interface{}) (interface{}, error) {
+			return best.loadWithHost(opts, host)
 		}
 	}
 
-	prov, err := load()
+	plug, err := load(opts)
 	if err != nil {
 		return nil, err
 	}
 
 	closer := nopCloser
 	if best.useGRPC {
-		prov, closer, err = wrapProviderWithGrpc(prov)
+		plug, closer, err = wrapProviderWithGrpc(plug.(plugin.Provider))
 		if err != nil {
 			return nil, err
 		}
@@ -259,8 +305,23 @@ func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (p
 	host.m.Lock()
 	defer host.m.Unlock()
 
-	host.providers[prov] = closer
-	return prov, nil
+	switch kind {
+	case workspace.AnalyzerPlugin:
+		host.analyzers = append(host.analyzers, plug.(plugin.Analyzer))
+	case workspace.ResourcePlugin:
+		host.providers = append(host.providers, plug.(plugin.Provider))
+	}
+
+	host.plugins[plug] = closer
+	return plug, nil
+}
+
+func (host *pluginHost) Provider(pkg tokens.Package, version *semver.Version) (plugin.Provider, error) {
+	plug, err := host.plugin(workspace.ResourcePlugin, string(pkg), version, nil)
+	if err != nil || plug == nil {
+		return nil, err
+	}
+	return plug.(plugin.Provider), nil
 }
 
 func (host *pluginHost) LanguageRuntime(runtime string) (plugin.LanguageRuntime, error) {
@@ -272,7 +333,7 @@ func (host *pluginHost) SignalCancellation() error {
 	defer host.m.Unlock()
 
 	var err error
-	for prov := range host.providers {
+	for _, prov := range host.providers {
 		if pErr := prov.SignalCancellation(); pErr != nil {
 			err = pErr
 		}
@@ -284,7 +345,7 @@ func (host *pluginHost) Close() error {
 	defer host.m.Unlock()
 
 	var err error
-	for _, closer := range host.providers {
+	for _, closer := range host.plugins {
 		if pErr := closer.Close(); pErr != nil {
 			err = pErr
 		}
@@ -308,13 +369,13 @@ func (host *pluginHost) LogStatus(sev diag.Severity, urn resource.URN, msg strin
 	}
 }
 func (host *pluginHost) Analyzer(nm tokens.QName) (plugin.Analyzer, error) {
-	return nil, errors.New("unsupported")
+	return host.PolicyAnalyzer(nm, "", nil)
 }
 func (host *pluginHost) CloseProvider(provider plugin.Provider) error {
 	host.m.Lock()
 	defer host.m.Unlock()
 
-	delete(host.providers, provider)
+	delete(host.plugins, provider)
 	return nil
 }
 func (host *pluginHost) ListPlugins() []workspace.PluginInfo {
@@ -330,9 +391,17 @@ func (host *pluginHost) GetRequiredPlugins(info plugin.ProgInfo,
 
 func (host *pluginHost) PolicyAnalyzer(name tokens.QName, path string,
 	opts *plugin.PolicyAnalyzerOptions) (plugin.Analyzer, error) {
-	return nil, errors.New("unsupported")
+
+	plug, err := host.plugin(workspace.AnalyzerPlugin, string(name), nil, opts)
+	if err != nil || plug == nil {
+		return nil, err
+	}
+	return plug.(plugin.Analyzer), nil
 }
 
 func (host *pluginHost) ListAnalyzers() []plugin.Analyzer {
-	return nil
+	host.m.Lock()
+	defer host.m.Unlock()
+
+	return host.analyzers
 }


### PR DESCRIPTION
Improve coverage of analyers and import plans (the state import half of
`pulumi import`) as well as some failure cases in the step generator.
Analyzer coverage required extending the deploytest package to support
loading analyzers.