### PR TITLE
added rate-limit response handling

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -23,6 +23,9 @@
 - [sdk/nodejs] - Support top-level default exports in ESM.
   [#8766](https://github.com/pulumi/pulumi/pull/8766)
 
+- [cli] Add better error message for pulumi service rate limit responses
+  [#7963](https://github.com/pulumi/pulumi/issues/7963)
+
 ### Bug Fixes
 
 - [sdk/python] - Prevent `ResourceOptions.merge` from promoting between the

--- a/pkg/backend/httpstate/client/client_test.go
+++ b/pkg/backend/httpstate/client/client_test.go
@@ -1,0 +1,78 @@
+// Copyright 2016-2021, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newMockServer(statusCode int, message string) *httptest.Server {
+	return httptest.NewServer(
+		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			rw.WriteHeader(statusCode)
+			_, err := rw.Write([]byte(message))
+			if err != nil {
+				return
+			}
+		}))
+}
+
+func newMockClient(server *httptest.Server) *Client {
+	return &Client{
+		apiURL:   server.URL,
+		apiToken: "",
+		apiUser:  "",
+		diag:     nil,
+	}
+}
+
+func TestAPIErrorResponses(t *testing.T) {
+	t.Run("TestAuthError", func(t *testing.T) {
+		// check 401 error is handled
+		unauthorizedServer := newMockServer(401, "401: Unauthorized")
+		defer unauthorizedServer.Close()
+
+		unauthorizedClient := newMockClient(unauthorizedServer)
+		_, _, unauthorizedErr := unauthorizedClient.GetCLIVersionInfo(context.Background())
+
+		assert.Error(t, unauthorizedErr)
+		assert.Equal(t, unauthorizedErr.Error(), "this command requires logging in; try running 'pulumi login' first")
+	})
+	t.Run("TestRateLimitError", func(t *testing.T) {
+		// test handling 429: Too Many Requests/rate-limit response
+		rateLimitedServer := newMockServer(429, "rate-limit error")
+		defer rateLimitedServer.Close()
+
+		rateLimitedClient := newMockClient(rateLimitedServer)
+		_, _, rateLimitErr := rateLimitedClient.GetCLIVersionInfo(context.Background())
+
+		assert.Error(t, rateLimitErr)
+		assert.Equal(t, rateLimitErr.Error(), "pulumi service: request rate-limit exceeded")
+	})
+	t.Run("TestDefaultError", func(t *testing.T) {
+		// test handling non-standard error message
+		defaultErrorServer := newMockServer(418, "I'm a teapot")
+		defer defaultErrorServer.Close()
+
+		defaultErrorClient := newMockClient(defaultErrorServer)
+		_, _, defaultErrorErr := defaultErrorClient.GetCLIVersionInfo(context.Background())
+
+		assert.Error(t, defaultErrorErr)
+	})
+}


### PR DESCRIPTION
<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description
Added handler for 429 rate limit response from pulumi service.
<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)
https://github.com/pulumi/pulumi/issues/7963
## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
