### PR TITLE
Accept `*` as an index in property paths

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -8,6 +8,9 @@
   [#8692](https://github.com/pulumi/pulumi/pull/8692)
   [#8702](https://github.com/pulumi/pulumi/pull/8702)
 
+- [sdk] - Allow property paths to accept `[*]` as sugar for `["*"]`.
+  [#8743](https://github.com/pulumi/pulumi/pull/8743)
+
 ### Bug Fixes
 
 - [auto/python] - Fixes an issue with exception isolation in a

--- a/sdk/go/common/resource/properties_path.go
+++ b/sdk/go/common/resource/properties_path.go
@@ -41,6 +41,8 @@ type PropertyPath []interface{}
 // - root["key with a ."]
 // - ["root key with \"escaped\" quotes"].nested
 // - ["root key with a ."][100]
+// - root.array[*].field
+// - root.array["*"].field
 func ParsePropertyPath(path string) (PropertyPath, error) {
 	// We interpret the grammar above a little loosely in order to keep things simple. Specifically, we will accept
 	// something close to the following:
@@ -82,11 +84,16 @@ func ParsePropertyPath(path string) (PropertyPath, error) {
 					return nil, errors.New("missing closing bracket in array index")
 				}
 
-				index, err := strconv.ParseInt(path[1:rbracket], 10, 0)
-				if err != nil {
-					return nil, errors.Wrap(err, "invalid array index")
+				segment := path[1:rbracket]
+				if segment == "*" {
+					pathElement, path = "*", path[rbracket:]
+				} else {
+					index, err := strconv.ParseInt(segment, 10, 0)
+					if err != nil {
+						return nil, errors.Wrap(err, "invalid array index")
+					}
+					pathElement, path = int(index), path[rbracket:]
 				}
-				pathElement, path = int(index), path[rbracket:]
 			}
 			elements, path = append(elements, pathElement), path[1:]
 		default:

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -144,6 +144,30 @@ func TestPropertyPath(t *testing.T) {
 		})
 	}
 
+	simpleCases := []struct {
+		path   string
+		parsed PropertyPath
+	}{
+		{
+			`root["*"].field[1]`,
+			PropertyPath{"root", "*", "field", 1},
+		},
+		{
+			`*.bar`,
+			PropertyPath{"*", "bar"},
+		},
+	}
+
+	t.Run("Simple", func(t *testing.T) {
+		for _, c := range simpleCases {
+			t.Run(c.path, func(t *testing.T) {
+				parsed, err := ParsePropertyPath(c.path)
+				assert.NoError(t, err)
+				assert.Equal(t, c.parsed, parsed)
+			})
+		}
+	})
+
 	negativeCases := []string{
 		// Syntax errors
 		"root[",

--- a/sdk/go/common/resource/properties_path_test.go
+++ b/sdk/go/common/resource/properties_path_test.go
@@ -145,12 +145,20 @@ func TestPropertyPath(t *testing.T) {
 	}
 
 	simpleCases := []struct {
-		path   string
-		parsed PropertyPath
+		path     string
+		expected PropertyPath
 	}{
 		{
 			`root["*"].field[1]`,
 			PropertyPath{"root", "*", "field", 1},
+		},
+		{
+			`root[*].field[2]`,
+			PropertyPath{"root", "*", "field", 2},
+		},
+		{
+			`root[3].*[3]`,
+			PropertyPath{"root", 3, "*", 3},
 		},
 		{
 			`*.bar`,
@@ -163,7 +171,7 @@ func TestPropertyPath(t *testing.T) {
 			t.Run(c.path, func(t *testing.T) {
 				parsed, err := ParsePropertyPath(c.path)
 				assert.NoError(t, err)
-				assert.Equal(t, c.parsed, parsed)
+				assert.Equal(t, c.expected, parsed)
 			})
 		}
 	})


### PR DESCRIPTION
# Description
`PropertyPaths` are used as path descriptors with wildcards (`*`). Users
know they can use `root["*"]` to wildcard on any entry in a map. Because
strings and numbers can both be used to index (map vs array), our users
expect to be able to use `root[*]` as a wildcard for an array. We should
parse `[*]` so wildcards work as expected. Internally, this will be
syntactic sugar for `["*"]`, but with much less user confusion.

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->


<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #8197
See also: https://github.com/pulumi/pulumi-hugo/issues/908
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [X] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
