### PR TITLE
Make PackageName just a QName

### DIFF
--- a/sdk/go/common/tokens/names.go
+++ b/sdk/go/common/tokens/names.go
@@ -124,20 +124,10 @@ func (nm QName) Namespace() QName {
 	return QName(qn)
 }
 
-// PackageName is a qualified name referring to an imported package.  It is similar to a QName, except that it permits
-// dashes "-" as is commonplace with packages of various kinds.
-type PackageName string
+// PackageName is a qualified name referring to an imported package.
+type PackageName QName
 
 func (nm PackageName) String() string { return string(nm) }
-
-var PackageNameRegexp = regexp.MustCompile(PackageNameRegexpPattern)
-var PackagePartRegexpPattern = "[A-Za-z_.][A-Za-z0-9_.-]*"
-var PackageNameRegexpPattern = "(" + PackagePartRegexpPattern + "\\" + QNameDelimiter + ")*" + PackagePartRegexpPattern
-
-// IsPackageName checks whether a string is a legal Name.
-func IsPackageName(s string) bool {
-	return s != "" && PackageNameRegexp.FindString(s) == s
-}
 
 // ModuleName is a qualified name referring to an imported module from a package.
 type ModuleName QName

--- a/sdk/go/common/tokens/names_test.go
+++ b/sdk/go/common/tokens/names_test.go
@@ -86,7 +86,7 @@ func TestIntoQName(t *testing.T) {
 		{"foo/bar", "foo/bar"},
 		{input: "https:", expected: "https_"},
 		{"https://github.com/pulumi/pulumi/blob/master/pkg/resource/deploy/providers/provider.go#L61-L86",
-			"https_/github.com/pulumi/pulumi/blob/master/pkg/resource/deploy/providers/provider.go_L61_L86"},
+			"https_/github.com/pulumi/pulumi/blob/master/pkg/resource/deploy/providers/provider.go_L61-L86"},
 		{"", "_"},
 		{"///", "_"},
 	}

--- a/sdk/go/common/tokens/tokens.go
+++ b/sdk/go/common/tokens/tokens.go
@@ -131,7 +131,7 @@ func (tok Token) ModuleMember() ModuleMember {
 type Package Token
 
 func NewPackageToken(nm PackageName) Package {
-	contract.Assertf(IsPackageName(string(nm)), "Package name '%v' is not a legal qualified name", nm)
+	contract.Assertf(IsQName(string(nm)), "Package name '%v' is not a legal qualified name", nm)
 	return Package(nm)
 }
 

--- a/sdk/go/common/tokens/tokens_test.go
+++ b/sdk/go/common/tokens/tokens_test.go
@@ -26,13 +26,13 @@ func TestTokens(t *testing.T) {
 	// Package tokens/names.
 	p := "test/package"
 	assert.False(t, IsName(p))
-	assert.True(t, IsPackageName(p))
+	assert.True(t, IsQName(p))
 	pkg := NewPackageToken(PackageName(p))
 	assert.Equal(t, p, pkg.Name().String())
 	assert.Equal(t, p, pkg.String())
 	p2 := "test/my-package"
 	assert.False(t, IsName(p2))
-	assert.True(t, IsPackageName(p2))
+	assert.True(t, IsQName(p2))
 	pkg2 := NewPackageToken(PackageName(p2))
 	assert.Equal(t, p2, pkg2.Name().String())
 	assert.Equal(t, p2, pkg2.String())


### PR DESCRIPTION
Since https://github.com/pulumi/pulumi/pull/8695 Name and thus QName has
allowed hyphens, making PackageName just the same as a QName now.