### PR TITLE
Don't allow protected resources to be replaced

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -25,3 +25,6 @@
 - [codegen/nodejs] - Generate an install script that runs `pulumi plugin install` with
   the `--server` flag when necessary.
   [#8730](https://github.com/pulumi/pulumi/pull/8730)
+
+- [cli] The engine will no longer try to replace resources that are protected as that entails a delete.
+  [#8810](https://github.com/pulumi/pulumi/pull/8810)

--- a/pkg/engine/lifeycletest/pulumi_test.go
+++ b/pkg/engine/lifeycletest/pulumi_test.go
@@ -2950,7 +2950,8 @@ func TestProtect(t *testing.T) {
 	// Run a new update which will cause a delete, we still shouldn't see a provider delete
 	expectedMessage = "<{%reset%}>unable to delete resource \"urn:pulumi:test::test::pkgA:m:typA::resA\"\n" +
 		"as it is currently marked for protection. To unprotect the resource, either remove the `protect` flag " +
-		"from the resource in your Pulumiprogram and run `pulumi up` or use the command:\n`pulumi state unprotect 'urn:pulumi:test::test::pkgA:m:typA::resA'`<{%reset%}>\n"
+		"from the resource in your Pulumiprogram and run `pulumi up` or use the command:\n" +
+		"`pulumi state unprotect 'urn:pulumi:test::test::pkgA:m:typA::resA'`<{%reset%}>\n"
 	createResource = false
 	snap, res = TestOp(Update).Run(project, p.GetTarget(t, snap), p.Options, false, p.BackendClient, validate)
 	assert.NotNil(t, res)

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -605,10 +605,13 @@ func (sg *stepGenerator) generateStepsFromDiff(
 			// Note that we do allow unprotecting and replacing to happen in a single update
 			// cycle, we don't look at old.Protect here.
 			if goal.Protect {
-				return nil, result.Errorf("unable to replace resource %q\n"+
+				message := fmt.Sprintf("unable to replace resource %q\n"+
 					"as it is currently marked for protection. To unprotect the resource, "+
 					"remove the `protect` flag from the resource in your Pulumi "+
 					"program and run `pulumi up`", urn)
+				sg.deployment.ctx.Diag.Errorf(diag.StreamMessage(urn, message, 0))
+				sg.sawError = true
+				return nil, result.Bail()
 			}
 
 			// If the goal state specified an ID, issue an error: the replacement will change the ID, and is

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -607,7 +607,7 @@ func (sg *stepGenerator) generateStepsFromDiff(
 			if goal.Protect {
 				return nil, result.Errorf("unable to replace resource %q\n"+
 					"as it is currently marked for protection. To unprotect the resource, "+
-					"remove the `protect` flag from the resource in your Pulumi"+
+					"remove the `protect` flag from the resource in your Pulumi "+
 					"program and run `pulumi up`", urn)
 			}
 

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -601,6 +601,16 @@ func (sg *stepGenerator) generateStepsFromDiff(
 	// If there were changes check for a replacement vs. an in-place update.
 	if diff.Changes == plugin.DiffSome {
 		if diff.Replace() {
+			// If this resource is protected we can't replace it because that entails a delete
+			// Note that we do allow unprotecting and replacing to happen in a single update
+			// cycle, we don't look at old.Protect here.
+			if goal.Protect {
+				return nil, result.Errorf("unable to replace resource %q\n"+
+					"as it is currently marked for protection. To unprotect the resource, "+
+					"either remove the `protect` flag from the resource in your Pulumi"+
+					"program and run `pulumi up`", urn)
+			}
+
 			// If the goal state specified an ID, issue an error: the replacement will change the ID, and is
 			// therefore incompatible with the goal state.
 			if goal.ID != "" {

--- a/pkg/resource/deploy/step_generator.go
+++ b/pkg/resource/deploy/step_generator.go
@@ -607,7 +607,7 @@ func (sg *stepGenerator) generateStepsFromDiff(
 			if goal.Protect {
 				return nil, result.Errorf("unable to replace resource %q\n"+
 					"as it is currently marked for protection. To unprotect the resource, "+
-					"either remove the `protect` flag from the resource in your Pulumi"+
+					"remove the `protect` flag from the resource in your Pulumi"+
 					"program and run `pulumi up`", urn)
 			}
 


### PR DESCRIPTION
# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

If a resource is protected we will no longer try to create a replacement for it. Previously the engine would of tried to create the replacement then issued a delete for the protected resource and then error out, that to-be-deleted-but-protected resource would then be left in the stack state and cause every `up` afterwards to also error.

Related to https://github.com/pulumi/pulumi/issues/5749

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [x] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [x] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
