### PR TITLE
Reduce windows PR testing

### DIFF
--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -62,11 +62,14 @@ jobs:
           - etc
         exclude:
           - platform: macos-latest
-        # Only run catch-all `etc` test-subset on Mac for PR
+          - platform: windows-latest
+        # Only run catch-all `etc` test-subset on Mac/Win for PR
         # verification because of a throughput bottleneck on Mac
-        # runners.
+        # runners, and slowdown on Windows test runners.
         include:
           - platform: macos-latest
+            test-subset: etc
+          - platform: windows-latest
             test-subset: etc
       fail-fast: false
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Just as we do already for the Mac OS testing, this PR reduces the scope of PR testing to exclude most integration tests on Windows, leaving only the fall-through `etc` test subset. The reason to do this is that we are losing a lot of builds to Windows OOM issues that are making builds flaky and are not related to regressions. If there are Windows specific regressions introduced on PRs that are caught by these tests, they will be caught once master.yml workflow runs and breaks, and we will have to back out the PR. This is inconvenient but optimizes for the common case - PRs that do not break on windows will go in faster.


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
