### PR TITLE
Change Output<T>.ToString() to return a message

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,4 +1,7 @@
 ### Improvements
 
+- [sdk/dotnet] - Changed `Output<T>.ToString()` to return an informative message rather than just "Output`1[X]"
+  [#8767](https://github.com/pulumi/pulumi/pull/8767)
+
 ### Bug Fixes
 

--- a/sdk/dotnet/Pulumi/Core/Output.cs
+++ b/sdk/dotnet/Pulumi/Core/Output.cs
@@ -341,5 +341,21 @@ namespace Pulumi
 
         private static Task<OutputData<T>> UnknownHelperAsync(T value)
             => Task.FromResult(new OutputData<T>(ImmutableHashSet<Resource>.Empty, value, isKnown: false, isSecret: false));
+
+        public override string ToString()
+        {
+            var message = string.Join(Environment.NewLine, new string[] {
+                "Calling [ToString] on an [Output<T>] is not supported.",
+                "",
+                "To get the value of an Output<T> as an Output<string> consider:",
+                "1. o.Apply(v => $\"prefix{v}suffix\")",
+                "2. Output.Format($\"prefix{hostname}suffix\");",
+                "",
+                "See https://pulumi.io/help/outputs for more details.",
+                "This function may throw in a future version of Pulumi.",
+            });
+
+            return message;
+        }
     }
 }

--- a/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
+++ b/sdk/dotnet/Pulumi/PublicAPI.Shipped.txt
@@ -143,6 +143,7 @@ Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Input<U>> func) -> Pulumi.Output
 Pulumi.Output<T>.Apply<U>(System.Func<T, Pulumi.Output<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, System.Threading.Tasks.Task<U>> func) -> Pulumi.Output<U>
 Pulumi.Output<T>.Apply<U>(System.Func<T, U> func) -> Pulumi.Output<U>
+override Pulumi.Output<T>.ToString() -> string
 Pulumi.OutputAttribute
 Pulumi.OutputAttribute.Name.get -> string
 Pulumi.OutputAttribute.OutputAttribute(string name = null) -> void


### PR DESCRIPTION
# Description

Fixes #4824

Changes `Output<T>.ToString()` to return an informative message similar to what we return for `toString` in the node sdk.

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
