### PR TITLE
Revert "[sdk/dotnet] Fix test by ensuring both sides of test strings trimmed"

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
@@ -38,8 +38,8 @@ namespace Pulumi.Automation.Tests
             Assert.Matches(@"^(warning: A new version of Pulumi[^\n]+\n)?",
                            result.StandardError);
 
-            Assert.Equal(Lines(result.StandardOutput), stdoutLines.Select(x => x.Trim()));
-            Assert.Equal(Lines(result.StandardError), stderrLines.Select(x => x.Trim()));
+            Assert.Equal(Lines(result.StandardOutput), stdoutLines);
+            Assert.Equal(Lines(result.StandardError), stderrLines);
         }
 
         private IEnumerable<string> Lines(string s) {


### PR DESCRIPTION
Reverts pulumi/pulumi#8771

Per @t0yv0 who observed we're still getting inconsistency in test results & an acceptance test failure on Windows even with this change. Will debug from a Windows dotnet build soon.