### PR TITLE
automation (python): Write canonical yamls to force quotes for strings

### DIFF
--- a/sdk/python/lib/pulumi/automation/_local_workspace.py
+++ b/sdk/python/lib/pulumi/automation/_local_workspace.py
@@ -133,7 +133,7 @@ class LocalWorkspace(Workspace):
             if found_ext == ".json":
                 json.dump(writable_settings, file, indent=4)
             else:
-                yaml.dump(writable_settings, stream=file)
+                yaml.dump(writable_settings, stream=file, canonical=True)
 
     def stack_settings(self, stack_name: str) -> StackSettings:
         stack_settings_name = get_stack_settings_name(stack_name)
@@ -159,7 +159,7 @@ class LocalWorkspace(Workspace):
             if found_ext == ".json":
                 json.dump(settings._serialize(), file, indent=4)
             else:
-                yaml.dump(settings._serialize(), stream=file)
+                yaml.dump(settings._serialize(), stream=file, canonical=True)
 
     def serialize_args_for_op(self, stack_name: str) -> List[str]:
         # Not used by LocalWorkspace


### PR DESCRIPTION
https://github.com/pulumi/pulumi/issues/8776

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->
automation (python): write canonical yamls to force quotes for strings
Fixes #8776 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
If you can suggest a way to write a meaningful test combining automation and cli, I will try to add it.
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
