### PR TITLE
[python/sdk] Disallow invalid provider option

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -2,3 +2,5 @@
 
 ### Bug Fixes
 
+- [python/sdk] - Disallow passing an invalid Provider `P` with
+  `ResourceOptions(provider=P)` to a custom resource.

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -982,9 +982,12 @@ class ProviderResource(CustomResource):
         :param bool dependency: True if this is a synthetic resource used internally for dependency tracking.
         """
 
-        if opts is not None and opts.provider is not None:
-            raise TypeError(
-                "Explicit providers may not be used with provider resources")
+        if opts is not None:
+            if not isinstance(opts, ResourceOptions):
+                raise TypeError("opts must be of type ResourceOptions")
+            if opts.provider is not None:
+                raise TypeError(
+                    "Explicit providers may not be used with provider resources")
         # Provider resources are given a well-known type, prefixed with "pulumi:providers".
         CustomResource.__init__(
             self, f"pulumi:providers:{pkg}", name, props, opts, dependency)

--- a/sdk/python/lib/pulumi/resource.py
+++ b/sdk/python/lib/pulumi/resource.py
@@ -806,10 +806,7 @@ class Resource:
             else:
                 # If a provider was specified, add it to the providers map under this type's package
                 # so that any children of this resource inherit its provider.
-                type_components = t.split(":")
-                if len(type_components) == 3:
-                    [pkg, _, _] = type_components
-                    self._providers = {**self._providers, pkg: provider}
+                self._providers = {**self._providers, provider.package: provider}
         else:
             providers = convert_providers(opts.provider, opts.providers)
             self._providers = {**self._providers, **providers}

--- a/sdk/python/lib/pulumi/runtime/resource.py
+++ b/sdk/python/lib/pulumi/runtime/resource.py
@@ -118,7 +118,16 @@ async def prepare_resource(res: 'Resource',
 
     # Construct the provider reference, if we were given a provider to use.
     provider_ref = None
-    if custom and opts is not None and opts.provider is not None:
+
+    pkg = None
+    try:
+        i = ty.index(":")
+        pkg = ty[:i]
+    except ValueError:
+        # If we don't find the index, we silently move on.
+        pass
+
+    if custom and opts is not None and opts.provider is not None and (opts.provider.package == pkg or pkg is None):
         provider = opts.provider
 
         # If we were given a provider, wait for it to resolve and construct a provider reference from it.

--- a/sdk/python/lib/test/langhost/component_provider_resolution/__init__.py
+++ b/sdk/python/lib/test/langhost/component_provider_resolution/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/sdk/python/lib/test/langhost/component_provider_resolution/__main__.py
+++ b/sdk/python/lib/test/langhost/component_provider_resolution/__main__.py
@@ -1,0 +1,55 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import functools
+from pulumi import ComponentResource, CustomResource, Output, ResourceOptions, ProviderResource
+
+class MyResource(CustomResource):
+    def __init__(self, name, args, opts=None):
+        CustomResource.__init__(self, "test:index:MyResource", name, props={
+            **args,
+            "outprop": None,
+        }, opts=opts)
+
+class OtherResource(CustomResource):
+    def __init__(self, name, args, opts=None):
+        super().__init__("other:index:OtherResource", name, props={
+            **args,
+            "outprop": None,
+        }, opts=opts)
+
+class OtherProvider(ProviderResource):
+    def __init__(self, name):
+        super().__init__("other", name)
+
+class CombinedComponent(ComponentResource):
+    def __init__(self, name, opts=None):
+        super().__init__("combined:index:CombinedResource", name, opts=opts)
+        parent = ResourceOptions(parent=self).merge(opts)
+        MyResource("combined-mine", {}, opts=parent)
+        OtherResource("combined-other", {}, opts=parent)
+
+class MyComponent(ComponentResource):
+    def __init__(self, name, opts=None):
+        ComponentResource.__init__(self, "test:index:MyComponent", name, opts=opts)
+
+prov1 = OtherProvider("prov1")
+comp3 = CombinedComponent(
+    "comp3",
+    ResourceOptions(
+        providers={
+            "other": prov1
+        },
+        protect=True,
+    )
+)

--- a/sdk/python/lib/test/langhost/component_provider_resolution/test_component_provider_resolution.py
+++ b/sdk/python/lib/test/langhost/component_provider_resolution/test_component_provider_resolution.py
@@ -1,0 +1,41 @@
+# Copyright 2016-2021, Pulumi Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from os import path
+import unittest
+from ..util import LanghostTest
+
+
+class ComponentDependenciesTest(LanghostTest):
+    def test_component_dependencies(self):
+        self.run_test(
+            program=path.join(self.base_path(), "component_provider_resolution"),
+            expected_resource_count=4)
+
+    def register_resource(self, _ctx, _dry_run, ty, name, _resource, _dependencies, _parent, _custom, protect,
+                          _provider, _property_deps, _delete_before_replace, _ignore_changes, _version, _import,
+                          _replace_on_changes):
+        if name == "combined-mine":
+            self.assertTrue(protect)
+            self.assertEqual(_provider, "")
+        elif name == "combined-other":
+            self.assertTrue(protect)
+            self.assertEqual(_provider, "prov1::prov1")
+
+        return {
+            "urn": name,
+            "id": name,
+            "object": {
+                "outprop": "qux",
+            }
+        }


### PR DESCRIPTION
When a resource R is created with `ResourceOptinos(provider=P)`, and when P.pkg disagrees with the package providing R, do not create R using P. Instead create R with the provider it finds in `providers` (or default) and pass `P` as an overriding member of `self._providers` to any child resources.

This makes `ResourceOptions(provider=P)` the same as `ResourceOptions(providers=[P])`. This is desirable since `ResourceOptinos(providers=[P]).merge(None) == ResourceOptions(provider=P)` already.

This is progress towards the reasonable expectation that `ResourceOptions(**kargs).merge(None) == ResourceOptions(**kargs)`.

I want to be super careful that this changes existing behavior only in harmless ways. I don't think it is possible to avoid a (technically) breaking change without providing an explicit opt in to correct behavior (`ResourceOptionsV2`) which I do not want. 

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes #5639

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
