### PR TITLE
Restore coverage collection for dotnet

### DIFF
--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -51,11 +51,11 @@ install:: build install_plugin
 
 dotnet_test:: $(TEST_ALL_DEPS)
 	$(TESTSUITE_SKIPPED) dotnet-test || \
-		dotnet test --no-build --filter FullyQualifiedName\!~Pulumi.Automation.Tests -p:Version=${DOTNET_VERSION} ${TEST_COVERAGE_ARGS}/dotnet.xml
+		dotnet test --filter FullyQualifiedName\!~Pulumi.Automation.Tests -p:Version=${DOTNET_VERSION} ${TEST_COVERAGE_ARGS}/dotnet.xml
 
 auto_test:: $(TEST_ALL_DEPS)
 	$(TESTSUITE_SKIPPED) auto-dotnet || \
-		dotnet test --no-build --filter FullyQualifiedName~Pulumi.Automation.Tests -p:Version=${DOTNET_VERSION} ${TEST_COVERAGE_ARGS}/dotnet-auto.xml
+		dotnet test --filter FullyQualifiedName~Pulumi.Automation.Tests -p:Version=${DOTNET_VERSION} ${TEST_COVERAGE_ARGS}/dotnet-auto.xml
 
 test_fast:: dotnet_test
 	$(GO_TEST_FAST) ${PROJECT_PKGS}

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -19,9 +19,9 @@ ensure::
 	dotnet restore dotnet.sln
 
 ifneq ($(PULUMI_TEST_COVERAGE_PATH),)
-TEST_COVERAGE_ARGS := /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CoverletOutput=$(PULUMI_TEST_COVERAGE_PATH)
+TEST_COVERAGE_ARGS := -p:CollectCoverage=true -p:CoverletOutputFormat=cobertura -p:CoverletOutput=$(PULUMI_TEST_COVERAGE_PATH)
 else
-TEST_COVERAGE_ARGS := /p:CollectCoverage=false /p:CoverletOutput=$(PULUMI_TEST_COVERAGE_PATH)
+TEST_COVERAGE_ARGS := -p:CollectCoverage=false -p:CoverletOutput=$(PULUMI_TEST_COVERAGE_PATH)
 endif
 
 build::
@@ -37,7 +37,7 @@ build::
 	#
 	#     -alpha: Alpha release, typically used for work-in-progress and experimentation
 	dotnet clean
-	dotnet build dotnet.sln /p:Version=${DOTNET_VERSION}
+	dotnet build dotnet.sln -p:Version=${DOTNET_VERSION}
 	go install -ldflags "-X github.com/pulumi/pulumi/sdk/v3/go/common/version.Version=${DOTNET_VERSION}" ${LANGHOST_PKG}
 
 install_plugin::
@@ -50,10 +50,12 @@ install:: build install_plugin
 	find . -name '*${VERSION_PREFIX}*.nupkg' -exec cp -p {} ${PULUMI_NUGET} \;
 
 dotnet_test:: $(TEST_ALL_DEPS)
-	$(TESTSUITE_SKIPPED) dotnet-test || (cd Pulumi.Tests && dotnet test)
+	$(TESTSUITE_SKIPPED) dotnet-test || \
+		dotnet test --no-build --filter FullyQualifiedName\!~Pulumi.Automation.Tests -p:Version=${DOTNET_VERSION} ${TEST_COVERAGE_ARGS}/dotnet.xml
 
 auto_test:: $(TEST_ALL_DEPS)
-	$(TESTSUITE_SKIPPED) auto-dotnet || (cd Pulumi.Automation.Tests && dotnet test)
+	$(TESTSUITE_SKIPPED) auto-dotnet || \
+		dotnet test --no-build --filter FullyQualifiedName~Pulumi.Automation.Tests -p:Version=${DOTNET_VERSION} ${TEST_COVERAGE_ARGS}/dotnet-auto.xml
 
 test_fast:: dotnet_test
 	$(GO_TEST_FAST) ${PROJECT_PKGS}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

@pgavlin I dug into this, looks like the issue was that the `/p:` syntax was not parsing on Windows under Bash. The `-p:` syntax is working better for me, so I can restore the original forms. Also restoring the cov parameters that I lost accidentally in the refactor. PTAL, also curious how the CI goes.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
