### PR TITLE
Allow Windows CI jobs to fail without failing check

### DIFF
--- a/.github/workflows/run-build-and-acceptance-tests.yml
+++ b/.github/workflows/run-build-and-acceptance-tests.yml
@@ -142,7 +142,7 @@ jobs:
   test:
     name: Test
     needs: build
-    uses: pulumi/pulumi/.github/workflows/test-fast.yml@master
+    uses: pulumi/pulumi/.github/workflows/test.yml@AaronFriel/issue8824
     if: github.event_name == 'repository_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       enable-coverage: true

--- a/.github/workflows/test-fast.yml
+++ b/.github/workflows/test-fast.yml
@@ -75,6 +75,10 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
+    # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
+    # resolved: https://github.com/pulumi/pulumi/issues/8820
+    continue-on-error: ${{ matrix.platform == 'windows-latest' }}
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,10 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
 
+    # [WINDOWS-CI] - Find other instances of this string to find related snippets when this issue is
+    # resolved: https://github.com/pulumi/pulumi/issues/8820
+    continue-on-error: ${{ matrix.platform == 'windows-latest' }}
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Windows CI failures are non-blocking while #8824 is worked on.