### PR TITLE
[sdk/dotnet] Fix test by ensuring both sides of test strings trimmed

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
@@ -38,13 +38,14 @@ namespace Pulumi.Automation.Tests
             Assert.Matches(@"^(warning: A new version of Pulumi[^\n]+\n)?",
                            result.StandardError);
 
-            Assert.Equal(Lines(result.StandardOutput), stdoutLines);
-            Assert.Equal(Lines(result.StandardError), stderrLines);
+            Assert.Equal(Lines(result.StandardOutput), stdoutLines.Select(x => x.Trim()));
+            Assert.Equal(Lines(result.StandardError), stderrLines.Select(x => x.Trim()));
         }
 
         private IEnumerable<string> Lines(string s) {
             return s.Split(Environment.NewLine,
-                           StringSplitOptions.RemoveEmptyEntries);
+                           StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim());
         }
     }
 }

--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
@@ -35,7 +35,7 @@ namespace Pulumi.Automation.Tests
             Assert.Equal(0, result.Code);
 
             Assert.Matches(@"^v?\d+\.\d+\.\d+", result.StandardOutput);
-            Assert.Matches(@"^(warning: A new version of Pulumi[^\n]+\n)?$",
+            Assert.Matches(@"^(warning: A new version of Pulumi[^\n]+\n)?",
                            result.StandardError);
 
             Assert.Equal(Lines(result.StandardOutput), stdoutLines);
@@ -44,8 +44,7 @@ namespace Pulumi.Automation.Tests
 
         private IEnumerable<string> Lines(string s) {
             return s.Split(Environment.NewLine,
-                           StringSplitOptions.RemoveEmptyEntries)
-                .Select(x => x.Trim());
+                           StringSplitOptions.RemoveEmptyEntries);
         }
     }
 }


### PR DESCRIPTION
Regarding:
- #8751

This code appears to hit an issue on Windows where the expected & actual values in the assertion are trimmed differently. That PR fixed the issue by not trimming the left hand side on Linux, but on Windows, a trailing `\n` is found in the expected value:

```
Expected: String[] ["v3.23.0-alpha.1642436772\n"]
Actual:   List<String> ["v3.23.0-alpha.1642436772"]
```

The types are, I believe, not relevant for the assertion though the `\n` at the end is.

This test will ensure that both sides are an IEnumerable<String> and are trimmed before asserting on. There is some underlying behavior here, likely related to Windows using CRLF line termination, which isn't relevant to the test at hand.