### PR TITLE
[CLI] Allow downloading plugins from GitHub Releases

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,8 @@
 ### Improvements
 
+- [cli] Download provider plugins from GitHub Releases
+  [#8785](https://github.com/pulumi/pulumi/pull/8785)
+
 - [sdk/dotnet] - Changed `Output<T>.ToString()` to return an informative message rather than just "Output`1[X]"
   [#8767](https://github.com/pulumi/pulumi/pull/8767)
 

--- a/sdk/go/common/workspace/plugins_test.go
+++ b/sdk/go/common/workspace/plugins_test.go
@@ -235,6 +235,49 @@ func TestPluginSelection_EmptyVersionWithAlternatives(t *testing.T) {
 	assert.Equal(t, "0.2.0", result.Version.String())
 }
 
+func TestPluginDownloadUrl(t *testing.T) {
+	t.Run("Test Downloading From GitHub Releases", func(t *testing.T) {
+		version := semver.MustParse("4.32.0")
+		info := PluginInfo{
+			PluginDownloadURL: "",
+			Name:              "aws",
+			Version:           &version,
+			Kind:              PluginKind("resource"),
+		}
+		serverURL := buildGitHubReleasesPluginURL(info.Kind, info.Name, info.Version, "darwin", "amd64")
+		assert.Equal(t,
+			"https://github.com/pulumi/pulumi-aws/releases/download/v4.32.0/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
+			serverURL)
+	})
+	t.Run("Test Downloading From get.pulumi.com", func(t *testing.T) {
+		version := semver.MustParse("4.32.0")
+		info := PluginInfo{
+			PluginDownloadURL: "",
+			Name:              "aws",
+			Version:           &version,
+			Kind:              PluginKind("resource"),
+		}
+		serverURL := buildPulumiHostedPluginURL(info.Kind, info.Name, info.Version, "darwin", "amd64")
+		assert.Equal(t,
+			"https://get.pulumi.com/releases/plugins/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz", serverURL)
+	})
+	t.Run("Test Downloading From Custom Server URL", func(t *testing.T) {
+		version := semver.MustParse("4.32.0")
+		info := PluginInfo{
+			PluginDownloadURL: "https://customurl.jfrog.io/artifactory/pulumi-packages/package-name",
+			Name:              "aws",
+			Version:           &version,
+			Kind:              PluginKind("resource"),
+		}
+		serverURL := buildUserSpecifiedPluginURL(info.PluginDownloadURL, info.Kind, info.Name, info.Version,
+			"darwin", "amd64")
+		assert.Equal(t,
+			"https://customurl.jfrog.io/artifactory/pulumi-packages/package-name"+
+				"/pulumi-resource-aws-v4.32.0-darwin-amd64.tar.gz",
+			serverURL)
+	})
+}
+
 func TestInterpolateURL(t *testing.T) {
 	version := semver.MustParse("1.0.0")
 	const os = "linux"


### PR DESCRIPTION
Rather than downloading from get.pulumi.com, we now have changed to
specify that providers are downloaded from GitHub Releases for
all of the official plugins

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
