### PR TITLE
Try a locked go toolchain

### DIFF
--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -147,6 +147,16 @@ jobs:
         with:
           repo: t0yv0/goteststats
           tag: v0.0.7
+      - name: Lock go toolchain to prevent concurrent OOM on go linker
+        if: ${{ matrix.platform == 'windows-latest' }}
+        run: |
+          LOCKED_GO=$(./scripts/locked-go-toolchain.sh)
+          echo "Adding LOCKED_GO=$LOCKED_GO to PATH"
+          echo $LOCKED_GO >> $GITHUB_PATH
+      - name: Verify go toolchain modification
+        run: |
+          command -v go
+          go version
       - name: Download Pulumi Go Binaries (linux-x64)
         if: ${{ matrix.platform == 'ubuntu-latest' }}
         uses: actions/download-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,6 +136,16 @@ jobs:
         with:
           repo: t0yv0/goteststats
           tag: v0.0.7
+      - name: Lock go toolchain to prevent concurrent OOM on go linker
+        if: ${{ matrix.platform == 'windows-latest' }}
+        run: |
+          LOCKED_GO=$(./scripts/locked-go-toolchain.sh)
+          echo "Adding LOCKED_GO=$LOCKED_GO to PATH"
+          echo $LOCKED_GO >> $GITHUB_PATH
+      - name: Verify go toolchain modification
+        run: |
+          command -v go
+          go version
       - name: Download Pulumi Go Binaries (linux-x64)
         if: ${{ matrix.platform == 'ubuntu-latest' }}
         uses: actions/download-artifact@v2

--- a/build/utils/locked-go/go.mod
+++ b/build/utils/locked-go/go.mod
@@ -1,0 +1,5 @@
+module locked-go
+
+go 1.17
+
+require github.com/rogpeppe/go-internal v1.8.1

--- a/build/utils/locked-go/go.sum
+++ b/build/utils/locked-go/go.sum
@@ -1,0 +1,8 @@
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/rogpeppe/go-internal v1.8.1 h1:geMPLpDpQOgVyCg5z5GoRwLHepNdb71NXb67XFkP+Eg=
+github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=

--- a/build/utils/locked-go/main.go
+++ b/build/utils/locked-go/main.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
+func main() {
+	flag.Parse()
+	args := flag.Args()
+
+	cfg := requireConfig()
+
+	if len(args) >= 1 && args[0] == "run" || args[0] == "build" {
+		exitCode := executeLockedGo(cfg.realgo, cfg.lockfile, args)
+		os.Exit(exitCode)
+	} else {
+		exitCode := executeGo(cfg.realgo, args)
+		os.Exit(exitCode)
+	}
+}
+
+type config struct {
+	lockfile string
+	realgo   string
+}
+
+func requireConfig() config {
+	runnerTemp := os.Getenv("RUNNER_TEMP")
+	if runnerTemp == "" {
+		log.Fatal("RUNNER_TEMP env var must be set")
+	}
+	lockfile := filepath.Join(runnerTemp, "go-wrapper", "go.lock")
+	realgoFile := filepath.Join(runnerTemp, "go-wrapper", "realgo.path")
+	realgoBytes, err := ioutil.ReadFile(realgoFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	realgo := strings.TrimSpace(string(realgoBytes))
+	return config{lockfile, realgo}
+}
+
+func executeLockedGo(realgo, lockfile string, args []string) int {
+	mutex := lockedfile.MutexAt(lockfile)
+	unlock, err := mutex.Lock()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer unlock()
+	return executeGo(realgo, args)
+}
+
+func executeGo(realgo string, args []string) int {
+	cmd := exec.Command(realgo, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	cmd.Run()
+	return cmd.ProcessState.ExitCode()
+}

--- a/scripts/locked-go-toolchain.sh
+++ b/scripts/locked-go-toolchain.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -euo pipefail
+
+: "${RUNNER_TEMP?Not finding RUNNER_TEMP expected in the GitHub Actions environment}"
+
+mkdir -p "$RUNNER_TEMP/go-wrapper"
+(cd build/utils/locked-go && go build -o "$RUNNER_TEMP/go-wrapper/go$(go env GOEXE)")
+echo "$(./scripts/normpath "$(command -v go)")" > "$RUNNER_TEMP/go-wrapper/realgo.path"
+echo $(./scripts/normpath "$RUNNER_TEMP/go-wrapper")


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The hypothesis being tested here is that we have OOMs in CI due to more than one instance of the `go` toolchain running at the same time, and the linker being particularly hungry (~300MB RAM) on Windows. The workaround locks the `go` toolchain at OS level so only one instance of `go build` or `go run` can run at a time. 

I've tested it a bit and it seems to work as designed. It slows down Windows verification a bit, the integration tests go into 1h7min territory, but they seem to complete so far without OOM. That'd still be a win in my book if this truly works. I think this is still conceptually better than tuning down test parallelism param (currently -p 10), since tests that do not use Go actually continue to run in parallel.

What would be best is eventually modifying the tests to set runtime.options.binary in Pulumi.yaml and also set `pt.opts.RunBuild: true` in programtest. What this does is it pre-builds the user program with `go build` (now under lock), followed by actual testing of the compiled program (not under lock). This way slow cloud-wait operations can still go in parallel.

The real test is to run the CI a few times and see if the incidence of OOMs is reduced. My sample here is too small.

I'd love to merge this in and run an experiment for a few weeks to see if the stability stats look any better.

Alternative would be to open 100 branches but I do not want to clog the CI workers so real PRs wait on this.

We can always back this out easily.


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
