### PR TITLE
[sdk/dotnet] Fix failing test

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
@@ -35,7 +35,7 @@ namespace Pulumi.Automation.Tests
             Assert.Equal(0, result.Code);
 
             Assert.Matches(@"^v?\d+\.\d+\.\d+", result.StandardOutput);
-            Assert.Matches(@"^(warning: A new version of Pulumi[^\n]+\n)?$",
+            Assert.Matches(@"^(warning: A new version of Pulumi[^\n]+\n)?",
                            result.StandardError);
 
             Assert.Equal(Lines(result.StandardOutput), stdoutLines);
@@ -44,8 +44,7 @@ namespace Pulumi.Automation.Tests
 
         private IEnumerable<string> Lines(string s) {
             return s.Split(Environment.NewLine,
-                           StringSplitOptions.RemoveEmptyEntries)
-                .Select(x => x.Trim());
+                           StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }


### PR DESCRIPTION
# Description

This test failed and, to be honest, I struggled to find good xunit documentation.

It appears there were two issues in this test:

1. The Assert.Matches was failing on the string termination `$`.
2. The automation API output was trimmed in the test on line 42, but the accumulated lines were not. I didn't see an obvious commit including the word trim, but I'm guessing some behavior changed with automation output?

The line 42 test failed on matching the line beginning:

```
   $ curl -sSL https://get.pulumi.com | sh
```

Which when trimmed would not equal itself.