### PR TITLE
Use Go build cache in tests

### DIFF
--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -106,7 +106,7 @@ jobs:
           path: |
               ${{ steps.go-cache-paths.outputs.go-build }}
               ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ matrix.platform }}-go-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ matrix.platform }}-${{ matrix.test-subset }}-go-test-cache-${{ hashFiles('**/go.sum') }}
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -95,6 +95,18 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.go-version }}
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - name: Go Cache
+        uses: actions/cache@v2
+        id: go-cache
+        with:
+          path: |
+              ${{ steps.go-cache-paths.outputs.go-build }}
+              ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ matrix.platform }}-go-cache-${{ hashFiles('**/go.sum') }}
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
           path: |
               ${{ steps.go-cache-paths.outputs.go-build }}
               ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ matrix.platform }}-go-cache-${{ hashFiles('**/go.sum') }}
+          key: ${{ matrix.platform }}-${{ matrix.test-subset }}-go-test-cache-${{ hashFiles('**/go.sum') }}
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,18 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: ${{ inputs.go-version }}
+      - id: go-cache-paths
+        run: |
+          echo "::set-output name=go-build::$(go env GOCACHE)"
+          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+      - name: Go Cache
+        uses: actions/cache@v2
+        id: go-cache
+        with:
+          path: |
+              ${{ steps.go-cache-paths.outputs.go-build }}
+              ${{ steps.go-cache-paths.outputs.go-mod }}
+          key: ${{ matrix.platform }}-go-cache-${{ hashFiles('**/go.sum') }}
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Copying Go cache setup from build.yml to test.yml, since test.yml rebuilds the tests it seems like it will benefit.

Minor issue: matrix.platform != matrix.os so it won't be the same exact cache key as in build.yml.

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
