### PR TITLE
[codegen/go] Improve optional params in invoke

### DIFF
--- a/CHANGELOG_PENDING.md
+++ b/CHANGELOG_PENDING.md
@@ -1,5 +1,17 @@
 ### Improvements
 
+- [codegen/go] - Implement go type conversions for optional string, boolean, int, and float32
+  arguments, and changes our behavior for optional spilling from variable declaration hoisting to
+  instead rewrite as calls to these functions. Fixes #8821.
+  [#8839](https://github.com/pulumi/pulumi/pull/8839)
+
+- [sdk/go] Added new conversion functions for Read methods on resources exported at the top level
+  of the Pulumi sdk. They are `StringRef`, `BoolRef`, `IntRef`, and `Float64Ref`. They are used for
+  creating a pointer to the type they name, e.g.: StringRef takes `string` and returns `*string`.
+  Data source methods which take optional strings, bools, ints, and float64 values can be set to
+  the return value of these functions. These functions will appear in generated programs as well as
+  future docs updates.
+
 - [cli] Experimental support for update plans. Only enabled when PULUMI_EXPERIMENTAL is
   set. This enables preview to save a plan of what the engine expects to happen in a file
   with --save-plan. That plan can then be read in by up with --plan and is used to ensure

--- a/pkg/codegen/go/gen_program_expressions.go
+++ b/pkg/codegen/go/gen_program_expressions.go
@@ -251,6 +251,14 @@ func (g *generator) GenFunctionCallExpression(w io.Writer, expr *model.FunctionC
 		g.Fgenf(w, "mime.TypeByExtension(path.Ext(%.v))", expr.Args[0])
 	case "sha1":
 		g.Fgenf(w, "sha1Hash(%v)", expr.Args[0])
+	case "goOptionalFloat64":
+		g.Fgenf(w, "pulumi.Float64Ref(%.v)", expr.Args[0])
+	case "goOptionalBool":
+		g.Fgenf(w, "pulumi.BoolRef(%.v)", expr.Args[0])
+	case "goOptionalInt":
+		g.Fgenf(w, "pulumi.IntRef(%.v)", expr.Args[0])
+	case "goOptionalString":
+		g.Fgenf(w, "pulumi.StringRef(%.v)", expr.Args[0])
 	default:
 		g.genNYI(w, "call %v", expr.Name)
 	}

--- a/pkg/codegen/go/gen_program_optionals.go
+++ b/pkg/codegen/go/gen_program_optionals.go
@@ -1,8 +1,6 @@
 package gen
 
 import (
-	"fmt"
-
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/pulumi/pulumi/pkg/v3/codegen"
@@ -30,48 +28,48 @@ func (ot *optionalTemp) SyntaxNode() hclsyntax.Node {
 }
 
 type optionalSpiller struct {
-	temps []*optionalTemp
-	count int
+	invocation         *model.FunctionCallExpression
+	intrinsicConvertTo *model.Type
 }
 
-func (os *optionalSpiller) spillExpressionHelper(
-	x model.Expression,
-	destType model.Type,
-	isInvoke bool,
-) (model.Expression, hcl.Diagnostics) {
-	var temp *optionalTemp
+func (os *optionalSpiller) preVisitor(x model.Expression) (model.Expression, hcl.Diagnostics) {
 	switch x := x.(type) {
 	case *model.FunctionCallExpression:
 		if x.Name == "invoke" {
 			// recurse into invoke args
 			isOutputInvoke, _, _ := pcl.RecognizeOutputVersionedInvoke(x)
 			// ignore output-versioned invokes as they do not need converting
-			isInvoke = !isOutputInvoke
-			_, diags := os.spillExpressionHelper(x.Args[1], x.Args[1].Type(), isInvoke)
-			return x, diags
+			if !isOutputInvoke {
+				os.invocation = x
+			}
+			os.intrinsicConvertTo = nil
+			return x, nil
 		}
 		if x.Name == pcl.IntrinsicConvert {
-			// propagate convert type
-			_, diags := os.spillExpressionHelper(x.Args[0], x.Signature.ReturnType, isInvoke)
-			return x, diags
+			if os.invocation != nil {
+				os.intrinsicConvertTo = &x.Signature.ReturnType
+			}
+			return x, nil
 		}
 	case *model.ObjectConsExpression:
-		// only rewrite invoke args (required to be prompt values in Go)
-		// pulumi.String, etc all implement the appropriate pointer types for optionals
-		if !isInvoke {
+		if os.invocation == nil {
 			return x, nil
+		}
+		destType := x.Type()
+		if os.intrinsicConvertTo != nil {
+			destType = *os.intrinsicConvertTo
 		}
 		if schemaType, ok := pcl.GetSchemaForType(destType); ok {
 			if schemaType, ok := schemaType.(*schema.ObjectType); ok {
-				var optionalPrimitives []string
+				// map of item name to optional type wrapper fn
+				optionalPrimitives := make(map[string]schema.Type)
 				for _, v := range schemaType.Properties {
-					isPrimitive := false
-					switch codegen.UnwrapType(v.Type) {
-					case schema.NumberType, schema.BoolType, schema.IntType, schema.StringType:
-						isPrimitive = true
-					}
-					if isPrimitive && !v.IsRequired() {
-						optionalPrimitives = append(optionalPrimitives, v.Name)
+					if !v.IsRequired() {
+						ty := codegen.UnwrapType(v.Type)
+						switch ty {
+						case schema.NumberType, schema.BoolType, schema.IntType, schema.StringType:
+							optionalPrimitives[v.Name] = ty
+						}
 					}
 				}
 				for i, item := range x.Items {
@@ -79,19 +77,20 @@ func (os *optionalSpiller) spillExpressionHelper(
 					if key, ok := item.Key.(*model.LiteralValueExpression); ok {
 						if model.StringType.AssignableFrom(key.Type()) {
 							strKey := key.Value.AsString()
-							for _, op := range optionalPrimitives {
-								if strKey == op {
-									temp = &optionalTemp{
-										Name:  fmt.Sprintf("opt%d", os.count),
-										Value: item.Value,
-									}
-									os.temps = append(os.temps, temp)
-									os.count++
-									x.Items[i].Value = &model.ScopeTraversalExpression{
-										RootName:  fmt.Sprintf("&%s", temp.Name),
-										Traversal: hcl.Traversal{hcl.TraverseRoot{Name: ""}},
-										Parts:     []model.Traversable{temp},
-									}
+							if schemaType, isOptional := optionalPrimitives[strKey]; isOptional {
+								functionName := os.getOptionalConversion(schemaType)
+								expectedModelType := os.getExpectedModelType(schemaType)
+
+								x.Items[i].Value = &model.FunctionCallExpression{
+									Name: functionName,
+									Signature: model.StaticFunctionSignature{
+										Parameters: []model.Parameter{{
+											Name: "val",
+											Type: expectedModelType,
+										}},
+										ReturnType: model.NewOptionalType(expectedModelType),
+									},
+									Args: []model.Expression{item.Value},
 								}
 							}
 						}
@@ -99,22 +98,67 @@ func (os *optionalSpiller) spillExpressionHelper(
 				}
 			}
 		}
+		// Clear before visiting children, require another __convert call to set again
+		os.intrinsicConvertTo = nil
+		return x, nil
+	default:
+		// Ditto
+		os.intrinsicConvertTo = nil
+		return x, nil
 	}
 	return x, nil
 }
 
-func (os *optionalSpiller) spillExpression(x model.Expression) (model.Expression, hcl.Diagnostics) {
-	isInvoke := false
-	return os.spillExpressionHelper(x, x.Type(), isInvoke)
+func (os *optionalSpiller) postVisitor(x model.Expression) (model.Expression, hcl.Diagnostics) {
+	switch x := x.(type) {
+	case *model.FunctionCallExpression:
+		if x.Name == "invoke" {
+			if x == os.invocation {
+				// Clear invocation flag once we're done traversing children.
+				os.invocation = nil
+			}
+		}
+	}
+	return x, nil
+}
+
+func (*optionalSpiller) getOptionalConversion(ty schema.Type) string {
+	switch ty {
+	case schema.NumberType:
+		return "goOptionalFloat64"
+	case schema.BoolType:
+		return "goOptionalBool"
+	case schema.IntType:
+		return "goOptionalInt"
+	case schema.StringType:
+		return "goOptionalString"
+	default:
+		return ""
+	}
+}
+
+func (*optionalSpiller) getExpectedModelType(ty schema.Type) model.Type {
+	switch ty {
+	case schema.NumberType:
+		return model.NumberType
+	case schema.BoolType:
+		return model.BoolType
+	case schema.IntType:
+		return model.IntType
+	case schema.StringType:
+		return model.StringType
+	default:
+		return nil
+	}
 }
 
 func (g *generator) rewriteOptionals(
 	x model.Expression,
 	spiller *optionalSpiller,
 ) (model.Expression, []*optionalTemp, hcl.Diagnostics) {
-	spiller.temps = nil
-	x, diags := model.VisitExpression(x, spiller.spillExpression, nil)
+	// We want to recurse but we only want to use the previsitor, if post visitor is nil we don't
+	// recurse.
+	x, diags := model.VisitExpression(x, spiller.preVisitor, spiller.postVisitor)
 
-	return x, spiller.temps, diags
-
+	return x, nil, diags
 }

--- a/pkg/codegen/go/gen_program_test.go
+++ b/pkg/codegen/go/gen_program_test.go
@@ -104,8 +104,8 @@ func goCheck(t *testing.T, path string, _ codegen.StringSet) {
 	err = integration.RunCommand(t, "point towards local Go SDK",
 		[]string{ex, "mod", "edit",
 			fmt.Sprintf("--replace=%s=%s",
-				"github.com/pulumi/pulumi/sdk/v3/go/pulumi",
-				"../../../../../../sdk")},
+				"github.com/pulumi/pulumi/sdk/v3",
+				"../../../../../../../sdk")},
 		dir, &integration.ProgramTestOptions{})
 	require.NoError(t, err)
 	err = integration.RunCommand(t, "test build", []string{ex, "build", "-v", "all"},

--- a/pkg/codegen/internal/test/program_driver.go
+++ b/pkg/codegen/internal/test/program_driver.go
@@ -69,7 +69,7 @@ var programTests = []programTest{
 		Directory:   "aws-optionals",
 		Description: "AWS get invoke with nested object constructor that takes an optional string",
 		// Testing Go behavior exclusively:
-		SkipCompile: allProgLanguages.Except("go"),
+		Skip: allProgLanguages.Except("go"),
 	},
 	{
 		Directory:   "aws-webserver",

--- a/pkg/codegen/internal/test/program_driver.go
+++ b/pkg/codegen/internal/test/program_driver.go
@@ -66,6 +66,14 @@ var programTests = []programTest{
 		// Flaky in go: TODO[pulumi/pulumi#8123]
 	},
 	{
+		Directory:   "aws-optionals",
+		Description: "AWS get invoke with nested object constructor that takes an optional string",
+		// SkipCompile: codegen.NewStringSet("dotnet", "nodejs", "go"),
+		// Blocked on dotnet: TODO[pulumi/pulumi#8069]
+		// Blocked on nodejs: TODO[pulumi/pulumi#8068]
+		// Flaky in go: TODO[pulumi/pulumi#8123]
+	},
+	{
 		Directory:   "aws-webserver",
 		Description: "AWS Webserver",
 		SkipCompile: codegen.NewStringSet("go"),

--- a/pkg/codegen/internal/test/program_driver.go
+++ b/pkg/codegen/internal/test/program_driver.go
@@ -68,10 +68,8 @@ var programTests = []programTest{
 	{
 		Directory:   "aws-optionals",
 		Description: "AWS get invoke with nested object constructor that takes an optional string",
-		// SkipCompile: codegen.NewStringSet("dotnet", "nodejs", "go"),
-		// Blocked on dotnet: TODO[pulumi/pulumi#8069]
-		// Blocked on nodejs: TODO[pulumi/pulumi#8068]
-		// Flaky in go: TODO[pulumi/pulumi#8123]
+		// Testing Go behavior exclusively:
+		SkipCompile: allProgLanguages.Except("go"),
 	},
 	{
 		Directory:   "aws-webserver",

--- a/pkg/codegen/internal/test/testdata/aws-fargate-pp/go/aws-fargate.go
+++ b/pkg/codegen/internal/test/testdata/aws-fargate-pp/go/aws-fargate.go
@@ -12,9 +12,8 @@ import (
 
 func main() {
 	pulumi.Run(func(ctx *pulumi.Context) error {
-		opt0 := true
 		vpc, err := ec2.LookupVpc(ctx, &ec2.LookupVpcArgs{
-			Default: &opt0,
+			Default: pulumi.BoolRef(true),
 		}, nil)
 		if err != nil {
 			return err

--- a/pkg/codegen/internal/test/testdata/aws-optionals-pp/aws-optionals.pp
+++ b/pkg/codegen/internal/test/testdata/aws-optionals-pp/aws-optionals.pp
@@ -1,0 +1,20 @@
+policyDocument = invoke("aws:iam:getPolicyDocument", {
+  statements = [{
+    sid = "1"
+
+    actions = [
+      "s3:ListAllMyBuckets",
+      "s3:GetBucketLocation",
+    ]
+
+    resources = [
+      "arn:aws:s3:::*",
+    ]
+  }]
+})
+
+resource example "aws:iam:Policy" {
+  name   = "example_policy"
+  path   = "/"
+  policy = policyDocument.json
+}

--- a/pkg/codegen/internal/test/testdata/aws-optionals-pp/go/aws-optionals.go
+++ b/pkg/codegen/internal/test/testdata/aws-optionals-pp/go/aws-optionals.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"github.com/pulumi/pulumi-aws/sdk/v4/go/aws/iam"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		policyDocument, err := iam.GetPolicyDocument(ctx, &iam.GetPolicyDocumentArgs{
+			Statements: []iam.GetPolicyDocumentStatement{
+				iam.GetPolicyDocumentStatement{
+					Sid: pulumi.StringRef("1"),
+					Actions: []string{
+						"s3:ListAllMyBuckets",
+						"s3:GetBucketLocation",
+					},
+					Resources: []string{
+						"arn:aws:s3:::*",
+					},
+				},
+			},
+		}, nil)
+		if err != nil {
+			return err
+		}
+		_, err = iam.NewPolicy(ctx, "example", &iam.PolicyArgs{
+			Name:   pulumi.String("example_policy"),
+			Path:   pulumi.String("/"),
+			Policy: pulumi.String(policyDocument.Json),
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/codegen/internal/test/testdata/aws-webserver-pp/go/aws-webserver.go
+++ b/pkg/codegen/internal/test/testdata/aws-webserver-pp/go/aws-webserver.go
@@ -25,7 +25,6 @@ func main() {
 		if err != nil {
 			return err
 		}
-		opt0 := true
 		ami, err := aws.GetAmi(ctx, &GetAmiArgs{
 			Filters: []GetAmiFilter{
 				GetAmiFilter{
@@ -38,7 +37,7 @@ func main() {
 			Owners: []string{
 				"137112412989",
 			},
-			MostRecent: &opt0,
+			MostRecent: pulumi.BoolRef(true),
 		}, nil)
 		if err != nil {
 			return err

--- a/sdk/go/pulumi/type_conversions.go
+++ b/sdk/go/pulumi/type_conversions.go
@@ -1,0 +1,39 @@
+// Copyright 2016-2022, Pulumi Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pulumi
+
+// StringRef returns a pointer to its argument, used in cases where a parameter requires an optional
+// string.
+func StringRef(v string) *string {
+	return &v
+}
+
+// BoolRef returns a pointer to its argument, used in cases where a parameter requires an optional
+// bool.
+func BoolRef(v bool) *bool {
+	return &v
+}
+
+// IntRef returns a pointer to its argument, used in cases where a parameter requires an optional
+// int.
+func IntRef(v int) *int {
+	return &v
+}
+
+// Float64Ref returns a pointer to its argument, used in cases where a parameter requires an optional
+// float64.
+func Float64Ref(v float64) *float64 {
+	return &v
+}


### PR DESCRIPTION
As described in #8821, docs generated for helper functions can be incorrect because optional arguments to parameter objects are not correctly handled.

Previously, code would be generated like so:

```go
    policyDocument, err := iam.GetPolicyDocument(ctx, &iam.GetPolicyDocumentArgs{
      Statements: []iam.GetPolicyDocumentStatement{
        iam.GetPolicyDocumentStatement{
          Sid: "1",
          //...
```

However "Sid" is of type `*string`.

This four helper conversion functions, to handle the primitive types we lower from, and modifies codegen to recursively apply these functions inside of an invoke call.

In the new code generation, the above is instead rendered as:

```go
    policyDocument, err := iam.GetPolicyDocument(ctx, &iam.GetPolicyDocumentArgs{
      Statements: []iam.GetPolicyDocumentStatement{
        iam.GetPolicyDocumentStatement{
          Sid: pulumi.StringRef("1"),
          //...
```
