### PR TITLE
[sdk/nodejs] Ensure deps installed before lint, tsc

### DIFF
--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -17,10 +17,13 @@ include ../../build/common.mk
 
 export PATH:=$(shell yarn bin 2>/dev/null):$(PATH)
 
-lint::
+ensure::
+	yarn
+
+lint:: ensure
 	yarn run eslint -c .eslintrc.js --ext .ts .
 
-build_package::
+build_package:: ensure
 	yarn run tsc
 	cp tests/runtime/jsClosureCases_8.js bin/tests/runtime
 	cp tests/runtime/jsClosureCases_10_4.js bin/tests/runtime


### PR DESCRIPTION
On first run of the makefile here, if a user doesn't have `eslint` or
`typescript` globally installed, `yarn run` won't succeed. If they do
have those dependencies globally, it'll use their locally installed
version, which is not the desired behavior.

This ensures `yarn` is run once before `lint` and `build_package`
targets, and since `build_package` is a dependency for all future
targets that use `yarn run` it covers the remainder of the cases.

Recreating #8750 with a branch on upstream vs fork to run tests.