### PR TITLE
Introduce timeout to commands run during testing

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -142,7 +142,7 @@ jobs:
   test:
     name: Test
     needs: build
-    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    uses: pulumi/pulumi/.github/workflows/test.yml@master
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       enable-coverage: true

--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -55,8 +55,8 @@ func RunCommand(t *testing.T, name string, args []string, wd string, opts *Progr
 		cmd.Stdout = opts.Stdout
 		cmd.Stderr = opts.Stderr
 	} else {
-		opts.Stdout = &runoutBuffer
-		opts.Stderr = &runoutBuffer
+		cmd.Stdout = &runoutBuffer
+		cmd.Stderr = &runoutBuffer
 	}
 
 	startTime := time.Now()

--- a/pkg/testing/integration/command.go
+++ b/pkg/testing/integration/command.go
@@ -46,7 +46,7 @@ func RunCommand(t *testing.T, name string, args []string, wd string, opts *Progr
 	env = append(env, "PULUMI_RETAIN_CHECKPOINTS=true")
 	env = append(env, "PULUMI_CONFIG_PASSPHRASE=correct horse battery staple")
 
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //nolint: gosec
 	cmd.Dir = wd
 	cmd.Env = env
 


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

The changes will kill the sub-process and fail with timeout after (currently hardcoded) 5 min.

Driven by https://github.com/pulumi/pulumi/runs/4881353869?check_suite_focus=true timing out after 1h on `pulumi login`.

Timeout value might need tuning.

But there is hope this can increase resiliency of the test runs.

Unfortunately killing the sub-process may still leave sub-sub-processes running as orphans and consuming memory.


Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
