### PR TITLE
Lower test parallelism for Windows testing

### DIFF
--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -73,6 +73,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+      - name: Reduce TESTPARALLELISM on Windows to work around OOM
+        if: ${{ matrix.platform == 'windows-latest' }}
+        run: |
+          echo "TESTPARALLELISM=1" >> $GITHUB_ENV
       - name: Set PULUMI_TEST_SUBSET env var
         run: |
           echo "PULUMI_TEST_SUBSET=${{ matrix.test-subset }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,10 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+      - name: Reduce TESTPARALLELISM on Windows to work around OOM
+        if: ${{ matrix.platform == 'windows-latest' }}
+        run: |
+          echo "TESTPARALLELISM=1" >> $GITHUB_ENV
       - name: Set PULUMI_TEST_SUBSET env var
         run: |
           echo "PULUMI_TEST_SUBSET=${{ matrix.test-subset }}" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PROJECT_PKGS    := $(shell cd ./pkg && go list ./... | grep -v /vendor/)
 TESTS_PKGS      := $(shell cd ./tests && go list -tags all ./... | grep -v tests/templates | grep -v /vendor/)
 VERSION         := $(shell pulumictl get version)
 
-TESTPARALLELISM := 10
+TESTPARALLELISM ?= 10
 
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running
 # `test_all` without the dependencies.

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -6,7 +6,7 @@ PROJECT_ROOT    := $(realpath ../..)
 
 DOTNET_VERSION  := $(shell cd ../../ && pulumictl get version --language dotnet)
 
-TESTPARALLELISM := 10
+TESTPARALLELISM ?= 10
 
 include ../../build/common.mk
 

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -3,7 +3,7 @@ LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/go/pulumi-language-go
 VERSION          := $(shell cd ../../ && pulumictl get version)
 TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
 TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
-TESTPARALLELISM  := 10
+TESTPARALLELISM  ?= 10
 PROJECT_ROOT     := $(realpath ../..)
 
 include ../../build/common.mk

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -6,7 +6,7 @@ LANGUAGE_HOST    := github.com/pulumi/pulumi/sdk/v3/nodejs/cmd/pulumi-language-n
 PROJECT_ROOT     := $(realpath ../..)
 
 PROJECT_PKGS    := $(shell go list ./cmd...)
-TESTPARALLELISM := 10
+TESTPARALLELISM ?= 10
 TEST_FAST_TIMEOUT := 2m
 
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -8,7 +8,7 @@ PYENV := ./env
 PYENVSRC := $(PYENV)/src
 
 PROJECT_PKGS    := $(shell go list ./cmd/...)
-TESTPARALLELISM := 10
+TESTPARALLELISM ?= 10
 
 include ../../build/common.mk
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Reduce probability of Windows test worker VM OOM issue by reducing test parallelism 10 to 1 on Windows. The impact is 60min --> 77min testing duration. I have not yet seen the CI OOM with these changes, but definitely need a larger sample to see if this works or not. I still would like to merge this and continue watching the builds.

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
