### PR TITLE
Link to the install page from the Node.js README

### DIFF
--- a/sdk/nodejs/README.md
+++ b/sdk/nodejs/README.md
@@ -17,7 +17,7 @@ $ yarn add @pulumi/pulumi
 ```
 
 This SDK is meant for use with the Pulumi CLI.  Please visit
-[pulumi.com](https://pulumi.com) for installation instructions.
+[pulumi.com](https://www.pulumi.com/docs/get-started/install/) for installation instructions.
 
 ## Building and Testing
 


### PR DESCRIPTION
Minor tweak that points users to the install page, since the homepage no longer has a download link.

Fixes https://github.com/pulumi/pulumi-hugo/issues/958.