### PR TITLE
Recreate broken programgen tests

### DIFF
--- a/pkg/codegen/internal/test/testdata/aws-native-pseudo-params-pp/aws-native-pseudo-params.pp
+++ b/pkg/codegen/internal/test/testdata/aws-native-pseudo-params-pp/aws-native-pseudo-params.pp
@@ -1,0 +1,57 @@
+awsPartition = invoke("aws-native::getPartition").partition
+
+config trailName string {
+}
+
+config bucketName string {
+}
+
+isOrganizationsSupported = awsPartition == "aws"
+
+resource trail "aws-native:cloudtrail:Trail" {
+	s3BucketName = bucketName
+	s3KeyPrefix = "Uluru"
+	isLogging = true
+	trailName = trailName
+	enableLogFileValidation = true
+	includeGlobalServiceEvents = true
+	isMultiRegionTrail = true
+	cloudWatchLogsLogGroupArn = invoke("aws-native::importValue", {
+		name = "TrailLogGroupTestArn"
+	}).value
+	cloudWatchLogsRoleArn = invoke("aws-native::importValue", {
+		name = "TrailLogGroupRoleTestArn"
+	}).value
+	kmsKeyId = invoke("aws-native::importValue", {
+		name = "TrailKeyTest"
+	}).value
+	tags = [
+		{
+			key = "TagKeyIntTest",
+			value = "TagValueIntTest"
+		},
+		{
+			key = "TagKeyIntTest2",
+			value = "TagValueIntTest2"
+		}
+	]
+	snsTopicName = invoke("aws-native::importValue", {
+		name = "TrailTopicTest"
+	}).value
+	eventSelectors = [{
+		dataResources = [{
+			type = "AWS::S3::Object",
+			values = ["arn:${awsPartition}:s3:::"]
+		}],
+		includeManagementEvents = true,
+		readWriteType = "All"
+	}]
+}
+
+output arn {
+	value = trail.arn
+}
+
+output topicArn {
+	value = trail.snsTopicArn
+}

--- a/pkg/codegen/pcl/invoke.go
+++ b/pkg/codegen/pcl/invoke.go
@@ -80,10 +80,11 @@ func (b *binder) bindInvokeSignature(args []model.Expression) (model.StaticFunct
 		return b.zeroSignature(), hcl.Diagnostics{unknownFunction(token, tokenRange)}
 	}
 
-	if len(args) < 2 {
-		return b.zeroSignature(), hcl.Diagnostics{errorf(tokenRange, "missing second arg")}
+	var fnArgs model.Expression
+	if len(args) > 1 {
+		fnArgs = args[1]
 	}
-	sig, err := b.signatureForArgs(fn, args[1])
+	sig, err := b.signatureForArgs(fn, fnArgs)
 	if err != nil {
 		diag := hcl.Diagnostics{errorf(tokenRange, "Invoke binding error: %v", err)}
 		return b.zeroSignature(), diag


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

Follow-on to #8805 where an aws-native example program causes issues when running progamgen

Also related to #8775 

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
