### PR TITLE
Revert "Lower test parallelism for Windows testing"

### DIFF
--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -76,10 +76,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - name: Reduce TESTPARALLELISM on Windows to work around OOM
-        if: ${{ matrix.platform == 'windows-latest' }}
-        run: |
-          echo "TESTPARALLELISM=1" >> $GITHUB_ENV
       - name: Set PULUMI_TEST_SUBSET env var
         run: |
           echo "PULUMI_TEST_SUBSET=${{ matrix.test-subset }}" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,10 +62,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - name: Reduce TESTPARALLELISM on Windows to work around OOM
-        if: ${{ matrix.platform == 'windows-latest' }}
-        run: |
-          echo "TESTPARALLELISM=1" >> $GITHUB_ENV
       - name: Set PULUMI_TEST_SUBSET env var
         run: |
           echo "PULUMI_TEST_SUBSET=${{ matrix.test-subset }}" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PROJECT_PKGS    := $(shell cd ./pkg && go list ./... | grep -v /vendor/)
 TESTS_PKGS      := $(shell cd ./tests && go list -tags all ./... | grep -v tests/templates | grep -v /vendor/)
 VERSION         := $(shell pulumictl get version)
 
-TESTPARALLELISM ?= 10
+TESTPARALLELISM := 10
 
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running
 # `test_all` without the dependencies.

--- a/sdk/dotnet/Makefile
+++ b/sdk/dotnet/Makefile
@@ -6,7 +6,7 @@ PROJECT_ROOT    := $(realpath ../..)
 
 DOTNET_VERSION  := $(shell cd ../../ && pulumictl get version --language dotnet)
 
-TESTPARALLELISM ?= 10
+TESTPARALLELISM := 10
 
 include ../../build/common.mk
 

--- a/sdk/go/Makefile
+++ b/sdk/go/Makefile
@@ -3,7 +3,7 @@ LANGHOST_PKG     := github.com/pulumi/pulumi/sdk/v3/go/pulumi-language-go
 VERSION          := $(shell cd ../../ && pulumictl get version)
 TEST_FAST_PKGS   := $(shell go list ./pulumi/... ./pulumi-language-go/... ./common/... | grep -v /vendor/ | grep -v templates)
 TEST_AUTO_PKGS   := $(shell go list ./auto/... | grep -v /vendor/ | grep -v templates)
-TESTPARALLELISM  ?= 10
+TESTPARALLELISM  := 10
 PROJECT_ROOT     := $(realpath ../..)
 
 include ../../build/common.mk

--- a/sdk/nodejs/Makefile
+++ b/sdk/nodejs/Makefile
@@ -6,7 +6,7 @@ LANGUAGE_HOST    := github.com/pulumi/pulumi/sdk/v3/nodejs/cmd/pulumi-language-n
 PROJECT_ROOT     := $(realpath ../..)
 
 PROJECT_PKGS    := $(shell go list ./cmd...)
-TESTPARALLELISM ?= 10
+TESTPARALLELISM := 10
 TEST_FAST_TIMEOUT := 2m
 
 # Motivation: running `make TEST_ALL_DEPS= test_all` permits running

--- a/sdk/python/Makefile
+++ b/sdk/python/Makefile
@@ -8,7 +8,7 @@ PYENV := ./env
 PYENVSRC := $(PYENV)/src
 
 PROJECT_PKGS    := $(shell go list ./cmd/...)
-TESTPARALLELISM ?= 10
+TESTPARALLELISM := 10
 
 include ../../build/common.mk
 


### PR DESCRIPTION
Reverts pulumi/pulumi#8755

Backing this out as it did not help our core problem of lost builds.