### PR TITLE
Fix new lint errors

### DIFF
--- a/pkg/cmd/pulumi/gen_completion.go
+++ b/pkg/cmd/pulumi/gen_completion.go
@@ -190,7 +190,7 @@ func genZshCompletion(out io.Writer, root *cobra.Command) error {
 		return err
 	}
 
-	if _, err := fmt.Fprint(out, zshHead); err != nil {
+	if _, err := fmt.Fprint(out, zshHead); err != nil { //nolint
 		return err
 	}
 

--- a/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
+++ b/sdk/dotnet/cmd/pulumi-language-dotnet/main.go
@@ -261,7 +261,7 @@ func (host *dotnetLanguageHost) DeterminePossiblePulumiPackages(
 
 	if !sawPulumi && len(packages) == 0 {
 		return nil, errors.Errorf(
-			"Unexpected output from 'dotnet %v'. Program does not appear to reference any 'Pulumi.*' packages.",
+			"unexpected output from 'dotnet %v'. Program does not appear to reference any 'Pulumi.*' packages",
 			commandStr)
 	}
 

--- a/sdk/go/auto/local_workspace.go
+++ b/sdk/go/auto/local_workspace.go
@@ -423,13 +423,13 @@ func (l *LocalWorkspace) ExportStack(ctx context.Context, stackName string) (api
 
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "export", "--show-secrets", "--stack", stackName)
 	if err != nil {
-		return state, newAutoError(errors.Wrap(err, "could not export stack."), stdout, stderr, errCode)
+		return state, newAutoError(errors.Wrap(err, "could not export stack"), stdout, stderr, errCode)
 	}
 
 	err = json.Unmarshal([]byte(stdout), &state)
 	if err != nil {
 		return state, newAutoError(
-			errors.Wrap(err, "failed to export stack, unable to unmarshall stack state."), stdout, stderr, errCode,
+			errors.Wrap(err, "failed to export stack, unable to unmarshall stack state"), stdout, stderr, errCode,
 		)
 	}
 
@@ -441,23 +441,23 @@ func (l *LocalWorkspace) ExportStack(ctx context.Context, stackName string) (api
 func (l *LocalWorkspace) ImportStack(ctx context.Context, stackName string, state apitype.UntypedDeployment) error {
 	f, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
-		return errors.Wrap(err, "could not import stack. failed to allocate temp file.")
+		return errors.Wrap(err, "could not import stack. failed to allocate temp file")
 	}
 	defer func() { contract.IgnoreError(os.Remove(f.Name())) }()
 
 	bytes, err := json.Marshal(state)
 	if err != nil {
-		return errors.Wrap(err, "could not import stack, failed to marshal stack state.")
+		return errors.Wrap(err, "could not import stack, failed to marshal stack state")
 	}
 
 	_, err = f.Write(bytes)
 	if err != nil {
-		return errors.Wrap(err, "could not import stack. failed to write out stack intermediate.")
+		return errors.Wrap(err, "could not import stack. failed to write out stack intermediate")
 	}
 
 	stdout, stderr, errCode, err := l.runPulumiCmdSync(ctx, "stack", "import", "--file", f.Name(), "--stack", stackName)
 	if err != nil {
-		return newAutoError(errors.Wrap(err, "could not import stack."), stdout, stderr, errCode)
+		return newAutoError(errors.Wrap(err, "could not import stack"), stdout, stderr, errCode)
 	}
 
 	return nil
@@ -525,10 +525,10 @@ func parseAndValidatePulumiVersion(minVersion semver.Version, currentVersion str
 		return version, nil
 	}
 	if minVersion.Major < version.Major {
-		return semver.Version{}, errors.Errorf("Major version mismatch. You are using Pulumi CLI version %s with Automation SDK v%v. Please update the SDK.", currentVersion, minVersion.Major)
+		return semver.Version{}, errors.Errorf("Major version mismatch. You are using Pulumi CLI version %s with Automation SDK v%v. Please update the SDK.", currentVersion, minVersion.Major) //nolint
 	}
 	if minVersion.GT(version) {
-		return semver.Version{}, errors.Errorf("Minimum version requirement failed. The minimum CLI version requirement is %s, your current CLI version is %s. Please update the Pulumi CLI.", minimumVersion, currentVersion)
+		return semver.Version{}, errors.Errorf("Minimum version requirement failed. The minimum CLI version requirement is %s, your current CLI version is %s. Please update the Pulumi CLI.", minimumVersion, currentVersion) //nolint
 	}
 	return version, nil
 }

--- a/sdk/go/auto/stack.go
+++ b/sdk/go/auto/stack.go
@@ -950,7 +950,7 @@ func (s *languageRuntimeServer) Run(ctx context.Context, req *pulumirpc.RunReque
 		defer func() {
 			if r := recover(); r != nil {
 				if pErr, ok := r.(error); ok {
-					err = errors.Wrap(pErr, "go inline source runtime error, an unhandled error occurred:")
+					err = errors.Wrap(pErr, "go inline source runtime error, an unhandled error occurred")
 				} else {
 					err = errors.New("go inline source runtime error, an unhandled error occurred: unknown error")
 				}


### PR DESCRIPTION
I encountered these when I upgraded `golangci-lint`. This fixes the newly active lints. 

<!--- 
Thanks so much for your contribution! If this is your first time contributing, please ensure that you have read the [CONTRIBUTING](https://github.com/pulumi/pulumi/blob/master/CONTRIBUTING.md) documentation.
-->

# Description

<!--- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. -->

Fixes # (issue)

## Checklist

<!--- Please provide details if the checkbox below is to be left unchecked. -->
- [ ] I have added tests that prove my fix is effective or that my feature works
<!--- 
User-facing changes require a CHANGELOG entry.
-->
- [ ] I have updated the [CHANGELOG-PENDING](https://github.com/pulumi/pulumi/blob/master/CHANGELOG_PENDING.md) file with my change
<!--
If the change(s) in this PR is a modification of an existing call to the Pulumi Service,
then the service should honor older versions of the CLI where this change would not exist.
You must then bump the API version in /pkg/backend/httpstate/client/api.go, as well as add
it to the service.
-->
- [ ] Yes, there are changes in this PR that warrants bumping the Pulumi Service API version
  <!-- @Pulumi employees: If yes, you must submit corresponding changes in the service repo. -->
