### PR TITLE
ci: Run windows platform tests if and only if workflow run with windows-ci: true

### DIFF
--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -35,6 +35,13 @@ on:
         default: false
         required: false
         type: boolean
+      # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
+      # resolved: https://github.com/pulumi/pulumi/issues/8820
+      windows-ci:
+        description: 'If set, tests only run on Windows CI'
+        default: false
+        required: false
+        type: boolean
     secrets:
       pulumi-access-token:
         required: true
@@ -74,6 +81,12 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.platform }}
+
+    # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
+    # resolved: https://github.com/pulumi/pulumi/issues/8820
+    # If windows-ci == false, then the platform must not contain "windows"
+    # If windows-ci == true, then the platform must contain "windows"
+    if: ${{ inputs.windows-ci }} == ( contains( ${{ matrix.platform }}, "windows" ) )
 
     steps:
       - name: Checkout Repo

--- a/.github/workflows/test-windows-ci.yml
+++ b/.github/workflows/test-windows-ci.yml
@@ -1,0 +1,17 @@
+name: Daily Windows CI tests
+
+on:
+  schedule:
+  - cron: '0 0 * * *'
+
+jobs:
+  test:
+    name: Test
+    uses: pulumi/pulumi/.github/workflows/test.yml@master
+    with:
+      enable-coverage: true
+      # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
+      # resolved: https://github.com/pulumi/pulumi/issues/8820
+      windows-ci: true
+    secrets:
+      pulumi-access-token: ${{ secrets.PULUMI_PROD_ACCESS_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,13 @@ on:
         default: false
         required: false
         type: boolean
+      # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
+      # resolved: https://github.com/pulumi/pulumi/issues/8820
+      windows-ci:
+        description: 'If set, tests only run on Windows CI. If not set, Windows tests are not run.'
+        default: false
+        required: false
+        type: boolean
     secrets:
       pulumi-access-token:
         required: true
@@ -60,6 +67,12 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.platform }}
+
+    # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
+    # resolved: https://github.com/pulumi/pulumi/issues/8820
+    # If windows-ci == false, then the platform must not contain "windows"
+    # If windows-ci == true, then the platform must contain "windows"
+    if: ${{ inputs.windows-ci }} == ( contains( ${{ matrix.platform }}, "windows" ) )
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
The `if` condition added in `test` and `test-fast`, along with the additional input, should enable Mac & Linux tests to proceed and Windows tests will be filtered out.

A scheduled job is added which runs _just_ the Windows tests, using the full test suite.

Related:

- #8820

Closes: #8824

