### PR TITLE
[sdk/nodejs] Support top-level default exports in ESM

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -20,6 +20,9 @@
 - [cli] - Add support for overriding plugin download URLs.
   [#8798](https://github.com/pulumi/pulumi/pull/8798)
 
+- [sdk/nodejs] - Support top-level default exports in ESM.
+  [#8766](https://github.com/pulumi/pulumi/pull/8766)
+
 ### Bug Fixes
 
 - [sdk/python] - Prevent `ResourceOptions.merge` from promoting between the

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -280,7 +280,7 @@ ${defaultMessage}`);
                 programExport = await dynamicImport(main);
                 // If there is a default export, use that instead of the named exports (and error if there are both).
                 if (Object.getOwnPropertyDescriptor(programExport, "default") !== undefined) {
-                    if (Object.keys(programExport).length != 1) {
+                    if (Object.keys(programExport).length !== 1) {
                         throw new Error("expected entrypoint module to have either a default export or named exports but not both");
                     }
                     programExport = programExport.default;
@@ -290,9 +290,9 @@ ${defaultMessage}`);
                 programExport = require(program);
             }
 
-            // If the exported value was itself a Function, then just execute it.  This allows for 
-            // exported top level async functions that pulumi programs can live in.  Finally, await 
-            // the value we get back.  That way, if it is async and throws an exception, we properly 
+            // If the exported value was itself a Function, then just execute it.  This allows for
+            // exported top level async functions that pulumi programs can live in.  Finally, await
+            // the value we get back.  That way, if it is async and throws an exception, we properly
             // capture it here and handle it.
             const invokeResult = programExport instanceof Function
                 ? programExport()

--- a/sdk/nodejs/cmd/run/run.ts
+++ b/sdk/nodejs/cmd/run/run.ts
@@ -278,10 +278,8 @@ ${defaultMessage}`);
                 // back.  That way, if it is async and throws an exception, we properly capture it here
                 // and handle it.
                 programExport = await dynamicImport(main);
-                console.log(programExport);
                 // If there is a default export, use that instead of the named exports (and error if there are both).
                 if (Object.getOwnPropertyDescriptor(programExport, "default") !== undefined) {
-                    console.log("default export")
                     if (Object.keys(programExport).length != 1) {
                         throw new Error("expected entrypoint module to have either a default export or named exports but not both");
                     }

--- a/tests/integration/integration_nodejs_test.go
+++ b/tests/integration/integration_nodejs_test.go
@@ -1176,6 +1176,20 @@ func TestESMTS(t *testing.T) {
 	})
 }
 
+func TestESMTSDefaultExport(t *testing.T) {
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Dir:          filepath.Join("nodejs", "esm-ts-default-export"),
+		Dependencies: []string{"@pulumi/pulumi"},
+		Quick:        true,
+		ExtraRuntimeValidation: func(t *testing.T, stack integration.RuntimeValidationStackInfo) {
+			assert.Len(t, stack.Outputs, 1)
+			helloWorld, ok := stack.Outputs["helloWorld"]
+			assert.True(t, ok)
+			assert.Equal(t, helloWorld, 123.0)
+		},
+	})
+}
+
 func TestESMTSSpecifierResolutionNode(t *testing.T) {
 	integration.ProgramTest(t, &integration.ProgramTestOptions{
 		Dir:          filepath.Join("nodejs", "esm-ts-specifier-resolution-node"),

--- a/tests/integration/nodejs/esm-ts-default-export/Pulumi.yaml
+++ b/tests/integration/nodejs/esm-ts-default-export/Pulumi.yaml
@@ -1,0 +1,7 @@
+name: esm-ts-default-export
+runtime: 
+  name: nodejs
+  options: 
+    # See https://github.com/TypeStrong/ts-node/issues/1007
+    nodeargs: "--loader ts-node/esm --no-warnings"
+description: Use ECMAScript modules for a TS program.

--- a/tests/integration/nodejs/esm-ts-default-export/index.ts
+++ b/tests/integration/nodejs/esm-ts-default-export/index.ts
@@ -1,0 +1,3 @@
+// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+
+export default async function() { return {helloWorld: 123} }

--- a/tests/integration/nodejs/esm-ts-default-export/index.ts
+++ b/tests/integration/nodejs/esm-ts-default-export/index.ts
@@ -1,3 +1,3 @@
-// Copyright 2016-2021, Pulumi Corporation.  All rights reserved.
+// Copyright 2016-2022, Pulumi Corporation.  All rights reserved.
 
 export default async function() { return {helloWorld: 123} }

--- a/tests/integration/nodejs/esm-ts-default-export/package.json
+++ b/tests/integration/nodejs/esm-ts-default-export/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "esm-ts-default-export",
+    "license": "Apache-2.0",
+    "type": "module",
+    "devDependencies": {
+        "@types/node": "^17.0.5"
+    },
+    "peerDependencies": {
+        "@pulumi/pulumi": "latest"
+    },
+    "dependencies": {
+        "ts-node": "^10.4.0",
+        "typescript": "^4.5.4"
+    },
+    "resolutions": {
+        "ts-node": "^10.4.0",
+        "typescript": "^4.5.4"
+    }
+}

--- a/tests/integration/nodejs/esm-ts-default-export/tsconfig.json
+++ b/tests/integration/nodejs/esm-ts-default-export/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "bin",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "sourceMap": true,
+    "stripInternal": true,
+    "experimentalDecorators": true,
+    "pretty": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.ts"
+  ]
+}
+


### PR DESCRIPTION
In #7764 and #8655 we added support for ESM entrypoints.  However, ESM "default exports" were handled just as "normal" in Node.js dynamic import of ESM - as a `default` proeprty in the export object.

This is not a particularly useful behaviour for Pulumi program entry points, and doesn't quite match some of the special logic we apply to non-object exports in CommonJS modules (invoking exported functions, and then awaiting exports promises).

Instead, this change adds support for default exports, treating the default export (if present) as the full returned export value.

It is for now an error to have both a default export and named exports, since it is unclear what this should mean.  In the future, we could potentially relax this and define how these two sets of exports are merged.

This is technically a breaking change from the support added in the recent releases, but only in a narrow case, and in that case the Pulumi stack exports were almost certainly not what the user wanted.

Fixes #8725, which includes a motivating example where this is ~necessary.
