### PR TITLE
Revert "[sdk/dotnet] Fix failing test (#8751)"

### DIFF
--- a/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
+++ b/sdk/dotnet/Pulumi.Automation.Tests/LocalPulumiCmdTests.cs
@@ -35,7 +35,7 @@ namespace Pulumi.Automation.Tests
             Assert.Equal(0, result.Code);
 
             Assert.Matches(@"^v?\d+\.\d+\.\d+", result.StandardOutput);
-            Assert.Matches(@"^(warning: A new version of Pulumi[^\n]+\n)?",
+            Assert.Matches(@"^(warning: A new version of Pulumi[^\n]+\n)?$",
                            result.StandardError);
 
             Assert.Equal(Lines(result.StandardOutput), stdoutLines);
@@ -44,7 +44,8 @@ namespace Pulumi.Automation.Tests
 
         private IEnumerable<string> Lines(string s) {
             return s.Split(Environment.NewLine,
-                           StringSplitOptions.RemoveEmptyEntries);
+                           StringSplitOptions.RemoveEmptyEntries)
+                .Select(x => x.Trim());
         }
     }
 }


### PR DESCRIPTION
This reverts commit dc30b7e426d361fd68c2166787a37af3e5db7b22.

Fully reverts #8778 - the revert produced by GitHub returned the upstream branch to an intermediate commit because the file was changed via two PRs, not just one.

This restores the file to the last version prior to me making any changes to the test file: 3530ba3205a97193f0a773635371d5ef4d548237.